### PR TITLE
BUG : ValueError in case on NaN value in groupby columns

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1782,8 +1782,7 @@ Groupby/Resample/Rolling
 - Bug in :meth:`DataFrame.groupby` did not respect the ``observed`` argument when selecting a column and instead always used ``observed=False`` (:issue:`23970`)
 - Bug in :func:`pandas.core.groupby.SeriesGroupBy.pct_change` or :func:`pandas.core.groupby.DataFrameGroupBy.pct_change` would previously work across groups when calculating the percent change, where it now correctly works per group (:issue:`21200`, :issue:`21235`).
 - Bug preventing hash table creation with very large number (2^32) of rows (:issue:`22805`)
-- Bug in groupby which casues ``ValueError`` if ``observed=True`` and ``nan`` is present in group column (:issue:`22805`).
-- Bug in groupby which casues wrong grouping of categorical if ``observed=True`` and ``nan`` is present in group column (:issue:`21151`).
+- Bug in groupby when grouping on categorical causes ``ValueError`` and incorrect grouping if ``observed=True`` and ``nan`` is present in categorical column (:issue:`24850`, :issue:`21151`).
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1782,6 +1782,7 @@ Groupby/Resample/Rolling
 - Bug in :meth:`DataFrame.groupby` did not respect the ``observed`` argument when selecting a column and instead always used ``observed=False`` (:issue:`23970`)
 - Bug in :func:`pandas.core.groupby.SeriesGroupBy.pct_change` or :func:`pandas.core.groupby.DataFrameGroupBy.pct_change` would previously work across groups when calculating the percent change, where it now correctly works per group (:issue:`21200`, :issue:`21235`).
 - Bug preventing hash table creation with very large number (2^32) of rows (:issue:`22805`)
+- Bug in :meth: `pandas.core.groupby.groups` which casues ``ValueError`` if ``observed=True`` and ``nan`` is present in group column (:issue:`22805`) 
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1782,7 +1782,7 @@ Groupby/Resample/Rolling
 - Bug in :meth:`DataFrame.groupby` did not respect the ``observed`` argument when selecting a column and instead always used ``observed=False`` (:issue:`23970`)
 - Bug in :func:`pandas.core.groupby.SeriesGroupBy.pct_change` or :func:`pandas.core.groupby.DataFrameGroupBy.pct_change` would previously work across groups when calculating the percent change, where it now correctly works per group (:issue:`21200`, :issue:`21235`).
 - Bug preventing hash table creation with very large number (2^32) of rows (:issue:`22805`)
-- Bug in groupby when grouping on categorical causes ``ValueError`` and incorrect grouping if ``observed=True`` and ``nan`` is present in categorical column (:issue:`24850`, :issue:`21151`).
+- Bug in groupby when grouping on categorical causes ``ValueError`` and incorrect grouping if ``observed=True`` and ``nan`` is present in categorical column (:issue:`24740`, :issue:`21151`).
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1782,7 +1782,7 @@ Groupby/Resample/Rolling
 - Bug in :meth:`DataFrame.groupby` did not respect the ``observed`` argument when selecting a column and instead always used ``observed=False`` (:issue:`23970`)
 - Bug in :func:`pandas.core.groupby.SeriesGroupBy.pct_change` or :func:`pandas.core.groupby.DataFrameGroupBy.pct_change` would previously work across groups when calculating the percent change, where it now correctly works per group (:issue:`21200`, :issue:`21235`).
 - Bug preventing hash table creation with very large number (2^32) of rows (:issue:`22805`)
-- Bug in :meth: `pandas.core.groupby.groups` which casues ``ValueError`` if ``observed=True`` and ``nan`` is present in group column (:issue:`22805`) 
+- Bug in :meth: `pandas.core.groupby.groups` which casues ``ValueError`` if ``observed=True`` and ``nan`` is present in group column (:issue:`22805`).
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1782,7 +1782,8 @@ Groupby/Resample/Rolling
 - Bug in :meth:`DataFrame.groupby` did not respect the ``observed`` argument when selecting a column and instead always used ``observed=False`` (:issue:`23970`)
 - Bug in :func:`pandas.core.groupby.SeriesGroupBy.pct_change` or :func:`pandas.core.groupby.DataFrameGroupBy.pct_change` would previously work across groups when calculating the percent change, where it now correctly works per group (:issue:`21200`, :issue:`21235`).
 - Bug preventing hash table creation with very large number (2^32) of rows (:issue:`22805`)
-- Bug in :meth: `pandas.core.groupby.groups` which casues ``ValueError`` if ``observed=True`` and ``nan`` is present in group column (:issue:`22805`).
+- Bug in groupby which casues ``ValueError`` if ``observed=True`` and ``nan`` is present in group column (:issue:`22805`).
+- Bug in groupby which casues wrong grouping of categorical if ``observed=True`` and ``nan`` is present in group column (:issue:`21151`).
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -299,6 +299,7 @@ class Grouping(object):
                 self._labels = self.grouper.codes
                 if observed:
                     codes = algorithms.unique1d(self.grouper.codes)
