### PR TITLE
CI: isort ci

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -101,7 +101,7 @@ if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
 
     # Imports - Check formatting using isort see setup.cfg for settings
     MSG='Check import format using isort ' ; echo $MSG
-    isort --recursive --check-only pandas
+    isort --recursive --check-only pandas asv_bench
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,7 +125,6 @@ skip=
     pandas/tests/computation/test_eval.py,
     pandas/types/common.py,
     pandas/tests/extension/arrow/test_bool.py,
-    doc/source/conf.py,
     asv_bench/benchmarks/algorithms.py,
     asv_bench/benchmarks/attrs_caching.py,
     asv_bench/benchmarks/binary_ops.py,
@@ -160,3 +159,8 @@ skip=
     asv_bench/benchmarks/sparse.py,
     asv_bench/benchmarks/stat_ops.py,
     asv_bench/benchmarks/timeseries.py
+    asv_bench/benchmarks/pandas_vb_common.py
+    asv_bench/benchmarks/offset.py
+    asv_bench/benchmarks/dtypes.py
+    asv_bench/benchmarks/strings.py
+    asv_bench/benchmarks/period.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -149,3 +149,8 @@ skip=
     asv_bench/benchmarks/sparse.py,
     asv_bench/benchmarks/stat_ops.py,
     asv_bench/benchmarks/timeseries.py
+    asv_bench/benchmarks/pandas_vb_common.py
+    asv_bench/benchmarks/offset.py
+    asv_bench/benchmarks/dtypes.py
+    asv_bench/benchmarks/strings.py
+    asv_bench/benchmarks/period.py


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

asv_bench and doc dir where [added](https://github.com/pandas-dev/pandas/pull/24092/files) to the isort skip section. We should actually check this directory in CI.

Checking doc dir is more effort that its worth ( barely any .py files ) so let's just leave this.