### PR TITLE
BUG: clip doesn't preserve dtype by column

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1405,6 +1405,7 @@ Conversion
 ^^^^^^^^^^
 
 - Bug in :meth:`DataFrame.combine_first` in which column types were unexpectedly converted to float (:issue:`20699`)
+- Bug in :meth:`DataFrame.clip` in which column types are not preserved and casted to float (:issue:`24162`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7132,28 +7132,23 @@ class NDFrame(PandasObject, SelectionMixin):
                 (upper is not None and np.any(isna(upper)))):
             raise ValueError("Cannot use an NA value as a clip threshold")
 
-        result = self.values
+        result = self
         mask = isna(result)
 
-        with np.errstate(all='ignore'):
-            if upper is not None:
-                result = np.where(result >= upper, upper, result)
-            if lower is not None:
-                result = np.where(result <= lower, lower, result)
+        if upper is not None:
+            subset = self.le(upper, axis=None) | isna(result)
+            result = self.where(subset, upper, axis=None, inplace=inplace)
+        if lower is not None:
+            subset = self.ge(lower, axis=None) | isna(result)
+            result = self.where(subset, lower, axis=None, inplace=inplace)
+
         if np.any(mask):
             result[mask] = np.nan
 
-        axes_dict = self._construct_axes_dict()
-        result = self._constructor(result, **axes_dict).__finalize__(self)
-
-        if inplace:
-            self._update_inplace(result)
-        else:
-            return result
+        return result
 
     def _clip_with_one_bound(self, threshold, method, axis, inplace):
 
-        inplace = validate_bool_kwarg(inplace, 'inplace')
         if axis is not None:
             axis = self._get_axis_number(axis)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7133,17 +7133,15 @@ class NDFrame(PandasObject, SelectionMixin):
             raise ValueError("Cannot use an NA value as a clip threshold")
 
         result = self
-        mask = isna(result)
 
         if upper is not None:
             subset = self.le(upper, axis=None) | isna(result)
-            result = self.where(subset, upper, axis=None, inplace=inplace)
+            result = result.where(subset, upper, axis=None, inplace=inplace)
         if lower is not None:
+            if inplace:
+                result = self
             subset = self.ge(lower, axis=None) | isna(result)
-            result = self.where(subset, lower, axis=None, inplace=inplace)
-
-        if np.any(mask):
-            result[mask] = np.nan
+            result = result.where(subset, lower, axis=None, inplace=inplace)
 
         return result
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7133,17 +7133,17 @@ class NDFrame(PandasObject, SelectionMixin):
             raise ValueError("Cannot use an NA value as a clip threshold")
 
         result = self
-
         if upper is not None:
             subset = self.le(upper, axis=None) | isna(result)
-            result = result.where(subset, upper, axis=None, inplace=inplace)
+            result = result.where(subset, upper, axis=None, inplace=False)
         if lower is not None:
-            if inplace:
-                result = self
             subset = self.ge(lower, axis=None) | isna(result)
-            result = result.where(subset, lower, axis=None, inplace=inplace)
+            result = result.where(subset, lower, axis=None, inplace=False)
 
-        return result
+        if inplace:
+            self._update_inplace(result)
+        else:
+            return result
 
     def _clip_with_one_bound(self, threshold, method, axis, inplace):
 

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1895,7 +1895,8 @@ class TestDataFrameAnalytics():
         df = DataFrame({'A': [1, 2, 3],
                         'B': [1., np.nan, 3.]})
         result = df.clip(1, 2)
-        expected = DataFrame({'A': [1, 2, 2.],
+        # GH 24162, clipping now preserves types
+        expected = DataFrame({'A': [1, 2, 2],
                               'B': [1., np.nan, 2.]})
         tm.assert_frame_equal(result, expected, check_like=True)
 

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1836,7 +1836,6 @@ class TestDataFrameAnalytics():
             tm.assert_frame_equal(result, expected)
 
     # Clip
-
     def test_clip(self, float_frame):
         median = float_frame.median().median()
         original = float_frame.copy()
@@ -1895,10 +1894,16 @@ class TestDataFrameAnalytics():
         df = DataFrame({'A': [1, 2, 3],
                         'B': [1., np.nan, 3.]})
         result = df.clip(1, 2)
-        # GH 24162, clipping now preserves types
         expected = DataFrame({'A': [1, 2, 2],
                               'B': [1., np.nan, 2.]})
         tm.assert_frame_equal(result, expected, check_like=True)
+
+        # GH 24162, clipping now preserves numeric types per column
+        df = DataFrame([[1, 2, 3.4], [3, 4, 5.6]],
+                       columns=['foo', 'bar', 'baz'])
+        expected = df.dtypes
+        result = df.clip(upper=3).dtypes
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("inplace", [True, False])
     def test_clip_against_series(self, inplace):


### PR DESCRIPTION
- [x] closes #24162
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

```python3
>>> import pandas as pd
>>> data = pd.DataFrame([[1, 2], [3, 4]], columns=['int1', 'int2'])
>>> data.clip_upper(1)
__main__:1: FutureWarning: clip_upper(threshold) is deprecated, use clip(upper=threshold) instead
   int1  int2
0     1     1
1     1     1
```
**Before**
```python3
>>> data['float'] = data['int1'].astype(float)
>>> data.clip_upper(1)
   int1  int2  float
0   1.0   1.0    1.0
1   1.0   1.0    1.0
```
**After**
```python3
>>> data['float'] = data['int1'].astype(float)
>>> data.clip_upper(1)
   int1  int2  float
0     1     1    1.0
1     1     1    1.0
```