### PR TITLE
CLN: keyerror in versioneer error message

### DIFF
--- a/pandas/_version.py
+++ b/pandas/_version.py
@@ -238,14 +238,14 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         # tag
         full_tag = mo.group(1)
         if not full_tag.startswith(tag_prefix):
+            fmt = ("tag '{full_tag}' doesn't start with prefix "
+                   "'{tag_prefix}'")
+            msg = fmt.format(full_tag=full_tag, tag_prefix=tag_prefix)
             if verbose:
-                fmt = "tag '{full_tag}' doesn't start with prefix " \
-                      "'{tag_prefix}'"
-                print(fmt.format(full_tag=full_tag, tag_prefix=tag_prefix))
-            pieces["error"] = ("tag '{full_tag}' doesn't start with "
-                               "prefix '{tag_prefix}'".format(
-                                   full_tag, tag_prefix))
+                print(msg)
+            pieces["error"] = msg
             return pieces
+
         pieces["closest-tag"] = full_tag[len(tag_prefix):]
 
         # distance: number of commits since tag


### PR DESCRIPTION
broken formatting code from the cleanup in #18010

Not sure if this can be realistically tested - something weird in my local git causing tags to not come through - only impacts dev version reporting.

before:
```python-tb
import pandas as pd  # import fails 

~\Documents\python-dev\pandas\pandas\__init__.py in <module>
     53 # use the closest tagged version if possible
     54 from ._version import get_versions
---> 55 v = get_versions()
     56 __version__ = v.get('closest-tag', v['version'])
     57 __git_version__ = v.get('full-revisionid')

~\Documents\python-dev\pandas\pandas\_version.py in get_versions()
    451
    452     try:
--> 453         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
    454         return render(pieces, cfg.style)
    455     except NotThisMethod:

~\Documents\python-dev\pandas\pandas\_version.py in git_pieces_from_vcs(tag_prefix, root, verbose, run_command)
    245             pieces["error"] = ("tag '{full_tag}' doesn't start with "
    246                                "prefix '{tag_prefix}'".format(
--> 247                                    full_tag, tag_prefix))
    248             return pieces
    249         pieces["closest-tag"] = full_tag[len(tag_prefix):]

KeyError: 'full_tag'
```

after:
```python
import pandas as pd

In [1]: pd.__version__
Out[1]: 'unknown'

In [2]: pd._version.get_versions()
Out[2]:
{'version': 'unknown',
 'full-revisionid': 'eb42b01f687438953cb4bb450205ff23b402bc1c',
 'dirty': None,
 'error': "tag 'list' doesn't start with prefix 'v'"}
```

