### PR TITLE
remove calls to DataFrame.consolidate in benchmarks

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -13,8 +13,7 @@ class GetNumericData(object):
         self.df = DataFrame(np.random.randn(10000, 25))
         self.df['foo'] = 'bar'
         self.df['bar'] = 'baz'
-        with warnings.catch_warnings(record=True):
-            self.df = self.df.consolidate()
+        self.df = self.df._consolidate()
 
     def time_frame_get_numeric_data(self):
         self.df._get_numeric_data()

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -23,11 +23,7 @@ class Append(object):
         self.mdf1['obj1'] = 'bar'
         self.mdf1['obj2'] = 'bar'
         self.mdf1['int1'] = 5
-        try:
-            with warnings.catch_warnings(record=True):
-                self.mdf1.consolidate(inplace=True)
-        except (AttributeError, TypeError):
-            pass
+        self.mdf1 = self.mdf1._consolidate()
         self.mdf2 = self.mdf1.copy()
         self.mdf2.index = self.df2.index
 


### PR DESCRIPTION
The ``DataFrame.consolidate`` method has been removed for 0.24 (in #23377), but there are still some calls to it in the asv benchmarks.  I had a failure in #23752 because of this, so hereby a fix.

This PR uses the internal  ``_consolidate`` method instead.