### PR TITLE
MAINT: tm.assert_raises_regex --> pytest.raises

### DIFF
--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -687,7 +687,7 @@ class TestTimestampSeriesArithmetic(object):
             # with 'operate' (from core/ops.py) for the ops that are not
             # defined
             op = getattr(get_ser, op_str, None)
-            with tm.assert_raises_regex(TypeError, 'operate|cannot'):
+            with pytest.raises(TypeError, match='operate|cannot'):
                 op(test_ser)
 
         # ## timedelta64 ###
@@ -1042,9 +1042,9 @@ class TestDatetimeIndexArithmetic(object):
         idx = DatetimeIndex(['2011-01-01', '2011-01-02'])
         idx = tm.box_expected(idx, box_with_datetime)
         msg = "cannot add"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             idx + Timestamp('2011-01-01')
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             Timestamp('2011-01-01') + idx
 
     # -------------------------------------------------------------
@@ -1268,7 +1268,7 @@ class TestDatetimeIndexArithmetic(object):
         tm.assert_index_equal(result, expected)
 
         msg = 'cannot subtract .*TimedeltaIndex'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             tdi - dti
 
         # sub with timedelta64 array
@@ -1276,7 +1276,7 @@ class TestDatetimeIndexArithmetic(object):
         tm.assert_index_equal(result, expected)
 
         msg = 'cannot subtract DatetimeIndex from'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             tdi.values - dti
 
     def test_dti_isub_tdi(self, tz_naive_fixture):
@@ -1292,7 +1292,7 @@ class TestDatetimeIndexArithmetic(object):
         tm.assert_index_equal(result, expected)
 
         msg = 'cannot subtract .*TimedeltaIndex'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             tdi -= dti
 
         # isub with timedelta64 array
@@ -1303,7 +1303,7 @@ class TestDatetimeIndexArithmetic(object):
         msg = '|'.join(['cannot perform __neg__ with this index type:',
                         'ufunc subtract cannot use operands with types',
                         'cannot subtract DatetimeIndex from'])
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             tdi.values -= dti
 
     # -------------------------------------------------------------
@@ -1323,9 +1323,9 @@ class TestDatetimeIndexArithmetic(object):
         # GH#9631
         dti = DatetimeIndex(['2011-01-01', '2011-01-02']).tz_localize(tz)
         msg = 'cannot add DatetimeIndex and {0}'.format(type(addend).__name__)
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             dti + addend
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             addend + dti
 
     # -------------------------------------------------------------

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -118,27 +118,27 @@ class TestPeriodIndexComparisons(object):
         base = tm.box_expected(base, box)
 
         msg = "Input has different freq=A-DEC from "
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             base <= Period('2011', freq='A')
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             Period('2011', freq='A') >= base
 
         # TODO: Could parametrize over boxes for idx?
         idx = PeriodIndex(['2011', '2012', '2013', '2014'], freq='A')
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             base <= idx
 
         # Different frequency
         msg = "Input has different freq=4M from "
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             base <= Period('2011', freq='4M')
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             Period('2011', freq='4M') >= base
 
         idx = PeriodIndex(['2011', '2012', '2013', '2014'], freq='4M')
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             base <= idx
 
     @pytest.mark.parametrize('freq', ['M', '2M', '3M'])
@@ -190,10 +190,10 @@ class TestPeriodIndexComparisons(object):
 
         diff = PeriodIndex(['2011-02', '2011-01', '2011-04', 'NaT'], freq='4M')
         msg = "Input has different freq=4M from PeriodIndex"
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             idx1 > diff
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             idx1 == diff
 
     # TODO: De-duplicate with test_pi_cmp_nat
@@ -708,13 +708,13 @@ class TestPeriodIndexArithmetic(object):
         other = not_daily
         rng = pd.period_range('2014-05-01', '2014-05-15', freq='D')
         msg = 'Input has different freq(=.+)? from Period.*?\\(freq=D\\)'
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng + other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng += other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng - other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng -= other
 
     def test_pi_add_iadd_timedeltalike_hourly(self, two_hours):
@@ -734,10 +734,10 @@ class TestPeriodIndexArithmetic(object):
         rng = pd.period_range('2014-01-01 10:00', '2014-01-05 10:00', freq='H')
         msg = 'Input has different freq(=.+)? from Period.*?\\(freq=H\\)'
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng + other
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng += other
 
     def test_pi_sub_isub_timedeltalike_hourly(self, two_hours):
@@ -768,13 +768,13 @@ class TestPeriodIndexArithmetic(object):
         rng = pd.period_range('2014', '2024', freq='A')
         msg = ('Input has different freq(=.+)? '
                'from Period.*?\\(freq=A-DEC\\)')
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng + other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng += other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng - other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng -= other
 
     def test_pi_add_iadd_timedeltalike_M(self):
@@ -792,13 +792,13 @@ class TestPeriodIndexArithmetic(object):
         other = mismatched_freq
         rng = pd.period_range('2014-01', '2016-12', freq='M')
         msg = 'Input has different freq(=.+)? from Period.*?\\(freq=M\\)'
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng + other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng += other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng - other
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             rng -= other
 
     def test_parr_add_sub_td64_nat(self, box):
@@ -907,14 +907,14 @@ class TestPeriodIndexSeriesMethods(object):
         obj = tm.box_expected(idx, box_with_period)
 
         msg = r"unsupported operand type\(s\)"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             obj + ng
 
         with pytest.raises(TypeError):
             # error message differs between PY2 and 3
             ng + obj
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             obj - ng
 
         with pytest.raises(TypeError):
@@ -1009,13 +1009,13 @@ class TestPeriodIndexSeriesMethods(object):
         # from Period
         msg = r"Input has different freq from Period.*?\(freq=D\)"
         for obj in [idx, ser]:
-            with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+            with pytest.raises(period.IncompatibleFrequency, match=msg):
                 obj + pd.offsets.Hour(2)
 
-            with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+            with pytest.raises(period.IncompatibleFrequency, match=msg):
                 pd.offsets.Hour(2) + obj
 
-            with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+            with pytest.raises(period.IncompatibleFrequency, match=msg):
                 obj - pd.offsets.Hour(2)
 
     def test_pi_sub_period(self):

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -161,22 +161,22 @@ class TestAddSubNaTMasking(object):
     def test_tdi_add_overflow(self):
         # See GH#14068
         msg = "too (big|large) to convert"
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             pd.to_timedelta(106580, 'D') + Timestamp('2000')
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             Timestamp('2000') + pd.to_timedelta(106580, 'D')
 
         _NaT = int(pd.NaT) + 1
         msg = "Overflow in int64 addition"
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             pd.to_timedelta([106580], 'D') + Timestamp('2000')
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             Timestamp('2000') + pd.to_timedelta([106580], 'D')
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             pd.to_timedelta([_NaT]) - Timedelta('1 days')
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             pd.to_timedelta(['5 days', _NaT]) - Timedelta('1 days')
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             (pd.to_timedelta([_NaT, '5 days', '1 hours']) -
              pd.to_timedelta(['7 seconds', _NaT, '4 hours']))
 
@@ -415,7 +415,7 @@ class TestTimedeltaArraylikeAddSubOps(object):
         msg = ("cannot subtract a datelike from|"
                "Could not operate|"
                "cannot perform operation")
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             idx - Timestamp('2011-01-01')
 
     def test_td64arr_add_timestamp(self, box, tz_naive_fixture):
@@ -1217,9 +1217,9 @@ class TestTimedeltaArraylikeMulDivOps(object):
         # with 'operate' (from core/ops.py) for the ops that are not
         # defined
         pattern = 'operate|unsupported|cannot|not supported'
-        with tm.assert_raises_regex(TypeError, pattern):
+        with pytest.raises(TypeError, match=pattern):
             td1 * scalar_td
-        with tm.assert_raises_regex(TypeError, pattern):
+        with pytest.raises(TypeError, match=pattern):
             scalar_td * td1
 
     def test_td64arr_mul_too_short_raises(self, box):
@@ -1399,8 +1399,8 @@ class TestTimedeltaArraylikeInvalidArithmeticOps(object):
         # with 'operate' (from core/ops.py) for the ops that are not
         # defined
         pattern = 'operate|unsupported|cannot|not supported'
-        with tm.assert_raises_regex(TypeError, pattern):
+        with pytest.raises(TypeError, match=pattern):
             scalar_td ** td1
 
-        with tm.assert_raises_regex(TypeError, pattern):
+        with pytest.raises(TypeError, match=pattern):
             td1 ** scalar_td

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -138,5 +138,5 @@ class TestTake(object):
         # https://github.com/pandas-dev/pandas/issues/23296
         cat = pd.Categorical(['a', 'b', 'c'])
         xpr = r"'fill_value' \('d'\) is not in this Categorical's categories."
-        with tm.assert_raises_regex(TypeError, xpr):
+        with pytest.raises(TypeError, match=xpr):
             cat.take([0, 1, -1], fill_value='d', allow_fill=True)

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -305,7 +305,8 @@ class TestCategoricalAnalytics(object):
         tm.assert_categorical_equal(np.repeat(cat, 2), exp)
 
         msg = "the 'axis' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.repeat, cat, 2, axis=1)
+        with pytest.raises(ValueError, match=msg):
+            np.repeat(cat, 2, axis=1)
 
     def test_isna(self):
         exp = np.array([False, False, True])

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -50,9 +50,9 @@ class TestCategoricalAPI(object):
 
         # removed in 0.19.0
         msg = "can\'t set attribute"
-        with tm.assert_raises_regex(AttributeError, msg):
+        with pytest.raises(AttributeError, match=msg):
             cat.ordered = True
-        with tm.assert_raises_regex(AttributeError, msg):
+        with pytest.raises(AttributeError, match=msg):
             cat.ordered = False
 
     def test_rename_categories(self):

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -26,10 +26,10 @@ class TestCategoricalConstructors(object):
         # This should be a boolean.
         ordered = np.array([0, 1, 2])
 
-        with tm.assert_raises_regex(exp_err, exp_msg):
+        with pytest.raises(exp_err, match=exp_msg):
             Categorical([1, 2, 3], ordered=ordered)
 
-        with tm.assert_raises_regex(exp_err, exp_msg):
+        with pytest.raises(exp_err, match=exp_msg):
             Categorical.from_codes([0, 0, 1], categories=['a', 'b', 'c'],
                                    ordered=ordered)
 
@@ -351,13 +351,13 @@ class TestCategoricalConstructors(object):
 
     def test_constructor_dtype_and_others_raises(self):
         dtype = CategoricalDtype(['a', 'b'], ordered=True)
-        with tm.assert_raises_regex(ValueError, "Cannot"):
+        with pytest.raises(ValueError, match="Cannot"):
             Categorical(['a', 'b'], categories=['a', 'b'], dtype=dtype)
 
-        with tm.assert_raises_regex(ValueError, "Cannot"):
+        with pytest.raises(ValueError, match="Cannot"):
             Categorical(['a', 'b'], ordered=True, dtype=dtype)
 
-        with tm.assert_raises_regex(ValueError, "Cannot"):
+        with pytest.raises(ValueError, match="Cannot"):
             Categorical(['a', 'b'], ordered=False, dtype=dtype)
 
     @pytest.mark.parametrize('categories', [
@@ -372,7 +372,7 @@ class TestCategoricalConstructors(object):
         tm.assert_categorical_equal(result, expected)
 
     def test_constructor_str_unknown(self):
-        with tm.assert_raises_regex(ValueError, "Unknown `dtype`"):
+        with pytest.raises(ValueError, match="Unknown `dtype`"):
             Categorical([1, 2], dtype="foo")
 
     def test_constructor_from_categorical_with_dtype(self):

--- a/pandas/tests/arrays/categorical/test_dtypes.py
+++ b/pandas/tests/arrays/categorical/test_dtypes.py
@@ -120,7 +120,7 @@ class TestCategoricalDtypes(object):
         tm.assert_numpy_array_equal(result, expected)
 
         msg = 'could not convert string to float'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             cat.astype(float)
 
         # numeric

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -143,5 +143,5 @@ def test_mask_with_boolean_raises(index):
     if index:
         idx = CategoricalIndex(idx)
 
-    with tm.assert_raises_regex(ValueError, 'NA / NaN'):
+    with pytest.raises(ValueError, match='NA / NaN'):
         s[idx]

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -70,7 +70,7 @@ class TestCategoricalMissing(object):
         # https://github.com/pandas-dev/pandas/issues/19682
         cat = Categorical([1, 2, 3])
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             cat.fillna(**fillna_kwargs)
 
     @pytest.mark.parametrize("named", [True, False])

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -238,15 +238,17 @@ class TestCategoricalOps(object):
     def test_unordered_different_categories_raises(self):
         c1 = Categorical(['a', 'b'], categories=['a', 'b'], ordered=False)
         c2 = Categorical(['a', 'c'], categories=['c', 'a'], ordered=False)
-        with tm.assert_raises_regex(TypeError,
-                                    "Categoricals can only be compared"):
+
+        with pytest.raises(TypeError, match=("Categoricals can "
+                                             "only be compared")):
             c1 == c2
 
     def test_compare_different_lengths(self):
         c1 = Categorical([], categories=['a', 'b'])
         c2 = Categorical([], categories=['a'])
+
         msg = "Categories are different lengths"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             c1 == c2
 
     def test_compare_unordered_different_order(self):

--- a/pandas/tests/arrays/categorical/test_sorting.py
+++ b/pandas/tests/arrays/categorical/test_sorting.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import pytest
 
 from pandas import Categorical, Index
 import pandas.util.testing as tm
@@ -30,12 +31,12 @@ class TestCategoricalSort(object):
                                     check_dtype=False)
 
         msg = "the 'axis' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.argsort,
-                               c, axis=0)
+        with pytest.raises(ValueError, match=msg):
+            np.argsort(c, axis=0)
 
         msg = "the 'order' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.argsort,
-                               c, order='C')
+        with pytest.raises(ValueError, match=msg):
+            np.argsort(c, order='C')
 
     def test_sort_values(self):
 

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -38,7 +38,7 @@ class TestMethods(object):
         ('foo', r'invalid literal for (int|long)\(\) with base 10')])
     def test_repeat_errors(self, bad_repeats, msg):
         array = IntervalArray.from_breaks(range(4))
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             array.repeat(bad_repeats)
 
     @pytest.mark.parametrize('new_closed', [

--- a/pandas/tests/arrays/interval/test_ops.py
+++ b/pandas/tests/arrays/interval/test_ops.py
@@ -78,5 +78,5 @@ class TestOverlaps(object):
         interval_container = constructor.from_breaks(range(5))
         msg = '`other` must be Interval-like, got {other}'.format(
             other=type(other).__name__)
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_container.overlaps(other)

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -97,7 +97,7 @@ class TestSparseArray(object):
 
     @pytest.mark.parametrize("dtype", [SparseDtype(int, 0), int])
     def test_constructor_na_dtype(self, dtype):
-        with tm.assert_raises_regex(ValueError, "Cannot convert"):
+        with pytest.raises(ValueError, match="Cannot convert"):
             SparseArray([0, 1, np.nan], dtype=dtype)
 
     def test_constructor_spindex_dtype(self):
@@ -224,13 +224,18 @@ class TestSparseArray(object):
         assert self.zarr[7] == 5
 
         errmsg = re.compile("bounds")
-        tm.assert_raises_regex(IndexError, errmsg, lambda: self.arr[11])
-        tm.assert_raises_regex(IndexError, errmsg, lambda: self.arr[-11])
+
+        with pytest.raises(IndexError, match=errmsg):
+            self.arr[11]
+
+        with pytest.raises(IndexError, match=errmsg):
+            self.arr[-11]
+
         assert self.arr[-1] == self.arr[len(self.arr) - 1]
 
     def test_take_scalar_raises(self):
         msg = "'indices' must be an array, not a scalar '2'."
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.arr.take(2)
 
     def test_take(self):
@@ -258,8 +263,8 @@ class TestSparseArray(object):
         tm.assert_sp_array_equal(self.arr.take([-4, -3, -2]), exp)
 
     def test_bad_take(self):
-        tm.assert_raises_regex(
-            IndexError, "bounds", lambda: self.arr.take([11]))
+        with pytest.raises(IndexError, match="bounds"):
+            self.arr.take([11])
 
     def test_take_filling(self):
         # similar tests as GH 12631
@@ -279,10 +284,11 @@ class TestSparseArray(object):
         expected = SparseArray([np.nan, np.nan, 4])
         tm.assert_sp_array_equal(result, expected)
 
-        msg = ("Invalid value in 'indices'")
-        with tm.assert_raises_regex(ValueError, msg):
+        msg = "Invalid value in 'indices'"
+        with pytest.raises(ValueError, match=msg):
             sparse.take(np.array([1, 0, -2]), allow_fill=True)
-        with tm.assert_raises_regex(ValueError, msg):
+
+        with pytest.raises(ValueError, match=msg):
             sparse.take(np.array([1, 0, -5]), allow_fill=True)
 
         with pytest.raises(IndexError):
@@ -314,9 +320,9 @@ class TestSparseArray(object):
         tm.assert_sp_array_equal(result, expected)
 
         msg = ("Invalid value in 'indices'.")
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             sparse.take(np.array([1, 0, -2]), allow_fill=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             sparse.take(np.array([1, 0, -5]), allow_fill=True)
 
         with pytest.raises(IndexError):
@@ -351,12 +357,15 @@ class TestSparseArray(object):
         def setslice():
             self.arr[1:5] = 2
 
-        tm.assert_raises_regex(TypeError, "item assignment", setitem)
-        tm.assert_raises_regex(TypeError, "item assignment", setslice)
+        with pytest.raises(TypeError, match="item assignment"):
+            setitem()
+
+        with pytest.raises(TypeError, match="item assignment"):
+            setslice()
 
     def test_constructor_from_too_large_array(self):
-        tm.assert_raises_regex(TypeError, "expected dimension <= 1 data",
-                               SparseArray, np.arange(10).reshape((2, 5)))
+        with pytest.raises(TypeError, match="expected dimension <= 1 data"):
+            SparseArray(np.arange(10).reshape((2, 5)))
 
     def test_constructor_from_sparse(self):
         res = SparseArray(self.zarr)
@@ -441,7 +450,7 @@ class TestSparseArray(object):
         tm.assert_sp_array_equal(result, expected)
 
         arr = SparseArray([0, np.nan, 0, 1], fill_value=0)
-        with tm.assert_raises_regex(ValueError, 'NA'):
+        with pytest.raises(ValueError, match='NA'):
             arr.astype('Sparse[i8]')
 
     def test_astype_bool(self):
@@ -481,12 +490,12 @@ class TestSparseArray(object):
         # sparsearray with NaN fill value, why not update one?
         # coerces to int
         # msg = "unable to set fill_value 3\\.1 to int64 dtype"
-        # with tm.assert_raises_regex(ValueError, msg):
+        # with pytest.raises(ValueError, match=msg):
         arr.fill_value = 3.1
         assert arr.fill_value == 3.1
 
         # msg = "unable to set fill_value nan to int64 dtype"
-        # with tm.assert_raises_regex(ValueError, msg):
+        # with pytest.raises(ValueError, match=msg):
         arr.fill_value = np.nan
         assert np.isnan(arr.fill_value)
 
@@ -496,12 +505,12 @@ class TestSparseArray(object):
 
         # coerces to bool
         # msg = "unable to set fill_value 0 to bool dtype"
-        # with tm.assert_raises_regex(ValueError, msg):
+        # with pytest.raises(ValueError, match=msg):
         arr.fill_value = 0
         assert arr.fill_value == 0
 
         # msg = "unable to set fill_value nan to bool dtype"
-        # with tm.assert_raises_regex(ValueError, msg):
+        # with pytest.raises(ValueError, match=msg):
         arr.fill_value = np.nan
         assert np.isnan(arr.fill_value)
 
@@ -510,7 +519,7 @@ class TestSparseArray(object):
         arr = SparseArray([True, False, True], fill_value=False, dtype=np.bool)
         msg = "fill_value must be a scalar"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             arr.fill_value = val
 
     def test_copy_shallow(self):
@@ -793,8 +802,8 @@ class TestSparseArrayAnalytics(object):
 
         # raises with a different message on py2.
         msg = "the \'out\' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.all,
-                               SparseArray(data), out=np.array([]))
+        with pytest.raises(ValueError, match=msg):
+            np.all(SparseArray(data), out=np.array([]))
 
     @pytest.mark.parametrize('data,pos,neg', [
         ([False, True, False], True, False),
@@ -838,8 +847,8 @@ class TestSparseArrayAnalytics(object):
         assert not out
 
         msg = "the \'out\' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.any,
-                               SparseArray(data), out=out)
+        with pytest.raises(ValueError, match=msg):
+            np.any(SparseArray(data), out=out)
 
     def test_sum(self):
         data = np.arange(10).astype(float)
@@ -866,12 +875,12 @@ class TestSparseArrayAnalytics(object):
         assert out == 40.0
 
         msg = "the 'dtype' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.sum,
-                               SparseArray(data), dtype=np.int64)
+        with pytest.raises(ValueError, match=msg):
+            np.sum(SparseArray(data), dtype=np.int64)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.sum,
-                               SparseArray(data), out=out)
+        with pytest.raises(ValueError, match=msg):
+            np.sum(SparseArray(data), out=out)
 
     @pytest.mark.parametrize("data,expected", [
         (np.array([1, 2, 3, 4, 5], dtype=float),  # non-null data
@@ -894,16 +903,16 @@ class TestSparseArrayAnalytics(object):
 
         if numpy:  # numpy compatibility checks.
             msg = "the 'dtype' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, np.cumsum,
-                                   SparseArray(data), dtype=np.int64)
+            with pytest.raises(ValueError, match=msg):
+                np.cumsum(SparseArray(data), dtype=np.int64)
 
             msg = "the 'out' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, np.cumsum,
-                                   SparseArray(data), out=out)
+            with pytest.raises(ValueError, match=msg):
+                np.cumsum(SparseArray(data), out=out)
         else:
             axis = 1  # SparseArray currently 1-D, so only axis = 0 is valid.
             msg = "axis\\(={axis}\\) out of bounds".format(axis=axis)
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 SparseArray(data).cumsum(axis=axis)
 
     def test_mean(self):
@@ -925,12 +934,12 @@ class TestSparseArrayAnalytics(object):
         assert out == 40.0 / 9
 
         msg = "the 'dtype' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.mean,
-                               SparseArray(data), dtype=np.int64)
+        with pytest.raises(ValueError, match=msg):
+            np.mean(SparseArray(data), dtype=np.int64)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.mean,
-                               SparseArray(data), out=out)
+        with pytest.raises(ValueError, match=msg):
+            np.mean(SparseArray(data), out=out)
 
     def test_ufunc(self):
         # GH 13853 make sure ufunc is applied to fill_value
@@ -1042,7 +1051,7 @@ class TestAccessor(object):
 
     def test_non_sparse_raises(self):
         ser = pd.Series([1, 2, 3])
-        with tm.assert_raises_regex(AttributeError, '.sparse'):
+        with pytest.raises(AttributeError, match='.sparse'):
             ser.sparse.density
 
 

--- a/pandas/tests/arrays/sparse/test_dtype.py
+++ b/pandas/tests/arrays/sparse/test_dtype.py
@@ -3,7 +3,6 @@ import pytest
 
 import pandas as pd
 from pandas.core.sparse.api import SparseDtype
-import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize("dtype, fill_value", [
@@ -138,5 +137,5 @@ def test_parse_subtype(string, expected):
     "Sparse[bool, True]",
 ])
 def test_construct_from_string_fill_value_raises(string):
-    with tm.assert_raises_regex(TypeError, 'fill_value in the string is not'):
+    with pytest.raises(TypeError, match='fill_value in the string is not'):
         SparseDtype.construct_from_string(string)

--- a/pandas/tests/arrays/sparse/test_libsparse.py
+++ b/pandas/tests/arrays/sparse/test_libsparse.py
@@ -478,37 +478,37 @@ class TestIntIndex(object):
         # Too many indices than specified in self.length
         msg = "Too many indices"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             IntIndex(length=1, indices=[1, 2, 3])
 
         # No index can be negative.
         msg = "No index can be less than zero"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             IntIndex(length=5, indices=[1, -2, 3])
 
         # No index can be negative.
         msg = "No index can be less than zero"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             IntIndex(length=5, indices=[1, -2, 3])
 
         # All indices must be less than the length.
         msg = "All indices must be less than the length"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             IntIndex(length=5, indices=[1, 2, 5])
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             IntIndex(length=5, indices=[1, 2, 6])
 
         # Indices must be strictly ascending.
         msg = "Indices must be strictly increasing"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             IntIndex(length=5, indices=[1, 3, 2])
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             IntIndex(length=5, indices=[1, 3, 3])
 
     def test_int_internal(self):

--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -453,17 +453,17 @@ class TestCasting(object):
 
         msg = "cannot safely"
         arr = [1.2, 2.3, 3.7]
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             integer_array(arr, dtype=dtype)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             pd.Series(arr).astype(dtype)
 
         arr = [1.2, 2.3, 3.7, np.nan]
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             integer_array(arr, dtype=dtype)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             pd.Series(arr).astype(dtype)
 
 
@@ -683,11 +683,11 @@ def test_reduce_to_float(op):
 
 
 def test_astype_nansafe():
-    # https://github.com/pandas-dev/pandas/pull/22343
+    # see gh-22343
     arr = integer_array([np.nan, 1, 2], dtype="Int8")
+    msg = "cannot convert float NaN to integer"
 
-    with tm.assert_raises_regex(
-            ValueError, 'cannot convert float NaN to integer'):
+    with pytest.raises(ValueError, match=msg):
         arr.astype('uint32')
 
 

--- a/pandas/tests/arrays/test_period.py
+++ b/pandas/tests/arrays/test_period.py
@@ -53,22 +53,22 @@ def test_from_datetime64_freq_changes():
      "Input has different freq"),
 ])
 def test_period_array_raises(data, freq, msg):
-    with tm.assert_raises_regex(IncompatibleFrequency, msg):
+    with pytest.raises(IncompatibleFrequency, match=msg):
         period_array(data, freq)
 
 
 def test_period_array_non_period_series_raies():
     ser = pd.Series([1, 2, 3])
-    with tm.assert_raises_regex(TypeError, 'dtype'):
+    with pytest.raises(TypeError, match='dtype'):
         PeriodArray(ser, freq='D')
 
 
 def test_period_array_freq_mismatch():
     arr = period_array(['2000', '2001'], freq='D')
-    with tm.assert_raises_regex(IncompatibleFrequency, 'freq'):
+    with pytest.raises(IncompatibleFrequency, match='freq'):
         PeriodArray(arr, freq='M')
 
-    with tm.assert_raises_regex(IncompatibleFrequency, 'freq'):
+    with pytest.raises(IncompatibleFrequency, match='freq'):
         PeriodArray(arr, freq=pd.tseries.offsets.MonthEnd())
 
 
@@ -80,11 +80,11 @@ def test_asi8():
 
 def test_take_raises():
     arr = period_array(['2000', '2001'], freq='D')
-    with tm.assert_raises_regex(IncompatibleFrequency, 'freq'):
+    with pytest.raises(IncompatibleFrequency, match='freq'):
         arr.take([0, -1], allow_fill=True,
                  fill_value=pd.Period('2000', freq='W'))
 
-    with tm.assert_raises_regex(ValueError, 'foo'):
+    with pytest.raises(ValueError, match='foo'):
         arr.take([0, -1], allow_fill=True, fill_value='foo')
 
 
@@ -129,13 +129,13 @@ def test_astype_period():
 def test_astype_datetime(other):
     arr = period_array(['2000', '2001', None], freq='D')
     # slice off the [ns] so that the regex matches.
-    with tm.assert_raises_regex(TypeError, other[:-4]):
+    with pytest.raises(TypeError, match=other[:-4]):
         arr.astype(other)
 
 
 def test_fillna_raises():
     arr = period_array(['2000', '2001', '2002'], freq='D')
-    with tm.assert_raises_regex(ValueError, 'Length'):
+    with pytest.raises(ValueError, match='Length'):
         arr.fillna(arr[:2])
 
 
@@ -167,23 +167,23 @@ def test_setitem(key, value, expected):
 
 def test_setitem_raises_incompatible_freq():
     arr = PeriodArray(np.arange(3), freq="D")
-    with tm.assert_raises_regex(IncompatibleFrequency, "freq"):
+    with pytest.raises(IncompatibleFrequency, match="freq"):
         arr[0] = pd.Period("2000", freq="A")
 
     other = period_array(['2000', '2001'], freq='A')
-    with tm.assert_raises_regex(IncompatibleFrequency, "freq"):
+    with pytest.raises(IncompatibleFrequency, match="freq"):
         arr[[0, 1]] = other
 
 
 def test_setitem_raises_length():
     arr = PeriodArray(np.arange(3), freq="D")
-    with tm.assert_raises_regex(ValueError, "length"):
+    with pytest.raises(ValueError, match="length"):
         arr[[0, 1]] = [pd.Period("2000", freq="D")]
 
 
 def test_setitem_raises_type():
     arr = PeriodArray(np.arange(3), freq="D")
-    with tm.assert_raises_regex(TypeError, "int"):
+    with pytest.raises(TypeError, match="int"):
         arr[0] = 1
 
 
@@ -193,5 +193,5 @@ def test_setitem_raises_type():
 def tet_sub_period():
     arr = period_array(['2000', '2001'], freq='D')
     other = pd.Period("2000", freq="M")
-    with tm.assert_raises_regex(IncompatibleFrequency, "freq"):
+    with pytest.raises(IncompatibleFrequency, match="freq"):
         arr - other

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -9,7 +9,6 @@ from pandas.core.dtypes.dtypes import (DatetimeTZDtype, PeriodDtype,
 from pandas.core.sparse.api import SparseDtype
 
 import pandas.core.dtypes.common as com
-import pandas.util.testing as tm
 import pandas.util._test_decorators as td
 
 
@@ -19,7 +18,7 @@ class TestPandasDtype(object):
     # Per issue GH15520
     @pytest.mark.parametrize('box', [pd.Timestamp, 'pd.Timestamp', list])
     def test_invalid_dtype_error(self, box):
-        with tm.assert_raises_regex(TypeError, 'not understood'):
+        with pytest.raises(TypeError, match='not understood'):
             com.pandas_dtype(box)
 
     @pytest.mark.parametrize('dtype', [

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -95,8 +95,8 @@ class TestCategoricalDtype(Base):
             TypeError, lambda: CategoricalDtype.construct_from_string('foo'))
 
     def test_constructor_invalid(self):
-        with tm.assert_raises_regex(TypeError,
-                                    "CategoricalIndex.* must be called"):
+        msg = "CategoricalIndex.* must be called"
+        with pytest.raises(TypeError, match=msg):
             CategoricalDtype("category")
 
     def test_is_dtype(self):
@@ -455,12 +455,12 @@ class TestIntervalDtype(Base):
         # GH 19016
         msg = ('category, object, and string subtypes are not supported '
                'for IntervalDtype')
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             IntervalDtype(subtype)
 
     def test_construction_errors(self):
         msg = 'could not construct IntervalDtype'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             IntervalDtype('xx')
 
     def test_construction_from_string(self):
@@ -475,7 +475,7 @@ class TestIntervalDtype(Base):
         # these are invalid entirely
         msg = 'a string needs to be passed, got type'
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             IntervalDtype.construct_from_string(string)
 
     @pytest.mark.parametrize('string', [
@@ -484,7 +484,7 @@ class TestIntervalDtype(Base):
         # this is an invalid subtype
         msg = 'could not construct IntervalDtype'
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             IntervalDtype.construct_from_string(string)
 
     def test_subclass(self):
@@ -698,10 +698,10 @@ class TestCategoricalDtypeParametrized(object):
         assert result is expected
 
     def test_invalid_raises(self):
-        with tm.assert_raises_regex(TypeError, 'ordered'):
+        with pytest.raises(TypeError, match='ordered'):
             CategoricalDtype(['a', 'b'], ordered='foo')
 
-        with tm.assert_raises_regex(TypeError, 'collection'):
+        with pytest.raises(TypeError, match='collection'):
             CategoricalDtype('category')
 
     def test_mixed(self):
@@ -782,7 +782,7 @@ class TestCategoricalDtypeParametrized(object):
     def test_update_dtype_errors(self, bad_dtype):
         dtype = CategoricalDtype(list('abc'), False)
         msg = 'a CategoricalDtype must be passed to perform an update, '
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             dtype.update_dtype(bad_dtype)
 
 

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -371,7 +371,7 @@ class TestInference(object):
                 tm.assert_numpy_array_equal(out, pos)
 
                 # too many characters
-                with tm.assert_raises_regex(ValueError, msg):
+                with pytest.raises(ValueError, match=msg):
                     lib.maybe_convert_numeric(
                         np.array(['foo_' + infinity], dtype=object),
                         na_values, maybe_int)

--- a/pandas/tests/extension/base/constructors.py
+++ b/pandas/tests/extension/base/constructors.py
@@ -2,7 +2,6 @@ import pytest
 
 import pandas as pd
 from pandas.core.internals import ExtensionBlock
-import pandas.util.testing as tm
 
 from .base import BaseExtensionTests
 
@@ -43,7 +42,7 @@ class BaseConstructorsTests(BaseExtensionTests):
 
     def test_series_given_mismatched_index_raises(self, data):
         msg = 'Length of passed values is 3, index implies 5'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.Series(data[:3], index=[0, 1, 2, 3, 4])
 
     def test_from_dtype(self, data):

--- a/pandas/tests/extension/base/getitem.py
+++ b/pandas/tests/extension/base/getitem.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import pandas as pd
-import pandas.util.testing as tm
 
 from .base import BaseExtensionTests
 
@@ -168,7 +167,7 @@ class BaseGetitemTests(BaseExtensionTests):
         assert result[0] == data[0]
         assert na_cmp(result[1], na_value)
 
-        with tm.assert_raises_regex(IndexError, "out of bounds"):
+        with pytest.raises(IndexError, match="out of bounds"):
             data.take([len(data) + 1])
 
     def test_take_empty(self, data, na_value, na_cmp):
@@ -180,7 +179,7 @@ class BaseGetitemTests(BaseExtensionTests):
         with pytest.raises(IndexError):
             empty.take([-1])
 
-        with tm.assert_raises_regex(IndexError, "cannot do a non-empty take"):
+        with pytest.raises(IndexError, match="cannot do a non-empty take"):
             empty.take([0, 1])
 
     def test_take_negative(self, data):

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -125,8 +125,8 @@ class BaseMethodsTests(BaseExtensionTests):
         assert ser._values is arr
 
     def test_fillna_length_mismatch(self, data_missing):
-        with (tm.assert_raises_regex(ValueError,
-              "Length of 'value' does not match.")):
+        msg = "Length of 'value' does not match."
+        with pytest.raises(ValueError, match=msg):
             data_missing.fillna(data_missing.take([1]))
 
     def test_combine_le(self, data_repeated):

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 import pandas as pd
-import pandas.util.testing as tm
 
 from .base import BaseExtensionTests
 
@@ -34,12 +33,12 @@ class BaseSetitemTests(BaseExtensionTests):
             value = data._from_sequence(value)
 
         xpr = 'cannot set using a {} indexer with a different length'
-        with tm.assert_raises_regex(ValueError, xpr.format('list-like')):
+        with pytest.raises(ValueError, match=xpr.format('list-like')):
             ser[[0, 1]] = value
         # Ensure no modifications made before the exception
         self.assert_series_equal(ser, original)
 
-        with tm.assert_raises_regex(ValueError, xpr.format('slice')):
+        with pytest.raises(ValueError, match=xpr.format('slice')):
             ser[slice(3)] = value
         self.assert_series_equal(ser, original)
 
@@ -164,7 +163,7 @@ class BaseSetitemTests(BaseExtensionTests):
     def test_setitem_frame_invalid_length(self, data):
         df = pd.DataFrame({"A": [1] * len(data)})
         xpr = "Length of values does not match length of index"
-        with tm.assert_raises_regex(ValueError, xpr):
+        with pytest.raises(ValueError, match=xpr):
             df['B'] = data[:5]
 
     @pytest.mark.xfail(reason="GH#20441: setitem on extension types.",

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -207,7 +207,7 @@ class TestSetitem(BaseDecimal, base.BaseSetitemTests):
 def test_series_constructor_coerce_data_to_extension_dtype_raises():
     xpr = ("Cannot cast data to extension dtype 'decimal'. Pass the "
            "extension array directly.")
-    with tm.assert_raises_regex(ValueError, xpr):
+    with pytest.raises(ValueError, match=xpr):
         pd.Series([0, 1, 2], dtype=DecimalDtype())
 
 

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -272,7 +272,7 @@ class TestArithmeticOps(BaseJSON, base.BaseArithmeticOpsTests):
 
     def test_add_series_with_extension_array(self, data):
         ser = pd.Series(data)
-        with tm.assert_raises_regex(TypeError, "unsupported"):
+        with pytest.raises(TypeError, match="unsupported"):
             ser + data
 
     def _check_divmod_op(self, s, op, other, exc=NotImplementedError):

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pandas import Categorical
 from pandas.api.types import CategoricalDtype
 from pandas.tests.extension import base
-import pandas.util.testing as tm
 
 
 def make_data():
@@ -213,7 +212,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
 
     def test_add_series_with_extension_array(self, data):
         ser = pd.Series(data)
-        with tm.assert_raises_regex(TypeError, "cannot perform"):
+        with pytest.raises(TypeError, match="cannot perform"):
             ser + data
 
     def _check_divmod_op(self, s, op, other, exc=NotImplementedError):

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -21,7 +21,6 @@ from pandas.core.dtypes.dtypes import IntervalDtype
 from pandas import Interval
 from pandas.core.arrays import IntervalArray
 from pandas.tests.extension import base
-import pandas.util.testing as tm
 
 
 def make_data():
@@ -137,7 +136,7 @@ class TestMissing(BaseInterval, base.BaseMissingTests):
 
     def test_non_scalar_raises(self, data_missing):
         msg = "Got a 'list' instead."
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             data_missing.fillna([1, 1])
 
 

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -8,7 +8,6 @@ from pandas.core.dtypes.dtypes import PeriodDtype
 import pandas as pd
 from pandas.core.arrays import PeriodArray
 from pandas.tests.extension import base
-import pandas.util.testing as tm
 
 
 @pytest.fixture
@@ -114,7 +113,7 @@ class TestArithmeticOps(BasePeriodTests, base.BaseArithmeticOpsTests):
         s = pd.Series(data)
         msg = (r"unsupported operand type\(s\) for \+: "
                r"\'PeriodArray\' and \'PeriodArray\'")
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             s + data
 
     def test_error(self):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -29,7 +29,7 @@ class TestDataFrameAlterAxes():
 
         df.index = idx
         tm.assert_index_equal(df.index, idx)
-        with tm.assert_raises_regex(ValueError, 'Length mismatch'):
+        with pytest.raises(ValueError, match='Length mismatch'):
             df.index = idx[::2]
 
     def test_set_index(self, float_string_frame):
@@ -38,7 +38,7 @@ class TestDataFrameAlterAxes():
 
         df = df.set_index(idx)
         tm.assert_index_equal(df.index, idx)
-        with tm.assert_raises_regex(ValueError, 'Length mismatch'):
+        with pytest.raises(ValueError, match='Length mismatch'):
             df.set_index(idx[::2])
 
     def test_set_index_cast(self):
@@ -134,7 +134,7 @@ class TestDataFrameAlterAxes():
         if box == list:
             # list of strings gets interpreted as list of keys
             msg = "['one', 'two', 'three', 'one', 'two']"
-            with tm.assert_raises_regex(KeyError, msg):
+            with pytest.raises(KeyError, match=msg):
                 df.set_index(key, drop=drop, append=append)
         else:
             # np.array/tuple/iter/list-of-list "forget" the name of B
@@ -232,12 +232,10 @@ class TestDataFrameAlterAxes():
     def test_set_index_verify_integrity(self, frame_of_index_cols):
         df = frame_of_index_cols
 
-        with tm.assert_raises_regex(ValueError,
-                                    'Index has duplicate keys'):
+        with pytest.raises(ValueError, match='Index has duplicate keys'):
             df.set_index('A', verify_integrity=True)
         # with MultiIndex
-        with tm.assert_raises_regex(ValueError,
-                                    'Index has duplicate keys'):
+        with pytest.raises(ValueError, match='Index has duplicate keys'):
             df.set_index([df['A'], df['A']], verify_integrity=True)
 
     @pytest.mark.parametrize('append', [True, False])
@@ -245,21 +243,21 @@ class TestDataFrameAlterAxes():
     def test_set_index_raise(self, frame_of_index_cols, drop, append):
         df = frame_of_index_cols
 
-        with tm.assert_raises_regex(KeyError, "['foo', 'bar', 'baz']"):
+        with pytest.raises(KeyError, match="['foo', 'bar', 'baz']"):
             # column names are A-E, as well as one tuple
             df.set_index(['foo', 'bar', 'baz'], drop=drop, append=append)
 
         # non-existent key in list with arrays
-        with tm.assert_raises_regex(KeyError, 'X'):
+        with pytest.raises(KeyError, match='X'):
             df.set_index([df['A'], df['B'], 'X'], drop=drop, append=append)
 
         msg = 'The parameter "keys" may only contain a combination of.*'
         # forbidden type, e.g. set
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             df.set_index(set(df['A']), drop=drop, append=append)
 
         # forbidden type in list, e.g. set
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             df.set_index(['A', df['A'], set(df['A'])],
                          drop=drop, append=append)
 
@@ -427,7 +425,7 @@ class TestDataFrameAlterAxes():
     def test_set_columns(self, float_string_frame):
         cols = Index(np.arange(len(float_string_frame.columns)))
         float_string_frame.columns = cols
-        with tm.assert_raises_regex(ValueError, 'Length mismatch'):
+        with pytest.raises(ValueError, match='Length mismatch'):
             float_string_frame.columns = cols[::2]
 
     def test_dti_set_index_reindex(self):
@@ -575,13 +573,13 @@ class TestDataFrameAlterAxes():
         assert result.columns.name == 'meh'
 
         # Test different error cases
-        with tm.assert_raises_regex(TypeError, 'Must pass'):
+        with pytest.raises(TypeError, match='Must pass'):
             df.rename_axis(index='wrong')
 
-        with tm.assert_raises_regex(ValueError, 'Length of names'):
+        with pytest.raises(ValueError, match='Length of names'):
             df.rename_axis(index=['wrong'])
 
-        with tm.assert_raises_regex(TypeError, 'bogus'):
+        with pytest.raises(TypeError, match='bogus'):
             df.rename_axis(bogus=None)
 
     def test_rename_multiindex(self):
@@ -858,9 +856,9 @@ class TestDataFrameAlterAxes():
 
         # Missing levels - for both MultiIndex and single-level Index:
         for idx_lev in ['A', 'B'], ['A']:
-            with tm.assert_raises_regex(KeyError, 'Level E '):
+            with pytest.raises(KeyError, match='Level E '):
                 df.set_index(idx_lev).reset_index(level=['A', 'E'])
-            with tm.assert_raises_regex(IndexError, 'Too many levels'):
+            with pytest.raises(IndexError, match='Too many levels'):
                 df.set_index(idx_lev).reset_index(level=[0, 1, 2])
 
     def test_reset_index_right_dtype(self):
@@ -1058,31 +1056,31 @@ class TestDataFrameAlterAxes():
         df = DataFrame({"A": [1, 2], "B": [1, 2]}, index=['0', '1'])
 
         # Named target and axis
-        with tm.assert_raises_regex(TypeError, None):
+        with pytest.raises(TypeError, match=None):
             df.rename(index=str.lower, axis=1)
 
-        with tm.assert_raises_regex(TypeError, None):
+        with pytest.raises(TypeError, match=None):
             df.rename(index=str.lower, axis='columns')
 
-        with tm.assert_raises_regex(TypeError, None):
+        with pytest.raises(TypeError, match=None):
             df.rename(index=str.lower, axis='columns')
 
-        with tm.assert_raises_regex(TypeError, None):
+        with pytest.raises(TypeError, match=None):
             df.rename(columns=str.lower, axis='columns')
 
-        with tm.assert_raises_regex(TypeError, None):
+        with pytest.raises(TypeError, match=None):
             df.rename(index=str.lower, axis=0)
 
         # Multiple targets and axis
-        with tm.assert_raises_regex(TypeError, None):
+        with pytest.raises(TypeError, match=None):
             df.rename(str.lower, str.lower, axis='columns')
 
         # Too many targets
-        with tm.assert_raises_regex(TypeError, None):
+        with pytest.raises(TypeError, match=None):
             df.rename(str.lower, str.lower, str.lower)
 
         # Duplicates
-        with tm.assert_raises_regex(TypeError, "multiple values"):
+        with pytest.raises(TypeError, match="multiple values"):
             df.rename(id, mapper=id)
 
     def test_reindex_api_equivalence(self):
@@ -1279,7 +1277,7 @@ class TestIntervalIndex(object):
 
         # wrong values for the "axis" parameter
         for axis in 3, 'foo':
-            with tm.assert_raises_regex(ValueError, 'No axis named'):
+            with pytest.raises(ValueError, match='No axis named'):
                 df.set_axis(list('abc'), axis=axis, inplace=False)
 
     def test_set_axis_prior_to_deprecation_signature(self):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -1052,31 +1052,31 @@ class TestDataFrameAlterAxes():
         tm.assert_frame_equal(result, expected)
 
     def test_rename_axis_style_raises(self):
-        # https://github.com/pandas-dev/pandas/issues/12392
-        df = DataFrame({"A": [1, 2], "B": [1, 2]}, index=['0', '1'])
+        # see gh-12392
+        df = DataFrame({"A": [1, 2], "B": [1, 2]}, index=["0", "1"])
 
         # Named target and axis
-        with pytest.raises(TypeError, match=None):
+        over_spec_msg = ("Cannot specify both 'axis' and "
+                         "any of 'index' or 'columns'")
+        with pytest.raises(TypeError, match=over_spec_msg):
             df.rename(index=str.lower, axis=1)
 
-        with pytest.raises(TypeError, match=None):
-            df.rename(index=str.lower, axis='columns')
+        with pytest.raises(TypeError, match=over_spec_msg):
+            df.rename(index=str.lower, axis="columns")
 
-        with pytest.raises(TypeError, match=None):
-            df.rename(index=str.lower, axis='columns')
+        with pytest.raises(TypeError, match=over_spec_msg):
+            df.rename(columns=str.lower, axis="columns")
 
-        with pytest.raises(TypeError, match=None):
-            df.rename(columns=str.lower, axis='columns')
-
-        with pytest.raises(TypeError, match=None):
+        with pytest.raises(TypeError, match=over_spec_msg):
             df.rename(index=str.lower, axis=0)
 
         # Multiple targets and axis
-        with pytest.raises(TypeError, match=None):
-            df.rename(str.lower, str.lower, axis='columns')
+        with pytest.raises(TypeError, match=over_spec_msg):
+            df.rename(str.lower, str.lower, axis="columns")
 
         # Too many targets
-        with pytest.raises(TypeError, match=None):
+        over_spec_msg = "Cannot specify all of 'mapper', 'index', 'columns'."
+        with pytest.raises(TypeError, match=over_spec_msg):
             df.rename(str.lower, str.lower, str.lower)
 
         # Duplicates

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -101,7 +101,8 @@ def assert_stat_op_calc(opname, alternative, frame, has_skipna=True,
         assert lcd_dtype == result1.dtype
 
     # bad axis
-    tm.assert_raises_regex(ValueError, 'No axis named 2', f, axis=2)
+    with pytest.raises(ValueError, match='No axis named 2'):
+        f(axis=2)
 
     # all NA case
     if has_skipna:
@@ -189,7 +190,8 @@ def assert_bool_op_calc(opname, alternative, frame, has_skipna=True):
                            check_dtype=False)
 
     # bad axis
-    tm.assert_raises_regex(ValueError, 'No axis named 2', f, axis=2)
+    with pytest.raises(ValueError, match='No axis named 2'):
+        f(axis=2)
 
     # all NA case
     if has_skipna:
@@ -343,7 +345,7 @@ class TestDataFrameAnalytics():
         df = pd.DataFrame(np.random.normal(size=(10, 2)))
         msg = ("method must be either 'pearson', 'spearman', "
                "or 'kendall'")
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.corr(method="____")
 
     def test_cov(self, float_frame, float_string_frame):
@@ -1469,7 +1471,7 @@ class TestDataFrameAnalytics():
                                           names=['out', 'in'])
         )
         xpr = "Must specify 'axis' when aggregating by level."
-        with tm.assert_raises_regex(ValueError, xpr):
+        with pytest.raises(ValueError, match=xpr):
             getattr(df, method)(axis=None, level='out')
 
     # ----------------------------------------------------------------------
@@ -1757,7 +1759,7 @@ class TestDataFrameAnalytics():
         tm.assert_frame_equal(out, expected)
 
         msg = "the 'out' parameter is not supported"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             np.round(df, decimals=0, out=df)
 
     def test_round_mixed_type(self):
@@ -1997,8 +1999,7 @@ class TestDataFrameAnalytics():
         expected = a.dot(a.iloc[0])
         tm.assert_series_equal(result, expected)
 
-        with tm.assert_raises_regex(ValueError,
-                                    'Dot product shape mismatch'):
+        with pytest.raises(ValueError, match='Dot product shape mismatch'):
             a.dot(row[:-1])
 
         a = np.random.rand(1, 5)
@@ -2015,7 +2016,7 @@ class TestDataFrameAnalytics():
         df = DataFrame(randn(3, 4), index=[1, 2, 3], columns=lrange(4))
         df2 = DataFrame(randn(5, 3), index=lrange(5), columns=[1, 2, 3])
 
-        with tm.assert_raises_regex(ValueError, 'aligned'):
+        with pytest.raises(ValueError, match='aligned'):
             df.dot(df2)
 
     @pytest.mark.skipif(not PY35,
@@ -2075,7 +2076,7 @@ class TestDataFrameAnalytics():
         df = DataFrame(randn(3, 4), index=[1, 2, 3], columns=lrange(4))
         df2 = DataFrame(randn(5, 3), index=lrange(5), columns=[1, 2, 3])
 
-        with tm.assert_raises_regex(ValueError, 'aligned'):
+        with pytest.raises(ValueError, match='aligned'):
             operator.matmul(df, df2)
 
 
@@ -2144,7 +2145,7 @@ class TestNLargestNSmallest(object):
 
             error_msg = self.dtype_error_msg_template.format(
                 column='b', method=nselect_method, dtype='object')
-            with tm.assert_raises_regex(TypeError, error_msg):
+            with pytest.raises(TypeError, match=error_msg):
                 getattr(df, nselect_method)(n, order)
         else:
             ascending = nselect_method == 'nsmallest'
@@ -2162,7 +2163,7 @@ class TestNLargestNSmallest(object):
         # escape some characters that may be in the repr
         error_msg = (error_msg.replace('(', '\\(').replace(")", "\\)")
                               .replace("[", "\\[").replace("]", "\\]"))
-        with tm.assert_raises_regex(TypeError, error_msg):
+        with pytest.raises(TypeError, match=error_msg):
             getattr(df, nselect_method)(2, columns)
 
     def test_n_all_dtypes(self, df_main_dtypes):

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -107,14 +107,17 @@ class SharedWithSparse(object):
         assert f._get_axis(0) is f.index
         assert f._get_axis(1) is f.columns
 
-        tm.assert_raises_regex(
-            ValueError, 'No axis named', f._get_axis_number, 2)
-        tm.assert_raises_regex(
-            ValueError, 'No axis.*foo', f._get_axis_name, 'foo')
-        tm.assert_raises_regex(
-            ValueError, 'No axis.*None', f._get_axis_name, None)
-        tm.assert_raises_regex(ValueError, 'No axis named',
-                               f._get_axis_number, None)
+        with pytest.raises(ValueError, match='No axis named'):
+            f._get_axis_number(2)
+
+        with pytest.raises(ValueError, match='No axis.*foo'):
+            f._get_axis_name('foo')
+
+        with pytest.raises(ValueError, match='No axis.*None'):
+            f._get_axis_name(None)
+
+        with pytest.raises(ValueError, match='No axis named'):
+            f._get_axis_number(None)
 
     def test_keys(self, float_frame):
         getkeys = float_frame.keys

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -173,7 +173,7 @@ class TestFrameFlexComparisons(object):
             # NAs
             msg = "Unable to coerce to Series/DataFrame"
             tm.assert_frame_equal(f(np.nan), o(df, np.nan))
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 f(ndim_5)
 
         # Series
@@ -382,7 +382,7 @@ class TestFrameFlexArithmetic(object):
         for dim in range(3, 6):
             arr = np.ones((1,) * dim)
             msg = "Unable to coerce to Series/DataFrame"
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 getattr(float_frame, op)(arr)
 
     def test_arith_flex_frame_corner(self, float_frame):
@@ -397,10 +397,10 @@ class TestFrameFlexArithmetic(object):
         result = float_frame[:0].add(float_frame)
         tm.assert_frame_equal(result, float_frame * np.nan)
 
-        with tm.assert_raises_regex(NotImplementedError, 'fill_value'):
+        with pytest.raises(NotImplementedError, match='fill_value'):
             float_frame.add(float_frame.iloc[0], fill_value=3)
 
-        with tm.assert_raises_regex(NotImplementedError, 'fill_value'):
+        with pytest.raises(NotImplementedError, match='fill_value'):
             float_frame.add(float_frame.iloc[0], axis='index', fill_value=3)
 
     def test_arith_flex_series(self, simple_frame):
@@ -441,10 +441,10 @@ class TestFrameFlexArithmetic(object):
         df_len0 = pd.DataFrame([], columns=['A', 'B'])
         df = pd.DataFrame([[1, 2], [3, 4]], columns=['A', 'B'])
 
-        with tm.assert_raises_regex(NotImplementedError, 'fill_value'):
+        with pytest.raises(NotImplementedError, match='fill_value'):
             df.add(ser_len0, fill_value='E')
 
-        with tm.assert_raises_regex(NotImplementedError, 'fill_value'):
+        with pytest.raises(NotImplementedError, match='fill_value'):
             df_len0.sub(df['A'], axis=None, fill_value=3)
 
 

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -476,36 +476,36 @@ class TestDataFrameSelectReindex(TestData):
     def test_reindex_axis_style_raises(self):
         # https://github.com/pandas-dev/pandas/issues/12392
         df = pd.DataFrame({"A": [1, 2, 3], 'B': [4, 5, 6]})
-        with tm.assert_raises_regex(TypeError, "Cannot specify both 'axis'"):
+        with pytest.raises(TypeError, match="Cannot specify both 'axis'"):
             df.reindex([0, 1], ['A'], axis=1)
 
-        with tm.assert_raises_regex(TypeError, "Cannot specify both 'axis'"):
+        with pytest.raises(TypeError, match="Cannot specify both 'axis'"):
             df.reindex([0, 1], ['A'], axis='index')
 
-        with tm.assert_raises_regex(TypeError, "Cannot specify both 'axis'"):
+        with pytest.raises(TypeError, match="Cannot specify both 'axis'"):
             df.reindex(index=[0, 1], axis='index')
 
-        with tm.assert_raises_regex(TypeError, "Cannot specify both 'axis'"):
+        with pytest.raises(TypeError, match="Cannot specify both 'axis'"):
             df.reindex(index=[0, 1], axis='columns')
 
-        with tm.assert_raises_regex(TypeError, "Cannot specify both 'axis'"):
+        with pytest.raises(TypeError, match="Cannot specify both 'axis'"):
             df.reindex(columns=[0, 1], axis='columns')
 
-        with tm.assert_raises_regex(TypeError, "Cannot specify both 'axis'"):
+        with pytest.raises(TypeError, match="Cannot specify both 'axis'"):
             df.reindex(index=[0, 1], columns=[0, 1], axis='columns')
 
-        with tm.assert_raises_regex(TypeError, 'Cannot specify all'):
+        with pytest.raises(TypeError, match='Cannot specify all'):
             df.reindex([0, 1], [0], ['A'])
 
         # Mixing styles
-        with tm.assert_raises_regex(TypeError, "Cannot specify both 'axis'"):
+        with pytest.raises(TypeError, match="Cannot specify both 'axis'"):
             df.reindex(index=[0, 1], axis='index')
 
-        with tm.assert_raises_regex(TypeError, "Cannot specify both 'axis'"):
+        with pytest.raises(TypeError, match="Cannot specify both 'axis'"):
             df.reindex(index=[0, 1], axis='columns')
 
         # Duplicates
-        with tm.assert_raises_regex(TypeError, "multiple values"):
+        with pytest.raises(TypeError, match="multiple values"):
             df.reindex([0, 1], labels=[0, 1])
 
     def test_reindex_single_named_indexer(self):
@@ -820,23 +820,23 @@ class TestDataFrameSelectReindex(TestData):
         tm.assert_frame_equal(filtered, expected)
 
         # pass in None
-        with tm.assert_raises_regex(TypeError, 'Must pass'):
+        with pytest.raises(TypeError, match='Must pass'):
             self.frame.filter()
-        with tm.assert_raises_regex(TypeError, 'Must pass'):
+        with pytest.raises(TypeError, match='Must pass'):
             self.frame.filter(items=None)
-        with tm.assert_raises_regex(TypeError, 'Must pass'):
+        with pytest.raises(TypeError, match='Must pass'):
             self.frame.filter(axis=1)
 
         # test mutually exclusive arguments
-        with tm.assert_raises_regex(TypeError, 'mutually exclusive'):
+        with pytest.raises(TypeError, match='mutually exclusive'):
             self.frame.filter(items=['one', 'three'], regex='e$', like='bbi')
-        with tm.assert_raises_regex(TypeError, 'mutually exclusive'):
+        with pytest.raises(TypeError, match='mutually exclusive'):
             self.frame.filter(items=['one', 'three'], regex='e$', axis=1)
-        with tm.assert_raises_regex(TypeError, 'mutually exclusive'):
+        with pytest.raises(TypeError, match='mutually exclusive'):
             self.frame.filter(items=['one', 'three'], regex='e$')
-        with tm.assert_raises_regex(TypeError, 'mutually exclusive'):
+        with pytest.raises(TypeError, match='mutually exclusive'):
             self.frame.filter(items=['one', 'three'], like='bbi', axis=0)
-        with tm.assert_raises_regex(TypeError, 'mutually exclusive'):
+        with pytest.raises(TypeError, match='mutually exclusive'):
             self.frame.filter(items=['one', 'three'], like='bbi')
 
         # objects
@@ -1160,5 +1160,5 @@ class TestDataFrameSelectReindex(TestData):
     @pytest.mark.parametrize('drop_labels', [[1, 4], [4, 5]])
     def test_drop_non_empty_list(self, index, drop_labels):
         # GH 21494
-        with tm.assert_raises_regex(KeyError, 'not found in axis'):
+        with pytest.raises(KeyError, match='not found in axis'):
             pd.DataFrame(index=index).drop(drop_labels)

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -474,7 +474,7 @@ starting,ending,measure
 
         # via astype, but errors
         converted = float_string_frame.copy()
-        with tm.assert_raises_regex(ValueError, 'invalid literal'):
+        with pytest.raises(ValueError, match='invalid literal'):
             converted['H'].astype('int32')
 
         # mixed in a single column

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -127,13 +127,13 @@ class TestDataFrameConcatCommon(TestData):
                        columns=['foo', 'bar', 'baz', 'qux'])
 
         series = df.loc[4]
-        with tm.assert_raises_regex(ValueError,
-                                    'Indexes have overlapping values'):
+        msg = 'Indexes have overlapping values'
+        with pytest.raises(ValueError, match=msg):
             df.append(series, verify_integrity=True)
+
         series.name = None
-        with tm.assert_raises_regex(TypeError,
-                                    'Can only append a Series if '
-                                    'ignore_index=True'):
+        msg = 'Can only append a Series if ignore_index=True'
+        with pytest.raises(TypeError, match=msg):
             df.append(series, verify_integrity=True)
 
         result = df.append(series[::-1], ignore_index=True)
@@ -321,7 +321,7 @@ class TestDataFrameConcatCommon(TestData):
 
         other = DataFrame([[2., nan],
                            [nan, 7]], index=[1, 3], columns=[1, 2])
-        with tm.assert_raises_regex(ValueError, "Data overlaps"):
+        with pytest.raises(ValueError, match="Data overlaps"):
             df.update(other, raise_conflict=True)
 
     def test_update_from_non_df(self):
@@ -470,7 +470,7 @@ class TestDataFrameConcatCommon(TestData):
         assert_frame_equal(concatted_1_series, expected_columns_series)
 
         # Testing ValueError
-        with tm.assert_raises_regex(ValueError, 'No axis named'):
+        with pytest.raises(ValueError, match='No axis named'):
             pd.concat([series1, series2], axis='something')
 
     def test_concat_numerical_names(self):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -292,10 +292,10 @@ class TestDataFrameConstructors(TestData):
         # GH10856
         # dict with scalar values should raise error, even if columns passed
         msg = 'If using all scalar values, you must pass an index'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame({'a': 0.7})
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame({'a': 0.7}, columns=['a'])
 
     @pytest.mark.parametrize("scalar", [2, np.nan, None, 'D'])
@@ -377,40 +377,43 @@ class TestDataFrameConstructors(TestData):
     def test_constructor_error_msgs(self):
         msg = "Empty data passed with indices specified."
         # passing an empty array with columns specified.
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame(np.empty(0), columns=list('abc'))
 
         msg = "Mixing dicts with non-Series may lead to ambiguous ordering."
         # mix dict and array, wrong size
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame({'A': {'a': 'a', 'b': 'b'},
                        'B': ['a', 'b', 'c']})
 
         # wrong size ndarray, GH 3105
         msg = r"Shape of passed values is \(3, 4\), indices imply \(3, 3\)"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame(np.arange(12).reshape((4, 3)),
                       columns=['foo', 'bar', 'baz'],
                       index=pd.date_range('2000-01-01', periods=3))
 
         # higher dim raise exception
-        with tm.assert_raises_regex(ValueError, 'Must pass 2-d input'):
+        with pytest.raises(ValueError, match='Must pass 2-d input'):
             DataFrame(np.zeros((3, 3, 3)), columns=['A', 'B', 'C'], index=[1])
 
         # wrong size axis labels
-        with tm.assert_raises_regex(ValueError, "Shape of passed values "
-                                    r"is \(3, 2\), indices "
-                                    r"imply \(3, 1\)"):
+        msg = ("Shape of passed values "
+               r"is \(3, 2\), indices "
+               r"imply \(3, 1\)")
+        with pytest.raises(ValueError, match=msg):
             DataFrame(np.random.rand(2, 3), columns=['A', 'B', 'C'], index=[1])
 
-        with tm.assert_raises_regex(ValueError, "Shape of passed values "
-                                    r"is \(3, 2\), indices "
-                                    r"imply \(2, 2\)"):
+        msg = ("Shape of passed values "
+               r"is \(3, 2\), indices "
+               r"imply \(2, 2\)")
+        with pytest.raises(ValueError, match=msg):
             DataFrame(np.random.rand(2, 3), columns=['A', 'B'], index=[1, 2])
 
-        with tm.assert_raises_regex(ValueError, "If using all scalar "
-                                    "values, you must pass "
-                                    "an index"):
+        msg = ("If using all scalar "
+               "values, you must pass "
+               "an index")
+        with pytest.raises(ValueError, match=msg):
             DataFrame({'a': False, 'b': True})
 
     def test_constructor_with_embedded_frames(self):
@@ -637,14 +640,14 @@ class TestDataFrameConstructors(TestData):
 
         # wrong size axis labels
         msg = r'Shape of passed values is \(3, 2\), indices imply \(3, 1\)'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame(mat, columns=['A', 'B', 'C'], index=[1])
         msg = r'Shape of passed values is \(3, 2\), indices imply \(2, 2\)'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame(mat, columns=['A', 'B'], index=[1, 2])
 
         # higher dim raise exception
-        with tm.assert_raises_regex(ValueError, 'Must pass 2-d input'):
+        with pytest.raises(ValueError, match='Must pass 2-d input'):
             DataFrame(empty((3, 3, 3)), columns=['A', 'B', 'C'],
                       index=[1])
 
@@ -829,7 +832,7 @@ class TestDataFrameConstructors(TestData):
         exp = DataFrame({'a': df['a'].values, 'b': [True] * 10})
 
         tm.assert_frame_equal(df, exp)
-        with tm.assert_raises_regex(ValueError, 'must pass an index'):
+        with pytest.raises(ValueError, match='must pass an index'):
             DataFrame({'a': False, 'b': True})
 
     def test_constructor_DataFrame(self):
@@ -862,7 +865,7 @@ class TestDataFrameConstructors(TestData):
 
         # can't cast
         mat = np.array(['foo', 'bar'], dtype=object).reshape(2, 1)
-        with tm.assert_raises_regex(ValueError, 'cast'):
+        with pytest.raises(ValueError, match='cast'):
             DataFrame(mat, index=[0, 1], columns=[0], dtype=float)
 
         dm = DataFrame(DataFrame(self.frame._series))
@@ -1108,8 +1111,7 @@ class TestDataFrameConstructors(TestData):
     def test_constructor_ragged(self):
         data = {'A': randn(10),
                 'B': randn(8)}
-        with tm.assert_raises_regex(ValueError,
-                                    'arrays must all be same length'):
+        with pytest.raises(ValueError, match='arrays must all be same length'):
             DataFrame(data)
 
     def test_constructor_scalar(self):
@@ -1131,7 +1133,7 @@ class TestDataFrameConstructors(TestData):
         assert result.index.is_monotonic
 
         # ordering ambiguous, raise exception
-        with tm.assert_raises_regex(ValueError, 'ambiguous ordering'):
+        with pytest.raises(ValueError, match='ambiguous ordering'):
             DataFrame({'A': ['a', 'b'], 'B': {'a': 'a', 'b': 'b'}})
 
         # this is OK though
@@ -1185,10 +1187,10 @@ class TestDataFrameConstructors(TestData):
         tm.assert_frame_equal(result, expected)
 
         msg = "cannot use columns parameter with orient='columns'"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame.from_dict(dict([('A', [1, 2]), ('B', [4, 5])]),
                                 orient='columns', columns=['one', 'two'])
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame.from_dict(dict([('A', [1, 2]), ('B', [4, 5])]),
                                 columns=['one', 'two'])
 
@@ -1299,9 +1301,8 @@ class TestDataFrameConstructors(TestData):
         tm.assert_frame_equal(recons, self.mixed_frame)
         assert recons['A'].dtype == np.float64
 
-        with tm.assert_raises_regex(TypeError,
-                                    "Must pass columns with "
-                                    "orient='index'"):
+        msg = "Must pass columns with orient='index'"
+        with pytest.raises(TypeError, match=msg):
             with tm.assert_produces_warning(FutureWarning,
                                             check_stacklevel=False):
                 DataFrame.from_items(row_items, orient='index')
@@ -1331,16 +1332,16 @@ class TestDataFrameConstructors(TestData):
 
     def test_constructor_from_items_scalars(self):
         # GH 17312
-        with tm.assert_raises_regex(ValueError,
-                                    r'The value in each \(key, value\) '
-                                    'pair must be an array, Series, or dict'):
+        msg = (r'The value in each \(key, value\) '
+               'pair must be an array, Series, or dict')
+        with pytest.raises(ValueError, match=msg):
             with tm.assert_produces_warning(FutureWarning,
                                             check_stacklevel=False):
                 DataFrame.from_items([('A', 1), ('B', 4)])
 
-        with tm.assert_raises_regex(ValueError,
-                                    r'The value in each \(key, value\) '
-                                    'pair must be an array, Series, or dict'):
+        msg = (r'The value in each \(key, value\) '
+               'pair must be an array, Series, or dict')
+        with pytest.raises(ValueError, match=msg):
             with tm.assert_produces_warning(FutureWarning,
                                             check_stacklevel=False):
                 DataFrame.from_items([('A', 1), ('B', 2)], columns=['col1'],
@@ -1363,8 +1364,8 @@ class TestDataFrameConstructors(TestData):
                         'B': list(self.frame['B'])}, columns=['A', 'B'])
         tm.assert_frame_equal(df, self.frame.loc[:, ['A', 'B']])
 
-        with tm.assert_raises_regex(ValueError, 'does not match '
-                                    'index length'):
+        msg = 'does not match index length'
+        with pytest.raises(ValueError, match=msg):
             DataFrame({'A': self.frame['A'], 'B': list(self.frame['B'])[:-2]})
 
     def test_constructor_miscast_na_int_dtype(self):
@@ -1419,8 +1420,9 @@ class TestDataFrameConstructors(TestData):
 
         pytest.raises(ValueError, DataFrame, 'a', [1, 2])
         pytest.raises(ValueError, DataFrame, 'a', columns=['a', 'c'])
-        with tm.assert_raises_regex(TypeError, 'incompatible data '
-                                    'and dtype'):
+
+        msg = 'incompatible data and dtype'
+        with pytest.raises(TypeError, match=msg):
             DataFrame('a', [1, 2], ['a', 'c'], float)
 
     def test_constructor_with_datetimes(self):
@@ -1783,7 +1785,7 @@ class TestDataFrameConstructors(TestData):
 
         # wrong length
         msg = r'Shape of passed values is \(3, 2\), indices imply \(3, 1\)'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             DataFrame.from_records(arr, index=index[:-1])
 
         indexed_frame = DataFrame.from_records(arr, index='f1')

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -329,9 +329,8 @@ class TestDataFrameDataTypes(TestData):
 
     def test_select_dtypes_empty(self):
         df = DataFrame({'a': list('abc'), 'b': list(range(1, 4))})
-        with tm.assert_raises_regex(ValueError, 'at least one of '
-                                    'include or exclude '
-                                    'must be nonempty'):
+        msg = 'at least one of include or exclude must be nonempty'
+        with pytest.raises(ValueError, match=msg):
             df.select_dtypes()
 
     def test_select_dtypes_bad_datetime64(self):
@@ -341,10 +340,10 @@ class TestDataFrameDataTypes(TestData):
                         'd': np.arange(4.0, 7.0, dtype='float64'),
                         'e': [True, False, True],
                         'f': pd.date_range('now', periods=3).values})
-        with tm.assert_raises_regex(ValueError, '.+ is too specific'):
+        with pytest.raises(ValueError, match='.+ is too specific'):
             df.select_dtypes(include=['datetime64[D]'])
 
-        with tm.assert_raises_regex(ValueError, '.+ is too specific'):
+        with pytest.raises(ValueError, match='.+ is too specific'):
             df.select_dtypes(exclude=['datetime64[as]'])
 
     def test_select_dtypes_datetime_with_tz(self):
@@ -373,7 +372,7 @@ class TestDataFrameDataTypes(TestData):
         msg = "string dtypes are not allowed"
         kwargs = {arg: [dtype]}
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             df.select_dtypes(**kwargs)
 
     def test_select_dtypes_bad_arg_raises(self):
@@ -384,8 +383,9 @@ class TestDataFrameDataTypes(TestData):
                         'd': np.arange(4.0, 7.0, dtype='float64'),
                         'e': [True, False, True],
                         'f': pd.date_range('now', periods=3).values})
-        with tm.assert_raises_regex(TypeError, 'data type.'
-                                    '*not understood'):
+
+        msg = 'data type.*not understood'
+        with pytest.raises(TypeError, match=msg):
             df.select_dtypes(['blargy, blarg, blarg'])
 
     def test_select_dtypes_typecodes(self):
@@ -514,7 +514,7 @@ class TestDataFrameDataTypes(TestData):
         msg = "Cannot convert non-finite values \\(NA or inf\\) to integer"
         df = DataFrame([val])
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.astype(dtype)
 
     def test_astype_str(self, text_dtype):
@@ -661,10 +661,10 @@ class TestDataFrameDataTypes(TestData):
     def test_astype_categoricaldtype_class_raises(self, cls):
         df = DataFrame({"A": ['a', 'a', 'b', 'c']})
         xpr = "Expected an instance of {}".format(cls.__name__)
-        with tm.assert_raises_regex(TypeError, xpr):
+        with pytest.raises(TypeError, match=xpr):
             df.astype({"A": cls})
 
-        with tm.assert_raises_regex(TypeError, xpr):
+        with pytest.raises(TypeError, match=xpr):
             df['A'].astype(cls)
 
     @pytest.mark.parametrize("dtype", ['Int64', 'Int32', 'Int16'])

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -54,7 +54,7 @@ class TestDataFrameIndexing(TestData):
             assert self.frame[key] is not None
 
         assert 'random' not in self.frame
-        with tm.assert_raises_regex(KeyError, 'random'):
+        with pytest.raises(KeyError, match='random'):
             self.frame['random']
 
         df = self.frame.copy()
@@ -129,7 +129,7 @@ class TestDataFrameIndexing(TestData):
         assert_frame_equal(result, expected)
 
         idx = idx_type(keys + [missing])
-        with tm.assert_raises_regex(KeyError, 'not in index'):
+        with pytest.raises(KeyError, match='not in index'):
             frame[idx]
 
     def test_getitem_callable(self):
@@ -153,13 +153,12 @@ class TestDataFrameIndexing(TestData):
         assert_series_equal(self.frame['B'], data['A'], check_names=False)
         assert_series_equal(self.frame['A'], data['B'], check_names=False)
 
-        with tm.assert_raises_regex(ValueError,
-                                    'Columns must be same length as key'):
+        msg = 'Columns must be same length as key'
+        with pytest.raises(ValueError, match=msg):
             data[['A']] = self.frame[['A', 'B']]
 
-        with tm.assert_raises_regex(ValueError, 'Length of values '
-                                    'does not match '
-                                    'length of index'):
+        msg = 'Length of values does not match length of index'
+        with pytest.raises(ValueError, match=msg):
             data['A'] = range(len(data.index) - 1)
 
         df = DataFrame(0, lrange(3), ['tt1', 'tt2'], dtype=np.int_)
@@ -242,13 +241,13 @@ class TestDataFrameIndexing(TestData):
         subframe = self.tsframe[indexer]
 
         tm.assert_index_equal(subindex, subframe.index)
-        with tm.assert_raises_regex(ValueError, 'Item wrong length'):
+        with pytest.raises(ValueError, match='Item wrong length'):
             self.tsframe[indexer[:-1]]
 
         subframe_obj = self.tsframe[indexer_obj]
         assert_frame_equal(subframe_obj, subframe)
 
-        with tm.assert_raises_regex(ValueError, 'boolean values only'):
+        with pytest.raises(ValueError, match='boolean values only'):
             self.tsframe[self.tsframe]
 
         # test that Series work
@@ -545,7 +544,7 @@ class TestDataFrameIndexing(TestData):
         assert_almost_equal(df.values, values)
 
         msg = "Must pass DataFrame or 2-d ndarray with boolean values only"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             df[df * 0] = 2
 
         # index with DataFrame
@@ -1466,7 +1465,7 @@ class TestDataFrameIndexing(TestData):
 
     def test_getitem_setitem_fancy_exceptions(self):
         ix = self.frame.iloc
-        with tm.assert_raises_regex(IndexingError, 'Too many indexers'):
+        with pytest.raises(IndexingError, match='Too many indexers'):
             ix[:, :, :]
 
         with pytest.raises(IndexingError):
@@ -1803,7 +1802,7 @@ class TestDataFrameIndexing(TestData):
         with pytest.raises(KeyError):
             self.frame.lookup([self.frame.index[0]], ['xyz'])
 
-        with tm.assert_raises_regex(ValueError, 'same size'):
+        with pytest.raises(ValueError, match='same size'):
             self.frame.lookup(['a', 'b', 'c'], ['a'])
 
     def test_set_value(self):
@@ -2513,7 +2512,7 @@ class TestDataFrameIndexing(TestData):
 
         df1[df1 > 2.0 * df2] = -1
         assert_frame_equal(df1, expected)
-        with tm.assert_raises_regex(ValueError, 'Item wrong length'):
+        with pytest.raises(ValueError, match='Item wrong length'):
             df1[df1.index[:-1] > 2] = -1
 
     def test_boolean_indexing_mixed(self):
@@ -2547,7 +2546,7 @@ class TestDataFrameIndexing(TestData):
         msg = ("boolean setting on mixed-type|"
                "not supported between|"
                "unorderable types")
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             # TODO: This message should be the same in PY2/PY3
             df[df > 0.3] = 1
 
@@ -2733,7 +2732,7 @@ class TestDataFrameIndexing(TestData):
         df = DataFrame({"a": [1, 2, 3]})
         msg = "Boolean array expected for the condition"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.where(cond)
 
     @pytest.mark.parametrize("cond", [
@@ -2751,7 +2750,7 @@ class TestDataFrameIndexing(TestData):
         df = DataFrame({"a": [1, 2, 3], "b": [2, 2, 2]})
         msg = "Boolean array expected for the condition"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.where(cond)
 
     def test_where_dataframe_col_match(self):
@@ -2773,7 +2772,7 @@ class TestDataFrameIndexing(TestData):
         df = DataFrame([[1, 2, 3], [4, 5, 6]])
 
         cond = [True]
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.where(cond)
 
         expected = DataFrame([[1, 2, 3], [np.nan, np.nan, np.nan]])
@@ -2782,7 +2781,7 @@ class TestDataFrameIndexing(TestData):
         tm.assert_frame_equal(out, expected)
 
         cond = np.array([False, True, False, True])
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.where(cond)
 
         expected = DataFrame([[np.nan, np.nan, np.nan], [4, 5, 6]])
@@ -2872,9 +2871,9 @@ class TestDataFrameIndexing(TestData):
         # GH 7656
         df = DataFrame([{'A': 1, 'B': np.nan, 'C': 'Test'}, {
                        'A': np.nan, 'B': 'Test', 'C': np.nan}])
-        expected = df.where(~isna(df), None)
-        with tm.assert_raises_regex(TypeError, 'boolean setting '
-                                    'on mixed-type'):
+        msg = 'boolean setting on mixed-type'
+
+        with pytest.raises(TypeError, match=msg):
             df.where(~isna(df), None, inplace=True)
 
     def test_where_empty_df_and_empty_cond_having_non_bool_dtypes(self):
@@ -3162,7 +3161,7 @@ class TestDataFrameIndexing(TestData):
         dg = df.pivot_table(index='i', columns='c',
                             values=['x', 'y'])
 
-        with tm.assert_raises_regex(TypeError, "is an invalid key"):
+        with pytest.raises(TypeError, match="is an invalid key"):
             str(dg[:, 0])
 
         index = Index(range(2), name='i')

--- a/pandas/tests/frame/test_join.py
+++ b/pandas/tests/frame/test_join.py
@@ -94,13 +94,13 @@ def test_join_index(frame):
     tm.assert_index_equal(joined.index, frame.index.sort_values())
     tm.assert_index_equal(joined.columns, expected_columns)
 
-    tm.assert_raises_regex(
-        ValueError, 'join method', f.join, f2, how='foo')
+    with pytest.raises(ValueError, match='join method'):
+        f.join(f2, how='foo')
 
     # corner case - overlapping columns
+    msg = 'columns overlap but no suffix'
     for how in ('outer', 'left', 'inner'):
-        with tm.assert_raises_regex(ValueError, 'columns overlap but '
-                                    'no suffix'):
+        with pytest.raises(ValueError, match=msg):
             frame.join(frame, how=how)
 
 
@@ -131,7 +131,8 @@ def test_join_index_series(frame):
     tm.assert_frame_equal(joined, frame, check_names=False)
 
     s.name = None
-    tm.assert_raises_regex(ValueError, 'must have a name', df.join, s)
+    with pytest.raises(ValueError, match='must have a name'):
+        df.join(s)
 
 
 def test_join_overlap(frame):

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -330,8 +330,8 @@ class TestDataFrameMissingData(TestData):
         res = df.fillna(value={"cats": 3, "vals": "b"})
         tm.assert_frame_equal(res, df_exp_fill)
 
-        with tm.assert_raises_regex(ValueError, "fill value must be "
-                                                "in categories"):
+        with pytest.raises(ValueError, match=("fill value must "
+                                              "be in categories")):
             df.fillna(value={"cats": 4, "vals": "c"})
 
         res = df.fillna(method='pad')
@@ -555,8 +555,7 @@ class TestDataFrameMissingData(TestData):
         assert_frame_equal(result, expected)
 
         # disable this for now
-        with tm.assert_raises_regex(NotImplementedError,
-                                    'column by column'):
+        with pytest.raises(NotImplementedError, match='column by column'):
             df.fillna(df.max(1), axis=1)
 
     def test_fillna_dataframe(self):
@@ -596,7 +595,7 @@ class TestDataFrameMissingData(TestData):
         assert_frame_equal(result, expected)
 
     def test_fillna_invalid_method(self):
-        with tm.assert_raises_regex(ValueError, 'ffil'):
+        with pytest.raises(ValueError, match='ffil'):
             self.frame.fillna(method='ffil')
 
     def test_fillna_invalid_value(self):
@@ -820,11 +819,10 @@ class TestDataFrameInterpolate(TestData):
             'A': [1, 2, 3],
             'B': [4, 5, 6]},
             dtype='object')
-        with tm.assert_raises_regex(
-                TypeError,
-                "Cannot interpolate with all object-dtype columns "
-                "in the DataFrame. Try setting at least one "
-                "column to a numeric dtype."):
+        msg = ("Cannot interpolate with all object-dtype columns "
+               "in the DataFrame. Try setting at least one "
+               "column to a numeric dtype.")
+        with pytest.raises(TypeError, match=msg):
             df.interpolate()
 
     def test_interp_inplace(self):

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -126,7 +126,7 @@ class TestDataFrameMutateColumns(TestData):
         s = DataFrame({'foo': ['a', 'b', 'c', 'a'], 'fiz': [
                       'g', 'h', 'i', 'j']}).set_index('foo')
         msg = 'cannot reindex from a duplicate axis'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df['newcol'] = s
 
         # GH 4107, more descriptive error message
@@ -134,7 +134,7 @@ class TestDataFrameMutateColumns(TestData):
                        columns=['a', 'b', 'c', 'd'])
 
         msg = 'incompatible index of inserted column with frame index'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             df['gr'] = df.groupby(['b', 'c']).count()
 
     def test_insert_benchmark(self):
@@ -178,7 +178,7 @@ class TestDataFrameMutateColumns(TestData):
         result = Series(dict(float32=2, float64=4, int32=1))
         assert (df.get_dtype_counts().sort_index() == result).all()
 
-        with tm.assert_raises_regex(ValueError, 'already exists'):
+        with pytest.raises(ValueError, match='already exists'):
             df.insert(1, 'a', df['b'])
         pytest.raises(ValueError, df.insert, 1, 'c', df['b'])
 

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -51,7 +51,7 @@ class TestDataFrameNonuniqueIndexes(TestData):
                               [2, 1, 3, 5, 'bah']],
                              columns=['foo', 'bar', 'foo', 'hello', 'string'])
         check(df, expected)
-        with tm.assert_raises_regex(ValueError, 'Length of value'):
+        with pytest.raises(ValueError, match='Length of value'):
             df.insert(0, 'AnotherColumn', range(len(df.index) - 1))
 
         # insert same dtype
@@ -101,8 +101,9 @@ class TestDataFrameNonuniqueIndexes(TestData):
         check(df, expected)
 
         # insert a dup
-        tm.assert_raises_regex(ValueError, 'cannot insert',
-                               df.insert, 2, 'new_col', 4.)
+        with pytest.raises(ValueError, match='cannot insert'):
+            df.insert(2, 'new_col', 4.)
+
         df.insert(2, 'new_col', 4., allow_duplicates=True)
         expected = DataFrame([[1, 1, 4., 5., 'bah', 3],
                               [1, 2, 4., 5., 'bah', 3],

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -496,8 +496,7 @@ class TestDataFrameOperators(TestData):
             tm.assert_numpy_array_equal(result.values,
                                         func(df1.values, df2.values))
 
-            with tm.assert_raises_regex(ValueError,
-                                        'dim must be <= 2'):
+            with pytest.raises(ValueError, match='dim must be <= 2'):
                 func(df1, ndim_5)
 
             result2 = func(self.simple, row)
@@ -508,9 +507,8 @@ class TestDataFrameOperators(TestData):
             tm.assert_numpy_array_equal(result3.values,
                                         func(self.frame.values, 0))
 
-            with tm.assert_raises_regex(ValueError,
-                                        'Can only compare identically'
-                                        '-labeled DataFrame'):
+            msg = 'Can only compare identically-labeled DataFrame'
+            with pytest.raises(ValueError, match=msg):
                 func(self.simple, self.simple[:2])
 
         test_comp(operator.eq)
@@ -551,11 +549,11 @@ class TestDataFrameOperators(TestData):
         msg1d = 'Unable to coerce to Series, length must be 2: given 3'
         msg2d = 'Unable to coerce to DataFrame, shape must be'
         msg2db = 'operands could not be broadcast together with shapes'
-        with tm.assert_raises_regex(ValueError, msg1d):
+        with pytest.raises(ValueError, match=msg1d):
             # wrong shape
             df > lst
 
-        with tm.assert_raises_regex(ValueError, msg1d):
+        with pytest.raises(ValueError, match=msg1d):
             # wrong shape
             result = df > tup
 
@@ -566,10 +564,10 @@ class TestDataFrameOperators(TestData):
         result = df.values > b_r
         assert_numpy_array_equal(result, expected.values)
 
-        with tm.assert_raises_regex(ValueError, msg2d):
+        with pytest.raises(ValueError, match=msg2d):
             df > b_c
 
-        with tm.assert_raises_regex(ValueError, msg2db):
+        with pytest.raises(ValueError, match=msg2db):
             df.values > b_c
 
         # ==
@@ -577,10 +575,10 @@ class TestDataFrameOperators(TestData):
         result = df == b
         assert_frame_equal(result, expected)
 
-        with tm.assert_raises_regex(ValueError, msg1d):
+        with pytest.raises(ValueError, match=msg1d):
             result = df == lst
 
-        with tm.assert_raises_regex(ValueError, msg1d):
+        with pytest.raises(ValueError, match=msg1d):
             result = df == tup
 
         # broadcasts like ndarray (GH#23000)
@@ -590,7 +588,7 @@ class TestDataFrameOperators(TestData):
         result = df.values == b_r
         assert_numpy_array_equal(result, expected.values)
 
-        with tm.assert_raises_regex(ValueError, msg2d):
+        with pytest.raises(ValueError, match=msg2d):
             df == b_c
 
         assert df.values.shape != b_c.shape
@@ -601,10 +599,10 @@ class TestDataFrameOperators(TestData):
         expected.index = df.index
         expected.columns = df.columns
 
-        with tm.assert_raises_regex(ValueError, msg1d):
+        with pytest.raises(ValueError, match=msg1d):
             result = df == lst
 
-        with tm.assert_raises_regex(ValueError, msg1d):
+        with pytest.raises(ValueError, match=msg1d):
             result = df == tup
 
     def test_combine_generic(self):
@@ -774,10 +772,10 @@ class TestDataFrameOperators(TestData):
         msg = 'Unable to coerce to Series, length must be 3: given 2'
         for val in [[1, 2], (1, 2), np.array([1, 2]), range(1, 3)]:
 
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 align(df, val, 'index')
 
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 align(df, val, 'columns')
 
         val = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -791,10 +789,10 @@ class TestDataFrameOperators(TestData):
         # shape mismatch
         msg = 'Unable to coerce to DataFrame, shape must be'
         val = np.array([[1, 2, 3], [4, 5, 6]])
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             align(df, val, 'index')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             align(df, val, 'columns')
 
         val = np.zeros((3, 3, 3))

--- a/pandas/tests/frame/test_period.py
+++ b/pandas/tests/frame/test_period.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from numpy.random import randn
 from datetime import timedelta
@@ -111,8 +112,8 @@ class TestPeriodIndex(object):
         tm.assert_index_equal(result.columns, exp_index)
 
         # invalid axis
-        tm.assert_raises_regex(
-            ValueError, 'axis', df.to_timestamp, axis=2)
+        with pytest.raises(ValueError, match='axis'):
+            df.to_timestamp(axis=2)
 
         result1 = df.to_timestamp('5t', axis=1)
         result2 = df.to_timestamp('t', axis=1)

--- a/pandas/tests/frame/test_quantile.py
+++ b/pandas/tests/frame/test_quantile.py
@@ -220,7 +220,7 @@ class TestDataFrameQuantile(TestData):
     def test_quantile_invalid(self):
         msg = 'percentiles should all be in the interval \\[0, 1\\]'
         for invalid in [-1, 2, [0.5, -1], [0.5, 2]]:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 self.tsframe.quantile(invalid)
 
     def test_quantile_box(self):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -141,10 +141,10 @@ class TestDataFrameEval(TestData):
         df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'b']})
 
         msg = "expr must be a string to be evaluated"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.query(lambda x: x.B == "b")
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.query(111)
 
     def test_query_empty_string(self):
@@ -152,7 +152,7 @@ class TestDataFrameEval(TestData):
         df = pd.DataFrame({'A': [1, 2, 3]})
 
         msg = "expr cannot be an empty string"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.query('')
 
     def test_eval_resolvers_as_list(self):
@@ -524,8 +524,8 @@ class TestDataFrameQueryNumExprPandas(object):
         df = DataFrame(np.random.randint(m, size=(n, 3)), columns=list('abc'))
 
         df.index.name = 'sin'
-        with tm.assert_raises_regex(NumExprClobberingError,
-                                    'Variables in expression.+'):
+        msg = 'Variables in expression.+'
+        with pytest.raises(NumExprClobberingError, match=msg):
             df.query('sin > 5', engine=engine, parser=parser)
 
     def test_query(self):
@@ -657,9 +657,11 @@ class TestDataFrameQueryNumExprPandas(object):
         from pandas.core.computation.ops import UndefinedVariableError
         engine, parser = self.engine, self.parser
         skip_if_no_pandas_parser(parser)
+
         df = DataFrame(np.random.rand(10, 2), columns=list('ab'))
-        with tm.assert_raises_regex(UndefinedVariableError,
-                                    "local variable 'c' is not defined"):
+        msg = "local variable 'c' is not defined"
+
+        with pytest.raises(UndefinedVariableError, match=msg):
             df.query('a == @c', engine=engine, parser=parser)
 
     def test_index_resolvers_come_after_columns_with_the_same_name(self):
@@ -1037,7 +1039,7 @@ class TestDataFrameEvalWithFrame(object):
     @pytest.mark.parametrize('op', ['+', '-', '*', '/'])
     def test_invalid_type_for_operator_raises(self, parser, engine, op):
         df = DataFrame({'a': [1, 2], 'b': ['c', 'd']})
-        with tm.assert_raises_regex(TypeError,
-                                    r"unsupported operand type\(s\) "
-                                    "for .+: '.+' and '.+'"):
+        msg = r"unsupported operand type\(s\) for .+: '.+' and '.+'"
+
+        with pytest.raises(TypeError, match=msg):
             df.eval('a {0} b'.format(op), engine=engine, parser=parser)

--- a/pandas/tests/frame/test_rank.py
+++ b/pandas/tests/frame/test_rank.py
@@ -194,11 +194,11 @@ class TestRank(TestData):
         # bad values throw error
         msg = "na_option must be one of 'keep', 'top', or 'bottom'"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.frame.rank(na_option='bad', ascending=False)
 
         # invalid type
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.frame.rank(na_option=True, ascending=False)
 
     def test_rank_axis(self):

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -17,9 +17,6 @@ import numpy as np
 
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal)
-
-import pandas.util.testing as tm
-
 from pandas.tests.frame.common import TestData
 
 
@@ -612,9 +609,9 @@ class TestDataFrameReplace(TestData):
         assert_frame_equal(result, expected)
 
         # GH 19266
-        with tm.assert_raises_regex(ValueError, "cannot assign mismatch"):
+        with pytest.raises(ValueError, match="cannot assign mismatch"):
             df.replace({np.nan: []})
-        with tm.assert_raises_regex(ValueError, "cannot assign mismatch"):
+        with pytest.raises(ValueError, match="cannot assign mismatch"):
             df.replace({np.nan: ['dummy', 'alt']})
 
     def test_replace_series_dict(self):
@@ -923,7 +920,7 @@ class TestDataFrameReplace(TestData):
 
     def test_replace_with_dict_with_bool_keys(self):
         df = DataFrame({0: [True, False], 1: [False, True]})
-        with tm.assert_raises_regex(TypeError, 'Cannot compare types .+'):
+        with pytest.raises(TypeError, match='Cannot compare types .+'):
             df.replace({'asdf': 'asdb', True: 'yes'})
 
     def test_replace_truthy(self):
@@ -934,8 +931,7 @@ class TestDataFrameReplace(TestData):
 
     def test_replace_int_to_int_chain(self):
         df = DataFrame({'a': lrange(1, 5)})
-        with tm.assert_raises_regex(ValueError,
-                                    "Replacement not allowed .+"):
+        with pytest.raises(ValueError, match="Replacement not allowed .+"):
             df.replace({'a': dict(zip(range(1, 5), range(2, 6)))})
 
     def test_replace_str_to_str_chain(self):
@@ -943,8 +939,7 @@ class TestDataFrameReplace(TestData):
         astr = a.astype(str)
         bstr = np.arange(2, 6).astype(str)
         df = DataFrame({'a': astr})
-        with tm.assert_raises_regex(ValueError,
-                                    "Replacement not allowed .+"):
+        with pytest.raises(ValueError, match="Replacement not allowed .+"):
             df.replace({'a': dict(zip(astr, bstr))})
 
     def test_replace_swapping_bug(self):

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -66,7 +66,7 @@ class TestDataFrameReshape(TestData):
         data = DataFrame({'a': ['bar', 'bar', 'foo', 'foo', 'foo'],
                           'b': ['one', 'two', 'one', 'one', 'two'],
                           'c': [1., 2., 3., 3., 4.]})
-        with tm.assert_raises_regex(ValueError, 'duplicate entries'):
+        with pytest.raises(ValueError, match='duplicate entries'):
             data.pivot('a', 'b', 'c')
 
     def test_pivot_empty(self):
@@ -317,7 +317,7 @@ class TestDataFrameReshape(TestData):
 
         # Fill with non-category results in a TypeError
         msg = r"'fill_value' \('d'\) is not in"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             data.unstack(fill_value='d')
 
         # Fill with category value replaces missing values as expected

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -79,7 +79,7 @@ class TestDataFrameSorting(TestData):
         assert_frame_equal(sorted_df, expected)
 
         msg = r'Length of ascending \(5\) != length of by \(2\)'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             frame.sort_values(by=['A', 'B'], axis=0, ascending=[True] * 5)
 
     def test_sort_values_inplace(self):
@@ -269,7 +269,7 @@ class TestDataFrameSorting(TestData):
 
     def test_frame_column_inplace_sort_exception(self):
         s = self.frame['A']
-        with tm.assert_raises_regex(ValueError, "This Series is a view"):
+        with pytest.raises(ValueError, match="This Series is a view"):
             s.sort_values(inplace=True)
 
         cp = s.copy()
@@ -447,26 +447,26 @@ class TestDataFrameSortIndexKinds(TestData):
         df = DataFrame([lrange(5, 9), lrange(4)],
                        columns=['a', 'a', 'b', 'b'])
 
-        with tm.assert_raises_regex(ValueError, 'not unique'):
+        with pytest.raises(ValueError, match='not unique'):
             # use .sort_values #9816
             with tm.assert_produces_warning(FutureWarning):
                 df.sort_index(by='a')
-        with tm.assert_raises_regex(ValueError, 'not unique'):
+        with pytest.raises(ValueError, match='not unique'):
             df.sort_values(by='a')
 
-        with tm.assert_raises_regex(ValueError, 'not unique'):
+        with pytest.raises(ValueError, match='not unique'):
             # use .sort_values #9816
             with tm.assert_produces_warning(FutureWarning):
                 df.sort_index(by=['a'])
-        with tm.assert_raises_regex(ValueError, 'not unique'):
+        with pytest.raises(ValueError, match='not unique'):
             df.sort_values(by=['a'])
 
-        with tm.assert_raises_regex(ValueError, 'not unique'):
+        with pytest.raises(ValueError, match='not unique'):
             # use .sort_values #9816
             with tm.assert_produces_warning(FutureWarning):
                 # multi-column 'by' is separate codepath
                 df.sort_index(by=['a', 'b'])
-        with tm.assert_raises_regex(ValueError, 'not unique'):
+        with pytest.raises(ValueError, match='not unique'):
             # multi-column 'by' is separate codepath
             df.sort_values(by=['a', 'b'])
 
@@ -474,11 +474,11 @@ class TestDataFrameSortIndexKinds(TestData):
         # GH4370
         df = DataFrame(np.random.randn(4, 2),
                        columns=MultiIndex.from_tuples([('a', 0), ('a', 1)]))
-        with tm.assert_raises_regex(ValueError, 'level'):
+        with pytest.raises(ValueError, match='level'):
             # use .sort_values #9816
             with tm.assert_produces_warning(FutureWarning):
                 df.sort_index(by='a')
-        with tm.assert_raises_regex(ValueError, 'level'):
+        with pytest.raises(ValueError, match='level'):
             df.sort_values(by='a')
 
         # convert tuples to a list of tuples

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -156,7 +156,7 @@ class TestDataFrameSubclassing(TestData):
             @property
             def bar(self):
                 return self.i_dont_exist
-        with tm.assert_raises_regex(AttributeError, '.*i_dont_exist.*'):
+        with pytest.raises(AttributeError, match='.*i_dont_exist.*'):
             A().bar
 
     def test_subclass_align(self):

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -18,8 +18,7 @@ import pandas.tseries.offsets as offsets
 
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal,
-                                 assert_index_equal,
-                                 assert_raises_regex)
+                                 assert_index_equal)
 
 import pandas.util.testing as tm
 from pandas.compat import product
@@ -276,9 +275,9 @@ class TestDataFrameTimeSeriesMethods(TestData):
         assert_frame_equal(shifted2, shifted3)
         assert_frame_equal(ps, shifted2.shift(-1, 'B'))
 
-        tm.assert_raises_regex(ValueError,
-                               'does not match PeriodIndex freq',
-                               ps.shift, freq='D')
+        msg = 'does not match PeriodIndex freq'
+        with pytest.raises(ValueError, match=msg):
+            ps.shift(freq='D')
 
         # shift other axis
         # GH 6371
@@ -360,8 +359,8 @@ class TestDataFrameTimeSeriesMethods(TestData):
         shifted3 = ps.tshift(freq=offsets.BDay())
         assert_frame_equal(shifted, shifted3)
 
-        tm.assert_raises_regex(
-            ValueError, 'does not match', ps.tshift, freq='M')
+        with pytest.raises(ValueError, match='does not match'):
+            ps.tshift(freq='M')
 
         # DatetimeIndex
         shifted = self.tsframe.tshift(1)
@@ -437,16 +436,16 @@ class TestDataFrameTimeSeriesMethods(TestData):
 
         df = pd.DataFrame({'A': ['a', 'b', 'c', 'd', 'e']},
                           index=[5, 3, 2, 9, 0])
-        with tm.assert_raises_regex(ValueError,
-                                    'truncate requires a sorted index'):
+        msg = 'truncate requires a sorted index'
+        with pytest.raises(ValueError, match=msg):
             df.truncate(before=3, after=9)
 
         rng = pd.date_range('2011-01-01', '2012-01-01', freq='W')
         ts = pd.DataFrame({'A': np.random.randn(len(rng)),
                            'B': np.random.randn(len(rng))},
                           index=rng)
-        with tm.assert_raises_regex(ValueError,
-                                    'truncate requires a sorted index'):
+        msg = 'truncate requires a sorted index'
+        with pytest.raises(ValueError, match=msg):
             ts.sort_values('A', ascending=False).truncate(before='2011-11',
                                                           after='2011-12')
 
@@ -455,8 +454,8 @@ class TestDataFrameTimeSeriesMethods(TestData):
                            2: np.random.randn(5),
                            0: np.random.randn(5)},
                           columns=[3, 20, 2, 0])
-        with tm.assert_raises_regex(ValueError,
-                                    'truncate requires a sorted index'):
+        msg = 'truncate requires a sorted index'
+        with pytest.raises(ValueError, match=msg):
             df.truncate(before=2, after=20, axis=1)
 
     def test_asfreq(self):
@@ -822,17 +821,17 @@ class TestDataFrameTimeSeriesMethods(TestData):
         # Bad Inputs
 
         # Not DatetimeIndex / PeriodIndex
-        with assert_raises_regex(TypeError, 'DatetimeIndex'):
+        with pytest.raises(TypeError, match='DatetimeIndex'):
             df = DataFrame(index=int_idx)
             df = getattr(df, fn)('US/Pacific')
 
         # Not DatetimeIndex / PeriodIndex
-        with assert_raises_regex(TypeError, 'DatetimeIndex'):
+        with pytest.raises(TypeError, match='DatetimeIndex'):
             df = DataFrame(np.ones(5),
                            MultiIndex.from_arrays([int_idx, l0]))
             df = getattr(df, fn)('US/Pacific', level=0)
 
         # Invalid level
-        with assert_raises_regex(ValueError, 'not valid'):
+        with pytest.raises(ValueError, match='not valid'):
             df = DataFrame(index=l0)
             df = getattr(df, fn)('US/Pacific', level=1)

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -621,12 +621,12 @@ class TestDataFrameToCSV(TestData):
 
             for i in [6, 7]:
                 msg = 'len of {i}, but only 5 lines in file'.format(i=i)
-                with tm.assert_raises_regex(ParserError, msg):
+                with pytest.raises(ParserError, match=msg):
                     read_csv(path, header=lrange(i), index_col=0)
 
             # write with cols
-            with tm.assert_raises_regex(TypeError, 'cannot specify cols '
-                                        'with a MultiIndex'):
+            msg = 'cannot specify cols with a MultiIndex'
+            with pytest.raises(TypeError, match=msg):
                 df.to_csv(path, columns=['foo', 'bar'])
 
         with ensure_clean('__tmp_to_csv_multiindex__') as path:
@@ -1124,11 +1124,11 @@ class TestDataFrameToCSV(TestData):
         assert result == expected
 
         msg = "need to escape, but no escapechar set"
-        tm.assert_raises_regex(csv.Error, msg, df.to_csv,
-                               quoting=csv.QUOTE_NONE)
-        tm.assert_raises_regex(csv.Error, msg, df.to_csv,
-                               quoting=csv.QUOTE_NONE,
-                               escapechar=None)
+        with pytest.raises(csv.Error, match=msg):
+            df.to_csv(quoting=csv.QUOTE_NONE)
+
+        with pytest.raises(csv.Error, match=msg):
+            df.to_csv(quoting=csv.QUOTE_NONE, escapechar=None)
 
         expected_rows = [',c_bool,c_float,c_int,c_string',
                          '0,True,1.0,42.0,a',

--- a/pandas/tests/frame/test_validate.py
+++ b/pandas/tests/frame/test_validate.py
@@ -1,7 +1,6 @@
 from pandas.core.frame import DataFrame
 
 import pytest
-import pandas.util.testing as tm
 
 
 @pytest.fixture
@@ -29,5 +28,5 @@ class TestDataFrameValidate(object):
         elif func == "sort_values":
             kwargs["by"] = ["a"]
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             getattr(dataframe, func)(**kwargs)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -15,8 +15,7 @@ from pandas import (Series, DataFrame, Panel,
 import pandas.io.formats.printing as printing
 
 from pandas.compat import range, zip, PY3
-from pandas.util.testing import (assert_raises_regex,
-                                 assert_series_equal,
+from pandas.util.testing import (assert_series_equal,
                                  assert_panel_equal,
                                  assert_frame_equal)
 
@@ -476,16 +475,16 @@ class Generic(object):
         ts = df['joe'].copy()
         ts[2] = np.nan
 
-        with assert_raises_regex(TypeError, 'unexpected keyword'):
+        with pytest.raises(TypeError, match='unexpected keyword'):
             df.drop('joe', axis=1, in_place=True)
 
-        with assert_raises_regex(TypeError, 'unexpected keyword'):
+        with pytest.raises(TypeError, match='unexpected keyword'):
             df.reindex([1, 0], inplace=True)
 
-        with assert_raises_regex(TypeError, 'unexpected keyword'):
+        with pytest.raises(TypeError, match='unexpected keyword'):
             ca.fillna(0, inplace=True)
 
-        with assert_raises_regex(TypeError, 'unexpected keyword'):
+        with pytest.raises(TypeError, match='unexpected keyword'):
             ts.fillna(0, in_place=True)
 
     # See gh-12301
@@ -494,13 +493,13 @@ class Generic(object):
         starwars = 'Star Wars'
         errmsg = 'unexpected keyword'
 
-        with assert_raises_regex(TypeError, errmsg):
+        with pytest.raises(TypeError, match=errmsg):
             obj.max(epic=starwars)  # stat_function
-        with assert_raises_regex(TypeError, errmsg):
+        with pytest.raises(TypeError, match=errmsg):
             obj.var(epic=starwars)  # stat_function_ddof
-        with assert_raises_regex(TypeError, errmsg):
+        with pytest.raises(TypeError, match=errmsg):
             obj.sum(epic=starwars)  # cum_function
-        with assert_raises_regex(TypeError, errmsg):
+        with pytest.raises(TypeError, match=errmsg):
             obj.any(epic=starwars)  # logical_function
 
     def test_api_compat(self):
@@ -520,13 +519,13 @@ class Generic(object):
         out = np.array([0])
         errmsg = "the 'out' parameter is not supported"
 
-        with assert_raises_regex(ValueError, errmsg):
+        with pytest.raises(ValueError, match=errmsg):
             obj.max(out=out)  # stat_function
-        with assert_raises_regex(ValueError, errmsg):
+        with pytest.raises(ValueError, match=errmsg):
             obj.var(out=out)  # stat_function_ddof
-        with assert_raises_regex(ValueError, errmsg):
+        with pytest.raises(ValueError, match=errmsg):
             obj.sum(out=out)  # cum_function
-        with assert_raises_regex(ValueError, errmsg):
+        with pytest.raises(ValueError, match=errmsg):
             obj.any(out=out)  # logical_function
 
     def test_truncate_out_of_bounds(self):
@@ -807,23 +806,23 @@ class TestNDFrame(object):
             for p in [tm.makePanel()]:
                 tm.assert_panel_equal(p.transpose(2, 0, 1)
                                       .transpose(1, 2, 0), p)
-                tm.assert_raises_regex(TypeError, msg, p.transpose,
-                                       2, 0, 1, axes=(2, 0, 1))
+                with pytest.raises(TypeError, match=msg):
+                    p.transpose(2, 0, 1, axes=(2, 0, 1))
 
     def test_numpy_transpose(self):
         msg = "the 'axes' parameter is not supported"
 
         s = tm.makeFloatSeries()
-        tm.assert_series_equal(
-            np.transpose(s), s)
-        tm.assert_raises_regex(ValueError, msg,
-                               np.transpose, s, axes=1)
+        tm.assert_series_equal(np.transpose(s), s)
+
+        with pytest.raises(ValueError, match=msg):
+            np.transpose(s, axes=1)
 
         df = tm.makeTimeDataFrame()
-        tm.assert_frame_equal(np.transpose(
-            np.transpose(df)), df)
-        tm.assert_raises_regex(ValueError, msg,
-                               np.transpose, df, axes=1)
+        tm.assert_frame_equal(np.transpose(np.transpose(df)), df)
+
+        with pytest.raises(ValueError, match=msg):
+            np.transpose(df, axes=1)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
@@ -869,16 +868,16 @@ class TestNDFrame(object):
 
         for obj in (s, df, p):
             msg = r"take\(\) got an unexpected keyword argument 'foo'"
-            tm.assert_raises_regex(TypeError, msg, obj.take,
-                                   indices, foo=2)
+            with pytest.raises(TypeError, match=msg):
+                obj.take(indices, foo=2)
 
             msg = "the 'out' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, obj.take,
-                                   indices, out=indices)
+            with pytest.raises(ValueError, match=msg):
+                obj.take(indices, out=indices)
 
             msg = "the 'mode' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, obj.take,
-                                   indices, mode='clip')
+            with pytest.raises(ValueError, match=msg):
+                obj.take(indices, mode='clip')
 
     def test_equals(self):
         s1 = pd.Series([1, 2, 3], index=[0, 2, 1])
@@ -1018,7 +1017,7 @@ class TestNDFrame(object):
             assert_panel_equal(result, expected)
 
             with pytest.raises(ValueError):
-                result = wp.pipe((f, 'y'), x=1, y=1)
+                wp.pipe((f, 'y'), x=1, y=1)
 
     @pytest.mark.parametrize('box', [pd.Series, pd.DataFrame])
     def test_axis_classmethods(self, box):

--- a/pandas/tests/generic/test_label_or_level_utils.py
+++ b/pandas/tests/generic/test_label_or_level_utils.py
@@ -128,7 +128,7 @@ def test_is_level_reference_series_axis1_error(df):
     # Make series with L1 as index
     s = df.set_index('L1').L2
 
-    with tm.assert_raises_regex(ValueError, "No axis named 1"):
+    with pytest.raises(ValueError, match="No axis named 1"):
         s._is_level_reference('L1', axis=1)
 
 
@@ -138,7 +138,7 @@ def test_is_level_reference_panel_error(panel):
     msg = ("_is_level_reference is not implemented for {type}"
            .format(type=type(panel)))
 
-    with tm.assert_raises_regex(NotImplementedError, msg):
+    with pytest.raises(NotImplementedError, match=msg):
         panel._is_level_reference('L1', axis=0)
 
 
@@ -146,7 +146,7 @@ def test_is_label_reference_panel_error(panel):
     msg = ("_is_label_reference is not implemented for {type}"
            .format(type=type(panel)))
 
-    with tm.assert_raises_regex(NotImplementedError, msg):
+    with pytest.raises(NotImplementedError, match=msg):
         panel._is_label_reference('L1', axis=0)
 
 
@@ -154,7 +154,7 @@ def test_is_label_or_level_reference_panel_error(panel):
     msg = ("_is_label_or_level_reference is not implemented for {type}"
            .format(type=type(panel)))
 
-    with tm.assert_raises_regex(NotImplementedError, msg):
+    with pytest.raises(NotImplementedError, match=msg):
         panel._is_label_or_level_reference('L1', axis=0)
 
 
@@ -176,7 +176,7 @@ def test_check_label_or_level_ambiguity_df(df_ambig, axis):
 
     # df_ambig has both an on-axis level and off-axis label named L1
     # Therefore, L1 is ambiguous.
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         df_ambig._check_label_or_level_ambiguity("L1", axis=axis)
 
     # df_ambig has an on-axis level named L2,, and it is not ambiguous.
@@ -209,7 +209,7 @@ def test_check_label_or_level_ambiguity_series_axis1_error(df):
     # Make series with L1 as index
     s = df.set_index('L1').L2
 
-    with tm.assert_raises_regex(ValueError, "No axis named 1"):
+    with pytest.raises(ValueError, match="No axis named 1"):
         s._check_label_or_level_ambiguity('L1', axis=1)
 
 
@@ -219,7 +219,7 @@ def test_check_label_or_level_ambiguity_panel_error(panel):
     msg = ("_check_label_or_level_ambiguity is not implemented for {type}"
            .format(type=type(panel)))
 
-    with tm.assert_raises_regex(NotImplementedError, msg):
+    with pytest.raises(NotImplementedError, match=msg):
         panel._check_label_or_level_ambiguity("L1", axis=0)
 
 
@@ -294,7 +294,7 @@ def test_get_label_or_level_values_df_duplabels(df_duplabels, axis):
     else:
         expected_msg = "The index label 'L2' is not unique"
 
-    with tm.assert_raises_regex(ValueError, expected_msg):
+    with pytest.raises(ValueError, match=expected_msg):
         assert_label_values(df_duplabels, ['L2'], axis=axis)
 
 
@@ -316,7 +316,7 @@ def test_get_label_or_level_values_series_axis1_error(df):
     # Make series with L1 as index
     s = df.set_index('L1').L2
 
-    with tm.assert_raises_regex(ValueError, "No axis named 1"):
+    with pytest.raises(ValueError, match="No axis named 1"):
         s._get_label_or_level_values('L1', axis=1)
 
 
@@ -326,7 +326,7 @@ def test_get_label_or_level_values_panel_error(panel):
     msg = ("_get_label_or_level_values is not implemented for {type}"
            .format(type=type(panel)))
 
-    with tm.assert_raises_regex(NotImplementedError, msg):
+    with pytest.raises(NotImplementedError, match=msg):
         panel._get_label_or_level_values('L1', axis=0)
 
 
@@ -371,7 +371,7 @@ def test_drop_labels_or_levels_df(df_levels, axis):
     assert_labels_dropped(df_levels, expected_labels, axis=axis)
     assert_levels_dropped(df_levels, expected_levels, axis=axis)
 
-    with tm.assert_raises_regex(ValueError, "not valid labels or levels"):
+    with pytest.raises(ValueError, match="not valid labels or levels"):
         df_levels._drop_labels_or_levels('L4', axis=axis)
 
 
@@ -383,14 +383,14 @@ def test_drop_labels_or_levels_series(df):
     s = df.set_index('L1').L2
     assert_levels_dropped(s, ['L1'], axis=0)
 
-    with tm.assert_raises_regex(ValueError, "not valid labels or levels"):
+    with pytest.raises(ValueError, match="not valid labels or levels"):
         s._drop_labels_or_levels('L4', axis=0)
 
     # Make series with L1 and L2 as index
     s = df.set_index(['L1', 'L2']).L3
     assert_levels_dropped(s, ['L1', 'L2'], axis=0)
 
-    with tm.assert_raises_regex(ValueError, "not valid labels or levels"):
+    with pytest.raises(ValueError, match="not valid labels or levels"):
         s._drop_labels_or_levels('L4', axis=0)
 
 
@@ -400,5 +400,5 @@ def test_drop_labels_or_levels_panel_error(panel):
     msg = ("_drop_labels_or_levels is not implemented for {type}"
            .format(type=type(panel)))
 
-    with tm.assert_raises_regex(NotImplementedError, msg):
+    with pytest.raises(NotImplementedError, match=msg):
         panel._drop_labels_or_levels('L1', axis=0)

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -27,9 +27,9 @@ def test_agg_must_agg(df):
     grouped = df.groupby('A')['C']
 
     msg = "Must produce aggregated value"
-    with tm.assert_raises_regex(Exception, msg):
+    with pytest.raises(Exception, match=msg):
         grouped.agg(lambda x: x.describe())
-    with tm.assert_raises_regex(Exception, msg):
+    with pytest.raises(Exception, match=msg):
         grouped.agg(lambda x: x.index[:2])
 
 
@@ -217,7 +217,7 @@ def test_agg_multiple_functions_too_many_lambdas(df):
     funcs = ['mean', lambda x: x.mean(), lambda x: x.std()]
 
     msg = 'Function names must be unique, found multiple named <lambda>'
-    with tm.assert_raises_regex(SpecificationError, msg):
+    with pytest.raises(SpecificationError, match=msg):
         grouped.agg(funcs)
 
 

--- a/pandas/tests/groupby/aggregate/test_cython.py
+++ b/pandas/tests/groupby/aggregate/test_cython.py
@@ -82,12 +82,12 @@ def test_cython_agg_nothing_to_agg():
                        'b': ['foo', 'bar'] * 25})
     msg = "No numeric types to aggregate"
 
-    with tm.assert_raises_regex(DataError, msg):
+    with pytest.raises(DataError, match=msg):
         frame.groupby('a')['b'].mean()
 
     frame = DataFrame({'a': np.random.randint(0, 5, 50),
                        'b': ['foo', 'bar'] * 25})
-    with tm.assert_raises_regex(DataError, msg):
+    with pytest.raises(DataError, match=msg):
         frame[['b']].groupby(frame['a']).mean()
 
 
@@ -96,7 +96,7 @@ def test_cython_agg_nothing_to_agg_with_dates():
                        'b': ['foo', 'bar'] * 25,
                        'dates': pd.date_range('now', periods=50, freq='T')})
     msg = "No numeric types to aggregate"
-    with tm.assert_raises_regex(DataError, msg):
+    with pytest.raises(DataError, match=msg):
         frame.groupby('b').dates.mean()
 
 

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -268,7 +268,7 @@ def test_agg_nested_dicts():
     g = df.groupby(['A', 'B'])
 
     msg = r'cannot perform renaming for r[1-2] with a nested dictionary'
-    with tm.assert_raises_regex(SpecificationError, msg):
+    with pytest.raises(SpecificationError, match=msg):
         g.aggregate({'r1': {'C': ['mean', 'sum']},
                      'r2': {'D': ['mean', 'sum']}})
 
@@ -302,7 +302,7 @@ def test_agg_item_by_item_raise_typeerror():
         pprint_thing(df.to_string())
         raise TypeError('test')
 
-    with tm.assert_raises_regex(TypeError, 'test'):
+    with pytest.raises(TypeError, match='test'):
         df.groupby(0).agg(raiseException)
 
 

--- a/pandas/tests/groupby/test_filters.py
+++ b/pandas/tests/groupby/test_filters.py
@@ -542,8 +542,7 @@ def test_filter_enforces_scalarness():
         ['worst', 'd', 'y'],
         ['best', 'd', 'z'],
     ], columns=['a', 'b', 'c'])
-    with tm.assert_raises_regex(TypeError,
-                                'filter function returned a.*'):
+    with pytest.raises(TypeError, match='filter function returned a.*'):
         df.groupby('c').filter(lambda g: g['a'] == 'best')
 
 
@@ -557,8 +556,7 @@ def test_filter_non_bool_raises():
         ['worst', 'd', 1],
         ['best', 'd', 1],
     ], columns=['a', 'b', 'c'])
-    with tm.assert_raises_regex(TypeError,
-                                'filter function returned a.*'):
+    with pytest.raises(TypeError, match='filter function returned a.*'):
         df.groupby('a').filter(lambda g: g.c.mean())
 
 

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -517,18 +517,20 @@ def test_nsmallest():
     tm.assert_series_equal(gb.nsmallest(3, keep='last'), e)
 
 
-def test_numpy_compat():
+@pytest.mark.parametrize("func", [
+    'mean', 'var', 'std', 'cumprod', 'cumsum'
+])
+def test_numpy_compat(func):
     # see gh-12811
     df = pd.DataFrame({'A': [1, 2, 1], 'B': [1, 2, 3]})
     g = df.groupby('A')
 
     msg = "numpy operations are not valid with groupby"
 
-    for func in ('mean', 'var', 'std', 'cumprod', 'cumsum'):
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(g, func), 1, 2, 3)
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(g, func), foo=1)
+    with pytest.raises(UnsupportedFunctionCall, match=msg):
+        getattr(g, func)(1, 2, 3)
+    with pytest.raises(UnsupportedFunctionCall, match=msg):
+        getattr(g, func)(foo=1)
 
 
 def test_cummin_cummax():

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -629,7 +629,7 @@ def test_as_index_series_column_slice_raises(df):
     grouped = df.groupby('A', as_index=False)
     msg = r"Column\(s\) C already selected"
 
-    with tm.assert_raises_regex(IndexError, msg):
+    with pytest.raises(IndexError, match=msg):
         grouped['C'].__getitem__('D')
 
 
@@ -1679,7 +1679,7 @@ def test_tuple_correct_keyerror():
     df = pd.DataFrame(1, index=range(3),
                       columns=pd.MultiIndex.from_product([[1, 2],
                                                           [3, 4]]))
-    with tm.assert_raises_regex(KeyError, "(7, 8)"):
+    with pytest.raises(KeyError, match="(7, 8)"):
         df.groupby((7, 8)).mean()
 
 

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -21,7 +21,7 @@ import pandas as pd
 # selection
 # --------------------------------
 
-class TestSelection():
+class TestSelection(object):
 
     def test_select_bad_cols(self):
         df = DataFrame([[1, 2]], columns=['A', 'B'])
@@ -29,7 +29,7 @@ class TestSelection():
         pytest.raises(KeyError, g.__getitem__, ['C'])  # g[['C']]
 
         pytest.raises(KeyError, g.__getitem__, ['A', 'C'])  # g[['A', 'C']]
-        with tm.assert_raises_regex(KeyError, '^[^A]+$'):
+        with pytest.raises(KeyError, match='^[^A]+$'):
             # A should not be referenced as a bad column...
             # will have to rethink regex if you change message!
             g[['A', 'C']]
@@ -506,17 +506,13 @@ class TestGrouping():
         # PR8618 and issue 8015
         frame = mframe
 
-        def j():
+        msg = "You have to supply one of 'by' and 'level'"
+        with pytest.raises(TypeError, match=msg):
             frame.groupby()
 
-        tm.assert_raises_regex(TypeError, "You have to supply one of "
-                               "'by' and 'level'", j)
-
-        def k():
+        msg = "You have to supply one of 'by' and 'level'"
+        with pytest.raises(TypeError, match=msg):
             frame.groupby(by=None, level=None)
-
-        tm.assert_raises_regex(TypeError, "You have to supply one of "
-                               "'by' and 'level'", k)
 
     @pytest.mark.parametrize('sort,labels', [
         [True, [2, 2, 2, 0, 0, 1, 1, 3, 3, 3]],

--- a/pandas/tests/groupby/test_rank.py
+++ b/pandas/tests/groupby/test_rank.py
@@ -249,7 +249,7 @@ def test_rank_object_raises(ties_method, ascending, na_option,
                             pct, vals):
     df = DataFrame({'key': ['foo'] * 5, 'val': vals})
 
-    with tm.assert_raises_regex(TypeError, "not callable"):
+    with pytest.raises(TypeError, match="not callable"):
         df.groupby('key').rank(method=ties_method,
                                ascending=ascending,
                                na_option=na_option, pct=pct)
@@ -269,7 +269,7 @@ def test_rank_naoption_raises(ties_method, ascending, na_option, pct, vals):
     df = DataFrame({'key': ['foo'] * 5, 'val': vals})
     msg = "na_option must be one of 'keep', 'top', or 'bottom'"
 
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         df.groupby('key').rank(method=ties_method,
                                ascending=ascending,
                                na_option=na_option, pct=pct)

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -658,11 +658,11 @@ def test_transform_with_non_scalar_group():
     df = pd.DataFrame(np.random.randint(1, 10, (4, 12)),
                       columns=cols,
                       index=['A', 'C', 'G', 'T'])
-    tm.assert_raises_regex(ValueError, 'transform must return '
-                           'a scalar value for each '
-                           'group.*',
-                           df.groupby(axis=1, level=1).transform,
-                           lambda z: z.div(z.sum(axis=1), axis=0))
+
+    msg = 'transform must return a scalar value for each group.*'
+    with pytest.raises(ValueError, match=msg):
+        df.groupby(axis=1, level=1).transform(
+            lambda z: z.div(z.sum(axis=1), axis=0))
 
 
 @pytest.mark.parametrize('cols,exp,comp_func', [

--- a/pandas/tests/groupby/test_whitelist.py
+++ b/pandas/tests/groupby/test_whitelist.py
@@ -263,7 +263,7 @@ def test_groupby_blacklist(df_letters):
         for obj in (df, s):
             gb = obj.groupby(df.letters)
             msg = fmt.format(bl, type(gb).__name__)
-            with tm.assert_raises_regex(AttributeError, msg):
+            with pytest.raises(AttributeError, match=msg):
                 getattr(gb, bl)
 
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -125,38 +125,39 @@ class Base(object):
     def test_numeric_compat(self):
 
         idx = self.create_index()
-        tm.assert_raises_regex(TypeError, "cannot perform __mul__",
-                               lambda: idx * 1)
-        tm.assert_raises_regex(TypeError, "cannot perform __rmul__",
-                               lambda: 1 * idx)
+        with pytest.raises(TypeError, match="cannot perform __mul__"):
+            idx * 1
+        with pytest.raises(TypeError, match="cannot perform __rmul__"):
+            1 * idx
 
-        div_err = "cannot perform __truediv__" if PY3 \
-            else "cannot perform __div__"
-        tm.assert_raises_regex(TypeError, div_err, lambda: idx / 1)
+        div_err = ("cannot perform __truediv__" if PY3
+                   else "cannot perform __div__")
+        with pytest.raises(TypeError, match=div_err):
+            idx / 1
+
         div_err = div_err.replace(' __', ' __r')
-        tm.assert_raises_regex(TypeError, div_err, lambda: 1 / idx)
-        tm.assert_raises_regex(TypeError, "cannot perform __floordiv__",
-                               lambda: idx // 1)
-        tm.assert_raises_regex(TypeError, "cannot perform __rfloordiv__",
-                               lambda: 1 // idx)
+        with pytest.raises(TypeError, match=div_err):
+            1 / idx
+        with pytest.raises(TypeError, match="cannot perform __floordiv__"):
+            idx // 1
+        with pytest.raises(TypeError, match="cannot perform __rfloordiv__"):
+            1 // idx
 
     def test_logical_compat(self):
         idx = self.create_index()
-        tm.assert_raises_regex(TypeError, 'cannot perform all',
-                               lambda: idx.all())
-        tm.assert_raises_regex(TypeError, 'cannot perform any',
-                               lambda: idx.any())
+        with pytest.raises(TypeError, match='cannot perform all'):
+            idx.all()
+        with pytest.raises(TypeError, match='cannot perform any'):
+            idx.any()
 
     def test_boolean_context_compat(self):
 
         # boolean context compat
         idx = self.create_index()
 
-        def f():
+        with pytest.raises(ValueError, match='The truth value of a'):
             if idx:
                 pass
-
-        tm.assert_raises_regex(ValueError, 'The truth value of a', f)
 
     def test_reindex_base(self):
         idx = self.create_index()
@@ -165,7 +166,7 @@ class Base(object):
         actual = idx.get_indexer(idx)
         tm.assert_numpy_array_equal(expected, actual)
 
-        with tm.assert_raises_regex(ValueError, 'Invalid fill method'):
+        with pytest.raises(ValueError, match='Invalid fill method'):
             idx.get_indexer(idx, method='invalid')
 
     def test_get_indexer_consistency(self):
@@ -180,8 +181,8 @@ class Base(object):
                 assert indexer.dtype == np.intp
             else:
                 e = "Reindexing only valid with uniquely valued Index objects"
-                with tm.assert_raises_regex(InvalidIndexError, e):
-                    indexer = index.get_indexer(index[0:2])
+                with pytest.raises(InvalidIndexError, match=e):
+                    index.get_indexer(index[0:2])
 
             indexer, _ = index.get_indexer_non_unique(index[0:2])
             assert isinstance(indexer, np.ndarray)
@@ -227,9 +228,8 @@ class Base(object):
             assert '...' not in str(idx)
 
     def test_wrong_number_names(self, indices):
-        def testit(ind):
-            ind.names = ["apple", "banana", "carrot"]
-        tm.assert_raises_regex(ValueError, "^Length", testit, indices)
+        with pytest.raises(ValueError, match="^Length"):
+            indices.names = ["apple", "banana", "carrot"]
 
     def test_set_name_methods(self, indices):
         new_name = "This is the new name for this index"
@@ -247,10 +247,10 @@ class Base(object):
         assert res is None
         assert indices.name == new_name
         assert indices.names == [new_name]
-        # with tm.assert_raises_regex(TypeError, "list-like"):
+        # with pytest.raises(TypeError, match="list-like"):
         #    # should still fail even if it would be the right length
         #    ind.set_names("a")
-        with tm.assert_raises_regex(ValueError, "Level must be None"):
+        with pytest.raises(ValueError, match="Level must be None"):
             indices.set_names("a", level=0)
 
         # rename in place just leaves tuples and other containers alone
@@ -261,8 +261,9 @@ class Base(object):
 
     def test_hash_error(self, indices):
         index = indices
-        tm.assert_raises_regex(TypeError, "unhashable type: %r" %
-                               type(index).__name__, hash, indices)
+        with pytest.raises(TypeError, match=("unhashable type: %r" %
+                                             type(index).__name__)):
+            hash(indices)
 
     def test_copy_name(self):
         # gh-12309: Check that the "name" argument
@@ -511,16 +512,16 @@ class Base(object):
             # backwards compatibility concerns
             if isinstance(type(ind), (CategoricalIndex, RangeIndex)):
                 msg = "the 'axis' parameter is not supported"
-                tm.assert_raises_regex(ValueError, msg,
-                                       np.argsort, ind, axis=1)
+                with pytest.raises(ValueError, match=msg):
+                    np.argsort(ind, axis=1)
 
                 msg = "the 'kind' parameter is not supported"
-                tm.assert_raises_regex(ValueError, msg, np.argsort,
-                                       ind, kind='mergesort')
+                with pytest.raises(ValueError, match=msg):
+                    np.argsort(ind, kind='mergesort')
 
                 msg = "the 'order' parameter is not supported"
-                tm.assert_raises_regex(ValueError, msg, np.argsort,
-                                       ind, order=('a', 'b'))
+                with pytest.raises(ValueError, match=msg):
+                    np.argsort(ind, order=('a', 'b'))
 
     def test_pickle(self, indices):
         self.verify_pickle(indices)
@@ -551,16 +552,16 @@ class Base(object):
         indices = [1, 2]
 
         msg = r"take\(\) got an unexpected keyword argument 'foo'"
-        tm.assert_raises_regex(TypeError, msg, idx.take,
-                               indices, foo=2)
+        with pytest.raises(TypeError, match=msg):
+            idx.take(indices, foo=2)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, idx.take,
-                               indices, out=indices)
+        with pytest.raises(ValueError, match=msg):
+            idx.take(indices, out=indices)
 
         msg = "the 'mode' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, idx.take,
-                               indices, mode='clip')
+        with pytest.raises(ValueError, match=msg):
+            idx.take(indices, mode='clip')
 
     def test_repeat(self):
         rep = 2
@@ -580,8 +581,8 @@ class Base(object):
         tm.assert_index_equal(np.repeat(i, rep), expected)
 
         msg = "the 'axis' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.repeat,
-                               i, rep, axis=0)
+        with pytest.raises(ValueError, match=msg):
+            np.repeat(i, rep, axis=0)
 
     @pytest.mark.parametrize('klass', [list, tuple, np.array, Series])
     def test_where(self, klass):
@@ -597,19 +598,16 @@ class Base(object):
         result = i.where(klass(cond))
         tm.assert_index_equal(result, expected)
 
-    def test_setops_errorcases(self):
+    @pytest.mark.parametrize("case", [0.5, "xxx"])
+    @pytest.mark.parametrize("method", ["intersection", "union",
+                                        "difference", "symmetric_difference"])
+    def test_set_ops_error_cases(self, case, method):
         for name, idx in compat.iteritems(self.indices):
-            # # non-iterable input
-            cases = [0.5, 'xxx']
-            methods = [idx.intersection, idx.union, idx.difference,
-                       idx.symmetric_difference]
+            # non-iterable input
 
-            for method in methods:
-                for case in cases:
-                    tm.assert_raises_regex(TypeError,
-                                           "Input must be Index "
-                                           "or array-like",
-                                           method, case)
+            msg = "Input must be Index or array-like"
+            with pytest.raises(TypeError, match=msg):
+                getattr(idx, method)(case)
 
     def test_intersection_base(self):
         for name, idx in compat.iteritems(self.indices):
@@ -628,8 +626,8 @@ class Base(object):
             for case in cases:
                 if isinstance(idx, PeriodIndex):
                     msg = "can only call with other PeriodIndex-ed objects"
-                    with tm.assert_raises_regex(ValueError, msg):
-                        result = first.intersection(case)
+                    with pytest.raises(ValueError, match=msg):
+                        first.intersection(case)
                 elif isinstance(idx, CategoricalIndex):
                     pass
                 else:
@@ -638,8 +636,8 @@ class Base(object):
 
             if isinstance(idx, MultiIndex):
                 msg = "other must be a MultiIndex or a list of tuples"
-                with tm.assert_raises_regex(TypeError, msg):
-                    result = first.intersection([1, 2, 3])
+                with pytest.raises(TypeError, match=msg):
+                    first.intersection([1, 2, 3])
 
     def test_union_base(self):
         for name, idx in compat.iteritems(self.indices):
@@ -655,8 +653,8 @@ class Base(object):
             for case in cases:
                 if isinstance(idx, PeriodIndex):
                     msg = "can only call with other PeriodIndex-ed objects"
-                    with tm.assert_raises_regex(ValueError, msg):
-                        result = first.union(case)
+                    with pytest.raises(ValueError, match=msg):
+                        first.union(case)
                 elif isinstance(idx, CategoricalIndex):
                     pass
                 else:
@@ -665,8 +663,8 @@ class Base(object):
 
             if isinstance(idx, MultiIndex):
                 msg = "other must be a MultiIndex or a list of tuples"
-                with tm.assert_raises_regex(TypeError, msg):
-                    result = first.union([1, 2, 3])
+                with pytest.raises(TypeError, match=msg):
+                    first.union([1, 2, 3])
 
     def test_difference_base(self):
         for name, idx in compat.iteritems(self.indices):
@@ -686,8 +684,8 @@ class Base(object):
             for case in cases:
                 if isinstance(idx, PeriodIndex):
                     msg = "can only call with other PeriodIndex-ed objects"
-                    with tm.assert_raises_regex(ValueError, msg):
-                        result = first.difference(case)
+                    with pytest.raises(ValueError, match=msg):
+                        first.difference(case)
                 elif isinstance(idx, CategoricalIndex):
                     pass
                 elif isinstance(idx, (DatetimeIndex, TimedeltaIndex)):
@@ -700,8 +698,8 @@ class Base(object):
 
             if isinstance(idx, MultiIndex):
                 msg = "other must be a MultiIndex or a list of tuples"
-                with tm.assert_raises_regex(TypeError, msg):
-                    result = first.difference([1, 2, 3])
+                with pytest.raises(TypeError, match=msg):
+                    first.difference([1, 2, 3])
 
     def test_symmetric_difference(self):
         for name, idx in compat.iteritems(self.indices):
@@ -720,8 +718,8 @@ class Base(object):
             for case in cases:
                 if isinstance(idx, PeriodIndex):
                     msg = "can only call with other PeriodIndex-ed objects"
-                    with tm.assert_raises_regex(ValueError, msg):
-                        result = first.symmetric_difference(case)
+                    with pytest.raises(ValueError, match=msg):
+                        first.symmetric_difference(case)
                 elif isinstance(idx, CategoricalIndex):
                     pass
                 else:
@@ -730,7 +728,7 @@ class Base(object):
 
             if isinstance(idx, MultiIndex):
                 msg = "other must be a MultiIndex or a list of tuples"
-                with tm.assert_raises_regex(TypeError, msg):
+                with pytest.raises(TypeError, match=msg):
                     first.symmetric_difference([1, 2, 3])
 
     def test_insert_base(self):
@@ -767,7 +765,7 @@ class Base(object):
 
             with pytest.raises((IndexError, ValueError)):
                 # either depending on numpy version
-                result = idx.delete(len(idx))
+                idx.delete(len(idx))
 
     def test_equals(self):
 
@@ -799,7 +797,7 @@ class Base(object):
         index_b = index_a[0:-1]
         index_c = index_a[0:-1].append(index_a[-2:-1])
         index_d = index_a[0:1]
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             index_a == index_b
         expected1 = np.array([True] * n)
         expected2 = np.array([True] * (n - 1) + [False])
@@ -811,7 +809,7 @@ class Base(object):
         array_b = np.array(index_a[0:-1])
         array_c = np.array(index_a[0:-1].append(index_a[-2:-1]))
         array_d = np.array(index_a[0:1])
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             index_a == array_b
         tm.assert_numpy_array_equal(index_a == array_a, expected1)
         tm.assert_numpy_array_equal(index_a == array_c, expected2)
@@ -821,23 +819,23 @@ class Base(object):
         series_b = Series(array_b)
         series_c = Series(array_c)
         series_d = Series(array_d)
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             index_a == series_b
 
         tm.assert_numpy_array_equal(index_a == series_a, expected1)
         tm.assert_numpy_array_equal(index_a == series_c, expected2)
 
         # cases where length is 1 for one of them
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             index_a == index_d
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             index_a == series_d
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             index_a == array_d
         msg = "Can only compare identically-labeled Series objects"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             series_a == series_d
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             series_a == array_d
 
         # comparing with a scalar should broadcast; note that we are excluding
@@ -947,7 +945,7 @@ class Base(object):
             elif isinstance(index, MultiIndex):
                 idx = index.copy()
                 msg = "isna is not defined for MultiIndex"
-                with tm.assert_raises_regex(NotImplementedError, msg):
+                with pytest.raises(NotImplementedError, match=msg):
                     idx.fillna(idx[0])
             else:
                 idx = index.copy()
@@ -956,7 +954,7 @@ class Base(object):
                 assert result is not idx
 
                 msg = "'value' must be a scalar, passed: "
-                with tm.assert_raises_regex(TypeError, msg):
+                with pytest.raises(TypeError, match=msg):
                     idx.fillna([idx[0]])
 
                 idx = index.copy()
@@ -990,7 +988,7 @@ class Base(object):
             elif isinstance(index, MultiIndex):
                 idx = index.copy()
                 msg = "isna is not defined for MultiIndex"
-                with tm.assert_raises_regex(NotImplementedError, msg):
+                with pytest.raises(NotImplementedError, match=msg):
                     idx.isna()
             else:
 

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -169,7 +169,7 @@ class TestDatetimeIndex(object):
         # GH 13149, GH 13209
         idx = DatetimeIndex(['2016-05-16', 'NaT', NaT, np.NaN])
         msg = 'Cannot cast DatetimeIndex to dtype'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             idx.astype(dtype)
 
     def test_index_convert_to_datetime_array(self):

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -253,8 +253,7 @@ class TestDatetimeIndex(object):
                            Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                           name='idx')
 
-        with tm.assert_raises_regex(TypeError,
-                                    'data is already tz-aware'):
+        with pytest.raises(TypeError, match='data is already tz-aware'):
             DatetimeIndex([Timestamp('2011-01-01 10:00'),
                            Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                           tz='Asia/Tokyo', name='idx')
@@ -264,8 +263,7 @@ class TestDatetimeIndex(object):
                            Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                           tz='US/Eastern', name='idx')
 
-        with tm.assert_raises_regex(TypeError,
-                                    'data is already tz-aware'):
+        with pytest.raises(TypeError, match='data is already tz-aware'):
             # passing tz should results in DatetimeIndex, then mismatch raises
             # TypeError
             Index([pd.NaT, Timestamp('2011-01-01 10:00'),
@@ -314,7 +312,7 @@ class TestDatetimeIndex(object):
         tm.assert_index_equal(rng, exp)
 
         msg = 'periods must be a number, got foo'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             DatetimeIndex(start='1/1/2000', periods='foo', freq='D')
 
         pytest.raises(ValueError, DatetimeIndex, start='1/1/2000',

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -167,7 +167,7 @@ class TestDateRanges(TestData):
 
         msg = ('Of the four parameters: start, end, periods, and '
                'freq, exactly three must be specified')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range(start, end, periods=10, freq='s')
 
     def test_date_range_convenience_periods(self):
@@ -245,25 +245,25 @@ class TestDateRanges(TestData):
         msg = ('Of the four parameters: start, end, periods, and '
                'freq, exactly three must be specified')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range(start='1/1/2000')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range(end='1/1/2000')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range(periods=10)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range(start='1/1/2000', freq='H')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range(end='1/1/2000', freq='H')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range(periods=10, freq='H')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range()
 
     @pytest.mark.parametrize('f', [compat.long, int])
@@ -311,7 +311,7 @@ class TestDateRanges(TestData):
 
     def test_error_with_zero_monthends(self):
         msg = r'Offset <0 \* MonthEnds> did not increment date'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range('1/1/2000', '1/1/2001', freq=MonthEnd(0))
 
     def test_range_bug(self):
@@ -515,7 +515,7 @@ class TestDateRanges(TestData):
     def test_timezone_comparaison_assert(self):
         start = Timestamp('20130220 10:00', tz='US/Eastern')
         msg = 'Inferred time zone not equal to passed time zone'
-        with tm.assert_raises_regex(AssertionError, msg):
+        with pytest.raises(AssertionError, match=msg):
             date_range(start, periods=2, tz='Europe/Berlin')
 
     def test_negative_non_tick_frequency_descending_dates(self,
@@ -613,14 +613,14 @@ class TestBusinessDateRange(object):
         bdate_range(end=START, periods=20, freq=BDay())
 
         msg = 'periods must be a number, got B'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             date_range('2011-1-1', '2012-1-1', 'B')
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             bdate_range('2011-1-1', '2012-1-1', 'B')
 
         msg = 'freq must be specified for bdate_range; use date_range instead'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             bdate_range(START, END, periods=10, freq=None)
 
     def test_naive_aware_conflicts(self):
@@ -628,10 +628,10 @@ class TestBusinessDateRange(object):
         aware = bdate_range(START, END, freq=BDay(), tz="Asia/Hong_Kong")
 
         msg = 'tz-naive.*tz-aware'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             naive.join(aware)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             aware.join(naive)
 
     def test_misc(self):
@@ -688,10 +688,10 @@ class TestCustomDateRange(object):
         bdate_range(end=START, periods=20, freq=CDay())
 
         msg = 'periods must be a number, got C'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             date_range('2011-1-1', '2012-1-1', 'C')
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             bdate_range('2011-1-1', '2012-1-1', 'C')
 
     def test_misc(self):
@@ -726,7 +726,7 @@ class TestCustomDateRange(object):
         # raise with non-custom freq
         msg = ('a custom frequency string is required when holidays or '
                'weekmask are passed, got frequency B')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             bdate_range('2013-05-01', periods=3,
                         weekmask='Sun Mon Tue Wed Thu')
 
@@ -739,7 +739,7 @@ class TestCustomDateRange(object):
         # raise with non-custom freq
         msg = ('a custom frequency string is required when holidays or '
                'weekmask are passed, got frequency B')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             bdate_range('2013-05-01', periods=3, holidays=['2013-05-01'])
 
     def test_cdaterange_weekmask_and_holidays(self):
@@ -752,7 +752,7 @@ class TestCustomDateRange(object):
         # raise with non-custom freq
         msg = ('a custom frequency string is required when holidays or '
                'weekmask are passed, got frequency B')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             bdate_range('2013-05-01', periods=3,
                         weekmask='Sun Mon Tue Wed Thu',
                         holidays=['2013-05-01'])
@@ -767,5 +767,5 @@ class TestCustomDateRange(object):
 
         bad_freq = freq + 'FOO'
         msg = 'invalid custom frequency string: {freq}'
-        with tm.assert_raises_regex(ValueError, msg.format(freq=bad_freq)):
+        with pytest.raises(ValueError, match=msg.format(freq=bad_freq)):
             bdate_range(START, END, freq=bad_freq)

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -95,8 +95,8 @@ class TestDatetimeIndex(object):
 
     def test_hash_error(self):
         index = date_range('20010101', periods=10)
-        with tm.assert_raises_regex(TypeError, "unhashable type: %r" %
-                                    type(index).__name__):
+        with pytest.raises(TypeError, match=("unhashable type: %r" %
+                                             type(index).__name__)):
             hash(index)
 
     def test_stringified_slice_with_tz(self):
@@ -303,9 +303,8 @@ class TestDatetimeIndex(object):
             c_idx_type='p', r_idx_type='dt')
         s = df.iloc[:5, 0]
 
-        with tm.assert_raises_regex(ValueError,
-                                    'can only call with other '
-                                    'PeriodIndex-ed objects'):
+        msg = 'can only call with other PeriodIndex-ed objects'
+        with pytest.raises(ValueError, match=msg):
             df.columns.join(s.index, how=join_type)
 
     def test_factorize(self):

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -181,16 +181,16 @@ class TestTake(object):
         indices = [1, 6, 5, 9, 10, 13, 15, 3]
 
         msg = r"take\(\) got an unexpected keyword argument 'foo'"
-        tm.assert_raises_regex(TypeError, msg, idx.take,
-                               indices, foo=2)
+        with pytest.raises(TypeError, match=msg):
+            idx.take(indices, foo=2)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, idx.take,
-                               indices, out=indices)
+        with pytest.raises(ValueError, match=msg):
+            idx.take(indices, out=indices)
 
         msg = "the 'mode' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, idx.take,
-                               indices, mode='clip')
+        with pytest.raises(ValueError, match=msg):
+            idx.take(indices, mode='clip')
 
     # TODO: This method came from test_datetime; de-dup with version above
     @pytest.mark.parametrize('tz', [None, 'US/Eastern', 'Asia/Tokyo'])
@@ -237,9 +237,9 @@ class TestTake(object):
 
         msg = ('When allow_fill=True and fill_value is not None, '
                'all indices must be >= -1')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):
@@ -268,9 +268,9 @@ class TestTake(object):
 
         msg = ('When allow_fill=True and fill_value is not None, '
                'all indices must be >= -1')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):
@@ -411,8 +411,8 @@ class TestDatetimeIndex(object):
             assert result.freq == expected.freq
 
         with pytest.raises((IndexError, ValueError)):
-            # either depeidnig on numpy version
-            result = idx.delete(5)
+            # either depending on numpy version
+            idx.delete(5)
 
         for tz in [None, 'Asia/Tokyo', 'US/Pacific']:
             idx = date_range(start='2000-01-01 09:00', periods=10, freq='H',
@@ -508,8 +508,7 @@ class TestDatetimeIndex(object):
                            tolerance=np.timedelta64(1, 'D')) == 1
         assert idx.get_loc('2000-01-01T12', method='nearest',
                            tolerance=timedelta(1)) == 1
-        with tm.assert_raises_regex(ValueError,
-                                    'unit abbreviation w/o a number'):
+        with pytest.raises(ValueError, match='unit abbreviation w/o a number'):
             idx.get_loc('2000-01-01T12', method='nearest', tolerance='foo')
         with pytest.raises(KeyError):
             idx.get_loc('2000-01-01T03', method='nearest', tolerance='2 hours')
@@ -583,12 +582,11 @@ class TestDatetimeIndex(object):
         with pytest.raises(ValueError):
             idx.get_indexer(idx[[0]], method='nearest', tolerance='foo')
 
-    def test_reasonable_keyerror(self):
+    def test_reasonable_key_error(self):
         # GH#1062
         index = DatetimeIndex(['1/3/2000'])
-        with pytest.raises(KeyError) as excinfo:
+        with pytest.raises(KeyError, match='2000'):
             index.get_loc('1/1/2000')
-        assert '2000' in str(excinfo.value)
 
     @pytest.mark.parametrize('key', [pd.Timedelta(0),
                                      pd.Timedelta(1),

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -84,17 +84,21 @@ class TestDatetimeIndexOps(Ops):
         assert np.max(dr) == Timestamp('2016-01-20 00:00:00', freq='D')
 
         errmsg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, errmsg, np.min, dr, out=0)
-        tm.assert_raises_regex(ValueError, errmsg, np.max, dr, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.min(dr, out=0)
+
+        with pytest.raises(ValueError, match=errmsg):
+            np.max(dr, out=0)
 
         assert np.argmin(dr) == 0
         assert np.argmax(dr) == 5
 
         errmsg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(
-            ValueError, errmsg, np.argmin, dr, out=0)
-        tm.assert_raises_regex(
-            ValueError, errmsg, np.argmax, dr, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.argmin(dr, out=0)
+
+        with pytest.raises(ValueError, match=errmsg):
+            np.argmax(dr, out=0)
 
     def test_repeat_range(self, tz_naive_fixture):
         tz = tz_naive_fixture
@@ -148,8 +152,8 @@ class TestDatetimeIndexOps(Ops):
         assert res.freq is None
 
         tm.assert_index_equal(np.repeat(rng, reps), expected_rng)
-        tm.assert_raises_regex(ValueError, msg, np.repeat,
-                               rng, reps, axis=1)
+        with pytest.raises(ValueError, match=msg):
+            np.repeat(rng, reps, axis=1)
 
     def test_resolution(self, tz_naive_fixture):
         tz = tz_naive_fixture
@@ -415,11 +419,11 @@ class TestDatetimeIndexOps(Ops):
         # setting with an incompatible freq
         msg = ('Inferred frequency 2D from passed values does not conform to '
                'passed frequency 5D')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.freq = '5D'
 
         # setting with non-freq string
-        with tm.assert_raises_regex(ValueError, 'Invalid frequency'):
+        with pytest.raises(ValueError, match='Invalid frequency'):
             idx.freq = 'foo'
 
     def test_offset_deprecated(self):

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -66,12 +66,12 @@ class TestSlicing(object):
     def test_slice_with_zero_step_raises(self):
         ts = Series(np.arange(20),
                     date_range('2014-01-01', periods=20, freq='MS'))
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts[::0])
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts.loc[::0])
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts.loc[::0])
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts[::0]
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts.loc[::0]
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts.loc[::0]
 
     def test_slice_bounds_empty(self):
         # GH 14354
@@ -222,8 +222,8 @@ class TestSlicing(object):
         tm.assert_series_equal(s['2005-1-1 00:01:00'], s.iloc[10:])
 
         assert s[Timestamp('2005-1-1 00:00:59.999990')] == s.iloc[0]
-        tm.assert_raises_regex(KeyError, '2005-1-1 00:00:00',
-                               lambda: s['2005-1-1 00:00:00'])
+        with pytest.raises(KeyError, match='2005-1-1 00:00:00'):
+            s['2005-1-1 00:00:00']
 
     def test_partial_slicing_dataframe(self):
         # GH14856
@@ -349,14 +349,14 @@ class TestSlicing(object):
         timestamp = pd.Timestamp('2014-01-10')
 
         tm.assert_series_equal(nonmonotonic['2014-01-10':], expected)
-        tm.assert_raises_regex(KeyError,
-                               r"Timestamp\('2014-01-10 00:00:00'\)",
-                               lambda: nonmonotonic[timestamp:])
+        with pytest.raises(KeyError,
+                           match=r"Timestamp\('2014-01-10 00:00:00'\)"):
+            nonmonotonic[timestamp:]
 
         tm.assert_series_equal(nonmonotonic.loc['2014-01-10':], expected)
-        tm.assert_raises_regex(KeyError,
-                               r"Timestamp\('2014-01-10 00:00:00'\)",
-                               lambda: nonmonotonic.loc[timestamp:])
+        with pytest.raises(KeyError,
+                           match=r"Timestamp\('2014-01-10 00:00:00'\)"):
+            nonmonotonic.loc[timestamp:]
 
     def test_loc_datetime_length_one(self):
         # GH16071

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -97,14 +97,16 @@ class TestDatetimeIndexOps(object):
         assert elt.round(freq='H') == expected_elt
 
         msg = pd._libs.tslibs.frequencies.INVALID_FREQ_ERR_MSG
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             rng.round(freq='foo')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             elt.round(freq='foo')
 
         msg = "<MonthEnd> is a non-fixed frequency"
-        tm.assert_raises_regex(ValueError, msg, rng.round, freq='M')
-        tm.assert_raises_regex(ValueError, msg, elt.round, freq='M')
+        with pytest.raises(ValueError, match=msg):
+            rng.round(freq='M')
+        with pytest.raises(ValueError, match=msg):
+            elt.round(freq='M')
 
         # GH#14440 & GH#15578
         index = DatetimeIndex(['2016-10-17 12:00:00.0015'], tz=tz)

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -586,7 +586,7 @@ class TestToDatetime(object):
         # GH16774
 
         msg = "Cannot use '%W' or '%U' without day and year"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.to_datetime(date, format=format)
 
     def test_iso_8601_strings_with_same_offset(self):
@@ -865,7 +865,7 @@ class TestToDatetimeUnit(object):
 
         msg = ("cannot assemble the datetimes: time data .+ does not "
                r"match format '%Y%m%d' \(match\)")
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             to_datetime(df2, cache=cache)
         result = to_datetime(df2, errors='coerce', cache=cache)
         expected = Series([Timestamp('20150204 00:00:00'),
@@ -875,7 +875,7 @@ class TestToDatetimeUnit(object):
         # extra columns
         msg = ("extra keys have been passed to the datetime assemblage: "
                r"\[foo\]")
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df2 = df.copy()
             df2['foo'] = 1
             to_datetime(df2, cache=cache)
@@ -888,7 +888,7 @@ class TestToDatetimeUnit(object):
                   ['year', 'month', 'second'],
                   ['month', 'day'],
                   ['year', 'day', 'second']]:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 to_datetime(df[c], cache=cache)
 
         # duplicates
@@ -897,7 +897,7 @@ class TestToDatetimeUnit(object):
                          'month': [2, 20],
                          'day': [4, 5]})
         df2.columns = ['year', 'year', 'day']
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             to_datetime(df2, cache=cache)
 
         df2 = DataFrame({'year': [2015, 2016],
@@ -905,7 +905,7 @@ class TestToDatetimeUnit(object):
                          'day': [4, 5],
                          'hour': [4, 5]})
         df2.columns = ['year', 'month', 'day', 'day']
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             to_datetime(df2, cache=cache)
 
     @pytest.mark.parametrize('cache', [True, False])

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -49,12 +49,12 @@ class Base(object):
         'datetime64[ns, US/Eastern]'])
     def test_astype_cannot_cast(self, index, dtype):
         msg = 'Cannot cast IntervalIndex to dtype'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             index.astype(dtype)
 
     def test_astype_invalid_dtype(self, index):
         msg = "data type 'fake_dtype' not understood"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             index.astype('fake_dtype')
 
 
@@ -127,7 +127,7 @@ class TestFloatSubtype(Base):
 
         # raises with NA
         msg = 'Cannot convert NA to integer'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             index.insert(0, np.nan).astype(dtype)
 
     @pytest.mark.xfail(reason='GH#15832', strict=True)
@@ -152,7 +152,7 @@ class TestFloatSubtype(Base):
     def test_subtype_datetimelike(self, index, subtype):
         dtype = IntervalDtype(subtype)
         msg = 'Cannot convert .* to .*; subtypes are incompatible'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             index.astype(dtype)
 
 
@@ -183,7 +183,7 @@ class TestDatetimelikeSubtype(Base):
     def test_subtype_float(self, index):
         dtype = IntervalDtype('float64')
         msg = 'Cannot convert .* to .*; subtypes are incompatible'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             index.astype(dtype)
 
     def test_subtype_datetimelike(self):
@@ -192,15 +192,15 @@ class TestDatetimelikeSubtype(Base):
         msg = 'Cannot convert .* to .*; subtypes are incompatible'
 
         index = interval_range(Timestamp('2018-01-01'), periods=10)
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             index.astype(dtype)
 
         index = interval_range(Timestamp('2018-01-01', tz='CET'), periods=10)
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             index.astype(dtype)
 
         # timedelta -> datetime raises
         dtype = IntervalDtype('datetime64[ns]')
         index = interval_range(Timedelta('0 days'), periods=10)
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             index.astype(dtype)

--- a/pandas/tests/indexes/interval/test_construction.py
+++ b/pandas/tests/indexes/interval/test_construction.py
@@ -107,7 +107,7 @@ class Base(object):
         # GH 19016
         msg = ('category, object, and string subtypes are not supported '
                'for IntervalIndex')
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             constructor(**self.get_kwargs_from_breaks(breaks))
 
     @pytest.mark.parametrize('cat_constructor', [
@@ -132,30 +132,30 @@ class Base(object):
 
         # invalid closed
         msg = "invalid option for 'closed': invalid"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             constructor(closed='invalid', **filler)
 
         # unsupported dtype
         msg = 'dtype must be an IntervalDtype, got int64'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             constructor(dtype='int64', **filler)
 
         # invalid dtype
         msg = "data type 'invalid' not understood"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             constructor(dtype='invalid', **filler)
 
         # no point in nesting periods in an IntervalIndex
         periods = period_range('2000-01-01', periods=10)
         periods_kwargs = self.get_kwargs_from_breaks(periods)
         msg = 'Period dtypes are not supported, use a PeriodIndex instead'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             constructor(**periods_kwargs)
 
         # decreasing values
         decreasing_kwargs = self.get_kwargs_from_breaks(range(10, -1, -1))
         msg = 'left side of interval must be <= right side'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             constructor(**decreasing_kwargs)
 
 
@@ -178,14 +178,14 @@ class TestFromArrays(Base):
         data = Categorical(list('01234abcde'), ordered=True)
         msg = ('category, object, and string subtypes are not supported '
                'for IntervalIndex')
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             IntervalIndex.from_arrays(data[:-1], data[1:])
 
         # unequal length
         left = [0, 1, 2]
         right = [2, 3]
         msg = 'left and right must have the same length'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             IntervalIndex.from_arrays(left, right)
 
     @pytest.mark.parametrize('left_subtype, right_subtype', [
@@ -224,7 +224,7 @@ class TestFromBreaks(Base):
         data = Categorical(list('01234abcde'), ordered=True)
         msg = ('category, object, and string subtypes are not supported '
                'for IntervalIndex')
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             IntervalIndex.from_breaks(data)
 
     def test_length_one(self):
@@ -261,17 +261,17 @@ class TestFromTuples(Base):
         # non-tuple
         tuples = [(0, 1), 2, (3, 4)]
         msg = 'IntervalIndex.from_tuples received an invalid item, 2'
-        with tm.assert_raises_regex(TypeError, msg.format(t=tuples)):
+        with pytest.raises(TypeError, match=msg.format(t=tuples)):
             IntervalIndex.from_tuples(tuples)
 
         # too few/many items
         tuples = [(0, 1), (2,), (3, 4)]
         msg = 'IntervalIndex.from_tuples requires tuples of length 2, got {t}'
-        with tm.assert_raises_regex(ValueError, msg.format(t=tuples)):
+        with pytest.raises(ValueError, match=msg.format(t=tuples)):
             IntervalIndex.from_tuples(tuples)
 
         tuples = [(0, 1), (2, 3, 4), (5, 6)]
-        with tm.assert_raises_regex(ValueError, msg.format(t=tuples)):
+        with pytest.raises(ValueError, match=msg.format(t=tuples)):
             IntervalIndex.from_tuples(tuples)
 
     def test_na_tuples(self):
@@ -318,19 +318,19 @@ class TestClassConstructors(Base):
         # mismatched closed within intervals with no constructor override
         ivs = [Interval(0, 1, closed='right'), Interval(2, 3, closed='left')]
         msg = 'intervals must all be closed on the same side'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             constructor(ivs)
 
         # scalar
         msg = (r'IntervalIndex\(...\) must be called with a collection of '
                'some kind, 5 was passed')
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             constructor(5)
 
         # not an interval
         msg = ("type <(class|type) 'numpy.int64'> with value 0 "
                "is not an interval")
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             constructor([0, 1])
 
     @pytest.mark.parametrize('data, closed', [

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -214,13 +214,13 @@ class TestIntervalIndex(Base):
 
         # invalid type
         msg = 'can only insert Interval objects and NA into an IntervalIndex'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             data.insert(1, 'foo')
 
         # invalid closed
         msg = 'inserted item must be closed on the same side as the index'
         for closed in {'left', 'right', 'both', 'neither'} - {item.closed}:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 bad_item = Interval(item.left, item.right, closed=closed)
                 data.insert(1, bad_item)
 
@@ -690,7 +690,7 @@ class TestIntervalIndex(Base):
         msg = ('Cannot index an IntervalIndex of subtype {dtype1} with '
                'values of dtype {dtype2}')
         msg = re.escape(msg.format(dtype1=breaks1.dtype, dtype2=breaks2.dtype))
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             index._maybe_convert_i8(key)
 
     # To be removed, replaced by test_interval_new.py (see #16316, #16386)
@@ -842,7 +842,7 @@ class TestIntervalIndex(Base):
         # non-IntervalIndex
         msg = ('the other index needs to be an IntervalIndex too, but '
                'was type Int64Index')
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             set_op(Index([1, 2, 3]))
 
         # mixed closed
@@ -850,14 +850,14 @@ class TestIntervalIndex(Base):
                'that are closed on the same side')
         for other_closed in {'right', 'left', 'both', 'neither'} - {closed}:
             other = self.create_index(closed=other_closed)
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 set_op(other)
 
         # GH 19016: incompatible dtypes
         other = interval_range(Timestamp('20180101'), periods=9, closed=closed)
         msg = ('can only do {op} between two IntervalIndex objects that have '
                'compatible dtypes').format(op=op_name)
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             set_op(other)
 
     def test_isin(self, closed):
@@ -934,9 +934,9 @@ class TestIntervalIndex(Base):
         actual = self.index == self.index.left
         tm.assert_numpy_array_equal(actual, np.array([False, False]))
 
-        with tm.assert_raises_regex(TypeError, 'unorderable types'):
+        with pytest.raises(TypeError, match='unorderable types'):
             self.index > 0
-        with tm.assert_raises_regex(TypeError, 'unorderable types'):
+        with pytest.raises(TypeError, match='unorderable types'):
             self.index <= 0
         with pytest.raises(TypeError):
             self.index > np.arange(2)
@@ -1039,7 +1039,7 @@ class TestIntervalIndex(Base):
         for other_closed in {'left', 'right', 'both', 'neither'} - {closed}:
             index_other_closed = IntervalIndex.from_arrays(
                 [0, 1], [1, 2], closed=other_closed)
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 index1.append(index_other_closed)
 
     def test_is_non_overlapping_monotonic(self, closed):
@@ -1148,7 +1148,7 @@ class TestIntervalIndex(Base):
         # GH 21670
         index = interval_range(0, 5)
         msg = "invalid option for 'closed': {closed}".format(closed=bad_closed)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             index.set_closed(bad_closed)
 
     def test_is_all_dates(self):

--- a/pandas/tests/indexes/interval/test_interval_new.py
+++ b/pandas/tests/indexes/interval/test_interval_new.py
@@ -199,7 +199,7 @@ class TestIntervalIndex(object):
 
         msg = ('cannot handle overlapping indices; use '
                'IntervalIndex.get_indexer_non_unique')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             index.get_indexer([0, 2])
 
     @pytest.mark.parametrize('query, expected', [

--- a/pandas/tests/indexes/interval/test_interval_range.py
+++ b/pandas/tests/indexes/interval/test_interval_range.py
@@ -232,84 +232,84 @@ class TestIntervalRange(object):
         msg = ('Of the four parameters: start, end, periods, and freq, '
                'exactly three must be specified')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(start=0)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(end=5)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(periods=2)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range()
 
         # too many params
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(start=0, end=5, periods=6, freq=1.5)
 
         # mixed units
         msg = 'start, end, freq need to be type compatible'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=0, end=Timestamp('20130101'), freq=2)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=0, end=Timedelta('1 day'), freq=2)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=0, end=10, freq='D')
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=Timestamp('20130101'), end=10, freq='D')
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=Timestamp('20130101'),
                            end=Timedelta('1 day'), freq='D')
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=Timestamp('20130101'),
                            end=Timestamp('20130110'), freq=2)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=Timedelta('1 day'), end=10, freq='D')
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=Timedelta('1 day'),
                            end=Timestamp('20130110'), freq='D')
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=Timedelta('1 day'),
                            end=Timedelta('10 days'), freq=2)
 
         # invalid periods
         msg = 'periods must be a number, got foo'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=0, periods='foo')
 
         # invalid start
         msg = 'start must be numeric or datetime-like, got foo'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(start='foo', periods=10)
 
         # invalid end
         msg = r'end must be numeric or datetime-like, got \(0, 1\]'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(end=Interval(0, 1), periods=10)
 
         # invalid freq for datetime-like
         msg = 'freq must be numeric or convertible to DateOffset, got foo'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(start=0, end=10, freq='foo')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(start=Timestamp('20130101'), periods=10, freq='foo')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             interval_range(end=Timedelta('1 day'), periods=10, freq='foo')
 
         # mixed tz
         start = Timestamp('2017-01-01', tz='US/Eastern')
         end = Timestamp('2017-01-07', tz='US/Pacific')
         msg = 'Start and end cannot both be tz-aware with different timezones'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval_range(start=start, end=end)

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -77,8 +77,8 @@ def test_where_array_like():
 
 def test_reorder_levels(idx):
     # this blows up
-    tm.assert_raises_regex(IndexError, '^Too many levels',
-                           idx.reorder_levels, [2, 1, 0])
+    with pytest.raises(IndexError, match='^Too many levels'):
+        idx.reorder_levels([2, 1, 0])
 
 
 def test_numpy_repeat():
@@ -93,8 +93,8 @@ def test_numpy_repeat():
     tm.assert_index_equal(np.repeat(m, reps), expected)
 
     msg = "the 'axis' parameter is not supported"
-    tm.assert_raises_regex(
-        ValueError, msg, np.repeat, m, reps, axis=1)
+    with pytest.raises(ValueError, match=msg):
+        np.repeat(m, reps, axis=1)
 
 
 def test_append_mixed_dtypes():
@@ -151,16 +151,16 @@ def test_take_invalid_kwargs(idx):
     indices = [1, 2]
 
     msg = r"take\(\) got an unexpected keyword argument 'foo'"
-    tm.assert_raises_regex(TypeError, msg, idx.take,
-                           indices, foo=2)
+    with pytest.raises(TypeError, match=msg):
+        idx.take(indices, foo=2)
 
     msg = "the 'out' parameter is not supported"
-    tm.assert_raises_regex(ValueError, msg, idx.take,
-                           indices, out=indices)
+    with pytest.raises(ValueError, match=msg):
+        idx.take(indices, out=indices)
 
     msg = "the 'mode' parameter is not supported"
-    tm.assert_raises_regex(ValueError, msg, idx.take,
-                           indices, mode='clip')
+    with pytest.raises(ValueError, match=msg):
+        idx.take(indices, mode='clip')
 
 
 def test_take_fill_value():
@@ -195,9 +195,9 @@ def test_take_fill_value():
 
     msg = ('When allow_fill=True and fill_value is not None, '
            'all indices must be >= -1')
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         idx.take(np.array([1, 0, -2]), fill_value=True)
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         idx.take(np.array([1, 0, -5]), fill_value=True)
 
     with pytest.raises(IndexError):

--- a/pandas/tests/indexes/multi/test_astype.py
+++ b/pandas/tests/indexes/multi/test_astype.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 
-import pandas.util.testing as tm
 from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.util.testing import assert_copy
 
@@ -15,7 +14,7 @@ def test_astype(idx):
     assert_copy(actual.labels, expected.labels)
     assert [level.name for level in actual.levels] == list(expected.names)
 
-    with tm.assert_raises_regex(TypeError, "^Setting.*dtype.*object"):
+    with pytest.raises(TypeError, match="^Setting.*dtype.*object"):
         idx.astype(np.dtype(int))
 
 
@@ -23,10 +22,10 @@ def test_astype(idx):
 def test_astype_category(idx, ordered):
     # GH 18630
     msg = '> 1 ndim Categorical are not supported at this time'
-    with tm.assert_raises_regex(NotImplementedError, msg):
+    with pytest.raises(NotImplementedError, match=msg):
         idx.astype(CategoricalDtype(ordered=ordered))
 
     if ordered is False:
         # dtype='category' defaults to ordered=False, so only test once
-        with tm.assert_raises_regex(NotImplementedError, msg):
+        with pytest.raises(NotImplementedError, match=msg):
             idx.astype('category')

--- a/pandas/tests/indexes/multi/test_compat.py
+++ b/pandas/tests/indexes/multi/test_compat.py
@@ -11,27 +11,34 @@ import pandas.util.testing as tm
 
 
 def test_numeric_compat(idx):
-    tm.assert_raises_regex(TypeError, "cannot perform __mul__",
-                           lambda: idx * 1)
-    tm.assert_raises_regex(TypeError, "cannot perform __rmul__",
-                           lambda: 1 * idx)
+    with pytest.raises(TypeError, match="cannot perform __mul__"):
+        idx * 1
 
-    div_err = "cannot perform __truediv__" if PY3 \
-        else "cannot perform __div__"
-    tm.assert_raises_regex(TypeError, div_err, lambda: idx / 1)
-    div_err = div_err.replace(' __', ' __r')
-    tm.assert_raises_regex(TypeError, div_err, lambda: 1 / idx)
-    tm.assert_raises_regex(TypeError, "cannot perform __floordiv__",
-                           lambda: idx // 1)
-    tm.assert_raises_regex(TypeError, "cannot perform __rfloordiv__",
-                           lambda: 1 // idx)
+    with pytest.raises(TypeError, match="cannot perform __rmul__"):
+        1 * idx
+
+    div_err = ("cannot perform __truediv__" if PY3
+               else "cannot perform __div__")
+    with pytest.raises(TypeError, match=div_err):
+        idx / 1
+
+    div_err = div_err.replace(" __", " __r")
+    with pytest.raises(TypeError, match=div_err):
+        1 / idx
+
+    with pytest.raises(TypeError, match="cannot perform __floordiv__"):
+        idx // 1
+
+    with pytest.raises(TypeError, match="cannot perform __rfloordiv__"):
+        1 // idx
 
 
-def test_logical_compat(idx):
-    tm.assert_raises_regex(TypeError, 'cannot perform all',
-                           lambda: idx.all())
-    tm.assert_raises_regex(TypeError, 'cannot perform any',
-                           lambda: idx.any())
+@pytest.mark.parametrize("method", ["all", "any"])
+def test_logical_compat(idx, method):
+    msg = "cannot perform {method}".format(method=method)
+
+    with pytest.raises(TypeError, match=msg):
+        getattr(idx, method)()
 
 
 def test_boolean_context_compat(idx):

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -25,13 +25,14 @@ def test_constructor_single_level():
 
 
 def test_constructor_no_levels():
-    tm.assert_raises_regex(ValueError, "non-zero number "
-                           "of levels/labels",
-                           MultiIndex, levels=[], labels=[])
+    msg = "non-zero number of levels/labels"
+    with pytest.raises(ValueError, match=msg):
+        MultiIndex(levels=[], labels=[])
+
     both_re = re.compile('Must pass both levels and labels')
-    with tm.assert_raises_regex(TypeError, both_re):
+    with pytest.raises(TypeError, match=both_re):
         MultiIndex(levels=[])
-    with tm.assert_raises_regex(TypeError, both_re):
+    with pytest.raises(TypeError, match=both_re):
         MultiIndex(labels=[])
 
 
@@ -39,44 +40,48 @@ def test_constructor_nonhashable_names():
     # GH 20527
     levels = [[1, 2], [u'one', u'two']]
     labels = [[0, 0, 1, 1], [0, 1, 0, 1]]
-    names = ((['foo'], ['bar']))
+    names = (['foo'], ['bar'])
     message = "MultiIndex.name must be a hashable type"
-    tm.assert_raises_regex(TypeError, message,
-                           MultiIndex, levels=levels,
-                           labels=labels, names=names)
+    with pytest.raises(TypeError, match=message):
+        MultiIndex(levels=levels, labels=labels, names=names)
 
     # With .rename()
     mi = MultiIndex(levels=[[1, 2], [u'one', u'two']],
                     labels=[[0, 0, 1, 1], [0, 1, 0, 1]],
                     names=('foo', 'bar'))
     renamed = [['foor'], ['barr']]
-    tm.assert_raises_regex(TypeError, message, mi.rename, names=renamed)
+    with pytest.raises(TypeError, match=message):
+        mi.rename(names=renamed)
+
     # With .set_names()
-    tm.assert_raises_regex(TypeError, message, mi.set_names, names=renamed)
+    with pytest.raises(TypeError, match=message):
+        mi.set_names(names=renamed)
 
 
 def test_constructor_mismatched_label_levels(idx):
     labels = [np.array([1]), np.array([2]), np.array([3])]
     levels = ["a"]
-    tm.assert_raises_regex(ValueError, "Length of levels and labels "
-                           "must be the same", MultiIndex,
-                           levels=levels, labels=labels)
+
+    msg = "Length of levels and labels must be the same"
+    with pytest.raises(ValueError, match=msg):
+        MultiIndex(levels=levels, labels=labels)
+
     length_error = re.compile('>= length of level')
     label_error = re.compile(r'Unequal label lengths: \[4, 2\]')
 
     # important to check that it's looking at the right thing.
-    with tm.assert_raises_regex(ValueError, length_error):
+    with pytest.raises(ValueError, match=length_error):
         MultiIndex(levels=[['a'], ['b']],
                    labels=[[0, 1, 2, 3], [0, 3, 4, 1]])
 
-    with tm.assert_raises_regex(ValueError, label_error):
+    with pytest.raises(ValueError, match=label_error):
         MultiIndex(levels=[['a'], ['b']], labels=[[0, 0, 0, 0], [0, 0]])
 
     # external API
-    with tm.assert_raises_regex(ValueError, length_error):
+    with pytest.raises(ValueError, match=length_error):
         idx.copy().set_levels([['a'], ['b']])
 
-    with tm.assert_raises_regex(ValueError, label_error):
+    with pytest.raises(ValueError, match=label_error):
         idx.copy().set_labels([[0, 0, 0, 0], [0, 0]])
 
 
@@ -121,8 +126,8 @@ def test_from_arrays_iterator(idx):
     tm.assert_index_equal(result, idx)
 
     # invalid iterator input
-    with tm.assert_raises_regex(
-            TypeError, "Input must be a list / sequence of array-likes."):
+    msg = "Input must be a list / sequence of array-likes."
+    with pytest.raises(TypeError, match=msg):
         MultiIndex.from_arrays(0)
 
 
@@ -217,8 +222,8 @@ def test_from_arrays_index_series_categorical():
 
 def test_from_arrays_empty():
     # 0 levels
-    with tm.assert_raises_regex(
-            ValueError, "Must pass non-zero number of levels/labels"):
+    msg = "Must pass non-zero number of levels/labels"
+    with pytest.raises(ValueError, match=msg):
         MultiIndex.from_arrays(arrays=[])
 
     # 1 level
@@ -261,15 +266,15 @@ def test_from_arrays_invalid_input(invalid_array):
 ])
 def test_from_arrays_different_lengths(idx1, idx2):
     # see gh-13599
-    tm.assert_raises_regex(ValueError, '^all arrays must '
-                           'be same length$',
-                           MultiIndex.from_arrays, [idx1, idx2])
+    msg = '^all arrays must be same length$'
+    with pytest.raises(ValueError, match=msg):
+        MultiIndex.from_arrays([idx1, idx2])
 
 
 def test_from_tuples():
-    tm.assert_raises_regex(TypeError, 'Cannot infer number of levels '
-                           'from empty list',
-                           MultiIndex.from_tuples, [])
+    msg = 'Cannot infer number of levels from empty list'
+    with pytest.raises(TypeError, match=msg):
+        MultiIndex.from_tuples([])
 
     expected = MultiIndex(levels=[[1, 3], [2, 4]],
                           labels=[[0, 1], [0, 1]],
@@ -291,8 +296,8 @@ def test_from_tuples_iterator():
     tm.assert_index_equal(result, expected)
 
     # input non-iterables
-    with tm.assert_raises_regex(
-            TypeError, 'Input must be a list / sequence of tuple-likes.'):
+    msg = 'Input must be a list / sequence of tuple-likes.'
+    with pytest.raises(TypeError, match=msg):
         MultiIndex.from_tuples(0)
 
 
@@ -311,8 +316,8 @@ def test_from_tuples_index_values(idx):
 
 def test_from_product_empty_zero_levels():
     # 0 levels
-    with tm.assert_raises_regex(
-            ValueError, "Must pass non-zero number of levels/labels"):
+    msg = "Must pass non-zero number of levels/labels"
+    with pytest.raises(ValueError, match=msg):
         MultiIndex.from_product([])
 
 
@@ -422,8 +427,8 @@ def test_from_product_iterator():
     tm.assert_index_equal(result, expected)
 
     # Invalid non-iterable input
-    with tm.assert_raises_regex(
-            TypeError, "Input must be a list / sequence of iterables."):
+    msg = "Input must be a list / sequence of iterables."
+    with pytest.raises(TypeError, match=msg):
         MultiIndex.from_product(0)
 
 

--- a/pandas/tests/indexes/multi/test_conversion.py
+++ b/pandas/tests/indexes/multi/test_conversion.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
+import pytest
 import numpy as np
 
 import pandas as pd
@@ -51,11 +51,11 @@ def test_to_frame():
     tm.assert_frame_equal(result, expected)
 
     msg = "'name' must be a list / sequence of column names."
-    with tm.assert_raises_regex(TypeError, msg):
+    with pytest.raises(TypeError, match=msg):
         index.to_frame(name='first')
 
     msg = "'name' should have same length as number of levels on index."
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         index.to_frame(name=['first'])
 
     # Tests for datetime index

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-
 import numpy as np
+import pytest
 
 from pandas.compat import lrange, lzip, range
 
@@ -35,7 +35,7 @@ def test_equals_op(idx):
     index_b = index_a[0:-1]
     index_c = index_a[0:-1].append(index_a[-2:-1])
     index_d = index_a[0:1]
-    with tm.assert_raises_regex(ValueError, "Lengths must match"):
+    with pytest.raises(ValueError, match="Lengths must match"):
         index_a == index_b
     expected1 = np.array([True] * n)
     expected2 = np.array([True] * (n - 1) + [False])
@@ -47,7 +47,7 @@ def test_equals_op(idx):
     array_b = np.array(index_a[0:-1])
     array_c = np.array(index_a[0:-1].append(index_a[-2:-1]))
     array_d = np.array(index_a[0:1])
-    with tm.assert_raises_regex(ValueError, "Lengths must match"):
+    with pytest.raises(ValueError, match="Lengths must match"):
         index_a == array_b
     tm.assert_numpy_array_equal(index_a == array_a, expected1)
     tm.assert_numpy_array_equal(index_a == array_c, expected2)
@@ -57,23 +57,23 @@ def test_equals_op(idx):
     series_b = Series(array_b)
     series_c = Series(array_c)
     series_d = Series(array_d)
-    with tm.assert_raises_regex(ValueError, "Lengths must match"):
+    with pytest.raises(ValueError, match="Lengths must match"):
         index_a == series_b
 
     tm.assert_numpy_array_equal(index_a == series_a, expected1)
     tm.assert_numpy_array_equal(index_a == series_c, expected2)
 
     # cases where length is 1 for one of them
-    with tm.assert_raises_regex(ValueError, "Lengths must match"):
+    with pytest.raises(ValueError, match="Lengths must match"):
         index_a == index_d
-    with tm.assert_raises_regex(ValueError, "Lengths must match"):
+    with pytest.raises(ValueError, match="Lengths must match"):
         index_a == series_d
-    with tm.assert_raises_regex(ValueError, "Lengths must match"):
+    with pytest.raises(ValueError, match="Lengths must match"):
         index_a == array_d
     msg = "Can only compare identically-labeled Series objects"
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         series_a == series_d
-    with tm.assert_raises_regex(ValueError, "Lengths must match"):
+    with pytest.raises(ValueError, match="Lengths must match"):
         series_a == array_d
 
     # comparing with a scalar should broadcast; note that we are excluding

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -26,8 +26,8 @@ def test_get_level_number_integer(idx):
     assert idx._get_level_number(1) == 0
     assert idx._get_level_number(0) == 1
     pytest.raises(IndexError, idx._get_level_number, 2)
-    tm.assert_raises_regex(KeyError, 'Level fourth not found',
-                           idx._get_level_number, 'fourth')
+    with pytest.raises(KeyError, match='Level fourth not found'):
+        idx._get_level_number('fourth')
 
 
 def test_get_level_values(idx):
@@ -125,7 +125,7 @@ def test_set_name_methods(idx, index_names):
     ind = idx.set_names(new_names)
     assert idx.names == index_names
     assert ind.names == new_names
-    with tm.assert_raises_regex(ValueError, "^Length"):
+    with pytest.raises(ValueError, match="^Length"):
         ind.set_names(new_names + new_names)
     new_names2 = [name + "SUFFIX2" for name in new_names]
     res = ind.set_names(new_names2, inplace=True)
@@ -226,23 +226,23 @@ def test_set_levels(idx):
     # GH 13754
     original_index = idx.copy()
     for inplace in [True, False]:
-        with tm.assert_raises_regex(ValueError, "^On"):
+        with pytest.raises(ValueError, match="^On"):
             idx.set_levels(['c'], level=0, inplace=inplace)
         assert_matching(idx.levels, original_index.levels,
                         check_dtype=True)
 
-        with tm.assert_raises_regex(ValueError, "^On"):
+        with pytest.raises(ValueError, match="^On"):
             idx.set_labels([0, 1, 2, 3, 4, 5], level=0,
                            inplace=inplace)
         assert_matching(idx.labels, original_index.labels,
                         check_dtype=True)
 
-        with tm.assert_raises_regex(TypeError, "^Levels"):
+        with pytest.raises(TypeError, match="^Levels"):
             idx.set_levels('c', level=0, inplace=inplace)
         assert_matching(idx.levels, original_index.levels,
                         check_dtype=True)
 
-        with tm.assert_raises_regex(TypeError, "^Labels"):
+        with pytest.raises(TypeError, match="^Labels"):
             idx.set_labels(1, level=0, inplace=inplace)
         assert_matching(idx.labels, original_index.labels,
                         check_dtype=True)
@@ -323,46 +323,46 @@ def test_set_levels_labels_names_bad_input(idx):
     levels, labels = idx.levels, idx.labels
     names = idx.names
 
-    with tm.assert_raises_regex(ValueError, 'Length of levels'):
+    with pytest.raises(ValueError, match='Length of levels'):
         idx.set_levels([levels[0]])
 
-    with tm.assert_raises_regex(ValueError, 'Length of labels'):
+    with pytest.raises(ValueError, match='Length of labels'):
         idx.set_labels([labels[0]])
 
-    with tm.assert_raises_regex(ValueError, 'Length of names'):
+    with pytest.raises(ValueError, match='Length of names'):
         idx.set_names([names[0]])
 
     # shouldn't scalar data error, instead should demand list-like
-    with tm.assert_raises_regex(TypeError, 'list of lists-like'):
+    with pytest.raises(TypeError, match='list of lists-like'):
         idx.set_levels(levels[0])
 
     # shouldn't scalar data error, instead should demand list-like
-    with tm.assert_raises_regex(TypeError, 'list of lists-like'):
+    with pytest.raises(TypeError, match='list of lists-like'):
         idx.set_labels(labels[0])
 
     # shouldn't scalar data error, instead should demand list-like
-    with tm.assert_raises_regex(TypeError, 'list-like'):
+    with pytest.raises(TypeError, match='list-like'):
         idx.set_names(names[0])
 
     # should have equal lengths
-    with tm.assert_raises_regex(TypeError, 'list of lists-like'):
+    with pytest.raises(TypeError, match='list of lists-like'):
         idx.set_levels(levels[0], level=[0, 1])
 
-    with tm.assert_raises_regex(TypeError, 'list-like'):
+    with pytest.raises(TypeError, match='list-like'):
         idx.set_levels(levels, level=0)
 
     # should have equal lengths
-    with tm.assert_raises_regex(TypeError, 'list of lists-like'):
+    with pytest.raises(TypeError, match='list of lists-like'):
         idx.set_labels(labels[0], level=[0, 1])
 
-    with tm.assert_raises_regex(TypeError, 'list-like'):
+    with pytest.raises(TypeError, match='list-like'):
         idx.set_labels(labels, level=0)
 
     # should have equal lengths
-    with tm.assert_raises_regex(ValueError, 'Length of names'):
+    with pytest.raises(ValueError, match='Length of names'):
         idx.set_names(names[0], level=[0, 1])
 
-    with tm.assert_raises_regex(TypeError, 'Names must be a'):
+    with pytest.raises(TypeError, match='Names must be a'):
         idx.set_names(names, level=0)
 
 

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -54,19 +54,17 @@ def test_slice_locs_with_type_mismatch():
     df = tm.makeTimeDataFrame()
     stacked = df.stack()
     idx = stacked.index
-    tm.assert_raises_regex(TypeError, '^Level type mismatch',
-                           idx.slice_locs, (1, 3))
-    tm.assert_raises_regex(TypeError, '^Level type mismatch',
-                           idx.slice_locs,
-                           df.index[5] + timedelta(
-                               seconds=30), (5, 2))
+    with pytest.raises(TypeError, match='^Level type mismatch'):
+        idx.slice_locs((1, 3))
+    with pytest.raises(TypeError, match='^Level type mismatch'):
+        idx.slice_locs(df.index[5] + timedelta(seconds=30), (5, 2))
     df = tm.makeCustomDataframe(5, 5)
     stacked = df.stack()
     idx = stacked.index
-    with tm.assert_raises_regex(TypeError, '^Level type mismatch'):
+    with pytest.raises(TypeError, match='^Level type mismatch'):
         idx.slice_locs(timedelta(seconds=30))
     # TODO: Try creating a UnicodeDecodeError in exception message
-    with tm.assert_raises_regex(TypeError, '^Level type mismatch'):
+    with pytest.raises(TypeError, match='^Level type mismatch'):
         idx.slice_locs(df.index[1], (16, "a"))
 
 
@@ -75,9 +73,9 @@ def test_slice_locs_not_sorted():
         lrange(4))], labels=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
             [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])])
 
-    tm.assert_raises_regex(KeyError, "[Kk]ey length.*greater than "
-                           "MultiIndex lexsort depth",
-                           index.slice_locs, (1, 0, 1), (2, 1, 0))
+    msg = "[Kk]ey length.*greater than MultiIndex lexsort depth"
+    with pytest.raises(KeyError, match=msg):
+        index.slice_locs((1, 0, 1), (2, 1, 0))
 
     # works
     sorted_index, _ = index.sortlevel(0)
@@ -172,7 +170,7 @@ def test_get_indexer():
     idx2 = Index(lrange(20))
 
     msg = "Reindexing only valid with uniquely valued Index objects"
-    with tm.assert_raises_regex(InvalidIndexError, msg):
+    with pytest.raises(InvalidIndexError, match=msg):
         idx1.get_indexer(idx2)
 
 
@@ -218,8 +216,8 @@ def test_get_indexer_consistency(idx):
         assert indexer.dtype == np.intp
     else:
         e = "Reindexing only valid with uniquely valued Index objects"
-        with tm.assert_raises_regex(InvalidIndexError, e):
-            indexer = idx.get_indexer(idx[0:2])
+        with pytest.raises(InvalidIndexError, match=e):
+            idx.get_indexer(idx[0:2])
 
     indexer, _ = idx.get_indexer_non_unique(idx[0:2])
     assert isinstance(indexer, np.ndarray)

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -139,16 +139,16 @@ def take_invalid_kwargs():
     indices = [1, 2]
 
     msg = r"take\(\) got an unexpected keyword argument 'foo'"
-    tm.assert_raises_regex(TypeError, msg, idx.take,
-                           indices, foo=2)
+    with pytest.raises(TypeError, match=msg):
+        idx.take(indices, foo=2)
 
     msg = "the 'out' parameter is not supported"
-    tm.assert_raises_regex(ValueError, msg, idx.take,
-                           indices, out=indices)
+    with pytest.raises(ValueError, match=msg):
+        idx.take(indices, out=indices)
 
     msg = "the 'mode' parameter is not supported"
-    tm.assert_raises_regex(ValueError, msg, idx.take,
-                           indices, mode='clip')
+    with pytest.raises(ValueError, match=msg):
+        idx.take(indices, mode='clip')
 
 
 def test_isna_behavior(idx):
@@ -183,8 +183,8 @@ def test_million_record_attribute_error():
     df = pd.DataFrame({'a': r, 'b': r},
                       index=pd.MultiIndex.from_tuples([(x, x) for x in r]))
 
-    with tm.assert_raises_regex(AttributeError,
-                                "'Series' object has no attribute 'foo'"):
+    msg = "'Series' object has no attribute 'foo'"
+    with pytest.raises(AttributeError, match=msg):
         df['a'].foo()
 
 
@@ -197,18 +197,18 @@ def test_metadata_immutable(idx):
     levels, labels = idx.levels, idx.labels
     # shouldn't be able to set at either the top level or base level
     mutable_regex = re.compile('does not support mutable operations')
-    with tm.assert_raises_regex(TypeError, mutable_regex):
+    with pytest.raises(TypeError, match=mutable_regex):
         levels[0] = levels[0]
-    with tm.assert_raises_regex(TypeError, mutable_regex):
+    with pytest.raises(TypeError, match=mutable_regex):
         levels[0][0] = levels[0][0]
     # ditto for labels
-    with tm.assert_raises_regex(TypeError, mutable_regex):
+    with pytest.raises(TypeError, match=mutable_regex):
         labels[0] = labels[0]
-    with tm.assert_raises_regex(TypeError, mutable_regex):
+    with pytest.raises(TypeError, match=mutable_regex):
         labels[0][0] = labels[0][0]
     # and for names
     names = idx.names
-    with tm.assert_raises_regex(TypeError, mutable_regex):
+    with pytest.raises(TypeError, match=mutable_regex):
         names[0] = names[0]
 
 
@@ -248,8 +248,9 @@ def test_rangeindex_fallback_coercion_bug():
 
 def test_hash_error(indices):
     index = indices
-    tm.assert_raises_regex(TypeError, "unhashable type: %r" %
-                           type(index).__name__, hash, indices)
+    with pytest.raises(TypeError, match=("unhashable type: %r" %
+                                         type(index).__name__)):
+        hash(indices)
 
 
 def test_mutability(indices):
@@ -259,9 +260,8 @@ def test_mutability(indices):
 
 
 def test_wrong_number_names(indices):
-    def testit(ind):
-        ind.names = ["apple", "banana", "carrot"]
-    tm.assert_raises_regex(ValueError, "^Length", testit, indices)
+    with pytest.raises(ValueError, match="^Length"):
+        indices.names = ["apple", "banana", "carrot"]
 
 
 def test_memory_usage(idx):

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -46,8 +46,8 @@ def test_join_level_corner_case(idx):
     result = index.join(idx, level='second')
     assert isinstance(result, MultiIndex)
 
-    tm.assert_raises_regex(TypeError, "Join.*MultiIndex.*ambiguous",
-                           idx.join, idx, level=1)
+    with pytest.raises(TypeError, match="Join.*MultiIndex.*ambiguous"):
+        idx.join(idx, level=1)
 
 
 def test_join_self(idx, join_type):

--- a/pandas/tests/indexes/multi/test_missing.py
+++ b/pandas/tests/indexes/multi/test_missing.py
@@ -20,7 +20,7 @@ def test_fillna(idx):
         elif isinstance(index, MultiIndex):
             idx = index.copy()
             msg = "isna is not defined for MultiIndex"
-            with tm.assert_raises_regex(NotImplementedError, msg):
+            with pytest.raises(NotImplementedError, match=msg):
                 idx.fillna(idx[0])
         else:
             idx = index.copy()
@@ -29,7 +29,7 @@ def test_fillna(idx):
             assert result is not idx
 
             msg = "'value' must be a scalar, passed: "
-            with tm.assert_raises_regex(TypeError, msg):
+            with pytest.raises(TypeError, match=msg):
                 idx.fillna([idx[0]])
 
             idx = index.copy()
@@ -71,7 +71,7 @@ def test_dropna():
     tm.assert_index_equal(idx.dropna(how='all'), exp)
 
     msg = "invalid how option: xxx"
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         idx.dropna(how='xxx')
 
 
@@ -80,7 +80,7 @@ def test_nulls(idx):
     # as these are adequately tested for function elsewhere
 
     msg = "isna is not defined for MultiIndex"
-    with tm.assert_raises_regex(NotImplementedError, msg):
+    with pytest.raises(NotImplementedError, match=msg):
         idx.isna()
 
 

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
+import pytest
 import pandas as pd
 import pandas.util.testing as tm
 from pandas import MultiIndex
@@ -92,23 +92,22 @@ def test_names(idx, index_names):
 
     # setting bad names on existing
     index = idx
-    tm.assert_raises_regex(ValueError, "^Length of names",
-                           setattr, index, "names",
-                           list(index.names) + ["third"])
-    tm.assert_raises_regex(ValueError, "^Length of names",
-                           setattr, index, "names", [])
+    with pytest.raises(ValueError, match="^Length of names"):
+        setattr(index, "names", list(index.names) + ["third"])
+    with pytest.raises(ValueError, match="^Length of names"):
+        setattr(index, "names", [])
 
     # initializing with bad names (should always be equivalent)
     major_axis, minor_axis = idx.levels
     major_labels, minor_labels = idx.labels
-    tm.assert_raises_regex(ValueError, "^Length of names", MultiIndex,
-                           levels=[major_axis, minor_axis],
-                           labels=[major_labels, minor_labels],
-                           names=['first'])
-    tm.assert_raises_regex(ValueError, "^Length of names", MultiIndex,
-                           levels=[major_axis, minor_axis],
-                           labels=[major_labels, minor_labels],
-                           names=['first', 'second', 'third'])
+    with pytest.raises(ValueError, match="^Length of names"):
+        MultiIndex(levels=[major_axis, minor_axis],
+                   labels=[major_labels, minor_labels],
+                   names=['first'])
+    with pytest.raises(ValueError, match="^Length of names"):
+        MultiIndex(levels=[major_axis, minor_axis],
+                   labels=[major_labels, minor_labels],
+                   names=['first', 'second', 'third'])
 
     # names are assigned
     index.names = ["a", "b"]
@@ -120,5 +119,5 @@ def test_names(idx, index_names):
 def test_duplicate_level_names_access_raises(idx):
     # GH19029
     idx.names = ['foo', 'foo']
-    tm.assert_raises_regex(ValueError, 'name foo occurs multiple times',
-                           idx._get_level_number, 'foo')
+    with pytest.raises(ValueError, match='name foo occurs multiple times'):
+        idx._get_level_number('foo')

--- a/pandas/tests/indexes/multi/test_reindex.py
+++ b/pandas/tests/indexes/multi/test_reindex.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
+import pytest
 import numpy as np
 
 import pandas as pd
@@ -40,13 +40,11 @@ def test_reindex_level(idx):
     exp_indexer2 = np.array([0, -1, 0, -1, 0, -1])
     tm.assert_numpy_array_equal(indexer2, exp_indexer2, check_dtype=False)
 
-    tm.assert_raises_regex(TypeError, "Fill method not supported",
-                           idx.reindex, idx,
-                           method='pad', level='second')
+    with pytest.raises(TypeError, match="Fill method not supported"):
+        idx.reindex(idx, method='pad', level='second')
 
-    tm.assert_raises_regex(TypeError, "Fill method not supported",
-                           index.reindex, index, method='bfill',
-                           level='first')
+    with pytest.raises(TypeError, match="Fill method not supported"):
+        index.reindex(index, method='bfill', level='first')
 
 
 def test_reindex_preserves_names_when_target_is_list_or_ndarray(idx):
@@ -96,7 +94,7 @@ def test_reindex_base(idx):
     actual = idx.get_indexer(idx)
     tm.assert_numpy_array_equal(expected, actual)
 
-    with tm.assert_raises_regex(ValueError, 'Invalid fill method'):
+    with pytest.raises(ValueError, match='Invalid fill method'):
         idx.get_indexer(idx, method='invalid')
 
 
@@ -104,6 +102,7 @@ def test_reindex_non_unique():
     idx = pd.MultiIndex.from_tuples([(0, 0), (1, 1), (1, 1), (2, 2)])
     a = pd.Series(np.arange(4), index=idx)
     new_idx = pd.MultiIndex.from_tuples([(0, 0), (1, 1), (2, 2)])
-    with tm.assert_raises_regex(ValueError,
-                                'cannot handle a non-unique multi-index!'):
+
+    msg = 'cannot handle a non-unique multi-index!'
+    with pytest.raises(ValueError, match=msg):
         a.reindex(new_idx)

--- a/pandas/tests/indexes/multi/test_reshape.py
+++ b/pandas/tests/indexes/multi/test_reshape.py
@@ -27,7 +27,7 @@ def test_insert(idx):
 
     # key wrong length
     msg = "Item must have length equal to number of levels"
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         idx.insert(0, ('foo2',))
 
     left = pd.DataFrame([['a', 'b', 0], ['b', 'd', 1]],

--- a/pandas/tests/indexes/multi/test_set_ops.py
+++ b/pandas/tests/indexes/multi/test_set_ops.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 import numpy as np
 
 import pandas as pd
@@ -7,18 +8,14 @@ import pandas.util.testing as tm
 from pandas import MultiIndex, Series
 
 
-def test_setops_errorcases(idx):
-    # # non-iterable input
-    cases = [0.5, 'xxx']
-    methods = [idx.intersection, idx.union, idx.difference,
-               idx.symmetric_difference]
-
-    for method in methods:
-        for case in cases:
-            tm.assert_raises_regex(TypeError,
-                                   "Input must be Index "
-                                   "or array-like",
-                                   method, case)
+@pytest.mark.parametrize("case", [0.5, "xxx"])
+@pytest.mark.parametrize("method", ["intersection", "union",
+                                    "difference", "symmetric_difference"])
+def test_set_ops_error_cases(idx, case, method):
+    # non-iterable input
+    msg = "Input must be Index or array-like"
+    with pytest.raises(TypeError, match=msg):
+        getattr(idx, method)(case)
 
 
 def test_intersection_base(idx):
@@ -36,8 +33,8 @@ def test_intersection_base(idx):
         assert tm.equalContents(result, second)
 
     msg = "other must be a MultiIndex or a list of tuples"
-    with tm.assert_raises_regex(TypeError, msg):
-        result = first.intersection([1, 2, 3])
+    with pytest.raises(TypeError, match=msg):
+        first.intersection([1, 2, 3])
 
 
 def test_union_base(idx):
@@ -55,8 +52,8 @@ def test_union_base(idx):
         assert tm.equalContents(result, everything)
 
     msg = "other must be a MultiIndex or a list of tuples"
-    with tm.assert_raises_regex(TypeError, msg):
-        result = first.union([1, 2, 3])
+    with pytest.raises(TypeError, match=msg):
+        first.union([1, 2, 3])
 
 
 def test_difference_base(idx):
@@ -75,8 +72,8 @@ def test_difference_base(idx):
         assert tm.equalContents(result, answer)
 
     msg = "other must be a MultiIndex or a list of tuples"
-    with tm.assert_raises_regex(TypeError, msg):
-        result = first.difference([1, 2, 3])
+    with pytest.raises(TypeError, match=msg):
+        first.difference([1, 2, 3])
 
 
 def test_symmetric_difference(idx):
@@ -94,7 +91,7 @@ def test_symmetric_difference(idx):
         assert tm.equalContents(result, answer)
 
     msg = "other must be a MultiIndex or a list of tuples"
-    with tm.assert_raises_regex(TypeError, msg):
+    with pytest.raises(TypeError, match=msg):
         first.symmetric_difference([1, 2, 3])
 
 
@@ -159,9 +156,10 @@ def test_difference(idx):
         'foo', 'two'), ('qux', 'one'), ('qux', 'two')])
     expected.names = first.names
     assert first.names == result.names
-    tm.assert_raises_regex(TypeError, "other must be a MultiIndex "
-                           "or a list of tuples",
-                           first.difference, [1, 2, 3, 4, 5])
+
+    msg = "other must be a MultiIndex or a list of tuples"
+    with pytest.raises(TypeError, match=msg):
+        first.difference([1, 2, 3, 4, 5])
 
 
 def test_union(idx):

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -80,16 +80,16 @@ def test_numpy_argsort(idx):
     # backwards compatibility concerns
     if isinstance(type(idx), (CategoricalIndex, RangeIndex)):
         msg = "the 'axis' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg,
-                               np.argsort, idx, axis=1)
+        with pytest.raises(ValueError, match=msg):
+            np.argsort(idx, axis=1)
 
         msg = "the 'kind' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.argsort,
-                               idx, kind='mergesort')
+        with pytest.raises(ValueError, match=msg):
+            np.argsort(idx, kind='mergesort')
 
         msg = "the 'order' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.argsort,
-                               idx, order=('a', 'b'))
+        with pytest.raises(ValueError, match=msg):
+            np.argsort(idx, order=('a', 'b'))
 
 
 def test_unsortedindex():

--- a/pandas/tests/indexes/period/test_astype.py
+++ b/pandas/tests/indexes/period/test_astype.py
@@ -15,7 +15,7 @@ class TestPeriodIndexAsType(object):
         # GH#13149, GH#13209
         idx = PeriodIndex(['2016-05-16', 'NaT', NaT, np.NaN], freq='D')
         msg = 'Cannot cast PeriodArray to dtype'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             idx.astype(dtype)
 
     def test_astype_conversion(self):

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -199,7 +199,7 @@ class TestPeriodIndex(object):
         assert res.dtype == 'period[M]'
 
         msg = 'specified freq and dtype are different'
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             PeriodIndex(['2011-01'], freq='M', dtype='period[D]')
 
     def test_constructor_empty(self):
@@ -208,7 +208,7 @@ class TestPeriodIndex(object):
         assert len(idx) == 0
         assert idx.freq == 'M'
 
-        with tm.assert_raises_regex(ValueError, 'freq not specified'):
+        with pytest.raises(ValueError, match='freq not specified'):
             pd.PeriodIndex([])
 
     def test_constructor_pi_nat(self):
@@ -234,35 +234,35 @@ class TestPeriodIndex(object):
         idx = PeriodIndex([pd.NaT, pd.NaT, '2011-01', '2011-01'], freq='M')
         tm.assert_index_equal(idx, exp)
 
-        with tm.assert_raises_regex(ValueError, 'freq not specified'):
+        with pytest.raises(ValueError, match='freq not specified'):
             PeriodIndex([pd.NaT, pd.NaT])
 
-        with tm.assert_raises_regex(ValueError, 'freq not specified'):
+        with pytest.raises(ValueError, match='freq not specified'):
             PeriodIndex(np.array([pd.NaT, pd.NaT]))
 
-        with tm.assert_raises_regex(ValueError, 'freq not specified'):
+        with pytest.raises(ValueError, match='freq not specified'):
             PeriodIndex(['NaT', 'NaT'])
 
-        with tm.assert_raises_regex(ValueError, 'freq not specified'):
+        with pytest.raises(ValueError, match='freq not specified'):
             PeriodIndex(np.array(['NaT', 'NaT']))
 
     def test_constructor_incompat_freq(self):
         msg = "Input has different freq=D from PeriodIndex\\(freq=M\\)"
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             PeriodIndex([Period('2011-01', freq='M'), pd.NaT,
                          Period('2011-01', freq='D')])
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             PeriodIndex(np.array([Period('2011-01', freq='M'), pd.NaT,
                                   Period('2011-01', freq='D')]))
 
         # first element is pd.NaT
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             PeriodIndex([pd.NaT, Period('2011-01', freq='M'),
                          Period('2011-01', freq='D')])
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             PeriodIndex(np.array([pd.NaT, Period('2011-01', freq='M'),
                                   Period('2011-01', freq='D')]))
 
@@ -339,15 +339,15 @@ class TestPeriodIndex(object):
 
         msg = ('Frequency must be positive, because it'
                ' represents span: -1M')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             PeriodIndex(['2011-01'], freq='-1M')
 
         msg = ('Frequency must be positive, because it' ' represents span: 0M')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             PeriodIndex(['2011-01'], freq='0M')
 
         msg = ('Frequency must be positive, because it' ' represents span: 0M')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             period_range('2011-01', periods=3, freq='0M')
 
     @pytest.mark.parametrize('freq', ['A', 'M', 'D', 'T', 'S'])
@@ -442,12 +442,12 @@ class TestPeriodIndex(object):
         end_intv = Period('2006-12-31', ('w', 1))
 
         msg = 'start and end must have same freq'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             PeriodIndex(start=start, end=end_intv)
 
         msg = ('Of the three parameters: start, end, and periods, '
                'exactly two must be specified')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             PeriodIndex(start=start)
 
     @pytest.mark.parametrize('freq', ['M', 'Q', 'A', 'D', 'B',

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -101,10 +101,9 @@ class TestGetItem(object):
         tm.assert_series_equal(exp, result)
 
         ts = ts[10:].append(ts[10:])
-        tm.assert_raises_regex(KeyError,
-                               "left slice bound for non-unique "
-                               "label: '2008'",
-                               ts.__getitem__, slice('2008', '2009'))
+        msg = "left slice bound for non-unique label: '2008'"
+        with pytest.raises(KeyError, match=msg):
+            ts[slice('2008', '2009')]
 
     def test_getitem_datetime(self):
         rng = period_range(start='2012-01-01', periods=10, freq='W-MON')
@@ -313,9 +312,9 @@ class TestTake(object):
 
         msg = ('When allow_fill=True and fill_value is not None, '
                'all indices must be >= -1')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):
@@ -362,9 +361,9 @@ class TestIndexing(object):
         assert idx0.get_loc(p2) == expected_idx1_p2
         assert idx0.get_loc(str(p2)) == expected_idx1_p2
 
-        tm.assert_raises_regex(KeyError,
-                               "Cannot interpret 'foo' as period",
-                               idx0.get_loc, 'foo')
+        msg = "Cannot interpret 'foo' as period"
+        with pytest.raises(KeyError, match=msg):
+            idx0.get_loc('foo')
         pytest.raises(KeyError, idx0.get_loc, 1.1)
         pytest.raises(TypeError, idx0.get_loc, idx0)
 
@@ -379,9 +378,10 @@ class TestIndexing(object):
         assert idx1.get_loc(p2) == expected_idx1_p2
         assert idx1.get_loc(str(p2)) == expected_idx1_p2
 
-        tm.assert_raises_regex(KeyError,
-                               "Cannot interpret 'foo' as period",
-                               idx1.get_loc, 'foo')
+        msg = "Cannot interpret 'foo' as period"
+        with pytest.raises(KeyError, match=msg):
+            idx1.get_loc('foo')
+
         pytest.raises(KeyError, idx1.get_loc, 1.1)
         pytest.raises(TypeError, idx1.get_loc, idx1)
 
@@ -564,12 +564,13 @@ class TestIndexing(object):
                            tolerance=np.timedelta64(1, 'D')) == 1
         assert idx.get_loc('2000-01-02T12', method='nearest',
                            tolerance=timedelta(1)) == 1
-        with tm.assert_raises_regex(ValueError,
-                                    'unit abbreviation w/o a number'):
+
+        msg = 'unit abbreviation w/o a number'
+        with pytest.raises(ValueError, match=msg):
             idx.get_loc('2000-01-10', method='nearest', tolerance='foo')
 
         msg = 'Input has different freq from PeriodArray\\(freq=D\\)'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.get_loc('2000-01-10', method='nearest', tolerance='1 hour')
         with pytest.raises(KeyError):
             idx.get_loc('2000-01-10', method='nearest', tolerance='1 day')
@@ -599,7 +600,7 @@ class TestIndexing(object):
                                     np.array([0, -1, 1], dtype=np.intp))
 
         msg = 'Input has different freq from PeriodArray\\(freq=H\\)'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.get_indexer(target, 'nearest', tolerance='1 minute')
 
         tm.assert_numpy_array_equal(idx.get_indexer(target, 'nearest',

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -65,17 +65,19 @@ class TestPeriodIndexOps(Ops):
         assert np.max(pr) == Period('2016-01-20', freq='D')
 
         errmsg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, errmsg, np.min, pr, out=0)
-        tm.assert_raises_regex(ValueError, errmsg, np.max, pr, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.min(pr, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.max(pr, out=0)
 
         assert np.argmin(pr) == 0
         assert np.argmax(pr) == 5
 
         errmsg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(
-            ValueError, errmsg, np.argmin, pr, out=0)
-        tm.assert_raises_regex(
-            ValueError, errmsg, np.argmax, pr, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.argmin(pr, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.argmax(pr, out=0)
 
     def test_resolution(self):
         for freq, expected in zip(['A', 'Q', 'M', 'D', 'H',

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -41,12 +41,12 @@ class TestPeriodIndex(object):
     def test_slice_with_zero_step_raises(self):
         ts = Series(np.arange(20),
                     period_range('2014-01', periods=20, freq='M'))
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts[::0])
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts.loc[::0])
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts.loc[::0])
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts[::0]
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts.loc[::0]
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts.loc[::0]
 
     def test_slice_keep_name(self):
         idx = period_range('20010101', periods=10, freq='D', name='bob')

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -92,8 +92,8 @@ class TestPeriodIndex(DatetimeLike):
 
     def test_hash_error(self):
         index = period_range('20010101', periods=10)
-        with tm.assert_raises_regex(TypeError, "unhashable type: %r" %
-                                    type(index).__name__):
+        with pytest.raises(TypeError, match=("unhashable type: %r" %
+                                             type(index).__name__)):
             hash(index)
 
     def test_make_time_series(self):
@@ -452,8 +452,8 @@ class TestPeriodIndex(DatetimeLike):
         tm.assert_index_equal(np.repeat(index, 2), expected)
 
         msg = "the 'axis' parameter is not supported"
-        tm.assert_raises_regex(
-            ValueError, msg, np.repeat, index, 2, axis=1)
+        with pytest.raises(ValueError, match=msg):
+            np.repeat(index, 2, axis=1)
 
     def test_pindex_multiples(self):
         pi = PeriodIndex(start='1/1/11', end='12/31/11', freq='2M')
@@ -568,5 +568,5 @@ def test_maybe_convert_timedelta():
     assert pi._maybe_convert_timedelta(2) == 2
 
     offset = offsets.BusinessDay()
-    with tm.assert_raises_regex(ValueError, 'freq'):
+    with pytest.raises(ValueError, match='freq'):
         pi._maybe_convert_timedelta(offset)

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -65,31 +65,31 @@ class TestPeriodRange(object):
         # not enough params
         msg = ('Of the three parameters: start, end, and periods, '
                'exactly two must be specified')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             period_range(start='2017Q1')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             period_range(end='2017Q1')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             period_range(periods=5)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             period_range()
 
         # too many params
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             period_range(start='2017Q1', end='2018Q1', periods=8, freq='Q')
 
         # start/end NaT
         msg = 'start and end must not be NaT'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             period_range(start=NaT, end='2018Q1')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             period_range(start='2017Q1', end=NaT)
 
         # invalid periods param
         msg = 'periods must be a number, got foo'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             period_range(start='2017Q1', periods='foo')

--- a/pandas/tests/indexes/period/test_setops.py
+++ b/pandas/tests/indexes/period/test_setops.py
@@ -106,7 +106,7 @@ class TestPeriodIndex(object):
             index.union(index2)
 
         msg = 'can only call with other PeriodIndex-ed objects'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             index.join(index.to_timestamp())
 
         index3 = period_range('1/1/2000', '1/20/2000', freq='2D')

--- a/pandas/tests/indexes/period/test_tools.py
+++ b/pandas/tests/indexes/period/test_tools.py
@@ -180,7 +180,7 @@ class TestPeriodIndex(object):
         assert prng.freq == 'M'
 
         msg = pd._libs.tslibs.frequencies.INVALID_FREQ_ERR_MSG
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             date_range('01-Jan-2012', periods=8, freq='EOM')
 
     def test_period_dt64_round_trip(self):
@@ -219,11 +219,11 @@ class TestPeriodIndex(object):
         assert pidx.searchsorted(p2) == 3
 
         msg = "Input has different freq=H from PeriodIndex"
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             pidx.searchsorted(pd.Period('2014-01-01', freq='H'))
 
         msg = "Input has different freq=5D from PeriodIndex"
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             pidx.searchsorted(pd.Period('2014-01-01', freq='5D'))
 
 
@@ -260,7 +260,7 @@ class TestPeriodIndexConversion(object):
 
         msg = ('Frequency must be positive, because it'
                ' represents span: -2A')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             result.to_period(freq='-2A')
 
     def test_to_timestamp_preserve_name(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -267,7 +267,7 @@ class TestIndex(Base):
         # see gh-15187
         data = [np.nan]
         msg = "cannot convert"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Index(data, dtype=dtype)
 
     @pytest.mark.parametrize("klass,dtype,na_val", [
@@ -464,29 +464,28 @@ class TestIndex(Base):
         assert isinstance(empty, klass)
         assert not len(empty)
 
-    def test_constructor_nonhashable_name(self, indices):
+    def test_constructor_non_hashable_name(self, indices):
         # GH 20527
 
         if isinstance(indices, MultiIndex):
             pytest.skip("multiindex handled in test_multi.py")
 
-        name = ['0']
         message = "Index.name must be a hashable type"
-        tm.assert_raises_regex(TypeError, message, name=name)
+        renamed = [['1']]
 
         # With .rename()
-        renamed = [['1']]
-        tm.assert_raises_regex(TypeError, message,
-                               indices.rename, name=renamed)
+        with pytest.raises(TypeError, match=message):
+            indices.rename(name=renamed)
+
         # With .set_names()
-        tm.assert_raises_regex(TypeError, message,
-                               indices.set_names, names=renamed)
+        with pytest.raises(TypeError, match=message):
+            indices.set_names(names=renamed)
 
     def test_constructor_overflow_int64(self):
         # see gh-15832
         msg = ("The elements provided in the data cannot "
                "all be casted to the dtype int64")
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             Index([np.iinfo(np.uint64).max - 1], dtype="int64")
 
     @pytest.mark.xfail(reason="see GH#21311: Index "
@@ -494,7 +493,7 @@ class TestIndex(Base):
                        strict=True)
     def test_constructor_cast(self):
         msg = "could not convert string to float"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Index(["a", "b", "c"], dtype=float)
 
     def test_view_with_args(self):
@@ -1327,10 +1326,10 @@ class TestIndex(Base):
         # GH10411
         index = Index(np.arange(10))
 
-        with tm.assert_raises_regex(ValueError, 'tolerance argument'):
+        with pytest.raises(ValueError, match='tolerance argument'):
             index.get_indexer([1, 0], tolerance=1)
 
-        with tm.assert_raises_regex(ValueError, 'limit argument'):
+        with pytest.raises(ValueError, match='limit argument'):
             index.get_indexer([1, 0], limit=1)
 
     @pytest.mark.parametrize(
@@ -1378,7 +1377,7 @@ class TestIndex(Base):
 
     def test_get_indexer_nearest_error(self):
         index = Index(np.arange(10))
-        with tm.assert_raises_regex(ValueError, 'limit argument'):
+        with pytest.raises(ValueError, match='limit argument'):
             index.get_indexer([1, 0], method='nearest', limit=1)
 
         with pytest.raises(ValueError, match='tolerance size must match'):
@@ -1465,7 +1464,7 @@ class TestIndex(Base):
         else:
             msg = 'invalid key'
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             index.get_loc([1, 2], method=method)
 
     @pytest.mark.parametrize("method,loc", [
@@ -1478,32 +1477,32 @@ class TestIndex(Base):
     @pytest.mark.parametrize("method", ['pad', 'backfill', 'nearest'])
     def test_get_loc_outside_tolerance_raises(self, method):
         index = pd.Index([0, 1, 2])
-        with tm.assert_raises_regex(KeyError, '1.1'):
+        with pytest.raises(KeyError, match='1.1'):
             index.get_loc(1.1, method, tolerance=0.05)
 
     def test_get_loc_bad_tolerance_raises(self):
         index = pd.Index([0, 1, 2])
-        with tm.assert_raises_regex(ValueError, 'must be numeric'):
+        with pytest.raises(ValueError, match='must be numeric'):
             index.get_loc(1.1, 'nearest', tolerance='invalid')
 
     def test_get_loc_tolerance_no_method_raises(self):
         index = pd.Index([0, 1, 2])
-        with tm.assert_raises_regex(ValueError, 'tolerance .* valid if'):
+        with pytest.raises(ValueError, match='tolerance .* valid if'):
             index.get_loc(1.1, tolerance=1)
 
     def test_get_loc_raises_missized_tolerance(self):
         index = pd.Index([0, 1, 2])
-        with tm.assert_raises_regex(ValueError, 'tolerance size must match'):
+        with pytest.raises(ValueError, match='tolerance size must match'):
             index.get_loc(1.1, 'nearest', tolerance=[1, 1])
 
     def test_get_loc_raises_object_nearest(self):
         index = pd.Index(['a', 'c'])
-        with tm.assert_raises_regex(TypeError, 'unsupported operand type'):
+        with pytest.raises(TypeError, match='unsupported operand type'):
             index.get_loc('a', method='nearest')
 
     def test_get_loc_raises_object_tolerance(self):
         index = pd.Index(['a', 'c'])
-        with tm.assert_raises_regex(TypeError, 'unsupported operand type'):
+        with pytest.raises(TypeError, match='unsupported operand type'):
             index.get_loc('a', method='pad', tolerance='invalid')
 
     @pytest.mark.parametrize("dtype", [int, float])
@@ -1585,10 +1584,10 @@ class TestIndex(Base):
 
     def test_slice_locs_na_raises(self):
         index = Index([np.nan, 1, 2])
-        with tm.assert_raises_regex(KeyError, ''):
+        with pytest.raises(KeyError, match=''):
             index.slice_locs(start=1.5)
 
-        with tm.assert_raises_regex(KeyError, ''):
+        with pytest.raises(KeyError, match=''):
             index.slice_locs(end=1.5)
 
     @pytest.mark.parametrize("in_slice,expected", [
@@ -1627,7 +1626,7 @@ class TestIndex(Base):
 
     @pytest.mark.parametrize("keys", [['foo', 'bar'], ['1', 'bar']])
     def test_drop_by_str_label_raises_missing_keys(self, keys):
-        with tm.assert_raises_regex(KeyError, ''):
+        with pytest.raises(KeyError, match=''):
             self.strIndex.drop(keys)
 
     def test_drop_by_str_label_errors_ignore(self):
@@ -1656,7 +1655,7 @@ class TestIndex(Base):
 
     def test_drop_by_numeric_label_raises_missing_keys(self):
         index = Index([1, 2, 3])
-        with tm.assert_raises_regex(KeyError, ''):
+        with pytest.raises(KeyError, match=''):
             index.drop([3, 4])
 
     @pytest.mark.parametrize("key,expected", [
@@ -1789,7 +1788,7 @@ class TestIndex(Base):
         # Float64Index overrides isin, so must be checked separately
         Float64Index([1.0, 2.0, 3.0, 4.0])])
     def test_isin_level_kwarg_raises_bad_index(self, level, index):
-        with tm.assert_raises_regex(IndexError, 'Too many levels'):
+        with pytest.raises(IndexError, match='Too many levels'):
             index.isin([], level=level)
 
     @pytest.mark.parametrize("level", [1.0, 'foobar', 'xyzzy', np.nan])
@@ -1797,7 +1796,7 @@ class TestIndex(Base):
         Index(['qux', 'baz', 'foo', 'bar']),
         Float64Index([1.0, 2.0, 3.0, 4.0])])
     def test_isin_level_kwarg_raises_key(self, level, index):
-        with tm.assert_raises_regex(KeyError, 'must be same as name'):
+        with pytest.raises(KeyError, match='must be same as name'):
             index.isin([], level=level)
 
     @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
@@ -1860,7 +1859,7 @@ class TestIndex(Base):
         MultiIndex.from_tuples([('foo', '1'), ('bar', '3')]),
         PeriodIndex(start='2000', end='2010', freq='A')])
     def test_str_attribute_raises(self, index):
-        with tm.assert_raises_regex(AttributeError, 'only use .str accessor'):
+        with pytest.raises(AttributeError, match='only use .str accessor'):
             index.str.repeat(2)
 
     @pytest.mark.parametrize("expand,expected", [
@@ -1951,14 +1950,14 @@ class TestIndex(Base):
         msg = ('When allow_fill=True and fill_value is not None, '
                'all indices must be >= -1')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             index.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             index.take(np.array([1, 0, -5]), fill_value=True)
 
     def test_take_bad_bounds_raises(self):
         index = pd.Index(list('ABC'), name='xxx')
-        with tm.assert_raises_regex(IndexError, 'out of bounds'):
+        with pytest.raises(IndexError, match='out of bounds'):
             index.take(np.array([1, -5]))
 
     @pytest.mark.parametrize("name", [None, 'foobar'])
@@ -2032,7 +2031,7 @@ class TestIndex(Base):
     def test_equals_op_mismatched_multiindex_raises(self, index):
         df = pd.read_csv(StringIO('a,b,c\n1,2,3\n4,5,6'), index_col=[0, 1])
 
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             df.index == index
 
     def test_equals_op_index_vs_mi_same_length(self):
@@ -2240,7 +2239,7 @@ Index([u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a',
 
     def test_cached_properties_not_settable(self):
         index = pd.Index([1, 2, 3])
-        with tm.assert_raises_regex(AttributeError, "Can't set attribute"):
+        with pytest.raises(AttributeError, match="Can't set attribute"):
             index.is_unique = False
 
     def test_get_duplicates_deprecated(self):
@@ -2277,10 +2276,10 @@ class TestMixedIntIndex(Base):
     def test_argsort(self):
         index = self.create_index()
         if PY36:
-            with tm.assert_raises_regex(TypeError, "'>|<' not supported"):
+            with pytest.raises(TypeError, match="'>|<' not supported"):
                 result = index.argsort()
         elif PY3:
-            with tm.assert_raises_regex(TypeError, "unorderable types"):
+            with pytest.raises(TypeError, match="unorderable types"):
                 result = index.argsort()
         else:
             result = index.argsort()
@@ -2290,10 +2289,10 @@ class TestMixedIntIndex(Base):
     def test_numpy_argsort(self):
         index = self.create_index()
         if PY36:
-            with tm.assert_raises_regex(TypeError, "'>|<' not supported"):
+            with pytest.raises(TypeError, match="'>|<' not supported"):
                 result = np.argsort(index)
         elif PY3:
-            with tm.assert_raises_regex(TypeError, "unorderable types"):
+            with pytest.raises(TypeError, match="unorderable types"):
                 result = np.argsort(index)
         else:
             result = np.argsort(index)
@@ -2462,7 +2461,7 @@ class TestMixedIntIndex(Base):
 
     def test_dropna_invalid_how_raises(self):
         msg = "invalid how option: xxx"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.Index([1, 2, 3]).dropna(how='xxx')
 
     def test_get_combined_index(self):
@@ -2586,7 +2585,7 @@ def test_generated_op_names(opname, indices):
 @pytest.mark.parametrize('index_maker', tm.index_subclass_makers_generator())
 def test_index_subclass_constructor_wrong_kwargs(index_maker):
     # GH #19348
-    with tm.assert_raises_regex(TypeError, 'unexpected keyword argument'):
+    with pytest.raises(TypeError, match='unexpected keyword argument'):
         index_maker(foo='bar')
 
 

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -342,7 +342,7 @@ class TestCategoricalIndex(Base):
         result = ci.append([])
         tm.assert_index_equal(result, ci, exact=True)
 
-        # appending with different categories or reoreded is not ok
+        # appending with different categories or reordered is not ok
         pytest.raises(
             TypeError,
             lambda: ci.append(ci.values.set_categories(list('abcd'))))
@@ -481,7 +481,7 @@ class TestCategoricalIndex(Base):
         actual = idx.get_indexer(idx)
         tm.assert_numpy_array_equal(expected, actual)
 
-        with tm.assert_raises_regex(ValueError, "Invalid fill method"):
+        with pytest.raises(ValueError, match="Invalid fill method"):
             idx.get_indexer(idx, method="invalid")
 
     def test_reindexing(self):
@@ -758,7 +758,7 @@ class TestCategoricalIndex(Base):
         assert (ci1 == ci1.values).all()
 
         # invalid comparisons
-        with tm.assert_raises_regex(ValueError, "Lengths must match"):
+        with pytest.raises(ValueError, match="Lengths must match"):
             ci1 == Index(['a', 'b', 'c'])
         pytest.raises(TypeError, lambda: ci1 == ci2)
         pytest.raises(
@@ -1000,8 +1000,8 @@ class TestCategoricalIndex(Base):
         tm.assert_index_equal(idx.fillna(1.0), exp)
 
         # fill by value not in categories raises ValueError
-        with tm.assert_raises_regex(ValueError,
-                                    'fill value must be in categories'):
+        msg = 'fill value must be in categories'
+        with pytest.raises(ValueError, match=msg):
             idx.fillna(2.0)
 
     def test_take_fill_value(self):
@@ -1055,9 +1055,9 @@ class TestCategoricalIndex(Base):
 
         msg = ('When allow_fill=True and fill_value is not None, '
                'all indices must be >= -1')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):
@@ -1093,9 +1093,9 @@ class TestCategoricalIndex(Base):
 
         msg = ('When allow_fill=True and fill_value is not None, '
                'all indices must be >= -1')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):
@@ -1106,16 +1106,16 @@ class TestCategoricalIndex(Base):
         indices = [1, 0, -1]
 
         msg = r"take\(\) got an unexpected keyword argument 'foo'"
-        tm.assert_raises_regex(TypeError, msg, idx.take,
-                               indices, foo=2)
+        with pytest.raises(TypeError, match=msg):
+            idx.take(indices, foo=2)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, idx.take,
-                               indices, out=indices)
+        with pytest.raises(ValueError, match=msg):
+            idx.take(indices, out=indices)
 
         msg = "the 'mode' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, idx.take,
-                               indices, mode='clip')
+        with pytest.raises(ValueError, match=msg):
+            idx.take(indices, mode='clip')
 
     @pytest.mark.parametrize('dtype, engine_type', [
         (np.int8, libindex.Int8Engine),

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -232,7 +232,7 @@ class TestFloat64Index(Numeric):
     def test_type_coercion_fail(self, any_int_dtype):
         # see gh-15832
         msg = "Trying to coerce float values to integers"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Index([1, 2, 3.5], dtype=any_int_dtype)
 
     def test_type_coercion_valid(self, float_dtype):
@@ -288,7 +288,7 @@ class TestFloat64Index(Numeric):
         pytest.raises(KeyError, idx.get_loc, True)
         pytest.raises(KeyError, idx.get_loc, False)
 
-        with tm.assert_raises_regex(ValueError, 'must be numeric'):
+        with pytest.raises(ValueError, match='must be numeric'):
             idx.get_loc(1.4, method='nearest', tolerance='foo')
 
         with pytest.raises(ValueError, match='must contain numeric elements'):
@@ -393,9 +393,9 @@ class TestFloat64Index(Numeric):
 
         msg = ('When allow_fill=True and fill_value is not None, '
                'all indices must be >= -1')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):
@@ -540,7 +540,7 @@ class NumericInt(Numeric):
                "{name} cannot contain NA").format(name=name)
 
         # fill_value=True
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -1]), fill_value=True)
 
         # allow_fill=False
@@ -549,9 +549,9 @@ class NumericInt(Numeric):
         expected = self._holder([2, 1, 3], name='xxx')
         tm.assert_index_equal(result, expected)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):
@@ -613,11 +613,11 @@ class TestInt64Index(NumericInt):
 
         # preventing casting
         arr = np.array([1, '2', 3, '4'], dtype=object)
-        with tm.assert_raises_regex(TypeError, 'casting'):
+        with pytest.raises(TypeError, match='casting'):
             Int64Index(arr)
 
         arr_with_floats = [0, 2, 3, 4, 5, 1.25, 3, -1]
-        with tm.assert_raises_regex(TypeError, 'casting'):
+        with pytest.raises(TypeError, match='casting'):
             Int64Index(arr_with_floats)
 
     def test_constructor_coercion_signed_to_unsigned(self, uint_dtype):
@@ -625,7 +625,7 @@ class TestInt64Index(NumericInt):
         # see gh-15832
         msg = "Trying to coerce negative values to unsigned integers"
 
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             Index([-1], dtype=uint_dtype)
 
     def test_coerce_list(self):

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -63,10 +63,8 @@ class TestRangeIndex(Numeric):
         self.check_binop(ops, scalars, idxs)
 
     def test_too_many_names(self):
-        def testit():
+        with pytest.raises(ValueError, match="^Length"):
             self.index.names = ["roger", "harold"]
-
-        tm.assert_raises_regex(ValueError, "^Length", testit)
 
     def test_constructor(self):
         index = RangeIndex(5)
@@ -91,7 +89,7 @@ class TestRangeIndex(Numeric):
         tm.assert_index_equal(Index(expected), index)
 
         msg = "RangeIndex\\(\\.\\.\\.\\) must be called with integers"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             RangeIndex()
 
         for index in [RangeIndex(0), RangeIndex(start=0), RangeIndex(stop=0),
@@ -103,7 +101,7 @@ class TestRangeIndex(Numeric):
             assert index._step == 1
             tm.assert_index_equal(Index(expected), index)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             RangeIndex(name='Foo')
 
         for index in [RangeIndex(0, name='Foo'),
@@ -765,7 +763,7 @@ class TestRangeIndex(Numeric):
 
         # fill_value
         msg = "Unable to fill values because RangeIndex cannot contain NA"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -1]), fill_value=True)
 
         # allow_fill=False
@@ -775,9 +773,9 @@ class TestRangeIndex(Numeric):
         tm.assert_index_equal(result, expected)
 
         msg = "Unable to fill values because RangeIndex cannot contain NA"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):

--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -75,5 +75,5 @@ class TestTimedeltaIndex(object):
         # GH 13149, GH 13209
         idx = TimedeltaIndex([1e14, 'NaT', NaT, np.NaN])
         msg = 'Cannot cast TimedeltaIndex to dtype'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             idx.astype(dtype)

--- a/pandas/tests/indexes/timedeltas/test_construction.py
+++ b/pandas/tests/indexes/timedeltas/test_construction.py
@@ -57,7 +57,7 @@ class TestTimedeltaIndex(object):
         tm.assert_index_equal(rng, exp)
 
         msg = 'periods must be a number, got foo'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             TimedeltaIndex(start='1 days', periods='foo', freq='D')
 
         pytest.raises(ValueError, TimedeltaIndex, start='1 days',

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -101,16 +101,16 @@ class TestTake(object):
         indices = [1, 6, 5, 9, 10, 13, 15, 3]
 
         msg = r"take\(\) got an unexpected keyword argument 'foo'"
-        tm.assert_raises_regex(TypeError, msg, idx.take,
-                               indices, foo=2)
+        with pytest.raises(TypeError, match=msg):
+            idx.take(indices, foo=2)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, idx.take,
-                               indices, out=indices)
+        with pytest.raises(ValueError, match=msg):
+            idx.take(indices, out=indices)
 
         msg = "the 'mode' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, idx.take,
-                               indices, mode='clip')
+        with pytest.raises(ValueError, match=msg):
+            idx.take(indices, mode='clip')
 
     # TODO: This method came from test_timedelta; de-dup with version above
     def test_take2(self):
@@ -151,9 +151,9 @@ class TestTake(object):
 
         msg = ('When allow_fill=True and fill_value is not None, '
                'all indices must be >= -1')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -2]), fill_value=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
         with pytest.raises(IndexError):
@@ -239,8 +239,8 @@ class TestTimedeltaIndex(object):
             assert result.freq == expected.freq
 
         with pytest.raises((IndexError, ValueError)):
-            # either depeidnig on numpy version
-            result = idx.delete(5)
+            # either depending on numpy version
+            idx.delete(5)
 
     def test_delete_slice(self):
         idx = timedelta_range(start='1 days', periods=10, freq='D', name='idx')
@@ -285,8 +285,7 @@ class TestTimedeltaIndex(object):
         assert idx.get_loc(idx[1], 'pad',
                            tolerance=timedelta(0)) == 1
 
-        with tm.assert_raises_regex(ValueError,
-                                    'unit abbreviation w/o a number'):
+        with pytest.raises(ValueError, match='unit abbreviation w/o a number'):
             idx.get_loc(idx[1], method='nearest', tolerance='foo')
 
         with pytest.raises(

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -61,17 +61,19 @@ class TestTimedeltaIndexOps(Ops):
         assert np.max(td) == Timedelta('16820 days')
 
         errmsg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, errmsg, np.min, td, out=0)
-        tm.assert_raises_regex(ValueError, errmsg, np.max, td, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.min(td, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.max(td, out=0)
 
         assert np.argmin(td) == 0
         assert np.argmax(td) == 5
 
         errmsg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(
-            ValueError, errmsg, np.argmin, td, out=0)
-        tm.assert_raises_regex(
-            ValueError, errmsg, np.argmax, td, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.argmin(td, out=0)
+        with pytest.raises(ValueError, match=errmsg):
+            np.argmax(td, out=0)
 
     def test_value_counts_unique(self):
         # GH 7735
@@ -317,16 +319,16 @@ class TestTimedeltaIndexOps(Ops):
         # setting with an incompatible freq
         msg = ('Inferred frequency 2D from passed values does not conform to '
                'passed frequency 5D')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.freq = '5D'
 
         # setting with a non-fixed frequency
         msg = r'<2 \* BusinessDays> is a non-fixed frequency'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             idx.freq = '2B'
 
         # setting with non-freq string
-        with tm.assert_raises_regex(ValueError, 'Invalid frequency'):
+        with pytest.raises(ValueError, match='Invalid frequency'):
             idx.freq = 'foo'
 
 

--- a/pandas/tests/indexes/timedeltas/test_partial_slicing.py
+++ b/pandas/tests/indexes/timedeltas/test_partial_slicing.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import pandas as pd
-import pandas.util.testing as tm
 from pandas import Series, Timedelta, timedelta_range
 from pandas.util.testing import assert_series_equal
 
@@ -78,9 +77,9 @@ class TestSlicing(object):
 
     def test_slice_with_zero_step_raises(self):
         ts = Series(np.arange(20), timedelta_range('0', periods=20, freq='H'))
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts[::0])
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts.loc[::0])
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: ts.loc[::0])
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts[::0]
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts.loc[::0]
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            ts.loc[::0]

--- a/pandas/tests/indexes/timedeltas/test_scalar_compat.py
+++ b/pandas/tests/indexes/timedeltas/test_scalar_compat.py
@@ -3,6 +3,7 @@
 Tests for TimedeltaIndex methods behaving like their Timedelta counterparts
 """
 
+import pytest
 import numpy as np
 
 import pandas as pd
@@ -51,13 +52,13 @@ class TestVectorizedTimedelta(object):
         assert elt.round(freq='H') == expected_elt
 
         msg = pd._libs.tslibs.frequencies.INVALID_FREQ_ERR_MSG
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             td.round(freq='foo')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             elt.round(freq='foo')
 
         msg = "<MonthEnd> is a non-fixed frequency"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             td.round(freq='M')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             elt.round(freq='M')

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -199,8 +199,8 @@ class TestTimedeltaIndex(DatetimeLike):
 
     def test_hash_error(self):
         index = timedelta_range('1 days', periods=10)
-        with tm.assert_raises_regex(TypeError, "unhashable type: %r" %
-                                    type(index).__name__):
+        with pytest.raises(TypeError, match=("unhashable type: %r" %
+                                             type(index).__name__)):
             hash(index)
 
     def test_append_join_nondatetimeindex(self):

--- a/pandas/tests/indexes/timedeltas/test_timedelta_range.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta_range.py
@@ -36,10 +36,10 @@ class TestTimedeltas(object):
         arr = np.arange(10).reshape(2, 5)
         df = pd.DataFrame(np.arange(10).reshape(2, 5))
         for arg in (arr, df):
-            with tm.assert_raises_regex(TypeError, "1-d array"):
+            with pytest.raises(TypeError, match="1-d array"):
                 to_timedelta(arg)
             for errors in ['ignore', 'raise', 'coerce']:
-                with tm.assert_raises_regex(TypeError, "1-d array"):
+                with pytest.raises(TypeError, match="1-d array"):
                     to_timedelta(arg, errors=errors)
 
         # issue10583
@@ -65,18 +65,18 @@ class TestTimedeltas(object):
         # not enough params
         msg = ('Of the four parameters: start, end, periods, and freq, '
                'exactly three must be specified')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             timedelta_range(start='0 days')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             timedelta_range(end='5 days')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             timedelta_range(periods=2)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             timedelta_range()
 
         # too many params
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             timedelta_range(start='0 days', end='5 days', periods=10, freq='H')

--- a/pandas/tests/indexes/timedeltas/test_tools.py
+++ b/pandas/tests/indexes/timedeltas/test_tools.py
@@ -110,8 +110,8 @@ class TestTimedeltas(object):
 
         # bad value for errors parameter
         msg = "errors must be one of"
-        tm.assert_raises_regex(ValueError, msg, to_timedelta,
-                               ['foo'], errors='never')
+        with pytest.raises(ValueError, match=msg):
+            to_timedelta(['foo'], errors='never')
 
         # these will error
         pytest.raises(ValueError, lambda: to_timedelta([1, 2], unit='foo'))

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -362,10 +362,9 @@ class TestCategoricalIndex(object):
         exp = DataFrame({'A': [1, 1, 2], 'B': [4, 4, 5]}, index=exp_index)
         tm.assert_frame_equal(res, exp, check_index_type=True)
 
-        with tm.assert_raises_regex(
-                KeyError,
-                'a list-indexer must only include values that are '
-                'in the categories'):
+        msg = ('a list-indexer must only include '
+               'values that are in the categories')
+        with pytest.raises(KeyError, match=msg):
             df.loc[['a', 'x']]
 
         # duplicated categories and codes
@@ -387,10 +386,9 @@ class TestCategoricalIndex(object):
                    ]}, index=CategoricalIndex(['a', 'a', 'a', 'a', 'b']))
         tm.assert_frame_equal(res, exp, check_index_type=True)
 
-        with tm.assert_raises_regex(
-                KeyError,
-                'a list-indexer must only include values '
-                'that are in the categories'):
+        msg = ('a list-indexer must only include values '
+               'that are in the categories')
+        with pytest.raises(KeyError, match=msg):
             df.loc[['a', 'x']]
 
         # contains unused category
@@ -417,10 +415,9 @@ class TestCategoricalIndex(object):
                                                categories=list('abcde')))
         tm.assert_frame_equal(res, exp, check_index_type=True)
 
-        with tm.assert_raises_regex(
-                KeyError,
-                'a list-indexer must only include values '
-                'that are in the categories'):
+        msg = ('a list-indexer must only include values '
+               'that are in the categories')
+        with pytest.raises(KeyError, match=msg):
             df.loc[['a', 'x']]
 
     def test_get_indexer_array(self):

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -374,14 +374,14 @@ class TestInsertIndexCoercion(CoercionBase):
 
         msg = "Passed item and index have different timezone"
         if fill_val.tz:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 obj.insert(1, pd.Timestamp('2012-01-01'))
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             obj.insert(1, pd.Timestamp('2012-01-01', tz='Asia/Tokyo'))
 
         msg = "cannot insert DatetimeIndex with incompatible label"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             obj.insert(1, 1)
 
         pytest.xfail("ToDo: must coerce to object")
@@ -397,12 +397,12 @@ class TestInsertIndexCoercion(CoercionBase):
 
         # ToDo: must coerce to object
         msg = "cannot insert TimedeltaIndex with incompatible label"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             obj.insert(1, pd.Timestamp('2012-01-01'))
 
         # ToDo: must coerce to object
         msg = "cannot insert TimedeltaIndex with incompatible label"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             obj.insert(1, 1)
 
     @pytest.mark.parametrize("insert, coerced_val, coerced_dtype", [
@@ -603,7 +603,7 @@ class TestWhereCoercion(CoercionBase):
 
         msg = ("Index\\(\\.\\.\\.\\) must be called with a collection "
                "of some kind")
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             obj.where(cond, fill_val)
 
         values = pd.Index(pd.date_range(fill_val, periods=4))
@@ -628,7 +628,7 @@ class TestWhereCoercion(CoercionBase):
 
         msg = ("Index\\(\\.\\.\\.\\) must be called with a collection "
                "of some kind")
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             obj.where(cond, fill_val)
 
         values = pd.Index(pd.date_range(fill_val, periods=4))

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -50,11 +50,9 @@ class TestFloatIndexers(object):
 
             s = Series(np.arange(len(i)), index=i)
 
-            def f():
+            msg = 'Cannot index by location index'
+            with pytest.raises(TypeError, match=msg):
                 s.iloc[3.0]
-            tm.assert_raises_regex(TypeError,
-                                   'Cannot index by location index',
-                                   f)
 
             def f():
                 s.iloc[3.0] = 0

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -21,12 +21,10 @@ class TestiLoc(Base):
         # GH6296
         # iloc should allow indexers that exceed the bounds
         df = DataFrame(np.random.random_sample((20, 5)), columns=list('ABCDE'))
-        expected = df
 
         # lists of positions should raise IndexErrror!
-        with tm.assert_raises_regex(IndexError,
-                                    'positional indexers '
-                                    'are out-of-bounds'):
+        msg = 'positional indexers are out-of-bounds'
+        with pytest.raises(IndexError, match=msg):
             df.iloc[:, [0, 1, 2, 3, 4, 5]]
         pytest.raises(IndexError, lambda: df.iloc[[1, 30]])
         pytest.raises(IndexError, lambda: df.iloc[[1, -30]])
@@ -38,14 +36,14 @@ class TestiLoc(Base):
 
         # still raise on a single indexer
         msg = 'single positional indexer is out-of-bounds'
-        with tm.assert_raises_regex(IndexError, msg):
+        with pytest.raises(IndexError, match=msg):
             df.iloc[30]
         pytest.raises(IndexError, lambda: df.iloc[-30])
 
         # GH10779
         # single positive/negative indexer exceeding Series bounds should raise
         # an IndexError
-        with tm.assert_raises_regex(IndexError, msg):
+        with pytest.raises(IndexError, match=msg):
             s.iloc[30]
         pytest.raises(IndexError, lambda: s.iloc[-30])
 
@@ -136,8 +134,8 @@ class TestiLoc(Base):
         else:
             s = DataFrame(np.arange(100).reshape(10, 10))
 
-        tm.assert_raises_regex(TypeError, 'Cannot index by location index',
-                               lambda: s.iloc['a'])
+        with pytest.raises(TypeError, match='Cannot index by location index'):
+            s.iloc['a']
 
     def test_iloc_array_not_mutating_negative_indices(self):
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -837,15 +837,14 @@ class TestMisc(Base):
 
     def test_slice_with_zero_step_raises(self):
         s = Series(np.arange(20), index=_mklbl('A', 20))
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: s[::0])
-        tm.assert_raises_regex(ValueError, 'slice step cannot be zero',
-                               lambda: s.loc[::0])
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            s[::0]
+        with pytest.raises(ValueError, match='slice step cannot be zero'):
+            s.loc[::0]
         with catch_warnings(record=True):
             simplefilter("ignore")
-            tm.assert_raises_regex(ValueError,
-                                   'slice step cannot be zero',
-                                   lambda: s.ix[::0])
+            with pytest.raises(ValueError, match='slice step cannot be zero'):
+                s.ix[::0]
 
     def test_indexing_assignment_dict_already_exists(self):
         df = DataFrame({'x': [1, 2, 6],
@@ -1062,18 +1061,18 @@ def test_validate_indices_ok():
 
 def test_validate_indices_low():
     indices = np.asarray([0, -2])
-    with tm.assert_raises_regex(ValueError, "'indices' contains"):
+    with pytest.raises(ValueError, match="'indices' contains"):
         validate_indices(indices, 2)
 
 
 def test_validate_indices_high():
     indices = np.asarray([0, 1, 2])
-    with tm.assert_raises_regex(IndexError, "indices are out"):
+    with pytest.raises(IndexError, match="indices are out"):
         validate_indices(indices, 2)
 
 
 def test_validate_indices_empty():
-    with tm.assert_raises_regex(IndexError, "indices are out"):
+    with pytest.raises(IndexError, match="indices are out"):
         validate_indices(np.array([0, 1]), 0)
 
 

--- a/pandas/tests/indexing/test_multiindex.py
+++ b/pandas/tests/indexing/test_multiindex.py
@@ -308,9 +308,9 @@ class TestMultiIndexBasic(object):
         tm.assert_frame_equal(result, expected)
 
         # missing item:
-        with tm.assert_raises_regex(KeyError, '1'):
+        with pytest.raises(KeyError, match='1'):
             df[1]
-        with tm.assert_raises_regex(KeyError, r"'\[1\] not in index'"):
+        with pytest.raises(KeyError, match=r"'\[1\] not in index'"):
             df[[1]]
 
     def test_loc_multiindex_indexer_none(self):
@@ -851,10 +851,10 @@ class TestMultiIndexSlicers(object):
         assert df.index.lexsort_depth == 2
         df = df.sort_index(level=1, axis=0)
         assert df.index.lexsort_depth == 0
-        with tm.assert_raises_regex(
-                UnsortedIndexError,
-                'MultiIndex slicing requires the index to be '
-                r'lexsorted: slicing on levels \[1\], lexsort depth 0'):
+
+        msg = ('MultiIndex slicing requires the index to be '
+               r'lexsorted: slicing on levels \[1\], lexsort depth 0')
+        with pytest.raises(UnsortedIndexError, match=msg):
             df.loc[(slice(None), slice('bar')), :]
 
         # GH 16734: not sorted, but no real slicing

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -151,8 +151,8 @@ class TestScalar(Base):
         df.columns = ['x', 'x', 'z']
 
         # Check that we get the correct value in the KeyError
-        tm.assert_raises_regex(KeyError, r"\['y'\] not in index",
-                               lambda: df[['x', 'y', 'z']])
+        with pytest.raises(KeyError, match=r"\['y'\] not in index"):
+            df[['x', 'y', 'z']]
 
     def test_at_with_tz(self):
         # gh-15822

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1055,8 +1055,8 @@ class TestBlockPlacement(object):
 
     def test_unbounded_slice_raises(self):
         def assert_unbounded_slice_error(slc):
-            tm.assert_raises_regex(ValueError, "unbounded slice",
-                                   lambda: BlockPlacement(slc))
+            with pytest.raises(ValueError, match="unbounded slice"):
+                BlockPlacement(slc)
 
         assert_unbounded_slice_error(slice(None, None))
         assert_unbounded_slice_error(slice(10, None))
@@ -1247,7 +1247,7 @@ class TestCanHoldElement(object):
 
         if (op, dtype) in invalid:
             with pytest.raises(TypeError):
-                result = op(s, e.value)
+                op(s, e.value)
         else:
             # FIXME: Since dispatching to Series, this test no longer
             # asserts anything meaningful
@@ -1281,5 +1281,5 @@ def test_validate_ndim():
     placement = slice(2)
     msg = r"Wrong number of dimensions. values.ndim != ndim \[1 != 2\]"
 
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         make_block(values, placement, ndim=2)

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1209,7 +1209,7 @@ class TestStylerMatplotlibDep(object):
     def test_text_color_threshold_raises(self, text_color_threshold):
         df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
         msg = "`text_color_threshold` must be a value from 0 to 1."
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.style.background_gradient(
                 text_color_threshold=text_color_threshold)._compute()
 

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -54,7 +54,7 @@ class TestToCSV(object):
             # Python 3 is uft-8.
             if pd.compat.PY2:
                 # the encoding argument parameter should be utf-8
-                with tm.assert_raises_regex(UnicodeEncodeError, 'ascii'):
+                with pytest.raises(UnicodeEncodeError, match='ascii'):
                     df.to_csv(path)
             else:
                 df.to_csv(path)
@@ -85,7 +85,7 @@ $1$,$2$
                 assert f.read() == expected
 
         with tm.ensure_clean('test.csv') as path:
-            with tm.assert_raises_regex(TypeError, 'quotechar'):
+            with pytest.raises(TypeError, match='quotechar'):
                 df.to_csv(path, quoting=1, quotechar=None)
 
     def test_to_csv_doublequote(self):
@@ -103,7 +103,7 @@ $1$,$2$
 
         from _csv import Error
         with tm.ensure_clean('test.csv') as path:
-            with tm.assert_raises_regex(Error, 'escapechar'):
+            with pytest.raises(Error, match='escapechar'):
                 df.to_csv(path, doublequote=False)  # no escapechar set
 
     def test_to_csv_escapechar(self):

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1580,7 +1580,7 @@ class TestToHTML(object):
         df = DataFrame()
         msg = "Invalid value for justify parameter"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df.to_html(justify=justify)
 
     def test_to_html_index(self):

--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -3,7 +3,7 @@ import pytest
 import pandas as pd
 import pandas.util.testing as tm
 import pandas.util._test_decorators as td
-from pandas.util.testing import assert_frame_equal, assert_raises_regex
+from pandas.util.testing import assert_frame_equal
 
 
 def test_compression_roundtrip(compression):
@@ -81,15 +81,15 @@ def test_write_unsupported_compression_type():
     df = pd.read_json('{"a": [1, 2, 3], "b": [4, 5, 6]}')
     with tm.ensure_clean() as path:
         msg = "Unrecognized compression type: unsupported"
-        assert_raises_regex(ValueError, msg, df.to_json,
-                            path, compression="unsupported")
+        with pytest.raises(ValueError, match=msg):
+            df.to_json(path, compression="unsupported")
 
 
 def test_read_unsupported_compression_type():
     with tm.ensure_clean() as path:
         msg = "Unrecognized compression type: unsupported"
-        assert_raises_regex(ValueError, msg, pd.read_json,
-                            path, compression="unsupported")
+        with pytest.raises(ValueError, match=msg):
+            pd.read_json(path, compression="unsupported")
 
 
 @pytest.mark.parametrize("to_infer", [True, False])

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -409,8 +409,8 @@ class TestTableOrient(object):
     @pytest.mark.parametrize("inp", ["geopoint", "geojson", "fake_type"])
     def test_convert_json_field_to_pandas_type_raises(self, inp):
         field = {'type': inp}
-        with tm.assert_raises_regex(ValueError, "Unsupported or invalid field "
-                                    "type: {}".format(inp)):
+        with pytest.raises(ValueError, match=("Unsupported or invalid field "
+                                              "type: {}".format(inp))):
             convert_json_field_to_pandas_type(field)
 
     def test_categorical(self):
@@ -480,7 +480,7 @@ class TestTableOrient(object):
             ['a'], [1]], names=["A", "a"]))
     ])
     def test_overlapping_names(self, case):
-        with tm.assert_raises_regex(ValueError, 'Overlapping'):
+        with pytest.raises(ValueError, match='Overlapping'):
             case.to_json(orient='table')
 
     def test_mi_falsey_name(self):
@@ -526,7 +526,7 @@ class TestTableOrientReader(object):
     def test_read_json_table_orient_raises(self, index_nm, vals, recwarn):
         df = DataFrame(vals, index=pd.Index(range(4), name=index_nm))
         out = df.to_json(orient="table")
-        with tm.assert_raises_regex(NotImplementedError, 'can not yet read '):
+        with pytest.raises(NotImplementedError, match='can not yet read '):
             pd.read_json(out, orient="table")
 
     def test_comprehensive(self):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -344,8 +344,7 @@ class TestPandasContainer(object):
         json = StringIO('{"badkey":["A","B"],'
                         '"index":["2","3"],'
                         '"data":[[1.0,"1"],[2.0,"2"],[null,"3"]]}')
-        with tm.assert_raises_regex(ValueError,
-                                    r"unexpected key\(s\): badkey"):
+        with pytest.raises(ValueError, match=r"unexpected key\(s\): badkey"):
             read_json(json, orient="split")
 
     def test_frame_from_json_nones(self):
@@ -839,7 +838,7 @@ class TestPandasContainer(object):
 DataFrame\\.index values are different \\(100\\.0 %\\)
 \\[left\\]:  Index\\(\\[u?'a', u?'b'\\], dtype='object'\\)
 \\[right\\]: RangeIndex\\(start=0, stop=2, step=1\\)"""
-        with tm.assert_raises_regex(AssertionError, error_msg):
+        with pytest.raises(AssertionError, match=error_msg):
             assert_frame_equal(result, expected, check_index_type=False)
 
         result = read_json('[{"a": 1, "b": 2}, {"b":2, "a" :1}]')
@@ -1122,9 +1121,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
     def test_latin_encoding(self):
         if compat.PY2:
-            tm.assert_raises_regex(
-                TypeError, r'\[unicode\] is not implemented as a table column')
-            return
+            pytest.skip("[unicode] is not implemented as a table column")
 
         # GH 13774
         pytest.skip("encoding not implemented in .to_json(), "
@@ -1229,7 +1226,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         df = pd.DataFrame([[1, 2], [4, 5]], columns=['a', 'b'])
 
-        with tm.assert_raises_regex(ValueError, "'index=False' is only "
-                                                "valid when 'orient' is "
-                                                "'split' or 'table'"):
+        msg = ("'index=False' is only valid when "
+               "'orient' is 'split' or 'table'")
+        with pytest.raises(ValueError, match=msg):
             df.to_json(orient=orient, index=False)

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -81,7 +81,7 @@ def test_readjson_chunks(lines_json_df, chunksize):
 
 def test_readjson_chunksize_requires_lines(lines_json_df):
     msg = "chunksize can only be passed if lines=True"
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         pd.read_json(StringIO(lines_json_df), lines=False, chunksize=2)
 
 
@@ -138,7 +138,7 @@ def test_readjson_chunks_closes(chunksize):
 def test_readjson_invalid_chunksize(lines_json_df, chunksize):
     msg = r"'chunksize' must be an integer >=1"
 
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         pd.read_json(StringIO(lines_json_df), lines=True,
                      chunksize=chunksize)
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -707,7 +707,7 @@ class TestUltraJSONTests(object):
         def my_handler_raises(_):
             raise TypeError("I raise for anything")
 
-        with tm.assert_raises_regex(TypeError, "I raise for anything"):
+        with pytest.raises(TypeError, match="I raise for anything"):
             ujson.encode(_TestObject("foo"), default_handler=my_handler_raises)
 
         def my_int_handler(_):

--- a/pandas/tests/io/msgpack/test_except.py
+++ b/pandas/tests/io/msgpack/test_except.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from pandas.io.msgpack import packb, unpackb
 
 import pytest
-import pandas.util.testing as tm
 
 
 class DummyException(Exception):
@@ -15,7 +14,7 @@ class TestExceptions(object):
 
     def test_raise_on_find_unsupported_value(self):
         msg = "can\'t serialize datetime"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             packb(datetime.now())
 
     def test_raise_from_object_hook(self):
@@ -35,5 +34,5 @@ class TestExceptions(object):
 
     def test_invalid_value(self):
         msg = "Unpack failed: error"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             unpackb(b"\xd9\x97#DL_")

--- a/pandas/tests/io/msgpack/test_limits.py
+++ b/pandas/tests/io/msgpack/test_limits.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 from pandas.io.msgpack import packb, unpackb, Packer, Unpacker, ExtType
 
 import pytest
-import pandas.util.testing as tm
 
 
 class TestLimits(object):
@@ -41,7 +40,7 @@ class TestLimits(object):
         unpacker.feed(packed)
 
         msg = "3 exceeds max_str_len"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             unpacker.unpack()
 
     def test_max_bin_len(self):
@@ -56,7 +55,7 @@ class TestLimits(object):
         unpacker.feed(packed)
 
         msg = "3 exceeds max_bin_len"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             unpacker.unpack()
 
     def test_max_array_len(self):
@@ -71,7 +70,7 @@ class TestLimits(object):
         unpacker.feed(packed)
 
         msg = "3 exceeds max_array_len"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             unpacker.unpack()
 
     def test_max_map_len(self):
@@ -86,7 +85,7 @@ class TestLimits(object):
         unpacker.feed(packed)
 
         msg = "3 exceeds max_map_len"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             unpacker.unpack()
 
     def test_max_ext_len(self):
@@ -101,5 +100,5 @@ class TestLimits(object):
         unpacker.feed(packed)
 
         msg = "4 exceeds max_ext_len"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             unpacker.unpack()

--- a/pandas/tests/io/msgpack/test_sequnpack.py
+++ b/pandas/tests/io/msgpack/test_sequnpack.py
@@ -5,7 +5,6 @@ from pandas.io.msgpack import Unpacker, BufferFull
 from pandas.io.msgpack import OutOfData
 
 import pytest
-import pandas.util.testing as tm
 
 
 class TestPack(object):
@@ -16,7 +15,7 @@ class TestPack(object):
 
         for data in [b"\xa5", b"h", b"a", b"l", b"l"]:
             unpacker.feed(data)
-            with tm.assert_raises_regex(StopIteration, msg):
+            with pytest.raises(StopIteration, match=msg):
                 next(iter(unpacker))
 
         unpacker.feed(b"o")

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -7,6 +7,7 @@ these tests out of this module as soon as the Python parser can accept
 further arguments when parsing.
 """
 
+from io import TextIOWrapper
 import os
 import sys
 import tarfile
@@ -14,7 +15,7 @@ import tarfile
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, lrange, range
+from pandas.compat import PY3, BytesIO, StringIO, lrange, range
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -34,9 +35,8 @@ class CParserTests(object):
         # see gh-9205: test certain malformed input files that cause
         # buffer overflows in tokenizer.c
         cperr = 'Buffer overflow caught - possible malformed input file.'
-        with pytest.raises(pd.errors.ParserError) as excinfo:
+        with pytest.raises(pd.errors.ParserError, match=cperr):
             self.read_table(StringIO(malf))
-        assert cperr in str(excinfo.value)
 
     def test_buffer_rd_bytes(self):
         # see gh-12098: src->buffer in the C parser can be freed twice leading
@@ -99,7 +99,7 @@ nan 2
 3.0 3
 """
         # fallback casting, but not castable
-        with tm.assert_raises_regex(ValueError, 'cannot safely convert'):
+        with pytest.raises(ValueError, match='cannot safely convert'):
             self.read_csv(StringIO(data), sep=r'\s+', header=None,
                           names=['a', 'b'], dtype={'a': np.int32})
 
@@ -454,6 +454,14 @@ No,No,No"""
         result = self.read_csv(NoNextBuffer(data))
 
         tm.assert_frame_equal(result, expected)
+
+    def test_buffer_rd_bytes_bad_unicode(self):
+        # see gh-22748
+        t = BytesIO(b"\xB0")
+        if PY3:
+            t = TextIOWrapper(t, encoding='ascii', errors='surrogateescape')
+        with pytest.raises(UnicodeError):
+            self.read_csv(t, encoding='UTF-8')
 
     @pytest.mark.parametrize("tar_suffix", [".tar", ".tar.gz"])
     def test_read_tarfile(self, tar_suffix):

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -4,7 +4,6 @@ import codecs
 from collections import OrderedDict
 import csv
 from datetime import datetime
-from io import TextIOWrapper
 import os
 import platform
 import re
@@ -45,7 +44,7 @@ bar2,12,13,14,15
 """
         # Parsers support only length-1 decimals
         msg = 'Only length-1 decimal markers supported'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), decimal='')
 
     def test_bad_stream_exception(self):
@@ -67,7 +66,7 @@ bar2,12,13,14,15
                 handle, utf8.encode, utf8.decode, codec.streamreader,
                 codec.streamwriter) as stream:
 
-            with tm.assert_raises_regex(UnicodeDecodeError, msg):
+            with pytest.raises(UnicodeDecodeError, match=msg):
                 self.read_csv(stream)
 
     def test_read_csv(self):
@@ -128,7 +127,7 @@ A,B,C
 2,3,4
 """
         msg = 'Expected 3 fields in line 4, saw 5'
-        with tm.assert_raises_regex(Exception, msg):
+        with pytest.raises(Exception, match=msg):
             self.read_table(StringIO(data), sep=',',
                             header=1, comment='#')
 
@@ -142,7 +141,7 @@ skip
 2,3,4
 """
         msg = 'Expected 3 fields in line 6, saw 5'
-        with tm.assert_raises_regex(Exception, msg):
+        with pytest.raises(Exception, match=msg):
             it = self.read_table(StringIO(data), sep=',',
                                  header=1, comment='#',
                                  iterator=True, chunksize=1,
@@ -159,7 +158,7 @@ skip
 2,3,4
 """
         msg = 'Expected 3 fields in line 6, saw 5'
-        with tm.assert_raises_regex(Exception, msg):
+        with pytest.raises(Exception, match=msg):
             it = self.read_table(StringIO(data), sep=',', header=1,
                                  comment='#', iterator=True, chunksize=1,
                                  skiprows=[2])
@@ -175,7 +174,7 @@ skip
 2,3,4
 """
         msg = 'Expected 3 fields in line 6, saw 5'
-        with tm.assert_raises_regex(Exception, msg):
+        with pytest.raises(Exception, match=msg):
             it = self.read_table(StringIO(data), sep=',', header=1,
                                  comment='#', iterator=True, chunksize=1,
                                  skiprows=[2])
@@ -192,7 +191,7 @@ A,B,C
 footer
 """
             msg = 'Expected 3 fields in line 4, saw 5'
-            with tm.assert_raises_regex(Exception, msg):
+            with pytest.raises(Exception, match=msg):
                 self.read_table(StringIO(data), sep=',',
                                 header=1, comment='#',
                                 skipfooter=1)
@@ -367,13 +366,13 @@ bar,foo"""
 
         msg = r"'nrows' must be an integer >=0"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(self.data1), nrows=1.2)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(self.data1), nrows='foo')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(self.data1), nrows=-1)
 
     def test_read_chunksize(self):
@@ -389,13 +388,13 @@ bar,foo"""
         # with invalid chunksize value:
         msg = r"'chunksize' must be an integer >=1"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(self.data1), chunksize=1.3)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(self.data1), chunksize='foo')
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(self.data1), chunksize=0)
 
     def test_read_chunksize_and_nrows(self):
@@ -1081,7 +1080,7 @@ A,B,C
         # make sure that an error is still thrown
         # when the 'usecols' parameter is not provided
         msg = r"Expected \d+ fields in line \d+, saw \d+"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             df = self.read_csv(StringIO(csv))
 
         expected = DataFrame({
@@ -1107,10 +1106,10 @@ A,B,C
         # throws the correct error, with or without usecols
         errmsg = "No columns to parse from file"
 
-        with tm.assert_raises_regex(EmptyDataError, errmsg):
+        with pytest.raises(EmptyDataError, match=errmsg):
             self.read_csv(StringIO(''))
 
-        with tm.assert_raises_regex(EmptyDataError, errmsg):
+        with pytest.raises(EmptyDataError, match=errmsg):
             self.read_csv(StringIO(''), usecols=usecols)
 
         expected = DataFrame(columns=usecols, index=[0], dtype=np.float64)
@@ -1149,8 +1148,7 @@ A,B,C
     def test_raise_on_sep_with_delim_whitespace(self):
         # see gh-6607
         data = 'a b c\n1 2 3'
-        with tm.assert_raises_regex(ValueError,
-                                    'you can only specify one'):
+        with pytest.raises(ValueError, match='you can only specify one'):
             self.read_table(StringIO(data), sep=r'\s', delim_whitespace=True)
 
     def test_single_char_leading_whitespace(self):
@@ -1395,7 +1393,7 @@ j,-inF"""
             tm.assert_frame_equal(out, expected)
         else:
             msg = "NULL byte detected"
-            with tm.assert_raises_regex(ParserError, msg):
+            with pytest.raises(ParserError, match=msg):
                 self.read_csv(StringIO(data), names=cols)
 
     def test_utf8_bom(self):
@@ -1537,7 +1535,7 @@ j,-inF"""
 
         msg = "Invalid file path or buffer object type"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(InvalidBuffer())
 
         # gh-16135: we want to ensure that "tell" and "seek"
@@ -1560,7 +1558,7 @@ j,-inF"""
 
         tm.assert_frame_equal(result, expected)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(mock.Mock())
 
     @tm.capture_stderr
@@ -1595,11 +1593,3 @@ j,-inF"""
         val = sys.stderr.getvalue()
         assert 'Skipping line 3' in val
         assert 'Skipping line 5' in val
-
-    def test_buffer_rd_bytes_bad_unicode(self):
-        # Regression test for #22748
-        t = BytesIO(b"\xB0")
-        if PY3:
-            t = TextIOWrapper(t, encoding='ascii', errors='surrogateescape')
-        with pytest.raises(UnicodeError):
-            pd.read_csv(t, encoding='UTF-8')

--- a/pandas/tests/io/parser/compression.py
+++ b/pandas/tests/io/parser/compression.py
@@ -52,19 +52,18 @@ class CompressionTests(object):
                 for file_name in inner_file_names:
                     tmp.writestr(file_name, data)
 
-            tm.assert_raises_regex(ValueError, 'Multiple files',
-                                   self.read_csv, path, compression='zip')
+            with pytest.raises(ValueError, match='Multiple files'):
+                self.read_csv(path, compression='zip')
 
-            tm.assert_raises_regex(ValueError, 'Multiple files',
-                                   self.read_csv, path,
-                                   compression='infer')
+            with pytest.raises(ValueError, match='Multiple files'):
+                self.read_csv(path, compression='infer')
 
         with tm.ensure_clean() as path:
-            with zipfile.ZipFile(path, mode='w') as tmp:
+            with zipfile.ZipFile(path, mode='w'):
                 pass
 
-            tm.assert_raises_regex(ValueError, 'Zero files',
-                                   self.read_csv, path, compression='zip')
+            with pytest.raises(ValueError, match='Zero files'):
+                self.read_csv(path, compression='zip')
 
         with tm.ensure_clean() as path:
             with open(path, 'wb') as f:
@@ -133,5 +132,5 @@ class CompressionTests(object):
 
     def test_invalid_compression(self):
         msg = 'Unrecognized compression type: sfark'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv('test_file.zip', compression='sfark')

--- a/pandas/tests/io/parser/converters.py
+++ b/pandas/tests/io/parser/converters.py
@@ -24,7 +24,7 @@ class ConverterTests(object):
         data = """index,A,B,C,D
 foo,2,3,4,5
 """
-        with tm.assert_raises_regex(TypeError, 'Type converters.+'):
+        with pytest.raises(TypeError, match='Type converters.+'):
             self.read_csv(StringIO(data), converters=0)
 
     def test_converters(self):

--- a/pandas/tests/io/parser/dialect.py
+++ b/pandas/tests/io/parser/dialect.py
@@ -7,6 +7,8 @@ for all of the parsers defined in parsers.py
 
 import csv
 
+import pytest
+
 from pandas.compat import StringIO
 from pandas.errors import ParserWarning
 
@@ -61,7 +63,7 @@ pear:tomato
         data = 'a\n1'
         msg = 'Invalid dialect'
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), dialect=InvalidDialect)
 
     def test_dialect_conflict(self):

--- a/pandas/tests/io/parser/header.py
+++ b/pandas/tests/io/parser/header.py
@@ -21,7 +21,7 @@ class HeaderTests(object):
     def test_read_with_bad_header(self):
         errmsg = r"but only \d+ lines in file"
 
-        with tm.assert_raises_regex(ValueError, errmsg):
+        with pytest.raises(ValueError, match=errmsg):
             s = StringIO(',,')
             self.read_csv(s, header=[10])
 
@@ -322,9 +322,9 @@ q,r,s,t,u,v
         # GH 16338
         msg = 'header must be integer or list of integers'
         data = """1,2\n3,4"""
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), sep=',', header=['a', 'b'])
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), sep=',', header='string_header')
 
     def test_singleton_header(self):

--- a/pandas/tests/io/parser/parse_dates.py
+++ b/pandas/tests/io/parser/parse_dates.py
@@ -429,11 +429,10 @@ KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000
         data = """A,B,C
         1,2,2003-11-1"""
 
-        tm.assert_raises_regex(TypeError, errmsg, self.read_csv,
-                               StringIO(data), parse_dates="C")
-        tm.assert_raises_regex(TypeError, errmsg, self.read_csv,
-                               StringIO(data), parse_dates="C",
-                               index_col="C")
+        with pytest.raises(TypeError, match=errmsg):
+            self.read_csv(StringIO(data), parse_dates="C")
+        with pytest.raises(TypeError, match=errmsg):
+            self.read_csv(StringIO(data), parse_dates="C", index_col="C")
 
     def test_read_with_parse_dates_invalid_type(self):
         errmsg = ("Only booleans, lists, and "
@@ -442,13 +441,12 @@ KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000
         data = """A,B,C
         1,2,2003-11-1"""
 
-        tm.assert_raises_regex(TypeError, errmsg, self.read_csv,
-                               StringIO(data), parse_dates=(1,))
-        tm.assert_raises_regex(TypeError, errmsg,
-                               self.read_csv, StringIO(data),
-                               parse_dates=np.array([4, 5]))
-        tm.assert_raises_regex(TypeError, errmsg, self.read_csv,
-                               StringIO(data), parse_dates={1, 3, 3})
+        with pytest.raises(TypeError, match=errmsg):
+            self.read_csv(StringIO(data), parse_dates=(1,))
+        with pytest.raises(TypeError, match=errmsg):
+            self.read_csv(StringIO(data), parse_dates=np.array([4, 5]))
+        with pytest.raises(TypeError, match=errmsg):
+            self.read_csv(StringIO(data), parse_dates={1, 3, 3})
 
     def test_parse_dates_empty_string(self):
         # see gh-2263

--- a/pandas/tests/io/parser/python_parser_only.py
+++ b/pandas/tests/io/parser/python_parser_only.py
@@ -36,17 +36,17 @@ class PythonParserTests(object):
 
         # see gh-15925 (comment)
         msg = "skipfooter must be an integer"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(text), skipfooter="foo")
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(text), skipfooter=1.5)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(text), skipfooter=True)
 
         msg = "skipfooter cannot be negative"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(text), skipfooter=-1)
 
     def test_sniff_delimiter(self):
@@ -220,13 +220,13 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         data = 'a,,b\n1,,a\n2,,"2,,b"'
         msg = 'ignored when a multi-char delimiter is used'
 
-        with tm.assert_raises_regex(ParserError, msg):
+        with pytest.raises(ParserError, match=msg):
             self.read_csv(StringIO(data), sep=',,')
 
         # We expect no match, so there should be an assertion
         # error out of the inner context manager.
         with pytest.raises(AssertionError):
-            with tm.assert_raises_regex(ParserError, msg):
+            with pytest.raises(ParserError, match=msg):
                 self.read_csv(StringIO(data), sep=',,',
                               quoting=csv.QUOTE_NONE)
 
@@ -255,11 +255,11 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         for data in ('a\n1\n"b"a',
                      'a,b,c\ncat,foo,bar\ndog,foo,"baz'):
-            with tm.assert_raises_regex(ParserError, msg):
+            with pytest.raises(ParserError, match=msg):
                 self.read_csv(StringIO(data), skipfooter=1)
 
             # We expect no match, so there should be an assertion
             # error out of the inner context manager.
             with pytest.raises(AssertionError):
-                with tm.assert_raises_regex(ParserError, msg):
+                with pytest.raises(ParserError, match=msg):
                     self.read_csv(StringIO(data))

--- a/pandas/tests/io/parser/quoting.py
+++ b/pandas/tests/io/parser/quoting.py
@@ -7,6 +7,8 @@ during parsing for all of the parsers defined in parsers.py
 
 import csv
 
+import pytest
+
 from pandas.compat import PY3, StringIO, u
 from pandas.errors import ParserError
 
@@ -22,29 +24,29 @@ class QuotingTests(object):
         # Python 2.x: "...must be an 1-character..."
         # Python 3.x: "...must be a 1-character..."
         msg = '"quotechar" must be a(n)? 1-character string'
-        tm.assert_raises_regex(TypeError, msg, self.read_csv,
-                               StringIO(data), quotechar='foo')
+        with pytest.raises(TypeError, match=msg):
+            self.read_csv(StringIO(data), quotechar='foo')
 
         msg = 'quotechar must be set if quoting enabled'
-        tm.assert_raises_regex(TypeError, msg, self.read_csv,
-                               StringIO(data), quotechar=None,
-                               quoting=csv.QUOTE_MINIMAL)
+        with pytest.raises(TypeError, match=msg):
+            self.read_csv(StringIO(data), quotechar=None,
+                          quoting=csv.QUOTE_MINIMAL)
 
         msg = '"quotechar" must be string, not int'
-        tm.assert_raises_regex(TypeError, msg, self.read_csv,
-                               StringIO(data), quotechar=2)
+        with pytest.raises(TypeError, match=msg):
+            self.read_csv(StringIO(data), quotechar=2)
 
     def test_bad_quoting(self):
         data = '1,2,3'
 
         msg = '"quoting" must be an integer'
-        tm.assert_raises_regex(TypeError, msg, self.read_csv,
-                               StringIO(data), quoting='foo')
+        with pytest.raises(TypeError, match=msg):
+            self.read_csv(StringIO(data), quoting='foo')
 
         # quoting must in the range [0, 3]
         msg = 'bad "quoting" value'
-        tm.assert_raises_regex(TypeError, msg, self.read_csv,
-                               StringIO(data), quoting=5)
+        with pytest.raises(TypeError, match=msg):
+            self.read_csv(StringIO(data), quoting=5)
 
     def test_quote_char_basic(self):
         data = 'a,b,c\n1,2,"cat"'
@@ -70,13 +72,13 @@ class QuotingTests(object):
         # sanity checks
         msg = 'quotechar must be set if quoting enabled'
 
-        tm.assert_raises_regex(TypeError, msg, self.read_csv,
-                               StringIO(data), quotechar=None,
-                               quoting=csv.QUOTE_MINIMAL)
+        with pytest.raises(TypeError, match=msg):
+            self.read_csv(StringIO(data), quotechar=None,
+                          quoting=csv.QUOTE_MINIMAL)
 
-        tm.assert_raises_regex(TypeError, msg, self.read_csv,
-                               StringIO(data), quotechar='',
-                               quoting=csv.QUOTE_MINIMAL)
+        with pytest.raises(TypeError, match=msg):
+            self.read_csv(StringIO(data), quotechar='',
+                          quoting=csv.QUOTE_MINIMAL)
 
         # no errors should be raised if quoting is None
         expected = DataFrame([[1, 2, 3]],
@@ -163,7 +165,7 @@ class QuotingTests(object):
         else:
             regex = "unexpected end of data"
 
-        with tm.assert_raises_regex(ParserError, regex):
+        with pytest.raises(ParserError, match=regex):
             self.read_csv(StringIO(data))
 
         expected = DataFrame([[1, 2, 3]], columns=["a", "b", "c"])

--- a/pandas/tests/io/parser/skiprows.py
+++ b/pandas/tests/io/parser/skiprows.py
@@ -8,6 +8,7 @@ parsing for all of the parsers defined in parsers.py
 from datetime import datetime
 
 import numpy as np
+import pytest
 
 from pandas.compat import StringIO, lrange, range
 from pandas.errors import EmptyDataError
@@ -215,11 +216,11 @@ line 22",2
 
         skiprows = lambda x: True
         msg = "No columns to parse from file"
-        with tm.assert_raises_regex(EmptyDataError, msg):
+        with pytest.raises(EmptyDataError, match=msg):
             self.read_csv(StringIO(data), skiprows=skiprows)
 
         # This is a bad callable and should raise.
         msg = "by zero"
         skiprows = lambda x: 1 / 0
-        with tm.assert_raises_regex(ZeroDivisionError, msg):
+        with pytest.raises(ZeroDivisionError, match=msg):
             self.read_csv(StringIO(data), skiprows=skiprows)

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -69,11 +69,10 @@ class TestFwfParsing(object):
             StringIO(data3), colspecs=colspecs, delimiter='~', header=None)
         tm.assert_frame_equal(df, expected)
 
-        with tm.assert_raises_regex(ValueError,
-                                    "must specify only one of"):
+        with pytest.raises(ValueError, match="must specify only one of"):
             read_fwf(StringIO(data3), colspecs=colspecs, widths=[6, 10, 10, 7])
 
-        with tm.assert_raises_regex(ValueError, "Must specify either"):
+        with pytest.raises(ValueError, match="Must specify either"):
             read_fwf(StringIO(data3), colspecs=None, widths=None)
 
     def test_BytesIO_input(self):
@@ -96,9 +95,8 @@ foo2,12,13,14,15
 bar2,12,13,14,15
 """
 
-        with tm.assert_raises_regex(TypeError,
-                                    'column specifications must '
-                                    'be a list or tuple.+'):
+        msg = 'column specifications must be a list or tuple.+'
+        with pytest.raises(TypeError, match=msg):
             pd.io.parsers.FixedWidthReader(StringIO(data),
                                            {'a': 1}, ',', '#')
 
@@ -112,9 +110,8 @@ foo2,12,13,14,15
 bar2,12,13,14,15
 """
 
-        with tm.assert_raises_regex(TypeError,
-                                    'Each column specification '
-                                    'must be.+'):
+        msg = 'Each column specification must be.+'
+        with pytest.raises(TypeError, match=msg):
             read_fwf(StringIO(data), [('a', 1)])
 
     def test_fwf_colspecs_None(self):

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -33,7 +33,7 @@ class TestUnsupportedFeatures(object):
         msg = 'is not supported'
 
         for engine in ('c', 'python'):
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 read_csv(StringIO(data), engine=engine,
                          mangle_dupe_cols=False)
 
@@ -43,14 +43,14 @@ class TestUnsupportedFeatures(object):
         msg = 'does not support'
 
         # specify C engine with unsupported options (raise)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_csv(StringIO(data), engine='c',
                      sep=None, delim_whitespace=False)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_csv(StringIO(data), engine='c', sep=r'\s')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_csv(StringIO(data), engine='c', sep='\t', quotechar=chr(128))
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_csv(StringIO(data), engine='c', skipfooter=1)
 
         # specify C-unsupported options without python-unsupported options
@@ -70,9 +70,9 @@ a   q   20      4     0.4473  1.4152  0.2834  1.00661  0.1744
 x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         msg = 'Error tokenizing data'
 
-        with tm.assert_raises_regex(ParserError, msg):
+        with pytest.raises(ParserError, match=msg):
             read_csv(StringIO(text), sep='\\s+')
-        with tm.assert_raises_regex(ParserError, msg):
+        with pytest.raises(ParserError, match=msg):
             read_csv(StringIO(text), engine='c', sep='\\s+')
 
         msg = "Only length-1 thousands markers supported"
@@ -80,14 +80,14 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 1|2,334|5
 10|13|10.
 """
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_csv(StringIO(data), thousands=',,')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_csv(StringIO(data), thousands='')
 
         msg = "Only length-1 line terminators supported"
         data = 'a,b,c~~1,2,3~~4,5,6'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_csv(StringIO(data), lineterminator='~~')
 
     def test_python_engine(self, python_engine):
@@ -104,7 +104,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                    'with the %r engine' % (default, python_engine))
 
             kwargs = {default: object()}
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 read_csv(StringIO(data), engine=python_engine, **kwargs)
 
     def test_python_engine_file_no_next(self, python_engine):
@@ -122,7 +122,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         data = "a\n1"
         msg = "The 'python' engine cannot iterate"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_csv(NoNextBuffer(data), engine=python_engine)
 
 

--- a/pandas/tests/io/parser/usecols.py
+++ b/pandas/tests/io/parser/usecols.py
@@ -31,7 +31,7 @@ class UsecolsTests(object):
 
         usecols = [0, 'b', 2]
 
-        with tm.assert_raises_regex(ValueError, self.msg_validate_usecols_arg):
+        with pytest.raises(ValueError, match=self.msg_validate_usecols_arg):
             self.read_csv(StringIO(data), usecols=usecols)
 
     def test_usecols(self):
@@ -97,7 +97,7 @@ a,b,c
 
         usecols = 'foo'
 
-        with tm.assert_raises_regex(ValueError, self.msg_validate_usecols_arg):
+        with pytest.raises(ValueError, match=self.msg_validate_usecols_arg):
             self.read_csv(StringIO(data), usecols=usecols)
 
     def test_usecols_index_col_False(self):
@@ -363,10 +363,10 @@ a,b,c
         3.568935038,7,False,a
         '''
 
-        with tm.assert_raises_regex(ValueError, self.msg_validate_usecols_arg):
+        with pytest.raises(ValueError, match=self.msg_validate_usecols_arg):
             self.read_csv(StringIO(s), usecols=[u'AAA', b'BBB'])
 
-        with tm.assert_raises_regex(ValueError, self.msg_validate_usecols_arg):
+        with pytest.raises(ValueError, match=self.msg_validate_usecols_arg):
             self.read_csv(StringIO(s), usecols=[b'AAA', u'BBB'])
 
     def test_usecols_with_multibyte_characters(self):
@@ -499,21 +499,21 @@ a,b,c
         tm.assert_frame_equal(df, expected)
 
         usecols = ['a', 'b', 'c', 'f']
-        with tm.assert_raises_regex(ValueError,
-                                    self.msg_validate_usecols_names.format(
-                                        r"\['f'\]")):
+        msg = self.msg_validate_usecols_names.format(r"\['f'\]")
+
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), usecols=usecols)
 
         usecols = ['a', 'b', 'f']
-        with tm.assert_raises_regex(ValueError,
-                                    self.msg_validate_usecols_names.format(
-                                        r"\['f'\]")):
+        msg = self.msg_validate_usecols_names.format(r"\['f'\]")
+
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), usecols=usecols)
 
         usecols = ['a', 'b', 'f', 'g']
-        with tm.assert_raises_regex(ValueError,
-                                    self.msg_validate_usecols_names.format(
-                                        r"\[('f', 'g'|'g', 'f')\]")):
+        msg = self.msg_validate_usecols_names.format(
+            r"\[('f', 'g'|'g', 'f')\]")
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), usecols=usecols)
 
         names = ['A', 'B', 'C', 'D']
@@ -537,13 +537,14 @@ a,b,c
         # tm.assert_frame_equal(df, expected)
 
         usecols = ['A', 'B', 'C', 'f']
-        with tm.assert_raises_regex(ValueError,
-                                    self.msg_validate_usecols_names.format(
-                                        r"\['f'\]")):
+        msg = self.msg_validate_usecols_names.format(r"\['f'\]")
+
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), header=0, names=names,
                           usecols=usecols)
+
         usecols = ['A', 'B', 'f']
-        with tm.assert_raises_regex(ValueError,
-                                    self.msg_validate_usecols_names.format(
-                                        r"\['f'\]")):
+        msg = self.msg_validate_usecols_names.format(r"\['f'\]")
+
+        with pytest.raises(ValueError, match=msg):
             self.read_csv(StringIO(data), names=names, usecols=usecols)

--- a/pandas/tests/io/sas/test_sas.py
+++ b/pandas/tests/io/sas/test_sas.py
@@ -1,7 +1,7 @@
+import pytest
+
 from pandas.compat import StringIO
 from pandas import read_sas
-
-import pandas.util.testing as tm
 
 
 class TestSas(object):
@@ -12,5 +12,5 @@ class TestSas(object):
 
         msg = ("If this is a buffer object rather than a string "
                "name, you must specify a format string")
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             read_sas(b)

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -269,14 +269,15 @@ class TestMMapWrapper(object):
             msg = "[Errno 22]"
             err = mmap.error
 
-        tm.assert_raises_regex(err, msg, icom.MMapWrapper, non_file)
+        with pytest.raises(err, match=msg):
+            icom.MMapWrapper(non_file)
 
         target = open(mmap_file, 'r')
         target.close()
 
         msg = "I/O operation on closed file"
-        tm.assert_raises_regex(
-            ValueError, msg, icom.MMapWrapper, target)
+        with pytest.raises(ValueError, match=msg):
+            icom.MMapWrapper(target)
 
     def test_get_attr(self, mmap_file):
         with open(mmap_file, 'r') as target:
@@ -307,5 +308,5 @@ class TestMMapWrapper(object):
         with tm.ensure_clean() as path:
             df = tm.makeDataFrame()
             df.to_csv(path)
-            with tm.assert_raises_regex(ValueError, 'Unknown engine'):
+            with pytest.raises(ValueError, match='Unknown engine'):
                 pd.read_csv(path, engine='pyt')

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -564,12 +564,12 @@ class ReadingTestsBase(SharedItems):
         tm.assert_frame_equal(df2_parse, dfref, check_names=False)
 
     def test_sheet_name_both_raises(self, ext):
-        with tm.assert_raises_regex(TypeError, "Cannot specify both"):
+        with pytest.raises(TypeError, match="Cannot specify both"):
             self.get_exceldf('test1', ext, sheetname='Sheet1',
                              sheet_name='Sheet1')
 
         excel = self.get_excelfile('test1', ext)
-        with tm.assert_raises_regex(TypeError, "Cannot specify both"):
+        with pytest.raises(TypeError, match="Cannot specify both"):
             excel.parse(sheetname='Sheet1',
                         sheet_name='Sheet1')
 
@@ -1040,7 +1040,7 @@ class TestXlrdReader(ReadingTestsBase):
     def test_read_excel_nrows_non_integer_parameter(self, ext):
         # GH 16645
         msg = "'nrows' must be an integer >=0"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.read_excel(os.path.join(self.dirpath, 'test1' + ext),
                           nrows='5')
 
@@ -2133,7 +2133,7 @@ class TestXlwtTests(_WriterBase):
         msg = "Append mode is not supported with xlwt!"
 
         with ensure_clean(ext) as f:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 ExcelWriter(f, engine=engine, mode='a')
 
 
@@ -2191,7 +2191,7 @@ class TestXlsxWriterTests(_WriterBase):
         msg = "Append mode is not supported with xlsxwriter!"
 
         with ensure_clean(ext) as f:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 ExcelWriter(f, engine=engine, mode='a')
 
 
@@ -2215,7 +2215,7 @@ class TestExcelWriterEngineTests(object):
                 assert isinstance(writer, klass)
 
     def test_ExcelWriter_dispatch_raises(self):
-        with tm.assert_raises_regex(ValueError, 'No engine'):
+        with pytest.raises(ValueError, match='No engine'):
             ExcelWriter('nothing')
 
     @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -56,7 +56,7 @@ def assert_framelist_equal(list1, list2, *args, **kwargs):
 def test_bs4_version_fails(monkeypatch, datapath):
     import bs4
     monkeypatch.setattr(bs4, '__version__', '4.2')
-    with tm.assert_raises_regex(ValueError, "minimum version"):
+    with pytest.raises(ValueError, match="minimum version"):
         read_html(datapath("io", "data", "spam.html"), flavor='bs4')
 
 
@@ -65,7 +65,7 @@ def test_invalid_flavor():
     flavor = "invalid flavor"
     msg = r"\{" + flavor + r"\} is not a valid set of flavors"
 
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         read_html(url, "google", flavor=flavor)
 
 
@@ -204,8 +204,8 @@ class TestReadHtml(object):
         assert_framelist_equal(df1, df2)
 
     def test_skiprows_invalid(self):
-        with tm.assert_raises_regex(TypeError, 'is not a valid type '
-                                    'for skipping rows'):
+        with pytest.raises(TypeError, match=('is not a valid type '
+                                             'for skipping rows')):
             self.read_html(self.spam_data, '.*Water.*', skiprows='asdf')
 
     def test_index(self):
@@ -288,7 +288,7 @@ class TestReadHtml(object):
     @pytest.mark.slow
     def test_invalid_table_attrs(self):
         url = self.banklist_data
-        with tm.assert_raises_regex(ValueError, 'No tables found'):
+        with pytest.raises(ValueError, match='No tables found'):
             self.read_html(url, 'First Federal Bank of Florida',
                            attrs={'id': 'tasdfable'})
 
@@ -341,8 +341,8 @@ class TestReadHtml(object):
             assert isinstance(df, DataFrame)
 
     def test_negative_skiprows(self):
-        with tm.assert_raises_regex(ValueError,
-                                    r'\(you passed a negative value\)'):
+        msg = r'\(you passed a negative value\)'
+        with pytest.raises(ValueError, match=msg):
             self.read_html(self.spam_data, 'Water', skiprows=-1)
 
     @network
@@ -822,10 +822,9 @@ class TestReadHtml(object):
 
     def test_computer_sales_page(self, datapath):
         data = datapath('io', 'data', 'computer_sales_page.html')
-        with tm.assert_raises_regex(ParserError,
-                                    r"Passed header=\[0,1\] are "
-                                    r"too many rows for this "
-                                    r"multi_index of columns"):
+        msg = (r"Passed header=\[0,1\] are too many "
+               r"rows for this multi_index of columns")
+        with pytest.raises(ParserError, match=msg):
             self.read_html(data, header=[0, 1])
 
         data = datapath('io', 'data', 'computer_sales_page.html')
@@ -839,10 +838,9 @@ class TestReadHtml(object):
         assert result['sq mi'].dtype == np.dtype('float64')
 
     def test_parser_error_on_empty_header_row(self):
-        with tm.assert_raises_regex(ParserError,
-                                    r"Passed header=\[0,1\] are "
-                                    r"too many rows for this "
-                                    r"multi_index of columns"):
+        msg = (r"Passed header=\[0,1\] are too many "
+               r"rows for this multi_index of columns")
+        with pytest.raises(ParserError, match=msg):
             self.read_html("""
                 <table>
                     <thead>

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -370,8 +370,7 @@ class TestCompression(object):
 
     @pytest.mark.parametrize('compression', ['', 'None', 'bad', '7z'])
     def test_write_explicit_bad(self, compression, get_random_path):
-        with tm.assert_raises_regex(ValueError,
-                                    "Unrecognized compression type"):
+        with pytest.raises(ValueError, match="Unrecognized compression type"):
             with tm.ensure_clean(get_random_path) as path:
                 df = tm.makeDataFrame()
                 df.to_pickle(path, compression=compression)
@@ -474,7 +473,7 @@ class TestProtocol(object):
         # For Python 2, HIGHEST_PROTOCOL should be 2.
         msg = ("pickle protocol {protocol} asked for; the highest available "
                "protocol is 2").format(protocol=protocol)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             with tm.ensure_clean(get_random_path) as path:
                 df = tm.makeDataFrame()
                 df.to_pickle(path, protocol=protocol)

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -1084,9 +1084,7 @@ class TestHDFStore(Base):
     def test_latin_encoding(self):
 
         if compat.PY2:
-            tm.assert_raises_regex(
-                TypeError, r'\[unicode\] is not implemented as a table column')
-            return
+            pytest.skip("[unicode] is not implemented as a table column")
 
         values = [[b'E\xc9, 17', b'', b'a', b'b', b'c'],
                   [b'E\xc9, 17', b'a', b'b', b'c'],
@@ -2598,8 +2596,8 @@ class TestHDFStore(Base):
                 for t in terms:
                     store.select('wp', t)
 
-                with tm.assert_raises_regex(
-                        TypeError, 'Only named functions are supported'):
+                with pytest.raises(TypeError,
+                                   match='Only named functions are supported'):
                     store.select(
                         'wp',
                         'major_axis == (lambda x: x)("20130101")')
@@ -2610,9 +2608,8 @@ class TestHDFStore(Base):
                 expected = Panel({-1: wpneg[-1]})
                 tm.assert_panel_equal(res, expected)
 
-                with tm.assert_raises_regex(NotImplementedError,
-                                            'Unary addition '
-                                            'not supported'):
+                msg = 'Unary addition not supported'
+                with pytest.raises(NotImplementedError, match=msg):
                     store.select('wpneg', 'items == +1')
 
     def test_term_compat(self):
@@ -4520,9 +4517,8 @@ class TestHDFStore(Base):
             pytest.raises(ClosedFileError, store.get_storer, 'df2')
             pytest.raises(ClosedFileError, store.remove, 'df2')
 
-            def f():
+            with pytest.raises(ClosedFileError, match='file is not open'):
                 store.select('df')
-            tm.assert_raises_regex(ClosedFileError, 'file is not open', f)
 
     def test_pytables_native_read(self, datapath):
         with ensure_clean_store(
@@ -4971,9 +4967,8 @@ class TestHDFStore(Base):
             df = DataFrame(np.random.randn(10, 2), columns=index(2))
             with ensure_clean_path(self.path) as path:
                 with catch_warnings(record=True):
-                    with tm.assert_raises_regex(
-                        ValueError, ("cannot have non-object label "
-                                     "DataIndexableCol")):
+                    msg = "cannot have non-object label DataIndexableCol"
+                    with pytest.raises(ValueError, match=msg):
                         df.to_hdf(path, 'df', format='table',
                                   data_columns=True)
 
@@ -5155,14 +5150,14 @@ class TestHDFStore(Base):
                           pd.Timedelta(1, 's')]:
                     query = 'date {op} v'.format(op=op)
                     with pytest.raises(TypeError):
-                        result = store.select('test', where=query)
+                        store.select('test', where=query)
 
                 # strings to other columns must be convertible to type
                 v = 'a'
                 for col in ['int', 'float', 'real_date']:
                     query = '{col} {op} v'.format(op=op, col=col)
                     with pytest.raises(ValueError):
-                        result = store.select('test', where=query)
+                        store.select('test', where=query)
 
                 for v, col in zip(['1', '1.1', '2014-01-01'],
                                   ['int', 'float', 'real_date']):

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -993,7 +993,7 @@ class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):
             pass
 
         db_uri = "postgresql+pg8000://user:pass@host/dbname"
-        with tm.assert_raises_regex(ImportError, "pg8000"):
+        with pytest.raises(ImportError, match="pg8000"):
             sql.read_sql("select * from table", db_uri)
 
     def _make_iris_table_metadata(self):

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -22,7 +22,7 @@ def test_import_error_message():
     # GH-19810
     df = DataFrame({"A": [1, 2]})
 
-    with tm.assert_raises_regex(ImportError, 'matplotlib is required'):
+    with pytest.raises(ImportError, match='matplotlib is required'):
         df.plot()
 
 

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -237,9 +237,9 @@ class TestJoin(object):
         # Edited test to remove the Series object from test parameters
 
         df = DataFrame({'a': [1, 1]})
-        with tm.assert_raises_regex(TypeError, str(type(wrong_type))):
+        with pytest.raises(TypeError, match=str(type(wrong_type))):
             merge(wrong_type, df, left_on='a', right_on='a')
-        with tm.assert_raises_regex(TypeError, str(type(wrong_type))):
+        with pytest.raises(TypeError, match=str(type(wrong_type))):
             merge(df, wrong_type, left_on='a', right_on='a')
 
     def test_join_on_pass_vector(self):

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -275,7 +275,7 @@ class TestMerge(object):
                'left_index={lidx}, right_index={ridx}'
                .format(lon=None, ron=None, lidx=False, ridx=False))
 
-        with tm.assert_raises_regex(MergeError, msg):
+        with pytest.raises(MergeError, match=msg):
             merge(df1, df2)
 
     def test_merge_non_unique_indexes(self):
@@ -1472,7 +1472,7 @@ class TestMergeDtypes(object):
                    "If you wish to proceed you should use "
                    "pd.concat".format(lk_dtype=left['A'].dtype,
                                       rk_dtype=right['A'].dtype))
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 pd.merge(left, right, on='A')
 
     @pytest.mark.parametrize('d1', [np.int64, np.int32,
@@ -1599,7 +1599,7 @@ class TestMergeDtypes(object):
                "you should use pd.concat".format(lk_dtype=df1['A'].dtype,
                                                  rk_dtype=df2['A'].dtype))
         msg = re.escape(msg)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.merge(df1, df2, on=['A'])
 
         # Check that error still raised when swapping order of dataframes
@@ -1608,7 +1608,7 @@ class TestMergeDtypes(object):
                "you should use pd.concat".format(lk_dtype=df2['A'].dtype,
                                                  rk_dtype=df1['A'].dtype))
         msg = re.escape(msg)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.merge(df2, df1, on=['A'])
 
 
@@ -1938,6 +1938,6 @@ def test_merge_series(on, left_on, right_on, left_index, right_index, nms, nm):
                           left_index=left_index, right_index=right_index)
         tm.assert_frame_equal(result, expected)
     else:
-        with tm.assert_raises_regex(ValueError, 'a Series without a name'):
+        with pytest.raises(ValueError, match='a Series without a name'):
             result = pd.merge(a, b, on=on, left_on=left_on, right_on=right_on,
                               left_index=left_index, right_index=right_index)

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -6,7 +6,6 @@ import pandas as pd
 from pandas import (merge_asof, read_csv,
                     to_datetime, Timedelta)
 from pandas.core.reshape.merge import MergeError
-from pandas.util import testing as tm
 from pandas.util.testing import assert_frame_equal
 
 
@@ -1005,7 +1004,7 @@ class TestAsOfMerge(object):
         right = pd.DataFrame({'right_val': [1, 2, 3, 6, 7],
                               'a': [1, 2, 3, 6, 7]})
 
-        with tm.assert_raises_regex(MergeError, msg):
+        with pytest.raises(MergeError, match=msg):
             merge_asof(left, right, on='a')
 
     @pytest.mark.parametrize('func', [lambda x: x, lambda x: to_datetime(x)],
@@ -1019,7 +1018,7 @@ class TestAsOfMerge(object):
         df_null = pd.DataFrame({'a': nulls, 'left_val': ['a', 'b', 'c']})
         df = pd.DataFrame({'a': non_nulls, 'right_val': [1, 6, 11]})
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             if side == 'left':
                 merge_asof(df_null, df, on='a')
             else:

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -1,6 +1,6 @@
+import pytest
 import pandas as pd
 from pandas import DataFrame, merge_ordered
-from pandas.util import testing as tm
 from pandas.util.testing import assert_frame_equal
 
 from numpy import nan
@@ -76,7 +76,8 @@ class TestMergeOrdered(object):
             ([None, None], none_pat)
         ]
         for df_seq, pattern in test_cases:
-            tm.assert_raises_regex(ValueError, pattern, pd.concat, df_seq)
+            with pytest.raises(ValueError, match=pattern):
+                pd.concat(df_seq)
 
         pd.concat([pd.DataFrame()])
         pd.concat([None, pd.DataFrame()])

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -147,12 +147,10 @@ class TestConcatAppendCommon(ConcatenateBase):
             tm.assert_index_equal(res, exp)
 
             # cannot append non-index
-            with tm.assert_raises_regex(TypeError,
-                                        'all inputs must be Index'):
+            with pytest.raises(TypeError, match='all inputs must be Index'):
                 pd.Index(vals1).append(vals2)
 
-            with tm.assert_raises_regex(TypeError,
-                                        'all inputs must be Index'):
+            with pytest.raises(TypeError, match='all inputs must be Index'):
                 pd.Index(vals1).append([pd.Index(vals2), vals3])
 
             # ----- Series ----- #
@@ -202,16 +200,16 @@ class TestConcatAppendCommon(ConcatenateBase):
             msg = (r'cannot concatenate object of type \"(.+?)\";'
                    ' only pd.Series, pd.DataFrame, and pd.Panel'
                    r' \(deprecated\) objs are valid')
-            with tm.assert_raises_regex(TypeError, msg):
+            with pytest.raises(TypeError, match=msg):
                 pd.Series(vals1).append(vals2)
 
-            with tm.assert_raises_regex(TypeError, msg):
+            with pytest.raises(TypeError, match=msg):
                 pd.Series(vals1).append([pd.Series(vals2), vals3])
 
-            with tm.assert_raises_regex(TypeError, msg):
+            with pytest.raises(TypeError, match=msg):
                 pd.concat([pd.Series(vals1), vals2])
 
-            with tm.assert_raises_regex(TypeError, msg):
+            with pytest.raises(TypeError, match=msg):
                 pd.concat([pd.Series(vals1), pd.Series(vals2), vals3])
 
     def test_concatlike_dtypes_coercion(self):

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -112,7 +112,7 @@ class TestMelt(object):
 
         for id_vars, value_vars in ((tuple_a, list_b), (list_a, tuple_b),
                                     (tuple_a, tuple_b)):
-            with tm.assert_raises_regex(ValueError, r'MultiIndex'):
+            with pytest.raises(ValueError, match=r'MultiIndex'):
                 self.df1.melt(id_vars=id_vars, value_vars=value_vars)
 
     def test_custom_var_name(self):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1674,22 +1674,22 @@ class TestCrosstab(object):
                            'c': [1, 1, np.nan, 1, 1]})
 
         error = 'values cannot be used without an aggfunc.'
-        with tm.assert_raises_regex(ValueError, error):
+        with pytest.raises(ValueError, match=error):
             pd.crosstab(df.a, df.b, values=df.c)
 
         error = 'aggfunc cannot be used without values'
-        with tm.assert_raises_regex(ValueError, error):
+        with pytest.raises(ValueError, match=error):
             pd.crosstab(df.a, df.b, aggfunc=np.mean)
 
         error = 'Not a valid normalize argument'
-        with tm.assert_raises_regex(ValueError, error):
+        with pytest.raises(ValueError, match=error):
             pd.crosstab(df.a, df.b, normalize='42')
 
-        with tm.assert_raises_regex(ValueError, error):
+        with pytest.raises(ValueError, match=error):
             pd.crosstab(df.a, df.b, normalize=42)
 
         error = 'Not a valid margins argument'
-        with tm.assert_raises_regex(ValueError, error):
+        with pytest.raises(ValueError, match=error):
             pd.crosstab(df.a, df.b, normalize='all', margins=42)
 
     def test_crosstab_with_categorial_columns(self):

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -205,8 +205,8 @@ class TestCut(object):
         tm.assert_categorical_equal(factor, expected)
 
     def test_qcut_all_bins_same(self):
-        tm.assert_raises_regex(ValueError, "edges.*unique", qcut,
-                               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 3)
+        with pytest.raises(ValueError, match="edges.*unique"):
+            qcut([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 3)
 
     def test_cut_out_of_bounds(self):
         arr = np.random.randn(100)

--- a/pandas/tests/reshape/test_union_categoricals.py
+++ b/pandas/tests/reshape/test_union_categoricals.py
@@ -58,11 +58,11 @@ class TestUnionCategoricals(object):
         s = Categorical([0, 1.2, 2])
         s2 = Categorical([2, 3, 4])
         msg = 'dtype of categories must be the same'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             union_categoricals([s, s2])
 
         msg = 'No Categoricals to union'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             union_categoricals([])
 
     def test_union_categoricals_nan(self):
@@ -143,7 +143,7 @@ class TestUnionCategoricals(object):
         c2 = Categorical([1, 2, 3], ordered=False)
 
         msg = 'Categorical.ordered must be the same'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             union_categoricals([c1, c2])
 
         res = union_categoricals([c1, c1])
@@ -161,7 +161,7 @@ class TestUnionCategoricals(object):
         c2 = Categorical([1, 2, 3], categories=[3, 2, 1], ordered=True)
 
         msg = "to union ordered Categoricals, all categories must be the same"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             union_categoricals([c1, c2])
 
     def test_union_categoricals_ignore_order(self):
@@ -174,7 +174,7 @@ class TestUnionCategoricals(object):
         tm.assert_categorical_equal(res, exp)
 
         msg = 'Categorical.ordered must be the same'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             union_categoricals([c1, c2], ignore_order=False)
 
         res = union_categoricals([c1, c1], ignore_order=True)
@@ -212,10 +212,10 @@ class TestUnionCategoricals(object):
         tm.assert_categorical_equal(result, expected)
 
         msg = "to union ordered Categoricals, all categories must be the same"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             union_categoricals([c1, c2], ignore_order=False)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             union_categoricals([c1, c2])
 
     def test_union_categoricals_sort(self):

--- a/pandas/tests/reshape/test_util.py
+++ b/pandas/tests/reshape/test_util.py
@@ -1,4 +1,4 @@
-
+import pytest
 import numpy as np
 from pandas import date_range, Index
 import pandas.util.testing as tm
@@ -41,9 +41,12 @@ class TestCartesianProduct(object):
         expected = []
         assert result == expected
 
-    def test_invalid_input(self):
-        invalid_inputs = [1, [1], [1, 2], [[1], 2],
-                          'a', ['a'], ['a', 'b'], [['a'], 'b']]
+    @pytest.mark.parametrize("X", [
+        1, [1], [1, 2], [[1], 2],
+        'a', ['a'], ['a', 'b'], [['a'], 'b']
+    ])
+    def test_invalid_input(self, X):
         msg = "Input must be a list-like of list-likes"
-        for X in invalid_inputs:
-            tm.assert_raises_regex(TypeError, msg, cartesian_product, X=X)
+
+        with pytest.raises(TypeError, match=msg):
+            cartesian_product(X=X)

--- a/pandas/tests/scalar/interval/test_interval.py
+++ b/pandas/tests/scalar/interval/test_interval.py
@@ -5,7 +5,6 @@ from pandas import Interval, Timestamp, Timedelta
 import pandas.core.common as com
 
 import pytest
-import pandas.util.testing as tm
 
 
 @pytest.fixture
@@ -35,7 +34,7 @@ class TestInterval(object):
         assert 0 not in interval
 
         msg = "__contains__ not defined for two intervals"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval in interval
 
         interval_both = Interval(0, 1, closed='both')
@@ -53,7 +52,7 @@ class TestInterval(object):
         assert Interval(0, 1) != 0
 
     def test_comparison(self):
-        with tm.assert_raises_regex(TypeError, 'unorderable types'):
+        with pytest.raises(TypeError, match='unorderable types'):
             Interval(0, 1) < 2
 
         assert Interval(0, 1) < Interval(1, 2)
@@ -106,7 +105,7 @@ class TestInterval(object):
         # GH 18789
         iv = Interval(left, right)
         msg = 'cannot compute length between .* and .*'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             iv.length
 
     def test_math_add(self, closed):
@@ -124,10 +123,10 @@ class TestInterval(object):
         assert result == expected
 
         msg = r"unsupported operand type\(s\) for \+"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval + interval
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval + 'foo'
 
     def test_math_sub(self, closed):
@@ -142,10 +141,10 @@ class TestInterval(object):
         assert result == expected
 
         msg = r"unsupported operand type\(s\) for -"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval - interval
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval - 'foo'
 
     def test_math_mult(self, closed):
@@ -163,11 +162,11 @@ class TestInterval(object):
         assert result == expected
 
         msg = r"unsupported operand type\(s\) for \*"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval * interval
 
         msg = r"can\'t multiply sequence by non-int"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval * 'foo'
 
     def test_math_div(self, closed):
@@ -182,10 +181,10 @@ class TestInterval(object):
         assert result == expected
 
         msg = r"unsupported operand type\(s\) for /"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval / interval
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval / 'foo'
 
     def test_math_floordiv(self, closed):
@@ -200,19 +199,19 @@ class TestInterval(object):
         assert result == expected
 
         msg = r"unsupported operand type\(s\) for //"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval // interval
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval // 'foo'
 
     def test_constructor_errors(self):
         msg = "invalid option for 'closed': foo"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Interval(0, 1, closed='foo')
 
         msg = 'left side of interval must be <= right side'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Interval(1, 0)
 
     @pytest.mark.parametrize('tz_left, tz_right', [

--- a/pandas/tests/scalar/interval/test_ops.py
+++ b/pandas/tests/scalar/interval/test_ops.py
@@ -2,7 +2,6 @@
 import pytest
 
 from pandas import Interval, Timedelta, Timestamp
-import pandas.util.testing as tm
 
 
 @pytest.fixture(params=[
@@ -57,5 +56,5 @@ class TestOverlaps(object):
         interval = Interval(0, 1)
         msg = '`other` must be an Interval, got {other}'.format(
             other=type(other).__name__)
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             interval.overlaps(other)

--- a/pandas/tests/scalar/period/test_asfreq.py
+++ b/pandas/tests/scalar/period/test_asfreq.py
@@ -329,26 +329,26 @@ class TestFreqConversion(object):
         assert ival_W.asfreq('W') == ival_W
 
         msg = pd._libs.tslibs.frequencies.INVALID_FREQ_ERR_MSG
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             ival_W.asfreq('WK')
 
     def test_conv_weekly_legacy(self):
         # frequency conversion tests: from Weekly Frequency
         msg = pd._libs.tslibs.frequencies.INVALID_FREQ_ERR_MSG
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(freq='WK', year=2007, month=1, day=1)
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(freq='WK-SAT', year=2007, month=1, day=6)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(freq='WK-FRI', year=2007, month=1, day=5)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(freq='WK-THU', year=2007, month=1, day=4)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(freq='WK-WED', year=2007, month=1, day=3)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(freq='WK-TUE', year=2007, month=1, day=2)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(freq='WK-MON', year=2007, month=1, day=1)
 
     def test_conv_business(self):
@@ -742,10 +742,10 @@ class TestFreqConversion(object):
         assert initial.asfreq(freq="M", how="S") == Period('2013-01', 'M')
 
         msg = pd._libs.tslibs.frequencies.INVALID_FREQ_ERR_MSG
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             initial.asfreq(freq="MS", how="S")
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.Period('2013-01', 'MS')
 
         assert _period_code_map.get("MS") is None

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -142,11 +142,11 @@ class TestPeriodProperties(object):
 
         msg = ('Frequency must be positive, because it'
                ' represents span: -3M')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period('2011-01', freq='-3M')
 
         msg = ('Frequency must be positive, because it' ' represents span: 0M')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period('2011-01', freq='0M')
 
     def test_period_cons_combined(self):
@@ -196,28 +196,28 @@ class TestPeriodProperties(object):
 
         msg = ('Frequency must be positive, because it'
                ' represents span: -25H')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period('2011-01', freq='-1D1H')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period('2011-01', freq='-1H1D')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(ordinal=1, freq='-1D1H')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(ordinal=1, freq='-1H1D')
 
         msg = ('Frequency must be positive, because it'
                ' represents span: 0D')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period('2011-01', freq='0D0H')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(ordinal=1, freq='0D0H')
 
         # You can only combine together day and intraday offsets
         msg = ('Invalid frequency: 1W1D')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period('2011-01', freq='1W1D')
         msg = ('Invalid frequency: 1D1W')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period('2011-01', freq='1D1W')
 
     @pytest.mark.parametrize('tzstr', ['Europe/Brussels',
@@ -528,9 +528,9 @@ class TestPeriodProperties(object):
         msg = pd._libs.tslibs.frequencies.INVALID_FREQ_ERR_MSG
         for exp, freqs in iteritems(cases):
             for freq in freqs:
-                with tm.assert_raises_regex(ValueError, msg):
+                with pytest.raises(ValueError, match=msg):
                     Period('2016-03-01 09:00', freq=freq)
-                with tm.assert_raises_regex(ValueError, msg):
+                with pytest.raises(ValueError, match=msg):
                     Period(ordinal=1, freq=freq)
 
             # check supported freq-aliases still works
@@ -774,7 +774,7 @@ class TestPeriodProperties(object):
         assert exp.days_in_month == 29
 
         msg = pd._libs.tslibs.frequencies.INVALID_FREQ_ERR_MSG
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Period(freq='WK', year=2007, month=1, day=7)
 
     def test_properties_daily(self):
@@ -1036,14 +1036,14 @@ class TestMethods(object):
         dt1 = Period(freq='D', year=2008, month=1, day=1)
         dt2 = Period(freq='D', year=2008, month=1, day=2)
         msg = r"unsupported operand type\(s\)"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             dt1 + "str"
 
         msg = r"unsupported operand type\(s\)"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             "str" + dt1
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             dt1 + dt2
 
     boxes = [lambda x: x, lambda x: pd.Series([x]), lambda x: pd.Index([x])]
@@ -1061,13 +1061,13 @@ class TestMethods(object):
         msg = (r"cannot add|unsupported operand|"
                r"can only operate on a|incompatible type|"
                r"ufunc add cannot use operands")
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             lbox(ts) + rbox(per)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             lbox(per) + rbox(ts)
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             lbox(per) + rbox(per)
 
     def test_sub(self):
@@ -1079,7 +1079,7 @@ class TestMethods(object):
         assert dt2 - dt1 == 14 * off
 
         msg = r"Input has different freq=M from Period\(freq=D\)"
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             dt1 - Period('2011-02', freq='M')
 
     def test_add_offset(self):
@@ -1435,10 +1435,10 @@ class TestMethods(object):
         assert result == exp
 
         msg = r"Input cannot be converted to Period\(freq=D\)"
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             p + offsets.Hour(2)
 
-        with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
+        with pytest.raises(period.IncompatibleFrequency, match=msg):
             p - offsets.Hour(2)
 
 

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -5,7 +5,6 @@ import pytest
 import numpy as np
 
 import pandas as pd
-import pandas.util.testing as tm
 from pandas import Timedelta
 
 
@@ -90,15 +89,16 @@ def test_construction():
         Timedelta('3.1415')
 
     # invalid construction
-    tm.assert_raises_regex(ValueError, "cannot construct a Timedelta",
-                           lambda: Timedelta())
-    tm.assert_raises_regex(ValueError,
-                           "unit abbreviation w/o a number",
-                           lambda: Timedelta('foo'))
-    tm.assert_raises_regex(ValueError,
-                           "cannot construct a Timedelta from the "
-                           "passed arguments, allowed keywords are ",
-                           lambda: Timedelta(day=10))
+    with pytest.raises(ValueError, match="cannot construct a Timedelta"):
+        Timedelta()
+
+    with pytest.raises(ValueError, match="unit abbreviation w/o a number"):
+        Timedelta('foo')
+
+    msg = ("cannot construct a Timedelta from "
+           "the passed arguments, allowed keywords are ")
+    with pytest.raises(ValueError, match=msg):
+        Timedelta(day=10)
 
     # floats
     expected = np.timedelta64(
@@ -190,8 +190,8 @@ def test_iso_constructor(fmt, exp):
     'P1DT0H0M0.0000000000000S', 'P1DT0H0M00000000000S',
     'P1DT0H0M0.S'])
 def test_iso_constructor_raises(fmt):
-    with tm.assert_raises_regex(ValueError, 'Invalid ISO 8601 Duration '
-                                'format - {}'.format(fmt)):
+    with pytest.raises(ValueError, match=('Invalid ISO 8601 Duration '
+                                          'format - {}'.format(fmt))):
         Timedelta(fmt)
 
 

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -334,20 +334,20 @@ class TestTimestampConstructors(object):
         assert result == eval(repr(result))
 
     def test_constructor_invalid(self):
-        with tm.assert_raises_regex(TypeError, 'Cannot convert input'):
+        with pytest.raises(TypeError, match='Cannot convert input'):
             Timestamp(slice(2))
-        with tm.assert_raises_regex(ValueError, 'Cannot convert Period'):
+        with pytest.raises(ValueError, match='Cannot convert Period'):
             Timestamp(Period('1000-01-01'))
 
     def test_constructor_invalid_tz(self):
         # GH#17690
-        with tm.assert_raises_regex(TypeError, 'must be a datetime.tzinfo'):
+        with pytest.raises(TypeError, match='must be a datetime.tzinfo'):
             Timestamp('2017-10-22', tzinfo='US/Eastern')
 
-        with tm.assert_raises_regex(ValueError, 'at most one of'):
+        with pytest.raises(ValueError, match='at most one of'):
             Timestamp('2017-10-22', tzinfo=utc, tz='UTC')
 
-        with tm.assert_raises_regex(ValueError, "Invalid frequency:"):
+        with pytest.raises(ValueError, match="Invalid frequency:"):
             # GH#5168
             # case where user tries to pass tz as an arg, not kwarg, gets
             # interpreted as a `freq`
@@ -577,7 +577,7 @@ class TestTimestampConstructors(object):
 
     def test_constructor_invalid_frequency(self):
         # GH 22311
-        with tm.assert_raises_regex(ValueError, "Invalid frequency:"):
+        with pytest.raises(ValueError, match="Invalid frequency:"):
             Timestamp('2012-01-01', freq=[])
 
 

--- a/pandas/tests/scalar/timestamp/test_timezones.py
+++ b/pandas/tests/scalar/timestamp/test_timezones.py
@@ -64,14 +64,14 @@ class TestTimestampTZOperations(object):
             ts.tz_localize('US/Eastern', ambiguous='infer')
 
         # GH#8025
-        with tm.assert_raises_regex(TypeError,
-                                    'Cannot localize tz-aware Timestamp, '
-                                    'use tz_convert for conversions'):
+        msg = ('Cannot localize tz-aware Timestamp, '
+               'use tz_convert for conversions')
+        with pytest.raises(TypeError, match=msg):
             Timestamp('2011-01-01', tz='US/Eastern').tz_localize('Asia/Tokyo')
 
-        with tm.assert_raises_regex(TypeError,
-                                    'Cannot convert tz-naive Timestamp, '
-                                    'use tz_localize to localize'):
+        msg = ('Cannot convert tz-naive Timestamp, '
+               'use tz_localize to localize')
+        with pytest.raises(TypeError, match=msg):
             Timestamp('2011-01-01').tz_convert('Asia/Tokyo')
 
     @pytest.mark.parametrize('stamp, tz', [

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -76,7 +76,7 @@ class TestTimestampUnaryOps(object):
 
     def test_round_invalid_arg(self):
         stamp = Timestamp('2000-01-05 05:09:15.13')
-        with tm.assert_raises_regex(ValueError, INVALID_FREQ_ERR_MSG):
+        with pytest.raises(ValueError, match=INVALID_FREQ_ERR_MSG):
             stamp.round('foo')
 
     @pytest.mark.parametrize('test_input, rounder, freq, expected', [

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -520,7 +520,7 @@ def test_drop_unique_and_non_unique_index(data, index, axis, drop_labels,
 def test_drop_exception_raised(data, index, drop_labels,
                                axis, error_type, error_desc):
 
-    with tm.assert_raises_regex(error_type, error_desc):
+    with pytest.raises(error_type, match=error_desc):
         Series(data, index=index).drop(drop_labels, axis=axis)
 
 
@@ -557,5 +557,5 @@ def test_drop_empty_list(index, drop_labels):
 ])
 def test_drop_non_empty_list(data, index, drop_labels):
     # GH 21494 and GH 16877
-    with tm.assert_raises_regex(KeyError, 'not found in axis'):
+    with pytest.raises(KeyError, match='not found in axis'):
         pd.Series(data=data, index=index).drop(drop_labels)

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -322,11 +322,11 @@ def test_where_invalid_input(cond):
     s = Series([1, 2, 3])
     msg = "Boolean array expected for the condition"
 
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         s.where(cond)
 
     msg = "Array conditional must be same shape as self"
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         s.where([True])
 
 
@@ -335,7 +335,7 @@ def test_where_ndframe_align():
     s = Series([1, 2, 3])
 
     cond = [True]
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         s.where(cond)
 
     expected = Series([1, np.nan, np.nan])
@@ -344,7 +344,7 @@ def test_where_ndframe_align():
     tm.assert_series_equal(out, expected)
 
     cond = np.array([False, True, False, True])
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         s.where(cond)
 
     expected = Series([np.nan, 2, np.nan])

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -394,9 +394,9 @@ def test_setslice(test_data):
 @pytest.mark.filterwarnings("ignore:Using a non-tuple:FutureWarning")
 def test_basic_getitem_setitem_corner(test_data):
     # invalid tuples, e.g. td.ts[:, None] vs. td.ts[:, 2]
-    with tm.assert_raises_regex(ValueError, 'tuple-index'):
+    with pytest.raises(ValueError, match='tuple-index'):
         test_data.ts[:, 2]
-    with tm.assert_raises_regex(ValueError, 'tuple-index'):
+    with pytest.raises(ValueError, match='tuple-index'):
         test_data.ts[:, 2] = 2
 
     # weird lists. [slice(0, 5)] will work but not two slices

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -80,7 +80,7 @@ class TestSeriesAlterAxes(object):
         s = Series(range(5))
         s.rename({}, axis=0)
         s.rename({}, axis='index')
-        with tm.assert_raises_regex(ValueError, 'No axis named 5'):
+        with pytest.raises(ValueError, match='No axis named 5'):
             s.rename({}, axis=5)
 
     def test_set_name_attribute(self):
@@ -169,7 +169,7 @@ class TestSeriesAlterAxes(object):
                                                           drop=True)
             tm.assert_frame_equal(result, df[['C']])
 
-            with tm.assert_raises_regex(KeyError, 'Level E '):
+            with pytest.raises(KeyError, match='Level E '):
                 s.reset_index(level=['A', 'E'])
 
             # With single-level Index
@@ -184,7 +184,7 @@ class TestSeriesAlterAxes(object):
             result = s.reset_index(level=levels[0], drop=True)
             tm.assert_series_equal(result, df['B'])
 
-            with tm.assert_raises_regex(IndexError, 'Too many levels'):
+            with pytest.raises(IndexError, match='Too many levels'):
                 s.reset_index(level=[0, 1, 2])
 
         # Check that .reset_index([],drop=True) doesn't fail
@@ -241,7 +241,7 @@ class TestSeriesAlterAxes(object):
         result = s.rename_axis(index=['foo', 'goo'])
         assert result.index.names == ['foo', 'goo']
 
-        with tm.assert_raises_regex(TypeError, 'unexpected'):
+        with pytest.raises(TypeError, match='unexpected'):
             s.rename_axis(columns='wrong')
 
     def test_rename_axis_inplace(self, datetime_series):
@@ -289,7 +289,7 @@ class TestSeriesAlterAxes(object):
 
         # wrong values for the "axis" parameter
         for axis in [2, 'foo']:
-            with tm.assert_raises_regex(ValueError, 'No axis named'):
+            with pytest.raises(ValueError, match='No axis named'):
                 s.set_axis(list('abcd'), axis=axis, inplace=False)
 
     def test_set_axis_prior_to_deprecation_signature(self):
@@ -308,14 +308,14 @@ class TestSeriesAlterAxes(object):
 
         # KeyError raised for series index when passed level name is missing
         s = Series(range(4))
-        with tm.assert_raises_regex(KeyError, 'must be same as name'):
+        with pytest.raises(KeyError, match='must be same as name'):
             s.reset_index('wrong', drop=True)
-        with tm.assert_raises_regex(KeyError, 'must be same as name'):
+        with pytest.raises(KeyError, match='must be same as name'):
             s.reset_index('wrong')
 
         # KeyError raised for series when level to be dropped is missing
         s = Series(range(4), index=MultiIndex.from_product([[1, 2]] * 2))
-        with tm.assert_raises_regex(KeyError, 'not found'):
+        with pytest.raises(KeyError, match='not found'):
             s.reset_index('wrong', drop=True)
 
     def test_droplevel(self):

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -26,7 +26,7 @@ from pandas.util.testing import (
     assert_series_equal)
 
 
-class TestSeriesAnalytics():
+class TestSeriesAnalytics(object):
 
     @pytest.mark.parametrize("use_bottleneck", [True, False])
     @pytest.mark.parametrize("method, unit", [
@@ -561,8 +561,8 @@ class TestSeriesAnalytics():
 
             # Unimplemented numeric_only parameter.
             if 'numeric_only' in compat.signature(f).args:
-                tm.assert_raises_regex(NotImplementedError, name, f,
-                                       string_series_, numeric_only=True)
+                with pytest.raises(NotImplementedError, match=name):
+                    f(string_series_, numeric_only=True)
 
     def _check_accum_op(self, name, datetime_series_, check_dtype=True):
         func = getattr(np, name)
@@ -601,12 +601,12 @@ class TestSeriesAnalytics():
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             msg = "the 'axis' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, np.compress,
-                                   cond, s, axis=1)
+            with pytest.raises(ValueError, match=msg):
+                np.compress(cond, s, axis=1)
 
             msg = "the 'out' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, np.compress,
-                                   cond, s, out=s)
+            with pytest.raises(ValueError, match=msg):
+                np.compress(cond, s, out=s)
 
     def test_round(self, datetime_series):
         datetime_series.index.name = "index_name"
@@ -624,7 +624,7 @@ class TestSeriesAnalytics():
         assert_series_equal(out, expected)
 
         msg = "the 'out' parameter is not supported"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             np.round(s, decimals=0, out=s)
 
     def test_built_in_round(self):
@@ -789,7 +789,7 @@ class TestSeriesAnalytics():
         s2 = pd.Series(np.random.randn(10))
         msg = ("method must be either 'pearson', 'spearman', "
                "or 'kendall'")
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             s1.corr(s2, method="____")
 
     def test_corr_callable_method(self, datetime_series):
@@ -1254,8 +1254,8 @@ class TestSeriesAnalytics():
         with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):
             msg = "the 'out' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, np.argmin,
-                                   s, out=data)
+            with pytest.raises(ValueError, match=msg):
+                np.argmin(s, out=data)
 
     def test_idxmax(self, string_series):
         # test idxmax
@@ -1322,8 +1322,8 @@ class TestSeriesAnalytics():
         with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):
             msg = "the 'out' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, np.argmax,
-                                   s, out=data)
+            with pytest.raises(ValueError, match=msg):
+                np.argmax(s, out=data)
 
     def test_ptp(self):
         # GH21614
@@ -1392,7 +1392,8 @@ class TestSeriesAnalytics():
         assert_series_equal(np.repeat(s, 2), expected)
 
         msg = "the 'axis' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.repeat, s, 2, axis=0)
+        with pytest.raises(ValueError, match=msg):
+            np.repeat(s, 2, axis=0)
 
     def test_searchsorted(self):
         s = Series([1, 2, 3])
@@ -1929,7 +1930,7 @@ class TestNLargestNSmallest(object):
         args = 2, len(r), 0, -1
         methods = r.nlargest, r.nsmallest
         for method, arg in product(methods, args):
-            with tm.assert_raises_regex(TypeError, msg):
+            with pytest.raises(TypeError, match=msg):
                 method(arg)
 
     def test_nsmallest_nlargest(self, s_main_dtypes_split):
@@ -1959,9 +1960,9 @@ class TestNLargestNSmallest(object):
         assert_series_equal(s.nsmallest(), s.iloc[[2, 3, 0, 4]])
 
         msg = 'keep must be either "first", "last"'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             s.nsmallest(keep='invalid')
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             s.nlargest(keep='invalid')
 
         # GH 15297

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -457,8 +457,7 @@ class TestSeriesMisc(TestData, SharedWithSparse):
 
         # str accessor only valid with string values
         s = Series(range(5))
-        with tm.assert_raises_regex(AttributeError,
-                                    'only use .str accessor'):
+        with pytest.raises(AttributeError, match='only use .str accessor'):
             s.str.repeat(2)
 
     def test_empty_method(self):
@@ -525,26 +524,25 @@ class TestCategoricalSeries(object):
         assert isinstance(s.cat, CategoricalAccessor)
 
         invalid = Series([1])
-        with tm.assert_raises_regex(AttributeError,
-                                    "only use .cat accessor"):
+        with pytest.raises(AttributeError, match="only use .cat accessor"):
             invalid.cat
         assert not hasattr(invalid, 'cat')
 
     def test_cat_accessor_no_new_attributes(self):
         # https://github.com/pandas-dev/pandas/issues/10673
         c = Series(list('aabbcde')).astype('category')
-        with tm.assert_raises_regex(AttributeError,
-                                    "You cannot add any new attribute"):
+        with pytest.raises(AttributeError,
+                           match="You cannot add any new attribute"):
             c.cat.xlabel = "a"
 
     def test_categorical_delegations(self):
 
         # invalid accessor
         pytest.raises(AttributeError, lambda: Series([1, 2, 3]).cat)
-        tm.assert_raises_regex(
-            AttributeError,
-            r"Can only use .cat accessor with a 'category' dtype",
-            lambda: Series([1, 2, 3]).cat)
+        with pytest.raises(AttributeError,
+                           match=(r"Can only use .cat accessor "
+                                  r"with a 'category' dtype")):
+            Series([1, 2, 3]).cat()
         pytest.raises(AttributeError, lambda: Series(['a', 'b', 'c']).cat)
         pytest.raises(AttributeError, lambda: Series(np.arange(5.)).cat)
         pytest.raises(AttributeError,
@@ -674,9 +672,9 @@ class TestCategoricalSeries(object):
                 tm.assert_series_equal(res, exp)
 
         invalid = Series([1, 2, 3]).astype('category')
-        with tm.assert_raises_regex(AttributeError,
-                                    "Can only use .str "
-                                    "accessor with string"):
+        msg = "Can only use .str accessor with string"
+
+        with pytest.raises(AttributeError, match=msg):
             invalid.str
         assert not hasattr(invalid, 'str')
 
@@ -760,7 +758,8 @@ class TestCategoricalSeries(object):
                 tm.assert_almost_equal(res, exp)
 
         invalid = Series([1, 2, 3]).astype('category')
-        with tm.assert_raises_regex(
-                AttributeError, "Can only use .dt accessor with datetimelike"):
+        msg = "Can only use .dt accessor with datetimelike"
+
+        with pytest.raises(AttributeError, match=msg):
             invalid.dt
         assert not hasattr(invalid, 'str')

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -82,7 +82,7 @@ class TestSeriesArithmetic(object):
         tm.assert_series_equal(result, expected)
 
         msg = "Input has different freq=D from PeriodIndex\\(freq=A-DEC\\)"
-        with tm.assert_raises_regex(IncompatibleFrequency, msg):
+        with pytest.raises(IncompatibleFrequency, match=msg):
             ts + ts.asfreq('D', how="end")
 
     def test_operators_datetimelike(self):
@@ -139,7 +139,7 @@ class TestSeriesFlexComparison(object):
         #
         msg = 'No axis named 1 for object type'
         for op in ['eq', 'ne', 'le', 'le', 'gt', 'ge']:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 getattr(left, op)(right, axis=1)
 
 

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -51,9 +51,9 @@ class TestSeriesCombine():
                                exp, check_index_type=True)
 
         msg = 'Indexes have overlapping values:'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             s1.append(s2, verify_integrity=True)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.concat([s1, s2], verify_integrity=True)
 
     def test_combine_scalar(self):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -33,7 +33,7 @@ class TestSeriesConstructors():
         msg = 'not understood'
         invalid_list = [pd.Timestamp, 'pd.Timestamp', list]
         for dtype in invalid_list:
-            with tm.assert_raises_regex(TypeError, msg):
+            with pytest.raises(TypeError, match=msg):
                 Series([], name='time', dtype=dtype)
 
     def test_scalar_conversion(self):
@@ -560,19 +560,19 @@ class TestSeriesConstructors():
 
     def test_constructor_cast(self):
         msg = "could not convert string to float"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Series(["a", "b", "c"], dtype=float)
 
     def test_constructor_unsigned_dtype_overflow(self, uint_dtype):
         # see gh-15832
         msg = 'Trying to coerce negative values to unsigned integers'
-        with tm.assert_raises_regex(OverflowError, msg):
+        with pytest.raises(OverflowError, match=msg):
             Series([-1], dtype=uint_dtype)
 
     def test_constructor_coerce_float_fail(self, any_int_dtype):
         # see gh-15832
         msg = "Trying to coerce float values to integers"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Series([1, 2, 3.5], dtype=any_int_dtype)
 
     def test_constructor_coerce_float_valid(self, float_dtype):
@@ -1162,7 +1162,7 @@ class TestSeriesConstructors():
             # PeriodIndex or PeriodArray
             type(index).__name__.rstrip("Index")
         )
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             Series(index, dtype=float)
 
         # ints are ok
@@ -1200,7 +1200,7 @@ class TestSeriesConstructors():
         # see gh-15524, gh-15987
         msg = "dtype has no unit. Please pass in"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             Series([], dtype=dtype)
 
     @pytest.mark.parametrize("dtype,msg", [
@@ -1210,7 +1210,7 @@ class TestSeriesConstructors():
     def test_constructor_generic_timestamp_bad_frequency(self, dtype, msg):
         # see gh-15524, gh-15987
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             Series([], dtype=dtype)
 
     @pytest.mark.parametrize('dtype', [None, 'uint8', 'category'])

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -216,7 +216,7 @@ class TestSeriesDatetimeValues():
 
         # no setting allowed
         s = Series(date_range('20130101', periods=5, freq='D'), name='xxx')
-        with tm.assert_raises_regex(ValueError, "modifications"):
+        with pytest.raises(ValueError, match="modifications"):
             s.dt.hour = 5
 
         # trying to set a copy
@@ -314,8 +314,8 @@ class TestSeriesDatetimeValues():
     def test_dt_accessor_no_new_attributes(self):
         # https://github.com/pandas-dev/pandas/issues/10673
         s = Series(date_range('20130101', periods=5, freq='D'))
-        with tm.assert_raises_regex(AttributeError,
-                                    "You cannot add any new attribute"):
+        with pytest.raises(AttributeError,
+                           match="You cannot add any new attribute"):
             s.dt.xlabel = "a"
 
     @pytest.mark.parametrize('time_locale', [
@@ -481,7 +481,7 @@ class TestSeriesDatetimeValues():
                                      Series(np.random.randn(5))])
     def test_dt_accessor_invalid(self, ser):
         # GH#9322 check that series with incorrect dtypes don't have attr
-        with tm.assert_raises_regex(AttributeError, "only use .dt accessor"):
+        with pytest.raises(AttributeError, match="only use .dt accessor"):
             ser.dt
         assert not hasattr(ser, 'dt')
 

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -68,7 +68,7 @@ class TestSeriesDtypes(object):
         msg = 'Cannot convert non-finite values \\(NA or inf\\) to integer'
         s = Series([value])
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             s.astype(dtype)
 
     @pytest.mark.parametrize("dtype", [int, np.int8, np.int64])
@@ -404,7 +404,7 @@ class TestSeriesDtypes(object):
         s = Series(data)
 
         msg = "dtype has no unit. Please pass in"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             s.astype(dtype)
 
     @pytest.mark.parametrize("dtype", np.typecodes['All'])

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -401,31 +401,31 @@ class TestSeriesMissingData():
         data = ['a', np.nan, 'b', np.nan, np.nan]
         s = Series(Categorical(data, categories=['a', 'b']))
 
-        with tm.assert_raises_regex(ValueError,
-                                    "fill value must be in categories"):
+        with pytest.raises(ValueError,
+                           match="fill value must be in categories"):
             s.fillna('d')
 
-        with tm.assert_raises_regex(ValueError,
-                                    "fill value must be in categories"):
+        with pytest.raises(ValueError,
+                           match="fill value must be in categories"):
             s.fillna(Series('d'))
 
-        with tm.assert_raises_regex(ValueError,
-                                    "fill value must be in categories"):
+        with pytest.raises(ValueError,
+                           match="fill value must be in categories"):
             s.fillna({1: 'd', 3: 'a'})
 
-        with tm.assert_raises_regex(TypeError,
-                                    '"value" parameter must be a scalar or '
-                                    'dict, but you passed a "list"'):
+        msg = ('"value" parameter must be a scalar or '
+               'dict, but you passed a "list"')
+        with pytest.raises(TypeError, match=msg):
             s.fillna(['a', 'b'])
 
-        with tm.assert_raises_regex(TypeError,
-                                    '"value" parameter must be a scalar or '
-                                    'dict, but you passed a "tuple"'):
+        msg = ('"value" parameter must be a scalar or '
+               'dict, but you passed a "tuple"')
+        with pytest.raises(TypeError, match=msg):
             s.fillna(('a', 'b'))
 
-        with tm.assert_raises_regex(TypeError,
-                                    '"value" parameter must be a scalar, dict '
-                                    'or Series, but you passed a "DataFrame"'):
+        msg = ('"value" parameter must be a scalar, dict '
+               'or Series, but you passed a "DataFrame"')
+        with pytest.raises(TypeError, match=msg):
             s.fillna(DataFrame({1: ['a'], 3: ['b']}))
 
     def test_fillna_nat(self):

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -604,23 +604,23 @@ class TestSeriesComparisons(object):
         for left, right in [(s1, s2), (s2, s1), (s3, s4), (s4, s3)]:
 
             msg = "Can only compare identically-labeled Series objects"
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 left == right
 
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 left != right
 
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 left < right
 
             msg = "Can only compare identically-labeled DataFrame objects"
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 left.to_frame() == right.to_frame()
 
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 left.to_frame() != right.to_frame()
 
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 left.to_frame() < right.to_frame()
 
 

--- a/pandas/tests/series/test_quantile.py
+++ b/pandas/tests/series/test_quantile.py
@@ -44,7 +44,7 @@ class TestSeriesQuantile(TestData):
 
         msg = 'percentiles should all be in the interval \\[0, 1\\]'
         for invalid in [-1, 2, [0.5, -1], [0.5, 2]]:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 self.ts.quantile(invalid)
 
     def test_quantile_multi(self):

--- a/pandas/tests/series/test_rank.py
+++ b/pandas/tests/series/test_rank.py
@@ -185,11 +185,11 @@ class TestSeriesRank(TestData):
         # Test invalid values for na_option
         msg = "na_option must be one of 'keep', 'top', or 'bottom'"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             na_ser.rank(na_option='bad', ascending=False)
 
         # invalid type
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             na_ser.rank(na_option=True, ascending=False)
 
         # Test with pct=True

--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -77,7 +77,7 @@ class TestSeriesReplace(TestData):
 
         # make sure that we aren't just masking a TypeError because bools don't
         # implement indexing
-        with tm.assert_raises_regex(TypeError, 'Cannot compare types .+'):
+        with pytest.raises(TypeError, match='Cannot compare types .+'):
             ser.replace([1, 2], [np.nan, 0])
 
         ser = pd.Series([0, 1, 2, 3, 4])
@@ -137,9 +137,9 @@ class TestSeriesReplace(TestData):
         tm.assert_series_equal(result, expected)
 
         # GH 19266
-        with tm.assert_raises_regex(ValueError, "cannot assign mismatch"):
+        with pytest.raises(ValueError, match="cannot assign mismatch"):
             s.replace({np.nan: []})
-        with tm.assert_raises_regex(ValueError, "cannot assign mismatch"):
+        with pytest.raises(ValueError, match="cannot assign mismatch"):
             s.replace({np.nan: ['dummy', 'alt']})
 
     def test_replace_mixed_types(self):
@@ -205,7 +205,7 @@ class TestSeriesReplace(TestData):
 
     def test_replace_with_dict_with_bool_keys(self):
         s = pd.Series([True, False, True])
-        with tm.assert_raises_regex(TypeError, 'Cannot compare types .+'):
+        with pytest.raises(TypeError, match='Cannot compare types .+'):
             s.replace({'asdf': 'asdb', True: 'yes'})
 
     def test_replace2(self):

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -248,14 +248,16 @@ class TestTimeSeries(TestData):
 
         s = pd.Series(['a', 'b', 'c', 'd', 'e'],
                       index=[5, 3, 2, 9, 0])
-        with tm.assert_raises_regex(ValueError,
-                                    'truncate requires a sorted index'):
+        msg = 'truncate requires a sorted index'
+
+        with pytest.raises(ValueError, match=msg):
             s.truncate(before=3, after=9)
 
         rng = pd.date_range('2011-01-01', '2012-01-01', freq='W')
         ts = pd.Series(np.random.randn(len(rng)), index=rng)
-        with tm.assert_raises_regex(ValueError,
-                                    'truncate requires a sorted index'):
+        msg = 'truncate requires a sorted index'
+
+        with pytest.raises(ValueError, match=msg):
             ts.sort_values(ascending=False).truncate(before='2011-11',
                                                      after='2011-12')
 

--- a/pandas/tests/series/test_timezones.py
+++ b/pandas/tests/series/test_timezones.py
@@ -31,8 +31,9 @@ class TestSeriesTimezones(object):
         # Can't localize if already tz-aware
         rng = date_range('1/1/2011', periods=100, freq='H', tz='utc')
         ts = Series(1, index=rng)
-        tm.assert_raises_regex(TypeError, 'Already tz-aware',
-                               ts.tz_localize, 'US/Eastern')
+
+        with pytest.raises(TypeError, match='Already tz-aware'):
+            ts.tz_localize('US/Eastern')
 
     @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_tz_localize_errors_deprecation(self):
@@ -123,8 +124,9 @@ class TestSeriesTimezones(object):
         # can't convert tz-naive
         rng = date_range('1/1/2011', periods=200, freq='D')
         ts = Series(1, index=rng)
-        tm.assert_raises_regex(TypeError, "Cannot convert tz-naive",
-                               ts.tz_convert, 'US/Eastern')
+
+        with pytest.raises(TypeError, match="Cannot convert tz-naive"):
+            ts.tz_convert('US/Eastern')
 
     def test_series_tz_convert_to_utc(self):
         base = DatetimeIndex(['2011-01-01', '2011-01-02', '2011-01-03'],

--- a/pandas/tests/series/test_validate.py
+++ b/pandas/tests/series/test_validate.py
@@ -1,7 +1,5 @@
 import pytest
 
-import pandas.util.testing as tm
-
 
 class TestSeriesValidate(object):
     """Tests for error handling related to data types of method arguments."""
@@ -17,5 +15,5 @@ class TestSeriesValidate(object):
         if func == "_set_name":
             kwargs["name"] = "hello"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             getattr(string_series, func)(**kwargs)

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -152,10 +152,10 @@ class TestSparseDataFrame(SharedWithSparse):
                       level=1)
 
         # wrong length index / columns
-        with tm.assert_raises_regex(ValueError, "^Index length"):
+        with pytest.raises(ValueError, match="^Index length"):
             SparseDataFrame(float_frame.values, index=float_frame.index[:-1])
 
-        with tm.assert_raises_regex(ValueError, "^Column length"):
+        with pytest.raises(ValueError, match="^Column length"):
             SparseDataFrame(float_frame.values,
                             columns=float_frame.columns[:-1])
 
@@ -638,7 +638,7 @@ class TestSparseDataFrame(SharedWithSparse):
 
     def test_ctor_reindex(self):
         idx = pd.Index([0, 1, 2, 3])
-        with tm.assert_raises_regex(ValueError, ''):
+        with pytest.raises(ValueError, match=''):
             pd.SparseDataFrame({"A": [1, 2]}, index=idx)
 
     def test_append(self, float_frame):
@@ -870,8 +870,7 @@ class TestSparseDataFrame(SharedWithSparse):
         right = float_frame.loc[:, ['B', 'D']]
         pytest.raises(Exception, left.join, right)
 
-        with tm.assert_raises_regex(ValueError,
-                                    'Other Series must have a name'):
+        with pytest.raises(ValueError, match='Other Series must have a name'):
             float_frame.join(Series(
                 np.random.randn(len(float_frame)), index=float_frame.index))
 
@@ -1130,7 +1129,8 @@ class TestSparseDataFrame(SharedWithSparse):
         tm.assert_sp_frame_equal(result, sdf)
 
         msg = "the 'axes' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.transpose, sdf, axes=1)
+        with pytest.raises(ValueError, match=msg):
+            np.transpose(sdf, axes=1)
 
     def test_combine_first(self, float_frame):
         df = float_frame
@@ -1300,12 +1300,12 @@ class TestSparseDataFrameAnalytics(object):
         tm.assert_sp_frame_equal(result, expected)
 
         msg = "the 'dtype' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.cumsum,
-                               float_frame, dtype=np.int64)
+        with pytest.raises(ValueError, match=msg):
+            np.cumsum(float_frame, dtype=np.int64)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.cumsum,
-                               float_frame, out=result)
+        with pytest.raises(ValueError, match=msg):
+            np.cumsum(float_frame, out=result)
 
     def test_numpy_func_call(self, float_frame):
         # no exception should be raised even though

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -553,12 +553,12 @@ class TestSparseSeries(SharedWithSparse):
                                np.take(sp.to_dense(), indices, axis=0))
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.take,
-                               sp, indices, out=np.empty(sp.shape))
+        with pytest.raises(ValueError, match=msg):
+            np.take(sp, indices, out=np.empty(sp.shape))
 
         msg = "the 'mode' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.take,
-                               sp, indices, out=None, mode='clip')
+        with pytest.raises(ValueError, match=msg):
+            np.take(sp, indices, out=None, mode='clip')
 
     def test_setitem(self):
         self.bseries[5] = 7.
@@ -776,9 +776,9 @@ class TestSparseSeries(SharedWithSparse):
         first_series = SparseSeries(values1,
                                     sparse_index=IntIndex(length, index1),
                                     fill_value=nan)
-        with tm.assert_raises_regex(TypeError,
-                                    'new index must be a SparseIndex'):
-            reindexed = first_series.sparse_reindex(0)  # noqa
+        with pytest.raises(TypeError,
+                           match='new index must be a SparseIndex'):
+            first_series.sparse_reindex(0)
 
     def test_repr(self):
         # TODO: These aren't used
@@ -870,7 +870,7 @@ class TestSparseSeries(SharedWithSparse):
         # must have NaN fill value
         data = {'a': SparseSeries(np.arange(7), sparse_index=expected2,
                                   fill_value=0)}
-        with tm.assert_raises_regex(TypeError, "NaN fill value"):
+        with pytest.raises(TypeError, match="NaN fill value"):
             spf.homogenize(data)
 
     def test_fill_value_corner(self):
@@ -1444,7 +1444,7 @@ class TestSparseSeriesAnalytics(object):
 
         axis = 1  # Series is 1-D, so only axis = 0 is valid.
         msg = "No axis named {axis}".format(axis=axis)
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             self.bseries.cumsum(axis=axis)
 
     def test_numpy_cumsum(self):
@@ -1457,12 +1457,12 @@ class TestSparseSeriesAnalytics(object):
         tm.assert_series_equal(result, expected)
 
         msg = "the 'dtype' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.cumsum,
-                               self.bseries, dtype=np.int64)
+        with pytest.raises(ValueError, match=msg):
+            np.cumsum(self.bseries, dtype=np.int64)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.cumsum,
-                               self.zbseries, out=result)
+        with pytest.raises(ValueError, match=msg):
+            np.cumsum(self.zbseries, out=result)
 
     def test_numpy_func_call(self):
         # no exception should be raised even though
@@ -1520,7 +1520,7 @@ def test_to_sparse():
 
 def test_constructor_mismatched_raises():
     msg = "Length of passed values is 2, index implies 3"
-    with tm.assert_raises_regex(ValueError, msg):
+    with pytest.raises(ValueError, match=msg):
         SparseSeries([1, 2], index=[1, 2, 3])
 
 

--- a/pandas/tests/sparse/test_indexing.py
+++ b/pandas/tests/sparse/test_indexing.py
@@ -451,7 +451,7 @@ class TestSparseSeriesIndexing(object):
 
         msg = ("iLocation based boolean indexing cannot "
                "use an indexable as a mask")
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             s.iloc[indexer]
 
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1328,7 +1328,7 @@ class TestHashTable(object):
         if safely_resizes:
             htable.get_labels(vals, uniques, 0, -1)
         else:
-            with tm.assert_raises_regex(ValueError, 'external reference.*'):
+            with pytest.raises(ValueError, match='external reference.*'):
                 htable.get_labels(vals, uniques, 0, -1)
 
         uniques.to_array()   # should not raise here
@@ -1459,7 +1459,7 @@ class TestRank(object):
         arr = np.array([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]])
         msg = "Array with ndim > 2 are not supported"
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             algos.rank(arr)
 
 
@@ -1664,27 +1664,27 @@ def test_int64_add_overflow():
     m = np.iinfo(np.int64).max
     n = np.iinfo(np.int64).min
 
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         algos.checked_add_with_arr(np.array([m, m]), m)
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]))
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         algos.checked_add_with_arr(np.array([n, n]), n)
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         algos.checked_add_with_arr(np.array([n, n]), np.array([n, n]))
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         algos.checked_add_with_arr(np.array([m, n]), np.array([n, n]))
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
                                    arr_mask=np.array([False, True]))
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
                                    b_mask=np.array([False, True]))
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
                                    arr_mask=np.array([False, True]),
                                    b_mask=np.array([False, True]))
-    with tm.assert_raises_regex(OverflowError, msg):
+    with pytest.raises(OverflowError, match=msg):
         with tm.assert_produces_warning(RuntimeWarning):
             algos.checked_add_with_arr(np.array([m, m]),
                                        np.array([np.nan, m]))
@@ -1692,19 +1692,13 @@ def test_int64_add_overflow():
     # Check that the nan boolean arrays override whether or not
     # the addition overflows. We don't check the result but just
     # the fact that an OverflowError is not raised.
-    with pytest.raises(AssertionError):
-        with tm.assert_raises_regex(OverflowError, msg):
-            algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
-                                       arr_mask=np.array([True, True]))
-    with pytest.raises(AssertionError):
-        with tm.assert_raises_regex(OverflowError, msg):
-            algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
-                                       b_mask=np.array([True, True]))
-    with pytest.raises(AssertionError):
-        with tm.assert_raises_regex(OverflowError, msg):
-            algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
-                                       arr_mask=np.array([True, False]),
-                                       b_mask=np.array([False, True]))
+    algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
+                               arr_mask=np.array([True, True]))
+    algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
+                               b_mask=np.array([True, True]))
+    algos.checked_add_with_arr(np.array([m, m]), np.array([m, m]),
+                               arr_mask=np.array([True, False]),
+                               b_mask=np.array([False, True]))
 
 
 class TestMode(object):

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -47,9 +47,9 @@ class CheckImmutable(object):
     mutable_regex = re.compile('does not support mutable operations')
 
     def check_mutable_error(self, *args, **kwargs):
-        # Pass whatever function you normally would to assert_raises_regex
+        # Pass whatever function you normally would to pytest.raises
         # (after the Exception kind).
-        tm.assert_raises_regex(
+        pytest.raises(
             TypeError, self.mutable_regex, *args, **kwargs)
 
     def test_no_mutable_funcs(self):
@@ -848,9 +848,9 @@ class TestIndexOps(Ops):
                 result = idx.drop_duplicates(keep=False)
                 tm.assert_index_equal(result, idx[~expected])
 
-                with tm.assert_raises_regex(
-                        TypeError, r"drop_duplicates\(\) got an unexpected "
-                        "keyword argument"):
+                with pytest.raises(TypeError,
+                                   match=(r"drop_duplicates\(\) got an "
+                                          r"unexpected keyword argument")):
                     idx.drop_duplicates(inplace=True)
 
             else:
@@ -1036,10 +1036,10 @@ class TestTranspose(Ops):
 
     def test_transpose_non_default_axes(self):
         for obj in self.objs:
-            tm.assert_raises_regex(ValueError, self.errmsg,
-                                   obj.transpose, 1)
-            tm.assert_raises_regex(ValueError, self.errmsg,
-                                   obj.transpose, axes=1)
+            with pytest.raises(ValueError, match=self.errmsg):
+                obj.transpose(1)
+            with pytest.raises(ValueError, match=self.errmsg):
+                obj.transpose(axes=1)
 
     def test_numpy_transpose(self):
         for obj in self.objs:
@@ -1048,8 +1048,8 @@ class TestTranspose(Ops):
             else:
                 tm.assert_series_equal(np.transpose(obj), obj)
 
-            tm.assert_raises_regex(ValueError, self.errmsg,
-                                   np.transpose, obj, axes=1)
+            with pytest.raises(ValueError, match=self.errmsg):
+                np.transpose(obj, axes=1)
 
 
 class TestNoNewAttributesMixin(object):

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -4,7 +4,6 @@ import pytest
 import pandas  # noqa
 import pandas as pd
 from pandas.errors import AbstractMethodError
-import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize(
@@ -62,13 +61,13 @@ class Foo(object):
 
 def test_AbstractMethodError_classmethod():
     xpr = "This classmethod must be defined in the concrete class Foo"
-    with tm.assert_raises_regex(AbstractMethodError, xpr):
+    with pytest.raises(AbstractMethodError, match=xpr):
         Foo.classmethod()
 
     xpr = "This property must be defined in the concrete class Foo"
-    with tm.assert_raises_regex(AbstractMethodError, xpr):
+    with pytest.raises(AbstractMethodError, match=xpr):
         Foo().property
 
     xpr = "This method must be defined in the concrete class Foo"
-    with tm.assert_raises_regex(AbstractMethodError, xpr):
+    with pytest.raises(AbstractMethodError, match=xpr):
         Foo().method()

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -379,22 +379,22 @@ class TestExpressions(object):
                 f = getattr(operator, name)
                 err_msg = re.escape(msg % op)
 
-                with tm.assert_raises_regex(NotImplementedError, err_msg):
+                with pytest.raises(NotImplementedError, match=err_msg):
                     f(df, df)
 
-                with tm.assert_raises_regex(NotImplementedError, err_msg):
+                with pytest.raises(NotImplementedError, match=err_msg):
                     f(df.a, df.b)
 
-                with tm.assert_raises_regex(NotImplementedError, err_msg):
+                with pytest.raises(NotImplementedError, match=err_msg):
                     f(df.a, True)
 
-                with tm.assert_raises_regex(NotImplementedError, err_msg):
+                with pytest.raises(NotImplementedError, match=err_msg):
                     f(False, df.a)
 
-                with tm.assert_raises_regex(NotImplementedError, err_msg):
+                with pytest.raises(NotImplementedError, match=err_msg):
                     f(False, df)
 
-                with tm.assert_raises_regex(NotImplementedError, err_msg):
+                with pytest.raises(NotImplementedError, match=err_msg):
                     f(df, True)
 
     def test_bool_ops_warn_on_arithmetic(self):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -325,7 +325,7 @@ class TestMultiLevel(Base):
         np.putmask(values[:-1], values[:-1] < 0, 2)
         tm.assert_almost_equal(df.values, values)
 
-        with tm.assert_raises_regex(TypeError, 'boolean values only'):
+        with pytest.raises(TypeError, match='boolean values only'):
             df[df * 0] = 2
 
     def test_frame_getitem_setitem_slice(self):
@@ -772,8 +772,8 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         # can't call with level on regular DataFrame
         df = tm.makeTimeDataFrame()
-        tm.assert_raises_regex(
-            TypeError, 'hierarchical', df.count, level=0)
+        with pytest.raises(TypeError, match='hierarchical'):
+            df.count(level=0)
 
         self.frame['D'] = 'foo'
         result = self.frame.count(level=0, numeric_only=True)
@@ -809,10 +809,9 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         tm.assert_frame_equal(result, expected)
 
     def test_get_level_number_out_of_bounds(self):
-        with tm.assert_raises_regex(IndexError, "Too many levels"):
+        with pytest.raises(IndexError, match="Too many levels"):
             self.frame.index._get_level_number(2)
-        with tm.assert_raises_regex(IndexError,
-                                    "not a valid level number"):
+        with pytest.raises(IndexError, match="not a valid level number"):
             self.frame.index._get_level_number(-3)
 
     def test_unstack(self):
@@ -1029,17 +1028,16 @@ Thur,Lunch,Yes,51.51,17"""
         unstacked = self.ymd.unstack(['year', 'month'])
 
         # Can't use mixture of names and numbers to stack
-        with tm.assert_raises_regex(ValueError, "level should contain"):
+        with pytest.raises(ValueError, match="level should contain"):
             unstacked.stack([0, 'month'])
 
     def test_stack_multiple_out_of_bounds(self):
         # nlevels == 3
         unstacked = self.ymd.unstack(['year', 'month'])
 
-        with tm.assert_raises_regex(IndexError, "Too many levels"):
+        with pytest.raises(IndexError, match="Too many levels"):
             unstacked.stack([2, 3])
-        with tm.assert_raises_regex(IndexError,
-                                    "not a valid level number"):
+        with pytest.raises(IndexError, match="not a valid level number"):
             unstacked.stack([-4, -3])
 
     def test_unstack_period_series(self):
@@ -1327,10 +1325,10 @@ Thur,Lunch,Yes,51.51,17"""
         expected = self.ymd.T.swaplevel(0, 1, axis=1).swaplevel(1, 2, axis=1)
         tm.assert_frame_equal(result, expected)
 
-        with tm.assert_raises_regex(TypeError, 'hierarchical axis'):
+        with pytest.raises(TypeError, match='hierarchical axis'):
             self.ymd.reorder_levels([1, 2], axis=1)
 
-        with tm.assert_raises_regex(IndexError, 'Too many levels'):
+        with pytest.raises(IndexError, match='Too many levels'):
             self.ymd.index.reorder_levels([1, 2, 3])
 
     def test_insert_index(self):
@@ -2351,9 +2349,9 @@ Thur,Lunch,Yes,51.51,17"""
         tm.assert_frame_equal(result, df)
 
         # gh-16120: already existing column
-        with tm.assert_raises_regex(ValueError,
-                                    (r"cannot insert \('A', ''\), "
-                                     "already exists")):
+        with pytest.raises(ValueError,
+                           match=(r"cannot insert \('A', ''\), "
+                                  "already exists")):
             df.rename_axis('A').reset_index()
 
         # gh-16164: multiindex (tuple) full key
@@ -2368,9 +2366,9 @@ Thur,Lunch,Yes,51.51,17"""
         tm.assert_frame_equal(result, expected)
 
         # with index name which is a too long tuple...
-        with tm.assert_raises_regex(ValueError,
-                                    ("Item must have length equal to number "
-                                     "of levels.")):
+        with pytest.raises(ValueError,
+                           match=("Item must have length equal "
+                                  "to number of levels.")):
             df.rename_axis([('C', 'c', 'i')]).reset_index()
 
         # or too short...
@@ -2384,9 +2382,9 @@ Thur,Lunch,Yes,51.51,17"""
         tm.assert_frame_equal(result, expected)
 
         # ... which is incompatible with col_fill=None
-        with tm.assert_raises_regex(ValueError,
-                                    ("col_fill=None is incompatible with "
-                                     r"incomplete column name \('C', 'c'\)")):
+        with pytest.raises(ValueError,
+                           match=("col_fill=None is incompatible with "
+                                  r"incomplete column name \('C', 'c'\)")):
             df2.rename_axis([('C', 'c')]).reset_index(col_fill=None)
 
         # with col_level != 0

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -177,8 +177,8 @@ class SafeForLongAndSparse(object):
 
         # Unimplemented numeric_only parameter.
         if 'numeric_only' in signature(f).args:
-            tm.assert_raises_regex(NotImplementedError, name, f,
-                                   numeric_only=True)
+            with pytest.raises(NotImplementedError, match=name):
+                f(numeric_only=True)
 
 
 @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
@@ -221,10 +221,10 @@ class SafeForSparse(object):
         assert self.panel._get_axis_number('major') == 1
         assert self.panel._get_axis_number('minor') == 2
 
-        with tm.assert_raises_regex(ValueError, "No axis named foo"):
+        with pytest.raises(ValueError, match="No axis named foo"):
             self.panel._get_axis_number('foo')
 
-        with tm.assert_raises_regex(ValueError, "No axis named foo"):
+        with pytest.raises(ValueError, match="No axis named foo"):
             self.panel.__ge__(self.panel, axis='foo')
 
     def test_get_axis_name(self):
@@ -502,10 +502,9 @@ class CheckIndexing(object):
 
         # bad shape
         p = Panel(np.random.randn(4, 3, 2))
-        with tm.assert_raises_regex(ValueError,
-                                    r"shape of value must be "
-                                    r"\(3, 2\), shape of given "
-                                    r"object was \(4, 2\)"):
+        msg = (r"shape of value must be \(3, 2\), "
+               r"shape of given object was \(4, 2\)")
+        with pytest.raises(ValueError, match=msg):
             p[0] = np.random.randn(4, 2)
 
     def test_setitem_ndarray(self):
@@ -853,9 +852,8 @@ class CheckIndexing(object):
                     assert_almost_equal(result, expected)
         with catch_warnings():
             simplefilter("ignore", FutureWarning)
-            with tm.assert_raises_regex(TypeError,
-                                        "There must be an argument "
-                                        "for each axis"):
+            msg = "There must be an argument for each axis"
+            with pytest.raises(TypeError, match=msg):
                 self.panel.get_value('a')
 
     def test_set_value(self):
@@ -880,7 +878,7 @@ class CheckIndexing(object):
 
             msg = ("There must be an argument for each "
                    "axis plus the value provided")
-            with tm.assert_raises_regex(TypeError, msg):
+            with pytest.raises(TypeError, match=msg):
                 self.panel.set_value('a')
 
 
@@ -1015,7 +1013,8 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
             _check_dtype(panel, dtype)
 
     def test_constructor_fails_with_not_3d_input(self):
-        with tm.assert_raises_regex(ValueError, "The number of dimensions required is 3"):  # noqa
+        msg = "The number of dimensions required is 3"
+        with pytest.raises(ValueError, match=msg):
                 Panel(np.random.randn(10, 2))
 
     def test_consolidate(self):
@@ -1144,35 +1143,23 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
         assert panel['A'].values.dtype == np.float64
 
     def test_constructor_error_msgs(self):
-        def testit():
+        msg = (r"Shape of passed values is \(3, 4, 5\), "
+               r"indices imply \(4, 5, 5\)")
+        with pytest.raises(ValueError, match=msg):
             Panel(np.random.randn(3, 4, 5),
                   lrange(4), lrange(5), lrange(5))
 
-        tm.assert_raises_regex(ValueError,
-                               r"Shape of passed values is "
-                               r"\(3, 4, 5\), indices imply "
-                               r"\(4, 5, 5\)",
-                               testit)
-
-        def testit():
+        msg = (r"Shape of passed values is \(3, 4, 5\), "
+               r"indices imply \(5, 4, 5\)")
+        with pytest.raises(ValueError, match=msg):
             Panel(np.random.randn(3, 4, 5),
                   lrange(5), lrange(4), lrange(5))
 
-        tm.assert_raises_regex(ValueError,
-                               r"Shape of passed values is "
-                               r"\(3, 4, 5\), indices imply "
-                               r"\(5, 4, 5\)",
-                               testit)
-
-        def testit():
+        msg = (r"Shape of passed values is \(3, 4, 5\), "
+               r"indices imply \(5, 5, 4\)")
+        with pytest.raises(ValueError, match=msg):
             Panel(np.random.randn(3, 4, 5),
                   lrange(5), lrange(5), lrange(4))
-
-        tm.assert_raises_regex(ValueError,
-                               r"Shape of passed values is "
-                               r"\(3, 4, 5\), indices imply "
-                               r"\(5, 5, 4\)",
-                               testit)
 
     def test_conform(self):
         df = self.panel['ItemA'][:-5].filter(items=['A', 'B'])
@@ -1634,12 +1621,12 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
         assert_panel_equal(result, expected)
 
         # duplicate axes
-        with tm.assert_raises_regex(TypeError,
-                                    'not enough/duplicate arguments'):
+        with pytest.raises(TypeError,
+                           match='not enough/duplicate arguments'):
             self.panel.transpose('minor', maj='major', minor='items')
 
-        with tm.assert_raises_regex(ValueError,
-                                    'repeated axis in transpose'):
+        with pytest.raises(ValueError,
+                           match='repeated axis in transpose'):
             self.panel.transpose('minor', 'major', major='minor',
                                  minor='items')
 
@@ -1833,8 +1820,9 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
         # #2441
         df = DataFrame({'a': [0, 0, 1], 'b': [1, 1, 1], 'c': [1, 2, 3]})
         idf = df.set_index(['a', 'b'])
-        tm.assert_raises_regex(
-            ValueError, 'non-uniquely indexed', idf.to_panel)
+
+        with pytest.raises(ValueError, match='non-uniquely indexed'):
+            idf.to_panel()
 
     def test_panel_dups(self):
 
@@ -1954,8 +1942,8 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
         shifted3 = ps.tshift(freq=BDay())
         assert_panel_equal(shifted, shifted3)
 
-        tm.assert_raises_regex(ValueError, 'does not match',
-                               ps.tshift, freq='M')
+        with pytest.raises(ValueError, match='does not match'):
+            ps.tshift(freq='M')
 
         # DatetimeIndex
         panel = make_test_panel()
@@ -2067,7 +2055,8 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
         assert_panel_equal(expected, result)
 
         msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.round, p, out=p)
+        with pytest.raises(ValueError, match=msg):
+            np.round(p, out=p)
 
     # removing Panel before NumPy enforces, so just ignore
     @pytest.mark.filterwarnings("ignore:Using a non-tuple:FutureWarning")
@@ -2493,8 +2482,8 @@ class TestPanelFrame(object):
     def test_to_sparse(self):
         if isinstance(self.panel, Panel):
             msg = 'sparsifying is not supported'
-            tm.assert_raises_regex(NotImplementedError, msg,
-                                   self.panel.to_sparse)
+            with pytest.raises(NotImplementedError, match=msg):
+                self.panel.to_sparse
 
     def test_truncate(self):
         dates = self.panel.index.levels[0]

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -85,5 +85,5 @@ def test_raises_attribute_error():
             def __init__(self, data):
                 raise AttributeError("whoops")
 
-        with tm.assert_raises_regex(AttributeError, "whoops"):
+        with pytest.raises(AttributeError, match="whoops"):
             pd.Series([]).bad

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -158,7 +158,7 @@ class TestResampleAPI(object):
         pytest.raises(KeyError, g.__getitem__, ['D'])
 
         pytest.raises(KeyError, g.__getitem__, ['A', 'D'])
-        with tm.assert_raises_regex(KeyError, '^[^A]+$'):
+        with pytest.raises(KeyError, match='^[^A]+$'):
             # A should not be referenced as a bad column...
             # will have to rethink regex if you change message!
             g[['A', 'D']]
@@ -940,11 +940,10 @@ class TestDatetimeIndex(Base):
 
         for func in ('min', 'max', 'sum', 'prod',
                      'mean', 'var', 'std'):
-            tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                                   getattr(r, func),
-                                   func, 1, 2, 3)
-            tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                                   getattr(r, func), axis=1)
+            with pytest.raises(UnsupportedFunctionCall, match=msg):
+                getattr(r, func)(func, 1, 2, 3)
+            with pytest.raises(UnsupportedFunctionCall, match=msg):
+                getattr(r, func)(axis=1)
 
     def test_resample_how_callables(self):
         # GH 7929
@@ -3308,11 +3307,10 @@ class TestTimeGrouper(object):
         for name, func in zip(index_names, index_funcs):
             index = func(n)
             df = DataFrame({'a': np.random.randn(n)}, index=index)
-            with tm.assert_raises_regex(TypeError,
-                                        "Only valid with "
-                                        "DatetimeIndex, TimedeltaIndex "
-                                        "or PeriodIndex, but got an "
-                                        "instance of %r" % name):
+
+            msg = ("Only valid with DatetimeIndex, TimedeltaIndex "
+                   "or PeriodIndex, but got an instance of %r" % name)
+            with pytest.raises(TypeError, match=msg):
                 df.groupby(TimeGrouper('D'))
 
     def test_aaa_group_order(self):

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -423,14 +423,14 @@ class TestSafeSort(object):
             pytest.raises(TypeError, safe_sort, arr)
 
     def test_exceptions(self):
-        with tm.assert_raises_regex(TypeError,
-                                    "Only list-like objects are allowed"):
+        with pytest.raises(TypeError,
+                           match="Only list-like objects are allowed"):
             safe_sort(values=1)
 
-        with tm.assert_raises_regex(TypeError,
-                                    "Only list-like objects or None"):
+        with pytest.raises(TypeError,
+                           match="Only list-like objects or None"):
             safe_sort(values=[0, 1, 2], labels=1)
 
-        with tm.assert_raises_regex(ValueError,
-                                    "values should be unique"):
+        with pytest.raises(ValueError,
+                           match="values should be unique"):
             safe_sort(values=[0, 1, 2, 1], labels=[0, 1])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2114,29 +2114,25 @@ class TestStringMethods(object):
         # If fillchar is not a charatter, normal str raises TypeError
         # 'aaa'.ljust(5, 'XY')
         # TypeError: must be char, not str
-        msg = "fillchar must be a character, not str"
-        with pytest.raises(TypeError, match=msg):
-            result = values.str.center(5, fillchar='XY')
+        template = "fillchar must be a character, not {dtype}"
 
-        msg = "fillchar must be a character, not str"
-        with pytest.raises(TypeError, match=msg):
-            result = values.str.ljust(5, fillchar='XY')
+        with pytest.raises(TypeError, match=template.format(dtype="str")):
+            values.str.center(5, fillchar='XY')
 
-        msg = "fillchar must be a character, not str"
-        with pytest.raises(TypeError, match=msg):
-            result = values.str.rjust(5, fillchar='XY')
+        with pytest.raises(TypeError, match=template.format(dtype="str")):
+            values.str.ljust(5, fillchar='XY')
 
-        msg = "fillchar must be a character, not int"
-        with pytest.raises(TypeError, match=msg):
-            result = values.str.center(5, fillchar=1)
+        with pytest.raises(TypeError, match=template.format(dtype="str")):
+            values.str.rjust(5, fillchar='XY')
 
-        msg = "fillchar must be a character, not int"
-        with pytest.raises(TypeError, match=msg):
-            result = values.str.ljust(5, fillchar=1)
+        with pytest.raises(TypeError, match=template.format(dtype="int")):
+            values.str.center(5, fillchar=1)
 
-        msg = "fillchar must be a character, not int"
-        with pytest.raises(TypeError, match=msg):
-            result = values.str.rjust(5, fillchar=1)
+        with pytest.raises(TypeError, match=template.format(dtype="int")):
+            values.str.ljust(5, fillchar=1)
+
+        with pytest.raises(TypeError, match=template.format(dtype="int")):
+            values.str.rjust(5, fillchar=1)
 
     def test_zfill(self):
         values = Series(['1', '22', 'aaa', '333', '45678'])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -36,8 +36,7 @@ class TestStringMethods(object):
 
         # GH 9184
         invalid = Series([1])
-        with tm.assert_raises_regex(AttributeError,
-                                    "only use .str accessor"):
+        with pytest.raises(AttributeError, match="only use .str accessor"):
             invalid.str
         assert not hasattr(invalid, 'str')
 
@@ -143,13 +142,13 @@ class TestStringMethods(object):
         rgx = 'All arrays must be same length, except those having an index.*'
         z = Series(['1', '2', '3'])
 
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat(z)
 
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat(z.values)
 
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat(list(z))
 
     @pytest.mark.parametrize('box', [Series, Index])
@@ -157,9 +156,9 @@ class TestStringMethods(object):
         # GH 11334
         s = box(['a', 'b', 'c', 'd'])
         message = "Did you mean to supply a `sep` keyword?"
-        with tm.assert_raises_regex(ValueError, message):
+        with pytest.raises(ValueError, match=message):
             s.str.cat('|')
-        with tm.assert_raises_regex(ValueError, message):
+        with pytest.raises(ValueError, match=message):
             s.str.cat('    ')
 
     @pytest.mark.parametrize('sep', ['', None])
@@ -262,23 +261,23 @@ class TestStringMethods(object):
         e = concat([z, z], axis=1)
 
         # DataFrame
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat(e)
 
         # two-dimensional ndarray
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat(e.values)
 
         # list of Series
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat([z, s])
 
         # list of list-likes
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat([z.values, s.values])
 
         # mixed list of Series/list-like
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat([z.values, s])
 
         # errors for incorrect arguments in list-like
@@ -287,33 +286,33 @@ class TestStringMethods(object):
         u = Series(['a', np.nan, 'c', None])
 
         # mix of string and Series
-        with tm.assert_raises_regex(TypeError, rgx):
+        with pytest.raises(TypeError, match=rgx):
             s.str.cat([u, 'u'])
 
         # DataFrame in list
-        with tm.assert_raises_regex(TypeError, rgx):
+        with pytest.raises(TypeError, match=rgx):
             s.str.cat([u, d])
 
         # 2-dim ndarray in list
-        with tm.assert_raises_regex(TypeError, rgx):
+        with pytest.raises(TypeError, match=rgx):
             s.str.cat([u, d.values])
 
         # nested lists
-        with tm.assert_raises_regex(TypeError, rgx):
+        with pytest.raises(TypeError, match=rgx):
             s.str.cat([u, [u, d]])
 
         # forbidden input type: set
         # GH 23009
-        with tm.assert_raises_regex(TypeError, rgx):
+        with pytest.raises(TypeError, match=rgx):
             s.str.cat(set(u))
 
         # forbidden input type: set in list
         # GH 23009
-        with tm.assert_raises_regex(TypeError, rgx):
+        with pytest.raises(TypeError, match=rgx):
             s.str.cat([u, set(u)])
 
         # other forbidden input type, e.g. int
-        with tm.assert_raises_regex(TypeError, rgx):
+        with pytest.raises(TypeError, match=rgx):
             s.str.cat(1)
 
     @pytest.mark.parametrize('join', ['left', 'outer', 'inner', 'right'])
@@ -371,17 +370,17 @@ class TestStringMethods(object):
         z = Series(['1', '2', '3']).values
 
         # unindexed object of wrong length
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat(z, join=join)
 
         # unindexed object of wrong length in list
-        with tm.assert_raises_regex(ValueError, rgx):
+        with pytest.raises(ValueError, match=rgx):
             s.str.cat([t, z], join=join)
 
     def test_str_cat_raises(self):
         # non-strings hiding behind object dtype
         s = Series([1, 2, 3, 4], dtype='object')
-        with tm.assert_raises_regex(TypeError, "unsupported operand type.*"):
+        with pytest.raises(TypeError, match="unsupported operand type.*"):
             s.str.cat(s)
 
     def test_str_cat_special_cases(self):
@@ -739,15 +738,15 @@ class TestStringMethods(object):
                      r'(?(3)required )positional arguments?')
 
         repl = lambda: None
-        with tm.assert_raises_regex(TypeError, p_err):
+        with pytest.raises(TypeError, match=p_err):
             values.str.replace('a', repl)
 
         repl = lambda m, x: None
-        with tm.assert_raises_regex(TypeError, p_err):
+        with pytest.raises(TypeError, match=p_err):
             values.str.replace('a', repl)
 
         repl = lambda m, x, y=None: None
-        with tm.assert_raises_regex(TypeError, p_err):
+        with pytest.raises(TypeError, match=p_err):
             values.str.replace('a', repl)
 
         # test regex named groups
@@ -800,16 +799,16 @@ class TestStringMethods(object):
         values = Series(['fooBAD__barBAD__bad', NA])
         pat = re.compile(r'BAD[_]*')
 
-        with tm.assert_raises_regex(ValueError,
-                                    "case and flags cannot be"):
+        with pytest.raises(ValueError,
+                           match="case and flags cannot be"):
             result = values.str.replace(pat, '', flags=re.IGNORECASE)
 
-        with tm.assert_raises_regex(ValueError,
-                                    "case and flags cannot be"):
+        with pytest.raises(ValueError,
+                           match="case and flags cannot be"):
             result = values.str.replace(pat, '', case=False)
 
-        with tm.assert_raises_regex(ValueError,
-                                    "case and flags cannot be"):
+        with pytest.raises(ValueError,
+                           match="case and flags cannot be"):
             result = values.str.replace(pat, '', case=True)
 
         # test with callable
@@ -908,8 +907,8 @@ class TestStringMethods(object):
 
     def test_extract_expand_None(self):
         values = Series(['fooBAD__barBAD', NA, 'foo'])
-        with tm.assert_raises_regex(ValueError,
-                                    'expand must be True or False'):
+        with pytest.raises(ValueError,
+                           match='expand must be True or False'):
             values.str.extract('.*(BAD[_]+).*(BAD)', expand=None)
 
     def test_extract_expand_unspecified(self):
@@ -948,7 +947,7 @@ class TestStringMethods(object):
         # Index only works with one regex group since
         # multi-group would expand to a frame
         idx = Index(['A1', 'A2', 'A3', 'A4', 'B5'])
-        with tm.assert_raises_regex(ValueError, "supported"):
+        with pytest.raises(ValueError, match="supported"):
             idx.str.extract('([AB])([123])', expand=False)
 
         # these should work for both Series and Index
@@ -1446,7 +1445,7 @@ class TestStringMethods(object):
         # no capture groups. (it returns DataFrame with one column for
         # each capture group)
         s = Series(['a3', 'b3', 'd4c2'], name='series_name')
-        with tm.assert_raises_regex(ValueError, "no capture groups"):
+        with pytest.raises(ValueError, match="no capture groups"):
             s.str.extractall(r'[a-z]')
 
     def test_extract_index_one_two_groups(self):
@@ -1817,12 +1816,12 @@ class TestStringMethods(object):
                             dtype=np.int64)
         tm.assert_numpy_array_equal(result.values, expected)
 
-        with tm.assert_raises_regex(TypeError,
-                                    "expected a string object, not int"):
+        with pytest.raises(TypeError,
+                           match="expected a string object, not int"):
             result = values.str.find(0)
 
-        with tm.assert_raises_regex(TypeError,
-                                    "expected a string object, not int"):
+        with pytest.raises(TypeError,
+                           match="expected a string object, not int"):
             result = values.str.rfind(0)
 
     def test_find_nan(self):
@@ -1892,13 +1891,11 @@ class TestStringMethods(object):
                                 dtype=np.int64)
             tm.assert_numpy_array_equal(result.values, expected)
 
-            with tm.assert_raises_regex(ValueError,
-                                        "substring not found"):
+            with pytest.raises(ValueError, match="substring not found"):
                 result = s.str.index('DE')
 
-            with tm.assert_raises_regex(TypeError,
-                                        "expected a string "
-                                        "object, not int"):
+            msg = "expected a string object, not int"
+            with pytest.raises(TypeError, match=msg):
                 result = s.str.index(0)
 
         # test with nan
@@ -1982,25 +1979,22 @@ class TestStringMethods(object):
         exp = Series(['XXaXX', 'XXbXX', NA, 'XXcXX', NA, 'eeeeee'])
         tm.assert_almost_equal(result, exp)
 
-        with tm.assert_raises_regex(TypeError,
-                                    "fillchar must be a "
-                                    "character, not str"):
+        msg = "fillchar must be a character, not str"
+        with pytest.raises(TypeError, match=msg):
             result = values.str.pad(5, fillchar='XY')
 
-        with tm.assert_raises_regex(TypeError,
-                                    "fillchar must be a "
-                                    "character, not int"):
+        msg = "fillchar must be a character, not int"
+        with pytest.raises(TypeError, match=msg):
             result = values.str.pad(5, fillchar=5)
 
-    def test_pad_width(self):
-        # GH 13598
+    @pytest.mark.parametrize("f", ['center', 'ljust', 'rjust', 'zfill', 'pad'])
+    def test_pad_width(self, f):
+        # see gh-13598
         s = Series(['1', '22', 'a', 'bb'])
+        msg = "width must be of integer type, not*"
 
-        for f in ['center', 'ljust', 'rjust', 'zfill', 'pad']:
-            with tm.assert_raises_regex(TypeError,
-                                        "width must be of "
-                                        "integer type, not*"):
-                getattr(s.str, f)('f')
+        with pytest.raises(TypeError, match=msg):
+            getattr(s.str, f)('f')
 
     def test_translate(self):
 
@@ -2031,8 +2025,8 @@ class TestStringMethods(object):
                 expected = klass(['abcde', 'abcc', 'cddd', 'cde'])
                 _check(result, expected)
             else:
-                with tm.assert_raises_regex(
-                        ValueError, "deletechars is not a valid argument"):
+                msg = "deletechars is not a valid argument"
+                with pytest.raises(ValueError, match=msg):
                     result = s.str.translate(table, deletechars='fg')
 
         # Series with non-string values
@@ -2120,34 +2114,28 @@ class TestStringMethods(object):
         # If fillchar is not a charatter, normal str raises TypeError
         # 'aaa'.ljust(5, 'XY')
         # TypeError: must be char, not str
-        with tm.assert_raises_regex(TypeError,
-                                    "fillchar must be a "
-                                    "character, not str"):
+        msg = "fillchar must be a character, not str"
+        with pytest.raises(TypeError, match=msg):
             result = values.str.center(5, fillchar='XY')
 
-        with tm.assert_raises_regex(TypeError,
-                                    "fillchar must be a "
-                                    "character, not str"):
+        msg = "fillchar must be a character, not str"
+        with pytest.raises(TypeError, match=msg):
             result = values.str.ljust(5, fillchar='XY')
 
-        with tm.assert_raises_regex(TypeError,
-                                    "fillchar must be a "
-                                    "character, not str"):
+        msg = "fillchar must be a character, not str"
+        with pytest.raises(TypeError, match=msg):
             result = values.str.rjust(5, fillchar='XY')
 
-        with tm.assert_raises_regex(TypeError,
-                                    "fillchar must be a "
-                                    "character, not int"):
+        msg = "fillchar must be a character, not int"
+        with pytest.raises(TypeError, match=msg):
             result = values.str.center(5, fillchar=1)
 
-        with tm.assert_raises_regex(TypeError,
-                                    "fillchar must be a "
-                                    "character, not int"):
+        msg = "fillchar must be a character, not int"
+        with pytest.raises(TypeError, match=msg):
             result = values.str.ljust(5, fillchar=1)
 
-        with tm.assert_raises_regex(TypeError,
-                                    "fillchar must be a "
-                                    "character, not int"):
+        msg = "fillchar must be a character, not int"
+        with pytest.raises(TypeError, match=msg):
             result = values.str.rjust(5, fillchar=1)
 
     def test_zfill(self):
@@ -2342,7 +2330,7 @@ class TestStringMethods(object):
                         index=['preserve', 'me'])
         tm.assert_frame_equal(result, exp)
 
-        with tm.assert_raises_regex(ValueError, "expand must be"):
+        with pytest.raises(ValueError, match="expand must be"):
             s.str.split('_', expand="not_a_boolean")
 
     def test_split_to_multiindex_expand(self):
@@ -2367,7 +2355,7 @@ class TestStringMethods(object):
         tm.assert_index_equal(result, exp)
         assert result.nlevels == 6
 
-        with tm.assert_raises_regex(ValueError, "expand must be"):
+        with pytest.raises(ValueError, match="expand must be"):
             idx.str.split('_', expand="not_a_boolean")
 
     def test_rsplit_to_dataframe_expand(self):
@@ -3038,8 +3026,7 @@ class TestStringMethods(object):
         result = s.str.normalize('NFC')
         tm.assert_series_equal(result, expected)
 
-        with tm.assert_raises_regex(ValueError,
-                                    "invalid normalization form"):
+        with pytest.raises(ValueError, match="invalid normalization form"):
             s.str.normalize('xxx')
 
         s = Index([u'ＡＢＣ', u'１２３', u'ｱｲｴ'])
@@ -3082,9 +3069,9 @@ class TestStringMethods(object):
         for values, tp in cases:
             idx = Index(values)
             message = 'Can only use .str accessor with string values'
-            with tm.assert_raises_regex(AttributeError, message):
+            with pytest.raises(AttributeError, match=message):
                 Series(values).str
-            with tm.assert_raises_regex(AttributeError, message):
+            with pytest.raises(AttributeError, match=message):
                 idx.str
             assert idx.inferred_type == tp
 
@@ -3092,14 +3079,14 @@ class TestStringMethods(object):
         idx = MultiIndex.from_tuples([('a', 'b'), ('a', 'b')])
         assert idx.inferred_type == 'mixed'
         message = 'Can only use .str accessor with Index, not MultiIndex'
-        with tm.assert_raises_regex(AttributeError, message):
+        with pytest.raises(AttributeError, match=message):
             idx.str
 
     def test_str_accessor_no_new_attributes(self):
         # https://github.com/pandas-dev/pandas/issues/10673
         s = Series(list('aabbcde'))
-        with tm.assert_raises_regex(AttributeError,
-                                    "You cannot add any new attribute"):
+        with pytest.raises(AttributeError,
+                           match="You cannot add any new attribute"):
             s.str.xlabel = "a"
 
     def test_method_on_bytes(self):

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -90,7 +90,7 @@ class TestTake(object):
             expected[3] = np.nan
             tm.assert_almost_equal(out, expected)
         else:
-            with tm.assert_raises_regex(TypeError, self.fill_error):
+            with pytest.raises(TypeError, match=self.fill_error):
                 algos.take_1d(data, indexer, out=out)
 
             # No Exception otherwise.
@@ -146,8 +146,7 @@ class TestTake(object):
             tm.assert_almost_equal(out1, expected1)
         else:
             for i, out in enumerate([out0, out1]):
-                with tm.assert_raises_regex(TypeError,
-                                            self.fill_error):
+                with pytest.raises(TypeError, match=self.fill_error):
                     algos.take_nd(data, indexer, out=out, axis=i)
 
                 # No Exception otherwise.
@@ -226,8 +225,7 @@ class TestTake(object):
             tm.assert_almost_equal(out2, expected2)
         else:
             for i, out in enumerate([out0, out1, out2]):
-                with tm.assert_raises_regex(TypeError,
-                                            self.fill_error):
+                with pytest.raises(TypeError, match=self.fill_error):
                     algos.take_nd(data, indexer, out=out, axis=i)
 
                 # No Exception otherwise.

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -90,7 +90,7 @@ class TestApi(Base):
         pytest.raises(KeyError, g.__getitem__, ['C'])  # g[['C']]
 
         pytest.raises(KeyError, g.__getitem__, ['A', 'C'])  # g[['A', 'C']]
-        with tm.assert_raises_regex(KeyError, '^[^A]+$'):
+        with pytest.raises(KeyError, match='^[^A]+$'):
             # A should not be referenced as a bad column...
             # will have to rethink regex if you change message!
             g[['A', 'C']]
@@ -116,7 +116,7 @@ class TestApi(Base):
         df = DataFrame({'A': range(5), 'B': range(5, 10), 'C': 'foo'})
         r = df.rolling(window=3)
 
-        with tm.assert_raises_regex(TypeError, 'cannot handle this type'):
+        with pytest.raises(TypeError, match='cannot handle this type'):
             r.sum()
 
     def test_agg(self):
@@ -410,10 +410,10 @@ class TestWindow(Base):
 
         msg = "numpy operations are not valid with window objects"
 
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(w, method), 1, 2, 3)
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(w, method), dtype=np.float64)
+        with pytest.raises(UnsupportedFunctionCall, match=msg):
+            getattr(w, method)(1, 2, 3)
+        with pytest.raises(UnsupportedFunctionCall, match=msg):
+            getattr(w, method)(dtype=np.float64)
 
 
 class TestRolling(Base):
@@ -507,10 +507,10 @@ class TestRolling(Base):
 
         msg = "numpy operations are not valid with window objects"
 
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(r, method), 1, 2, 3)
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(r, method), dtype=np.float64)
+        with pytest.raises(UnsupportedFunctionCall, match=msg):
+            getattr(r, method)(1, 2, 3)
+        with pytest.raises(UnsupportedFunctionCall, match=msg):
+            getattr(r, method)(dtype=np.float64)
 
     def test_closed(self):
         df = DataFrame({'A': [0, 1, 2, 3, 4]})
@@ -686,10 +686,10 @@ class TestExpanding(Base):
 
         msg = "numpy operations are not valid with window objects"
 
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(e, method), 1, 2, 3)
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(e, method), dtype=np.float64)
+        with pytest.raises(UnsupportedFunctionCall, match=msg):
+            getattr(e, method)(1, 2, 3)
+        with pytest.raises(UnsupportedFunctionCall, match=msg):
+            getattr(e, method)(dtype=np.float64)
 
     @pytest.mark.parametrize(
         'expander',
@@ -812,10 +812,10 @@ class TestEWM(Base):
 
         msg = "numpy operations are not valid with window objects"
 
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(e, method), 1, 2, 3)
-        tm.assert_raises_regex(UnsupportedFunctionCall, msg,
-                               getattr(e, method), dtype=np.float64)
+        with pytest.raises(UnsupportedFunctionCall, match=msg):
+            getattr(e, method)(1, 2, 3)
+        with pytest.raises(UnsupportedFunctionCall, match=msg):
+            getattr(e, method)(dtype=np.float64)
 
 
 # gh-12373 : rolling functions error on float32 data
@@ -1999,12 +1999,12 @@ class TestPairwise(object):
                 tm.assert_index_equal(result.index, expected_index)
                 tm.assert_index_equal(result.columns, expected_columns)
             else:
-                tm.assert_raises_regex(
-                    ValueError, "'arg1' columns are not unique", f, df,
-                    self.df2)
-                tm.assert_raises_regex(
-                    ValueError, "'arg2' columns are not unique", f,
-                    self.df2, df)
+                with pytest.raises(ValueError,
+                                   match="'arg1' columns are not unique"):
+                    f(df, self.df2)
+                with pytest.raises(ValueError,
+                                   match="'arg2' columns are not unique"):
+                    f(self.df2, df)
 
     @pytest.mark.parametrize(
         'f', [lambda x, y: x.expanding().cov(y),

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -54,7 +54,7 @@ class TestToNumeric(object):
     def test_error(self):
         s = pd.Series([1, -3.14, 'apple'])
         msg = 'Unable to parse string "apple" at position 2'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             to_numeric(s, errors='raise')
 
         res = to_numeric(s, errors='ignore')
@@ -67,13 +67,13 @@ class TestToNumeric(object):
 
         s = pd.Series(['orange', 1, -3.14, 'apple'])
         msg = 'Unable to parse string "orange" at position 0'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             to_numeric(s, errors='raise')
 
     def test_error_seen_bool(self):
         s = pd.Series([True, False, 'apple'])
         msg = 'Unable to parse string "apple" at position 2'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             to_numeric(s, errors='raise')
 
         res = to_numeric(s, errors='ignore')
@@ -166,7 +166,7 @@ class TestToNumeric(object):
         # see gh-11776
         df = pd.DataFrame({"a": [1, -3.14, 7], "b": ["4", "5", "6"]})
         kwargs = dict(errors=errors) if errors is not None else dict()
-        error_ctx = tm.assert_raises_regex(TypeError, "1-d array")
+        error_ctx = pytest.raises(TypeError, match="1-d array")
 
         with error_ctx:
             to_numeric(df, **kwargs)
@@ -269,7 +269,7 @@ class TestToNumeric(object):
         res = pd.to_numeric(s, errors='ignore')
         tm.assert_series_equal(res, pd.Series([[10.0, 2], 1.0, 'apple']))
 
-        with tm.assert_raises_regex(TypeError, "Invalid object type"):
+        with pytest.raises(TypeError, match="Invalid object type"):
             pd.to_numeric(s)
 
     @pytest.mark.parametrize("data", [
@@ -283,7 +283,7 @@ class TestToNumeric(object):
         invalid_downcast = "unsigned-integer"
         msg = "invalid downcasting method provided"
 
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             pd.to_numeric(data, downcast=invalid_downcast)
 
         expected = np.array([1, 2, 3], dtype=np.int64)
@@ -436,5 +436,5 @@ class TestToNumeric(object):
         tm.assert_series_equal(result, s)
 
         msg = "Unable to parse string"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             to_numeric(s, errors="raise")

--- a/pandas/tests/tseries/offsets/test_fiscal.py
+++ b/pandas/tests/tseries/offsets/test_fiscal.py
@@ -7,8 +7,6 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import pytest
 
-import pandas.util.testing as tm
-
 from pandas import Timestamp
 from pandas.tseries.frequencies import get_offset
 from pandas._libs.tslibs.frequencies import INVALID_FREQ_ERR_MSG
@@ -44,9 +42,9 @@ def test_get_offset_name():
 
 
 def test_get_offset():
-    with tm.assert_raises_regex(ValueError, INVALID_FREQ_ERR_MSG):
+    with pytest.raises(ValueError, match=INVALID_FREQ_ERR_MSG):
         get_offset('gibberish')
-    with tm.assert_raises_regex(ValueError, INVALID_FREQ_ERR_MSG):
+    with pytest.raises(ValueError, match=INVALID_FREQ_ERR_MSG):
         get_offset('QS-JAN-B')
 
     pairs = [

--- a/pandas/tests/tseries/test_frequencies.py
+++ b/pandas/tests/tseries/test_frequencies.py
@@ -105,8 +105,7 @@ class TestToOffset(object):
         assert (result == expected)
 
         # malformed
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: 2h20m'):
+        with pytest.raises(ValueError, match='Invalid frequency: 2h20m'):
             frequencies.to_offset('2h20m')
 
     def test_to_offset_negative(self):
@@ -128,23 +127,17 @@ class TestToOffset(object):
 
     def test_to_offset_invalid(self):
         # GH 13930
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: U1'):
+        with pytest.raises(ValueError, match='Invalid frequency: U1'):
             frequencies.to_offset('U1')
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: -U'):
+        with pytest.raises(ValueError, match='Invalid frequency: -U'):
             frequencies.to_offset('-U')
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: 3U1'):
+        with pytest.raises(ValueError, match='Invalid frequency: 3U1'):
             frequencies.to_offset('3U1')
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: -2-3U'):
+        with pytest.raises(ValueError, match='Invalid frequency: -2-3U'):
             frequencies.to_offset('-2-3U')
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: -2D:3H'):
+        with pytest.raises(ValueError, match='Invalid frequency: -2D:3H'):
             frequencies.to_offset('-2D:3H')
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: 1.5.0S'):
+        with pytest.raises(ValueError, match='Invalid frequency: 1.5.0S'):
             frequencies.to_offset('1.5.0S')
 
         # split offsets with spaces are valid
@@ -157,11 +150,9 @@ class TestToOffset(object):
 
         # special cases
         assert frequencies.to_offset('2SMS-15') == offsets.SemiMonthBegin(2)
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: 2SMS-15-15'):
+        with pytest.raises(ValueError, match='Invalid frequency: 2SMS-15-15'):
             frequencies.to_offset('2SMS-15-15')
-        with tm.assert_raises_regex(ValueError,
-                                    'Invalid frequency: 2SMS-15D'):
+        with pytest.raises(ValueError, match='Invalid frequency: 2SMS-15D'):
             frequencies.to_offset('2SMS-15D')
 
     def test_to_offset_leading_zero(self):
@@ -183,7 +174,7 @@ class TestToOffset(object):
         assert (result.n == 150)
 
         for bad_freq in ['+-1d', '-+1h', '+1', '-7', '+d', '-m']:
-            with tm.assert_raises_regex(ValueError, 'Invalid frequency:'):
+            with pytest.raises(ValueError, match='Invalid frequency:'):
                 frequencies.to_offset(bad_freq)
 
     def test_to_offset_pd_timedelta(self):
@@ -270,8 +261,7 @@ class TestToOffset(object):
                            'SMS-BAR', 'SMS-BYR' 'BSMS',
                            'SMS--2']
         for invalid_anchor in invalid_anchors:
-            with tm.assert_raises_regex(ValueError,
-                                        'Invalid frequency: '):
+            with pytest.raises(ValueError, match='Invalid frequency: '):
                 frequencies.to_offset(invalid_anchor)
 
 
@@ -464,13 +454,13 @@ class TestFrequencyCode(object):
         expected = offsets.Minute(5)
         assert result == expected
 
-        with tm.assert_raises_regex(ValueError, 'Invalid frequency'):
+        with pytest.raises(ValueError, match='Invalid frequency'):
             frequencies.get_freq_code((5, 'baz'))
 
-        with tm.assert_raises_regex(ValueError, 'Invalid frequency'):
+        with pytest.raises(ValueError, match='Invalid frequency'):
             frequencies.to_offset('100foo')
 
-        with tm.assert_raises_regex(ValueError, 'Could not evaluate'):
+        with pytest.raises(ValueError, match='Could not evaluate'):
             frequencies.to_offset(('', ''))
 
 
@@ -799,8 +789,8 @@ class TestFrequencyInference(object):
 
         msg = INVALID_FREQ_ERR_MSG
         for freq in freqs:
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 frequencies.get_offset(freq)
 
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 date_range('2011-01-01', periods=5, freq=freq)

--- a/pandas/tests/tslibs/test_libfrequencies.py
+++ b/pandas/tests/tslibs/test_libfrequencies.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pandas.util.testing as tm
+import pytest
 
 from pandas.tseries import offsets
 from pandas._libs.tslibs.frequencies import (get_rule_month,
@@ -14,7 +14,7 @@ def assert_aliases_deprecated(freq, expected, aliases):
     assert (_period_str_to_code(freq) == expected)
 
     for alias in aliases:
-        with tm.assert_raises_regex(ValueError, INVALID_FREQ_ERR_MSG):
+        with pytest.raises(ValueError, match=INVALID_FREQ_ERR_MSG):
             _period_str_to_code(alias)
 
 

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -60,13 +60,13 @@ class TestDatetimeParsingWrappers(object):
     def test_parsers_quarterly_with_freq(self):
         msg = ('Incorrect quarterly string is given, quarter '
                'must be between 1 and 4: 2013Q5')
-        with tm.assert_raises_regex(parsing.DateParseError, msg):
+        with pytest.raises(parsing.DateParseError, match=msg):
             parsing.parse_time_string('2013Q5')
 
         # GH 5418
         msg = ('Unable to retrieve month information from given freq: '
                'INVLD-L-DEC-SAT')
-        with tm.assert_raises_regex(parsing.DateParseError, msg):
+        with pytest.raises(parsing.DateParseError, match=msg):
             parsing.parse_time_string('2013Q1', freq='INVLD-L-DEC-SAT')
 
         cases = {('2013Q2', None): datetime(2013, 4, 1),

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -47,7 +47,7 @@ class TestHashing(object):
     @pytest.mark.parametrize('val', [5, 'foo', pd.Timestamp('20130101')])
     def test_hash_array_errors(self, val):
         msg = 'must pass a ndarray-like'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             hash_array(val)
 
     def check_equal(self, obj, **kwargs):
@@ -104,7 +104,7 @@ class TestHashing(object):
     @pytest.mark.parametrize('val', [5, 'foo', pd.Timestamp('20130101')])
     def test_hash_tuples_err(self, val):
         msg = 'must be convertible to a list-of-tuples'
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             hash_tuples(val)
 
     def test_multiindex_unique(self):
@@ -238,7 +238,7 @@ class TestHashing(object):
     def test_invalid_key(self):
         # this only matters for object dtypes
         msg = 'key should be a 16-byte string encoded'
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             hash_pandas_object(Series(list('abc')), hash_key='foo')
 
     def test_alread_encoded(self):

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -6,6 +6,7 @@ import textwrap
 import numpy as np
 import pytest
 
+from pandas.compat import raise_with_traceback
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -13,7 +14,7 @@ from pandas import DataFrame, Series, compat
 import pandas.util.testing as tm
 from pandas.util.testing import (
     RNGContext, assert_almost_equal, assert_frame_equal, assert_index_equal,
-    assert_numpy_array_equal, assert_series_equal, raise_with_traceback)
+    assert_numpy_array_equal, assert_series_equal)
 
 
 class TestAssertAlmostEqual(object):
@@ -152,13 +153,13 @@ class TestAssertAlmostEqual(object):
 class TestUtilTesting(object):
 
     def test_raise_with_traceback(self):
-        with tm.assert_raises_regex(LookupError, "error_text"):
+        with pytest.raises(LookupError, match="error_text"):
             try:
                 raise ValueError("THIS IS AN ERROR")
             except ValueError as e:
                 e = LookupError("error_text")
                 raise_with_traceback(e)
-        with tm.assert_raises_regex(LookupError, "error_text"):
+        with pytest.raises(LookupError, match="error_text"):
             try:
                 raise ValueError("This is another error")
             except ValueError:
@@ -189,18 +190,18 @@ numpy array shapes are different
 \\[left\\]:  \\(2,\\)
 \\[right\\]: \\(3,\\)"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(np.array([1, 2]), np.array([3, 4, 5]))
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(np.array([1, 2]), np.array([3, 4, 5]))
 
         # scalar comparison
         expected = """Expected type """
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(1, 2)
         expected = """expected 2\\.00000 but got 1\\.00000, with decimal 5"""
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(1, 2)
 
         # array / scalar array comparison
@@ -210,10 +211,10 @@ numpy array classes are different
 \\[left\\]:  ndarray
 \\[right\\]: int"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             # numpy_array_equal only accepts np.ndarray
             assert_numpy_array_equal(np.array([1]), 1)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(np.array([1]), 1)
 
         # scalar / array comparison
@@ -223,9 +224,9 @@ numpy array classes are different
 \\[left\\]:  int
 \\[right\\]: ndarray"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(1, np.array([1]))
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(1, np.array([1]))
 
         expected = """numpy array are different
@@ -234,10 +235,10 @@ numpy array values are different \\(66\\.66667 %\\)
 \\[left\\]:  \\[nan, 2\\.0, 3\\.0\\]
 \\[right\\]: \\[1\\.0, nan, 3\\.0\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(np.array([np.nan, 2, 3]),
                                      np.array([1, np.nan, 3]))
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(np.array([np.nan, 2, 3]),
                                 np.array([1, np.nan, 3]))
 
@@ -247,9 +248,9 @@ numpy array values are different \\(50\\.0 %\\)
 \\[left\\]:  \\[1, 2\\]
 \\[right\\]: \\[1, 3\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(np.array([1, 2]), np.array([1, 3]))
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(np.array([1, 2]), np.array([1, 3]))
 
         expected = """numpy array are different
@@ -258,7 +259,7 @@ numpy array values are different \\(50\\.0 %\\)
 \\[left\\]:  \\[1\\.1, 2\\.000001\\]
 \\[right\\]: \\[1\\.1, 2.0\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(
                 np.array([1.1, 2.000001]), np.array([1.1, 2.0]))
 
@@ -271,10 +272,10 @@ numpy array values are different \\(16\\.66667 %\\)
 \\[left\\]:  \\[\\[1, 2\\], \\[3, 4\\], \\[5, 6\\]\\]
 \\[right\\]: \\[\\[1, 3\\], \\[3, 4\\], \\[5, 6\\]\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(np.array([[1, 2], [3, 4], [5, 6]]),
                                      np.array([[1, 3], [3, 4], [5, 6]]))
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(np.array([[1, 2], [3, 4], [5, 6]]),
                                 np.array([[1, 3], [3, 4], [5, 6]]))
 
@@ -284,10 +285,10 @@ numpy array values are different \\(25\\.0 %\\)
 \\[left\\]:  \\[\\[1, 2\\], \\[3, 4\\]\\]
 \\[right\\]: \\[\\[1, 3\\], \\[3, 4\\]\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(np.array([[1, 2], [3, 4]]),
                                      np.array([[1, 3], [3, 4]]))
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(np.array([[1, 2], [3, 4]]),
                                 np.array([[1, 3], [3, 4]]))
 
@@ -298,10 +299,10 @@ Index shapes are different
 \\[left\\]:  \\(2,\\)
 \\[right\\]: \\(3,\\)"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(np.array([1, 2]), np.array([3, 4, 5]),
                                      obj='Index')
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(np.array([1, 2]), np.array([3, 4, 5]),
                                 obj='Index')
 
@@ -316,10 +317,10 @@ numpy array values are different \\(33\\.33333 %\\)
 \\[left\\]:  \\[á, à, ä\\]
 \\[right\\]: \\[á, à, å\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(np.array([u'á', u'à', u'ä']),
                                      np.array([u'á', u'à', u'å']))
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(np.array([u'á', u'à', u'ä']),
                                 np.array([u'á', u'à', u'å']))
 
@@ -335,9 +336,9 @@ numpy array values are different \\(50\\.0 %\\)
 \\[left\\]:  \\[2011-01-01 00:00:00, 2011-01-01 00:00:00\\]
 \\[right\\]: \\[2011-01-01 00:00:00, 2011-01-02 00:00:00\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(a, b)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal(a, b)
 
     def test_numpy_array_equal_copy_flag(self):
@@ -345,10 +346,10 @@ numpy array values are different \\(50\\.0 %\\)
         b = a.copy()
         c = a.view()
         expected = r'array\(\[1, 2, 3\]\) is not array\(\[1, 2, 3\]\)'
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(a, b, check_same='same')
         expected = r'array\(\[1, 2, 3\]\) is array\(\[1, 2, 3\]\)'
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_numpy_array_equal(a, c, check_same='copy')
 
     def test_assert_almost_equal_iterable_message(self):
@@ -359,7 +360,7 @@ Iterable length are different
 \\[left\\]:  2
 \\[right\\]: 3"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal([1, 2], [3, 4, 5])
 
         expected = """Iterable are different
@@ -368,7 +369,7 @@ Iterable values are different \\(50\\.0 %\\)
 \\[left\\]:  \\[1, 2\\]
 \\[right\\]: \\[1, 3\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_almost_equal([1, 2], [1, 3])
 
 
@@ -386,7 +387,7 @@ Index levels are different
         idx1 = pd.Index([1, 2, 3])
         idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2),
                                           ('B', 3), ('B', 4)])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2, exact=False)
 
         expected = """MultiIndex level \\[1\\] are different
@@ -399,9 +400,9 @@ MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
                                           ('B', 3), ('B', 4)])
         idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2),
                                           ('B', 3), ('B', 4)])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2, check_exact=False)
 
         expected = """Index are different
@@ -412,9 +413,9 @@ Index length are different
 
         idx1 = pd.Index([1, 2, 3])
         idx2 = pd.Index([1, 2, 3, 4])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2, check_exact=False)
 
         expected = """Index are different
@@ -425,9 +426,9 @@ Index classes are different
 
         idx1 = pd.Index([1, 2, 3])
         idx2 = pd.Index([1, 2, 3.0])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2, exact=True)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2, exact=True, check_exact=False)
 
         expected = """Index are different
@@ -438,7 +439,7 @@ Index values are different \\(33\\.33333 %\\)
 
         idx1 = pd.Index([1, 2, 3.])
         idx2 = pd.Index([1, 2, 3.0000000001])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2)
 
         # must success
@@ -452,9 +453,9 @@ Index values are different \\(33\\.33333 %\\)
 
         idx1 = pd.Index([1, 2, 3.])
         idx2 = pd.Index([1, 2, 3.0001])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2, check_exact=False)
         # must success
         assert_index_equal(idx1, idx2, check_exact=False,
@@ -468,9 +469,9 @@ Index values are different \\(33\\.33333 %\\)
 
         idx1 = pd.Index([1, 2, 3])
         idx2 = pd.Index([1, 2, 4])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2, check_less_precise=True)
 
         expected = """MultiIndex level \\[1\\] are different
@@ -483,9 +484,9 @@ MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
                                           ('B', 3), ('B', 4)])
         idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2),
                                           ('B', 3), ('B', 4)])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2, check_exact=False)
 
     def test_index_equal_metadata_message(self):
@@ -498,7 +499,7 @@ Attribute "names" are different
 
         idx1 = pd.Index([1, 2, 3])
         idx2 = pd.Index([1, 2, 3], name='x')
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2)
 
         # same name, should pass
@@ -515,7 +516,7 @@ Attribute "names" are different
 
         idx1 = pd.Index([1, 2, 3], name=np.nan)
         idx2 = pd.Index([1, 2, 3], name=pd.NaT)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(idx1, idx2)
 
     def test_categorical_index_equality(self):
@@ -526,7 +527,7 @@ Attribute "dtype" are different
 \\[right\\]: CategoricalDtype\\(categories=\\[u?'a', u?'b', u?'c'\\], \
 ordered=False\\)"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_index_equal(pd.Index(pd.Categorical(['a', 'b'])),
                                pd.Index(pd.Categorical(['a', 'b'],
                                         categories=['a', 'b', 'c'])))
@@ -619,7 +620,7 @@ Series length are different
 \\[left\\]:  3, RangeIndex\\(start=0, stop=3, step=1\\)
 \\[right\\]: 4, RangeIndex\\(start=0, stop=4, step=1\\)"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_series_equal(pd.Series([1, 2, 3]), pd.Series([1, 2, 3, 4]))
 
         expected = """Series are different
@@ -628,9 +629,9 @@ Series values are different \\(33\\.33333 %\\)
 \\[left\\]:  \\[1, 2, 3\\]
 \\[right\\]: \\[1, 2, 4\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_series_equal(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]))
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_series_equal(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]),
                                 check_less_precise=True)
 
@@ -642,7 +643,7 @@ Attribute "dtype" are different
 \\[right\\]: CategoricalDtype\\(categories=\\[u?'a', u?'b', u?'c'\\], \
 ordered=False\\)"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_series_equal(pd.Series(pd.Categorical(['a', 'b'])),
                                 pd.Series(pd.Categorical(['a', 'b'],
                                           categories=['a', 'b', 'c'])))
@@ -709,7 +710,7 @@ DataFrame shape mismatch
 \\[left\\]:  \\(3, 2\\)
 \\[right\\]: \\(3, 1\\)"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
                                pd.DataFrame({'A': [1, 2, 3]}))
 
@@ -719,7 +720,7 @@ DataFrame\\.index values are different \\(33\\.33333 %\\)
 \\[left\\]:  Index\\(\\[u?'a', u?'b', u?'c'\\], dtype='object'\\)
 \\[right\\]: Index\\(\\[u?'a', u?'b', u?'d'\\], dtype='object'\\)"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]},
                                             index=['a', 'b', 'c']),
                                pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]},
@@ -731,7 +732,7 @@ DataFrame\\.columns values are different \\(50\\.0 %\\)
 \\[left\\]:  Index\\(\\[u?'A', u?'B'\\], dtype='object'\\)
 \\[right\\]: Index\\(\\[u?'A', u?'b'\\], dtype='object'\\)"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]},
                                             index=['a', 'b', 'c']),
                                pd.DataFrame({'A': [1, 2, 3], 'b': [4, 5, 6]},
@@ -743,11 +744,11 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
 \\[left\\]:  \\[4, 5, 6\\]
 \\[right\\]: \\[4, 5, 7\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
                                pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 7]}))
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
                                pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 7]}),
                                by_blocks=True)
@@ -763,13 +764,13 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
 \\[left\\]:  \\[é, è, ë\\]
 \\[right\\]: \\[é, è, e̊\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [u'á', u'à', u'ä'],
                                              'E': [u'é', u'è', u'ë']}),
                                pd.DataFrame({'A': [u'á', u'à', u'ä'],
                                              'E': [u'é', u'è', u'e̊']}))
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [u'á', u'à', u'ä'],
                                              'E': [u'é', u'è', u'ë']}),
                                pd.DataFrame({'A': [u'á', u'à', u'ä'],
@@ -782,13 +783,13 @@ DataFrame\\.iloc\\[:, 0\\] values are different \\(100\\.0 %\\)
 \\[left\\]:  \\[á, à, ä\\]
 \\[right\\]: \\[a, a, a\\]"""
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [u'á', u'à', u'ä'],
                                              'E': [u'é', u'è', u'ë']}),
                                pd.DataFrame({'A': ['a', 'a', 'a'],
                                              'E': ['e', 'e', 'e']}))
 
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             assert_frame_equal(pd.DataFrame({'A': [u'á', u'à', u'ä'],
                                              'E': [u'é', u'è', u'ë']}),
                                pd.DataFrame({'A': ['a', 'a', 'a'],
@@ -808,7 +809,7 @@ Categorical\\.categories values are different \\(25\\.0 %\\)
 
         a = pd.Categorical([1, 2, 3, 4])
         b = pd.Categorical([1, 2, 3, 5])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             tm.assert_categorical_equal(a, b)
 
         expected = """Categorical\\.codes are different
@@ -819,7 +820,7 @@ Categorical\\.codes values are different \\(50\\.0 %\\)
 
         a = pd.Categorical([1, 2, 4, 3], categories=[1, 2, 3, 4])
         b = pd.Categorical([1, 2, 3, 4], categories=[1, 2, 3, 4])
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             tm.assert_categorical_equal(a, b)
 
         expected = """Categorical are different
@@ -830,7 +831,7 @@ Attribute "ordered" are different
 
         a = pd.Categorical([1, 2, 3, 4], ordered=False)
         b = pd.Categorical([1, 2, 3, 4], ordered=True)
-        with tm.assert_raises_regex(AssertionError, expected):
+        with pytest.raises(AssertionError, match=expected):
             tm.assert_categorical_equal(a, b)
 
 
@@ -845,7 +846,7 @@ class TestAssertIntervalArrayEqual(object):
             IntervalArray.left values are different \\(100.0 %\\)
             \\[left\\]:  Int64Index\\(\\[0, 1, 2, 3\\], dtype='int64'\\)
             \\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)""")
-        with tm.assert_raises_regex(AssertionError, msg):
+        with pytest.raises(AssertionError, match=msg):
             tm.assert_interval_array_equal(a, b)
 
 

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -884,3 +884,13 @@ def test_create_temp_directory():
         assert os.path.exists(path)
         assert os.path.isdir(path)
     assert not os.path.exists(path)
+
+
+def test_assert_raises_regex_deprecated():
+    # see gh-23592
+
+    with tm.assert_produces_warning(FutureWarning):
+        msg = "Not equal!"
+
+        with tm.assert_raises_regex(AssertionError, msg):
+            assert 1 == 2, msg

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -108,7 +108,7 @@ class TestValidateArgs(object):
 
     def test_bad_min_fname_arg_count(self):
         msg = "'max_fname_arg_count' must be non-negative"
-        with tm.assert_raises_regex(ValueError, msg):
+        with pytest.raises(ValueError, match=msg):
             validate_args(self.fname, (None,), -1, 'foo')
 
     def test_bad_arg_length_max_value_single(self):
@@ -123,7 +123,7 @@ class TestValidateArgs(object):
                .format(fname=self.fname, max_length=max_length,
                        actual_length=actual_length))
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             validate_args(self.fname, args,
                           min_fname_arg_count,
                           compat_args)
@@ -140,7 +140,7 @@ class TestValidateArgs(object):
                .format(fname=self.fname, max_length=max_length,
                        actual_length=actual_length))
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             validate_args(self.fname, args,
                           min_fname_arg_count,
                           compat_args)
@@ -159,7 +159,7 @@ class TestValidateArgs(object):
         arg_vals = (1, -1, 3)
 
         for i in range(1, 3):
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 validate_args(self.fname, arg_vals[:i], 2, compat_args)
 
     def test_validation(self):
@@ -188,7 +188,7 @@ class TestValidateKwargs(object):
                r"keyword argument '{arg}'".format(
                    fname=self.fname, arg=badarg))
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             validate_kwargs(self.fname, kwargs, compat_args)
 
     def test_not_all_none(self):
@@ -209,7 +209,7 @@ class TestValidateKwargs(object):
             kwargs = dict(zip(kwarg_keys[:i],
                               kwarg_vals[:i]))
 
-            with tm.assert_raises_regex(ValueError, msg):
+            with pytest.raises(ValueError, match=msg):
                 validate_kwargs(self.fname, kwargs, compat_args)
 
     def test_validation(self):
@@ -228,11 +228,11 @@ class TestValidateKwargs(object):
 
         for name in arg_names:
             for value in invalid_values:
-                with tm.assert_raises_regex(ValueError,
-                                            "For argument \"%s\" "
-                                            "expected type bool, "
-                                            "received type %s" %
-                                            (name, type(value).__name__)):
+                msg = ("For argument \"%s\" "
+                       "expected type bool, "
+                       "received type %s" %
+                       (name, type(value).__name__))
+                with pytest.raises(ValueError, match=msg):
                     validate_bool_kwarg(value, name)
 
             for value in valid_values:
@@ -255,7 +255,7 @@ class TestValidateKwargsAndArgs(object):
                .format(fname=self.fname, max_length=max_length,
                        actual_length=actual_length))
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             validate_args_and_kwargs(self.fname, args, kwargs,
                                      min_fname_arg_count,
                                      compat_args)
@@ -273,7 +273,7 @@ class TestValidateKwargsAndArgs(object):
                .format(fname=self.fname, max_length=max_length,
                        actual_length=actual_length))
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             validate_args_and_kwargs(self.fname, args, kwargs,
                                      min_fname_arg_count,
                                      compat_args)
@@ -292,17 +292,15 @@ class TestValidateKwargsAndArgs(object):
 
         args = ()
         kwargs = {'foo': -5, bad_arg: 2}
-        tm.assert_raises_regex(ValueError, msg,
-                               validate_args_and_kwargs,
-                               self.fname, args, kwargs,
-                               min_fname_arg_count, compat_args)
+        with pytest.raises(ValueError, match=msg):
+            validate_args_and_kwargs(self.fname, args, kwargs,
+                                     min_fname_arg_count, compat_args)
 
         args = (-5, 2)
         kwargs = {}
-        tm.assert_raises_regex(ValueError, msg,
-                               validate_args_and_kwargs,
-                               self.fname, args, kwargs,
-                               min_fname_arg_count, compat_args)
+        with pytest.raises(ValueError, match=msg):
+            validate_args_and_kwargs(self.fname, args, kwargs,
+                                     min_fname_arg_count, compat_args)
 
     def test_duplicate_argument(self):
         min_fname_arg_count = 2
@@ -316,7 +314,7 @@ class TestValidateKwargsAndArgs(object):
         msg = (r"{fname}\(\) got multiple values for keyword "
                r"argument '{arg}'".format(fname=self.fname, arg='foo'))
 
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             validate_args_and_kwargs(self.fname, args, kwargs,
                                      min_fname_arg_count,
                                      compat_args)
@@ -343,7 +341,7 @@ class TestMove(object):
         ``move_into_mutable_buffer`` which has a bunch of checks in it.
         """
         msg = "cannot create 'pandas.util._move.stolenbuf' instances"
-        with tm.assert_raises_regex(TypeError, msg):
+        with pytest.raises(TypeError, match=msg):
             stolenbuf()
 
     def test_more_than_one_ref(self):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -21,7 +21,7 @@ from pandas._libs import testing as _testing
 import pandas.compat as compat
 from pandas.compat import (
     PY2, PY3, Counter, StringIO, callable, filter, httplib, lmap, lrange, lzip,
-    map, raise_with_traceback, range, string_types, u, unichr, zip)
+    map, range, string_types, u, unichr, zip)
 
 from pandas.core.dtypes.common import (
     is_bool, is_categorical_dtype, is_datetimelike_v_numeric,
@@ -2530,130 +2530,6 @@ def network(t, url="http://www.google.com",
 
 
 with_connectivity_check = network
-
-
-def assert_raises_regex(_exception, _regexp, _callable=None,
-                        *args, **kwargs):
-    r"""
-    Check that the specified Exception is raised and that the error message
-    matches a given regular expression pattern. This may be a regular
-    expression object or a string containing a regular expression suitable
-    for use by `re.search()`. This is a port of the `assertRaisesRegexp`
-    function from unittest in Python 2.7.
-
-    Examples
-    --------
-    >>> assert_raises_regex(ValueError, 'invalid literal for.*XYZ', int, 'XYZ')
-    >>> import re
-    >>> assert_raises_regex(ValueError, re.compile('literal'), int, 'XYZ')
-
-    If an exception of a different type is raised, it bubbles up.
-
-    >>> assert_raises_regex(TypeError, 'literal', int, 'XYZ')
-    Traceback (most recent call last):
-        ...
-    ValueError: invalid literal for int() with base 10: 'XYZ'
-    >>> dct = dict()
-    >>> assert_raises_regex(KeyError, 'pear', dct.__getitem__, 'apple')
-    Traceback (most recent call last):
-        ...
-    AssertionError: "pear" does not match "'apple'"
-
-    You can also use this in a with statement.
-
-    >>> with assert_raises_regex(TypeError, r'unsupported operand type\(s\)'):
-    ...     1 + {}
-    >>> with assert_raises_regex(TypeError, 'banana'):
-    ...     'apple'[0] = 'b'
-    Traceback (most recent call last):
-        ...
-    AssertionError: "banana" does not match "'str' object does not support \
-item assignment"
-    """
-    manager = _AssertRaisesContextmanager(exception=_exception, regexp=_regexp)
-    if _callable is not None:
-        with manager:
-            _callable(*args, **kwargs)
-    else:
-        return manager
-
-
-class _AssertRaisesContextmanager(object):
-    """
-    Context manager behind `assert_raises_regex`.
-    """
-
-    def __init__(self, exception, regexp=None):
-        """
-        Initialize an _AssertRaisesContextManager instance.
-
-        Parameters
-        ----------
-        exception : class
-            The expected Exception class.
-        regexp : str, default None
-            The regex to compare against the Exception message.
-        """
-
-        self.exception = exception
-
-        if regexp is not None and not hasattr(regexp, "search"):
-            regexp = re.compile(regexp, re.DOTALL)
-
-        self.regexp = regexp
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, trace_back):
-        expected = self.exception
-
-        if not exc_type:
-            exp_name = getattr(expected, "__name__", str(expected))
-            raise AssertionError("{name} not raised.".format(name=exp_name))
-
-        return self.exception_matches(exc_type, exc_value, trace_back)
-
-    def exception_matches(self, exc_type, exc_value, trace_back):
-        """
-        Check that the Exception raised matches the expected Exception
-        and expected error message regular expression.
-
-        Parameters
-        ----------
-        exc_type : class
-            The type of Exception raised.
-        exc_value : Exception
-            The instance of `exc_type` raised.
-        trace_back : stack trace object
-            The traceback object associated with `exc_value`.
-
-        Returns
-        -------
-        is_matched : bool
-            Whether or not the Exception raised matches the expected
-            Exception class and expected error message regular expression.
-
-        Raises
-        ------
-        AssertionError : The error message provided does not match
-                         the expected error message regular expression.
-        """
-
-        if issubclass(exc_type, self.exception):
-            if self.regexp is not None:
-                val = str(exc_value)
-
-                if not self.regexp.search(val):
-                    msg = '"{pat}" does not match "{val}"'.format(
-                        pat=self.regexp.pattern, val=val)
-                    e = AssertionError(msg)
-                    raise_with_traceback(e, trace_back)
-
-            return True
-        else:
-            # Failed, so allow Exception to bubble up.
-            return False
 
 
 @contextmanager

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -21,7 +21,7 @@ from pandas._libs import testing as _testing
 import pandas.compat as compat
 from pandas.compat import (
     PY2, PY3, Counter, StringIO, callable, filter, httplib, lmap, lrange, lzip,
-    map, range, string_types, u, unichr, zip)
+    map, raise_with_traceback, range, string_types, u, unichr, zip)
 
 from pandas.core.dtypes.common import (
     is_bool, is_categorical_dtype, is_datetimelike_v_numeric,
@@ -2530,6 +2530,137 @@ def network(t, url="http://www.google.com",
 
 
 with_connectivity_check = network
+
+
+def assert_raises_regex(_exception, _regexp, _callable=None,
+                        *args, **kwargs):
+    r"""
+    Check that the specified Exception is raised and that the error message
+    matches a given regular expression pattern. This may be a regular
+    expression object or a string containing a regular expression suitable
+    for use by `re.search()`. This is a port of the `assertRaisesRegexp`
+    function from unittest in Python 2.7.
+
+    .. deprecated:: 0.24.0
+        Use `pytest.raises` instead.
+
+    Examples
+    --------
+    >>> assert_raises_regex(ValueError, 'invalid literal for.*XYZ', int, 'XYZ')
+    >>> import re
+    >>> assert_raises_regex(ValueError, re.compile('literal'), int, 'XYZ')
+
+    If an exception of a different type is raised, it bubbles up.
+
+    >>> assert_raises_regex(TypeError, 'literal', int, 'XYZ')
+    Traceback (most recent call last):
+        ...
+    ValueError: invalid literal for int() with base 10: 'XYZ'
+    >>> dct = dict()
+    >>> assert_raises_regex(KeyError, 'pear', dct.__getitem__, 'apple')
+    Traceback (most recent call last):
+        ...
+    AssertionError: "pear" does not match "'apple'"
+
+    You can also use this in a with statement.
+
+    >>> with assert_raises_regex(TypeError, r'unsupported operand type\(s\)'):
+    ...     1 + {}
+    >>> with assert_raises_regex(TypeError, 'banana'):
+    ...     'apple'[0] = 'b'
+    Traceback (most recent call last):
+        ...
+    AssertionError: "banana" does not match "'str' object does not support \
+item assignment"
+    """
+    warnings.warn(("assert_raises_regex has been deprecated and will "
+                   "be removed in the next release. Please use "
+                   "`pytest.raises` instead."), FutureWarning, stacklevel=2)
+
+    manager = _AssertRaisesContextmanager(exception=_exception, regexp=_regexp)
+    if _callable is not None:
+        with manager:
+            _callable(*args, **kwargs)
+    else:
+        return manager
+
+
+class _AssertRaisesContextmanager(object):
+    """
+    Context manager behind `assert_raises_regex`.
+    """
+
+    def __init__(self, exception, regexp=None):
+        """
+        Initialize an _AssertRaisesContextManager instance.
+
+        Parameters
+        ----------
+        exception : class
+            The expected Exception class.
+        regexp : str, default None
+            The regex to compare against the Exception message.
+        """
+
+        self.exception = exception
+
+        if regexp is not None and not hasattr(regexp, "search"):
+            regexp = re.compile(regexp, re.DOTALL)
+
+        self.regexp = regexp
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, trace_back):
+        expected = self.exception
+
+        if not exc_type:
+            exp_name = getattr(expected, "__name__", str(expected))
+            raise AssertionError("{name} not raised.".format(name=exp_name))
+
+        return self.exception_matches(exc_type, exc_value, trace_back)
+
+    def exception_matches(self, exc_type, exc_value, trace_back):
+        """
+        Check that the Exception raised matches the expected Exception
+        and expected error message regular expression.
+
+        Parameters
+        ----------
+        exc_type : class
+            The type of Exception raised.
+        exc_value : Exception
+            The instance of `exc_type` raised.
+        trace_back : stack trace object
+            The traceback object associated with `exc_value`.
+
+        Returns
+        -------
+        is_matched : bool
+            Whether or not the Exception raised matches the expected
+            Exception class and expected error message regular expression.
+
+        Raises
+        ------
+        AssertionError : The error message provided does not match
+                         the expected error message regular expression.
+        """
+
+        if issubclass(exc_type, self.exception):
+            if self.regexp is not None:
+                val = str(exc_value)
+
+                if not self.regexp.search(val):
+                    msg = '"{pat}" does not match "{val}"'.format(
+                        pat=self.regexp.pattern, val=val)
+                    e = AssertionError(msg)
+                    raise_with_traceback(e, trace_back)
+
+            return True
+        else:
+            # Failed, so allow Exception to bubble up.
+            return False
 
 
 @contextmanager


### PR DESCRIPTION
`pytest.raises` has all of the functionality that we need from `tm.assert_raises_regex`.

Closes #16521 (for good this time! 🙂 ).

If this is something we would like to have for `0.24.0`, I would ask that this get reviewed and merged ASAP, given how massive the refactoring is and the high probability of merge conflicts.

cc @pandas-dev/pandas-core