### PR TITLE
PERF: speed up .ix by moving deprecation string out of __init__

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1405,17 +1405,16 @@ class _IXIndexer(_NDFrameIndexer):
     See more at :ref:`Advanced Indexing <advanced>`.
     """
 
+    _ix_deprecation_warning = textwrap.dedent("""
+        .ix is deprecated. Please use
+        .loc for label based indexing or
+        .iloc for positional indexing
+
+        See the documentation here:
+        http://pandas.pydata.org/pandas-docs/stable/indexing.html#ix-indexer-is-deprecated""")  # noqa
+
     def __init__(self, name, obj):
-
-        _ix_deprecation_warning = textwrap.dedent("""
-            .ix is deprecated. Please use
-            .loc for label based indexing or
-            .iloc for positional indexing
-
-            See the documentation here:
-            http://pandas.pydata.org/pandas-docs/stable/indexing.html#ix-indexer-is-deprecated""")  # noqa
-
-        warnings.warn(_ix_deprecation_warning,
+        warnings.warn(self._ix_deprecation_warning,
                       DeprecationWarning, stacklevel=2)
         super(_IXIndexer, self).__init__(name, obj)
 


### PR DESCRIPTION
While `.ix` is deprecated, the `DeprecationWarning` itself adds a decent fraction of overhead to calling it. Simply storing the warning string on the class (or global scope) yields a sizable speedup:
```
$ asv compare v0.24.0rc1 HEAD -s --only-changed --sort ratio
       before           after         ratio
     [fdc4db25]       [d0821a4c]
     <v0.24.0rc1^0>       <ix_speedup>
-      2.57±0.1ms      2.29±0.01ms     0.89  indexing.NumericSeriesIndexing.time_ix_list_like(<class 'pandas.core.indexes.numeric.UInt64Index'>, 'nonunique_monotonic_inc')
-      2.69±0.2ms      2.39±0.02ms     0.89  indexing.NumericSeriesIndexing.time_ix_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>, 'nonunique_monotonic_inc')
-         124±2μs          103±5μs     0.83  indexing.NumericSeriesIndexing.time_ix_scalar(<class 'pandas.core.indexes.numeric.UInt64Index'>, 'unique_monotonic_inc')
-         149±4μs          121±4μs     0.81  indexing.NumericSeriesIndexing.time_ix_slice(<class 'pandas.core.indexes.numeric.Float64Index'>, 'unique_monotonic_inc')
-     2.43±0.08ms      1.96±0.05ms     0.81  indexing.NumericSeriesIndexing.time_ix_list_like(<class 'pandas.core.indexes.numeric.Int64Index'>, 'unique_monotonic_inc')
-        179±20μs          138±7μs     0.77  indexing.NumericSeriesIndexing.time_ix_slice(<class 'pandas.core.indexes.numeric.Int64Index'>, 'unique_monotonic_inc')
-         506±6μs          384±6μs     0.76  indexing.NumericSeriesIndexing.time_ix_scalar(<class 'pandas.core.indexes.numeric.Float64Index'>, 'nonunique_monotonic_inc')
-        84.6±1μs         63.5±2μs     0.75  indexing.NumericSeriesIndexing.time_ix_scalar(<class 'pandas.core.indexes.numeric.Float64Index'>, 'unique_monotonic_inc')
-        69.1±4μs         50.4±2μs     0.73  indexing.NumericSeriesIndexing.time_ix_scalar(<class 'pandas.core.indexes.numeric.Int64Index'>, 'unique_monotonic_inc')
-     1.22±0.02ms          728±2μs     0.60  indexing.NumericSeriesIndexing.time_ix_slice(<class 'pandas.core.indexes.numeric.Float64Index'>, 'nonunique_monotonic_inc')
-        31.3±4μs       8.67±0.9μs     0.28  indexing.DataFrameStringIndexing.time_ix
-        16.5±1μs       2.67±0.3μs     0.16  indexing.MethodLookup.time_lookup_ix
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
