### PR TITLE
DOC: State that we support scalars in to_numeric

### DIFF
--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -21,7 +21,7 @@ def to_numeric(arg, errors='raise', downcast=None):
 
     Parameters
     ----------
-    arg : list, tuple, 1-d array, or Series
+    arg : scalar, list, tuple, 1-d array, or Series
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception
         - If 'coerce', then invalid parsing will be set as NaN


### PR DESCRIPTION
We [support it](https://github.com/pandas-dev/pandas/blob/0c4113f/pandas/core/tools/numeric.py#L114-L120) and [test it](https://github.com/pandas-dev/pandas/blob/0c4113f/pandas/tests/tools/test_numeric.py#L174-L185) already.

xref #24910.
