### PR TITLE
CLN: remove values attribute from datetimelike EAs

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -66,7 +66,7 @@ def _make_comparison_op(cls, op):
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings("ignore", "elementwise", FutureWarning)
             with np.errstate(all='ignore'):
-                result = op(self.values, np.asarray(other))
+                result = op(self._data, np.asarray(other))
 
         return result
 
@@ -120,14 +120,9 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
         return (self._box_func(v) for v in self.asi8)
 
     @property
-    def values(self):
-        """ return the underlying data as an ndarray """
-        return self._data.view(np.ndarray)
-
-    @property
     def asi8(self):
         # do not cache or you'll create a memory leak
-        return self.values.view('i8')
+        return self._data.view('i8')
 
     # ------------------------------------------------------------------
     # Array-like Methods

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -886,7 +886,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
 
             freq = get_period_alias(freq)
 
-        return PeriodArray._from_datetime64(self.values, freq, tz=self.tz)
+        return PeriodArray._from_datetime64(self._data, freq, tz=self.tz)
 
     def to_perioddelta(self, freq):
         """

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -81,7 +81,7 @@ def _td_array_cmp(cls, op):
             raise TypeError(msg.format(cls=type(self).__name__,
                                        typ=type(other).__name__))
         else:
-            other = type(self)(other).values
+            other = type(self)(other)._data
             result = meth(self, other)
             result = com.values_from_object(result)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -292,7 +292,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                            'set specified tz: {1}')
                     raise TypeError(msg.format(data.tz, tz))
 
-            subarr = data.values
+            subarr = data._data
 
             if freq is None:
                 freq = data.freq

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -75,9 +75,7 @@ class TestMethods(BasePeriodTests, base.BaseMethodsTests):
 
 class TestInterface(BasePeriodTests, base.BaseInterfaceTests):
 
-    def test_no_values_attribute(self, data):
-        # We have a values attribute.
-        pass
+    pass
 
 
 class TestArithmeticOps(BasePeriodTests, base.BaseArithmeticOpsTests):


### PR DESCRIPTION
We don't need a `.values` attribute on the EAs (in the interface, we actually explicitly disallow it (in words and tests)). 

I thought there was a reason during the PeriodArray PR that this couldn't yet be removed, but relevant tests seem to be passing locally.

cc @jbrockmendel 