### PR TITLE
ENH: Add sort parameter to set operations for some Indexes and adjust…

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -413,7 +413,7 @@ Other Enhancements
 - :func:`read_fwf` now accepts keyword ``infer_nrows`` (:issue:`15138`).
 - :func:`~DataFrame.to_parquet` now supports writing a ``DataFrame`` as a directory of parquet files partitioned by a subset of the columns when ``engine = 'pyarrow'`` (:issue:`23283`)
 - :meth:`Timestamp.tz_localize`, :meth:`DatetimeIndex.tz_localize`, and :meth:`Series.tz_localize` have gained the ``nonexistent`` argument for alternative handling of nonexistent times. See :ref:`timeseries.timezone_nonexistent` (:issue:`8917`, :issue:`24466`)
-- :meth:`Index.difference` now has an optional ``sort`` parameter to specify whether the results should be sorted if possible (:issue:`17839`)
+- :meth:`Index.difference`, :meth:`Index.intersection`, :meth:`Index.union`, and :meth:`Index.symmetric_difference` now have an optional ``sort`` parameter to control whether the results should be sorted if possible (:issue:`17839`, :issue:`24471`)
 - :meth:`read_excel()` now accepts ``usecols`` as a list of column names or callable (:issue:`18273`)
 - :meth:`MultiIndex.to_flat_index` has been added to flatten multiple levels into a single-level :class:`Index` object.
 - :meth:`DataFrame.to_stata` and :class:`pandas.io.stata.StataWriter117` can write mixed sting columns to Stata strl format (:issue:`23633`)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -201,6 +201,20 @@ def item_from_zerodim(val: object) -> object:
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def fast_unique_multiple(list arrays, sort: bool=True):
+    """
+    Generate a list of unique values from a list of arrays.
+
+    Parameters
+    ----------
+    list : array-like
+        A list of array-like objects
+    sort : boolean
+        Whether or not to sort the resulting unique list
+
+    Returns
+    -------
+    unique_list : list of unique values
+    """
     cdef:
         ndarray[object] buf
         Py_ssize_t k = len(arrays)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -200,7 +200,7 @@ def item_from_zerodim(val: object) -> object:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def fast_unique_multiple(list arrays):
+def fast_unique_multiple(list arrays, sort: bool=True):
     cdef:
         ndarray[object] buf
         Py_ssize_t k = len(arrays)
@@ -217,10 +217,11 @@ def fast_unique_multiple(list arrays):
             if val not in table:
                 table[val] = stub
                 uniques.append(val)
-    try:
-        uniques.sort()
-    except Exception:
-        pass
+    if sort:
+        try:
+            uniques.sort()
+        except Exception:
+            pass
 
     return uniques
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -112,7 +112,7 @@ def _get_combined_index(indexes, intersect=False, sort=False):
     elif intersect:
         index = indexes[0]
         for other in indexes[1:]:
-            index = index.intersection(other)
+            index = index.intersection(other, sort=sort)
     else:
         index = _union_indexes(indexes, sort=sort)
         index = ensure_index(index)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2393,15 +2393,23 @@ class Index(IndexOpsMixin, PandasObject):
             indexer = indexer[indexer != -1]
 
         taken = other.take(indexer)
-        if self.name != other.name:
-            taken.name = None
+
         if sort:
             try:
-                taken = taken.sort_values()
+                taken = sorting.safe_sort(taken.values)
+                if self.name != other.name:
+                    name = None
+                else:
+                    name = self.name
+                return self._shallow_copy(taken, name=name)
             except TypeError as e:
                 warnings.warn("%s, sort order is undefined for "
                               "incomparable objects" % e, RuntimeWarning,
                               stacklevel=3)
+
+        if self.name != other.name:
+            taken.name = None
+
         return taken
 
     def difference(self, other, sort=True):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3246,7 +3246,7 @@ class Index(IndexOpsMixin, PandasObject):
         elif how == 'inner':
             join_index = self.intersection(other, sort=sort)
         elif how == 'outer':
-            join_index = self.union(other)
+            join_index = self.union(other, sort=sort)
 
         if sort:
             join_index = join_index.sort_values()

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2241,13 +2241,17 @@ class Index(IndexOpsMixin, PandasObject):
             return self._shallow_copy(name=name)
         return self
 
-    def union(self, other):
+    def union(self, other, sort=True):
         """
-        Form the union of two Index objects and sorts if possible.
+        Form the union of two Index objects.
 
         Parameters
         ----------
         other : Index or array-like
+        sort : bool, default True
+            Sort the resulting index if possible
+
+            .. versionadded:: 0.24.0
 
         Returns
         -------
@@ -2277,7 +2281,7 @@ class Index(IndexOpsMixin, PandasObject):
         if not is_dtype_union_equal(self.dtype, other.dtype):
             this = self.astype('O')
             other = other.astype('O')
-            return this.union(other)
+            return this.union(other, sort=sort)
 
         # TODO(EA): setops-refactor, clean all this up
         if is_period_dtype(self) or is_datetime64tz_dtype(self):
@@ -2311,12 +2315,13 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 result = lvals
 
-            try:
-                result = sorting.safe_sort(result)
-            except TypeError as e:
-                warnings.warn("%s, sort order is undefined for "
-                              "incomparable objects" % e, RuntimeWarning,
-                              stacklevel=3)
+            if sort:
+                try:
+                    result = sorting.safe_sort(result)
+                except TypeError as e:
+                    warnings.warn("%s, sort order is undefined for "
+                                  "incomparable objects" % e, RuntimeWarning,
+                                  stacklevel=3)
 
         # for subclasses
         return self._wrap_setop_result(other, result)
@@ -2324,16 +2329,19 @@ class Index(IndexOpsMixin, PandasObject):
     def _wrap_setop_result(self, other, result):
         return self._constructor(result, name=get_op_result_name(self, other))
 
-    def intersection(self, other):
+    def intersection(self, other, sort=True):
         """
         Form the intersection of two Index objects.
 
