### PR TITLE
DOC: Removed duplicate doc line

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6217,8 +6217,6 @@ class DataFrame(NDFrame):
     array, e.g., ``numpy.mean(arr_2d)`` as opposed to ``numpy.mean(arr_2d,
     axis=0)``.
 
-    `agg` is an alias for `aggregate`. Use the alias.
-
     See Also
     --------
     DataFrame.apply : Perform any type of operations.


### PR DESCRIPTION
This line of documentation is already included in the parent shared docs. So the line appears twice. See the screenshot below from [the Dataframe.aggregate page](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.aggregate.html). My patch cleans that up.

![screenshot from 2019-01-07 17-00-12](https://user-images.githubusercontent.com/9993/50803035-ca04fa00-129d-11e9-8078-a0a3d9a55400.png)
