### PR TITLE
PERF: speed up PeriodArray creation by exposing dayfirst/yearfirst params

### DIFF
--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -1,5 +1,6 @@
 from pandas import (
     DataFrame, Period, PeriodIndex, Series, date_range, period_range)
+from pandas.tseries.frequencies import to_offset
 
 
 class PeriodProperties(object):
@@ -35,24 +36,47 @@ class PeriodUnaryMethods(object):
         self.per.asfreq('A')
 
 
+class PeriodConstructor(object):
+    params = [['D'], [True, False]]
+    param_names = ['freq', 'is_offset']
+
+    def setup(self, freq, is_offset):
+        if is_offset:
+            self.freq = to_offset(freq)
+        else:
+            self.freq = freq
+
+    def time_period_constructor(self, freq, is_offset):
+        Period('2012-06-01', freq=freq)
+
+
 class PeriodIndexConstructor(object):
 
-    params = ['D']
-    param_names = ['freq']
+    params = [['D'], [True, False]]
+    param_names = ['freq', 'is_offset']
 
-    def setup(self, freq):
+    def setup(self, freq, is_offset):
         self.rng = date_range('1985', periods=1000)
         self.rng2 = date_range('1985', periods=1000).to_pydatetime()
         self.ints = list(range(2000, 3000))
+        self.daily_ints = date_range('1/1/2000', periods=1000,
+                                     freq=freq).strftime('%Y%m%d').map(int)
+        if is_offset:
+            self.freq = to_offset(freq)
+        else:
+            self.freq = freq
 
-    def time_from_date_range(self, freq):
+    def time_from_date_range(self, freq, is_offset):
         PeriodIndex(self.rng, freq=freq)
 
-    def time_from_pydatetime(self, freq):
+    def time_from_pydatetime(self, freq, is_offset):
         PeriodIndex(self.rng2, freq=freq)
 
-    def time_from_ints(self, freq):
+    def time_from_ints(self, freq, is_offset):
         PeriodIndex(self.ints, freq=freq)
+
+    def time_from_ints_daily(self, freq, is_offset):
+        PeriodIndex(self.daily_ints, freq=freq)
 
 
 class DataFramePeriodColumn(object):

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1294,6 +1294,7 @@ Performance Improvements
 - Improved performance of :meth:`~DataFrame.where` for Categorical data (:issue:`24077`)
 - Improved performance of iterating over a :class:`Series`. Using :meth:`DataFrame.itertuples` now creates iterators
   without internally allocating lists of all elements (:issue:`20783`)
+- Improved performance of :class:`Period` constructor, additionally benefitting ``PeriodArray`` and ``PeriodIndex`` creation (:issue:`24084` and :issue:`24118`)
 
 .. _whatsnew_0240.docs:
 

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -47,6 +47,20 @@ cdef set _not_datelike_strings = {'a', 'A', 'm', 'M', 'p', 'P', 't', 'T'}
 
 # ----------------------------------------------------------------------
 
+_get_option = None
+
+
+def get_option(param):
+    """ Defer import of get_option to break an import cycle that caused
+    significant performance degradation in Period construction. See
+    GH#24118 for details
+    """
+    global _get_option
+    if _get_option is None:
+        from pandas.core.config import get_option
+        _get_option = get_option
+    return _get_option(param)
+
 
 def parse_datetime_string(date_string, freq=None, dayfirst=False,
                           yearfirst=False, **kwargs):
@@ -117,7 +131,6 @@ def parse_time_string(arg, freq=None, dayfirst=None, yearfirst=None):
         freq = freq.rule_code
 
     if dayfirst is None or yearfirst is None:
-        from pandas.core.config import get_option
         if dayfirst is None:
             dayfirst = get_option("display.date_dayfirst")
         if yearfirst is None:


### PR DESCRIPTION
As much of the time creating a `PeriodArray` from `int`s is actually spent importing/querying `get_option('display.date_dayfirst')` and its `yearfirst` cousin, this PR exposes those parameters in `Period.__new__()` to allow them to be queried once per array creation.

This yields a ~15x speedup:
```
asv compare upstream/master HEAD -s --sort ratio

Benchmarks that have improved:

       before           after         ratio
     [210538e4]       [32288230]
     <period_dayfirst~1>       <period_dayfirst>
-       102±0.9ms       7.08±0.2ms     0.07  period.PeriodIndexConstructor.time_from_ints('D', True)
-         101±2ms       6.56±0.3ms     0.06  period.PeriodIndexConstructor.time_from_ints('D', False)
```
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
