### PR TITLE
REF: prelim for fixing array_to_datetime

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -463,8 +463,7 @@ def array_with_unit_to_datetime(ndarray values, object unit,
 @cython.boundscheck(False)
 cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                         bint dayfirst=False, bint yearfirst=False,
-                        object format=None, object utc=None,
-                        bint require_iso8601=False):
+                        object utc=None, bint require_iso8601=False):
     """
     Converts a 1D array of date-like values to a numpy array of either:
         1) datetime64[ns] data
@@ -488,8 +487,6 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
          dayfirst parsing behavior when encountering datetime strings
     yearfirst : bool, default False
          yearfirst parsing behavior when encountering datetime strings
-    format : str, default None
-         format of the string to parse
     utc : bool, default None
          indicator whether the dates should be UTC
     require_iso8601 : bool, default False


### PR DESCRIPTION
`tslib.array_to_datetime` has an unused `format` kwarg.  This gets rid of it.

`to_datetime` (or more specifically, `_convert_listlike_datetimes`) has a bunch of boxing logic inside a try/except that doesn't need to be, obscures what Exception we're trying to catch.  This moves that code outside the try/except and de-indents it.  This overlaps with #23675.

xref #23722 (the conversation there less than the OP)  cc @mroeschke 