### PR TITLE
add histogram method to series

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -237,6 +237,7 @@ Other Enhancements
 - Compatibility with Matplotlib 3.0 (:issue:`22790`).
 - Added :meth:`Interval.overlaps`, :meth:`IntervalArray.overlaps`, and :meth:`IntervalIndex.overlaps` for determining overlaps between interval-like objects (:issue:`21998`)
 - :meth:`Timestamp.tz_localize`, :meth:`DatetimeIndex.tz_localize`, and :meth:`Series.tz_localize` have gained the ``nonexistent`` argument for alternative handling of nonexistent times. See :ref:`timeseries.timezone_nonexsistent` (:issue:`8917`)
+- Added :meth: `Series.histogram` (:pr:`23576`)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1888,6 +1888,37 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             # scalar
             return result
 
+    def histogram(self, *args, **kwargs):
+        """
+        Compute the histogram of a Series.
+
+        (convenience wrapper for `np.histogram`)
+
+        Parameters
+        ----------
+            see `numpy.histogram`
+        Returns
+        -------
+        hist : array
+            The values of the histogram. See *density* and *weights* for a
+            description of the possible semantics.
+        bin_edges : array of dtype float
+            Return the bin edges `(length(hist)+1)`.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> np.random.seed(3)
+        >>> s = pd.Series(np.random.normal(0, 1, 100))
+        >>> h, b = s.histogram(20)
+        >>> h
+        array([ 1,  1,  1,  1,  3,  3,  4, 10,  7, 11, 11,  7,  7,  5,  9,  7,
+            3, 2,  4,  3])
+        >>> len(b)
+        21
+        """
+        return np.histogram(self, *args, **kwargs)
+
     def corr(self, other, method='pearson', min_periods=None):
         """
         Compute correlation with `other` Series, excluding missing values

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1916,6 +1916,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             3, 2,  4,  3])
         >>> len(b)
         21
+
+        .. versionadded:: 0.24.0
         """
         return np.histogram(self, *args, **kwargs)
 

--- a/pandas/tests/series/test_histogram.py
+++ b/pandas/tests/series/test_histogram.py
@@ -1,9 +1,8 @@
 # coding=utf-8
 
-import pytest
 import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
+
 
 def test_histogram():
     np.random.seed(3)

--- a/pandas/tests/series/test_histogram.py
+++ b/pandas/tests/series/test_histogram.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+
+import pytest
+import numpy as np
+import pandas as pd
+import pandas.util.testing as tm
+
+def test_histogram():
+    np.random.seed(3)
+    s = pd.Series(np.random.normal(0, 1, 100))
+    h, b = s.histogram(20)
+    _h, _b = np.histogram(s, 20)
+    assert np.all(h == _h)
+    assert np.all(b == _b)


### PR DESCRIPTION
Add a histogram method to `pandas.Series` -- just a thin wrapper around `np.histogram`.

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
