### PR TITLE
GH20591 read_csv raise ValueError for bool columns with missing values (C engine)

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -330,7 +330,7 @@ Backwards incompatible API changes
 - :meth:`Series.str.cat` will now raise if `others` is a `set` (:issue:`23009`)
 - Passing scalar values to :class:`DatetimeIndex` or :class:`TimedeltaIndex` will now raise ``TypeError`` instead of ``ValueError`` (:issue:`23539`)
 - ``max_rows`` and ``max_cols`` parameters removed from :class:`HTMLFormatter` since truncation is handled by :class:`DataFrameFormatter` (:issue:`23818`)
-- :meth:`read_csv` with C engine will now throw a ``ValueError`` if a column with missing values is declared as having ``dtype`` ``bool`` (:issue:`20591`)
+- :meth:`read_csv` will now throw a ``ValueError`` if a column with missing values is declared as having dtype ``bool`` (:issue:`20591`)
 
 .. _whatsnew_0240.api_breaking.deps:
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -330,7 +330,7 @@ Backwards incompatible API changes
 - :meth:`Series.str.cat` will now raise if `others` is a `set` (:issue:`23009`)
 - Passing scalar values to :class:`DatetimeIndex` or :class:`TimedeltaIndex` will now raise ``TypeError`` instead of ``ValueError`` (:issue:`23539`)
 - ``max_rows`` and ``max_cols`` parameters removed from :class:`HTMLFormatter` since truncation is handled by :class:`DataFrameFormatter` (:issue:`23818`)
-- :meth:`read_csv` will now throw a ``ValueError`` if a column with missing values is declared as having ``dtype`` ``bool`` (:issue:`20591`)
+- :meth:`read_csv` with C engine will now throw a ``ValueError`` if a column with missing values is declared as having ``dtype`` ``bool`` (:issue:`20591`)
 
 .. _whatsnew_0240.api_breaking.deps:
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -330,6 +330,7 @@ Backwards incompatible API changes
 - :meth:`Series.str.cat` will now raise if `others` is a `set` (:issue:`23009`)
 - Passing scalar values to :class:`DatetimeIndex` or :class:`TimedeltaIndex` will now raise ``TypeError`` instead of ``ValueError`` (:issue:`23539`)
 - ``max_rows`` and ``max_cols`` parameters removed from :class:`HTMLFormatter` since truncation is handled by :class:`DataFrameFormatter` (:issue:`23818`)
+- :meth:`read_csv` will now throw a ``ValueError`` if a column with missing values is declared as having ``dtype`` ``bool`` (:issue:`20591`)
 
 .. _whatsnew_0240.api_breaking.deps:
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -330,7 +330,7 @@ Backwards incompatible API changes
 - :meth:`Series.str.cat` will now raise if `others` is a `set` (:issue:`23009`)
 - Passing scalar values to :class:`DatetimeIndex` or :class:`TimedeltaIndex` will now raise ``TypeError`` instead of ``ValueError`` (:issue:`23539`)
 - ``max_rows`` and ``max_cols`` parameters removed from :class:`HTMLFormatter` since truncation is handled by :class:`DataFrameFormatter` (:issue:`23818`)
-- :meth:`read_csv` will now throw a ``ValueError`` if a column with missing values is declared as having dtype ``bool`` (:issue:`20591`)
+- :meth:`read_csv` will now raise a ``ValueError`` if a column with missing values is declared as having dtype ``bool`` (:issue:`20591`)
 
 .. _whatsnew_0240.api_breaking.deps:
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1245,6 +1245,10 @@ cdef class TextReader:
             result, na_count = _try_bool_flex(self.parser, i, start, end,
                                               na_filter, na_hashset,
                                               self.true_set, self.false_set)
