### PR TITLE
CLN: remove unused import causing flake8 error on master

### DIFF
--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -7,7 +7,6 @@ are contained *in* the SeriesGroupBy and DataFrameGroupBy objects.
 """
 
 import collections
-import copy
 
 import numpy as np
 


### PR DESCRIPTION
Cleanup in #23971 removed the last use of the `copy` module, so `flake8` is now failing master due to an unused import. This fixes master by removing the import.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
