### PR TITLE
DOC: hide warning from arrow about deprecated MultiIndex labels

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -4647,6 +4647,7 @@ Write to a feather file.
 Read from a feather file.
 
 .. ipython:: python
+   :okwarning:
 
    result = pd.read_feather('example.feather')
    result
@@ -4721,6 +4722,7 @@ Write to a parquet file.
 Read from a parquet file.
 
 .. ipython:: python
+   :okwarning:
 
    result = pd.read_parquet('example_fp.parquet', engine='fastparquet')
    result = pd.read_parquet('example_pa.parquet', engine='pyarrow')
@@ -4791,6 +4793,7 @@ Partitioning Parquet files
 Parquet supports partitioning of data based on the values of one or more columns.
 
 .. ipython:: python
+    :okwarning:
 
     df = pd.DataFrame({'a': [0, 0, 1, 1], 'b': [0, 1, 0, 1]})
     df.to_parquet(fname='test', engine='pyarrow',


### PR DESCRIPTION
This is fixed upstream in arrow (https://github.com/apache/arrow/pull/3120), but until a new release is there, avoiding the warning in our docs to have a cleaner doc build output.