### PR TITLE
TST: Skip db tests unless explicitly specified in -m pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ matrix:
     include:
     - dist: trusty
       env:
-        - JOB="3.7" ENV_FILE="ci/deps/travis-37.yaml" PATTERN="not slow and not network and not db"
+        - JOB="3.7" ENV_FILE="ci/deps/travis-37.yaml" PATTERN="not slow and not network"
 
     - dist: trusty
       env:
-        - JOB="2.7" ENV_FILE="ci/deps/travis-27.yaml" PATTERN="not slow"
+        - JOB="2.7" ENV_FILE="ci/deps/travis-27.yaml" PATTERN="not slow and db"
       addons:
         apt:
           packages:
@@ -46,11 +46,11 @@ matrix:
 
     - dist: trusty
       env:
-        - JOB="3.6, locale" ENV_FILE="ci/deps/travis-36-locale.yaml" PATTERN="not slow and not network" LOCALE_OVERRIDE="zh_CN.UTF-8"
+        - JOB="3.6, locale" ENV_FILE="ci/deps/travis-36-locale.yaml" PATTERN="not slow and not network and db" LOCALE_OVERRIDE="zh_CN.UTF-8"
 
     - dist: trusty
       env:
-        - JOB="3.6, coverage" ENV_FILE="ci/deps/travis-36.yaml" PATTERN="not slow and not network" PANDAS_TESTING_MODE="deprecate" COVERAGE=true
+        - JOB="3.6, coverage" ENV_FILE="ci/deps/travis-36.yaml" PATTERN="not slow and not network and db" PANDAS_TESTING_MODE="deprecate" COVERAGE=true
 
     # In allow_failures
     - dist: trusty

--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -12,37 +12,37 @@ jobs:
         py35_np_120:
           ENV_FILE: ci/deps/azure-macos-35.yaml
           CONDA_PY: "35"
-          PATTERN: "not slow and not network and not db"
+          PATTERN: "not slow and not network"
 
       ${{ if eq(parameters.name, 'Linux') }}:
         py27_np_120:
           ENV_FILE: ci/deps/azure-27-compat.yaml
           CONDA_PY: "27"
-          PATTERN: "not slow and not network and not db"
+          PATTERN: "not slow and not network"
 
         py27_locale_slow_old_np:
           ENV_FILE: ci/deps/azure-27-locale.yaml
           CONDA_PY: "27"
-          PATTERN: "slow and not db"
+          PATTERN: "slow"
           LOCALE_OVERRIDE: "zh_CN.UTF-8"
           EXTRA_APT: "language-pack-zh-hans"
 
         py36_locale_slow:
           ENV_FILE: ci/deps/azure-36-locale_slow.yaml
           CONDA_PY: "36"
-          PATTERN: "not slow and not network and not db"
+          PATTERN: "not slow and not network"
           LOCALE_OVERRIDE: "it_IT.UTF-8"
 
         py37_locale:
           ENV_FILE: ci/deps/azure-37-locale.yaml
           CONDA_PY: "37"
-          PATTERN: "not slow and not network and not db"
+          PATTERN: "not slow and not network"
           LOCALE_OVERRIDE: "zh_CN.UTF-8"
 
         py37_np_dev:
           ENV_FILE: ci/deps/azure-37-numpydev.yaml
           CONDA_PY: "37"
-          PATTERN: "not slow and not network and not db"
+          PATTERN: "not slow and not network"
           TEST_ARGS: "-W error"
           PANDAS_TESTING_MODE: "deprecate"
           EXTRA_APT: "xsel"

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -38,7 +38,7 @@ jobs:
       displayName: 'Build'
     - script: |
         call activate pandas-dev
-        pytest -m "not slow and not network and not db" --junitxml=test-data.xml pandas -n 2 -r sxX --strict --durations=10 %*
+        pytest -m "not slow and not network" --junitxml=test-data.xml pandas -n 2 -r sxX --strict --durations=10 %*
       displayName: 'Test'
     - task: PublishTestResults@2
       inputs:

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1,3 +1,4 @@
+import collections
 from datetime import date, time, timedelta
 from decimal import Decimal
 import importlib
@@ -60,7 +61,6 @@ def pytest_runtest_setup(item):
             "skipping high memory test since --run-high-memory was not set")
 
     # if "db" not explicitly set in the -m pattern, we skip the db tests
-    import collections
     if 'db' in item.keywords:
         pattern = item.config.getoption('-m')
         markers = collections.defaultdict(bool)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -54,13 +54,22 @@ def pytest_runtest_setup(item):
     if 'network' in item.keywords and item.config.getoption("--skip-network"):
         pytest.skip("skipping due to --skip-network")
 
-    if 'db' in item.keywords and item.config.getoption("--skip-db"):
-        pytest.skip("skipping due to --skip-db")
-
     if 'high_memory' in item.keywords and not item.config.getoption(
             "--run-high-memory"):
         pytest.skip(
             "skipping high memory test since --run-high-memory was not set")
+
+    # if "db" not explicitly set in the -m pattern, we skip the db tests
+    import collections
+    if 'db' in item.keywords:
+        pattern = item.config.getoption('-m')
+        markers = collections.defaultdict(bool)
+        for marker in item.iter_markers():
+            markers[marker.name] = True
+        markers['db'] = False
+        db_in_pattern = not eval(pattern, {}, markers)
+        if not db_in_pattern:
+            pytest.skip('skipping db unless -m "db" is specified')
 
 
 # Configurations for all tests and all test modules

--- a/pandas/util/_tester.py
+++ b/pandas/util/_tester.py
@@ -16,7 +16,7 @@ def test(extra_args=None):
         import hypothesis  # noqa
     except ImportError:
         raise ImportError("Need hypothesis>=3.58 to run tests")
-    cmd = ['--skip-slow', '--skip-network', '--skip-db']
+    cmd = ['--skip-slow', '--skip-network']
     if extra_args:
         if not isinstance(extra_args, list):
             extra_args = [extra_args]


### PR DESCRIPTION
- [x] closes #24485

Since #24450 we don't skip the db tests if the connection fails. That's useful, because the CI won't fail silently if there is any problem with the databases. But as reported in #24485, it's common to have `pymysql` or `psycopg2` installed locally, but no database connection. This is making the tests fail locally, and the agreed solution is to skip the db tests unless they are explicitly requested. 

But pytest doesn't make it easy to skip tests by default when using `-m`, but this solution should work. Another option would be an `--include-db` option, but I think it makes reading the expressions in the build very difficult (like, what `--only-slow --include-db` runs?). With `-m` the expressions are much clearer (e.g. `slow and db`), so I think this option is better.

The `eval` is how `pytest` itself evaluates the value of the `-m` parameter.
