### PR TITLE
API/DEPR: replace kwarg "pat" with "sep" in str.[r]partition

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1030,6 +1030,7 @@ Deprecations
 - :meth:`Timestamp.tz_localize`, :meth:`DatetimeIndex.tz_localize`, and :meth:`Series.tz_localize` have deprecated the ``errors`` argument in favor of the ``nonexistent`` argument (:issue:`8917`)
 - The class ``FrozenNDArray`` has been deprecated. When unpickling, ``FrozenNDArray`` will be unpickled to ``np.ndarray`` once this class is removed (:issue:`9031`)
 - The methods :meth:`DataFrame.update` and :meth:`Panel.update` have deprecated the ``raise_conflict=False|True`` keyword in favor of ``errors='ignore'|'raise'`` (:issue:`23585`)
+- The methods :meth:`Series.str.partition` and :meth:`Series.str.rpartition` have deprecated the ``pat`` keyword in favor of ``sep`` (:issue:`22676`)
 - Deprecated the `nthreads` keyword of :func:`pandas.read_feather` in favor of
   `use_threads` to reflect the changes in pyarrow 0.11.0. (:issue:`23053`)
 - :func:`pandas.read_excel` has deprecated accepting ``usecols`` as an integer. Please pass in a list of ints from 0 to ``usecols`` inclusive instead (:issue:`23527`)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2412,9 +2412,9 @@ class StringMethods(NoNewAttributesMixin):
     ----------
     sep : str, default whitespace
         String to split on.
-
-        .. versionchanged :: 0.24.0
-            Changed name of parameter from `pat` to `sep`.
+    pat : str, default whitespace
+        .. deprecated:: 0.24.0
+           Use ``sep`` instead
     expand : bool, default True
         If True, return DataFrame/MultiIndex expanding dimensionality.
         If False, return Series/Index.

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -19,7 +19,7 @@ import pandas.core.common as com
 from pandas.core.algorithms import take_1d
 import pandas.compat as compat
 from pandas.core.base import NoNewAttributesMixin
-from pandas.util._decorators import Appender
+from pandas.util._decorators import Appender, deprecate_kwarg
 import re
 import pandas._libs.lib as lib
 import pandas._libs.ops as libops
@@ -2410,8 +2410,11 @@ class StringMethods(NoNewAttributesMixin):
 
     Parameters
     ----------
-    pat : str, default whitespace
+    sep : str, default whitespace
         String to split on.
+
+        .. versionchanged :: 0.24.0
+            Changed name of parameter from `pat` to `sep`.
     expand : bool, default True
         If True, return DataFrame/MultiIndex expanding dimensionality.
         If False, return Series/Index.
@@ -2485,8 +2488,9 @@ class StringMethods(NoNewAttributesMixin):
                   'empty strings',
         'also': 'rpartition : Split the string at the last occurrence of `sep`'
     })
-    def partition(self, pat=' ', expand=True):
-        f = lambda x: x.partition(pat)
+    @deprecate_kwarg(old_arg_name='pat', new_arg_name='sep')
+    def partition(self, sep=' ', expand=True):
+        f = lambda x: x.partition(sep)
         result = _na_map(f, self._parent)
         return self._wrap_result(result, expand=expand)
 
@@ -2496,8 +2500,9 @@ class StringMethods(NoNewAttributesMixin):
                   'string itself',
         'also': 'partition : Split the string at the first occurrence of `sep`'
     })
-    def rpartition(self, pat=' ', expand=True):
-        f = lambda x: x.rpartition(pat)
+    @deprecate_kwarg(old_arg_name='pat', new_arg_name='sep')
+    def rpartition(self, sep=' ', expand=True):
+        f = lambda x: x.rpartition(sep)
         result = _na_map(f, self._parent)
         return self._wrap_result(result, expand=expand)
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2586,6 +2586,24 @@ class TestStringMethods(object):
         assert res.nlevels == 1
         tm.assert_index_equal(res, exp)
 
+    def test_partition_deprecation(self):
+        # GH 22676; depr kwarg "pat" in favor of "sep"
+        values = Series(['a_b_c', 'c_d_e', NA, 'f_g_h'])
+
+        # str.partition
+        # using sep -> no warning
+        expected = values.str.partition(sep='_')
+        with tm.assert_produces_warning(FutureWarning):
+            result = values.str.partition(pat='_')
+            tm.assert_frame_equal(result, expected)
+
+        # str.rpartition
+        # using sep -> no warning
+        expected = values.str.rpartition(sep='_')
+        with tm.assert_produces_warning(FutureWarning):
+            result = values.str.rpartition(pat='_')
+            tm.assert_frame_equal(result, expected)
+
     def test_pipe_failures(self):
         # #2119
         s = Series(['A|B|C'])


### PR DESCRIPTION
- [x] closes #22676
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
