### PR TITLE
Floor and ceil methods during pandas.eval which are provided by numexpr

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1440,7 +1440,7 @@ Numeric
 - :meth:`Series.agg` can now handle numpy NaN-aware methods like :func:`numpy.nansum` (:issue:`19629`)
 - Bug in :meth:`Series.rank` and :meth:`DataFrame.rank` when ``pct=True`` and more than 2:sup:`24` rows are present resulted in percentages greater than 1.0 (:issue:`18271`)
 - Calls such as :meth:`DataFrame.round` with a non-unique :meth:`CategoricalIndex` now return expected data. Previously, data would be improperly duplicated (:issue:`21809`).
-- Added ``log10`` to the list of supported functions in :meth:`DataFrame.eval` (:issue:`24139`)
+- Added ``log10``, `floor` and `ceil` to the list of supported functions in :meth:`DataFrame.eval` (:issue:`24139`, :issue:`24353`)
 - Logical operations ``&, |, ^`` between :class:`Series` and :class:`Index` will no longer raise ``ValueError`` (:issue:`22092`)
 - Checking PEP 3141 numbers in :func:`~pandas.api.types.is_scalar` function returns ``True`` (:issue:`22903`)
 - Reduction methods like :meth:`Series.sum` now accept the default value of ``keepdims=False`` when called from a NumPy ufunc, rather than raising a ``TypeError``. Full support for ``keepdims`` has not been implemented (:issue:`24356`).

--- a/pandas/core/computation/check.py
+++ b/pandas/core/computation/check.py
@@ -3,11 +3,13 @@ import warnings
 
 _NUMEXPR_INSTALLED = False
 _MIN_NUMEXPR_VERSION = "2.6.1"
+_ne_version_under_2_6_9 = None
 
 try:
     import numexpr as ne
     ver = LooseVersion(ne.__version__)
     _NUMEXPR_INSTALLED = ver >= LooseVersion(_MIN_NUMEXPR_VERSION)
