### PR TITLE
DOC: Fixing more doc warnings

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -780,10 +780,10 @@ values **not** in the categories, similarly to how you can reindex **any** panda
 
 .. ipython:: python
 
-   df2.reindex(['a','e'])
-   df2.reindex(['a','e']).index
-   df2.reindex(pd.Categorical(['a','e'],categories=list('abcde')))
-   df2.reindex(pd.Categorical(['a','e'],categories=list('abcde'))).index
+   df2.reindex(['a', 'e'])
+   df2.reindex(['a', 'e']).index
+   df2.reindex(pd.Categorical(['a', 'e'], categories=list('abcde')))
+   df2.reindex(pd.Categorical(['a', 'e'], categories=list('abcde'))).index
 
 .. warning::
 

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -778,7 +778,7 @@ a ``Categorical`` will return a ``CategoricalIndex``, indexed according to the c
 of the **passed** ``Categorical`` dtype. This allows one to arbitrarily index these even with
 values **not** in the categories, similarly to how you can reindex **any** pandas index.
 
-.. ipython :: python
+.. ipython:: python
 
    df2.reindex(['a','e'])
    df2.reindex(['a','e']).index
@@ -1040,7 +1040,8 @@ than integer locations. Therefore, with an integer axis index *only*
 label-based indexing is possible with the standard tools like ``.loc``. The
 following code will generate exceptions:
 
-.. code-block:: python
+.. ipython:: python
+   :okexcept:
 
    s = pd.Series(range(5))
    s[-1]
@@ -1130,7 +1131,7 @@ index can be somewhat complicated. For example, the following does not work:
 
 ::
 
-    s.loc['c':'e'+1]
+    s.loc['c':'e' + 1]
 
 A very common use case is to limit a time series to start and end at two
 specific dates. To enable this, we made the design to make label-based

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -977,21 +977,17 @@ categorical (categories and ordering). So if you read back the CSV file you have
 relevant columns back to `category` and assign the right categories and categories ordering.
 
 .. ipython:: python
-    :suppress:
 
-
-.. ipython:: python
-
-    from pandas.compat import StringIO
+    import io
     s = pd.Series(pd.Categorical(['a', 'b', 'b', 'a', 'a', 'd']))
     # rename the categories
     s.cat.categories = ["very good", "good", "bad"]
     # reorder the categories and add missing categories
     s = s.cat.set_categories(["very bad", "bad", "medium", "good", "very good"])
     df = pd.DataFrame({"cats": s, "vals": [1, 2, 3, 4, 5, 6]})
-    csv = StringIO()
+    csv = io.StringIO()
     df.to_csv(csv)
-    df2 = pd.read_csv(StringIO(csv.getvalue()))
+    df2 = pd.read_csv(io.StringIO(csv.getvalue()))
     df2.dtypes
     df2["cats"]
     # Redo the category
@@ -1206,6 +1202,7 @@ Use ``copy=True`` to prevent such a behaviour or simply don't reuse ``Categorica
     cat
 
 .. note::
