### PR TITLE
BUG: Fix index bug due to parse_time_string GH24091

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1611,6 +1611,7 @@ Other
 - Bug in :meth:`DataFrame.combine_first` in which column types were unexpectedly converted to float (:issue:`20699`)
 - Bug where C variables were declared with external linkage causing import errors if certain other C libraries were imported before Pandas. (:issue:`24113`)
 - Constructing a DataFrame with an index argument that wasn't already an instance of :class:`~pandas.core.Index` was broken in `4efb39f <https://github.com/pandas-dev/pandas/commit/4efb39f01f5880122fa38d91e12d217ef70fad9e>`_ (:issue:`22227`).
+- :meth:`~pandas._libs.tslibs.parsing.parse_time_string` now raises a type error if the passed argument is not a string, (:issue:`24091`)
 
 .. _whatsnew_0.24.0.contributors:
 

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -113,7 +113,7 @@ def parse_time_string(arg, freq=None, dayfirst=None, yearfirst=None):
     if not isinstance(arg, (str, unicode)):
         # Note: cython recognizes `unicode` in both py2/py3, optimizes
         # this check into a C call.
-        return arg
+        raise TypeError("arg must be str/unicode")
 
     if getattr(freq, "_typ", None) == "dateoffset":
         freq = freq.rule_code

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -8,7 +8,7 @@ from dateutil.parser import parse
 import numpy as np
 import pytest
 
-from pandas._libs.tslibs import parsing
+from pandas._libs.tslibs import parsing, Period
 from pandas._libs.tslibs.parsing import parse_time_string
 import pandas.compat as compat
 import pandas.util._test_decorators as td
@@ -24,6 +24,8 @@ class TestParseQuarters(object):
         assert date == date_lower
         assert parsed == parsed_lower
         assert reso == reso_lower
+
+        pytest.raises(TypeError, parse_time_string, Period('2018-11-01', 'B'))
 
     def test_parse_time_quarter_w_dash(self):
         # https://github.com/pandas-dev/pandas/issue/9688


### PR DESCRIPTION
- [x] closes #24091
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

In Issue #24091 I detailed the root cause of the bug, and implemented the @toobaz suggestion.

I added a single line to test this case in the existing test, ran the full UT suite, checked the linting, and added a whatsnew (I added the whatsnew in the other category, as It wasn't clear where it belonged).


