### PR TITLE
CI/TST: Making ci/run_tests.sh fail if one of the steps fail

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$DOC" ]; then
     echo "We are not running pytest as this is a doc-build"
     exit 0

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -52,8 +52,7 @@ do
 
     if [[ "$COVERAGE" && $? == 0 ]]; then
         echo "uploading coverage for $TYPE tests"
-        COVERAGE_CMD="bash <(curl -s https://codecov.io/bash) -Z -c -F $TYPE -f $COVERAGE_FNAME"
-        echo $COVERAGE_CMD
-        $COVERAGE_CMD
+        echo "bash <(curl -s https://codecov.io/bash) -Z -c -F $TYPE -f $COVERAGE_FNAME"
+              bash <(curl -s https://codecov.io/bash) -Z -c -F $TYPE -f $COVERAGE_FNAME
     fi
 done

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -45,10 +45,15 @@ do
         NUM_JOBS=2
     fi
 
-    pytest -m "$TYPE_PATTERN$PATTERN" -n $NUM_JOBS -s --strict --durations=10 --junitxml=test-data-$TYPE.xml $TEST_ARGS $COVERAGE pandas
+    PYTEST_CMD="pytest -m \"$TYPE_PATTERN$PATTERN\" -n $NUM_JOBS -s --strict --durations=10 --junitxml=test-data-$TYPE.xml $TEST_ARGS $COVERAGE pandas"
+    echo $PYTEST_CMD
+    # if no tests are found (the case of "single and slow"), pytest exits with code 5, and would make the script fail, if not for the below code
+    sh -c "$PYTEST_CMD; ret=\$?; [ \$ret = 5 ] && exit 0 || exit \$ret"
 
     if [[ "$COVERAGE" && $? == 0 ]]; then
         echo "uploading coverage for $TYPE tests"
-        bash <(curl -s https://codecov.io/bash) -Z -c -F $TYPE -f $COVERAGE_FNAME
+        COVERAGE_CMD="bash <(curl -s https://codecov.io/bash) -Z -c -F $TYPE -f $COVERAGE_FNAME"
+        echo $COVERAGE_CMD
+        $COVERAGE_CMD
     fi
 done


### PR DESCRIPTION
Looks like when simplifying the running of the tests in the CI (#23924), I missed the `-e` in the bash header. And that makes the `ci/run_tests.sh` exit with status code 0, even if the calls to pytests fail.

This left the CI in green, even when tests fail for the last 3 days (sorry about that). I think nothing is broken.

This PR fixes the problem.

CC: @pandas-dev/pandas-core 