### PR TITLE
DOC: Adding version to the whatsnew section in the home page

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -39,7 +39,7 @@ See the :ref:`overview` for more detail about what's in the library.
 {% endif %}
 
     {% if not single_doc -%}
-    What's New <whatsnew/v0.24.0>
+    whatsnew/v0.24.0
     install
     getting_started/index
     user_guide/index

--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -39,7 +39,7 @@ See the :ref:`overview` for more detail about what's in the library.
 {% endif %}
 
     {% if not single_doc -%}
-    whatsnew/v0.24.0
+    What's New in 0.24.0 <whatsnew/v0.24.0>
     install
     getting_started/index
     user_guide/index


### PR DESCRIPTION
@TomAugspurger @jorisvandenbossche 

Not so important, but looking at the home, feels quite weird to have the "What's New" section first thing in the toctree, without specifying what's new of in which version.

May be it's just me, feel free to dismiss this, but wanted to open as it's a trivial change, and IMO makes it much clearer.

You can see how this looks here: https://datapythonista.github.io/pandas-doc-preview/

Sorry for the last minute stuff.