### PR TITLE
CLN: replace lambdas with named functions so they are labeled in asv

### DIFF
--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -3,17 +3,55 @@ import pandas.util.testing as tm
 from pandas import Series, Index, DatetimeIndex, Timestamp, MultiIndex
 
 
+def no_change(arr):
+    return arr
+
+
+def list_of_str(arr):
+    return list(arr.astype(str))
+
+
+def gen_of_str(arr):
+    return (x for x in arr.astype(str))
+
+
+def arr_dict(arr):
+    return dict(zip(range(len(arr)), arr))
+
+
+def list_of_tuples(arr):
+    return [(i, -i) for i in arr]
+
+
+def gen_of_tuples(arr):
+    return ((i, -i) for i in arr)
+
+
+def list_of_lists(arr):
+    return [[i, -i] for i in arr]
+
+
+def list_of_tuples_with_none(arr):
+    return [(i, -i) for i in arr][:-1] + [None]
+
+
+def list_of_lists_with_none(arr):
+    return [[i, -i] for i in arr][:-1] + [None]
+
+
 class SeriesConstructors(object):
 
     param_names = ["data_fmt", "with_index"]
-    params = [[lambda x: x,
+    params = [[no_change,
                list,
-               lambda arr: list(arr.astype(str)),
-               lambda arr: dict(zip(range(len(arr)), arr)),
-               lambda arr: [(i, -i) for i in arr],
-               lambda arr: [[i, -i] for i in arr],
-               lambda arr: ([(i, -i) for i in arr][:-1] + [None]),
-               lambda arr: ([[i, -i] for i in arr][:-1] + [None])],
+               list_of_str,
+               gen_of_str,
+               arr_dict,
+               list_of_tuples,
+               gen_of_tuples,
+               list_of_lists,
+               list_of_tuples_with_none,
+               list_of_lists_with_none],
               [False, True]]
 
     def setup(self, data_fmt, with_index):


### PR DESCRIPTION
This complements a PR in `asv` (https://github.com/airspeed-velocity/asv/pull/771), but would be worthwhile on its own.

`asv` compares benchmarks based on the `repr()` of the parameters, which causes issues when the parameter is an object that doesn't override the default `repr()` (such as functions, especially lambda functions):
```
Benchmarks that have stayed the same:

       before           after         ratio
     [24ab22f7]       [d7cef344]
              n/a          997±3μs      n/a  ctors.SeriesConstructors.time_series_constructor(<function SeriesConstructors.<lambda> at 0x7f0deb0800d0>, False)
              n/a         1.05±0ms      n/a  ctors.SeriesConstructors.time_series_constructor(<function SeriesConstructors.<lambda> at 0x7f0deb0800d0>, True)
      1.04±0.01ms              n/a      n/a  ctors.SeriesConstructors.time_series_constructor(<function SeriesConstructors.<lambda> at 0x7fd9d0bbc598>, False)
      1.06±0.02ms              n/a      n/a  ctors.SeriesConstructors.time_series_constructor(<function SeriesConstructors.<lambda> at 0x7fd9d0bbc598>, True)
```
As the memory address component of the name changes between runs, `asv` fails at lining up the comparison. This has to be fixed upstream.

However, passing `lambda` functions is particularly unhelpful, as we have no idea which of the six such objects are represented in the example above.

This PR simply gives each function a descriptive name:
```
asv continuous -b SeriesConstructors v0.20.0..HEAD
[...]
[ 50.00%] · For pandas commit 20c2a780 <asv_change> (round 2/2):
[ 50.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 75.00%] ··· ctors.SeriesConstructors.time_series_constructor                                                                                                                                                   ok
[ 75.00%] ··· ======================================================= ============= =============
              --                                                               with_index        
              ------------------------------------------------------- ---------------------------
                                      data_fmt                            False          True    
              ======================================================= ============= =============
                       <function no_change at 0x7efcd7b67c80>           74.0±0.4μs     131±3μs   
                                        list                           1.15±0.03ms   1.20±0.01ms 
                      <function list_of_str at 0x7efcd7b67d08>           688±9μs       741±6μs   
                       <function arr_dict at 0x7efcd7b67b70>           4.49±0.01ms   4.71±0.02ms 
                    <function list_of_tuples at 0x7efcd7b679d8>        1.02±0.01ms   1.10±0.01ms 
                     <function list_of_lists at 0x7efcd7b67a60>        1.04±0.03ms   1.09±0.04ms 
               <function list_of_tuples_with_none at 0x7efcd7b67ae8>   1.02±0.02ms   1.08±0.02ms 
                <function list_of_lists_with_none at 0x7efcd7b676a8>   1.05±0.01ms   1.10±0.01ms 
              ======================================================= ============= =============

[ 75.00%] · For pandas commit 91753873 <maybe_convert_objects_int_overflow_fix~1> (round 2/2):
[ 75.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt.....
[ 75.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[100.00%] ··· ctors.SeriesConstructors.time_series_constructor                                                                                                                                                   ok
[100.00%] ··· ======================================================= ============= =============
              --                                                               with_index        
              ------------------------------------------------------- ---------------------------
                                      data_fmt                            False          True    
              ======================================================= ============= =============
                       <function no_change at 0x7efcd7b67c80>           72.9±0.9μs     126±1μs   
                                        list                             1.10±0ms    1.16±0.02ms 
                      <function list_of_str at 0x7efcd7b67d08>           699±10μs      760±3μs   
                       <function arr_dict at 0x7efcd7b67b70>           4.54±0.08ms   4.71±0.04ms 
                    <function list_of_tuples at 0x7efcd7b679d8>        1.01±0.01ms   1.08±0.02ms 
                     <function list_of_lists at 0x7efcd7b67a60>        1.01±0.01ms   1.07±0.01ms 
               <function list_of_tuples_with_none at 0x7efcd7b67ae8>   1.02±0.01ms   1.09±0.02ms 
                <function list_of_lists_with_none at 0x7efcd7b676a8>     1.05±0ms    1.08±0.01ms 
              ======================================================= ============= =============


BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
