### PR TITLE
Fix flake8 issues on v22, v23 and v24rst

### DIFF
--- a/doc/source/whatsnew/v0.22.0.rst
+++ b/doc/source/whatsnew/v0.22.0.rst
@@ -137,8 +137,8 @@ sum and ``1`` for product.
 .. code-block:: ipython
 
    In [11]: s = pd.Series([1, 1, np.nan, np.nan],
-      ...:                index=pd.date_range('2017', periods=4))
-      ...:  s
+      ....:               index=pd.date_range('2017', periods=4))
+      ....: s
    Out[11]:
    2017-01-01    1.0
    2017-01-02    1.0

--- a/doc/source/whatsnew/v0.23.0.rst
+++ b/doc/source/whatsnew/v0.23.0.rst
@@ -337,7 +337,7 @@ outside the existing valid values while preserving those inside.  (:issue:`16284
 .. ipython:: python
 
    ser = pd.Series([np.nan, np.nan, 5, np.nan, np.nan,
-                   np.nan, 13, np.nan, np.nan])
+                    np.nan, 13, np.nan, np.nan])
    ser
 
 Fill one consecutive inside value in both directions

--- a/doc/source/whatsnew/v0.23.0.rst
+++ b/doc/source/whatsnew/v0.23.0.rst
@@ -53,10 +53,10 @@ A ``DataFrame`` can now be written to and subsequently read back via JSON while 
 .. ipython:: python
 
    df = pd.DataFrame({'foo': [1, 2, 3, 4],
-		      'bar': ['a', 'b', 'c', 'd'],
-		      'baz': pd.date_range('2018-01-01', freq='d', periods=4),
-		      'qux': pd.Categorical(['a', 'b', 'c', 'c'])
-		      }, index=pd.Index(range(4), name='idx'))
+                      'bar': ['a', 'b', 'c', 'd'],
+                      'baz': pd.date_range('2018-01-01', freq='d', periods=4),
+                      'qux': pd.Categorical(['a', 'b', 'c', 'c'])},
+                     index=pd.Index(range(4), name='idx'))
    df
    df.dtypes
    df.to_json('test.json', orient='table')
@@ -97,7 +97,7 @@ The :func:`DataFrame.assign` now accepts dependent keyword arguments for python 
 
     df = pd.DataFrame({'A': [1, 2, 3]})
     df
-    df.assign(B=df.A, C=lambda x:x['A']+ x['B'])
+    df.assign(B=df.A, C=lambda x: x['A'] + x['B'])
 
 .. warning::
 
@@ -122,7 +122,7 @@ The :func:`DataFrame.assign` now accepts dependent keyword arguments for python 
 
   .. ipython:: python
 
-      df.assign(A=df.A+1, C= lambda df: df.A* -1)
+      df.assign(A=df.A + 1, C=lambda df: df.A * -1)
 
 
 
@@ -284,7 +284,7 @@ For pivotting operations, this behavior is *already* controlled by the ``dropna`
                          categories=["a", "b", "z"], ordered=True)
    cat2 = pd.Categorical(["c", "d", "c", "d"],
                          categories=["c", "d", "y"], ordered=True)
-   df = DataFrame({"A": cat1, "B": cat2, "values": [1, 2, 3, 4]})
+   df = pd.DataFrame({"A": cat1, "B": cat2, "values": [1, 2, 3, 4]})
    df
 
 .. ipython:: python
