### PR TITLE
implement _index_data parts of #24024

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -519,6 +519,12 @@ class Index(IndexOpsMixin, PandasObject):
 
         result = object.__new__(cls)
         result._data = values
+        # _index_data is a (temporary?) fix to ensure that the direct data
+        # manipulation we do in `_libs/reduction.pyx` continues to work.
+        # We need access to the actual ndarray, since we're messing with
+        # data buffers and strides. We don't re-use `_ndarray_values`, since
+        # we actually set this value too.
+        result._index_data = values
         result.name = name
         for k, v in compat.iteritems(kwargs):
             setattr(result, k, v)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -269,6 +269,8 @@ class DatetimeIndex(DatetimeArray, DatetimeIndexOpsMixin, Int64Index):
 
         result = super(DatetimeIndex, cls)._simple_new(values, freq, tz)
         result.name = name
+        # For groupby perf. See note in indexes/base about _index_data
+        result._index_data = result._data
         result._reset_identity()
         return result
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -235,6 +235,8 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index,
             raise TypeError("PeriodIndex._simple_new only accepts PeriodArray")
         result = object.__new__(cls)
         result._data = values
+        # For groupby perf. See note in indexes/base about _index_data
+        result._index_data = values._data
         result.name = name
         result._reset_identity()
         return result

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -199,6 +199,8 @@ class TimedeltaIndex(TimedeltaArray, DatetimeIndexOpsMixin,
 
         result = super(TimedeltaIndex, cls)._simple_new(values, freq)
         result.name = name
+        # For groupby perf. See note in indexes/base about _index_data
+        result._index_data = result._data
         result._reset_identity()
         return result
 


### PR DESCRIPTION
Besides narrowing down the scope of #24024, I _think_ this might fix the segfaults I had in my old DTA branch, which may make it feasible to hugely simplify the composition changeover.

Aside from removing apparently-unused imports in reduction.pyx, the affected code is copied verbatim from #24024.