### PR TITLE
REF: Move Excel names parameter handling to CSV

### DIFF
--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -651,6 +651,7 @@ class ExcelFile(object):
             # GH 12292 : error when read one empty column from excel file
             try:
                 parser = TextParser(data,
+                                    names=names,
                                     header=header,
                                     index_col=index_col,
                                     has_index_names=has_index_names,
@@ -670,9 +671,6 @@ class ExcelFile(object):
                                     **kwds)
 
                 output[asheetname] = parser.read(nrows=nrows)
-
-                if names is not None:
-                    output[asheetname].columns = names
 
                 if not squeeze or isinstance(output[asheetname], DataFrame):
                     output[asheetname].columns = output[


### PR DESCRIPTION
Let the CSV `TextFileParser` do the work.  No need to duplicate logic in the `ExcelFile` class.
