### PR TITLE
BUG-24212 fix regression in #24897

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1836,6 +1836,7 @@ Reshaping
 - Bug in :func:`DataFrame.stack` where timezone aware values were converted to timezone naive values (:issue:`19420`)
 - Bug in :func:`merge_asof` where a ``TypeError`` was raised when ``by_col`` were timezone aware values (:issue:`21184`)
 - Bug showing an incorrect shape when throwing error during ``DataFrame`` construction. (:issue:`20742`)
+- Bug in :func:`merge` when merging by index name would sometimes result in an incorrectly numbered index (:issue:`24212`)
 
 .. _whatsnew_0240.bug_fixes.sparse:
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1836,7 +1836,6 @@ Reshaping
 - Bug in :func:`DataFrame.stack` where timezone aware values were converted to timezone naive values (:issue:`19420`)
 - Bug in :func:`merge_asof` where a ``TypeError`` was raised when ``by_col`` were timezone aware values (:issue:`21184`)
 - Bug showing an incorrect shape when throwing error during ``DataFrame`` construction. (:issue:`20742`)
-- Bug in :func:`merge` when merging by index name would sometimes result in an incorrectly numbered index (:issue:`24212`)
 
 .. _whatsnew_0240.bug_fixes.sparse:
 

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -63,6 +63,9 @@ Bug Fixes
 -
 -
 
+**Reshaping**
+
+- Bug in :func:`merge` when merging by index name would sometimes result in an incorrectly numbered index (:issue:`24212`)
 
 **Other**
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -758,12 +758,26 @@ class _MergeOperation(object):
             if self.right_index:
                 if len(self.left) > 0:
                     join_index = self.left.index.take(left_indexer)
+                    if (self.how == 'right' and -1 in left_indexer
+                            and not isinstance(self.right.index, MultiIndex)):
+                        join_list = join_index.to_numpy()
+                        absent = left_indexer == -1
+                        join_list[absent] = self.right.index.to_numpy()[absent]
+                        join_index = Index(join_list, dtype=join_index.dtype,
+                                           name=join_index.name)
                 else:
                     join_index = self.right.index.take(right_indexer)
                     left_indexer = np.array([-1] * len(join_index))
             elif self.left_index:
                 if len(self.right) > 0:
                     join_index = self.right.index.take(right_indexer)
+                    if (self.how == 'left' and -1 in right_indexer
+                            and not isinstance(self.left.index, MultiIndex)):
+                        join_list = join_index.to_numpy()
+                        absent = right_indexer == -1
+                        join_list[absent] = self.left.index.to_numpy()[absent]
+                        join_index = Index(join_list, dtype=join_index.dtype,
+                                           name=join_index.name)
                 else:
                     join_index = self.left.index.take(left_indexer)
                     right_indexer = np.array([-1] * len(join_index))

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -777,6 +777,7 @@ class _MergeOperation(object):
                             and not isinstance(self.left.index, MultiIndex)):
                         # if values missing (-1) from right index,
                         # take from left index instead
+                        print(right_indexer)
                         join_list = join_index.to_numpy()
                         absent = right_indexer == -1
                         join_list[absent] = self.left.index.to_numpy()[absent]

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -757,6 +757,7 @@ class _MergeOperation(object):
 
             if self.right_index:
                 if len(self.left) > 0:
