### PR TITLE
TST: avoid DST transitions when testing DateTimeIndex roundtrip

### DIFF
--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -434,24 +434,19 @@ class TestDatetimeIndexTimezones(object):
         with pytest.raises(pytz.NonExistentTimeError):
             rng.tz_localize(tz)
 
-    @pytest.mark.parametrize('idx', [
-        date_range(start='2014-01-01', end='2014-12-31', freq='M'),
-        date_range(start='2014-01-01', end='2014-12-31', freq='D'),
-        date_range(start='2014-01-01', end='2014-03-01', freq='H'),
-        date_range(start='2014-08-01', end='2014-10-31', freq='T')
-    ])
-    def test_dti_tz_localize_roundtrip(self, tz_aware_fixture, idx):
+    def test_dti_tz_localize_roundtrip(self, tz_aware_fixture):
+        # note: this tz tests that a tz-naive index can be localized
+        # and de-localized successfully, when there are no DST transitions
+        # in the range.
+        idx = date_range(start='2014-06-01', end='2014-08-30', freq='15T')
         tz = tz_aware_fixture
         localized = idx.tz_localize(tz)
-        expected = date_range(start=idx[0], end=idx[-1], freq=idx.freq,
-                              tz=tz)
-        tm.assert_index_equal(localized, expected)
+        # cant localize a tz-aware object
         with pytest.raises(TypeError):
             localized.tz_localize(tz)
-
         reset = localized.tz_localize(None)
-        tm.assert_index_equal(reset, idx)
         assert reset.tzinfo is None
+        tm.assert_index_equal(reset, idx)
 
     def test_dti_tz_localize_naive(self):
         rng = date_range('1/1/2011', periods=100, freq='H')


### PR DESCRIPTION
- [x] closes #24689
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
