### PR TITLE
BUG: avoid usage in_qtconsole for recent IPython versions

### DIFF
--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -83,7 +83,7 @@ Bug Fixes
 
 **Other**
 
--
+- Fixed AttributeError when printing a DataFrame's HTML repr after accessing the IPython config object (:issue:`25036`)
 -
 
 .. _whatsnew_0.241.contributors:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -640,6 +640,16 @@ class DataFrame(NDFrame):
 
         Mainly for IPython notebook.
         """
+        # qtconsole doesn't report its line width, and also
+        # behaves badly when outputting an HTML table
+        # that doesn't fit the window, so disable it.
+        # XXX: In IPython 3.x and above, the Qt console will not attempt to
+        # display HTML, so this check can be removed when support for
+        # IPython 2.x is no longer needed.
+        if console.in_qtconsole():
+            # 'HTML output is disabled in QtConsole'
+            return None
+
         if self._info_repr():
             buf = StringIO(u(""))
             self.info(buf=buf)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -640,16 +640,6 @@ class DataFrame(NDFrame):
 
         Mainly for IPython notebook.
         """
-        # qtconsole doesn't report its line width, and also
-        # behaves badly when outputting an HTML table
-        # that doesn't fit the window, so disable it.
-        # XXX: In IPython 3.x and above, the Qt console will not attempt to
-        # display HTML, so this check can be removed when support for
-        # IPython 2.x is no longer needed.
-        if console.in_qtconsole():
-            # 'HTML output is disabled in QtConsole'
-            return None
-
         if self._info_repr():
             buf = StringIO(u(""))
             self.info(buf=buf)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -17,6 +17,7 @@ import functools
 import itertools
 import sys
 import warnings
+from distutils.version import LooseVersion
 from textwrap import dedent
 
 import numpy as np
@@ -646,9 +647,15 @@ class DataFrame(NDFrame):
         # XXX: In IPython 3.x and above, the Qt console will not attempt to
         # display HTML, so this check can be removed when support for
         # IPython 2.x is no longer needed.
-        if console.in_qtconsole():
-            # 'HTML output is disabled in QtConsole'
-            return None
+        try:
+            import IPython
+        except ImportError:
+            pass
+        else:
+            if LooseVersion(IPython.__version__) < LooseVersion('3.0'):
+                if console.in_qtconsole():
+                    # 'HTML output is disabled in QtConsole'
+                    return None
 
         if self._info_repr():
             buf = StringIO(u(""))

--- a/pandas/io/formats/console.py
+++ b/pandas/io/formats/console.py
@@ -108,6 +108,44 @@ def in_interactive_session():
         return check_main()
 
 
+def in_qtconsole():
+    """
+    check if we're inside an IPython qtconsole
+
+    .. deprecated:: 0.14.1
+       This is no longer needed, or working, in IPython 3 and above.
+    """
+    try:
+        ip = get_ipython()  # noqa
+        front_end = (
+            ip.config.get('KernelApp', {}).get('parent_appname', "") or
+            ip.config.get('IPKernelApp', {}).get('parent_appname', ""))
+        if 'qtconsole' in front_end.lower():
+            return True
+    except NameError:
+        return False
+    return False
+
+
+def in_ipnb():
+    """
+    check if we're inside an IPython Notebook
+
+    .. deprecated:: 0.14.1
+       This is no longer needed, or working, in IPython 3 and above.
+    """
+    try:
+        ip = get_ipython()  # noqa
+        front_end = (
+            ip.config.get('KernelApp', {}).get('parent_appname', "") or
+            ip.config.get('IPKernelApp', {}).get('parent_appname', ""))
+        if 'notebook' in front_end.lower():
+            return True
+    except NameError:
+        return False
+    return False
+
+
 def in_ipython_frontend():
     """
     check if we're inside an an IPython zmq frontend

--- a/pandas/io/formats/console.py
+++ b/pandas/io/formats/console.py
@@ -108,44 +108,6 @@ def in_interactive_session():
         return check_main()
 
 
-def in_qtconsole():
-    """
-    check if we're inside an IPython qtconsole
-
-    .. deprecated:: 0.14.1
-       This is no longer needed, or working, in IPython 3 and above.
-    """
-    try:
-        ip = get_ipython()  # noqa
-        front_end = (
-            ip.config.get('KernelApp', {}).get('parent_appname', "") or
-            ip.config.get('IPKernelApp', {}).get('parent_appname', ""))
-        if 'qtconsole' in front_end.lower():
-            return True
-    except NameError:
-        return False
-    return False
-
-
-def in_ipnb():
-    """
-    check if we're inside an IPython Notebook
-
-    .. deprecated:: 0.14.1
-       This is no longer needed, or working, in IPython 3 and above.
-    """
-    try:
-        ip = get_ipython()  # noqa
-        front_end = (
-            ip.config.get('KernelApp', {}).get('parent_appname', "") or
-            ip.config.get('IPKernelApp', {}).get('parent_appname', ""))
-        if 'notebook' in front_end.lower():
-            return True
-    except NameError:
-        return False
-    return False
-
-
 def in_ipython_frontend():
     """
     check if we're inside an an IPython zmq frontend

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -12,6 +12,7 @@ from operator import methodcaller
 import os
 import re
 import sys
+import textwrap
 import warnings
 
 import dateutil
@@ -2777,3 +2778,17 @@ def test_format_percentiles():
         fmt.format_percentiles([2, 0.1, 0.5])
     with pytest.raises(ValueError, match=msg):
         fmt.format_percentiles([0.1, 0.5, 'a'])
+
+
+def test_repr_html_ipython_config(ip):
+    code = textwrap.dedent("""\
+    import pandas as pd
+    df = pd.DataFrame({"A": [1, 2]})
+    df._repr_html_()
+
+    cfg = get_ipython().config
+    cfg['IPKernelApp']['parent_appname']
+    df._repr_html_()
+    """)
+    result = ip.run_cell(code)
+    assert not result.error_in_exec


### PR DESCRIPTION
I've verified this manually with qtconsole 4.4.0, but if others want to check that'd be helpful.

![screen shot 2019-01-30 at 2 22 06 pm](https://user-images.githubusercontent.com/1312546/52010178-794a8080-249a-11e9-9376-a9254ce6bbf9.png)

What release should this be done in? 0.24.1, 0.24.2 or 0.25.0?

Closes https://github.com/pandas-dev/pandas/issues/25036