### PR TITLE
ERR: Fail-fast with incompatible skipfooter combos

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1368,7 +1368,7 @@ Notice how we now instead output ``np.nan`` itself instead of a stringified form
 - Bug in :func:`DataFrame.to_string()` that caused representations of :class:`DataFrame` to not take up the whole window (:issue:`22984`)
 - Bug in :func:`DataFrame.to_csv` where a single level MultiIndex incorrectly wrote a tuple. Now just the value of the index is written (:issue:`19589`).
 - Bug in :meth:`HDFStore.append` when appending a :class:`DataFrame` with an empty string column and ``min_itemsize`` < 8 (:issue:`12242`)
-- Bug in :meth:`read_csv()` in which incorrect error messages were being raised when ``skipfooter`` was passed in along with ``nrows``, ``iterator``, or ``chunksize`` (:issue`23711`)
+- Bug in :func:`read_csv()` in which incorrect error messages were being raised when ``skipfooter`` was passed in along with ``nrows``, ``iterator``, or ``chunksize`` (:issue:`23711`)
 - Bug in :meth:`read_csv()` in which :class:`MultiIndex` index names were being improperly handled in the cases when they were not provided (:issue:`23484`)
 - Bug in :meth:`read_html()` in which the error message was not displaying the valid flavors when an invalid one was provided (:issue:`23549`)
 - Bug in :meth:`read_excel()` in which ``index_col=None`` was not being respected and parsing index columns anyway (:issue:`20480`)

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1368,6 +1368,7 @@ Notice how we now instead output ``np.nan`` itself instead of a stringified form
 - Bug in :func:`DataFrame.to_string()` that caused representations of :class:`DataFrame` to not take up the whole window (:issue:`22984`)
 - Bug in :func:`DataFrame.to_csv` where a single level MultiIndex incorrectly wrote a tuple. Now just the value of the index is written (:issue:`19589`).
 - Bug in :meth:`HDFStore.append` when appending a :class:`DataFrame` with an empty string column and ``min_itemsize`` < 8 (:issue:`12242`)
+- Bug in :meth:`read_csv()` in which incorrect error messages were being raised when ``skipfooter`` was passed in along with ``nrows``, ``iterator``, or ``chunksize`` (:issue`23711`)
 - Bug in :meth:`read_csv()` in which :class:`MultiIndex` index names were being improperly handled in the cases when they were not provided (:issue:`23484`)
 - Bug in :meth:`read_html()` in which the error message was not displaying the valid flavors when an invalid one was provided (:issue:`23549`)
 - Bug in :meth:`read_excel()` in which ``index_col=None`` was not being respected and parsing index columns anyway (:issue:`20480`)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -787,6 +787,12 @@ class TextFileReader(BaseIterator):
                                   stacklevel=2)
                 kwds[param] = dialect_val
 
+        if kwds.get("skipfooter"):
+            if kwds.get("iterator") or kwds.get("chunksize"):
+                raise ValueError("'skipfooter' not supported for 'iteration'")
+            if kwds.get("nrows"):
+                raise ValueError("'skipfooter' not supported with 'nrows'")
+
         if kwds.get('header', 'infer') == 'infer':
             kwds['header'] = 0 if kwds.get('names') is None else None
 
@@ -1054,11 +1060,6 @@ class TextFileReader(BaseIterator):
 
     def read(self, nrows=None):
         nrows = _validate_integer('nrows', nrows)
-
-        if nrows is not None:
-            if self.options.get('skipfooter'):
-                raise ValueError('skipfooter not supported for iteration')
-
         ret = self._engine.read(nrows)
 
         # May alter columns / col_dict

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -537,12 +537,21 @@ baz,7,8,9
         assert len(result) == 3
         tm.assert_frame_equal(pd.concat(result), expected)
 
-        # skipfooter is not supported with the C parser yet
-        if self.engine == 'python':
-            # test bad parameter (skipfooter)
-            reader = self.read_csv(StringIO(self.data1), index_col=0,
-                                   iterator=True, skipfooter=1)
-            pytest.raises(ValueError, reader.read, 3)
+    @pytest.mark.parametrize("kwargs", [
+        dict(iterator=True,
+             chunksize=1),
+        dict(iterator=True),
+        dict(chunksize=1)
+    ])
+    def test_iterator_skipfooter_errors(self, kwargs):
+        msg = "'skipfooter' not supported for 'iteration'"
+        with pytest.raises(ValueError, match=msg):
+            self.read_csv(StringIO(self.data1), skipfooter=1, **kwargs)
+
+    def test_nrows_skipfooter_errors(self):
+        msg = "'skipfooter' not supported with 'nrows'"
+        with pytest.raises(ValueError, match=msg):
+            self.read_csv(StringIO(self.data1), skipfooter=1, nrows=5)
 
     def test_pass_names_with_index(self):
         lines = self.data1.split('\n')


### PR DESCRIPTION
Setup:

~~~python
from pandas import read_csv
from pandas.compat import StringIO

data = "a\n1\n2\n3\n4\n5"

# Case 1:
read_csv(StringIO(data), skipfooter=1, nrows=2)

# Case 2:
read_csv(StringIO(data), skipfooter=1, chunksize=2)
~~~

Currently, we get:

~~~python
# Case 1:
...
ValueError: skipfooter not supported for iteration

# Case 2:
...
<pandas.io.parsers.TextFileReader object at ...>
~~~

In Case 1, the error message is not correct.  True, passing in `nrows` and `skipfooter` is not supported (`skipfooter` should be skipping lines at the end of the file, **NOT** at the end of the `nrows` of data that we read in, which is what happens currently), but we should raise a better error message.

(BTW, the only way to make this combo work is that we read in the entire file before cutting off the last `skipfooter` rows but can look into that subsequently...)

In Case 2, creating this reader is deceiving.  Any attempt to call `.read()` on this will raise the `ValueError` seen in Case 1.  It is better that we alert end-users immediately that this reader doesn't work.  After this PR, we get some more useful error messages out of the gate:

~~~python
# Case 1:
...
ValueError: 'skipfooter' not supported with 'nrows'

# Case 2:
...
ValueError: 'skipfooter' not supported for iteration
~~~