### PR TITLE
PERF: support parallel calculation of nancorr

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6996,7 +6996,8 @@ class DataFrame(NDFrame):
         mat = numeric_df.values
 
         if method == 'pearson':
-            correl = libalgos.nancorr(ensure_float64(mat), minp=min_periods)
+            correl = libalgos.nancorr(ensure_float64(mat), minp=min_periods,
+                                      parallel=True)
         elif method == 'spearman':
             correl = libalgos.nancorr_spearman(ensure_float64(mat),
                                                minp=min_periods)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ BSD license. Parts are from lxml (https://github.com/lxml/lxml)
 import os
 from os.path import join as pjoin
 
+import numpy
 import pkg_resources
 import platform
 from distutils.sysconfig import get_config_var
@@ -677,10 +678,11 @@ for name, data in ext_data.items():
     obj = Extension('pandas.{name}'.format(name=name),
                     sources=sources,
                     depends=data.get('depends', []),
-                    include_dirs=include,
+                    include_dirs=include + [numpy.get_include()],
                     language=data.get('language', 'c'),
                     define_macros=data.get('macros', macros),
-                    extra_compile_args=extra_compile_args)
+                    extra_compile_args=['-fopenmp'] + extra_compile_args,
+                    extra_link_args=['-fopenmp'])
 
     extensions.append(obj)
 
@@ -704,11 +706,12 @@ ujson_ext = Extension('pandas._libs.json',
                                np_datetime_sources),
                       include_dirs=['pandas/_libs/src/ujson/python',
                                     'pandas/_libs/src/ujson/lib',
-                                    'pandas/_libs/src/datetime'],
-                      extra_compile_args=(['-D_GNU_SOURCE'] +
+                                    'pandas/_libs/src/datetime',
+                                    numpy.get_include()],
+                      extra_compile_args=(['-D_GNU_SOURCE', '-fopenmp'] +
                                           extra_compile_args),
+                      extra_link_args=['-fopenmp'],
                       define_macros=macros)
-
 
 extensions.append(ujson_ext)
 


### PR DESCRIPTION
This is a proposal for using openmp to speedup the nancorr function (used by pd.DataFrame.corr).

If this is something that is useful, it can probably be implemented for other cython algorithms implemented in algos.pyx.

Also, the interface has to be decided on: how to choose whether to use parallelization or not, how many cpus, schedule strategy for the prange, etc.

I am not sure what the implications are for adding openmp to compilation and linkage in terms of portability.

Using 4 cpus I got ~60% speedup on a pd.DataFrame.corr (of size 20000 x 1300).