### PR TITLE
Support hard-masked numpy arrays

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1537,6 +1537,7 @@ Missing
 - Bug in :func:`Series.hasnans` that could be incorrectly cached and return incorrect answers if null elements are introduced after an initial call (:issue:`19700`)
 - :func:`Series.isin` now treats all NaN-floats as equal also for ``np.object``-dtype. This behavior is consistent with the behavior for float64 (:issue:`22119`)
 - :func:`unique` no longer mangles NaN-floats and the ``NaT``-object for ``np.object``-dtype, i.e. ``NaT`` is no longer coerced to a NaN-value and is treated as a different entity. (:issue:`22295`)
+- :func:`DataFrame` and :func:`Series` now properly handle numpy masked arrays with hardened masks. Previously, constructing a DataFrame or Series from a masked array with a hard mask would create a pandas object containing the underlying value, rather than the expected NaN. (:issue:`24574`)
 
 
 MultiIndex

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -400,6 +400,7 @@ class DataFrame(NDFrame):
                 mask = ma.getmaskarray(data)
                 if mask.any():
                     data, fill_value = maybe_upcast(data, copy=True)
+                    data.soften_mask() # set hardmask False if it was True
                     data[mask] = fill_value
                 else:
                     data = data.copy()

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -400,7 +400,7 @@ class DataFrame(NDFrame):
                 mask = ma.getmaskarray(data)
                 if mask.any():
                     data, fill_value = maybe_upcast(data, copy=True)
-                    data.soften_mask() # set hardmask False if it was True
+                    data.soften_mask()  # set hardmask False if it was True
                     data[mask] = fill_value
                 else:
                     data = data.copy()

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -547,6 +547,7 @@ def sanitize_array(data, index, dtype=None, copy=False,
         mask = ma.getmaskarray(data)
         if mask.any():
             data, fill_value = maybe_upcast(data, copy=True)
+            data.soften_mask() # set hardmask False if it was True
             data[mask] = fill_value
         else:
             data = data.copy()

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -547,7 +547,7 @@ def sanitize_array(data, index, dtype=None, copy=False,
         mask = ma.getmaskarray(data)
         if mask.any():
             data, fill_value = maybe_upcast(data, copy=True)
-            data.soften_mask() # set hardmask False if it was True
+            data.soften_mask()  # set hardmask False if it was True
             data[mask] = fill_value
         else:
             data = data.copy()

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -757,6 +757,20 @@ class TestDataFrameConstructors(TestData):
         assert frame['A'][1] is True
         assert frame['C'][2] is False
 
+        # Check hardened masks
+        mat_hard = ma.masked_all((2, 3), dtype=float).harden_mask()
+        frame = DataFrame(mat_hard, columns=['A', 'B', 'C'], index=[1, 2])
+        assert len(frame.index) == 2
+        assert len(frame.columns) == 3
+        assert np.all(~np.asarray(frame == frame))
+        # Check case where mask is hard but no data are masked
+        mat_hard = ma.ones((2,3), dtype=float).harden_mask()
+        frame = DataFrame(mat_hard, columns=['A', 'B', 'C'], index=[1, 2])
+        assert len(frame.index) == 2
+        assert len(frame.columns) == 3
+        assert np.all(np.asarray(frame == 1.0))
+
+
     def test_constructor_mrecarray(self):
         # Ensure mrecarray produces frame identical to dict of masked arrays
         # from GH3479

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -763,8 +763,7 @@ class TestDataFrameConstructors(TestData):
         result = pd.DataFrame(mat_hard, columns=['A', 'B'], index=[1, 2])
         expected = pd.DataFrame({
             'A': [np.nan, np.nan],
-            'B': [np.nan, np.nan],
-            },
+            'B': [np.nan, np.nan]},
             columns=['A', 'B'],
             index=[1, 2],
             dtype=float)
@@ -774,8 +773,7 @@ class TestDataFrameConstructors(TestData):
         result = pd.DataFrame(mat_hard, columns=['A', 'B'], index=[1, 2])
         expected = pd.DataFrame({
             'A': [1.0, 1.0],
-            'B': [1.0, 1.0],
-            },
+            'B': [1.0, 1.0]},
             columns=['A', 'B'],
             index=[1, 2],
             dtype=float)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -757,19 +757,29 @@ class TestDataFrameConstructors(TestData):
         assert frame['A'][1] is True
         assert frame['C'][2] is False
 
