### PR TITLE
API: Change default for Index.union sort

### DIFF
--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -53,8 +53,8 @@ This allows ``sort=True`` to now mean "always sort". A ``TypeError`` is raised i
 
    idx.union(idx, sort=True)
 
-The same change applies to :meth:`Index.symmetric_difference`, which would previously not
-sort the result when ``sort=True`` but the values could not be compared.
+The same change applies to :meth:`Index.difference` and :meth:`Index.symmetric_difference`, which
+would previously not sort the result when ``sort=True`` but the values could not be compared.
 
 Changed the behavior of :meth:`Index.intersection` with ``sort=True``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -23,7 +23,7 @@ API Changes
 Changing the ``sort`` parameter for :meth:`Index.union`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default ``sort`` value for :meth:`Index.union` has changed from ``True`` to ``None``.
+The default ``sort`` value for :meth:`Index.union` has changed from ``True`` to ``None`` (:issue:`24959`).
 The default *behavior* remains the same: The result is sorted, unless
 
 1. ``self`` and ``other`` are identical
@@ -52,6 +52,9 @@ This allows ``sort=True`` to now mean "always sort". A ``TypeError`` is raised i
    idx.union(idx)  # sort=None is the default. Don't sort identical operands.
 
    idx.union(idx, sort=True)
+
+The same change applies to :meth:`Index.symmetric_difference`, which would previously not
+sort the result when ``sort=True`` but the values could not be compared.
 
 Changed the behavior of :meth:`Index.intersection` with ``sort=True``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -15,10 +15,34 @@ Whats New in 0.24.1 (February XX, 2019)
 These are the changes in pandas 0.24.1. See :ref:`release` for a full changelog
 including other versions of pandas.
 
+.. _whatsnew_0241.api:
+
+API Changes
+~~~~~~~~~~~
+
+Changing the ``sort`` parameter for :meth:`Index.Union`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default ``sort`` value for :meth:`Index.union` has changed from ``True`` to ``None``.
+The default *behavior* remains the same: The result is sorted, unless
+
+1. ``self`` and ``other`` are identical
+2. ``self`` or ``other`` is empty
+3. ``self`` or ``other`` contain values that can not be compared (a ``RuntimeWarning`` is raised).
+
+This allows ``sort=True`` to now mean "always sort" A ``TypeError`` is raised if the values cannot be compared.
+
+Changed the behavior of :meth:`Index.intersection` with ``sort=True``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When ``sort=True`` is provided to :meth:`Index.intersection`, the values are always sorted. In 0.24.0,
+the values would not be sorted when ``self`` and ``other`` were identical. Pass ``sort=False`` to not
+sort the values.
+
 .. _whatsnew_0241.regressions:
 
 Fixed Regressions
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 - Bug in :meth:`DataFrame.itertuples` with ``records`` orient raising an ``AttributeError`` when the ``DataFrame`` contained more than 255 columns (:issue:`24939`)
 - Bug in :meth:`DataFrame.itertuples` orient converting integer column names to strings prepended with an underscore (:issue:`24940`)
@@ -27,7 +51,7 @@ Fixed Regressions
 .. _whatsnew_0241.enhancements:
 
 Enhancements
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 
 .. _whatsnew_0241.bug_fixes:

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -20,7 +20,7 @@ including other versions of pandas.
 API Changes
 ~~~~~~~~~~~
 
-Changing the ``sort`` parameter for :meth:`Index.Union`
+Changing the ``sort`` parameter for :meth:`Index.union`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default ``sort`` value for :meth:`Index.union` has changed from ``True`` to ``None``.
@@ -30,14 +30,61 @@ The default *behavior* remains the same: The result is sorted, unless
 2. ``self`` or ``other`` is empty
 3. ``self`` or ``other`` contain values that can not be compared (a ``RuntimeWarning`` is raised).
 
