### PR TITLE
BLD: json deprecated unicode capi

### DIFF
--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -433,8 +433,7 @@ static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
     }
 #endif
 
-    newObj = PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(obj),
-                                  PyUnicode_GET_SIZE(obj), NULL);
+    newObj = PyUnicode_AsUTF8String(obj);
 
     GET_TC(tc)->newObj = newObj;
 


### PR DESCRIPTION
closes #24221

just copying the upstream fix
https://github.com/esnme/ultrajson/commit/ab8f41954a282c67acda7f07a670bb953b98b7c9
