### PR TITLE
PERF: speed up factorization of categoricals

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2644,26 +2644,16 @@ def _factorize_from_iterable(values):
         If `values` has a categorical dtype, then `categories` is
         a CategoricalIndex keeping the categories and order of `values`.
     """
-    from pandas.core.indexes.category import CategoricalIndex
-
     if not is_list_like(values):
         raise TypeError("Input must be list-like")
 
-    if is_categorical(values):
-        if isinstance(values, (ABCCategoricalIndex, ABCSeries)):
-            values = values._values
-        categories = CategoricalIndex(values.categories,
-                                      categories=values.categories,
-                                      ordered=values.ordered)
-        codes = values.codes
-    else:
-        # The value of ordered is irrelevant since we don't use cat as such,
+    if not is_categorical(values):
+        # The value of ordered is irrelevant since we don't use value as such,
         # but only the resulting categories, the order of which is independent
         # from ordered. Set ordered to False as default. See GH #15457
-        cat = Categorical(values, ordered=False)
-        categories = cat.categories
-        codes = cat.codes
-    return codes, categories
+        values = Categorical(values, ordered=False)
+
+    return values.codes, values.categories
 
 
 def _factorize_from_iterables(iterables):


### PR DESCRIPTION
Factorizing Categoricals/CategoricalIndexes in ``_factorize_from_iterable`` is unneccesary slow, because a unneeded CategoricalIndex is created. This fixes that.

```python
>>> n = 1_000_000
>>> c = pd.Categorical(list('a' * n) + (['bcd'] * n), categories=['a', 'bcd'])
>>> %timeit pd.core.arrays.categorical._factorize_from_iterable(c)
120 µs  # master
2.84 µs  # this PR
```
