### PR TITLE
Fix hard-coded pandas version to infer the current

### DIFF
--- a/pandas/io/json/table_schema.py
+++ b/pandas/io/json/table_schema.py
@@ -6,6 +6,7 @@ http://specs.frictionlessdata.io/json-table-schema/
 import warnings
 
 import pandas._libs.json as json
+import pandas
 
 from pandas.core.dtypes.common import (
     is_bool_dtype, is_categorical_dtype, is_datetime64_dtype,
@@ -223,7 +224,7 @@ def build_table_schema(data, index=True, primary_key=None, version=True):
     {'name': 'A', 'type': 'integer'},
     {'name': 'B', 'type': 'string'},
     {'name': 'C', 'type': 'datetime'}],
-    'pandas_version': '0.20.0',
+    'pandas_version': '0.23.4',
     'primaryKey': ['idx']}
     """
     if index is True:
@@ -255,7 +256,7 @@ def build_table_schema(data, index=True, primary_key=None, version=True):
         schema['primaryKey'] = primary_key
 
     if version:
-        schema['pandas_version'] = '0.20.0'
+        schema['pandas_version'] = pandas.__version__
     return schema
 
 


### PR DESCRIPTION
Fix hard-coded pandas version to infer the current version in `pd.io.json.build_table_schema` output. 

```python
>>> import pandas as pd
>>> pd.__version__
'0.23.4'
>>> df = pd.DataFrame({'A': [1,2], 'B': ['a','b']})
>>> # BEFORE
>>> pd.io.json.build_table_schema(df, index=0)['pandas_version']
'0.20.0'
>>> # AFTER
>>> pd.io.json.build_table_schema(df, index=0)['pandas_version']
'0.23.4'
```
