### PR TITLE
BUG Rename during dependency generation from conda

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ numexpr>=2.6.1
 openpyxl
 pyarrow>=0.7.0
 pymysql
-pytables>=3.4.2
+tables>=3.4.2
 pytest-cov
 pytest-xdist
 s3fs

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -36,10 +36,19 @@ def conda_package_to_pip(package):
     if package in EXCLUDE:
         return
 
-    if package in RENAME:
-        return RENAME[package]
+    package = re.sub('(?<=[^<>])=', '==', package).strip()
+    for compare in ('<=', '>=', '=='):
+        if compare not in package:
+            continue
 
-    return re.sub('(?<=[^<>])=', '==', package).strip()
+        pkg, version = package.split(compare)
+
+        if pkg in RENAME:
+            return ''.join((RENAME[pkg], compare, version))
+
+        break
+
+    return package
 
 
 def main(conda_fname, pip_fname, compare=False):


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Package pytables wasn't renamed as it was compared to full package specification.

