### PR TITLE
BUG: Fix error message for invalid HTML flavor

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1292,6 +1292,7 @@ Notice how we now instead output ``np.nan`` itself instead of a stringified form
 - Bug in :func:`DataFrame.to_csv` where a single level MultiIndex incorrectly wrote a tuple. Now just the value of the index is written (:issue:`19589`).
 - Bug in :meth:`HDFStore.append` when appending a :class:`DataFrame` with an empty string column and ``min_itemsize`` < 8 (:issue:`12242`)
 - Bug in :meth:`read_csv()` in which :class:`MultiIndex` index names were being improperly handled in the cases when they were not provided (:issue:`23484`)
+- Bug in :meth:`read_html()` in which the error message was not displaying the valid flavors when an invalid one was provided (:issue:`23549`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -854,7 +854,8 @@ def _parser_dispatch(flavor):
 
 
 def _print_as_set(s):
-    return '{{arg}}'.format(arg=', '.join(pprint_thing(el) for el in s))
+    return ('{' + '{arg}'.format(arg=', '.join(
+        pprint_thing(el) for el in s)) + '}')
 
 
 def _validate_flavor(flavor):

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -61,9 +61,12 @@ def test_bs4_version_fails(monkeypatch, datapath):
 
 
 def test_invalid_flavor():
-    url = 'google.com'
-    with pytest.raises(ValueError):
-        read_html(url, 'google', flavor='not a* valid**++ flaver')
+    url = "google.com"
+    flavor = "invalid flavor"
+    msg = r"\{" + flavor + r"\} is not a valid set of flavors"
+
+    with tm.assert_raises_regex(ValueError, msg):
+        read_html(url, "google", flavor=flavor)
 
 
 @td.skip_if_no('bs4')


### PR DESCRIPTION
The flavors were not rendering properly in the string formatting.

Closes #23549.
Follow-up to #17660.