### PR TITLE
Revert handling of i8values to DatetimeIndex

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1352,6 +1352,53 @@ the object's ``freq`` attribute (:issue:`21939`, :issue:`23878`).
     dti + pd.Index([1 * dti.freq, 2 * dti.freq])
 
 
+.. _whatsnew_0240.deprecations.integer_tz:
+
+Passing Integer data and a timezone to DatetimeIndex
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The behavior of :class:`DatetimeIndex` when passed integer data and
+a timezone is changing in a future version of pandas. Previously, these
+were interpreted as wall times in the desired timezone. In the future,
+these will be interpreted as wall times in UTC, which are then converted
+to the desired timezone (:issue:`24559`).
+
+The default behavior remains the same, but issues a warning:
+
+.. code-block:: ipython
+
+   In [3]: pd.DatetimeIndex([946684800000000000], tz="US/Central")
+   /bin/ipython:1: FutureWarning:
+       Passing integer-dtype data and a timezone to DatetimeIndex.
+       Integer values will be interpreted differently in a future version
+       of pandas. Previously, these were viewed as datetime64[ns] values
+       representing the wall time *in the specified timezone*.
+       In the future, these will be viewed as datetime64[ns] values
+       representing the wall time *in UTC*. This is similar to a
+       nanosecond-precision UNIX epoch.
+       To accept the future behavior, use
+
+           pd.to_datetime(integer_data, utc=True).tz_convert(tz)
+
+       To keep the previous behavior, use
+
+       pd.to_datetime(integer_data).tz_localize(tz)
+
+      #!/bin/python3
+    Out[3]: DatetimeIndex(['2000-01-01 00:00:00-06:00'], dtype='datetime64[ns, US/Central]', freq=None)
+
+As the warning message explains, opt in to the future behavior with
+
+.. ipython:: python
+
+   pd.to_datetime([946684800000000000], utc=True).tz_convert('US/Central')
+
+And the old behavior can be retained with
+
+.. ipython:: python
+
+   pd.to_datetime([946684800000000000]).tz_localize('US/Central')
+
 .. _whatsnew_0240.deprecations.tz_aware_array:
 
 Converting Timezone-Aware Series and Index to NumPy Arrays

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1369,31 +1369,30 @@ The default behavior remains the same, but issues a warning:
 
    In [3]: pd.DatetimeIndex([946684800000000000], tz="US/Central")
    /bin/ipython:1: FutureWarning:
-       Passing integer-dtype data and a timezone to DatetimeIndex.
-       Integer values will be interpreted differently in a future version
-       of pandas. Previously, these were viewed as datetime64[ns] values
-       representing the wall time *in the specified timezone*.
-       In the future, these will be viewed as datetime64[ns] values
-       representing the wall time *in UTC*. This is similar to a
-       nanosecond-precision UNIX epoch.
-       To accept the future behavior, use
+       Passing integer-dtype data and a timezone to DatetimeIndex. Integer values
+       will be interpreted differently in a future version of pandas. Previously,
+       these were viewed as datetime64[ns] values representing the wall time
+       *in the specified timezone*. In the future, these will be viewed as
+       datetime64[ns] values representing the wall time *in UTC*. This is similar
+       to a nanosecond-precision UNIX epoch. To accept the future behavior, use
 
            pd.to_datetime(integer_data, utc=True).tz_convert(tz)
 
        To keep the previous behavior, use
 
-       pd.to_datetime(integer_data).tz_localize(tz)
+           pd.to_datetime(integer_data).tz_localize(tz)
 
-      #!/bin/python3
+    #!/bin/python3
     Out[3]: DatetimeIndex(['2000-01-01 00:00:00-06:00'], dtype='datetime64[ns, US/Central]', freq=None)
 
-As the warning message explains, opt in to the future behavior with
+As the warning message explains, opt in to the future behavior by specifying that
+the integer values are UTC, and then converting to the final timezone:
 
 .. ipython:: python
 
    pd.to_datetime([946684800000000000], utc=True).tz_convert('US/Central')
 
