### PR TITLE
DOC: Use top-level pd.IntervalArray in doc examples

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -30,10 +30,8 @@ from pandas.core.indexes.base import Index, ensure_index
 _VALID_CLOSED = {'left', 'right', 'both', 'neither'}
 _interval_shared_docs = {}
 
-# TODO(jschendel) remove constructor key when IntervalArray is public (GH22860)
 _shared_docs_kwargs = dict(
     klass='IntervalArray',
-    constructor='pd.core.arrays.IntervalArray',
     name=''
 )
 
@@ -105,7 +103,6 @@ for more.
 """
 
 
-# TODO(jschendel) use a more direct call in Examples when made public (GH22860)
 @Appender(_interval_shared_docs['class'] % dict(
     klass="IntervalArray",
     summary="Pandas array for interval data that are closed on the same side.",
@@ -119,7 +116,7 @@ for more.
     A new ``IntervalArray`` can be constructed directly from an array-like of
     ``Interval`` objects:
 
-    >>> pd.core.arrays.IntervalArray([pd.Interval(0, 1), pd.Interval(1, 5)])
+    >>> pd.IntervalArray([pd.Interval(0, 1), pd.Interval(1, 5)])
     IntervalArray([(0, 1], (1, 5]],
                   closed='right',
                   dtype='interval[int64]')
@@ -1035,7 +1032,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
         Examples
         --------
-        >>> intervals = %(constructor)s.from_tuples([(0, 1), (1, 3), (2, 4)])
+        >>> intervals = pd.%(klass)s.from_tuples([(0, 1), (1, 3), (2, 4)])
         >>> intervals
         %(klass)s([(0, 1], (1, 3], (2, 4]],
               closed='right',

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -36,10 +36,8 @@ from pandas.tseries.offsets import DateOffset
 _VALID_CLOSED = {'left', 'right', 'both', 'neither'}
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 
-# TODO(jschendel) remove constructor key when IntervalArray is public (GH22860)
 _index_doc_kwargs.update(
     dict(klass='IntervalIndex',
-         constructor='pd.IntervalIndex',
          target_klass='IntervalIndex or list of Intervals',
          name=textwrap.dedent("""\
          name : object, optional


### PR DESCRIPTION
Follow-up to #23581

Minor changes to make sure `pd.IntervalArray` is used in the doc examples instead of `pd.core.arrays.IntervalArray`.  Pretty sure this is all the instances of them; I tried to be diligent in marking these with a TODO, and can't find any additional examples via a quick search.