### PR TITLE
DOC: Fixing broken references in the docs

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -921,7 +921,7 @@ If you need integer based selection, you should use ``iloc``:
 
    dfir.iloc[0:5]
 
-.. _indexing.intervallindex:
+.. _advanced.intervallindex:
 
 IntervalIndex
 ~~~~~~~~~~~~~

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -156,7 +156,7 @@ to these in old code bases and online. Going forward, we recommend avoiding
 ``.values`` and using ``.array`` or ``.to_numpy()``. ``.values`` has the following
 drawbacks:
 
-1. When your Series contains an :ref:`extension type <extending.extension-type>`, it's
+1. When your Series contains an :ref:`extension type <extending.extension-types>`, it's
    unclear whether :attr:`Series.values` returns a NumPy array or the extension array.
    :attr:`Series.array` will always return an ``ExtensionArray``, and will never
    copy data. :meth:`Series.to_numpy` will always return a NumPy array,

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -142,7 +142,8 @@ which are utilized by Jupyter Notebook for displaying
 (Note: HTML tables may or may not be
 compatible with non-HTML Jupyter output formats.)
 
-See :ref:`Options and Settings <options>` and :ref:`<options.available>`
+See :ref:`Options and Settings <options>` and
+:ref:`Available Options <options.available>`
 for pandas ``display.`` settings.
 
 `quantopian/qgrid <https://github.com/quantopian/qgrid>`__

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1334,7 +1334,7 @@ class GroupBy(_GroupBy):
         Given a grouper, the function resamples it according to a string
         "string" -> "frequency".
 
-        See the :ref:`frequency aliases <timeseries.offset-aliases>`
+        See the :ref:`frequency aliases <timeseries.offset_aliases>`
         documentation for more details.
 
         Parameters


### PR DESCRIPTION
Just fixing some typos that are breaking references in the docs.
