### PR TITLE
Avoid unnecessary use of _coerce_scalar_to_timedelta_type

### DIFF
--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -16,7 +16,6 @@ from pandas.core.computation import expr, ops
 from pandas.core.computation.common import _ensure_decoded
 from pandas.core.computation.expr import BaseExprVisitor
 from pandas.core.computation.ops import UndefinedVariableError, is_term
-from pandas.core.tools.timedeltas import _coerce_scalar_to_timedelta_type
 
 from pandas.io.formats.printing import pprint_thing, pprint_thing_encoded
 
@@ -191,7 +190,7 @@ class BinOp(ops.BinOp):
                 v = v.tz_convert('UTC')
             return TermValue(v, v.value, kind)
         elif kind == u('timedelta64') or kind == u('timedelta'):
-            v = _coerce_scalar_to_timedelta_type(v, unit='s').value
+            v = pd.Timedelta(v, unit='s').value
             return TermValue(int(v), v, kind)
         elif meta == u('category'):
             metadata = com.values_from_object(self.metadata)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -569,8 +569,6 @@ def coerce_to_dtypes(result, dtypes):
     if len(result) != len(dtypes):
         raise AssertionError("_coerce_to_dtypes requires equal len arrays")
 
-    from pandas.core.tools.timedeltas import _coerce_scalar_to_timedelta_type
-
     def conv(r, dtype):
         try:
             if isna(r):
@@ -578,7 +576,7 @@ def coerce_to_dtypes(result, dtypes):
             elif dtype == _NS_DTYPE:
                 r = tslibs.Timestamp(r)
             elif dtype == _TD_DTYPE:
-                r = _coerce_scalar_to_timedelta_type(r)
+                r = tslibs.Timedelta(r)
             elif dtype == np.bool_:
                 # messy. non 0/1 integers do not get converted.
                 if is_integer(r) and r not in [0, 1]:

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -26,7 +26,6 @@ from pandas.core.indexes.datetimelike import (
     wrap_arithmetic_op)
 from pandas.core.indexes.numeric import Int64Index
 from pandas.core.ops import get_op_result_name
-from pandas.core.tools.timedeltas import _coerce_scalar_to_timedelta_type
 
 from pandas.tseries.frequencies import to_offset
 
@@ -582,7 +581,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, dtl.TimelikeOps, Int64Index,
         assert kind in ['ix', 'loc', 'getitem', None]
 
         if isinstance(label, compat.string_types):
-            parsed = _coerce_scalar_to_timedelta_type(label, box=True)
+            parsed = Timedelta(label)
             lbound = parsed.round(parsed.resolution)
             if side == 'left':
                 return lbound

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import timedelta
 import operator
 from string import ascii_lowercase
@@ -1128,7 +1126,6 @@ class TestDataFrameAnalytics():
         tm.assert_frame_equal(result, expected)
 
     def test_operators_timedelta64(self):
-        from datetime import timedelta
         df = DataFrame(dict(A=date_range('2012-1-1', periods=3, freq='D'),
                             B=date_range('2012-1-2', periods=3, freq='D'),
                             C=Timestamp('20120101') -
@@ -1169,12 +1166,9 @@ class TestDataFrameAnalytics():
         mixed['F'] = Timestamp('20130101')
 
         # results in an object array
-        from pandas.core.tools.timedeltas import (
-            _coerce_scalar_to_timedelta_type as _coerce)
-
         result = mixed.min()
-        expected = Series([_coerce(timedelta(seconds=5 * 60 + 5)),
-                           _coerce(timedelta(days=-1)),
+        expected = Series([pd.Timedelta(timedelta(seconds=5 * 60 + 5)),
+                           pd.Timedelta(timedelta(days=-1)),
                            'foo', 1, 1.0,
                            Timestamp('20130101')],
                           index=mixed.columns)


### PR DESCRIPTION
In nearly all the places where its used, we can just use `Timedelta` instead.  Way simpler, avoids using a private function.