### PR TITLE
CLN: do not use .repeat asv setting for storing benchmark data

### DIFF
--- a/asv_bench/benchmarks/strings.py
+++ b/asv_bench/benchmarks/strings.py
@@ -102,10 +102,10 @@ class Repeat(object):
         N = 10**5
         self.s = Series(tm.makeStringIndex(N))
         repeat = {'int': 1, 'array': np.random.randint(1, 3, N)}
-        self.repeat = repeat[repeats]
+        self.values = repeat[repeats]
 
     def time_repeat(self, repeats):
-        self.s.str.repeat(self.repeat)
+        self.s.str.repeat(self.values)
 
 
 class Cat(object):


### PR DESCRIPTION
`asv` uses `.repeat` to specify the number of times a benchmark should be repeated; our `strings.Replace` benchmark inadvertently uses this to store benchmark data. This doesn't cause issues until after the first parameter:
```
[ 99.87%] ··· strings.Repeat.time_repeat                                                                                                                                                          1/2 failed
[ 99.87%] ··· ========= ===========
               repeats             
              --------- -----------
                 int     151±0.9ms 
                array      failed  
              ========= ===========

[ 99.87%] ···· For parameters: 'array'
               Traceback (most recent call last):
                 File "/home/chris/code/asv/asv/benchmark.py", line 595, in run
                   min_repeat, max_repeat, max_time = self.repeat
               ValueError: too many values to unpack (expected 3)
               
               During handling of the above exception, another exception occurred:
               
               Traceback (most recent call last):
                 File "/home/chris/code/asv/asv/benchmark.py", line 1170, in main_run_server
                   main_run(run_args)
                 File "/home/chris/code/asv/asv/benchmark.py", line 1044, in main_run
                   result = benchmark.do_run()
                 File "/home/chris/code/asv/asv/benchmark.py", line 523, in do_run
                   return self.run(*self._current_params)
                 File "/home/chris/code/asv/asv/benchmark.py", line 597, in run
                   if self.repeat == 0:
               ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

```
With this PR, both parameters now succeed:
```
[  0.00%] · For pandas commit 8825f78e <repeat>:
[  0.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 50.00%] ··· Running (strings.Repeat.time_repeat--).
[100.00%] ··· strings.Repeat.time_repeat                                                                                                                                                                  ok
[100.00%] ··· ========= ===========
               repeats             
              --------- -----------
                 int      152±1ms  
                array    150±0.6ms 
              ========= ===========
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
