### PR TITLE
DOC/CI: Fixes to make validate_docstrings.py to not generate warnings or unwanted output

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5091,7 +5091,7 @@ class NDFrame(PandasObject, SelectionMixin):
         1   b    2    2.0
         2   c    3    3.0
 
-        >>> df.get_ftype_counts()
+        >>> df.get_ftype_counts()  # doctest: +SKIP
         float64:dense    1
         int64:dense      1
         object:dense     1

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1875,12 +1875,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         Works on different Index of types.
 
-        >>> pd.Index([1, 2, 2, 3, 3, 3, 4]).get_duplicates()
+        >>> pd.Index([1, 2, 2, 3, 3, 3, 4]).get_duplicates()  # doctest: +SKIP
         [2, 3]
-        >>> pd.Index([1., 2., 2., 3., 3., 3., 4.]).get_duplicates()
-        [2.0, 3.0]
-        >>> pd.Index(['a', 'b', 'b', 'c', 'c', 'c', 'd']).get_duplicates()
-        ['b', 'c']
 
         Note that for a DatetimeIndex, it does not return a list but a new
         DatetimeIndex:
@@ -1888,22 +1884,22 @@ class Index(IndexOpsMixin, PandasObject):
         >>> dates = pd.to_datetime(['2018-01-01', '2018-01-02', '2018-01-03',
         ...                         '2018-01-03', '2018-01-04', '2018-01-04'],
         ...                        format='%Y-%m-%d')
-        >>> pd.Index(dates).get_duplicates()
+        >>> pd.Index(dates).get_duplicates()  # doctest: +SKIP
         DatetimeIndex(['2018-01-03', '2018-01-04'],
                       dtype='datetime64[ns]', freq=None)
 
         Sorts duplicated elements even when indexes are unordered.
 
-        >>> pd.Index([1, 2, 3, 2, 3, 4, 3]).get_duplicates()
+        >>> pd.Index([1, 2, 3, 2, 3, 4, 3]).get_duplicates()  # doctest: +SKIP
         [2, 3]
 
         Return empty array-like structure when all elements are unique.
 
-        >>> pd.Index([1, 2, 3, 4]).get_duplicates()
+        >>> pd.Index([1, 2, 3, 4]).get_duplicates()  # doctest: +SKIP
         []
         >>> dates = pd.to_datetime(['2018-01-01', '2018-01-02', '2018-01-03'],
         ...                        format='%Y-%m-%d')
-        >>> pd.Index(dates).get_duplicates()
+        >>> pd.Index(dates).get_duplicates()  # doctest: +SKIP
         DatetimeIndex([], dtype='datetime64[ns]', freq=None)
         """
         warnings.warn("'get_duplicates' is deprecated and will be removed in "

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1013,21 +1013,21 @@ class Panel(NDFrame):
 
         Returns a Panel with the square root of each element
 
-        >>> p = pd.Panel(np.random.rand(4,3,2))
+        >>> p = pd.Panel(np.random.rand(4, 3, 2))  # doctest: +SKIP
         >>> p.apply(np.sqrt)
 
         Equivalent to p.sum(1), returning a DataFrame
 
-        >>> p.apply(lambda x: x.sum(), axis=1)
+        >>> p.apply(lambda x: x.sum(), axis=1)  # doctest: +SKIP
 
         Equivalent to previous:
 
-        >>> p.apply(lambda x: x.sum(), axis='major')
+        >>> p.apply(lambda x: x.sum(), axis='major')  # doctest: +SKIP
 
         Return the shapes of each DataFrame over axis 2 (i.e the shapes of
         items x major), as a Series
 
-        >>> p.apply(lambda x: x.shape, axis=(0,1))
+        >>> p.apply(lambda x: x.shape, axis=(0,1))  # doctest: +SKIP
 
         Returns
         -------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2156,13 +2156,6 @@ class StringMethods(NoNewAttributesMixin):
         `join`-keyword works as in other methods.
 
         >>> t = pd.Series(['d', 'a', 'e', 'c'], index=[3, 0, 4, 2])
-        >>> s.str.cat(t, join=None, na_rep='-')
-        0    ad
-        1    ba
-        2    -e
-        3    dc
-        dtype: object
-        >>>
         >>> s.str.cat(t, join='left', na_rep='-')
         0    aa
         1    b-

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -133,7 +133,7 @@ class ParserWarning(Warning):
     >>> csv = u'''a;b;c
     ...           1;1,8
     ...           1;2,1'''
-    >>> df = pd.read_csv(io.StringIO(csv), sep='[;,]')
+    >>> df = pd.read_csv(io.StringIO(csv), sep='[;,]')  # doctest: +SKIP
     ... # ParserWarning: Falling back to the 'python' engine...
 
     Adding `engine='python'` to `pd.read_csv` removes the Warning:

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -206,7 +206,7 @@ def radviz(frame, class_column, ax=None, color=None, colormap=None, **kwds):
         ...                      'versicolor', 'setosa', 'virginica',
         ...                      'setosa']
         ...     })
-        >>> rad_viz = pd.plotting.radviz(df, 'Category')
+        >>> rad_viz = pd.plotting.radviz(df, 'Category')  # doctest: +SKIP
     """
     import matplotlib.pyplot as plt
     import matplotlib.patches as patches
