### PR TITLE
PERF: fix some of .clip() performance regression by using numpy arrays where possible

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -140,11 +140,13 @@ class Map(object):
 
 
 class Clip(object):
+    params = [50, 1000, 10**5]
+    param_names = ['n']
 
-    def setup(self):
-        self.s = Series(np.random.randn(50))
+    def setup(self, n):
+        self.s = Series(np.random.randn(n))
 
-    def time_clip(self):
+    def time_clip(self, n):
         self.s.clip(0, 1)
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7148,12 +7148,18 @@ class NDFrame(PandasObject, SelectionMixin):
             raise ValueError("Cannot use an NA value as a clip threshold")
 
         result = self
-        if upper is not None:
-            subset = self.le(upper, axis=None) | isna(result)
-            result = result.where(subset, upper, axis=None, inplace=False)
-        if lower is not None:
-            subset = self.ge(lower, axis=None) | isna(result)
-            result = result.where(subset, lower, axis=None, inplace=False)
+        mask = isna(self.values)
+
+        with np.errstate(all='ignore'):
+            if upper is not None:
+                subset = self.to_numpy() <= upper
+                result = result.where(subset, upper, axis=None, inplace=False)
+            if lower is not None:
+                subset = self.to_numpy() >= lower
+                result = result.where(subset, lower, axis=None, inplace=False)
+
+        if np.any(mask):
+            result[mask] = np.nan
 
         if inplace:
             self._update_inplace(result)


### PR DESCRIPTION
A recent change to respect dtypes in `.clip()` (https://github.com/pandas-dev/pandas/pull/24458) introduced a decent overhead of ~2ms to the call:
```
$ asv compare v0.23.4 v0.24.0rc1 --only-changed
       before           after         ratio
     [04095216]       [fdc4db25]
     <v0.23.4^0>       <v0.24.0rc1^0>
+         120±1μs      2.04±0.04ms    17.01  series_methods.Clip.time_clip(1000)
+        936±40μs      3.09±0.02ms     3.31  series_methods.Clip.time_clip(100000)
+         111±3μs      2.05±0.08ms    18.55  series_methods.Clip.time_clip(50)
```
This PR cuts the overhead from ~2ms to ~0.6ms by keeping `subset` as a numpy array; it's entirely boolean regardless of underlying dtype, so a DataFrame only adds overhead here:
```
$ asv compare v0.24.0rc1 HEAD --only-changed -s
       before           after         ratio
     [fdc4db25]       [63c47c58]
     <v0.24.0rc1^0>       <clip>
-     2.04±0.04ms         759±20μs     0.37  series_methods.Clip.time_clip(1000)
-     3.09±0.02ms      1.46±0.04ms     0.47  series_methods.Clip.time_clip(100000)
-     2.05±0.08ms         724±20μs     0.35  series_methods.Clip.time_clip(50)
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
