### PR TITLE
DOC: Clean up of API doc sections

### DIFF
--- a/doc/source/api/extensions.rst
+++ b/doc/source/api/extensions.rst
@@ -2,8 +2,9 @@
 
 .. _api.extensions:
 
+==========
 Extensions
-----------
+==========
 .. currentmodule:: pandas
 
 These are primarily intended for library authors looking to extend pandas

--- a/doc/source/api/frame.rst
+++ b/doc/source/api/frame.rst
@@ -2,8 +2,9 @@
 
 .. _api.dataframe:
 
+=========
 DataFrame
----------
+=========
 .. currentmodule:: pandas
 
 Constructor

--- a/doc/source/api/general_functions.rst
+++ b/doc/source/api/general_functions.rst
@@ -2,8 +2,9 @@
 
 .. _api.general_functions:
 
+=================
 General functions
------------------
+=================
 .. currentmodule:: pandas
 
 Data manipulations

--- a/doc/source/api/general_utility_functions.rst
+++ b/doc/source/api/general_utility_functions.rst
@@ -2,12 +2,13 @@
 
 .. _api.general_utility_functions:
 
+=========================
 General utility functions
--------------------------
+=========================
 .. currentmodule:: pandas
 
 Working with options
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 .. autosummary::
    :toctree: generated/
 
@@ -18,7 +19,7 @@ Working with options
    option_context
 
 Testing functions
-~~~~~~~~~~~~~~~~~
+-----------------
 .. autosummary::
    :toctree: generated/
 
@@ -27,7 +28,7 @@ Testing functions
    testing.assert_index_equal
 
 Exceptions and warnings
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 .. autosummary::
    :toctree: generated/
 
@@ -41,7 +42,7 @@ Exceptions and warnings
    errors.UnsupportedFunctionCall
 
 Data types related functionality
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -50,7 +51,7 @@ Data types related functionality
    api.types.pandas_dtype
 
 Dtype introspection
-
+~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
@@ -77,7 +78,7 @@ Dtype introspection
     api.types.is_sparse
 
 Iterable introspection
-
+~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
@@ -88,7 +89,7 @@ Iterable introspection
     api.types.is_iterator
 
 Scalar introspection
-
+~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 

--- a/doc/source/api/groupby.rst
+++ b/doc/source/api/groupby.rst
@@ -2,14 +2,15 @@
 
 .. _api.groupby:
 
+=======
 GroupBy
--------
+=======
 .. currentmodule:: pandas.core.groupby
 
 GroupBy objects are returned by groupby calls: :func:`pandas.DataFrame.groupby`, :func:`pandas.Series.groupby`, etc.
 
 Indexing, iteration
-~~~~~~~~~~~~~~~~~~~
+-------------------
 .. autosummary::
    :toctree: generated/
 
@@ -29,7 +30,7 @@ Indexing, iteration
 .. currentmodule:: pandas.core.groupby
 
 Function application
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 .. autosummary::
    :toctree: generated/
 
@@ -40,7 +41,7 @@ Function application
    GroupBy.pipe
 
 Computations / Descriptive Stats
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 .. autosummary::
    :toctree: generated/
 

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -2,9 +2,9 @@
 
 .. _api:
 
-*************
+=============
 API Reference
-*************
+=============
 
 This page gives an overview of all public pandas objects, functions and
 methods. All classes and functions exposed in ``pandas.*`` namespace are public.
@@ -27,7 +27,7 @@ public functions related to data types in pandas.
    series
    frame
    panel
-   indices
+   indexing
    scalars
    offset_frequency
    window

--- a/doc/source/api/indexing.rst
+++ b/doc/source/api/indexing.rst
@@ -1,6 +1,10 @@
 {{ header }}
 
-.. _api.index:
+.. _api.indexing:
+
+========
+Indexing
+========
 
 Index
 -----
@@ -15,7 +19,7 @@ used before calling these methods directly.**
 
    Index
 
