### PR TITLE
Change MultiIndex repr (labels -> codes)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1302,15 +1302,15 @@ class Index(IndexOpsMixin, PandasObject):
         ...                                   [2018, 2019]])
         >>> idx
         MultiIndex(levels=[['cobra', 'python'], [2018, 2019]],
-                   labels=[[1, 1, 0, 0], [0, 1, 0, 1]])
+                   codes=[[1, 1, 0, 0], [0, 1, 0, 1]])
         >>> idx.set_names(['kind', 'year'], inplace=True)
         >>> idx
         MultiIndex(levels=[['cobra', 'python'], [2018, 2019]],
-                   labels=[[1, 1, 0, 0], [0, 1, 0, 1]],
+                   codes=[[1, 1, 0, 0], [0, 1, 0, 1]],
                    names=['kind', 'year'])
         >>> idx.set_names('species', level=0)
         MultiIndex(levels=[['cobra', 'python'], [2018, 2019]],
-                   labels=[[1, 1, 0, 0], [0, 1, 0, 1]],
+                   codes=[[1, 1, 0, 0], [0, 1, 0, 1]],
                    names=['species', 'year'])
         """
 
@@ -1373,11 +1373,11 @@ class Index(IndexOpsMixin, PandasObject):
         ...                                   names=['kind', 'year'])
         >>> idx
         MultiIndex(levels=[['cobra', 'python'], [2018, 2019]],
-                   labels=[[1, 1, 0, 0], [0, 1, 0, 1]],
+                   codes=[[1, 1, 0, 0], [0, 1, 0, 1]],
                    names=['kind', 'year'])
         >>> idx.rename(['species', 'year'])
         MultiIndex(levels=[['cobra', 'python'], [2018, 2019]],
-                   labels=[[1, 1, 0, 0], [0, 1, 0, 1]],
+                   codes=[[1, 1, 0, 0], [0, 1, 0, 1]],
                    names=['species', 'year'])
         >>> idx.rename('species')
         Traceback (most recent call last):
@@ -4511,7 +4511,7 @@ class Index(IndexOpsMixin, PandasObject):
         ...                                  names=('number', 'color'))
         >>> midx
         MultiIndex(levels=[[1, 2, 3], ['blue', 'green', 'red']],
-                   labels=[[0, 1, 2], [2, 0, 1]],
+                   codes=[[0, 1, 2], [2, 0, 1]],
                    names=['number', 'color'])
 
         Check whether the strings in the 'color' level of the MultiIndex
@@ -5214,7 +5214,7 @@ def ensure_index_from_sequences(sequences, names=None):
     >>> ensure_index_from_sequences([['a', 'a'], ['a', 'b']],
                                     names=['L1', 'L2'])
     MultiIndex(levels=[['a'], ['a', 'b']],
-               labels=[[0, 0], [0, 1]],
+               codes=[[0, 0], [0, 1]],
                names=['L1', 'L2'])
 
     See Also
@@ -5255,7 +5255,7 @@ def ensure_index(index_like, copy=False):
 
     >>> ensure_index([['a', 'a'], ['b', 'c']])
     MultiIndex(levels=[['a'], ['b', 'c']],
-               labels=[[0, 0], [0, 1]])
+               codes=[[0, 0], [0, 1]])
 
     See Also
     --------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -910,7 +910,7 @@ class MultiIndex(Index):
             ('levels', ibase.default_pprint(self._levels,
                                             max_seq_items=False)),
             ('codes', ibase.default_pprint(self._codes,
-                                            max_seq_items=False))]
+                                           max_seq_items=False))]
         if com._any_not_none(*self.names):
             attrs.append(('names', ibase.default_pprint(self.names)))
         if self.sortorder is not None:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -190,8 +190,8 @@ class MultiIndex(Index):
     >>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
     >>> pd.MultiIndex.from_arrays(arrays, names=('number', 'color'))
     MultiIndex(levels=[[1, 2], ['blue', 'red']],
-           labels=[[0, 0, 1, 1], [1, 0, 1, 0]],
-           names=['number', 'color'])
+               codes=[[0, 0, 1, 1], [1, 0, 1, 0]],
+               names=['number', 'color'])
 
     See further examples for how to construct a MultiIndex in the doc strings
     of the mentioned helper methods.
@@ -321,7 +321,7 @@ class MultiIndex(Index):
         >>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
         >>> pd.MultiIndex.from_arrays(arrays, names=('number', 'color'))
         MultiIndex(levels=[[1, 2], ['blue', 'red']],
-                   labels=[[0, 0, 1, 1], [1, 0, 1, 0]],
+                   codes=[[0, 0, 1, 1], [1, 0, 1, 0]],
                    names=['number', 'color'])
         """
         if not is_list_like(arrays):
