### PR TITLE
remove uses of (ts)?lib.(NaT|iNaT|Timestamp)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 import pandas as pd
 
-from pandas._libs import tslib, properties
+from pandas._libs import properties, Timestamp, iNaT
 from pandas.core.dtypes.common import (
     ensure_int64,
     ensure_object,
@@ -9273,9 +9273,9 @@ class NDFrame(PandasObject, SelectionMixin):
                     tz = data.dt.tz
                     asint = data.dropna().values.view('i8')
                     names += ['top', 'freq', 'first', 'last']
-                    result += [tslib.Timestamp(top, tz=tz), freq,
-                               tslib.Timestamp(asint.min(), tz=tz),
-                               tslib.Timestamp(asint.max(), tz=tz)]
+                    result += [Timestamp(top, tz=tz), freq,
+                               Timestamp(asint.min(), tz=tz),
+                               Timestamp(asint.max(), tz=tz)]
                 else:
                     names += ['top', 'freq']
                     result += [top, freq]
@@ -10613,7 +10613,7 @@ def _make_cum_function(cls, name, name1, name2, axis_descr, desc,
                 issubclass(y.dtype.type, (np.datetime64, np.timedelta64))):
             result = accum_func(y, axis)
             mask = isna(self)
-            np.putmask(result, mask, tslib.iNaT)
+            np.putmask(result, mask, iNaT)
         elif skipna and not issubclass(y.dtype.type, (np.integer, np.bool_)):
             mask = isna(self)
             np.putmask(y, mask, mask_a)

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -22,11 +22,11 @@ from pandas.core.indexes.datetimelike import (
 )
 from pandas.core.tools.datetimes import parse_time_string, DateParseError
 
-from pandas._libs import tslib, index as libindex
+from pandas._libs import index as libindex
 from pandas._libs.tslibs.period import (Period, IncompatibleFrequency,
                                         DIFFERENT_FREQ_INDEX)
 
-from pandas._libs.tslibs import resolution
+from pandas._libs.tslibs import resolution, NaT, iNaT
 
 from pandas.core.algorithms import unique1d
 import pandas.core.arrays.datetimelike as dtl
@@ -336,7 +336,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin,
         # places outside of indexes/period.py are calling this _box_func,
         # but passing data that's already boxed.
         def func(x):
-            if isinstance(x, Period) or x is tslib.NaT:
+            if isinstance(x, Period) or x is NaT:
                 return x
             else:
                 return Period._from_ordinal(ordinal=x, freq=self.freq)
@@ -726,7 +726,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin,
                 raise KeyError(key)
 
             try:
-                ordinal = tslib.iNaT if key is tslib.NaT else key.ordinal
+                ordinal = iNaT if key is NaT else key.ordinal
                 if tolerance is not None:
                     tolerance = self._convert_tolerance(tolerance,
                                                         np.asarray(key))

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -15,7 +15,7 @@ import pytz
 import pytest
 
 import pandas as pd
-from pandas._libs import tslib, lib, missing as libmissing
+from pandas._libs import lib, iNaT, missing as libmissing
 from pandas import (Series, Index, DataFrame, Timedelta,
                     DatetimeIndex, TimedeltaIndex, Timestamp,
                     Panel, Period, Categorical, isna, Interval,
@@ -1263,7 +1263,7 @@ def test_nan_to_nat_conversions():
     }))
     df.iloc[3:6, :] = np.nan
     result = df.loc[4, 'B'].value
-    assert (result == tslib.iNaT)
+    assert (result == iNaT)
 
     s = df['B'].copy()
     s._data = s._data.setitem(indexer=tuple([slice(8, 9)]), value=np.nan)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -711,7 +711,7 @@ class TestDataFrameConstructors(TestData):
         assert 1 == frame['A'][1]
         assert 2 == frame['C'][2]
 
-        # masked np.datetime64 stays (use lib.NaT as null)
+        # masked np.datetime64 stays (use NaT as null)
         mat = ma.masked_all((2, 3), dtype='M8[ns]')
         # 2-D input
         frame = DataFrame(mat, columns=['A', 'B', 'C'], index=[1, 2])

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -13,7 +13,7 @@ import pytest
 import pytz
 
 from pandas._libs import tslib
-from pandas._libs.tslibs import parsing
+from pandas._libs.tslibs import iNaT, parsing
 from pandas.compat import PY3, lmap
 from pandas.errors import OutOfBoundsDatetime
 import pandas.util._test_decorators as td
@@ -652,7 +652,7 @@ class TestToDatetimeUnit(object):
         with pytest.raises(ValueError):
             to_datetime([1], unit='D', format='%Y%m%d', cache=cache)
 
