### PR TITLE
DOC: Fixes to the whatsnew structure

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -164,5 +164,5 @@ See the package overview for more detail about what's in the library.
     developer
     internals
     extending
-    releases
+    whatsnew/index
     {% endif -%}

--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -16,7 +16,7 @@ Version 0.24
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.24.0
+   v0.24.0
 
 Version 0.23
 ------------
@@ -24,11 +24,11 @@ Version 0.23
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.23.4
-   whatsnew/v0.23.3
-   whatsnew/v0.23.2
-   whatsnew/v0.23.1
-   whatsnew/v0.23.0
+   v0.23.4
+   v0.23.3
+   v0.23.2
+   v0.23.1
+   v0.23.0
 
 Version 0.22
 ------------
@@ -36,7 +36,7 @@ Version 0.22
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.22.0
+   v0.22.0
 
 Version 0.21
 ------------
@@ -44,8 +44,8 @@ Version 0.21
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.21.0
-   whatsnew/v0.21.1
+   v0.21.1
+   v0.21.0
 
 Version 0.20
 ------------
@@ -53,9 +53,9 @@ Version 0.20
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.20.0
-   whatsnew/v0.20.2
-   whatsnew/v0.20.3
+   v0.20.3
+   v0.20.2
+   v0.20.0
 
 Version 0.19
 ------------
@@ -63,9 +63,9 @@ Version 0.19
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.19.0
-   whatsnew/v0.19.1
-   whatsnew/v0.19.2
+   v0.19.2
+   v0.19.1
+   v0.19.0
 
 Version 0.18
 ------------
@@ -73,8 +73,8 @@ Version 0.18
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.18.0
-   whatsnew/v0.18.1
+   v0.18.1
+   v0.18.0
 
 Version 0.17
 ------------
@@ -82,8 +82,8 @@ Version 0.17
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.17.0
-   whatsnew/v0.17.1
+   v0.17.1
+   v0.17.0
 
 Version 0.16
 ------------
@@ -91,9 +91,9 @@ Version 0.16
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.16.0
-   whatsnew/v0.16.1
-   whatsnew/v0.16.2
+   v0.16.2
+   v0.16.1
+   v0.16.0
 
 Version 0.15
 ------------
@@ -101,9 +101,9 @@ Version 0.15
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.15.0
-   whatsnew/v0.15.1
-   whatsnew/v0.15.2
+   v0.15.2
+   v0.15.1
+   v0.15.0
 
 Version 0.14
 ------------
@@ -111,8 +111,8 @@ Version 0.14
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.14.0
-   whatsnew/v0.14.1
+   v0.14.1
+   v0.14.0
 
 Version 0.13
 ------------
@@ -120,8 +120,8 @@ Version 0.13
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.13.0
-   whatsnew/v0.13.1
+   v0.13.1
+   v0.13.0
 
 Version 0.12
 ------------
@@ -129,7 +129,7 @@ Version 0.12
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.12.0
+   v0.12.0
 
 Version 0.11
 ------------
@@ -137,7 +137,7 @@ Version 0.11
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.11.0
+   v0.11.0
 
 Version 0.10
 ------------
@@ -145,8 +145,8 @@ Version 0.10
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.10.0
-   whatsnew/v0.10.1
+   v0.10.1
+   v0.10.0
 
 Version 0.9
 -----------
@@ -154,8 +154,8 @@ Version 0.9
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.9.0
-   whatsnew/v0.9.1
+   v0.9.1
+   v0.9.0
 
 Version 0.8
 ------------
@@ -163,8 +163,8 @@ Version 0.8
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.8.0
-   whatsnew/v0.8.1
+   v0.8.1
+   v0.8.0
 
 Version 0.7
 -----------
@@ -172,10 +172,10 @@ Version 0.7
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.7.0
-   whatsnew/v0.7.1
-   whatsnew/v0.7.2
-   whatsnew/v0.7.3
+   v0.7.3
+   v0.7.2
+   v0.7.1
+   v0.7.0
 
 Version 0.6
 -----------
@@ -183,9 +183,8 @@ Version 0.6
 .. toctree::
    :maxdepth: 2
 
-
-   whatsnew/v0.6.0
-   whatsnew/v0.6.1
+   v0.6.1
+   v0.6.0
 
 Version 0.5
 -----------
@@ -193,8 +192,7 @@ Version 0.5
 .. toctree::
    :maxdepth: 2
 
-
-   whatsnew/v0.5.0
+   v0.5.0
 
 Version 0.4
 -----------
@@ -202,4 +200,4 @@ Version 0.4
 .. toctree::
    :maxdepth: 2
 
-   whatsnew/v0.4.x
+   v0.4.x

--- a/doc/source/whatsnew/v0.4.x.rst
+++ b/doc/source/whatsnew/v0.4.x.rst
@@ -1,6 +1,6 @@
 .. _whatsnew_04x:
 
-v.0.4.3 through v0.4.1 (September 25 - October 9, 2011)
+v.0.4.1 through v0.4.3 (September 25 - October 9, 2011)
 -------------------------------------------------------
 
 {{ header }}


### PR DESCRIPTION
- [X] xref #24499
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Changes in this PR:
- Moving `releases.rst` to `whatsnew/index.rst`, which is more consistent with the new structure of the documentation
- Sorting the `whatsnew/index` from the newest to the oldest (was from newest to oldest for the major version, but inside them, the minor versions were sorted from oldest to newest, except for 0.23).

CC: @TomAugspurger 
