### PR TITLE
Fix the docstring of xs in pandas/core/generic.py #22892 

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3310,14 +3310,14 @@ class NDFrame(PandasObject, SelectionMixin):
         Examples
         --------
         >>> df = pd.DataFrame({"num_legs": [4, 4, 2],
-        ...                    "num_arms": [0, 0, 2],
+        ...                    "num_arms": [0, 0, 0],
         ...                    "num_wings": [0, 0, 2]},
         ...                   ["dog", "cat", "duck"])
         >>> df
               num_legs  num_arms  num_wings
         dog          4         0          0
         cat          4         0          0
-        duck         2         2          2
+        duck         2         0          2
         >>> df.xs('dog')
         num_legs     4
         num_arms     0

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3270,23 +3270,40 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def xs(self, key, axis=0, level=None, drop_level=True):
         """
-        Returns a cross-section (row(s) or column(s)) from the
-        Series/DataFrame. Defaults to cross-section on the rows (axis=0).
+        Return cross-section from the Series/DataFrame.
+
+        Returns a cross-section (row(s) or column(s))
+        from the Series/DataFrame.
+        Defaults to cross-section on the rows (axis=0).
 
         Parameters
         ----------
         key : object
-            Some label contained in the index, or partially in a MultiIndex
+            Some label contained in the index, or partially in a MultiIndex.
         axis : int, default 0
-            Axis to retrieve cross-section on
+            Axis to retrieve cross-section on.
         level : object, defaults to first n levels (n=1 or len(key))
             In case of a key partially contained in a MultiIndex, indicate
             which levels are used. Levels can be referred by label or position.
-        drop_level : boolean, default True
+        drop_level : bool, default True
             If False, returns object with same levels as self.
+
+        Returns
+        -------
+        xs : Series or DataFrame
+
+        Notes
+        -----
+        xs is only for getting, not setting values.
+
+        MultiIndex Slicers is a generic way to get/set values on any level or
+        levels.  It is a superset of xs functionality, see
+        :ref:`MultiIndex Slicers <advanced.mi_slicers>`
 
         Examples
         --------
+        >>> d = {'A': [4, 4, 9], 'B': [5, 0, 7], 'C': [2, 9, 3]}
+        >>> df = pd.DataFrame(data=d, index=['a', 'b', 'c'])
         >>> df
            A  B  C
         a  4  5  2
@@ -3296,13 +3313,21 @@ class NDFrame(PandasObject, SelectionMixin):
         A    4
         B    5
         C    2
-        Name: a
+        Name: a, dtype: int64
         >>> df.xs('C', axis=1)
         a    2
         b    9
         c    3
-        Name: C
-
+        Name: C, dtype: int64
+        >>> d = {'A': [4, 7, 6, 5],
+        ...      'B': [1, 5, 6, 3],
+        ...      'C': [8, 5, 8, 5],
+        ...      'D': [9, 0, 0, 3],
+        ...      'first': ['bar', 'bar', 'baz', 'baz'],
+        ...      'second': ['one', 'two', 'one', 'three'],
+        ...      'third': [1, 1, 1, 2]}
+        >>> df = pd.DataFrame(data=d)
+        >>> df = df.set_index(['first', 'second', 'third'])
         >>> df
                             A  B  C  D
         first second third
@@ -3323,18 +3348,6 @@ class NDFrame(PandasObject, SelectionMixin):
                 A  B  C  D
         second
         three   5  3  5  3
-
-        Returns
-        -------
-        xs : Series or DataFrame
-
-        Notes
-        -----
-        xs is only for getting, not setting values.
-
-        MultiIndex Slicers is a generic way to get/set values on any level or
-        levels.  It is a superset of xs functionality, see
-        :ref:`MultiIndex Slicers <advanced.mi_slicers>`
         """
         axis = self._get_axis_number(axis)
         labels = self._get_axis(axis)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3278,9 +3278,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        key : object
+        key : label
             Some label contained in the index, or partially in a MultiIndex.
-        axis : int, default 0
+        axis : {0 or 'index', 1 or 'columns'}, default 0
             Axis to retrieve cross-section on.
         level : object, defaults to first n levels (n=1 or len(key))
             In case of a key partially contained in a MultiIndex, indicate

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3272,12 +3272,12 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Return cross-section from the Series/DataFrame.
 
