### PR TITLE
diff reduction for 24024

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1162,9 +1162,10 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
         left = lib.values_from_object(self.astype('O'))
 
         res_values = op(left, np.array(other))
+        kwargs = {}
         if not is_period_dtype(self):
-            return type(self)(res_values, freq='infer')
-        return self._from_sequence(res_values)
+            kwargs['freq'] = 'infer'
+        return self._from_sequence(res_values, **kwargs)
 
     def _time_shift(self, periods, freq=None):
         """

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1162,10 +1162,9 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
         left = lib.values_from_object(self.astype('O'))
 
         res_values = op(left, np.array(other))
-        kwargs = {}
         if not is_period_dtype(self):
-            kwargs['freq'] = 'infer'
-        return self._from_sequence(res_values, **kwargs)
+            return type(self)(res_values, freq='infer')
+        return self._from_sequence(res_values)
 
     def _time_shift(self, periods, freq=None):
         """

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -19,7 +19,7 @@ from pandas.core.dtypes.common import (
     is_extension_type, is_float_dtype, is_int64_dtype, is_object_dtype,
     is_period_dtype, is_string_dtype, is_timedelta64_dtype, pandas_dtype)
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
-from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
+from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries, ABCPandasArray
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import ops
@@ -224,7 +224,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin,
             # for compat with datetime/timedelta/period shared methods,
             #  we can sometimes get here with int64 values.  These represent
             #  nanosecond UTC (or tz-naive) unix timestamps
-            values = values.view('M8[ns]')
+            values = values.view(_NS_DTYPE)
 
         assert values.dtype == 'M8[ns]', values.dtype
 
@@ -417,7 +417,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin,
             Returns None when the array is tz-naive.
         """
         # GH 18595
-        return getattr(self._dtype, "tz", None)
+        return getattr(self.dtype, "tz", None)
 
     @tz.setter
     def tz(self, value):
@@ -516,10 +516,6 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin,
 
     # ----------------------------------------------------------------
     # ExtensionArray Interface
-
-    @property
-    def _ndarray_values(self):
-        return self._data
 
     @Appender(dtl.DatetimeLikeArrayMixin._validate_fill_value.__doc__)
     def _validate_fill_value(self, fill_value):
@@ -1568,6 +1564,8 @@ def sequence_to_dt64ns(data, dtype=None, copy=False,
         copy = False
     elif isinstance(data, ABCSeries):
         data = data._values
+    if isinstance(data, ABCPandasArray):
+        data = data.to_numpy()
 
     if hasattr(data, "freq"):
         # i.e. DatetimeArray/Index

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -19,7 +19,7 @@ from pandas.core.dtypes.common import (
     is_extension_type, is_float_dtype, is_int64_dtype, is_object_dtype,
     is_period_dtype, is_string_dtype, is_timedelta64_dtype, pandas_dtype)
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
-from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries, ABCPandasArray
+from pandas.core.dtypes.generic import ABCIndexClass, ABCPandasArray, ABCSeries
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import ops

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -270,11 +270,6 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         return self._dtype
 
     @property
-    def _ndarray_values(self):
-        # Ordinals
-        return self._data
-
-    @property
     def freq(self):
         """
         Return the frequency object for this PeriodArray.
@@ -475,7 +470,6 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         """
         actually format my specific types
         """
