### PR TITLE
BUG/PERF: Use EA in Index.get_value

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1209,7 +1209,7 @@ Performance Improvements
 - Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.rank` when dealing with tied rankings (:issue:`21237`)
 - Improved performance of :func:`DataFrame.set_index` with columns consisting of :class:`Period` objects (:issue:`21582`, :issue:`21606`)
-- Improved performance of :meth:`Series.at` and :meth:`Index.get_value` for Extension Arrays values (e.g. :class:`Categorical`) (:issue:``)
+- Improved performance of :meth:`Series.at` and :meth:`Index.get_value` for Extension Arrays values (e.g. :class:`Categorical`) (:issue:`24204`)
 - Improved performance of membership checks in :class:`Categorical` and :class:`CategoricalIndex`
   (i.e. ``x in cat``-style checks are much faster). :meth:`CategoricalIndex.contains`
   is likewise much faster (:issue:`21369`, :issue:`21508`)

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1209,6 +1209,7 @@ Performance Improvements
 - Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.rank` when dealing with tied rankings (:issue:`21237`)
 - Improved performance of :func:`DataFrame.set_index` with columns consisting of :class:`Period` objects (:issue:`21582`, :issue:`21606`)
+- Improved performance of :meth:`Series.at` and :meth:`Index.get_value` for Extension Arrays values (e.g. :class:`Categorical`) (:issue:``)
 - Improved performance of membership checks in :class:`Categorical` and :class:`CategoricalIndex`
   (i.e. ``x in cat``-style checks are much faster). :meth:`CategoricalIndex.contains`
   is likewise much faster (:issue:`21369`, :issue:`21508`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4281,7 +4281,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         # if we have something that is Index-like, then
         # use this, e.g. DatetimeIndex
-        s = getattr(series, '_values', None)
+        # Things like `Series._get_value` (via .at) pass the EA directly here.
+        s = getattr(series, '_values', series)
         if isinstance(s, (ExtensionArray, Index)) and is_scalar(key):
             # GH 20882, 21257
             # Unify Index and ExtensionArray treatment

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -145,3 +145,15 @@ def test_mask_with_boolean_raises(index):
 
     with pytest.raises(ValueError, match='NA / NaN'):
         s[idx]
+
+
+class NonCoercaibleCategorical(Categorical):
+    def __array__(self, dtype=None):
+        raise ValueError("I cannot be converted.")
+
+
+def test_series_at():
+    arr = NonCoercaibleCategorical(['a', 'b', 'c'])
+    ser = Series(arr)
+    result = ser.at[0]
+    assert result == 'a'


### PR DESCRIPTION
Avoid converting the ExtensionArray to an ndarray.

Before

```
pandas/tests/arrays/categorical/test_indexing.py F                                                                                                   [100%]

========================================================================= FAILURES =========================================================================
______________________________________________________________________ test_series_at ______________________________________________________________________

    def test_series_at():
        arr = NonCoercaibleCategorical(['a', 'b', 'c'])
        ser = Series(arr)
>       result = ser.at[0]

pandas/tests/arrays/categorical/test_indexing.py:158:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pandas/core/indexing.py:2266: in __getitem__
    return self.obj._get_value(*key, takeable=self._takeable)
pandas/core/series.py:1078: in _get_value
    return self.index.get_value(self._values, label)
pandas/core/indexes/base.py:4303: in get_value
    s = com.values_from_object(series)
pandas/_libs/lib.pyx:82: in pandas._libs.lib.values_from_object
    obj = func()
pandas/core/arrays/categorical.py:1509: in get_values
    return np.array(self)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[ValueError("I cannot be converted.") raised in repr()] NonCoercaibleCategorical object at 0x113d8b6a0>, dtype = None

    def __array__(self, dtype=None):
>       raise ValueError("I cannot be converted.")
E       ValueError: I cannot be converted.

```

Perf:

```
In [3]: a = pd.Series(pd.Categorical(np.random.choice(list(string.ascii_letters[:10]), 10_000)))

In [4]: %timeit a.at[0]
143 µs ± 4.86 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [3]: a = pd.Series(pd.Categorical(np.random.choice(list(string.ascii_letters[:10]), 10_000)))

In [4]: %timeit a.at[0]
11.1 µs ± 95.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

---

Split from #24024