### PR TITLE
CI: Pinning flake8-rst, last version raises incorrect errors

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - cython>=0.28.2
   - flake8
   - flake8-comprehensions
-  - flake8-rst=0.7.0
+  - flake8-rst>=0.6.0,<=0.7.0
   - gitpython
   - hypothesis>=3.82
   - isort

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - cython>=0.28.2
   - flake8
   - flake8-comprehensions
-  - flake8-rst>=0.6.0
+  - flake8-rst=0.7.0
   - gitpython
   - hypothesis>=3.82
   - isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ asv
 cython>=0.28.2
 flake8
 flake8-comprehensions
-flake8-rst>=0.6.0
+flake8-rst>=0.6.0,<=0.7.0
 gitpython
 hypothesis>=3.82
 isort


### PR DESCRIPTION
- [X] closes #24755
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

CC: @jreback @FHaase 
