### PR TITLE
GH24241 make Categorical.map transform nans

### DIFF
--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -1145,7 +1145,8 @@ dtype in apply
 
 Pandas currently does not preserve the dtype in apply functions: If you apply along rows you get
 a `Series` of ``object`` `dtype` (same as getting a row -> getting one element will return a
-basic type) and applying along columns will also convert to object.
+basic type) and applying along columns will also convert to object. ``NaN`` values are unaffected.
+You can use ``fillna`` to handle missing values before applying a function.
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1273,6 +1273,7 @@ Categorical
 - Bug when resampling :meth:`Dataframe.resample()` and aggregating on categorical data, the categorical dtype was getting lost. (:issue:`23227`)
 - Bug in many methods of the ``.str``-accessor, which always failed on calling the ``CategoricalIndex.str`` constructor (:issue:`23555`, :issue:`23556`)
 - Bug in :meth:`Series.where` losing the categorical dtype for categorical data (:issue:`24077`)
+- Bug in :meth:`Categorical.apply` where the given function would not be applied to ``NaN`` values (:issue:`24241`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1273,7 +1273,7 @@ Categorical
 - Bug when resampling :meth:`Dataframe.resample()` and aggregating on categorical data, the categorical dtype was getting lost. (:issue:`23227`)
 - Bug in many methods of the ``.str``-accessor, which always failed on calling the ``CategoricalIndex.str`` constructor (:issue:`23555`, :issue:`23556`)
 - Bug in :meth:`Series.where` losing the categorical dtype for categorical data (:issue:`24077`)
-- Bug in :meth:`Categorical.apply` where the given function would not be applied to ``NaN`` values (:issue:`24241`)
+- Bug in :meth:`Categorical.apply` where ``NaN`` values could be handled unpredictably. They now remain unchanged (:issue:`24241`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1231,7 +1231,7 @@ class Categorical(ExtensionArray, PandasObject):
         new_categories = self.categories.map(mapper)
 
         try:
-            if isinstance(mapper, (dict, ABCSeries)):
+            if is_dict_like(mapper):
                 new_value = mapper[np.nan]
             else:
                 new_value = mapper(np.nan)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1236,7 +1236,7 @@ class Categorical(ExtensionArray, PandasObject):
         except ValueError:
             # NA values are represented in self._codes with -1
             # np.take causes NA values to take final element in new_categories
-            if any(self._codes == -1):
+            if np.any(self._codes == -1):
                 new_categories = new_categories.insert(len(new_categories),
                                                        np.nan)
             return np.take(new_categories, self._codes)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1234,6 +1234,8 @@ class Categorical(ExtensionArray, PandasObject):
                                    categories=new_categories,
                                    ordered=self.ordered)
         except ValueError:
+            # NA values are represented in self._codes with -1
+            # np.take causes NA values to take final element in new_categories
             if any(self._codes == -1):
                 new_categories = new_categories.insert(len(new_categories),
                                                        np.nan)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -319,35 +319,20 @@ class TestCategoricalIndex(Base):
         (
             ([1, 1, np.nan], pd.isna),
             ([1, 2, np.nan], pd.isna),
-            ([1, 1, np.nan], {1: False, np.nan: True}),
-            ([1, 2, np.nan], {1: False, 2: False, np.nan: True})
-        ))
-    def test_map_fill_nan(self, data, f):  # GH 24241
-        values = pd.Categorical(data)
-        result = values.map(f)
-        if data[1] == 1:
-            expected = pd.Categorical([False, False, True])
-            tm.assert_categorical_equal(result, expected)
-        else:
-            expected = pd.Index([False, False, True])
-            tm.assert_index_equal(result, expected)
-
-    @pytest.mark.parametrize(
-        (
-            'data',
-            'f'
-        ),
-        (
             ([1, 1, np.nan], {1: False}),
             ([1, 2, np.nan], {1: False, 2: False}),
             ([1, 1, np.nan], pd.Series([False, False])),
             ([1, 2, np.nan], pd.Series([False, False, False]))
         ))
-    def test_map_dont_fill_nan(self, data, f):  # GH 24241
+    def test_map_with_nan(self, data, f):  # GH 24241
         values = pd.Categorical(data)
         result = values.map(f)
