### PR TITLE
REF/ENH: Constructors for DatetimeArray/TimedeltaArray

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -801,6 +801,12 @@ DatetimeLikeArrayMixin._add_comparison_ops()
 # -------------------------------------------------------------------
 # Shared Constructor Helpers
 
+def scalar_data_error(scalar, cls):
+    return ('{cls}() must be called with a '
+            'collection of some kind, {data} was passed'
+            .format(cls=cls.__name__, data=repr(scalar)))
+
+
 def validate_periods(periods):
     """
     If a `periods` argument is passed to the Datetime/Timedelta Array/Index

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -928,6 +928,26 @@ def maybe_define_freq(freq_infer, result):
             result.freq = frequencies.to_offset(inferred)
 
 
+def maybe_validate_freq(result, verify, freq, freq_infer, **kwargs):
+    """
+    If a frequency was passed by the user and not inferred or extracted
+    from the underlying data, then validate that the data is consistent with
+    the user-provided frequency.
+
+    Parameters
+    ----------
+    result : DatetimeIndex or TimedeltaIndex
+    verify : bool
+    freq : DateOffset or None
+    freq_infer : bool
+    **kwargs : arguments to pass to `_validate_frequency`
+        For DatetimeIndex this is just "ambiguous", empty for TimedeltaIndex
+    """
+    if verify and len(result) > 0:
+        if freq is not None and not freq_infer:
+            result._validate_frequency(result, freq, **kwargs)
+
+
 def validate_tz_from_dtype(dtype, tz):
     """
     If the given dtype is a DatetimeTZDtype, extract the implied

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -897,6 +897,11 @@ def maybe_define_freq(freq_infer, result):
     ----------
     freq_infer : bool
     result : DatetimeArray or TimedeltaArray
+
+    Notes
+    -----
+    This may alter `result` in-place, should only ever be called
+    from __new__/__init__.
     """
     if freq_infer:
         inferred = result.inferred_freq

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -888,6 +888,22 @@ def maybe_infer_freq(freq):
     return freq, freq_infer
 
 
+def maybe_define_freq(freq_infer, result):
+    """
+    If appropriate, infer the frequency of the given Datetime/Timedelta Array
+    and pin it to the object at the end of the construction.
+
+    Parameters
+    ----------
+    freq_infer : bool
+    result : DatetimeArray or TimedeltaArray
+    """
+    if freq_infer:
+        inferred = result.inferred_freq
+        if inferred:
+            result.freq = frequencies.to_offset(inferred)
+
+
 def validate_tz_from_dtype(dtype, tz):
     """
     If the given dtype is a DatetimeTZDtype, extract the implied

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -802,6 +802,19 @@ DatetimeLikeArrayMixin._add_comparison_ops()
 # Shared Constructor Helpers
 
 def scalar_data_error(scalar, cls):
+    """
+    Produce the error message to issue when raising a TypeError if a scalar
+    is passed to an array constructor.
+
+    Parameters
+    ----------
+    scalar : object
+    cls : class
+
+    Returns
+    -------
+    message : str
+    """
     return ('{cls}() must be called with a '
             'collection of some kind, {data} was passed'
             .format(cls=cls.__name__, data=repr(scalar)))

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -217,7 +217,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         if lib.is_scalar(values):
             raise ValueError('{cls}() must be called with a '
                              'collection of some kind, {data} was passed'
-                             .format(cls=cls.__name__, data=repr(data)))
+                             .format(cls=cls.__name__, data=repr(values)))
         elif isinstance(values, DatetimeArrayMixin):
             # extract nanosecond unix timestamps
             values = values.asi8
@@ -230,10 +230,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         values = conversion.ensure_datetime64ns(values, copy=copy)
 
         result = cls._simple_new(values, freq=freq, tz=tz)
-        if freq_infer:
-            inferred = result.inferred_freq
-            if inferred:
-                result.freq = to_offset(inferred)
+        dtl.maybe_define_freq(freq_infer, result)
 
         # NB: Among other things not yet ported from the DatetimeIndex
         # constructor, this does not call _deepcopy_if_needed

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -245,6 +245,8 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
     def _from_sequence(cls, scalars, dtype=None, copy=False):
         # list, tuple, or object-dtype ndarray/Index
         values = np.array(scalars, dtype=np.object_, copy=copy)
