### PR TITLE
DOC: FIx flake8 errors for whatsnew v0.7.* -v0.9.* rst

### DIFF
--- a/doc/source/whatsnew/v0.7.0.rst
+++ b/doc/source/whatsnew/v0.7.0.rst
@@ -5,11 +5,6 @@ v.0.7.0 (February 9, 2012)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 New features
 ~~~~~~~~~~~~
@@ -38,7 +33,7 @@ New features
 
 .. ipython:: python
 
-   df = DataFrame(randn(10, 4))
+   df = pd.DataFrame(np.random.randn(10, 4))
    df.apply(lambda x: x.describe())
 
 - :ref:`Add<advanced.reorderlevels>` ``reorder_levels`` method to Series and
@@ -123,7 +118,7 @@ regard to label-based indexing. Here is an example:
 
 .. ipython:: python
 
-    s = Series(randn(10), index=range(0, 20, 2))
+    s = pd.Series(np.random.randn(10), index=range(0, 20, 2))
     s
     s[0]
     s[2]
@@ -142,7 +137,7 @@ This change also has the same impact on DataFrame:
 
 .. code-block:: ipython
 
-   In [3]: df = DataFrame(randn(8, 4), index=range(0, 16, 2))
+   In [3]: df = pd.DataFrame(np.random.randn(8, 4), index=range(0, 16, 2))
 
    In [4]: df
        0        1       2       3
@@ -179,7 +174,7 @@ Label-based slicing using ``ix`` now requires that the index be sorted
 
 .. code-block:: python
 
-   In [1]: s = Series(randn(6), index=list('gmkaec'))
+   In [1]: s = pd.Series(np.random.randn(6), index=list('gmkaec'))
 
    In [2]: s
    Out[2]:
@@ -242,7 +237,7 @@ passing similar input to ``ix`` **except in the case of integer indexing**:
 
 .. ipython:: python
 
-   s = Series(randn(6), index=list('acegkm'))
+   s = pd.Series(np.random.randn(6), index=list('acegkm'))
    s
    s[['m', 'a', 'c', 'e']]
    s['b':'l']
@@ -253,7 +248,7 @@ In the case of integer indexes, the behavior will be exactly as before
 
 .. ipython:: python
 
-   s = Series(randn(6), index=range(0, 12, 2))
+   s = pd.Series(np.random.randn(6), index=range(0, 12, 2))
    s[[4, 0, 2]]
    s[1:5]
 

--- a/doc/source/whatsnew/v0.7.1.rst
+++ b/doc/source/whatsnew/v0.7.1.rst
@@ -5,11 +5,6 @@ v.0.7.1 (February 29, 2012)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This release includes a few new features and addresses over a dozen bugs in
 0.7.0.

--- a/doc/source/whatsnew/v0.7.2.rst
+++ b/doc/source/whatsnew/v0.7.2.rst
@@ -5,11 +5,6 @@ v.0.7.2 (March 16, 2012)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This release targets bugs in 0.7.1, and adds a few minor features.
 

--- a/doc/source/whatsnew/v0.7.3.rst
+++ b/doc/source/whatsnew/v0.7.3.rst
@@ -3,13 +3,6 @@
 v.0.7.3 (April 12, 2012)
 ------------------------
 
-{{ header }}
-
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This is a minor release from 0.7.2 and fixes many minor bugs and adds a number
 of nice new features. There are also a couple of API changes to note; these

--- a/doc/source/whatsnew/v0.7.3.rst
+++ b/doc/source/whatsnew/v0.7.3.rst
@@ -3,6 +3,8 @@
 v.0.7.3 (April 12, 2012)
 ------------------------
 
+{{ header }}
+
 
 This is a minor release from 0.7.2 and fixes many minor bugs and adds a number
 of nice new features. There are also a couple of API changes to note; these

--- a/doc/source/whatsnew/v0.7.3.rst
+++ b/doc/source/whatsnew/v0.7.3.rst
@@ -21,7 +21,7 @@ New features
 .. code-block:: python
 
    from pandas.tools.plotting import scatter_matrix
-   scatter_matrix(df, alpha=0.2)
+   scatter_matrix(df, alpha=0.2)        # noqa F821
 
 .. image:: ../savefig/scatter_matrix_kde.png
    :width: 5in
@@ -38,7 +38,7 @@ New features
 
 .. code-block:: python
 
-   df.plot(kind='barh', stacked=True)    # noqa F821
+   df.plot(kind='barh', stacked=True)   # noqa F821
 
 .. image:: ../savefig/barh_plot_stacked_ex.png
    :width: 4in

--- a/doc/source/whatsnew/v0.7.3.rst
+++ b/doc/source/whatsnew/v0.7.3.rst
@@ -38,14 +38,14 @@ New features
 
 .. code-block:: python
 
-   df.plot(kind='bar', stacked=True)
+   df.plot(kind='bar', stacked=True)    # noqa F821
 
 .. image:: ../savefig/bar_plot_stacked_ex.png
    :width: 4in
 
 .. code-block:: python
 
