### PR TITLE
DOC: Example from docstring was proposing wrong interpolation order

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6601,7 +6601,7 @@ class NDFrame(PandasObject, SelectionMixin):
               'barycentric', 'polynomial': Passed to
               `scipy.interpolate.interp1d`. Both 'polynomial' and 'spline'
               require that you also specify an `order` (int),
-              e.g. ``df.interpolate(method='polynomial', order=4)``.
+              e.g. ``df.interpolate(method='polynomial', order=5)``.
               These use the numerical values of the index.
             * 'krogh', 'piecewise_polynomial', 'spline', 'pchip', 'akima':
               Wrappers around the SciPy interpolation methods of similar


### PR DESCRIPTION
Currently doctring explaining interpolation proposes using polynomial interpolation with order equal to 4. Unfortunately, scipy does not allow that value to be used, throwing an ValueError from here: https://github.com/scipy/scipy/blob/5875fd397eb4e6adcfa0c65f7b9006424c066cb0/scipy/interpolate/_bsplines.py#L583
Looking at the blame, last edit was 5 years ago so that rather do not depend on any reasonable scipy version.

Interpolations with order equal to 2 that are spread around docstrings (and doctests) do not pass through the method throwing that exception so they are okay.

- [-] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [-] whatsnew entry
