### PR TITLE
TST: fix ci failures on master

### DIFF
--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -291,8 +291,8 @@ class TestSeriesDtypes(object):
         expected = s
         tm.assert_series_equal(s.astype('category'), expected)
         tm.assert_series_equal(s.astype(CategoricalDtype()), expected)
-        msg = (r"could not convert string to float: '(0 - 499|9500 - 9999)'|"
-               r"invalid literal for float\(\): (0 - 499|9500 - 9999)")
+        msg = (r"could not convert string to float|"
+               r"invalid literal for float\(\)")
         with pytest.raises(ValueError, match=msg):
             s.astype('float64')
 


### PR DESCRIPTION
appear to have ci failures on master since #25182 

the match check in `test_astype_categorical_to_other` is probably too explicit and dependent on random numbers.