### PR TITLE
API/ENH/DEPR: Series.unique returns Series

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -320,6 +320,64 @@ Example:
 See the :ref:`advanced docs on renaming<advanced.index_names>` for more details.
 
 
+.. _whatsnew_0240.enhancements.unique:
+
+Changes to the ``unique``-method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The three related methods :meth:`pandas.unique`, :meth:`Series.unique` and
+:meth:`Index.unique` now support the keyword ``return_inverse``, which, if passed,
+makes the output a tuple where the second component is an object that contains the
+mapping from the indices of the values to their location in the return unique values.
+
+.. ipython:: python
+
+    idx = pd.Index([1, 0, 0, 1])
+    uniques, inverse = idx.unique(return_inverse=True)
+    uniques
+    inverse
+    reconstruct = uniques[inverse]
+    reconstruct.equals(idx)
+
+For :class:`Series`, the ``unique`` method has also gained the ``raw``-keyword, which
+allows to toggle between the behavior before v.0.24 (returning an ``np.ndarray``
+or ``Categorical``), and the future behavior of returning a ``Series``.
+
+.. ipython:: python
+
+    pd.Series([1, 1, 3, 2], name='A').unique(raw=False)
+    pd.Series([1, 1, 3, 2], name='A').unique(raw=True)
+
+The ``return_inverse``-keyword is only available if ``raw=False``, since it is necessary
+to reconstruct both the values and the index of a ``Series`` for an inverse (to illustrate
+that the index is maintained, we pass a non-default index in the example below).
+
+.. ipython:: python
+
+    animals = pd.Series(['lama', 'cow', 'lama', 'beetle', 'lama'],
+                        index=[1, 4, 9, 16, 25])
+    animals_unique, inverse = animals.unique(raw=False, return_inverse=True)
+    animals_unique
+    inverse
+
+This can be used to reconstruct the original object from its unique values as follows:
+
+.. ipython:: python
+
+    reconstruct = animals_unique.reindex(inverse)
+    reconstruct
+
+We see that the values of `animals` get reconstructed correctly, but the index does
+not match yet  -- consequently, the last step is to correctly set the index.
+
+
+.. ipython:: python
+
+    reconstruct.index = inverse.index
+    reconstruct
+    reconstruct.equals(animals)
+
+
 .. _whatsnew_0240.enhancements.other:
 
 Other Enhancements
@@ -1103,6 +1161,8 @@ Deprecations
 - :meth:`DataFrame.to_stata`, :meth:`read_stata`, :class:`StataReader` and :class:`StataWriter` have deprecated the ``encoding`` argument. The encoding of a Stata dta file is determined by the file type and cannot be changed (:issue:`21244`)
 - :meth:`MultiIndex.to_hierarchical` is deprecated and will be removed in a future version (:issue:`21613`)
 - :meth:`Series.ptp` is deprecated. Use ``numpy.ptp`` instead (:issue:`21614`)