-Attributes
+Properties
 ~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
@@ -280,7 +284,7 @@ MultiIndex Constructors
    MultiIndex.from_product
    MultiIndex.from_frame
 
-MultiIndex Attributes
+MultiIndex Properties
 ~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
@@ -433,14 +437,14 @@ Conversion
 .. currentmodule:: pandas
 
 PeriodIndex
---------------
+-----------
 .. autosummary::
    :toctree: generated/
    :template: autosummary/class_without_autosummary.rst
 
    PeriodIndex
 
-Attributes
+Properties
 ~~~~~~~~~~
 .. autosummary::
     :toctree: generated/

--- a/doc/source/api/io.rst
+++ b/doc/source/api/io.rst
@@ -2,8 +2,9 @@
 
 .. _api.io:
 
+============
 Input/Output
-------------
+============
 .. currentmodule:: pandas
 
 Pickling

--- a/doc/source/api/offset_frequency.rst
+++ b/doc/source/api/offset_frequency.rst
@@ -2,12 +2,13 @@
 
 .. _api.dateoffsets:
 
+============
 Date Offsets
-------------
+============
 .. currentmodule:: pandas.tseries.offsets
 
 DateOffset
-~~~~~~~~~~
+----------
 .. autosummary::
    :toctree: generated/
 
@@ -36,7 +37,7 @@ Methods
     DateOffset.onOffset
 
 BusinessDay
-~~~~~~~~~~~
+-----------
 .. autosummary::
    :toctree: generated/
 
@@ -66,7 +67,7 @@ Methods
     BusinessDay.onOffset
 
 BusinessHour
-~~~~~~~~~~~~
+------------
 .. autosummary::
    :toctree: generated/
 
@@ -95,7 +96,7 @@ Methods
     BusinessHour.onOffset
 
 CustomBusinessDay
-~~~~~~~~~~~~~~~~~
+-----------------
 .. autosummary::
    :toctree: generated/
 
@@ -124,7 +125,7 @@ Methods
     CustomBusinessDay.onOffset
 
 CustomBusinessHour
-~~~~~~~~~~~~~~~~~~
+------------------
 .. autosummary::
    :toctree: generated/
 
@@ -153,7 +154,7 @@ Methods
     CustomBusinessHour.onOffset
 
 MonthOffset
-~~~~~~~~~~~
+-----------
 .. autosummary::
    :toctree: generated/
 
@@ -183,7 +184,7 @@ Methods
     MonthOffset.onOffset
 
 MonthEnd
-~~~~~~~~
+--------
 .. autosummary::
    :toctree: generated/
 
@@ -213,7 +214,7 @@ Methods
     MonthEnd.onOffset
 
 MonthBegin
-~~~~~~~~~~
+----------
 .. autosummary::
    :toctree: generated/
 
@@ -243,7 +244,7 @@ Methods
     MonthBegin.onOffset
 
 BusinessMonthEnd
-~~~~~~~~~~~~~~~~
+----------------
 .. autosummary::
    :toctree: generated/
 
@@ -273,7 +274,7 @@ Methods
     BusinessMonthEnd.onOffset
 
 BusinessMonthBegin
-~~~~~~~~~~~~~~~~~~
+------------------
 .. autosummary::
    :toctree: generated/
 
@@ -303,7 +304,7 @@ Methods
     BusinessMonthBegin.onOffset
 
 CustomBusinessMonthEnd
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 .. autosummary::
    :toctree: generated/
 
@@ -333,7 +334,7 @@ Methods
     CustomBusinessMonthEnd.onOffset
 
 CustomBusinessMonthBegin
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -363,7 +364,7 @@ Methods
     CustomBusinessMonthBegin.onOffset
 
 SemiMonthOffset
-~~~~~~~~~~~~~~~
+---------------
 .. autosummary::
    :toctree: generated/
 
