### PR TITLE
PERF: do NPY_NAT check inside get_datetime64_nanos

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -571,16 +571,13 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
 
             elif is_datetime64_object(val):
                 seen_datetime = 1
-                if get_datetime64_value(val) == NPY_NAT:
-                    iresult[i] = NPY_NAT
-                else:
-                    try:
-                        iresult[i] = get_datetime64_nanos(val)
-                    except OutOfBoundsDatetime:
-                        if is_coerce:
-                            iresult[i] = NPY_NAT
-                            continue
-                        raise
+                try:
+                    iresult[i] = get_datetime64_nanos(val)
+                except OutOfBoundsDatetime:
+                    if is_coerce:
+                        iresult[i] = NPY_NAT
+                        continue
+                    raise
 
             elif is_integer_object(val) or is_float_object(val):
                 # these must be ns unit by-definition

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -62,8 +62,11 @@ cdef inline int64_t get_datetime64_nanos(object val) except? -1:
         NPY_DATETIMEUNIT unit
         npy_datetime ival
 
-    unit = get_datetime64_unit(val)
     ival = get_datetime64_value(val)
+    if ival == NPY_NAT:
+        return NPY_NAT
+
+    unit = get_datetime64_unit(val)
 
     if unit != NPY_FR_ns:
         pandas_datetime_to_datetimestruct(ival, unit, &dts)
@@ -283,10 +286,8 @@ cdef convert_to_tsobject(object ts, object tz, object unit,
     if ts is None or ts is NaT:
         obj.value = NPY_NAT
     elif is_datetime64_object(ts):
-        if ts.view('i8') == NPY_NAT:
-            obj.value = NPY_NAT
-        else:
-            obj.value = get_datetime64_nanos(ts)
+        obj.value = get_datetime64_nanos(ts)
+        if obj.value != NPY_NAT:
             dt64_to_dtstruct(obj.value, &obj.dts)
     elif is_integer_object(ts):
         if ts == NPY_NAT:


### PR DESCRIPTION
Bonus of a little simplification in `array_to_datetime`

The perf pickup comes from changing a python call `ts.view('i8')` to a cython call `get_datetime64_value(ts)`.

```
In [3]: val = np.datetime64('NaT', 'D')
In [4]: %timeit pd.Timestamp(val)
```

master (leaving out "The slowest run [...]"
```
100000 loops, best of 3: 2.33 µs per loop
1000000 loops, best of 3: 2.02 µs per loop
100000 loops, best of 3: 2.44 µs per loop
100000 loops, best of 3: 1.4 µs per loop
1000000 loops, best of 3: 2.32 µs per loop
```

PR
```
1000000 loops, best of 3: 533 ns per loop
1000000 loops, best of 3: 758 ns per loop
1000000 loops, best of 3: 734 ns per loop
1000000 loops, best of 3: 570 ns per loop
1000000 loops, best of 3: 779 ns per loop
```

```
In [9]: val2 = np.datetime64(55, 'us')
In [10]: %timeit pd.Timestamp(val2)
```

master
```
100000 loops, best of 3: 3.58 µs per loop
100000 loops, best of 3: 3.49 µs per loop
100000 loops, best of 3: 3.65 µs per loop
100000 loops, best of 3: 2.99 µs per loop
```

PR
```
1000000 loops, best of 3: 1.61 µs per loop
1000000 loops, best of 3: 1.76 µs per loop
1000000 loops, best of 3: 1.66 µs per loop
1000000 loops, best of 3: 1.49 µs per loop
```