### PR TITLE
DOC: avoid SparseArray.take error

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -266,7 +266,7 @@ These changes conform sparse handling to return the correct types and work to ma
 
 ``SparseArray.take`` now returns a scalar for scalar input, ``SparseArray`` for others. Furthermore, it handles a negative indexer with the same rule as ``Index`` (:issue:`10560`, :issue:`12796`)
 
-.. ipython:: python
+.. code-block:: python
 
    s = pd.SparseArray([np.nan, np.nan, 1, 2, 3, np.nan, 4, 5, np.nan, 6])
    s.take(0)


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/22215

SparseArray.take not accepting scalars is already in 0.24.0.txt