+            if user_dtype and na_count is not None:
+                if na_count > 0:
+                    raise ValueError("Bool column has NA values in "
+                                     "column {column}".format(column=i))
             return result, na_count
 
         elif dtype.kind == 'S':

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1672,7 +1672,7 @@ class ParserBase(object):
                     try:
                         if (is_bool_dtype(cast_type) and
                                 not is_categorical_dtype(cast_type)
-                                and na_count > 0):
+                                and na_count):
                             raise ValueError("Bool column has NA values in "
                                              "column {column}"
                                              .format(column=c))

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1672,7 +1672,7 @@ class ParserBase(object):
                     try:
                         if (is_bool_dtype(cast_type) and
                                 not is_categorical_dtype(cast_type)
-                                and set(values) - set(col_na_values)):
+                                and na_count > 0):
                             raise ValueError("Bool column has NA values in "
                                              "column {column}"
                                              .format(column=c))

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1672,7 +1672,7 @@ class ParserBase(object):
                     try:
                         if (is_bool_dtype(cast_type) and
                                 not is_categorical_dtype(cast_type)
-                                and na_count):
+                                and na_count > 0):
                             raise ValueError("Bool column has NA values in "
                                              "column {column}"
                                              .format(column=c))

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2441,7 +2441,8 @@ class PythonParser(ParserBase):
                     if is_bool_dtype(dt) and data[col][data[col] == ''].size:
                         raise ValueError("Bool column has NA values in "
                                          "column {column}".format(column=col))
-            elif isinstance(clean_dtypes, string_types):
+            elif (isinstance(clean_dtypes, string_types) and
+                  is_bool_dtype(clean_dtypes)):
                 for col, values in data.items():
                     if any(isna(values)):
                         raise ValueError("Bool column has NA values in "

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -27,9 +27,9 @@ from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.cast import astype_nansafe
 from pandas.core.dtypes.common import (
-    ensure_object, is_categorical_dtype, is_dtype_equal, is_float, is_integer,
-    is_integer_dtype, is_list_like, is_object_dtype, is_scalar,
-    is_string_dtype)
+    ensure_object, is_bool_dtype, is_categorical_dtype, is_dtype_equal,
+    is_float, is_integer, is_integer_dtype, is_list_like, is_object_dtype,
+    is_scalar, is_string_dtype)
 from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.core.dtypes.missing import isna
 
@@ -2434,6 +2434,20 @@ class PythonParser(ParserBase):
         else:
             clean_na_values = self.na_values
             clean_na_fvalues = self.na_fvalues
+
+        try:
+            if isinstance(clean_dtypes, dict):
+                for col, dt in clean_dtypes.items():
+                    if is_bool_dtype(dt) and data[col][data[col] == ''].size:
+                        raise ValueError("Bool column has NA values in "
+                                         "column {column}".format(column=col))
+            elif isinstance(clean_dtypes, string_types):
+                for col, values in data.items():
+                    if any(isna(values)):
+                        raise ValueError("Bool column has NA values in "
+                                         "column {column}".format(column=col))
+        except (AttributeError, TypeError):  # invalid input to is_bool_dtype
+            pass
 
         return self._convert_to_ndarrays(data, clean_na_values,
                                          clean_na_fvalues, self.verbose,

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -421,3 +421,12 @@ def test_na_values_with_dtype_str_and_na_filter(all_parsers, na_filter):
 
     result = parser.read_csv(StringIO(data), na_filter=na_filter, dtype=str)
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.xfail
+def test_cast_NA_to_bool_raises_error(all_parsers):
+    parser = all_parsers
+    data = "false,1\n,1\ntrue,"
+
+    parser.read_csv(StringIO(data), header=None, names=['a', 'b'],
+                    dtype={'a': 'bool'})

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -431,8 +431,8 @@ def test_na_values_with_dtype_str_and_na_filter(all_parsers, na_filter):
 def test_cast_NA_to_bool_raises_error(all_parsers, data):
     parser = all_parsers
     msg = ("(Bool column has NA values in column [0a])|"
-            "(cannot safely convert passed user dtype of "
-            " bool for object dtyped data in column 0)")
+           "(cannot safely convert passed user dtype of "
+           " bool for object dtyped data in column 0)")
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), header=None, names=['a', 'b'],
                         dtype={'a': 'bool'})

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -423,10 +423,16 @@ def test_na_values_with_dtype_str_and_na_filter(all_parsers, na_filter):
     tm.assert_frame_equal(result, expected)
 
 
