### PR TITLE
REF/TST: Add more pytest idiom to indexing/multiindex/test_getitem.py

### DIFF
--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -303,14 +303,17 @@ def test_frame_setitem_copy_no_write(multiindex_dataframe_random_data):
 
 
 def test_getitem_lowerdim_corner(multiindex_dataframe_random_data):
-    frame = multiindex_dataframe_random_data
-    msg = "11"
-    with pytest.raises(KeyError, match=msg):
-        frame.loc.__getitem__((('bar', 'three'), 'B'))
+    df = multiindex_dataframe_random_data
+
+    # test setup - check key not in dataframe
+    with pytest.raises(KeyError, match="11"):
+        df.loc[('bar', 'three'), 'B']
 
     # in theory should be inserting in a sorted space????
-    frame.loc[('bar', 'three'), 'B'] = 0
-    assert frame.sort_index().loc[('bar', 'three'), 'B'] == 0
+    df.loc[('bar', 'three'), 'B'] = 0
+    expected = 0
+    result = df.sort_index().loc[('bar', 'three'), 'B']
+    assert result == expected
 
 
 @pytest.mark.parametrize('unicode_strings', [True, False])

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -228,22 +228,18 @@ def test_getitem_tuple_plus_slice():
     tm.assert_series_equal(result, expected)
 
 
-def test_getitem_toplevel(multiindex_dataframe_random_data):
-    frame = multiindex_dataframe_random_data
-    df = frame.T
-
-    result = df['foo']
-    expected = df.reindex(columns=df.columns[:3])
+@pytest.mark.parametrize('indexer,expected_slice', [
+    (lambda df: df['foo'], slice(3)),
+    (lambda df: df['bar'], slice(3, 5)),
+    (lambda df: df.loc[:, 'bar'], slice(3, 5))
+])
+def test_getitem_toplevel(
+        multiindex_dataframe_random_data, indexer, expected_slice):
+    df = multiindex_dataframe_random_data.T
+    expected = df.reindex(columns=df.columns[expected_slice])
     expected.columns = expected.columns.droplevel(0)
+    result = indexer(df)
     tm.assert_frame_equal(result, expected)
