### PR TITLE
DOC: Handle exceptions when computing contributors.

### DIFF
--- a/doc/sphinxext/contributors.py
+++ b/doc/sphinxext/contributors.py
@@ -8,10 +8,10 @@ This will be replaced with a message indicating the number of
 code contributors and commits, and then list each contributor
 individually.
 """
+from announce import build_components
 from docutils import nodes
 from docutils.parsers.rst import Directive
-
-from announce import build_components
+import git
 
 
 class ContributorsDirective(Directive):
@@ -19,17 +19,25 @@ class ContributorsDirective(Directive):
     name = 'contributors'
 
     def run(self):
-        components = build_components(self.arguments[0])
+        range_ = self.arguments[0]
+        try:
+            components = build_components(range_)
+        except git.GitCommandError:
+            return [
+                self.state.document.reporter.warning(
+                    "Cannot find contributors for range '{}'".format(range_),
+                    line=self.lineno)
+            ]
+        else:
+            message = nodes.paragraph()
+            message += nodes.Text(components['author_message'])
 
-        message = nodes.paragraph()
-        message += nodes.Text(components['author_message'])
+            listnode = nodes.bullet_list()
 
-        listnode = nodes.bullet_list()
-
-        for author in components['authors']:
-            para = nodes.paragraph()
-            para += nodes.Text(author)
-            listnode += nodes.list_item('', para)
+            for author in components['authors']:
+                para = nodes.paragraph()
+                para += nodes.Text(author)
+                listnode += nodes.list_item('', para)
 
         return [message, listnode]
 

--- a/doc/sphinxext/contributors.py
+++ b/doc/sphinxext/contributors.py
@@ -8,10 +8,11 @@ This will be replaced with a message indicating the number of
 code contributors and commits, and then list each contributor
 individually.
 """
-from announce import build_components
 from docutils import nodes
 from docutils.parsers.rst import Directive
 import git
+
+from announce import build_components
 
 
 class ContributorsDirective(Directive):


### PR DESCRIPTION
We're failing on master right now https://travis-ci.org/pandas-dev/pandas/jobs/455255389#L4369

```
Exception occurred:
  File "/home/travis/miniconda3/envs/pandas/lib/python3.6/site-packages/git/cmd.py", line 825, in execute
    raise GitCommandError(command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git shortlog -s v0.9.0..v0.10.0
  stderr: 'fatal: ambiguous argument 'v0.9.0..v0.10.0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]''
The full traceback has been saved in /tmp/sphinx-err-hzfqasu4.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

I'm not sure why that is. Perhaps something with how the repo is cloned.

Anyway, this will work around the error.

```
/Users/taugspurger/sandbox/pandas/doc/source/whatsnew/v0.10.0.rst:450: WARNING: Cannot find contributors for range 'v0.9.0..v0.1.0'
looking for now-outdated files... none found
```