### PR TITLE
POC: move to_offset to libfrequencies

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -39,7 +39,7 @@ from pandas._libs.tslibs.nattype import nat_strings, iNaT  # noqa:F821
 from pandas._libs.tslibs.nattype cimport (
     checknull_with_nat, NPY_NAT, c_NaT as NaT)
 
-from pandas._libs.tslibs.offsets cimport to_offset
+from pandas._libs.tslibs.frequencies cimport to_offset
 
 from pandas._libs.tslibs.timestamps cimport create_timestamp_from_ts
 from pandas._libs.tslibs.timestamps import Timestamp

--- a/pandas/_libs/tslibs/frequencies.pxd
+++ b/pandas/_libs/tslibs/frequencies.pxd
@@ -7,3 +7,5 @@ cpdef object get_freq(object freq)
 cpdef str get_base_alias(freqstr)
 cpdef int get_to_timestamp_base(int base)
 cpdef str get_freq_str(base, mult=*)
+
+cpdef object to_offset(object freq)

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -130,7 +130,7 @@ _lite_rule_alias = {
 
 _dont_uppercase = {'MS', 'ms'}
 
-#: cache of previously seen offsets
+# cache of previously seen offsets
 cdef dict _c_offset_map = {}
 _offset_map = _c_offset_map  # visible from python modules
 
@@ -140,9 +140,10 @@ prefix_mapping = _c_prefix_mapping  # visible from python modules
 cdef dict _c_name_to_offset_map = {}
 _name_to_offset_map = _c_name_to_offset_map  # visible from python modules
 
+
 # ----------------------------------------------------------------------
 
-def to_offset(freq):
+cpdef object to_offset(object freq):
     """
     Return DateOffset object from string or tuple representation
     or datetime.timedelta object

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -202,7 +202,7 @@ cpdef object to_offset(object freq):
 
     elif PyDelta_Check(freq):
         delta = None
-        from .timedeltas import Timedelta  # TODO: avoid runtime/circular import
+        from .timedeltas import Timedelta
         freq = Timedelta(freq)
         try:
             for name in freq.components._fields:
@@ -259,7 +259,9 @@ cpdef object to_offset(object freq):
     return delta
 
 
-def get_offset(name):
+# TODO: If we can get rid of getOffset alias in frequencies.py, we get make
+#  this just cdef
+cpdef get_offset(name):
     """
     Return DateOffset object associated with rule name
 

--- a/pandas/_libs/tslibs/offsets.pxd
+++ b/pandas/_libs/tslibs/offsets.pxd
@@ -1,3 +1,0 @@
-# -*- coding: utf-8 -*-
-
-cdef to_offset(object obj)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -84,17 +84,6 @@ for _d in DAYS:
 # ---------------------------------------------------------------------
 # Misc Helpers
 
-cdef to_offset(object obj):
-    """
-    Wrap pandas.tseries.frequencies.to_offset to keep centralize runtime
-    imports
-    """
-    if isinstance(obj, _BaseOffset):
-        return obj
-    from pandas.tseries.frequencies import to_offset
-    return to_offset(obj)
-
-
 def as_datetime(obj):
     f = getattr(obj, 'to_pydatetime', None)
     if f is not None:
@@ -333,6 +322,7 @@ class _BaseOffset(object):
 
     def __eq__(self, other):
         if is_string_object(other):
+            from .frequencies import to_offset
             try:
                 # GH#23524 if to_offset fails, we are dealing with an
                 #  incomparable type so == is False and != is True

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -43,13 +43,12 @@ from pandas._libs.tslibs.ccalendar import MONTH_NUMBERS
 from pandas._libs.tslibs.conversion cimport tz_convert_utc_to_tzlocal
 from pandas._libs.tslibs.frequencies cimport (
     get_freq_code, get_base_alias, get_to_timestamp_base, get_freq_str,
-    get_rule_month)
+    get_rule_month, to_offset)
 from pandas._libs.tslibs.parsing import parse_time_string
 from pandas._libs.tslibs.resolution import Resolution
 from pandas._libs.tslibs.nattype import nat_strings
 from pandas._libs.tslibs.nattype cimport (
     _nat_scalar_rules, NPY_NAT, is_null_datetimelike, c_NaT as NaT)