-
-    result = df['bar']
-    result2 = df.loc[:, 'bar']
-
-    expected = df.reindex(columns=df.columns[3:5])
-    expected.columns = expected.columns.droplevel(0)
-    tm.assert_frame_equal(result, expected)
-    tm.assert_frame_equal(result, result2)
 
 
 def test_getitem_int(multiindex_dataframe_random_data):

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, lrange, range, u, zip
+from pandas.compat import StringIO, range, u, zip
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
@@ -206,34 +206,26 @@ def test_series_getitem_corner_generator(
 
 
 def test_frame_getitem_multicolumn_empty_level():
-    f = DataFrame({'a': ['1', '2', '3'], 'b': ['2', '3', '4']})
-    f.columns = [['level1 item1', 'level1 item2'], ['', 'level2 item2'],
-                 ['level3 item1', 'level3 item2']]
+    df = DataFrame({'a': ['1', '2', '3'], 'b': ['2', '3', '4']})
+    df.columns = [['level1 item1', 'level1 item2'], ['', 'level2 item2'],
+                  ['level3 item1', 'level3 item2']]
 
-    result = f['level1 item1']
-    expected = DataFrame([['1'], ['2'], ['3']], index=f.index,
+    result = df['level1 item1']
+    expected = DataFrame([['1'], ['2'], ['3']], index=df.index,
                          columns=['level3 item1'])
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.filterwarnings("ignore:\\n.ix:DeprecationWarning")
 def test_getitem_tuple_plus_slice():
-    # GH #671
-    df = DataFrame({'a': lrange(10),
-                    'b': lrange(10),
+    # GH 671
+    df = DataFrame({'a': np.arange(10),
+                    'b': np.arange(10),
                     'c': np.random.randn(10),
-                    'd': np.random.randn(10)})
-
-    idf = df.set_index(['a', 'b'])
-
-    result = idf.loc[(0, 0), :]
-    expected = idf.loc[0, 0]
-    expected2 = idf.xs((0, 0))
-    expected3 = idf.ix[0, 0]
-
+                    'd': np.random.randn(10)}
+                   ).set_index(['a', 'b'])
+    expected = df.loc[0, 0]
+    result = df.loc[(0, 0), :]
     tm.assert_series_equal(result, expected)
-    tm.assert_series_equal(result, expected2)
-    tm.assert_series_equal(result, expected3)
 
 
 def test_getitem_toplevel(multiindex_dataframe_random_data):

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -5,7 +5,7 @@ from pandas.compat import range, u, zip
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
-from pandas.core.common import SettingWithCopyError
+import pandas.core.common as com
 from pandas.core.indexing import IndexingError
 from pandas.util import testing as tm
 
@@ -284,7 +284,7 @@ def test_frame_setitem_copy_raises(multiindex_dataframe_random_data):
     # will raise/warn as its chained assignment
     df = multiindex_dataframe_random_data.T
     msg = "A value is trying to be set on a copy of a slice from a DataFrame"
-    with pytest.raises(SettingWithCopyError, match=msg):
+    with pytest.raises(com.SettingWithCopyError, match=msg):
         df['foo']['one'] = 2
 
 
@@ -295,7 +295,7 @@ def test_frame_setitem_copy_no_write(multiindex_dataframe_random_data):
 
     try:
         df['foo']['one'] = 2
-    except SettingWithCopyError:
+    except com.SettingWithCopyError:
         pass
 
     result = df

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -242,27 +242,33 @@ def test_getitem_toplevel(
     tm.assert_frame_equal(result, expected)
 
 
-def test_getitem_int(multiindex_dataframe_random_data):
+@pytest.fixture
+def frame_random_data_integer_multi_index():
     levels = [[0, 1], [0, 1, 2]]
     codes = [[0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 1, 2]]
     index = MultiIndex(levels=levels, codes=codes)
+    return DataFrame(np.random.randn(6, 2), index=index)
 
-    frame = DataFrame(np.random.randn(6, 2), index=index)
 
-    result = frame.loc[1]
-    expected = frame[-3:]
+def test_getitem_int(frame_random_data_integer_multi_index):
+    df = frame_random_data_integer_multi_index
+    result = df.loc[1]
+    expected = df[-3:]
     expected.index = expected.index.droplevel(0)
     tm.assert_frame_equal(result, expected)
 
-    # raises exception
+
+def test_getitem_int_raises_exception(frame_random_data_integer_multi_index):
+    df = frame_random_data_integer_multi_index
     msg = "3"
     with pytest.raises(KeyError, match=msg):
-        frame.loc.__getitem__(3)
+        df.loc.__getitem__(3)
 
-    # however this will work
-    frame = multiindex_dataframe_random_data
-    result = frame.iloc[2]
-    expected = frame.xs(frame.index[2])
+
+def test_getitem_iloc(multiindex_dataframe_random_data):
+    df = multiindex_dataframe_random_data
+    result = df.iloc[2]
+    expected = df.xs(df.index[2])
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -10,6 +10,28 @@ from pandas.core.indexing import IndexingError
 from pandas.util import testing as tm
 
 
+@pytest.fixture
+def frame_random_data_integer_multi_index():
+    levels = [[0, 1], [0, 1, 2]]
+    codes = [[0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 1, 2]]
+    index = MultiIndex(levels=levels, codes=codes)
+    return DataFrame(np.random.randn(6, 2), index=index)
+
+
+@pytest.fixture
+def dataframe_with_duplicate_index():
+    """Fixture for DataFrame used in tests for gh-4145 and gh-4146"""
+    data = [['a', 'd', 'e', 'c', 'f', 'b'],
+            [1, 4, 5, 3, 6, 2],
+            [1, 4, 5, 3, 6, 2]]
+    index = ['h1', 'h3', 'h5']
+    columns = MultiIndex(
+        levels=[['A', 'B'], ['A1', 'A2', 'B1', 'B2']],
+        codes=[[0, 0, 0, 1, 1, 1], [0, 3, 3, 0, 1, 2]],
+        names=['main', 'sub'])
+    return DataFrame(data, index=index, columns=columns)
+
+
 @pytest.mark.parametrize('access_method', [lambda s, x: s[:, x],
                                            lambda s, x: s.loc[:, x],
                                            lambda s, x: s.xs(x, level=1)])
@@ -242,14 +264,6 @@ def test_getitem_toplevel(
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.fixture
-def frame_random_data_integer_multi_index():
-    levels = [[0, 1], [0, 1, 2]]
-    codes = [[0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 1, 2]]
-    index = MultiIndex(levels=levels, codes=codes)
-    return DataFrame(np.random.randn(6, 2), index=index)
-
-
 def test_getitem_int(frame_random_data_integer_multi_index):
     df = frame_random_data_integer_multi_index
     result = df.loc[1]
@@ -341,20 +355,6 @@ def test_mixed_depth_get(unicode_strings):
     expected = df['routine1', 'result1', '']
     expected = expected.rename(('routine1', 'result1'))
     tm.assert_series_equal(result, expected)
-
-
-@pytest.fixture
-def dataframe_with_duplicate_index():
-    """Fixture for DataFrame used in tests for gh-4145 and gh-4146"""
-    data = [['a', 'd', 'e', 'c', 'f', 'b'],
-            [1, 4, 5, 3, 6, 2],
-            [1, 4, 5, 3, 6, 2]]
-    index = ['h1', 'h3', 'h5']
-    columns = MultiIndex(
-        levels=[['A', 'B'], ['A1', 'A2', 'B1', 'B2']],
-        codes=[[0, 0, 0, 1, 1, 1], [0, 3, 3, 0, 1, 2]],
-        names=['main', 'sub'])
-    return DataFrame(data, index=index, columns=columns)
 
 
 @pytest.mark.parametrize('indexer', [

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -306,11 +306,9 @@ def test_frame_setitem_copy_no_write(multiindex_dataframe_random_data):
     frame = multiindex_dataframe_random_data.T
     expected = frame
     df = frame.copy()
-
-    try:
+    msg = "A value is trying to be set on a copy of a slice from a DataFrame"
+    with pytest.raises(com.SettingWithCopyError, match=msg):
         df['foo']['one'] = 2
-    except com.SettingWithCopyError:
-        pass
 
     result = df
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ n/a] xref #24040
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ n/a] whatsnew entry

in this pass:
- follow-on from #24409