### PR TITLE
BUG: fixed plotting of boolean dataframes

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -357,6 +357,7 @@ class MPLPlot(object):
         # with ``dtype == object``
         data = data._convert(datetime=True, timedelta=True)
         numeric_data = data.select_dtypes(include=[np.number,
+                                                   np.bool_,
                                                    "datetime",
                                                    "datetimetz",
                                                    "timedelta"])


### PR DESCRIPTION
Boolean data was not recognised as plottable data. Adding it to the list of valid dtypes fixed this and allows plotting.

- [x] closes #23719
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
