### PR TITLE
BUG: Return KeyError for invalid string key

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1205,6 +1205,7 @@ Indexing
 ^^^^^^^^
 
 - The traceback from a ``KeyError`` when asking ``.loc`` for a single missing label is now shorter and more clear (:issue:`21557`)
+- :class:`PeriodIndex` now emits a ``KeyError`` when a malformed string is looked up, which is consistent with the behavior of :class:`DateTimeIndex` (:issue:`22803`)
 - When ``.ix`` is asked for a missing integer label in a :class:`MultiIndex` with a first level of integer type, it now raises a ``KeyError``, consistently with the case of a flat :class:`Int64Index`, rather than falling back to positional indexing (:issue:`21593`)
 - Bug in :meth:`DatetimeIndex.reindex` when reindexing a tz-naive and tz-aware :class:`DatetimeIndex` (:issue:`8306`)
 - Bug in :meth:`Series.reindex` when reindexing an empty series with a ``datetime64[ns, tz]`` dtype (:issue:`20869`)

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from pandas._libs import tslibs
 from pandas._libs.tslibs import period as libperiod
 from pandas.compat import lrange
 
@@ -363,7 +362,9 @@ class TestIndexing(object):
         assert idx0.get_loc(p2) == expected_idx1_p2
         assert idx0.get_loc(str(p2)) == expected_idx1_p2
 
-        pytest.raises(tslibs.parsing.DateParseError, idx0.get_loc, 'foo')
+        tm.assert_raises_regex(KeyError,
+                               "Cannot interpret 'foo' as period",
+                               idx0.get_loc, 'foo')
         pytest.raises(KeyError, idx0.get_loc, 1.1)
         pytest.raises(TypeError, idx0.get_loc, idx0)
 
@@ -378,7 +379,9 @@ class TestIndexing(object):
         assert idx1.get_loc(p2) == expected_idx1_p2
         assert idx1.get_loc(str(p2)) == expected_idx1_p2
 
-        pytest.raises(tslibs.parsing.DateParseError, idx1.get_loc, 'foo')
+        tm.assert_raises_regex(KeyError,
+                               "Cannot interpret 'foo' as period",
+                               idx1.get_loc, 'foo')
         pytest.raises(KeyError, idx1.get_loc, 1.1)
         pytest.raises(TypeError, idx1.get_loc, idx1)
 


### PR DESCRIPTION
- [x] closes #22803
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

In principle, it is nice to raise different errors if the string is invalid, or if the resulting period is missing. However, we want, and need, methods such as ``.loc`` to return errors of predictable types.
And indeed, this is how ``PeriodIndex``, for instance, works:

``` python
In [2]: pd.date_range('2010-10-10', '2010-10-11').get_loc('pippo')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
```
[...]
``` python
/home/nobackup/repo/pandas/pandas/core/indexes/datetimes.py in get_loc(self, key, method, tolerance)
   1019                 if 'list-like' in str(e):
   1020                     raise e
-> 1021                 raise KeyError(key)
   1022 
   1023     def _maybe_cast_slice_bound(self, label, side, kind):

KeyError: 'pippo'

```