-        values = [11111111, 1, 1.0, tslib.iNaT, NaT, np.nan,
+        values = [11111111, 1, 1.0, iNaT, NaT, np.nan,
                   'NaT', '']
         result = to_datetime(values, unit='D', errors='ignore', cache=cache)
         expected = Index([11111111, Timestamp('1970-01-02'),
@@ -669,7 +669,7 @@ class TestToDatetimeUnit(object):
         with pytest.raises(tslib.OutOfBoundsDatetime):
             to_datetime(values, unit='D', errors='raise', cache=cache)
 
-        values = [1420043460000, tslib.iNaT, NaT, np.nan, 'NaT']
+        values = [1420043460000, iNaT, NaT, np.nan, 'NaT']
 
         result = to_datetime(values, errors='ignore', unit='s', cache=cache)
         expected = Index([1420043460000, NaT, NaT,
@@ -1104,7 +1104,7 @@ class TestToDatetimeMisc(object):
         expected = np.empty(4, dtype='M8[ns]')
         for i, val in enumerate(strings):
             if isna(val):
-                expected[i] = tslib.iNaT
+                expected[i] = iNaT
             else:
                 expected[i] = parse_date(val)
 
@@ -1145,7 +1145,7 @@ class TestToDatetimeMisc(object):
         for i in range(5):
             x = series[i]
             if isna(x):
-                expected[i] = tslib.iNaT
+                expected[i] = iNaT
             else:
                 expected[i] = to_datetime(x, cache=cache)
 
@@ -1420,10 +1420,10 @@ class TestDatetimeParsingWrappers(object):
         result2 = to_datetime('NaT')
         result3 = Timestamp('NaT')
         result4 = DatetimeIndex(['NaT'])[0]
-        assert result1 is tslib.NaT
-        assert result2 is tslib.NaT
-        assert result3 is tslib.NaT
-        assert result4 is tslib.NaT
+        assert result1 is NaT
+        assert result2 is NaT
+        assert result3 is NaT
+        assert result4 is NaT
 
     @pytest.mark.parametrize('cache', [True, False])
     def test_parsers_dayfirst_yearfirst(self, cache):

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -2,10 +2,8 @@
 import numpy as np
 import pytest
 
-import pandas._libs.tslib as tslib
-
 import pandas as pd
-from pandas import DatetimeIndex, Index, Period, PeriodIndex, Series
+from pandas import DatetimeIndex, Index, Period, PeriodIndex, Series, NaT
 from pandas.core.arrays import PeriodArray
 from pandas.tests.test_base import Ops
 import pandas.util.testing as tm
@@ -29,13 +27,13 @@ class TestPeriodIndexOps(Ops):
     def test_minmax(self):
 
         # monotonic
-        idx1 = pd.PeriodIndex([pd.NaT, '2011-01-01', '2011-01-02',
+        idx1 = pd.PeriodIndex([NaT, '2011-01-01', '2011-01-02',
                                '2011-01-03'], freq='D')
         assert idx1.is_monotonic
 
         # non-monotonic
-        idx2 = pd.PeriodIndex(['2011-01-01', pd.NaT, '2011-01-03',
-                               '2011-01-02', pd.NaT], freq='D')
+        idx2 = pd.PeriodIndex(['2011-01-01', NaT, '2011-01-03',
+                               '2011-01-02', NaT], freq='D')
         assert not idx2.is_monotonic
 
         for idx in [idx1, idx2]:
@@ -50,15 +48,15 @@ class TestPeriodIndexOps(Ops):
             # Return NaT
             obj = PeriodIndex([], freq='M')
             result = getattr(obj, op)()
-            assert result is tslib.NaT
+            assert result is NaT
 
-            obj = PeriodIndex([pd.NaT], freq='M')
+            obj = PeriodIndex([NaT], freq='M')
             result = getattr(obj, op)()
-            assert result is tslib.NaT
+            assert result is NaT
 
-            obj = PeriodIndex([pd.NaT, pd.NaT, pd.NaT], freq='M')
+            obj = PeriodIndex([NaT, NaT, NaT], freq='M')
             result = getattr(obj, op)()
-            assert result is tslib.NaT
+            assert result is NaT
 
     def test_numpy_minmax(self):
         pr = pd.period_range(start='2016-01-15', end='2016-01-20')
@@ -113,7 +111,7 @@ class TestPeriodIndexOps(Ops):
 
         idx = PeriodIndex(['2013-01-01 09:00', '2013-01-01 09:00',
                            '2013-01-01 09:00', '2013-01-01 08:00',
-                           '2013-01-01 08:00', pd.NaT], freq='H')
+                           '2013-01-01 08:00', NaT], freq='H')
 
         exp_idx = PeriodIndex(['2013-01-01 09:00', '2013-01-01 08:00'],
                               freq='H')
@@ -123,7 +121,7 @@ class TestPeriodIndexOps(Ops):
             tm.assert_series_equal(obj.value_counts(), expected)
 
         exp_idx = PeriodIndex(['2013-01-01 09:00', '2013-01-01 08:00',
-                               pd.NaT], freq='H')
+                               NaT], freq='H')
         expected = Series([3, 2, 1], index=exp_idx)
 
         for obj in [idx, Series(idx)]:
@@ -284,9 +282,9 @@ class TestPeriodIndexOps(Ops):
                             '2011-01-03', '2011-01-05'],
                            freq='D', name='idx2')
 
-        idx3 = PeriodIndex([pd.NaT, '2011-01-03', '2011-01-05',
-                            '2011-01-02', pd.NaT], freq='D', name='idx3')
-        exp3 = PeriodIndex([pd.NaT, pd.NaT, '2011-01-02', '2011-01-03',
+        idx3 = PeriodIndex([NaT, '2011-01-03', '2011-01-05',
+                            '2011-01-02', NaT], freq='D', name='idx3')
+        exp3 = PeriodIndex([NaT, NaT, '2011-01-02', '2011-01-03',
                             '2011-01-05'], freq='D', name='idx3')
 
         for idx, expected in [(idx1, exp1), (idx2, exp2), (idx3, exp3)]:
@@ -338,8 +336,8 @@ class TestPeriodIndexOps(Ops):
             tm.assert_index_equal(res, exp)
 
     def test_nat(self):
-        assert pd.PeriodIndex._na_value is pd.NaT
-        assert pd.PeriodIndex([], freq='M')._na_value is pd.NaT
+        assert pd.PeriodIndex._na_value is NaT
+        assert pd.PeriodIndex([], freq='M')._na_value is NaT
 
         idx = pd.PeriodIndex(['2011-01-01', '2011-01-02'], freq='D')
         assert idx._can_hold_na
@@ -460,10 +458,10 @@ class TestPeriodIndexSeriesMethods(object):
         f = lambda x: pd.Period('2011-03', freq='M') == x
         self._check(idx, f, exp)
 
-        f = lambda x: x == tslib.NaT
+        f = lambda x: x == NaT
         exp = np.array([False, False, False, False], dtype=np.bool)
         self._check(idx, f, exp)
-        f = lambda x: tslib.NaT == x
+        f = lambda x: NaT == x
         self._check(idx, f, exp)
 
         f = lambda x: x != pd.Period('2011-03', freq='M')
@@ -472,10 +470,10 @@ class TestPeriodIndexSeriesMethods(object):
         f = lambda x: pd.Period('2011-03', freq='M') != x
         self._check(idx, f, exp)
 
-        f = lambda x: x != tslib.NaT
+        f = lambda x: x != NaT
         exp = np.array([True, True, True, True], dtype=np.bool)
         self._check(idx, f, exp)
-        f = lambda x: tslib.NaT != x
+        f = lambda x: NaT != x
         self._check(idx, f, exp)
 
         f = lambda x: pd.Period('2011-03', freq='M') >= x
@@ -486,11 +484,11 @@ class TestPeriodIndexSeriesMethods(object):
         exp = np.array([True, False, False, False], dtype=np.bool)
         self._check(idx, f, exp)
 
-        f = lambda x: x > tslib.NaT
+        f = lambda x: x > NaT
         exp = np.array([False, False, False, False], dtype=np.bool)
         self._check(idx, f, exp)
 
-        f = lambda x: tslib.NaT >= x
+        f = lambda x: NaT >= x
         exp = np.array([False, False, False, False], dtype=np.bool)
         self._check(idx, f, exp)
 

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import DatetimeIndex, Index, Period, PeriodIndex, Series, NaT
+from pandas import DatetimeIndex, Index, NaT, Period, PeriodIndex, Series
 from pandas.core.arrays import PeriodArray
 from pandas.tests.test_base import Ops
 import pandas.util.testing as tm

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -5,17 +5,15 @@ import numpy as np
 from datetime import datetime, date, timedelta
 
 import pandas as pd
-from pandas import Timedelta
+from pandas import Timedelta, NaT, Period, Timestamp, offsets
 import pandas.util.testing as tm
 import pandas.core.indexes.period as period
 from pandas.compat import text_type, iteritems
 from pandas.compat.numpy import np_datetime64_compat
 
-from pandas._libs import tslib
-from pandas._libs.tslibs import period as libperiod
+from pandas._libs.tslibs import iNaT, period as libperiod
 from pandas._libs.tslibs.ccalendar import DAYS, MONTHS
 from pandas._libs.tslibs.parsing import DateParseError
-from pandas import Period, Timestamp, offsets
 
 
 class TestPeriodProperties(object):
@@ -91,32 +89,32 @@ class TestPeriodProperties(object):
         assert isinstance(result, Period)
 
     def test_period_from_ordinal(self):
-        p = pd.Period('2011-01', freq='M')
-        res = pd.Period._from_ordinal(p.ordinal, freq='M')
+        p = Period('2011-01', freq='M')
+        res = Period._from_ordinal(p.ordinal, freq='M')
         assert p == res
         assert isinstance(res, Period)
 
     def test_period_cons_nat(self):
         p = Period('NaT', freq='M')
-        assert p is pd.NaT
+        assert p is NaT
 
         p = Period('nat', freq='W-SUN')
-        assert p is pd.NaT
+        assert p is NaT
 
-        p = Period(tslib.iNaT, freq='D')
-        assert p is pd.NaT
+        p = Period(iNaT, freq='D')
+        assert p is NaT
 
-        p = Period(tslib.iNaT, freq='3D')
-        assert p is pd.NaT
+        p = Period(iNaT, freq='3D')
+        assert p is NaT
 
-        p = Period(tslib.iNaT, freq='1D1H')
-        assert p is pd.NaT
+        p = Period(iNaT, freq='1D1H')
+        assert p is NaT
 
         p = Period('NaT')
-        assert p is pd.NaT
+        assert p is NaT
 
-        p = Period(tslib.iNaT)
-        assert p is pd.NaT
+        p = Period(iNaT)
+        assert p is NaT
 
     def test_period_cons_mult(self):
         p1 = Period('2011-01', freq='3M')
@@ -283,12 +281,12 @@ class TestPeriodProperties(object):
         assert p.tz == dateutil_gettz('Europe/Brussels')
 
     def test_timestamp_mult(self):
-        p = pd.Period('2011-01', freq='M')
+        p = Period('2011-01', freq='M')
         assert p.to_timestamp(how='S') == Timestamp('2011-01-01')
         expected = Timestamp('2011-02-01') - Timedelta(1, 'ns')
         assert p.to_timestamp(how='E') == expected
 
-        p = pd.Period('2011-01', freq='3M')
+        p = Period('2011-01', freq='3M')
         assert p.to_timestamp(how='S') == Timestamp('2011-01-01')
         expected = Timestamp('2011-04-01') - Timedelta(1, 'ns')
         assert p.to_timestamp(how='E') == expected
@@ -563,7 +561,7 @@ class TestPeriodProperties(object):
 
     def test_repr_nat(self):
         p = Period('nat', freq='M')
-        assert repr(tslib.NaT) in repr(p)
+        assert repr(NaT) in repr(p)
 
     def test_millisecond_repr(self):
         p = Period('2000-01-01 12:15:02.123')
@@ -865,7 +863,7 @@ class TestPeriodProperties(object):
         pytest.raises(ValueError, Period, 1.6, freq='D')
         pytest.raises(ValueError, Period, ordinal=1.6, freq='D')
         pytest.raises(ValueError, Period, ordinal=2, value=1, freq='D')
-        assert Period(None) is pd.NaT
+        assert Period(None) is NaT
         pytest.raises(ValueError, Period, month=1)
 
         p = Period('2007-01-01', freq='D')
@@ -1002,8 +1000,8 @@ class TestComparisons(object):
         p_nat = Period('NaT', freq='D')
         p = Period('2011-01-01', freq='D')
 
-        nat = pd.Timestamp('NaT')
-        t = pd.Timestamp('2011-01-01')
+        nat = Timestamp('NaT')
+        t = Timestamp('2011-01-01')
         # confirm Period('NaT') work identical with Timestamp('NaT')
         for left, right in [(p_nat, p), (p, p_nat), (p_nat, p_nat), (nat, t),
                             (t, nat), (nat, nat)]:
@@ -1025,13 +1023,13 @@ class TestMethods(object):
             assert 1 + dt1 == dt2
 
     def test_add_pdnat(self):
-        p = pd.Period('2011-01', freq='M')
-        assert p + pd.NaT is pd.NaT
-        assert pd.NaT + p is pd.NaT
+        p = Period('2011-01', freq='M')
+        assert p + NaT is NaT
+        assert NaT + p is NaT
 
-        p = pd.Period('NaT', freq='M')
-        assert p + pd.NaT is pd.NaT
-        assert pd.NaT + p is pd.NaT
+        p = Period('NaT', freq='M')
+        assert p + NaT is NaT
+        assert NaT + p is NaT
 
     def test_add_raises(self):
         # GH 4731
@@ -1054,9 +1052,9 @@ class TestMethods(object):
     @pytest.mark.parametrize('lbox', boxes, ids=ids)
     @pytest.mark.parametrize('rbox', boxes, ids=ids)
     def test_add_timestamp_raises(self, rbox, lbox):
-        # GH # 17983
-        ts = pd.Timestamp('2017')
-        per = pd.Period('2017', freq='M')
+        # GH#17983
+        ts = Timestamp('2017')
+        per = Period('2017', freq='M')
 
         # We may get a different message depending on which class raises
         # the error.
@@ -1082,7 +1080,7 @@ class TestMethods(object):
 
         msg = r"Input has different freq=M from Period\(freq=D\)"
         with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
-            dt1 - pd.Period('2011-02', freq='M')
+            dt1 - Period('2011-02', freq='M')
 
     def test_add_offset(self):
         # freq is DateOffset
@@ -1218,41 +1216,41 @@ class TestMethods(object):
         for freq in ['A', '2A', '3A']:
             p = Period('NaT', freq=freq)
             for o in [offsets.YearEnd(2)]:
-                assert p + o is tslib.NaT
-                assert o + p is tslib.NaT
+                assert p + o is NaT
+                assert o + p is NaT
 
             for o in [offsets.YearBegin(2), offsets.MonthBegin(1),
                       offsets.Minute(), np.timedelta64(365, 'D'),
                       timedelta(365)]:
-                assert p + o is tslib.NaT
+                assert p + o is NaT
 
                 if isinstance(o, np.timedelta64):
                     with pytest.raises(TypeError):
                         o + p
                 else:
-                    assert o + p is tslib.NaT
+                    assert o + p is NaT
 
         for freq in ['M', '2M', '3M']:
             p = Period('NaT', freq=freq)
             for o in [offsets.MonthEnd(2), offsets.MonthEnd(12)]:
-                assert p + o is tslib.NaT
+                assert p + o is NaT
 
                 if isinstance(o, np.timedelta64):
                     with pytest.raises(TypeError):
                         o + p
                 else:
-                    assert o + p is tslib.NaT
+                    assert o + p is NaT
 
             for o in [offsets.YearBegin(2), offsets.MonthBegin(1),
                       offsets.Minute(), np.timedelta64(365, 'D'),
                       timedelta(365)]:
-                assert p + o is tslib.NaT
+                assert p + o is NaT
 
                 if isinstance(o, np.timedelta64):
                     with pytest.raises(TypeError):
                         o + p
                 else:
-                    assert o + p is tslib.NaT
+                    assert o + p is NaT
 
         # freq is Tick
         for freq in ['D', '2D', '3D']:
@@ -1260,55 +1258,55 @@ class TestMethods(object):
             for o in [offsets.Day(5), offsets.Hour(24), np.timedelta64(2, 'D'),
                       np.timedelta64(3600 * 24, 's'), timedelta(-2),
                       timedelta(hours=48)]:
-                assert p + o is tslib.NaT
+                assert p + o is NaT
 
                 if isinstance(o, np.timedelta64):
                     with pytest.raises(TypeError):
                         o + p
                 else:
-                    assert o + p is tslib.NaT
+                    assert o + p is NaT
 
             for o in [offsets.YearBegin(2), offsets.MonthBegin(1),
                       offsets.Minute(), np.timedelta64(4, 'h'),
                       timedelta(hours=23)]:
-                assert p + o is tslib.NaT
+                assert p + o is NaT
 
                 if isinstance(o, np.timedelta64):
                     with pytest.raises(TypeError):
                         o + p
                 else:
-                    assert o + p is tslib.NaT
+                    assert o + p is NaT
 
         for freq in ['H', '2H', '3H']:
             p = Period('NaT', freq=freq)
             for o in [offsets.Day(2), offsets.Hour(3), np.timedelta64(3, 'h'),
                       np.timedelta64(3600, 's'), timedelta(minutes=120),
                       timedelta(days=4, minutes=180)]:
-                assert p + o is tslib.NaT
+                assert p + o is NaT
 
                 if not isinstance(o, np.timedelta64):
-                    assert o + p is tslib.NaT
+                    assert o + p is NaT
 
             for o in [offsets.YearBegin(2), offsets.MonthBegin(1),
                       offsets.Minute(), np.timedelta64(3200, 's'),
                       timedelta(hours=23, minutes=30)]:
-                assert p + o is tslib.NaT
+                assert p + o is NaT
 
                 if isinstance(o, np.timedelta64):
                     with pytest.raises(TypeError):
                         o + p
                 else:
-                    assert o + p is tslib.NaT
+                    assert o + p is NaT
 
     def test_sub_pdnat(self):
         # GH 13071
-        p = pd.Period('2011-01', freq='M')
-        assert p - pd.NaT is pd.NaT
-        assert pd.NaT - p is pd.NaT
+        p = Period('2011-01', freq='M')
+        assert p - NaT is NaT
+        assert NaT - p is NaT
 
-        p = pd.Period('NaT', freq='M')
-        assert p - pd.NaT is pd.NaT
-        assert pd.NaT - p is pd.NaT
+        p = Period('NaT', freq='M')
+        assert p - NaT is NaT
+        assert NaT - p is NaT
 
     def test_sub_offset(self):
         # freq is DateOffset
@@ -1375,22 +1373,22 @@ class TestMethods(object):
         for freq in ['A', '2A', '3A']:
             p = Period('NaT', freq=freq)
             for o in [offsets.YearEnd(2)]:
-                assert p - o is tslib.NaT
+                assert p - o is NaT
 
             for o in [offsets.YearBegin(2), offsets.MonthBegin(1),
                       offsets.Minute(), np.timedelta64(365, 'D'),
                       timedelta(365)]:
-                assert p - o is tslib.NaT
+                assert p - o is NaT
 
         for freq in ['M', '2M', '3M']:
             p = Period('NaT', freq=freq)
             for o in [offsets.MonthEnd(2), offsets.MonthEnd(12)]:
-                assert p - o is tslib.NaT
+                assert p - o is NaT
 
             for o in [offsets.YearBegin(2), offsets.MonthBegin(1),
                       offsets.Minute(), np.timedelta64(365, 'D'),
                       timedelta(365)]:
-                assert p - o is tslib.NaT
+                assert p - o is NaT
 
         # freq is Tick
         for freq in ['D', '2D', '3D']:
@@ -1398,42 +1396,42 @@ class TestMethods(object):
             for o in [offsets.Day(5), offsets.Hour(24), np.timedelta64(2, 'D'),
                       np.timedelta64(3600 * 24, 's'), timedelta(-2),
                       timedelta(hours=48)]:
-                assert p - o is tslib.NaT
+                assert p - o is NaT
 
             for o in [offsets.YearBegin(2), offsets.MonthBegin(1),
                       offsets.Minute(), np.timedelta64(4, 'h'),
                       timedelta(hours=23)]:
-                assert p - o is tslib.NaT
+                assert p - o is NaT
 
         for freq in ['H', '2H', '3H']:
             p = Period('NaT', freq=freq)
             for o in [offsets.Day(2), offsets.Hour(3), np.timedelta64(3, 'h'),
                       np.timedelta64(3600, 's'), timedelta(minutes=120),
                       timedelta(days=4, minutes=180)]:
-                assert p - o is tslib.NaT
+                assert p - o is NaT
 
             for o in [offsets.YearBegin(2), offsets.MonthBegin(1),
                       offsets.Minute(), np.timedelta64(3200, 's'),
                       timedelta(hours=23, minutes=30)]:
-                assert p - o is tslib.NaT
+                assert p - o is NaT
 
     @pytest.mark.parametrize('freq', ['M', '2M', '3M'])
     def test_nat_ops(self, freq):
         p = Period('NaT', freq=freq)
-        assert p + 1 is tslib.NaT
-        assert 1 + p is tslib.NaT
-        assert p - 1 is tslib.NaT
-        assert p - Period('2011-01', freq=freq) is tslib.NaT
-        assert Period('2011-01', freq=freq) - p is tslib.NaT
+        assert p + 1 is NaT
+        assert 1 + p is NaT
+        assert p - 1 is NaT
+        assert p - Period('2011-01', freq=freq) is NaT
+        assert Period('2011-01', freq=freq) - p is NaT
 
     def test_period_ops_offset(self):
         p = Period('2011-04-01', freq='D')
         result = p + offsets.Day()
-        exp = pd.Period('2011-04-02', freq='D')
+        exp = Period('2011-04-02', freq='D')
         assert result == exp
 
         result = p - offsets.Day(2)
-        exp = pd.Period('2011-03-30', freq='D')
+        exp = Period('2011-03-30', freq='D')
         assert result == exp
 
         msg = r"Input cannot be converted to Period\(freq=D\)"
@@ -1446,7 +1444,7 @@ class TestMethods(object):
 
 def test_period_immutable():
     # see gh-17116
-    per = pd.Period('2014Q1')
+    per = Period('2014Q1')
     with pytest.raises(AttributeError):
         per.ordinal = 14
 

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from pandas._libs import tslib
+from pandas._libs import iNaT
 import pandas._libs.index as _index
 from pandas.compat import lrange, range
 
@@ -459,7 +459,7 @@ def test_index_unique(dups):
     tm.assert_index_equal(result, expected)
 
     # NaT, note this is excluded
-    arr = [1370745748 + t for t in range(20)] + [tslib.iNaT]
+    arr = [1370745748 + t for t in range(20)] + [iNaT]
     idx = DatetimeIndex(arr * 3)
     tm.assert_index_equal(idx.unique(), DatetimeIndex(arr))
     assert idx.nunique() == 20

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -6,10 +6,9 @@ import string
 import sys
 
 import numpy as np
-from numpy import nan
 import pytest
 
-import pandas._libs.tslib as tslib
+from pandas._libs.tslibs import iNaT
 import pandas.compat as compat
 from pandas.compat import lrange, range, u
 
@@ -85,7 +84,7 @@ class TestSeriesDtypes(object):
         tm.assert_series_equal(result, Series(np.arange(1, 5)))
 
     def test_astype_datetime(self):
-        s = Series(tslib.iNaT, dtype='M8[ns]', index=lrange(5))
+        s = Series(iNaT, dtype='M8[ns]', index=lrange(5))
 
         s = s.astype('O')
         assert s.dtype == np.object_
@@ -137,7 +136,7 @@ class TestSeriesDtypes(object):
                                                 tm.rands(1000)]),
                                         Series([string.digits * 10,
                                                 tm.rands(63),
-                                                tm.rands(64), nan, 1.0])])
+                                                tm.rands(64), np.nan, 1.0])])
     def test_astype_str_map(self, dtype, series):
         # see gh-4405
         result = series.astype(dtype)

