### PR TITLE
PERF: avoid object-dtype comparisons

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2465,6 +2465,12 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
                               klass=ObjectBlock,)
             return newb.setitem(indexer, value)
 
+    def equals(self, other):
+        # override for significant performance improvement
+        if self.dtype != other.dtype or self.shape != other.shape:
+            return False
+        return (self.values.view('i8') == other.values.view('i8')).all()
+
 
 class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
     __slots__ = ()

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1199,6 +1199,11 @@ def assert_extension_array_equal(left, right, check_dtype=True,
     if check_dtype:
         assert_attr_equal('dtype', left, right, obj='ExtensionArray')
 
+    if hasattr(left, "asi8") and type(right) == type(left):
+        # Avoid slow object-dtype comparisons
+        assert_numpy_array_equal(left.asi8, right.asi8)
+        return
+
     left_na = np.asarray(left.isna())
     right_na = np.asarray(right.isna())
     assert_numpy_array_equal(left_na, right_na, obj='ExtensionArray NA mask')


### PR DESCRIPTION
Looking at the --durations=10 results in the tests, one that stands out is

```
7.08s call     pandas/tests/series/test_datetime_values.py::TestSeriesDatetimeValues::test_dt_namespace_accessor
```

It turns out all but about 0.15 seconds of this is spent in a `tm.assert_series_equal` call for a Datetime64TZ Series.  Tracking that down, its in array_equivalent, which casts to object-dtype before comparing.  This avoids that casting, shaves almost 7 seconds off that test.