### PR TITLE
clarified the documentation for DF.drop_duplicates

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4625,7 +4625,7 @@ class DataFrame(NDFrame):
     def drop_duplicates(self, subset=None, keep='first', inplace=False):
         """
         Return DataFrame with duplicate rows removed, optionally only
-        considering certain columns. Indexes, including time indexes 
+        considering certain columns. Indexes, including time indexes
         are ignored.
 
         Parameters

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4625,7 +4625,8 @@ class DataFrame(NDFrame):
     def drop_duplicates(self, subset=None, keep='first', inplace=False):
         """
         Return DataFrame with duplicate rows removed, optionally only
-        considering certain columns.
+        considering certain columns. Indexes, including time indexes 
+        are ignored.
 
         Parameters
         ----------


### PR DESCRIPTION
I hit an issue with a time series index where I wanted to keep duplicate data with different time values and only delete rows with the same time and columns. This documentation change would have saved me a lot of time.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
