### PR TITLE
PERF: Define PeriodArray._values_for_argsort

### DIFF
--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -828,6 +828,9 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, ExtensionArray):
                                     .format(cls=type(self).__name__,
                                             freqstr=self.freqstr))
 
+    def _values_for_argsort(self):
+        return self._data
+
 
 PeriodArray._add_comparison_ops()
 PeriodArray._add_datetimelike_methods()


### PR DESCRIPTION
This PR speeds up `.groupby()` and `.set_index()` operations involving a `PeriodArray` by 25-64x:
```
asv compare upstream/master HEAD -s --sort ratio

Benchmarks that have improved:

       before           after         ratio
     [08395af4]       [696b40f1]
     <period_array_argsort~1>       <parse_time_string>
-       4.77±0.1s          191±3ms     0.04  period.DataFramePeriodColumn.time_set_index
-       2.23±0.2s         35.6±2ms     0.02  groupby.Datelike.time_sum('period_range')
```
The underlying issue was that `pd.core.algorithms.factorize()` calls `argsort()` on the input arrays. Calling this resulted in raw `Period` objects being sorted via equality comparisons that also generated `Offset` objects. Assuming all elements of the array have the same frequency, we can simply sort the underlying `ordinals` and achieve the same result far faster. 

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
