### PR TITLE
DOC: switch headline whatsnew to 0.25

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -39,7 +39,7 @@ See the :ref:`overview` for more detail about what's in the library.
 {% endif %}
 
     {% if not single_doc -%}
-    What's New in 0.24.0 <whatsnew/v0.24.0>
+    What's New in 0.25.0 <whatsnew/v0.25.0>
     install
     getting_started/index
     user_guide/index

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1,9 +1,12 @@
-:orphan:
-
 .. _whatsnew_0250:
 
 What's New in 0.25.0 (April XX, 2019)
 -------------------------------------
+
+.. warning::
+
+   Starting with the 0.25.x series of releases, pandas only supports Python 3.5 and higher.
+   See :ref:`install.dropping-27` for more details.
 
 {{ header }}
 


### PR DESCRIPTION
@TomAugspurger 

Not sure if the warning is still desired or necessary. I'm just thinking that "explicit is better than implicit".
