### PR TITLE
TST: Add test case when the key is a reserved key

### DIFF
--- a/pandas/tests/test_config.py
+++ b/pandas/tests/test_config.py
@@ -62,6 +62,10 @@ class TestConfig(object):
         pytest.raises(KeyError, self.cf.register_option, 'a.b.c.d2', 1,
                       'doc')
 
+        # can't register a reserved key option
+        pytest.raises(KeyError, self.cf.register_option, 'all', 1,
+                      'doc')
+
         # no python keywords
         pytest.raises(ValueError, self.cf.register_option, 'for', 0)
         pytest.raises(ValueError, self.cf.register_option, 'a.for.b', 0)


### PR DESCRIPTION
- [ ] closes #24192 
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I saw the reserved_key array on top of the `pandas/core/config.py` file.
```
_reserved_keys = ['all']  # keys which have a special meaning
```

So, I added the test case for test_register_option when the key is a reserved word, which is 'all'.

Please let me know if there is any issue. Thanks.
