### PR TITLE
BLD: silence npy_no_deprecated warnings with numpy>=1.16.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -460,6 +460,7 @@ if linetrace:
 # in numpy>=1.16.0, silence build warnings about deprecated API usage
 macros.append(('NPY_NO_DEPRECATED_API', '0'))
 
+
 # ----------------------------------------------------------------------
 # Specification of Dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -457,6 +457,8 @@ if linetrace:
     directives['linetrace'] = True
     macros = [('CYTHON_TRACE', '1'), ('CYTHON_TRACE_NOGIL', '1')]
 
+# in numpy>=1.16.0, silence build warnings about deprecated API usage
+macros.append(('NPY_NO_DEPRECATED_API', '0'))
 
 # ----------------------------------------------------------------------
 # Specification of Dependencies

--- a/setup.py
+++ b/setup.py
@@ -458,6 +458,8 @@ if linetrace:
     macros = [('CYTHON_TRACE', '1'), ('CYTHON_TRACE_NOGIL', '1')]
 
 # in numpy>=1.16.0, silence build warnings about deprecated API usage
+#  we can't do anything about these warnings because they stem from
+#  cython+numpy version mismatches.
 macros.append(('NPY_NO_DEPRECATED_API', '0'))
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
