### PR TITLE
Get rid of MultiIndex conversion in IntervalIndex.is_unique

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas.util.testing as tm
 from pandas import (Series, date_range, DatetimeIndex, Index, RangeIndex,
-                    Float64Index)
+                    Float64Index, IntervalIndex)
 
 
 class SetOperations(object):
@@ -179,6 +179,18 @@ class Float64IndexMethod(object):
 
     def time_get_loc(self):
         self.ind.get_loc(0)
+
+
+class IntervalIndexMethod(object):
+    # GH 24813
+    def setup(self):
+        N = 10**5
+        left = np.append(np.arange(N), np.array(0))
+        right = np.append(np.arange(1, N + 1), np.array(1))
+        self.intv = IntervalIndex.from_arrays(left, right)
+
+    def time_is_unique(self):
+        self.intv.is_unique
 
 
 from .pandas_vb_common import setup  # noqa: F401

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -177,6 +177,7 @@ Performance Improvements
 - Improved performance of :meth:`pandas.core.groupby.GroupBy.quantile` (:issue:`20405`)
 - Improved performance of :meth:`read_csv` by faster tokenizing and faster parsing of small float numbers (:issue:`25784`)
 - Improved performance of :meth:`read_csv` by faster parsing of N/A and boolean values (:issue:`25804`)
+- Improved performance of :meth:`IntervalIndex.is_unique` by removing conversion to `MultiIndex` (:issue:`24813`)
 
 .. _whatsnew_0250.bug_fixes:
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -463,7 +463,7 @@ class IntervalIndex(IntervalMixin, Index):
         """
         Return True if the IntervalIndex contains unique elements, else False
         """
-        return self._multiindex.is_unique
+        return len(self) == len(self.unique())
 
     @cache_readonly
     @Appender(_interval_shared_docs['is_non_overlapping_monotonic']

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -463,7 +463,13 @@ class IntervalIndex(IntervalMixin, Index):
         """
         Return True if the IntervalIndex contains unique elements, else False
         """
-        return len(self) == len(self.unique())
+        left = self.values.left
+        right = self.values.right
+        for i in range(len(self)):
+            mask = (left[i] == left) & (right[i] == right)
+            if mask.sum() > 1:
+                return False
+        return True
 
     @cache_readonly
     @Appender(_interval_shared_docs['is_non_overlapping_monotonic']


### PR DESCRIPTION
-  xref #24813 
-  passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Actually, this modification doesn't improve the performance. But the code is more explanatory.
