### PR TITLE
DOC: Add new required sphinx setting latex_elements

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -351,6 +351,8 @@ nbsphinx_allow_errors = True
 
 # -- Options for LaTeX output --------------------------------------------
 
+latex_elements = {}
+
 # The paper size ('letter' or 'a4').
 # latex_paper_size = 'letter'
 


### PR DESCRIPTION
nbsphinx released a new version,  `0.4.0`, and it requires a sphinx setting that we don't have.

This is making the doc build fail, this PR adds it so the doc build works again.

CC: @jreback 
