### PR TITLE
CI: Exclude asv benchmark envs from flake8 checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ exclude =
     doc/build/*.py,
     doc/temp/*.py,
     .eggs/*.py,
-    versioneer.py
+    versioneer.py,
+    env  # exclude asv benchmark environments from linting
 
 [yapf]
 based_on_style = pep8


### PR DESCRIPTION
When running `ci/code_checks.sh` on a local repository that has also been used to run `asv` benchmarks, `flake8` also lints the environments created. This massively increases the runtime and leads to linting errors on non-`pandas` packages, which is not informative.

This change simply adds `env` to the `flake8` exclude list, which resolves the issue seen above.

### Before
```
~/projects/pandas$ LINT=true ./ci/code_checks.sh
inside ./ci/code_checks.sh

flake8 --version
3.6.0 (mccabe: 0.6.1, pycodestyle: 2.4.0, pyflakes: 2.0.0) CPython 3.6.5 on Linux
Linting .py code
./asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/bin/runxlrd.py:18:80: E501 line too long (80 > 79 characters)
./asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/bin/runxlrd.py:38:15: E401 multiple imports on one line
./asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/bin/runxlrd.py:43:5: E303 too many blank lines (2)
./asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/bin/runxlrd.py:65:24: E701 multiple statements on one line (colon)
./asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/bin/runxlrd.py:66:19: E701 multiple statements on one line (colon)
./asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/bin/runxlrd.py:71:25: E128 continuation line under-indented for visual indent
...
```

### After
```
~/projects/pandas$ LINT=true ./ci/code_checks.sh
inside ./ci/code_checks.sh

flake8 --version
3.6.0 (mccabe: 0.6.1, pycodestyle: 2.4.0, pyflakes: 2.0.0) CPython 3.6.5 on Linux
Linting .py code
./versioneer.py:423:1: E305 expected 2 blank lines after class or function definition, found 1
./versioneer.py:467:1: E305 expected 2 blank lines after class or function definition, found 0
./versioneer.py:927:-11937: W605 invalid escape sequence '\s'
```

### Output comparison
```
~/projects/pandas$ ls -altrh code_check*
-rw-rw-rw- 1 chris chris 32M Nov  4 12:31 code_check_old.log
-rw-rw-rw- 1 chris chris 14K Nov  4 12:33 code_check_new.log
```