### PR TITLE
DOC: remove long listings in the tutorials.rst page

### DIFF
--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -18,117 +18,28 @@ A handy pandas `cheat sheet <http://pandas.pydata.org/Pandas_Cheat_Sheet.pdf>`_.
 Community Guides
 ================
 
-pandas Cookbook
----------------
+pandas Cookbook by Julia Evans
+------------------------------
 
 The goal of this 2015 cookbook (by `Julia Evans <http://jvns.ca>`_) is to
 give you some concrete examples for getting started with pandas. These
 are examples with real-world data, and all the bugs and weirdness that
 entails.
+For the table of contents, see the `pandas-cookbook GitHub
+repository <http://github.com/jvns/pandas-cookbook>`_. 
 
-Here are links to the v0.2 release. For an up-to-date table of contents, see the `pandas-cookbook GitHub
-repository <http://github.com/jvns/pandas-cookbook>`_. To run the examples in this tutorial, you'll need to
-clone the GitHub repository and get IPython Notebook running.
-See `How to use this cookbook <https://github.com/jvns/pandas-cookbook#how-to-use-this-cookbook>`_.
-
-*  `A quick tour of the IPython Notebook: <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/A%20quick%20tour%20of%20IPython%20Notebook.ipynb>`_
-   Shows off IPython's awesome tab completion and magic functions.
-*  `Chapter 1: <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%201%20-%20Reading%20from%20a%20CSV.ipynb>`_
-   Reading your data into pandas is pretty much the easiest thing. Even
-   when the encoding is wrong!
-*  `Chapter 2: <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%202%20-%20Selecting%20data%20%26%20finding%20the%20most%20common%20complaint%20type.ipynb>`_
-   It's not totally obvious how to select data from a pandas dataframe.
-   Here we explain the basics (how to take slices and get columns)
-*  `Chapter 3: <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%203%20-%20Which%20borough%20has%20the%20most%20noise%20complaints%20%28or%2C%20more%20selecting%20data%29.ipynb>`_
-   Here we get into serious slicing and dicing and learn how to filter
-   dataframes in complicated ways, really fast.
-*  `Chapter 4: <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%204%20-%20Find%20out%20on%20which%20weekday%20people%20bike%20the%20most%20with%20groupby%20and%20aggregate.ipynb>`_
-   Groupby/aggregate is seriously my favorite thing about pandas
-   and I use it all the time. You should probably read this.
-*  `Chapter 5:  <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%205%20-%20Combining%20dataframes%20and%20scraping%20Canadian%20weather%20data.ipynb>`_
-   Here you get to find out if it's cold in Montreal in the winter
-   (spoiler: yes). Web scraping with pandas is fun! Here we combine dataframes.
-*  `Chapter 6:  <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%206%20-%20String%20Operations-%20Which%20month%20was%20the%20snowiest.ipynb>`_
-   Strings with pandas are great. It has all these vectorized string
-   operations and they're the best. We will turn a bunch of strings
-   containing "Snow" into vectors of numbers in a trice.
-*  `Chapter 7: <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%207%20-%20Cleaning%20up%20messy%20data.ipynb>`_
-   Cleaning up messy data is never a joy, but with pandas it's easier.
-*  `Chapter 8:  <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%208%20-%20How%20to%20deal%20with%20timestamps.ipynb>`_
-   Parsing Unix timestamps is confusing at first but it turns out
-   to be really easy.
-*  `Chapter 9:  <http://nbviewer.jupyter.org/github/jvns/pandas-cookbook/blob/v0.2/cookbook/Chapter%209%20-%20Loading%20data%20from%20SQL%20databases.ipynb>`_
-   Reading data from SQL databases.
-
-
-Lessons for new pandas users
+Learn Pandas by Hernan Rojas
 ----------------------------
 
