### PR TITLE
DOC: Fixes to the docs style

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -563,7 +563,8 @@ they need to be sorted. As with any index, you can use :meth:`~DataFrame.sort_in
 
 .. ipython:: python
 
-   import random; random.shuffle(tuples)
+   import random
+   random.shuffle(tuples)
    s = pd.Series(np.random.randn(8), index=pd.MultiIndex.from_tuples(tuples))
    s
    s.sort_index()

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -782,7 +782,7 @@ Setting values by assigning categorical data will also check that the `categorie
     df
     try:
         df.loc["j":"k", "cats"] = pd.Categorical(["b", "b"],
-                                                  categories=["a", "b", "c"])
+                                                 categories=["a", "b", "c"])
     except ValueError as e:
         print("ValueError:", str(e))
 

--- a/doc/source/extending.rst
+++ b/doc/source/extending.rst
@@ -160,6 +160,8 @@ your ``MyExtensionArray`` class, as follows:
 
 .. code-block:: python
 
+    from pandas.core.arrays import ExtensionArray, ExtensionScalarOpsMixin
+
     class MyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         pass
 
@@ -269,7 +271,7 @@ Below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame
 
 .. code-block:: python
 
-   class SubclassedSeries(Series):
+   class SubclassedSeries(pd.Series):
 
        @property
        def _constructor(self):
@@ -280,7 +282,7 @@ Below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame
            return SubclassedDataFrame
 
 
-   class SubclassedDataFrame(DataFrame):
+   class SubclassedDataFrame(pd.DataFrame):
 
        @property
        def _constructor(self):
@@ -342,7 +344,7 @@ Below is an example to define two original properties, "internal_cache" as a tem
 
 .. code-block:: python
 
-   class SubclassedDataFrame2(DataFrame):
+   class SubclassedDataFrame2(pd.DataFrame):
 
        # temporary properties
        _internal_names = pd.DataFrame._internal_names + ['internal_cache']

--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -5,6 +5,7 @@
 .. ipython:: python
    :suppress:
 
+   from matplotlib import pyplot as plt
    import pandas.util._doctools as doctools
    p = doctools.TablePlotter()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,10 +32,18 @@ exclude =
 
 [flake8-rst]
 bootstrap =
-    import pandas as pd
     import numpy as np
+    import pandas as pd
+    np  # avoiding error when importing again numpy or pandas
+    pd  # (in some cases we want to do it to show users)
 ignore = E402,  # module level import not at top of file
          W503,  # line break before binary operator
+         # Classes/functions in different blocks can generate those errors
+         E302,  # expected 2 blank lines, found 0
+         E305,  # expected 2 blank lines after class or function definition, found 0
+         # We use semicolon at the end to avoid displaying plot objects
+         E703,  # statement ends with a semicolon
+
 exclude =
     doc/source/whatsnew/v0.7.0.rst
     doc/source/whatsnew/v0.7.3.rst
@@ -69,23 +77,16 @@ exclude =
     doc/source/whatsnew/v0.23.2.rst
     doc/source/whatsnew/v0.24.0.rst
     doc/source/10min.rst
-    doc/source/advanced.rst
     doc/source/basics.rst
-    doc/source/categorical.rst
     doc/source/contributing_docstring.rst
-    doc/source/contributing.rst
     doc/source/dsintro.rst
     doc/source/enhancingperf.rst
-    doc/source/extending.rst
     doc/source/groupby.rst
     doc/source/indexing.rst
     doc/source/merging.rst
     doc/source/missing_data.rst
     doc/source/options.rst
     doc/source/release.rst
-    doc/source/comparison_with_sas.rst
-    doc/source/comparison_with_sql.rst
-    doc/source/comparison_with_stata.rst
     doc/source/reshaping.rst
     doc/source/visualization.rst
 


### PR DESCRIPTION
Fixing flake8 errors in documentation pages that are mostly correct. Also changing `setup.cfg` to avoid false positives.

- [X] refs #24173
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