-        # TODO(DatetimeArray): remove
         values = self.astype(object)
 
         if date_format:

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -369,8 +369,9 @@ class TimedeltaArrayMixin(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
             # TimedeltaIndex can only operate with a subset of DateOffset
             # subclasses.  Incompatible classes will raise AttributeError,
             # which we re-raise as TypeError
-            return dtl.DatetimeLikeArrayMixin._addsub_offset_array(self, other,
-                                                                   op)
+            return super(TimedeltaArrayMixin, self)._addsub_offset_array(
+                other, op
+            )
         except AttributeError:
             raise TypeError("Cannot add/subtract non-tick DateOffset to {cls}"
                             .format(cls=type(self).__name__))

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -55,6 +55,7 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
     """
     common ops mixin to support a unified interface datetimelike Index
     """
+    _data = None  # type: DatetimeLikeArrayMixin
 
     # DatetimeLikeArrayMixin assumes subclasses are mutable, so these are
     # properties there.  They can be made into cache_readonly for Index
@@ -72,6 +73,9 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
 
     @property
     def freq(self):
+        """
+        Return the frequency object if it is set, otherwise None.
+        """
         return self._eadata.freq
 
     @freq.setter
@@ -81,6 +85,9 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
 
     @property
     def freqstr(self):
+        """
+        Return the frequency object as a string if it is set, otherwise None.
+        """
         return self._eadata.freqstr
 
     def unique(self, level=None):
@@ -110,6 +117,20 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
     @property
     def _ndarray_values(self):
         return self._eadata._ndarray_values
+
+    # ------------------------------------------------------------------------
+    # Abstract data attributes
+
+    @property
+    def values(self):
+        # type: () -> np.ndarray
+        # Note: PeriodArray overrides this to return an ndarray of objects.
+        return self._eadata._data
+
+    @property
+    @Appender(DatetimeLikeArrayMixin.asi8.__doc__)
+    def asi8(self):
+        return self._eadata.asi8
 
     # ------------------------------------------------------------------------
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -330,7 +330,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         result._eadata = dtarr
         result.name = name
         # For groupby perf. See note in indexes/base about _index_data
-        # TODO: make sure this is updated correctly if edited
         result._index_data = result._data
         result._reset_identity()
         return result

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -70,9 +70,9 @@ class PeriodDelegateMixin(DatetimelikeDelegateMixin):
                 typ='property')
 @delegate_names(PeriodArray,
                 PeriodDelegateMixin._delegated_methods,
-                typ="method")
-class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index,
-                  PeriodDelegateMixin):
+                typ="method",
+                overwrite=True)
+class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
     """
     Immutable ndarray holding ordinal values indicating regular periods in
     time such as particular years, quarters, months, etc.
@@ -292,19 +292,14 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index,
         return np.asarray(self)
 
     @property
-    def _values(self):
-        return self._data
-
-    @property
     def freq(self):
-        # TODO(DatetimeArray): remove
-        # Can't simply use delegate_names since our base class is defining
-        # freq
         return self._data.freq
 
     @freq.setter
     def freq(self, value):
         value = Period._maybe_convert_freq(value)
+        # Note: When this deprecation is enforced, PeriodIndex.freq can
+        # be removed entirely, and we'll just inherit.
         msg = ('Setting {cls}.freq has been deprecated and will be '
                'removed in a future version; use {cls}.asfreq instead. '
                'The {cls}.freq setter is not guaranteed to work.')
@@ -896,11 +891,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index,
                       "in a future version".format(obj=type(self).__name__),
                       FutureWarning, stacklevel=2)
         return self._ndarray_values.flags
-
-    @property
-    def asi8(self):
-        # TODO(DatetimeArray): remove
-        return self.view('i8')
 
     def item(self):
         """

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -297,7 +297,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
     @freq.setter
     def freq(self, value):
         value = Period._maybe_convert_freq(value)
