### PR TITLE
DTA Followups - remove redundant methods

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -19,12 +19,11 @@ from pandas.util._decorators import Appender, Substitution
 from pandas.util._validators import validate_fillna_kwargs
 
 from pandas.core.dtypes.common import (
-    is_bool_dtype, is_categorical_dtype, is_datetime64_any_dtype,
-    is_datetime64_dtype, is_datetime64tz_dtype, is_datetime_or_timedelta_dtype,
-    is_dtype_equal, is_extension_array_dtype, is_float_dtype, is_integer_dtype,
-    is_list_like, is_object_dtype, is_offsetlike, is_period_dtype,
-    is_string_dtype, is_timedelta64_dtype, is_unsigned_integer_dtype,
-    needs_i8_conversion, pandas_dtype)
+    is_categorical_dtype, is_datetime64_any_dtype, is_datetime64_dtype,
+    is_datetime64tz_dtype, is_datetime_or_timedelta_dtype, is_dtype_equal,
+    is_extension_array_dtype, is_float_dtype, is_integer_dtype, is_list_like,
+    is_object_dtype, is_offsetlike, is_period_dtype, is_string_dtype,
+    is_timedelta64_dtype, is_unsigned_integer_dtype, pandas_dtype)
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import is_array_like
 from pandas.core.dtypes.missing import isna
@@ -38,32 +37,6 @@ from pandas.tseries import frequencies
 from pandas.tseries.offsets import DateOffset, Tick
 
 from .base import ExtensionArray, ExtensionOpsMixin
-
-
-def _make_comparison_op(cls, op):
-    # TODO: share code with indexes.base version?  Main difference is that
-    # the block for MultiIndex was removed here.
-    def cmp_method(self, other):
-        if isinstance(other, ABCDataFrame):
-            return NotImplemented
-
-        if needs_i8_conversion(self) and needs_i8_conversion(other):
-            # we may need to directly compare underlying
-            # representations
-            return self._evaluate_compare(other, op)
-
-        # numpy will show a DeprecationWarning on invalid elementwise
-        # comparisons, this will raise in the future
-        with warnings.catch_warnings(record=True):
-            warnings.filterwarnings("ignore", "elementwise", FutureWarning)
-            with np.errstate(all='ignore'):
-                result = op(self._data, np.asarray(other))
-
-        return result
-
-    name = '__{name}__'.format(name=op.__name__)
-    # TODO: docstring?
-    return compat.set_function_name(cmp_method, name, cls)
 
 
 class AttributesMixin(object):
@@ -1358,41 +1331,6 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
     # --------------------------------------------------------------
     # Comparison Methods
 
