### PR TITLE
BUG-25061 fix printing indices with NaNs

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -52,7 +52,7 @@ Bug Fixes
 **I/O**
 
 - Bug in reading a HDF5 table-format ``DataFrame`` created in Python 2, in Python 3 (:issue:`24925`)
--
+- Bug where float indexes could have misaligned values when printing (:issue:`25061`)
 -
 
 **Categorical**

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1063,7 +1063,9 @@ class FloatArrayFormatter(GenericArrayFormatter):
             # default formatter leaves a space to the left when formatting
             # floats, must be consistent for left-justifying NaNs (GH #25061)
             if self.justify == 'left':
-                self.na_rep = ' ' + self.na_rep
+                na_rep = ' ' + self.na_rep
+            else:
+                na_rep = self.na_rep
 
             # separate the wheat from the chaff
             values = self.values
@@ -1071,13 +1073,13 @@ class FloatArrayFormatter(GenericArrayFormatter):
             if hasattr(values, 'to_dense'):  # sparse numpy ndarray
                 values = values.to_dense()
             values = np.array(values, dtype='object')
-            values[mask] = self.na_rep
+            values[mask] = na_rep
             imask = (~mask).ravel()
             values.flat[imask] = np.array([formatter(val)
                                            for val in values.ravel()[imask]])
 
             if self.fixed_width:
-                return _trim_zeros(values, self.na_rep)
+                return _trim_zeros(values, na_rep)
 
             return values
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1060,6 +1060,11 @@ class FloatArrayFormatter(GenericArrayFormatter):
         def format_values_with(float_format):
             formatter = self._value_formatter(float_format, threshold)
 
+            # default formatter leaves a space to the left when formatting
+            # floats, must be consistent for left-justifying NaNs (GH #25061)
+            if self.justify == 'left':
+                self.na_rep = ' ' + self.na_rep
+
             # separate the wheat from the chaff
             values = self.values
             mask = isna(values)

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -198,8 +198,8 @@ class TestSeriesRepr(TestData):
 
         assert s._repr_latex_() is None
 
-    # GH 25061
     def test_index_repr_in_frame_with_nan(self):
+        # see gh-25061
         i = Index([1, np.nan])
         s = Series([1, 2], index=i)
         exp = """1.0    1\nNaN    2\ndtype: int64"""

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -198,6 +198,13 @@ class TestSeriesRepr(TestData):
 
         assert s._repr_latex_() is None
 
+    def test_categorical_index_repr_in_frame_with_nan(self):
+        i = Index([1, np.nan])
+        s = Series([1, 2], index=i)
+        exp = """1.0    1\nNaN    2\ndtype: int64"""
+
+        assert repr(s) == exp
+
 
 class TestCategoricalRepr(object):
 

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -198,7 +198,8 @@ class TestSeriesRepr(TestData):
 
         assert s._repr_latex_() is None
 
-    def test_categorical_index_repr_in_frame_with_nan(self):
+    # GH 25061
+    def test_index_repr_in_frame_with_nan(self):
         i = Index([1, np.nan])
         s = Series([1, 2], index=i)
         exp = """1.0    1\nNaN    2\ndtype: int64"""


### PR DESCRIPTION
- [X] closes #25061- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

The `FloatArrayFormatter` leaves a space in front of the floats it formats (expected behaviour as demonstrated by [this test](https://github.com/pandas-dev/pandas/blob/638ddebaa7da1e569836a5b89593b120dbbf491c/pandas/tests/io/formats/test_format.py#L2395)). To avoid misaligned values when printing indices, `NaN` values must be treated similarly.