### PR TITLE
Add tests for NaT when performing dt.to_period

### DIFF
--- a/pandas/tests/series/test_period.py
+++ b/pandas/tests/series/test_period.py
@@ -165,12 +165,11 @@ class TestSeriesPeriod(object):
         expected = s.apply(lambda x: x.end_time)
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize('input_vals, expected', [
-        (Series(['2001'], dtype='datetime64[ns]'),
-         Series(['2001'], dtype='period[D]')),
-        (Series(['NaT'], dtype='datetime64[ns]'),
-         Series(['NaT'], dtype='period[D]'))
+    @pytest.mark.parametrize('input_vals', [
+        ('2001'), ('NaT')
     ])
-    def test_to_period(self, input_vals, expected):
-        result = input_vals.dt.to_period('D')
+    def test_to_period(self, input_vals):
+        # GH 21205
+        expected = Series([input_vals], dtype='Period[D]')
+        result = Series([input_vals], dtype='datetime64[ns]').dt.to_period('D')
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/test_period.py
+++ b/pandas/tests/series/test_period.py
@@ -165,9 +165,12 @@ class TestSeriesPeriod(object):
         expected = s.apply(lambda x: x.end_time)
         tm.assert_series_equal(result, expected)
 
-    def test_to_period(self):
-        series = pd.Series(['2001'], dtype='datetime64[ns]')
-        assert series.dt.to_period('D').dtype == 'Period[D]'
-
-        series = pd.Series(['NaT'], dtype='datetime64[ns]')
-        assert series.dt.to_period('D').dtype == 'Period[D]'
+    @pytest.mark.parametrize('input_vals, expected', [
+        (Series(['2001'], dtype='datetime64[ns]'),
+         Series(['2001'], dtype='period[D]')),
+        (Series(['NaT'], dtype='datetime64[ns]'),
+         Series(['NaT'], dtype='period[D]'))
+    ])
+    def test_to_period(self, input_vals, expected):
+        result = input_vals.dt.to_period('D')
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/test_period.py
+++ b/pandas/tests/series/test_period.py
@@ -164,3 +164,10 @@ class TestSeriesPeriod(object):
         result = s.dt.end_time
         expected = s.apply(lambda x: x.end_time)
         tm.assert_series_equal(result, expected)
+
+    def test_to_period(self):
+        series = pd.Series(['2001'], dtype='datetime64[ns]')
+        assert series.dt.to_period('D').dtype == 'Period[D]'
+
+        series = pd.Series(['NaT'], dtype='datetime64[ns]')
+        assert series.dt.to_period('D').dtype == 'Period[D]'


### PR DESCRIPTION

@mroeschke Here is a test that tests the functionality discussed in the issue. Please let me know if it needs to be done differently and if more tests should be added.

- [x] closes #21205 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
