### PR TITLE
Patch for pandas.core.computation.eval with str/byte ndarrays

### DIFF
--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -58,7 +58,7 @@ class AbstractEngine(object):
         """
         return printing.pprint_thing(self.expr)
 
-    def evaluate(self):
+    def evaluate(self, as_dataframe=True):
         """Run the engine on the expression
 
         This method performs alignment which is necessary no matter what engine
@@ -69,11 +69,13 @@ class AbstractEngine(object):
         obj : object
             The result of the passed expression.
         """
-        if not self._is_aligned:
+        if as_dataframe and not self._is_aligned:
             self.result_type, self.aligned_axes = _align(self.expr.terms)
 
         # make sure no names in resolvers and locals/globals clash
         res = self._evaluate()
+        if not as_dataframe:
+            return res
         return _reconstruct_object(self.result_type, res, self.aligned_axes,
                                    self.expr.terms.return_type)
 
@@ -141,7 +143,7 @@ class PythonEngine(AbstractEngine):
     def __init__(self, expr):
         super(PythonEngine, self).__init__(expr)
 
-    def evaluate(self):
+    def evaluate(self, as_dataframe=True):
         return self.expr()
 
     def _evaluate(self):

--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -58,7 +58,7 @@ class AbstractEngine(object):
         """
         return printing.pprint_thing(self.expr)
 
-    def evaluate(self, as_dataframe=True):
+    def evaluate(self, align_result=True):
         """Run the engine on the expression
 
         This method performs alignment which is necessary no matter what engine
@@ -69,12 +69,12 @@ class AbstractEngine(object):
         obj : object
             The result of the passed expression.
         """
-        if as_dataframe and not self._is_aligned:
+        if align_result and not self._is_aligned:
             self.result_type, self.aligned_axes = _align(self.expr.terms)
 
         # make sure no names in resolvers and locals/globals clash
         res = self._evaluate()
-        if not as_dataframe:
+        if not align_result:
             return res
         return _reconstruct_object(self.result_type, res, self.aligned_axes,
                                    self.expr.terms.return_type)
@@ -143,7 +143,7 @@ class PythonEngine(AbstractEngine):
     def __init__(self, expr):
         super(PythonEngine, self).__init__(expr)
 
-    def evaluate(self, as_dataframe=True):
+    def evaluate(self, align_result=True):
         return self.expr()
 
     def _evaluate(self):

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -155,7 +155,7 @@ def _check_for_locals(expr, stack_level, parser):
 
 def eval(expr, parser='pandas', engine=None, truediv=True,
          local_dict=None, global_dict=None, resolvers=(), level=0,
-         target=None, inplace=False):
+         target=None, inplace=False, as_dataframe=True):
     """Evaluate a Python expression as a string using various backends.
 
     The following arithmetic operations are supported: ``+``, ``-``, ``*``,
@@ -296,7 +296,7 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
         # construct the engine and evaluate the parsed expression
         eng = _engines[engine]
         eng_inst = eng(parsed_expr)
-        ret = eng_inst.evaluate()
+        ret = eng_inst.evaluate(as_dataframe=as_dataframe)
 
         if parsed_expr.assigner is None:
             if multi_line:

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -155,7 +155,7 @@ def _check_for_locals(expr, stack_level, parser):
 
 def eval(expr, parser='pandas', engine=None, truediv=True,
          local_dict=None, global_dict=None, resolvers=(), level=0,
-         target=None, inplace=False, as_dataframe=True, str_as_bytes=False):
+         target=None, inplace=False, align_result=True, str_as_bytes=False):
     """Evaluate a Python expression as a string using various backends.
 
     The following arithmetic operations are supported: ``+``, ``-``, ``*``,
@@ -221,6 +221,12 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
         If `target` is provided, and the expression mutates `target`, whether
         to modify `target` inplace. Otherwise, return a copy of `target` with
         the mutation.
+    align_result : bool, default True
+        If none of the terms are Dataframes or Series, whether to infer the
+        result type and align the result. This only works if all terms are
+        numeric.
+        If any term is a Dataframe or Series, alignment is already done
+        automatically.
 
     Returns
     -------
@@ -296,7 +302,7 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
         # construct the engine and evaluate the parsed expression
         eng = _engines[engine]
         eng_inst = eng(parsed_expr)