-And the old behavior can be retained with
+The old behavior can be retained with by localizing directly to the final timezone:
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1235,7 +1235,6 @@ Datetimelike API Changes
 - :class:`PeriodIndex` subtraction of another ``PeriodIndex`` will now return an object-dtype :class:`Index` of :class:`DateOffset` objects instead of raising a ``TypeError`` (:issue:`20049`)
 - :func:`cut` and :func:`qcut` now returns a :class:`DatetimeIndex` or :class:`TimedeltaIndex` bins when the input is datetime or timedelta dtype respectively and ``retbins=True`` (:issue:`19891`)
 - :meth:`DatetimeIndex.to_period` and :meth:`Timestamp.to_period` will issue a warning when timezone information will be lost (:issue:`21333`)
-- :class:`DatetimeIndex` now accepts :class:`Int64Index` arguments as epoch timestamps (:issue:`20997`)
 - :meth:`PeriodIndex.tz_convert` and :meth:`PeriodIndex.tz_localize` have been removed (:issue:`21781`)
 
 .. _whatsnew_0240.api.other:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1707,6 +1707,7 @@ def sequence_to_dt64ns(data, dtype=None, copy=False,
             data, inferred_tz = objects_to_datetime64ns(
                 data, dayfirst=dayfirst, yearfirst=yearfirst)
             tz = maybe_infer_tz(tz, inferred_tz)
+            int_as_wall_time = False
 
     # `data` may have originally been a Categorical[datetime64[ns, tz]],
     # so we need to handle these types.

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -33,6 +33,7 @@ from pandas.tseries.frequencies import get_period_alias, to_offset
 from pandas.tseries.offsets import Day, Tick
 
 _midnight = time(0, 0)
+# TODO(GH-24559): Remove warning, int_as_wall_time parameter.
 _i8_message = """
     Passing integer-dtype data and a timezone to DatetimeIndex. Integer values
     will be interpreted differently in a future version of pandas. Previously,
@@ -1681,8 +1682,10 @@ def sequence_to_dt64ns(data, dtype=None, copy=False,
     int_as_wall_time : bool, default False
         Whether to treat ints as wall time in specified timezone, or as
         nanosecond-precision UNIX epoch (wall time in UTC).
-        This is used in DatetimeIndex.__init__ to deprecated the wall-time
+        This is used in DatetimeIndex.__init__ to deprecate the wall-time
         behaviour.
+
+        ..versionadded:: 0.24.0
 
     Returns
     -------

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1650,7 +1650,6 @@ DatetimeArray._add_comparison_ops()
 # -------------------------------------------------------------------
 # Constructor Helpers
 
-
 def sequence_to_dt64ns(data, dtype=None, copy=False,
                        tz=None,
                        dayfirst=False, yearfirst=False, ambiguous='raise',
@@ -1666,6 +1665,11 @@ def sequence_to_dt64ns(data, dtype=None, copy=False,
     yearfirst : bool, default False
     ambiguous : str, bool, or arraylike, default 'raise'
         See pandas._libs.tslibs.conversion.tz_localize_to_utc
+    int_as_wall_time : bool, default False
+        Whether to treat ints as wall time in specified timezone, or as
+        nanosecond-precision UNIX epoch (wall time in UTC).
+        This is used in DatetimeIndex.__init__ to deprecated the wall-time
+        behaviour.
 
     Returns
     -------
@@ -1680,6 +1684,7 @@ def sequence_to_dt64ns(data, dtype=None, copy=False,
     ------
     TypeError : PeriodDType data is passed
     """
+
     inferred_freq = None
 
     dtype = _validate_dt64_dtype(dtype)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -34,14 +34,12 @@ from pandas.tseries.offsets import Day, Tick
 
 _midnight = time(0, 0)
 _i8_message = """
-    Passing integer-dtype data and a timezone to DatetimeIndex.
-    Integer values will be interpreted differently in a future version
-    of pandas. Previously, these were viewed as datetime64[ns] values
-    representing the wall time *in the specified timezone*.
-    In the future, these will be viewed as datetime64[ns] values
-    representing the wall time *in UTC*. This is similar to a
-    nanosecond-precision UNIX epoch.
-    To accept the future behavior, use
+    Passing integer-dtype data and a timezone to DatetimeIndex. Integer values
+    will be interpreted differently in a future version of pandas. Previously,
+    these were viewed as datetime64[ns] values representing the wall time
+    *in the specified timezone*. In the future, these will be viewed as
+    datetime64[ns] values representing the wall time *in UTC*. This is similar
+    to a nanosecond-precision UNIX epoch. To accept the future behavior, use
 
         pd.to_datetime(integer_data, utc=True).tz_convert(tz)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -734,6 +734,7 @@ class Index(IndexOpsMixin, PandasObject):
             return CategoricalIndex(self.values, name=self.name, dtype=dtype,
                                     copy=copy)
         elif is_datetime64tz_dtype(dtype):
+            # TODO(GH-24559): Remove this block, use the following elif.
             # avoid FutureWarning from DatetimeIndex constructor.
             from pandas import DatetimeIndex
             tz = pandas_dtype(dtype).tz

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -22,7 +22,8 @@ from pandas.core.dtypes.common import (
     is_dtype_union_equal, is_extension_array_dtype, is_float, is_float_dtype,
     is_hashable, is_integer, is_integer_dtype, is_interval_dtype, is_iterator,
     is_list_like, is_object_dtype, is_period_dtype, is_scalar,
-    is_signed_integer_dtype, is_timedelta64_dtype, is_unsigned_integer_dtype)
+    is_signed_integer_dtype, is_timedelta64_dtype, is_unsigned_integer_dtype,
+    pandas_dtype)
 import pandas.core.dtypes.concat as _concat
 from pandas.core.dtypes.generic import (
     ABCDataFrame, ABCDateOffset, ABCDatetimeArray, ABCIndexClass,
@@ -732,6 +733,12 @@ class Index(IndexOpsMixin, PandasObject):
             from .category import CategoricalIndex
             return CategoricalIndex(self.values, name=self.name, dtype=dtype,
                                     copy=copy)
+        elif is_datetime64tz_dtype(dtype):
+            # avoid FutureWarning from DatetimeIndex constructor.
+            from pandas import DatetimeIndex
+            tz = pandas_dtype(dtype).tz
+            return (DatetimeIndex(np.asarray(self))
+                    .tz_localize("UTC").tz_convert(tz))
 
         elif is_extension_array_dtype(dtype):
             return Index(np.asarray(self), dtype=dtype, copy=copy)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -299,7 +299,8 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
 
         dtarr = DatetimeArray._from_sequence(
             data, dtype=dtype, copy=copy, tz=tz, freq=freq,
-            dayfirst=dayfirst, yearfirst=yearfirst, ambiguous=ambiguous)
+            dayfirst=dayfirst, yearfirst=yearfirst, ambiguous=ambiguous,
+            int_as_wall_time=True)
 
         subarr = cls._simple_new(dtarr, name=name,
                                  freq=dtarr.freq, tz=dtarr.tz)

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -449,7 +449,10 @@ def _convert_bin_to_datelike_type(bins, dtype):
     bins : Array-like of bins, DatetimeIndex or TimedeltaIndex if dtype is
            datelike
     """
-    if is_datetime64tz_dtype(dtype) or is_datetime_or_timedelta_dtype(dtype):
+    if is_datetime64tz_dtype(dtype):
+        bins = to_datetime(bins.astype(np.int64),
+                           utc=True).tz_convert(dtype.tz)
+    elif is_datetime_or_timedelta_dtype(dtype):
         bins = Index(bins.astype(np.int64), dtype=dtype)
     return bins
 

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -209,8 +209,8 @@ def test_is_datetime64tz_dtype():
     assert not com.is_datetime64tz_dtype(object)
     assert not com.is_datetime64tz_dtype([1, 2, 3])
     assert not com.is_datetime64tz_dtype(pd.DatetimeIndex([1, 2, 3]))
-    assert com.is_datetime64tz_dtype(pd.DatetimeIndex(
-        [1, 2, 3], tz="US/Eastern"))
+    assert com.is_datetime64tz_dtype(pd.DatetimeIndex(['2000'],
+                                                      tz="US/Eastern"))
 
 
 def test_is_timedelta64_dtype():
@@ -286,7 +286,7 @@ def test_is_datetimelike():
     assert com.is_datetimelike(pd.PeriodIndex([], freq="A"))
     assert com.is_datetimelike(np.array([], dtype=np.datetime64))
     assert com.is_datetimelike(pd.Series([], dtype="timedelta64[ns]"))
-    assert com.is_datetimelike(pd.DatetimeIndex([1, 2, 3], tz="US/Eastern"))
+    assert com.is_datetimelike(pd.DatetimeIndex(["2000"], tz="US/Eastern"))
 
     dtype = DatetimeTZDtype("ns", tz="US/Eastern")
     s = pd.Series([], dtype=dtype)
@@ -480,7 +480,7 @@ def test_needs_i8_conversion():
     assert com.needs_i8_conversion(np.datetime64)
     assert com.needs_i8_conversion(pd.Series([], dtype="timedelta64[ns]"))
     assert com.needs_i8_conversion(pd.DatetimeIndex(
-        [1, 2, 3], tz="US/Eastern"))
+        ["2000"], tz="US/Eastern"))
 
 
 def test_is_numeric_dtype():
