### PR TITLE
TST: Mark test_pct_max_many_rows with pytest.mark.single

### DIFF
--- a/pandas/tests/frame/test_rank.py
+++ b/pandas/tests/frame/test_rank.py
@@ -310,6 +310,7 @@ class TestRank(TestData):
         expected = DataFrame(exp)
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.single
     def test_pct_max_many_rows(self):
         # GH 18271
         df = DataFrame({'A': np.arange(2**24 + 1),

--- a/pandas/tests/series/test_rank.py
+++ b/pandas/tests/series/test_rank.py
@@ -497,6 +497,7 @@ def test_rank_first_pct(dtype, ser, exp):
         assert_series_equal(result, expected)
 
 
+@pytest.mark.single
 def test_pct_max_many_rows():
         # GH 18271
         s = Series(np.arange(2**24 + 1))

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1462,6 +1462,7 @@ class TestRank(object):
         with pytest.raises(TypeError, match=msg):
             algos.rank(arr)
 
+    @pytest.mark.single
     @pytest.mark.parametrize('values', [
         np.arange(2**24 + 1),
         np.arange(2**25 + 2).reshape(2**24 + 1, 2)],


### PR DESCRIPTION
- [X] closes #23726
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

See this comment for context: https://github.com/pandas-dev/pandas/issues/23726#issuecomment-440076164