+                    print(left_indexer)
                     join_index = self._create_join_index(self.left.index,
                                                          self.right.index,
                                                          left_indexer,

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -760,6 +760,7 @@ class _MergeOperation(object):
                     join_index = self._create_join_index(self.left.index,
                                                          self.right.index,
                                                          left_indexer,
+                                                         right_indexer,
                                                          how='right')
                 else:
                     join_index = self.right.index.take(right_indexer)
@@ -769,6 +770,7 @@ class _MergeOperation(object):
                     join_index = self._create_join_index(self.right.index,
                                                          self.left.index,
                                                          right_indexer,
+                                                         left_indexer,
                                                          how='left')
                 else:
                     join_index = self.left.index.take(left_indexer)
@@ -780,7 +782,8 @@ class _MergeOperation(object):
             join_index = join_index.astype(object)
         return join_index, left_indexer, right_indexer
 
-    def _create_join_index(self, index, other_index, indexer, how='left'):
+    def _create_join_index(self, index, other_index, indexer,
+                           other_indexer, how='left'):
         """
         Create a join index by rearranging one index to match another
 
@@ -806,7 +809,8 @@ class _MergeOperation(object):
                 # if values missing (-1) from target index,
                 # take from other_index instead
                 join_list = join_index.to_numpy()
-                join_list[mask] = other_index.to_numpy()[mask]
+                other_list = other_index.take(other_indexer).to_numpy()
+                join_list[mask] = other_list[mask]
                 join_index = Index(join_list, dtype=join_index.dtype,
                                    name=join_index.name)
         return join_index

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -757,15 +757,19 @@ class _MergeOperation(object):
 
             if self.right_index:
                 if len(self.left) > 0:
-                    join_index = self._create_join_index(left_indexer,
-                                                         using_left=True)
+                    join_index = self._create_join_index(self.left.index,
+                                                         self.right.index,
+                                                         left_indexer,
+                                                         how='right')
                 else:
                     join_index = self.right.index.take(right_indexer)
                     left_indexer = np.array([-1] * len(join_index))
             elif self.left_index:
                 if len(self.right) > 0:
-                    join_index = self._create_join_index(right_indexer,
-                                                         using_left=False)
+                    join_index = self._create_join_index(self.right.index,
+                                                         self.left.index,
+                                                         right_indexer,
+                                                         how='left')
                 else:
                     join_index = self.left.index.take(left_indexer)
                     right_indexer = np.array([-1] * len(join_index))
@@ -776,24 +780,33 @@ class _MergeOperation(object):
             join_index = join_index.astype(object)
         return join_index, left_indexer, right_indexer
 
-    def _create_join_index(self, indexer, using_left=True):
-        if using_left:
-            index = self.left.index
-            other_index = self.right.index
-            how_check = 'right'
-        else:
-            index = self.right.index
-            other_index = self.left.index
-            how_check = 'left'
+    def _create_join_index(self, index, other_index, indexer, how='left'):
+        """
+        Create a join index by rearranging one index to match another
 
+        Parameters
+        ----------
+        index: Index being rearranged
+        other_index: Index used to supply values not found in index
+        indexer: how to rearrange index
+        how: replacement is only necessary if indexer based on other_index
+
+        Returns
+        -------
+        join_index
+        """
         join_index = index.take(indexer)
-        if self.how == how_check and not isinstance(other_index, MultiIndex):
-            absent = indexer == -1
-            if any(absent):
+        if (self.how in (how, 'outer') and
+                not isinstance(other_index, MultiIndex)):
+            # if final index requires values in other_index but not target
+            # index, indexer may hold missing (-1) values, causing Index.take
+            # to take the final value in target index
+            mask = indexer == -1
+            if np.any(mask):
                 # if values missing (-1) from target index,
-                # take from other index instead
+                # take from other_index instead
                 join_list = join_index.to_numpy()
-                join_list[absent] = other_index.to_numpy()[absent]
+                join_list[mask] = other_index.to_numpy()[mask]
                 join_index = Index(join_list, dtype=join_index.dtype,
                                    name=join_index.name)
         return join_index

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -757,7 +757,6 @@ class _MergeOperation(object):
 
             if self.right_index:
                 if len(self.left) > 0:
-                    print(left_indexer)
                     join_index = self._create_join_index(self.left.index,
                                                          self.right.index,
                                                          left_indexer,

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -760,6 +760,8 @@ class _MergeOperation(object):
                     join_index = self.left.index.take(left_indexer)
                     if (self.how == 'right' and -1 in left_indexer
                             and not isinstance(self.right.index, MultiIndex)):
+                        # if values missing (-1) from left index,
+                        # take from right index instead
                         join_list = join_index.to_numpy()
                         absent = left_indexer == -1
                         join_list[absent] = self.right.index.to_numpy()[absent]
@@ -773,6 +775,8 @@ class _MergeOperation(object):
                     join_index = self.right.index.take(right_indexer)
                     if (self.how == 'left' and -1 in right_indexer
                             and not isinstance(self.left.index, MultiIndex)):
+                        # if values missing (-1) from right index,
+                        # take from left index instead
                         join_list = join_index.to_numpy()
                         absent = right_indexer == -1
                         join_list[absent] = self.left.index.to_numpy()[absent]

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1170,7 +1170,8 @@ class TestMergeDtypes(object):
         with pytest.raises(ValueError, match=msg):
             pd.merge(df2, df1, on=['A'])
 
-    def test_merge_on_index_with_more_values(self):  # GH 24212
+    def test_merge_on_index_with_more_values(self):
+        # GH 24212
         df1 = pd.DataFrame([[1, 2], [2, 4], [3, 6], [4, 8]],
                            columns=['a', 'b'])
         df2 = pd.DataFrame([[3, 30], [4, 40]],

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -964,7 +964,7 @@ class TestMerge(object):
         left = pd.DataFrame({'a': [1, 2, 3], 'key': [0, 1, 1]})
         right = pd.DataFrame({'b': [1, 2, 3]})
 
-        expected = pd.DataFrame({'a': [1, 2, 3, None, None, None],
+        expected = pd.DataFrame({'a': [1, 2, 3, None],
                                  'key': [0, 1, 1, 2],
                                  'b': [1, 2, 2, 3]},
                                 columns=['a', 'key', 'b'],

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1170,6 +1170,16 @@ class TestMergeDtypes(object):
         with pytest.raises(ValueError, match=msg):
             pd.merge(df2, df1, on=['A'])
 
+    def test_merge_on_index_with_more_values(self):  # GH 24212
+        df1 = pd.DataFrame([[1, 2], [2, 4], [3, 6], [4, 8]],
+                           columns=['a', 'b'])
+        df2 = pd.DataFrame([[3, 30], [4, 40]],
+                           columns=['a', 'c'])
+        df1.set_index('a', drop=False, inplace=True)
+        df2.set_index('a', inplace=True)
+        result = pd.merge(df1, df2, left_index=True, right_on='a', how='left')
+        assert 1 in result.index
+
 
 @pytest.fixture
 def left():

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -940,7 +940,6 @@ class TestMerge(object):
             merge(a, a, on=('a', 'b'))
 
     @pytest.mark.parametrize('how', ['left', 'outer'])
-    @pytest.mark.xfail(reason="GH-24897")
     def test_merge_on_index_with_more_values(self, how):
         # GH 24212
         # pd.merge gets [-1, -1, 0, 1] as right_indexer, ensure that -1 is
@@ -1169,17 +1168,6 @@ class TestMergeDtypes(object):
         msg = re.escape(msg)
         with pytest.raises(ValueError, match=msg):
             pd.merge(df2, df1, on=['A'])
-
-    def test_merge_on_index_with_more_values(self):
-        # GH 24212
-        df1 = pd.DataFrame([[1, 2], [2, 4], [3, 6], [4, 8]],
-                           columns=['a', 'b'])
-        df2 = pd.DataFrame([[3, 30], [4, 40]],
-                           columns=['a', 'c'])
-        df1.set_index('a', drop=False, inplace=True)
-        df2.set_index('a', inplace=True)
-        result = pd.merge(df1, df2, left_index=True, right_on='a', how='left')
-        assert 1 in result.index
 
 
 @pytest.fixture

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -939,31 +939,11 @@ class TestMerge(object):
         with np.errstate(divide='raise'):
             merge(a, a, on=('a', 'b'))
 
-    @pytest.mark.parametrize('how', ['left', 'outer'])
-    def test_merge_on_index_with_more_values(self, how):
-        # GH 24212
-        # pd.merge gets [-1, -1, 0, 1] as right_indexer, ensure that -1 is
-        # interpreted as a missing value instead of the last element
-        df1 = pd.DataFrame([[1, 2], [2, 4], [3, 6], [4, 8]],
-                           columns=['a', 'b'])
-        df2 = pd.DataFrame([[3, 30], [4, 40]],
-                           columns=['a', 'c'])
-        df1.set_index('a', drop=False, inplace=True)
-        df2.set_index('a', inplace=True)
-        result = pd.merge(df1, df2, left_index=True, right_on='a', how=how)
-        expected = pd.DataFrame([[1, 2, np.nan],
-                                 [2, 4, np.nan],
-                                 [3, 6, 30.0],
-                                 [4, 8, 40.0]],
-                                columns=['a', 'b', 'c'])
-        expected.set_index('a', drop=False, inplace=True)
-        assert_frame_equal(result, expected)
-
     @pytest.mark.parametrize('how', ['right', 'outer'])
     def test_merge_on_index_with_more_values(self, how):
         # GH 24212
-        # pd.merge gets [-1, -1, 0, 1] as right_indexer, ensure that -1 is
-        # interpreted as a missing value instead of the last element
+        # pd.merge gets [0, 1, 2, -1, -1, -1] as left_indexer, ensure that
+        # -1 is interpreted as a missing value instead of the last element
         df1 = pd.DataFrame({'a': [1, 2, 3], 'key': [0, 2, 2]})
         df2 = pd.DataFrame({'b': [1, 2, 3, 4, 5]})
         result = df1.merge(df2, left_on='key', right_index=True, how=how)
@@ -984,7 +964,7 @@ class TestMerge(object):
         left = pd.DataFrame({'a': [1, 2, 3], 'key': [0, 1, 1]})
         right = pd.DataFrame({'b': [1, 2, 3]})
 
-        expected = pd.DataFrame({'a': [1, 2, 3, None],
+        expected = pd.DataFrame({'a': [1, 2, 3, None, None, None],
                                  'key': [0, 1, 1, 2],
                                  'b': [1, 2, 2, 3]},
                                 columns=['a', 'key', 'b'],


### PR DESCRIPTION
- [ ] closes #24897
- [x] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Use an extra take to ensure the `other_index` is arranged correctly for replacing values (in the original issue, the `other_index` would've taken from [0, 1, 2, 3] and be left unchanged, so this step was overlooked)