### PR TITLE
API/VIS: remove misc plotting methods from plot accessor (revert #23811)

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -429,7 +429,6 @@ Other Enhancements
 - :meth:`MultiIndex.to_flat_index` has been added to flatten multiple levels into a single-level :class:`Index` object.
 - :meth:`DataFrame.to_stata` and :class:`pandas.io.stata.StataWriter117` can write mixed sting columns to Stata strl format (:issue:`23633`)
 - :meth:`DataFrame.between_time` and :meth:`DataFrame.at_time` have gained the ``axis`` parameter (:issue:`8839`)
-- The ``scatter_matrix``, ``andrews_curves``, ``parallel_coordinates``, ``lag_plot``, ``autocorrelation_plot``, ``bootstrap_plot``, and ``radviz`` plots from the ``pandas.plotting`` module are now accessible from calling :meth:`DataFrame.plot` (:issue:`11978`)
 - :meth:`DataFrame.to_records` now accepts ``index_dtypes`` and ``column_dtypes`` parameters to allow different data types in stored column and index records (:issue:`18146`)
 - :class:`IntervalIndex` has gained the :attr:`~IntervalIndex.is_overlapping` attribute to indicate if the ``IntervalIndex`` contains any overlapping intervals (:issue:`23309`)
 - :func:`pandas.DataFrame.to_sql` has gained the ``method`` argument to control SQL insertion clause. See the :ref:`insertion method <io.sql.method>` section in the documentation. (:issue:`8953`)

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -26,7 +26,6 @@ from pandas.core.config import get_option
 from pandas.core.generic import _shared_doc_kwargs, _shared_docs
 
 from pandas.io.formats.printing import pprint_thing
-from pandas.plotting import _misc as misc
 from pandas.plotting._compat import _mpl_ge_3_0_0
 from pandas.plotting._style import _get_standard_colors, plot_params
 from pandas.plotting._tools import (
@@ -2906,15 +2905,6 @@ class SeriesPlotMethods(BasePlotMethods):
         """
         return self(kind='pie', **kwds)
 
-    def lag(self, *args, **kwds):
-        return misc.lag_plot(self._parent, *args, **kwds)
-
-    def autocorrelation(self, *args, **kwds):
-        return misc.autocorrelation_plot(self._parent, *args, **kwds)
-
-    def bootstrap(self, *args, **kwds):
-        return misc.bootstrap_plot(self._parent, *args, **kwds)
-
 
 class FramePlotMethods(BasePlotMethods):
     """DataFrame plotting accessor and method
@@ -3610,16 +3600,3 @@ class FramePlotMethods(BasePlotMethods):
         if gridsize is not None:
             kwds['gridsize'] = gridsize
         return self(kind='hexbin', x=x, y=y, C=C, **kwds)
-
-    def scatter_matrix(self, *args, **kwds):
-        return misc.scatter_matrix(self._parent, *args, **kwds)
-
-    def andrews_curves(self, class_column, *args, **kwds):
-        return misc.andrews_curves(self._parent, class_column, *args, **kwds)
-
-    def parallel_coordinates(self, class_column, *args, **kwds):
-        return misc.parallel_coordinates(self._parent, class_column,
-                                         *args, **kwds)
-
-    def radviz(self, class_column, *args, **kwds):
-        return misc.radviz(self._parent, class_column, *args, **kwds)

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -2988,22 +2988,6 @@ class TestDataFramePlots(TestPlotBase):
         self._check_ticks_props(axes=ax.right_ax,
                                 ylabelsize=fontsize)
 
-    def test_misc_bindings(self, monkeypatch):
-        df = pd.DataFrame(randn(10, 10), columns=list('abcdefghij'))
-        monkeypatch.setattr('pandas.plotting._misc.scatter_matrix',
-                            lambda x: 2)
-        monkeypatch.setattr('pandas.plotting._misc.andrews_curves',
-                            lambda x, y: 2)
-        monkeypatch.setattr('pandas.plotting._misc.parallel_coordinates',
-                            lambda x, y: 2)
-        monkeypatch.setattr('pandas.plotting._misc.radviz',
-                            lambda x, y: 2)
-
-        assert df.plot.scatter_matrix() == 2
-        assert df.plot.andrews_curves('a') == 2
-        assert df.plot.parallel_coordinates('a') == 2
-        assert df.plot.radviz('a') == 2
-
 
 def _generate_4_axes_via_gridspec():
     import matplotlib.pyplot as plt

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -878,19 +878,6 @@ class TestSeriesPlots(TestPlotBase):
 
         _check_plot_works(s.plot)
 
-    def test_misc_bindings(self, monkeypatch):
-        s = Series(randn(10))
-        monkeypatch.setattr('pandas.plotting._misc.lag_plot',
-                            lambda x: 2)
-        monkeypatch.setattr('pandas.plotting._misc.autocorrelation_plot',
-                            lambda x: 2)
-        monkeypatch.setattr('pandas.plotting._misc.bootstrap_plot',
-                            lambda x: 2)
-
-        assert s.plot.lag() == 2
-        assert s.plot.autocorrelation() == 2
-        assert s.plot.bootstrap() == 2
-
     @pytest.mark.xfail
     def test_plot_accessor_updates_on_inplace(self):
         s = Series([1, 2, 3, 4])


### PR DESCRIPTION
To be clear: I am opening this for discussion, but directly as a PR instead of an issue so it is easier to merge it in case we agree.

https://github.com/pandas-dev/pandas/pull/23811 added the misc plotting methods (like 'andrew_curves', 'parallel_coordinates', .. see http://pandas.pydata.org/pandas-docs/stable/visualization.html#plotting-tools) to the `DataFrame/Series.plot` accessor. 

But personally, I think we really shouldn't expose those methods too much (we should rather be deprecating them, but we only kept them for historical reasons). 

cc @jreback @mroeschke 