### PR TITLE
Fix DeprecationWarning: invalid escape sequence in versioneer.py

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1731,7 +1731,6 @@ Other
 
 - Bug where C variables were declared with external linkage causing import errors if certain other C libraries were imported before Pandas. (:issue:`24113`)
 - Require at least 0.28.2 version of ``cython`` to support read-only memoryviews (:issue:`21688`)
-- Fixing a `DeprecationWarning`: invalid escape sequence in versioneer.py (:issue:`24636`)
 
 .. _whatsnew_0.24.0.contributors:
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1731,6 +1731,7 @@ Other
 
 - Bug where C variables were declared with external linkage causing import errors if certain other C libraries were imported before Pandas. (:issue:`24113`)
 - Require at least 0.28.2 version of ``cython`` to support read-only memoryviews (:issue:`21688`)
+- Fixing a `DeprecationWarning`: invalid escape sequence in versioneer.py (:issue:`24636`)
 
 .. _whatsnew_0.24.0.contributors:
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -464,7 +464,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
             print("unable to run %s (error)" % dispcmd)
         return None
     return stdout
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY['git'] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build

--- a/versioneer.py
+++ b/versioneer.py
@@ -464,6 +464,8 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
             print("unable to run %s (error)" % dispcmd)
         return None
     return stdout
+
+
 LONG_VERSION_PY['git'] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag


### PR DESCRIPTION
Hello,

This is a little patch to fix a `DeprecationWarning: invalid escape sequence` in `versioneer.py`.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