@@ -393,7 +394,7 @@ Methods
     SemiMonthOffset.onOffset
 
 SemiMonthEnd
-~~~~~~~~~~~~
+------------
 .. autosummary::
    :toctree: generated/
 
@@ -423,7 +424,7 @@ Methods
     SemiMonthEnd.onOffset
 
 SemiMonthBegin
-~~~~~~~~~~~~~~
+--------------
 .. autosummary::
    :toctree: generated/
 
@@ -453,7 +454,7 @@ Methods
     SemiMonthBegin.onOffset
 
 Week
-~~~~
+----
 .. autosummary::
    :toctree: generated/
 
@@ -483,7 +484,7 @@ Methods
     Week.onOffset
 
 WeekOfMonth
-~~~~~~~~~~~
+-----------
 .. autosummary::
    :toctree: generated/
 
@@ -512,7 +513,7 @@ Methods
     WeekOfMonth.onOffset
 
 LastWeekOfMonth
-~~~~~~~~~~~~~~~
+---------------
 .. autosummary::
    :toctree: generated/
 
@@ -541,7 +542,7 @@ Methods
     LastWeekOfMonth.onOffset
 
 QuarterOffset
-~~~~~~~~~~~~~
+-------------
 .. autosummary::
    :toctree: generated/
 
@@ -571,7 +572,7 @@ Methods
     QuarterOffset.onOffset
 
 BQuarterEnd
-~~~~~~~~~~~
+-----------
 .. autosummary::
    :toctree: generated/
 
@@ -601,7 +602,7 @@ Methods
     BQuarterEnd.onOffset
 
 BQuarterBegin
-~~~~~~~~~~~~~
+-------------
 .. autosummary::
    :toctree: generated/
 
@@ -631,7 +632,7 @@ Methods
     BQuarterBegin.onOffset
 
 QuarterEnd
-~~~~~~~~~~
+----------
 .. autosummary::
    :toctree: generated/
 
@@ -661,7 +662,7 @@ Methods
     QuarterEnd.onOffset
 
 QuarterBegin
-~~~~~~~~~~~~
+------------
 .. autosummary::
    :toctree: generated/
 
@@ -691,7 +692,7 @@ Methods
     QuarterBegin.onOffset
 
 YearOffset
-~~~~~~~~~~
+----------
 .. autosummary::
    :toctree: generated/
 
@@ -721,7 +722,7 @@ Methods
     YearOffset.onOffset
 
 BYearEnd
-~~~~~~~~
+--------
 .. autosummary::
    :toctree: generated/
 
@@ -751,7 +752,7 @@ Methods
     BYearEnd.onOffset
 
 BYearBegin
-~~~~~~~~~~
+----------
 .. autosummary::
    :toctree: generated/
 
@@ -781,7 +782,7 @@ Methods
     BYearBegin.onOffset
 
 YearEnd
-~~~~~~~
+-------
 .. autosummary::
    :toctree: generated/
 
@@ -811,7 +812,7 @@ Methods
     YearEnd.onOffset
 
 YearBegin
-~~~~~~~~~
+---------
 .. autosummary::
    :toctree: generated/
 
@@ -841,7 +842,7 @@ Methods
     YearBegin.onOffset
 
 FY5253
-~~~~~~
+------
 .. autosummary::
    :toctree: generated/
 
@@ -872,7 +873,7 @@ Methods
     FY5253.onOffset
 
 FY5253Quarter
-~~~~~~~~~~~~~
+-------------
 .. autosummary::
    :toctree: generated/
 
@@ -903,7 +904,7 @@ Methods
     FY5253Quarter.year_has_extra_week
 
 Easter
-~~~~~~
+------
 .. autosummary::
    :toctree: generated/
 
@@ -932,7 +933,7 @@ Methods
     Easter.onOffset
 
 Tick
-~~~~
+----
 .. autosummary::
    :toctree: generated/
 
@@ -961,7 +962,7 @@ Methods
     Tick.onOffset
 
 Day
