### PR TITLE
DOC: also redirect old whatsnew url

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -1,6 +1,9 @@
 # This file should contain all the redirects in the documentation
 # in the format `<old_path>,<new_path>`
 
+# whatsnew
+whatsnew,whatsnew/index
+
 # getting started
 10min,getting_started/10min
 basics,getting_started/basics

--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -3,6 +3,7 @@
 
 # whatsnew
 whatsnew,whatsnew/index
+release,whatsnew/index
 
 # getting started
 10min,getting_started/10min


### PR DESCRIPTION
The whatsnew was already splitted longer time ago, but I think we can also add a redirect for the main release page.