-This allows ``sort=True`` to now mean "always sort" A ``TypeError`` is raised if the values cannot be compared.
+This allows ``sort=True`` to now mean "always sort". A ``TypeError`` is raised if the values cannot be compared.
+
+**Behavior in 0.24.0**
+
+.. ipython:: python
+
+   In [1]: idx = pd.Index(['b', 'a'])
+
+   In [2]: idx.union(idx)  # sort=True was the default.
+   Out[2]: Index(['b', 'a'], dtype='object')
+
+   In [3]: idx.union(idx, sort=True)  # result is still not sorted.
+   Out[32]: Index(['b', 'a'], dtype='object')
+
+**New Behavior**
+
+.. ipython:: python
+
+   idx = pd.Index(['b', 'a'])
+   idx.union(idx)  # sort=None is the default. Don't sort identical operands.
+
+   idx.union(idx, sort=True)
 
 Changed the behavior of :meth:`Index.intersection` with ``sort=True``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When ``sort=True`` is provided to :meth:`Index.intersection`, the values are always sorted. In 0.24.0,
 the values would not be sorted when ``self`` and ``other`` were identical. Pass ``sort=False`` to not
-sort the values.
+sort the values. This matches the behavior of pandas 0.23.4 and earlier.
+
+**Behavior in 0.23.4**
+
+.. ipython:: python
+
+   In [2]: idx = pd.Index(['b', 'a'])
+
+   In [3]: idx.intersection(idx)  # sort was not a keyword.
+   Out[3]: Index(['b', 'a'], dtype='object')
+
+**Behavior in 0.24.0**
+
+.. ipython:: python
+
+   In [5]: idx.intersection(idx)  # sort=True by default. Don't sort identical.
+   Out[5]: Index(['b', 'a'], dtype='object')
+
+   In [6]: idx.intersection(idx, sort=True)
+   Out[6]: Index(['b', 'a'], dtype='object')
+
+**New Behavior**
+
+.. ipython:: python
+
+   idx.intersection(idx)  # sort=False by default
+   idx.intersection(idx, sort=True)
 
 .. _whatsnew_0241.regressions:
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -233,11 +233,14 @@ def fast_unique_multiple(list arrays, sort: bool=True):
             if val not in table:
                 table[val] = stub
                 uniques.append(val)
-    if sort:
+    if sort is None:
         try:
             uniques.sort()
         except Exception:
+            # TODO: RuntimeWarning?
             pass
+    elif sort:
+        uniques.sort()
 
     return uniques
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2268,7 +2268,7 @@ class Index(IndexOpsMixin, PandasObject):
 
             .. versionadded:: 0.24.0
 
-            .. versionchanged:: 0.24.0
+            .. versionchanged:: 0.24.1
 
                Changed the default `sort` to None, matching the
                behavior of pandas 0.23.4 and earlier.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2500,7 +2500,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return this._shallow_copy(the_diff, name=result_name, freq=None)
 
-    def symmetric_difference(self, other, result_name=None, sort=True):
+    def symmetric_difference(self, other, result_name=None, sort=None):
         """
         Compute the symmetric difference of two Index objects.
 
@@ -2508,10 +2508,22 @@ class Index(IndexOpsMixin, PandasObject):
         ----------
         other : Index or array-like
         result_name : str
-        sort : bool, default True
-            Sort the resulting index if possible
+        sort : bool or None, default None.
+            Whether to sort the resulting index. By default, the
+            values are attempted to be sorted, but any TypeError from
+            incomparable elements is caught by pandas.
+
+            * None : Attempt to sort the result, but catch any TypeErrors
+              from comparing incomparable elements.
+            * False : Do not sort the result.
+            * True : Sort the result, raising a TypeError if any elements
+              cannot be compared.
 
             .. versionadded:: 0.24.0
+
+            .. versionchanged:: 0.24.1
+
+               Added the `None` option.
 
         Returns
         -------
@@ -2556,11 +2568,13 @@ class Index(IndexOpsMixin, PandasObject):
         right_diff = other.values.take(right_indexer)
 
         the_diff = _concat._concat_compat([left_diff, right_diff])
-        if sort:
+        if sort is None:
             try:
                 the_diff = sorting.safe_sort(the_diff)
             except TypeError:
                 pass
+        elif sort:
+            the_diff = sorting.safe_sort(the_diff)
 
         attribs = self._get_attributes_dict()
         attribs['name'] = result_name

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2523,7 +2523,8 @@ class Index(IndexOpsMixin, PandasObject):
 
             .. versionchanged:: 0.24.1
 
-               Added the `None` option.
+               Added the `None` option, which matches the behavior of
+               pandas 0.23.4 and earlier.
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2447,7 +2447,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return taken
 
-    def difference(self, other, sort=True):
+    def difference(self, other, sort=None):
         """
         Return a new Index with elements from the index that are not in
         `other`.