-        This returns a new Index with elements common to the index and `other`,
-        preserving the order of the calling index.
+        This returns a new Index with elements common to the index and `other`.
 
         Parameters
         ----------
         other : Index or array-like
+        sort : bool, default True
+            Sort the resulting index if possible
+
+            .. versionadded:: 0.24.0
 
         Returns
         -------
@@ -2356,7 +2364,7 @@ class Index(IndexOpsMixin, PandasObject):
         if not is_dtype_equal(self.dtype, other.dtype):
             this = self.astype('O')
             other = other.astype('O')
-            return this.intersection(other)
+            return this.intersection(other, sort=sort)
 
         # TODO(EA): setops-refactor, clean all this up
         if is_period_dtype(self):
@@ -2387,6 +2395,13 @@ class Index(IndexOpsMixin, PandasObject):
         taken = other.take(indexer)
         if self.name != other.name:
             taken.name = None
+        if sort:
+            try:
+                taken = taken.sort_values()
+            except TypeError as e:
+                warnings.warn("%s, sort order is undefined for "
+                              "incomparable objects" % e, RuntimeWarning,
+                              stacklevel=3)
         return taken
 
     def difference(self, other, sort=True):
@@ -2442,16 +2457,18 @@ class Index(IndexOpsMixin, PandasObject):
 
         return this._shallow_copy(the_diff, name=result_name, freq=None)
 
-    def symmetric_difference(self, other, result_name=None):
+    def symmetric_difference(self, other, result_name=None, sort=True):
         """
         Compute the symmetric difference of two Index objects.
-
-        It's sorted if sorting is possible.
 
         Parameters
         ----------
         other : Index or array-like
         result_name : str
+        sort : bool, default True
+            Sort the resulting index if possible
+
+            .. versionadded:: 0.24.0
 
         Returns
         -------
@@ -2496,10 +2513,11 @@ class Index(IndexOpsMixin, PandasObject):
         right_diff = other.values.take(right_indexer)
 
         the_diff = _concat._concat_compat([left_diff, right_diff])
-        try:
-            the_diff = sorting.safe_sort(the_diff)
-        except TypeError:
-            pass
+        if sort:
+            try:
+                the_diff = sorting.safe_sort(the_diff)
+            except TypeError:
+                pass
 
         attribs = self._get_attributes_dict()
         attribs['name'] = result_name
@@ -3226,7 +3244,7 @@ class Index(IndexOpsMixin, PandasObject):
         elif how == 'right':
             join_index = other
         elif how == 'inner':
-            join_index = self.intersection(other)
+            join_index = self.intersection(other, sort=sort)
         elif how == 'outer':
             join_index = self.union(other)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2319,9 +2319,9 @@ class Index(IndexOpsMixin, PandasObject):
                 try:
                     result = sorting.safe_sort(result)
                 except TypeError as e:
-                    warnings.warn("%s, sort order is undefined for "
-                                  "incomparable objects" % e, RuntimeWarning,
-                                  stacklevel=3)
+                    warnings.warn("{}, sort order is undefined for "
+                                  "incomparable objects".format(e),
+                                  RuntimeWarning, stacklevel=3)
 
         # for subclasses
         return self._wrap_setop_result(other, result)
@@ -2395,17 +2395,12 @@ class Index(IndexOpsMixin, PandasObject):
         taken = other.take(indexer)
 
         if sort:
-            try:
-                taken = sorting.safe_sort(taken.values)
-                if self.name != other.name:
-                    name = None
-                else:
-                    name = self.name
-                return self._shallow_copy(taken, name=name)
-            except TypeError as e:
-                warnings.warn("%s, sort order is undefined for "
-                              "incomparable objects" % e, RuntimeWarning,
-                              stacklevel=3)
+            taken = sorting.safe_sort(taken.values)
+            if self.name != other.name:
+                name = None
+            else:
+                name = self.name
+            return self._shallow_copy(taken, name=name)
 
         if self.name != other.name:
             taken.name = None
@@ -3252,8 +3247,12 @@ class Index(IndexOpsMixin, PandasObject):
         elif how == 'right':
             join_index = other
         elif how == 'inner':
+            # TODO: sort=False here for backwards compat. It may
+            # be better to use the sort parameter passed into join
             join_index = self.intersection(other, sort=False)
         elif how == 'outer':
+            # TODO: sort=True here for backwards compat. It may
+            # be better to use the sort parameter passed into join
             join_index = self.union(other)
 
         if sort:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3244,9 +3244,9 @@ class Index(IndexOpsMixin, PandasObject):
         elif how == 'right':
             join_index = other
         elif how == 'inner':
-            join_index = self.intersection(other, sort=sort)
+            join_index = self.intersection(other, sort=False)
         elif how == 'outer':
-            join_index = self.union(other, sort=sort)
+            join_index = self.union(other)
 
         if sort:
             join_index = join_index.sort_values()

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -594,7 +594,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         name = get_op_result_name(self, other)
         return self._shallow_copy(result, name=name, freq=None, tz=self.tz)
 
-    def intersection(self, other):
+    def intersection(self, other, sort=True):
         """
         Specialized intersection for DatetimeIndex objects. May be much faster
         than Index.intersection