@@ -541,7 +541,7 @@ def test_is_extension_type(check_scipy):
     assert com.is_extension_type(pd.Series(cat))
     assert com.is_extension_type(pd.SparseArray([1, 2, 3]))
     assert com.is_extension_type(pd.SparseSeries([1, 2, 3]))
-    assert com.is_extension_type(pd.DatetimeIndex([1, 2, 3], tz="US/Eastern"))
+    assert com.is_extension_type(pd.DatetimeIndex(['2000'], tz="US/Eastern"))
 
     dtype = DatetimeTZDtype("ns", tz="US/Eastern")
     s = pd.Series([], dtype=dtype)
@@ -635,8 +635,8 @@ def test__get_dtype_fails(input_param):
     (pd.DatetimeIndex([1, 2]), np.datetime64),
     (pd.DatetimeIndex([1, 2]).dtype, np.datetime64),
     ('<M8[ns]', np.datetime64),
-    (pd.DatetimeIndex([1, 2], tz='Europe/London'), pd.Timestamp),
-    (pd.DatetimeIndex([1, 2], tz='Europe/London').dtype,
+    (pd.DatetimeIndex(['2000'], tz='Europe/London'), pd.Timestamp),
+    (pd.DatetimeIndex(['2000'], tz='Europe/London').dtype,
      pd.Timestamp),
     ('datetime64[ns, Europe/London]', pd.Timestamp),
     (pd.SparseSeries([1, 2], dtype='int32'), np.int32),

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -183,6 +183,7 @@ class TestDataFrame(Generic):
                   'StringIndex', 'UnicodeIndex',
                   'DateIndex', 'PeriodIndex',
                   'CategoricalIndex', 'TimedeltaIndex'])
