### PR TITLE
TST: Fix integer ops comparison test

### DIFF
--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -314,11 +314,11 @@ class TestArithmeticOps(BaseOpsUtil):
 
 class TestComparisonOps(BaseOpsUtil):
 
-    def _compare_other(self, s, data, op_name, other):
+    def _compare_other(self, data, op_name, other):
         op = self.get_op_from_name(op_name)
 
         # array
-        result = op(s, other)
+        result = pd.Series(op(data, other))
         expected = pd.Series(op(data._data, other))
 
         # fill the nan locations
@@ -340,14 +340,12 @@ class TestComparisonOps(BaseOpsUtil):
 
     def test_compare_scalar(self, data, all_compare_operators):
         op_name = all_compare_operators
-        s = pd.Series(data)
-        self._compare_other(s, data, op_name, 0)
+        self._compare_other(data, op_name, 0)
 
     def test_compare_array(self, data, all_compare_operators):
         op_name = all_compare_operators
-        s = pd.Series(data)
         other = pd.Series([0] * len(data))
-        self._compare_other(s, data, op_name, other)
+        self._compare_other(data, op_name, other)
 
 
 class TestCasting(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,7 @@ known_post_core=pandas.tseries,pandas.io,pandas.plotting
 sections=FUTURE,STDLIB,THIRDPARTY,PRE_CORE,DTYPES,FIRSTPARTY,POST_CORE,LOCALFOLDER
 
 known_first_party=pandas
-known_third_party=Cython,numpy,python-dateutil,pytz,pyarrow
+known_third_party=Cython,numpy,python-dateutil,pytz,pyarrow,pytest
 multi_line_output=4
 force_grid_wrap=0
 combine_as_imports=True


### PR DESCRIPTION
The `op(Series[integer], other)` path was being tested twice.
The `op(IntegerArray, other)` path was not being tested.

Closes https://github.com/pandas-dev/pandas/issues/22096