### PR TITLE
PERF: 10x speedup in Series/DataFrame construction for lists of ints

### DIFF
--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -41,7 +41,7 @@ def list_of_lists_with_none(arr):
 
 class SeriesConstructors(object):
 
-    param_names = ["data_fmt", "with_index"]
+    param_names = ["data_fmt", "with_index", "dtype"]
     params = [[no_change,
                list,
                list_of_str,
@@ -52,15 +52,19 @@ class SeriesConstructors(object):
                list_of_lists,
                list_of_tuples_with_none,
                list_of_lists_with_none],
-              [False, True]]
+              [False, True],
+              ['float', 'int']]
 
-    def setup(self, data_fmt, with_index):
+    def setup(self, data_fmt, with_index, dtype):
         N = 10**4
-        arr = np.random.randn(N)
+        if dtype == 'float':
+            arr = np.random.randn(N)
+        else:
+            arr = np.arange(N)
         self.data = data_fmt(arr)
         self.index = np.arange(N) if with_index else None
 
-    def time_series_constructor(self, data_fmt, with_index):
+    def time_series_constructor(self, data_fmt, with_index, dtype):
         Series(self.data, index=self.index)
 
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2011,7 +2011,8 @@ def maybe_convert_objects(ndarray[object] objects, bint try_float=0,
             floats[i] = <float64_t>val
             complexes[i] = <double complex>val
             if not seen.null_:
-                seen.saw_int(int(val))
+                val = int(val)
+                seen.saw_int(val)
 
                 if ((seen.uint_ and seen.sint_) or
                         val > oUINT64_MAX or val < oINT64_MIN):


### PR DESCRIPTION
This PR is a minor tweak to the `int64`/`uint64` overflow fix added in https://github.com/pandas-dev/pandas/pull/18624 

Simply casting to an `int` after doing a typecheck is sufficient for the compiler to generate a 10x speedup:
```
$ asv compare upstream/master HEAD --sort ratio -s

Benchmarks that have improved:

       before           after         ratio
     [f074abef]       [80641ddf]
     <series_list_int_speedup~1>       <series_list_int_speedup>
           failed          7.39±0s      n/a  strings.Dummies.time_get_dummies
-        61.7±3ms       11.7±0.5ms     0.19  ctors.SeriesConstructors.time_series_constructor(<function arr_dict>, True, 'int')
-        63.0±2ms       11.1±0.3ms     0.18  ctors.SeriesConstructors.time_series_constructor(<function arr_dict>, False, 'int')
-        55.8±2ms       5.37±0.2ms     0.10  ctors.SeriesConstructors.time_series_constructor(<class 'list'>, True, 'int')
-        55.3±5ms       4.84±0.2ms     0.09  ctors.SeriesConstructors.time_series_constructor(<class 'list'>, False, 'int')
```
This is how `maybe_convert_numeric()` already handles `int`s, so this just brings `maybe_convert_object()` back into alignment.

I believe this would yield a similar speedup for `DataFrame`s but we don't have any benchmarks explicitly testing as such. However, the `get_dummies()` benchmark involves expanding to a `DataFrame` and gets a speedup of similar magnitude (not visible as it previously would time out after 30s).

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
