### PR TITLE
ModuleNotFoundError in  in_interactive_session

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1749,6 +1749,7 @@ I/O
 - Bug in :meth:`DataFrame.to_stata`, :class:`pandas.io.stata.StataWriter` and :class:`pandas.io.stata.StataWriter117` where a exception would leave a partially written and invalid dta file (:issue:`23573`)
 - Bug in :meth:`DataFrame.to_stata` and :class:`pandas.io.stata.StataWriter117` that produced invalid files when using strLs with non-ASCII characters (:issue:`23573`)
 - Bug in :class:`HDFStore` that caused it to raise ``ValueError`` when reading a Dataframe in Python 3 from fixed format written in Python 2 (:issue:`24510`)
+- Bug in :func:`in_interactive_session` that caused it to raise ``ModuleNotFoundError`` (:issue:`24690`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1749,7 +1749,6 @@ I/O
 - Bug in :meth:`DataFrame.to_stata`, :class:`pandas.io.stata.StataWriter` and :class:`pandas.io.stata.StataWriter117` where a exception would leave a partially written and invalid dta file (:issue:`23573`)
 - Bug in :meth:`DataFrame.to_stata` and :class:`pandas.io.stata.StataWriter117` that produced invalid files when using strLs with non-ASCII characters (:issue:`23573`)
 - Bug in :class:`HDFStore` that caused it to raise ``ValueError`` when reading a Dataframe in Python 3 from fixed format written in Python 2 (:issue:`24510`)
-- Bug in :func:`in_interactive_session` that caused it to raise ``ModuleNotFoundError`` (:issue:`24690`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/formats/console.py
+++ b/pandas/io/formats/console.py
@@ -95,7 +95,10 @@ def in_interactive_session():
     from pandas import get_option
 
     def check_main():
-        import __main__ as main
+        try:
+            import __main__ as main
+        except ModuleNotFoundError:
+            return get_option('mode.sim_interactive')
         return (not hasattr(main, '__file__') or
                 get_option('mode.sim_interactive'))
 


### PR DESCRIPTION
- [x] closes #24690
- [na] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