@@ -336,7 +336,8 @@ outside the existing valid values while preserving those inside.  (:issue:`16284
 
 .. ipython:: python
 
-   ser = pd.Series([np.nan, np.nan, 5, np.nan, np.nan, np.nan, 13, np.nan, np.nan])
+   ser = pd.Series([np.nan, np.nan, 5, np.nan, np.nan,
+                   np.nan, 13, np.nan, np.nan])
    ser
 
 Fill one consecutive inside value in both directions
@@ -600,15 +601,16 @@ Previous Behavior (and current behavior if on Python < 3.6):
 
 .. code-block:: ipython
 
-   pd.Series({'Income': 2000,
-              'Expenses': -1500,
-              'Taxes': -200,
-              'Net result': 300})
-   Expenses     -1500
-   Income        2000
-   Net result     300
-   Taxes         -200
-   dtype: int64
+    In [16]: pd.Series({'Income': 2000,
+       ....:            'Expenses': -1500,
+       ....:            'Taxes': -200,
+       ....:            'Net result': 300})
+    Out[16]:
+    Expenses     -1500
+    Income        2000
+    Net result     300
+    Taxes         -200
+    dtype: int64
 
 Note the Series above is ordered alphabetically by the index values.
 
@@ -696,7 +698,8 @@ where a list-like (e.g. ``tuple`` or ``list`` is returned) (:issue:`16353`, :iss
 
 .. ipython:: python
 
-    df = pd.DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1, columns=['A', 'B', 'C'])
+    df = pd.DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1,
+                      columns=['A', 'B', 'C'])
     df
 
 Previous Behavior: if the returned shape happened to match the length of original columns, this would return a ``DataFrame``.
@@ -750,7 +753,7 @@ Returning a ``Series`` allows one to control the exact return structure and colu
 
 .. ipython:: python
 
-    df.apply(lambda x: Series([1, 2, 3], index=['D', 'E', 'F']), axis=1)
+    df.apply(lambda x: pd.Series([1, 2, 3], index=['D', 'E', 'F']), axis=1)
 
 .. _whatsnew_0230.api_breaking.concat:
 
@@ -825,10 +828,12 @@ Current Behavior:
 .. ipython:: python
 
     index = pd.Int64Index([-1, 0, 1])
-    # division by zero gives -infinity where negative, +infinity where positive, and NaN for 0 / 0
+    # division by zero gives -infinity where negative,
+    # +infinity where positive, and NaN for 0 / 0
     index / 0
 
-    # The result of division by zero should not depend on whether the zero is int or float
+    # The result of division by zero should not depend on
+    # whether the zero is int or float
     index / 0.0
 
     index = pd.UInt64Index([0, 1])
@@ -853,7 +858,7 @@ Previous Behavior:
 
     In [1]: s = pd.Series(['number 10', '12 eggs'])
 
-    In [2]: extracted = s.str.extract('.*(\d\d).*')
+    In [2]: extracted = s.str.extract(r'.*(\d\d).*')
 
     In [3]: extracted
     Out [3]:
@@ -870,7 +875,7 @@ New Behavior:
 .. ipython:: python
 
     s = pd.Series(['number 10', '12 eggs'])
-    extracted = s.str.extract('.*(\d\d).*')
+    extracted = s.str.extract(r'.*(\d\d).*')
     extracted
     type(extracted)
 
@@ -879,7 +884,7 @@ To restore previous behavior, simply set ``expand`` to ``False``:
 .. ipython:: python
 
     s = pd.Series(['number 10', '12 eggs'])
-    extracted = s.str.extract('.*(\d\d).*', expand=False)
+    extracted = s.str.extract(r'.*(\d\d).*', expand=False)
     extracted
     type(extracted)
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -252,7 +252,7 @@ convenient way to apply users' predefined styling functions, and can help reduce
 
 .. ipython:: python
 
-    df = pandas.DataFrame({'N': [1250, 1500, 1750], 'X': [0.25, 0.35, 0.50]})
+    df = pd.DataFrame({'N': [1250, 1500, 1750], 'X': [0.25, 0.35, 0.50]})
 
     def format_and_align(styler):
         return (styler.format({'N': '{:,}', 'X': '{:.1%}'})
@@ -282,8 +282,7 @@ See the :ref:`Merge, join, and concatenate
 
 
    left = pd.DataFrame({'A': ['A0', 'A1', 'A2'],
-                        'B': ['B0', 'B1', 'B2']},
-                         index=index_left)
+                        'B': ['B0', 'B1', 'B2']}, index=index_left)
 
 
    index_right = pd.MultiIndex.from_tuples([('K0', 'Y0'), ('K1', 'Y1'),
@@ -292,11 +291,9 @@ See the :ref:`Merge, join, and concatenate
 
 
    right = pd.DataFrame({'C': ['C0', 'C1', 'C2', 'C3'],
-                         'D': ['D0', 'D1', 'D2', 'D3']},
-                        index=index_right)
+                         'D': ['D0', 'D1', 'D2', 'D3']}, index=index_right)
 
-
-    left.join(right)
+   left.join(right)
 
 For earlier versions this can be done using the following.
 
@@ -441,26 +438,26 @@ Previous Behavior on Windows:
 
 .. code-block:: ipython
 
-    In [1]: data = pd.DataFrame({
-    ...:     "string_with_lf": ["a\nbc"],
-    ...:     "string_with_crlf": ["a\r\nbc"]
-    ...: })
+    In [1]: data = pd.DataFrame({"string_with_lf": ["a\nbc"],
+       ...:                      "string_with_crlf": ["a\r\nbc"]})
 
-    In [2]: # When passing file PATH to to_csv, line_terminator does not work, and csv is saved with '\r\n'.
-    ...: # Also, this converts all '\n's in the data to '\r\n'.
-    ...: data.to_csv("test.csv", index=False, line_terminator='\n')
+    In [2]: # When passing file PATH to to_csv,
+       ...: # line_terminator does not work, and csv is saved with '\r\n'.
+       ...: # Also, this converts all '\n's in the data to '\r\n'.
+       ...: data.to_csv("test.csv", index=False, line_terminator='\n')
 
     In [3]: with open("test.csv", mode='rb') as f:
-    ...:     print(f.read())
-    b'string_with_lf,string_with_crlf\r\n"a\r\nbc","a\r\r\nbc"\r\n'
+       ...:     print(f.read())
+    Out[3]: b'string_with_lf,string_with_crlf\r\n"a\r\nbc","a\r\r\nbc"\r\n'
 
-    In [4]: # When passing file OBJECT with newline option to to_csv, line_terminator works.
-    ...: with open("test2.csv", mode='w', newline='\n') as f:
-    ...:     data.to_csv(f, index=False, line_terminator='\n')
+    In [4]: # When passing file OBJECT with newline option to
+       ...: # to_csv, line_terminator works.
+       ...: with open("test2.csv", mode='w', newline='\n') as f:
+       ...:     data.to_csv(f, index=False, line_terminator='\n')
 
     In [5]: with open("test2.csv", mode='rb') as f:
-    ...:     print(f.read())
-    b'string_with_lf,string_with_crlf\n"a\nbc","a\r\nbc"\n'
+       ...:     print(f.read())
+    Out[5]: b'string_with_lf,string_with_crlf\n"a\nbc","a\r\nbc"\n'
 
 
 New Behavior on Windows:
@@ -471,16 +468,14 @@ New Behavior on Windows:
 
   .. code-block:: ipython
 
-    In [1]: data = pd.DataFrame({
-    ...:     "string_with_lf": ["a\nbc"],
-    ...:     "string_with_crlf": ["a\r\nbc"]
-    ...: })
+    In [1]: data = pd.DataFrame({"string_with_lf": ["a\nbc"],
+       ...:                      "string_with_crlf": ["a\r\nbc"]})
 
     In [2]: data.to_csv("test.csv", index=False, line_terminator='\n')
 
     In [3]: with open("test.csv", mode='rb') as f:
-    ...:     print(f.read())
-    b'string_with_lf,string_with_crlf\n"a\nbc","a\r\nbc"\n'
+       ...:     print(f.read())
+    Out[3]: b'string_with_lf,string_with_crlf\n"a\nbc","a\r\nbc"\n'
 
 
 - On Windows, the value of ``os.linesep`` is ``'\r\n'``,
@@ -489,16 +484,14 @@ New Behavior on Windows:
 
   .. code-block:: ipython
 
-    In [1]: data = pd.DataFrame({
-    ...: "string_with_lf": ["a\nbc"],
-    ...: "string_with_crlf": ["a\r\nbc"]
-    ...: })
+    In [1]: data = pd.DataFrame({"string_with_lf": ["a\nbc"],
+       ...:                      "string_with_crlf": ["a\r\nbc"]})
 
     In [2]: data.to_csv("test.csv", index=False)
 
     In [3]: with open("test.csv", mode='rb') as f:
-    ...:     print(f.read())
-    b'string_with_lf,string_with_crlf\r\n"a\nbc","a\r\nbc"\r\n'
+       ...:     print(f.read())
+    Out[3]: b'string_with_lf,string_with_crlf\r\n"a\nbc","a\r\nbc"\r\n'
 
 
 - For files objects, specifying ``newline`` is not sufficient to set the line terminator.
@@ -506,17 +499,15 @@ New Behavior on Windows:
 
   .. code-block:: ipython
 
-    In [1]: data = pd.DataFrame({
-    ...: "string_with_lf": ["a\nbc"],
-    ...: "string_with_crlf": ["a\r\nbc"]
-    ...: })
+    In [1]: data = pd.DataFrame({"string_with_lf": ["a\nbc"],
+       ...:                      "string_with_crlf": ["a\r\nbc"]})
 
     In [2]: with open("test2.csv", mode='w', newline='\n') as f:
-    ...:     data.to_csv(f, index=False)
+       ...:     data.to_csv(f, index=False)
 
     In [3]: with open("test2.csv", mode='rb') as f:
-    ...:     print(f.read())
-    b'string_with_lf,string_with_crlf\r\n"a\nbc","a\r\nbc"\r\n'
+       ...:     print(f.read())
+    Out[3]: b'string_with_lf,string_with_crlf\r\n"a\nbc","a\r\nbc"\r\n'
 
 .. _whatsnew_0240.api.timezone_offset_parsing:
 
@@ -563,7 +554,8 @@ Parsing datetime strings with different UTC offsets will now create an Index of
 
 .. ipython:: python
 
-    idx = pd.to_datetime(["2015-11-18 15:30:00+05:30", "2015-11-18 16:30:00+06:30"])
+    idx = pd.to_datetime(["2015-11-18 15:30:00+05:30",
+                          "2015-11-18 16:30:00+06:30"])
     idx
     idx[0]
     idx[1]
@@ -573,7 +565,8 @@ that the dates have been converted to UTC
 
 .. ipython:: python
 
-    pd.to_datetime(["2015-11-18 15:30:00+05:30", "2015-11-18 16:30:00+06:30"], utc=True)
+    pd.to_datetime(["2015-11-18 15:30:00+05:30",
+                    "2015-11-18 16:30:00+06:30"], utc=True)
 
 .. _whatsnew_0240.api_breaking.calendarday:
 
@@ -845,7 +838,7 @@ Previous Behavior:
    In [4]: df = pd.DataFrame(arr)
 
    In [5]: df == arr[[0], :]
-      ...: # comparison previously broadcast where arithmetic would raise
+       ...: # comparison previously broadcast where arithmetic would raise
    Out[5]:
           0      1
    0   True   True
@@ -856,8 +849,8 @@ Previous Behavior:
    ValueError: Unable to coerce to DataFrame, shape must be (3, 2): given (1, 2)
 
    In [7]: df == (1, 2)
-      ...: # length matches number of columns;
-      ...: # comparison previously raised where arithmetic would broadcast
+       ...: # length matches number of columns;
+       ...: # comparison previously raised where arithmetic would broadcast
    ...
    ValueError: Invalid broadcasting comparison [(1, 2)] with block values
    In [8]: df + (1, 2)
@@ -868,8 +861,8 @@ Previous Behavior:
    2  5  7
 
    In [9]: df == (1, 2, 3)
-      ...: # length matches number of rows
-      ...: # comparison previously broadcast where arithmetic would raise
+       ...:  # length matches number of rows
+       ...:  # comparison previously broadcast where arithmetic would raise
    Out[9]:
           0      1
    0  False   True
@@ -1032,7 +1025,8 @@ Current Behavior:
 
 .. code-block:: ipython
 
-    In [3]: df = pd.DataFrame({'a': [1, 2, 2, 2, 2], 'b': [3, 3, 4, 4, 4],
+    In [3]: df = pd.DataFrame({'a': [1, 2, 2, 2, 2],
+       ...:                    'b': [3, 3, 4, 4, 4],
        ...:                    'c': [1, 1, np.nan, 1, 1]})
     In [4]: pd.crosstab(df.a, df.b, normalize='columns')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,8 +71,6 @@ exclude =
     doc/source/whatsnew/v0.19.0.rst
     doc/source/whatsnew/v0.20.0.rst
     doc/source/whatsnew/v0.21.0.rst
-    doc/source/whatsnew/v0.22.0.rst
-    doc/source/whatsnew/v0.23.0.rst
     doc/source/whatsnew/v0.23.1.rst
     doc/source/whatsnew/v0.23.2.rst
     doc/source/whatsnew/v0.24.0.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,6 @@ exclude =
     doc/source/whatsnew/v0.21.0.rst
     doc/source/whatsnew/v0.23.1.rst
     doc/source/whatsnew/v0.23.2.rst
-    doc/source/whatsnew/v0.24.0.rst
     doc/source/basics.rst
     doc/source/contributing_docstring.rst
     doc/source/enhancingperf.rst


### PR DESCRIPTION
- [x] closes #24200, #24201 and #24202 
- [x] `flake8-rst source/whatsnew/v0.22.0.rst` and `flake8-rst source/whatsnew/v0.23.0.rst` 
This is related to #24177

