### PR TITLE
BLD: Require enum34 for Python < 3.4

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1579,7 +1579,7 @@ Build Changes
 
 - Building pandas for development now requires ``cython >= 0.28.2`` (:issue:`21688`)
 - Testing pandas now requires ``hypothesis>=3.58``.  You can find `the Hypothesis docs here <https://hypothesis.readthedocs.io/en/latest/index.html>`_, and a pandas-specific introduction :ref:`in the contributing guide <using-hypothesis>`. (:issue:`22280`)
--
+- Installing pandas for Python 2.7 now requires ``enum34``.
 
 Other
 ^^^^^

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools_kwargs = {
     'install_requires': [
         'python-dateutil >= 2.5.0',
         'pytz >= 2011k',
+        'enum34; python_version < "3.4"',
         'numpy >= {numpy_ver}'.format(numpy_ver=min_numpy_ver),
     ],
     'setup_requires': ['numpy >= {numpy_ver}'.format(numpy_ver=min_numpy_ver)],


### PR DESCRIPTION
pandas-dev/pandas#22802 imports `enum`, which was added to the built-ins in Python 3.4. The `enum34` package backports `enum` to earlier Python versions, so this should be a dependency as long as Python 2.7 is still supported.

To demonstrate the issue, creating a minimal environment using `conda` and installing the nightly Pandas build suffices:

```Shell
conda create -y -n pandas_nightly python=2.7
conda activate pandas_nightly
pip install --pre --find-links=https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com --find-links https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com pandas
```

Then:

```Shell
$ python -c 'import pandas'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/anaconda3/envs/pandas_nightly/lib/python2.7/site-packages/pandas/__init__.py", line 35, in <module>
    "the C extensions first.".format(module))
ImportError: C extension: No module named enum not built. If you want to import pandas from the source directory, you may need to run 'python setup.py build_ext --inplace --force' to build the C extensions first.
```

If I install `enum34`:

```Shell
$ pip install enum34
Collecting enum34
  Using cached https://files.pythonhosted.org/packages/c5/db/e56e6b4bbac7c4a06de1c50de6fe1ef3810018ae11732a50f15f62c7d050/enum34-1.1.6-py2-none-any.whl
Installing collected packages: enum34
Successfully installed enum34-1.1.6
$ python -c 'import pandas'
$
```

- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Not sure what the best way to test this would be. Currently, installing `hypothesis` masks this error, because it contains the requirement `enum34; python_version == "2.7"`.

Related: MacPython/pandas-wheels#36, bids-standard/pybids#276, bids-standard/pybids#315