### PR TITLE
TST: use s3_resource fixture consistently

### DIFF
--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -723,25 +723,19 @@ class TestXlrdReader(ReadingTestsBase):
         local_table = self.get_exceldf('test1', ext)
         tm.assert_frame_equal(url_table, local_table)
 
-    @td.skip_if_no("s3fs")
     @td.skip_if_not_us_locale
-    def test_read_from_s3_url(self, ext):
-        moto = pytest.importorskip("moto")
-        boto3 = pytest.importorskip("boto3")
+    def test_read_from_s3_url(self, ext, s3_resource):
+        # Bucket "pandas-test" created in tests/io/conftest.py
+        file_name = os.path.join(self.dirpath, 'test1' + ext)
 
-        with moto.mock_s3():
-            conn = boto3.resource("s3", region_name="us-east-1")
-            conn.create_bucket(Bucket="pandas-test")
-            file_name = os.path.join(self.dirpath, 'test1' + ext)
+        with open(file_name, "rb") as f:
+            s3_resource.Bucket("pandas-test").put_object(Key="test1" + ext,
+                                                         Body=f)
 
-            with open(file_name, "rb") as f:
-                conn.Bucket("pandas-test").put_object(Key="test1" + ext,
-                                                      Body=f)
-
-            url = ('s3://pandas-test/test1' + ext)
-            url_table = read_excel(url)
-            local_table = self.get_exceldf('test1', ext)
-            tm.assert_frame_equal(url_table, local_table)
+        url = ('s3://pandas-test/test1' + ext)
+        url_table = read_excel(url)
+        local_table = self.get_exceldf('test1', ext)
+        tm.assert_frame_equal(url_table, local_table)
 
     @pytest.mark.slow
     # ignore warning from old xlrd


### PR DESCRIPTION
- [x] split off from #23731
- [x] tests modified / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

There are two boto tests that are not using the dedicated `s3_resource` fixture which takes care of all the mocking etc. This PR adapts those tests accordingly, which also allows unified treatment of things like #23754.
