### PR TITLE
REF: clearer Categorical/CategoricalIndex construction

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -200,22 +200,25 @@ def contains(cat, key, container):
         return any(loc_ in container for loc_ in loc)
 
 
-def create_categorical_dtype(values, categories=None, ordered=None,
+def create_categorical_dtype(values=None, categories=None, ordered=None,
                              dtype=None):
     """
-    Helper function to Construct/return a :class:`CategoricalDtype`.
+    Construct and return a :class:`~pandas.api.types.CategoricalDtype`.
 
-    Construct the CategoricalDtype from typical inputs to :class:`Categorical`.
+    This is a helper function, and specifically does not do the
+    factorization step, if that is needed.
 
     Parameters
     ----------
-    values : array-like or Categorical, (1-dimensional), optional
+    values : list-like, optional
+        The list-like must be 1-dimensional.
     categories : list-like, optional
-        categories for the CategoricalDtype
+        Categories for the CategoricalDtype.
     ordered : bool, optional
-        designating if the categories are ordered
-    dtype : CategoricalDtype, optional
-        Cannot be used in combination with `categories` or `ordered`.
+        Designating if the categories are ordered.
+    dtype : CategoricalDtype or the string "category", optional
+        If ``CategoricalDtype`` cannot be used together with
+        `categories` or `ordered`.
 
     Returns
     -------
@@ -227,10 +230,16 @@ def create_categorical_dtype(values, categories=None, ordered=None,
     CategoricalDtype(categories=None, ordered=None)
     >>> create_categorical_dtype(categories=['a', 'b'], ordered=True)
     CategoricalDtype(categories=['a', 'b'], ordered=True)
-    >>> dtype = CategoricalDtype(['a', 'b'], ordered=True)
-    >>> c = Categorical([0, 1], dtype=dtype, fastpath=True)
-    >>> create_categorical_dtype(c, ['x', 'y'], True, dtype=dtype)
-    CategoricalDtype(['a', 'b'], ordered=True)
+    >>> dtype1 = CategoricalDtype(['a', 'b'], ordered=True)
+    >>> dtype2 = CategoricalDtype(['x', 'y'], ordered=False)
+    >>> c = Categorical([0, 1], dtype=dtype1, fastpath=True)
+    >>> create_categorical_dtype(c, ['x', 'y'], ordered=True, dtype=dtype2)
+    ValueError: Cannot specify `categories` or `ordered` together with `dtype`.
+
+    The supplied dtype takes precedence over values's dtype:
+
+    >>> create_categorical_dtype(c, dtype=dtype2)
+    CategoricalDtype(['x', 'y'], ordered=False)
     """
     if dtype is not None:
         # The dtype argument takes precedence over values.dtype (if any)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -200,6 +200,62 @@ def contains(cat, key, container):
         return any(loc_ in container for loc_ in loc)
 
 
+def create_categorical_dtype(values, categories=None, ordered=None,
+                             dtype=None):
+    """
+    Helper function to Construct/return a :class:`CategoricalDtype`.
+
+    Construct the CategoricalDtype from typical inputs to :class:`Categorical`.
+
+    Parameters
+    ----------
+    values : array-like or Categorical, (1-dimensional), optional
+    categories : list-like, optional
+        categories for the CategoricalDtype
+    ordered : bool, optional
+        designating if the categories are ordered
+    dtype : CategoricalDtype, optional
+        Cannot be used in combination with `categories` or `ordered`.
+
+    Returns
+    -------
+    CategoricalDtype
+
+    Examples
+    --------
+    >>> create_categorical_dtype()
+    CategoricalDtype(categories=None, ordered=None)
+    >>> create_categorical_dtype(categories=['a', 'b'], ordered=True)
+    CategoricalDtype(categories=['a', 'b'], ordered=True)
+    >>> dtype = CategoricalDtype(['a', 'b'], ordered=True)
+    >>> c = Categorical([0, 1], dtype=dtype, fastpath=True)
+    >>> create_categorical_dtype(c, ['x', 'y'], True, dtype=dtype)
+    CategoricalDtype(['a', 'b'], ordered=True)
+    """
+    if dtype is not None:
+        # The dtype argument takes precedence over values.dtype (if any)
+        if isinstance(dtype, compat.string_types):
+            if dtype == 'category':
+                dtype = CategoricalDtype(categories, ordered)
+            else:
+                msg = "Unknown dtype {dtype!r}"
+                raise ValueError(msg.format(dtype=dtype))
+        elif categories is not None or ordered is not None:
+            raise ValueError("Cannot specify `categories` or `ordered` "
+                             "together with `dtype`.")
+    elif is_categorical(values):
+        # If no "dtype" was passed, use the one from "values", but honor
+        # the "ordered" and "categories" arguments
+        dtype = values.dtype._from_categorical_dtype(values.dtype,
+                                                     categories, ordered)
+    else:
+        # If dtype=None and values is not categorical, create a new dtype.
+        # Note: This could potentially have categories=None and ordered=None.
+        dtype = CategoricalDtype(categories, ordered)
+
+    return dtype
+
+
 _codes_doc = """\
 The category codes of this categorical.
 
@@ -316,50 +372,18 @@ class Categorical(ExtensionArray, PandasObject):
     def __init__(self, values, categories=None, ordered=None, dtype=None,
                  fastpath=False):
 
-        # Ways of specifying the dtype (prioritized ordered)
-        # 1. dtype is a CategoricalDtype
-        #    a.) with known categories, use dtype.categories
-        #    b.) else with Categorical values, use values.dtype
-        #    c.) else, infer from values
-        #    d.) specifying dtype=CategoricalDtype and categories is an error
-        # 2. dtype is a string 'category'
-        #    a.) use categories, ordered
-        #    b.) use values.dtype
-        #    c.) infer from values
-        # 3. dtype is None
-        #    a.) use categories, ordered
-        #    b.) use values.dtype
-        #    c.) infer from values
-        if dtype is not None:
-            # The dtype argument takes precedence over values.dtype (if any)
-            if isinstance(dtype, compat.string_types):
-                if dtype == 'category':
-                    dtype = CategoricalDtype(categories, ordered)
-                else:
-                    msg = "Unknown `dtype` {dtype}"
-                    raise ValueError(msg.format(dtype=dtype))
-            elif categories is not None or ordered is not None:
-                raise ValueError("Cannot specify both `dtype` and `categories`"
-                                 " or `ordered`.")
-        elif is_categorical(values):
-            # If no "dtype" was passed, use the one from "values", but honor
-            # the "ordered" and "categories" arguments
-            dtype = values.dtype._from_categorical_dtype(values.dtype,
-                                                         categories, ordered)
+        dtype = create_categorical_dtype(values, categories, ordered, dtype)
+        # At this point, dtype is always a CategoricalDtype, but
+        # we may have dtype.categories be None, and we need to
+        # infer categories in a factorization step futher below
 
+        if is_categorical(values):
             # GH23814, for perf, if values._values already an instance of
             # Categorical, set values to codes, and run fastpath
             if (isinstance(values, (ABCSeries, ABCIndexClass)) and
                isinstance(values._values, type(self))):
                 values = values._values.codes.copy()
                 fastpath = True
-        else:
-            # If dtype=None and values is not categorical, create a new dtype
-            dtype = CategoricalDtype(categories, ordered)
-
-        # At this point, dtype is always a CategoricalDtype and you should not
-        # use categories and ordered seperately.
-        # if dtype.categories is None, we are inferring
 
         if fastpath:
             self._codes = coerce_indexer_dtype(values, dtype.categories)
@@ -656,6 +680,8 @@ class Categorical(ExtensionArray, PandasObject):
             categorical. If not given, the resulting categorical will be
             unordered.
         """
+        dtype = create_categorical_dtype(codes, categories, ordered)
+
         codes = np.asarray(codes)  # #21767
         if not is_integer_dtype(codes):
             msg = "codes need to be array-like integers"
@@ -675,14 +701,12 @@ class Categorical(ExtensionArray, PandasObject):
             raise ValueError(
                 "codes need to be convertible to an arrays of integers")
 
-        categories = CategoricalDtype.validate_categories(categories)
-
-        if len(codes) and (codes.max() >= len(categories) or codes.min() < -1):
+        if len(codes) and (
+                codes.max() >= len(dtype.categories) or codes.min() < -1):
             raise ValueError("codes need to be between -1 and "
                              "len(categories)-1")
 
-        return cls(codes, categories=categories, ordered=ordered,
-                   fastpath=True)
+        return cls(codes, dtype=dtype, fastpath=True)
 
     _codes = None
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -9,11 +9,11 @@ from pandas._libs.interval import Interval
 from pandas._libs.tslibs import NaT, Period, Timestamp, timezones
 
 from pandas.core.dtypes.generic import ABCCategoricalIndex, ABCIndexClass
-from .inference import is_list_like
 
 from pandas import compat
 
 from .base import ExtensionDtype, _DtypeOpsMixin
+from .inference import is_list_like
 
 
 def register_extension_dtype(cls):

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -9,6 +9,7 @@ from pandas._libs.interval import Interval
 from pandas._libs.tslibs import NaT, Period, Timestamp, timezones
 
 from pandas.core.dtypes.generic import ABCCategoricalIndex, ABCIndexClass
+from .inference import is_list_like
 
 from pandas import compat
 
@@ -408,7 +409,10 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         """
         from pandas import Index
 
-        if not isinstance(categories, ABCIndexClass):
+        if not fastpath and not is_list_like(categories, allow_sets=True):
+            msg = "Parameter 'categories' must be list-like, was {!r}"
+            raise TypeError(msg.format(categories))
+        elif not isinstance(categories, ABCIndexClass):
             categories = Index(categories, tupleize_cols=False)
 
         if not fastpath:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -245,11 +245,23 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
     def _from_values_or_dtype(cls, values=None, categories=None, ordered=None,
                               dtype=None):
         """
-        Construct from the inputs used in :class:`Categorical` construction.
+        Construct dtype from the input parameters used in :class:`Categorical`.
 
-        This is an internal helper method, and specifically does not do the
-        factorization step, if that is needed. Additional steps may
-        therefore have to be taken to create the final dtype.
+        This constructor method specifically does not do the factorization
+        step, if that is needed to find the categories. This constructor may
+        therefore return ``CategoricalDtype(categories=None, ordered=None)``,
+        which may not be useful. Additional steps may therefore have to be
+        taken to create the final dtype.
+
+        The return dtype is specified from the inputs in this prioritized
+        order:
+        1. if dtype is a CategoricalDtype, return dtype
+        2. if dtype is the string 'category', create a CategoricalDtype from
+           the supplied categories and ordered parameters, and return that.
+        3. if values is a categorical, use value.dtype, but override it with
+           categories and ordered if either/both of those are not None.
+        4. if dtype is None and values is not a categorical, construct the
+           dtype from categories and ordered, even if either of those is None.
 
         Parameters
         ----------
@@ -307,7 +319,8 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
                                                          categories, ordered)
         else:
             # If dtype=None and values is not categorical, create a new dtype.
