### PR TITLE
CLN: tslibs imports and unused variables

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import cython
-from cython import Py_ssize_t
 
 from cpython.datetime cimport (PyDateTime_Check, PyDate_Check,
                                PyDateTime_CheckExact,

--- a/pandas/_libs/tslibs/ccalendar.pyx
+++ b/pandas/_libs/tslibs/ccalendar.pyx
@@ -5,7 +5,6 @@ Cython implementations of functions resembling the stdlib calendar module
 """
 
 import cython
-from cython import Py_ssize_t
 
 from numpy cimport int64_t, int32_t
 
@@ -151,11 +150,8 @@ cpdef int32_t get_week_of_year(int year, int month, int day) nogil:
     Assumes the inputs describe a valid date.
     """
     cdef:
-        bint isleap
         int32_t doy, dow
         int woy
-
-    isleap = is_leapyear(year)
 
     doy = get_day_of_year(year, month, day)
     dow = dayofweek(year, month, day)

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -37,7 +37,7 @@ def get_time_micros(ndarray[int64_t] dtindex):
         ndarray[int64_t] micros
 
     micros = np.mod(dtindex, DAY_SECONDS * 1000000000, dtype=np.int64)
-    micros //= 1000LL
+    micros //= 1000
     return micros
 
 
@@ -48,11 +48,9 @@ def build_field_sarray(int64_t[:] dtindex):
     Datetime as int64 representation to a structured array of fields
     """
     cdef:
-        Py_ssize_t i, count = 0
+        Py_ssize_t i, count = len(dtindex)
         npy_datetimestruct dts
         ndarray[int32_t] years, months, days, hours, minutes, seconds, mus
-
-    count = len(dtindex)
 
     sa_dtype = [('Y', 'i4'),  # year
                 ('M', 'i4'),  # month
@@ -93,12 +91,11 @@ def get_date_name_field(int64_t[:] dtindex, object field, object locale=None):
     name based on requested field (e.g. weekday_name)
     """
     cdef:
-        Py_ssize_t i, count = 0
+        Py_ssize_t i, count = len(dtindex)
         ndarray[object] out, names
         npy_datetimestruct dts
         int dow
 
-    count = len(dtindex)
     out = np.empty(count, dtype=object)
 
     if field == 'day_name' or field == 'weekday_name':
@@ -147,7 +144,7 @@ def get_start_end_field(int64_t[:] dtindex, object field,
     """
     cdef:
         Py_ssize_t i
-        int count = 0
+        int count = len(dtindex)
         bint is_business = 0
         int end_month = 12
         int start_month = 1
@@ -162,7 +159,6 @@ def get_start_end_field(int64_t[:] dtindex, object field,
          [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366]],
         dtype=np.int32)
 
-    count = len(dtindex)
     out = np.zeros(count, dtype='int8')
 
     if freqstr:
@@ -388,11 +384,10 @@ def get_date_field(ndarray[int64_t] dtindex, object field):
     field and return an array of these values.
     """
     cdef:
-        Py_ssize_t i, count = 0
+        Py_ssize_t i, count = len(dtindex)
         ndarray[int32_t] out
         npy_datetimestruct dts
 
-    count = len(dtindex)
     out = np.empty(count, dtype='i4')
 
     if field == 'Y':
@@ -551,11 +546,10 @@ def get_timedelta_field(int64_t[:] tdindex, object field):
     field and return an array of these values.
     """
     cdef:
-        Py_ssize_t i, count = 0
+        Py_ssize_t i, count = len(tdindex)
         ndarray[int32_t] out
         pandas_timedeltastruct tds
 
-    count = len(tdindex)
     out = np.empty(count, dtype='i4')
 
     if field == 'days':

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import cython
-from cython import Py_ssize_t
 
 import time
 from cpython.datetime cimport (PyDateTime_IMPORT,

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -6,8 +6,6 @@ import sys
 import re
 import time
 
-from cython import Py_ssize_t
-
 from cpython.datetime cimport datetime
 
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime, date
+from datetime import datetime
 
 from cpython cimport (
     PyObject_RichCompareBool,

--- a/pandas/_libs/tslibs/resolution.pyx
+++ b/pandas/_libs/tslibs/resolution.pyx
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from cython import Py_ssize_t
-
 import numpy as np
 from numpy cimport ndarray, int64_t, int32_t
 

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -20,8 +20,6 @@ except:
         except:
             from _dummy_thread import allocate_lock as _thread_allocate_lock
 
-from cython import Py_ssize_t
-
 
 import pytz
 
@@ -69,7 +67,7 @@ def array_strptime(object[:] values, object fmt,
     values : ndarray of string-like objects
     fmt : string-like regex
     exact : matches must be exact if True, search if False
-    coerce : if invalid values found, coerce to NaT
+    errors : string specifying error handling, {'raise', 'ignore', 'coerce'}
     """
 
     cdef:

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -7,7 +7,6 @@ import sys
 cdef bint PY3 = (sys.version_info[0] >= 3)
 
 import cython
-from cython import Py_ssize_t
 
 from cpython cimport Py_NE, Py_EQ, PyObject_RichCompare
 

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from cython import Py_ssize_t
-
-from cpython.datetime cimport tzinfo
-
 # dateutil compat
 from dateutil.tz import (
     tzutc as _dateutil_tzutc,


### PR DESCRIPTION
- [x] tests added / passed


- Remove unused imports, mostly `Py_ssize_t`, and variables
- Remove a block that is not hit after the `DatetimeIndex.normalize` performance upgrades https://github.com/pandas-dev/pandas/pull/23634 
