### PR TITLE
CI: fix db usage in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
 
     - dist: trusty
       env:
-        - JOB="2.7" ENV_FILE="ci/deps/travis-27.yaml" PATTERN="not slow and db"
+        - JOB="2.7" ENV_FILE="ci/deps/travis-27.yaml" PATTERN="not slow or db"
       addons:
         apt:
           packages:
@@ -46,11 +46,11 @@ matrix:
 
     - dist: trusty
       env:
-        - JOB="3.6, locale" ENV_FILE="ci/deps/travis-36-locale.yaml" PATTERN="not slow and not network and db" LOCALE_OVERRIDE="zh_CN.UTF-8"
+        - JOB="3.6, locale" ENV_FILE="ci/deps/travis-36-locale.yaml" PATTERN="(not slow and not network) or db" LOCALE_OVERRIDE="zh_CN.UTF-8"
 
     - dist: trusty
       env:
-        - JOB="3.6, coverage" ENV_FILE="ci/deps/travis-36.yaml" PATTERN="not slow and not network and db" PANDAS_TESTING_MODE="deprecate" COVERAGE=true
+        - JOB="3.6, coverage" ENV_FILE="ci/deps/travis-36.yaml" PATTERN="(not slow and not network) or db" PANDAS_TESTING_MODE="deprecate" COVERAGE=true
 
     # In allow_failures
     - dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ matrix:
     include:
     - dist: trusty
       env:
-        - JOB="3.7" ENV_FILE="ci/deps/travis-37.yaml" PATTERN="not slow and not network"
+        - JOB="3.7" ENV_FILE="ci/deps/travis-37.yaml" PATTERN="(not slow and not network)"
 
     - dist: trusty
       env:
-        - JOB="2.7" ENV_FILE="ci/deps/travis-27.yaml" PATTERN="not slow or db"
+        - JOB="2.7" ENV_FILE="ci/deps/travis-27.yaml" PATTERN="(not slow or (single and db))"
       addons:
         apt:
           packages:
@@ -46,11 +46,11 @@ matrix:
 
     - dist: trusty
       env:
-        - JOB="3.6, locale" ENV_FILE="ci/deps/travis-36-locale.yaml" PATTERN="(not slow and not network) or db" LOCALE_OVERRIDE="zh_CN.UTF-8"
+        - JOB="3.6, locale" ENV_FILE="ci/deps/travis-36-locale.yaml" PATTERN="((not slow and not network) or (single and db))" LOCALE_OVERRIDE="zh_CN.UTF-8"
 
     - dist: trusty
       env:
-        - JOB="3.6, coverage" ENV_FILE="ci/deps/travis-36.yaml" PATTERN="(not slow and not network) or db" PANDAS_TESTING_MODE="deprecate" COVERAGE=true
+        - JOB="3.6, coverage" ENV_FILE="ci/deps/travis-36.yaml" PATTERN="((not slow and not network) or (single and db))" PANDAS_TESTING_MODE="deprecate" COVERAGE=true
 
     # In allow_failures
     - dist: trusty

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1,4 +1,3 @@
-import collections
 from datetime import date, time, timedelta
 from decimal import Decimal
 import importlib

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -55,23 +55,13 @@ def pytest_runtest_setup(item):
     if 'network' in item.keywords and item.config.getoption("--skip-network"):
         pytest.skip("skipping due to --skip-network")
 
+    if 'db' in item.keywords and item.config.getoption("--skip-db"):
+        pytest.skip("skipping due to --skip-db")
+
     if 'high_memory' in item.keywords and not item.config.getoption(
             "--run-high-memory"):
         pytest.skip(
             "skipping high memory test since --run-high-memory was not set")
-
-    # if "db" not explicitly set in the -m pattern, we skip the db tests
-    pattern = item.config.getoption('-m')
-    if 'db' in item.keywords and not pattern:
-        pytest.skip('skipping db unless -m "db" is specified')
-    elif 'db' in item.keywords and pattern:
-        markers = collections.defaultdict(bool)
-        for marker in item.iter_markers():
-            markers[marker.name] = True
-        markers['db'] = False
-        db_in_pattern = not eval(pattern, {}, markers)
-        if not db_in_pattern:
-            pytest.skip('skipping db unless -m "db" is specified')
 
 
 # Configurations for all tests and all test modules

--- a/pandas/util/_tester.py
+++ b/pandas/util/_tester.py
@@ -16,7 +16,7 @@ def test(extra_args=None):
         import hypothesis  # noqa
     except ImportError:
         raise ImportError("Need hypothesis>=3.58 to run tests")
-    cmd = ['--skip-slow', '--skip-network']
+    cmd = ['--skip-slow', '--skip-network', '--skip-db']
     if extra_args:
         if not isinstance(extra_args, list):
             extra_args = [extra_args]

--- a/test_fast.bat
+++ b/test_fast.bat
@@ -1,3 +1,3 @@
 :: test on windows
 set PYTHONHASHSEED=314159265
-pytest --skip-slow --skip-network -m "not single" -n 4 -r sXX --strict pandas
+pytest --skip-slow --skip-network --skip-db -m "not single" -n 4 -r sXX --strict pandas

--- a/test_fast.sh
+++ b/test_fast.sh
@@ -5,4 +5,4 @@
 # https://github.com/pytest-dev/pytest/issues/1075
 export PYTHONHASHSEED=$(python -c 'import random; print(random.randint(1, 4294967295))')
 
-pytest pandas --skip-slow --skip-network -m "not single" -n 4 -r sxX --strict "$@"
+pytest pandas --skip-slow --skip-network --skip-db -m "not single" -n 4 -r sxX --strict "$@"


### PR DESCRIPTION
closes #24528
reverts behavior in #24485 
canonical way to run tests is ``test_fast.sh`` (or can also specify ``-m 'not single'`` (or ``--skip-db``)