-For more resources, please visit the main `repository <https://bitbucket.org/hrojas/learn-pandas>`__.
-
-* `01 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/01%20-%20Lesson.ipynb>`_
-    * Importing libraries
-    * Creating data sets
-    * Creating data frames
-    * Reading from CSV
-    * Exporting to CSV
-    * Finding maximums
-    * Plotting data
-
-* `02 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/02%20-%20Lesson.ipynb>`_
-    * Reading from TXT
-    * Exporting to TXT
-    * Selecting top/bottom records
-    * Descriptive statistics
-    * Grouping/sorting data
-
-* `03 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/03%20-%20Lesson.ipynb>`_
-    * Creating functions
-    * Reading from EXCEL
-    * Exporting to EXCEL
-    * Outliers
-    * Lambda functions
-    * Slice and dice data
-
-* `04 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/04%20-%20Lesson.ipynb>`_
-    * Adding/deleting columns
-    * Index operations
-
-* `05 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/05%20-%20Lesson.ipynb>`_
-    * Stack/Unstack/Transpose functions
-
-* `06 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/06%20-%20Lesson.ipynb>`_
-    * GroupBy function
-
-* `07 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/07%20-%20Lesson.ipynb>`_
-    * Ways to calculate outliers
-
-* `08 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/08%20-%20Lesson.ipynb>`_
-    * Read from Microsoft SQL databases
-
-* `09 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/09%20-%20Lesson.ipynb>`_
-    * Export to CSV/EXCEL/TXT
-
-* `10 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/10%20-%20Lesson.ipynb>`_
-    * Converting between different kinds of formats
-
-* `11 - Lesson: <http://nbviewer.ipython.org/urls/bitbucket.org/hrojas/learn-pandas/raw/master/lessons/11%20-%20Lesson.ipynb>`_
-    * Combining data from various sources
-
+A set of lesson for new pandas users: `https://bitbucket.org/hrojas/learn-pandas>`__.
 
 Practical data analysis with Python
 -----------------------------------
 
-This `guide <http://wavedatalab.github.io/datawithpython>`_ is a comprehensive introduction to the data analysis process using the Python data ecosystem and an interesting open dataset.
-There are four sections covering selected topics as follows:
-
-* `Munging Data <http://wavedatalab.github.io/datawithpython/munge.html>`_
-
-* `Aggregating Data <http://wavedatalab.github.io/datawithpython/aggregate.html>`_
-
-* `Visualizing Data <http://wavedatalab.github.io/datawithpython/visualize.html>`_
-
-* `Time Series <http://wavedatalab.github.io/datawithpython/timeseries.html>`_
+This `guide <http://wavedatalab.github.io/datawithpython>`_ is an introduction to the data analysis process using the Python data ecosystem and an interesting open dataset.
+There are four sections covering selected topics as `munging data <http://wavedatalab.github.io/datawithpython/munge.html>`__,
+`aggregating data <http://wavedatalab.github.io/datawithpython/aggregate.html>`_, `visualizing data <http://wavedatalab.github.io/datawithpython/visualize.html>`_
+and `time series <http://wavedatalab.github.io/datawithpython/timeseries.html>`_.
 
 .. _tutorial-exercises-new-users:
 
@@ -137,25 +48,6 @@ Exercises for new users
 Practice your skills with real data sets and exercises.
 For more resources, please visit the main `repository <https://github.com/guipsamora/pandas_exercises>`__.
 
-* `01 - Getting & Knowing Your Data <https://github.com/guipsamora/pandas_exercises/tree/master/01_Getting_%26_Knowing_Your_Data>`_
-
-* `02 - Filtering & Sorting <https://github.com/guipsamora/pandas_exercises/tree/master/02_Filtering_%26_Sorting>`_
-
-* `03 - Grouping <https://github.com/guipsamora/pandas_exercises/tree/master/03_Grouping>`_
-
-* `04 - Apply <https://github.com/guipsamora/pandas_exercises/tree/master/04_Apply>`_
-
-* `05 - Merge <https://github.com/guipsamora/pandas_exercises/tree/master/05_Merge>`_
-
-* `06 - Stats <https://github.com/guipsamora/pandas_exercises/tree/master/06_Stats>`_
-
-* `07 - Visualization <https://github.com/guipsamora/pandas_exercises/tree/master/07_Visualization>`_
-
-* `08 - Creating Series and DataFrames <https://github.com/guipsamora/pandas_exercises/tree/master/08_Creating_Series_and_DataFrames/Pokemon>`_
-
-* `09 - Time Series <https://github.com/guipsamora/pandas_exercises/tree/master/09_Time_Series>`_
-
-* `10 - Deleting <https://github.com/guipsamora/pandas_exercises/tree/master/10_Deleting>`_
 
 .. _tutorial-modern:
 


### PR DESCRIPTION
Triggered by discussion in https://github.com/pandas-dev/pandas/pull/24117: currently some of the listed tutorials have a very long included table of content, others much less. Here I kept the current list of tutorials, but simply removed detailed tocs of all of them. Each of them can do that on the page you land on when clicking on the single link.