### PR TITLE
BUG GH23451 Allow setting date in string index for Series

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1115,7 +1115,7 @@ Datetimelike
 - Bug in :func:`DataFrame.combine` with datetimelike values raising a TypeError (:issue:`23079`)
 - Bug in :func:`date_range` with frequency of ``Day`` or higher where dates sufficiently far in the future could wrap around to the past instead of raising ``OutOfBoundsDatetime`` (:issue:`14187`)
 - Bug in :class:`PeriodIndex` with attribute ``freq.n`` greater than 1 where adding a :class:`DateOffset` object would return incorrect results (:issue:`23215`)
-- Bug in :class:`Series` that interpreted string indices as lists of characters when setting datetimelike values
+- Bug in :class:`Series` that interpreted string indices as lists of characters when setting datetimelike values (:issue:`23451`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1115,6 +1115,7 @@ Datetimelike
 - Bug in :func:`DataFrame.combine` with datetimelike values raising a TypeError (:issue:`23079`)
 - Bug in :func:`date_range` with frequency of ``Day`` or higher where dates sufficiently far in the future could wrap around to the past instead of raising ``OutOfBoundsDatetime`` (:issue:`14187`)
 - Bug in :class:`PeriodIndex` with attribute ``freq.n`` greater than 1 where adding a :class:`DateOffset` object would return incorrect results (:issue:`23215`)
+- Bug in :class:`Series` that interpreted string indices as lists of characters when setting datetimelike values
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -947,6 +947,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 except Exception:
                     pass
 
+            if isinstance(key, str):
+                key = [key]
+
             if not isinstance(key, (list, Series, np.ndarray, Series)):
                 try:
                     key = list(key)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -947,10 +947,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 except Exception:
                     pass
 
-            if isinstance(key, str):
+            if is_scalar(key):
                 key = [key]
-
-            if not isinstance(key, (list, Series, np.ndarray, Series)):
+            elif not isinstance(key, (list, Series, np.ndarray)):
                 try:
                     key = list(key)
                 except Exception:

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -550,7 +550,8 @@ class TestSeriesDatetimeValues():
         assert nat.max()[0] is pd.NaT
 
     def test_set_dt_with_string_index(self):
-        from datetime import date
+        # GH 23451
         x = pd.Series([1, 2, 3], index=['Date', 'b', 'other'])
-        x.Date = date.today()
+        x['Date'] = date.today()
         assert x.Date == date.today()
+        assert x['Date'] == date.today()

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -549,7 +549,7 @@ class TestSeriesDatetimeValues():
         assert nat.min()[0] is pd.NaT
         assert nat.max()[0] is pd.NaT
 
-    def test_set_dt_with_string_index(self):
+    def test_setitem_with_string_index(self):
         # GH 23451
         x = pd.Series([1, 2, 3], index=['Date', 'b', 'other'])
         x['Date'] = date.today()

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -548,3 +548,9 @@ class TestSeriesDatetimeValues():
     def test_minmax_nat_dataframe(self, nat):
         assert nat.min()[0] is pd.NaT
         assert nat.max()[0] is pd.NaT
+
+    def test_set_dt_with_string_index(self):
+        from datetime import date
+        x = pd.Series([1, 2, 3], index=['Date', 'b', 'other'])
+        x.Date = date.today()
+        assert x.Date == date.today()


### PR DESCRIPTION
- [X] closes #23451 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Prevents string indices from turning into lists of characters when setting a date.
