### PR TITLE
DOC: Fixed implicit imports for whatsnew (v >= version 20.0)

### DIFF
--- a/doc/source/whatsnew/v0.23.1.rst
+++ b/doc/source/whatsnew/v0.23.1.rst
@@ -38,7 +38,7 @@ To summarize, here's the behavior in 0.22.0, 0.23.0, 0.23.1:
 .. code-block:: python
 
    # 0.22.0... Silently coerce the datetime.date
-   >>> import datetime as datetime
+   >>> import datetime
    >>> pd.Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
    0     True
    1    False

--- a/doc/source/whatsnew/v0.23.1.rst
+++ b/doc/source/whatsnew/v0.23.1.rst
@@ -5,11 +5,6 @@ What's New in 0.23.1 (June 12, 2018)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This is a minor bug-fix release in the 0.23.x series and includes some small regression fixes
 and bug fixes. We recommend that all users upgrade to this version.
@@ -43,19 +38,20 @@ To summarize, here's the behavior in 0.22.0, 0.23.0, 0.23.1:
 .. code-block:: python
 
    # 0.22.0... Silently coerce the datetime.date
-   >>> Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
+   >>> import datetime as datetime
+   >>> pd.Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
    0     True
    1    False
    dtype: bool
 
    # 0.23.0... Do not coerce the datetime.date
-   >>> Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
+   >>> pd.Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
    0    False
    1    False
    dtype: bool
 
    # 0.23.1... Coerce the datetime.date with a warning
-   >>> Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
+   >>> pd.Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
    /bin/python:1: FutureWarning: Comparing Series of datetimes with 'datetime.date'.  Currently, the
    'datetime.date' is coerced to a datetime. In the future pandas will
    not coerce, and the values not compare equal to the 'datetime.date'.

--- a/doc/source/whatsnew/v0.23.2.rst
+++ b/doc/source/whatsnew/v0.23.2.rst
@@ -5,11 +5,6 @@ What's New in 0.23.2 (July 5, 2018)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This is a minor bug-fix release in the 0.23.x series and includes some small regression fixes
 and bug fixes. We recommend that all users upgrade to this version.

--- a/doc/source/whatsnew/v0.23.4.rst
+++ b/doc/source/whatsnew/v0.23.4.rst
@@ -5,11 +5,6 @@ What's New in 0.23.4 (August 3, 2018)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This is a minor bug-fix release in the 0.23.x series and includes some small regression fixes
 and bug fixes. We recommend that all users upgrade to this version.

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -10,11 +10,6 @@ What's New in 0.24.0 (Month XX, 2018)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 These are the changes in pandas 0.24.0. See :ref:`release` for a full changelog
 including other versions of pandas.


### PR DESCRIPTION
- [x] xref #24177 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
This partially resolves #24177 .