-   df.plot(kind='barh', stacked=True)
+   df.plot(kind='barh', stacked=True)    # noqa F821
 
 .. image:: ../savefig/barh_plot_stacked_ex.png
    :width: 4in
@@ -63,7 +63,7 @@ Reverted some changes to how NA values (represented typically as ``NaN`` or
 
 .. ipython:: python
 
-   series = Series(['Steve', np.nan, 'Joe'])
+   series = pd.Series(['Steve', np.nan, 'Joe'])
    series == 'Steve'
    series != 'Steve'
 
@@ -93,15 +93,15 @@ Series, to be more consistent with the ``groupby`` behavior with DataFrame:
 .. ipython:: python
     :okwarning:
 
-    df = DataFrame({'A' : ['foo', 'bar', 'foo', 'bar',
-                        'foo', 'bar', 'foo', 'foo'],
-                    'B' : ['one', 'one', 'two', 'three',
-                           'two', 'two', 'one', 'three'],
-                    'C' : np.random.randn(8), 'D' : np.random.randn(8)})
+    df = pd.DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
+                             'foo', 'bar', 'foo', 'foo'],
+                       'B': ['one', 'one', 'two', 'three',
+                             'two', 'two', 'one', 'three'],
+                       'C': np.random.randn(8), 'D': np.random.randn(8)})
     df
     grouped = df.groupby('A')['C']
     grouped.describe()
-    grouped.apply(lambda x: x.sort_values()[-2:]) # top 2 values
+    grouped.apply(lambda x: x.sort_values()[-2:])    # top 2 values
 
 
 .. _whatsnew_0.7.3.contributors:

--- a/doc/source/whatsnew/v0.8.0.rst
+++ b/doc/source/whatsnew/v0.8.0.rst
@@ -5,11 +5,6 @@ v0.8.0 (June 29, 2012)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This is a major release from 0.7.3 and includes extensive work on the time
 series handling and processing infrastructure as well as a great deal of new
@@ -183,8 +178,8 @@ types. For example, ``'kde'`` is a new option:
 
 .. ipython:: python
 
-   s = Series(np.concatenate((np.random.randn(1000),
-                              np.random.randn(1000) * 0.5 + 3)))
+   s = pd.Series(np.concatenate((np.random.randn(1000),
+                                 np.random.randn(1000) * 0.5 + 3)))
    plt.figure()
    s.hist(density=True, alpha=0.2)
    s.plot(kind='kde')
@@ -211,7 +206,7 @@ with code using scalar values because you are handing control over to NumPy:
 .. ipython:: python
 
    import datetime
-   rng = date_range('1/1/2000', periods=10)
+   rng = pd.date_range('1/1/2000', periods=10)
    rng[5]
    isinstance(rng[5], datetime.datetime)
    rng_asarray = np.asarray(rng)
@@ -257,7 +252,7 @@ type. See `matplotlib documentation
 
     .. ipython:: python
 
-       rng = date_range('1/1/2000', periods=10)
+       rng = pd.date_range('1/1/2000', periods=10)
        rng
        np.asarray(rng)
        converted = np.asarray(rng, dtype=object)

--- a/doc/source/whatsnew/v0.8.1.rst
+++ b/doc/source/whatsnew/v0.8.1.rst
@@ -5,11 +5,6 @@ v0.8.1 (July 22, 2012)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This release includes a few new features, performance enhancements, and over 30
 bug fixes from 0.8.0.  New features include notably NA friendly string

--- a/doc/source/whatsnew/v0.9.0.rst
+++ b/doc/source/whatsnew/v0.9.0.rst
@@ -2,11 +2,6 @@
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 v0.9.0 (October 7, 2012)
 ------------------------
@@ -44,8 +39,10 @@ API changes
 
 .. ipython:: python
 
+   from pandas.compat import StringIO
+
    data = '0,0,1\n1,1,0\n0,1,0'
-   df = read_csv(StringIO(data), header=None)
+   df = pd.read_csv(StringIO(data), header=None)
    df
 
 
@@ -57,10 +54,10 @@ API changes
 
 .. ipython:: python
 
-   s1 = Series([1, 2, 3])
+   s1 = pd.Series([1, 2, 3])
    s1
 
-   s2 = Series(s1, index=['foo', 'bar', 'baz'])
+   s2 = pd.Series(s1, index=['foo', 'bar', 'baz'])
    s2
 
 - Deprecated ``day_of_year`` API removed from PeriodIndex, use ``dayofyear``

--- a/doc/source/whatsnew/v0.9.0.rst
+++ b/doc/source/whatsnew/v0.9.0.rst
@@ -39,10 +39,12 @@ API changes
 
 .. ipython:: python
 
-   from pandas.compat import StringIO
+   import io
 
-   data = '0,0,1\n1,1,0\n0,1,0'
-   df = pd.read_csv(StringIO(data), header=None)
+   data = ('0,0,1\n'
+           '1,1,0\n'
+           '0,1,0')
+   df = pd.read_csv(io.StringIO(data), header=None)
    df
 
 

--- a/doc/source/whatsnew/v0.9.1.rst
+++ b/doc/source/whatsnew/v0.9.1.rst
@@ -149,10 +149,12 @@ API changes
 
     .. ipython:: python
 
-        from io import StringIO
+        import io
 
-        data = 'A,B,C\n00001,001,5\n00002,002,6'
-        pd.read_csv(StringIO(data), converters={'A': lambda x: x.strip()})
+        data = ('A,B,C\n'
+                '00001,001,5\n'
+                '00002,002,6')
+        pd.read_csv(io.StringIO(data), converters={'A': lambda x: x.strip()})
 
 
 See the :ref:`full release notes