-        This methode takes a level argument to select data at a particular
-        level of a MultiIndex easier.
+        This method takes a `key` argument to select data at a particular
+        level of a MultiIndex.
 
         Parameters
         ----------
-        key : label or tuple of label, e.g. ['a', 'b', 'c']
+        key : label or tuple of label
             Label contained in the index, or partially in a MultiIndex.
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Axis to retrieve cross-section on.
@@ -3289,8 +3289,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        Series or DataFrame of the cross-section (row(s) or column(s)) from
-        the original Series/DataFrame.
+        Series or DataFrame
+            Cross-section from the original Series or DataFrame
+            corresponding to the selected index levels.
 
         See Also
         --------
@@ -3303,8 +3304,9 @@ class NDFrame(PandasObject, SelectionMixin):
         -----
         `xs` can not be used to set values.
 
-        MultiIndex Slicers is a generic way to get/set values on any level or
-        levels.  It is a superset of `xs` functionality, see
+        MultiIndex Slicers is a generic way to get/set values on
+        any level or levels.
+        It is a superset of `xs` functionality, see
         :ref:`MultiIndex Slicers <advanced.mi_slicers>`.
 
         Examples
@@ -3323,23 +3325,40 @@ class NDFrame(PandasObject, SelectionMixin):
                dog     walks              4          0
                bat     flies              2          2
         bird   penguin walks              2          2
+
+        Get values at specified index
+
         >>> df.xs('mammal')
                            num_legs  num_wings
         animal locomotion
         cat    walks              4          0
         dog    walks              4          0
         bat    flies              2          2
-        >>> df.xs('num_wings', axis=1)
-        class   animal   locomotion
-        mammal  cat      walks         0
-                dog      walks         0
-                bat      flies         2
-        bird    penguin  walks         2
-        Name: num_wings, dtype: int64
+
+        Get values at several indexes
+
         >>> df.xs(('mammal', 'dog'))
                     num_legs  num_wings
         locomotion
         walks              4          0
+
+        Get values at specified index and level
+
+        >>> df.xs('cat', level=1)
+                           num_legs  num_wings
+        class  locomotion
+        mammal walks              4          0
+
+        Get values at several indexes and levels
+
+        >>> df.xs(('bird', 'walks'),
+        ...       level=[0, 'locomotion'])
+                 num_legs  num_wings
+        animal
+        penguin         2          2
+
+        Get values at specified column and axis
+
         >>> df.xs('num_wings', axis=1)
         class   animal   locomotion
         mammal  cat      walks         0
@@ -3347,18 +3366,6 @@ class NDFrame(PandasObject, SelectionMixin):
                 bat      flies         2
         bird    penguin  walks         2
         Name: num_wings, dtype: int64
