### PR TITLE
BUG: fix .iat assignment creates a new column

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1493,6 +1493,7 @@ Indexing
 - Bug in :class:`Index` slicing with boolean :class:`Index` may raise ``TypeError`` (:issue:`22533`)
 - Bug in ``PeriodArray.__setitem__`` when accepting slice and list-like value (:issue:`23978`)
 - Bug in :class:`DatetimeIndex`, :class:`TimedeltaIndex` where indexing with ``Ellipsis`` would lose their ``freq`` attribute (:issue:`21282`)
+- Bug in ``iat`` where using it to assign an incompatible value would create a new column (:issue:`23236`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2716,7 +2716,10 @@ class DataFrame(NDFrame):
         except (KeyError, TypeError):
 
             # set using a non-recursive method & reset the cache
-            self.loc[index, col] = value
+            if takeable:
+                self.iloc[index, col] = value
+            else:
+                self.loc[index, col] = value
             self._item_cache.pop(col, None)
 
             return self

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -198,3 +198,10 @@ class TestScalar(Base):
             df.at[0, 3]
         with pytest.raises(KeyError):
             df.loc[0, 3]
+
+    def test_iat_setter_incompatible_assignment(self):
+        # GH 23236
+        df = DataFrame({'a': [0, 1], 'b': [4, 5]})
+        df.iat[0, 0] = None
+        assert np.isnan(df.iat[0, 0])
+        assert len(df.index) == 2

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -201,7 +201,7 @@ class TestScalar(Base):
 
     def test_iat_setter_incompatible_assignment(self):
         # GH 23236
-        df = DataFrame({'a': [0, 1], 'b': [4, 5]})
-        df.iat[0, 0] = None
-        assert np.isnan(df.iat[0, 0])
-        assert len(df.index) == 2
+        result = DataFrame({'a': [0, 1], 'b': [4, 5]})
+        result.iat[0, 0] = None
+        expected = DataFrame({"a": [None, 1], "b": [4, 5]})
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- in response to gh-23236
- changes the fallback of .iat to .iloc on type error

using .iat to assign incompatible value after this change:
```python
>>> import pandas as pd
>>> df = pd.DataFrame({"a":[0]})
>>> df
   a
0  0
>>> df.iat[0,0] = None
>>> df
    a
0 NaN
```

- [x] closes #23236
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
