### PR TITLE
DOC: Fix flake8 issues with whatsnew v0.18.*

### DIFF
--- a/doc/source/whatsnew/v0.18.0.rst
+++ b/doc/source/whatsnew/v0.18.0.rst
@@ -5,11 +5,6 @@ v0.18.0 (March 13, 2016)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This is a major release from 0.17.1 and includes a small number of API changes, several new features,
 enhancements, and performance improvements along with a large number of bug fixes. We recommend that all
@@ -102,7 +97,7 @@ with tab-completion of available methods and properties.
 
 .. code-block:: ipython
 
-   In [9]: r.<TAB>
+   In [9]: r.<TAB>  # noqa E225, E999
    r.A           r.agg         r.apply       r.count       r.exclusions  r.max         r.median      r.name        r.skew        r.sum
    r.B           r.aggregate   r.corr        r.cov         r.kurt        r.mean        r.min         r.quantile    r.std         r.var
 
@@ -1138,7 +1133,7 @@ and setting
 
 Positional setting with ``.ix`` and a float indexer will ADD this value to the index, rather than previously setting the value by position.
 
-.. code-block:: python
+.. code-block:: ipython
 
    In [3]: s2.ix[1.0] = 10
    In [4]: s2

--- a/doc/source/whatsnew/v0.18.0.rst
+++ b/doc/source/whatsnew/v0.18.0.rst
@@ -64,14 +64,14 @@ Window functions have been refactored to be methods on ``Series/DataFrame`` obje
 .. ipython:: python
 
    np.random.seed(1234)
-   df = pd.DataFrame({'A' : range(10), 'B' : np.random.randn(10)})
+   df = pd.DataFrame({'A': range(10), 'B': np.random.randn(10)})
    df
 
 Previous Behavior:
 
 .. code-block:: ipython
 
-   In [8]: pd.rolling_mean(df,window=3)
+   In [8]: pd.rolling_mean(df, window=3)
            FutureWarning: pd.rolling_mean is deprecated for DataFrame and will be removed in a future version, replace with
                           DataFrame.rolling(window=3,center=False).mean()
    Out[8]:
@@ -102,7 +102,7 @@ with tab-completion of available methods and properties.
 
 .. code-block:: ipython
 
-   In [9]: r.
+   In [9]: r.<TAB>
    r.A           r.agg         r.apply       r.count       r.exclusions  r.max         r.median      r.name        r.skew        r.sum
    r.B           r.aggregate   r.corr        r.cov         r.kurt        r.mean        r.min         r.quantile    r.std         r.var
 
@@ -122,8 +122,8 @@ And multiple aggregations
 
 .. ipython:: python
 
-   r.agg({'A' : ['mean','std'],
-          'B' : ['mean','std']})
+   r.agg({'A': ['mean', 'std'],
+          'B': ['mean', 'std']})
 
 .. _whatsnew_0180.enhancements.rename:
 
@@ -201,7 +201,7 @@ Currently the default is ``expand=None`` which gives a ``FutureWarning`` and use
 
 .. code-block:: ipython
 
-   In [1]: pd.Series(['a1', 'b2', 'c3']).str.extract('[ab](\d)', expand=None)
+   In [1]: pd.Series(['a1', 'b2', 'c3']).str.extract(r'[ab](\d)', expand=None)
    FutureWarning: currently extract(expand=None) means expand=False (return Index/Series/DataFrame)
    but in a future version of pandas this will be changed to expand=True (return DataFrame)
 
@@ -216,13 +216,13 @@ Extracting a regular expression with one group returns a Series if
 
 .. ipython:: python
 
-   pd.Series(['a1', 'b2', 'c3']).str.extract('[ab](\d)', expand=False)
+   pd.Series(['a1', 'b2', 'c3']).str.extract(r'[ab](\d)', expand=False)
 
 It returns a ``DataFrame`` with one column if ``expand=True``.
 
 .. ipython:: python
 
-   pd.Series(['a1', 'b2', 'c3']).str.extract('[ab](\d)', expand=True)
+   pd.Series(['a1', 'b2', 'c3']).str.extract(r'[ab](\d)', expand=True)
 
 Calling on an ``Index`` with a regex with exactly one capture group
 returns an ``Index`` if ``expand=False``.
@@ -270,13 +270,13 @@ match.
 
    s = pd.Series(["a1a2", "b1", "c1"], ["A", "B", "C"])
    s