@@ -2457,10 +2457,23 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         other : Index or array-like
-        sort : bool, default True
-            Sort the resulting index if possible
+        sort : bool or None, default None
+            Whether to sort the resulting index. By default, the
+            values are attempted to be sorted, but any TypeError from
+            incomparable elements is caught by pandas.
+
+            * None : Attempt to sort the result, but catch any TypeErrors
+              from comparing incomparable elements.
+            * False : Do not sort the result.
+            * True : Sort the result, raising a TypeError if any elements
+              cannot be compared.
 
             .. versionadded:: 0.24.0
+
+            .. versionchanged:: 0.24.1
+
+               Added the `None` option, which matches the behavior of
+               pandas 0.23.4 and earlier.
 
         Returns
         -------
@@ -2492,11 +2505,13 @@ class Index(IndexOpsMixin, PandasObject):
         label_diff = np.setdiff1d(np.arange(this.size), indexer,
                                   assume_unique=True)
         the_diff = this.values.take(label_diff)
-        if sort:
+        if sort is None:
             try:
                 the_diff = sorting.safe_sort(the_diff)
             except TypeError:
                 pass
+        elif sort:
+            the_diff = sorting.safe_sort(the_diff)
 
         return this._shallow_copy(the_diff, name=result_name, freq=None)
 
@@ -2508,7 +2523,7 @@ class Index(IndexOpsMixin, PandasObject):
         ----------
         other : Index or array-like
         result_name : str
-        sort : bool or None, default None.
+        sort : bool or None, default None
             Whether to sort the resulting index. By default, the
             values are attempted to be sorted, but any TypeError from
             incomparable elements is caught by pandas.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2367,8 +2367,12 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         other : Index or array-like
-        sort : bool, default False
-            Sort the resulting index if possible
+        sort : bool or None, default False
+            Whether to sort the resulting index.
+
+            * False : do not sort the result.
+            * True : sort the result. A TypeError is raised when the
+              values cannot be compared.
 
             .. versionadded:: 0.24.0
 
@@ -2392,7 +2396,10 @@ class Index(IndexOpsMixin, PandasObject):
         other = ensure_index(other)
 
         if self.equals(other):
-            return self._get_reconciled_name_object(other)
+            result = self._get_reconciled_name_object(other)
+            if sort:
+                result = result.sort_values()
+            return result
 
         if not is_dtype_equal(self.dtype, other.dtype):
             this = self.astype('O')

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2937,7 +2937,7 @@ class MultiIndex(Index):
         Parameters
         ----------
         other : MultiIndex or array / Index of tuples
-        sort : bool, default True
+        sort : bool, default False
             Sort the resulting MultiIndex if possible
 
             .. versionadded:: 0.24.0

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2879,17 +2879,33 @@ class MultiIndex(Index):
                 return False
         return True
 
-    def union(self, other, sort=True):
+    def union(self, other, sort=None):
         """
         Form the union of two MultiIndex objects
 
         Parameters
         ----------
         other : MultiIndex or array / Index of tuples
-        sort : bool, default True
-            Sort the resulting MultiIndex if possible
+        sort : bool or None, default None
+            Whether to sort the resulting Index.
+
+            * None : Sort the result, except when
+
+              1. `self` and `other` are equal.
+              2. `self` has length 0.
+              3. Some values in `self` or `other` cannot be compared.
+                 A RuntimeWarning is issued in this case.
+
+            * True : sort the result. A TypeError is raised when the
+              values cannot be compared.
+            * False : do not sort the result.
 
             .. versionadded:: 0.24.0
+
+            .. versionchanged:: 0.24.1
+
+               Changed the default `sort` to None, matching the
+               behavior of pandas 0.23.4 and earlier.
 
         Returns
         -------
@@ -2901,7 +2917,11 @@ class MultiIndex(Index):
         other, result_names = self._convert_can_do_setop(other)
 
         if len(other) == 0 or self.equals(other):
+            if sort:
+                return self.sort_values()
             return self
+
+        # TODO: Index.union returns other when `len(self)` is 0.
 
         uniq_tuples = lib.fast_unique_multiple([self._ndarray_values,
                                                 other._ndarray_values],

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2973,7 +2973,7 @@ class MultiIndex(Index):
             return MultiIndex.from_arrays(lzip(*uniq_tuples), sortorder=0,
                                           names=result_names)
 
-    def difference(self, other, sort=True):
+    def difference(self, other, sort=None):
         """
         Compute set difference of two MultiIndex objects
 
