### PR TITLE
DOC: fix DataFrame.replace and DataFrame.set_index docstrings

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -147,7 +147,7 @@ if [[ -z "$CHECK" || "$CHECK" == "doctests" ]]; then
 
     MSG='Doctests frame.py' ; echo $MSG
     pytest -q --doctest-modules pandas/core/frame.py \
-        -k"-axes -combine -itertuples -join -pivot_table -quantile -query -reindex -reindex_axis -replace -round -set_index -stack"
+        -k"-axes -combine -itertuples -join -pivot_table -quantile -query -reindex -reindex_axis -round"
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Doctests series.py' ; echo $MSG

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3955,10 +3955,6 @@ class DataFrame(NDFrame):
         DataFrame.reindex : Change to new indices or expand indices.
         DataFrame.reindex_like : Change to same indices as other DataFrame.
 
-        Returns
-        -------
-        DataFrame
-
         Examples
         --------
         >>> df = pd.DataFrame({'month': [1, 4, 7, 10],

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5949,7 +5949,7 @@ class NDFrame(PandasObject, SelectionMixin):
             value to use for each column (columns not in the dict will not be
             filled). Regular expressions, strings and lists or dicts of such
             objects are also allowed.
-        inplace : boolean, default False
+        inplace : bool, default False
             If True, in place. Note: this will modify any
             other views on this object (e.g. a column from a DataFrame).
             Returns the caller if this is True.
@@ -5967,12 +5967,6 @@ class NDFrame(PandasObject, SelectionMixin):
 
             .. versionchanged:: 0.23.0
                 Added to DataFrame.
-
-        See Also
-        --------
-        %(klass)s.fillna : Fill NA values.
-        %(klass)s.where : Replace values based on boolean condition.
-        Series.str.replace : Simple string replacement.
 
         Returns
         -------
@@ -5996,6 +5990,12 @@ class NDFrame(PandasObject, SelectionMixin):
         ValueError
             * If a ``list`` or an ``ndarray`` is passed to `to_replace` and
               `value` but they are not the same length.
+
+        See Also
+        --------
+        %(klass)s.fillna : Fill NA values.
+        %(klass)s.where : Replace values based on boolean condition.
+        Series.str.replace : Simple string replacement.
 
         Notes
         -----
@@ -6111,7 +6111,7 @@ class NDFrame(PandasObject, SelectionMixin):
         1   foo  new
         2  bait  xyz
 
-        >>> df.replace(regex={r'^ba.$':'new', 'foo':'xyz'})
+        >>> df.replace(regex={r'^ba.$': 'new', 'foo': 'xyz'})
               A    B
         0   new  abc
         1   xyz  new


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Based on #22459. Fix the docstring for DataFrame.replace and DataFrame.set_index. I put them together since set_index was quite simple: there was two Returns sections.

I also updated ci/code_checks.sh. DataFrame.stack was already correct.