+    @pytest.mark.filterwarnings("ignore")  # TODO: Remove. GH-24716
     def test_to_xarray_index_types(self, index):
         from xarray import Dataset
 
@@ -221,6 +222,7 @@ class TestDataFrame(Generic):
                            check_index_type=False, check_categorical=False)
 
     @td.skip_if_no('xarray', min_version='0.7.0')
+    @pytest.mark.filterwarnings("ignore")  # TODO: Remove. GH-24716
     def test_to_xarray(self):
         from xarray import Dataset
 

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -183,7 +183,6 @@ class TestDataFrame(Generic):
                   'StringIndex', 'UnicodeIndex',
                   'DateIndex', 'PeriodIndex',
                   'CategoricalIndex', 'TimedeltaIndex'])
-    @pytest.mark.filterwarnings("ignore")  # TODO: Remove. GH-24716
     def test_to_xarray_index_types(self, index):
         from xarray import Dataset
 
@@ -222,7 +221,6 @@ class TestDataFrame(Generic):
                            check_index_type=False, check_categorical=False)
 
     @td.skip_if_no('xarray', min_version='0.7.0')
-    @pytest.mark.filterwarnings("ignore")  # TODO: Remove. GH-24716
     def test_to_xarray(self):
         from xarray import Dataset
 

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -240,8 +240,19 @@ class TestDatetimeIndex(object):
     def test_integer_index_astype_datetime(self, tz, dtype):
         # GH 20997, 20964
         val = [pd.Timestamp('2018-01-01', tz=tz).value]
-        result = pd.Index(val).astype(dtype)
-        expected = pd.DatetimeIndex(['2018-01-01'], tz=tz)
+
+        if tz:
+            ex_warn = FutureWarning
+        else:
+            ex_warn = None
+
+        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+            # XXX: This likely shouldn't warn.
+            # This raised on 0.24.x, so we can probably do the right thing
+            # now.
+            result = pd.Index(val).astype(dtype)
+        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+            expected = pd.DatetimeIndex(val, tz=tz)
         tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -238,21 +238,10 @@ class TestDatetimeIndex(object):
         ['US/Pacific', 'datetime64[ns, US/Pacific]'],
         [None, 'datetime64[ns]']])
     def test_integer_index_astype_datetime(self, tz, dtype):
