### PR TITLE
DOC: Fix building of a single API document

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -50,7 +50,7 @@ class DocBuilder:
         if single_doc and single_doc.endswith('.rst'):
             self.single_doc_html = os.path.splitext(single_doc)[0] + '.html'
         elif single_doc:
-            self.single_doc_html = 'generated/pandas.{}.html'.format(
+            self.single_doc_html = 'api/generated/pandas.{}.html'.format(
                 single_doc)
 
     def _process_single_doc(self, single_doc):

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -98,8 +98,7 @@ if pattern:
                 if (fname == 'index.rst'
                         and os.path.abspath(dirname) == source_path):
                     continue
-                elif (pattern == '-api'
-                        and (fname == 'api.rst' or dirname == 'generated')):
+                elif pattern == '-api' and dirname == 'api':
                     exclude_patterns.append(fname)
                 elif fname != pattern:
                     exclude_patterns.append(fname)

--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -113,7 +113,7 @@ See the package overview for more detail about what's in the library.
     {{ single_doc[:-4] }}
 {% elif single_doc %}
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/generated/
 
     {{ single_doc }}
 {% else -%}


### PR DESCRIPTION
As reported in #24503#issuecomment-450586329, building a single document of the API (e.g. `./doc/make.py html --single=pandas.read_excel`) is broken after splitting `api.rst` in multiple files in #24462.

This PR fixes it.