### PR TITLE
 BUG: to_datetime(Timestamp, utc=True) localizes to UTC

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1368,6 +1368,7 @@ Timezones
 - Bug in :meth:`DatetimeIndex.tz_localize` and :meth:`Timestamp.tz_localize` with ``dateutil.tz.tzlocal`` near a DST transition that would return an incorrectly localized datetime (:issue:`23807`)
 - Bug in :class:`Timestamp` constructor where a ``dateutil.tz.tzutc`` timezone passed with a ``datetime.datetime`` argument would be converted to a ``pytz.UTC`` timezone (:issue:`23807`)
 - Bug in :func:`to_datetime` where ``utc=True`` was not respected when specifying a ``unit`` and ``errors='ignore'`` (:issue:`23758`)
+- bug in :func:`to_datetime` where ``utc=True`` was not respected when passing a :class:`Timestamp` (:issue:`24415`)
 
 Offsets
 ^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1368,7 +1368,7 @@ Timezones
 - Bug in :meth:`DatetimeIndex.tz_localize` and :meth:`Timestamp.tz_localize` with ``dateutil.tz.tzlocal`` near a DST transition that would return an incorrectly localized datetime (:issue:`23807`)
 - Bug in :class:`Timestamp` constructor where a ``dateutil.tz.tzutc`` timezone passed with a ``datetime.datetime`` argument would be converted to a ``pytz.UTC`` timezone (:issue:`23807`)
 - Bug in :func:`to_datetime` where ``utc=True`` was not respected when specifying a ``unit`` and ``errors='ignore'`` (:issue:`23758`)
-- bug in :func:`to_datetime` where ``utc=True`` was not respected when passing a :class:`Timestamp` (:issue:`24415`)
+- Bug in :func:`to_datetime` where ``utc=True`` was not respected when passing a :class:`Timestamp` (:issue:`24415`)
 
 Offsets
 ^^^^^^^

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -568,6 +568,8 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
 
     if isinstance(arg, Timestamp):
         result = arg
+        if tz is not None:
+            result = arg.tz_localize(tz)
     elif isinstance(arg, ABCSeries):
         cache_array = _maybe_cache(arg, format, cache, convert_listlike)
         if not cache_array.empty:

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -569,7 +569,10 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
     if isinstance(arg, Timestamp):
         result = arg
         if tz is not None:
-            result = arg.tz_localize(tz)
+            if arg.tz is not None:
+                result = result.tz_convert(tz)
+            else:
+                result = result.tz_localize(tz)
     elif isinstance(arg, ABCSeries):
         cache_array = _maybe_cache(arg, format, cache, convert_listlike)
         if not cache_array.empty:

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -655,16 +655,14 @@ class TestToDatetime(object):
                                            tzinfo=pytz.FixedOffset(240))] * 2)
         tm.assert_index_equal(result, expected)
 
-    def test_timestamp_utc_true(self):
+    @pytest.mark.parametrize('ts, expected', [
+        (Timestamp('2018-01-01'),
+         Timestamp('2018-01-01', tz='UTC')),
+        (Timestamp('2018-01-01', tz='US/Pacific'),
+         Timestamp('2018-01-01 08:00', tz='UTC'))])
+    def test_timestamp_utc_true(self, ts, expected):
         # GH 24415
-        ts = Timestamp(2018, 1, 1)
         result = to_datetime(ts, utc=True)
-        expected = ts.tz_localize('UTC')
-        assert result == expected
-
-        ts = ts.tz_localize('US/Pacific')
-        result = to_datetime(ts, utc=True)
-        expected = ts.tz_convert('UTC')
         assert result == expected
 
 

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -662,10 +662,10 @@ class TestToDatetime(object):
         expected = ts.tz_localize('UTC')
         assert result == expected
 
-        msg = ('Cannot localize tz-aware Timestamp, use tz_convert for '
-               'conversions')
-        with pytest.raises(TypeError, match=msg):
-            to_datetime(ts.tz_localize('US/Pacific'), utc=True)
+        ts = ts.tz_localize('US/Pacific')
+        result = to_datetime(ts, utc=True)
+        expected = ts.tz_convert('UTC')
+        assert result == expected
 
 
 class TestToDatetimeUnit(object):

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -655,6 +655,18 @@ class TestToDatetime(object):
                                            tzinfo=pytz.FixedOffset(240))] * 2)
         tm.assert_index_equal(result, expected)
 
+    def test_timestamp_utc_true(self):
+        # GH 24415
+        ts = Timestamp(2018, 1, 1)
+        result = to_datetime(ts, utc=True)
+        expected = ts.tz_localize('UTC')
+        assert result == expected
+
+        msg = ('Cannot localize tz-aware Timestamp, use tz_convert for '
+               'conversions')
+        with pytest.raises(TypeError, match=msg):
+            to_datetime(ts.tz_localize('US/Pacific'), utc=True)
+
 
 class TestToDatetimeUnit(object):
     @pytest.mark.parametrize('cache', [True, False])


### PR DESCRIPTION
- [x] closes #24415
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
