### PR TITLE
CI: Not forcing imports to be sorted alphabetically

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -142,7 +142,7 @@ known_third_party=Cython,numpy,python-dateutil,pytz,pyarrow,pytest
 multi_line_output=4
 force_grid_wrap=0
 combine_as_imports=True
-force_sort_within_sections=True
+force_sort_within_sections=False
 skip=
     pandas/core/api.py,
     pandas/core/frame.py,


### PR DESCRIPTION
Not sure what's your experience with it since we added the validation of the order of the imports. But most files are skipped and there is no work anymore on sorting the imports, and for the ones that we validate, the super strict order is bothering more than adding any value.

I'm +1 on enforcing PEP8 and sorting imports by stdlib, 3rd party and pandas. And +0 on importing `pandas.core`, `pandas.util` and not sure if something else before the rest of pandas.

But more complexity than that, and specially sorting alphabetically, I think it's just annoying us for no reason.

@jreback @jorisvandenbossche @TomAugspurger @jbrockmendel 