### PR TITLE
CLN: minor cleanups for MultiIndex.codes

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1102,8 +1102,9 @@ Deprecations
 
 - :attr:`MultiIndex.labels` has been deprecated and replaced by :attr:`MultiIndex.codes`.
   The functionality is unchanged. The new name better reflects the natures of
-  these codes and makes the ``MultiIndex`` API more similar to the API for :class:`CategoricalIndex`(:issue:`13443`).
+  these codes and makes the ``MultiIndex`` API more similar to the API for :class:`CategoricalIndex` (:issue:`13443`).
   As a consequence, other uses of the name ``labels`` in ``MultiIndex`` have also been deprecated and replaced with ``codes``:
+
   - You should initialize a ``MultiIndex`` instance using a parameter named ``codes`` rather than ``labels``.
   - ``MultiIndex.set_labels`` has been deprecated in favor of :meth:`MultiIndex.set_codes`.
   - For method :meth:`MultiIndex.copy`, the ``labels`` parameter has been deprecated and replaced by a ``codes`` parameter.

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -4,7 +4,7 @@ frozen (immutable) data structures to support MultiIndexing
 These are used for:
 
 - .names (FrozenList)
-- .levels & .labels (FrozenNDArray)
+- .levels & .codes (FrozenNDArray)
 
 """
 


### PR DESCRIPTION
Minor cleanup for #23752. The whatsnew didn't parse properly and other small stuff.