### PR TITLE
fixed regression commit

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -118,9 +118,8 @@
     // skipped for the matching benchmark.
     //
     "regressions_first_commits": {
-        ".*": "v0.20.0"
+        ".*": "0409521665"
     },
     "regression_thresholds": {
-        ".*": 0.05
     }
 }


### PR DESCRIPTION
Fixes an issue with the ASV config.

It seems that ASV may not understand tags in the regressions_first_commit. I've replaced that tag with the commit for 0.23.4

I removed the regression threashold, as it's already the default.