### PR TITLE
CLN: fix typo in ctors.SeriesDtypesConstructors setup

### DIFF
--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -72,7 +72,7 @@ class SeriesDtypesConstructors(object):
 
     def setup(self):
         N = 10**4
-        self.arr = np.random.randn(N, N)
+        self.arr = np.random.randn(N)
         self.arr_str = np.array(['foo', 'bar', 'baz'], dtype=object)
         self.s = Series([Timestamp('20110101'), Timestamp('20120101'),
                          Timestamp('20130101')] * N * 10)


### PR DESCRIPTION
Our benchmark for creating an `Index` from an array of floats does so from a **2-d** array, seemingly dating from when this benchmark tested `DataFrame` creation (see https://github.com/pandas-dev/pandas/commit/04db779d4c93d286bb0ab87780a85d50ec490266#diff-408a9d5de471447a365854703ca1856dL22).

Changing this to a 1-d array has no significant impact on benchmark times while reducing setup by ~40 seconds.

Before:
```
$ time asv dev -b ctors.SeriesDtypes
· Discovering benchmarks
· Running 4 total benchmarks (1 commits * 1 environments * 4 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_chris_anaconda3_bin_python
[ 12.50%] ··· ctors.SeriesDtypesConstructors.time_dtindex_from_index_with_series        2.44±0ms
[ 25.00%] ··· ctors.SeriesDtypesConstructors.time_dtindex_from_series                   2.25±0ms
[ 37.50%] ··· ctors.SeriesDtypesConstructors.time_index_from_array_floats                760±0μs
[ 50.00%] ··· ctors.SeriesDtypesConstructors.time_index_from_array_string                942±0μs

real    0m51.040s
user    0m39.813s
sys     0m10.172s
```

After:
```
$ time asv dev -b ctors.SeriesDtypes
· Discovering benchmarks
· Running 4 total benchmarks (1 commits * 1 environments * 4 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_chris_anaconda3_bin_python
[ 12.50%] ··· ctors.SeriesDtypesConstructors.time_dtindex_from_index_with_series        2.37±0ms
[ 25.00%] ··· ctors.SeriesDtypesConstructors.time_dtindex_from_series                   2.33±0ms
[ 37.50%] ··· ctors.SeriesDtypesConstructors.time_index_from_array_floats                763±0μs
[ 50.00%] ··· ctors.SeriesDtypesConstructors.time_index_from_array_string                885±0μs

real    0m13.000s
user    0m9.031s
sys     0m3.547s
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
