### PR TITLE
BUG: DataFrame/Series.tz_convert does not modifies original data with copy=False

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1596,6 +1596,7 @@ Timezones
 - Bug in :func:`to_datetime` where ``utc=True`` was not respected when passing a :class:`Timestamp` (:issue:`24415`)
 - Bug in :meth:`DataFrame.any` returns wrong value when ``axis=1`` and the data is of datetimelike type (:issue:`23070`)
 - Bug in :meth:`DatetimeIndex.to_period` where a timezone aware index was converted to UTC first before creating :class:`PeriodIndex` (:issue:`22905`)
+- Bug in :meth:`DataFrame.tz_localize`, :meth:`DataFrame.tz_convert`, :meth:`Series.tz_localize`, and :meth:`Series.tz_convert` where ``copy=False`` would mutate the original argument inplace (:issue:`6326`)
 
 Offsets
 ^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9224,9 +9224,8 @@ class NDFrame(PandasObject, SelectionMixin):
             if level not in (None, 0, ax.name):
                 raise ValueError("The level {0} is not valid".format(level))
             ax = _tz_convert(ax, tz)
-
         result = self._constructor(self._data, copy=copy)
-        result.set_axis(ax, axis=axis, inplace=True)
+        result = result.set_axis(ax, axis=axis, inplace=False)
         return result.__finalize__(self)
 
     def tz_localize(self, tz, axis=0, level=None, copy=True,
@@ -9390,7 +9389,7 @@ class NDFrame(PandasObject, SelectionMixin):
             ax = _tz_localize(ax, tz, ambiguous, nonexistent)
 
         result = self._constructor(self._data, copy=copy)
-        result.set_axis(ax, axis=axis, inplace=True)
+        result = result.set_axis(ax, axis=axis, inplace=False)
         return result.__finalize__(self)
 
     # ----------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9224,6 +9224,7 @@ class NDFrame(PandasObject, SelectionMixin):
             if level not in (None, 0, ax.name):
                 raise ValueError("The level {0} is not valid".format(level))
             ax = _tz_convert(ax, tz)
+
         result = self._constructor(self._data, copy=copy)
         result = result.set_axis(ax, axis=axis, inplace=False)
         return result.__finalize__(self)

--- a/pandas/tests/frame/test_timezones.py
+++ b/pandas/tests/frame/test_timezones.py
@@ -180,3 +180,19 @@ class TestDataFrameTimezones(object):
         result = df.T == df.T
         expected = DataFrame(True, index=list('ab'), columns=idx)
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize('copy', [True, False])
+    @pytest.mark.parametrize('method, tz', [
+        ['tz_localize', None],
+        ['tz_convert', 'Europe/Berlin']
+    ])
+    def test_tz_localize_convert_copy_inplace_mutate(self, copy, method, tz):
+        # GH 6326
+        result = DataFrame(np.arange(0, 5),
+                           index=date_range('20131027', periods=5,
+                                            freq='1H', tz=tz))
+        getattr(result, method)('UTC', copy=copy)
+        expected = DataFrame(np.arange(0, 5),
+                             index=date_range('20131027', periods=5,
+                                              freq='1H', tz=tz))
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/series/test_timezones.py
+++ b/pandas/tests/series/test_timezones.py
@@ -348,3 +348,19 @@ class TestSeriesTimezones(object):
         result = s.truncate(datetime(2005, 4, 2), datetime(2005, 4, 4))
         expected = Series([1, 2, 3], index=idx[1:4])
         tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize('copy', [True, False])
+    @pytest.mark.parametrize('method, tz', [
+        ['tz_localize', None],
+        ['tz_convert', 'Europe/Berlin']
+    ])
+    def test_tz_localize_convert_copy_inplace_mutate(self, copy, method, tz):
+        # GH 6326
+        result = Series(np.arange(0, 5),
+                        index=date_range('20131027', periods=5, freq='1H',
+                                         tz=tz))
+        getattr(result, method)('UTC', copy=copy)
+        expected = Series(np.arange(0, 5),
+                          index=date_range('20131027', periods=5, freq='1H',
+                                           tz=tz))
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #6326
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This also impacted `tz_localize` as well. Non blocking for 0.24
