### PR TITLE
REF/TST: remove patch from testing.py

### DIFF
--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -1,31 +1,27 @@
+import datetime
+from distutils.version import LooseVersion
+import glob
+import os
+from warnings import catch_warnings
+
+import numpy as np
 import pytest
 
-from warnings import catch_warnings
-import os
-import datetime
-import glob
-import numpy as np
-from distutils.version import LooseVersion
-
-from pandas import compat
-from pandas.compat import u, PY3
-from pandas import (Series, DataFrame, Panel, MultiIndex, bdate_range,
-                    date_range, period_range, Index, Categorical,
-                    Period, Interval)
+from pandas._libs.tslib import iNaT
+from pandas.compat import PY3, u
 from pandas.errors import PerformanceWarning
-from pandas.io.packers import to_msgpack, read_msgpack
-import pandas.util.testing as tm
-from pandas.util.testing import (ensure_clean,
-                                 assert_categorical_equal,
-                                 assert_frame_equal,
-                                 assert_index_equal,
-                                 assert_series_equal,
-                                 patch)
-from pandas.tests.test_panel import assert_panel_equal
 
 import pandas
-from pandas import Timestamp, NaT
-from pandas._libs.tslib import iNaT
+from pandas import (
+    Categorical, DataFrame, Index, Interval, MultiIndex, NaT, Panel, Period,
+    Series, Timestamp, bdate_range, compat, date_range, period_range)
+from pandas.tests.test_panel import assert_panel_equal
+import pandas.util.testing as tm
+from pandas.util.testing import (
+    assert_categorical_equal, assert_frame_equal, assert_index_equal,
+    assert_series_equal, ensure_clean)
+
+from pandas.io.packers import read_msgpack, to_msgpack
 
 nan = np.nan
 
@@ -660,7 +656,8 @@ class TestCompression(TestPackers):
             pytest.skip('no blosc')
         self._test_compression('blosc')
 
-    def _test_compression_warns_when_decompress_caches(self, compress):
+    def _test_compression_warns_when_decompress_caches(
+            self, monkeypatch, compress):
         not_garbage = []
         control = []  # copied data
 
@@ -685,9 +682,9 @@ class TestCompression(TestPackers):
             np.dtype('timedelta64[ns]'): np.timedelta64(1, 'ns'),
         }
 
-        with patch(compress_module, 'decompress', decompress), \
+        with monkeypatch.context() as m, \
                 tm.assert_produces_warning(PerformanceWarning) as ws:
-
+            m.setattr(compress_module, 'decompress', decompress)
             i_rec = self.encode_decode(self.frame, compress=compress)
             for k in self.frame.keys():
 
@@ -712,15 +709,17 @@ class TestCompression(TestPackers):
             # original buffers
             assert buf == control_buf
 
-    def test_compression_warns_when_decompress_caches_zlib(self):
+    def test_compression_warns_when_decompress_caches_zlib(self, monkeypatch):
         if not _ZLIB_INSTALLED:
             pytest.skip('no zlib')
-        self._test_compression_warns_when_decompress_caches('zlib')
+        self._test_compression_warns_when_decompress_caches(
+            monkeypatch, 'zlib')
 
-    def test_compression_warns_when_decompress_caches_blosc(self):
+    def test_compression_warns_when_decompress_caches_blosc(self, monkeypatch):
         if not _BLOSC_INSTALLED:
             pytest.skip('no blosc')
-        self._test_compression_warns_when_decompress_caches('blosc')
+        self._test_compression_warns_when_decompress_caches(
+            monkeypatch, 'blosc')
 
     def _test_small_strings_no_warn(self, compress):
         empty = np.array([], dtype='uint8')

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2974,58 +2974,6 @@ class SubclassedCategorical(Categorical):
 
 
 @contextmanager
-def patch(ob, attr, value):
-    """Temporarily patch an attribute of an object.
-
-    Parameters
-    ----------
-    ob : any
-        The object to patch. This must support attribute assignment for `attr`.
-    attr : str
-        The name of the attribute to patch.
-    value : any
-        The temporary attribute to assign.
-
-    Examples
-    --------
-    >>> class C(object):
-    ...     attribute = 'original'
-    ...
-    >>> C.attribute
-    'original'
-    >>> with patch(C, 'attribute', 'patched'):
-    ...     in_context = C.attribute
-    ...
-    >>> in_context
-    'patched'
-    >>> C.attribute  # the value is reset when the context manager exists
-    'original'
-
-    Correctly replaces attribute when the manager exits with an exception.
-    >>> with patch(C, 'attribute', 'patched'):
-    ...     in_context = C.attribute
-    ...     raise ValueError()
-    Traceback (most recent call last):
-       ...
-    ValueError
-    >>> in_context
-    'patched'
-    >>> C.attribute
-    'original'
-    """
-    noattr = object()  # mark that the attribute never existed
-    old = getattr(ob, attr, noattr)
-    setattr(ob, attr, value)
-    try:
-        yield
-    finally:
-        if old is noattr:
-            delattr(ob, attr)
-        else:
-            setattr(ob, attr, old)
-
-
-@contextmanager
 def set_timezone(tz):
     """Context manager for temporarily setting a timezone.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -184,7 +184,6 @@ skip=
     pandas/tests/io/test_s3.py,
     pandas/tests/io/test_html.py,
     pandas/tests/io/test_sql.py,
-    pandas/tests/io/test_packers.py,
     pandas/tests/io/test_stata.py,
     pandas/tests/io/conftest.py,
     pandas/tests/io/test_pickle.py,


### PR DESCRIPTION
logical follow-on from #24501

replace use of `patch` from `testing.py` with `pytest` builtin fixture `monkeypatch`