### PR TITLE
Increase timeout in hypothesis for test_apply.py

### DIFF
--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -11,7 +11,7 @@ from itertools import chain
 
 import warnings
 import numpy as np
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import composite, dates, integers, sampled_from
 
 from pandas import (notna, DataFrame, Series, MultiIndex, date_range,
@@ -1157,6 +1157,7 @@ class TestDataFrameAggregate():
             df.agg(func, axis=axis)
 
     @given(index=indices(max_length=5), num_columns=integers(0, 5))
+    @settings(deadline=1000)
     def test_frequency_is_original(self, index, num_columns):
         # GH 22150
         original = index.copy()


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`


In this [build](https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=3781&view=logs)

We see the following error:

`
<pandas.tests.frame.test_apply.TestDataFrameAggregate instance at 0x0000000036892A48>, 2018-11-Unreliable test timings! On an initial run, this test took 631.00ms, which exceeded the deadline of 500.00ms, but on a subsequent run it took 3.00 ms, which did not. If you expect this sort of variability in your test timings, consider turning deadlines off for this test by setting deadline=None.
`

Time difference perhaps due to given parameters for the test case, currently this test case uses the default value which is 500ms. Perhaps I could be more aggressive here and go for 800ms, thoughts? 

Issue introduced in [this change](https://github.com/pandas-dev/pandas/pull/22561) 
