### PR TITLE
BLD: pin cython language level to '2'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -450,7 +450,8 @@ if '--with-cython-coverage' in sys.argv:
 # Note: if not using `cythonize`, coverage can be enabled by
 # pinning `ext.cython_directives = directives` to each ext in extensions.
 # github.com/cython/cython/wiki/enhancements-compilerdirectives#in-setuppy
-directives = {'linetrace': False}
+directives = {'linetrace': False,
+              'language_level': 2}
 macros = []
 if linetrace:
     # https://pypkg.com/pypi/pytest-cython/f/tests/example-project/setup.py


### PR DESCRIPTION
Not explicitly pinning the language level has been producing future
warnings from cython.  The next release of cython is going to change
the default level to '3str' under which the pandas cython extensions
do not compile.

The long term solution is to update the cython files to the next
language level, but this is a stop-gap to keep pandas building.


- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry