### PR TITLE
REGR: Preserve order by default in Index.intersection

### DIFF
--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -16,6 +16,13 @@ These are the changes in pandas 0.24.1. See :ref:`release` for a full changelog
 including other versions of pandas.
 
 
+.. _whatsnew_0241.regressions:
+
+Fixed Regressions
+^^^^^^^^^^^^^^^^^
+
+- Fixed regression in :class:`Index.intersection` incorrectly sorting the values by default (:issue:`24959`).
+
 .. _whatsnew_0241.enhancements:
 
 Enhancements

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -22,12 +22,6 @@ Fixed Regressions
 
 - Bug in :meth:`DataFrame.itertuples` with ``records`` orient raising an ``AttributeError`` when the ``DataFrame`` contained more than 255 columns (:issue:`24939`)
 - Bug in :meth:`DataFrame.itertuples` orient converting integer column names to strings prepended with an underscore (:issue:`24940`)
-
-.. _whatsnew_0241.regressions:
-
-Fixed Regressions
-^^^^^^^^^^^^^^^^^
-
 - Fixed regression in :class:`Index.intersection` incorrectly sorting the values by default (:issue:`24959`).
 
 .. _whatsnew_0241.enhancements:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2333,7 +2333,7 @@ class Index(IndexOpsMixin, PandasObject):
     def _wrap_setop_result(self, other, result):
         return self._constructor(result, name=get_op_result_name(self, other))
 
-    def intersection(self, other, sort=True):
+    def intersection(self, other, sort=False):
         """
         Form the intersection of two Index objects.
 
@@ -2342,10 +2342,14 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         other : Index or array-like
-        sort : bool, default True
+        sort : bool, default False
             Sort the resulting index if possible
 
             .. versionadded:: 0.24.0
+
+            .. versionchanged:: 0.24.1
+
+               Changed the default from ``True`` to ``False``.
 
         Returns
         -------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -603,7 +603,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         ----------
         other : DatetimeIndex or array-like
         sort : bool, default True
-            Sort the resulting MultiIndex if possible
+            Sort the resulting index if possible.
 
             .. versionadded:: 0.24.0
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -594,7 +594,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         name = get_op_result_name(self, other)
         return self._shallow_copy(result, name=name, freq=None, tz=self.tz)
 
-    def intersection(self, other, sort=True):
+    def intersection(self, other, sort=False):
         """
         Specialized intersection for DatetimeIndex objects. May be much faster
         than Index.intersection
@@ -602,6 +602,14 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         Parameters
         ----------
         other : DatetimeIndex or array-like
+        sort : bool, default True
+            Sort the resulting MultiIndex if possible
+
+            .. versionadded:: 0.24.0
+
+            .. versionchanged:: 0.24.1
+
+               Changed the default from ``True`` to ``False``.
 
         Returns
         -------

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1093,8 +1093,8 @@ class IntervalIndex(IntervalMixin, Index):
     def overlaps(self, other):
         return self._data.overlaps(other)
 
-    def _setop(op_name):
-        def func(self, other, sort=True):
+    def _setop(op_name, sort=True):
+        def func(self, other, sort=sort):
             other = self._as_like_interval_index(other)
 
             # GH 19016: ensure set op will not return a prohibited dtype
@@ -1128,7 +1128,7 @@ class IntervalIndex(IntervalMixin, Index):
         return False
 
     union = _setop('union')
-    intersection = _setop('intersection')
+    intersection = _setop('intersection', sort=False)
     difference = _setop('difference')
     symmetric_difference = _setop('symmetric_difference')
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2910,7 +2910,7 @@ class MultiIndex(Index):
         return MultiIndex.from_arrays(lzip(*uniq_tuples), sortorder=0,
                                       names=result_names)
 
-    def intersection(self, other, sort=True):
+    def intersection(self, other, sort=False):
         """
         Form the intersection of two MultiIndex objects.
 
@@ -2921,6 +2921,10 @@ class MultiIndex(Index):
             Sort the resulting MultiIndex if possible
 
             .. versionadded:: 0.24.0
+
+            .. versionchanged:: 0.24.1
+
+               Changed the default from ``True`` to ``False``.
 
         Returns
         -------

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -343,7 +343,7 @@ class RangeIndex(Int64Index):
 
         return super(RangeIndex, self).equals(other)
 
-    def intersection(self, other, sort=True):
+    def intersection(self, other, sort=False):
         """
         Form the intersection of two Index objects.
 
@@ -354,6 +354,10 @@ class RangeIndex(Int64Index):
             Sort the resulting index if possible
 
             .. versionadded:: 0.24.0
+
+            .. versionchanged:: 0.24.1
+
+               Changed the default from ``True`` to ``False``.
 
         Returns
         -------

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -765,6 +765,11 @@ class TestIndex(Base):
 
         assert len(result) == 0
 
+    def test_intersect_nosort(self):
+        result = pd.Index(['c', 'b', 'a']).intersection(['b', 'a'])
+        expected = pd.Index(['b', 'a'])
+        tm.assert_index_equal(result, expected)
+
     @pytest.mark.parametrize("sort", [True, False])
     def test_chained_union(self, sort):
         # Chained unions handles names correctly
@@ -1595,20 +1600,27 @@ class TestIndex(Base):
         for drop_me in to_drop[1], [to_drop[1]]:
             pytest.raises(KeyError, removed.drop, drop_me)
 
-    @pytest.mark.parametrize("method,expected", [
+    @pytest.mark.parametrize("method,expected,sort", [
+        ('intersection', np.array([(1, 'A'), (2, 'A'), (1, 'B'), (2, 'B')],
+                                  dtype=[('num', int), ('let', 'a1')]),
+         False),
+
         ('intersection', np.array([(1, 'A'), (1, 'B'), (2, 'A'), (2, 'B')],
-                                  dtype=[('num', int), ('let', 'a1')])),
+                                  dtype=[('num', int), ('let', 'a1')]),
+         True),
+
         ('union', np.array([(1, 'A'), (1, 'B'), (1, 'C'), (2, 'A'), (2, 'B'),
-                            (2, 'C')], dtype=[('num', int), ('let', 'a1')]))
+                            (2, 'C')], dtype=[('num', int), ('let', 'a1')]),
+         True)
     ])
-    def test_tuple_union_bug(self, method, expected):
+    def test_tuple_union_bug(self, method, expected, sort):
         index1 = Index(np.array([(1, 'A'), (2, 'A'), (1, 'B'), (2, 'B')],
                                 dtype=[('num', int), ('let', 'a1')]))
         index2 = Index(np.array([(1, 'A'), (2, 'A'), (1, 'B'),
                                  (2, 'B'), (1, 'C'), (2, 'C')],
                                 dtype=[('num', int), ('let', 'a1')]))
 
-        result = getattr(index1, method)(index2)
+        result = getattr(index1, method)(index2, sort=sort)
         assert result.ndim == 1
 
         expected = Index(expected)


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/24959