### PR TITLE
DOC: Make sphinx fail the build when --warnings-are-errors is set

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -738,6 +738,10 @@ suppress_warnings = [
     # suppress this warning.
     'app.add_directive'
 ]
+if pattern:
+    # When building a single document we don't want to warn because references
+    # to other documents are unknown, as it's expected
+    suppress_warnings.append('ref.ref')
 
 
 def rstjinja(app, docname, source):


### PR DESCRIPTION
xref #22743 

We already had an option `--warnings-are-errors` in `doc/make.py`, but it was making the doc build cancel after the first warning was found, generating a Python exception. Changed to finish the build, and not raise any error, but exit with 1.

Also, when building a single document, ignore the broken reference warnings (they are broken because we don't build the referenced documents).