@@ -407,7 +407,7 @@ def bootstrap_plot(series, fig=None, size=50, samples=500, **kwds):
             :context: close-figs
 
             >>> s = pd.Series(np.random.uniform(size=100))
-            >>> fig = pd.plotting.bootstrap_plot(s)
+            >>> fig = pd.plotting.bootstrap_plot(s)  # doctest: +SKIP
     """
     import random
     import matplotlib.pyplot as plt

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -785,10 +785,10 @@ class TestValidator(object):
             assert msg in ' '.join(err[1] for err in result['errors'])
 
 
-class ApiItems(object):
+class TestApiItems(object):
     @property
     def api_doc(self):
-        return textwrap.dedent(io.StringIO('''
+        return io.StringIO(textwrap.dedent('''
             .. currentmodule:: itertools
 
             Itertools
@@ -861,93 +861,90 @@ class ApiItems(object):
         assert result[idx][3] == subsection
 
 
-class MainFunction(object):
-    def test_num_errors_for_validate_one(self, monkeypatch):
+class TestMainFunction(object):
+    def test_exit_status_for_validate_one(self, monkeypatch):
         monkeypatch.setattr(
-            validate_docstrings, 'validate_one',
-            lambda func_name: {'docstring': 'docstring1',
-                               'errors': [('ER01', 'err desc'),
-                                          ('ER02', 'err desc')
+            validate_docstrings, 'validate_one', lambda func_name: {
+                'docstring': 'docstring1',
+                'errors': [('ER01', 'err desc'),
+                           ('ER02', 'err desc'),
+                           ('ER03', 'err desc')],
+                'warnings': [],
+                'examples_errors': ''})
+        exit_status = validate_docstrings.main(func_name='docstring1',
+                                               prefix=None,
+                                               errors=[],
+                                               output_format='default')
+        assert exit_status == 0
+
+    def test_exit_status_errors_for_validate_all(self, monkeypatch):
+        monkeypatch.setattr(
+            validate_docstrings, 'validate_all', lambda prefix: {
+                'docstring1': {'errors': [('ER01', 'err desc'),
+                                          ('ER02', 'err desc'),
                                           ('ER03', 'err desc')],
-                               'warnings': [],
-                               'examples_errors': ''})
-        num_errors = validate_docstrings.main(func_name='docstring1',
-                                              prefix=None,
-                                              errors=[],
-                                              output_format='default')
-        assert num_errors == 3
+                               'file': 'module1.py',
+                               'file_line': 23},
+                'docstring2': {'errors': [('ER04', 'err desc'),
+                                          ('ER05', 'err desc')],
+                               'file': 'module2.py',
+                               'file_line': 925}})
+        exit_status = validate_docstrings.main(func_name=None,
+                                               prefix=None,
+                                               errors=[],
+                                               output_format='default')
+        assert exit_status == 5
 
-    def test_no_num_errors_for_validate_one(self, monkeypatch):
+    def test_no_exit_status_noerrors_for_validate_all(self, monkeypatch):
         monkeypatch.setattr(
-            validate_docstrings, 'validate_one',
-            lambda func_name: {'docstring': 'docstring1',
-                               'errors': [],
-                               'warnings': [('WN01', 'warn desc')],
-                               'examples_errors': ''})
-        num_errors = validate_docstrings.main(func_name='docstring1',
-                                              prefix=None,
-                                              errors=[],
-                                              output_format='default')
-        assert num_errors == 0
+            validate_docstrings, 'validate_all', lambda prefix: {
+                'docstring1': {'errors': [],
+                               'warnings': [('WN01', 'warn desc')]},
+                'docstring2': {'errors': []}})
+        exit_status = validate_docstrings.main(func_name=None,
+                                               prefix=None,
+                                               errors=[],
+                                               output_format='default')
+        assert exit_status == 0
 
-    def test_num_errors_for_validate_all(self, monkeypatch):
+    def test_exit_status_for_validate_all_json(self, monkeypatch):
+        print('EXECUTED')
         monkeypatch.setattr(
-            validate_docstrings, 'validate_all',
-            lambda: {'docstring1': {'errors': [('ER01', 'err desc'),
-                                               ('ER02', 'err desc'),
-                                               ('ER03', 'err desc')]},
-                     'docstring2': {'errors': [('ER04', 'err desc'),
-                                               ('ER05', 'err desc')]}})
-        num_errors = validate_docstrings.main(func_name=None,
-                                              prefix=None,
-                                              errors=[],
-                                              output_format='default')
-        assert num_errors == 5
-
-    def test_no_num_errors_for_validate_all(self, monkeypatch):
-        monkeypatch.setattr(
-            validate_docstrings, 'validate_all',
-            lambda: {'docstring1': {'errors': [],
-                                    'warnings': [('WN01', 'warn desc')]},
-                     'docstring2': {'errors': []}})
-        num_errors = validate_docstrings.main(func_name=None,
-                                              prefix=None,
-                                              errors=[],
-                                              output_format='default')
-        assert num_errors == 0
-
-    def test_prefix_param_filters_docstrings(self, monkeypatch):
-        monkeypatch.setattr(
-            validate_docstrings, 'validate_all',
-            lambda: {'Series.foo': {'errors': [('ER01', 'err desc'),
-                                               ('ER02', 'err desc'),
-                                               ('ER03', 'err desc')]},
-                     'DataFrame.bar': {'errors': [('ER04', 'err desc'),
-                                                  ('ER05', 'err desc')]},
-                     'Series.foobar': {'errors': [('ER06', 'err desc')]}})
-        num_errors = validate_docstrings.main(func_name=None,
-                                              prefix='Series.',
-                                              errors=[],
-                                              output_format='default')
-        assert num_errors == 4
+            validate_docstrings, 'validate_all', lambda prefix: {
+                'docstring1': {'errors': [('ER01', 'err desc'),
+                                          ('ER02', 'err desc'),
+                                          ('ER03', 'err desc')]},
+                'docstring2': {'errors': [('ER04', 'err desc'),
+                                          ('ER05', 'err desc')]}})
+        exit_status = validate_docstrings.main(func_name=None,
+                                               prefix=None,
+                                               errors=[],
+                                               output_format='json')
+        assert exit_status == 0
 
     def test_errors_param_filters_errors(self, monkeypatch):
         monkeypatch.setattr(
-            validate_docstrings, 'validate_all',
-            lambda: {'Series.foo': {'errors': [('ER01', 'err desc'),
-                                               ('ER02', 'err desc'),
-                                               ('ER03', 'err desc')]},
-                     'DataFrame.bar': {'errors': [('ER01', 'err desc'),
-                                                  ('ER02', 'err desc')]},
-                     'Series.foobar': {'errors': [('ER01', 'err desc')]}})
-        num_errors = validate_docstrings.main(func_name=None,
-                                              prefix=None,
-                                              errors=['E01'],
-                                              output_format='default')
-        assert num_errors == 3
+            validate_docstrings, 'validate_all', lambda prefix: {
+                'Series.foo': {'errors': [('ER01', 'err desc'),
+                                          ('ER02', 'err desc'),
+                                          ('ER03', 'err desc')],
+                               'file': 'series.py',
+                               'file_line': 142},
+                'DataFrame.bar': {'errors': [('ER01', 'err desc'),
+                                             ('ER02', 'err desc')],
+                                  'file': 'frame.py',
+                                  'file_line': 598},
+                'Series.foobar': {'errors': [('ER01', 'err desc')],
+                                  'file': 'series.py',
+                                  'file_line': 279}})
+        exit_status = validate_docstrings.main(func_name=None,
+                                               prefix=None,
+                                               errors=['ER01'],
+                                               output_format='default')
+        assert exit_status == 3
 
-        num_errors = validate_docstrings.main(func_name=None,
-                                              prefix=None,
-                                              errors=['E03'],
-                                              output_format='default')
-        assert num_errors == 1
+        exit_status = validate_docstrings.main(func_name=None,
+                                               prefix=None,
+                                               errors=['ER03'],
+                                               output_format='default')
+        assert exit_status == 1


### PR DESCRIPTION
Follow up of #23514. Making `validate_docstrings.py` not generate warnings or other unwanted output, mainly when called with `--format=json`. This includes preventing matplotlib of opening windows with the plots, and also canceling output from flake8.

Also, fixed some bugs, and corrected some tests that weren't being run. 

The script should now be ready to be added to the CI (and to generate the json file with the docstrings state of the art).

- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

CC @TomAugspurger 