+- :meth:`Series.unique` has deprecated returning an array and will return a Series in the future. The behavior can be controlled by the ``raw``-keyword.
+  The recommended method to get an array is to pass `raw=False` and use `.array` on the result.
 - :meth:`Series.compress` is deprecated. Use ``Series[condition]`` instead (:issue:`18262`)
 - The signature of :meth:`Series.to_csv` has been uniformed to that of :meth:`DataFrame.to_csv`: the name of the first argument is now ``path_or_buf``, the order of subsequent arguments has changed, the ``header`` argument now defaults to ``True``. (:issue:`19715`)
 - :meth:`Categorical.from_codes` has deprecated providing float values for the ``codes`` argument. (:issue:`21767`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -347,7 +347,10 @@ def unique(values, return_inverse=False):
 
     values = _ensure_arraylike(values)
 
-    if is_extension_array_dtype(values):
+    if isinstance(values, ABCSeries):
+        # this calls through Series, need raw=True to not raise warning
+        return values.unique(raw=True)
+    elif is_extension_array_dtype(values):
         # Dispatch to extension dtype's unique.
         return values.unique()
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -271,7 +271,7 @@ def match(to_match, values, na_sentinel=-1):
     return result
 
 
-def unique(values):
+def unique(values, return_inverse=False):
     """
     Hash table-based unique. Uniques are returned in order
     of appearance. This does NOT sort.
@@ -355,7 +355,11 @@ def unique(values):
     htable, _, values, dtype, ndtype = _get_hashtable_algo(values)
 
     table = htable(len(values))
-    uniques = table.unique(values)
+    if return_inverse:
+        uniques, inverse = table.unique(values, return_inverse=True)
+    else:
+        uniques = table.unique(values)
+
     uniques = _reconstruct_data(uniques, dtype, original)
 
     if isinstance(original, ABCSeries) and is_datetime64tz_dtype(dtype):
@@ -365,6 +369,8 @@ def unique(values):
         # TODO: it must return DatetimeArray with tz in pandas 2.0
         uniques = uniques.astype(object).values
 
+    if return_inverse:
+        return uniques, inverse
     return uniques
 
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1244,7 +1244,10 @@ class IndexOpsMixin(object):
         -------
         nunique : int
         """
-        uniqs = self.unique()
+        if isinstance(self, ABCSeries):
+            uniqs = self.unique(raw=True)
+        else:
+            uniqs = self.unique()
         n = len(uniqs)
         if dropna and isna(uniqs).any():
             n -= 1

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1208,15 +1208,24 @@ class IndexOpsMixin(object):
                               normalize=normalize, bins=bins, dropna=dropna)
         return result
 
-    def unique(self):
+    def unique(self, return_inverse=False):
         values = self._values
 
-        if hasattr(values, 'unique'):
-
-            result = values.unique()
+        if is_extension_array_dtype(values):
+            if return_inverse:
+                # as long as return_inverse is not part of the EA.unique
+                # contract, test if this works
+                try:
+                    result = values.unique(return_inverse=return_inverse)
+                except TypeError:
+                    raise ValueError('extension array of dtype {dtype} does '
+                                     'not yet support unique with '
+                                     'return_inverse.')
+            else:
+                result = values.unique()
         else:
             from pandas.core.algorithms import unique1d
-            result = unique1d(values)
+            result = unique1d(values, return_inverse=return_inverse)
 
         return result
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1985,9 +1985,21 @@ class Index(IndexOpsMixin, PandasObject):
 
             .. versionadded:: 0.23.0
 
+        return_inverse : boolean, default False
+            Whether to return the inverse of the unique values. If True, the
+            output will be a tuple where the second component is again an
+            np.ndarray that contains the mapping between the indices of the
+            elements in the calling Categorical and their locations in the
+            unique values. See examples for how to reconstruct.
+
+            .. versionadded:: 0.24.0
+
         Returns
         -------
-        Index without duplicates
+        uniques : Index
+            The ``Index`` without duplicates
+        inverse : np.ndarray (if `return_inverse=True`)
+            The inverse from the `uniques` back to the calling ``Index``.
 
         See Also
         --------
