### PR TITLE
BLD: remove spellcheck from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,3 @@ doc:
 	cd doc; \
 	python make.py clean; \
 	python make.py html
-	python make.py spellcheck


### PR DESCRIPTION
Spell checking for docs was removed in #24287 and #24299, however it
was still called from the Makefile.