### PR TITLE
Make _freq/freq/tz/_tz/dtype/_dtype/offset/_offset all inherit reliably

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1138,8 +1138,6 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
                 freq = frequencies.to_offset(freq)
             offset = periods * freq
             result = self + offset
-            if getattr(self, 'tz', None):
-                result._dtype = self._dtype
             return result
 
         if periods == 0:

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1138,8 +1138,8 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
                 freq = frequencies.to_offset(freq)
             offset = periods * freq
             result = self + offset
-            if hasattr(self, 'tz'):
-                result._tz = self.tz
+            if getattr(self, 'tz', None):
+                result._dtype = self._dtype
             return result
 
         if periods == 0:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -210,7 +210,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin,
     # Constructors
 
     _attributes = ["freq", "tz"]
-    _dtype = None
+    _dtype = None  # type: Union[np.dtype, DatetimeTZDtype]
     _freq = None
 
     @classmethod
@@ -407,11 +407,6 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin,
         return self._dtype
 
     @property
-    def _tz(self):
-        # TODO: Can we get rid of the private version of this?
-        return getattr(self._dtype, "tz", None)
-
-    @property
     def tz(self):
         """
         Return timezone, if any.
@@ -422,7 +417,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin,
             Returns None when the array is tz-naive.
         """
         # GH 18595
-        return self._tz
+        return getattr(self._dtype, "tz", None)
 
     @tz.setter
     def tz(self, value):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -100,30 +100,6 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
 
     # ------------------------------------------------------------------------
 
-    @property
-    def offset(self):
-        """
-        get/set the frequency of the instance
-        """
-        msg = ('{cls}.offset has been deprecated and will be removed '
-               'in a future version; use {cls}.freq instead.'
-               .format(cls=type(self).__name__))
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-        return self.freq
-
-    @offset.setter
-    def offset(self, value):
-        """
-        get/set the frequency of the instance
-        """
-        msg = ('{cls}.offset has been deprecated and will be removed '
-               'in a future version; use {cls}.freq instead.'
-               .format(cls=type(self).__name__))
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-        self.freq = value
-
-    # ------------------------------------------------------------------------
-
     def equals(self, other):
         """
         Determines if two Index objects contain the same elements.

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -100,6 +100,30 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
 
     # ------------------------------------------------------------------------
 
+    @property
+    def offset(self):
+        """
+        get/set the frequency of the instance
+        """
+        msg = ('{cls}.offset has been deprecated and will be removed '
+               'in a future version; use {cls}.freq instead.'
+               .format(cls=type(self).__name__))
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+        return self.freq
+
+    @offset.setter
+    def offset(self, value):
+        """
+        get/set the frequency of the instance
+        """
+        msg = ('{cls}.offset has been deprecated and will be removed '
+               'in a future version; use {cls}.freq instead.'
+               .format(cls=type(self).__name__))
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+        self.freq = value
+
+    # ------------------------------------------------------------------------
+
     def equals(self, other):
         """
         Determines if two Index objects contain the same elements.

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -71,6 +71,15 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
     __iter__ = ea_passthrough("__iter__")
 
     @property
+    def freq(self):
+        return self._eadata.freq
+
+    @freq.setter
+    def freq(self, value):
+        # validation is handled by _eadata setter
+        self._eadata.freq = value
+
+    @property
     def freqstr(self):
         return self._eadata.freqstr
 
@@ -97,6 +106,10 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
         wrapper.__doc__ = op.__doc__
         wrapper.__name__ = '__{}__'.format(op.__name__)
         return wrapper
+
+    @property
+    def _ndarray_values(self):
+        return self._eadata._ndarray_values
 
     # ------------------------------------------------------------------------
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1180,28 +1180,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     _has_same_tz = ea_passthrough("_has_same_tz")
     __array__ = ea_passthrough("__array__")
 
-    @property
-    def offset(self):
-        """
-        get/set the frequency of the instance
-        """
-        msg = ('{cls}.offset has been deprecated and will be removed '
-               'in a future version; use {cls}.freq instead.'
-               .format(cls=type(self).__name__))
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-        return self.freq
-
-    @offset.setter
-    def offset(self, value):
-        """
-        get/set the frequency of the instance
-        """
-        msg = ('{cls}.offset has been deprecated and will be removed '
-               'in a future version; use {cls}.freq instead.'
-               .format(cls=type(self).__name__))
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-        self.freq = value
-
     def __getitem__(self, key):
         result = self._eadata.__getitem__(key)
         if is_scalar(result):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1180,6 +1180,28 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     _has_same_tz = ea_passthrough("_has_same_tz")
     __array__ = ea_passthrough("__array__")
 
+    @property
+    def offset(self):
+        """
+        get/set the frequency of the instance
+        """
+        msg = ('{cls}.offset has been deprecated and will be removed '
+               'in a future version; use {cls}.freq instead.'
+               .format(cls=type(self).__name__))
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+        return self.freq
+
+    @offset.setter
+    def offset(self, value):
+        """
+        get/set the frequency of the instance
+        """
+        msg = ('{cls}.offset has been deprecated and will be removed '
+               'in a future version; use {cls}.freq instead.'
+               .format(cls=type(self).__name__))
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+        self.freq = value
+
     def __getitem__(self, key):
         result = self._eadata.__getitem__(key)
         if is_scalar(result):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1133,37 +1133,14 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         return self._eadata._data
 
     @property
