### PR TITLE
Fix docstring of functions created with the deprecate() function

### DIFF
--- a/pandas/tests/util/test_deprecate.py
+++ b/pandas/tests/util/test_deprecate.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 import pytest
 
 from pandas.util._decorators import deprecate
+
 import pandas.util.testing as tm
 
 

--- a/pandas/tests/util/test_deprecate.py
+++ b/pandas/tests/util/test_deprecate.py
@@ -12,11 +12,16 @@ def new_func():
 
     This is the extended summary. The deprecate directive goes before this.
     """
-    return 1234
+    return 'new_func called'
 
 
 def new_func_no_docstring():
-    pass
+    return 'new_func_no_docstring called'
+
+
+def new_func_wrong_docstring():
+    """Summary should be in the next line."""
+    return 'new_func_wrong_docstring called'
 
 
 def new_func_with_deprecation():
@@ -38,13 +43,20 @@ def test_deprecate_ok():
     with tm.assert_produces_warning(FutureWarning):
         result = depr_func()
 
-    assert result == 1234
-
+    assert result == 'new_func called'
     assert depr_func.__doc__ == dedent(new_func_with_deprecation.__doc__)
 
 
 def test_deprecate_no_docstring():
-    with pytest.raises(ValueError, match='deprecate needs a correctly '
-                                         'formatted docstring'):
-        deprecate('depr_func', new_func_no_docstring, '1.0',
+    depr_func = deprecate('depr_func', new_func_no_docstring, '1.0',
+                          msg='Use new_func instead.')
+    with tm.assert_produces_warning(FutureWarning):
+        result = depr_func()
+    assert result == 'new_func_no_docstring called'
+
+
+def test_deprecate_wrong_docstring():
+    with pytest.raises(AssertionError, match='deprecate needs a correctly '
+                                             'formatted docstring'):
+        deprecate('depr_func', new_func_wrong_docstring, '1.0',
                   msg='Use new_func instead.')

--- a/pandas/tests/util/test_deprecate.py
+++ b/pandas/tests/util/test_deprecate.py
@@ -1,0 +1,50 @@
+from textwrap import dedent
+
+import pytest
+
+from pandas.util._decorators import deprecate
+import pandas.util.testing as tm
+
+
+def new_func():
+    """
+    This is the summary. The deprecate directive goes next.
+
+    This is the extended summary. The deprecate directive goes before this.
+    """
+    return 1234
+
+
+def new_func_no_docstring():
+    pass
+
+
+def new_func_with_deprecation():
+    """
+    This is the summary. The deprecate directive goes next.
+
+    .. deprecated:: 1.0
+        Use new_func instead.
+
+    This is the extended summary. The deprecate directive goes before this.
+    """
+    pass
+
+
+def test_deprecate_ok():
+    depr_func = deprecate('depr_func', new_func, '1.0',
+                          msg='Use new_func instead.')
+
+    with tm.assert_produces_warning(FutureWarning):
+        result = depr_func()
+
+    assert result == 1234
+
+    assert depr_func.__doc__ == dedent(new_func_with_deprecation.__doc__)
+
+
+def test_deprecate_no_docstring():
+    with pytest.raises(ValueError, match='deprecate needs a correctly '
+                                         'formatted docstring'):
+        deprecate('depr_func', new_func_no_docstring, '1.0',
+                  msg='Use new_func instead.')

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 import inspect
-from textwrap import dedent, wrap
+from textwrap import dedent
 import warnings
 
 from pandas._libs.properties import cache_readonly  # noqa


### PR DESCRIPTION
Functions created with `deprecate` function in `pandas.util._decorators` are causing us some problems, for example in #24188, as the docstring is created automatically, and the `.. deprecate::` directive was added at the start. This PR fixes the docstring of the functions created with `deprecate` and adds tests to the function, as they were non-existent.

- [ ] closes #xxxx
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
