### PR TITLE
DOC: add back currentmodule to api.rst

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: pandas
+
 .. _api:
 
 {{ header }}

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,3 +1,7 @@
+.. The currentmodule is needed here because the autosummary generation of files
+.. happens before reading the files / substituting the header.
+.. See https://github.com/pandas-dev/pandas/pull/24232
+
 .. currentmodule:: pandas
 
 .. _api:


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/24191

@datapythonista I don't understand why, but the `.. currentmodule:: pandas` does not seem to be picked up from `header.rst`, giving extra warnings and missing links (because in api.rst, everything up to the first inline `currentmodule`, is not found)

See eg http://pandas-docs.github.io/pandas-docs-travis/api.html, only from json there are actual links.