### PR TITLE
Include tables module in required libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools_kwargs = {
         'python-dateutil >= 2.5.0',
         'pytz >= 2011k',
         'numpy >= {numpy_ver}'.format(numpy_ver=min_numpy_ver),
+        'tables >= 3.4.4'
     ],
     'setup_requires': ['numpy >= {numpy_ver}'.format(numpy_ver=min_numpy_ver)],
     'zip_safe': False,


### PR DESCRIPTION
Using `to_hdf` method without the tables module installed may results in infinite recursion crash: Fatal Python error: Cannot recover from stack overflow.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
