### PR TITLE
ENH: Support index=True for io.sql.get_schema

### DIFF
--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -31,6 +31,12 @@ Fixed Regressions
 Enhancements
 ^^^^^^^^^^^^
 
+.. _whatsnew_0241.enhancements.get_schema:
+
+``get_schema`` Enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:func:`get_schema` now accepts an `index` parameter (default: `False`) that includes the index in the generated schema. (:issue:`9084`)
 
 .. _whatsnew_0241.bug_fixes:
 

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -31,13 +31,6 @@ Fixed Regressions
 Enhancements
 ^^^^^^^^^^^^
 
-.. _whatsnew_0241.enhancements.get_schema:
-
-``get_schema`` Enhancements
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-:func:`get_schema` now accepts an `index` parameter (default: `False`) that includes the index in the generated schema. (:issue:`9084`)
-
 .. _whatsnew_0241.bug_fixes:
 
 Bug Fixes

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -165,7 +165,7 @@ MultiIndex
 I/O
 ^^^
 
--
+- :func:`get_schema` now accepts an `index` parameter (default: `False`) that includes the index in the generated schema. (:issue:`9084`)
 -
 -
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1592,7 +1592,7 @@ def get_schema(frame, name, keys=None, con=None, dtype=None, index=False):
         Optional specifying the datatype for columns. The SQL type should
         be a SQLAlchemy type, or a string for sqlite3 fallback connection.
     index : boolean, default False
-        include DataFrame index as a column
+        Whether to include DataFrame index as a column
 
     """
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1223,8 +1223,9 @@ class SQLDatabase(PandasSQL):
             self.get_table(table_name, schema).drop()
             self.meta.clear()
 
-    def _create_sql_schema(self, frame, table_name, keys=None, dtype=None):
-        table = SQLTable(table_name, self, frame=frame, index=False, keys=keys,
+    def _create_sql_schema(self, frame, table_name, keys=None, dtype=None,
+                           index=False):
+        table = SQLTable(table_name, self, frame=frame, index=index, keys=keys,
                          dtype=dtype)
         return str(table.sql_schema())
 
@@ -1565,13 +1566,14 @@ class SQLiteDatabase(PandasSQL):
             name=_get_valid_sqlite_name(name))
         self.execute(drop_sql)
 
-    def _create_sql_schema(self, frame, table_name, keys=None, dtype=None):
-        table = SQLiteTable(table_name, self, frame=frame, index=False,
+    def _create_sql_schema(self, frame, table_name, keys=None, dtype=None,
+                           index=False):
+        table = SQLiteTable(table_name, self, frame=frame, index=index,
                             keys=keys, dtype=dtype)
         return str(table.sql_schema())
 
 
-def get_schema(frame, name, keys=None, con=None, dtype=None):
+def get_schema(frame, name, keys=None, con=None, dtype=None, index=False):
     """
     Get the SQL db table schema for the given frame.
 
@@ -1593,4 +1595,5 @@ def get_schema(frame, name, keys=None, con=None, dtype=None):
     """
 
     pandas_sql = pandasSQL_builder(con=con)
-    return pandas_sql._create_sql_schema(frame, name, keys=keys, dtype=dtype)
+    return pandas_sql._create_sql_schema(
+        frame, name, keys=keys, dtype=dtype, index=index)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1591,6 +1591,8 @@ def get_schema(frame, name, keys=None, con=None, dtype=None, index=False):
     dtype : dict of column name to SQL type, default None
         Optional specifying the datatype for columns. The SQL type should
         be a SQLAlchemy type, or a string for sqlite3 fallback connection.
+    index : boolean, default False
+        include DataFrame index as a column
 
     """
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -823,18 +823,20 @@ class _TestSQLApi(PandasSQLTest):
         constraint_sentence = 'CONSTRAINT test_pk PRIMARY KEY ("A", "B")'
         assert constraint_sentence in create_sql
 
-    def test_get_schema_with_index(self):
+    @pytest.mark.parametrize("index_arg, expected", [
+        ({}, False),
+        ({"index": False}, False),
+        ({"index": True}, True),
+    ])
+    def test_get_schema_with_index(self, index_arg, expected):
         frame = DataFrame({
             'one': pd.Series([1, 2, 3], index=['a', 'b', 'c']),
             'two': pd.Series([1, 2, 3], index=['a', 'b', 'c'])
         })
         frame.index.name = 'alphabet'
 
-        create_sql = sql.get_schema(frame, 'test', con=self.conn)
-        assert 'alphabet' not in create_sql
-
-        create_sql = sql.get_schema(frame, 'test', con=self.conn, index=True)
-        assert 'alphabet' in create_sql
+        create_sql = sql.get_schema(frame, 'test', con=self.conn, **index_arg)
+        assert ('alphabet' in create_sql) == expected
 
     def test_chunksize_read(self):
         df = DataFrame(np.random.randn(22, 5), columns=list('abcde'))

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -823,6 +823,19 @@ class _TestSQLApi(PandasSQLTest):
         constraint_sentence = 'CONSTRAINT test_pk PRIMARY KEY ("A", "B")'
         assert constraint_sentence in create_sql
 
+    def test_get_schema_with_index(self):
+        frame = DataFrame({
+            'one': pd.Series([1, 2, 3], index=['a', 'b', 'c']),
+            'two': pd.Series([1, 2, 3], index=['a', 'b', 'c'])
+        })
+        frame.index.name = 'alphabet'
+
+        create_sql = sql.get_schema(frame, 'test', con=self.conn)
+        assert 'alphabet' not in create_sql
+
+        create_sql = sql.get_schema(frame, 'test', con=self.conn, index=True)
+        assert 'alphabet' in create_sql
+
     def test_chunksize_read(self):
         df = DataFrame(np.random.randn(22, 5), columns=list('abcde'))
         df.to_sql('test_chunksize', self.conn, index=False)


### PR DESCRIPTION
Closes pandas-dev/pandas#9084

- Decided to keep the default as `index=False` to keep the API consistent. `to_sql` has `index=True`.
- Tempted to name the parameter `include_dataframe_index` as "index" has
a different meaning in a SQL context.

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
