### PR TITLE
ERR: Improve error message for cut with infinity in input and integer bins

### DIFF
--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -205,7 +205,11 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         rng = (nanops.nanmin(x), nanops.nanmax(x))
         mn, mx = [mi + 0.0 for mi in rng]
 
-        if mn == mx:  # adjust end points before binning
+        if np.isinf(mn) or np.isinf(mx):
+            # GH 24314
+            raise ValueError('cannot specify integer `bins` when input data '
+                             'contains infinity')
+        elif mn == mx:  # adjust end points before binning
             mn -= .001 * abs(mn) if mn != 0 else .001
             mx += .001 * abs(mx) if mx != 0 else .001
             bins = np.linspace(mn, mx, bins + 1, endpoint=True)

--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -137,6 +137,17 @@ def test_cut_not_1d_arg(arg, cut_func):
         cut_func(arg, 2)
 
 
+@pytest.mark.parametrize('data', [
+    [0, 1, 2, 3, 4, np.inf],
+    [-np.inf, 0, 1, 2, 3, 4],
+    [-np.inf, 0, 1, 2, 3, 4, np.inf]])
+def test_int_bins_with_inf(data):
+    # GH 24314
+    msg = 'cannot specify integer `bins` when input data contains infinity'
+    with pytest.raises(ValueError, match=msg):
+        cut(data, bins=3)
+
+
 def test_cut_out_of_range_more():
     # see gh-1511
     name = "x"


### PR DESCRIPTION
- [X] closes #24314
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Doesn't seem like a whatsnew entry is needed, since this is just changing the error message and not the actual behavior of `cut`.  Can add an entry if deemed appropriate.