### PR TITLE
Have Categorical ops defer to DataFrame; broken off of #24282

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1353,6 +1353,7 @@ Categorical
 - Bug in many methods of the ``.str``-accessor, which always failed on calling the ``CategoricalIndex.str`` constructor (:issue:`23555`, :issue:`23556`)
 - Bug in :meth:`Series.where` losing the categorical dtype for categorical data (:issue:`24077`)
 - Bug in :meth:`Categorical.apply` where ``NaN`` values could be handled unpredictably. They now remain unchanged (:issue:`24241`)
+- Bug in :class:`Categorical` comparison methods incorrectly raising ``ValueError`` when operating against a :class:`DataFrame` (:issue:`24630`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -23,7 +23,7 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype)
 from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.core.dtypes.generic import (
-    ABCCategoricalIndex, ABCIndexClass, ABCSeries)
+    ABCCategoricalIndex, ABCDataFrame, ABCIndexClass, ABCSeries)
 from pandas.core.dtypes.inference import is_hashable
 from pandas.core.dtypes.missing import isna, notna
 
@@ -59,8 +59,10 @@ def _cat_compare_op(op):
         # results depending whether categories are the same or not is kind of
         # insane, so be a bit stricter here and use the python3 idea of
         # comparing only things of equal type.
-        if isinstance(other, ABCSeries):
+        if isinstance(other, (ABCDataFrame, ABCSeries, ABCIndexClass)):
             return NotImplemented
+
+        other = lib.item_from_zerodim(other)
 
         if not self.ordered:
             if op in ['__lt__', '__gt__', '__le__', '__ge__']:
@@ -105,7 +107,6 @@ def _cat_compare_op(op):
         #
         # With cat[0], for example, being ``np.int64(1)`` by the time it gets
         # into this function would become ``np.array(1)``.
-        other = lib.item_from_zerodim(other)
         if is_scalar(other):
             if other in self.categories:
                 i = self.categories.get_loc(other)

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import operator
 
 import numpy as np
 import pytest
@@ -113,8 +114,33 @@ class TestCategoricalOpsWithFactor(TestCategorical):
         res = cat_rev > "b"
         tm.assert_numpy_array_equal(res, exp)
 
+        # check that zero-dim array gets unboxed
+        res = cat_rev > np.array("b")
+        tm.assert_numpy_array_equal(res, exp)
+
 
 class TestCategoricalOps(object):
+
+    def test_compare_frame(self):
+        # GH#24282 check that Categorical.__cmp__(DataFrame) defers to frame
+        data = ["a", "b", 2, "a"]
+        cat = Categorical(data)
+
+        df = DataFrame(cat)
+
+        for op in [operator.eq, operator.ne, operator.ge,
+                   operator.gt, operator.le, operator.lt]:
+            with pytest.raises(ValueError):
+                # alignment raises unless we transpose
+                op(cat, df)
+
+        result = cat == df.T
+        expected = DataFrame([[True, True, True, True]])
+        tm.assert_frame_equal(result, expected)
+
+        result = cat[::-1] != df.T
+        expected = DataFrame([[False, True, True, False]])
+        tm.assert_frame_equal(result, expected)
 
     def test_datetime_categorical_comparison(self):
         dt_cat = Categorical(date_range('2014-01-01', periods=3), ordered=True)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
