### PR TITLE
DOC: Remove pandas. prefix from See Also section in Series #23659

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -509,8 +509,8 @@ _shared_docs['factorize'] = """
 
     See Also
     --------
-    pandas.cut : Discretize continuous-valued array.
-    pandas.unique : Find the unique value in an array.
+    cut : Discretize continuous-valued array.
+    unique : Find the unique value in an array.
 
     Examples
     --------

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -897,8 +897,8 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
 
         See Also
         --------
-        pandas.PeriodIndex: Immutable ndarray holding ordinal values.
-        pandas.DatetimeIndex.to_pydatetime: Return DatetimeIndex as object.
+        PeriodIndex: Immutable ndarray holding ordinal values.
+        DatetimeIndex.to_pydatetime: Return DatetimeIndex as object.
         """
         from pandas.core.arrays import PeriodArray
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -565,7 +565,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.rename_axis : Alter the name of the index or columns.
+        DataFrame.rename_axis : Alter the name of the index or columns.
 
         Examples
         --------
@@ -1164,9 +1164,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.Series.rename : Alter Series index labels or name.
-        pandas.DataFrame.rename : Alter DataFrame index labels or name.
-        pandas.Index.rename : Set new names on index.
+        Series.rename : Alter Series index labels or name.
+        DataFrame.rename : Alter DataFrame index labels or name.
+        Index.rename : Set new names on index.
 
         Examples
         --------
@@ -2042,8 +2042,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
     See Also
     --------
-    pandas.read_excel
-    pandas.ExcelWriter
+    read_excel
+    ExcelWriter
 
     Examples
     --------
@@ -2161,7 +2161,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.read_json
+        read_json
 
         Examples
         --------
@@ -2393,7 +2393,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.read_sql : Read a DataFrame from a table.
+        read_sql : Read a DataFrame from a table.
 
         Notes
         -----
@@ -4216,7 +4216,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.loc
+        DataFrame.loc
 
         Notes
         -----
@@ -4275,7 +4275,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.tail: Returns the last `n` rows.
+        DataFrame.tail: Returns the last `n` rows.
 
         Examples
         --------
@@ -4334,7 +4334,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.head : The first `n` rows of the caller object.
+        DataFrame.head : The first `n` rows of the caller object.
 
         Examples
         --------
@@ -4584,9 +4584,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.apply
-        pandas.DataFrame.applymap
-        pandas.Series.map
+        DataFrame.apply
+        DataFrame.applymap
+        Series.map
     """)
 
     @Appender(_shared_docs['pipe'] % _shared_doc_kwargs)
@@ -4899,7 +4899,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.values
+        DataFrame.values
         """
         warnings.warn("Method .as_matrix will be removed in a future version. "
                       "Use .values instead.", FutureWarning, stacklevel=2)
@@ -5305,9 +5305,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.to_datetime : Convert argument to datetime.
-        pandas.to_timedelta : Convert argument to timedelta.
-        pandas.to_numeric : Convert argument to a numeric type.
+        to_datetime : Convert argument to datetime.
+        to_timedelta : Convert argument to timedelta.
+        to_numeric : Convert argument to a numeric type.
         numpy.ndarray.astype : Cast a numpy array to a specified type.
         """
         if is_dict_like(dtype):
@@ -5527,9 +5527,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.to_datetime : Convert argument to datetime.
-        pandas.to_timedelta : Convert argument to timedelta.
-        pandas.to_numeric : Convert argument to numeric type.
+        to_datetime : Convert argument to datetime.
+        to_timedelta : Convert argument to timedelta.
+        to_numeric : Convert argument to numeric type.
 
         Returns
         -------
@@ -5561,9 +5561,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.to_datetime : Convert argument to datetime.
-        pandas.to_timedelta : Convert argument to timedelta.
-        pandas.to_numeric : Convert argument to numeric type.
+        to_datetime : Convert argument to datetime.
+        to_timedelta : Convert argument to timedelta.
+        to_numeric : Convert argument to numeric type.
 
         Returns
         -------
@@ -9904,8 +9904,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.read_csv : Load a CSV file into a DataFrame.
-        pandas.to_excel : Load an Excel file into a DataFrame.
+        read_csv : Load a CSV file into a DataFrame.
+        to_excel : Load an Excel file into a DataFrame.
 
         Examples
         --------
@@ -10101,8 +10101,8 @@ False
 _all_see_also = """\
 See Also
 --------
