### PR TITLE
DOC: 0.24.1 whatsnew

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -39,7 +39,7 @@ See the :ref:`overview` for more detail about what's in the library.
 {% endif %}
 
     {% if not single_doc -%}
-    What's New in 0.24.0 <whatsnew/v0.24.0>
+    What's New in 0.24.1 <whatsnew/v0.24.1>
     install
     getting_started/index
     user_guide/index


### PR DESCRIPTION
This PR has the documentation changes that are just for 0.24.x. I'll have another PR later with changes to 0.24.1.rst that should go to master first, before being backported.