### PR TITLE
 CLN: read_sql date parsing

### DIFF
--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1356,9 +1356,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         # even with the same versions of psycopg2 & sqlalchemy, possibly a
         # Postgrsql server version difference
         col = df.DateColWithTz
-        assert (is_object_dtype(col.dtype) or
-                is_datetime64_dtype(col.dtype) or
-                is_datetime64tz_dtype(col.dtype))
+        assert is_datetime64tz_dtype(col.dtype)
 
         df = pd.read_sql_query("select * from types_test_data",
                                self.conn, parse_dates=['DateColWithTz'])

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -28,9 +28,8 @@ import pandas as pd
 
 from datetime import datetime, date, time
 
-from pandas.core.dtypes.common import (
-    is_object_dtype, is_datetime64_dtype,
-    is_datetime64tz_dtype)
+from pandas.core.dtypes.common import (is_datetime64_dtype,
+                                       is_datetime64tz_dtype)
 from pandas import DataFrame, Series, Index, MultiIndex, isna, concat
 from pandas import date_range, to_datetime, to_timedelta, Timestamp
 import pandas.compat as compat


### PR DESCRIPTION
- [x] closes #15119
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Cleaning up the date parsing portion of the read_sql functionality. Also checking that #15119 can be closed as we are already testing the solution.