-~~~
+---
 .. autosummary::
    :toctree: generated/
 
@@ -990,7 +991,7 @@ Methods
     Day.onOffset
 
 Hour
-~~~~
+----
 .. autosummary::
    :toctree: generated/
 
@@ -1019,7 +1020,7 @@ Methods
     Hour.onOffset
 
 Minute
-~~~~~~
+------
 .. autosummary::
    :toctree: generated/
 
@@ -1048,7 +1049,7 @@ Methods
     Minute.onOffset
 
 Second
-~~~~~~
+------
 .. autosummary::
    :toctree: generated/
 
@@ -1077,7 +1078,7 @@ Methods
     Second.onOffset
 
 Milli
-~~~~~
+-----
 .. autosummary::
    :toctree: generated/
 
@@ -1106,7 +1107,7 @@ Methods
     Milli.onOffset
 
 Micro
-~~~~~
+-----
 .. autosummary::
    :toctree: generated/
 
@@ -1135,7 +1136,7 @@ Methods
     Micro.onOffset
 
 Nano
-~~~~
+----
 .. autosummary::
    :toctree: generated/
 
@@ -1164,7 +1165,7 @@ Methods
     Nano.onOffset
 
 BDay
-~~~~
+----
 .. autosummary::
    :toctree: generated/
 
@@ -1198,7 +1199,7 @@ Methods
     BDay.rollforward
 
 BMonthEnd
-~~~~~~~~~
+---------
 .. autosummary::
    :toctree: generated/
 
@@ -1231,7 +1232,7 @@ Methods
     BMonthEnd.rollforward
 
 BMonthBegin
-~~~~~~~~~~~
+-----------
 .. autosummary::
    :toctree: generated/
 
@@ -1264,7 +1265,7 @@ Methods
     BMonthBegin.rollforward
 
 CBMonthEnd
-~~~~~~~~~~
+----------
 .. autosummary::
    :toctree: generated/
 
@@ -1301,7 +1302,7 @@ Methods
     CBMonthEnd.rollforward
 
 CBMonthBegin
-~~~~~~~~~~~~
+------------
 .. autosummary::
    :toctree: generated/
 
@@ -1338,7 +1339,7 @@ Methods
     CBMonthBegin.rollforward
 
 CDay
-~~~~
+----
 .. autosummary::
    :toctree: generated/
 
@@ -1373,8 +1374,9 @@ Methods
 
 .. _api.frequencies:
 
+===========
 Frequencies
------------
+===========
 .. currentmodule:: pandas.tseries.frequencies
 
 .. _api.offsets:

--- a/doc/source/api/panel.rst
+++ b/doc/source/api/panel.rst
@@ -2,8 +2,9 @@
 
 .. _api.panel:
 
+=====
 Panel
-------
+=====
 .. currentmodule:: pandas
 
 Constructor
@@ -13,7 +14,7 @@ Constructor
 
    Panel
 
-Attributes and underlying data
+Properties and underlying data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Axes**
 

--- a/doc/source/api/plotting.rst
+++ b/doc/source/api/plotting.rst
@@ -2,8 +2,9 @@
 
 .. _api.plotting:
 
+========
 Plotting
---------
+========
 .. currentmodule:: pandas.plotting
 
 The following functions are contained in the `pandas.plotting` module.

--- a/doc/source/api/resampling.rst
+++ b/doc/source/api/resampling.rst
@@ -2,8 +2,9 @@
 
 .. _api.resampling:
 
+==========
 Resampling
-----------
+==========
 .. currentmodule:: pandas.core.resample
 
 Resampler objects are returned by resample calls: :func:`pandas.DataFrame.resample`, :func:`pandas.Series.resample`.

--- a/doc/source/api/scalars.rst
+++ b/doc/source/api/scalars.rst
@@ -2,18 +2,19 @@
 
 .. _api.scalars:
 
