### PR TITLE
DOC: Fix syntax error in groupby docs

### DIFF
--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -133,7 +133,8 @@ but the specified columns
 .. ipython:: python
 
    df2 = df.set_index(['A', 'B'])
-   grouped = df2.groupby(level=df2.index.names.difference(['B'])
+   grouped = df2.groupby(level=df2.index.names.difference(['B']))
+   grouped.sum()
 
 These will split the DataFrame on its index (rows). We could also split by the
 columns:


### PR DESCRIPTION
https://travis-ci.org/pandas-dev/pandas/jobs/450582832

#15559 has been rearing its head again.  Turns out the reason for the timeout is one silly, missing parenthesis in the `groupby.rst` docs (that was the cause as well in #15506). 😆 

Follow-up to #23394.