+                    codes = codes[codes != -1]
                 else:
                     codes = np.arange(len(categories))
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -420,16 +420,37 @@ def test_observed_groups(observed):
     tm.assert_dict_equal(result, expected)
 
 
-def test_observed_groups_with_nan():
+def test_observed_groups_with_nan(observed):
     # GH 24740
-    df = pd.DataFrame({'cat': pd.Categorical(['a', 'c', 'a'],
-                       categories=['a', 'b', 'd', 'e', 'f']),
+    df = pd.DataFrame({'cat': pd.Categorical(['a', np.nan, 'a'],
+                       categories=['a', 'b', 'd']),
                        'vals': [1, 2, 3]})
-
-    g = df.groupby('cat', observed=True)
+    g = df.groupby('cat', observed=observed)
     result = g.groups
-    expected = {'a': Index([0, 2], dtype='int64')}
+    if observed:
+        expected = {'a': Index([0, 2], dtype='int64')}
+    else:
+        expected = {'a': Index([0, 2], dtype='int64'),
+                    'b': Index([], dtype='int64'),
+                    'd': Index([], dtype='int64')}
     tm.assert_dict_equal(result, expected)
+
+
+def test_dataframe_categorical_with_nan(observed):
+    # GH 21151
+    s1 = pd.Categorical([np.nan, 'a', np.nan, 'a'],
+                        categories=['a', 'b', 'c'])
+    s2 = pd.Series([1, 2, 3, 4])
+    df = pd.DataFrame({'s1': s1, 's2': s2})
+    result = df.groupby('s1', observed=observed).first().reset_index()
+    if observed:
+        expected = DataFrame({'s1': pd.Categorical(['a'],
+                              categories=['a', 'b', 'c']), 's2': [2]})
+    else:
+        expected = DataFrame({'s1': pd.Categorical(['a', 'b', 'c'],
+                              categories=['a', 'b', 'c']),
+                              's2': [2, np.nan, np.nan]})
+    tm.assert_frame_equal(result, expected)
 
 
 def test_datetime():

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -420,6 +420,18 @@ def test_observed_groups(observed):
     tm.assert_dict_equal(result, expected)
 
 
+def test_observed_groups_with_nan(observed=True):
+    # GH 24740
+    df = pd.DataFrame({'cat': pd.Categorical(['a', 'c', 'a'],
+                       categories=['a', 'b', 'd', 'e', 'f']),
+                       'vals': [1, 2, 3]})
+
+    g = df.groupby('cat', observed=observed)
+    result = g.groups
+    expected = {'a': Index([0, 2], dtype='int64')}
+    tm.assert_dict_equal(result, expected)
+
+
 def test_datetime():
     # GH9049: ensure backward compatibility
     levels = pd.date_range('2014-01-01', periods=4)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -420,13 +420,13 @@ def test_observed_groups(observed):
     tm.assert_dict_equal(result, expected)
 
 
-def test_observed_groups_with_nan(observed=True):
+def test_observed_groups_with_nan():
     # GH 24740
     df = pd.DataFrame({'cat': pd.Categorical(['a', 'c', 'a'],
                        categories=['a', 'b', 'd', 'e', 'f']),
                        'vals': [1, 2, 3]})
 
-    g = df.groupby('cat', observed=observed)
+    g = df.groupby('cat', observed=True)
     result = g.groups
     expected = {'a': Index([0, 2], dtype='int64')}
     tm.assert_dict_equal(result, expected)


### PR DESCRIPTION
Fixes GH24740

- [x] closes #24740 
- [x] closes #21151
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

**Before**
```python
In [5]: ds.groupby("b").groups                                                                                   
Out[5]: {'b': Int64Index([1], dtype='int64'), 'c': Int64Index([2], dtype='int64')}
In [6]: ds.groupby("b", observed=True).groups                                                                    
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-6-d76af2ea5948> in <module>
----> 1 ds.groupby("b", observed=True).groups

~/Softwares/pandas/pandas/core/groupby/groupby.py in groups(self)
    388         """
    389         self._assure_grouper()
--> 390         return self.grouper.groups
    391 

```
**After**
```python
In [5]: ds.groupby('b',observed=True).groups                                                                     
Out[5]: {'b': Int64Index([1], dtype='int64'), 'c': Int64Index([2], dtype='int64')}

```

**Better Example**
```python
In [6]:  df = pd.DataFrame({'cat': pd.Categorical(['a', 'c', 'a'], 
   ...:                        categories=['a', 'b', 'd', 'e', 'f']), 
   ...:                        'vals': [1, 2, 3]})                                                               

In [7]: df                                                                                                       
Out[7]: 
   cat  vals
0    a     1
1  NaN     2
2    a     3

In [8]: df.groupby('cat').groups                                                                                 
Out[8]: 
{'a': Int64Index([0, 2], dtype='int64'),
 'b': Int64Index([], dtype='int64'),
 'd': Int64Index([], dtype='int64'),
 'e': Int64Index([], dtype='int64'),
 'f': Int64Index([], dtype='int64')}

In [9]: df.groupby('cat',observed=True).groups                                                                   
Out[9]: {'a': Int64Index([0, 2], dtype='int64')}



```