--- a/doc/source/whatsnew/v0.9.1.rst
+++ b/doc/source/whatsnew/v0.9.1.rst
@@ -97,9 +97,7 @@ New features
 
     .. ipython:: python
 
-        from pandas import ExcelFile
-
-        xl = ExcelFile('data/test.xls')
+        xl = pd.ExcelFile('data/test.xls')
         xl.parse('Sheet1', index_col=0, parse_dates=True,
                  parse_cols='A:D')
 

--- a/doc/source/whatsnew/v0.9.1.rst
+++ b/doc/source/whatsnew/v0.9.1.rst
@@ -149,7 +149,7 @@ API changes
 
     .. ipython:: python
 
-        from pandas.compat import StringIO
+        from io import StringIO
 
         data = 'A,B,C\n00001,001,5\n00002,002,6'
         pd.read_csv(StringIO(data), converters={'A': lambda x: x.strip()})

--- a/doc/source/whatsnew/v0.9.1.rst
+++ b/doc/source/whatsnew/v0.9.1.rst
@@ -5,11 +5,6 @@ v0.9.1 (November 14, 2012)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This is a bug fix release from 0.9.0 and includes several new features and
 enhancements along with a large number of bug fixes. The new features include
@@ -25,7 +20,8 @@ New features
 
     .. code-block:: ipython
 
-       In [2]:  df = DataFrame(np.random.randint(0, 2, (6, 3)), columns=['A', 'B', 'C'])
+       In [2]: df = pd.DataFrame(np.random.randint(0, 2, (6, 3)),
+          ...:                   columns=['A', 'B', 'C'])
 
        In [3]: df.sort(['A', 'B'], ascending=[1, 0])
 
@@ -44,7 +40,7 @@ New features
 
     .. ipython:: python
 
-        df = DataFrame(np.random.randn(6, 3), columns=['A', 'B', 'C'])
+        df = pd.DataFrame(np.random.randn(6, 3), columns=['A', 'B', 'C'])
 
         df.loc[2:4] = np.nan
 
@@ -101,6 +97,8 @@ New features
 
     .. ipython:: python
 
+        from pandas import ExcelFile
+
         xl = ExcelFile('data/test.xls')
         xl.parse('Sheet1', index_col=0, parse_dates=True,
                  parse_cols='A:D')
@@ -124,9 +122,9 @@ API changes
 
     .. code-block:: ipython
 
-       In [1]: prng = period_range('2012Q1', periods=2, freq='Q')
+       In [1]: prng = pd.period_range('2012Q1', periods=2, freq='Q')
 
-       In [2]: s = Series(np.random.randn(len(prng)), prng)
+       In [2]: s = pd.Series(np.random.randn(len(prng)), prng)
 
        In [4]: s.resample('M')
        Out[4]:
@@ -143,7 +141,7 @@ API changes
 
     .. ipython:: python
 
-        p = Period('2012')
+        p = pd.Period('2012')
 
         p.end_time
 
@@ -153,9 +151,10 @@ API changes
 
     .. ipython:: python
 
-        data = 'A,B,C\n00001,001,5\n00002,002,6'
+        from pandas.compat import StringIO
 
-        read_csv(StringIO(data), converters={'A' : lambda x: x.strip()})
+        data = 'A,B,C\n00001,001,5\n00002,002,6'
+        pd.read_csv(StringIO(data), converters={'A': lambda x: x.strip()})
 
 
 See the :ref:`full release notes

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,11 +45,6 @@ ignore = E402,  # module level import not at top of file
          E703,  # statement ends with a semicolon
 
 exclude =
-    doc/source/whatsnew/v0.7.0.rst
-    doc/source/whatsnew/v0.7.3.rst
-    doc/source/whatsnew/v0.8.0.rst
-    doc/source/whatsnew/v0.9.0.rst
-    doc/source/whatsnew/v0.9.1.rst
     doc/source/whatsnew/v0.10.0.rst
     doc/source/whatsnew/v0.10.1.rst
     doc/source/whatsnew/v0.11.0.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,8 +63,6 @@ exclude =
     doc/source/whatsnew/v0.17.1.rst
     doc/source/whatsnew/v0.18.0.rst
     doc/source/whatsnew/v0.18.1.rst
-    doc/source/whatsnew/v0.23.1.rst
-    doc/source/whatsnew/v0.23.2.rst
     doc/source/basics.rst
     doc/source/contributing_docstring.rst
     doc/source/enhancingperf.rst


### PR DESCRIPTION
- [x] closes #24260
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