-        ret = eng_inst.evaluate(as_dataframe=as_dataframe)
+        ret = eng_inst.evaluate(align_result=align_result)
 
         if parsed_expr.assigner is None:
             if multi_line:

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -229,7 +229,7 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
         automatically.
     str_as_bytes : bool, default False
         Whether to interpret string literals in `expr` as bytes.
-        
+
 
     Returns
     -------

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -155,7 +155,7 @@ def _check_for_locals(expr, stack_level, parser):
 
 def eval(expr, parser='pandas', engine=None, truediv=True,
          local_dict=None, global_dict=None, resolvers=(), level=0,
-         target=None, inplace=False, as_dataframe=True):
+         target=None, inplace=False, as_dataframe=True, str_as_bytes=False):
     """Evaluate a Python expression as a string using various backends.
 
     The following arithmetic operations are supported: ``+``, ``-``, ``*``,
@@ -291,7 +291,7 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
                             target=target)
 
         parsed_expr = Expr(expr, engine=engine, parser=parser, env=env,
-                           truediv=truediv)
+                           truediv=truediv, str_as_bytes=str_as_bytes)
 
         # construct the engine and evaluate the parsed expression
         eng = _engines[engine]

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -227,6 +227,9 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
         numeric.
         If any term is a Dataframe or Series, alignment is already done
         automatically.
+    str_as_bytes : bool, default False
+        Whether to interpret string literals in `expr` as bytes.
+        
 
     Returns
     -------


### PR DESCRIPTION
Hello,
I am interested in using Pandas as a numexpr replacement, since its eval/query syntax is much cleaner. However, it doesn't quite work for me, since I rely on byte ndarrays, and I want to avoid DataFrames. Here is an example script that shows the problems I had, and how they are solved in a patched version. I am not very used to open source projects, I hope my patch will be acceptable.

cheers

Sjoerd

### Example script

```python
import numpy as np
import numexpr as ne
from pandas import DataFrame
from pandas.core.computation.eval import eval as pd_eval

# Sample data
s = np.zeros(6, 'S5')
v = np.array([5,8,3,6,7,2])
s[:4] = "Test", "Test2", "Test", "Test"
s_u = np.array([ss.decode() for ss in s])  # s as unicode
dic = {"s": s, "v": v}
dic_u = {"s": s_u, "v": v}


print("Golden standard (numexpr with ugly syntax)\t", ne.evaluate("(s == 'Test') & (v > 3)", dic))

df = DataFrame(dic)
print("df with bytes (wrong)\t\t\t\t", df.eval("s == 'Test' and v > 3").values)
try:  # ugly syntax AND does not work
    print(df.eval("s == b'Test' and v > 3").values)
except AttributeError:
    print("*" * 50)
    import traceback; traceback.print_exc(0)
    print("*" * 50)

df = DataFrame(dic_u)
print("df with unicode (works)\t\t\t\t", df.eval("s == 'Test' and v > 3").values)


from pandas.core.computation.eval import eval as pd_eval
print("pd_eval with bytes (wrong)\t\t\t", pd_eval("s == 'Test' and v > 3", global_dict=dic))
print("pd_eval with unicode (wrong)\t\t\t", pd_eval("s == 'Test' and v > 3", global_dict=dic_u))

print("patched pd_eval with bytes (works)\t\t", pd_eval("s == 'Test' and v > 3", global_dict=dic, align_result=False, str_as_bytes=True))
print("patched pd_eval with unicode (works)\t\t", pd_eval("s == 'Test' and v > 3", global_dict=dic_u, align_result=False, str_as_bytes=True))
```

### Output
```
Golden standard (numexpr with ugly syntax)       [ True False False  True False False]
df with bytes (wrong)                            [False False False False False False]
**************************************************
Traceback (most recent call last):
AttributeError: 'PandasExprVisitor' object has no attribute 'visit_Bytes'
**************************************************
df with unicode (works)                          [ True False False  True False False]
pd_eval with bytes (wrong)                       [False False False False False False]
pd_eval with unicode (wrong)                     [False False False False False False]
patched pd_eval with bytes (works)               [ True False False  True False False]
patched pd_eval with unicode (works)             [ True False False  True False False]
```