### PR TITLE
REGR: rename_axis with None should remove axis name

### DIFF
--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -25,6 +25,7 @@ Fixed Regressions
 - Fixed regression in :func:`read_sql` when passing certain queries with MySQL/pymysql (:issue:`24988`).
 - Fixed regression in :class:`Index.intersection` incorrectly sorting the values by default (:issue:`24959`).
 - Fixed regression in :func:`merge` when merging an empty ``DataFrame`` with multiple timezone-aware columns on one of the timezone-aware columns (:issue:`25014`).
+- Fixed regression in :meth:`Series.rename_axis` and :meth:`DataFrame.rename_axis` where passing ``None`` failed to remove the axis name (:issue:`25034`) 
 
 .. _whatsnew_0241.enhancements:
 

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -25,7 +25,7 @@ Fixed Regressions
 - Fixed regression in :func:`read_sql` when passing certain queries with MySQL/pymysql (:issue:`24988`).
 - Fixed regression in :class:`Index.intersection` incorrectly sorting the values by default (:issue:`24959`).
 - Fixed regression in :func:`merge` when merging an empty ``DataFrame`` with multiple timezone-aware columns on one of the timezone-aware columns (:issue:`25014`).
-- Fixed regression in :meth:`Series.rename_axis` and :meth:`DataFrame.rename_axis` where passing ``None`` failed to remove the axis name (:issue:`25034`) 
+- Fixed regression in :meth:`Series.rename_axis` and :meth:`DataFrame.rename_axis` where passing ``None`` failed to remove the axis name (:issue:`25034`)
 
 .. _whatsnew_0241.enhancements:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -63,7 +63,7 @@ _shared_doc_kwargs = dict(
 
 # sentinel value to use as kwarg in place of None when None has special meaning
 # and needs to be distinguished from a user explicitly passing None.
-sentinel = com.sentinel_factory()
+sentinel = object()
 
 
 def _single_replace(self, to_replace, method, inplace, limit):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -600,6 +600,26 @@ class TestDataFrameAlterAxes():
         with pytest.raises(TypeError, match='bogus'):
             df.rename_axis(bogus=None)
 
+    @pytest.mark.parametrize('kwargs, rename_index, rename_columns', [
+        ({'mapper': None, 'axis': 0}, True, False),
+        ({'mapper': None, 'axis': 1}, False, True),
+        ({'index': None}, True, False),
+        ({'columns': None}, False, True),
+        ({'index': None, 'columns': None}, True, True),
+        ({}, False, False)])
+    def test_rename_axis_none(self, kwargs, rename_index, rename_columns):
+        # GH 25034
+        index = Index(list('abc'), name='foo')
+        columns = Index(['col1', 'col2'], name='bar')
+        data = np.arange(6).reshape(3, 2)
+        df = DataFrame(data, index, columns)
+
+        result = df.rename_axis(**kwargs)
+        expected_index = index.rename(None) if rename_index else index
+        expected_columns = columns.rename(None) if rename_columns else columns
+        expected = DataFrame(data, expected_index, expected_columns)
+        tm.assert_frame_equal(result, expected)
+
     def test_rename_multiindex(self):
 
         tuples_index = [('foo1', 'bar1'), ('foo2', 'bar2')]

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -258,6 +258,17 @@ class TestSeriesAlterAxes(object):
         assert no_return is None
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize('kwargs', [{'mapper': None}, {'index': None}, {}])
+    def test_rename_axis_none(self, kwargs):
+        # GH 25034
+        index = Index(list('abc'), name='foo')
+        df = Series([1, 2, 3], index=index)
+
+        result = df.rename_axis(**kwargs)
+        expected_index = index.rename(None) if kwargs else index
+        expected = Series([1, 2, 3], index=expected_index)
+        tm.assert_series_equal(result, expected)
+
     def test_set_axis_inplace_axes(self, axis_series):
         # GH14636
         ser = Series(np.arange(4), index=[1, 3, 5, 7], dtype='int64')


### PR DESCRIPTION
- [X] closes #25034
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Fix amounts to using [~`com.sentinel_factory()`~](https://github.com/pandas-dev/pandas/blob/ea013a254847fbc5551e3ec91a468370c7118589/pandas/core/common.py#L386-L390)  `object()` as a sentinel value instead of `None`.

Had to add a `sentinel` kwarg to `_construct_axes_from_arguments` since it's responsible for the `index` and `columns` kwargs, which need to be treated similarly to `mapper`.

One change in behavior that I kept from 0.24.0: passing nothing to `rename_axis` does nothing, i.e. `s.rename_axis()` does not alter the existing axis name(s).  In 0.23.4 this would raise a `TypeError`, as `mapper` was a required positional argument.
