### PR TITLE
TST: IntervalTree.get_loc_interval should return platform int

### DIFF
--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -116,7 +116,7 @@ cdef class IntervalTree(IntervalMixin):
         enclosing = self.get_loc(0.5 * (key_left + key_right))
         combined = np.concatenate([left_overlap, right_overlap, enclosing])
         uniques = pd.unique(combined)
-        return uniques
+        return uniques.astype('intp')
 
     def get_indexer(self, scalar_t[:] target):
         """Return the positions corresponding to unique intervals that overlap


### PR DESCRIPTION
One line change: missed this conversion in #23609