### PR TITLE
DOC: flake8-per-pr for windows users

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -591,21 +591,14 @@ run this slightly modified command::
 
    git diff master --name-only -- "*.py" | grep "pandas/" | xargs flake8
 
-Note that on Windows, these commands are unfortunately not possible because
-commands like ``grep`` and ``xargs`` are not available natively. To imitate the
-behavior with the commands above, you should run::
+Windows does not support the ``grep`` and ``xargs`` commands (unless installed
+for example via the `MinGW <http://www.mingw.org/>`__ toolchain), but one can
+imitate the behaviour as follows::
 
-    git diff master --name-only -- "*.py"
+    for /f %i in ('git diff upstream/master --name-only ^| findstr pandas/') do flake8 %i
 
-This will list all of the Python files that have been modified. The only ones
-that matter during linting are any whose directory filepath begins with "pandas."
-For each filepath, copy and paste it after the ``flake8`` command as shown below:
-
-    flake8 <python-filepath>
-
-Alternatively, you can install the ``grep`` and ``xargs`` commands via the
-`MinGW <http://www.mingw.org/>`__ toolchain, and it will allow you to run the
-commands above.
+This will also get all the files being changed by the PR (and within the
+``pandas/`` folder), and run ``flake8`` on them one after the other.
 
 .. _contributing.import-formatting:
 


### PR DESCRIPTION
This was vaguely inspired by #23658, and by me finding out that windows has a built-in kinda-sorta-grep called `findstr`.

I've already started using it, and it's proven very useful. However, windows CLI tools are horrible, horribly documented, and just generally have terrible syntax. The command was built together from (approximately):
* https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/for#BKMK_examples
* https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/findstr
* https://ss64.com/nt/for.html
* https://blogs.msdn.microsoft.com/oldnewthing/20120731-00/?p=7003
* https://stackoverflow.com/questions/8844868/what-are-the-undocumented-features-and-limitations-of-the-windows-findstr-comman

Some general notes for someone wanting to embark on a similar path:
* use `findstr /?`
* piping is easy (normally), with `|`
* the `/f` in `for` is a flag for determining what's being iterated over, while `%i` is the variable
* to execute a function in the "set" of the `for`, it must be in single quotes
* inside those single quotes, the pipe must be "escaped" with `^`.
* order of flags matters
* `findstr` has... suboptimal... regex mechanics.

Nevertheless, there could be an even better version (that makes sure we're only checking `.py` files), that I didn't put in this PR, because I fear it will exceed the line length that's rendered without being cut off:
```
for /f %i in ('git diff upstream/master --name-only ^| findstr /r "pandas/.*\.py"') do flake8 %i
```

