### PR TITLE
REF: Remove many Panel tests

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -268,20 +268,6 @@ class Block(PandasObject):
         """ return a slice of my values """
         return self.values[slicer]
 
-    def reshape_nd(self, labels, shape, ref_items):
-        """
-        Parameters
-        ----------
-        labels : list of new axis labels
-        shape : new shape
-        ref_items : new ref_items
-
-        return a new block that is transformed to a nd block
-        """
-        return _block2d_to_blocknd(values=self.get_values().T,
-                                   placement=self.mgr_locs, shape=shape,
-                                   labels=labels, ref_items=ref_items)
-
     def getitem_block(self, slicer, new_mgr_locs=None):
         """
         Perform __getitem__-like, return result as block.

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -584,10 +584,6 @@ class BlockManager(PandasObject):
         bm._consolidate_inplace()
         return bm
 
-    def reshape_nd(self, axes, **kwargs):
-        """ a 2d-nd reshape operation on a BlockManager """
-        return self.apply('reshape_nd', axes=axes, **kwargs)
-
     def is_consolidated(self):
         """
         Return True if more than one block with the same dtype

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -197,7 +197,6 @@ _TABLE_MAP = {
     u'appendable_multiseries': 'AppendableMultiSeriesTable',
     u'appendable_frame': 'AppendableFrameTable',
     u'appendable_multiframe': 'AppendableMultiFrameTable',
-    u'appendable_panel': 'AppendablePanelTable',
     u'worm': 'WORMTable',
     u'legacy_frame': 'LegacyFrameTable',
     u'legacy_panel': 'LegacyPanelTable',
@@ -4418,24 +4417,6 @@ class AppendableMultiFrameTable(AppendableFrameTable):
         ])
 
         return df
-
-
-class AppendablePanelTable(AppendableTable):
-
-    """ suppor the new appendable table formats """
-    table_type = u'appendable_panel'
-    ndim = 3
-    obj_type = Panel
-
-    def get_object(self, obj):
-        """ these are written transposed """
-        if self.is_transposed:
-            obj = obj.transpose(*self.data_orientation)
-        return obj
-
-    @property
-    def is_transposed(self):
-        return self.data_orientation != tuple(range(self.ndim))
 
 
 def _reindex_axis(obj, axis, labels, other=None):

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from decimal import Decimal
-from warnings import catch_warnings, filterwarnings, simplefilter
+from warnings import catch_warnings, filterwarnings
 
 import numpy as np
 import pytest
@@ -93,15 +93,6 @@ class TestIsNA(object):
             result = isna_f(df)
             expected = df.apply(isna_f)
             tm.assert_frame_equal(result, expected)
-
-        # panel
-        with catch_warnings(record=True):
-            simplefilter("ignore", FutureWarning)
-            for p in [tm.makePanel(), tm.makePeriodPanel(),
-                      tm.add_nans(tm.makePanel())]:
-                result = isna_f(p)
-                expected = p.apply(isna_f)
-                tm.assert_panel_equal(result, expected)
 
     def test_isna_lists(self):
         result = isna([[False]])

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -14,7 +14,6 @@ import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, date_range
 from pandas.core.computation.check import _NUMEXPR_INSTALLED
 from pandas.tests.frame.common import TestData
-import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_frame_equal, assert_series_equal, makeCustomDataframe as mkdf)
 
@@ -354,13 +353,6 @@ class TestDataFrameQueryWithMultiIndex(object):
                 assert_series_equal(v, expected[k])
             else:
                 raise AssertionError("object must be a Series or Index")
-
-    @pytest.mark.filterwarnings("ignore::FutureWarning")
-    def test_raise_on_panel_with_multiindex(self, parser, engine):
-        p = tm.makePanel(7)
-        p.items = tm.makeCustomIndex(len(p.items), nlevels=2)
-        with pytest.raises(NotImplementedError):
-            pd.eval('p + 1', parser=parser, engine=engine)
 
 
 @td.skip_if_no_ne

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1219,26 +1219,6 @@ def test_groupby_nat_exclude():
             grouped.get_group(pd.NaT)
 
 
