### PR TITLE
BUG: Fix regression in DataFrame.apply causing RecursionError

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -21,10 +21,8 @@ Fixed Regressions
 ^^^^^^^^^^^^^^^^^
 
 - Fixed regression in :meth:`DataFrame.all` and :meth:`DataFrame.any` where ``bool_only=True`` was ignored (:issue:`25101`)
-
 - Fixed issue in ``DataFrame`` construction with passing a mixed list of mixed types could segfault. (:issue:`25075`)
-
-- Fixed regression in :meth:`DataFrame.apply` causing RecursionError when ``dict`` or ``Series`` were passed as argument. (:issue:`25196`)
+- Fixed regression in :meth:`DataFrame.apply` causing ``RecursionError`` when ``dict``-like classes were passed as argument. (:issue:`25196`)
 
 .. _whatsnew_0242.enhancements:
 

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -24,6 +24,8 @@ Fixed Regressions
 
 - Fixed issue in ``DataFrame`` construction with passing a mixed list of mixed types could segfault. (:issue:`25075`)
 
+- Fixed regression in :meth:`DataFrame.apply` causing RecursionError when classes like ``dict`` were passed as argument. (:issue:`25196`)
+
 .. _whatsnew_0242.enhancements:
 
 Enhancements

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -24,7 +24,7 @@ Fixed Regressions
 
 - Fixed issue in ``DataFrame`` construction with passing a mixed list of mixed types could segfault. (:issue:`25075`)
 
-- Fixed regression in :meth:`DataFrame.apply` causing RecursionError when classes like ``dict`` were passed as argument. (:issue:`25196`)
+- Fixed regression in :meth:`DataFrame.apply` causing RecursionError when ``dict`` or ``Series`` were passed as argument. (:issue:`25196`)
 
 .. _whatsnew_0242.enhancements:
 

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -397,12 +397,15 @@ def is_dict_like(obj):
     True
     >>> is_dict_like([1, 2, 3])
     False
+    >>> is_dict_like(dict)
+    False
+    >>> is_dict_like(dict())
+    True
     """
-    for attr in ("__getitem__", "keys", "__contains__"):
-        if not hasattr(obj, attr):
-            return False
-
-    return True
+    dict_like_attrs = ("__getitem__", "keys", "__contains__")
+    return (all(hasattr(obj, attr) for attr in dict_like_attrs)
+            # [GH 25196] exclude classes
+            and not isinstance(obj, type))
 
 
 def is_named_tuple(obj):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -159,13 +159,15 @@ def test_is_nested_list_like_fails(obj):
 
 
 @pytest.mark.parametrize(
-    "ll", [{}, {'A': 1}, Series([1])])
+    "ll", [{}, {'A': 1}, Series([1]), collections.defaultdict()])
 def test_is_dict_like_passes(ll):
     assert inference.is_dict_like(ll)
 
 
-@pytest.mark.parametrize(
-    "ll", ['1', 1, [1, 2], (1, 2), range(2), Index([1])])
+@pytest.mark.parametrize("ll", [
+    '1', 1, [1, 2], (1, 2), range(2), Index([1]),
+    dict, collections.defaultdict
+])
 def test_is_dict_like_fails(ll):
     assert not inference.is_dict_like(ll)
 

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -166,7 +166,7 @@ def test_is_dict_like_passes(ll):
 
 @pytest.mark.parametrize("ll", [
     '1', 1, [1, 2], (1, 2), range(2), Index([1]),
-    dict, collections.defaultdict
+    dict, collections.defaultdict, Series
 ])
 def test_is_dict_like_fails(ll):
     assert not inference.is_dict_like(ll)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -319,9 +319,11 @@ class TestDataFrameApply():
         assert_series_equal(result, expected)
 
     def test_apply_reduce_rows_to_dict(self):
+        # GH 25196
         data = pd.DataFrame([[1, 2], [3, 4]])
         expected = pd.Series([{0: 1, 1: 3}, {0: 2, 1: 4}])
-        assert_series_equal(data.apply(dict), expected)
+        result = data.apply(dict)
+        assert_series_equal(result, expected)
 
     def test_apply_differently_indexed(self):
         df = DataFrame(np.random.randn(20, 10))

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -318,6 +318,11 @@ class TestDataFrameApply():
         result = float_frame.apply(np.mean, axis=1)
         assert_series_equal(result, expected)
 
+    def test_apply_reduce_rows_to_dict(self):
+        data = pd.DataFrame([[1, 2], [3, 4]])
+        expected = pd.Series([{0: 1, 1: 3}, {0: 2, 1: 4}])
+        assert_series_equal(data.apply(dict), expected)
+
     def test_apply_differently_indexed(self):
         df = DataFrame(np.random.randn(20, 10))
 


### PR DESCRIPTION
- [X] closes #25196
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

With this change the snippets reported in the issue work as expected:

```
>>> import numpy as np
>>> import pandas as pd
>>> df = pd.DataFrame(np.zeros((100, 15)))
>>> df.T.apply(dict)
0     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
1     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
2     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
3     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
4     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
5     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
6     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
7     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
8     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
9     {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
10    {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
11    {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0....
...
```