### PR TITLE
BUG: Fix segfault in Categorical.set_categories

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1501,6 +1501,7 @@ Categorical
 - Bug in :meth:`Series.where` losing the categorical dtype for categorical data (:issue:`24077`)
 - Bug in :meth:`Categorical.apply` where ``NaN`` values could be handled unpredictably. They now remain unchanged (:issue:`24241`)
 - Bug in :class:`Categorical` comparison methods incorrectly raising ``ValueError`` when operating against a :class:`DataFrame` (:issue:`24630`)
+- Bug in :meth:`Categorical.set_categories` where setting fewer new categories with ``rename=True`` caused a segmentation fault (:issue:`24675`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -852,9 +852,9 @@ class Categorical(ExtensionArray, PandasObject):
             if (cat.dtype.categories is not None and
                     len(new_dtype.categories) < len(cat.dtype.categories)):
                 # remove all _codes which are larger and set to -1/NaN
-                self._codes[self._codes >= len(new_dtype.categories)] = -1
+                cat._codes[cat._codes >= len(new_dtype.categories)] = -1
         else:
-            codes = _recode_for_categories(self.codes, self.categories,
+            codes = _recode_for_categories(cat.codes, cat.categories,
                                            new_dtype.categories)
             cat._codes = codes
         cat._dtype = new_dtype

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -310,6 +310,13 @@ class TestCategoricalAPI(object):
         result = c.set_categories(new_categories, ordered=ordered)
         tm.assert_categorical_equal(result, expected)
 
+    def test_set_categories_rename_less(self):
+        # GH 24675
+        cat = Categorical(['A', 'B'])
+        result = cat.set_categories(['A'], rename=True)
+        expected = Categorical(['A', np.nan])
+        tm.assert_categorical_equal(result, expected)
+
     def test_set_categories_private(self):
         cat = Categorical(['a', 'b', 'c'], categories=['a', 'b', 'c', 'd'])
         cat._set_categories(['a', 'c', 'd', 'e'])


### PR DESCRIPTION
- [X] closes #24675
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

---

The fix basically amounts to changing `self._codes` --> `cat._codes` in the code block below:
https://github.com/pandas-dev/pandas/blob/caf462c2a7699daf4b149d49f5aeaff822700113/pandas/core/arrays/categorical.py#L850-L855

Since the new object is being referred to as `cat` instead of `self`, the existing version didn't actually change the `_codes` of the resulting object.  The segfault would occur when try to view the resulting `Categorical`, as you'd have `take_1d` trying to take out of bounds `_codes` here:

https://github.com/pandas-dev/pandas/blob/caf462c2a7699daf4b149d49f5aeaff822700113/pandas/core/arrays/categorical.py#L1297