@@ -376,7 +376,7 @@ class MultiIndex(Index):
         ...           (2, u'red'), (2, u'blue')]
         >>> pd.MultiIndex.from_tuples(tuples, names=('number', 'color'))
         MultiIndex(levels=[[1, 2], ['blue', 'red']],
-                   labels=[[0, 0, 1, 1], [1, 0, 1, 0]],
+                   codes=[[0, 0, 1, 1], [1, 0, 1, 0]],
                    names=['number', 'color'])
         """
         if not is_list_like(tuples):
@@ -433,7 +433,7 @@ class MultiIndex(Index):
         >>> pd.MultiIndex.from_product([numbers, colors],
         ...                            names=['number', 'color'])
         MultiIndex(levels=[[0, 1, 2], ['green', 'purple']],
-                   labels=[[0, 0, 1, 1, 2, 2], [0, 1, 0, 1, 0, 1]],
+                   codes=[[0, 0, 1, 1, 2, 2], [0, 1, 0, 1, 0, 1]],
                    names=['number', 'color'])
         """
         from pandas.core.arrays.categorical import _factorize_from_iterables
@@ -493,14 +493,14 @@ class MultiIndex(Index):
 
         >>> pd.MultiIndex.from_frame(df)
         MultiIndex(levels=[['HI', 'NJ'], ['Precip', 'Temp']],
-                   labels=[[0, 0, 1, 1], [1, 0, 1, 0]],
+                   codes=[[0, 0, 1, 1], [1, 0, 1, 0]],
                    names=['a', 'b'])
 
         Using explicit names, instead of the column names
 
         >>> pd.MultiIndex.from_frame(df, names=['state', 'observation'])
         MultiIndex(levels=[['HI', 'NJ'], ['Precip', 'Temp']],
-                   labels=[[0, 0, 1, 1], [1, 0, 1, 0]],
+                   codes=[[0, 0, 1, 1], [1, 0, 1, 0]],
                    names=['state', 'observation'])
         """
         if not isinstance(df, ABCDataFrame):
@@ -619,19 +619,19 @@ class MultiIndex(Index):
                                             names=['foo', 'bar'])
         >>> idx.set_levels([['a','b'], [1,2]])
         MultiIndex(levels=[[u'a', u'b'], [1, 2]],
-                   labels=[[0, 0, 1, 1], [0, 1, 0, 1]],
+                   codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                    names=[u'foo', u'bar'])
         >>> idx.set_levels(['a','b'], level=0)
         MultiIndex(levels=[[u'a', u'b'], [u'one', u'two']],
-                   labels=[[0, 0, 1, 1], [0, 1, 0, 1]],
+                   codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                    names=[u'foo', u'bar'])
         >>> idx.set_levels(['a','b'], level='bar')
         MultiIndex(levels=[[1, 2], [u'a', u'b']],
-                   labels=[[0, 0, 1, 1], [0, 1, 0, 1]],
+                   codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                    names=[u'foo', u'bar'])
         >>> idx.set_levels([['a','b'], [1,2]], level=[0,1])
         MultiIndex(levels=[[u'a', u'b'], [1, 2]],
-                   labels=[[0, 0, 1, 1], [0, 1, 0, 1]],
+                   codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                    names=[u'foo', u'bar'])
         """
         if is_list_like(levels) and not isinstance(levels, Index):