-        # GH 20997, 20964
+        # GH 20997, 20964, 24559
         val = [pd.Timestamp('2018-01-01', tz=tz).value]
-
-        if tz:
-            ex_warn = FutureWarning
-        else:
-            ex_warn = None
-
-        with tm.assert_produces_warning(ex_warn):
-            # XXX: This likely shouldn't warn.
-            # This raised on 0.24.x, so we can probably do the right thing
-            # now.
-            result = pd.Index(val).astype(dtype)
-        with tm.assert_produces_warning(ex_warn):
-            expected = pd.DatetimeIndex(val, tz=tz)
+        result = pd.Index(val).astype(dtype)
+        expected = pd.DatetimeIndex(["2018-01-01"], tz=tz)
         tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -246,12 +246,12 @@ class TestDatetimeIndex(object):
         else:
             ex_warn = None
 
-        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+        with tm.assert_produces_warning(ex_warn):
             # XXX: This likely shouldn't warn.
             # This raised on 0.24.x, so we can probably do the right thing
             # now.
             result = pd.Index(val).astype(dtype)
-        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+        with tm.assert_produces_warning(ex_warn):
             expected = pd.DatetimeIndex(val, tz=tz)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -11,7 +11,7 @@ from pandas._libs.tslibs import OutOfBoundsDatetime, conversion
 
 import pandas as pd
 from pandas import (
-    DatetimeIndex, Index, Timestamp, date_range, datetime, offsets,
+    DatetimeIndex, Index, Timestamp, compat, date_range, datetime, offsets,
     to_datetime)
 from pandas.core.arrays import DatetimeArray, period_array
 import pandas.util.testing as tm
@@ -581,6 +581,7 @@ class TestDatetimeIndex(object):
     @pytest.mark.parametrize('tz, dtype', [
         pytest.param('US/Pacific', 'datetime64[ns, US/Pacific]',
                      marks=[pytest.mark.xfail(),
+                            pytest.mark.skipif(compat.PY2, reason="warn"),
                             pytest.mark.filterwarnings(
                                 "ignore:\\n    Passing:FutureWarning")]),
         [None, 'datetime64[ns]'],

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -380,6 +380,13 @@ class TestDatetimeIndex(object):
         with tm.assert_produces_warning(FutureWarning):
             DatetimeIndex(start='1/1/2000', end='1/10/2000', freq='D')
 
+    def test_integer_values_and_tz_deprecated(self):
+        values = np.array([946684800000000000])
+        with tm.assert_produces_warning(FutureWarning):
+            result = DatetimeIndex(values, tz='US/Central')
+        expected = pd.DatetimeIndex(['2000-01-01T00:00:00'], tz="US/Central")
+        tm.assert_index_equal(result, expected)
+
     def test_constructor_coverage(self):
         rng = date_range('1/1/2000', periods=10.5)
         exp = date_range('1/1/2000', periods=10)

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -11,7 +11,7 @@ from pandas._libs.tslibs import OutOfBoundsDatetime, conversion
 
 import pandas as pd
 from pandas import (
-    DatetimeIndex, Index, Timestamp, compat, date_range, datetime, offsets,
+    DatetimeIndex, Index, Timestamp, date_range, datetime, offsets,
     to_datetime)
 from pandas.core.arrays import DatetimeArray, period_array
 import pandas.util.testing as tm
@@ -581,7 +581,6 @@ class TestDatetimeIndex(object):
     @pytest.mark.parametrize('tz, dtype', [
         pytest.param('US/Pacific', 'datetime64[ns, US/Pacific]',
                      marks=[pytest.mark.xfail(),
-                            pytest.mark.skipif(compat.PY2, reason="warn"),
                             pytest.mark.filterwarnings(
                                 "ignore:\\n    Passing:FutureWarning")]),
         [None, 'datetime64[ns]'],

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -582,7 +582,7 @@ class TestDatetimeIndex(object):
         pytest.param('US/Pacific', 'datetime64[ns, US/Pacific]',
                      marks=[pytest.mark.xfail(),
                             pytest.mark.filterwarnings(
-                                "ignore:Passing:FutureWarning")]),
+                                "ignore:\\n    Passing:FutureWarning")]),
         [None, 'datetime64[ns]'],
     ])
     def test_constructor_with_int_tz(self, klass, box, tz, dtype):

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -592,8 +592,9 @@ class TestDatetimeIndex(object):
         expected = klass([ts])
         assert result == expected
 