@@ -2993,6 +2993,8 @@ class MultiIndex(Index):
         other, result_names = self._convert_can_do_setop(other)
 
         if len(other) == 0:
+            if sort:
+                return self.sort_values()
             return self
 
         if self.equals(other):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2954,6 +2954,8 @@ class MultiIndex(Index):
         other, result_names = self._convert_can_do_setop(other)
 
         if self.equals(other):
+            if sort:
+                return self.sort_values()
             return self
 
         self_tuples = self._ndarray_values

--- a/pandas/tests/indexes/multi/test_set_ops.py
+++ b/pandas/tests/indexes/multi/test_set_ops.py
@@ -203,10 +203,16 @@ def test_union(idx, sort):
 
     # corner case, pass self or empty thing:
     the_union = idx.union(idx, sort=sort)
-    assert the_union is idx
+    if sort:
+        tm.assert_index_equal(the_union, idx.sort_values())
+    else:
+        assert the_union is idx
 
     the_union = idx.union(idx[:0], sort=sort)
-    assert the_union is idx
+    if sort:
+        tm.assert_index_equal(the_union, idx.sort_values())
+    else:
+        assert the_union is idx
 
     # won't work in python 3
     # tuples = _index.values
@@ -238,7 +244,10 @@ def test_intersection(idx, sort):
 
     # corner case, pass self
     the_int = idx.intersection(idx, sort=sort)
-    assert the_int is idx
+    if sort:
+        tm.assert_index_equal(the_int, idx.sort_values())
+    else:
+        assert the_int is idx
 
     # empty intersection: disjoint
     empty = idx[:2].intersection(idx[2:], sort=sort)
@@ -249,6 +258,13 @@ def test_intersection(idx, sort):
     # tuples = _index.values
     # result = _index & tuples
     # assert result.equals(tuples)
+
+
+def test_intersect_equal_sort():
+    idx = pd.MultiIndex.from_product([[1, 0], ['a', 'b']])
+    sorted_ = pd.MultiIndex.from_product([[0, 1], ['a', 'b']])
+    tm.assert_index_equal(idx.intersection(idx, sort=False), idx)
+    tm.assert_index_equal(idx.intersection(idx, sort=True), sorted_)
 
 
 @pytest.mark.parametrize('slice_', [slice(None), slice(0)])

--- a/pandas/tests/indexes/multi/test_set_ops.py
+++ b/pandas/tests/indexes/multi/test_set_ops.py
@@ -249,3 +249,42 @@ def test_intersection(idx, sort):
     # tuples = _index.values
     # result = _index & tuples
     # assert result.equals(tuples)
+
+
+@pytest.mark.parametrize('slice_', [slice(None), slice(0)])
+def test_union_sort_other_empty(slice_):
+    idx = pd.MultiIndex.from_product([[1, 0], ['a', 'b']])
+    # Two cases:
+    # 1. idx is other
+    # 2. other is empty
+
+    # default, sort=None
+    other = idx[slice_]
+    tm.assert_index_equal(idx.union(other), idx)
+    # MultiIndex does not special case empty.union(idx)
+    # tm.assert_index_equal(other.union(idx), idx)
+
+    # sort=False
+    tm.assert_index_equal(idx.union(other, sort=False), idx)
+
+    # sort=True
+    result = idx.union(other, sort=True)
+    expected = pd.MultiIndex.from_product([[0, 1], ['a', 'b']])
+    tm.assert_index_equal(result, expected)
+
+
+def test_union_sort_other_incomparable():
+    idx = pd.MultiIndex.from_product([[1, pd.Timestamp('2000')], ['a', 'b']])
+
+    # default, sort=None
+    # with tm.assert_produces_warning(RuntimeWarning):
+    result = idx.union(idx[:1])
+    tm.assert_index_equal(result, idx)
+
+    # sort=True
+    with pytest.raises(TypeError, match='Cannot compare'):
+        idx.union(idx[:1], sort=True)
+
+    # sort=False
+    result = idx.union(idx[:1], sort=False)
+    tm.assert_index_equal(result, idx)

--- a/pandas/tests/indexes/multi/test_set_ops.py
+++ b/pandas/tests/indexes/multi/test_set_ops.py
@@ -174,7 +174,10 @@ def test_difference(idx, sort):
 
     # name from empty array
     result = first.difference([], sort=sort)
