### PR TITLE
PERF: consolidate imports inside parse_time_string

### DIFF
--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -43,12 +43,16 @@ class PeriodIndexConstructor(object):
     def setup(self, freq):
         self.rng = date_range('1985', periods=1000)
         self.rng2 = date_range('1985', periods=1000).to_pydatetime()
+        self.ints = list(range(2000, 3000))
 
     def time_from_date_range(self, freq):
         PeriodIndex(self.rng, freq=freq)
 
     def time_from_pydatetime(self, freq):
         PeriodIndex(self.rng2, freq=freq)
+
+    def time_from_ints(self, freq):
+        PeriodIndex(self.ints, freq=freq)
 
 
 class DataFramePeriodColumn(object):

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -118,12 +118,12 @@ def parse_time_string(arg, freq=None, dayfirst=None, yearfirst=None):
     if getattr(freq, "_typ", None) == "dateoffset":
         freq = freq.rule_code
 
-    if dayfirst is None:
+    if dayfirst is None or yearfirst is None:
         from pandas.core.config import get_option
-        dayfirst = get_option("display.date_dayfirst")
-    if yearfirst is None:
-        from pandas.core.config import get_option
-        yearfirst = get_option("display.date_yearfirst")
+        if dayfirst is None:
+            dayfirst = get_option("display.date_dayfirst")
+        if yearfirst is None:
+            yearfirst = get_option("display.date_yearfirst")
 
     res = parse_datetime_string_with_reso(arg, freq=freq,
                                           dayfirst=dayfirst,


### PR DESCRIPTION
This PR adds an asv benchmark for the creation of `Period` objects directly from integers, and an associated speedup for the same case.

When calling `Period._from_ordinal()`, the runtime is unfortunately dominated by a pair of import statements needed to pull in the global config settings `display.date_dayfirst` and `display.date_yearfirst`. Thus, simply consolidating them leads to a significant speedup:
```
Benchmarks that have improved:

       before           after         ratio
     [08395af4]       [696b40f1]
     <parse_time_string~1>       <parse_time_string>
-         176±3ms         98.7±3ms     0.56  period.PeriodIndexConstructor.time_from_ints('D')
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
