### PR TITLE
Revert unnecessary changes from 22019

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1163,36 +1163,6 @@ data is incompatible with a passed ``dtype=`` (:issue:`15832`)
     ...
     OverflowError: Trying to coerce negative values to unsigned integers
 
-.. _whatsnew_0240.api.crosstab_dtypes:
-
-Crosstab Preserves Dtypes
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-:func:`crosstab` will preserve now dtypes in some cases that previously would
-cast from integer dtype to floating dtype (:issue:`22019`)
-
-*Previous Behavior*:
-
-.. code-block:: ipython
-
-    In [3]: df = pd.DataFrame({'a': [1, 2, 2, 2, 2], 'b': [3, 3, 4, 4, 4],
-       ...:                    'c': [1, 1, np.nan, 1, 1]})
-    In [4]: pd.crosstab(df.a, df.b, normalize='columns')
-    Out[4]:
-    b    3    4
-    a
-    1  0.5  0.0
-    2  0.5  1.0
-
-*New Behavior*:
-
-.. code-block:: ipython
-
-    In [3]: df = pd.DataFrame({'a': [1, 2, 2, 2, 2],
-       ...:                    'b': [3, 3, 4, 4, 4],
-       ...:                    'c': [1, 1, np.nan, 1, 1]})
-    In [4]: pd.crosstab(df.a, df.b, normalize='columns')
-
 .. _whatsnew_0240.api.concat_categorical:
 
 Concatenation Changes

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -717,7 +717,7 @@ class TestDataFrameSelectReindex(TestData):
 
         result = df1 - df1.mean()
         expected = df2 - df2.mean()
-        assert_frame_equal(result.astype('f8'), expected)
+        assert_frame_equal(result, expected)
 
     def test_align_multiindex(self):
         # GH 10665

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1573,9 +1573,8 @@ class TestCrosstab(object):
                               full_normal)
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize='index'),
                               row_normal)
-        tm.assert_frame_equal(
-            pd.crosstab(df.a, df.b, normalize='columns').astype('f8'),
-            col_normal)
+        tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize='columns'),
+                              col_normal)
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize=1),
                               pd.crosstab(df.a, df.b, normalize='columns'))
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize=0),
@@ -1608,7 +1607,7 @@ class TestCrosstab(object):
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize='index',
                                           margins=True), row_normal_margins)
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize='columns',
-                                          margins=True).astype('f8'),
+                                          margins=True),
                               col_normal_margins)
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize=True,
                                           margins=True), all_normal_margins)


### PR DESCRIPTION
At the time, https://github.com/pandas-dev/pandas/pull/22019 seemed to
break API in a few places. Since then, those API breaking changes have
disappeared, so the changes to the tests and the release note are no
longer necessary.

This restores the tests to the 0.23.4 version.

Closes https://github.com/pandas-dev/pandas/issues/24789