### PR TITLE
TST: Test .loc with uint64 numbers

### DIFF
--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -132,6 +132,18 @@ class TestDataFrameIndexing(TestData):
         with pytest.raises(KeyError, match='not in index'):
             frame[idx]
 
+    @pytest.mark.parametrize("val,expected", [
+        (2**63 - 1, Series([1])),
+        (2**63, Series([2])),
+    ])
+    def test_loc_uint64(self, val, expected):
+        # see gh-19399
+        df = DataFrame([1, 2], index=[2**63 - 1, 2**63])
+        result = df.loc[val]
+
+        expected.name = val
+        tm.assert_series_equal(result, expected)
+
     def test_getitem_callable(self):
         # GH 12533
         result = self.frame[lambda x: 'A']

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -11,6 +11,16 @@ from pandas import Series, Timestamp
 from pandas.util.testing import assert_series_equal
 
 
+@pytest.mark.parametrize("val,expected", [
+    (2**63 - 1, 3),
+    (2**63, 4),
+])
+def test_loc_uint64(val, expected):
+    # see gh-19399
+    s = Series({2**63 - 1: 3, 2**63: 4})
+    assert s.loc[val] == expected
+
+
 def test_loc_getitem(test_data):
     inds = test_data.series.index[[3, 4, 7]]
     assert_series_equal(


### PR DESCRIPTION
Closes #19399.