### PR TITLE
DOC: IntervalArray and IntervalIndex minor doc fixes

### DIFF
--- a/doc/source/api/indexing.rst
+++ b/doc/source/api/indexing.rst
@@ -258,6 +258,7 @@ IntervalIndex Components
    IntervalIndex.get_indexer
    IntervalIndex.set_closed
    IntervalIndex.overlaps
+   IntervalIndex.to_tuples
 
 .. _api.multiindex:
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -71,7 +71,6 @@ right
 closed
 mid
 length
-values
 is_non_overlapping_monotonic
 %(extra_attributes)s\
 
@@ -936,13 +935,16 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             # datetime safe version
             return self.left + 0.5 * self.length
 
-    @property
-    def is_non_overlapping_monotonic(self):
-        """
-        Return True if the IntervalArray is non-overlapping (no Intervals share
+    _interval_shared_docs['is_non_overlapping_monotonic'] = """
+        Return True if the %(klass)s is non-overlapping (no Intervals share
         points) and is either monotonic increasing or monotonic decreasing,
         else False
         """
+
+    @property
+    @Appender(_interval_shared_docs['is_non_overlapping_monotonic']
+              % _shared_docs_kwargs)
+    def is_non_overlapping_monotonic(self):
         # must be increasing  (e.g., [0, 1), [1, 2), [2, 3), ... )
         # or decreasing (e.g., [-1, 0), [-2, -1), [-3, -2), ...)
         # we already require left <= right
@@ -986,7 +988,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             Returns NA as a tuple if True, ``(nan, nan)``, or just as the NA
             value itself if False, ``nan``.
 
-            ..versionadded:: 0.23.0
+            .. versionadded:: 0.23.0
 
         Returns
         -------

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -102,7 +102,7 @@ def _new_IntervalIndex(cls, d):
     summary="Immutable index of intervals that are closed on the same side.",
     name=_index_doc_kwargs['name'],
     versionadded="0.20.0",
-    extra_attributes="is_overlapping\n",
+    extra_attributes="is_overlapping\nvalues\n",
     extra_methods="contains\n",
     examples=textwrap.dedent("""\
     Examples
@@ -465,6 +465,8 @@ class IntervalIndex(IntervalMixin, Index):
         return self._multiindex.is_unique
 
     @cache_readonly
+    @Appender(_interval_shared_docs['is_non_overlapping_monotonic']
+              % _index_doc_kwargs)
     def is_non_overlapping_monotonic(self):
         return self._data.is_non_overlapping_monotonic
 


### PR DESCRIPTION
Some minor fixes for things that aren't rendering correctly for `IntervalArray` and `IntervalIndex`.  I've built the docs locally and the changes look good.

For [`IntervalArray` ](https://pandas-docs.github.io/pandas-docs-travis/api/generated/pandas.IntervalArray.html):
- `IntervalArray.values` doesn't exist, so removing it.

![image](https://user-images.githubusercontent.com/5332445/51159115-bf6dd600-1844-11e9-9d0f-ec5a1e132a5f.png)

For [`IntervalIndex`](https://pandas-docs.github.io/pandas-docs-travis/api/generated/pandas.IntervalIndex.html):
- `IntervalIndex.is_non_overlapping_monotonic` lost it's docstring, so adding it back via shared docs
- `IntervalIndex.to_tuples` isn't being generated, so now generating it. Also fixed versionadded directive.

![image](https://user-images.githubusercontent.com/5332445/51159221-520e7500-1845-11e9-8633-fdfc5d646d52.png)


