### PR TITLE
DOC: Fixing doc upload (no such remote origin)

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -45,7 +45,6 @@ if [ "$DOC" ]; then
         git add --all .
         git commit -m "Version" --allow-empty
 
-        git remote remove origin
         git remote add origin "https://${PANDAS_GH_TOKEN}@github.com/pandas-dev/pandas-docs-travis.git"
         git fetch origin
         git remote -v


### PR DESCRIPTION
- [X] closes #24455
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Didn't test it locally, as it's quite complicated (besides needing a token, the script changes the global git config).

But I think this should fix the problem. Seems like the problem is that we're deleting the remote origin of the github pages repo, just in case. Before it was ok, because we didn't make the script fail if something went wrong, but in #24292 we implemented that if something goes wrong in the doc build, we cancel and we fail it (with the shell option `-e`).

CC: @jreback 