-        # Note: When this deprecation is enforced, PeriodIndex.freq can
+        # TODO: When this deprecation is enforced, PeriodIndex.freq can
         # be removed entirely, and we'll just inherit.
         msg = ('Setting {cls}.freq has been deprecated and will be '
                'removed in a future version; use {cls}.asfreq instead. '

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -18,7 +18,6 @@ from pandas import compat
 from pandas.core import common as com
 from pandas.core.accessor import delegate_names
 from pandas.core.algorithms import unique1d
-from pandas.core.arrays.datetimelike import DatelikeOps
 from pandas.core.arrays.period import (
     PeriodArray, period_array, validate_dtype_freq)
 from pandas.core.base import _shared_docs

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -70,8 +70,8 @@ class TimedeltaDelegateMixin(DatetimelikeDelegateMixin):
 @delegate_names(TimedeltaArray,
                 TimedeltaDelegateMixin._delegated_methods,
                 typ="method", overwrite=False)
-class TimedeltaIndex(DatetimeIndexOpsMixin,
-                     dtl.TimelikeOps, Int64Index, TimedeltaDelegateMixin):
+class TimedeltaIndex(DatetimeIndexOpsMixin, dtl.TimelikeOps, Int64Index,
+                     TimedeltaDelegateMixin):
     """
     Immutable ndarray of timedelta64 data, represented internally as int64, and
     which can be boxed to timedelta objects
@@ -238,7 +238,6 @@ class TimedeltaIndex(DatetimeIndexOpsMixin,
         result._eadata = tdarr
         result.name = name
         # For groupby perf. See note in indexes/base about _index_data
-        # TODO: make sure this is updated correctly if edited
         result._index_data = tdarr._data
 
         result._reset_identity()

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1539,16 +1539,19 @@ def _arith_method_SERIES(cls, op, special):
             raise TypeError("{typ} cannot perform the operation "
                             "{op}".format(typ=type(left).__name__, op=str_rep))
 
-        elif (is_extension_array_dtype(left) or
-                (is_extension_array_dtype(right) and not is_scalar(right))):
-            # GH#22378 disallow scalar to exclude e.g. "category", "Int64"
-            return dispatch_to_extension_op(op, left, right)
-
         elif is_datetime64_dtype(left) or is_datetime64tz_dtype(left):
+            # Give dispatch_to_index_op a chance for tests like
+            # test_dt64_series_add_intlike, which the index dispatching handles
+            # specifically.
             result = dispatch_to_index_op(op, left, right, pd.DatetimeIndex)
             return construct_result(left, result,
                                     index=left.index, name=res_name,
                                     dtype=result.dtype)
+
+        elif (is_extension_array_dtype(left) or
+                (is_extension_array_dtype(right) and not is_scalar(right))):
+            # GH#22378 disallow scalar to exclude e.g. "category", "Int64"
+            return dispatch_to_extension_op(op, left, right)
 
         elif is_timedelta64_dtype(left):
             result = dispatch_to_index_op(op, left, right, pd.TimedeltaIndex)

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -17,7 +17,7 @@ import pandas.util.testing as tm
 
 class TestDatetimeArrayConstructor(object):
     def test_from_pandas_array(self):
-        arr = pd.array(np.arange(5)) * 3600 * 10**9
+        arr = pd.array(np.arange(5, dtype=np.int64)) * 3600 * 10**9
 
         result = DatetimeArray._from_sequence(arr, freq='infer')
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -16,6 +16,14 @@ import pandas.util.testing as tm
 
 
 class TestDatetimeArrayConstructor(object):
+    def test_from_pandas_array(self):
+        arr = pd.array(np.arange(5)) * 3600 * 10**9
+
+        result = DatetimeArray._from_sequence(arr, freq='infer')
+
+        expected = pd.date_range('1970-01-01', periods=5, freq='H')._eadata
+        tm.assert_datetime_array_equal(result, expected)
+
     def test_mismatched_timezone_raises(self):
         arr = DatetimeArray(np.array(['2000-01-01T06:00:00'], dtype='M8[ns]'),
                             dtype=DatetimeTZDtype(tz='US/Central'))

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3245,7 +3245,8 @@ class TestDataFrameIndexingDatetimeWithTZ(TestData):
         b1 = df._data.blocks[1]
         b2 = df._data.blocks[2]
         assert b1.values.equals(b2.values)
-        assert id(b1.values.values.base) != id(b2.values.values.base)
+        if b1.values.values.base is not None:
+            assert id(b1.values.values.base) != id(b2.values.values.base)
 
         # with nan
         df2 = df.copy()

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3246,6 +3246,7 @@ class TestDataFrameIndexingDatetimeWithTZ(TestData):
         b2 = df._data.blocks[2]
         assert b1.values.equals(b2.values)
         if b1.values.values.base is not None:
+            # base being None suffices to assure a copy was made
             assert id(b1.values.values.base) != id(b2.values.values.base)
 
         # with nan


### PR DESCRIPTION
docstrings, comments, edits that are correct both before and after #24024

the only substantive change is adding a test specifically for constructing a DatetimeArray from a PandasArray.