### PR TITLE
DOC: Not pushing the docs to github pages in PRs

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -25,28 +25,30 @@ if [ "$DOC" ]; then
     echo # Create and send docs #
     echo ########################
 
-    cd build/html
-    git config --global user.email "pandas-docs-bot@localhost.foo"
-    git config --global user.name "pandas-docs-bot"
+    if ["${TRAVIS_PULL_REQUEST}" != "false"]; then
+        cd build/html
+        git config --global user.email "pandas-docs-bot@localhost.foo"
+        git config --global user.name "pandas-docs-bot"
 
-    # create the repo
-    git init
+        # create the repo
+        git init
 
-    touch README
-    git add README
-    git commit -m "Initial commit" --allow-empty
-    git branch gh-pages
-    git checkout gh-pages
-    touch .nojekyll
-    git add --all .
-    git commit -m "Version" --allow-empty
+        touch README
+        git add README
+        git commit -m "Initial commit" --allow-empty
+        git branch gh-pages
+        git checkout gh-pages
+        touch .nojekyll
+        git add --all .
+        git commit -m "Version" --allow-empty
 
-    git remote remove origin
-    git remote add origin "https://${PANDAS_GH_TOKEN}@github.com/pandas-dev/pandas-docs-travis.git"
-    git fetch origin
-    git remote -v
+        git remote remove origin
+        git remote add origin "https://${PANDAS_GH_TOKEN}@github.com/pandas-dev/pandas-docs-travis.git"
+        git fetch origin
+        git remote -v
 
-    git push origin gh-pages -f
+        git push origin gh-pages -f
+    fi
 fi
 
 exit 0

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -25,7 +25,10 @@ if [ "$DOC" ]; then
     echo # Create and send docs #
     echo ########################
 
-    if ["${TRAVIS_PULL_REQUEST}" != "false"]; then
+    echo "Only uploading docs when TRAVIS_PULL_REQUEST is 'false'"
+    echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+
+    if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
         cd build/html
         git config --global user.email "pandas-docs-bot@localhost.foo"
         git config --global user.name "pandas-docs-bot"


### PR DESCRIPTION
In #24292 we made the doc build fail when there is a failure. But in PR builds, pushing to github pages is expected to fail, so the build job is failing for every PR now. Pushing docs to github pages only for `master` builds in this PR (we still build the docs, to make sure it doesn't fail).