### PR TITLE
CLN: Resample time bin cruft

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1393,7 +1393,6 @@ class TimeGrouper(Grouper):
                                                  self.freq,
                                                  closed=self.closed,
                                                  base=self.base)
-        tz = ax.tz
         # GH #12037
         # use first/last directly instead of call replace() on them
         # because replace() will swallow the nanosecond part
@@ -1402,28 +1401,10 @@ class TimeGrouper(Grouper):
         binner = labels = date_range(freq=self.freq,
                                      start=first,
                                      end=last,
-                                     tz=tz,
+                                     tz=ax.tz,
                                      name=ax.name,
                                      ambiguous='infer',
                                      nonexistent='shift')
-
-        # GH 15549
-        # In edge case of tz-aware resapmling binner last index can be
-        # less than the last variable in data object, this happens because of
-        # DST time change
-        if len(binner) > 1 and binner[-1] < last:
-            extra_date_range = pd.date_range(binner[-1], last + self.freq,
-                                             freq=self.freq, tz=tz,
-                                             name=ax.name)
-            binner = labels = binner.append(extra_date_range[1:])
-
-        # a little hack
-        trimmed = False
-        if (len(binner) > 2 and binner[-2] == last and
-                self.closed == 'right'):
-
-            binner = binner[:-1]
-            trimmed = True
 
         ax_values = ax.asi8
         binner, bin_edges = self._adjust_bin_edges(binner, ax_values)
@@ -1436,13 +1417,8 @@ class TimeGrouper(Grouper):
             labels = binner
             if self.label == 'right':
                 labels = labels[1:]
-            elif not trimmed:
-                labels = labels[:-1]
-        else:
-            if self.label == 'right':
-                labels = labels[1:]
-            elif not trimmed:
-                labels = labels[:-1]
+        elif self.label == 'right':
+            labels = labels[1:]
 
         if ax.hasnans:
             binner = binner.insert(0, NaT)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Passes locally. Removes some old code for determining the time bins for resample.