+    _ne_version_under_2_6_9 = ver < LooseVersion('2.6.9')
 
     if not _NUMEXPR_INSTALLED:
         warnings.warn(

--- a/pandas/core/computation/check.py
+++ b/pandas/core/computation/check.py
@@ -3,13 +3,13 @@ import warnings
 
 _NUMEXPR_INSTALLED = False
 _MIN_NUMEXPR_VERSION = "2.6.1"
-_ne_version_under_2_6_9 = None
+_NUMEXPR_VERSION = None
 
 try:
     import numexpr as ne
     ver = LooseVersion(ne.__version__)
     _NUMEXPR_INSTALLED = ver >= LooseVersion(_MIN_NUMEXPR_VERSION)
-    _ne_version_under_2_6_9 = ver < LooseVersion('2.6.9')
+    _NUMEXPR_VERSION = ver
 
     if not _NUMEXPR_INSTALLED:
         warnings.warn(

--- a/pandas/core/computation/check.py
+++ b/pandas/core/computation/check.py
@@ -1,4 +1,3 @@
-import sys
 from distutils.version import LooseVersion
 import warnings
 
@@ -7,12 +6,10 @@ _MIN_NUMEXPR_VERSION = "2.6.1"
 _NUMEXPR_VERSION = None
 
 try:
-    modules = sys.modules.copy()
     import numexpr as ne
     ver = LooseVersion(ne.__version__)
     _NUMEXPR_INSTALLED = ver >= LooseVersion(_MIN_NUMEXPR_VERSION)
     _NUMEXPR_VERSION = ver
-    sys.modules = modules
 
     if not _NUMEXPR_INSTALLED:
         warnings.warn(
@@ -24,4 +21,4 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-__all__ = ['_NUMEXPR_INSTALLED', '_NUMEXPR_VERSION']
+__all__ = ['_NUMEXPR_INSTALLED']

--- a/pandas/core/computation/check.py
+++ b/pandas/core/computation/check.py
@@ -21,4 +21,4 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-__all__ = ['_NUMEXPR_INSTALLED']
+__all__ = ['_NUMEXPR_INSTALLED', '_NUMEXPR_VERSION']

--- a/pandas/core/computation/check.py
+++ b/pandas/core/computation/check.py
@@ -1,3 +1,4 @@
+import sys
 from distutils.version import LooseVersion
 import warnings
 
@@ -6,10 +7,12 @@ _MIN_NUMEXPR_VERSION = "2.6.1"
 _NUMEXPR_VERSION = None
 
 try:
+    modules = sys.modules.copy()
     import numexpr as ne
     ver = LooseVersion(ne.__version__)
     _NUMEXPR_INSTALLED = ver >= LooseVersion(_MIN_NUMEXPR_VERSION)
     _NUMEXPR_VERSION = ver
+    sys.modules = modules
 
     if not _NUMEXPR_INSTALLED:
         warnings.warn(
@@ -21,4 +24,4 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-__all__ = ['_NUMEXPR_INSTALLED']
+__all__ = ['_NUMEXPR_INSTALLED', '_NUMEXPR_VERSION']

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 
 import pandas.core.common as com
-from pandas.core.computation.check import _NUMEXPR_INSTALLED, _NUMEXPR_VERSION
+from pandas.core.computation.check import _NUMEXPR_INSTALLED
 from pandas.core.config import get_option
 
 if _NUMEXPR_INSTALLED:

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 
 import pandas.core.common as com
-from pandas.core.computation.check import _NUMEXPR_INSTALLED
+from pandas.core.computation.check import _NUMEXPR_INSTALLED, _ne_version_under_2_6_9
 from pandas.core.config import get_option
 
 if _NUMEXPR_INSTALLED:
@@ -20,6 +20,7 @@ if _NUMEXPR_INSTALLED:
 _TEST_MODE = None
 _TEST_RESULT = None
 _USE_NUMEXPR = _NUMEXPR_INSTALLED
+_ne_version_under2_6_9 = _ne_version_under_2_6_9
 _evaluate = None
 _where = None
 

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 
 import pandas.core.common as com
-from pandas.core.computation.check import _NUMEXPR_INSTALLED, _ne_version_under_2_6_9
+from pandas.core.computation.check import _NUMEXPR_INSTALLED
 from pandas.core.config import get_option
 
 if _NUMEXPR_INSTALLED:
@@ -20,7 +20,6 @@ if _NUMEXPR_INSTALLED:
 _TEST_MODE = None
 _TEST_RESULT = None
 _USE_NUMEXPR = _NUMEXPR_INSTALLED
-_ne_version_under2_6_9 = _ne_version_under_2_6_9
 _evaluate = None
 _where = None
 

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 
 import pandas.core.common as com
-from pandas.core.computation.check import _NUMEXPR_INSTALLED
+from pandas.core.computation.check import _NUMEXPR_INSTALLED, _NUMEXPR_VERSION
 from pandas.core.config import get_option
 
 if _NUMEXPR_INSTALLED:

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -542,7 +542,7 @@ class MathCall(Op):
 class FuncNode(object):
 
     def __init__(self, name):
-        if name not in _mathops or not hasattr(np, name) :
+        if name not in _mathops or not hasattr(np, name):
             raise ValueError(
                 "\"{0}\" is not a supported function".format(name))
         self.name = name

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -2,6 +2,7 @@
 """
 
 from datetime import datetime
+from distutils.version import LooseVersion
 from functools import partial
 import operator as op
 
@@ -14,6 +15,7 @@ from pandas.core.dtypes.common import is_list_like, is_scalar
 import pandas as pd
 from pandas.core.base import StringMixin
 import pandas.core.common as com
+from pandas.core.computation.check import _NUMEXPR_VERSION
 from pandas.core.computation.common import _ensure_decoded, _result_type_many
 from pandas.core.computation.expressions import (_NUMEXPR_INSTALLED,
                                                  _ne_version_under_2_6_9)
@@ -25,10 +27,11 @@ _reductions = 'sum', 'prod'
 
 _unary_math_ops = ('sin', 'cos', 'exp', 'log', 'expm1', 'log1p',
                    'sqrt', 'sinh', 'cosh', 'tanh', 'arcsin', 'arccos',
-                   'arctan', 'arccosh', 'arcsinh', 'arctanh', 'abs', 'log10',
-                   'floor', 'ceil')
+                   'arctan', 'arccosh', 'arcsinh', 'arctanh', 'abs', 'log10')
 _binary_math_ops = ('arctan2',)
-_ops_for_ne_gt_2_6_9 = ('floor', 'ceil')
+if _NUMEXPR_INSTALLED and _NUMEXPR_VERSION >= LooseVersion('2.6.9'):
+    _unary_math_ops += ('floor', 'ceil')
+
 _mathops = _unary_math_ops + _binary_math_ops
 
 
@@ -545,9 +548,7 @@ class MathCall(Op):
 class FuncNode(object):
 
     def __init__(self, name):
-        if name not in _mathops or (
-                _NUMEXPR_INSTALLED and _ne_version_under_2_6_9 and name in _ops_for_ne_gt_2_6_9
-        ):
+        if name not in _mathops:
             raise ValueError(
                 "\"{0}\" is not a supported function".format(name))
 

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -15,6 +15,8 @@ import pandas as pd
 from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.core.computation.common import _ensure_decoded, _result_type_many
+from pandas.core.computation.expressions import (_NUMEXPR_INSTALLED,
+                                                 _ne_version_under_2_6_9)
 from pandas.core.computation.scope import _DEFAULT_GLOBALS
 
 from pandas.io.formats.printing import pprint_thing, pprint_thing_encoded
@@ -26,6 +28,7 @@ _unary_math_ops = ('sin', 'cos', 'exp', 'log', 'expm1', 'log1p',
                    'arctan', 'arccosh', 'arcsinh', 'arctanh', 'abs', 'log10',
                    'floor', 'ceil')
 _binary_math_ops = ('arctan2',)
+_ops_for_ne_gt_2_6_9 = ('floor', 'ceil')
 _mathops = _unary_math_ops + _binary_math_ops
 
 
@@ -542,9 +545,12 @@ class MathCall(Op):
 class FuncNode(object):
 
     def __init__(self, name):
-        if name not in _mathops or not hasattr(np, name):
+        if name not in _mathops or (
+                _NUMEXPR_INSTALLED and _ne_version_under_2_6_9 and name in _ops_for_ne_gt_2_6_9
+        ):
             raise ValueError(
                 "\"{0}\" is not a supported function".format(name))
+
         self.name = name
         self.func = getattr(np, name)
 

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -15,9 +15,8 @@ from pandas.core.dtypes.common import is_list_like, is_scalar
 import pandas as pd
 from pandas.core.base import StringMixin
 import pandas.core.common as com
-from pandas.core.computation.check import _NUMEXPR_VERSION
+from pandas.core.computation.check import _NUMEXPR_INSTALLED, _NUMEXPR_VERSION
 from pandas.core.computation.common import _ensure_decoded, _result_type_many
-from pandas.core.computation.expressions import _NUMEXPR_INSTALLED
 from pandas.core.computation.scope import _DEFAULT_GLOBALS
 
 from pandas.io.formats.printing import pprint_thing, pprint_thing_encoded

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -15,7 +15,6 @@ from pandas.core.dtypes.common import is_list_like, is_scalar
 import pandas as pd
 from pandas.core.base import StringMixin
 import pandas.core.common as com
-from pandas.core.computation.check import _NUMEXPR_INSTALLED, _NUMEXPR_VERSION
 from pandas.core.computation.common import _ensure_decoded, _result_type_many
 from pandas.core.computation.scope import _DEFAULT_GLOBALS
 
@@ -25,10 +24,10 @@ _reductions = 'sum', 'prod'
 
 _unary_math_ops = ('sin', 'cos', 'exp', 'log', 'expm1', 'log1p',
                    'sqrt', 'sinh', 'cosh', 'tanh', 'arcsin', 'arccos',
-                   'arctan', 'arccosh', 'arcsinh', 'arctanh', 'abs', 'log10')
+                   'arctan', 'arccosh', 'arcsinh', 'arctanh', 'abs', 'log10',
+                   'floor', 'ceil'
+                   )
 _binary_math_ops = ('arctan2',)
-if _NUMEXPR_INSTALLED and _NUMEXPR_VERSION >= LooseVersion('2.6.9'):
-    _unary_math_ops += ('floor', 'ceil')
 
 _mathops = _unary_math_ops + _binary_math_ops
 
@@ -544,9 +543,14 @@ class MathCall(Op):
 
 
 class FuncNode(object):
-
     def __init__(self, name):
-        if name not in _mathops:
+        from pandas.core.computation.check import (_NUMEXPR_INSTALLED,
+                                                   _NUMEXPR_VERSION)
+        if name not in _mathops or (
+                _NUMEXPR_INSTALLED and
+                _NUMEXPR_VERSION < LooseVersion('2.6.9') and
+                name in ('floor', 'ceil')
+        ):
             raise ValueError(
                 "\"{0}\" is not a supported function".format(name))
 

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -23,7 +23,8 @@ _reductions = 'sum', 'prod'
 
 _unary_math_ops = ('sin', 'cos', 'exp', 'log', 'expm1', 'log1p',
                    'sqrt', 'sinh', 'cosh', 'tanh', 'arcsin', 'arccos',
-                   'arctan', 'arccosh', 'arcsinh', 'arctanh', 'abs', 'log10')
+                   'arctan', 'arccosh', 'arcsinh', 'arctanh', 'abs', 'log10',
+                   'floor', 'ceil')
 _binary_math_ops = ('arctan2',)
 _mathops = _unary_math_ops + _binary_math_ops
 

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -542,7 +542,7 @@ class MathCall(Op):
 class FuncNode(object):
 
     def __init__(self, name):
-        if name not in _mathops:
+        if name not in _mathops or not hasattr(np, name) :
             raise ValueError(
                 "\"{0}\" is not a supported function".format(name))
         self.name = name

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -17,8 +17,7 @@ from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.core.computation.check import _NUMEXPR_VERSION
 from pandas.core.computation.common import _ensure_decoded, _result_type_many
-from pandas.core.computation.expressions import (_NUMEXPR_INSTALLED,
-                                                 _ne_version_under_2_6_9)
+from pandas.core.computation.expressions import _NUMEXPR_INSTALLED
 from pandas.core.computation.scope import _DEFAULT_GLOBALS
 
 from pandas.io.formats.printing import pprint_thing, pprint_thing_encoded

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1627,10 +1627,21 @@ class TestMathPythonPython(object):
         a = df.a
         for fn in self.unary_fns:
             expr = "{0}(a)".format(fn)
-            got = self.eval(expr)
             with np.errstate(all='ignore'):
-                expect = getattr(np, fn)(a)
-            tm.assert_series_equal(got, expect, check_names=False)
+                if hasattr(np, fn):
+                    got = self.eval(expr)
+                    expect = getattr(np, fn)(a)
+                    tm.assert_series_equal(got, expect, check_names=False)
+
+    def test_all_unary_functions_not_supported_in_numpy_112(self):
+        df = DataFrame({'a': np.random.randn(10)})
+        for fn in self.unary_fns:
+            expr = "{0}(a)".format(fn)
+            with np.errstate(all='ignore'):
+                if not hasattr(np, fn):
+                    msg = f"\"{fn}\" is not a supported function"
+                    with pytest.raises(ValueError, match=msg):
+                        self.eval(expr)
 
     def test_binary_functions(self):
         df = DataFrame({'a': np.random.randn(10),

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -64,13 +64,6 @@ def ne_lt_2_6_9():
     return 'numexpr'
 
 
-@pytest.fixture
-def ne_gt_2_6_9():
-    if _NUMEXPR_INSTALLED and _NUMEXPR_VERSION < LooseVersion('2.6.9'):
-        pytest.skip("numexpr is < 2.6.9")
-    return 'numexpr'
-
-
 def engine_has_neg_frac(engine):
     return _engines[engine].has_neg_frac
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1635,6 +1635,7 @@ class TestMathPythonPython(object):
 
     def test_all_unary_functions_not_supported_in_numpy_112(self):
         df = DataFrame({'a': np.random.randn(10)})
+        a = df.a
         for fn in self.unary_fns:
             expr = "{0}(a)".format(fn)
             with np.errstate(all='ignore'):

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -63,6 +63,7 @@ def ne_lt_2_6_9():
         pytest.skip("numexpr is >= 2.6.9")
     return 'numexpr'
 
+
 @pytest.fixture
 def ne_gt_2_6_9():
     if _NUMEXPR_INSTALLED and _NUMEXPR_VERSION < LooseVersion('2.6.9'):

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -15,10 +15,11 @@ from pandas import DataFrame, Series, Panel, date_range
 from pandas.util.testing import makeCustomDataframe as mkdf
 
 from pandas.core.computation import pytables
+from pandas.core.computation.check import _NUMEXPR_VERSION
 from pandas.core.computation.engines import _engines, NumExprClobberingError
 from pandas.core.computation.expr import PythonExprVisitor, PandasExprVisitor
 from pandas.core.computation.expressions import (
-    _USE_NUMEXPR, _NUMEXPR_INSTALLED, _NUMEXPR_VERSION)
+    _USE_NUMEXPR, _NUMEXPR_INSTALLED)
 from pandas.core.computation.ops import (
     _binary_ops_dict,
     _special_case_arith_ops_syms,

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1639,7 +1639,7 @@ class TestMathPythonPython(object):
             expr = "{0}(a)".format(fn)
             with np.errstate(all='ignore'):
                 if not hasattr(np, fn):
-                    msg = f"\"{fn}\" is not a supported function"
+                    msg = '"{0}" is not a supported function'.format(fn)
                     with pytest.raises(ValueError, match=msg):
                         self.eval(expr)
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -18,7 +18,7 @@ from pandas.core.computation import pytables
 from pandas.core.computation.engines import _engines, NumExprClobberingError
 from pandas.core.computation.expr import PythonExprVisitor, PandasExprVisitor
 from pandas.core.computation.expressions import (
-    _USE_NUMEXPR, _NUMEXPR_INSTALLED)
+    _USE_NUMEXPR, _NUMEXPR_INSTALLED, _NUMEXPR_VERSION)
 from pandas.core.computation.ops import (
     _binary_ops_dict,
     _special_case_arith_ops_syms,
@@ -32,7 +32,6 @@ from pandas.util.testing import (assert_frame_equal, randbool,
                                  assert_numpy_array_equal, assert_series_equal,
                                  assert_produces_warning)
 from pandas.compat import PY3, reduce
-from pandas.core.computation.check import _NUMEXPR_VERSION
 
 
 _series_frame_incompatible = _bool_ops_syms

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1,5 +1,6 @@
 import warnings
 import operator
+from distutils.version import LooseVersion
 from itertools import product
 
 import pytest
@@ -31,8 +32,7 @@ from pandas.util.testing import (assert_frame_equal, randbool,
                                  assert_numpy_array_equal, assert_series_equal,
                                  assert_produces_warning)
 from pandas.compat import PY3, reduce
-from pandas.core.computation.expressions import (
-    _ne_version_under_2_6_9)
+from pandas.core.computation.check import _NUMEXPR_VERSION
 
 
 _series_frame_incompatible = _bool_ops_syms
@@ -59,13 +59,13 @@ def parser(request):
 
 @pytest.fixture
 def ne_lt_2_6_9():
-    if not _ne_version_under_2_6_9:
-        pytest.skip("numexpr is > 2.6.9")
+    if _NUMEXPR_INSTALLED and _NUMEXPR_VERSION >= LooseVersion('2.6.9'):
+        pytest.skip("numexpr is >= 2.6.9")
     return 'numexpr'
 
 @pytest.fixture
 def ne_gt_2_6_9():
-    if _ne_version_under_2_6_9:
+    if _NUMEXPR_INSTALLED and _NUMEXPR_VERSION < LooseVersion('2.6.9'):
         pytest.skip("numexpr is < 2.6.9")
     return 'numexpr'
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1641,9 +1641,8 @@ class TestMathPythonPython(object):
     def test_unary_functions(self):
         df = DataFrame({'a': np.random.randn(10)})
         a = df.a
-        unary_functions = [x for x in self.unary_fns
-                           if x not in ('floor', 'ceil')]
-        for fn in unary_functions:
+
+        for fn in self.unary_fns:
             expr = "{0}(a)".format(fn)
             got = self.eval(expr)
             with np.errstate(all='ignore'):
@@ -1656,16 +1655,6 @@ class TestMathPythonPython(object):
             with pytest.raises(ValueError, match=msg):
                 expr = "{0}(100)".format(fn)
                 self.eval(expr)
-
-    def test_floor_and_ceil_functions_evaluate_expressions(self, ne_gt_2_6_9):
-        df = DataFrame({'a': np.random.randn(10)})
-        a = df.a
-        for fn in ('floor', 'ceil'):
-            expr = "{0}(a)".format(fn)
-            got = self.eval(expr)
-            with np.errstate(all='ignore'):
-                expect = getattr(np, fn)(a)
-            tm.assert_series_equal(got, expect, check_names=False)
 
     def test_binary_functions(self):
         df = DataFrame({'a': np.random.randn(10),


### PR DESCRIPTION
- [x] closes #24353
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