+
     This also happens in some cases when you supply a NumPy array instead of a ``Categorical``:
     using an int array (e.g. ``np.array([1,2,3,4])``) will exhibit the same behavior, while using
     a string array (e.g. ``np.array(["a","b","c","a"])``) will not.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -296,7 +296,10 @@ header = """\
    np.random.seed(123456)
    np.set_printoptions(precision=4, suppress=True)
    pd.options.display.max_rows = 15
-"""
+
+   import os
+   os.chdir('{}')
+""".format(os.path.dirname(os.path.dirname(__file__)))
 
 
 html_context = {

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -1236,7 +1236,7 @@ the following Python code will read the binary file ``'binary.dat'`` into a
 pandas ``DataFrame``, where each element of the struct corresponds to a column
 in the frame:
 
-.. code-block:: python
+.. ipython:: python
 
    names = 'count', 'avg', 'scale'
 
@@ -1398,7 +1398,6 @@ function, we can create a dict where the keys are column names and the values ar
 of the data values:
 
 .. ipython:: python
-
 
    def expand_grid(data_dict):
        rows = itertools.product(*data_dict.values())

--- a/doc/source/gotchas.rst
+++ b/doc/source/gotchas.rst
@@ -301,9 +301,7 @@ Byte-Ordering Issues
 --------------------
 Occasionally you may have to deal with data that were created on a machine with
 a different byte order than the one on which you are running Python. A common
-symptom of this issue is an error like:
-
-.. code-block:: python-traceback
+symptom of this issue is an error like:::
 
     Traceback
         ...

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -4879,7 +4879,7 @@ below and the SQLAlchemy `documentation <https://docs.sqlalchemy.org/en/latest/c
 
 If you want to manage your own connections you can pass one of those instead:
 
-.. code-block:: python
+.. ipython:: python
 
    with engine.connect() as conn, conn.begin():
        data = pd.read_sql_table('data', conn)

--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -1122,6 +1122,8 @@ This is equivalent but less verbose and more memory efficient / faster than this
           labels=['left', 'right'], vertical=False);
    plt.close('all');
 
+.. _merging.join_with_two_multi_indexes:
+
 Joining with two MultiIndexes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -151,6 +151,7 @@ It raises if any value cannot be coerced to specified dtype.
 .. code-block:: ipython
 
    In [1]: ss = pd.Series([1, np.nan, np.nan]).to_sparse()
+   Out[1]:
    0    1.0
    1    NaN
    2    NaN
@@ -160,6 +161,7 @@ It raises if any value cannot be coerced to specified dtype.
    Block lengths: array([1], dtype=int32)
 
    In [2]: ss.astype(np.int64)
+   Out[2]:
    ValueError: unable to coerce current fill_value nan to int64 dtype
 
 .. _sparse.calculation:
@@ -224,10 +226,6 @@ A :meth:`SparseSeries.to_coo` method is implemented for transforming a ``SparseS
 The method requires a ``MultiIndex`` with two or more levels.
 
 .. ipython:: python
-   :suppress:
-
-
-.. ipython:: python
 
    s = pd.Series([3.0, np.nan, 1.0, 3.0, np.nan, np.nan])
    s.index = pd.MultiIndex.from_tuples([(1, 2, 'a', 0),
@@ -270,9 +268,6 @@ Specifying different row and column labels (and not sorting them) yields a diffe
    columns
 
 A convenience method :meth:`SparseSeries.from_coo` is implemented for creating a ``SparseSeries`` from a ``scipy.sparse.coo_matrix``.
-
-.. ipython:: python
-   :suppress:
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.13.1.rst
+++ b/doc/source/whatsnew/v0.13.1.rst
@@ -220,7 +220,7 @@ Enhancements
 
       pd.MultiIndex.from_product([shades, colors], names=['shade', 'color'])
 
-- Panel :meth:`~pandas.Panel.apply` will work on non-ufuncs. See :ref:`the docs<basics.apply_panel>`.
+- Panel :meth:`~pandas.Panel.apply` will work on non-ufuncs. See :ref:`the docs<basics.apply>`.
 
   .. ipython:: python
 

--- a/doc/source/whatsnew/v0.19.0.rst
+++ b/doc/source/whatsnew/v0.19.0.rst
@@ -1250,8 +1250,8 @@ Operators now preserve dtypes
    s
    s.astype(np.int64)
 
-  ``astype`` fails if data contains values which cannot be converted to specified ``dtype``.
-  Note that the limitation is applied to ``fill_value`` which default is ``np.nan``.
+``astype`` fails if data contains values which cannot be converted to specified ``dtype``.
+Note that the limitation is applied to ``fill_value`` which default is ``np.nan``.
 
 .. code-block:: ipython
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -59,8 +59,8 @@ _doc_read_csv_and_table = r"""
 Also supports optionally iterating or breaking of the file
 into chunks.
 
-Additional help can be found in the `online docs for IO Tools
-<http://pandas.pydata.org/pandas-docs/stable/io.html>`_.
+Additional help can be found in the online docs for
+`IO Tools <http://pandas.pydata.org/pandas-docs/stable/io.html>`_.
 
 Parameters
 ----------


### PR DESCRIPTION
Follow up of #24430 and #24431. Addressing more doc warnings.

Also, forcing the docs Python code to be executed with the current directory `doc/`, so no matter where the actual current directory, operations like `pd.read_csv('data/baseball.csv')` always work.