@@ -617,7 +617,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
                 other = DatetimeIndex(other)
             except (TypeError, ValueError):
                 pass
-            result = Index.intersection(self, other)
+            result = Index.intersection(self, other, sort=sort)
             if isinstance(result, DatetimeIndex):
                 if result.freq is None:
                     result.freq = to_offset(result.inferred_freq)
@@ -627,7 +627,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
               other.freq != self.freq or
               not other.freq.isAnchored() or
               (not self.is_monotonic or not other.is_monotonic)):
-            result = Index.intersection(self, other)
+            result = Index.intersection(self, other, sort=sort)
             # Invalidate the freq of `result`, which may not be correct at
             # this point, depending on the values.
             result.freq = None

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1104,11 +1104,8 @@ class IntervalIndex(IntervalMixin, Index):
                        'objects that have compatible dtypes')
                 raise TypeError(msg.format(op=op_name))
 
-            if op_name == 'difference':
-                result = getattr(self._multiindex, op_name)(other._multiindex,
-                                                            sort)
-            else:
-                result = getattr(self._multiindex, op_name)(other._multiindex)
+            result = getattr(self._multiindex, op_name)(other._multiindex,
+                                                        sort=sort)
             result_name = get_op_result_name(self, other)
 
             # GH 19101: ensure empty results have correct dtype

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2879,13 +2879,17 @@ class MultiIndex(Index):
                 return False
         return True
 
-    def union(self, other):
+    def union(self, other, sort=True):
         """
-        Form the union of two MultiIndex objects, sorting if possible
+        Form the union of two MultiIndex objects
 
         Parameters
         ----------
         other : MultiIndex or array / Index of tuples
+        sort : bool, default True
+            Sort the resulting MultiIndex if possible
+
+            .. versionadded:: 0.24.0
 
         Returns
         -------
@@ -2900,17 +2904,23 @@ class MultiIndex(Index):
             return self
 
         uniq_tuples = lib.fast_unique_multiple([self._ndarray_values,
-                                                other._ndarray_values])
+                                                other._ndarray_values],
+                                               sort=sort)
+
         return MultiIndex.from_arrays(lzip(*uniq_tuples), sortorder=0,
                                       names=result_names)
 
-    def intersection(self, other):
+    def intersection(self, other, sort=True):
         """
-        Form the intersection of two MultiIndex objects, sorting if possible
+        Form the intersection of two MultiIndex objects.
 
         Parameters
         ----------
         other : MultiIndex or array / Index of tuples
+        sort : bool, default True
+            Sort the resulting MultiIndex if possible
+
+            .. versionadded:: 0.24.0
 
         Returns
         -------
@@ -2924,7 +2934,11 @@ class MultiIndex(Index):
 
         self_tuples = self._ndarray_values
         other_tuples = other._ndarray_values
