### PR TITLE
TimedeltaArray freq validation without _from_sequence

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -137,6 +137,8 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         if isinstance(values, (ABCSeries, ABCIndexClass)):
             values = values._values
 
+        inferred_freq = getattr(values, "_freq", None)
+
         if isinstance(values, type(self)):
             values, freq, freq_infer = extract_values_freq(values, freq)
 
@@ -179,6 +181,9 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         self._data = values
         self._dtype = dtype
         self._freq = freq
+
+        if inferred_freq is None and freq is not None:
+            type(self)._validate_frequency(self, freq)
 
     @classmethod
     def _simple_new(cls, values, freq=None, dtype=_TD_DTYPE):

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -43,7 +43,7 @@ class TestTimedeltaArrayConstructor(object):
     def test_copy(self):
         data = np.array([1, 2, 3], dtype='m8[ns]')
         arr = TimedeltaArray(data, copy=False)
-        assert arr._data.base is data
+        assert arr._data is data
 
         arr = TimedeltaArray(data, copy=True)
         assert arr._data is not data


### PR DESCRIPTION
This aligns `TimedeltaArray.__init__` with `DatetimeArray.__init__`, using the same approach how @jbrockmendel now handled the freq validation in `DatetimeArray` in the merged https://github.com/pandas-dev/pandas/pull/24686 
First commits removes usage of `from_sequence` (from https://github.com/pandas-dev/pandas/pull/24666), second commit adds the freq validation as in https://github.com/pandas-dev/pandas/pull/24686 

So related to the discussion at the end https://github.com/pandas-dev/pandas/pull/24666 (and a partial revert of that). This makes the `TimedeltaArray` constructor again more restricted (only accepts correctly typed (int or timedelta64) containers. 
Until we decide on the constructors in general (https://github.com/pandas-dev/pandas/issues/24684), I would prefer to keep them strict: it is always easier to later expand functionality (and then also test it), than remove functionality.