### PR TITLE
CI/DOC: Fixing bug in validate_docstrings.py

### DIFF
--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -345,6 +345,11 @@ class BadGenericDocStrings(object):
         """
         pass
 
+    def private_classes(self):
+        """
+        This mentions NDFrame, which is not correct.
+        """
+
 
 class BadSummaries(object):
 
@@ -688,7 +693,8 @@ class TestValidator(object):
 
     @capture_stderr
     @pytest.mark.parametrize("func", [
-        'func', 'astype', 'astype1', 'astype2', 'astype3', 'plot', 'method'])
+        'func', 'astype', 'astype1', 'astype2', 'astype3', 'plot', 'method',
+        'private_classes'])
     def test_bad_generic_functions(self, func):
         errors = validate_one(self._import_path(  # noqa:F821
             klass='BadGenericDocStrings', func=func))['errors']
@@ -697,6 +703,9 @@ class TestValidator(object):
 
     @pytest.mark.parametrize("klass,func,msgs", [
         # See Also tests
+        ('BadGenericDocStrings', 'private_classes',
+         ("Private classes (NDFrame) should not be mentioned in public "
+          'docstrings',)),
         ('BadSeeAlso', 'desc_no_period',
          ('Missing period at end of description for See Also "Series.iloc"',)),
         ('BadSeeAlso', 'desc_first_letter_lowercase',

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -57,7 +57,7 @@ ERROR_MSGS = {
             'quotes)',
     'GL03': 'Use only one blank line to separate sections or paragraphs',
     'GL04': 'Private classes ({mentioned_private_classes}) should not be '
-            'mentioned in public docstring',
+            'mentioned in public docstrings',
     'GL05': 'Tabs found at the start of line "{line_with_tabs}", please use '
             'whitespace only',
     'SS01': 'No summary found (a short summary in a single line should be '
@@ -562,7 +562,8 @@ def validate_one(func_name):
         errs.append(error('GL03'))
     mentioned_errs = doc.mentioned_private_classes
     if mentioned_errs:
-        errs.append(error('GL04'), mentioned_private_classes=mentioned_errs)
+        errs.append(error('GL04',
+                          mentioned_private_classes=', '.join(mentioned_errs)))
     for line in doc.raw_doc.splitlines():
         if re.match("^ *\t", line):
             errs.append(error('GL05', line_with_tabs=line.lstrip()))


### PR DESCRIPTION
Follow up of #23514. One of the validation error wasn't tested, and with the refactoring a typo was introduced, where a bracket closed in the wrong place, raised a KeyError when a private class was found in a docstrings (and adding test for that case

- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