+        if values.ndim != 1:
+            raise TypeError("Values must be 1-dimensional")
 
         # TODO: See if we can decrease circularity
         from pandas.core.tools.datetimes import to_datetime

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -195,9 +195,10 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         result._tz = timezones.tz_standardize(tz)
         return result
 
-    def __new__(cls, values, freq=None, tz=None, dtype=None):
+    def __new__(cls, values, freq=None, tz=None, dtype=None, copy=False):
         if isinstance(values, (list, tuple)) or is_object_dtype(values):
-            values = cls._from_sequence(values)
+            values = cls._from_sequence(values, copy=copy)
+            # TODO: Can we set copy=False here to avoid re-coping?
 
         if tz is None and hasattr(values, 'tz'):
             # e.g. DatetimeIndex
@@ -215,7 +216,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         if lib.is_scalar(values):
             raise ValueError('{cls}() must be called with a '
                              'collection of some kind, {data} was passed'
-                             .format(cls=type(self).__name__, data=repr(data)))
+                             .format(cls=cls.__name__, data=repr(data)))
         elif isinstance(values, DatetimeArrayMixin):
             # extract nanosecond unix timestamps
             values = values.asi8
@@ -225,7 +226,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
 
         assert isinstance(values, np.ndarray), type(values)
         assert is_datetime64_dtype(values)  # not yet assured nanosecond
-        values = conversion.ensure_datetime64ns(values, copy=False)
+        values = conversion.ensure_datetime64ns(values, copy=copy)
 
         result = cls._simple_new(values, freq=freq, tz=tz)
         if freq_infer:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -213,11 +213,13 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         # if dtype has an embedded tz, capture it
         tz = dtl.validate_tz_from_dtype(dtype, tz)
 
-        # TODO: what about ABCSeries?
         if lib.is_scalar(values):
             raise ValueError('{cls}() must be called with a '
                              'collection of some kind, {data} was passed'
                              .format(cls=cls.__name__, data=repr(values)))
+        elif isinstance(values, ABCSeries):
+            # extract nanosecond unix timestamps
+            values = values._values.asi8
         elif isinstance(values, DatetimeArrayMixin):
             # extract nanosecond unix timestamps
             values = values.asi8

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -216,9 +216,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         tz = dtl.validate_tz_from_dtype(dtype, tz)
 
         if lib.is_scalar(values):
-            raise ValueError('{cls}() must be called with a '
-                             'collection of some kind, {data} was passed'
-                             .format(cls=cls.__name__, data=repr(values)))
+            raise TypeError(dtl.scalar_data_error(values, cls))
         elif isinstance(values, ABCSeries):
             # extract nanosecond unix timestamps
             if tz is None:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -201,7 +201,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
             # TODO: Can we set copy=False here to avoid re-coping?
 
         if tz is None and hasattr(values, 'tz'):
-            # e.g. DatetimeIndex
+            # e.g. DatetimeArray, DatetimeIndex
             tz = values.tz
 
         if freq is None and hasattr(values, "freq"):
@@ -213,6 +213,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         # if dtype has an embedded tz, capture it
         tz = dtl.validate_tz_from_dtype(dtype, tz)
 
+        # TODO: what about ABCSeries?
         if lib.is_scalar(values):
             raise ValueError('{cls}() must be called with a '
                              'collection of some kind, {data} was passed'

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -165,7 +165,9 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, ExtensionArray):
 
     # --------------------------------------------------------------------
     # Constructors
-    def __init__(self, values, freq=None, copy=False):
+    def __init__(self, values, freq=None, dtype=None, copy=False):
+        freq = dtl.validate_dtype_freq(dtype, freq)
+
         if freq is not None:
             freq = Period._maybe_convert_freq(freq)
 

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -125,11 +125,12 @@ class TimedeltaArrayMixin(dtl.DatetimeLikeArrayMixin):
         result._freq = freq
         return result
 
-    def __new__(cls, values, freq=None, dtype=_TD_DTYPE):
+    def __new__(cls, values, freq=None, dtype=_TD_DTYPE, copy=False):
         _require_m8ns_dtype(dtype)
 
         if isinstance(values, (list, tuple)) or is_object_dtype(values):