+=======
 Scalars
--------
+=======
 .. currentmodule:: pandas
 
 Period
-~~~~~~
+------
 .. autosummary::
     :toctree: generated/
 
     Period
 
-Attributes
+Properties
 ~~~~~~~~~~
 .. autosummary::
     :toctree: generated/
@@ -51,7 +52,7 @@ Methods
     Period.to_timestamp
 
 Timestamp
-~~~~~~~~~
+---------
 .. autosummary::
     :toctree: generated/
 
@@ -140,7 +141,7 @@ Methods
     Timestamp.weekday
 
 Interval
-~~~~~~~~
+--------
 .. autosummary::
     :toctree: generated/
 
@@ -163,7 +164,7 @@ Properties
     Interval.right
 
 Timedelta
-~~~~~~~~~
+---------
 .. autosummary::
     :toctree: generated/
 

--- a/doc/source/api/series.rst
+++ b/doc/source/api/series.rst
@@ -2,19 +2,20 @@
 
 .. _api.series:
 
+======
 Series
-------
+======
 .. currentmodule:: pandas
 
 Constructor
-~~~~~~~~~~~
+-----------
 .. autosummary::
    :toctree: generated/
 
    Series
 
 Attributes
-~~~~~~~~~~
+----------
 **Axes**
 
 .. autosummary::
@@ -48,7 +49,7 @@ Attributes
    Series.put
 
 Conversion
-~~~~~~~~~~
+----------
 .. autosummary::
    :toctree: generated/
 
@@ -63,7 +64,7 @@ Conversion
    Series.get_values
 
 Indexing, iteration
-~~~~~~~~~~~~~~~~~~~
+-------------------
 .. autosummary::
    :toctree: generated/
 
@@ -84,7 +85,7 @@ For more information on ``.at``, ``.iat``, ``.loc``, and
 ``.iloc``,  see the :ref:`indexing documentation <indexing>`.
 
 Binary operator functions
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -117,7 +118,7 @@ Binary operator functions
    Series.dot
 
 Function application, GroupBy & Window
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -135,7 +136,7 @@ Function application, GroupBy & Window
 .. _api.series.stats:
 
 Computations / Descriptive Stats
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -187,7 +188,7 @@ Computations / Descriptive Stats
    Series.nonzero
 
 Reindexing / Selection / Label manipulation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -221,7 +222,7 @@ Reindexing / Selection / Label manipulation
    Series.filter
 
 Missing data handling
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 .. autosummary::
    :toctree: generated/
 
@@ -232,7 +233,7 @@ Missing data handling
    Series.interpolate
 
 Reshaping, sorting
-~~~~~~~~~~~~~~~~~~
+------------------
 .. autosummary::
    :toctree: generated/
 
@@ -251,7 +252,7 @@ Reshaping, sorting
    Series.view
 
 Combining / joining / merging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -260,7 +261,7 @@ Combining / joining / merging
    Series.update
 
 Time series-related
-~~~~~~~~~~~~~~~~~~~
+-------------------
 .. autosummary::
    :toctree: generated/
 
@@ -278,13 +279,13 @@ Time series-related
    Series.slice_shift
 
 Datetimelike Properties
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 ``Series.dt`` can be used to access the values of the series as
 datetimelike and return several properties.
 These can be accessed like ``Series.dt.<property>``.
 
-**Datetime Properties**
-
+Datetime Properties
+~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
    :template: autosummary/accessor_attribute.rst
@@ -318,8 +319,8 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.tz
    Series.dt.freq
 
-**Datetime Methods**
-
+Datetime Methods
+~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
    :template: autosummary/accessor_method.rst
@@ -336,8 +337,8 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.month_name
    Series.dt.day_name
 
-**Period Properties**
-
+Period Properties
+~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
    :template: autosummary/accessor_attribute.rst
@@ -346,8 +347,8 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.start_time
    Series.dt.end_time
 
