### PR TITLE
REF: io/formats/html.py (and io/formats/format.py)

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -732,9 +732,7 @@ class DataFrameFormatter(TableFormatter):
          """
         from pandas.io.formats.html import HTMLFormatter, NotebookFormatter
         Klass = NotebookFormatter if notebook else HTMLFormatter
-        html = Klass(
-            self, classes=classes, border=border, table_id=self.table_id,
-            render_links=self.render_links).render()
+        html = Klass(self, classes=classes, border=border).render()
         if hasattr(self.buf, 'write'):
             buffer_put_lines(self.buf, html)
         elif isinstance(self.buf, compat.string_types):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -732,14 +732,14 @@ class DataFrameFormatter(TableFormatter):
          """
         from pandas.io.formats.html import HTMLFormatter, NotebookFormatter
         Klass = NotebookFormatter if notebook else HTMLFormatter
-        html_renderer = Klass(
+        html = Klass(
             self, classes=classes, border=border, table_id=self.table_id,
-            render_links=self.render_links)
+            render_links=self.render_links).render()
         if hasattr(self.buf, 'write'):
-            html_renderer.write_result(self.buf)
+            buffer_put_lines(self.buf, html)
         elif isinstance(self.buf, compat.string_types):
             with open(self.buf, 'w') as f:
-                html_renderer.write_result(f)
+                buffer_put_lines(f, html)
         else:
             raise TypeError('buf is not a file name and it has no write '
                             ' method')

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -730,10 +730,11 @@ class DataFrameFormatter(TableFormatter):
 
             .. versionadded:: 0.19.0
          """
-        from pandas.io.formats.html import HTMLFormatter
-        html_renderer = HTMLFormatter(self, classes=classes, notebook=notebook,
-                                      border=border, table_id=self.table_id,
-                                      render_links=self.render_links)
+        from pandas.io.formats.html import HTMLFormatter, NotebookFormatter
+        Klass = NotebookFormatter if notebook else HTMLFormatter
+        html_renderer = Klass(
+            self, classes=classes, border=border, table_id=self.table_id,
+            render_links=self.render_links)
         if hasattr(self.buf, 'write'):
             html_renderer.write_result(self.buf)
         elif isinstance(self.buf, compat.string_types):

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -513,6 +513,6 @@ class NotebookFormatter(HTMLFormatter):
     def render(self):
         self.write('<div>')
         self.write_style()
-        super(HTMLFormatter, self).render()
+        super(NotebookFormatter, self).render()
         self.write('</div>')
         return self.elements

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -513,6 +513,6 @@ class NotebookFormatter(HTMLFormatter):
     def render(self):
         self.write('<div>')
         self.write_style()
-        super().render()
+        super(HTMLFormatter, self).render()
         self.write('</div>')
         return self.elements

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -16,8 +16,7 @@ import pandas.core.common as com
 from pandas.core.config import get_option
 
 from pandas.io.common import _is_url
-from pandas.io.formats.format import (
-    TableFormatter, buffer_put_lines, get_level_lengths)
+from pandas.io.formats.format import TableFormatter, get_level_lengths
 from pandas.io.formats.printing import pprint_thing
 
 
@@ -136,7 +135,7 @@ class HTMLFormatter(TableFormatter):
         indent -= indent_delta
         self.write('</tr>', indent)
 
-    def write_result(self, buf):
+    def render(self):
         self._write_table()
 
         if self.should_show_dimensions:
@@ -146,7 +145,7 @@ class HTMLFormatter(TableFormatter):
                                by=by,
                                cols=len(self.frame.columns)))
 
-        buffer_put_lines(buf, self.elements)
+        return self.elements
 
     def _write_table(self, indent=0):
         _classes = ['dataframe']  # Default class.
@@ -512,10 +511,9 @@ class NotebookFormatter(HTMLFormatter):
                                      template_last)))
         self.write(template)
 
-    def write_result(self, buf):
+    def render(self):
         self.write('<div>')
         self.write_style()
-        super().write_result(buf)
+        super().render()
         self.write('</div>')
-
-        buffer_put_lines(buf, self.elements)
+        return self.elements

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -24,8 +24,7 @@ class HTMLFormatter(TableFormatter):
 
     indent_delta = 2
 
-    def __init__(self, formatter, classes=None, border=None,
-                 table_id=None, render_links=False):
+    def __init__(self, formatter, classes=None, border=None):
         self.fmt = formatter
         self.classes = classes
 
@@ -38,8 +37,8 @@ class HTMLFormatter(TableFormatter):
         if border is None:
             border = get_option('display.html.border')
         self.border = border
-        self.table_id = table_id
-        self.render_links = render_links
+        self.table_id = self.fmt.table_id
+        self.render_links = self.fmt.render_links
 
     @property
     def show_row_idx_names(self):

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -21,6 +21,14 @@ from pandas.io.formats.printing import pprint_thing
 
 
 class HTMLFormatter(TableFormatter):
+    """
+    Internal class for formatting output data in html.
+    This class is intended for shared functionality between
+    DataFrame.to_html() and DataFrame._repr_html_().
+    Any logic in common with other output formatting methods
+    should ideally be inherited from classes in format.py
+    and this class responsible for only producing html markup.
+    """
 
     indent_delta = 2
 
@@ -472,6 +480,11 @@ class HTMLFormatter(TableFormatter):
 
 
 class NotebookFormatter(HTMLFormatter):
+    """
+    Internal class for formatting output data in html for display in Jupyter
+    Notebooks. This class is intended for functionality specific to
+    DataFrame._repr_html_() and DataFrame.to_html(notebook=True)
+    """
 
     def write_style(self):
         # We use the "scoped" attribute here so that the desired


### PR DESCRIPTION
- [ n/a] follow-on #24637
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ n/a] whatsnew entry

this refactor further limits responsibilities of functions/module and should allow a simpler implementation for fixes of #17004, #9690 etc.