### PR TITLE
Alternative implementation for `.where` on EA-backed Indexes

### DIFF
--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -507,7 +507,9 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         # 3. Rebuild CategoricalIndex.
         if other is None:
             other = self._na_value
-        cat = CategoricalIndex(self.values.where(cond, other),
+        copied_cat = Categorical(self.values, dtype=self.dtype)
+        copied_cat[cond] = other
+        cat = CategoricalIndex(copied_cat,
                                dtype=self.dtype)
         return self._shallow_copy(cat, **self._get_attributes_dict())
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -507,8 +507,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         # 3. Rebuild CategoricalIndex.
         if other is None:
             other = self._na_value
-        values = np.where(cond, self.values, other)
-        cat = Categorical(values, dtype=self.dtype)
+        cat = CategoricalIndex(self.values.where(cond, other), dtype=self.dtype)
         return self._shallow_copy(cat, **self._get_attributes_dict())
 
     def reindex(self, target, method=None, level=None, limit=None,

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -507,7 +507,8 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         # 3. Rebuild CategoricalIndex.
         if other is None:
             other = self._na_value
-        cat = CategoricalIndex(self.values.where(cond, other), dtype=self.dtype)
+        cat = CategoricalIndex(self.values.where(cond, other),
+                               dtype=self.dtype)
         return self._shallow_copy(cat, **self._get_attributes_dict())
 
     def reindex(self, target, method=None, level=None, limit=None,


### PR DESCRIPTION
- [ ] closes #24144
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