-            # Note: This could potentially have categories=None and ordered=None.
+            # Note: This could potentially have categories=None and
+            # ordered=None.
             dtype = CategoricalDtype(categories, ordered)
 
         return dtype

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -272,7 +272,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         ordered : bool, optional
             Designating if the categories are ordered.
         dtype : CategoricalDtype or the string "category", optional
-            If ``CategoricalDtype`` cannot be used together with
+            If ``CategoricalDtype``, cannot be used together with
             `categories` or `ordered`.
 
         Returns
@@ -294,7 +294,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         ValueError: Cannot specify `categories` or `ordered` together with
         `dtype`.
 
-        The supplied dtype takes precedence over values's dtype:
+        The supplied dtype takes precedence over values' dtype:
 
         >>> CategoricalDtype._from_values_or_dtype(c, dtype=dtype2)
         CategoricalDtype(['x', 'y'], ordered=False)
@@ -493,7 +493,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         """
         from pandas import Index
 
-        if not fastpath and not is_list_like(categories, allow_sets=True):
+        if not fastpath and not is_list_like(categories):
             msg = "Parameter 'categories' must be list-like, was {!r}"
             raise TypeError(msg.format(categories))
         elif not isinstance(categories, ABCIndexClass):

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -241,6 +241,77 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
             ordered = dtype.ordered
         return cls(categories, ordered)
 
+    @classmethod
+    def _from_values_or_dtype(cls, values=None, categories=None, ordered=None,
+                              dtype=None):
+        """
+        Construct from the inputs used in :class:`Categorical` construction.
+
+        This is an internal helper method, and specifically does not do the
+        factorization step, if that is needed. Additional steps may
+        therefore have to be taken to create the final dtype.
+
+        Parameters
+        ----------
+        values : list-like, optional
+            The list-like must be 1-dimensional.
+        categories : list-like, optional
+            Categories for the CategoricalDtype.
+        ordered : bool, optional
+            Designating if the categories are ordered.
+        dtype : CategoricalDtype or the string "category", optional
+            If ``CategoricalDtype`` cannot be used together with
+            `categories` or `ordered`.
+
+        Returns
+        -------
+        CategoricalDtype
+
+        Examples
+        --------
+        >>> CategoricalDtype._from_values_or_dtype()
+        CategoricalDtype(categories=None, ordered=None)
+        >>> CategoricalDtype._from_values_or_dtype(categories=['a', 'b'],
+        ...                                        ordered=True)
+        CategoricalDtype(categories=['a', 'b'], ordered=True)
+        >>> dtype1 = CategoricalDtype(['a', 'b'], ordered=True)
+        >>> dtype2 = CategoricalDtype(['x', 'y'], ordered=False)
+        >>> c = Categorical([0, 1], dtype=dtype1, fastpath=True)
+        >>> CategoricalDtype._from_values_or_dtype(c, ['x', 'y'], ordered=True,
+        ...                                        dtype=dtype2)
+        ValueError: Cannot specify `categories` or `ordered` together with
+        `dtype`.
+
+        The supplied dtype takes precedence over values's dtype:
+
+        >>> CategoricalDtype._from_values_or_dtype(c, dtype=dtype2)
+        CategoricalDtype(['x', 'y'], ordered=False)
+        """
+        from pandas.core.dtypes.common import is_categorical
+
+        if dtype is not None:
+            # The dtype argument takes precedence over values.dtype (if any)
+            if isinstance(dtype, compat.string_types):
+                if dtype == 'category':
+                    dtype = CategoricalDtype(categories, ordered)
+                else:
+                    msg = "Unknown dtype {dtype!r}"
+                    raise ValueError(msg.format(dtype=dtype))
+            elif categories is not None or ordered is not None:
+                raise ValueError("Cannot specify `categories` or `ordered` "
+                                 "together with `dtype`.")
+        elif is_categorical(values):
+            # If no "dtype" was passed, use the one from "values", but honor
+            # the "ordered" and "categories" arguments
+            dtype = values.dtype._from_categorical_dtype(values.dtype,
+                                                         categories, ordered)
+        else:
+            # If dtype=None and values is not categorical, create a new dtype.
+            # Note: This could potentially have categories=None and ordered=None.
+            dtype = CategoricalDtype(categories, ordered)
+
+        return dtype
+
     def _finalize(self, categories, ordered, fastpath=False):
 
         if ordered is not None:

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -17,8 +17,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core import accessor
 from pandas.core.algorithms import take_1d
-from pandas.core.arrays.categorical import (
-    Categorical, contains, create_categorical_dtype)
+from pandas.core.arrays.categorical import Categorical, contains
 import pandas.core.common as com
 from pandas.core.config import get_option
 import pandas.core.indexes.base as ibase
@@ -108,7 +107,8 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             if fastpath:
                 return cls._simple_new(data, name=name, dtype=dtype)
 
-        dtype = create_categorical_dtype(data, categories, ordered, dtype)
+        dtype = CategoricalDtype._from_values_or_dtype(data, categories,
+                                                       ordered, dtype)
 
         if name is None and hasattr(data, 'name'):
             name = data.name

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -13,7 +13,6 @@ from pandas import (
     Categorical, CategoricalIndex, DatetimeIndex, Index, Interval,
     IntervalIndex, NaT, Series, Timestamp, date_range, period_range,
     timedelta_range)
-from pandas.core.arrays.categorical import create_categorical_dtype
 import pandas.util.testing as tm
 
 
@@ -531,32 +530,3 @@ class TestCategoricalConstructors(object):
         c1 = Categorical(values)
         tm.assert_index_equal(c1.categories, Index(values))
         tm.assert_numpy_array_equal(np.array(c1), np.array(values))
-
-
-class TestCreateCategoricalDtype(object):
-    dtype1 = CategoricalDtype(['a', 'b'], ordered=True)
-    dtype2 = CategoricalDtype(['x', 'y'], ordered=False)
-    c = Categorical([0, 1], dtype=dtype1, fastpath=True)
-
-    @pytest.mark.parametrize('values, categories, ordered, dtype, expected', [
-        [None, None, None, None, CategoricalDtype()],
-        [None, ['a', 'b'], True, None, dtype1],
-        [c, None, None, dtype2, dtype2],
-        [c, ['x', 'y'], False, None, dtype2],
-    ])
-    def test_create_categorical_dtype(
-            self, values, categories, ordered, dtype, expected):
-        result = create_categorical_dtype(values, categories, ordered, dtype)
-        assert result == expected
-
-    @pytest.mark.parametrize('values, categories, ordered, dtype', [
-        [None, ['a', 'b'], True, dtype2],
-        [None, ['a', 'b'], None, dtype2],
-        [None, None, True, dtype2],
-    ])
-    def test_create_categorical_dtype_raises(self, values, categories, ordered,
-                                             dtype):
-        msg = "Cannot specify `categories` or `ordered` together with `dtype`."
-
-        with pytest.raises(ValueError, match=msg):
-            create_categorical_dtype(values, categories, ordered, dtype)

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -368,7 +368,7 @@ class TestCategoricalConstructors(object):
         tm.assert_categorical_equal(result, expected)
 
     def test_constructor_str_unknown(self):
-        with pytest.raises(ValueError, match="Unknown `dtype`"):
+        with pytest.raises(ValueError, match="Unknown dtype"):
             Categorical([1, 2], dtype="foo")
 
     def test_constructor_from_categorical_with_dtype(self):

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -13,6 +13,7 @@ from pandas import (
     Categorical, CategoricalIndex, DatetimeIndex, Index, Interval,
     IntervalIndex, NaT, Series, Timestamp, date_range, period_range,
     timedelta_range)
+from pandas.core.arrays.categorical import create_categorical_dtype
 import pandas.util.testing as tm
 
 
@@ -530,3 +531,32 @@ class TestCategoricalConstructors(object):
         c1 = Categorical(values)
         tm.assert_index_equal(c1.categories, Index(values))
         tm.assert_numpy_array_equal(np.array(c1), np.array(values))
+
+
+class TestCreateCategoricalDtype(object):
+    dtype1 = CategoricalDtype(['a', 'b'], ordered=True)
+    dtype2 = CategoricalDtype(['x', 'y'], ordered=False)
+    c = Categorical([0, 1], dtype=dtype1, fastpath=True)
+
+    @pytest.mark.parametrize('values, categories, ordered, dtype, expected', [
+        [None, None, None, None, CategoricalDtype()],
+        [None, ['a', 'b'], True, None, dtype1],
+        [c, None, None, dtype2, dtype2],
+        [c, ['x', 'y'], False, None, dtype2],
+    ])
+    def test_create_categorical_dtype(
+            self, values, categories, ordered, dtype, expected):
+        result = create_categorical_dtype(values, categories, ordered, dtype)
+        assert result == expected
+
+    @pytest.mark.parametrize('values, categories, ordered, dtype', [
+        [None, ['a', 'b'], True, dtype2],
+        [None, ['a', 'b'], None, dtype2],
+        [None, None, True, dtype2],
+    ])
+    def test_create_categorical_dtype_raises(self, values, categories, ordered,
+                                             dtype):
+        msg = "Cannot specify `categories` or `ordered` together with `dtype`."
+
+        with pytest.raises(ValueError, match=msg):
+            create_categorical_dtype(values, categories, ordered, dtype)

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -90,7 +90,7 @@ class TestCategoricalDtype(Base):
             TypeError, lambda: CategoricalDtype.construct_from_string('foo'))
 
     def test_constructor_invalid(self):
-        msg = "categories must be list-like"
+        msg = "Parameter 'categories' must be list-like"
         with pytest.raises(TypeError, match=msg):
             CategoricalDtype("category")
 
@@ -706,7 +706,7 @@ class TestCategoricalDtypeParametrized(object):
         with pytest.raises(TypeError, match='ordered'):
             CategoricalDtype(['a', 'b'], ordered='foo')
 
-        with pytest.raises(TypeError, match='categories must be list-like'):
+        with pytest.raises(TypeError, match="'categories' must be list-like"):
             CategoricalDtype('category')
 
     def test_mixed(self):

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -94,6 +94,38 @@ class TestCategoricalDtype(Base):
         with pytest.raises(TypeError, match=msg):
             CategoricalDtype("category")
 
+    dtype1 = CategoricalDtype(['a', 'b'], ordered=True)
+    dtype2 = CategoricalDtype(['x', 'y'], ordered=False)
+    c = Categorical([0, 1], dtype=dtype1, fastpath=True)
+
+    @pytest.mark.parametrize('values, categories, ordered, dtype, expected',
+                             [
+                                 [None, None, None, None,
+                                  CategoricalDtype()],
+                                 [None, ['a', 'b'], True, None, dtype1],
+                                 [c, None, None, dtype2, dtype2],
+                                 [c, ['x', 'y'], False, None, dtype2],
+                             ])
+    def test_create_categorical_dtype(
+            self, values, categories, ordered, dtype, expected):
+        result = CategoricalDtype._from_values_or_dtype(values, categories,
+                                                        ordered, dtype)
+        assert result == expected
+
+    @pytest.mark.parametrize('values, categories, ordered, dtype', [
+        [None, ['a', 'b'], True, dtype2],
+        [None, ['a', 'b'], None, dtype2],
+        [None, None, True, dtype2],
+    ])
+    def test_create_categorical_dtype_raises(self, values, categories,
+                                             ordered,
+                                             dtype):
+        msg = "Cannot specify `categories` or `ordered` together with `dtype`."
+
+        with pytest.raises(ValueError, match=msg):
+            CategoricalDtype._from_values_or_dtype(values, categories,
+                                                   ordered, dtype)
+
     def test_is_dtype(self):
         assert CategoricalDtype.is_dtype(self.dtype)
         assert CategoricalDtype.is_dtype('category')

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -90,7 +90,7 @@ class TestCategoricalDtype(Base):
             TypeError, lambda: CategoricalDtype.construct_from_string('foo'))
 
     def test_constructor_invalid(self):
-        msg = "CategoricalIndex.* must be called"
+        msg = "categories must be list-like"
         with pytest.raises(TypeError, match=msg):
             CategoricalDtype("category")
 
@@ -706,7 +706,7 @@ class TestCategoricalDtypeParametrized(object):
         with pytest.raises(TypeError, match='ordered'):
             CategoricalDtype(['a', 'b'], ordered='foo')
 
-        with pytest.raises(TypeError, match='collection'):
+        with pytest.raises(TypeError, match='categories must be list-like'):
             CategoricalDtype('category')
 
     def test_mixed(self):

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -106,7 +106,7 @@ class TestCategoricalDtype(Base):
                                  [c, None, None, dtype2, dtype2],
                                  [c, ['x', 'y'], False, None, dtype2],
                              ])
-    def test_create_categorical_dtype(
+    def test_from_values_or_dtype(
             self, values, categories, ordered, dtype, expected):
         result = CategoricalDtype._from_values_or_dtype(values, categories,
                                                         ordered, dtype)
@@ -117,11 +117,9 @@ class TestCategoricalDtype(Base):
         [None, ['a', 'b'], None, dtype2],
         [None, None, True, dtype2],
     ])
-    def test_create_categorical_dtype_raises(self, values, categories,
-                                             ordered,
-                                             dtype):
+    def test_from_values_or_dtype_raises(self, values, categories,
+                                         ordered, dtype):
         msg = "Cannot specify `categories` or `ordered` together with `dtype`."
-
         with pytest.raises(ValueError, match=msg):
             CategoricalDtype._from_values_or_dtype(values, categories,
                                                    ordered, dtype)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -158,7 +158,7 @@ class TestCategoricalIndex(Base):
         tm.assert_index_equal(result, expected, exact=True)
 
         # error when combining categories/ordered and dtype kwargs
-        msg = 'Cannot specify both `dtype` and `categories` or `ordered`.'
+        msg = 'Cannot specify `categories` or `ordered` together with `dtype`.'
         with pytest.raises(ValueError, match=msg):
             CategoricalIndex(data, categories=cats, dtype=dtype)
 


### PR DESCRIPTION
Construction ATM of ``Categorical`` and ``CategoricalIndex`` each uses their own ways to construct the dtype. This makes the construction look more complex than it need to.

By collecting the dtype construction in a shared function, a lot of things become more simple. An additional advantage is that we can now have a higher confidence in dtype being the same for the same inputs, easing reasoning about the construction phase.

The above is all internal changes, so no whatsnew note is supplied.

A very minor issue was discovered, where an error message for CategoricalDtype made it look like the problem was in ``CategoricalIndex``, which is confusing, especially if we're not constructing a ``CategoricalIndex``.

```python
>>> pd.api.type.CategoricalDtype('category')
TypeError: CategoricalIndex(...) must be called with a collection of some kind, 'category' was passed  # master
TypeError: Parameter 'categories' must be list-like, was 'category'  # this PR
```

Otherwise the API is unchanged, but the code paths are now much simpler IMO.