### PR TITLE
STY: use pytest.raises context syntax (series/indexing/*)

### DIFF
--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -243,7 +243,10 @@ def test_reindex_corner(test_data):
 
     # bad fill method
     ts = test_data.ts[::2]
-    pytest.raises(Exception, ts.reindex, test_data.ts.index, method='foo')
+    msg = (r"Invalid fill method\. Expecting pad \(ffill\), backfill"
+           r" \(bfill\) or nearest\. Got foo")
+    with pytest.raises(ValueError, match=msg):
+        ts.reindex(test_data.ts.index, method='foo')
 
 
 def test_reindex_pad():

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -49,10 +49,12 @@ def test_getitem_boolean_empty():
 
     # invalid because of the boolean indexer
     # that's empty or not-aligned
-    with pytest.raises(IndexingError):
+    msg = (r"Unalignable boolean Series provided as indexer \(index of"
+           r" the boolean Series and of the indexed object do not match")
+    with pytest.raises(IndexingError, match=msg):
         s[Series([], dtype=bool)]
 
-    with pytest.raises(IndexingError):
+    with pytest.raises(IndexingError, match=msg):
         s[Series([True], dtype=bool)]
 
 
@@ -77,8 +79,11 @@ def test_getitem_boolean_object(test_data):
 
     # nans raise exception
     omask[5:10] = np.nan
-    pytest.raises(Exception, s.__getitem__, omask)
-    pytest.raises(Exception, s.__setitem__, omask, 5)
+    msg = "cannot index with vector containing NA / NaN values"
+    with pytest.raises(ValueError, match=msg):
+        s[omask]
+    with pytest.raises(ValueError, match=msg):
+        s[omask] = 5
 
 
 def test_getitem_setitem_boolean_corner(test_data):
@@ -87,15 +92,17 @@ def test_getitem_setitem_boolean_corner(test_data):
 
     # these used to raise...??
 
-    pytest.raises(Exception, ts.__getitem__, mask_shifted)
-    pytest.raises(Exception, ts.__setitem__, mask_shifted, 1)
-    # ts[mask_shifted]
-    # ts[mask_shifted] = 1
+    msg = (r"Unalignable boolean Series provided as indexer \(index of"
+           r" the boolean Series and of the indexed object do not match")
+    with pytest.raises(IndexingError, match=msg):
+        ts[mask_shifted]
+    with pytest.raises(IndexingError, match=msg):
+        ts[mask_shifted] = 1
 
-    pytest.raises(Exception, ts.loc.__getitem__, mask_shifted)
-    pytest.raises(Exception, ts.loc.__setitem__, mask_shifted, 1)
-    # ts.loc[mask_shifted]
-    # ts.loc[mask_shifted] = 2
+    with pytest.raises(IndexingError, match=msg):
+        ts.loc[mask_shifted]
+    with pytest.raises(IndexingError, match=msg):
+        ts.loc[mask_shifted] = 1
 
 
 def test_setitem_boolean(test_data):
@@ -165,6 +172,7 @@ def test_where_unsafe_upcast(dtype):
     assert_series_equal(s, expected)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("dtype", [
     np.int8, np.int16, np.int32, np.float32
 ])
@@ -175,7 +183,8 @@ def test_where_unsafe_itemsize_fail(dtype):
     mask = s < 5
 
     values = [2.5, 3.5, 4.5, 5.5, 6.5]
-    pytest.raises(Exception, s.__setitem__, tuple(mask), values)
+    with pytest.raises(Exception):
+        s[mask] = values
 
 
 def test_where_unsafe():
@@ -206,10 +215,11 @@ def test_where_unsafe():
     s = Series(np.arange(10))
     mask = s > 5
 
-    with pytest.raises(ValueError):
+    msg = "cannot assign mismatch length to masked array"
+    with pytest.raises(ValueError, match=msg):
         s[mask] = [5, 4, 3, 2, 1]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg):
         s[mask] = [0] * 5
 
     # dtype changes
@@ -276,8 +286,11 @@ def test_where_error():
     s = Series(np.random.randn(5))
     cond = s > 0
 
-    pytest.raises(ValueError, s.where, 1)
-    pytest.raises(ValueError, s.where, cond[:3].values, -s)
+    msg = "Array conditional must be same shape as self"
+    with pytest.raises(ValueError, match=msg):
+        s.where(1)
+    with pytest.raises(ValueError, match=msg):
+        s.where(cond[:3].values, -s)
 
     # GH 2745
     s = Series([1, 2])
@@ -286,10 +299,13 @@ def test_where_error():
     assert_series_equal(s, expected)
 
     # failures
-    pytest.raises(ValueError, s.__setitem__, tuple([[[True, False]]]),
-                  [0, 2, 3])
-    pytest.raises(ValueError, s.__setitem__, tuple([[[True, False]]]),
-                  [])
+    msg = "cannot assign mismatch length to masked array"
+    with pytest.raises(ValueError, match=msg):
+        s[[True, False]] = [0, 2, 3]
+    msg = ("NumPy boolean array indexing assignment cannot assign 0 input"
+           " values to the 1 output values where the mask is true")
+    with pytest.raises(ValueError, match=msg):
+        s[[True, False]] = []
 
 
 @pytest.mark.parametrize('klass', [list, tuple, np.array, Series])
@@ -349,10 +365,13 @@ def test_where_setitem_invalid():
     # GH 2702
     # make sure correct exceptions are raised on invalid list assignment
 
+    msg = ("cannot set using a {} indexer with a different length than"
+           " the value")
+
     # slice
     s = Series(list('abc'))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg.format('slice')):
         s[0:3] = list(range(27))
 
     s[0:3] = list(range(3))
@@ -362,7 +381,7 @@ def test_where_setitem_invalid():
     # slice with step
     s = Series(list('abcdef'))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg.format('slice')):
         s[0:4:2] = list(range(27))
 
     s = Series(list('abcdef'))
@@ -373,7 +392,7 @@ def test_where_setitem_invalid():
     # neg slices
     s = Series(list('abcdef'))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg.format('slice')):
         s[:-1] = list(range(27))
 
     s[-3:-1] = list(range(2))
@@ -383,12 +402,12 @@ def test_where_setitem_invalid():
     # list
     s = Series(list('abc'))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg.format('list-like')):
         s[[0, 1, 2]] = list(range(27))
 
     s = Series(list('abc'))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg.format('list-like')):
         s[[0, 1, 2]] = list(range(2))
 
     # scalar
@@ -590,8 +609,11 @@ def test_mask():
     rs2 = s2.mask(cond[:3], -s2)
     assert_series_equal(rs, rs2)
 
-    pytest.raises(ValueError, s.mask, 1)
-    pytest.raises(ValueError, s.mask, cond[:3].values, -s)
+    msg = "Array conditional must be same shape as self"
+    with pytest.raises(ValueError, match=msg):
+        s.mask(1)
+    with pytest.raises(ValueError, match=msg):
+        s.mask(cond[:3].values, -s)
 
     # dtype changes
     s = Series([1, 2, 3, 4])

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -172,7 +172,7 @@ def test_where_unsafe_upcast(dtype):
     assert_series_equal(s, expected)
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="Failed: DID NOT RAISE <class 'Exception'>")
 @pytest.mark.parametrize("dtype", [
     np.int8, np.int16, np.int32, np.float32
 ])

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -172,19 +172,16 @@ def test_where_unsafe_upcast(dtype):
     assert_series_equal(s, expected)
 
 
-@pytest.mark.xfail(reason="Failed: DID NOT RAISE <class 'Exception'>")
 @pytest.mark.parametrize("dtype", [
     np.int8, np.int16, np.int32, np.float32
 ])
-def test_where_unsafe_itemsize_fail(dtype):
-    # Can't do these, as we are forced to change the
-    # item size of the input to something we cannot.
+def test_where_upcast(dtype):
+    # see gh-9743
     s = Series(np.arange(10), dtype=dtype)
     mask = s < 5
 
     values = [2.5, 3.5, 4.5, 5.5, 6.5]
-    with pytest.raises(Exception):
-        s[mask] = values
+    s[mask] = values
 
 
 def test_where_unsafe():

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -33,8 +33,8 @@ def test_fancy_getitem():
     assert s['2009-1-2'] == 48
     assert s[datetime(2009, 1, 2)] == 48
     assert s[Timestamp(datetime(2009, 1, 2))] == 48
-    pytest.raises(KeyError, s.__getitem__, '2009-1-3')
-
+    with pytest.raises(KeyError, match=r"^'2009-1-3'$"):
+        s['2009-1-3']
     assert_series_equal(s['3/6/2009':'2009-06-05'],
                         s[datetime(2009, 3, 6):datetime(2009, 6, 5)])
 
@@ -298,7 +298,8 @@ def test_getitem_setitem_datetimeindex():
 
     lb = datetime(1990, 1, 1, 4)
     rb = datetime(1990, 1, 1, 7)
-    with pytest.raises(TypeError):
+    msg = "Cannot compare tz-naive and tz-aware datetime-like objects"
+    with pytest.raises(TypeError, match=msg):
         # tznaive vs tzaware comparison is invalid
         # see GH#18376, GH#18162
         ts[(ts.index >= lb) & (ts.index <= rb)]
@@ -400,7 +401,8 @@ def test_datetime_indexing():
     s = Series(len(index), index=index)
     stamp = Timestamp('1/8/2000')
 
-    pytest.raises(KeyError, s.__getitem__, stamp)
+    with pytest.raises(KeyError, match=r"^947289600000000000$"):
+        s[stamp]
     s[stamp] = 0
     assert s[stamp] == 0
 
@@ -408,7 +410,8 @@ def test_datetime_indexing():
     s = Series(len(index), index=index)
     s = s[::-1]
 
-    pytest.raises(KeyError, s.__getitem__, stamp)
+    with pytest.raises(KeyError, match=r"^947289600000000000$"):
+        s.__getitem__(stamp)
     s[stamp] = 0
     assert s[stamp] == 0
 
@@ -499,7 +502,8 @@ def test_duplicate_dates_indexing(dups):
         expected = Series(np.where(mask, 0, ts), index=ts.index)
         assert_series_equal(cp, expected)
 
-    pytest.raises(KeyError, ts.__getitem__, datetime(2000, 1, 6))
+    with pytest.raises(KeyError, match=r"^947116800000000000$"):
+        ts[datetime(2000, 1, 6)]
 
     # new index
     ts[datetime(2000, 1, 6)] = 0
@@ -664,8 +668,11 @@ def test_indexing():
     expected = df.loc[[df.index[2]]]
 
     # this is a single date, so will raise
-    pytest.raises(KeyError, df.__getitem__, '2012-01-02 18:01:02', )
-    pytest.raises(KeyError, df.__getitem__, df.index[2], )
+    with pytest.raises(KeyError, match=r"^'2012-01-02 18:01:02'$"):
+        df['2012-01-02 18:01:02']
+    msg = r"Timestamp\('2012-01-02 18:01:02-0600', tz='US/Central', freq='S'\)"
+    with pytest.raises(KeyError, match=msg):
+        df[df.index[2]]
 
 
 """

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -401,7 +401,7 @@ def test_datetime_indexing():
     s = Series(len(index), index=index)
     stamp = Timestamp('1/8/2000')
 
-    with pytest.raises(KeyError, match=r"^947289600000000000$"):
+    with pytest.raises(KeyError, match=r"^947289600000000000L?$"):
         s[stamp]
     s[stamp] = 0
     assert s[stamp] == 0
@@ -410,7 +410,7 @@ def test_datetime_indexing():
     s = Series(len(index), index=index)
     s = s[::-1]
 
-    with pytest.raises(KeyError, match=r"^947289600000000000$"):
+    with pytest.raises(KeyError, match=r"^947289600000000000L?$"):
         s[stamp]
     s[stamp] = 0
     assert s[stamp] == 0
@@ -502,7 +502,7 @@ def test_duplicate_dates_indexing(dups):
         expected = Series(np.where(mask, 0, ts), index=ts.index)
         assert_series_equal(cp, expected)
 
-    with pytest.raises(KeyError, match=r"^947116800000000000$"):
+    with pytest.raises(KeyError, match=r"^947116800000000000L?$"):
         ts[datetime(2000, 1, 6)]
 
     # new index

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -411,7 +411,7 @@ def test_datetime_indexing():
     s = s[::-1]
 
     with pytest.raises(KeyError, match=r"^947289600000000000$"):
-        s.__getitem__(stamp)
+        s[stamp]
     s[stamp] = 0
     assert s[stamp] == 0
 

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -36,9 +36,10 @@ def test_basic_indexing():
 
     s = s.sort_index()
 
-    with pytest.raises(IndexError, match=r"^5$"):
+    msg = r"index out of bounds|^5$"
+    with pytest.raises(IndexError, match=msg):
         s[5]
-    msg = "index 5 is out of bounds for axis 0 with size 5"
+    msg = r"index 5 is out of bounds for axis (0|1) with size 5|^5$"
     with pytest.raises(IndexError, match=msg):
         s[5] = 0
 
@@ -257,9 +258,9 @@ def test_series_box_timestamp():
 
 def test_getitem_ambiguous_keyerror():
     s = Series(lrange(10), index=lrange(0, 20, 2))
-    with pytest.raises(KeyError, match=r"^1$"):
+    with pytest.raises(KeyError, match=r"^1L?$"):
         s[1]
-    with pytest.raises(KeyError, match=r"^1$"):
+    with pytest.raises(KeyError, match=r"^1L?$"):
         s.loc[1]
 
 
@@ -423,7 +424,7 @@ def test_basic_getitem_setitem_corner(test_data):
     assert_series_equal(result, expected)
 
     # OK
-    msg = "unhashable type: 'slice'"
+    msg = r"unhashable type(: 'slice')?"
     with pytest.raises(TypeError, match=msg):
         test_data.ts[[5, slice(None, None)]]
     with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -24,15 +24,23 @@ from pandas.tseries.offsets import BDay
 def test_basic_indexing():
     s = Series(np.random.randn(5), index=['a', 'b', 'a', 'a', 'b'])
 
-    pytest.raises(IndexError, s.__getitem__, 5)
-    pytest.raises(IndexError, s.__setitem__, 5, 0)
+    msg = "index out of bounds"
+    with pytest.raises(IndexError, match=msg):
+        s[5]
+    msg = "index 5 is out of bounds for axis 0 with size 5"
+    with pytest.raises(IndexError, match=msg):
+        s[5] = 0
 
-    pytest.raises(KeyError, s.__getitem__, 'c')
+    with pytest.raises(KeyError, match=r"^'c'$"):
+        s['c']
 
     s = s.sort_index()
 
-    pytest.raises(IndexError, s.__getitem__, 5)
-    pytest.raises(IndexError, s.__setitem__, 5, 0)
+    with pytest.raises(IndexError, match=r"^5$"):
+        s[5]
+    msg = "index 5 is out of bounds for axis 0 with size 5"
+    with pytest.raises(IndexError, match=msg):
+        s[5] = 0
 
 
 def test_basic_getitem_with_labels(test_data):
@@ -105,7 +113,8 @@ def test_getitem_get(test_data):
 
     # missing
     d = test_data.ts.index[0] - BDay()
-    pytest.raises(KeyError, test_data.ts.__getitem__, d)
+    with pytest.raises(KeyError, match=r"Timestamp\('1999-12-31 00:00:00'\)"):
+        test_data.ts[d]
 
     # None
     # GH 5652
@@ -166,11 +175,14 @@ def test_getitem_with_duplicates_indices(
 
 def test_getitem_out_of_bounds(test_data):
     # don't segfault, GH #495
-    pytest.raises(IndexError, test_data.ts.__getitem__, len(test_data.ts))
+    msg = "index out of bounds"
+    with pytest.raises(IndexError, match=msg):
+        test_data.ts[len(test_data.ts)]
 
     # GH #917
     s = Series([])
-    pytest.raises(IndexError, s.__getitem__, -1)
+    with pytest.raises(IndexError, match=msg):
+        s[-1]
 
 
 def test_getitem_setitem_integers():
@@ -245,8 +257,10 @@ def test_series_box_timestamp():
 
 def test_getitem_ambiguous_keyerror():
     s = Series(lrange(10), index=lrange(0, 20, 2))
-    pytest.raises(KeyError, s.__getitem__, 1)
-    pytest.raises(KeyError, s.loc.__getitem__, 1)
+    with pytest.raises(KeyError, match=r"^1$"):
+        s[1]
+    with pytest.raises(KeyError, match=r"^1$"):
+        s.loc[1]
 
 
 def test_getitem_unordered_dup():
@@ -295,7 +309,10 @@ def test_getitem_dataframe():
     rng = list(range(10))
     s = pd.Series(10, index=rng)
     df = pd.DataFrame(rng, index=rng)
-    pytest.raises(TypeError, s.__getitem__, df > 5)
+    msg = ("Indexing a Series with DataFrame is not supported,"
+           " use the appropriate DataFrame column")
+    with pytest.raises(TypeError, match=msg):
+        s[df > 5]
 
 
 def test_setitem(test_data):
@@ -394,9 +411,10 @@ def test_setslice(test_data):
 @pytest.mark.filterwarnings("ignore:Using a non-tuple:FutureWarning")
 def test_basic_getitem_setitem_corner(test_data):
     # invalid tuples, e.g. td.ts[:, None] vs. td.ts[:, 2]
-    with pytest.raises(ValueError, match='tuple-index'):
+    msg = "Can only tuple-index with a MultiIndex"
+    with pytest.raises(ValueError, match=msg):
         test_data.ts[:, 2]
-    with pytest.raises(ValueError, match='tuple-index'):
+    with pytest.raises(ValueError, match=msg):
         test_data.ts[:, 2] = 2
 
     # weird lists. [slice(0, 5)] will work but not two slices
@@ -405,10 +423,11 @@ def test_basic_getitem_setitem_corner(test_data):
     assert_series_equal(result, expected)
 
     # OK
-    pytest.raises(Exception, test_data.ts.__getitem__,
-                  [5, slice(None, None)])
-    pytest.raises(Exception, test_data.ts.__setitem__,
-                  [5, slice(None, None)], 2)
+    msg = "unhashable type: 'slice'"
+    with pytest.raises(TypeError, match=msg):
+        test_data.ts[[5, slice(None, None)]]
+    with pytest.raises(TypeError, match=msg):
+        test_data.ts[[5, slice(None, None)]] = 2
 
 
 @pytest.mark.parametrize('tz', ['US/Eastern', 'UTC', 'Asia/Tokyo'])
@@ -730,7 +749,8 @@ def test_setitem_scalar_into_readonly_backing_data():
     series = Series(array)
 
     for n in range(len(series)):
-        with pytest.raises(ValueError):
+        msg = "assignment destination is read-only"
+        with pytest.raises(ValueError, match=msg):
             series[n] = 1
 
         assert array[n] == 0
@@ -743,7 +763,8 @@ def test_setitem_slice_into_readonly_backing_data():
     array.flags.writeable = False  # make the array immutable
     series = Series(array)
 
-    with pytest.raises(ValueError):
+    msg = "assignment destination is read-only"
+    with pytest.raises(ValueError, match=msg):
         series[1:3] = 1
 
     assert not array.any()
@@ -791,8 +812,11 @@ def test_take():
     expected = Series([4, 2, 4], index=[4, 3, 4])
     tm.assert_series_equal(actual, expected)
 
-    pytest.raises(IndexError, s.take, [1, 10])
-    pytest.raises(IndexError, s.take, [2, 5])
+    msg = "index {} is out of bounds for size 5"
+    with pytest.raises(IndexError, match=msg.format(10)):
+        s.take([1, 10])
+    with pytest.raises(IndexError, match=msg.format(5)):
+        s.take([2, 5])
 
     with tm.assert_produces_warning(FutureWarning):
         s.take([-1, 3, 4], convert=False)

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -48,8 +48,11 @@ def test_loc_getitem_not_monotonic(test_data):
 
     ts2 = test_data.ts[::2][[1, 2, 0]]
 
-    pytest.raises(KeyError, ts2.loc.__getitem__, slice(d1, d2))
-    pytest.raises(KeyError, ts2.loc.__setitem__, slice(d1, d2), 0)
+    msg = r"Timestamp\('2000-01-10 00:00:00'\)"
+    with pytest.raises(KeyError, match=msg):
+        ts2.loc[d1:d2]
+    with pytest.raises(KeyError, match=msg):
+        ts2.loc[d1:d2] = 0
 
 
 def test_loc_getitem_setitem_integer_slice_keyerrors():
@@ -74,8 +77,10 @@ def test_loc_getitem_setitem_integer_slice_keyerrors():
 
     # non-monotonic, raise KeyError
     s2 = s.iloc[lrange(5) + lrange(5, 10)[::-1]]
-    pytest.raises(KeyError, s2.loc.__getitem__, slice(3, 11))
-    pytest.raises(KeyError, s2.loc.__setitem__, slice(3, 11), 0)
+    with pytest.raises(KeyError, match=r"^3$"):
+        s2.loc[3:11]
+    with pytest.raises(KeyError, match=r"^3$"):
+        s2.loc[3:11] = 0
 
 
 def test_loc_getitem_iterator(test_data):
@@ -97,8 +102,9 @@ def test_loc_setitem_boolean(test_data):
 def test_loc_setitem_corner(test_data):
     inds = list(test_data.series.index[[5, 8, 12]])
     test_data.series.loc[inds] = 5
-    pytest.raises(Exception, test_data.series.loc.__setitem__,
-                  inds + ['foo'], 5)
+    msg = r"\['foo'\] not in index"
+    with pytest.raises(KeyError, match=msg):
+        test_data.series.loc[inds + ['foo']] = 5
 
 
 def test_basic_setitem_with_labels(test_data):
@@ -135,8 +141,11 @@ def test_basic_setitem_with_labels(test_data):
 
     inds_notfound = [0, 4, 5, 6]
     arr_inds_notfound = np.array([0, 4, 5, 6])
-    pytest.raises(Exception, s.__setitem__, inds_notfound, 0)
-    pytest.raises(Exception, s.__setitem__, arr_inds_notfound, 0)
+    msg = r"\[5\] not contained in the index"
+    with pytest.raises(ValueError, match=msg):
+        s[inds_notfound] = 0
+    with pytest.raises(Exception, match=msg):
+        s[arr_inds_notfound] = 0
 
     # GH12089
     # with tz for values

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -77,9 +77,9 @@ def test_loc_getitem_setitem_integer_slice_keyerrors():
 
     # non-monotonic, raise KeyError
     s2 = s.iloc[lrange(5) + lrange(5, 10)[::-1]]
-    with pytest.raises(KeyError, match=r"^3$"):
+    with pytest.raises(KeyError, match=r"^3L?$"):
         s2.loc[3:11]
-    with pytest.raises(KeyError, match=r"^3$"):
+    with pytest.raises(KeyError, match=r"^3L?$"):
         s2.loc[3:11] = 0
 
 

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -209,7 +209,7 @@ def test_setitem_float_labels():
 def test_slice_float_get_set(test_data):
     msg = (r"cannot do slice indexing on <class 'pandas\.core\.indexes"
            r"\.datetimes\.DatetimeIndex'> with these indexers \[{key}\]"
-           r" of <class 'float'>")
+           r" of <(class|type) 'float'>")
     with pytest.raises(TypeError, match=msg.format(key=r"4\.0")):
         test_data.ts[4.0:10.0]
 

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -96,7 +96,7 @@ def test_delitem():
     # empty
     s = Series()
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match=r"^0$"):
         del s[0]
 
     # only 1 left, del, add, del
@@ -150,8 +150,12 @@ def test_slice_float64():
 def test_getitem_negative_out_of_bounds():
     s = Series(tm.rands_array(5, 10), index=tm.rands_array(10, 10))
 
-    pytest.raises(IndexError, s.__getitem__, -11)
-    pytest.raises(IndexError, s.__setitem__, -11, 'foo')
+    msg = "index out of bounds"
+    with pytest.raises(IndexError, match=msg):
+        s[-11]
+    msg = "index -11 is out of bounds for axis 0 with size 10"
+    with pytest.raises(IndexError, match=msg):
+        s[-11] = 'foo'
 
 
 def test_getitem_regression():
@@ -203,13 +207,19 @@ def test_setitem_float_labels():
 
 
 def test_slice_float_get_set(test_data):
-    pytest.raises(TypeError, lambda: test_data.ts[4.0:10.0])
+    msg = (r"cannot do slice indexing on <class 'pandas\.core\.indexes"
+           r"\.datetimes\.DatetimeIndex'> with these indexers \[{key}\]"
+           r" of <class 'float'>")
+    with pytest.raises(TypeError, match=msg.format(key=r"4\.0")):
+        test_data.ts[4.0:10.0]
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=msg.format(key=r"4\.0")):
         test_data.ts[4.0:10.0] = 0
 
-    pytest.raises(TypeError, test_data.ts.__getitem__, slice(4.5, 10.0))
-    pytest.raises(TypeError, test_data.ts.__setitem__, slice(4.5, 10.0), 0)
+    with pytest.raises(TypeError, match=msg.format(key=r"4\.5")):
+        test_data.ts[4.5:10.0]
+    with pytest.raises(TypeError, match=msg.format(key=r"4\.5")):
+        test_data.ts[4.5:10.0] = 0
 
 
 def test_slice_floats2():
@@ -228,16 +238,20 @@ def test_slice_floats2():
 def test_int_indexing():
     s = Series(np.random.randn(6), index=[0, 0, 1, 1, 2, 2])
 
-    pytest.raises(KeyError, s.__getitem__, 5)
+    with pytest.raises(KeyError, match=r"^5$"):
+        s[5]
 
-    pytest.raises(KeyError, s.__getitem__, 'c')
+    with pytest.raises(KeyError, match=r"^'c'$"):
+        s['c']
 
     # not monotonic
     s = Series(np.random.randn(6), index=[2, 2, 0, 0, 1, 1])
 
-    pytest.raises(KeyError, s.__getitem__, 5)
+    with pytest.raises(KeyError, match=r"^5$"):
+        s[5]
 
-    pytest.raises(KeyError, s.__getitem__, 'c')
+    with pytest.raises(KeyError, match=r"^'c'$"):
+        s['c']
 
 
 def test_getitem_int64(test_data):


### PR DESCRIPTION
xref #24332 

`@pytest.mark.xfail` applied to `test_where_unsafe_itemsize_fail` : does not raise using python index operator instead of `__setitem__` with `tuple`