### PR TITLE
Fix build by removing flake8-rst

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -46,11 +46,11 @@ if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
     flake8 pandas/_libs --filename=*.pxi.in,*.pxd --select=E501,E302,E203,E111,E114,E221,E303,E231,E126,F403
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
-    echo "flake8-rst --version"
-    flake8-rst --version
+    #echo "flake8-rst --version"
+    #flake8-rst --version
 
-    MSG='Linting code-blocks in .rst documentation' ; echo $MSG
-    flake8-rst doc/source --filename=*.rst
+    MSG='(SKIPPING) Linting code-blocks in .rst documentation' ; echo $MSG
+    #flake8-rst doc/source --filename=*.rst
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     # Check that cython casting is of the form `<type>obj` as opposed to `<type> obj`;

--- a/ci/deps/travis-36.yaml
+++ b/ci/deps/travis-36.yaml
@@ -9,7 +9,6 @@ dependencies:
   - fastparquet
   - flake8>=3.5
   - flake8-comprehensions
-  - flake8-rst=0.4.2
   - gcsfs
   - geopandas
   - html5lib

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
   - Cython>=0.28.2
   - flake8
   - flake8-comprehensions
-  - flake8-rst=0.4.2
   - gitpython
   - hypothesis>=3.58.0
   - isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ pytz
 Cython>=0.28.2
 flake8
 flake8-comprehensions
-flake8-rst==0.4.2
 gitpython
 hypothesis>=3.58.0
 isort


### PR DESCRIPTION
Seems like `flake8-rst==0.4.2` is not available in conda anymore. This is making the Travis build fail. Newer versions of `flake8-rst` are not usable yet, as they validate more things than `0.4.2` and validating our docs would fail the CI too.

We're working on fixing all the flake8-rst linting problems in the docs, and soon we'll be able to upgrade to a newer version. But for now, I think removing `flake8-rst` from the dependencies, and disabling the docs validation in the CI is the best, so Travis builds pass again.

CC: @jreback @FHaase 