### PR TITLE
CLN: Follow-up to #24100

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1438,7 +1438,6 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin,
 
 
 DatetimeArrayMixin._add_comparison_ops()
-DatetimeArrayMixin._add_datetimelike_methods()
 
 
 # -------------------------------------------------------------------

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -830,7 +830,6 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, ExtensionArray):
 
 
 PeriodArray._add_comparison_ops()
-PeriodArray._add_datetimelike_methods()
 
 
 # -------------------------------------------------------------------

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -734,7 +734,6 @@ class TimedeltaArrayMixin(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
 
 
 TimedeltaArrayMixin._add_comparison_ops()
-TimedeltaArrayMixin._add_datetimelike_methods()
 
 
 # ---------------------------------------------------------------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -463,19 +463,6 @@ class DataFrame(NDFrame):
 
         NDFrame.__init__(self, mgr, fastpath=True)
 
-    def _init_dict(self, data, index, columns, dtype=None):
-        """
-        Segregate Series based on type and coerce into matrices.
-        Needs to handle a lot of exceptional cases.
-        """
-        return init_dict(data, index, columns, dtype=dtype)
-        # TODO: Can we get rid of this as a method?
-
-    def _init_ndarray(self, values, index, columns, dtype=None, copy=False):
-        # input must be a ndarray, list, Series, index
-        return init_ndarray(values, index, columns, dtype=dtype, copy=copy)
-        # TODO: can we just get rid of this as a method?
-
     # ----------------------------------------------------------------------
 
     @property

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -191,9 +191,9 @@ def init_dict(data, index, columns, dtype=None):
                 nan_dtype = object
             else:
                 nan_dtype = dtype
-            v = construct_1d_arraylike_from_scalar(np.nan, len(index),
-                                                   nan_dtype)
-            arrays.loc[missing] = [v] * missing.sum()
+            val = construct_1d_arraylike_from_scalar(np.nan, len(index),
+                                                     nan_dtype)
+            arrays.loc[missing] = [val] * missing.sum()
 
     else:
         keys = com.dict_keys_to_ordered_list(data)
@@ -246,28 +246,28 @@ def _homogenize(data, index, dtype=None):
     oindex = None
     homogenized = []
 
-    for v in data:
-        if isinstance(v, ABCSeries):
+    for val in data:
+        if isinstance(val, ABCSeries):
             if dtype is not None:
-                v = v.astype(dtype)
-            if v.index is not index:
+                val = val.astype(dtype)
+            if val.index is not index:
                 # Forces alignment. No need to copy data since we
                 # are putting it into an ndarray later
-                v = v.reindex(index, copy=False)
+                val = val.reindex(index, copy=False)
         else:
-            if isinstance(v, dict):
+            if isinstance(val, dict):
                 if oindex is None:
                     oindex = index.astype('O')
 
                 if isinstance(index, (ABCDatetimeIndex, ABCTimedeltaIndex)):
-                    v = com.dict_compat(v)
+                    val = com.dict_compat(val)
                 else:
-                    v = dict(v)
-                v = lib.fast_multiget(v, oindex.values, default=np.nan)
-            v = sanitize_array(v, index, dtype=dtype, copy=False,
-                               raise_cast_failure=False)
+                    val = dict(val)
+                val = lib.fast_multiget(val, oindex.values, default=np.nan)
+            val = sanitize_array(val, index, dtype=dtype, copy=False,
+                                 raise_cast_failure=False)
 
-        homogenized.append(v)
+        homogenized.append(val)
 
     return homogenized
 
@@ -284,16 +284,16 @@ def extract_index(data):
         have_series = False
         have_dicts = False
 
-        for v in data:
-            if isinstance(v, ABCSeries):
+        for val in data:
+            if isinstance(val, ABCSeries):
                 have_series = True
-                indexes.append(v.index)
-            elif isinstance(v, dict):
+                indexes.append(val.index)
+            elif isinstance(val, dict):
                 have_dicts = True
-                indexes.append(list(v.keys()))
-            elif is_list_like(v) and getattr(v, 'ndim', 1) == 1:
+                indexes.append(list(val.keys()))
+            elif is_list_like(v) and getattr(val, 'ndim', 1) == 1:
                 have_raw_arrays = True
-                raw_lengths.append(len(v))
+                raw_lengths.append(len(val))
 
         if not indexes and not raw_lengths:
             raise ValueError('If using all scalar values, you must pass'
@@ -506,7 +506,7 @@ def sanitize_index(data, index, copy=False):
         return data
 
     if len(data) != len(index):
-        raise ValueError('Length of values does not match length of ' 'index')
+        raise ValueError('Length of values does not match length of index')
 
     if isinstance(data, ABCIndexClass) and not copy:
         pass

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -291,7 +291,7 @@ def extract_index(data):
             elif isinstance(val, dict):
                 have_dicts = True
                 indexes.append(list(val.keys()))
-            elif is_list_like(v) and getattr(val, 'ndim', 1) == 1:
+            elif is_list_like(val) and getattr(val, 'ndim', 1) == 1:
                 have_raw_arrays = True
                 raw_lengths.append(len(val))
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -1,6 +1,6 @@
 """
 Functions for preparing various inputs passed to the DataFrame or Series
-constructors before passing them to aBlockManager.
+constructors before passing them to a BlockManager.
 """
 from collections import OrderedDict
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -313,8 +313,9 @@ def extract_index(data):
 
             if have_series:
                 if lengths[0] != len(index):
-                    msg = ('array length %d does not match index length %d' %
-                           (lengths[0], len(index)))
+                    msg = ('array length {length} does not match index '
+                           'length {idx_len}'
+                           .format(length=lengths[0], idx_len=len(index)))
                     raise ValueError(msg)
             else:
                 index = ibase.default_index(lengths[0])
@@ -344,7 +345,7 @@ def get_names_from_index(data):
         if n is not None:
             index[i] = n
         else:
-            index[i] = 'Unnamed %d' % count
+            index[i] = 'Unnamed {count}'.format(count=count)
             count += 1
 
     return index


### PR DESCRIPTION
Avoid 1-letter variable names
Modernize string formatting
Avoid an unnecessary level of indirection in add_datetimelike_methods for DTA/TDA/PA