### PR TITLE
DOC: avoid warnings ipython 'Code input with no code'

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -694,7 +694,7 @@ Finally, as a small note on performance, because the ``take`` method handles
 a narrower range of inputs, it can offer performance that is a good deal
 faster than fancy indexing.
 
-.. ipython::
+.. ipython:: python
 
    arr = np.random.randn(10000, 5)
    indexer = np.arange(10000)

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -575,7 +575,6 @@ with the original ``DataFrame``:
    dummies = pd.get_dummies(df['key'], prefix='key')
    dummies
 
-
    df[['data1']].join(dummies)
 
 This function is often used along with discretization functions like ``cut``:
@@ -585,9 +584,7 @@ This function is often used along with discretization functions like ``cut``:
    values = np.random.randn(10)
    values
 
-
    bins = [0, 0.2, 0.4, 0.6, 0.8, 1]
-
 
    pd.get_dummies(pd.cut(values, bins))
 

--- a/doc/source/whatsnew/v0.17.0.rst
+++ b/doc/source/whatsnew/v0.17.0.rst
@@ -627,8 +627,6 @@ New Behavior:
    In [3]: pd.to_datetime(['2009-07-31', 'asd'])
    ValueError: Unknown string format
 
-.. ipython:: python
-
 Of course you can coerce this as well.
 
 .. ipython:: python

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -275,15 +275,12 @@ See the :ref:`Merge, join, and concatenate
                                           ('K1', 'X2')],
                                           names=['key', 'X'])
 
-
    left = pd.DataFrame({'A': ['A0', 'A1', 'A2'],
                         'B': ['B0', 'B1', 'B2']}, index=index_left)
-
 
    index_right = pd.MultiIndex.from_tuples([('K0', 'Y0'), ('K1', 'Y1'),
                                            ('K2', 'Y2'), ('K2', 'Y3')],
                                            names=['key', 'Y'])
-
 
    right = pd.DataFrame({'C': ['C0', 'C1', 'C2', 'C3'],
                          'D': ['D0', 'D1', 'D2', 'D3']}, index=index_right)


### PR DESCRIPTION
Need to check in the doc build log if this actually solves some of the warnings like

```
/home/travis/miniconda3/envs/pandas-dev/lib/python3.6/site-packages/IPython/sphinxext/ipython_directive.py:1020: UserWarning: Code input with no code at /home/travis/build/pandas-dev/pandas/doc/source/whatsnew/v0.24.0.rst, line 304
```

@datapythonista one annoying thing with the included `{{ header }}` is that the reported line numbers no longer are correct ... 