-from pandas._libs.tslibs.offsets cimport to_offset
 from pandas._libs.tslibs.offsets import _Tick
 
 cdef bint PY2 = str == bytes

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -28,6 +28,7 @@ from pandas._libs.tslibs.util cimport (
     is_float_object, is_string_object)
 
 from pandas._libs.tslibs.ccalendar import DAY_SECONDS
+from pandas._libs.tslibs.frequencies cimport to_offset
 
 from pandas._libs.tslibs.np_datetime cimport (
     cmp_scalar, reverse_ops, td64_to_tdstruct, pandas_timedeltastruct)
@@ -35,7 +36,6 @@ from pandas._libs.tslibs.np_datetime cimport (
 from pandas._libs.tslibs.nattype import nat_strings
 from pandas._libs.tslibs.nattype cimport (
     checknull_with_nat, NPY_NAT, c_NaT as NaT)
-from pandas._libs.tslibs.offsets cimport to_offset
 from pandas._libs.tslibs.offsets import _Tick as Tick
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -27,12 +27,12 @@ from pandas._libs.tslibs.conversion cimport (
     tz_convert_single, _TSObject, convert_to_tsobject,
     convert_datetime_to_tsobject)
 from pandas._libs.tslibs.fields import get_start_end_field, get_date_name_field
+from pandas._libs.tslibs.frequencies cimport to_offset
 from pandas._libs.tslibs.nattype cimport NPY_NAT, c_NaT as NaT
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 from pandas._libs.tslibs.np_datetime cimport (
     reverse_ops, cmp_scalar, check_dts_bounds, npy_datetimestruct,
     dt64_to_dtstruct)
-from pandas._libs.tslibs.offsets cimport to_offset
 from pandas._libs.tslibs.timedeltas import Timedelta
 from pandas._libs.tslibs.timedeltas cimport delta_to_nanoseconds
 from pandas._libs.tslibs.timezones cimport (

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -292,7 +292,7 @@ class TestSeriesDtypes(object):
         tm.assert_series_equal(s.astype('category'), expected)
         tm.assert_series_equal(s.astype(CategoricalDtype()), expected)
         msg = (r"could not convert string to float: '(0 - 499|9500 - 9999)'|"
-               r"invalid literal for float\(\): 9500 - 9999")
+               r"invalid literal for float\(\): (0 - 499|9500 - 9999)")
         with pytest.raises(ValueError, match=msg):
             s.astype('float64')
 

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -7,7 +7,7 @@ import pytest
 from pandas._libs.tslibs import (
     NaT, OutOfBoundsDatetime, Timestamp, conversion, timezones)
 from pandas._libs.tslibs.frequencies import (
-    INVALID_FREQ_ERR_MSG, get_freq_code, get_freq_str)
+    INVALID_FREQ_ERR_MSG, _offset_map, get_freq_code, get_freq_str, get_offset)
 import pandas._libs.tslibs.offsets as liboffsets
 import pandas.compat as compat
 from pandas.compat import range
@@ -18,7 +18,6 @@ from pandas.core.series import Series
 import pandas.util.testing as tm
 
 from pandas.io.pickle import read_pickle
-from pandas.tseries.frequencies import _offset_map, get_offset
 from pandas.tseries.holiday import USFederalHolidayCalendar
 import pandas.tseries.offsets as offsets
 from pandas.tseries.offsets import (

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -8,7 +8,8 @@ from pandas._libs.tslibs import Timestamp
 from pandas._libs.tslibs.ccalendar import MONTH_ALIASES, int_to_weekday
 from pandas._libs.tslibs.conversion import tz_convert
 from pandas._libs.tslibs.fields import build_field_sarray
-from pandas._libs.tslibs.frequencies import _name_to_offset_map
+from pandas._libs.tslibs.frequencies import (  # noqa:F401
+    _name_to_offset_map, to_offset)
 from pandas._libs.tslibs.offsets import _offset_to_period_map
 import pandas._libs.tslibs.resolution as libresolution
 from pandas._libs.tslibs.resolution import Resolution  # noqa:F401

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -9,7 +9,7 @@ from pandas._libs.tslibs.ccalendar import MONTH_ALIASES, int_to_weekday
 from pandas._libs.tslibs.conversion import tz_convert
 from pandas._libs.tslibs.fields import build_field_sarray
 from pandas._libs.tslibs.frequencies import (  # noqa:F401
-    _name_to_offset_map, to_offset)
+    _name_to_offset_map, get_offset, to_offset)
 from pandas._libs.tslibs.offsets import _offset_to_period_map
 import pandas._libs.tslibs.resolution as libresolution
 from pandas._libs.tslibs.resolution import Resolution  # noqa:F401

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -13,7 +13,8 @@ from pandas._libs.tslibs.fields import build_field_sarray
 import pandas._libs.tslibs.frequencies as libfreqs
 from pandas._libs.tslibs.frequencies import (  # noqa, semi-public API
     FreqGroup, get_base_alias, get_freq, get_freq_code, get_to_timestamp_base,
-    is_subperiod, is_superperiod, _offset_map, get_offset)
+    is_subperiod, is_superperiod, _offset_map, get_offset, to_offset,
+    _name_to_offset_map)
 from pandas._libs.tslibs.offsets import _offset_to_period_map  # noqa:E402
 import pandas._libs.tslibs.resolution as libresolution
 from pandas._libs.tslibs.resolution import Resolution