-        expected = pd.Index([False, False, np.nan])
-        tm.assert_index_equal(result, expected)
+        if data[1] == 1:
+            expected = pd.Categorical([False, False, np.nan])
+            tm.assert_categorical_equal(result, expected)
+        else:
+            expected = pd.Index([False, False, np.nan])
+            tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize('klass', [list, tuple, np.array, pd.Series])
     def test_where(self, klass):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -311,6 +311,37 @@ class TestCategoricalIndex(Base):
         exp = pd.Index(["odd", "even", "odd", np.nan])
         tm.assert_index_equal(a.map(c), exp)
 
+    @pytest.mark.parametrize('data, f', [[[1, 1, np.nan], pd.isna],
+                                         [[1, 2, np.nan], pd.isna],
+                                         [[1, 1, np.nan], {1: False,
+                                                           np.nan: True}],
+                                         [[1, 2, np.nan], {1: False,
+                                                           2: False,
+                                                           np.nan: True}]])
+    def test_map_fill_nan(self, data, f):
+        values = pd.Categorical(data)
+        result = values.map(f)
+        if data[1] == 1:
+            expected = pd.Categorical([False, False, True])
+            tm.assert_categorical_equal(result, expected)
+        else:
+            expected = pd.Index([False, False, True])
+            tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize('data, f', [[[1, 1, np.nan], {1: False}],
+                                         [[1, 2, np.nan], {1: False,
+                                                           2: False}],
+                                         [[1, 1, np.nan], pd.Series([False,
+                                                                     False])],
+                                         [[1, 2, np.nan], pd.Series([False,
+                                                                     False,
+                                                                     False])]])
+    def test_map_dont_fill_nan(self, data, f):
+        values = pd.Categorical(data)
+        result = values.map(f)
+        expected = pd.Index([False, False, np.nan])
+        tm.assert_index_equal(result, expected)
+
     @pytest.mark.parametrize('klass', [list, tuple, np.array, pd.Series])
     def test_where(self, klass):
         i = self.create_index()

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -311,14 +311,18 @@ class TestCategoricalIndex(Base):
         exp = pd.Index(["odd", "even", "odd", np.nan])
         tm.assert_index_equal(a.map(c), exp)
 
-    @pytest.mark.parametrize('data, f', [[[1, 1, np.nan], pd.isna],
-                                         [[1, 2, np.nan], pd.isna],
-                                         [[1, 1, np.nan], {1: False,
-                                                           np.nan: True}],
-                                         [[1, 2, np.nan], {1: False,
-                                                           2: False,
-                                                           np.nan: True}]])
-    def test_map_fill_nan(self, data, f):
+    @pytest.mark.parametrize(
+        (
+            'data',
+            'f'
+        ),
+        (
+            ([1, 1, np.nan], pd.isna),
+            ([1, 2, np.nan], pd.isna),
+            ([1, 1, np.nan], {1: False, np.nan: True}),
+            ([1, 2, np.nan], {1: False, 2: False, np.nan: True})
+        ))
+    def test_map_fill_nan(self, data, f):  # GH 24241
         values = pd.Categorical(data)
         result = values.map(f)
         if data[1] == 1:
@@ -328,15 +332,18 @@ class TestCategoricalIndex(Base):
             expected = pd.Index([False, False, True])
             tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize('data, f', [[[1, 1, np.nan], {1: False}],
-                                         [[1, 2, np.nan], {1: False,
-                                                           2: False}],
-                                         [[1, 1, np.nan], pd.Series([False,
-                                                                     False])],
-                                         [[1, 2, np.nan], pd.Series([False,
-                                                                     False,
-                                                                     False])]])
-    def test_map_dont_fill_nan(self, data, f):
+    @pytest.mark.parametrize(
+        (
+            'data',
+            'f'
+        ),
+        (
+            ([1, 1, np.nan], {1: False}),
+            ([1, 2, np.nan], {1: False, 2: False}),
+            ([1, 1, np.nan], pd.Series([False, False])),
+            ([1, 2, np.nan], pd.Series([False, False, False]))
+        ))
+    def test_map_dont_fill_nan(self, data, f):  # GH 24241
         values = pd.Categorical(data)
         result = values.map(f)
         expected = pd.Index([False, False, np.nan])


### PR DESCRIPTION
- [ ] closes #24241
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Alters `Categorical.map` so that the mapper function is also applied to NaN values. The mentioned bug report brings up the example of calling `apply(pd.isna)` on a categorical series, arguing that the values and dtype of the returned list should be consistent with non-categorical series. This PR makes the values consistent. The discrepancies in dtypes are present in categorical series without NaN's and consistent with documentation.