### PR TITLE
bug fix: parameter name changed to use_threads in read_feather

### DIFF
--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -116,6 +116,6 @@ def read_feather(path, use_threads=True):
         int_use_threads = int(use_threads)
         if int_use_threads < 1:
             int_use_threads = 1
-        return feather.read_feather(path, nthreads=int_use_threads)
+        return feather.read_feather(path, use_threads=int_use_threads)
 
     return feather.read_feather(path, use_threads=bool(use_threads))


### PR DESCRIPTION
Bug:
```python
>>> import pandas as pd
>>> pd.read_feather('tmp/test')
...
```
```bash
in read_feather(path, nthreads)
    110         return feather.read_dataframe(path)
    111 
--> 112     return feather.read_dataframe(path, nthreads=nthreads)

TypeError: read_feather() got an unexpected keyword argument 'nthreads'
```

Full Version string of pandas and dependencies:
                                                                                                     
commit: None                                                                                                                                                  
python: 3.6.6.final.0                                                                                                                                         
python-bits: 64                                                                                                                                               
OS: Linux                                                                                                                                                     
OS-release: 4.15.0-39-generic                                                                                                                                 
machine: x86_64                                                                                                                                               
processor: x86_64                                                                                                                                             
byteorder: little                                                                                                                                             
LC_ALL: None                                                                                                                                                  
LANG: en_US.UTF-8                                                                                                                                             
LOCALE: en_US.UTF-8                                                                                                                                           
                                                                                                                                                              
pandas: 0.23.4                                                                                                                                                
pytest: None
pip: 18.1
setuptools: 40.6.2
Cython: None
numpy: 1.15.4
scipy: 1.1.0
pyarrow: 0.11.1
xarray: None
IPython: 7.1.1
sphinx: None
patsy: 0.5.1
dateutil: 2.7.5
pytz: 2018.7
blosc: None
bottleneck: 1.2.1
tables: 3.4.4
numexpr: 2.6.8
feather: 0.4.0
matplotlib: 3.0.1
openpyxl: None
xlrd: None
xlwt: None
xlsxwriter: None
lxml: None
bs4: None
html5lib: 1.0.1
sqlalchemy: None
pymysql: None
psycopg2: None
jinja2: 2.10
s3fs: None
fastparquet: None
pandas_gbq: None
pandas_datareader: None

---

- [Yes] tests passed
- [Yes] passes `git diff upstream/master -u -- pandas/io/feather_format.py | flake8 --diff`
