### PR TITLE
DEP/CI: Pin flake8-rst version

### DIFF
--- a/ci/deps/travis-36.yaml
+++ b/ci/deps/travis-36.yaml
@@ -9,7 +9,7 @@ dependencies:
   - fastparquet
   - flake8>=3.5
   - flake8-comprehensions
-  - flake8-rst
+  - flake8-rst=0.4.2
   - gcsfs
   - geopandas
   - html5lib

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - Cython>=0.28.2
   - flake8
   - flake8-comprehensions
-  - flake8-rst
+  - flake8-rst=0.4.2
   - hypothesis>=3.58.0
   - isort
   - moto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytz
 Cython>=0.28.2
 flake8
 flake8-comprehensions
-flake8-rst
+flake8-rst==0.4.2
 hypothesis>=3.58.0
 isort
 moto


### PR DESCRIPTION
- [x] closes #23665

Pins version of `flake8-rst` to `0.4.2`. 

* Newer versions of this plugin will cover more code-blocks within the documentation. Thus CI will fail when new version is released to conda-forge. 
* Devs using pip already get issues as version `0.4.3` is released to PyPI.

`flake8-rst` is getting upgraded shortly to a version `>0.4.3`. I'm currently updating the doc so it becomes compliant with that newer version, therefore I don't open issues to fix the doc for version `0.4.3`. 
