### PR TITLE
Decouple xlrd reading from ExcelFile class

### DIFF
--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -360,12 +360,12 @@ def read_excel(io,
 
 class _XlrdReader(object):
 
-    def __init__(self, filepath_or_wb):
+    def __init__(self, filepath_or_buffer):
         """Reader using xlrd engine.
 
         Parameters
         ----------
-        filepath_or_wb : string, path object or Workbook
+        filepath_or_buffer : string, path object or Workbook
             Object to be parsed.
         """
         err_msg = "Install xlrd >= 1.0.0 for Excel support"
@@ -379,31 +379,32 @@ class _XlrdReader(object):
                 raise ImportError(err_msg +
                                   ". Current version " + xlrd.__VERSION__)
 
-        # If filepath_or_wb is a url, want to keep the data as bytes so can't
-        # pass to get_filepath_or_buffer()
-        if _is_url(filepath_or_wb):
-            filepath_or_wb = _urlopen(filepath_or_wb)
-        elif not isinstance(filepath_or_wb, (ExcelFile, xlrd.Book)):
-            filepath_or_wb, _, _, _ = get_filepath_or_buffer(filepath_or_wb)
+        # If filepath_or_buffer is a url, want to keep the data as bytes so
+        # can't pass to get_filepath_or_buffer()
+        if _is_url(filepath_or_buffer):
+            filepath_or_buffer = _urlopen(filepath_or_buffer)
+        elif not isinstance(filepath_or_buffer, (ExcelFile, xlrd.Book)):
+            filepath_or_buffer, _, _, _ = get_filepath_or_buffer(
+                filepath_or_buffer)
 
-        if isinstance(filepath_or_wb, xlrd.Book):
-            self.book = filepath_or_wb
-        elif not isinstance(filepath_or_wb, xlrd.Book) and hasattr(
-                filepath_or_wb, "read"):
+        if isinstance(filepath_or_buffer, xlrd.Book):
+            self.book = filepath_or_buffer
+        elif not isinstance(filepath_or_buffer, xlrd.Book) and hasattr(
+                filepath_or_buffer, "read"):
             # N.B. xlrd.Book has a read attribute too
-            if hasattr(filepath_or_wb, 'seek'):
+            if hasattr(filepath_or_buffer, 'seek'):
                 try:
                     # GH 19779
-                    filepath_or_wb.seek(0)
+                    filepath_or_buffer.seek(0)
                 except UnsupportedOperation:
                     # HTTPResponse does not support seek()
                     # GH 20434
                     pass
 
-            data = filepath_or_wb.read()
+            data = filepath_or_buffer.read()
             self.book = xlrd.open_workbook(file_contents=data)
-        elif isinstance(filepath_or_wb, compat.string_types):
-            self.book = xlrd.open_workbook(filepath_or_wb)
+        elif isinstance(filepath_or_buffer, compat.string_types):
+            self.book = xlrd.open_workbook(filepath_or_buffer)
         else:
             raise ValueError('Must explicitly set engine if not passing in'
                              ' buffer or path for io.')
@@ -611,10 +612,10 @@ class ExcelFile(object):
     ----------
     io : string, path object (pathlib.Path or py._path.local.LocalPath),
         file-like object or xlrd workbook
-        If a string or path object, expected to be a path to xls or xlsx file
+        If a string or path object, expected to be a path to xls or xlsx file.
     engine : string, default None
         If io is not a buffer or path, this must be set to identify io.
-        Acceptable values are None or xlrd
+        Acceptable values are None or ``xlrd``.
     """
 
     _engines = {

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -119,6 +119,15 @@ class SharedItems(object):
 class ReadingTestsBase(SharedItems):
     # This is based on ExcelWriterBase
 
+    @pytest.fixture(autouse=True, params=['xlrd', None])
+    def set_engine(self, request):
+        func_name = "get_exceldf"
+        old_func = getattr(self, func_name)
+        new_func = partial(old_func, engine=request.param)
+        setattr(self, func_name, new_func)
+        yield
+        setattr(self, func_name, old_func)
+
     @td.skip_if_no("xlrd", "1.0.1")  # see gh-22682
     def test_usecols_int(self, ext):
 

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -692,34 +692,6 @@ class ReadingTestsBase(SharedItems):
         with pytest.raises(ValueError, message="Unknown engine: foo"):
             read_excel('', engine=bad_engine)
 
-
-@pytest.mark.parametrize("ext", ['.xls', '.xlsx', '.xlsm'])
-class TestXlrdReader(ReadingTestsBase):
-    """
-    This is the base class for the xlrd tests, and 3 different file formats
-    are supported: xls, xlsx, xlsm
-    """
-
-    @td.skip_if_no("xlwt")
-    def test_read_xlrd_book(self, ext):
-        import xlrd
-        df = self.frame
-
-        engine = "xlrd"
-        sheet_name = "SheetA"
-
-        with ensure_clean(ext) as pth:
-            df.to_excel(pth, sheet_name)
-            book = xlrd.open_workbook(pth)
-
-            with ExcelFile(book, engine=engine) as xl:
-                result = read_excel(xl, sheet_name, index_col=0)
-                tm.assert_frame_equal(df, result)
-
-            result = read_excel(book, sheet_name=sheet_name,
-                                engine=engine, index_col=0)
-            tm.assert_frame_equal(df, result)
-
     @tm.network
     def test_read_from_http_url(self, ext):
         url = ('https://raw.github.com/pandas-dev/pandas/master/'
@@ -1159,6 +1131,34 @@ class TestXlrdReader(ReadingTestsBase):
         actual = pd.read_excel(f, 'one_column', squeeze=True)
         expected = pd.Series([1, 2, 3], name='a')
         tm.assert_series_equal(actual, expected)
+
+
+@pytest.mark.parametrize("ext", ['.xls', '.xlsx', '.xlsm'])
+class TestXlrdReader(ReadingTestsBase):
+    """
+    This is the base class for the xlrd tests, and 3 different file formats
+    are supported: xls, xlsx, xlsm
+    """
+
+    @td.skip_if_no("xlwt")
+    def test_read_xlrd_book(self, ext):
+        import xlrd
+        df = self.frame
+
+        engine = "xlrd"
+        sheet_name = "SheetA"
+
+        with ensure_clean(ext) as pth:
+            df.to_excel(pth, sheet_name)
+            book = xlrd.open_workbook(pth)
+
+            with ExcelFile(book, engine=engine) as xl:
+                result = read_excel(xl, sheet_name, index_col=0)
+                tm.assert_frame_equal(df, result)
+
+            result = read_excel(book, sheet_name=sheet_name,
+                                engine=engine, index_col=0)
+            tm.assert_frame_equal(df, result)
 
 
 class _WriterBase(SharedItems):

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -674,14 +674,6 @@ class ReadingTestsBase(SharedItems):
             excel.parse(sheetname='Sheet1',
                         sheet_name='Sheet1')
 
-
-@pytest.mark.parametrize("ext", ['.xls', '.xlsx', '.xlsm'])
-class TestXlrdReader(ReadingTestsBase):
-    """
-    This is the base class for the xlrd tests, and 3 different file formats
-    are supported: xls, xlsx, xlsm
-    """
-
     def test_excel_read_buffer(self, ext):
 
         pth = os.path.join(self.dirpath, 'test1' + ext)
@@ -694,6 +686,19 @@ class TestXlrdReader(ReadingTestsBase):
             xls = ExcelFile(f)
             actual = read_excel(xls, 'Sheet1', index_col=0)
             tm.assert_frame_equal(expected, actual)
+
+    def test_bad_engine_raises(self, ext):
+        bad_engine = 'foo'
+        with pytest.raises(ValueError, message="Unknown engine: foo"):
+            read_excel('', engine=bad_engine)
+
+
+@pytest.mark.parametrize("ext", ['.xls', '.xlsx', '.xlsm'])
+class TestXlrdReader(ReadingTestsBase):
+    """
+    This is the base class for the xlrd tests, and 3 different file formats
+    are supported: xls, xlsx, xlsm
+    """
 
     @td.skip_if_no("xlwt")
     def test_read_xlrd_book(self, ext):


### PR DESCRIPTION
To support community engagement on #11499 I figured it was worth refactoring the existing code for read_excel which very tightly couples xlrd. 

There are quite a few ways to go about this but here I am creating a separate private reader class for the xlrd engine which gets dispatched to for parsing and metadata inspection. In theory a similar class could be made for openpyxl.

I didn't make a base class here to keep diff minimal though I certainly could if we see a need for it