-    @pytest.mark.xfail(reason="TBD", strict=False)  # non-strict for tz-naive
-    @pytest.mark.filterwarnings("ignore:Passing integer:FutureWarning")
+    # This is the desired future behavior
+    @pytest.mark.xfail(reason="TBD", strict=False)
+    @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
     def test_construction_int_rountrip(self, tz_naive_fixture):
         # GH 12619
         tz = tz_naive_fixture

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -127,7 +127,6 @@ class TestDatetimeIndex(object):
         with tm.assert_produces_warning(warn, check_stacklevel=False):
             result = DatetimeIndex(i.tz_localize(None).asi8, **kwargs)
         expected = DatetimeIndex(i, **kwargs)
-        # expected = i.tz_localize(None).tz_localize('UTC').tz_convert(tz)
         tm.assert_index_equal(result, expected)
 
         # localize into the provided tz
@@ -386,6 +385,7 @@ class TestDatetimeIndex(object):
             DatetimeIndex(start='1/1/2000', end='1/10/2000', freq='D')
 
     def test_integer_values_and_tz_deprecated(self):
+        # GH-24559
         values = np.array([946684800000000000])
         with tm.assert_produces_warning(FutureWarning):
             result = DatetimeIndex(values, tz='US/Central')
@@ -575,6 +575,7 @@ class TestDatetimeIndex(object):
                                   ts[1].to_pydatetime()])
         tm.assert_index_equal(result, expected)
 
+    # TODO(GH-24559): Remove the xfail for the tz-aware case.
     @pytest.mark.parametrize('klass', [Index, DatetimeIndex])
     @pytest.mark.parametrize('box', [
         np.array, partial(np.array, dtype=object), list])
@@ -593,10 +594,11 @@ class TestDatetimeIndex(object):
         assert result == expected
 
     # This is the desired future behavior
-    @pytest.mark.xfail(reason="TBD", strict=False)
+    @pytest.mark.xfail(reason="Future behavior", strict=False)
     @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
     def test_construction_int_rountrip(self, tz_naive_fixture):
         # GH 12619
+        # TODO(GH-24559): Remove xfail
         tz = tz_naive_fixture
         result = 1293858000000000000
         expected = DatetimeIndex([1293858000000000000], tz=tz).asi8[0]

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -50,6 +50,7 @@ def test_values_multiindex_datetimeindex():
     # Test to ensure we hit the boxing / nobox part of MI.values
     ints = np.arange(10 ** 18, 10 ** 18 + 5)
     naive = pd.DatetimeIndex(ints)
+    # TODO(GH-24559): Remove the FutureWarning
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
         aware = pd.DatetimeIndex(ints, tz='US/Central')
 

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -50,7 +50,8 @@ def test_values_multiindex_datetimeindex():
     # Test to ensure we hit the boxing / nobox part of MI.values
     ints = np.arange(10 ** 18, 10 ** 18 + 5)
     naive = pd.DatetimeIndex(ints)
-    aware = pd.DatetimeIndex(ints, tz='US/Central')
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        aware = pd.DatetimeIndex(ints, tz='US/Central')
 
     idx = pd.MultiIndex.from_arrays([naive, aware])
     result = idx.values

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -409,6 +409,7 @@ class TestIndex(Base):
         index = index.tz_localize(tz_naive_fixture)
         dtype = index.dtype
 
+        # TODO(GH-24559): Remove the sys.modules and warnings
         # not sure what this is from. It's Py2 only.
         modules = [sys.modules['pandas.core.indexes.base']]
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from decimal import Decimal
 import math
+import sys
 
 import numpy as np
 import pytest
@@ -408,6 +409,9 @@ class TestIndex(Base):
         index = index.tz_localize(tz_naive_fixture)
         dtype = index.dtype
 