-    # Called by _add_comparison_methods defined in ExtensionOpsMixin
-    _create_comparison_method = classmethod(_make_comparison_op)
-
-    def _evaluate_compare(self, other, op):
-        """
-        We have been called because a comparison between
-        8 aware arrays. numpy will warn about NaT comparisons
-        """
-        # Called by comparison methods when comparing datetimelike
-        # with datetimelike
-
-        if not isinstance(other, type(self)):
-            # coerce to a similar object
-            if not is_list_like(other):
-                # scalar
-                other = [other]
-            elif lib.is_scalar(lib.item_from_zerodim(other)):
-                # ndarray scalar
-                other = [other.item()]
-            other = type(self)._from_sequence(other)
-
-        # compare
-        result = op(self.asi8, other.asi8)
-
-        # technically we could support bool dtyped Index
-        # for now just return the indexing array directly
-        mask = (self._isnan) | (other._isnan)
-
-        filler = iNaT
-        if is_bool_dtype(result):
-            filler = False
-
-        result[mask] = filler
-        return result
-
     def _ensure_localized(self, arg, ambiguous='raise', nonexistent='raise',
                           from_utc=False):
         """
@@ -1491,9 +1429,6 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
         result = nanops.nanmax(values, skipna=skipna)
         # Don't have to worry about NA `result`, since no NA went in.
         return self._box_func(result)
-
-
-DatetimeLikeArrayMixin._add_comparison_ops()
 
 
 # -------------------------------------------------------------------

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -34,7 +34,7 @@ from pandas.tseries.offsets import Day, Tick
 _midnight = time(0, 0)
 
 
-def _to_m8(key, tz=None):
+def _to_M8(key, tz=None):
     """
     Timestamp-like => dt64
     """
@@ -96,7 +96,6 @@ def _dt_array_cmp(cls, op):
     nat_result = True if opname == '__ne__' else False
 
     def wrapper(self, other):
-        meth = getattr(dtl.DatetimeLikeArrayMixin, opname)
         # TODO: return NotImplemented for Series / Index and let pandas unbox
         # Right now, returning NotImplemented for Index fails because we
         # go into the index implementation, which may be a bug?
@@ -109,7 +108,7 @@ def _dt_array_cmp(cls, op):
                 self._assert_tzawareness_compat(other)
 
             try:
-                other = _to_m8(other, tz=self.tz)
+                other = _to_M8(other, tz=self.tz)
             except ValueError:
                 # string that cannot be parsed to Timestamp
                 return ops.invalid_comparison(self, other, op)
@@ -158,7 +157,7 @@ def _dt_array_cmp(cls, op):
                     # or an object-dtype ndarray
                     other = type(self)._from_sequence(other)
 
-                result = meth(self, other)
+                result = op(self.view('i8'), other.view('i8'))
                 o_mask = other._isnan
 
             result = com.values_from_object(result)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -13,8 +13,8 @@ from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, cache_readonly, deprecate_kwarg
 
 from pandas.core.dtypes.common import (
-    ensure_int64, is_bool_dtype, is_dtype_equal, is_float, is_integer,
-    is_list_like, is_period_dtype, is_scalar)
+    ensure_int64, is_dtype_equal, is_float, is_integer, is_list_like,
+    is_period_dtype, is_scalar)
 from pandas.core.dtypes.generic import ABCIndex, ABCIndexClass, ABCSeries
 
 from pandas.core import algorithms, ops
@@ -190,16 +190,6 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
             return results
 
         return wrapper
-
-    @Appender(DatetimeLikeArrayMixin._evaluate_compare.__doc__)
-    def _evaluate_compare(self, other, op):
-        result = self._eadata._evaluate_compare(other, op)
-        if is_bool_dtype(result):
-            return result
-        try:
-            return Index(result)
-        except TypeError:
-            return result
 
     def _ensure_localized(self, arg, ambiguous='raise', nonexistent='raise',
                           from_utc=False):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -22,7 +22,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core.accessor import delegate_names
 from pandas.core.arrays.datetimes import (
-    DatetimeArrayMixin as DatetimeArray, _to_m8, validate_tz_from_dtype)
+    DatetimeArrayMixin as DatetimeArray, _to_M8, validate_tz_from_dtype)
 from pandas.core.base import _shared_docs
 import pandas.core.common as com
 from pandas.core.indexes.base import Index
@@ -405,7 +405,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     def _convert_for_op(self, value):
         """ Convert value to be insertable to ndarray """
         if self._has_same_tz(value):
-            return _to_m8(value)
+            return _to_M8(value)
         raise ValueError('Passed item and index have different timezone')
 
     def _maybe_update_attributes(self, attrs):
@@ -1161,7 +1161,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         if isinstance(value, (np.ndarray, Index)):
             value = np.array(value, dtype=_NS_DTYPE, copy=False)
         else:
-            value = _to_m8(value, tz=self.tz)
+            value = _to_M8(value, tz=self.tz)
 
         return self.values.searchsorted(value, side=side)
 
@@ -1211,7 +1211,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
                     freq = self.freq
                 elif (loc == len(self)) and item - self.freq == self[-1]:
                     freq = self.freq
-            item = _to_m8(item, tz=self.tz)
+            item = _to_M8(item, tz=self.tz)
 
         try:
             new_dates = np.concatenate((self[:loc].asi8, [item.view(np.int64)],

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -277,9 +277,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         return result
 
     # ------------------------------------------------------------------------
-    # Wrapping PeriodArray
-
-    # ------------------------------------------------------------------------
     # Data
 
     @property
@@ -416,6 +413,10 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         # how to represent ourselves to matplotlib
         return self.astype(object).values
 
+    @property
+    def _formatter_func(self):
+        return self.array._formatter(boxed=False)
+
     # ------------------------------------------------------------------------
     # Indexing
 
@@ -495,10 +496,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         # the result is object dtype array of Period
         # cannot pass _simple_new as it is
         return type(self)(result, freq=self.freq, name=self.name)
-
-    @property
-    def _formatter_func(self):
-        return self.array._formatter(boxed=False)
 
     def asof_locs(self, where, mask):
         """

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -18,7 +18,7 @@ from pandas.core.dtypes.missing import isna
 from pandas.core.accessor import delegate_names
 from pandas.core.arrays import datetimelike as dtl
 from pandas.core.arrays.timedeltas import (
-    TimedeltaArrayMixin as TimedeltaArray, _is_convertible_to_td, _to_m8)
+    TimedeltaArrayMixin as TimedeltaArray, _is_convertible_to_td)
 from pandas.core.base import _shared_docs
 import pandas.core.common as com
 from pandas.core.indexes.base import Index, _index_shared_docs