-pandas.Series.all : Return True if all elements are True.
-pandas.DataFrame.any : Return True if one (or more) elements are True.
+Series.all : Return True if all elements are True.
+DataFrame.any : Return True if one (or more) elements are True.
 """
 
 _cnum_doc = """
@@ -10128,7 +10128,7 @@ Returns
 %(examples)s
 See Also
 --------
-pandas.core.window.Expanding.%(accum_func_name)s : Similar functionality
+core.window.Expanding.%(accum_func_name)s : Similar functionality
     but ignores ``NaN`` values.
 %(name2)s.%(accum_func_name)s : Return the %(desc)s over
     %(name2)s axis.

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -58,7 +58,7 @@ class DatelikeOps(object):
 
     See Also
     --------
-    pandas.to_datetime : Convert the given argument to datetime.
+    to_datetime : Convert the given argument to datetime.
     DatetimeIndex.normalize : Return DatetimeIndex with times to midnight.
     DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
     DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1454,7 +1454,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.unique : Top-level unique method for any 1-d array-like object.
+        unique : Top-level unique method for any 1-d array-like object.
         Index.unique : Return Index with unique values from an Index object.
 
         Examples
@@ -1636,9 +1636,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.Index.duplicated : Equivalent method on pandas.Index.
-        pandas.DataFrame.duplicated : Equivalent method on pandas.DataFrame.
-        pandas.Series.drop_duplicates : Remove duplicate values from Series.
+        Index.duplicated : Equivalent method on pandas.Index.
+        DataFrame.duplicated : Equivalent method on pandas.DataFrame.
+        Series.drop_duplicates : Remove duplicate values from Series.
         """
         return super(Series, self).duplicated(keep=keep)
 
@@ -1869,7 +1869,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.core.window.Rolling.quantile
+        core.window.Rolling.quantile
         numpy.percentile
         """
 
@@ -2179,7 +2179,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.concat : General function to concatenate DataFrame, Series
+        concat : General function to concatenate DataFrame, Series
             or Panel objects.
 
         Returns
@@ -3192,8 +3192,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     See Also
     --------
-    pandas.Series.apply : Invoke function on a Series.
-    pandas.Series.transform : Transform function producing
+    Series.apply : Invoke function on a Series.
+    Series.transform : Transform function producing
         a Series with like indexes.
     """)
 
@@ -3458,7 +3458,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.Series.rename_axis
+        Series.rename_axis
 
         Examples
         --------
@@ -3732,7 +3732,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.DataFrame.isin : Equivalent method on DataFrame.
+        DataFrame.isin : Equivalent method on DataFrame.
 
         Examples
         --------
@@ -3790,8 +3790,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.Series.gt : Greater than of series and other.
-        pandas.Series.lt : Less than of series and other.
+        Series.gt : Greater than of series and other.
+        Series.lt : Less than of series and other.
 
         Examples
         --------
@@ -3883,7 +3883,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.read_csv
+        read_csv
 
         Returns
         -------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -999,7 +999,7 @@ def str_get_dummies(arr, sep='|'):
 
     See Also
     --------
-    pandas.get_dummies
+    get_dummies
     """
     arr = arr.fillna('')
     try:


### PR DESCRIPTION
- [x] closes #23659
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Cleaned up so that `./scripts/validate_docstrings.py --prefix=pandas.Series --errors=SA05` does not return any cases.