### PR TITLE
add to_frame method to DataFrame

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1221,6 +1221,7 @@ Serialization / IO / Conversion
    DataFrame.to_msgpack
    DataFrame.to_gbq
    DataFrame.to_records
+   DataFrame.to_frame
    DataFrame.to_sparse
    DataFrame.to_dense
    DataFrame.to_string

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -28,6 +28,7 @@ New features
   dataframe's indexes from the resulting Parquet file. (:issue:`20768`)
 - :meth:`DataFrame.corr` and :meth:`Series.corr` now accept a callable for generic calculation methods of correlation, e.g. histogram intersection (:issue:`22684`)
 - :func:`DataFrame.to_string` now accepts ``decimal`` as an argument, allowing the user to specify which decimal separator should be used in the output. (:issue:`23614`)
+- :func:`DataFrame.to_frame` which returns itself was introduced
 - :func:`read_feather` now accepts ``columns`` as an argument, allowing the user to specify which columns should be read. (:issue:`24025`)
 - :func:`DataFrame.to_html` now accepts ``render_links`` as an argument, allowing the user to generate HTML with links to any URLs that appear in the DataFrame.
   See the :ref:`section on writing HTML <io.html>` in the IO docs for example usage. (:issue:`2679`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1735,6 +1735,16 @@ class DataFrame(NDFrame):
                         encoding=encoding, tupleize_cols=tupleize_cols,
                         infer_datetime_format=infer_datetime_format)
 
+    def to_frame(self):
+        """
+        Returns self.
+
+        Returns
+        -------
+        data_frame : DataFrame
+        """
+        return self
+
     def to_sparse(self, fill_value=None, kind='block'):
         """
         Convert to SparseDataFrame.

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -1169,6 +1169,9 @@ class TestSparseDataFrame(SharedWithSparse):
         rs = sparse_df[sparse_df.flag.isin([1.])]
         tm.assert_frame_equal(xp, rs)
 
+    def test_to_frame(self, float_frame):
+        tm.assert_frame_equal(float_frame, float_frame.to_frame())
+
     def test_sparse_pow_issue(self):
         # 2220
         df = SparseDataFrame({'A': [1.1, 3.3], 'B': [2.5, -3.9]})


### PR DESCRIPTION
Add convenience method which makes sure that we can safely call `to_frame` on any method returning both `Series` and `DataFrame` instances, such as `groupby` etc.

- [ ] ~~closes #11292 xxx~~ (there is no issue, should I open one?)
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
