### PR TITLE
BUG: concat warning bubbling up through str.cat

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2241,7 +2241,7 @@ class StringMethods(NoNewAttributesMixin):
             # Need to add keys for uniqueness in case of duplicate columns
             others = concat(others, axis=1,
                             join=(join if join == 'inner' else 'outer'),
-                            keys=range(len(others)), copy=False)
+                            keys=range(len(others)), sort=False, copy=False)
             data, others = data.align(others, join=join)
             others = [others[x] for x in others]  # again list of Series
 


### PR DESCRIPTION
This was an unexpected realisation from #23723 -- the change of `pd.concat` in #20613 to add `sort` and raise a warning if it's not specified was not caught in the `.str.cat` code, because it was being shadowed (apparently in all relevant tests) by another `FutureWarning` that's being raised if `join` is not specified (from #20347).

This PR only adds the kwarg to the `.str.cat` internals where necessary.

Example from #23723:
```
>>> import pandas as pd
>>> s2 = pd.Series(['a', 'b', 'c', 'd'], index=['a', 'b', 'c', 'd'])
>>> u2 = pd.Series(['b', 'd', 'a', 'c'], index=['b', 'd', 'a', 'c'])
>>> s2.str.cat([pd.Index(['d', 'c', 'b', 'a']), u2, u2.values], na_rep='-', join='left')
[...] FutureWarning: Sorting because non-concatenation axis is not aligned. A future version
of pandas will change to not sort by default.
To accept the future behavior, pass 'sort=False'.
To retain the current behavior and silence the warning, pass 'sort=True'.
a    aaab
b    bbbd
c    ccca
d    dddc
dtype: object
```