### PR TITLE
TST: groupby with daily frequency fails with NonExistentTimeError on clock change day in Brazil

### DIFF
--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -2515,6 +2515,15 @@ class TestPeriodIndex(Base):
         result = expected.resample('900S').mean()
         tm.assert_series_equal(result, expected)
 
+        # GH 23742
+        index = date_range(start='2017-10-10', end='2017-10-20', freq='1H')
+        index = index.tz_localize('UTC').tz_convert('America/Sao_Paulo')
+        df = DataFrame(data=list(range(len(index))), index=index)
+        result = df.groupby(pd.Grouper(freq='1D'))
+        expected = date_range(start='2017-10-09', end='2017-10-20', freq='D',
+                              tz="America/Sao_Paulo")
+        tm.assert_index_equal(result.count().index, expected)
+
     def test_resample_ambiguous_time_bin_edge(self):
         # GH 10117
         idx = pd.date_range("2014-10-25 22:00:00", "2014-10-26 00:30:00",


### PR DESCRIPTION
- [x] closes #23742
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [n/a ] whatsnew entry