-            values = cls._from_sequence(values)._data
+            values = cls._from_sequence(values, copy=copy)._data
+            # TODO: can we set copy=False to avoid re-copying?
 
         freq, freq_infer = dtl.maybe_infer_freq(freq)
 
@@ -139,7 +140,7 @@ class TimedeltaArrayMixin(dtl.DatetimeLikeArrayMixin):
                 freq_infer = False
             values = values._data
 
-        values = np.array(values, copy=False)
+        values = np.array(values, copy=copy)
 
         if values.dtype == 'i8':
             pass

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -19,7 +19,6 @@ import pandas.core.common as com
 from pandas.core.algorithms import checked_add_with_arr
 
 from pandas.tseries.offsets import Tick
-from pandas.tseries.frequencies import to_offset
 
 from . import datetimelike as dtl
 
@@ -152,11 +151,7 @@ class TimedeltaArrayMixin(dtl.DatetimeLikeArrayMixin):
             values = values.astype(_TD_DTYPE)
 
         result = cls._simple_new(values, freq=freq)
-        if freq_infer:
-            inferred = result.inferred_freq
-            if inferred:
-                result.freq = to_offset(inferred)
-
+        dtl.maybe_define_freq(freq_infer, result)
         return result
 
     @classmethod

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -263,7 +263,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                              .format(cls=cls.__name__, data=repr(data)))
 
         elif not isinstance(data, (np.ndarray, Index, ABCSeries,
-                                 DatetimeArrayMixin)):
+                                   DatetimeArrayMixin)):
             if not isinstance(data, (list, tuple)):
                 data = list(data)
             data = np.asarray(data, dtype='O')
@@ -321,11 +321,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
             if freq is not None and not freq_infer:
                 cls._validate_frequency(subarr, freq, ambiguous=ambiguous)
 
-        if freq_infer:
-            inferred = subarr.inferred_freq
-            if inferred:
-                subarr.freq = to_offset(inferred)
-
+        dtl.maybe_define_freq(freq_infer, subarr)
         return subarr._deepcopy_if_needed(ref_to_data, copy)
 
     @classmethod

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1101,6 +1101,9 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
             else:
                 raise
 
+    # -----------------------------------------------------------------
+    # Wrapping DatetimeArray
+
     year = wrap_field_accessor(DatetimeArrayMixin.year)
     month = wrap_field_accessor(DatetimeArrayMixin.month)
     day = wrap_field_accessor(DatetimeArrayMixin.day)
@@ -1138,6 +1141,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                                        False)
     month_name = wrap_array_method(DatetimeArrayMixin.month_name, True)
     day_name = wrap_array_method(DatetimeArrayMixin.day_name, True)
+
+    # -----------------------------------------------------------------
 
     @Substitution(klass='DatetimeIndex')
     @Appender(_shared_docs['searchsorted'])

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -219,6 +219,9 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
     _timezone = cache_readonly(DatetimeArrayMixin._timezone.fget)
     is_normalized = cache_readonly(DatetimeArrayMixin.is_normalized.fget)
 
+    # --------------------------------------------------------------------
+    # Constructors
+
     def __new__(cls, data=None,
                 freq=None, start=None, end=None, periods=None, tz=None,
                 normalize=False, closed=None, ambiguous='raise',
@@ -252,7 +255,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                              'collection of some kind, {data} was passed'
                              .format(cls=cls.__name__, data=repr(data)))
 
