### PR TITLE
CLN: remove redundant mac wheel-build code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -401,20 +401,6 @@ class DummyBuildSrc(Command):
 cmdclass.update({'clean': CleanCommand,
                  'build': build})
 
-try:
-    from wheel.bdist_wheel import bdist_wheel
-
-    class BdistWheel(bdist_wheel):
-        def get_tag(self):
-            tag = bdist_wheel.get_tag(self)
-            repl = 'macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64'
-            if tag[2] == 'macosx_10_6_intel':
-                tag = (tag[0], tag[1], repl)
-            return tag
-    cmdclass['bdist_wheel'] = BdistWheel
-except ImportError:
-    pass
-
 if cython:
     suffix = '.pyx'
     cmdclass['build_ext'] = CheckingBuildExt


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

this code is redundant for wheels built using https://github.com/MacPython/pandas-wheels, as the line https://github.com/matthew-brett/multibuild/blob/266d88fe1e474748cc8a3823dc3934bf55e76383/osx_utils.sh#L306 adds tags for 10.9 and 10.10.

Note: circleci fails as I forgot to turn it off on my fork, after it was turned off upstream