### PR TITLE
BUG: to_clipboard text truncated for Python 3 on Windows for UTF-16 text

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -163,6 +163,7 @@ MultiIndex
 I/O
 ^^^
 
+- Fixed bug in missing text when using `to_clipboard` if copying utf-16 characters in Python 3 on Windows (:issue:`25040`)
 -
 -
 -

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -163,7 +163,7 @@ MultiIndex
 I/O
 ^^^
 
-- Fixed bug in missing text when using `to_clipboard` if copying utf-16 characters in Python 3 on Windows (:issue:`25040`)
+- Fixed bug in missing text when using :meth:`to_clipboard` if copying utf-16 characters in Python 3 on Windows (:issue:`25040`)
 -
 -
 -

--- a/pandas/io/clipboard/windows.py
+++ b/pandas/io/clipboard/windows.py
@@ -3,7 +3,7 @@ This module implements clipboard handling on Windows using ctypes.
 """
 import contextlib
 import ctypes
-from ctypes import c_size_t, c_wchar, c_wchar_p, c_char_p, get_errno, sizeof
+from ctypes import c_char_p, c_size_t, c_wchar, c_wchar_p, get_errno, sizeof
 import time
 
 from .exceptions import PyperclipWindowsException

--- a/pandas/io/clipboard/windows.py
+++ b/pandas/io/clipboard/windows.py
@@ -3,7 +3,7 @@ This module implements clipboard handling on Windows using ctypes.
 """
 import contextlib
 import ctypes
-from ctypes import c_char_p, c_size_t, c_wchar, c_wchar_p, get_errno, sizeof
+from ctypes import c_size_t, c_wchar, c_wchar_p, get_errno, sizeof
 import time
 
 from .exceptions import PyperclipWindowsException
@@ -29,6 +29,7 @@ def init_windows_clipboard():
                                  HINSTANCE, HMENU, BOOL, UINT, HANDLE)
 
     windll = ctypes.windll
+    msvcrt = ctypes.CDLL('msvcrt')
 
     safeCreateWindowExA = CheckedCall(windll.user32.CreateWindowExA)
     safeCreateWindowExA.argtypes = [DWORD, LPCSTR, LPCSTR, DWORD, INT, INT,
@@ -70,6 +71,10 @@ def init_windows_clipboard():
     safeGlobalUnlock = CheckedCall(windll.kernel32.GlobalUnlock)
     safeGlobalUnlock.argtypes = [HGLOBAL]
     safeGlobalUnlock.restype = BOOL
+
+    wcslen = CheckedCall(msvcrt.wcslen)
+    wcslen.argtypes = [c_wchar_p]
+    wcslen.restype = UINT
 
     GMEM_MOVEABLE = 0x0002
     CF_UNICODETEXT = 13
@@ -129,15 +134,13 @@ def init_windows_clipboard():
                     # If the hMem parameter identifies a memory object,
                     # the object must have been allocated using the
                     # function with the GMEM_MOVEABLE flag.
-                    text = text.encode('utf-16LE')
-                    mem_size = len(text) + sizeof(c_wchar)
+                    count = wcslen(text) + 1
                     handle = safeGlobalAlloc(GMEM_MOVEABLE,
-                                             mem_size)
-
+                                             count * sizeof(c_wchar))
                     locked_handle = safeGlobalLock(handle)
 
-                    ctypes.memmove(c_char_p(locked_handle),
-                                   c_char_p(text), mem_size)
+                    ctypes.memmove(c_wchar_p(locked_handle), c_wchar_p(text),
+                                   count * sizeof(c_wchar))
 
                     safeGlobalUnlock(handle)
                     safeSetClipboardData(CF_UNICODETEXT, handle)

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -13,7 +13,7 @@ from pandas.util import testing as tm
 from pandas.util.testing import makeCustomDataframe as mkdf
 
 from pandas.io.clipboard.exceptions import PyperclipException
-
+from pandas.io.clipboard import clipboard_get, clipboard_set
 try:
     DataFrame({'A': [1, 2]}).to_clipboard()
     _DEPS_INSTALLED = 1
@@ -30,8 +30,8 @@ def build_kwargs(sep, excel):
     return kwargs
 
 
-@pytest.fixture(params=['delims', 'utf8', 'string', 'long', 'nonascii',
-                        'colwidth', 'mixed', 'float', 'int'])
+@pytest.fixture(params=['delims', 'utf8', 'utf16', 'string', 'long',
+                        'nonascii', 'colwidth', 'mixed', 'float', 'int'])
 def df(request):
     data_type = request.param
 
@@ -41,6 +41,10 @@ def df(request):
     elif data_type == 'utf8':
         return pd.DataFrame({'a': ['µasd', 'Ωœ∑´'],
                              'b': ['øπ∆˚¬', 'œ∑´®']})
