### PR TITLE
DOC: Adding missing module, causing sphinx not to find functions/methods

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1,5 +1,8 @@
 .. _io:
 
+.. currentmodule:: pandas
+
+
 {{ header }}
 
 .. ipython:: python


### PR DESCRIPTION
sphinx is generating warnings because we reference API pages that don't exist.

This is because autosummary is processed before the `currentmodule` directive is injected to `{{ header }}`
