### PR TITLE
BUG: use internal linkage (static variables) in move.c

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1582,6 +1582,7 @@ Other
 - Logical operations ``&, |, ^`` between :class:`Series` and :class:`Index` will no longer raise ``ValueError`` (:issue:`22092`)
 - Checking PEP 3141 numbers in :func:`~pandas.api.types.is_scalar` function returns ``True`` (:issue:`22903`)
 - Bug in :meth:`DataFrame.combine_first` in which column types were unexpectedly converted to float (:issue:`20699`)
+- Bug where C variables were declared with external linkage causing import errors if certain other C libraries were imported before Pandas. (:issue:`24113`)
 
 .. _whatsnew_0.24.0.contributors:
 

--- a/pandas/util/move.c
+++ b/pandas/util/move.c
@@ -20,7 +20,7 @@
 #define Py_TPFLAGS_HAVE_NEWBUFFER 0
 #endif
 
-PyObject *badmove;  /* bad move exception class */
+static PyObject *badmove;  /* bad move exception class */
 
 typedef struct {
     PyObject_HEAD
@@ -28,7 +28,7 @@ typedef struct {
     PyObject *invalid_bytes;
 } stolenbufobject;
 
-PyTypeObject stolenbuf_type;  /* forward declare type */
+static PyTypeObject stolenbuf_type;  /* forward declare type */
 
 static void
 stolenbuf_dealloc(stolenbufobject *self)
@@ -71,7 +71,7 @@ stolenbuf_getsegcount(stolenbufobject *self, Py_ssize_t *len)
     return 1;
 }
 
-PyBufferProcs stolenbuf_as_buffer = {
+static PyBufferProcs stolenbuf_as_buffer = {
     (readbufferproc) stolenbuf_getreadwritebuf,
     (writebufferproc) stolenbuf_getreadwritebuf,
     (segcountproc) stolenbuf_getsegcount,
@@ -81,7 +81,7 @@ PyBufferProcs stolenbuf_as_buffer = {
 
 #else  /* Python 3 */
 
-PyBufferProcs stolenbuf_as_buffer = {
+static PyBufferProcs stolenbuf_as_buffer = {
     (getbufferproc) stolenbuf_getbuffer,
     NULL,
 };
@@ -91,7 +91,7 @@ PyBufferProcs stolenbuf_as_buffer = {
 PyDoc_STRVAR(stolenbuf_doc,
              "A buffer that is wrapping a stolen bytes object's buffer.");
 
-PyTypeObject stolenbuf_type = {
+static PyTypeObject stolenbuf_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "pandas.util._move.stolenbuf",              /* tp_name */
     sizeof(stolenbufobject),                    /* tp_basicsize */
@@ -185,7 +185,7 @@ move_into_mutable_buffer(PyObject *self, PyObject *bytes_rvalue)
     return (PyObject*) ret;
 }
 
-PyMethodDef methods[] = {
+static PyMethodDef methods[] = {
     {"move_into_mutable_buffer",
      (PyCFunction) move_into_mutable_buffer,
      METH_O,
@@ -196,7 +196,7 @@ PyMethodDef methods[] = {
 #define MODULE_NAME "pandas.util._move"
 
 #if !COMPILING_IN_PY2
-PyModuleDef _move_module = {
+static PyModuleDef move_module = {
     PyModuleDef_HEAD_INIT,
     MODULE_NAME,
     NULL,
@@ -242,7 +242,7 @@ init_move(void)
     }
 
 #if !COMPILING_IN_PY2
-    if (!(m = PyModule_Create(&_move_module)))
+    if (!(m = PyModule_Create(&move_module)))
 #else
     if (!(m = Py_InitModule(MODULE_NAME, methods)))
 #endif  /* !COMPILING_IN_PY2 */


### PR DESCRIPTION
move.c declared global variables without explicitly declaring them static, so
they had global visibility. This meant that if you linked against a shared
object that provided the same symbols, the wrong data would be read. In
particular: linking to libgtk, which provides the symbol 'methods', would cause
an import error of pandas.util._move.

- [x] closes #19706
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
