### PR TITLE
CLN: reduce overhead in setup for categoricals benchmarks in asv

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -223,11 +223,16 @@ class CategoricalSlicing(object):
 
     def setup(self, index):
         N = 10**6
-        values = list('a' * N + 'b' * N + 'c' * N)
+        categories = ['a', 'b', 'c']
+        values = [0] * N + [1] * N + [2] * N
         indices = {
-            'monotonic_incr': pd.Categorical(values),
-            'monotonic_decr': pd.Categorical(reversed(values)),
-            'non_monotonic': pd.Categorical(list('abc' * N))}
+            'monotonic_incr': pd.Categorical.from_codes(values,
+                                                        categories=categories),
+            'monotonic_decr': pd.Categorical.from_codes(list(reversed(values)),
+                                                        categories=categories),
+            'non_monotonic': pd.Categorical.from_codes([0, 1, 2] * N,
+                                                       categories=categories)
+        }
         self.data = indices[index]
 
         self.scalar = 10000

--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -225,15 +225,17 @@ class CategoricalSlicing(object):
         N = 10**6
         categories = ['a', 'b', 'c']
         values = [0] * N + [1] * N + [2] * N
-        indices = {
-            'monotonic_incr': pd.Categorical.from_codes(values,
-                                                        categories=categories),
-            'monotonic_decr': pd.Categorical.from_codes(list(reversed(values)),
-                                                        categories=categories),
-            'non_monotonic': pd.Categorical.from_codes([0, 1, 2] * N,
-                                                       categories=categories)
-        }
-        self.data = indices[index]
+        if index == 'monotonic_incr':
+            self.data = pd.Categorical.from_codes(values,
+                                                  categories=categories)
+        elif index == 'monotonic_decr':
+            self.data = pd.Categorical.from_codes(list(reversed(values)),
+                                                  categories=categories)
+        elif index == 'non_monotonic':
+            self.data = pd.Categorical.from_codes([0, 1, 2] * N,
+                                                  categories=categories)
+        else:
+            raise ValueError('Invalid index param: {}'.format(index))
 
         self.scalar = 10000
         self.list = list(range(10000))


### PR DESCRIPTION
The setup functions for the `categoricals.CategoricalSlicing` suite have ~40s of overhead that can be eliminated by two approaches:

- Use `pd.CategoricalIndex.from_codes()` instead of `pd.CategoricalIndex()`
  - ~30s of the speedup comes from this
- Replace the dict of all cases with an `if`/`else` block to minimize unnecessary construction
  - Another ~10s speedup from this

Before:
```
$ time asv dev -b CategoricalSlicing
[...]
real    1m3.747s
user    0m46.250s
sys     0m15.141s
```

After:
```
$ time asv dev -b CategoricalSlicing
real    0m23.893s
user    0m14.578s
sys     0m6.578s
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
