### PR TITLE
PERF: 3x speedup in Series of dicts with datetime keys by not having error message scale with input

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -686,16 +686,19 @@ class DatetimeTZDtype(PandasExtensionDtype, ExtensionDtype):
         >>> DatetimeTZDtype.construct_from_string('datetime64[ns, UTC]')
         datetime64[ns, UTC]
         """
-        msg = "Could not construct DatetimeTZDtype from '{}'"
-        try:
-            match = cls._match.match(string)
-            if match:
-                d = match.groupdict()
-                return cls(unit=d['unit'], tz=d['tz'])
-        except Exception:
-            # TODO(py3): Change this pass to `raise TypeError(msg) from e`
-            pass
-        raise TypeError(msg.format(string))
+        if isinstance(string, compat.string_types):
+            msg = "Could not construct DatetimeTZDtype from '{}'"
+            try:
+                match = cls._match.match(string)
+                if match:
+                    d = match.groupdict()
+                    return cls(unit=d['unit'], tz=d['tz'])
+            except Exception:
+                # TODO(py3): Change this pass to `raise TypeError(msg) from e`
+                pass
+            raise TypeError(msg.format(string))
+
+        raise TypeError("Could not construct DatetimeTZDtype")
 
     def __unicode__(self):
         return "datetime64[{unit}, {tz}]".format(unit=self.unit, tz=self.tz)

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -232,6 +232,10 @@ class TestDatetimeTZDtype(Base):
         with pytest.raises(TypeError, match="notatz"):
             DatetimeTZDtype.construct_from_string('datetime64[ns, notatz]')
 
+        with pytest.raises(TypeError,
+                           match="^Could not construct DatetimeTZDtype$"):
+            DatetimeTZDtype.construct_from_string(['datetime64[ns, notatz]'])
+
     def test_is_dtype(self):
         assert not DatetimeTZDtype.is_dtype(None)
         assert DatetimeTZDtype.is_dtype(self.dtype)


### PR DESCRIPTION
Surprisingly, the majority of the time spent in constructing a `Series` from a dict with `datetime`-like keys is spent formatting the keys into strings for an error message that gets suppressed.

As there's a test ensuring the string case makes it into the error message, we preserve the behavior there. In non-string cases, we mirror how the other `Dtypes` handle this case and do not include the input.
```
$ asv compare v0.24.0rc1 HEAD -s
       before           after         ratio
     [fdc4db25]       [5c82eab5]
     <v0.24.0rc1^0>       <series_dict_speedup>
-      1.14±0.02s          303±4ms     0.27  series_methods.SeriesConstructor.time_constructor('dict') 
```

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
