### PR TITLE
BLD: Include tslibs src

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -491,7 +491,7 @@ def srcpath(name=None, suffix='.pyx', subdir='src'):
 
 
 common_include = ['pandas/_libs/src/klib', 'pandas/_libs/src']
-ts_include = ['pandas/_libs/tslibs/src']
+ts_include = ['pandas/_libs/tslibs/src', 'pandas/_libs/tslibs']
 
 
 lib_depends = ['pandas/_libs/src/parse_helper.h',


### PR DESCRIPTION
Fixes the pip build in pandas-dev/pandas-ci. This worked for me locally in an env setup with https://github.com/pandas-dev/pandas-release. 

Closes https://github.com/pandas-dev/pandas/issues/22192