### PR TITLE
CLN: fix typo in asv eval.Query suite

### DIFF
--- a/asv_bench/benchmarks/eval.py
+++ b/asv_bench/benchmarks/eval.py
@@ -45,7 +45,7 @@ class Query(object):
         index = pd.date_range('20010101', periods=N, freq='T')
         s = pd.Series(index)
         self.ts = s.iloc[halfway]
-        self.df = pd.DataFrame({'a': np.random.randn(N), 'dates': s},
+        self.df = pd.DataFrame({'a': np.random.randn(N), 'dates': index},
                                index=index)
         data = np.random.randn(N)
         self.min_val = data.min()


### PR DESCRIPTION
The `eval.Query` asv suite has a large amount of setup overhead due to a typo:
```
$ time asv dev -b eval.Query
· Discovering benchmarks
· Running 3 total benchmarks (1 commits * 1 environments * 3 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_chris_anaconda3_bin_python
[ 16.67%] ··· eval.Query.time_query_datetime_column                                                                                                                 18.3±0ms
[ 33.33%] ··· eval.Query.time_query_datetime_index                                                                                                                  24.8±0ms
[ 50.00%] ··· eval.Query.time_query_with_boolean_selection                                                                                                          44.2±0ms

real ***0m25.883s***
user    0m23.047s
sys     0m2.531s
```

This typo also breaks the intent of the benchmark, as a test done on a datetime column is being done on one entirely of `NaT`s:
```
                            a dates
2001-01-01 00:00:00 -1.228806   NaT
2001-01-01 00:01:00 -2.561029   NaT
2001-01-01 00:02:00  0.879283   NaT
2001-01-01 00:03:00 -0.814045   NaT
2001-01-01 00:04:00 -0.905315   NaT
```
This occurs due to `s` having a `RangeIndex` and being re-indexed to `DatetimeIndex`. This triggers a casting of both to `object` type to find any intersection; this is both slow and unsuccessful here. Instead, we pass the index directly as the input for the dates column:
```
                            a               dates
2001-01-01 00:00:00 -1.068134 2001-01-01 00:00:00
2001-01-01 00:01:00  0.440343 2001-01-01 00:01:00
2001-01-01 00:02:00 -0.767818 2001-01-01 00:02:00
2001-01-01 00:03:00 -0.849333 2001-01-01 00:03:00
2001-01-01 00:04:00  0.737811 2001-01-01 00:04:00
```
And get a nice speedup in `asv` setup time as well:
```
$ time asv dev -b eval.Query
· Discovering benchmarks
· Running 3 total benchmarks (1 commits * 1 environments * 3 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_chris_anaconda3_bin_python
[ 16.67%] ··· eval.Query.time_query_datetime_column                                                                                                                 26.9±0ms
[ 33.33%] ··· eval.Query.time_query_datetime_index                                                                                                                  28.1±0ms
[ 50.00%] ··· eval.Query.time_query_with_boolean_selection                                                                                                          47.1±0ms

real    0m6.336s
user    0m4.281s
sys     0m1.828s
```
And here's the timings on the fixed benchmark:
```
$ asv compare v0.23.4 v0.24.0rc1

All benchmarks:

       before           after         ratio
     [04095216]       [fdc4db25]
     <v0.23.4^0>       <v0.24.0rc1^0>
         14.8±2ms         12.3±1ms    ~0.83  eval.Query.time_query_datetime_column
         15.7±1ms         14.0±1ms    ~0.89  eval.Query.time_query_datetime_index
         21.0±4ms         20.9±7ms     0.99  eval.Query.time_query_with_boolean_selection
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
