### PR TITLE
See also description formatting

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -389,8 +389,8 @@ cdef class Interval(IntervalMixin):
 
         See Also
         --------
-        IntervalArray.overlaps : The corresponding method for IntervalArray
-        IntervalIndex.overlaps : The corresponding method for IntervalIndex
+        IntervalArray.overlaps : The corresponding method for IntervalArray.
+        IntervalIndex.overlaps : The corresponding method for IntervalIndex.
 
         Examples
         --------

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1830,9 +1830,8 @@ cdef class _Period(object):
 
         See Also
         --------
-        Period.dayofweek : Get the day of the week
-
-        Period.dayofyear : Get the day of the year
+        Period.dayofweek : Get the day of the week.
+        Period.dayofyear : Get the day of the year.
 
         Examples
         --------
@@ -2189,8 +2188,8 @@ cdef class _Period(object):
 
         See Also
         --------
-        Period.days_in_month : Return the days of the month
-        Period.dayofyear : Return the day of the year
+        Period.days_in_month : Return the days of the month.
+        Period.dayofyear : Return the day of the year.
 
         Examples
         --------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -660,9 +660,9 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan):
 
     See Also
     --------
-    contains : analogous, but less strict, relying on re.search instead of
-        re.match
-    extract : extract matched groups
+    contains : Analogous, but less strict, relying on re.search instead of
+        re.match.
+    extract : Extract matched groups.
     """
     if not case:
         flags |= re.IGNORECASE
@@ -1255,13 +1255,13 @@ def str_pad(arr, width, side='left', fillchar=' '):
 
     See Also
     --------
-    Series.str.rjust: Fills the left side of strings with an arbitrary
+    Series.str.rjust : Fills the left side of strings with an arbitrary
         character. Equivalent to ``Series.str.pad(side='left')``.
-    Series.str.ljust: Fills the right side of strings with an arbitrary
+    Series.str.ljust : Fills the right side of strings with an arbitrary
         character. Equivalent to ``Series.str.pad(side='right')``.
-    Series.str.center: Fills boths sides of strings with an arbitrary
+    Series.str.center : Fills boths sides of strings with an arbitrary
         character. Equivalent to ``Series.str.pad(side='both')``.
-    Series.str.zfill:  Pad strings in the Series/Index by prepending '0'
+    Series.str.zfill :  Pad strings in the Series/Index by prepending '0'
         character. Equivalent to ``Series.str.pad(side='left', fillchar='0')``.
 
     Examples
@@ -2485,7 +2485,8 @@ class StringMethods(NoNewAttributesMixin):
         'side': 'first',
         'return': '3 elements containing the string itself, followed by two '
                   'empty strings',
-        'also': 'rpartition : Split the string at the last occurrence of `sep`'
+        'also': 'rpartition : Split the string at the last occurrence of '
+                '`sep`.'
     })
     @deprecate_kwarg(old_arg_name='pat', new_arg_name='sep')
     def partition(self, sep=' ', expand=True):
@@ -2497,7 +2498,8 @@ class StringMethods(NoNewAttributesMixin):
         'side': 'last',
         'return': '3 elements containing two empty strings, followed by the '
                   'string itself',
-        'also': 'partition : Split the string at the first occurrence of `sep`'
+        'also': 'partition : Split the string at the first occurrence of '
+                '`sep`.'
     })
     @deprecate_kwarg(old_arg_name='pat', new_arg_name='sep')
     def rpartition(self, sep=' ', expand=True):
@@ -2593,13 +2595,13 @@ class StringMethods(NoNewAttributesMixin):
 
         See Also
         --------
-        Series.str.rjust: Fills the left side of strings with an arbitrary
+        Series.str.rjust : Fills the left side of strings with an arbitrary
             character.
-        Series.str.ljust: Fills the right side of strings with an arbitrary
+        Series.str.ljust : Fills the right side of strings with an arbitrary
             character.
-        Series.str.pad: Fills the specified sides of strings with an arbitrary
+        Series.str.pad : Fills the specified sides of strings with an arbitrary
             character.
-        Series.str.center: Fills boths sides of strings with an arbitrary
+        Series.str.center : Fills boths sides of strings with an arbitrary
             character.
 
         Notes
@@ -2793,14 +2795,14 @@ class StringMethods(NoNewAttributesMixin):
 
     @Appender(_shared_docs['find'] %
               dict(side='lowest', method='find',
-                   also='rfind : Return highest indexes in each strings'))
+                   also='rfind : Return highest indexes in each strings.'))
     def find(self, sub, start=0, end=None):
         result = str_find(self._parent, sub, start=start, end=end, side='left')
         return self._wrap_result(result)
 
     @Appender(_shared_docs['find'] %
               dict(side='highest', method='rfind',
-                   also='find : Return lowest indexes in each strings'))
+                   also='find : Return lowest indexes in each strings.'))
     def rfind(self, sub, start=0, end=None):
         result = str_find(self._parent, sub,
                           start=start, end=end, side='right')
@@ -2852,7 +2854,7 @@ class StringMethods(NoNewAttributesMixin):
 
     @Appender(_shared_docs['index'] %
               dict(side='lowest', similar='find', method='index',
-                   also='rindex : Return highest indexes in each strings'))
+                   also='rindex : Return highest indexes in each strings.'))
     def index(self, sub, start=0, end=None):
         result = str_index(self._parent, sub,
                            start=start, end=end, side='left')
@@ -2860,7 +2862,7 @@ class StringMethods(NoNewAttributesMixin):
 
     @Appender(_shared_docs['index'] %
               dict(side='highest', similar='rfind', method='rindex',
-                   also='index : Return lowest indexes in each strings'))
+                   also='index : Return lowest indexes in each strings.'))
     def rindex(self, sub, start=0, end=None):
         result = str_index(self._parent, sub,
                            start=start, end=end, side='right')

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -660,9 +660,9 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan):
 
     See Also
     --------
-    contains : analogous, but less strict, relying on re.search instead of
-        re.match
-    extract : extract matched groups
+    contains : Analogous, but less strict, relying on re.search instead of
+        re.match.
+    extract : Extract matched groups.
     """
     if not case:
         flags |= re.IGNORECASE
