### PR TITLE
BUG GH16983 fix df.where with extension dtypes

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1418,6 +1418,7 @@ Indexing
 - Bug in :func:`Index.union` and :func:`Index.intersection` where name of the ``Index`` of the result was not computed correctly for certain cases (:issue:`9943`, :issue:`9862`)
 - Bug in :class:`Index` slicing with boolean :class:`Index` may raise ``TypeError`` (:issue:`22533`)
 - Bug in ``PeriodArray.__setitem__`` when accepting slice and list-like value (:issue:`23978`)
+- Bug in :func:`DataFrame.where` where a ``ValueError`` would raise when a column had an extension dtype (:issue:`16983`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1341,6 +1341,8 @@ class Block(PandasObject):
                 return values
 
             values, other = self._try_coerce_args(values, other)
+            if isinstance(values, ExtensionArray):
+                values = values.get_values().reshape(-1, 1)  # GH 16983
 
             try:
                 return self._try_coerce_result(expressions.where(

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3089,6 +3089,15 @@ class TestDataFrameIndexing(TestData):
         result = df1.where(mask, df2)
         assert_frame_equal(exp, result)
 
+    def test_where_extension_dtypes_with_na(self):
+        from pandas.core.sparse.api import SparseDataFrame
+        sdf = DataFrame(SparseDataFrame([1, None]))
+        cdf = DataFrame([1, None]).astype('category')
+        df = DataFrame([1, None])
+
+        assert_frame_equal(df.where(df.isna()), sdf.where(sdf.isna()))
+        assert_frame_equal(df.where(df.isna()), cdf.where(cdf.isna()))
+
     def test_mask(self):
         df = DataFrame(np.random.randn(5, 3))
         cond = df > 0


### PR DESCRIPTION
- [ ] closes #16983???
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The referenced issue showcases two bugs. I was not able to replicate the first one, but I tracked down the cause of the ndim ValueError in the second example. An ExtensionBlock passed to `df.where` used to be unpacked [here](https://github.com/pandas-dev/pandas/blob/defa8a8ed6f627310500388a477186bed995fef1/pandas/core/computation/expressions.py#L126-128) into a 1D array while normal blocks are unpacked earlier [here](https://github.com/pandas-dev/pandas/blob/defa8a8ed6f627310500388a477186bed995fef1/pandas/core/internals/blocks.py#L1343) into a 2D nx1 array.