+        # not sure what this is from. It's Py2 only.
+        modules = [sys.modules['pandas.core.indexes.base']]
+
         if (tz_naive_fixture and attr == "asi8" and
                 str(tz_naive_fixture) not in ('UTC', 'tzutc()')):
             ex_warn = FutureWarning
@@ -416,7 +420,8 @@ class TestIndex(Base):
 
         # stacklevel is checked elsewhere. We don't do it here since
         # Index will have an frame, throwing off the expected.
-        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+        with tm.assert_produces_warning(ex_warn, check_stacklevel=False,
+                                        clear=modules):
             result = klass(arg, tz=tz_naive_fixture)
         tm.assert_index_equal(result, index)
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -398,10 +398,11 @@ class TestIndex(Base):
     @pytest.mark.parametrize("klass", [pd.Index, pd.DatetimeIndex])
     def test_constructor_dtypes_datetime(self, tz_naive_fixture, attr, utc,
                                          klass):
-        # TODO: update comment
         # Test constructing with a datetimetz dtype
         # .values produces numpy datetimes, so these are considered naive
         # .asi8 produces integers, so these are considered epoch timestamps
+        # ^the above will be true in a later version. Right now we `.view`
+        # the i8 values as NS_DTYPE, effectively treating them as wall times.
         index = pd.date_range('2011-01-01', periods=5)
         arg = getattr(index, attr)
         index = index.tz_localize(tz_naive_fixture)
@@ -413,6 +414,8 @@ class TestIndex(Base):
         else:
             ex_warn = None
 
+        # stacklevel is checked elsewhere. We don't do it here since
+        # Index will have an frame, throwing off the expected.
         with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
             result = klass(arg, tz=tz_naive_fixture)
         tm.assert_index_equal(result, index)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -398,27 +398,34 @@ class TestIndex(Base):
     @pytest.mark.parametrize("klass", [pd.Index, pd.DatetimeIndex])
     def test_constructor_dtypes_datetime(self, tz_naive_fixture, attr, utc,
                                          klass):
+        # TODO: update comment
         # Test constructing with a datetimetz dtype
         # .values produces numpy datetimes, so these are considered naive
         # .asi8 produces integers, so these are considered epoch timestamps
         index = pd.date_range('2011-01-01', periods=5)
         arg = getattr(index, attr)
-        if utc:
-            index = index.tz_localize('UTC').tz_convert(tz_naive_fixture)
-        else:
-            index = index.tz_localize(tz_naive_fixture)
+        index = index.tz_localize(tz_naive_fixture)
         dtype = index.dtype
 
-        result = klass(arg, tz=tz_naive_fixture)
+        if tz_naive_fixture and attr == "asi8":
+            ex_warn = FutureWarning
+        else:
+            ex_warn = None
+
+        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+            result = klass(arg, tz=tz_naive_fixture)
         tm.assert_index_equal(result, index)
 
-        result = klass(arg, dtype=dtype)
+        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+            result = klass(arg, dtype=dtype)
         tm.assert_index_equal(result, index)
 
-        result = klass(list(arg), tz=tz_naive_fixture)
+        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+            result = klass(list(arg), tz=tz_naive_fixture)
         tm.assert_index_equal(result, index)
 
-        result = klass(list(arg), dtype=dtype)
+        with tm.assert_produces_warning(ex_warn, check_stacklevel=False):
+            result = klass(list(arg), dtype=dtype)
         tm.assert_index_equal(result, index)
 
     @pytest.mark.parametrize("attr", ['values', 'asi8'])

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -407,7 +407,8 @@ class TestIndex(Base):
         index = index.tz_localize(tz_naive_fixture)
         dtype = index.dtype
 
-        if tz_naive_fixture and attr == "asi8":
+        if (tz_naive_fixture and attr == "asi8" and
+                str(tz_naive_fixture) not in ('UTC', 'tzutc()')):
             ex_warn = FutureWarning
         else:
             ex_warn = None

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -517,8 +517,10 @@ class TestPeriodIndex(object):
 
     def test_resample_with_dst_time_change(self):
         # GH 15549
