### PR TITLE
DOC: Removal of return variable names [WIP]

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9994,8 +9994,7 @@ class NDFrame(PandasObject, SelectionMixin):
             cls, 'all', name, name2, axis_descr, _all_desc, nanops.nanall,
             _all_see_also, _all_examples, empty_value=True)
 
-        @Substitution(outname='mad',
-                      desc="Return the mean absolute deviation of the values "
+        @Substitution(desc="Return the mean absolute deviation of the values "
                            "for the requested axis.",
                       name1=name, name2=name2, axis_descr=axis_descr,
                       min_count='', see_also='', examples='')
@@ -10036,8 +10035,7 @@ class NDFrame(PandasObject, SelectionMixin):
             "ddof argument",
             nanops.nanstd)
 
-        @Substitution(outname='compounded',
-                      desc="Return the compound percentage of the values for "
+        @Substitution(desc="Return the compound percentage of the values for "
                       "the requested axis.", name1=name, name2=name2,
                       axis_descr=axis_descr,
                       min_count='', see_also='', examples='')
@@ -10274,7 +10272,7 @@ numeric_only : bool, default None
 
 Returns
 -------
-%(outname)s : %(name1)s or %(name2)s (if level specified)
+%(name1)s or %(name2)s (if level specified)
 %(see_also)s
 %(examples)s\
 """
@@ -10300,7 +10298,7 @@ numeric_only : boolean, default None
 
 Returns
 -------
-%(outname)s : %(name1)s or %(name2)s (if level specified)\n"""
+%(name1)s or %(name2)s (if level specified)\n"""
 
 _bool_doc = """
 %(desc)s
@@ -10419,7 +10417,7 @@ skipna : boolean, default True
 
 Returns
 -------
-%(outname)s : %(name1)s or %(name2)s\n
+%(name1)s or %(name2)s\n
 See Also
 --------
 core.window.Expanding.%(accum_func_name)s : Similar functionality
@@ -10912,7 +10910,7 @@ min_count : int, default 0
 
 def _make_min_count_stat_function(cls, name, name1, name2, axis_descr, desc,
                                   f, see_also='', examples=''):
-    @Substitution(outname=name, desc=desc, name1=name1, name2=name2,
+    @Substitution(desc=desc, name1=name1, name2=name2,
                   axis_descr=axis_descr, min_count=_min_count_stub,
                   see_also=see_also, examples=examples)
     @Appender(_num_doc)
@@ -10940,7 +10938,7 @@ def _make_min_count_stat_function(cls, name, name1, name2, axis_descr, desc,
 
 def _make_stat_function(cls, name, name1, name2, axis_descr, desc, f,
                         see_also='', examples=''):
-    @Substitution(outname=name, desc=desc, name1=name1, name2=name2,
+    @Substitution(desc=desc, name1=name1, name2=name2,
                   axis_descr=axis_descr, min_count='', see_also=see_also,
                   examples=examples)
     @Appender(_num_doc)
@@ -10964,7 +10962,7 @@ def _make_stat_function(cls, name, name1, name2, axis_descr, desc, f,
 
 
 def _make_stat_function_ddof(cls, name, name1, name2, axis_descr, desc, f):
-    @Substitution(outname=name, desc=desc, name1=name1, name2=name2,
+    @Substitution(desc=desc, name1=name1, name2=name2,
                   axis_descr=axis_descr)
     @Appender(_num_ddof_doc)
     def stat_func(self, axis=None, skipna=None, level=None, ddof=1,
@@ -10985,7 +10983,7 @@ def _make_stat_function_ddof(cls, name, name1, name2, axis_descr, desc, f):
 
 def _make_cum_function(cls, name, name1, name2, axis_descr, desc,
                        accum_func, accum_func_name, mask_a, mask_b, examples):
-    @Substitution(outname=name, desc=desc, name1=name1, name2=name2,
+    @Substitution(desc=desc, name1=name1, name2=name2,
                   axis_descr=axis_descr, accum_func_name=accum_func_name,
                   examples=examples)
     @Appender(_cnum_doc)
@@ -11020,7 +11018,7 @@ def _make_cum_function(cls, name, name1, name2, axis_descr, desc,
 
 def _make_logical_function(cls, name, name1, name2, axis_descr, desc, f,
                            see_also, examples, empty_value):
-    @Substitution(outname=name, desc=desc, name1=name1, name2=name2,
+    @Substitution(desc=desc, name1=name1, name2=name2,
                   axis_descr=axis_descr, see_also=see_also, examples=examples,
                   empty_value=empty_value)
     @Appender(_bool_doc)


### PR DESCRIPTION
@datapythonista 

This is part of the sprint (3rd February). It removes the return variable name from the docstrings.