### PR TITLE
BUG: Fix lxml import in show_versions

### DIFF
--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -3,6 +3,7 @@ import codecs
 from collections import OrderedDict
 import locale
 import os
+import subprocess
 import sys
 from uuid import uuid4
 
@@ -530,3 +531,10 @@ def test_safe_import(monkeypatch):
     monkeypatch.setitem(sys.modules, mod_name, mod)
     assert not td.safe_import(mod_name, min_version="2.0")
     assert td.safe_import(mod_name, min_version="1.0")
+
+
+def test_lxml_import():
+    # See GH 23934
+    # lxml does not have attribute etree exception should not be thrown
+    subprocess.check_call([sys.executable, "-c",
+                           "import pandas; pandas.show_versions()"])

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -3,7 +3,6 @@ import codecs
 from collections import OrderedDict
 import locale
 import os
-import subprocess
 import sys
 from uuid import uuid4
 

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -531,10 +531,3 @@ def test_safe_import(monkeypatch):
     monkeypatch.setitem(sys.modules, mod_name, mod)
     assert not td.safe_import(mod_name, min_version="2.0")
     assert td.safe_import(mod_name, min_version="1.0")
-
-
-def test_lxml_import():
-    # See GH 23934
-    # lxml does not have attribute etree exception should not be thrown
-    subprocess.check_call([sys.executable, "-c",
-                           "import pandas; pandas.show_versions()"])

--- a/pandas/util/_print_versions.py
+++ b/pandas/util/_print_versions.py
@@ -85,7 +85,7 @@ def show_versions(as_json=False):
         ("xlrd", lambda mod: mod.__VERSION__),
         ("xlwt", lambda mod: mod.__VERSION__),
         ("xlsxwriter", lambda mod: mod.__version__),
-        ("lxml", lambda mod: mod.etree.__version__),
+        ("lxml.etree", lambda mod: mod.__version__),
         ("bs4", lambda mod: mod.__version__),
         ("html5lib", lambda mod: mod.__version__),
         ("sqlalchemy", lambda mod: mod.__version__),


### PR DESCRIPTION
Fixed lxml import issue

- [x] closes #23934
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`