### PR TITLE
DOC: fix warnings in docstrings examples for deprecated functions

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -766,8 +766,8 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
         With the `tz` parameter, we can change the DatetimeIndex
         to other time zones:
 
-        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',
-        ...                        freq='H', periods=3, tz='Europe/Berlin')
+        >>> dti = pd.date_range(start='2014-08-01 09:00',
+        ...                     freq='H', periods=3, tz='Europe/Berlin')
 
         >>> dti
         DatetimeIndex(['2014-08-01 09:00:00+02:00',
@@ -784,8 +784,8 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
         With the ``tz=None``, we can remove the timezone (after converting
         to UTC if necessary):
 
-        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',freq='H',
-        ...                        periods=3, tz='Europe/Berlin')
+        >>> dti = pd.date_range(start='2014-08-01 09:00',freq='H',
+        ...                     periods=3, tz='Europe/Berlin')
 
         >>> dti
         DatetimeIndex(['2014-08-01 09:00:00+02:00',
@@ -1037,8 +1037,8 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
 
         Examples
         --------
-        >>> idx = pd.DatetimeIndex(start='2014-08-01 10:00', freq='H',
-        ...                        periods=3, tz='Asia/Calcutta')
+        >>> idx = pd.date_range(start='2014-08-01 10:00', freq='H',
+        ...                     periods=3, tz='Asia/Calcutta')
         >>> idx
         DatetimeIndex(['2014-08-01 10:00:00+05:30',
                        '2014-08-01 11:00:00+05:30',
@@ -1164,7 +1164,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
 
         Examples
         --------
-        >>> idx = pd.DatetimeIndex(start='2018-01', freq='M', periods=3)
+        >>> idx = pd.date_range(start='2018-01', freq='M', periods=3)
         >>> idx
         DatetimeIndex(['2018-01-31', '2018-02-28', '2018-03-31'],
                       dtype='datetime64[ns]', freq='M')
@@ -1200,7 +1200,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
 
         Examples
         --------
-        >>> idx = pd.DatetimeIndex(start='2018-01-01', freq='D', periods=3)
+        >>> idx = pd.date_range(start='2018-01-01', freq='D', periods=3)
         >>> idx
         DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03'],
                       dtype='datetime64[ns]', freq='D')

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4433,8 +4433,8 @@ class NDFrame(PandasObject, SelectionMixin):
               num_legs  num_wings
         dog          4          0
         hawk         2          2
-        >>> df.reindex_axis(['num_wings', 'num_legs', 'num_heads'],
-        ...                 axis='columns')
+        >>> df.reindex(['num_wings', 'num_legs', 'num_heads'],
+        ...            axis='columns')
               num_wings  num_legs  num_heads
         dog           0         4        NaN
         hawk          2         2        NaN
@@ -7352,7 +7352,7 @@ class NDFrame(PandasObject, SelectionMixin):
         4    5
         dtype: int64
 
-        >>> s.clip_upper(3)
+        >>> s.clip(upper=3)
         0    1
         1    2
         2    3
@@ -7360,11 +7360,11 @@ class NDFrame(PandasObject, SelectionMixin):
         4    3
         dtype: int64
 
-        >>> t = [5, 4, 3, 2, 1]
-        >>> t
+        >>> elemwise_thresholds = [5, 4, 3, 2, 1]
+        >>> elemwise_thresholds
         [5, 4, 3, 2, 1]
 
-        >>> s.clip_upper(t)
+        >>> s.clip(upper=elemwise_thresholds)
         0    1
         1    2
         2    3
@@ -7428,7 +7428,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Series single threshold clipping:
 
         >>> s = pd.Series([5, 6, 7, 8, 9])
-        >>> s.clip_lower(8)
+        >>> s.clip(lower=8)
         0    8
         1    8
         2    8
@@ -7440,7 +7440,7 @@ class NDFrame(PandasObject, SelectionMixin):
         should be the same length as the Series.
 
         >>> elemwise_thresholds = [4, 8, 7, 2, 5]
-        >>> s.clip_lower(elemwise_thresholds)
+        >>> s.clip(lower=elemwise_thresholds)
         0    5
         1    8
         2    7
@@ -7457,7 +7457,7 @@ class NDFrame(PandasObject, SelectionMixin):
         1  3  4
         2  5  6
 
-        >>> df.clip_lower(3)
+        >>> df.clip(lower=3)
            A  B
         0  3  3
         1  3  4
@@ -7466,7 +7466,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Or to an array of values. By default, `threshold` should be the same
         shape as the DataFrame.
 
-        >>> df.clip_lower(np.array([[3, 4], [2, 2], [6, 2]]))
+        >>> df.clip(lower=np.array([[3, 4], [2, 2], [6, 2]]))
            A  B
         0  3  4
         1  3  4
@@ -7476,13 +7476,13 @@ class NDFrame(PandasObject, SelectionMixin):
         `threshold` should be the same length as the axis specified by
         `axis`.
 
-        >>> df.clip_lower([3, 3, 5], axis='index')
+        >>> df.clip(lower=[3, 3, 5], axis='index')
            A  B
         0  3  3
         1  3  4
         2  5  6
 
-        >>> df.clip_lower([4, 5], axis='columns')
+        >>> df.clip(lower=[4, 5], axis='columns')
            A  B
         0  4  5
         1  4  5


### PR DESCRIPTION
- [x] closes #24525
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I have updated all the `FutureWarning`, let me know if `PerformanceWarning` and `DtypeWarning`  shown below also needs a fix.

```zsh
python scripts/validate_docstrings.py --errors GL06,GL07,GL09,SS04,PR03,PR05,EX04
scripts/validate_docstrings.py:764: PerformanceWarning: indexing past lexsort depth may impact performance.
  errs, wrns, examples_errs = get_validation_data(doc)
scripts/validate_docstrings.py:764: PerformanceWarning: indexing past lexsort depth may impact performance.
  errs, wrns, examples_errs = get_validation_data(doc)
scripts/validate_docstrings.py:524: DtypeWarning: Columns (0) have mixed types. Specify dtype option on import or set low_memory=False.
  runner.run(test, out=f.write)
```
