### PR TITLE
More helpful Stata string length error.

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -461,7 +461,8 @@ def _datetime_to_stata_elapsed_vec(dates, fmt):
 
 excessive_string_length_error = """
 Fixed width strings in Stata .dta files are limited to 244 (or fewer)
-characters.  Column '%s' does not satisfy this restriction.
+characters.  Column '%s' does not satisfy this restriction. Use the
+'version=117' parameter to write the newer (Stata 13 and later) format.
 """
 
 


### PR DESCRIPTION
The current error string when trying to write a string longer than 244 characters does not point users toward a solution that already exists: using the `version=117` parameter.
xref #23564 
- [x] closes: no issue that I see
- [x] tests: not needed; error string change only
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry: too small a change?