@@ -63,123 +64,15 @@ def get_period_alias(offset_str):
     return _offset_to_period_map.get(offset_str, None)
 
 
-_name_to_offset_map = {'days': Day(1),
-                       'hours': Hour(1),
-                       'minutes': Minute(1),
-                       'seconds': Second(1),
-                       'milliseconds': Milli(1),
-                       'microseconds': Micro(1),
-                       'nanoseconds': Nano(1)}
-
-
-def to_offset(freq):
-    """
-    Return DateOffset object from string or tuple representation
-    or datetime.timedelta object
-
-    Parameters
-    ----------
-    freq : str, tuple, datetime.timedelta, DateOffset or None
-
-    Returns
-    -------
-    delta : DateOffset
-        None if freq is None
-
-    Raises
-    ------
-    ValueError
-        If freq is an invalid frequency
-
-    See Also
-    --------
-    pandas.DateOffset
-
-    Examples
-    --------
-    >>> to_offset('5min')
-    <5 * Minutes>
-
-    >>> to_offset('1D1H')
-    <25 * Hours>
-
-    >>> to_offset(('W', 2))
-    <2 * Weeks: weekday=6>
-
-    >>> to_offset((2, 'B'))
-    <2 * BusinessDays>
-
-    >>> to_offset(datetime.timedelta(days=1))
-    <Day>
-
-    >>> to_offset(Hour())
-    <Hour>
-    """
-    if freq is None:
-        return None
-
-    if isinstance(freq, DateOffset):
-        return freq
-
-    if isinstance(freq, tuple):
-        name = freq[0]
-        stride = freq[1]
-        if isinstance(stride, compat.string_types):
-            name, stride = stride, name
-        name, _ = libfreqs._base_and_stride(name)
-        delta = get_offset(name) * stride
-
-    elif isinstance(freq, timedelta):
-        delta = None
-        freq = Timedelta(freq)
-        try:
-            for name in freq.components._fields:
-                offset = _name_to_offset_map[name]
-                stride = getattr(freq.components, name)
-                if stride != 0:
-                    offset = stride * offset
-                    if delta is None:
-                        delta = offset
-                    else:
-                        delta = delta + offset
-        except Exception:
-            raise ValueError(libfreqs.INVALID_FREQ_ERR_MSG.format(freq))
-
-    else:
-        delta = None
-        stride_sign = None
-        try:
-            splitted = re.split(libfreqs.opattern, freq)
-            if splitted[-1] != '' and not splitted[-1].isspace():
-                # the last element must be blank
-                raise ValueError('last element must be blank')
-            for sep, stride, name in zip(splitted[0::4], splitted[1::4],
-                                         splitted[2::4]):
-                if sep != '' and not sep.isspace():
-                    raise ValueError('separator must be spaces')
-                prefix = libfreqs._lite_rule_alias.get(name) or name
-                if stride_sign is None:
-                    stride_sign = -1 if stride.startswith('-') else 1
-                if not stride:
-                    stride = 1
-                if prefix in Resolution._reso_str_bump_map:
-                    stride, name = Resolution.get_stride_from_decimal(
-                        float(stride), prefix
-                    )
-                stride = int(stride)
-                offset = get_offset(name)
-                offset = offset * int(np.fabs(stride) * stride_sign)
-                if delta is None:
-                    delta = offset
-                else:
-                    delta = delta + offset
-        except Exception:
-            raise ValueError(libfreqs.INVALID_FREQ_ERR_MSG.format(freq))
-
-    if delta is None:
-        raise ValueError(libfreqs.INVALID_FREQ_ERR_MSG.format(freq))
-
-    return delta
+_name_to_offset_map.update({
+    'days': Day(1),
+    'hours': Hour(1),
+    'minutes': Minute(1),
+    'seconds': Second(1),
+    'milliseconds': Milli(1),
+    'microseconds': Micro(1),
+    'nanoseconds': Nano(1)
+})
 
 
 getOffset = get_offset

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -1,26 +1,21 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
-import re
 
 import numpy as np
 from pytz import AmbiguousTimeError
 
 from pandas._libs.algos import unique_deltas
