### PR TITLE
DOC: Implement javascript to redirect old whatsnew pages to new ones

### DIFF
--- a/doc/source/_static/js/whatsnew_links.js
+++ b/doc/source/_static/js/whatsnew_links.js
@@ -11,12 +11,12 @@
 	const links = Array.from(document.getElementsByTagName("a"));
 	links.forEach((link) => {
 		const re = /(whatsnew.html)#(whatsnew)-[\d]+(-\w+)+/g;
-		let linkElements = link.href.split("/");		
+		let linkElements = link.href.split("/");
 		if (re.test(linkElements.slice(-1)[0])) {
 			let whatsNew = linkElements.slice(-1)[0].split("#");
 			whatsNew = generateWhatsNew(whatsNew);
 			linkElements[linkElements.length - 1] = whatsNew;
-			link.href = linkElements.join("/")
+			link.href = linkElements.join("/");
 		}
 	});
 })();

--- a/doc/source/_static/js/whatsnew_links.js
+++ b/doc/source/_static/js/whatsnew_links.js
@@ -1,0 +1,22 @@
+(function() {
+	/* Reformats last part of 'whatsnew' URLs */
+	const generateWhatsNew = (whatsNew) => {
+		let url = whatsNew[0], anchor = whatsNew[1];
+		url = ((url) => url.split(".")[0] + "/")(url);
+		let anchorEls = anchor.slice(9).split("-");
+		anchorEls[0] = ((version) => "v" + version.slice(0,1) + "." + version.slice(1,-1) + "." + version.slice(-1) + ".html#")(anchorEls[0]);
+		return url + anchorEls[0] + anchorEls.slice(1).join("-");
+	}
+
+	const links = Array.from(document.getElementsByTagName("a"));
+	links.forEach((link) => {
+		const re = /(whatsnew.html)#(whatsnew)-[\d]+(-\w+)+/g;
+		let linkElements = link.href.split("/");		
+		if (re.test(linkElements.slice(-1)[0])) {
+			let whatsNew = linkElements.slice(-1)[0].split("#");
+			whatsNew = generateWhatsNew(whatsNew);
+			linkElements[linkElements.length - 1] = whatsNew;
+			link.href = linkElements.join("/")
+		}
+	});
+})();

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -698,3 +698,4 @@ def setup(app):
     app.add_autodocumenter(AccessorMethodDocumenter)
     app.add_autodocumenter(AccessorCallableDocumenter)
     app.add_directive('autosummary', PandasAutosummary)
+    app.add_js('js/whatsnew_links.js')

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -698,4 +698,4 @@ def setup(app):
     app.add_autodocumenter(AccessorMethodDocumenter)
     app.add_autodocumenter(AccessorCallableDocumenter)
     app.add_directive('autosummary', PandasAutosummary)
-    app.add_js('js/whatsnew_links.js')
+    app.add_js_file('js/whatsnew_links.js')


### PR DESCRIPTION
- [x] closes #23695 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Javascript file to reformat / redirect 'whatsnew' href links in documentation.