-def test_cast_NA_to_bool_raises_error(all_parsers):
+@pytest.mark.parametrize("data", [
+    "false,1\n,1\ntrue,",
+    "false,1\nnull,1\ntrue,",
+    "false,1\nnan,1\ntrue,",
+])
+def test_cast_NA_to_bool_raises_error(all_parsers, data):
     parser = all_parsers
-    data = "false,1\n,1\ntrue,"
-    msg = "Bool column has NA values in column [0a]"
+    msg = ("(Bool column has NA values in column [0a])|"
+            "(cannot safely convert passed user dtype of "
+            " bool for object dtyped data in column 0)")
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), header=None, names=['a', 'b'],
                         dtype={'a': 'bool'})

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -423,16 +423,19 @@ def test_na_values_with_dtype_str_and_na_filter(all_parsers, na_filter):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("data", [
-    "false,1\n,1\ntrue,",
-    "false,1\nnull,1\ntrue,",
-    "false,1\nnan,1\ntrue,",
+@pytest.mark.parametrize("data, na_values", [
+    ("false,1\n,1\ntrue", None),
+    ("false,1\nnull,1\ntrue", None),
+    ("false,1\nnan,1\ntrue", None),
+    ("false,1\nfoo,1\ntrue", 'foo'),
+    ("false,1\nfoo,1\ntrue", ['foo']),
+    ("false,1\nfoo,1\ntrue", {'a': 'foo'}),
 ])
-def test_cast_NA_to_bool_raises_error(all_parsers, data):
+def test_cast_NA_to_bool_raises_error(all_parsers, data, na_values):
     parser = all_parsers
     msg = ("(Bool column has NA values in column [0a])|"
            "(cannot safely convert passed user dtype of "
-           " bool for object dtyped data in column 0)")
+           "bool for object dtyped data in column 0)")
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), header=None, names=['a', 'b'],
-                        dtype={'a': 'bool'})
+                        dtype={'a': 'bool'}, na_values=na_values)

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -423,10 +423,10 @@ def test_na_values_with_dtype_str_and_na_filter(all_parsers, na_filter):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail
-def test_cast_NA_to_bool_raises_error(all_parsers):
-    parser = all_parsers
+def test_cast_NA_to_bool_raises_error(c_parser_only):
+    parser = c_parser_only
     data = "false,1\n,1\ntrue,"
-
-    parser.read_csv(StringIO(data), header=None, names=['a', 'b'],
-                    dtype={'a': 'bool'})
+    msg = "Bool column has NA values in column 0"
+    with pytest.raises(ValueError, match=msg):
+        parser.read_csv(StringIO(data), header=None, names=['a', 'b'],
+                        dtype={'a': 'bool'})

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -423,10 +423,10 @@ def test_na_values_with_dtype_str_and_na_filter(all_parsers, na_filter):
     tm.assert_frame_equal(result, expected)
 
 
-def test_cast_NA_to_bool_raises_error(c_parser_only):
-    parser = c_parser_only
+def test_cast_NA_to_bool_raises_error(all_parsers):
+    parser = all_parsers
     data = "false,1\n,1\ntrue,"
-    msg = "Bool column has NA values in column 0"
+    msg = "Bool column has NA values in column [0a]"
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), header=None, names=['a', 'b'],
                         dtype={'a': 'bool'})


### PR DESCRIPTION
- [X] closes #20591
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

As explained in the referenced issue, trying to cast missing values to bool dtype should result in a ValueError similar to when casting to int