@@ -614,7 +614,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, dtl.TimelikeOps, Int64Index,
         if isinstance(value, (np.ndarray, Index)):
             value = np.array(value, dtype=_TD_DTYPE, copy=False)
         else:
-            value = _to_m8(value)
+            value = Timedelta(value).asm8.view(_TD_DTYPE)
 
         return self.values.searchsorted(value, side=side, sorter=sorter)
 
@@ -664,7 +664,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, dtl.TimelikeOps, Int64Index,
                     freq = self.freq
                 elif (loc == len(self)) and item - self.freq == self[-1]:
                     freq = self.freq
-            item = _to_m8(item)
+            item = Timedelta(item).asm8.view(_TD_DTYPE)
 
         try:
             new_tds = np.concatenate((self[:loc].asi8, [item.view(np.int64)],

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -20,7 +20,7 @@ from pandas.errors import PerformanceWarning, NullFrequencyError
 from pandas._libs.tslibs.conversion import localize_pydatetime
 from pandas._libs.tslibs.offsets import shift_months
 
-from pandas.core.indexes.datetimes import _to_m8
+from pandas.core.indexes.datetimes import _to_M8
 
 from pandas import (
     Timestamp, Timedelta, Period, Series, date_range, NaT,
@@ -349,7 +349,7 @@ class TestDatetimeIndexComparisons(object):
     def test_comparators(self, op):
         index = tm.makeDateIndex(100)
         element = index[len(index) // 2]
-        element = _to_m8(element)
+        element = _to_M8(element)
 
         arr = np.array(index)
         arr_result = op(arr, element)

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -13,7 +13,7 @@ import pandas.compat as compat
 from pandas.compat import range
 from pandas.compat.numpy import np_datetime64_compat
 
-from pandas.core.indexes.datetimes import DatetimeIndex, _to_m8, date_range
+from pandas.core.indexes.datetimes import DatetimeIndex, _to_M8, date_range
 from pandas.core.series import Series
 import pandas.util.testing as tm
 
@@ -47,9 +47,9 @@ class WeekDay(object):
 ####
 
 
-def test_to_m8():
+def test_to_M8():
     valb = datetime(2007, 10, 1)
-    valu = _to_m8(valb)
+    valu = _to_M8(valb)
     assert isinstance(valu, np.datetime64)
 
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1861,10 +1861,6 @@ def getCols(k):
     return string.ascii_uppercase[:k]
 
 
-def getArangeMat():
-    return np.arange(N * K).reshape((N, K))
-
-
 # make index
 def makeStringIndex(k=10, name=None):
     return Index(rands_array(nchars=10, size=k), name=name)
@@ -2320,13 +2316,6 @@ def add_nans(panel):
         for j, col in enumerate(dm.columns):
             dm[col][:i + j] = np.NaN
     return panel
-
-
-def add_nans_panel4d(panel4d):
-    for l, label in enumerate(panel4d.labels):
-        panel = panel4d[label]
-        add_nans(panel)
-    return panel4d
 
 
 class TestSubDict(dict):


### PR DESCRIPTION
Both arrays.datetimes and arrays.timedeltas have a `_to_m8` function.  The timedeltas one is removed since it is unnecessary, the datetimes one is given a more accurate name `_to_M8`

A couple of unused funcs from `tm` are removed.

A test is parametrized.