### PR TITLE
DOC: fix DataFrame.nunique docstring and doctests

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -148,7 +148,7 @@ if [[ -z "$CHECK" || "$CHECK" == "doctests" ]]; then
 
     MSG='Doctests frame.py' ; echo $MSG
     pytest -q --doctest-modules pandas/core/frame.py \
-        -k"-axes -combine -itertuples -join -nunique -pivot_table -quantile -query -reindex -reindex_axis -replace -round -set_index -stack"
+        -k"-axes -combine -itertuples -join -pivot_table -quantile -query -reindex -reindex_axis -replace -round -set_index -stack"
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Doctests series.py' ; echo $MSG

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7281,8 +7281,7 @@ class DataFrame(NDFrame):
         """
         Return Series with number of distinct observations.
 
-        Return Series with number of distinct observations over requested
-        axis. Can ignore NaN values.
+        Count distinct observations over requested axis. Can ignore NaN values.
 
         .. versionadded:: 0.20.0
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7279,20 +7279,29 @@ class DataFrame(NDFrame):
 
     def nunique(self, axis=0, dropna=True):
         """
+        Return Series with number of distinct observations.
+
         Return Series with number of distinct observations over requested
-        axis.
+        axis. Can ignore NaN values.
 
         .. versionadded:: 0.20.0
 
         Parameters
         ----------
         axis : {0 or 'index', 1 or 'columns'}, default 0
-        dropna : boolean, default True
+            The axis to use. 0 or 'index' for row-wise, 1 or 'columns' for
+            column-wise.
+        dropna : bool, default True
             Don't include NaN in the counts.
 
         Returns
         -------
         nunique : Series
+
+        See Also
+        --------
+        Series.nunique: Method nunique for Series.
+        DataFrame.count: Count non-NA cells for each column or row.
 
         Examples
         --------
@@ -7300,11 +7309,13 @@ class DataFrame(NDFrame):
         >>> df.nunique()
         A    3
         B    1
+        dtype: int64
 
         >>> df.nunique(axis=1)
         0    1
         1    2
         2    2
+        dtype: int64
         """
         return self.apply(Series.nunique, axis=axis, dropna=dropna)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7279,9 +7279,10 @@ class DataFrame(NDFrame):
 
     def nunique(self, axis=0, dropna=True):
         """
-        Return Series with number of distinct observations.
+        Count distinct observations over requested axis.
 
-        Count distinct observations over requested axis. Can ignore NaN values.
+        Return Series with number of distinct observations. Can ignore NaN
+        values.
 
         .. versionadded:: 0.20.0
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Based on #22459. Fix the docstring for DataFrame.nunique. I also updated `ci/code_checks.sh`.

