### PR TITLE
REF: move methods into cdef classes

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -18,7 +18,6 @@ cnp.import_array()
 
 
 cimport pandas._libs.util as util
-util.import_array()
 
 from pandas._libs.hashtable cimport Int64Vector, Int64VectorData
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -382,7 +382,7 @@ class NaTType(_NaT):
     )
     combine = _make_error_func('combine',  # noqa:E128
         """
-        Timsetamp.combine(date, time)
+        Timestamp.combine(date, time)
 
         date, time -> datetime with same date and time fields
         """
@@ -401,24 +401,7 @@ class NaTType(_NaT):
     # GH9513 NaT methods (except to_datetime64) to raise, return np.nan, or
     # return NaT create functions that raise, for binding to NaTType
     astimezone = _make_error_func('astimezone',  # noqa:E128
-        """
-        Convert tz-aware Timestamp to another time zone.
-
-        Parameters
-        ----------
-        tz : str, pytz.timezone, dateutil.tz.tzfile or None
-            Time zone for time which Timestamp will be converted to.
-            None will remove timezone holding UTC time.
-
-        Returns
-        -------
-        converted : Timestamp
-
-        Raises
-        ------
-        TypeError
-            If Timestamp is tz-naive.
-        """)
+        """Alias for tz_convert.  See tz_convert.__doc__""")
     fromordinal = _make_error_func('fromordinal',  # noqa:E128
         """
         Timestamp.fromordinal(ordinal, freq=None, tz=None)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1105,6 +1105,36 @@ cdef class _Timedelta(timedelta):
                .format(td=components, seconds=seconds))
         return tpl
 
+    # ----------------------------------------------------------------
+
+    def _round(self, freq, rounder):
+        cdef:
+            int64_t result, unit
+
+        unit = to_offset(freq).nanos
+        result = unit * rounder(self.value / float(unit))
+        return Timedelta(result, unit='ns')
+
+    def floor(self, freq):
+        """
+        return a new Timedelta floored to this resolution
+
+        Parameters
+        ----------
+        freq : a freq string indicating the flooring resolution
+        """
+        return self._round(freq, np.floor)
+
+    def ceil(self, freq):
+        """
+        return a new Timedelta ceiled to this resolution
+
+        Parameters
+        ----------
+        freq : a freq string indicating the ceiling resolution
+        """
+        return self._round(freq, np.ceil)
+
 
 # Python front end to C extension type _Timedelta
 # This serves as the box for timedelta64
@@ -1206,14 +1236,6 @@ class Timedelta(_Timedelta):
         object_state = self.value,
         return (Timedelta, object_state)
 
-    def _round(self, freq, rounder):
-        cdef:
-            int64_t result, unit
-
-        unit = to_offset(freq).nanos
-        result = unit * rounder(self.value / float(unit))
-        return Timedelta(result, unit='ns')
-
     def round(self, freq):
         """
         Round the Timedelta to the specified resolution
@@ -1231,26 +1253,6 @@ class Timedelta(_Timedelta):
         ValueError if the freq cannot be converted
         """
         return self._round(freq, np.round)
-
-    def floor(self, freq):
-        """
-        return a new Timedelta floored to this resolution
-
-        Parameters
-        ----------
-        freq : a freq string indicating the flooring resolution
-        """
-        return self._round(freq, np.floor)
-
-    def ceil(self, freq):
-        """
-        return a new Timedelta ceiled to this resolution
-
-        Parameters
-        ----------
-        freq : a freq string indicating the ceiling resolution
-        """
-        return self._round(freq, np.ceil)
 
     # ----------------------------------------------------------------
     # Arithmetic Methods

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -497,6 +497,11 @@ cdef class _Timestamp(datetime):
         elif hasattr(other, '_typ'):
             return NotImplemented
 
+        elif not PyDateTime_Check(self):
+            # cython has called this method with `self, other` swapped,
+            #  since __radd__ is not called by cython classes
+            return other + self
+
         result = datetime.__add__(self, other)
         if PyDateTime_Check(result):
             result = Timestamp(result)
@@ -1351,11 +1356,6 @@ class Timestamp(_Timestamp):
             freq = to_offset(freq)
 
         return create_timestamp_from_ts(ts.value, ts.dts, ts.tzinfo, freq)
-
-    def __radd__(self, other):
-        # __radd__ on cython extension types like _Timestamp is not used, so
-        # define it here instead
-        return self + other
 
 
 # Add the min and max fields at the class level

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -420,20 +420,6 @@ cdef class _Timestamp(datetime):
         elif other.tzinfo is None:
             raise TypeError('Cannot compare tz-naive and tz-aware timestamps')
 
-    cpdef datetime to_pydatetime(_Timestamp self, bint warn=True):
-        """
-        Convert a Timestamp object to a native Python datetime object.
-
-        If warn=True, issue a warning if nanoseconds is nonzero.
-        """
-        if self.nanosecond != 0 and warn:
-            warnings.warn("Discarding nonzero nanoseconds in conversion",
-                          UserWarning, stacklevel=2)
-
-        return datetime(self.year, self.month, self.day,
-                        self.hour, self.minute, self.second,
-                        self.microsecond, self.tzinfo)
-
     def __add__(self, other):
         cdef:
             int64_t other_int, nanos
@@ -661,6 +647,20 @@ cdef class _Timestamp(datetime):
 
     # --------------------------------------------------------------------
     # Conversion
+
+    cpdef datetime to_pydatetime(_Timestamp self, bint warn=True):
+        """
+        Convert a Timestamp object to a native Python datetime object.
+
+        If warn=True, issue a warning if nanoseconds is nonzero.
+        """
+        if self.nanosecond != 0 and warn:
+            warnings.warn("Discarding nonzero nanoseconds in conversion",
+                          UserWarning, stacklevel=2)
+
+        return datetime(self.year, self.month, self.day,
+                        self.hour, self.minute, self.second,
+                        self.microsecond, self.tzinfo)
 
     def timestamp(self):
         """Return POSIX timestamp as float."""


### PR DESCRIPTION
A bunch of methods are defined in Timestamp/Timedelta that can be defined in _Timestamp/_Timedelta.  Moving these into the cdef classes is supposedly slightly more efficient.  If we can work around the `__cinit__/__new__` rules, we might be able to get rid of _Timestamp entirely.

Fix a couple of typos while we're at it.