--- a/pandas/tests/series/test_internals.py
+++ b/pandas/tests/series/test_internals.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import Series, Timestamp, NaT
+from pandas import NaT, Series, Timestamp
 import pandas.util.testing as tm
 from pandas.util.testing import assert_series_equal
 

--- a/pandas/tests/series/test_internals.py
+++ b/pandas/tests/series/test_internals.py
@@ -4,14 +4,10 @@
 from datetime import datetime
 
 import numpy as np
-from numpy import nan
 import pytest
 
-import pandas._libs.lib as lib
-
 import pandas as pd
-from pandas import Series
-from pandas.core.indexes.datetimes import Timestamp
+from pandas import Series, Timestamp, NaT
 import pandas.util.testing as tm
 from pandas.util.testing import assert_series_equal
 
@@ -87,7 +83,7 @@ class TestSeriesInternals(object):
 
         expected = Series([Timestamp('20010101'), Timestamp('20010102'),
                            Timestamp('20010103'),
-                           lib.NaT, lib.NaT, lib.NaT, Timestamp('20010104'),
+                           NaT, NaT, NaT, Timestamp('20010104'),
                            Timestamp('20010105')], dtype='M8[ns]')
         with tm.assert_produces_warning(FutureWarning):
             result = s2.convert_objects(convert_dates='coerce',
@@ -103,7 +99,7 @@ class TestSeriesInternals(object):
         with tm.assert_produces_warning(FutureWarning):
             result = s.convert_objects(convert_dates='coerce',
                                        convert_numeric=False)
-        expected = Series([lib.NaT] * 2 + [Timestamp(1)] * 2)
+        expected = Series([NaT] * 2 + [Timestamp(1)] * 2)
         assert_series_equal(result, expected)
 
         # preserver if non-object
@@ -149,14 +145,14 @@ class TestSeriesInternals(object):
         # Test coercion returns correct type
         s = Series(['a', 'b', 'c'])
         results = s._convert(datetime=True, coerce=True)
-        expected = Series([lib.NaT] * 3)
+        expected = Series([NaT] * 3)
         assert_series_equal(results, expected)
 
         results = s._convert(numeric=True, coerce=True)
         expected = Series([np.nan] * 3)
         assert_series_equal(results, expected)
 
-        expected = Series([lib.NaT] * 3, dtype=np.dtype('m8[ns]'))
+        expected = Series([NaT] * 3, dtype=np.dtype('m8[ns]'))
         results = s._convert(timedelta=True, coerce=True)
         assert_series_equal(results, expected)
 
@@ -166,15 +162,15 @@ class TestSeriesInternals(object):
         # Test coercion with mixed types
         s = Series(['a', '3.1415', dt, td])
         results = s._convert(datetime=True, coerce=True)
-        expected = Series([lib.NaT, lib.NaT, dt, lib.NaT])
+        expected = Series([NaT, NaT, dt, NaT])
         assert_series_equal(results, expected)
 
         results = s._convert(numeric=True, coerce=True)
-        expected = Series([nan, 3.1415, nan, nan])
+        expected = Series([np.nan, 3.1415, np.nan, np.nan])
         assert_series_equal(results, expected)
 
         results = s._convert(timedelta=True, coerce=True)
-        expected = Series([lib.NaT, lib.NaT, lib.NaT, td],
+        expected = Series([NaT, NaT, NaT, td],
                           dtype=np.dtype('m8[ns]'))
         assert_series_equal(results, expected)
 
@@ -182,7 +178,7 @@ class TestSeriesInternals(object):
         results = s._convert(datetime=True)
         assert_series_equal(results, s)
         results = s._convert(numeric=True)
-        expected = Series([nan, 3.1415, nan, nan])
+        expected = Series([np.nan, 3.1415, np.nan, np.nan])
         assert_series_equal(results, expected)
         results = s._convert(timedelta=True)
         assert_series_equal(results, s)
@@ -231,13 +227,13 @@ class TestSeriesInternals(object):
         r['a'] = 'garbled'
         result = r._convert(numeric=True)
         expected = s.copy()
-        expected['a'] = nan
+        expected['a'] = np.nan
         assert_series_equal(result, expected)
 
         # GH 4119, not converting a mixed type (e.g.floats and object)
         s = Series([1, 'na', 3, 4])
         result = s._convert(datetime=True, numeric=True)
-        expected = Series([1, nan, 3, 4])
+        expected = Series([1, np.nan, 3, 4])
         assert_series_equal(result, expected)
 
         s = Series([1, '', 3, 4])
@@ -260,7 +256,7 @@ class TestSeriesInternals(object):
         assert_series_equal(result, expected)
 
         expected = Series([Timestamp('20010101'), Timestamp('20010102'),
-                           Timestamp('20010103'), lib.NaT, lib.NaT, lib.NaT,
+                           Timestamp('20010103'), NaT, NaT, NaT,
                            Timestamp('20010104'), Timestamp('20010105')],
                           dtype='M8[ns]')
         result = s2._convert(datetime=True, numeric=False, timedelta=False,
@@ -271,7 +267,7 @@ class TestSeriesInternals(object):
 
         s = Series(['foo', 'bar', 1, 1.0], dtype='O')
         result = s._convert(datetime=True, coerce=True)
-        expected = Series([lib.NaT] * 2 + [Timestamp(1)] * 2)
+        expected = Series([NaT] * 2 + [Timestamp(1)] * 2)
         assert_series_equal(result, expected)
 
         # preserver if non-object
@@ -285,7 +281,7 @@ class TestSeriesInternals(object):
         # assert result.dtype == 'M8[ns]'
 
         # dateutil parses some single letters into today's value as a date
-        expected = Series([lib.NaT])
+        expected = Series([NaT])
         for x in 'abcdefghijklmnopqrstuvwxyz':
             s = Series([x])
             result = s._convert(datetime=True, coerce=True)
@@ -321,4 +317,4 @@ def test_hasnans_unchached_for_series():
     assert not hasattr(ser, '_cache')
     ser.iloc[-1] = np.nan
     assert ser.hasnans is True
-    assert pd.Series.hasnans.__doc__ == pd.Index.hasnans.__doc__
+    assert Series.hasnans.__doc__ == pd.Index.hasnans.__doc__

--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -4,8 +4,6 @@
 import numpy as np
 import pytest
 
-import pandas._libs.lib as lib
-
 import pandas as pd
 import pandas.util.testing as tm
 
@@ -65,7 +63,7 @@ class TestSeriesReplace(TestData):
         ser = pd.Series([np.nan, 0, np.inf])
         tm.assert_series_equal(ser.replace(np.nan, 0), ser.fillna(0))
 
-        ser = pd.Series([np.nan, 0, 'foo', 'bar', np.inf, None, lib.NaT])
+        ser = pd.Series([np.nan, 0, 'foo', 'bar', np.inf, None, pd.NaT])
         tm.assert_series_equal(ser.replace(np.nan, 0), ser.fillna(0))
         filled = ser.copy()
         filled[4] = 0

--- a/pandas/tests/tslibs/test_array_to_datetime.py
+++ b/pandas/tests/tslibs/test_array_to_datetime.py
@@ -6,7 +6,7 @@ import pytest
 import pytz
 from dateutil.tz.tz import tzoffset
 
-from pandas._libs import tslib
+from pandas._libs import iNaT, tslib
 from pandas.compat.numpy import np_array_datetime64_compat
 import pandas.util.testing as tm
 
@@ -130,13 +130,13 @@ class TestArrayToDatetime(object):
             tslib.array_to_datetime(arr, errors='raise')
 
         result, _ = tslib.array_to_datetime(arr, errors='coerce')
-        expected = np.array([tslib.iNaT], dtype='M8[ns]')
+        expected = np.array([iNaT], dtype='M8[ns]')
         tm.assert_numpy_array_equal(result, expected)
 
     def test_coerce_outside_ns_bounds_one_valid(self):
         arr = np.array(['1/1/1000', '1/1/2000'], dtype=object)
         result, _ = tslib.array_to_datetime(arr, errors='coerce')
-        expected = [tslib.iNaT,
+        expected = [iNaT,
                     '2000-01-01T00:00:00.000000000-0000']
         tm.assert_numpy_array_equal(
             result,
@@ -153,8 +153,8 @@ class TestArrayToDatetime(object):
         # With coercing, the invalid dates becomes iNaT
         result, _ = tslib.array_to_datetime(arr, errors='coerce')
         expected = ['2013-01-01T00:00:00.000000000-0000',
-                    tslib.iNaT,
-                    tslib.iNaT]
+                    iNaT,
+                    iNaT]
 
         tm.assert_numpy_array_equal(
             result,


### PR DESCRIPTION
Since they are no longer defined there; instead import then from more appropriate places.