-from pandas._libs.tslibs import Timedelta, Timestamp
+from pandas._libs.tslibs import Timestamp
 from pandas._libs.tslibs.ccalendar import MONTH_ALIASES, int_to_weekday
 from pandas._libs.tslibs.conversion import tz_convert
 from pandas._libs.tslibs.fields import build_field_sarray
-import pandas._libs.tslibs.frequencies as libfreqs
 from pandas._libs.tslibs.frequencies import (  # noqa, semi-public API
     FreqGroup, get_base_alias, get_freq, get_freq_code, get_to_timestamp_base,
     is_subperiod, is_superperiod, _offset_map, get_offset, to_offset,
     _name_to_offset_map)
 from pandas._libs.tslibs.offsets import _offset_to_period_map  # noqa:E402
 import pandas._libs.tslibs.resolution as libresolution
-from pandas._libs.tslibs.resolution import Resolution
+from pandas._libs.tslibs.resolution import Resolution  # noqa:F401
 from pandas._libs.tslibs.timezones import UTC
-import pandas.compat as compat
-from pandas.compat import zip
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -9,9 +9,9 @@ from pandas._libs.tslibs.ccalendar import MONTH_ALIASES, int_to_weekday
 from pandas._libs.tslibs.conversion import tz_convert
 from pandas._libs.tslibs.fields import build_field_sarray
 from pandas._libs.tslibs.frequencies import (  # noqa, semi-public API
-    FreqGroup, get_base_alias, get_freq, get_freq_code, get_to_timestamp_base,
-    is_subperiod, is_superperiod, _offset_map, get_offset, to_offset,
-    _name_to_offset_map)
+    FreqGroup, _name_to_offset_map, _offset_map, get_base_alias, get_freq,
+    get_freq_code, get_offset, get_to_timestamp_base, is_subperiod,
+    is_superperiod, to_offset)
 from pandas._libs.tslibs.offsets import _offset_to_period_map  # noqa:E402
 import pandas._libs.tslibs.resolution as libresolution
 from pandas._libs.tslibs.resolution import Resolution  # noqa:F401

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -10,6 +10,7 @@ from pandas._libs.tslibs import (
     NaT, OutOfBoundsDatetime, Timedelta, Timestamp, ccalendar, conversion,
     delta_to_nanoseconds, frequencies as libfrequencies, normalize_date,
     offsets as liboffsets, timezones)
+from pandas._libs.tslibs.frequencies import prefix_mapping
 from pandas._libs.tslibs.offsets import (
     ApplyTypeError, BaseOffset, _get_calendar, _is_normalized, _to_dt64,
     apply_index_wraps, as_datetime, roll_yearday, shift_month)
@@ -2479,7 +2480,9 @@ def generate_range(start=None, end=None, periods=None, offset=BDay()):
             cur = next_date
 
 
-prefix_mapping = {offset._prefix: offset for offset in [
+# We use a dict defined in libfrequencies and update it here to avoid
+#  circular import.
+prefix_mapping.update({offset._prefix: offset for offset in [
     YearBegin,                 # 'AS'
     YearEnd,                   # 'A'
     BYearBegin,                # 'BAS'
@@ -2511,4 +2514,4 @@ prefix_mapping = {offset._prefix: offset for offset in [
     WeekOfMonth,               # 'WOM'
     FY5253,
     FY5253Quarter
-]}
+]})


### PR DESCRIPTION
The runtime non-cython import of to_offset is a sticking point in a bunch of tslibs code.  The reason we haven't moved to_offset up into cython is because it requires all of tseries.offsets, and we haven't wanted to move all of that up.

This moves to_offset up by defining appropriate dictionaries in the cython module and then filling them in the python modules.  It's a bit roundabout, but may be worthwhile (about to run asvs)

The refactor that was left out of this PR is moving tslibs.resolution.Resolution into tslibs.frequencies to avoid a circular/runtime import.