### PR TITLE
feature : forces index_type comparaison when asserting that one Dataf…

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3744,15 +3744,23 @@ class NDFrame(PandasObject, SelectionMixin):
                                        copy=copy, limit=limit,
                                        tolerance=tolerance)
 
-        if isinstance(self.index, MultiIndex) and isinstance(other.index, MultiIndex):
-            assert [f"{self.index.names[i]}: {self.index.get_level_values(n).dtype}"
-                    for i, n in enumerate(self.index.names)] == [
-                       f"{other.index.names[i]}: {other.index.get_level_values(n).dtype}"
-                       for i, n in enumerate(other.index.names)],\
+        if isinstance(self.index, MultiIndex) and isinstance(other.index,
+                                                             MultiIndex):
+            types_self = ["{} : {}".format(self.index.names[i],
+                                           self.index.get_level_values(
+                                               n).dtype)
+                          for i, n in enumerate(self.index.names)]
+            types_other = ["{} : {}".format(other.index.names[i],
+                                            other.index.get_level_values(
+                                                n).dtype)
+                           for i, n in enumerate(other.index.names)]
+            assert types_other == types_self, \
                 "columns must have same names and dtypes when reindexing"
+
         else:
-            assert type(self.index) == type(other.index),\
-                "columns must have same names and dtypes when reindexing"
+            assert type(self.index) == type(other.index), \
+                "columns must have same names and dtypes when reindexing" \
+            # noqa: E721
 
         return self.reindex(**d)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3744,6 +3744,16 @@ class NDFrame(PandasObject, SelectionMixin):
                                        copy=copy, limit=limit,
                                        tolerance=tolerance)
 
+        if isinstance(self.index, MultiIndex) and isinstance(other.index, MultiIndex):
+            assert [f"{self.index.names[i]}: {self.index.get_level_values(n).dtype}"
+                    for i, n in enumerate(self.index.names)] == [
+                       f"{other.index.names[i]}: {other.index.get_level_values(n).dtype}"
+                       for i, n in enumerate(other.index.names)],\
+                "columns must have same names and dtypes when reindexing"
+        else:
+            assert type(self.index) == type(other.index),\
+                "columns must have same names and dtypes when reindexing"
+
         return self.reindex(**d)
 
     def drop(self, labels=None, axis=0, index=None, columns=None, level=None,

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -207,3 +207,17 @@ def test_frame_equal_unicode(df1, df2, msg, by_blocks):
     # when comparing DataFrames containing differing unicode objects.
     with pytest.raises(AssertionError, match=msg):
         assert_frame_equal(df1, df2, by_blocks=by_blocks)
+
+
+def test_frame_equal_index_different_type():
+    left = DataFrame(data=[[3, 7.45678], [12, 37.45678]],
+                     columns=["one", "two"])
+
+    right = left.copy()
+    right.iloc[0, :], right.iloc[1, :] = right.iloc[1, :], right.iloc[0, :]
+    right.one = right.one.astype(str)
+
+    right = right.set_index("one")
+    left = left.set_index("one")
+
+    assert_frame_equal(left, right, check_like=True)

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -220,4 +220,24 @@ def test_frame_equal_index_different_type():
     right = right.set_index("one")
     left = left.set_index("one")
 
-    assert_frame_equal(left, right, check_like=True)
+    msg = "columns must have same names and dtypes when reindexing"
+
+    with pytest.raises(AssertionError, match=msg):
+        assert_frame_equal(left, right, check_like=True)
+
+
+def test_frame_equal_index_crossed_different_type():
+    honest = DataFrame(data=[["2", 3, 4], ["1", 2, 3], ["6", 6, 8]],
+                       columns=["a_string", "a_int", "some_data"])
+    liar = DataFrame(data=[["2", 3, 4], ["1", 2, 3], ["6", 6, 8]],
+                     columns=["a_int", "a_string", "some_data"])
+
+    honest = honest.set_index(["a_string", "a_int"])
+    liar = liar.set_index(["a_string", "a_int"])
+
+    msg = """columns must have same names and dtypes when reindexing"""
+
+    with pytest.raises(AssertionError, match=msg):
+        assert_frame_equal(honest, liar, check_like=True)
+
+test_frame_equal_index_crossed_different_type()

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -240,4 +240,9 @@ def test_frame_equal_index_crossed_different_type():
     with pytest.raises(AssertionError, match=msg):
         assert_frame_equal(honest, liar, check_like=True)
 
-test_frame_equal_index_crossed_different_type()
+
+def test_frame_equal_multi_index():
+    a = DataFrame(data=[["2", 3, 4], ["1", 2, 3], ["6", 6, 8]],
+                  columns=["a_string", "a_int", "some_data"])
+
+    _assert_frame_equal_both(a, a.copy())

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1453,6 +1453,7 @@ def assert_frame_equal(left, right, check_dtype=True,
                             '{shape!r}'.format(shape=right.shape))
 
     if check_like:
+        check_index_type = True
         left, right = left.reindex_like(right), right
 
     # index comparison

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1453,7 +1453,6 @@ def assert_frame_equal(left, right, check_dtype=True,
                             '{shape!r}'.format(shape=right.shape))
 
     if check_like:
-        check_index_type = True
         left, right = left.reindex_like(right), right
 
     # index comparison


### PR DESCRIPTION
Until now, when comparing if 2 Dataframes were like each other, reindexing occurred as a inner mechanism. It turns out, if the two indexes are not of the same type, one of the Dataframe was emptied and the assertion always failed.
This fix forces the comparison of the index types if this specific case.

Example of code that will work with this fix
```
import pandas as pd

left = pd.DataFrame(data=[['20181130', 3, 7.45678, '20181129'], ['20181130', 12, 37.45678, '20181129']],
                    columns=["tomorrow", "one", "two", "today"])

left.today = left.today.astype('datetime64')

right = left.copy()
right.iloc[0, :], right.iloc[1, :] = right.iloc[1, :], right.iloc[0, :]
right.one = right.one.astype(str)

right = right.set_index("one")
left = left.set_index("one")

print(left)
print(right)

pd.testing.assert_frame_equal(left, right, check_like=True)
```