### PR TITLE
ENH: Support fold argument in Timestamp.replace

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -19,7 +19,7 @@ including other versions of pandas.
 Other Enhancements
 ^^^^^^^^^^^^^^^^^^
 
--
+- :meth:`Timestamp.replace` now supports the ``fold`` argument to disambiguate DST transition times (:issue:`25017`)
 -
 -
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -669,7 +669,6 @@ class NaTType(_NaT):
         nanosecond : int, optional
         tzinfo : tz-convertible, optional
         fold : int, optional, default is 0
-            added in 3.6, NotImplemented
 
         Returns
         -------

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 import warnings
 
 from cpython cimport (PyObject_RichCompareBool, PyObject_RichCompare,
@@ -43,7 +44,7 @@ from pandas._libs.tslibs.timezones import UTC
 # Constants
 _zero_time = datetime_time(0, 0)
 _no_input = object()
-
+PY36 = sys.version_info >= (3, 6)
 
 # ----------------------------------------------------------------------
 
@@ -1255,9 +1256,12 @@ class Timestamp(_Timestamp):
                                         is_dst=not bool(fold))
             _tzinfo = ts_input.tzinfo
         else:
-            ts_input = datetime(dts.year, dts.month, dts.day,
-                                dts.hour, dts.min, dts.sec, dts.us,
-                                tzinfo=_tzinfo, fold=fold)
+            kwargs = {'year': dts.year, 'month': dts.month, 'day': dts.day,
+                      'hour': dts.hour, 'minute': dts.min, 'second': dts.sec,
+                      'microsecond': dts.us, 'tzinfo': _tzinfo}
+            if PY36:
+                kwargs['fold'] = fold
+            ts_input = datetime(**kwargs)
 
         ts = convert_datetime_to_tsobject(ts_input, _tzinfo)
         value = ts.value + (dts.ps // 1000)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1195,7 +1195,6 @@ class Timestamp(_Timestamp):
         nanosecond : int, optional
         tzinfo : tz-convertible, optional
         fold : int, optional, default is 0
-            added in 3.6, NotImplemented
 
         Returns
         -------
@@ -1252,12 +1251,13 @@ class Timestamp(_Timestamp):
             # see GH#18319
             ts_input = _tzinfo.localize(datetime(dts.year, dts.month, dts.day,
                                                  dts.hour, dts.min, dts.sec,
-                                                 dts.us))
+                                                 dts.us),
+                                        is_dst=not bool(fold))
             _tzinfo = ts_input.tzinfo
         else:
             ts_input = datetime(dts.year, dts.month, dts.day,
                                 dts.hour, dts.min, dts.sec, dts.us,
-                                tzinfo=_tzinfo)
+                                tzinfo=_tzinfo, fold=fold)
 
         ts = convert_datetime_to_tsobject(ts_input, _tzinfo)
         value = ts.value + (dts.ps // 1000)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -48,6 +48,7 @@ PY36 = sys.version_info >= (3, 6)
 
 # ----------------------------------------------------------------------
 
+
 def maybe_integer_op_deprecated(obj):
     # GH#22535 add/sub of integers and int-arrays is deprecated
     if obj.freq is not None:

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -329,6 +329,17 @@ class TestTimestampUnaryOps(object):
         expected = Timestamp('2013-11-3 03:00:00', tz='America/Chicago')
         assert result == expected
 
+    @pytest.mark.parametrize('fold', [0, 1])
+    def test_replace_dst_fold(self, fold):
+        # GH 25017
+        tz = pytz.timezone('Europe/London')
+        d = datetime(2019, 10, 27, 1, 0)
+        d_loc = tz.localize(d, is_dst=True)
+        ts = Timestamp(d_loc)
+        result = ts.replace(minute=0, fold=fold)
+        expected = Timestamp(d).tz_localize(tz, ambiguous=not fold)
+        assert result == expected
+
     # --------------------------------------------------------------
     # Timestamp.normalize
 

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -330,14 +330,15 @@ class TestTimestampUnaryOps(object):
         assert result == expected
 
     @pytest.mark.parametrize('fold', [0, 1])
-    def test_replace_dst_fold(self, fold):
+    @pytest.mark.parametrize('tz', ['dateutil/Europe/London', 'Europe/London'])
+    def test_replace_dst_fold(self, fold, tz):
         # GH 25017
-        tz = pytz.timezone('Europe/London')
-        d = datetime(2019, 10, 27, 1, 0)
-        d_loc = tz.localize(d, is_dst=True)
-        ts = Timestamp(d_loc)
-        result = ts.replace(minute=0, fold=fold)
-        expected = Timestamp(d).tz_localize(tz, ambiguous=not fold)
+        d = datetime(2019, 10, 27, 2, 30)
+        ts = Timestamp(d, tz=tz)
+        result = ts.replace(hour=1, fold=fold)
+        expected = Timestamp(datetime(2019, 10, 27, 1, 30)).tz_localize(
+            tz, ambiguous=not fold
+        )
         assert result == expected
 
     # --------------------------------------------------------------

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -329,7 +329,7 @@ class TestTimestampUnaryOps(object):
         expected = Timestamp('2013-11-3 03:00:00', tz='America/Chicago')
         assert result == expected
 
-    @pytest.mark.skif(not PY36, reason='Fold not available until PY3.6')
+    @pytest.mark.skipif(not PY36, reason='Fold not available until PY3.6')
     @pytest.mark.parametrize('fold', [0, 1])
     @pytest.mark.parametrize('tz', ['dateutil/Europe/London', 'Europe/London'])
     def test_replace_dst_fold(self, fold, tz):

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -8,7 +8,7 @@ from pytz import utc
 
 from pandas._libs.tslibs import conversion
 from pandas._libs.tslibs.frequencies import INVALID_FREQ_ERR_MSG
-from pandas.compat import PY3
+from pandas.compat import PY3, PY36
 import pandas.util._test_decorators as td
 
 from pandas import NaT, Timestamp
@@ -329,6 +329,7 @@ class TestTimestampUnaryOps(object):
         expected = Timestamp('2013-11-3 03:00:00', tz='America/Chicago')
         assert result == expected
 
+    @pytest.mark.skif(not PY36, reason='Fold not available until PY3.6')
     @pytest.mark.parametrize('fold', [0, 1])
     @pytest.mark.parametrize('tz', ['dateutil/Europe/London', 'Europe/London'])
     def test_replace_dst_fold(self, fold, tz):


### PR DESCRIPTION
- [x] closes #25017
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Since `Timestamp` has its own `replace` method, I think we can still introduce this while still supporting PY3.5 (`datetime.replace` gained the `fold` argument in 3.6) while it mimics the functionality in PY3.6