### PR TITLE
BUG: Keep column level names during resample nunique (#23222)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -2346,6 +2346,7 @@ application to columns of a specific data type.
    DataFrameGroupBy.idxmax
    DataFrameGroupBy.idxmin
    DataFrameGroupBy.mad
+   DataFrameGroupBy.nunique
    DataFrameGroupBy.pct_change
    DataFrameGroupBy.plot
    DataFrameGroupBy.quantile

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1335,6 +1335,7 @@ Groupby/Resample/Rolling
 - Bug in :meth:`DataFrame.resample` and :meth:`Series.resample` when resampling by a weekly offset (``'W'``) across a DST transition (:issue:`9119`, :issue:`21459`)
 - Bug in :meth:`DataFrame.expanding` in which the ``axis`` argument was not being respected during aggregations (:issue:`23372`)
 - Bug in :meth:`pandas.core.groupby.DataFrameGroupBy.transform` which caused missing values when the input function can accept a :class:`DataFrame` but renames it (:issue:`23455`).
+- Bug in :meth:`pandas.core.groupby.DataFrameGroupBy.nunique` in which the names of column levels were lost (:issue:`23222`).
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1568,6 +1568,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
             from pandas.core.reshape.concat import concat
             results = [groupby_series(obj[col], col) for col in obj.columns]
             results = concat(results, axis=1)
+            results.columns.names = obj.columns.names
 
         if not self.as_index:
             results.index = ibase.default_index(len(results))

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -892,6 +892,15 @@ def test_nunique_with_timegrouper():
     tm.assert_series_equal(result, expected)
 
 
+def test_nunique_preserves_column_level_names():
+    # GH 23222
+    test = pd.DataFrame([1, 2, 2],
+                        columns=pd.Index(['A'], name="level_0"))
+    result = test.groupby([0, 0, 0]).nunique()
+    expected = pd.DataFrame([2], columns=test.columns)
+    tm.assert_frame_equal(result, expected)
+
+
 # count
 # --------------------------------
 

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -1947,6 +1947,14 @@ class TestDatetimeIndex(Base):
         result = df.ID.groupby(pd.Grouper(freq='D')).nunique()
         assert_series_equal(result, expected)
 
+    def test_resample_nunique_preserves_column_level_names(self):
+        # GH 23222
+        df = tm.makeTimeDataFrame(freq='1D').abs()
+        df.columns = pd.MultiIndex.from_arrays([df.columns.tolist()] * 2,
+                                               names=["lev0", "lev1"])
+        result = df.resample("1h").nunique()
+        tm.assert_index_equal(df.columns, result.columns)
+
     def test_resample_nunique_with_date_gap(self):
         # GH 13453
         index = pd.date_range('1-1-2000', '2-15-2000', freq='h')


### PR DESCRIPTION
- [X] closes #23222
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

nunique is the only one I found in a quick search which manifested the problem.