### PR TITLE
TST: move misplaced modulo test

### DIFF
--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -597,6 +597,44 @@ class TestMultiplicationDivision(object):
         tm.assert_series_equal(ts / ts, ts / df['A'],
                                check_names=False)
 
+    # TODO: this came from tests.series.test_analytics, needs cleannup and
+    #  de-duplication with test_modulo above
+    def test_modulo2(self):
+        with np.errstate(all='ignore'):
+
+            # GH#3590, modulo as ints
+            p = pd.DataFrame({'first': [3, 4, 5, 8], 'second': [0, 0, 0, 3]})
+            result = p['first'] % p['second']
+            expected = Series(p['first'].values % p['second'].values,
+                              dtype='float64')
+            expected.iloc[0:3] = np.nan
+            tm.assert_series_equal(result, expected)
+
+            result = p['first'] % 0
+            expected = Series(np.nan, index=p.index, name='first')
+            tm.assert_series_equal(result, expected)
+
+            p = p.astype('float64')
+            result = p['first'] % p['second']
+            expected = Series(p['first'].values % p['second'].values)
+            tm.assert_series_equal(result, expected)
+
+            p = p.astype('float64')
+            result = p['first'] % p['second']
+            result2 = p['second'] % p['first']
+            assert not result.equals(result2)
+
+            # GH#9144
+            s = Series([0, 1])
+
+            result = s % 0
+            expected = Series([np.nan, np.nan])
+            tm.assert_series_equal(result, expected)
+
+            result = 0 % s
+            expected = Series([np.nan, 0.0])
+            tm.assert_series_equal(result, expected)
+
 
 class TestAdditionSubtraction(object):
     # __add__, __sub__, __radd__, __rsub__, __iadd__, __isub__

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -681,42 +681,6 @@ class TestSeriesAnalytics(object):
         pytest.raises(NotImplementedError, s.any, bool_only=True)
         pytest.raises(NotImplementedError, s.all, bool_only=True)
 
-    def test_modulo(self):
-        with np.errstate(all='ignore'):
-
-            # GH3590, modulo as ints
-            p = DataFrame({'first': [3, 4, 5, 8], 'second': [0, 0, 0, 3]})
-            result = p['first'] % p['second']
-            expected = Series(p['first'].values % p['second'].values,
-                              dtype='float64')
-            expected.iloc[0:3] = np.nan
-            assert_series_equal(result, expected)
-
-            result = p['first'] % 0
-            expected = Series(np.nan, index=p.index, name='first')
-            assert_series_equal(result, expected)
-
-            p = p.astype('float64')
-            result = p['first'] % p['second']
-            expected = Series(p['first'].values % p['second'].values)
-            assert_series_equal(result, expected)
-
-            p = p.astype('float64')
-            result = p['first'] % p['second']
-            result2 = p['second'] % p['first']
-            assert not result.equals(result2)
-
-            # GH 9144
-            s = Series([0, 1])
-
-            result = s % 0
-            expected = Series([nan, nan])
-            assert_series_equal(result, expected)
-
-            result = 0 % s
-            expected = Series([nan, 0.0])
-            assert_series_equal(result, expected)
-
     @td.skip_if_no_scipy
     def test_corr(self, datetime_series):
         import scipy.stats as stats


### PR DESCRIPTION
Found this while looking at tests for reduction ops.  I'm wondering if we should collect+parametrize those over DataFrame/Series/Index/EA the same way we do for arithmetic.  Thoughts?