### PR TITLE
MAINT: Use context manager in test_c_parser_only

### DIFF
--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -111,7 +111,24 @@ nan 2
                         names=["a", "b"], dtype={"a": np.int32})
 
 
-def test_unsupported_dtype(c_parser_only):
+@pytest.mark.parametrize("match,kwargs", [
+    # For each of these cases, all of the dtypes are valid, just unsupported.
+    (("the dtype datetime64 is not supported for parsing, "
+      "pass this column using parse_dates instead"),
+     dict(dtype={"A": "datetime64", "B": "float64"})),
+
+    (("the dtype datetime64 is not supported for parsing, "
+      "pass this column using parse_dates instead"),
+     dict(dtype={"A": "datetime64", "B": "float64"},
+          parse_dates=["B"])),
+
+    ("the dtype timedelta64 is not supported for parsing",
+     dict(dtype={"A": "timedelta64", "B": "float64"})),
+
+    ("the dtype <U8 is not supported for parsing",
+     dict(dtype={"A": "U8"}))
+], ids=["dt64-0", "dt64-1", "td64", "<U8"])
+def test_unsupported_dtype(c_parser_only, match, kwargs):
     parser = c_parser_only
     df = DataFrame(np.random.rand(5, 2), columns=list(
         "AB"), index=["1A", "1B", "1C", "1D", "1E"])
@@ -119,23 +136,8 @@ def test_unsupported_dtype(c_parser_only):
     with tm.ensure_clean("__unsupported_dtype__.csv") as path:
         df.to_csv(path)
 
-        # valid but we don"t support it (date)
-        pytest.raises(TypeError, parser.read_csv, path,
-                      dtype={"A": "datetime64", "B": "float64"},
-                      index_col=0)
-        pytest.raises(TypeError, parser.read_csv, path,
-                      dtype={"A": "datetime64", "B": "float64"},
-                      index_col=0, parse_dates=["B"])
-
-        # valid but we don"t support it
-        pytest.raises(TypeError, parser.read_csv, path,
-                      dtype={"A": "timedelta64", "B": "float64"},
-                      index_col=0)
-
-        # valid but unsupported - fixed width unicode string
-        pytest.raises(TypeError, parser.read_csv, path,
-                      dtype={"A": "U8"},
-                      index_col=0)
+        with pytest.raises(TypeError, match=match):
+            parser.read_csv(path, index_col=0, **kwargs)
 
 
 @td.skip_if_32bit


### PR DESCRIPTION
Specifically, use context manager for `pytest.raises`.

xref #24332.