+    elif data_type == 'utf16':
+        return pd.DataFrame({'a': ['\U0001f44d\U0001f44d',
+                                   '\U0001f44d\U0001f44d'],
+                             'b': ['abc', 'def']})
     elif data_type == 'string':
         return mkdf(5, 3, c_idx_type='s', r_idx_type='i',
                     c_idx_names=[None], r_idx_names=[None])
@@ -231,10 +235,7 @@ class TestClipboard(object):
 @pytest.mark.clipboard
 @pytest.mark.skipif(not _DEPS_INSTALLED,
                     reason="clipboard primitives not installed")
-class TestRawClipboard(object):
-
-    @pytest.mark.parametrize('data', [u'\U0001f44d...', u'Ωœ∑´...', 'abcd...'])
-    def test_raw_roundtrip(self, data):
-        import pandas.io.clipboard
-        pandas.io.clipboard.clipboard_set(data)
-        assert data == pandas.io.clipboard.clipboard_get()
+@pytest.mark.parametrize('data', [u'\U0001f44d...', u'Ωœ∑´...', 'abcd...'])
+def test_raw_roundtrip(data):
+    clipboard_set(data)
+    assert data == clipboard_get()

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -233,7 +233,7 @@ class TestClipboard(object):
                     reason="clipboard primitives not installed")
 class TestRawClipboard(object):
 
-    @pytest.mark.parametrize('data', [u'\U0001f44d...', 'Ωœ∑´...', 'abcd...'])
+    @pytest.mark.parametrize('data', [u'\U0001f44d...', u'Ωœ∑´...', 'abcd...'])
     def test_raw_roundtrip(self, data):
         import pandas.io.clipboard
         pandas.io.clipboard.clipboard_set(data)

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -12,8 +12,9 @@ from pandas import DataFrame, get_option, read_clipboard
 from pandas.util import testing as tm
 from pandas.util.testing import makeCustomDataframe as mkdf
 
-from pandas.io.clipboard.exceptions import PyperclipException
 from pandas.io.clipboard import clipboard_get, clipboard_set
+from pandas.io.clipboard.exceptions import PyperclipException
+
 try:
     DataFrame({'A': [1, 2]}).to_clipboard()
     _DEPS_INSTALLED = 1

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -238,5 +238,6 @@ class TestClipboard(object):
                     reason="clipboard primitives not installed")
 @pytest.mark.parametrize('data', [u'\U0001f44d...', u'Ωœ∑´...', 'abcd...'])
 def test_raw_roundtrip(data):
+    # PR #25040 wide unicode wasn't copied correctly on PY3 on windows
     clipboard_set(data)
     assert data == clipboard_get()

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -225,3 +225,16 @@ class TestClipboard(object):
     @pytest.mark.parametrize('enc', ['UTF-8', 'utf-8', 'utf8'])
     def test_round_trip_valid_encodings(self, enc, df):
         self.check_round_trip_frame(df, encoding=enc)
+
+
+@pytest.mark.single
+@pytest.mark.clipboard
+@pytest.mark.skipif(not _DEPS_INSTALLED,
+                    reason="clipboard primitives not installed")
+class TestRawClipboard(object):
+
+    @pytest.mark.parametrize('data', [u'\U0001f44d...', 'Ωœ∑´...', 'abcd...'])
+    def test_raw_roundtrip(self, data):
+        import pandas.io.clipboard
+        pandas.io.clipboard.clipboard_set(data)
+        assert data == pandas.io.clipboard.clipboard_get()


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

For windows users where Python is compiled with UCS-4 (Python 3 primarily), tables copied to clipboard are missing data from the end when there are any unicode characters in the dataframe that have a 4-byte representation in UTF-16 (i.e. in the U+010000 to U+10FFFF range).  The bug can be reproduced here:

```python
import pandas
obj=pandas.DataFrame([u'\U0001f44d\U0001f44d',
              u'12345'])
obj.to_clipboard()
```
where the clipboard text results in 
```
	0
0	👍👍
1	1234
```
One character is chopped from the end of the clipboard string for each 4-byte unicode character copied.

or more to the point:
```python
pandas.io.clipboard.clipboard_set(u'\U0001f44d 12345')
```
produces
```
👍 1234
```

The cause of this issue is that ```len(u'\U0001f44d')==1``` when python is in UCS-4, and Pandas allocates 2 bytes per python character in the clipboard buffer but the character consumes 4 bytes, displacing another character at the end of the string to be copied.  In UCS-2 (most Python 2 builds), ```len(u'\U0001f44d')==2``` and so 4 bytes are allocated and consumed by the character.

My proposed change (affecting only windows clipboard operations) first converts the text to UTF-16 little endian because that is the format used by windows, then measures the length of the resulting byte string, rather than using Python's ```len(text) * 2``` to measure how many bytes should be allocated to the clipboard buffer.

I've tested this change in python 3.6 and 2.7 on windows 7 x64.  I don't expect this causing other issues with other versions of windows but I would appreciate if anyone on older versions of windows would double check.