@@ -1996,9 +2008,14 @@ class Index(IndexOpsMixin, PandasObject):
         """)
 
     @Appender(_index_shared_docs['index_unique'] % _index_doc_kwargs)
-    def unique(self, level=None):
+    def unique(self, level=None, return_inverse=False):
         if level is not None:
             self._validate_index_level(level)
+
+        if return_inverse:
+            result, inverse = super(Index, self).unique(return_inverse=True)
+            return self._shallow_copy(result), inverse
+
         result = super(Index, self).unique()
         return self._shallow_copy(result)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1646,7 +1646,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         We see that the values of `animals` get reconstructed correctly, but
         the index does not match yet  -- consequently, the last step is to
         correctly set the index.
-    
+
         >>> reconstruct.index = inverse.index
         >>> reconstruct
         1       lama
@@ -1682,11 +1682,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                              'supported if "raw=True"')
         elif raw:
             result = super(Series, self).unique()
-    
+
             if is_datetime64tz_dtype(self.dtype):
                 # we are special casing datetime64tz_dtype
                 # to return an object array of tz-aware Timestamps
-    
+
                 # TODO: it must return DatetimeArray with tz in pandas 2.0
                 result = result.astype(object).values
             return result

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -183,13 +183,13 @@ class TestCategoricalAnalytics(object):
         tm.assert_categorical_equal(c.unique(), exp)
 
         tm.assert_index_equal(Index(c).unique(), Index(exp))
-        tm.assert_categorical_equal(Series(c).unique(), exp)
+        tm.assert_categorical_equal(Series(c).unique(raw=True), exp)
 
         c = Categorical([1, 1, 2, 2], categories=[3, 2, 1])
         exp = Categorical([1, 2], categories=[1, 2])
         tm.assert_categorical_equal(c.unique(), exp)
         tm.assert_index_equal(Index(c).unique(), Index(exp))
-        tm.assert_categorical_equal(Series(c).unique(), exp)
+        tm.assert_categorical_equal(Series(c).unique(raw=True), exp)
 
         c = Categorical([3, 1, 2, 2, 1], categories=[3, 2, 1], ordered=True)
         # Categorical.unique keeps categories order if ordered=True
@@ -197,7 +197,7 @@ class TestCategoricalAnalytics(object):
         tm.assert_categorical_equal(c.unique(), exp)
 
         tm.assert_index_equal(Index(c).unique(), Index(exp))
-        tm.assert_categorical_equal(Series(c).unique(), exp)
+        tm.assert_categorical_equal(Series(c).unique(raw=True), exp)
 
     def test_shift(self):
         # GH 9416

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1150,7 +1150,7 @@ def test_first_fill_value_loc(arr, loc):
 ])
 def test_unique_na_fill(arr, fill_value):
     a = pd.SparseArray(arr, fill_value=fill_value).unique()
-    b = pd.Series(arr).unique()
+    b = pd.Series(arr).unique(raw=True)
     assert isinstance(a, SparseArray)
     a = np.asarray(a)
     tm.assert_numpy_array_equal(a, b)

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.core.dtypes.generic import ABCSeries
+
 import pandas as pd
 import pandas.util.testing as tm
 
@@ -75,11 +77,15 @@ class BaseMethodsTests(BaseExtensionTests):
         self.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize('box', [pd.Series, lambda x: x])
-    @pytest.mark.parametrize('method', [lambda x: x.unique(), pd.unique])
+    @pytest.mark.parametrize('method', [lambda x, **kwargs: x.unique(**kwargs),
+                                        pd.unique])
     def test_unique(self, data, box, method):
         duplicated = box(data._from_sequence([data[0], data[0]]))
 
-        result = method(duplicated)
+        if isinstance(duplicated, ABCSeries) and method != pd.unique:
+            result = method(duplicated, raw=True)
+        else:
+            result = method(duplicated)
 
         assert len(result) == 1
         assert isinstance(result, type(data))

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -2226,7 +2226,7 @@ class TestDataFrameIndexing(TestData):
                             for x in [2, 3, 3, 2, 3, 2, 3, 2]]),
                         'joline': np.random.randn(20).round(3) * 10})
 
-        for idx in permutations(df['jim'].unique()):
+        for idx in permutations(df['jim'].unique(raw=True)):
             for i in range(3):
                 verify_first_level(df, 'jim', idx[:i + 1])
 

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -156,7 +156,7 @@ class TestPlotBase(object):
             assert patch.get_visible() == visible
 
     def _get_colors_mapped(self, series, colors):
-        unique = series.unique()
+        unique = series.unique(raw=True)
         # unique and colors length can be differed
         # depending on slice value
         mapped = dict(zip(unique, colors))

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -433,7 +433,7 @@ class TestMerge(object):
                       datetime(2010, 2, 3),
                       datetime(2012, 2, 3)]}
         df = DataFrame.from_dict(d)
-        var3 = df.var3.unique()
+        var3 = df.var3.unique(raw=True)
         var3.sort()
         new = DataFrame.from_dict({"var3": var3,
                                    "var8": np.random.random(7)})
@@ -442,7 +442,7 @@ class TestMerge(object):
         exp = merge(df, new, on='var3', sort=False)
         assert_frame_equal(result, exp)
 
-        assert (df.var3.unique() == result.var3.unique()).all()
+        assert (df.var3.unique(raw=True) == result.var3.unique(raw=True)).all()
 
     def test_merge_nan_right(self):
         df1 = DataFrame({"i1": [0, 1], "i2": [0, 1]})

--- a/pandas/tests/series/test_duplicates.py
+++ b/pandas/tests/series/test_duplicates.py
@@ -26,37 +26,38 @@ def test_unique():
     # GH714 also, dtype=float
     s = Series([1.2345] * 100)
     s[::2] = np.nan
-    result = s.unique()
+    result = s.unique(raw=True)
     assert len(result) == 2
 
     s = Series([1.2345] * 100, dtype='f4')
     s[::2] = np.nan
-    result = s.unique()
+    result = s.unique(raw=True)
     assert len(result) == 2
 
     # NAs in object arrays #714
     s = Series(['foo'] * 100, dtype='O')
     s[::2] = np.nan
-    result = s.unique()
+    result = s.unique(raw=True)
     assert len(result) == 2
 
     # decision about None
     s = Series([1, 2, 3, None, None, None], dtype=object)
-    result = s.unique()
+    result = s.unique(raw=True)
     expected = np.array([1, 2, 3, None], dtype=object)
     tm.assert_numpy_array_equal(result, expected)
 
     # GH 18051
     s = Series(Categorical([]))
-    tm.assert_categorical_equal(s.unique(), Categorical([]), check_dtype=False)
+    tm.assert_categorical_equal(s.unique(raw=True), Categorical([]),
+                                check_dtype=False)
     s = Series(Categorical([np.nan]))
-    tm.assert_categorical_equal(s.unique(), Categorical([np.nan]),
+    tm.assert_categorical_equal(s.unique(raw=True), Categorical([np.nan]),
                                 check_dtype=False)
 
 
 def test_unique_data_ownership():
     # it works! #1807
-    Series(Series(["a", "c", "b"]).unique()).sort_values()
+    Series(Series(["a", "c", "b"]).unique(raw=True)).sort_values()
 
 
 def test_is_unique():

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -434,7 +434,7 @@ class TestUnique(object):
 
         # Series of categorical dtype
         s = Series(Categorical(list('baabc')), name='foo')
-        result = s.unique()
+        result = s.unique(raw=True)
         tm.assert_categorical_equal(result, expected)
 
         result = pd.unique(s)
@@ -455,7 +455,7 @@ class TestUnique(object):
 
         result = Series(
             Index([Timestamp('20160101', tz='US/Eastern'),
-                   Timestamp('20160101', tz='US/Eastern')])).unique()
+                   Timestamp('20160101', tz='US/Eastern')])).unique(raw=True)
         expected = np.array([Timestamp('2016-01-01 00:00:00-0500',
                                        tz='US/Eastern')], dtype=object)
         tm.assert_numpy_array_equal(result, expected)
@@ -1293,7 +1293,7 @@ class TestHashTable(object):
     def test_get_unique(self):
         s = Series([1, 2, 2**63, 2**63], dtype=np.uint64)
         exp = np.array([1, 2, 2**63], dtype=np.uint64)
-        tm.assert_numpy_array_equal(s.unique(), exp)
+        tm.assert_numpy_array_equal(s.unique(raw=True), exp)
 
     @pytest.mark.parametrize('nvals', [0, 10])  # resizing to 0 is special case
     @pytest.mark.parametrize('htable, uniques, dtype, safely_resizes', [

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -442,11 +442,12 @@ class TestIndexOps(Ops):
             assert result.index.name is None
             assert result.name == 'a'
 
-            result = o.unique()
             if isinstance(o, Index):
+                result = o.unique()
                 assert isinstance(result, o.__class__)
                 tm.assert_index_equal(result, orig)
             elif is_datetime64tz_dtype(o):
+                result = o.unique(raw=True)
                 # datetimetz Series returns array of Timestamp
                 assert result[0] == orig[0]
                 for r in result:
@@ -454,6 +455,7 @@ class TestIndexOps(Ops):
                 tm.assert_numpy_array_equal(result,
                                             orig._values.astype(object).values)
             else:
+                result = o.unique(raw=True)
                 tm.assert_numpy_array_equal(result, orig.values)
 
             assert o.nunique() == len(np.unique(o.values))
@@ -534,16 +536,18 @@ class TestIndexOps(Ops):
                 assert result_s.index.name is None
                 assert result_s.name == 'a'
 
-                result = o.unique()
                 if isinstance(o, Index):
+                    result = o.unique()
                     tm.assert_index_equal(result,
                                           Index(values[1:], name='a'))
                 elif is_datetime64tz_dtype(o):
+                    result = o.unique(raw=True)
                     # unable to compare NaT / nan
                     vals = values[2:].astype(object).values
                     tm.assert_numpy_array_equal(result[1:], vals)
                     assert result[0] is pd.NaT
                 else:
+                    result = o.unique(raw=True)
                     tm.assert_numpy_array_equal(result[1:], values[2:])
 
                     assert pd.isna(result[0])
@@ -565,7 +569,7 @@ class TestIndexOps(Ops):
                 tm.assert_index_equal(s.unique(), exp)
             else:
                 exp = np.unique(np.array(s_values, dtype=np.object_))
-                tm.assert_numpy_array_equal(s.unique(), exp)
+                tm.assert_numpy_array_equal(s.unique(raw=True), exp)
 
             assert s.nunique() == 4
             # don't sort, have to sort after the fact as not sorting is
@@ -605,7 +609,7 @@ class TestIndexOps(Ops):
                 tm.assert_index_equal(s1.unique(), Index([1, 2, 3]))
             else:
                 exp = np.array([1, 2, 3], dtype=np.int64)
-                tm.assert_numpy_array_equal(s1.unique(), exp)
+                tm.assert_numpy_array_equal(s1.unique(raw=True), exp)
 
             assert s1.nunique() == 3
 
@@ -637,7 +641,7 @@ class TestIndexOps(Ops):
                 tm.assert_index_equal(s.unique(), exp)
             else:
                 exp = np.array(['a', 'b', np.nan, 'd'], dtype=object)
-                tm.assert_numpy_array_equal(s.unique(), exp)
+                tm.assert_numpy_array_equal(s.unique(raw=True), exp)
             assert s.nunique() == 3
 
             s = klass({})
@@ -648,7 +652,7 @@ class TestIndexOps(Ops):
             if isinstance(s, Index):
                 tm.assert_index_equal(s.unique(), Index([]), exact=False)
             else:
-                tm.assert_numpy_array_equal(s.unique(), np.array([]),
+                tm.assert_numpy_array_equal(s.unique(raw=True), np.array([]),
                                             check_dtype=False)
 
             assert s.nunique() == 0
@@ -681,7 +685,7 @@ class TestIndexOps(Ops):
         if isinstance(s, Index):
             tm.assert_index_equal(s.unique(), DatetimeIndex(expected))
         else:
-            tm.assert_numpy_array_equal(s.unique(), expected)
+            tm.assert_numpy_array_equal(s.unique(raw=True), expected)
 
         assert s.nunique() == 3
 
@@ -697,7 +701,10 @@ class TestIndexOps(Ops):
         expected_s[pd.NaT] = 1
         tm.assert_series_equal(result, expected_s)
 
-        unique = s.unique()
+        if isinstance(s, Index):
+            unique = s.unique()
+        else:
+            unique = s.unique(raw=True)
         assert unique.dtype == 'datetime64[ns]'
 
         # numpy_array_equal cannot compare pd.NaT
@@ -723,7 +730,7 @@ class TestIndexOps(Ops):
         if isinstance(td, Index):
             tm.assert_index_equal(td.unique(), expected)
         else:
-            tm.assert_numpy_array_equal(td.unique(), expected.values)
+            tm.assert_numpy_array_equal(td.unique(raw=True), expected.values)
 
         td2 = timedelta(1) + (df.dt - df.dt)
         td2 = klass(td2, name='dt')


### PR DESCRIPTION
 I know this PR is too big, but I need it to initiate discussion before `v.0.24` cutoff.

I've been working on adding a `return_inverse` to `unique` since mid June (as fast as possible). I know that changing the return type of `Series.unique` is potentially a controversial issue, but I truly believe that this should be done for v.0.24 (as otherwise the behavior is locked in past 1.0 and who knows if it ever changes then).

IMO, it's even a necessity if pandas ever wants to support `return_inverse` for `unique`. Here's a few arguments from working on this for a while:

* This is both a long-standing issue (#4087 milestoned since 0.14) and *very* hard for a user to do any other way.
* `.unique` is the obvious place for an inverse (as opposed to `.duplicated`, which I was directed to work on first, #21645)
* An inverse for `Series` only works well if the return type of `Series.unique` is a `Series`, see https://github.com/pandas-dev/pandas/issues/22824#issuecomment-432841642. This is not even the strongest reason IMO to change the type, as `.unique` is a patchwork currently (see rest OP of #22824):
  * `Index.unique` is already an `Index` (and changing that back to `ndarray` would be equally disruptive, and wouldn't lead anyhwere re:reconstruction)
  * The current `Series.unique` already special-cases `Categorical` and (effectively) `DatetimeArray`.

The reason I'm pushing this WIP for discussion is that this is obviously needs a deprecation cycle, and I *really* think this should be part of `v.0.24`. I'm sorry for the late timing, but I've been working as fast as feedback speed allowed (as often as politeness allowed me to ping) - #21645 was lying around mostly finished for 2 month, the cython backend (#22986 / #23400) took about 2 months, and I haven't been able to get an answer at #22824 for about 5 weeks (e.g. @jorisvandenbossche seems to be very busy or simply not available)

As for the PR itself, I *only* wanted to change the return-type in this PR, but `Series.unique` touches several important paths:
1. `Series.unique`
1. `IndexOpsMixin.unique` and hence `Index.unique`
1. `Categorical.unique`
1. `EA.unique`

So, as a demo here, I've adapted the first three, and it's a separate issue that **the EA contract should support the possibility for `return_inverse`**. This is also something that should IMO needs to make it to `v.0.24`.

- [x] actually closes #4087 (milestoned since 0.14), makes several big steps towards #21357 / #22824
- [x] tests modified / pass
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
- [ ] this obviously still needs tests
- [ ] splitting this up could work as follows:
  - [ ] add `return_inverse` to `pd.unique`
  - [ ] add `return_inverse` to `Index.unique`
  - [ ] add `return_inverse` to `Categorical.unique`
  - [ ] add `raw` to `Series.unique`
  - [ ] **Alternatively**, I could avoid passing the `unique`-calls through class hierarchy and just directly call the cython methods from `Series.unique`, which would allow introducing the deprecation *without* introducing the `return_inverse` kwarg yet.