-        index = pd.DatetimeIndex([1457537600000000000, 1458059600000000000],
-                                 tz='UTC').tz_convert('America/Chicago')
+        index = (
+            pd.DatetimeIndex([1457537600000000000, 1458059600000000000])
+            .tz_localize("UTC").tz_convert('America/Chicago')
+        )
         df = pd.DataFrame([1, 2], index=index)
         result = df.resample('12h', closed='right',
                              label='right').last().ffill()

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1037,7 +1037,7 @@ class TestToIterable(object):
             lambda x: list(x.__iter__()),
         ], ids=['tolist', 'to_list', 'list', 'iter'])
     @pytest.mark.parametrize('typ', [Series, Index])
-    @pytest.mark.filterwarnings("ignore:Passing integer:FutureWarning")
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_iterable(self, typ, method, dtype, rdtype):
         # gh-10904
         # gh-13258
@@ -1090,7 +1090,7 @@ class TestToIterable(object):
             ('object', (int, long)),
             ('category', (int, long))])
     @pytest.mark.parametrize('typ', [Series, Index])
-    @pytest.mark.filterwarnings("ignore:Passing integer:FutureWarning")
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_iterable_map(self, typ, dtype, rdtype):
         # gh-13236
         # coerce iteration to underlying python / pandas types

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1038,6 +1038,7 @@ class TestToIterable(object):
         ], ids=['tolist', 'to_list', 'list', 'iter'])
     @pytest.mark.parametrize('typ', [Series, Index])
     @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
+    # TODO(GH-24559): Remove the filterwarnings
     def test_iterable(self, typ, method, dtype, rdtype):
         # gh-10904
         # gh-13258
@@ -1091,6 +1092,7 @@ class TestToIterable(object):
             ('category', (int, long))])
     @pytest.mark.parametrize('typ', [Series, Index])
     @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
+    # TODO(GH-24559): Remove the filterwarnings
     def test_iterable_map(self, typ, dtype, rdtype):
         # gh-13236
         # coerce iteration to underlying python / pandas types

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1037,7 +1037,7 @@ class TestToIterable(object):
             lambda x: list(x.__iter__()),
         ], ids=['tolist', 'to_list', 'list', 'iter'])
     @pytest.mark.parametrize('typ', [Series, Index])
-    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    @pytest.mark.filterwarnings("ignore:Passing integer:FutureWarning")
     def test_iterable(self, typ, method, dtype, rdtype):
         # gh-10904
         # gh-13258
@@ -1090,6 +1090,7 @@ class TestToIterable(object):
             ('object', (int, long)),
             ('category', (int, long))])
     @pytest.mark.parametrize('typ', [Series, Index])
+    @pytest.mark.filterwarnings("ignore:Passing integer:FutureWarning")
     def test_iterable_map(self, typ, dtype, rdtype):
         # gh-13236
         # coerce iteration to underlying python / pandas types

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1037,7 +1037,7 @@ class TestToIterable(object):
             lambda x: list(x.__iter__()),
         ], ids=['tolist', 'to_list', 'list', 'iter'])
     @pytest.mark.parametrize('typ', [Series, Index])
-    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
     def test_iterable(self, typ, method, dtype, rdtype):
         # gh-10904
         # gh-13258
@@ -1090,7 +1090,7 @@ class TestToIterable(object):
             ('object', (int, long)),
             ('category', (int, long))])
     @pytest.mark.parametrize('typ', [Series, Index])
-    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
     def test_iterable_map(self, typ, dtype, rdtype):
         # gh-13236
         # coerce iteration to underlying python / pandas types

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1037,6 +1037,7 @@ class TestToIterable(object):
             lambda x: list(x.__iter__()),
         ], ids=['tolist', 'to_list', 'list', 'iter'])
     @pytest.mark.parametrize('typ', [Series, Index])
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_iterable(self, typ, method, dtype, rdtype):
         # gh-10904
         # gh-13258


### PR DESCRIPTION
TODO:

- [x] decide if we're deprecating anything.
- [x] update the message (and update filterwarnings)
- [x] whatsnew

Questions

1. What's the expected behavior of `pd.Index(i8).dtype(DatetimeTZDtype)`?
2. Do we prefer this `int_as_wall_time` parameter, or @jbrockmendel's `_from_sequence_dti` from https://github.com/jbrockmendel/pandas/commit/635b267cbb7ad63edb86157b35f027898d99542a
3. 


cc @jbrockmendel @jorisvandenbossche @jreback @mroeschke 

xref https://github.com/pandas-dev/pandas/issues/24559