-    def _freq(self):
-        return self._eadata._freq
-
-    @_freq.setter
-    def _freq(self, value):
-        # Validation will be handled by _eadata setter
-        self._eadata._freq = value
-
-    @property
-    def freq(self):
-        return self._freq
-
-    @freq.setter
-    def freq(self, value):
-        # validation is handled by _eadata setter
-        self._eadata.freq = value
-
-    @property
-    def _tz(self):
-        return self._eadata._tz
-
-    @property
     def tz(self):
         # GH#18595
-        return self._tz
+        return self._eadata.tz
 
     @tz.setter
     def tz(self, value):
-        # GH 3746: Prevent localizing or converting the index by setting tz
-        raise AttributeError("Cannot directly set timezone. Use tz_localize() "
-                             "or tz_convert() as appropriate")
+        # GH#3746; DatetimeArray will raise to disallow setting
+        self._eadata.tz = value
 
     tzinfo = tz
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -491,14 +491,9 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         else:
             result = Index.union(this, other)
             if isinstance(result, DatetimeIndex):
-                if this.tz is not None:
-                    # TODO: can this be simplified?  It used to just be
-                    # `result._tz = timezones.tz_standardize(this.tz)`
-                    tz = timezones.tz_standardize(this.tz)
-                    if result.tz is None:
-                        result = result.tz_localize(tz)
-                    else:
-                        result = result.tz_convert(tz)
+                # TODO: we shouldn't be setting attributes like this;
+                #  in all the tests this equality already holds
+                result._eadata._dtype = this.dtype
                 if (result.freq is None and
                         (this.freq is not None or other.freq is not None)):
                     result.freq = to_offset(result.inferred_freq)
@@ -526,15 +521,12 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
             if this._can_fast_union(other):
                 this = this._fast_union(other)
             else:
-                tz = this.tz
+                dtype = this.dtype
                 this = Index.union(this, other)
-                if isinstance(this, DatetimeIndex) and tz is not None:
-                    # TODO: can this be simplified?  it used to just be
-                    # `this._tz = tz_standardize(tz)`
-                    if this.tz is None:
-                        this = this.tz_localize(timezones.tz_standardize(tz))
-                    else:
-                        this = this.tz_convert(timezones.tz_standardize(tz))
+                if isinstance(this, DatetimeIndex):
+                    # TODO: we shouldn't be setting attributes like this;
+                    #  in all the tests this equality already holds
+                    this._eadata._dtype = dtype
         return this
 
     def _can_fast_union(self, other):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -288,10 +288,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index,
         return self._data
 
     @property
-    def _ndarray_values(self):
-        return self._data._ndarray_values
-
-    @property
     def values(self):
         return np.asarray(self)
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -8,8 +8,7 @@ from pandas._libs import index as libindex
 from pandas._libs.tslibs import NaT, iNaT, resolution
 from pandas._libs.tslibs.period import (
     DIFFERENT_FREQ, IncompatibleFrequency, Period)
-from pandas.util._decorators import (
-    Appender, Substitution, cache_readonly, deprecate_kwarg)
+from pandas.util._decorators import Appender, Substitution, cache_readonly
 
 from pandas.core.dtypes.common import (
     is_bool_dtype, is_datetime64_any_dtype, is_float, is_float_dtype,
@@ -471,34 +470,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index,
 
     # ------------------------------------------------------------------------
     # Index Methods
-
-    @deprecate_kwarg(old_arg_name='n', new_arg_name='periods')
-    def shift(self, periods):
-        """
-        Shift index by desired number of increments.
-
-        This method is for shifting the values of period indexes
-        by a specified time increment.
-
-        Parameters
-        ----------
-        periods : int, default 1
-            Number of periods (or increments) to shift by,
-            can be positive or negative.
-
-            .. versionchanged:: 0.24.0
-
-        Returns
-        -------
-        pandas.PeriodIndex
-            Shifted index.
-
-        See Also
-        --------
-        DatetimeIndex.shift : Shift values of DatetimeIndex.
-        """
-        i8values = self._data._time_shift(periods)
-        return self._simple_new(i8values, name=self.name, freq=self.freq)
 
     def _coerce_scalar_to_index(self, item):
         """

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -283,23 +283,6 @@ class TimedeltaIndex(DatetimeIndexOpsMixin,
     def _data(self):
         return self._eadata._data
 
-    @property
-    def _freq(self):
-        return self._eadata._freq
-
-    @_freq.setter
-    def _freq(self, value):
-        self._eadata._freq = value
-
-    @property
-    def freq(self):
-        return self._freq
-
-    @freq.setter
-    def freq(self, value):
-        # Validation will be done in _eadata setter
-        self._eadata.freq = value
-
     __mul__ = _make_wrapped_arith_op("__mul__")
     __rmul__ = _make_wrapped_arith_op("__rmul__")
     __floordiv__ = _make_wrapped_arith_op("__floordiv__")

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1476,7 +1476,7 @@ class TestTimedeltaArraylikeMulDivOps(object):
 
         tdi = TimedeltaIndex(['1 Day'] * 10)
         expected = timedelta_range('1 days', '10 days')
-        expected._freq = None
+        expected._eadata._freq = None
 
         tdi = tm.box_expected(tdi, box)
         expected = tm.box_expected(expected, xbox)


### PR DESCRIPTION
There was an issue in rebasing #24024 in which index._freq didn't match index._eadata._freq.  This ensures that is never an issue by removing _freq/freq from the Index subclasses and making them properties aliasing the _eadata attrs.

To do this, we have to make _eadata not-a-property for the time being.

Also make the _tz --> _dtype transition in #24024, and fix a couple of places in DatetimeIndex where it sets _tz manually that would otherwise be missed.

Remove PeriodIndex.shift, since it now can use the DatetimeIndexOpsMixin version (also done in 24024)