### PR TITLE
BUG: Fixing regression in DataFrame.all and DataFrame.any with bool_only=True

### DIFF
--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -56,6 +56,7 @@ Fixed Regressions
 - Fixed regression in :class:`Index.intersection` incorrectly sorting the values by default (:issue:`24959`).
 - Fixed regression in :func:`merge` when merging an empty ``DataFrame`` with multiple timezone-aware columns on one of the timezone-aware columns (:issue:`25014`).
 - Fixed regression in :meth:`Series.rename_axis` and :meth:`DataFrame.rename_axis` where passing ``None`` failed to remove the axis name (:issue:`25034`)
+- Fixed regression in :meth:`DataFrame.all` and :meth:`DataFrame.any` where ``bool_only`` as ``True`` was ignored (:issue:`25101`)
 
 **Timedelta**
 

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -58,7 +58,6 @@ Fixed Regressions
 - Fixed regression in :func:`merge` when merging an empty ``DataFrame`` with multiple timezone-aware columns on one of the timezone-aware columns (:issue:`25014`).
 - Fixed regression in :meth:`Series.rename_axis` and :meth:`DataFrame.rename_axis` where passing ``None`` failed to remove the axis name (:issue:`25034`)
 - Fixed regression in :func:`to_timedelta` with `box=False` incorrectly returning a ``datetime64`` object instead of a ``timedelta64`` object (:issue:`24961`)
-- Fixed regression in :meth:`DataFrame.all` and :meth:`DataFrame.any` where ``bool_only`` as ``True`` was ignored (:issue:`25101`)
 
 .. _whatsnew_0241.bug_fixes:
 

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -20,9 +20,7 @@ including other versions of pandas.
 Fixed Regressions
 ^^^^^^^^^^^^^^^^^
 
--
--
--
+- Fixed regression in :meth:`DataFrame.all` and :meth:`DataFrame.any` where ``bool_only=True`` was ignored (:issue:`25101`)
 
 .. _whatsnew_0242.enhancements:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7476,7 +7476,8 @@ class DataFrame(NDFrame):
                 if filter_type is None or filter_type == 'numeric':
                     data = self._get_numeric_data()
                 elif filter_type == 'bool':
-                    data = self
+                    # GH 25101, # GH 24434
+                    data = self._get_bool_data() if axis == 0 else self
                 else:  # pragma: no cover
                     msg = ("Generating numeric_only data with filter_type {f}"
                            "not supported.".format(f=filter_type))

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1451,7 +1451,7 @@ class TestDataFrameAnalytics():
 
         result = df.all(bool_only=True)
         expected = Series(dtype=np.bool)
-        tm.assert_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"col1": [1, 2, 3],
                         "col2": [4, 5, 6],
@@ -1460,7 +1460,7 @@ class TestDataFrameAnalytics():
 
         result = df.all(bool_only=True)
         expected = Series({"col4": False})
-        tm.assert_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize('func, data, expected', [
         (np.any, {}, False),

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1450,7 +1450,7 @@ class TestDataFrameAnalytics():
                         "col3": [None, None, None]})
 
         result = df.all(bool_only=True)
-        expected = Series()
+        expected = Series(dtype=np.bool)
         tm.assert_equal(result, expected)
 
         df = DataFrame({"col1": [1, 2, 3],
@@ -1459,7 +1459,7 @@ class TestDataFrameAnalytics():
                         "col4": [False, False, True]})
 
         result = df.all(bool_only=True)
-        expected = Series()
+        expected = Series({"col4": False})
         tm.assert_equal(result, expected)
 
     @pytest.mark.parametrize('func, data, expected', [

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1442,6 +1442,26 @@ class TestDataFrameAnalytics():
         expected = Series([True, True, True, False])
         tm.assert_series_equal(result, expected)
 
+    def test_any_all_bool_only(self):
+
+        # GH 25101
+        df = DataFrame({"col1": [1,2,3],
+                        "col2": [4,5,6],
+                        "col3": [None, None, None]})
+
+        result = df.all(bool_only=True)
+        expected = Series()
+        tm.assert_equal(result, expected)
+
+        df = DataFrame({"col1": [1,2,3],
+                        "col2": [4,5,6],
+                        "col3": [None, None, None],
+                        "col4":[False, False, True]}
+
+        result = df.all(bool_only=True)
+        expected = Series()
+        tm.assert_equal(result, expected)
+
     @pytest.mark.parametrize('func, data, expected', [
         (np.any, {}, False),
         (np.all, {}, True),

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1445,18 +1445,18 @@ class TestDataFrameAnalytics():
     def test_any_all_bool_only(self):
 
         # GH 25101
-        df = DataFrame({"col1": [1,2,3],
-                        "col2": [4,5,6],
+        df = DataFrame({"col1": [1, 2, 3],
+                        "col2": [4, 5, 6],
                         "col3": [None, None, None]})
 
         result = df.all(bool_only=True)
         expected = Series()
         tm.assert_equal(result, expected)
 
-        df = DataFrame({"col1": [1,2,3],
-                        "col2": [4,5,6],
+        df = DataFrame({"col1": [1, 2, 3],
+                        "col2": [4, 5, 6],
                         "col3": [None, None, None],
-                        "col4":[False, False, True]}
+                        "col4": [False, False, True]})
 
         result = df.all(bool_only=True)
         expected = Series()


### PR DESCRIPTION
* `bool_only` parameter is supported again
* Commit 36ab8c95a41bbadc286a5a520883b149c86931bd created this regression
  due to a bug in all/any (pandas-dev/pandas#23070)
* Reverted the regression and fixed the bug with a condition
* Added tests for `bool_only` parameter

- [x] closes #25101 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