-   s.str.extract("(?P<letter>[ab])(?P<digit>\d)", expand=False)
+   s.str.extract(r"(?P<letter>[ab])(?P<digit>\d)", expand=False)
 
 The ``extractall`` method returns all matches.
 
 .. ipython:: python
 
-   s.str.extractall("(?P<letter>[ab])(?P<digit>\d)")
+   s.str.extractall(r"(?P<letter>[ab])(?P<digit>\d)")
 
 .. _whatsnew_0180.enhancements.strcat:
 
@@ -289,12 +289,12 @@ A new, friendlier ``ValueError`` is added to protect against the mistake of supp
 
 .. ipython:: python
 
-    pd.Series(['a','b',np.nan,'c']).str.cat(sep=' ')
-    pd.Series(['a','b',np.nan,'c']).str.cat(sep=' ', na_rep='?')
+    pd.Series(['a', 'b', np.nan, 'c']).str.cat(sep=' ')
+    pd.Series(['a', 'b', np.nan, 'c']).str.cat(sep=' ', na_rep='?')
 
 .. code-block:: ipython
 
-    In [2]: pd.Series(['a','b',np.nan,'c']).str.cat(' ')
+    In [2]: pd.Series(['a', 'b', np.nan, 'c']).str.cat(' ')
     ValueError: Did you mean to supply a `sep` keyword?
 
 
@@ -329,7 +329,7 @@ Timedeltas
 
 .. ipython:: python
 
-   t = timedelta_range('1 days 2 hr 13 min 45 us',periods=3,freq='d')
+   t = timedelta_range('1 days 2 hr 13 min 45 us', periods=3, freq='d')
    t
    t.round('10min')
 
@@ -356,7 +356,7 @@ Previous Behavior:
 
 .. code-block:: ipython
 
-   In [2]: s = pd.Series([1,2,3], index=np.arange(3.))
+   In [2]: s = pd.Series([1, 2, 3], index=np.arange(3.))
 
    In [3]: s
    Out[3]:
@@ -378,7 +378,7 @@ New Behavior:
 
 .. ipython:: python
 
-   s = pd.Series([1,2,3], index=np.arange(3.))
+   s = pd.Series([1, 2, 3], index=np.arange(3.))
    s
    s.index
    print(s.to_csv(path_or_buf=None, header=False))
