### PR TITLE
TST: use capsys.readouterr() as named tuple

### DIFF
--- a/pandas/tests/series/test_duplicates.py
+++ b/pandas/tests/series/test_duplicates.py
@@ -76,12 +76,12 @@ def test_is_unique_class_ne(capsys):
         def __ne__(self, other):
             raise Exception("NEQ not supported")
 
-    li = [Foo(i) for i in range(5)]
-    s = Series(li, index=[i for i in range(5)])
-    _, err = capsys.readouterr()
+    with capsys.disabled():
+        li = [Foo(i) for i in range(5)]
+        s = Series(li, index=[i for i in range(5)])
     s.is_unique
-    _, err = capsys.readouterr()
-    assert len(err) == 0
+    captured = capsys.readouterr()
+    assert len(captured.err) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
currently only one test in codebase uses capsys.readouterr().

from pytest 3.3, the return value from readouterr changed to a namedtuple with two attributes, out and err.

this change in the style of https://docs.pytest.org/en/latest/capture.html#accessing-captured-output-from-a-test-function is to ensure that the current usage in the codebase does not set a precedent for future usage.