-        # Check hardened masks
-        mat_hard = ma.masked_all((2, 3), dtype=float).harden_mask()
-        frame = DataFrame(mat_hard, columns=['A', 'B', 'C'], index=[1, 2])
-        assert len(frame.index) == 2
-        assert len(frame.columns) == 3
-        assert np.all(~np.asarray(frame == frame))
+    def test_constructor_maskedarray_hardened(self):
+        # Check numpy masked arrays with hard masks -- from GH24574
+        mat_hard = ma.masked_all((2, 2), dtype=float).harden_mask()
+        result = pd.DataFrame(mat_hard, columns=['A', 'B'], index=[1, 2])
+        expected = pd.DataFrame({
+            'A': [np.nan, np.nan],
+            'B': [np.nan, np.nan],
+            },
+            columns=['A', 'B'],
+            index=[1, 2],
+            dtype=float)
+        tm.assert_frame_equal(result, expected)
         # Check case where mask is hard but no data are masked
-        mat_hard = ma.ones((2,3), dtype=float).harden_mask()
-        frame = DataFrame(mat_hard, columns=['A', 'B', 'C'], index=[1, 2])
-        assert len(frame.index) == 2
-        assert len(frame.columns) == 3
-        assert np.all(np.asarray(frame == 1.0))
-
+        mat_hard = ma.ones((2, 2), dtype=float).harden_mask()
+        result = pd.DataFrame(mat_hard, columns=['A', 'B'], index=[1, 2])
+        expected = pd.DataFrame({
+            'A': [1.0, 1.0],
+            'B': [1.0, 1.0],
+            },
+            columns=['A', 'B'],
+            index=[1, 2],
+            dtype=float)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_mrecarray(self):
         # Ensure mrecarray produces frame identical to dict of masked arrays

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -386,6 +386,11 @@ class TestSeriesConstructors():
         expected = Series([nan, nan, nan])
         assert_series_equal(result, expected)
 
+        data_hard = ma.copy(data).harden_mask()
+        result = Series(data_hard)
+        expected = Series([nan, nan, nan])
+        assert_series_equal(result, expected)
+
         data[0] = 0.0
         data[2] = 2.0
         index = ['a', 'b', 'c']

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -386,11 +386,6 @@ class TestSeriesConstructors():
         expected = Series([nan, nan, nan])
         assert_series_equal(result, expected)
 
-        data_hard = ma.copy(data).harden_mask()
-        result = Series(data_hard)
-        expected = Series([nan, nan, nan])
-        assert_series_equal(result, expected)
-
         data[0] = 0.0
         data[2] = 2.0
         index = ['a', 'b', 'c']
@@ -455,6 +450,13 @@ class TestSeriesConstructors():
         expected = Series([datetime(2001, 1, 1), datetime(2001, 1, 2),
                            datetime(2001, 1, 3)], index=index, dtype='M8[ns]')
         assert_series_equal(result, expected)
+
+    def test_constructor_maskedarray_hardened(self):
+        # Check numpy masked arrays with hard masks -- from GH24574
+        data = ma.masked_all((3, ), dtype=float).harden_mask()
+        result = pd.Series(data)
+        expected = pd.Series([nan, nan, nan])
+        tm.assert_series_equal(result, expected)
 
     def test_series_ctor_plus_datetimeindex(self):
         rng = date_range('20090415', '20090519', freq='B')


### PR DESCRIPTION
- [x] closes #24574
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

For the whatsnew entry, is this reasonable?
```rst
- :func:`DataFrame` and :func:`Series` now properly handle 
numpy masked arrays with hardened masks. Previously, constructing 
a DataFrame or Series from a masked array with a hard mask would 
create a pandas object containing the underlying value, rather than the
expected NaN. (:issue:`24574`)
```