-@pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
-def test_sparse_friendly(df):
-    sdf = df[['C', 'D']].to_sparse()
-    panel = tm.makePanel()
-    tm.add_nans(panel)
-
-    def _check_work(gp):
-        gp.mean()
-        gp.agg(np.mean)
-        dict(iter(gp))
-
-    # it works!
-    _check_work(sdf.groupby(lambda x: x // 2))
-    _check_work(sdf['C'].groupby(lambda x: x // 2))
-    _check_work(sdf.groupby(df['A']))
-
-    # do this someday
-    # _check_work(panel.groupby(lambda x: x.month, axis=1))
-
-
 def test_groupby_2d_malformed():
     d = DataFrame(index=lrange(2))
     d['group'] = ['g1', 'g2']

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -356,8 +356,6 @@ class TestChaining(object):
         result4 = df['A'].iloc[2]
         check(result4, expected)
 
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-    @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
     def test_cache_updating(self):
         # GH 4939, make sure to update the cache on setitem
 
@@ -366,12 +364,6 @@ class TestChaining(object):
         df.ix["Hello Friend"] = df.ix[0]
         assert "Hello Friend" in df['A'].index
         assert "Hello Friend" in df['B'].index
-
-        panel = tm.makePanel()
-        panel.ix[0]  # get first item into cache
-        panel.ix[:, :, 'A+1'] = panel.ix[:, :, 'A'] + 1
-        assert "A+1" in panel.ix[0].columns
-        assert "A+1" in panel.ix[1].columns
 
         # 10264
         df = DataFrame(np.zeros((5, 5), dtype='int64'), columns=[

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -356,6 +356,7 @@ class TestChaining(object):
         result4 = df['A'].iloc[2]
         check(result4, expected)
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_cache_updating(self):
         # GH 4939, make sure to update the cache on setitem
 

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -5,7 +5,6 @@ from distutils.version import LooseVersion
 from functools import partial
 import os
 import warnings
-from warnings import catch_warnings
 
 import numpy as np
 from numpy import nan
@@ -2382,15 +2381,12 @@ class TestExcelWriterEngineTests(object):
             assert isinstance(writer, DummyClass)
             df = tm.makeCustomDataframe(1, 1)
 
-            with catch_warnings(record=True):
-                panel = tm.makePanel()
-                func = lambda: df.to_excel('something.test')
-                check_called(func)
-                check_called(lambda: panel.to_excel('something.test'))
-                check_called(lambda: df.to_excel('something.xlsx'))
-                check_called(
-                    lambda: df.to_excel(
-                        'something.xls', engine='dummy'))
+            func = lambda: df.to_excel('something.test')
+            check_called(func)
+            check_called(lambda: df.to_excel('something.xlsx'))
+            check_called(
+                lambda: df.to_excel(
+                    'something.xls', engine='dummy'))
 
 
 @pytest.mark.parametrize('engine', [

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -19,11 +19,11 @@ from pandas.core.dtypes.common import is_categorical_dtype
 import pandas as pd
 from pandas import (
     Categorical, DataFrame, DatetimeIndex, Index, Int64Index, MultiIndex,
-    Panel, RangeIndex, Series, Timestamp, bdate_range, compat, concat,
+    RangeIndex, Series, Timestamp, bdate_range, compat, concat,
     date_range, isna, timedelta_range)
 import pandas.util.testing as tm
 from pandas.util.testing import (
-    assert_frame_equal, assert_panel_equal, assert_series_equal, set_timezone)
+    assert_frame_equal, assert_series_equal, set_timezone)
 
 from pandas.io import pytables as pytables  # noqa:E402
 from pandas.io.formats.printing import pprint_thing
@@ -185,11 +185,6 @@ class TestHDFStore(Base):
             o = tm.makeDataFrame()
             assert_frame_equal(o, roundtrip('frame', o))
 
-            with catch_warnings(record=True):
-
-                o = tm.makePanel()
-                assert_panel_equal(o, roundtrip('panel', o))
-
             # table
             df = DataFrame(dict(A=lrange(5), B=lrange(5)))
             df.to_hdf(path, 'table', append=True)
@@ -348,11 +343,9 @@ class TestHDFStore(Base):
             store['a'] = tm.makeTimeSeries()
             store['b'] = tm.makeStringSeries()
             store['c'] = tm.makeDataFrame()
-            with catch_warnings(record=True):
-                store['d'] = tm.makePanel()
-                store['foo/bar'] = tm.makePanel()
-            assert len(store) == 5
-            expected = {'/a', '/b', '/c', '/d', '/foo/bar'}
+
+            assert len(store) == 3
+            expected = {'/a', '/b', '/c'}
             assert set(store.keys()) == expected
             assert set(store) == expected
 
@@ -387,11 +380,6 @@ class TestHDFStore(Base):
             store['a'] = tm.makeTimeSeries()
             store['b'] = tm.makeStringSeries()
             store['c'] = tm.makeDataFrame()
-
-            with catch_warnings(record=True):
-                store['d'] = tm.makePanel()
-                store['foo/bar'] = tm.makePanel()
-                store.append('e', tm.makePanel())
 
             df = tm.makeDataFrame()
             df['obj1'] = 'foo'
@@ -936,21 +924,6 @@ class TestHDFStore(Base):
                 store.append('/df3 foo', df[10:])
                 tm.assert_frame_equal(store['df3 foo'], df)
 
-                # panel
-                wp = tm.makePanel()
-                _maybe_remove(store, 'wp1')
-                store.append('wp1', wp.iloc[:, :10, :])
-                store.append('wp1', wp.iloc[:, 10:, :])
-                assert_panel_equal(store['wp1'], wp)
-
-                # test using differt order of items on the non-index axes
-                _maybe_remove(store, 'wp1')
-                wp_append1 = wp.iloc[:, :10, :]
-                store.append('wp1', wp_append1)
-                wp_append2 = wp.iloc[:, 10:, :].reindex(items=wp.items[::-1])
-                store.append('wp1', wp_append2)
-                assert_panel_equal(store['wp1'], wp)
-
                 # dtype issues - mizxed type in a single object column
                 df = DataFrame(data=[[1, 2], [0, 1], [1, 2], [0, 0]])
                 df['mixed_column'] = 'testing'
@@ -1254,22 +1227,6 @@ class TestHDFStore(Base):
             reloaded = read_hdf(path, 'df_with_missing')
             tm.assert_frame_equal(df_with_missing, reloaded)
 
-        matrix = [[[np.nan, np.nan, np.nan], [1, np.nan, np.nan]],
-                  [[np.nan, np.nan, np.nan], [np.nan, 5, 6]],
-                  [[np.nan, np.nan, np.nan], [np.nan, 3, np.nan]]]
-
-        with catch_warnings(record=True):
-            panel_with_missing = Panel(matrix,
-                                       items=['Item1', 'Item2', 'Item3'],
-                                       major_axis=[1, 2],
-                                       minor_axis=['A', 'B', 'C'])
-
-            with ensure_clean_path(self.path) as path:
-                panel_with_missing.to_hdf(
-                    path, 'panel_with_missing', format='table')
-                reloaded_panel = read_hdf(path, 'panel_with_missing')
-                tm.assert_panel_equal(panel_with_missing, reloaded_panel)
-
     def test_append_frame_column_oriented(self):
 
         with ensure_clean_store(self.path) as store:
@@ -1342,39 +1299,10 @@ class TestHDFStore(Base):
 
         with ensure_clean_store(self.path) as store:
             with catch_warnings(record=True):
-                simplefilter("ignore", FutureWarning)
-                wp = tm.makePanel()
-                wp2 = wp.rename(
-                    minor_axis={x: "%s_extra" % x for x in wp.minor_axis})
 
                 def check_col(key, name, size):
                     assert getattr(store.get_storer(key)
                                    .table.description, name).itemsize == size
-
-                store.append('s1', wp, min_itemsize=20)
-                store.append('s1', wp2)
-                expected = concat([wp, wp2], axis=2)
-                expected = expected.reindex(
-                    minor_axis=sorted(expected.minor_axis))
-                assert_panel_equal(store['s1'], expected)
-                check_col('s1', 'minor_axis', 20)
-
-                # test dict format
-                store.append('s2', wp, min_itemsize={'minor_axis': 20})
-                store.append('s2', wp2)
-                expected = concat([wp, wp2], axis=2)
-                expected = expected.reindex(
-                    minor_axis=sorted(expected.minor_axis))
-                assert_panel_equal(store['s2'], expected)
-                check_col('s2', 'minor_axis', 20)
-
-                # apply the wrong field (similar to #1)
-                store.append('s3', wp, min_itemsize={'major_axis': 20})
-                pytest.raises(ValueError, store.append, 's3', wp2)
-
-                # test truncation of bigger strings
-                store.append('s4', wp)
-                pytest.raises(ValueError, store.append, 's4', wp2)
 
                 # avoid truncation on elements
                 df = DataFrame([[123, 'asdqwerty'], [345, 'dggnhebbsdfbdfb']])
@@ -1674,32 +1602,6 @@ class TestHDFStore(Base):
                              (df_dc.string == 'foo')]
             tm.assert_frame_equal(result, expected)
 
-        with ensure_clean_store(self.path) as store:
-            with catch_warnings(record=True):
-                # panel
-                # GH5717 not handling data_columns
-                np.random.seed(1234)
-                p = tm.makePanel()
-
-                store.append('p1', p)
-                tm.assert_panel_equal(store.select('p1'), p)
-
-                store.append('p2', p, data_columns=True)
-                tm.assert_panel_equal(store.select('p2'), p)
-
-                result = store.select('p2', where='ItemA>0')
-                expected = p.to_frame()
-                expected = expected[expected['ItemA'] > 0]
-                tm.assert_frame_equal(result.to_frame(), expected)
-
-                result = store.select(
-                    'p2', where='ItemA>0 & minor_axis=["A","B"]')
-                expected = p.to_frame()
-                expected = expected[expected['ItemA'] > 0]
-                expected = expected[expected.reset_index(
-                    level=['major']).index.isin(['A', 'B'])]
-                tm.assert_frame_equal(result.to_frame(), expected)
-
     def test_create_table_index(self):
 
         with ensure_clean_store(self.path) as store:
@@ -1707,37 +1609,6 @@ class TestHDFStore(Base):
             with catch_warnings(record=True):
                 def col(t, column):
                     return getattr(store.get_storer(t).table.cols, column)
-
-                # index=False
-                wp = tm.makePanel()
-                store.append('p5', wp, index=False)
-                store.create_table_index('p5', columns=['major_axis'])
-                assert(col('p5', 'major_axis').is_indexed is True)
-                assert(col('p5', 'minor_axis').is_indexed is False)
-
-                # index=True
-                store.append('p5i', wp, index=True)
-                assert(col('p5i', 'major_axis').is_indexed is True)
-                assert(col('p5i', 'minor_axis').is_indexed is True)
-
-                # default optlevels
-                store.get_storer('p5').create_index()
-                assert(col('p5', 'major_axis').index.optlevel == 6)
-                assert(col('p5', 'minor_axis').index.kind == 'medium')
-
-                # let's change the indexing scheme
-                store.create_table_index('p5')
-                assert(col('p5', 'major_axis').index.optlevel == 6)
-                assert(col('p5', 'minor_axis').index.kind == 'medium')
-                store.create_table_index('p5', optlevel=9)
-                assert(col('p5', 'major_axis').index.optlevel == 9)
-                assert(col('p5', 'minor_axis').index.kind == 'medium')
-                store.create_table_index('p5', kind='full')
-                assert(col('p5', 'major_axis').index.optlevel == 9)
-                assert(col('p5', 'minor_axis').index.kind == 'full')
-                store.create_table_index('p5', optlevel=1, kind='light')
-                assert(col('p5', 'major_axis').index.optlevel == 1)
-                assert(col('p5', 'minor_axis').index.kind == 'light')
 
                 # data columns
                 df = tm.makeTimeDataFrame()
@@ -1760,19 +1631,6 @@ class TestHDFStore(Base):
                 _maybe_remove(store, 'f2')
                 store.put('f2', df)
                 pytest.raises(TypeError, store.create_table_index, 'f2')
-
-    def test_append_diff_item_order(self):
-
-        with catch_warnings(record=True):
-            wp = tm.makePanel()
-            wp1 = wp.iloc[:, :10, :]
-            wp2 = wp.iloc[wp.items.get_indexer(['ItemC', 'ItemB', 'ItemA']),
-                          10:, :]
-
-            with ensure_clean_store(self.path) as store:
-                store.put('panel', wp1, format='table')
-                pytest.raises(ValueError, store.put, 'panel', wp2,
-                              append=True)
 
     def test_append_hierarchical(self):
         index = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux'],
@@ -1987,10 +1845,6 @@ class TestHDFStore(Base):
         df['time2'] = Timestamp('20130102')
         check(df, tm.assert_frame_equal)
 
-        with catch_warnings(record=True):
-            p = tm.makePanel()
-            check(p, assert_panel_equal)
-
         # empty frame, GH4273
         with ensure_clean_store(self.path) as store:
 
@@ -2010,24 +1864,6 @@ class TestHDFStore(Base):
             df = DataFrame(columns=list('ABC'))
             store.put('df2', df)
             assert_frame_equal(store.select('df2'), df)
-
-            with catch_warnings(record=True):
-
-                # 0 len
-                p_empty = Panel(items=list('ABC'))
-                store.append('p', p_empty)
-                pytest.raises(KeyError, store.select, 'p')
-
-                # repeated append of 0/non-zero frames
-                p = Panel(np.random.randn(3, 4, 5), items=list('ABC'))
-                store.append('p', p)
-                assert_panel_equal(store.select('p'), p)
-                store.append('p', p_empty)
-                assert_panel_equal(store.select('p'), p)
-
-                # store
-                store.put('p2', p_empty)
-                assert_panel_equal(store.select('p2'), p_empty)
 
     def test_append_raise(self):
 
@@ -2142,24 +1978,6 @@ class TestHDFStore(Base):
         with ensure_clean_store(self.path) as store:
             store.append('df1_mixed', df)
             tm.assert_frame_equal(store.select('df1_mixed'), df)
-
-        with catch_warnings(record=True):
-
-            # panel
-            wp = tm.makePanel()
-            wp['obj1'] = 'foo'
-            wp['obj2'] = 'bar'
-            wp['bool1'] = wp['ItemA'] > 0
-            wp['bool2'] = wp['ItemB'] > 0
-            wp['int1'] = 1
-            wp['int2'] = 2
-            wp = wp._consolidate()
-
-        with catch_warnings(record=True):
-
-            with ensure_clean_store(self.path) as store:
-                store.append('p1_mixed', wp)
-                assert_panel_equal(store.select('p1_mixed'), wp)
 
     def test_unimplemented_dtypes_table_columns(self):
 
@@ -2308,193 +2126,6 @@ class TestHDFStore(Base):
             del store['b']
             assert len(store) == 0
 
-    def test_remove_where(self):
-
-        with ensure_clean_store(self.path) as store:
-
-            with catch_warnings(record=True):
-
-                # non-existance
-                crit1 = 'index>foo'
-                pytest.raises(KeyError, store.remove, 'a', [crit1])
-
-                # try to remove non-table (with crit)
-                # non-table ok (where = None)
-                wp = tm.makePanel(30)
-                store.put('wp', wp, format='table')
-                store.remove('wp', ["minor_axis=['A', 'D']"])
-                rs = store.select('wp')
-                expected = wp.reindex(minor_axis=['B', 'C'])
-                assert_panel_equal(rs, expected)
-
-                # empty where
-                _maybe_remove(store, 'wp')
-                store.put('wp', wp, format='table')
-
-                # deleted number (entire table)
-                n = store.remove('wp', [])
-                assert n == 120
-
-                # non - empty where
-                _maybe_remove(store, 'wp')
-                store.put('wp', wp, format='table')
-                pytest.raises(ValueError, store.remove,
-                              'wp', ['foo'])
-
-    def test_remove_startstop(self):
-        # GH #4835 and #6177
-
-        with ensure_clean_store(self.path) as store:
-
-            with catch_warnings(record=True):
-                wp = tm.makePanel(30)
-
-                # start
-                _maybe_remove(store, 'wp1')
-                store.put('wp1', wp, format='t')
-                n = store.remove('wp1', start=32)
-                assert n == 120 - 32
-                result = store.select('wp1')
-                expected = wp.reindex(major_axis=wp.major_axis[:32 // 4])
-                assert_panel_equal(result, expected)
-
-                _maybe_remove(store, 'wp2')
-                store.put('wp2', wp, format='t')
-                n = store.remove('wp2', start=-32)
-                assert n == 32
-                result = store.select('wp2')
-                expected = wp.reindex(major_axis=wp.major_axis[:-32 // 4])
-                assert_panel_equal(result, expected)
-
-                # stop
-                _maybe_remove(store, 'wp3')
-                store.put('wp3', wp, format='t')
-                n = store.remove('wp3', stop=32)
-                assert n == 32
-                result = store.select('wp3')
-                expected = wp.reindex(major_axis=wp.major_axis[32 // 4:])
-                assert_panel_equal(result, expected)
-
-                _maybe_remove(store, 'wp4')
-                store.put('wp4', wp, format='t')
-                n = store.remove('wp4', stop=-32)
-                assert n == 120 - 32
-                result = store.select('wp4')
-                expected = wp.reindex(major_axis=wp.major_axis[-32 // 4:])
-                assert_panel_equal(result, expected)
-
-                # start n stop
-                _maybe_remove(store, 'wp5')
-                store.put('wp5', wp, format='t')
-                n = store.remove('wp5', start=16, stop=-16)
-                assert n == 120 - 32
-                result = store.select('wp5')
-                expected = wp.reindex(
-                    major_axis=(wp.major_axis[:16 // 4]
-                                .union(wp.major_axis[-16 // 4:])))
-                assert_panel_equal(result, expected)
-
-                _maybe_remove(store, 'wp6')
-                store.put('wp6', wp, format='t')
-                n = store.remove('wp6', start=16, stop=16)
-                assert n == 0
-                result = store.select('wp6')
-                expected = wp.reindex(major_axis=wp.major_axis)
-                assert_panel_equal(result, expected)
-
-                # with where
-                _maybe_remove(store, 'wp7')
-
-                # TODO: unused?
-                date = wp.major_axis.take(np.arange(0, 30, 3))  # noqa
-
-                crit = 'major_axis=date'
-                store.put('wp7', wp, format='t')
-                n = store.remove('wp7', where=[crit], stop=80)
-                assert n == 28
-                result = store.select('wp7')
-                expected = wp.reindex(major_axis=wp.major_axis.difference(
-                    wp.major_axis[np.arange(0, 20, 3)]))
-                assert_panel_equal(result, expected)
-
-    def test_remove_crit(self):
-
-        with ensure_clean_store(self.path) as store:
-
-            with catch_warnings(record=True):
-                wp = tm.makePanel(30)
-
-                # group row removal
-                _maybe_remove(store, 'wp3')
-                date4 = wp.major_axis.take([0, 1, 2, 4, 5, 6, 8, 9, 10])
-                crit4 = 'major_axis=date4'
-                store.put('wp3', wp, format='t')
-                n = store.remove('wp3', where=[crit4])
-                assert n == 36
-
-                result = store.select('wp3')
-                expected = wp.reindex(
-                    major_axis=wp.major_axis.difference(date4))
-                assert_panel_equal(result, expected)
-
-                # upper half
-                _maybe_remove(store, 'wp')
-                store.put('wp', wp, format='table')
-                date = wp.major_axis[len(wp.major_axis) // 2]
-
-                crit1 = 'major_axis>date'
-                crit2 = "minor_axis=['A', 'D']"
-                n = store.remove('wp', where=[crit1])
-                assert n == 56
-
-                n = store.remove('wp', where=[crit2])
-                assert n == 32
-
-                result = store['wp']
-                expected = wp.truncate(after=date).reindex(minor=['B', 'C'])
-                assert_panel_equal(result, expected)
-
-                # individual row elements
-                _maybe_remove(store, 'wp2')
-                store.put('wp2', wp, format='table')
-
-                date1 = wp.major_axis[1:3]
-                crit1 = 'major_axis=date1'
-                store.remove('wp2', where=[crit1])
-                result = store.select('wp2')
-                expected = wp.reindex(
-                    major_axis=wp.major_axis.difference(date1))
-                assert_panel_equal(result, expected)
-
-                date2 = wp.major_axis[5]
-                crit2 = 'major_axis=date2'
-                store.remove('wp2', where=[crit2])
-                result = store['wp2']
-                expected = wp.reindex(
-                    major_axis=(wp.major_axis
-                                .difference(date1)
-                                .difference(Index([date2]))
-                                ))
-                assert_panel_equal(result, expected)
-
-                date3 = [wp.major_axis[7], wp.major_axis[9]]
-                crit3 = 'major_axis=date3'
-                store.remove('wp2', where=[crit3])
-                result = store['wp2']
-                expected = wp.reindex(major_axis=wp.major_axis
-                                      .difference(date1)
-                                      .difference(Index([date2]))
-                                      .difference(Index(date3)))
-                assert_panel_equal(result, expected)
-
-                # corners
-                _maybe_remove(store, 'wp4')
-                store.put('wp4', wp, format='table')
-                n = store.remove(
-                    'wp4', where="major_axis>wp.major_axis[-1]")
-                result = store.select('wp4')
-                assert_panel_equal(result, wp)
-
     def test_invalid_terms(self):
 
         with ensure_clean_store(self.path) as store:
@@ -2504,27 +2135,16 @@ class TestHDFStore(Base):
                 df = tm.makeTimeDataFrame()
                 df['string'] = 'foo'
                 df.loc[0:4, 'string'] = 'bar'
-                wp = tm.makePanel()
 
                 store.put('df', df, format='table')
-                store.put('wp', wp, format='table')
 
                 # some invalid terms
-                pytest.raises(ValueError, store.select,
-                              'wp', "minor=['A', 'B']")
-                pytest.raises(ValueError, store.select,
-                              'wp', ["index=['20121114']"])
-                pytest.raises(ValueError, store.select, 'wp', [
-                    "index=['20121114', '20121114']"])
                 pytest.raises(TypeError, Term)
 
                 # more invalid
                 pytest.raises(
                     ValueError, store.select, 'df', 'df.index[3]')
                 pytest.raises(SyntaxError, store.select, 'df', 'index>')
-                pytest.raises(
-                    ValueError, store.select, 'wp',
-                    "major_axis<'20000108' & minor_axis['A', 'B']")
 
         # from the docs
         with ensure_clean_path(self.path) as path:
@@ -2545,127 +2165,6 @@ class TestHDFStore(Base):
 
             pytest.raises(ValueError, read_hdf, path,
                           'dfq', where="A>0 or C>0")
-
-    def test_terms(self):
-
-        with ensure_clean_store(self.path) as store:
-
-            with catch_warnings(record=True):
-                simplefilter("ignore", FutureWarning)
-
-                wp = tm.makePanel()
-                wpneg = Panel.fromDict({-1: tm.makeDataFrame(),
-                                        0: tm.makeDataFrame(),
-                                        1: tm.makeDataFrame()})
-
-                store.put('wp', wp, format='table')
-                store.put('wpneg', wpneg, format='table')
-
-                # panel
-                result = store.select(
-                    'wp',
-                    "major_axis<'20000108' and minor_axis=['A', 'B']")
-                expected = wp.truncate(
-                    after='20000108').reindex(minor=['A', 'B'])
-                assert_panel_equal(result, expected)
-
-                # with deprecation
-                result = store.select(
-                    'wp', where=("major_axis<'20000108' "
-                                 "and minor_axis=['A', 'B']"))
-                expected = wp.truncate(
-                    after='20000108').reindex(minor=['A', 'B'])
-                tm.assert_panel_equal(result, expected)
-
-            with catch_warnings(record=True):
-
-                # valid terms
-                terms = [('major_axis=20121114'),
-                         ('major_axis>20121114'),
-                         (("major_axis=['20121114', '20121114']"),),
-                         ('major_axis=datetime.datetime(2012, 11, 14)'),
-                         'major_axis> 20121114',
-                         'major_axis >20121114',
-                         'major_axis > 20121114',
-                         (("minor_axis=['A', 'B']"),),
-                         (("minor_axis=['A', 'B']"),),
-                         ((("minor_axis==['A', 'B']"),),),
-                         (("items=['ItemA', 'ItemB']"),),
-                         ('items=ItemA'),
-                         ]
-
-                for t in terms:
-                    store.select('wp', t)
-
-                with pytest.raises(TypeError,
-                                   match='Only named functions are supported'):
-                    store.select(
-                        'wp',
-                        'major_axis == (lambda x: x)("20130101")')
-
-            with catch_warnings(record=True):
-                # check USub node parsing
-                res = store.select('wpneg', 'items == -1')
-                expected = Panel({-1: wpneg[-1]})
-                tm.assert_panel_equal(res, expected)
-
-                msg = 'Unary addition not supported'
-                with pytest.raises(NotImplementedError, match=msg):
-                    store.select('wpneg', 'items == +1')
-
-    def test_term_compat(self):
-        with ensure_clean_store(self.path) as store:
-
-            with catch_warnings(record=True):
-                wp = Panel(np.random.randn(2, 5, 4), items=['Item1', 'Item2'],
-                           major_axis=date_range('1/1/2000', periods=5),
-                           minor_axis=['A', 'B', 'C', 'D'])
-                store.append('wp', wp)
-
-                result = store.select(
-                    'wp', where=("major_axis>20000102 "
-                                 "and minor_axis=['A', 'B']"))
-                expected = wp.loc[:, wp.major_axis >
-                                  Timestamp('20000102'), ['A', 'B']]
-                assert_panel_equal(result, expected)
-
-                store.remove('wp', 'major_axis>20000103')
-                result = store.select('wp')
-                expected = wp.loc[:, wp.major_axis <= Timestamp('20000103'), :]
-                assert_panel_equal(result, expected)
-
-        with ensure_clean_store(self.path) as store:
-
-            with catch_warnings(record=True):
-                wp = Panel(np.random.randn(2, 5, 4),
-                           items=['Item1', 'Item2'],
-                           major_axis=date_range('1/1/2000', periods=5),
-                           minor_axis=['A', 'B', 'C', 'D'])
-                store.append('wp', wp)
-
-                # stringified datetimes
-                result = store.select(
-                    'wp', 'major_axis>datetime.datetime(2000, 1, 2)')
-                expected = wp.loc[:, wp.major_axis > Timestamp('20000102')]
-                assert_panel_equal(result, expected)
-
-                result = store.select(
-                    'wp', 'major_axis>datetime.datetime(2000, 1, 2)')
-                expected = wp.loc[:, wp.major_axis > Timestamp('20000102')]
-                assert_panel_equal(result, expected)
-
-                result = store.select(
-                    'wp',
-                    "major_axis=[datetime.datetime(2000, 1, 2, 0, 0), "
-                    "datetime.datetime(2000, 1, 3, 0, 0)]")
-                expected = wp.loc[:, [Timestamp('20000102'),
-                                      Timestamp('20000103')]]
-                assert_panel_equal(result, expected)
-
-                result = store.select(
-                    'wp', "minor_axis=['A', 'B']")
-                expected = wp.loc[:, :, ['A', 'B']]
-                assert_panel_equal(result, expected)
 
     def test_same_name_scoping(self):
 
@@ -2982,12 +2481,6 @@ class TestHDFStore(Base):
         self._check_roundtrip(df1['int1'], tm.assert_series_equal,
                               compression=compression)
 
-    def test_wide(self):
-
-        with catch_warnings(record=True):
-            wp = tm.makePanel()
-            self._check_roundtrip(wp, assert_panel_equal)
-
     @pytest.mark.filterwarnings(
         "ignore:\\nduplicate:pandas.io.pytables.DuplicateWarning"
     )
@@ -3096,34 +2589,6 @@ class TestHDFStore(Base):
         with ensure_clean_store(self.path) as store:
 
             with catch_warnings(record=True):
-                wp = tm.makePanel()
-
-                # put/select ok
-                _maybe_remove(store, 'wp')
-                store.put('wp', wp, format='table')
-                store.select('wp')
-
-                # non-table ok (where = None)
-                _maybe_remove(store, 'wp')
-                store.put('wp2', wp)
-                store.select('wp2')
-
-                # selection on the non-indexable with a large number of columns
-                wp = Panel(np.random.randn(100, 100, 100),
-                           items=['Item%03d' % i for i in range(100)],
-                           major_axis=date_range('1/1/2000', periods=100),
-                           minor_axis=['E%03d' % i for i in range(100)])
-
-                _maybe_remove(store, 'wp')
-                store.append('wp', wp)
-                items = ['Item%03d' % i for i in range(80)]
-                result = store.select('wp', 'items=items')
-                expected = wp.reindex(items=items)
-                assert_panel_equal(expected, result)
-
-                # selectin non-table with a where
-                # pytest.raises(ValueError, store.select,
-                #                  'wp2', ('column', ['A', 'D']))
 
                 # select with columns=
                 df = tm.makeTimeDataFrame()
@@ -3651,31 +3116,6 @@ class TestHDFStore(Base):
                 df2.to_hdf(path, 'data', append=True)
 
             assert read_hdf(path, 'data').index.name is None
-
-    def test_panel_select(self):
-
-        with ensure_clean_store(self.path) as store:
-
-            with catch_warnings(record=True):
-
-                wp = tm.makePanel()
-
-                store.put('wp', wp, format='table')
-                date = wp.major_axis[len(wp.major_axis) // 2]
-
-                crit1 = ('major_axis>=date')
-                crit2 = ("minor_axis=['A', 'D']")
-
-                result = store.select('wp', [crit1, crit2])
-                expected = wp.truncate(before=date).reindex(minor=['A', 'D'])
-                assert_panel_equal(result, expected)
-
-                result = store.select(
-                    'wp', ['major_axis>="20000124"',
-                           ("minor_axis=['A', 'B']")])
-                expected = wp.truncate(
-                    before='20000124').reindex(minor=['A', 'B'])
-                assert_panel_equal(result, expected)
 
     def test_frame_select(self):
 
@@ -5300,35 +4740,30 @@ class TestHDFComplexValues(Base):
             reread = read_hdf(path, 'df')
             assert_frame_equal(df, reread)
 
-    @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
     def test_complex_across_dimensions_fixed(self):
         with catch_warnings(record=True):
             complex128 = np.array(
                 [1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])
             s = Series(complex128, index=list('abcd'))
             df = DataFrame({'A': s, 'B': s})
-            p = Panel({'One': df, 'Two': df})
 
-            objs = [s, df, p]
-            comps = [tm.assert_series_equal, tm.assert_frame_equal,
-                     tm.assert_panel_equal]
+            objs = [s, df]
+            comps = [tm.assert_series_equal, tm.assert_frame_equal]
             for obj, comp in zip(objs, comps):
                 with ensure_clean_path(self.path) as path:
                     obj.to_hdf(path, 'obj', format='fixed')
                     reread = read_hdf(path, 'obj')
                     comp(obj, reread)
 
-    @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
     def test_complex_across_dimensions(self):
         complex128 = np.array([1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])
         s = Series(complex128, index=list('abcd'))
         df = DataFrame({'A': s, 'B': s})
 
         with catch_warnings(record=True):
-            p = Panel({'One': df, 'Two': df})
 
-            objs = [df, p]
-            comps = [tm.assert_frame_equal, tm.assert_panel_equal]
+            objs = [df]
+            comps = [tm.assert_frame_equal]
             for obj, comp in zip(objs, comps):
                 with ensure_clean_path(self.path) as path:
                     obj.to_hdf(path, 'obj', format='table')

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -19,8 +19,8 @@ from pandas.core.dtypes.common import is_categorical_dtype
 import pandas as pd
 from pandas import (
     Categorical, DataFrame, DatetimeIndex, Index, Int64Index, MultiIndex,
-    RangeIndex, Series, Timestamp, bdate_range, compat, concat,
-    date_range, isna, timedelta_range)
+    RangeIndex, Series, Timestamp, bdate_range, compat, concat, date_range,
+    isna, timedelta_range)
 import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_frame_equal, assert_series_equal, set_timezone)

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -1,7 +1,5 @@
 # pylint: disable=E1103
 
-from warnings import catch_warnings
-
 import numpy as np
 from numpy.random import randn
 import pytest
@@ -656,95 +654,6 @@ class TestJoin(object):
         expected.columns = ['x_x', 'y_x', 'x_y',
                             'y_y', 'x_x', 'y_x', 'x_y', 'y_y']
         assert_frame_equal(dta, expected)
-
-    def test_panel_join(self):
-        with catch_warnings(record=True):
-            panel = tm.makePanel()
-            tm.add_nans(panel)
-
-            p1 = panel.iloc[:2, :10, :3]
-            p2 = panel.iloc[2:, 5:, 2:]
-
-            # left join
-            result = p1.join(p2)
-            expected = p1.copy()
-            expected['ItemC'] = p2['ItemC']
-            tm.assert_panel_equal(result, expected)
-
-            # right join
-            result = p1.join(p2, how='right')
-            expected = p2.copy()
-            expected['ItemA'] = p1['ItemA']
-            expected['ItemB'] = p1['ItemB']
-            expected = expected.reindex(items=['ItemA', 'ItemB', 'ItemC'])
-            tm.assert_panel_equal(result, expected)
-
-            # inner join
-            result = p1.join(p2, how='inner')
-            expected = panel.iloc[:, 5:10, 2:3]
-            tm.assert_panel_equal(result, expected)
-
-            # outer join
-            result = p1.join(p2, how='outer')
-            expected = p1.reindex(major=panel.major_axis,
-                                  minor=panel.minor_axis)
-            expected = expected.join(p2.reindex(major=panel.major_axis,
-                                                minor=panel.minor_axis))
-            tm.assert_panel_equal(result, expected)
-
-    def test_panel_join_overlap(self):
-        with catch_warnings(record=True):
-            panel = tm.makePanel()
-            tm.add_nans(panel)
-
-            p1 = panel.loc[['ItemA', 'ItemB', 'ItemC']]
-            p2 = panel.loc[['ItemB', 'ItemC']]
-
-            # Expected index is
-            #
-            # ItemA, ItemB_p1, ItemC_p1, ItemB_p2, ItemC_p2
-            joined = p1.join(p2, lsuffix='_p1', rsuffix='_p2')
-            p1_suf = p1.loc[['ItemB', 'ItemC']].add_suffix('_p1')
-            p2_suf = p2.loc[['ItemB', 'ItemC']].add_suffix('_p2')
-            no_overlap = panel.loc[['ItemA']]
-            expected = no_overlap.join(p1_suf.join(p2_suf))
-            tm.assert_panel_equal(joined, expected)
-
-    def test_panel_join_many(self):
-        with catch_warnings(record=True):
-            tm.K = 10
-            panel = tm.makePanel()
-            tm.K = 4
-
-            panels = [panel.iloc[:2], panel.iloc[2:6], panel.iloc[6:]]
-
-            joined = panels[0].join(panels[1:])
-            tm.assert_panel_equal(joined, panel)
-
-            panels = [panel.iloc[:2, :-5],
-                      panel.iloc[2:6, 2:],
-                      panel.iloc[6:, 5:-7]]
-
-            data_dict = {}
-            for p in panels:
-                data_dict.update(p.iteritems())
-
-            joined = panels[0].join(panels[1:], how='inner')
-            expected = pd.Panel.from_dict(data_dict, intersect=True)
-            tm.assert_panel_equal(joined, expected)
-
-            joined = panels[0].join(panels[1:], how='outer')
-            expected = pd.Panel.from_dict(data_dict, intersect=False)
-            tm.assert_panel_equal(joined, expected)
-
-            # edge cases
-            msg = "Suffixes not supported when passing multiple panels"
-            with pytest.raises(ValueError, match=msg):
-                panels[0].join(panels[1:], how='outer', lsuffix='foo',
-                               rsuffix='bar')
-            msg = "Right join not supported with multiple panels"
-            with pytest.raises(ValueError, match=msg):
-                panels[0].join(panels[1:], how='right')
 
     def test_join_multi_to_multi(self, join_type):
         # GH 20475

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -3,7 +3,7 @@ import datetime as dt
 from datetime import datetime
 from decimal import Decimal
 from itertools import combinations
-from warnings import catch_warnings, simplefilter
+from warnings import catch_warnings
 
 import dateutil
 import numpy as np
@@ -1499,15 +1499,6 @@ class TestConcatenate(ConcatenateBase):
         result = concat([s1, df, s2], ignore_index=True)
         assert_frame_equal(result, expected)
 
-        # invalid concatente of mixed dims
-        with catch_warnings(record=True):
-            simplefilter("ignore", FutureWarning)
-            panel = tm.makePanel()
-            msg = ("cannot concatenate unaligned mixed dimensional NDFrame"
-                   " objects")
-            with pytest.raises(ValueError, match=msg):
-                concat([panel, s1], axis=1)
-
     def test_empty_dtype_coerce(self):
 
         # xref to #12411
@@ -1542,34 +1533,6 @@ class TestConcatenate(ConcatenateBase):
         df = DataFrame({'text': ['some words'] + [None] * 9})
         result = concat([df.iloc[[0]], df.iloc[[1]]])
         tm.assert_series_equal(result.dtypes, df.dtypes)
-
-    @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
-    def test_panel_concat_other_axes(self):
-        panel = tm.makePanel()
-
-        p1 = panel.iloc[:, :5, :]
-        p2 = panel.iloc[:, 5:, :]
-
-        result = concat([p1, p2], axis=1)
-        tm.assert_panel_equal(result, panel)
-
-        p1 = panel.iloc[:, :, :2]
-        p2 = panel.iloc[:, :, 2:]
-
-        result = concat([p1, p2], axis=2)
-        tm.assert_panel_equal(result, panel)
-
-        # if things are a bit misbehaved
-        p1 = panel.iloc[:2, :, :2]
-        p2 = panel.iloc[:, :, 2:]
-        p1['ItemC'] = 'baz'
-
-        result = concat([p1, p2], axis=2)
-
-        expected = panel.copy()
-        expected['ItemC'] = expected['ItemC'].astype('O')
-        expected.loc['ItemC', :, :2] = 'baz'
-        tm.assert_panel_equal(result, expected)
 
     @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
     # Panel.rename warning we don't care about

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1858,21 +1858,6 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
         assert_series_equal(mixed_panel.dtypes, shifted.dtypes)
 
     def test_tshift(self):
-        # PeriodIndex
-        ps = tm.makePeriodPanel()
-        shifted = ps.tshift(1)
-        unshifted = shifted.tshift(-1)
-
-        assert_panel_equal(unshifted, ps)
-
-        shifted2 = ps.tshift(freq='B')
-        assert_panel_equal(shifted, shifted2)
-
-        shifted3 = ps.tshift(freq=BDay())
-        assert_panel_equal(shifted, shifted3)
-
-        with pytest.raises(ValueError, match='does not match'):
-            ps.tshift(freq='M')
 
         # DatetimeIndex
         panel = make_test_panel()

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -257,8 +257,7 @@ def test_categorical_with_nan_consistency():
     assert result[1] in expected
 
 
-@pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
-@pytest.mark.parametrize("obj", [pd.Timestamp("20130101"), tm.makePanel()])
+@pytest.mark.parametrize("obj", [pd.Timestamp("20130101")])
 def test_pandas_errors(obj):
     msg = "Unexpected type for hashing"
     with pytest.raises(TypeError, match=msg):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2059,14 +2059,6 @@ def makePanel(nper=None):
         return Panel.fromDict(data)
 
 
-def makePeriodPanel(nper=None):
-    with warnings.catch_warnings(record=True):
-        warnings.filterwarnings("ignore", "\\nPanel", FutureWarning)
-        cols = ['Item' + c for c in string.ascii_uppercase[:K - 1]]
-        data = {c: makePeriodFrame(nper) for c in cols}
-        return Panel.fromDict(data)
-
-
 def makeCustomIndex(nentries, nlevels, prefix='#', names=False, ndupe_l=None,
                     idx_type=None):
     """Create an index/multindex with given dimensions, levels, names, etc'


### PR DESCRIPTION
Stopped this branch at the point where I'd have to do surgery on `legacy_table.h5` to fix `test_legacy_table_read`.  If we're dropping that entirely and can just remove the file, I can push forward on removing a bunch more of `io.pytables`.