-**Timedelta Properties**
-
+Timedelta Properties
+~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
    :template: autosummary/accessor_attribute.rst
@@ -358,8 +359,8 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.nanoseconds
    Series.dt.components
 
-**Timedelta Methods**
-
+Timedelta Methods
+~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
    :template: autosummary/accessor_method.rst
@@ -368,7 +369,7 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.total_seconds
 
 String handling
-~~~~~~~~~~~~~~~
+---------------
 ``Series.str`` can be used to access the values of the series as
 strings and apply several methods to it. These can be accessed like
 ``Series.str.<function/property>``.
@@ -543,7 +544,7 @@ following usable methods and properties:
    Series.cat.as_unordered
 
 Plotting
-~~~~~~~~
+--------
 ``Series.plot`` is both a callable method and a namespace attribute for
 specific plotting methods of the form ``Series.plot.<kind>``.
 
@@ -573,7 +574,7 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.hist
 
 Serialization / IO / Conversion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -594,7 +595,7 @@ Serialization / IO / Conversion
    Series.to_latex
 
 Sparse
-~~~~~~
+------
 .. autosummary::
    :toctree: generated/
 

--- a/doc/source/api/style.rst
+++ b/doc/source/api/style.rst
@@ -2,22 +2,23 @@
 
 .. _api.style:
 
+=====
 Style
------
+=====
 .. currentmodule:: pandas.io.formats.style
 
 ``Styler`` objects are returned by :attr:`pandas.DataFrame.style`.
 
 Styler Constructor
-~~~~~~~~~~~~~~~~~~
+------------------
 .. autosummary::
    :toctree: generated/
 
    Styler
    Styler.from_custom_template
 
-Styler Attributes
-~~~~~~~~~~~~~~~~~
+Styler Properties
+-----------------
 .. autosummary::
    :toctree: generated/
 
@@ -26,7 +27,7 @@ Styler Attributes
    Styler.loader
 
 Style Application
-~~~~~~~~~~~~~~~~~
+-----------------
 .. autosummary::
    :toctree: generated/
 
@@ -44,7 +45,7 @@ Style Application
    Styler.pipe
 
 Builtin Styles
-~~~~~~~~~~~~~~
+--------------
 .. autosummary::
    :toctree: generated/
 
@@ -55,7 +56,7 @@ Builtin Styles
    Styler.bar
 
 Style Export and Import
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 .. autosummary::
    :toctree: generated/
 

--- a/doc/source/api/window.rst
+++ b/doc/source/api/window.rst
@@ -2,8 +2,9 @@
 
 .. _api.window:
 
+======
 Window
-------
+======
 .. currentmodule:: pandas.core.window
 
 Rolling objects are returned by ``.rolling`` calls: :func:`pandas.DataFrame.rolling`, :func:`pandas.Series.rolling`, etc.
@@ -11,7 +12,7 @@ Expanding objects are returned by ``.expanding`` calls: :func:`pandas.DataFrame.
 EWM objects are returned by ``.ewm`` calls: :func:`pandas.DataFrame.ewm`, :func:`pandas.Series.ewm`, etc.
 
 Standard moving window functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -36,7 +37,7 @@ Standard moving window functions
 .. _api.functions_expanding:
 
 Standard expanding window functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 .. autosummary::
    :toctree: generated/
 
@@ -57,7 +58,7 @@ Standard expanding window functions
    Expanding.quantile
 
 Exponentially-weighted moving window functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------
 .. autosummary::
    :toctree: generated/
 


### PR DESCRIPTION
Follow up of the splitting of `api.rst` in #24462.

- Making better use of the titles and subtitles (in date offsets, the class name, and the properties and methods sections where at the same level for example).
- We were inconsistently using `Attributes` and `Properties`, left just properties, as it was the most common one.
- Renamed `indices.rst` to `indexing.rst`, I think it makes more sense (`index.rst` is kind of reserved to the home)
