### PR TITLE
CLN: remove unused import of warnings module

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -1,5 +1,4 @@
 import string
-import warnings
 
 import numpy as np
 import pandas.util.testing as tm


### PR DESCRIPTION
I forgot to remove a import line in #24080 as the warning module is no longur used in ``frame_methods.py`` and we now get a linting error.

This PR fixes that.
