### PR TITLE
TST: Add test for C parser handling binary mode

### DIFF
--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -575,3 +575,17 @@ def test_file_handles_mmap(c_parser_only, csv1):
         if PY3:
             assert not m.closed
         m.close()
+
+
+def test_file_binary_mode(c_parser_only):
+    # see gh-23779
+    parser = c_parser_only
+    expected = DataFrame([[1, 2, 3], [4, 5, 6]])
+
+    with tm.ensure_clean() as path:
+        with open(path, "w") as f:
+            f.write("1,2,3\n4,5,6")
+
+        with open(path, "rb") as f:
+            result = parser.read_csv(f, header=None)
+            tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Python's native CSV library doesn't accept such files, but we do for the C parser.

Closes #23779.