### PR TITLE
Make DTA/TDA/PA return NotImplemented on comparisons

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -19,7 +19,8 @@ from pandas.core.dtypes.common import (
     is_extension_type, is_float_dtype, is_int64_dtype, is_object_dtype,
     is_period_dtype, is_string_dtype, is_timedelta64_dtype, pandas_dtype)
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
-from pandas.core.dtypes.generic import ABCIndexClass, ABCPandasArray, ABCSeries
+from pandas.core.dtypes.generic import (
+    ABCDataFrame, ABCIndexClass, ABCPandasArray, ABCSeries)
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import ops
@@ -96,9 +97,8 @@ def _dt_array_cmp(cls, op):
     nat_result = True if opname == '__ne__' else False
 
     def wrapper(self, other):
-        # TODO: return NotImplemented for Series / Index and let pandas unbox
-        # Right now, returning NotImplemented for Index fails because we
-        # go into the index implementation, which may be a bug?
+        if isinstance(other, (ABCDataFrame, ABCSeries, ABCIndexClass)):
+            return NotImplemented
 
         other = lib.item_from_zerodim(other)
 

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -64,6 +64,9 @@ def _td_array_cmp(cls, op):
     nat_result = True if opname == '__ne__' else False
 
     def wrapper(self, other):
+        if isinstance(other, (ABCDataFrame, ABCSeries, ABCIndexClass)):
+            return NotImplemented
+
         if _is_convertible_to_td(other) or other is NaT:
             try:
                 other = Timedelta(other)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -109,7 +109,8 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
         Create a comparison method that dispatches to ``cls.values``.
         """
         def wrapper(self, other):
-            result = op(self._data, maybe_unwrap_index(other))
+            other = maybe_unwrap_index(other, unwrap_series=True)
+            result = op(self._data, other)
             return result
 
         wrapper.__doc__ = op.__doc__
@@ -655,7 +656,7 @@ def wrap_arithmetic_op(self, other, result):
     return result
 
 
-def maybe_unwrap_index(obj):
+def maybe_unwrap_index(obj, unwrap_series=False):
     """
     If operating against another Index object, we need to unwrap the underlying
     data before deferring to the DatetimeArray/TimedeltaArray/PeriodArray
@@ -664,6 +665,8 @@ def maybe_unwrap_index(obj):
     Parameters
     ----------
     obj : object
+    unwrap_series : bool
+        Whether to also unwrap Series objects.
 
     Returns
     -------
@@ -671,6 +674,8 @@ def maybe_unwrap_index(obj):
     """
     if isinstance(obj, ABCIndexClass):
         return obj._data
+    elif isinstance(obj, ABCSeries) and unwrap_series:
+        obj = obj._values
     return obj
 
 

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -152,7 +152,10 @@ class TestPeriodIndexComparisons(object):
 
         # TODO: Could parametrize over boxes for idx?
         idx = PeriodIndex(['2011', '2012', '2013', '2014'], freq='A')
-        with pytest.raises(IncompatibleFrequency, match=msg):
+        rev_msg = (r'Input has different freq=(M|2M|3M) from '
+                   r'PeriodArray\(freq=A-DEC\)')
+        idx_msg = rev_msg if box_with_array is tm.to_array else msg
+        with pytest.raises(IncompatibleFrequency, match=idx_msg):
             base <= idx
 
         # Different frequency
@@ -164,7 +167,10 @@ class TestPeriodIndexComparisons(object):
             Period('2011', freq='4M') >= base
 
         idx = PeriodIndex(['2011', '2012', '2013', '2014'], freq='4M')
-        with pytest.raises(IncompatibleFrequency, match=msg):
+        rev_msg = (r'Input has different freq=(M|2M|3M) from '
+                   r'PeriodArray\(freq=4M\)')
+        idx_msg = rev_msg if box_with_array is tm.to_array else msg
+        with pytest.raises(IncompatibleFrequency, match=idx_msg):
             base <= idx
 
     @pytest.mark.parametrize('freq', ['M', '2M', '3M'])


### PR DESCRIPTION
Before implementing a boilerplate decorator like in #24282, going through to standardize the affected behaviors.