@@ -727,7 +727,8 @@ Like the change in the window functions API :ref:`above <whatsnew_0180.enhanceme
    np.random.seed(1234)
    df = pd.DataFrame(np.random.rand(10,4),
                      columns=list('ABCD'),
-                     index=pd.date_range('2010-01-01 09:00:00', periods=10, freq='s'))
+                     index=pd.date_range('2010-01-01 09:00:00',
+                                         periods=10, freq='s'))
    df
 
 

--- a/doc/source/whatsnew/v0.18.1.rst
+++ b/doc/source/whatsnew/v0.18.1.rst
@@ -53,6 +53,7 @@ Friday before MLK Day
 
 .. ipython:: python
 
+    from datetime import datetime
     dt = datetime(2014, 1, 17, 15)
 
     dt + bhour_us
@@ -171,8 +172,7 @@ without using temporary variable.
    bb = pd.read_csv('data/baseball.csv', index_col='id')
    (bb.groupby(['year', 'team'])
       .sum()
-      .loc[lambda df: df.r > 100]
-   )
+      .loc[lambda df: df.r > 100])
 
 .. _whatsnew_0181.partial_string_indexing:
 
@@ -185,10 +185,11 @@ Partial string indexing now matches on ``DateTimeIndex`` when part of a ``MultiI
 
    dft2 = pd.DataFrame(np.random.randn(20, 1),
                        columns=['A'],
-                       index=pd.MultiIndex.from_product([pd.date_range('20130101',
-                                                                       periods=10,
-                                                                       freq='12H'),
-                                                        ['a', 'b']]))
+                       index=pd.MultiIndex.
+                       from_product([pd.date_range('20130101',
+                                                   periods=10,
+                                                   freq='12H'),
+                                     ['a', 'b']]))
    dft2
    dft2.loc['2013-01-05']
 
@@ -317,8 +318,8 @@ The index in ``.groupby(..).nth()`` output is now more consistent when the ``as_
 
 .. ipython:: python
 
-   df = DataFrame({'A' : ['a', 'b', 'a'],
-                   'B' : [1, 2, 3]})
+   df = pd.DataFrame({'A': ['a', 'b', 'a'],
+                      'B': [1, 2, 3]})
    df
 
 Previous Behavior:
@@ -433,13 +434,15 @@ Previous behavior:
 
 .. code-block:: ipython
 
-    In [1]: df.groupby(pd.TimeGrouper(key='date', freq='M')).apply(lambda x: x.value.sum())
+    In [1]: df.groupby(pd.TimeGrouper(key='date',
+       ...:                           freq='M')).apply(lambda x: x.value.sum())
     Out[1]:
     ...
     TypeError: cannot concatenate a non-NDFrame object
 
     # Output is a Series
-    In [2]: df.groupby(pd.TimeGrouper(key='date', freq='M')).apply(lambda x: x[['value']].sum())
+    In [2]: df.groupby(pd.TimeGrouper(key='date',
+       ...:                           freq='M')).apply(lambda x: x[['value']].sum())
     Out[2]:
     date
     2000-10-31  value    10
@@ -451,7 +454,8 @@ New Behavior:
 .. code-block:: python
 
     # Output is a Series
-    In [55]: df.groupby(pd.TimeGrouper(key='date', freq='M')).apply(lambda x: x.value.sum())
+    In [55]: df.groupby(pd.TimeGrouper(key='date',
+        ...:                           freq='M')).apply(lambda x: x.value.sum())
     Out[55]:
     date
     2000-10-31    10
@@ -459,7 +463,8 @@ New Behavior:
     Freq: M, dtype: int64
 
     # Output is a DataFrame
-    In [56]: df.groupby(pd.TimeGrouper(key='date', freq='M')).apply(lambda x: x[['value']].sum())
+    In [56]: df.groupby(pd.TimeGrouper(key='date',
+        ...:                           freq='M')).apply(lambda x: x[['value']].sum())
     Out[56]:
                 value
     date
@@ -470,6 +475,11 @@ New Behavior:
 
 Changes in ``read_csv`` exceptions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. ipython:: python
+   :suppress:
+
+   from pandas.compat import StringIO
 
 In order to standardize the ``read_csv`` API for both the ``c`` and ``python`` engines, both will now raise an
 ``EmptyDataError``, a subclass of ``ValueError``, in response to empty columns or header (:issue:`12493`, :issue:`12506`)

--- a/doc/source/whatsnew/v0.18.1.rst
+++ b/doc/source/whatsnew/v0.18.1.rst
@@ -479,7 +479,7 @@ Changes in ``read_csv`` exceptions
 .. ipython:: python
    :suppress:
 
-   from pandas.compat import StringIO
+   from io import StringIO
 
 In order to standardize the ``read_csv`` API for both the ``c`` and ``python`` engines, both will now raise an
 ``EmptyDataError``, a subclass of ``ValueError``, in response to empty columns or header (:issue:`12493`, :issue:`12506`)

--- a/doc/source/whatsnew/v0.18.1.rst
+++ b/doc/source/whatsnew/v0.18.1.rst
@@ -478,6 +478,7 @@ In order to standardize the ``read_csv`` API for both the ``c`` and ``python`` e
 Previous behaviour:
 
 .. code-block:: ipython
+
    In [1]: import io
 
    In [2]: df = pd.read_csv(io.StringIO(''), engine='c')

--- a/doc/source/whatsnew/v0.18.1.rst
+++ b/doc/source/whatsnew/v0.18.1.rst
@@ -471,10 +471,6 @@ New Behavior:
 Changes in ``read_csv`` exceptions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. ipython:: python
-   :suppress:
-
-   import io
 
 In order to standardize the ``read_csv`` API for both the ``c`` and ``python`` engines, both will now raise an
 ``EmptyDataError``, a subclass of ``ValueError``, in response to empty columns or header (:issue:`12493`, :issue:`12506`)
@@ -482,12 +478,13 @@ In order to standardize the ``read_csv`` API for both the ``c`` and ``python`` e
 Previous behaviour:
 
 .. code-block:: ipython
+   In [1]: import io
 
-   In [1]: df = pd.read_csv(io.StringIO(''), engine='c')
+   In [2]: df = pd.read_csv(io.StringIO(''), engine='c')
    ...
    ValueError: No columns to parse from file
 
-   In [2]: df = pd.read_csv(io.StringIO(''), engine='python')
+   In [3]: df = pd.read_csv(io.StringIO(''), engine='python')
    ...
    StopIteration
 

--- a/doc/source/whatsnew/v0.18.1.rst
+++ b/doc/source/whatsnew/v0.18.1.rst
@@ -53,8 +53,8 @@ Friday before MLK Day
 
 .. ipython:: python
 
-    from datetime import datetime
-    dt = datetime(2014, 1, 17, 15)
+    import datetime
+    dt = datetime.datetime(2014, 1, 17, 15)
 
     dt + bhour_us
 
@@ -183,13 +183,13 @@ Partial string indexing now matches on ``DateTimeIndex`` when part of a ``MultiI
 
 .. ipython:: python
 
-   dft2 = pd.DataFrame(np.random.randn(20, 1),
-                       columns=['A'],
-                       index=pd.MultiIndex.
-                       from_product([pd.date_range('20130101',
-                                                   periods=10,
-                                                   freq='12H'),
-                                     ['a', 'b']]))
+   dft2 = pd.DataFrame(
+       np.random.randn(20, 1),
+       columns=['A'],
+       index=pd.MultiIndex.from_product([pd.date_range('20130101',
+                                                       periods=10,
+                                                       freq='12H'),
+                                         ['a', 'b']]))
    dft2
    dft2.loc['2013-01-05']
 
@@ -451,7 +451,7 @@ Previous behavior:
 
 New Behavior:
 
-.. code-block:: python
+.. code-block:: ipython
 
     # Output is a Series
     In [55]: df.groupby(pd.TimeGrouper(key='date',
@@ -479,7 +479,7 @@ Changes in ``read_csv`` exceptions
 .. ipython:: python
    :suppress:
 
-   from io import StringIO
+   import io
 
 In order to standardize the ``read_csv`` API for both the ``c`` and ``python`` engines, both will now raise an
 ``EmptyDataError``, a subclass of ``ValueError``, in response to empty columns or header (:issue:`12493`, :issue:`12506`)
@@ -488,11 +488,11 @@ Previous behaviour:
 
 .. code-block:: ipython
 
-   In [1]: df = pd.read_csv(StringIO(''), engine='c')
+   In [1]: df = pd.read_csv(io.StringIO(''), engine='c')
    ...
    ValueError: No columns to parse from file
 
-   In [2]: df = pd.read_csv(StringIO(''), engine='python')
+   In [2]: df = pd.read_csv(io.StringIO(''), engine='python')
    ...
    StopIteration
 
@@ -500,11 +500,11 @@ New behaviour:
 
 .. code-block:: ipython
 
-   In [1]: df = pd.read_csv(StringIO(''), engine='c')
+   In [1]: df = pd.read_csv(io.StringIO(''), engine='c')
    ...
    pandas.io.common.EmptyDataError: No columns to parse from file
 
-   In [2]: df = pd.read_csv(StringIO(''), engine='python')
+   In [2]: df = pd.read_csv(io.StringIO(''), engine='python')
    ...
    pandas.io.common.EmptyDataError: No columns to parse from file
 

--- a/doc/source/whatsnew/v0.18.1.rst
+++ b/doc/source/whatsnew/v0.18.1.rst
@@ -5,11 +5,6 @@ v0.18.1 (May 3, 2016)
 
 {{ header }}
 
-.. ipython:: python
-   :suppress:
-
-   from pandas import * # noqa F401, F403
-
 
 This is a minor bug-fix release from 0.18.0 and includes a large number of
 bug fixes along with several new features, enhancements, and performance improvements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,6 @@ exclude =
     doc/source/whatsnew/v0.16.2.rst
     doc/source/whatsnew/v0.17.0.rst
     doc/source/whatsnew/v0.17.1.rst
-    doc/source/whatsnew/v0.18.0.rst
-    doc/source/whatsnew/v0.18.1.rst
     doc/source/basics.rst
     doc/source/contributing_docstring.rst
     doc/source/enhancingperf.rst


### PR DESCRIPTION
Fixed almost every flake8 issues in v0.18.*.rst except one issue
about tab-completion.

- [x] closes #24233 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I fixed almost every flake8 issues except one.
An issue about **tab-completion** and I have no idea how to fix it.

In `doc/source/whatsnew/v0.18.0.rst` there is a code like below.
```python
In [9]: r.<TAB>
r.A           r.agg         r.apply       r.count       r.exclusions  r.max         r.median      r.name        r.skew        r.sum
r.B           r.aggregate   r.corr        r.cov         r.kurt        r.mean        r.min         r.quantile    r.std         r.var
```

I've searched with `grep` in every whatsnew files but there was only one other example about this in `v0.17.0.rst`. Would you review this PR?