### PR TITLE
PERF: use new to_records() argument in to_stata()

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -23,14 +23,6 @@ Other Enhancements
 -
 -
 
-.. _whatsnew_0250.performance:
-
-Performance Improvements
-~~~~~~~~~~~~~~~~~~~~~~~~
- - Significant speedup in `SparseArray` initialization that benefits most operations, fixing performance regression introduced in v0.20.0 (:issue:`24985`)
-
-
-
 .. _whatsnew_0250.api_breaking:
 
 Backwards incompatible API changes
@@ -69,8 +61,8 @@ Removal of prior version deprecations/changes
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
--
--
+- Significant speedup in `SparseArray` initialization that benefits most operations, fixing performance regression introduced in v0.20.0 (:issue:`24985`)
+- `DataFrame.to_stata()` is now faster when outputting data with any string or non-native endian columns (:issue:`25045`)
 -
 
 


### PR DESCRIPTION
The `to_stata()` function spends ~25-50% of its time massaging string/different endian data and creating a `np.recarray` in a roundabout way. Using `column_dtypes` in `to_records()` allows some cleanup and for a decent performance bump:
```
$ asv compare upstream/master HEAD -s --sort ratio

Benchmarks that have improved:

       before           after         ratio
     [4cbee179]       [9bf67cc5]
     <to_stata~1>       <to_stata>
-         709±9ms         552±20ms     0.78  io.stata.Stata.time_write_stata('tw')
-        409±30ms         233±30ms     0.57  io.stata.Stata.time_write_stata('tq')
-        402±20ms         227±30ms     0.56  io.stata.Stata.time_write_stata('tc')
-         398±9ms         222±30ms     0.56  io.stata.Stata.time_write_stata('th')
-        420±20ms         231±30ms     0.55  io.stata.Stata.time_write_stata('tm')
-        396±10ms          214±3ms     0.54  io.stata.Stata.time_write_stata('ty')
-         389±8ms         207±10ms     0.53  io.stata.Stata.time_write_stata('td')

Benchmarks that have stayed the same:

       before           after         ratio
     [4cbee179]       [9bf67cc5]
     <to_stata~1>       <to_stata>
          527±6ms         563±30ms     1.07  io.stata.Stata.time_read_stata('th')
         507±20ms          531±9ms     1.05  io.stata.Stata.time_read_stata('ty')
         519±10ms         543±30ms     1.05  io.stata.Stata.time_read_stata('tm')
         484±10ms         504±10ms     1.04  io.stata.Stata.time_read_stata('tw')
          149±6ms          152±2ms     1.02  io.stata.Stata.time_read_stata('tc')
          152±3ms          153±8ms     1.01  io.stata.Stata.time_read_stata('td')
         533±20ms          533±6ms     1.00  io.stata.Stata.time_read_stata('tq')

```
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