-        if not isinstance(data, (np.ndarray, Index, ABCSeries,
+        elif not isinstance(data, (np.ndarray, Index, ABCSeries,
                                  DatetimeArrayMixin)):
             if not isinstance(data, (list, tuple)):
                 data = list(data)
@@ -318,12 +321,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
 
         return subarr._deepcopy_if_needed(ref_to_data, copy)
 
-    def _convert_for_op(self, value):
-        """ Convert value to be insertable to ndarray """
-        if self._has_same_tz(value):
-            return _to_m8(value)
-        raise ValueError('Passed item and index have different timezone')
-
     @classmethod
     def _simple_new(cls, values, name=None, freq=None, tz=None,
                     dtype=None, **kwargs):
@@ -339,6 +336,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         result.name = name
         result._reset_identity()
         return result
+
+    # --------------------------------------------------------------------
 
     @property
     def _values(self):
@@ -390,6 +389,12 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         """Return a boolean if we are only dates (and don't have a timezone)"""
         from pandas.io.formats.format import _is_dates_only
         return _is_dates_only(self.values) and self.tz is None
+
+    def _convert_for_op(self, value):
+        """ Convert value to be insertable to ndarray """
+        if self._has_same_tz(value):
+            return _to_m8(value)
+        raise ValueError('Passed item and index have different timezone')
 
     @property
     def _formatter_func(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -258,9 +258,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
             return result
 
         if is_scalar(data):
-            raise ValueError('{cls}() must be called with a '
-                             'collection of some kind, {data} was passed'
-                             .format(cls=cls.__name__, data=repr(data)))
+            raise TypeError(dtl.scalar_data_error(data, cls))
 
         elif not isinstance(data, (np.ndarray, Index, ABCSeries,
                                    DatetimeArrayMixin)):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -309,11 +309,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         assert subarr.dtype == 'M8[ns]', subarr.dtype
 
         subarr = cls._simple_new(subarr, name=name, freq=freq, tz=tz)
-
-        if verify_integrity and len(subarr) > 0:
-            if freq is not None and not freq_infer:
-                cls._validate_frequency(subarr, freq, ambiguous=ambiguous)
-
+        dtl.maybe_validate_freq(subarr, verify_integrity, freq, freq_infer,
+                                ambiguous=ambiguous)
         dtl.maybe_define_freq(freq_infer, subarr)
         return subarr._deepcopy_if_needed(ref_to_data, copy)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -309,11 +309,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         assert subarr.dtype == 'M8[ns]', subarr.dtype
 
         subarr = cls._simple_new(subarr, name=name, freq=freq, tz=tz)
-        if dtype is not None:
-            if not is_dtype_equal(subarr.dtype, dtype):
-                # dtype must be coerced to DatetimeTZDtype above
-                if subarr.tz is not None:
-                    raise ValueError("cannot localize from non-UTC data")
 
         if verify_integrity and len(subarr) > 0:
             if freq is not None and not freq_infer:

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -156,7 +156,7 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
             data = to_timedelta(data, unit=unit, box=False)
 
         if is_scalar(data):
-            raise dtl.scalar_data_error(data, cls)
+            raise TypeError(dtl.scalar_data_error(data, cls))
 
         # convert if not already
         if getattr(data, 'dtype', None) != _TD_DTYPE:

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -167,16 +167,12 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
         elif copy:
             data = np.array(data, copy=True)
 
-        data = np.array(data, copy=False)
-        if data.dtype == np.object_:
-            data = array_to_timedelta64(data)
-        if data.dtype != _TD_DTYPE:
-            if is_timedelta64_dtype(data):
-                # non-nano unit
-                # TODO: watch out for overflows
-                data = data.astype(_TD_DTYPE)
-            else:
-                data = ensure_int64(data).view(_TD_DTYPE)
+        arr = TimedeltaArrayMixin(data, freq=freq)
+        if freq_infer and arr.freq is not None:
+            freq_infer = False
+            verify_integrity = False
+        freq = arr.freq
+        data = arr._data
 
         assert data.dtype == 'm8[ns]', data.dtype
 
@@ -208,8 +204,6 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
         result.name = name
         result._reset_identity()
         return result
-
-    _shallow_copy = Index._shallow_copy
 
     @property
     def _formatter_func(self):

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -156,9 +156,7 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
             data = to_timedelta(data, unit=unit, box=False)
 
         if is_scalar(data):
-            raise ValueError('TimedeltaIndex() must be called with a '
-                             'collection of some kind, {data} was passed'
-                             .format(data=repr(data)))
+            raise dtl.scalar_data_error(data, cls)
 
         # convert if not already
         if getattr(data, 'dtype', None) != _TD_DTYPE:
@@ -232,12 +230,22 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
                                     nat_rep=na_rep,
                                     justify='all').get_result()
 
+    # -----------------------------------------------------------------
+    # Wrapping TimedeltaArray
+
     days = wrap_field_accessor(TimedeltaArrayMixin.days)
     seconds = wrap_field_accessor(TimedeltaArrayMixin.seconds)
     microseconds = wrap_field_accessor(TimedeltaArrayMixin.microseconds)
     nanoseconds = wrap_field_accessor(TimedeltaArrayMixin.nanoseconds)
 
     total_seconds = wrap_array_method(TimedeltaArrayMixin.total_seconds, True)
+
+    # override TimedeltaArray versions
+    is_monotonic_increasing = Index.is_monotonic_increasing
+    is_monotonic_decreasing = Index.is_monotonic_decreasing
+    is_unique = Index.is_unique
+
+    # -----------------------------------------------------------------
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -35,7 +35,6 @@ from pandas.core.tools.timedeltas import (
     to_timedelta, _coerce_scalar_to_timedelta_type)
 from pandas._libs import (lib, index as libindex,
                           join as libjoin, Timedelta, NaT)
-from pandas._libs.tslibs.timedeltas import array_to_timedelta64
 
 
 class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
@@ -182,11 +181,7 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
             if freq is not None and not freq_infer:
                 cls._validate_frequency(subarr, freq)
 
-        if freq_infer:
-            inferred = subarr.inferred_freq
-            if inferred:
-                subarr.freq = to_offset(inferred)
-
+        dtl.maybe_define_freq(freq_infer, subarr)
         return subarr
 
     @classmethod

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -174,11 +174,7 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
         assert data.dtype == 'm8[ns]', data.dtype
 
         subarr = cls._simple_new(data, name=name, freq=freq)
-        # check that we are matching freqs
-        if verify_integrity and len(subarr) > 0:
-            if freq is not None and not freq_infer:
-                cls._validate_frequency(subarr, freq)
-
+        dtl.maybe_validate_freq(subarr, verify_integrity, freq, freq_infer)
         dtl.maybe_define_freq(freq_infer, subarr)
         return subarr
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -12,7 +12,16 @@ import pandas.util.testing as tm
 
 class TestDatetimeArrayConstructors(object):
 
+    def test_scalar_raises_type_error(self):
+        # GH#23493
+        with pytest.raises(TypeError):
+            DatetimeArray(2)
+
+        with pytest.raises(TypeError):
+            pd.DatetimeIndex(pd.Timestamp.now())
+
     def test_init_from_object_dtype(self, tz_naive_fixture):
+        # GH#23493
         tz = tz_naive_fixture
         if tz is not None:
             pytest.xfail(reason="Casting DatetimeIndex to object-dtype raises "
@@ -35,6 +44,7 @@ class TestDatetimeArrayConstructors(object):
     # NB: for now we re-wrap in DatetimeIndex to use assert_index_equal
     #  once assert_datetime_array_equal is in place, this will be changed
     def test_init_only_freq_infer(self, tz_naive_fixture):
+        # GH#23493
         # just pass data and freq='infer' if relevant; no other kwargs
         tz = tz_naive_fixture
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -10,8 +10,6 @@ import pandas as pd
 import pandas.util.testing as tm
 
 
-
-
 class TestDatetimeArrayConstructors(object):
 
     def test_init_from_object_dtype(self, tz_naive_fixture):

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -20,6 +20,21 @@ class TestDatetimeArrayConstructors(object):
         with pytest.raises(TypeError):
             pd.DatetimeIndex(pd.Timestamp.now())
 
+    def test_from_sequence_requires_1dim(self):
+        arr2d = np.arange(10).view('M8[s]').astype(object).reshape(2, 5)
+        with pytest.raises(TypeError):
+            DatetimeArray(arr2d)
+
+        with pytest.raises(TypeError):
+            pd.DatetimeIndex(arr2d)
+
+        arr0d = np.array(pd.Timestamp.now())
+        with pytest.raises(TypeError):
+            DatetimeArray(arr0d)
+
+        with pytest.raises(TypeError):
+            pd.DatetimeIndex(arr0d)
+
     def test_init_from_object_dtype(self, tz_naive_fixture):
         # GH#23493
         tz = tz_naive_fixture
@@ -31,7 +46,6 @@ class TestDatetimeArrayConstructors(object):
         # arbitrary DatetimeIndex; this should work for any DatetimeIndex
         #  with non-None freq
         dti = pd.date_range('2016-01-1', freq='MS', periods=9, tz=tz)
-        expected = DatetimeArray(dti)
 
         # Fails because np.array(dti, dtype=object) incorrectly returns Longs
         result = DatetimeArray(np.array(dti, dtype=object), freq='infer')

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -1,0 +1,74 @@
+"""
+Tests for DatetimeArray
+"""
+import pytest
+import numpy as np
+
+from pandas.core.arrays import DatetimeArrayMixin as DatetimeArray
+
+import pandas as pd
+import pandas.util.testing as tm
+
+
+
+
+class TestDatetimeArrayConstructors(object):
+
+    def test_init_from_object_dtype(self, tz_naive_fixture):
+        tz = tz_naive_fixture
+        if tz is not None:
+            pytest.xfail(reason="Casting DatetimeIndex to object-dtype raises "
+                                "for pd.Index and is incorrect for np.array; "
+                                "GH#24391")
+
+        # arbitrary DatetimeIndex; this should work for any DatetimeIndex
+        #  with non-None freq
+        dti = pd.date_range('2016-01-1', freq='MS', periods=9, tz=tz)
+        expected = DatetimeArray(dti)
+
+        # Fails because np.array(dti, dtype=object) incorrectly returns Longs
+        result = DatetimeArray(np.array(dti, dtype=object), freq='infer')
+        tm.assert_equal(pd.DatetimeIndex(result), dti)
+
+        # Fails because `pd.Index(dti, dtype=object) raises incorrectly
+        result = DatetimeArray(pd.Index(dti, dtype=object), freq='infer')
+        tm.assert_equal(pd.DatetimeIndex(result), dti)
+
+    # NB: for now we re-wrap in DatetimeIndex to use assert_index_equal
+    #  once assert_datetime_array_equal is in place, this will be changed
+    def test_init_only_freq_infer(self, tz_naive_fixture):
+        # just pass data and freq='infer' if relevant; no other kwargs
+        tz = tz_naive_fixture
+
+        # arbitrary DatetimeIndex; this should work for any DatetimeIndex
+        #  with non-None freq
+        dti = pd.date_range('2016-01-1', freq='MS', periods=9, tz=tz)
+        expected = DatetimeArray(dti)
+        assert expected.freq == dti.freq
+        assert expected.tz == dti.tz
+
+        # broken until ABCDatetimeArray and isna is fixed
+        # assert (dti == expected).all()
+        # assert (expected == dti).all()
+
+        result = DatetimeArray(expected)
+        tm.assert_equal(pd.DatetimeIndex(result), dti)
+
+        result = DatetimeArray(list(dti), freq='infer')
+        tm.assert_equal(pd.DatetimeIndex(result), dti)
+
+        result = DatetimeArray(tuple(dti), freq='infer')
+        tm.assert_equal(pd.DatetimeIndex(result), dti)
+
+        if tz is None:
+            result = DatetimeArray(np.array(dti), freq='infer')
+            tm.assert_equal(pd.DatetimeIndex(result), dti)
+
+            result = DatetimeArray(np.array(dti).astype('M8[s]'), freq='infer')
+            tm.assert_equal(pd.DatetimeIndex(result), dti)
+
+        result = DatetimeArray(pd.Series(dti), freq='infer')
+        tm.assert_equal(pd.DatetimeIndex(result), dti)
+
+        result = DatetimeArray(pd.Series(dti, dtype=object), freq='infer')
+        tm.assert_equal(pd.DatetimeIndex(result), dti)

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -1,0 +1,89 @@
+"""
+Tests for TimedeltaArray
+"""
+
+import numpy as np
+import pytest
+
+from pandas.core.arrays import TimedeltaArrayMixin as TimedeltaArray
+
+import pandas as pd
+import pandas.util.testing as tm
+
+
+# TODO: Many of these tests are mirrored in test_datetimes; see if these
+#  can be shared
+class TestTimedeltaArrayConstructors(object):
+    def test_scalar_raises_type_error(self):
+        # GH#23493
+        with pytest.raises(TypeError):
+            TimedeltaArray(2)
+
+        with pytest.raises(TypeError):
+            pd.TimedeltaIndex(pd.Timedelta(days=4))
+
+    def test_from_sequence_requires_1dim(self):
+        arr2d = np.arange(10).view('m8[s]').astype(object).reshape(2, 5)
+        with pytest.raises(TypeError):
+            TimedeltaArray(arr2d)
+
+        with pytest.raises(TypeError):
+            pd.TimedeltaIndex(arr2d)
+
+        arr0d = np.array(pd.Timedelta('49 days'))
+        with pytest.raises(TypeError):
+            TimedeltaArray(arr0d)
+
+        with pytest.raises(TypeError):
+            pd.TimedeltaIndex(arr0d)
+
+    def test_init_from_object_dtype(self):
+        # GH#23493
+
+        # arbitrary TimedeltaIndex; this should work for any TimedeltaIndex
+        #  with non-None freq
+        tdi = pd.timedelta_range('3 Days', freq='ms', periods=9)
+
+        # Fails because np.array(tdi, dtype=object) incorrectly returns Longs
+        result = TimedeltaArray(np.array(tdi, dtype=object), freq='infer')
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)
+
+        # Fails because `pd.Index(tdi, dtype=object) raises incorrectly
+        result = TimedeltaArray(pd.Index(tdi, dtype=object), freq='infer')
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)
+
+    # NB: for now we re-wrap in TimedeltaIndex to use assert_index_equal
+    #  once assert_timedelta_array_equal is in place, this will be changed
+    def test_init_only_freq_infer(self):
+        # GH#23493
+        # just pass data and freq='infer' if relevant; no other kwargs
+
+        # arbitrary TimedeltaIndex; this should work for any TimedeltaIndex
+        #  with non-None freq
+        tdi = pd.timedelta_range('3 Days', freq='H', periods=9)
+        expected = TimedeltaArray(tdi)
+        assert expected.freq == tdi.freq
+
+        assert (tdi == expected).all()
+        assert (expected == tdi).all()
+
+        result = TimedeltaArray(expected)
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)
+
+        result = TimedeltaArray(list(tdi), freq='infer')
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)
+
+        result = TimedeltaArray(tuple(tdi), freq='infer')
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)
+
+        result = TimedeltaArray(np.array(tdi), freq='infer')
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)
+
+        result = TimedeltaArray(np.array(tdi).astype('m8[s]'), freq='infer')
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)
+
+        result = TimedeltaArray(pd.Series(tdi), freq='infer')
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)
+
+        result = TimedeltaArray(pd.Series(tdi, dtype=object), freq='infer')
+        tm.assert_equal(pd.TimedeltaIndex(result), tdi)

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -320,7 +320,9 @@ class TestDatetimeIndex(object):
         pytest.raises(ValueError, DatetimeIndex, start='1/1/2000',
                       end='1/10/2000')
 
