### PR TITLE
DOC: Correct import location for extension classes

### DIFF
--- a/doc/source/extending.rst
+++ b/doc/source/extending.rst
@@ -162,7 +162,7 @@ your ``MyExtensionArray`` class, as follows:
 
 .. code-block:: python
 
-    from pandas.core.arrays import ExtensionArray, ExtensionScalarOpsMixin
+    from pandas.api.extensions import ExtensionArray, ExtensionScalarOpsMixin
 
     class MyExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         pass


### PR DESCRIPTION
Minor correction of import location for ``ExtensionArray`` and ``ExtensionScalarOpsMixin``.
