### PR TITLE
[Bug] Comparison between two PeriodIndexes doesn't validate length (GH #23078)

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1319,6 +1319,7 @@ Datetimelike
 - Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` where indexing with ``Ellipsis`` would incorrectly lose the index's ``freq`` attribute (:issue:`21282`)
 - Clarified error message produced when passing an incorrect ``freq`` argument to :class:`DatetimeIndex` with ``NaT`` as the first entry in the passed data (:issue:`11587`)
 - Bug in :func:`to_datetime` where ``box`` and ``utc`` arguments were ignored when passing a :class:`DataFrame` or ``dict`` of unit mappings (:issue:`23760`)
+- Bug in :class:`PeriodIndex` when comparing indexes of different lengths, ValueError is not raised (:issue:`23078`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -917,6 +917,10 @@ class ExtensionOpsMixin(object):
         cls.__le__ = cls._create_comparison_method(operator.le)
         cls.__ge__ = cls._create_comparison_method(operator.ge)
 
+    def _validate_shape(self, other):
+        if len(self) != len(other):
+            raise ValueError('Lengths must match to compare')
+
 
 class ExtensionScalarOpsMixin(ExtensionOpsMixin):
     """

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -67,6 +67,9 @@ def _period_array_cmp(cls, op):
         elif isinstance(other, cls):
             self._check_compatible_with(other)
 
+            if other.ndim > 0 and len(self) != len(other):
+                raise ValueError('Lengths must match to compare')
+
             if not_implemented:
                 return NotImplemented
             result = op(other.asi8)

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -67,8 +67,7 @@ def _period_array_cmp(cls, op):
         elif isinstance(other, cls):
             self._check_compatible_with(other)
 
-            if other.ndim > 0 and len(self) != len(other):
-                raise ValueError('Lengths must match to compare')
+            self._validate_shape(other)
 
             if not_implemented:
                 return NotImplemented

--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -119,6 +119,12 @@ class BaseArithmeticOpsTests(BaseOpsUtil):
                 "{} does not implement add".format(data.__class__.__name__)
             )
 
+    def test_arith_diff_lengths(self, data, all_arithmetic_operators):
+        op = self.get_op_from_name(all_arithmetic_operators)
+        other = data[:3]
+        with pytest.raises(ValueError):
+            op(data, other)
+
 
 class BaseComparisonOpsTests(BaseOpsUtil):
     """Various Series and DataFrame comparison ops methods."""
@@ -164,3 +170,9 @@ class BaseComparisonOpsTests(BaseOpsUtil):
             raise pytest.skip(
                 "{} does not implement __eq__".format(data.__class__.__name__)
             )
+
+    def test_compare_diff_lengths(self, data, all_compare_operators):
+        op = self.get_op_from_name(all_compare_operators)
+        other = data[:3]
+        with pytest.raises(ValueError):
+            op(data, other)

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -299,11 +299,12 @@ class TestArithmeticOps(BaseDecimal, base.BaseArithmeticOpsTests):
     def test_error(self):
         pass
 
-    def test_arith_diff_lengths(self):
-        # TODO
-        # Raise ValueError when carrying out arithmetic operation
-        # on two decimal arrays of different lengths
-        pass
+    # TODO
+    # Raise ValueError when carrying out arithmetic operation
+    # on two decimal arrays of different lengths
+    @pytest.mark.xfail(reason="raise of ValueError not implemented")
+    def test_arith_diff_lengths(self, data, all_compare_operators):
+        super().test_arith_diff_lengths(data, all_compare_operators)
 
 
 class TestComparisonOps(BaseDecimal, base.BaseComparisonOpsTests):
@@ -330,10 +331,11 @@ class TestComparisonOps(BaseDecimal, base.BaseComparisonOpsTests):
                                    for i in alter]
         self._compare_other(s, data, op_name, other)
 
-    def test_compare_diff_lengths(self):
-        # TODO:
-        # Raise ValueError when comparing decimal arrays of different lenghts
-        pass
+    # TODO:
+    # Raise ValueError when comparing decimal arrays of different lenghts
+    @pytest.mark.xfail(reason="raise of ValueError not implemented")
+    def test_compare_diff_lengths(self, data, all_compare_operators):
+        super().test_compare_diff_lenths(data, all_compare_operators)
 
 
 class DecimalArrayWithoutFromSequence(DecimalArray):

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -299,6 +299,12 @@ class TestArithmeticOps(BaseDecimal, base.BaseArithmeticOpsTests):
     def test_error(self):
         pass
 
+    def test_arith_diff_lengths(self):
+        # TODO
+        # Raise ValueError when carrying out arithmetic operation
+        # on two decimal arrays of different lengths
+        pass
+
 
 class TestComparisonOps(BaseDecimal, base.BaseComparisonOpsTests):
 
@@ -323,6 +329,11 @@ class TestComparisonOps(BaseDecimal, base.BaseComparisonOpsTests):
         other = pd.Series(data) * [decimal.Decimal(pow(2.0, i))
                                    for i in alter]
         self._compare_other(s, data, op_name, other)
+
+    def test_compare_diff_lengths(self):
+        # TODO:
+        # Raise ValueError when comparing decimal arrays of different lenghts
+        pass
 
 
 class DecimalArrayWithoutFromSequence(DecimalArray):

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -291,9 +291,13 @@ class TestArithmeticOps(BaseJSON, base.BaseArithmeticOpsTests):
             s, op, other, exc=TypeError
         )
 
+    def test_arith_diff_lengths(self):
+        pass
+
 
 class TestComparisonOps(BaseJSON, base.BaseComparisonOpsTests):
-    pass
+    def test_compare_diff_lengths(self):
+        pass
 
 
 class TestPrinting(BaseJSON, base.BasePrintingTests):

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -215,6 +215,9 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
             s, op, other, exc=TypeError
         )
 
+    def test_arith_diff_lengths(self):
+        pass
+
 
 class TestComparisonOps(base.BaseComparisonOpsTests):
 
@@ -233,3 +236,11 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         else:
             with pytest.raises(TypeError):
                 op(data, other)
+
+    @pytest.mark.parametrize('op_name',
+                             ['__eq__', '__ne__'])
+    def test_compare_diff_lengths(self, data, op_name):
+        op = self.get_op_from_name(op_name)
+        other = data[:3]
+        with pytest.raises(ValueError):
+            op(data, other)

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -153,7 +153,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     def _compare_other(self, s, data, op_name, other):
         self.check_opname(s, op_name, other)
 
-    @pytest.mark.filterwarnings("ignore:DeprecationWarning")
+    @pytest.mark.filterwarnings("ignore:elementwise:DeprecationWarning")
     def test_compare_diff_lengths(self, data, all_compare_operators):
         op = self.get_op_from_name(all_compare_operators)
         other = data[:3]

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -153,6 +153,13 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     def _compare_other(self, s, data, op_name, other):
         self.check_opname(s, op_name, other)
 
+    @pytest.mark.filterwarnings("ignore:DeprecationWarning")
+    def test_compare_diff_lengths(self, data, all_compare_operators):
+        op = self.get_op_from_name(all_compare_operators)
+        other = data[:3]
+        with pytest.raises(ValueError):
+            op(data, other)
+
 
 class TestInterface(base.BaseInterfaceTests):
     pass

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -119,6 +119,12 @@ class TestArithmeticOps(BasePeriodTests, base.BaseArithmeticOpsTests):
     def test_error(self):
         pass
 
+    def test_arith_diff_lengths(self, data):
+        op = self.get_op_from_name('__sub__')
+        other = data[:3]
+        with pytest.raises(ValueError):
+            op(data, other)
+
     def test_direct_arith_with_series_returns_not_implemented(self, data):
         # Override to use __sub__ instead of __add__
         other = pd.Series(data)

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -321,6 +321,17 @@ class TestArithmeticOps(BaseSparseTests, base.BaseArithmeticOpsTests):
             all_arithmetic_operators
         )
 
+    def test_arith_diff_lengths(self, data, all_arithmetic_operators):
+        from pandas.core.dtypes.common import is_float_dtype
+
+        if is_float_dtype(data):
+            op = self.get_op_from_name(all_arithmetic_operators)
+            other = data[:3]
+            with pytest.raises(ValueError):
+                op(data, other)
+        else:
+            pass
+
 
 class TestComparisonOps(BaseSparseTests, base.BaseComparisonOpsTests):
 
@@ -347,6 +358,17 @@ class TestComparisonOps(BaseSparseTests, base.BaseComparisonOpsTests):
         s = pd.Series(data)
         result = op(s, other)
         tm.assert_series_equal(result, expected)
+
+    def test_compare_diff_lengths(self, data, all_compare_operators):
+        from pandas.core.dtypes.common import is_float_dtype
+
+        if is_float_dtype(data):
+            op = self.get_op_from_name(all_compare_operators)
+            other = data[:3]
+            with pytest.raises(ValueError):
+                op(data, other)
+        else:
+            pass
 
 
 class TestPrinting(BaseSparseTests, base.BasePrintingTests):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -555,6 +555,12 @@ class TestPeriodIndex(DatetimeLike):
             result = period_range('2017Q1', periods=4, freq='Q').insert(1, na)
             tm.assert_index_equal(result, expected)
 
+    def test_comp_op(self):
+        # GH 23078
+        index = period_range('2017', periods=12, freq="A-DEC")
+        with pytest.raises(ValueError, match="Lengths must match"):
+            index <= index[[0]]
+
 
 def test_maybe_convert_timedelta():
     pi = PeriodIndex(['2000', '2001'], freq='D')


### PR DESCRIPTION
- [x] closes #23078
- [x] tests added
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