-        pytest.raises(ValueError, DatetimeIndex, '1/1/2000')
+        with pytest.raises(TypeError):
+            # GH#24393
+            DatetimeIndex('1/1/2000')
 
         # generator expression
         gen = (datetime(2000, 1, 1) + timedelta(i) for i in range(10))

--- a/pandas/tests/indexes/timedeltas/test_construction.py
+++ b/pandas/tests/indexes/timedeltas/test_construction.py
@@ -63,7 +63,9 @@ class TestTimedeltaIndex(object):
         pytest.raises(ValueError, TimedeltaIndex, start='1 days',
                       end='10 days')
 
-        pytest.raises(ValueError, TimedeltaIndex, '1 days')
+        with pytest.raises(TypeError):
+            # GH#23493
+            TimedeltaIndex('1 days')
 
         # generator expression
         gen = (timedelta(i) for i in range(10))

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -292,7 +292,7 @@ class _FrequencyInferer(object):
 
     def __init__(self, index, warn=True):
         self.index = index
-        self.values = np.asarray(index).view('i8')
+        self.values = index.asi8
 
         # This moves the values, which are implicitly in UTC, to the
         # the timezone so they are in local time


### PR DESCRIPTION
Big push on the constructors for DatetimeArray/TimedeltaArray, some progress de-duplicating code from their Index counterparts.

As discussed elsewhere, adds `dtype` to `PeriodArray.__init__`

@TomAugspurger can you confirm that the `_from_sequence`s implemented here handle the right cases?  It wasn't obvious if object-dtyped array/indexes were supposed to be handled there, but combining those cases was too clean to overlook.

Small fix in DatetimeArray comparison methods, just enough to make the tests work.  A separate PR forthcoming PR will do a more thorough fix/improvements of those.

One non-obvious point on which input would be especially welcome is how/when to use the `copy` kwarg in such a way as to copy at-most-once.  (related: deep_copy_if_needed and #21907)

#23491 found during this process, will be addressed in a follow-up.