-        uniq_tuples = sorted(set(self_tuples) & set(other_tuples))
+        uniq_tuples = set(self_tuples) & set(other_tuples)
+
+        if sort:
+            uniq_tuples = sorted(uniq_tuples)
+
         if len(uniq_tuples) == 0:
             return MultiIndex(levels=self.levels,
                               codes=[[]] * self.nlevels,
@@ -2935,7 +2949,7 @@ class MultiIndex(Index):
 
     def difference(self, other, sort=True):
         """
-        Compute sorted set difference of two MultiIndex objects
+        Compute set difference of two MultiIndex objects
 
         Parameters
         ----------

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -343,14 +343,17 @@ class RangeIndex(Int64Index):
 
         return super(RangeIndex, self).equals(other)
 
-    def intersection(self, other):
+    def intersection(self, other, sort=True):
         """
-        Form the intersection of two Index objects. Sortedness of the result is
-        not guaranteed
+        Form the intersection of two Index objects.
 
         Parameters
         ----------
         other : Index or array-like
+        sort : bool, default True
+            Sort the resulting index if possible
+
+            .. versionadded:: 0.24.0
 
         Returns
         -------
@@ -361,7 +364,7 @@ class RangeIndex(Int64Index):
             return self._get_reconciled_name_object(other)
 
         if not isinstance(other, RangeIndex):
-            return super(RangeIndex, self).intersection(other)
+            return super(RangeIndex, self).intersection(other, sort=sort)
 
         if not len(self) or not len(other):
             return RangeIndex._simple_new(None)
@@ -398,6 +401,8 @@ class RangeIndex(Int64Index):
 
         if (self._step < 0 and other._step < 0) is not (new_index._step < 0):
             new_index = new_index[::-1]
+        if sort:
+            new_index = new_index.sort_values()
         return new_index
 
     def _min_fitting_element(self, lower_limit):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -4473,7 +4473,7 @@ def _reindex_axis(obj, axis, labels, other=None):
 
     labels = ensure_index(labels.unique())
     if other is not None:
-        labels = ensure_index(other.unique()) & labels
+        labels = ensure_index(other.unique()).intersection(labels, sort=False)
     if not labels.equals(ax):
         slicer = [slice(None, None)] * obj.ndim
         slicer[axis] = labels

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -138,7 +138,8 @@ class TestDatetimeIndexSetOps(object):
 
     @pytest.mark.parametrize("tz", [None, 'Asia/Tokyo', 'US/Eastern',
                                     'dateutil/US/Pacific'])
-    def test_intersection(self, tz):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection(self, tz, sort):
         # GH 4690 (with tz)
         base = date_range('6/1/2000', '6/30/2000', freq='D', name='idx')
 
@@ -185,7 +186,9 @@ class TestDatetimeIndexSetOps(object):
 
         for (rng, expected) in [(rng2, expected2), (rng3, expected3),
                                 (rng4, expected4)]:
-            result = base.intersection(rng)
+            result = base.intersection(rng, sort=sort)
+            if sort:
+                expected = expected.sort_values()
             tm.assert_index_equal(result, expected)
             assert result.name == expected.name
             assert result.freq is None

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -783,53 +783,63 @@ class TestIntervalIndex(Base):
 
         assert 1.5 not in index
 
-    def test_union(self, closed):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_union(self, closed, sort):
         index = self.create_index(closed=closed)
         other = IntervalIndex.from_breaks(range(5, 13), closed=closed)
 
         expected = IntervalIndex.from_breaks(range(13), closed=closed)
-        result = index.union(other)
-        tm.assert_index_equal(result, expected)
+        result = index[::-1].union(other, sort=sort)
+        if sort:
+            tm.assert_index_equal(result, expected)
+        assert tm.equalContents(result, expected)
 
-        result = other.union(index)
-        tm.assert_index_equal(result, expected)
+        result = other[::-1].union(index, sort=sort)
+        if sort:
+            tm.assert_index_equal(result, expected)
+        assert tm.equalContents(result, expected)
 
-        tm.assert_index_equal(index.union(index), index)
-        tm.assert_index_equal(index.union(index[:1]), index)
+        tm.assert_index_equal(index.union(index, sort=sort), index)
+        tm.assert_index_equal(index.union(index[:1], sort=sort), index)
 
         # GH 19101: empty result, same dtype
         index = IntervalIndex(np.array([], dtype='int64'), closed=closed)
-        result = index.union(index)
+        result = index.union(index, sort=sort)
         tm.assert_index_equal(result, index)
 
         # GH 19101: empty result, different dtypes
         other = IntervalIndex(np.array([], dtype='float64'), closed=closed)
-        result = index.union(other)
+        result = index.union(other, sort=sort)
         tm.assert_index_equal(result, index)
 
-    def test_intersection(self, closed):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection(self, closed, sort):
         index = self.create_index(closed=closed)
         other = IntervalIndex.from_breaks(range(5, 13), closed=closed)
 
         expected = IntervalIndex.from_breaks(range(5, 11), closed=closed)
-        result = index.intersection(other)
-        tm.assert_index_equal(result, expected)
+        result = index[::-1].intersection(other, sort=sort)
+        if sort:
+            tm.assert_index_equal(result, expected)
+        assert tm.equalContents(result, expected)
 
-        result = other.intersection(index)
-        tm.assert_index_equal(result, expected)
+        result = other[::-1].intersection(index, sort=sort)
+        if sort:
+            tm.assert_index_equal(result, expected)
+        assert tm.equalContents(result, expected)
 
-        tm.assert_index_equal(index.intersection(index), index)
+        tm.assert_index_equal(index.intersection(index, sort=sort), index)
 
         # GH 19101: empty result, same dtype
         other = IntervalIndex.from_breaks(range(300, 314), closed=closed)
         expected = IntervalIndex(np.array([], dtype='int64'), closed=closed)
-        result = index.intersection(other)
+        result = index.intersection(other, sort=sort)
         tm.assert_index_equal(result, expected)
 
         # GH 19101: empty result, different dtypes
         breaks = np.arange(300, 314, dtype='float64')
         other = IntervalIndex.from_breaks(breaks, closed=closed)
-        result = index.intersection(other)
+        result = index.intersection(other, sort=sort)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("sort", [True, False])
@@ -837,43 +847,49 @@ class TestIntervalIndex(Base):
         index = IntervalIndex.from_arrays([1, 0, 3, 2],
                                           [1, 2, 3, 4],
                                           closed=closed)
-        result = index.difference(index[:1], sort)
+        result = index.difference(index[:1], sort=sort)
         expected = index[1:]
         if sort:
             expected = expected.sort_values()
         tm.assert_index_equal(result, expected)
 
         # GH 19101: empty result, same dtype
-        result = index.difference(index, sort)
+        result = index.difference(index, sort=sort)
         expected = IntervalIndex(np.array([], dtype='int64'), closed=closed)
         tm.assert_index_equal(result, expected)
 
         # GH 19101: empty result, different dtypes
         other = IntervalIndex.from_arrays(index.left.astype('float64'),
                                           index.right, closed=closed)
-        result = index.difference(other, sort)
+        result = index.difference(other, sort=sort)
         tm.assert_index_equal(result, expected)
 
-    def test_symmetric_difference(self, closed):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_symmetric_difference(self, closed, sort):
         index = self.create_index(closed=closed)
-        result = index[1:].symmetric_difference(index[:-1])
+        result = index[1:].symmetric_difference(index[:-1], sort=sort)
         expected = IntervalIndex([index[0], index[-1]])
-        tm.assert_index_equal(result, expected)
+        if sort:
+            tm.assert_index_equal(result, expected)
+        assert tm.equalContents(result, expected)
 
         # GH 19101: empty result, same dtype
-        result = index.symmetric_difference(index)
+        result = index.symmetric_difference(index, sort=sort)
         expected = IntervalIndex(np.array([], dtype='int64'), closed=closed)
-        tm.assert_index_equal(result, expected)
+        if sort:
+            tm.assert_index_equal(result, expected)
+        assert tm.equalContents(result, expected)
 
         # GH 19101: empty result, different dtypes
         other = IntervalIndex.from_arrays(index.left.astype('float64'),
                                           index.right, closed=closed)
-        result = index.symmetric_difference(other)
+        result = index.symmetric_difference(other, sort=sort)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize('op_name', [
         'union', 'intersection', 'difference', 'symmetric_difference'])
-    def test_set_operation_errors(self, closed, op_name):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_set_operation_errors(self, closed, op_name, sort):
         index = self.create_index(closed=closed)
         set_op = getattr(index, op_name)
 
@@ -881,7 +897,7 @@ class TestIntervalIndex(Base):
         msg = ('the other index needs to be an IntervalIndex too, but '
                'was type Int64Index')
         with pytest.raises(TypeError, match=msg):
-            set_op(Index([1, 2, 3]))
+            set_op(Index([1, 2, 3]), sort=sort)
 
         # mixed closed
         msg = ('can only do set operations between two IntervalIndex objects '
@@ -889,14 +905,14 @@ class TestIntervalIndex(Base):
         for other_closed in {'right', 'left', 'both', 'neither'} - {closed}:
             other = self.create_index(closed=other_closed)
             with pytest.raises(ValueError, match=msg):
-                set_op(other)
+                set_op(other, sort=sort)
 
         # GH 19016: incompatible dtypes
         other = interval_range(Timestamp('20180101'), periods=9, closed=closed)
         msg = ('can only do {op} between two IntervalIndex objects that have '
                'compatible dtypes').format(op=op_name)
         with pytest.raises(TypeError, match=msg):
-            set_op(other)
+            set_op(other, sort=sort)
 
     def test_isin(self, closed):
         index = self.create_index(closed=closed)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2254,17 +2254,8 @@ class TestMixedIntIndex(Base):
         first = index[:5]
         second = index[:3]
 
-        if PY3 and sort:
-            # unorderable types
-            warn_type = RuntimeWarning
-            expected = Index([0, 'a', 1])
-        else:
-            warn_type = None
-            expected = Index([0, 1, 'a']) if sort else Index([0, 'a', 1])
-
-        with tm.assert_produces_warning(warn_type):
-            result = first.intersection(second, sort=sort)
-
+        expected = Index([0, 1, 'a']) if sort else Index([0, 'a', 1])
+        result = first.intersection(second, sort=sort)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("klass", [
@@ -2276,14 +2267,7 @@ class TestMixedIntIndex(Base):
         first = index[:5]
         second = index[:3]
 
-        if PY3 and sort:
-            # unorderable types
-            warn_type = RuntimeWarning
-        else:
-            warn_type = None
-
-        with tm.assert_produces_warning(warn_type):
-            result = first.intersection(klass(second.values), sort=sort)
+        result = first.intersection(klass(second.values), sort=sort)
         assert tm.equalContents(result, second)
 
     @pytest.mark.parametrize("sort", [True, False])

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2257,12 +2257,14 @@ class TestMixedIntIndex(Base):
         if PY3 and sort:
             # unorderable types
             warn_type = RuntimeWarning
+            expected = Index([0, 'a', 1])
         else:
             warn_type = None
+            expected = Index([0, 1, 'a']) if sort else Index([0, 'a', 1])
 
         with tm.assert_produces_warning(warn_type):
             result = first.intersection(second, sort=sort)
-        expected = Index([0, 'a', 1])
+
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("klass", [

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -684,24 +684,28 @@ class TestIndex(Base):
         # np.ndarray only accepts ndarray of int & bool dtypes, so should Index
         pytest.raises(IndexError, index.__getitem__, empty_farr)
 
-    def test_intersection(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection(self, sort):
         first = self.strIndex[:20]
         second = self.strIndex[:10]
-        intersect = first.intersection(second)
+        intersect = first.intersection(second, sort=sort)
+        if sort:
+            tm.assert_index_equal(intersect, second.sort_values())
         assert tm.equalContents(intersect, second)
 
         # Corner cases
-        inter = first.intersection(first)
+        inter = first.intersection(first, sort=sort)
         assert inter is first
 
     @pytest.mark.parametrize("index2,keeps_name", [
         (Index([3, 4, 5, 6, 7], name="index"), True),  # preserve same name
         (Index([3, 4, 5, 6, 7], name="other"), False),  # drop diff names
         (Index([3, 4, 5, 6, 7]), False)])
-    def test_intersection_name_preservation(self, index2, keeps_name):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection_name_preservation(self, index2, keeps_name, sort):
         index1 = Index([1, 2, 3, 4, 5], name='index')
         expected = Index([3, 4, 5])
-        result = index1.intersection(index2)
+        result = index1.intersection(index2, sort)
 
         if keeps_name:
             expected.name = 'index'
@@ -711,75 +715,89 @@ class TestIndex(Base):
 
     @pytest.mark.parametrize("first_name,second_name,expected_name", [
         ('A', 'A', 'A'), ('A', 'B', None), (None, 'B', None)])
+    @pytest.mark.parametrize("sort", [True, False])
     def test_intersection_name_preservation2(self, first_name, second_name,
-                                             expected_name):
+                                             expected_name, sort):
         first = self.strIndex[5:20]
         second = self.strIndex[:10]
         first.name = first_name
         second.name = second_name
-        intersect = first.intersection(second)
+        intersect = first.intersection(second, sort=sort)
         assert intersect.name == expected_name
 
     @pytest.mark.parametrize("index2,keeps_name", [
         (Index([4, 7, 6, 5, 3], name='index'), True),
         (Index([4, 7, 6, 5, 3], name='other'), False)])
-    def test_intersection_monotonic(self, index2, keeps_name):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection_monotonic(self, index2, keeps_name, sort):
         index1 = Index([5, 3, 2, 4, 1], name='index')
         expected = Index([5, 3, 4])
 
         if keeps_name:
             expected.name = "index"
 
-        result = index1.intersection(index2)
+        result = index1.intersection(index2, sort=sort)
+        if sort:
+            expected = expected.sort_values()
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("index2,expected_arr", [
         (Index(['B', 'D']), ['B']),
         (Index(['B', 'D', 'A']), ['A', 'B', 'A'])])
-    def test_intersection_non_monotonic_non_unique(self, index2, expected_arr):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection_non_monotonic_non_unique(self, index2, expected_arr,
+                                                   sort):
         # non-monotonic non-unique
         index1 = Index(['A', 'B', 'A', 'C'])
         expected = Index(expected_arr, dtype='object')
-        result = index1.intersection(index2)
+        result = index1.intersection(index2, sort=sort)
+        if sort:
+            expected = expected.sort_values()
         tm.assert_index_equal(result, expected)
 
-    def test_intersect_str_dates(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersect_str_dates(self, sort):
         dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]
 
         i1 = Index(dt_dates, dtype=object)
         i2 = Index(['aa'], dtype=object)
-        result = i2.intersection(i1)
+        result = i2.intersection(i1, sort=sort)
 
         assert len(result) == 0
 
-    def test_chained_union(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_chained_union(self, sort):
         # Chained unions handles names correctly
         i1 = Index([1, 2], name='i1')
-        i2 = Index([3, 4], name='i2')
-        i3 = Index([5, 6], name='i3')
-        union = i1.union(i2.union(i3))
-        expected = i1.union(i2).union(i3)
+        i2 = Index([5, 6], name='i2')
+        i3 = Index([3, 4], name='i3')
+        union = i1.union(i2.union(i3, sort=sort), sort=sort)
+        expected = i1.union(i2, sort=sort).union(i3, sort=sort)
         tm.assert_index_equal(union, expected)
 
         j1 = Index([1, 2], name='j1')
         j2 = Index([], name='j2')
         j3 = Index([], name='j3')
-        union = j1.union(j2.union(j3))
-        expected = j1.union(j2).union(j3)
+        union = j1.union(j2.union(j3, sort=sort), sort=sort)
+        expected = j1.union(j2, sort=sort).union(j3, sort=sort)
         tm.assert_index_equal(union, expected)
 
-    def test_union(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_union(self, sort):
         # TODO: Replace with fixturesult
         first = self.strIndex[5:20]
         second = self.strIndex[:10]
         everything = self.strIndex[:20]
 
-        union = first.union(second)
+        union = first.union(second, sort=sort)
+        if sort:
+            tm.assert_index_equal(union, everything.sort_values())
         assert tm.equalContents(union, everything)
 
     @pytest.mark.parametrize("klass", [
         np.array, Series, list])
-    def test_union_from_iterables(self, klass):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_union_from_iterables(self, klass, sort):
         # GH 10149
         # TODO: Replace with fixturesult
         first = self.strIndex[5:20]
@@ -787,37 +805,47 @@ class TestIndex(Base):
         everything = self.strIndex[:20]
 
         case = klass(second.values)
-        result = first.union(case)
+        result = first.union(case, sort=sort)
+        if sort:
+            tm.assert_index_equal(result, everything.sort_values())
         assert tm.equalContents(result, everything)
 
-    def test_union_identity(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_union_identity(self, sort):
         # TODO: replace with fixturesult
         first = self.strIndex[5:20]
 
-        union = first.union(first)
+        union = first.union(first, sort=sort)
         assert union is first
 
-        union = first.union([])
+        union = first.union([], sort=sort)
         assert union is first
 
-        union = Index([]).union(first)
+        union = Index([]).union(first, sort=sort)
         assert union is first
 
-    @pytest.mark.parametrize("first_list", [list('ab'), list()])
+    @pytest.mark.parametrize("first_list", [list('ba'), list()])
     @pytest.mark.parametrize("second_list", [list('ab'), list()])
     @pytest.mark.parametrize("first_name, second_name, expected_name", [
         ('A', 'B', None), (None, 'B', None), ('A', None, None)])
+    @pytest.mark.parametrize("sort", [True, False])
     def test_union_name_preservation(self, first_list, second_list, first_name,
-                                     second_name, expected_name):
+                                     second_name, expected_name, sort):
         first = Index(first_list, name=first_name)
         second = Index(second_list, name=second_name)
-        union = first.union(second)
+        union = first.union(second, sort=sort)
 
-        vals = sorted(set(first_list).union(second_list))
-        expected = Index(vals, name=expected_name)
-        tm.assert_index_equal(union, expected)
+        vals = set(first_list).union(second_list)
 
-    def test_union_dt_as_obj(self):
+        if sort and len(first_list) > 0 and len(second_list) > 0:
+            expected = Index(sorted(vals), name=expected_name)
+            tm.assert_index_equal(union, expected)
+        else:
+            expected = Index(vals, name=expected_name)
+            assert tm.equalContents(union, expected)
+
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_union_dt_as_obj(self, sort):
         # TODO: Replace with fixturesult
         firstCat = self.strIndex.union(self.dateIndex)
         secondCat = self.strIndex.union(self.strIndex)
@@ -963,7 +991,7 @@ class TestIndex(Base):
 
         first.name = 'name'
         second.name = second_name
-        result = first.difference(second, sort)
+        result = first.difference(second, sort=sort)
 
         assert tm.equalContents(result, answer)
 
@@ -1003,47 +1031,60 @@ class TestIndex(Base):
 
         tm.assert_index_equal(result, expected)
 
-    def test_symmetric_difference(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_symmetric_difference(self, sort):
         # smoke
-        index1 = Index([1, 2, 3, 4], name='index1')
-        index2 = Index([2, 3, 4, 5])
-        result = index1.symmetric_difference(index2)
-        expected = Index([1, 5])
+        index1 = Index([5, 2, 3, 4], name='index1')
+        index2 = Index([2, 3, 4, 1])
+        result = index1.symmetric_difference(index2, sort=sort)
+        expected = Index([5, 1])
         assert tm.equalContents(result, expected)
         assert result.name is None
+        if sort:
+            expected = expected.sort_values()
+        tm.assert_index_equal(result, expected)
 
         # __xor__ syntax
         expected = index1 ^ index2
         assert tm.equalContents(result, expected)
         assert result.name is None
 
-    def test_symmetric_difference_mi(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_symmetric_difference_mi(self, sort):
         index1 = MultiIndex.from_tuples(self.tuples)
         index2 = MultiIndex.from_tuples([('foo', 1), ('bar', 3)])
-        result = index1.symmetric_difference(index2)
+        result = index1.symmetric_difference(index2, sort=sort)
         expected = MultiIndex.from_tuples([('bar', 2), ('baz', 3), ('bar', 3)])
+        if sort:
+            expected = expected.sort_values()
+        tm.assert_index_equal(result, expected)
         assert tm.equalContents(result, expected)
 
     @pytest.mark.parametrize("index2,expected", [
-        (Index([0, 1, np.nan]), Index([0.0, 2.0, 3.0])),
-        (Index([0, 1]), Index([0.0, 2.0, 3.0, np.nan]))])
-    def test_symmetric_difference_missing(self, index2, expected):
+        (Index([0, 1, np.nan]), Index([2.0, 3.0, 0.0])),
+        (Index([0, 1]), Index([np.nan, 2.0, 3.0, 0.0]))])
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_symmetric_difference_missing(self, index2, expected, sort):
         # GH 13514 change: {nan} - {nan} == {}
         # (GH 6444, sorting of nans, is no longer an issue)
         index1 = Index([1, np.nan, 2, 3])
 
-        result = index1.symmetric_difference(index2)
+        result = index1.symmetric_difference(index2, sort=sort)
+        if sort:
+            expected = expected.sort_values()
         tm.assert_index_equal(result, expected)
 
-    def test_symmetric_difference_non_index(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_symmetric_difference_non_index(self, sort):
         index1 = Index([1, 2, 3, 4], name='index1')
         index2 = np.array([2, 3, 4, 5])
         expected = Index([1, 5])
-        result = index1.symmetric_difference(index2)
+        result = index1.symmetric_difference(index2, sort=sort)
         assert tm.equalContents(result, expected)
         assert result.name == 'index1'
 
-        result = index1.symmetric_difference(index2, result_name='new_name')
+        result = index1.symmetric_difference(index2, result_name='new_name',
+                                             sort=sort)
         assert tm.equalContents(result, expected)
         assert result.name == 'new_name'
 
@@ -1054,7 +1095,7 @@ class TestIndex(Base):
         # needs to preserve the type of the index
         skip_index_keys = ['repeats']
         for key, index in self.generate_index_types(skip_index_keys):
-            result = index.difference(index, sort)
+            result = index.difference(index, sort=sort)
             expected = index.drop(index)
             tm.assert_index_equal(result, expected)
 
@@ -1067,7 +1108,7 @@ class TestIndex(Base):
         skip_index_keys = ['repeats']
         for key, index in self.generate_index_types(skip_index_keys):
             inter = index.intersection(index.drop(index))
-            diff = index.difference(index, sort)
+            diff = index.difference(index, sort=sort)
             tm.assert_index_equal(inter, diff)
 
     @pytest.mark.parametrize("attr,expected", [
@@ -1555,7 +1596,7 @@ class TestIndex(Base):
             pytest.raises(KeyError, removed.drop, drop_me)
 
     @pytest.mark.parametrize("method,expected", [
-        ('intersection', np.array([(1, 'A'), (2, 'A'), (1, 'B'), (2, 'B')],
+        ('intersection', np.array([(1, 'A'), (1, 'B'), (2, 'A'), (2, 'B')],
                                   dtype=[('num', int), ('let', 'a1')])),
         ('union', np.array([(1, 'A'), (1, 'B'), (1, 'C'), (2, 'A'), (2, 'B'),
                             (2, 'C')], dtype=[('num', int), ('let', 'a1')]))
@@ -2206,25 +2247,41 @@ class TestMixedIntIndex(Base):
         result = idx.unique()
         tm.assert_index_equal(result, expected)
 
-    def test_intersection_base(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection_base(self, sort):
         # (same results for py2 and py3 but sortedness not tested elsewhere)
         index = self.create_index()
         first = index[:5]
         second = index[:3]
 
-        result = first.intersection(second)
+        if PY3 and sort:
+            # unorderable types
+            warn_type = RuntimeWarning
+        else:
+            warn_type = None
+
+        with tm.assert_produces_warning(warn_type):
+            result = first.intersection(second, sort=sort)
         expected = Index([0, 'a', 1])
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("klass", [
         np.array, Series, list])
-    def test_intersection_different_type_base(self, klass):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection_different_type_base(self, klass, sort):
         # GH 10149
         index = self.create_index()
         first = index[:5]
         second = index[:3]
 
-        result = first.intersection(klass(second.values))
+        if PY3 and sort:
+            # unorderable types
+            warn_type = RuntimeWarning
+        else:
+            warn_type = None
+
+        with tm.assert_produces_warning(warn_type):
+            result = first.intersection(klass(second.values), sort=sort)
         assert tm.equalContents(result, second)
 
     @pytest.mark.parametrize("sort", [True, False])

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -503,74 +503,75 @@ class TestRangeIndex(Numeric):
             joined = self.index.join(self.index, how=kind)
             assert self.index is joined
 
-    def test_intersection(self):
+    @pytest.mark.parametrize("sort", [True, False])
+    def test_intersection(self, sort):
         # intersect with Int64Index
         other = Index(np.arange(1, 6))
-        result = self.index.intersection(other)
+        result = self.index.intersection(other, sort=sort)
         expected = Index(np.sort(np.intersect1d(self.index.values,
                                                 other.values)))
         tm.assert_index_equal(result, expected)
 
-        result = other.intersection(self.index)
+        result = other.intersection(self.index, sort=sort)
         expected = Index(np.sort(np.asarray(np.intersect1d(self.index.values,
                                                            other.values))))
         tm.assert_index_equal(result, expected)
 
         # intersect with increasing RangeIndex
         other = RangeIndex(1, 6)
-        result = self.index.intersection(other)
+        result = self.index.intersection(other, sort=sort)
         expected = Index(np.sort(np.intersect1d(self.index.values,
                                                 other.values)))
         tm.assert_index_equal(result, expected)
 
         # intersect with decreasing RangeIndex
         other = RangeIndex(5, 0, -1)
-        result = self.index.intersection(other)
+        result = self.index.intersection(other, sort=sort)
         expected = Index(np.sort(np.intersect1d(self.index.values,
                                                 other.values)))
         tm.assert_index_equal(result, expected)
 
         # reversed (GH 17296)
-        result = other.intersection(self.index)
+        result = other.intersection(self.index, sort=sort)
         tm.assert_index_equal(result, expected)
 
         # GH 17296: intersect two decreasing RangeIndexes
         first = RangeIndex(10, -2, -2)
         other = RangeIndex(5, -4, -1)
-        expected = first.astype(int).intersection(other.astype(int))
-        result = first.intersection(other).astype(int)
+        expected = first.astype(int).intersection(other.astype(int), sort=sort)
+        result = first.intersection(other, sort=sort).astype(int)
         tm.assert_index_equal(result, expected)
 
         # reversed
-        result = other.intersection(first).astype(int)
+        result = other.intersection(first, sort=sort).astype(int)
         tm.assert_index_equal(result, expected)
 
         index = RangeIndex(5)
 
         # intersect of non-overlapping indices
         other = RangeIndex(5, 10, 1)
-        result = index.intersection(other)
+        result = index.intersection(other, sort=sort)
         expected = RangeIndex(0, 0, 1)
         tm.assert_index_equal(result, expected)
 
         other = RangeIndex(-1, -5, -1)
-        result = index.intersection(other)
+        result = index.intersection(other, sort=sort)
         expected = RangeIndex(0, 0, 1)
         tm.assert_index_equal(result, expected)
 
         # intersection of empty indices
         other = RangeIndex(0, 0, 1)
-        result = index.intersection(other)
+        result = index.intersection(other, sort=sort)
         expected = RangeIndex(0, 0, 1)
         tm.assert_index_equal(result, expected)
 
-        result = other.intersection(index)
+        result = other.intersection(index, sort=sort)
         tm.assert_index_equal(result, expected)
 
         # intersection of non-overlapping values based on start value and gcd
         index = RangeIndex(1, 10, 2)
         other = RangeIndex(0, 10, 4)
-        result = index.intersection(other)
+        result = index.intersection(other, sort=sort)
         expected = RangeIndex(0, 0, 1)
         tm.assert_index_equal(result, expected)
 


### PR DESCRIPTION
… tests

- [ ] Progress towards #24471
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This PR makes some progress towards adding a ``sort`` parameter with a default of ``True`` to the set operations (``union``, ``intersection``, ``difference`` and ``symmetric_difference``) on ``Index`` classes. Adding this parameter into every type of ``Index`` would result in a very big PR so I have decided to break it up and try to add it in stages. I have tried to focus on ``Index``, ``MultiIndex``,  ``PeriodIndex`` and ``Intervalndex`` in this PR but have made some very small changes to set operations on other indices where necessary.

Some issues to consider:
- I'm not sure whether it will be possible to control the sorting behaviour of the results of all of the set operations for all of the ``Index`` types. For example, because of the way some of the set operations are implemented on some ``Index`` types the results may always be sorted even if ``sort=False`` is passed (e.g., a ``union`` operation on ``DatetimeIndex``s may always return a sorted result in some cases even if ``sort=False``). Perhaps this is not really a problem as long as we document it.
- There are some other corner cases that always ignore the ``sort`` parameter at the moment. For example, the ``intersection`` of an unsorted ``Index`` with itself will return the original unsorted ``Index`` even if ``sort=True`` is passed because the ``sort`` parameter is simply ignored in this case. Similarly, the ``intersection`` of an unsorted ``Index`` with an empty ``Index`` will also return the original unsorted ``Index`` even if ``sort=True``. There is similar behaviour for the other set operations.