-        >>> df.xs(('mammal', 'bat'))
-                    num_legs  num_wings
-        locomotion
-        flies              2          2
-        >>> df.xs('cat', level=1)
-                           num_legs  num_wings
-        class  locomotion
-        mammal walks              4          0
-        >>> df.xs(('bird', 'walks'), level=[0, 'locomotion'])
-                 num_legs  num_wings
-        animal
-        penguin         2          2
         """
         axis = self._get_axis_number(axis)
         labels = self._get_axis(axis)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3290,64 +3290,72 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        xs : Series or DataFrame
+        Series or DataFrame
+
+        See Also
+        --------
+        DataFrame.loc : Access a group of rows and columns
+                        by label(s) or a boolean array.
+        DataFrame.iloc : Purely integer-location based indexing
+                         for selection by position.
 
         Notes
         -----
-        xs is only for getting, not setting values.
+        'xs' can not be used to set values.
 
         MultiIndex Slicers is a generic way to get/set values on any level or
-        levels.  It is a superset of xs functionality, see
-        :ref:`MultiIndex Slicers <advanced.mi_slicers>`
+        levels.  It is a superset of 'xs' functionality, see
+        :ref:`MultiIndex Slicers <advanced.mi_slicers>`.
 
         Examples
         --------
-        >>> d = {'A': [4, 4, 9], 'B': [5, 0, 7], 'C': [2, 9, 3]}
-        >>> df = pd.DataFrame(data=d, index=['a', 'b', 'c'])
+        >>> df = pd.DataFrame({"num_legs": [4, 4, 2],
+        ...                    "num_arms": [0, 0, 2],
+        ...                    "num_wings": [0, 0, 2]},
+        ...                   ["dog", "cat", "duck"])
         >>> df
-           A  B  C
-        a  4  5  2
-        b  4  0  9
-        c  9  7  3
-        >>> df.xs('a')
-        A    4
-        B    5
-        C    2
-        Name: a, dtype: int64
-        >>> df.xs('C', axis=1)
-        a    2
-        b    9
-        c    3
-        Name: C, dtype: int64
-        >>> d = {'A': [4, 7, 6, 5],
-        ...      'B': [1, 5, 6, 3],
-        ...      'C': [8, 5, 8, 5],
-        ...      'D': [9, 0, 0, 3],
-        ...      'first': ['bar', 'bar', 'baz', 'baz'],
-        ...      'second': ['one', 'two', 'one', 'three'],
-        ...      'third': [1, 1, 1, 2]}
+              num_legs  num_arms  num_wings
+        dog          4         0          0
+        cat          4         0          0
+        duck         2         2          2
+        >>> df.xs('dog')
+        num_legs     4
+        num_arms     0
+        num_wings    0
+        Name: dog, dtype: int64
+        >>> df.xs('num_wings', axis=1)
+        dog     0
+        cat     0
+        duck    2
+        Name: num_wings, dtype: int64
+        >>> d = {'num_legs': [4, 4, 2, 4],
+        ...      'num_arms': [0, 0, 0, 0],
+        ...      'num_wings': [0, 0, 2, 0],
+        ...      'num_spec_seen': [9, 2, 7, 3],
+        ...      'class': ['mammal', 'mammal', 'sauropsida', 'sauropsida'],
+        ...      'animal': ['cat', 'dog', 'duck', 'turtle'],
+        ...      'area': [1, 1, 2, 3]}
         >>> df = pd.DataFrame(data=d)
-        >>> df = df.set_index(['first', 'second', 'third'])
+        >>> df = df.set_index(['class', 'animal', 'area'])
         >>> df
-                            A  B  C  D
-        first second third
-        bar   one    1      4  1  8  9
-              two    1      7  5  5  0
-        baz   one    1      6  6  8  0
-              three  2      5  3  5  3
-        >>> df.xs(('baz', 'three'))
-               A  B  C  D
-        third
-        2      5  3  5  3
-        >>> df.xs('one', level=1)
-                     A  B  C  D
-        first third
-        bar   1      4  1  8  9
-        baz   1      6  6  8  0
-        >>> df.xs(('baz', 2), level=[0, 'third'])
-                A  B  C  D
-        second
-        three   5  3  5  3
+                                num_legs  num_arms  num_wings  num_spec_seen
+        class      animal area
+        mammal     cat    1            4         0          0              9
+                   dog    1            4         0          0              2
+        sauropsida duck   2            2         0          2              7
+                   turtle 3            4         0          0              3
+        >>> df.xs(('mammal', 'dog'))
+              num_legs  num_arms  num_wings  num_spec_seen
+        area
+        1            4         0          0              2
+        >>> df.xs('cat', level=1)
+                     num_legs  num_arms  num_wings  num_spec_seen
+        class  area
+        mammal 1            4         0          0              9
+        >>> df.xs(('sauropsida', 2), level=[0, 'area'])
+                num_legs  num_arms  num_wings  num_spec_seen
+        animal
+        duck           2         0          2              7
         """
         axis = self._get_axis_number(axis)
         labels = self._get_axis(axis)


### PR DESCRIPTION
- [X] closes #22892
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Hello @datapythonista !
As requested in #22892 , I corrected the docstring of the pandas/core/generic.py xs function to pass correctly the following command :

    ./scripts/validate_docstrings.py pandas.Series.xs

And I also validate the PEP-8 according to : 

    flake8 --doctests pandas/core/generic.py

Is it ok for you ?
