### PR TITLE
DOC: Fix Order of parameters in docstrings

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2032,8 +2032,7 @@ class DataFrame(NDFrame):
     @Substitution(header='Write out the column names. If a list of strings '
                          'is given, it is assumed to be aliases for the '
                          'column names')
-    @Substitution(shared_params1=fmt.common_docstring[:-320],
-                  shared_params2=fmt.common_docstring[-315:-5],
+    @Substitution(shared_params=fmt.common_docstring,
                   returns=fmt.return_docstring)
     def to_string(self, buf=None, columns=None, col_space=None, header=True,
                   index=True, na_rep='NaN', formatters=None, float_format=None,
@@ -2042,11 +2041,13 @@ class DataFrame(NDFrame):
                   show_dimensions=False):
         """
         Render a DataFrame to a console-friendly tabular output.
-        %(shared_params1)s
+
+        %(shared_params)s
         line_width : int, optional
             Width to wrap a line in characters.
-        %(shared_params2)s
+
         %(returns)s
+
         See Also
         --------
         to_html : Convert DataFrame to HTML.
@@ -2080,8 +2081,7 @@ class DataFrame(NDFrame):
             return result
 
     @Substitution(header='whether to print column labels, default True')
-    @Substitution(shared_params1=fmt.common_docstring[:-320],
-                  shared_params2=fmt.common_docstring[-315:-5],
+    @Substitution(shared_params=fmt.common_docstring,
                   returns=fmt.return_docstring)
     def to_html(self, buf=None, columns=None, col_space=None, header=True,
                 index=True, na_rep='NaN', formatters=None, float_format=None,
@@ -2091,14 +2091,14 @@ class DataFrame(NDFrame):
                 border=None, table_id=None):
         """
         Render a DataFrame as an HTML table.
-        %(shared_params1)s
+
+        %(shared_params)s
         bold_rows : boolean, default True
             Make the row labels bold in the output
         classes : str or list or tuple, default None
             CSS class(es) to apply to the resulting html table
         escape : boolean, default True
             Convert the characters <, >, and & to HTML-safe sequences.
-        %(shared_params2)s
         notebook : {True, False}, default False
             Whether the generated HTML is for IPython Notebook.
         decimal : string, default '.'
@@ -2116,7 +2116,9 @@ class DataFrame(NDFrame):
             A css id is included in the opening `<table>` tag if specified.
 
             .. versionadded:: 0.23.0
+
         %(returns)s
+
         See Also
         --------
         to_string : Convert DataFrame to a string.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2032,7 +2032,8 @@ class DataFrame(NDFrame):
     @Substitution(header='Write out the column names. If a list of strings '
                          'is given, it is assumed to be aliases for the '
                          'column names')
-    @Substitution(shared_params=fmt.common_docstring,
+    @Substitution(shared_params1=fmt.common_docstring[:-320],
+                  shared_params2=fmt.common_docstring[-315:-5],
                   returns=fmt.return_docstring)
     def to_string(self, buf=None, columns=None, col_space=None, header=True,
                   index=True, na_rep='NaN', formatters=None, float_format=None,
@@ -2041,13 +2042,11 @@ class DataFrame(NDFrame):
                   show_dimensions=False):
         """
         Render a DataFrame to a console-friendly tabular output.
-
-        %(shared_params)s
+        %(shared_params1)s
         line_width : int, optional
             Width to wrap a line in characters.
-
+        %(shared_params2)s
         %(returns)s
-
         See Also
         --------
         to_html : Convert DataFrame to HTML.
@@ -2081,7 +2080,8 @@ class DataFrame(NDFrame):
             return result
 
     @Substitution(header='whether to print column labels, default True')
-    @Substitution(shared_params=fmt.common_docstring,
+    @Substitution(shared_params1=fmt.common_docstring[:-320],
+                  shared_params2=fmt.common_docstring[-315:-5],
                   returns=fmt.return_docstring)
     def to_html(self, buf=None, columns=None, col_space=None, header=True,
                 index=True, na_rep='NaN', formatters=None, float_format=None,
@@ -2091,14 +2091,14 @@ class DataFrame(NDFrame):
                 border=None, table_id=None):
         """
         Render a DataFrame as an HTML table.
-
-        %(shared_params)s
+        %(shared_params1)s
         bold_rows : boolean, default True
             Make the row labels bold in the output
         classes : str or list or tuple, default None
             CSS class(es) to apply to the resulting html table
         escape : boolean, default True
             Convert the characters <, >, and & to HTML-safe sequences.
+        %(shared_params2)s
         notebook : {True, False}, default False
             Whether the generated HTML is for IPython Notebook.
         decimal : string, default '.'
@@ -2116,9 +2116,7 @@ class DataFrame(NDFrame):
             A css id is included in the opening `<table>` tag if specified.
 
             .. versionadded:: 0.23.0
-
         %(returns)s
-
         See Also
         --------
         to_string : Convert DataFrame to a string.

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -407,12 +407,12 @@ def crosstab(index, columns, values=None, rownames=None, colnames=None,
     values : array-like, optional
         Array of values to aggregate according to the factors.
         Requires `aggfunc` be specified.
-    aggfunc : function, optional
-        If specified, requires `values` be specified as well
     rownames : sequence, default None
         If passed, must match number of row arrays passed
     colnames : sequence, default None
         If passed, must match number of column arrays passed
+    aggfunc : function, optional
+        If specified, requires `values` be specified as well
     margins : boolean, default False
         Add row/column margins (subtotals)
     margins_name : string, default 'All'

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -136,7 +136,7 @@ class _Window(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        key : string / list of selections
+        key : str / list of selections
         ndim : 1,2
             requested ndim of result
         subset : object, default None
@@ -464,16 +464,16 @@ class Window(_Window):
         (otherwise result is NA). For a window that is specified by an offset,
         `min_periods` will default to 1. Otherwise, `min_periods` will default
         to the size of the window.
-    center : boolean, default False
+    center : bool, default False
         Set the labels at the center of the window.
-    win_type : string, default None
+    win_type : str, default None
         Provide a window type. If ``None``, all points are evenly weighted.
         See the notes below for further information.
-    on : string, optional
+    on : str, optional
         For a DataFrame, column on which to calculate
         the rolling window, rather than the index
-    axis : int or string, default 0
-    closed : string, default None
+    axis : int or str, default 0
+    closed : str, default None
         Make the interval closed on the 'right', 'left', 'both' or
         'neither' endpoints.
         For offset-based windows, it defaults to 'right'.
@@ -660,7 +660,7 @@ class Window(_Window):
 
         Parameters
         ----------
-        mean : boolean, default True
+        mean : bool, default True
             If True computes weighted mean, else weighted sum
 
         Returns
@@ -818,11 +818,11 @@ class _Rolling(_Window):
 
         Parameters
         ----------
-        func : string/callable to apply
-        name : string, optional
+        func : str/callable to apply
+        name : str, optional
            name of this function
         window : int/array, default to _get_window()
-        center : boolean, default to self.center
+        center : bool, default to self.center
         check_minp : function, default to _use_window
 
         Returns
@@ -1815,9 +1815,9 @@ class Expanding(_Rolling_and_Expanding):
     min_periods : int, default 1
         Minimum number of observations in window required to have a value
         (otherwise result is NA).
-    center : boolean, default False
+    center : bool, default False
         Set the labels at the center of the window.
-    axis : int or string, default 0
+    axis : int or str, default 0
 
     Returns
     -------
@@ -2061,7 +2061,7 @@ _bias_template = """
 
 Parameters
 ----------
-bias : boolean, default False
+bias : bool, default False
     Use a standard estimation bias correction
 """
 
@@ -2078,7 +2078,7 @@ pairwise : bool, default None
     will be a MultiIndex DataFrame in the case of DataFrame inputs.
     In the case of missing elements, only complete pairwise observations will
     be used.
-bias : boolean, default False
+bias : bool, default False
    Use a standard estimation bias correction
 """
 
@@ -2109,10 +2109,10 @@ class EWM(_Rolling):
     min_periods : int, default 0
         Minimum number of observations in window required to have a value
         (otherwise result is NA).
-    adjust : boolean, default True
+    adjust : bool, default True
         Divide by decaying adjustment factor in beginning periods to account
         for imbalance in relative weightings (viewing EWMA as a moving average)
-    ignore_na : boolean, default False
+    ignore_na : bool, default False
         Ignore missing values when calculating weights;
         specify True to reproduce pre-0.15.0 behavior
 
@@ -2241,7 +2241,7 @@ class EWM(_Rolling):
 
         Parameters
         ----------
-        func : string/callable to apply
+        func : str/callable to apply
 
         Returns
         -------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -472,6 +472,7 @@ class Window(_Window):
     on : string, optional
         For a DataFrame, column on which to calculate
         the rolling window, rather than the index
+    axis : int or string, default 0
     closed : string, default None
         Make the interval closed on the 'right', 'left', 'both' or
         'neither' endpoints.
@@ -480,8 +481,6 @@ class Window(_Window):
         for fixed windows.
 
         .. versionadded:: 0.20.0
-
-    axis : int or string, default 0
 
     Returns
     -------

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -110,10 +110,10 @@ def json_normalize(data, record_path=None, meta=None,
         assumed to be an array of records
     meta : list of paths (string or list of strings), default None
         Fields to use as metadata for each record in resulting table
+    meta_prefix : string, default None
     record_prefix : string, default None
         If True, prefix records with dotted (?) path, e.g. foo.bar.field if
         path to records is ['foo', 'bar']
-    meta_prefix : string, default None
     errors : {'raise', 'ignore'}, default 'raise'
 
         * 'ignore' : will ignore KeyError if keys listed in meta are not

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -814,7 +814,7 @@ class CustomBusinessDay(_CustomMixin, BusinessDay):
     holidays : list
         list/array of dates to exclude from the set of valid business days,
         passed to ``numpy.busdaycalendar``
-    calendar : pd.HolidayCalendar or np.
+    calendar : pd.HolidayCalendar or np.busdaycalendar
     offset : timedelta, default timedelta(0)
     """
     _prefix = 'C'

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -807,7 +807,6 @@ class CustomBusinessDay(_CustomMixin, BusinessDay):
     Parameters
     ----------
     n : int, default 1
-    offset : timedelta, default timedelta(0)
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range
     weekmask : str, Default 'Mon Tue Wed Thu Fri'
@@ -815,7 +814,8 @@ class CustomBusinessDay(_CustomMixin, BusinessDay):
     holidays : list
         list/array of dates to exclude from the set of valid business days,
         passed to ``numpy.busdaycalendar``
-    calendar : pd.HolidayCalendar or np.busdaycalendar
+    calendar : pd.HolidayCalendar or np.
+    offset : timedelta, default timedelta(0)
     """
     _prefix = 'C'
     _attributes = frozenset(['n', 'normalize',
@@ -958,7 +958,6 @@ class _CustomBusinessMonth(_CustomMixin, BusinessMixin, MonthOffset):
     Parameters
     ----------
     n : int, default 1
-    offset : timedelta, default timedelta(0)
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range
     weekmask : str, Default 'Mon Tue Wed Thu Fri'
@@ -967,6 +966,7 @@ class _CustomBusinessMonth(_CustomMixin, BusinessMixin, MonthOffset):
         list/array of dates to exclude from the set of valid business days,
         passed to ``numpy.busdaycalendar``
     calendar : pd.HolidayCalendar or np.busdaycalendar
+    offset : timedelta, default timedelta(0)
     """
     _attributes = frozenset(['n', 'normalize',
                              'weekmask', 'holidays', 'calendar', 'offset'])

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1222,18 +1222,18 @@ def assert_series_equal(left, right, check_dtype=True,
     check_less_precise : bool or int, default False
         Specify comparison precision. Only used when check_exact is False.
         5 digits (False) or 3 digits (True) after decimal points are compared.
-        If int, then specify the digits to compare
-    check_exact : bool, default False
-        Whether to compare number exactly.
+        If int, then specify the digits to compare.
     check_names : bool, default True
         Whether to check the Series and Index names attribute.
+    check_exact : bool, default False
+        Whether to compare number exactly.
     check_datetimelike_compat : bool, default False
         Compare datetime-like which is comparable ignoring dtype.
     check_categorical : bool, default True
         Whether to compare internal Categorical exactly.
     obj : str, default 'Series'
         Specify object name being compared, internally used to show appropriate
-        assertion message
+        assertion message.
     """
     __tracebackhide__ = True
 


### PR DESCRIPTION
- [ ] closes #23596 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Fix the following:

```diff
pandas.io.json.json_normalize: Wrong parameters order. Actual: ('data', 'record_path', 'meta', 'meta_prefix', 'record_prefix', 'errors', 'sep'). Documented: ('data', 'record_path', 'meta', 'record_prefix', 'meta_prefix', 'errors', 'sep')
pandas.crosstab: Wrong parameters order. Actual: ('index', 'columns', 'values', 'rownames', 'colnames', 'aggfunc', 'margins', 'margins_name', 'dropna', 'normalize'). Documented: ('index', 'columns', 'values', 'aggfunc', 'rownames', 'colnames', 'margins', 'margins_name', 'dropna', 'normalize')
pandas.Series.rolling: Wrong parameters order. Actual: ('window', 'min_periods', 'center', 'win_type', 'on', 'axis', 'closed'). Documented: ('window', 'min_periods', 'center', 'win_type', 'on', 'closed', 'axis')
pandas.DataFrame.rolling: Wrong parameters order. Actual: ('window', 'min_periods', 'center', 'win_type', 'on', 'axis', 'closed'). Documented: ('window', 'min_periods', 'center', 'win_type', 'on', 'closed', 'axis')
-pandas.DataFrame.to_html: Wrong parameters order. Actual: ('buf', 'columns', 'col_space', 'header', 'index', 'na_rep', 'formatters', 'float_format', 'sparsify', 'index_names', 'justify', 'bold_rows', 'classes', 'escape', 'max_rows', 'max_cols', 'show_dimensions', 'notebook', 'decimal', 'border', 'table_id'). Documented: ('buf', 'columns', 'col_space', 'header', 'index', 'na_rep', 'formatters', 'float_format', 'sparsify', 'index_names', 'justify', 'max_rows', 'max_cols', 'show_dimensions', 'bold_rows', 'classes', 'escape', 'notebook', 'decimal', 'border', 'table_id')
-pandas.DataFrame.to_string: Wrong parameters order. Actual: ('buf', 'columns', 'col_space', 'header', 'index', 'na_rep', 'formatters', 'float_format', 'sparsify', 'index_names', 'justify', 'line_width', 'max_rows', 'max_cols', 'show_dimensions'). Documented: ('buf', 'columns', 'col_space', 'header', 'index', 'na_rep', 'formatters', 'float_format', 'sparsify', 'index_names', 'justify', 'max_rows', 'max_cols', 'show_dimensions', 'line_width')
pandas.tseries.offsets.CustomBusinessDay: Wrong parameters order. Actual: ('n', 'normalize', 'weekmask', 'holidays', 'calendar', 'offset'). Documented: ('n', 'offset', 'normalize', 'weekmask', 'holidays', 'calendar')
pandas.tseries.offsets.CustomBusinessMonthEnd: Wrong parameters order. Actual: ('n', 'normalize', 'weekmask', 'holidays', 'calendar', 'offset'). Documented: ('n', 'offset', 'normalize', 'weekmask', 'holidays', 'calendar')
pandas.tseries.offsets.CustomBusinessMonthBegin: Wrong parameters order. Actual: ('n', 'normalize', 'weekmask', 'holidays', 'calendar', 'offset'). Documented: ('n', 'offset', 'normalize', 'weekmask', 'holidays', 'calendar')
pandas.tseries.offsets.CBMonthEnd: Wrong parameters order. Actual: ('n', 'normalize', 'weekmask', 'holidays', 'calendar', 'offset'). Documented: ('n', 'offset', 'normalize', 'weekmask', 'holidays', 'calendar')
pandas.tseries.offsets.CBMonthBegin: Wrong parameters order. Actual: ('n', 'normalize', 'weekmask', 'holidays', 'calendar', 'offset'). Documented: ('n', 'offset', 'normalize', 'weekmask', 'holidays', 'calendar')
pandas.tseries.offsets.CDay: Wrong parameters order. Actual: ('n', 'normalize', 'weekmask', 'holidays', 'calendar', 'offset'). Documented: ('n', 'offset', 'normalize', 'weekmask', 'holidays', 'calendar')
pandas.testing.assert_series_equal: Wrong parameters order. Actual: ('left', 'right', 'check_dtype', 'check_index_type', 'check_series_type', 'check_less_precise', 'check_names', 'check_exact', 'check_datetimelike_compat', 'check_categorical', 'obj'). Documented: ('left', 'right', 'check_dtype', 'check_index_type', 'check_series_type', 'check_less_precise', 'check_exact', 'check_names', 'check_datetimelike_compat', 'check_categorical', 'obj')```