### PR TITLE
DOC: Ignoring F821 in developer.rst, that are breaking the build

### DIFF
--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -65,8 +65,8 @@ for each column, *including the index columns*. This has JSON form:
     .. code-block:: python
 
        # assuming there's at least 3 levels in the index
-       index_columns = metadata['index_columns']
-       columns = metadata['columns']
+       index_columns = metadata['index_columns']  # noqa: F821
+       columns = metadata['columns']  # noqa: F821
        ith_index = 2
        assert index_columns[ith_index] == '__index_level_2__'
        ith_index_info = columns[-len(index_columns):][ith_index]


### PR DESCRIPTION
I merged #18201 without a rebase, and I didn't realize it'd break the CI, because of flake8 errors (variable not defined) in an example that is not supposed to run.

Fixing the CI by ignoring the `F821` errors.