@@ -738,19 +738,19 @@ class MultiIndex(Index):
                                             names=['foo', 'bar'])
         >>> idx.set_codes([[1,0,1,0], [0,0,1,1]])
         MultiIndex(levels=[[1, 2], [u'one', u'two']],
-                   labels=[[1, 0, 1, 0], [0, 0, 1, 1]],
+                   codes=[[1, 0, 1, 0], [0, 0, 1, 1]],
                    names=[u'foo', u'bar'])
         >>> idx.set_codes([1,0,1,0], level=0)
         MultiIndex(levels=[[1, 2], [u'one', u'two']],
-                   labels=[[1, 0, 1, 0], [0, 1, 0, 1]],
+                   codes=[[1, 0, 1, 0], [0, 1, 0, 1]],
                    names=[u'foo', u'bar'])
         >>> idx.set_codes([0,0,1,1], level='bar')
         MultiIndex(levels=[[1, 2], [u'one', u'two']],
-                   labels=[[0, 0, 1, 1], [0, 0, 1, 1]],
+                   codes=[[0, 0, 1, 1], [0, 0, 1, 1]],
                    names=[u'foo', u'bar'])
         >>> idx.set_codes([[1,0,1,0], [0,0,1,1]], level=[0,1])
         MultiIndex(levels=[[1, 2], [u'one', u'two']],
-                   labels=[[1, 0, 1, 0], [0, 0, 1, 1]],
+                   codes=[[1, 0, 1, 0], [0, 0, 1, 1]],
                    names=[u'foo', u'bar'])
         """
         if level is not None and not is_list_like(level):
@@ -909,7 +909,7 @@ class MultiIndex(Index):
         attrs = [
             ('levels', ibase.default_pprint(self._levels,
                                             max_seq_items=False)),
-            ('labels', ibase.default_pprint(self._codes,
+            ('codes', ibase.default_pprint(self._codes,
                                             max_seq_items=False))]
         if com._any_not_none(*self.names):
             attrs.append(('names', ibase.default_pprint(self.names)))
@@ -1509,8 +1509,8 @@ class MultiIndex(Index):
                                             (2, u'one'), (2, u'two')])
         >>> idx.to_hierarchical(3)
         MultiIndex(levels=[[1, 2], [u'one', u'two']],
-                   labels=[[0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
-                           [0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1]])
+                   codes=[[0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+                          [0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1]])
         """
         levels = self.levels
         codes = [np.repeat(level_codes, n_repeat) for
@@ -1601,11 +1601,11 @@ class MultiIndex(Index):
                               codes=[[0, 0, 1, 1], [0, 1, 0, 1]])
         >>> i
         MultiIndex(levels=[['a', 'b'], ['bb', 'aa']],
-                   labels=[[0, 0, 1, 1], [0, 1, 0, 1]])
+                   codes=[[0, 0, 1, 1], [0, 1, 0, 1]])
 
         >>> i.sort_monotonic()
         MultiIndex(levels=[['a', 'b'], ['aa', 'bb']],
-                   labels=[[0, 0, 1, 1], [1, 0, 1, 0]])
+                   codes=[[0, 0, 1, 1], [1, 0, 1, 0]])
 
         """
 
@@ -1657,18 +1657,18 @@ class MultiIndex(Index):
         --------
         >>> i = pd.MultiIndex.from_product([range(2), list('ab')])
         MultiIndex(levels=[[0, 1], ['a', 'b']],
-                   labels=[[0, 0, 1, 1], [0, 1, 0, 1]])
+                   codes=[[0, 0, 1, 1], [0, 1, 0, 1]])
 
         >>> i[2:]
         MultiIndex(levels=[[0, 1], ['a', 'b']],
-                   labels=[[1, 1], [0, 1]])
+                   codes=[[1, 1], [0, 1]])
 
         The 0 from the first level is not represented
         and can be removed
 
         >>> i[2:].remove_unused_levels()
         MultiIndex(levels=[[1], ['a', 'b']],
-                   labels=[[0, 0], [0, 1]])
+                   codes=[[0, 0], [0, 1]])
         """
 
         new_levels = []
@@ -1975,10 +1975,10 @@ class MultiIndex(Index):
         ...                    codes=[[0, 0, 1, 1], [0, 1, 0, 1]])
         >>> mi
         MultiIndex(levels=[['a', 'b'], ['bb', 'aa']],
-           labels=[[0, 0, 1, 1], [0, 1, 0, 1]])
+                   codes=[[0, 0, 1, 1], [0, 1, 0, 1]])
         >>> mi.swaplevel(0, 1)
         MultiIndex(levels=[['bb', 'aa'], ['a', 'b']],
-           labels=[[0, 1, 0, 1], [0, 0, 1, 1]])
+                   codes=[[0, 1, 0, 1], [0, 0, 1, 1]])
         """
         new_levels = list(self.levels)
         new_codes = list(self.codes)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2473,7 +2473,7 @@ class StringMethods(NoNewAttributesMixin):
 
     >>> idx.str.partition()
     MultiIndex(levels=[['X', 'Y'], [' '], ['123', '999']],
-               labels=[[0, 1], [0, 0], [0, 1]])
+               codes=[[0, 1], [0, 0], [0, 1]])
 
     Or an index with tuples with ``expand=False``:
 

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -13,7 +13,7 @@ def test_index_equal_levels_mismatch():
 Index levels are different
 \\[left\\]:  1, Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
 \\[right\\]: 2, MultiIndex\\(levels=\\[\\[u?'A', u?'B'\\], \\[1, 2, 3, 4\\]\\],
-           labels=\\[\\[0, 0, 1, 1\\], \\[0, 1, 2, 3\\]\\]\\)"""
+           codes=\\[\\[0, 0, 1, 1\\], \\[0, 1, 2, 3\\]\\]\\)"""
 
     idx1 = Index([1, 2, 3])
     idx2 = MultiIndex.from_tuples([("A", 1), ("A", 2),


### PR DESCRIPTION
As I mentioned in https://github.com/pandas-dev/pandas/pull/22511#issuecomment-451667687, the repr for MultiIndex ATM uses ``labels``, even though the parameter/attribute has been changed to ``codes``.

```python
>>> mi = pd.MultiIndex.from_product([[8,9,0], ['a', 'b', 'c']])
>>> MultiIndex(levels=[[0, 8, 9], ['a', 'b', 'c']],
...            labels=[[1, 1, 1, 2, 2, 2, 0, 0, 0], [0, 1, 2, 0, 1, 2, 0, 1, 2]])
```

This PR changes the repr, so it uses ``codes``.

Fot the record I think we should either decide to adapt #22511 soon, or soon come up with an consensus about an alternative repr to be implemented. The current MultiIndex repr is really, really (really!) bad for large indexes and needs to be be changed.
