### PR TITLE
EHN: Add filename to FileNotFoundError

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -6,6 +6,7 @@ import time
 import warnings
 
 from csv import QUOTE_MINIMAL, QUOTE_NONNUMERIC, QUOTE_NONE
+from errno import ENOENT
 
 from libc.stdlib cimport free
 from libc.string cimport strncpy, strlen, strcasecmp
@@ -696,7 +697,9 @@ cdef class TextReader:
             if ptr == NULL:
                 if not os.path.exists(source):
                     raise compat.FileNotFoundError(
-                        'File {source} does not exist'.format(source=source))
+                        ENOENT,
+                        'File {source} does not exist'.format(source=source),
+                        source)
                 raise IOError('Initializing from file failed')
 
             self.parser.source = ptr

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -898,8 +898,14 @@ def test_nonexistent_path(all_parsers):
 
     msg = ("does not exist" if parser.engine == "c"
            else r"\[Errno 2\]")
-    with pytest.raises(compat.FileNotFoundError, match=msg):
+    with pytest.raises(compat.FileNotFoundError, match=msg) as e:
         parser.read_csv(path)
+
+        filename = e.value.filename
+        filename = filename.decode() if isinstance(
+            filename, bytes) else filename
+
+        assert path == filename
 
 
 def test_missing_trailing_delimiters(all_parsers):


### PR DESCRIPTION
When pandas raises a `FileNotFoundError`, it was not setting the [`filename`](https://docs.python.org/3/library/exceptions.html#OSError.filename) component.

This adds in that feature as well a test for it.