### PR TITLE
DOC: fixups

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -13,6 +13,9 @@ What's New in 0.24.0 (January XX, 2019)
 These are the changes in pandas 0.24.0. See :ref:`release` for a full changelog
 including other versions of pandas.
 
+Enhancements
+~~~~~~~~~~~~
+
 Highlights include
 
 * :ref:`Optional Nullable Integer Support <whatsnew_0240.enhancements.intna>`
@@ -1165,7 +1168,7 @@ Other API Changes
 .. _whatsnew_0240.api.extension:
 
 ExtensionType Changes
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~
 
 **Equality and Hashability**
 


### PR DESCRIPTION
* Fixed heading on whatnew
* Remove empty scalars.rst

If you look at http://pandas-docs.github.io/pandas-docs-travis/whatsnew/v0.24.0.html, you'll see that the TOC-tree is messed up. It includes every "level-3" header, since the highlights aren't nested under a "level-2" header.