### PR TITLE
remove unused kwarg

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -599,6 +599,7 @@ class Block(PandasObject):
                 return self.copy()
             return self
 
+        klass = None
         if is_sparse(self.values):
             # special case sparse, Series[Sparse].astype(object) is sparse
             klass = ExtensionBlock

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -534,7 +534,7 @@ class Block(PandasObject):
                             **kwargs)
 
     def _astype(self, dtype, copy=False, errors='raise', values=None,
-                klass=None, **kwargs):
+                **kwargs):
         """Coerce to the new type
 
         Parameters
@@ -599,14 +599,13 @@ class Block(PandasObject):
                 return self.copy()
             return self
 
-        if klass is None:
-            if is_sparse(self.values):
-                # special case sparse, Series[Sparse].astype(object) is sparse
-                klass = ExtensionBlock
-            elif is_object_dtype(dtype):
-                klass = ObjectBlock
-            elif is_extension_array_dtype(dtype):
-                klass = ExtensionBlock
+        if is_sparse(self.values):
+            # special case sparse, Series[Sparse].astype(object) is sparse
+            klass = ExtensionBlock
+        elif is_object_dtype(dtype):
+            klass = ObjectBlock
+        elif is_extension_array_dtype(dtype):
+            klass = ExtensionBlock
 
         try:
             # force the copy here


### PR DESCRIPTION
AFAICT `klass` is never passed to `astype`, so the kwarg can be removed.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