-    assert first.equals(result)
+    if sort:
+        assert first.sort_values().equals(result)
+    else:
+        assert first.equals(result)
     assert first.names == result.names
 
     # name from non-empty array
@@ -187,6 +190,36 @@ def test_difference(idx, sort):
     msg = "other must be a MultiIndex or a list of tuples"
     with pytest.raises(TypeError, match=msg):
         first.difference([1, 2, 3, 4, 5], sort=sort)
+
+
+def test_difference_sort_special():
+    idx = pd.MultiIndex.from_product([[1, 0], ['a', 'b']])
+    # sort=None, the default
+    result = idx.difference([])
+    tm.assert_index_equal(result, idx)
+
+    result = idx.difference([], sort=True)
+    expected = pd.MultiIndex.from_product([[0, 1], ['a', 'b']])
+    tm.assert_index_equal(result, expected)
+
+
+def test_difference_sort_incomparable():
+    idx = pd.MultiIndex.from_product([[1, pd.Timestamp('2000'), 2],
+                                      ['a', 'b']])
+
+    other = pd.MultiIndex.from_product([[3, pd.Timestamp('2000'), 4],
+                                        ['c', 'd']])
+    # sort=None, the default
+    # result = idx.difference(other)
+    # tm.assert_index_equal(result, idx)
+
+    # sort=False
+    result = idx.difference(other)
+    tm.assert_index_equal(result, idx)
+
+    # sort=True, raises
+    with pytest.raises(TypeError):
+        idx.difference(other, sort=True)
 
 
 @pytest.mark.parametrize("sort", [True, False])

--- a/pandas/tests/indexes/multi/test_set_ops.py
+++ b/pandas/tests/indexes/multi/test_set_ops.py
@@ -253,10 +253,8 @@ def test_intersection(idx, sort):
 
 @pytest.mark.parametrize('slice_', [slice(None), slice(0)])
 def test_union_sort_other_empty(slice_):
+    # https://github.com/pandas-dev/pandas/issues/24959
     idx = pd.MultiIndex.from_product([[1, 0], ['a', 'b']])
-    # Two cases:
-    # 1. idx is other
-    # 2. other is empty
 
     # default, sort=None
     other = idx[slice_]
@@ -274,17 +272,17 @@ def test_union_sort_other_empty(slice_):
 
 
 def test_union_sort_other_incomparable():
+    # https://github.com/pandas-dev/pandas/issues/24959
     idx = pd.MultiIndex.from_product([[1, pd.Timestamp('2000')], ['a', 'b']])
 
     # default, sort=None
-    # with tm.assert_produces_warning(RuntimeWarning):
     result = idx.union(idx[:1])
+    tm.assert_index_equal(result, idx)
+
+    # sort=False
+    result = idx.union(idx[:1], sort=False)
     tm.assert_index_equal(result, idx)
 
     # sort=True
     with pytest.raises(TypeError, match='Cannot compare'):
         idx.union(idx[:1], sort=True)
-
-    # sort=False
-    result = idx.union(idx[:1], sort=False)
-    tm.assert_index_equal(result, idx)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -695,7 +695,10 @@ class TestIndex(Base):
 
         # Corner cases
         inter = first.intersection(first, sort=sort)
