### PR TITLE
CLN: fix typo in asv benchmark of non_unique_sorted, which was not sorted

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -138,7 +138,8 @@ class Indexing(object):
         self.sorted = self.idx.sort_values()
         half = N // 2
         self.non_unique = self.idx[:half].append(self.idx[:half])
-        self.non_unique_sorted = self.sorted[:half].append(self.sorted[:half])
+        self.non_unique_sorted = (self.sorted[:half].append(self.sorted[:half])
+                                  .sort_values())
         self.key = self.sorted[N // 4]
 
     def time_boolean_array(self, dtype):


### PR DESCRIPTION
Our benchmark for sorted, non-unique indexes is not sorted. This PR sorts the test data, leading to significantly different benchmark results. Before:
```
[  0.01%] ··· index_object.Indexing.time_get_loc_non_unique_sorted
                                                                                                        ok
[  0.01%] ··· ======== ============
               dtype
              -------- ------------
               String    319±4ms
               Float    2.74±0.1ms
                Int     1.80±0.1ms
              ======== ============
```
New:
```
[  0.01%] ··· index_object.Indexing.time_get_loc_non_unique_sorted                                                                                                        ok
[  0.01%] ··· ======== ==========
               dtype
              -------- ----------
               String   187±20ms
               Float    57.2±2μs
                Int     16.6±3μs
              ======== ==========
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