@@ -1255,13 +1255,13 @@ def str_pad(arr, width, side='left', fillchar=' '):
 
     See Also
     --------
-    Series.str.rjust: Fills the left side of strings with an arbitrary
+    Series.str.rjust : Fills the left side of strings with an arbitrary
         character. Equivalent to ``Series.str.pad(side='left')``.
-    Series.str.ljust: Fills the right side of strings with an arbitrary
+    Series.str.ljust : Fills the right side of strings with an arbitrary
         character. Equivalent to ``Series.str.pad(side='right')``.
-    Series.str.center: Fills boths sides of strings with an arbitrary
+    Series.str.center : Fills boths sides of strings with an arbitrary
         character. Equivalent to ``Series.str.pad(side='both')``.
-    Series.str.zfill:  Pad strings in the Series/Index by prepending '0'
+    Series.str.zfill :  Pad strings in the Series/Index by prepending '0'
         character. Equivalent to ``Series.str.pad(side='left', fillchar='0')``.
 
     Examples
@@ -2485,7 +2485,7 @@ class StringMethods(NoNewAttributesMixin):
         'side': 'first',
         'return': '3 elements containing the string itself, followed by two '
                   'empty strings',
-        'also': 'rpartition : Split the string at the last occurrence of `sep`'
+        'also': 'rpartition : Split the string at the last occurrence of `sep`.'
     })
     @deprecate_kwarg(old_arg_name='pat', new_arg_name='sep')
     def partition(self, sep=' ', expand=True):
@@ -2497,7 +2497,7 @@ class StringMethods(NoNewAttributesMixin):
         'side': 'last',
         'return': '3 elements containing two empty strings, followed by the '
                   'string itself',
-        'also': 'partition : Split the string at the first occurrence of `sep`'
+        'also': 'partition : Split the string at the first occurrence of `sep`.'
     })
     @deprecate_kwarg(old_arg_name='pat', new_arg_name='sep')
     def rpartition(self, sep=' ', expand=True):
@@ -2593,13 +2593,13 @@ class StringMethods(NoNewAttributesMixin):
 
         See Also
         --------
-        Series.str.rjust: Fills the left side of strings with an arbitrary
+        Series.str.rjust : Fills the left side of strings with an arbitrary
             character.
-        Series.str.ljust: Fills the right side of strings with an arbitrary
+        Series.str.ljust : Fills the right side of strings with an arbitrary
             character.
-        Series.str.pad: Fills the specified sides of strings with an arbitrary
+        Series.str.pad : Fills the specified sides of strings with an arbitrary
             character.
-        Series.str.center: Fills boths sides of strings with an arbitrary
+        Series.str.center : Fills boths sides of strings with an arbitrary
             character.
 
         Notes
@@ -2793,14 +2793,14 @@ class StringMethods(NoNewAttributesMixin):
 
     @Appender(_shared_docs['find'] %
               dict(side='lowest', method='find',
-                   also='rfind : Return highest indexes in each strings'))
+                   also='rfind : Return highest indexes in each strings.'))
     def find(self, sub, start=0, end=None):
         result = str_find(self._parent, sub, start=start, end=end, side='left')
         return self._wrap_result(result)
 
     @Appender(_shared_docs['find'] %
               dict(side='highest', method='rfind',
-                   also='find : Return lowest indexes in each strings'))
+                   also='find : Return lowest indexes in each strings.'))
     def rfind(self, sub, start=0, end=None):
         result = str_find(self._parent, sub,
                           start=start, end=end, side='right')
@@ -2852,7 +2852,7 @@ class StringMethods(NoNewAttributesMixin):
 
     @Appender(_shared_docs['index'] %
               dict(side='lowest', similar='find', method='index',
-                   also='rindex : Return highest indexes in each strings'))
+                   also='rindex : Return highest indexes in each strings.'))
     def index(self, sub, start=0, end=None):
         result = str_index(self._parent, sub,
                            start=start, end=end, side='left')
@@ -2860,7 +2860,7 @@ class StringMethods(NoNewAttributesMixin):
 
     @Appender(_shared_docs['index'] %
               dict(side='highest', similar='rfind', method='rindex',
-                   also='index : Return lowest indexes in each strings'))
+                   also='index : Return lowest indexes in each strings.'))
     def rindex(self, sub, start=0, end=None):
         result = str_index(self._parent, sub,
                            start=start, end=end, side='right')


### PR DESCRIPTION
- [x] xref #23630 DOC: Fix format of the See Also descriptions
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