-        assert inter is first
+        if sort:
+            tm.assert_index_equal(inter, first.sort_values())
+        else:
+            assert inter is first
 
     @pytest.mark.parametrize("index2,keeps_name", [
         (Index([3, 4, 5, 6, 7], name="index"), True),  # preserve same name
@@ -769,6 +772,12 @@ class TestIndex(Base):
         result = pd.Index(['c', 'b', 'a']).intersection(['b', 'a'])
         expected = pd.Index(['b', 'a'])
         tm.assert_index_equal(result, expected)
+
+    def test_intersect_equal_sort(self):
+        idx = pd.Index(['c', 'a', 'b'])
+        sorted_ = pd.Index(['a', 'b', 'c'])
+        tm.assert_index_equal(idx.intersection(idx, sort=False), idx)
+        tm.assert_index_equal(idx.intersection(idx, sort=True), sorted_)
 
     @pytest.mark.parametrize("sort", [True, False])
     def test_chained_union(self, sort):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -794,6 +794,52 @@ class TestIndex(Base):
             tm.assert_index_equal(union, everything.sort_values())
         assert tm.equalContents(union, everything)
 
+    def test_union_sort_other_equal(self):
+        a = pd.Index([1, 0, 2])
+        # default, sort=None
+        result = a.union(a)
+        tm.assert_index_equal(result, a)
+
+        # sort=True
+        result = a.union(a, sort=True)
+        expected = pd.Index([0, 1, 2])
+        tm.assert_index_equal(result, expected)
+
+        # sort=False
+        result = a.union(a, sort=False)
+        tm.assert_index_equal(result, a)
+
+    def test_union_sort_other_empty(self):
+        a = pd.Index([1, 0, 2])
+        # default, sort=None
+        tm.assert_index_equal(a.union(a[:0]), a)
+        tm.assert_index_equal(a[:0].union(a), a)
+
+        # sort=True
+        expected = pd.Index([0, 1, 2])
+        tm.assert_index_equal(a.union(a[:0], sort=True), expected)
+        tm.assert_index_equal(a[:0].union(a, sort=True), expected)
+
+        # sort=False
+        tm.assert_index_equal(a.union(a[:0], sort=False), a)
+        tm.assert_index_equal(a[:0].union(a, sort=False), a)
+
+    def test_union_sort_other_incomparable(self):
+        a = pd.Index([1, pd.Timestamp('2000')])
+        # default, sort=None
+        with tm.assert_produces_warning(RuntimeWarning):
+            result = a.union(a[:1])
+
+        tm.assert_index_equal(result, a)
+
+        # sort=True
+        with pytest.raises(TypeError, match='.*'):
+            a.union(a[:1], sort=True)
+
+        # sort=False
+        result = a.union(a[:1], sort=False)
+        tm.assert_index_equal(result, a)
+
     @pytest.mark.parametrize("klass", [
         np.array, Series, list])
     @pytest.mark.parametrize("sort", [True, False])

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -801,9 +801,7 @@ class TestIndex(Base):
 
     @pytest.mark.parametrize('slice_', [slice(None), slice(0)])
     def test_union_sort_other_special(self, slice_):
-        # Two cases:
-        # 1. idx is other
-        # 2. other is empty
+        # https://github.com/pandas-dev/pandas/issues/24959
 
         idx = pd.Index([1, 0, 2])
         # default, sort=None
@@ -820,6 +818,7 @@ class TestIndex(Base):
         tm.assert_index_equal(result, expected)
 
     def test_union_sort_other_incomparable(self):
+        # https://github.com/pandas-dev/pandas/issues/24959
         idx = pd.Index([1, pd.Timestamp('2000')])
         # default, sort=None
         with tm.assert_produces_warning(RuntimeWarning):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 import math
+import operator
 import sys
 
 import numpy as np
@@ -1099,22 +1100,28 @@ class TestIndex(Base):
         assert tm.equalContents(result, expected)
         assert result.name is None
 
-    def test_symmetric_difference_incomparable(self):
+    @pytest.mark.parametrize('opname', ['difference', 'symmetric_difference'])
+    def test_difference_incomparable(self, opname):
         a = pd.Index([3, pd.Timestamp('2000'), 1])
         b = pd.Index([2, pd.Timestamp('1999'), 1])
+        op = operator.methodcaller(opname, b)
 
         # sort=None, the default
-        result = a.symmetric_difference(b)
+        result = op(a)
         expected = pd.Index([3, pd.Timestamp('2000'), 2, pd.Timestamp('1999')])
+        if opname == 'difference':
+            expected = expected[:2]
         tm.assert_index_equal(result, expected)
 
         # sort=False
-        result = a.symmetric_difference(b, sort=False)
+        op = operator.methodcaller(opname, b, sort=False)
+        result = op(a)
         tm.assert_index_equal(result, expected)
 
         # sort=True, raises
+        op = operator.methodcaller(opname, b, sort=True)
         with pytest.raises(TypeError, match='Cannot compare'):
-            a.symmetric_difference(b, sort=True)
+            op(a)
 
     @pytest.mark.parametrize("sort", [True, False])
     def test_symmetric_difference_mi(self, sort):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -794,51 +794,41 @@ class TestIndex(Base):
             tm.assert_index_equal(union, everything.sort_values())
         assert tm.equalContents(union, everything)
 
-    def test_union_sort_other_equal(self):
-        a = pd.Index([1, 0, 2])
+    @pytest.mark.parametrize('slice_', [slice(None), slice(0)])
+    def test_union_sort_other_special(self, slice_):
+        # Two cases:
+        # 1. idx is other
+        # 2. other is empty
+
+        idx = pd.Index([1, 0, 2])
         # default, sort=None
-        result = a.union(a)
-        tm.assert_index_equal(result, a)
+        other = idx[slice_]
+        tm.assert_index_equal(idx.union(other), idx)
+        tm.assert_index_equal(other.union(idx), idx)
+
+        # sort=False
+        tm.assert_index_equal(idx.union(other, sort=False), idx)
 
         # sort=True
-        result = a.union(a, sort=True)
+        result = idx.union(other, sort=True)
         expected = pd.Index([0, 1, 2])
         tm.assert_index_equal(result, expected)
 
-        # sort=False
-        result = a.union(a, sort=False)
-        tm.assert_index_equal(result, a)
-
-    def test_union_sort_other_empty(self):
-        a = pd.Index([1, 0, 2])
-        # default, sort=None
-        tm.assert_index_equal(a.union(a[:0]), a)
-        tm.assert_index_equal(a[:0].union(a), a)
-
-        # sort=True
-        expected = pd.Index([0, 1, 2])
-        tm.assert_index_equal(a.union(a[:0], sort=True), expected)
-        tm.assert_index_equal(a[:0].union(a, sort=True), expected)
-
-        # sort=False
-        tm.assert_index_equal(a.union(a[:0], sort=False), a)
-        tm.assert_index_equal(a[:0].union(a, sort=False), a)
-
     def test_union_sort_other_incomparable(self):
-        a = pd.Index([1, pd.Timestamp('2000')])
+        idx = pd.Index([1, pd.Timestamp('2000')])
         # default, sort=None
         with tm.assert_produces_warning(RuntimeWarning):
-            result = a.union(a[:1])
+            result = idx.union(idx[:1])
 
-        tm.assert_index_equal(result, a)
+        tm.assert_index_equal(result, idx)
 
         # sort=True
         with pytest.raises(TypeError, match='.*'):
-            a.union(a[:1], sort=True)
+            idx.union(idx[:1], sort=True)
 
         # sort=False
-        result = a.union(a[:1], sort=False)
-        tm.assert_index_equal(result, a)
+        result = idx.union(idx[:1], sort=False)
+        tm.assert_index_equal(result, idx)
 
     @pytest.mark.parametrize("klass", [
         np.array, Series, list])

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -856,19 +856,20 @@ class TestIndex(Base):
             tm.assert_index_equal(result, everything.sort_values())
         assert tm.equalContents(result, everything)
 
-    @pytest.mark.parametrize("sort", [True, False])
+    @pytest.mark.parametrize("sort", [None, True, False])
     def test_union_identity(self, sort):
         # TODO: replace with fixturesult
         first = self.strIndex[5:20]
 
         union = first.union(first, sort=sort)
-        assert union is first
+        # i.e. identity is not preserved when sort is True
+        assert (union is first) is (not sort)
 
         union = first.union([], sort=sort)
-        assert union is first
+        assert (union is first) is (not sort)
 
         union = Index([]).union(first, sort=sort)
-        assert union is first
+        assert (union is first) is (not sort)
 
     @pytest.mark.parametrize("first_list", [list('ba'), list()])
     @pytest.mark.parametrize("second_list", [list('ab'), list()])

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1099,6 +1099,23 @@ class TestIndex(Base):
         assert tm.equalContents(result, expected)
         assert result.name is None
 
+    def test_symmetric_difference_incomparable(self):
+        a = pd.Index([3, pd.Timestamp('2000'), 1])
+        b = pd.Index([2, pd.Timestamp('1999'), 1])
+
+        # sort=None, the default
+        result = a.symmetric_difference(b)
+        expected = pd.Index([3, pd.Timestamp('2000'), 2, pd.Timestamp('1999')])
+        tm.assert_index_equal(result, expected)
+
+        # sort=False
+        result = a.symmetric_difference(b, sort=False)
+        tm.assert_index_equal(result, expected)
+
+        # sort=True, raises
+        with pytest.raises(TypeError, match='Cannot compare'):
+            a.symmetric_difference(b, sort=True)
+
     @pytest.mark.parametrize("sort", [True, False])
     def test_symmetric_difference_mi(self, sort):
         index1 = MultiIndex.from_tuples(self.tuples)


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/24959

Haven't done MultiIndex yet, just opening for discussion on *if* we should do this for 0.24.1.