### PR TITLE
BUG: Fix exceptions when Series.interpolate's `order` parameter is missing or invalid

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -139,7 +139,7 @@ Indexing
 Missing
 ^^^^^^^
 
--
+- Fixed misleading exception message in :meth:`Series.missing` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 -
 -
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1118,18 +1118,15 @@ class Block(PandasObject):
         # validate the interp method
         m = missing.clean_interp_method(method, **kwargs)
 
-        if m is not None:
-            r = check_int_bool(self, inplace)
-            if r is not None:
-                return r
-            return self._interpolate(method=m, index=index, values=values,
-                                     axis=axis, limit=limit,
-                                     limit_direction=limit_direction,
-                                     limit_area=limit_area,
-                                     fill_value=fill_value, inplace=inplace,
-                                     downcast=downcast, **kwargs)
-
-        raise ValueError("invalid method '{0}' to interpolate.".format(method))
+        r = check_int_bool(self, inplace)
+        if r is not None:
+            return r
+        return self._interpolate(method=m, index=index, values=values,
+                                 axis=axis, limit=limit,
+                                 limit_direction=limit_direction,
+                                 limit_area=limit_area,
+                                 fill_value=fill_value, inplace=inplace,
+                                 downcast=downcast, **kwargs)
 
     def _interpolate_with_fill(self, method='pad', axis=0, inplace=False,
                                limit=None, fill_value=None, coerce=False,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1115,11 +1115,8 @@ class Block(PandasObject):
                                                fill_value=fill_value,
                                                coerce=coerce,
                                                downcast=downcast)
-        # try an interp method
-        try:
-            m = missing.clean_interp_method(method, **kwargs)
-        except ValueError:
-            m = None
+        # validate the interp method
+        m = missing.clean_interp_method(method, **kwargs)
 
         if m is not None:
             r = check_int_bool(self, inplace)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -294,7 +294,7 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
         new_y = terp(new_x)
     elif method == 'spline':
         # GH #10633, #24014
-        if order is None or not (0 < order):
+        if order is None or (order <= 0):
             raise ValueError("order needs to be specified and greater than 0")
         terp = interpolate.UnivariateSpline(x, y, k=order, **kwargs)
         new_y = terp(new_x)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -294,7 +294,7 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
         new_y = terp(new_x)
     elif method == 'spline':
         # GH #10633, #24014
-        if order is None or (order <= 0):
+        if isna(order) or (order <= 0):
             raise ValueError("order needs to be specified and greater than 0; "
                              "got order: {}".format(order))
         terp = interpolate.UnivariateSpline(x, y, k=order, **kwargs)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -295,7 +295,8 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
     elif method == 'spline':
         # GH #10633, #24014
         if order is None or (order <= 0):
-            raise ValueError("order needs to be specified and greater than 0")
+            raise ValueError("order needs to be specified and greater than 0; "
+                             "got order: {}".format(order))
         terp = interpolate.UnivariateSpline(x, y, k=order, **kwargs)
         new_y = terp(new_x)
     else:

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -293,8 +293,8 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
                                     bounds_error=bounds_error)
         new_y = terp(new_x)
     elif method == 'spline':
-        # GH #10633
-        if not order:
+        # GH #10633, #24014
+        if order is None or not (0 < order):
             raise ValueError("order needs to be specified and greater than 0")
         terp = interpolate.UnivariateSpline(x, y, k=order, **kwargs)
         new_y = terp(new_x)

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1336,8 +1336,9 @@ class TestSeriesInterpolateData():
             s.interpolate(method='spline')
 
         msg = "order needs to be specified and greater than 0"
-        with pytest.raises(ValueError, match=msg):
-            s.interpolate(method='spline', order=0)
+        for invalid_order in [-1, -1., 0, 0., np.nan]:
+            with pytest.raises(ValueError, match=msg):
+                s.interpolate(method='spline', order=invalid_order)
 
     def test_interp_timedelta64(self):
         # GH 6424

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -886,7 +886,8 @@ class TestSeriesInterpolateData():
         # When method='time' is used on a non-TimeSeries that contains a null
         # value, a ValueError should be raised.
         non_ts = Series([0, 1, 2, np.NaN])
-        msg = "time-weighted interpolation only works on Series.* with a DatetimeIndex"
+        msg = ("time-weighted interpolation only works on Series.* "
+               "with a DatetimeIndex")
         with pytest.raises(ValueError, match=msg):
             non_ts.interpolate(method='time')
 
@@ -1089,7 +1090,7 @@ class TestSeriesInterpolateData():
     def test_interp_invalid_method(self, invalid_method):
         s = Series([1, 3, np.nan, 12, np.nan, 25])
 
-        msg = "method must be one of.*\\. Got '{}' instead".format(invalid_method)
+        msg = "method must be one of.* Got '{}' instead".format(invalid_method)
         with pytest.raises(ValueError, match=msg):
             s.interpolate(method=invalid_method)
 

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -882,12 +882,11 @@ class TestSeriesInterpolateData():
         time_interp = ord_ts_copy.interpolate(method='time')
         tm.assert_series_equal(time_interp, ord_ts)
 
-        # try time interpolation on a non-TimeSeries
-        # Only raises ValueError if there are NaNs.
-        non_ts = string_series.copy()
-        non_ts[0] = np.NaN
-        msg = ("time-weighted interpolation only works on Series or DataFrames"
-               " with a DatetimeIndex")
+    def test_interpolate_time_raises_for_non_timeseries(self):
+        # When method='time' is used on a non-TimeSeries that contains a null
+        # value, a ValueError should be raised.
+        non_ts = Series([0, 1, 2, np.NaN])
+        msg = "time-weighted interpolation only works on Series.* with a DatetimeIndex"
         with pytest.raises(ValueError, match=msg):
             non_ts.interpolate(method='time')
 

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1296,7 +1296,7 @@ class TestSeriesInterpolateData():
             s.interpolate(method=method)
 
     @td.skip_if_no_scipy
-    @pytest.mark.parametrize('order', [-1, -1.0, 0, 0.0])
+    @pytest.mark.parametrize('order', [-1, -1.0, 0, 0.0, np.nan])
     def test_interpolate_spline_invalid_order(self, order):
         s = Series([0, 1, np.nan, 3])
         msg = "order needs to be specified and greater than 0"


### PR DESCRIPTION
closes #24014
xref #10633
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Before this change, when the `Series.interpolate()` method was called with invalid arguments,  exceptions with informative messages would be raised internally, but then caught and suppressed.  An exception with a potentially misleading message would be raised instead.

For example, when interpolate is called with `method='spline'`, an `order` argument must also be supplied.  This is checked internally, but when the `order` argument was missing, a confusing error would be raised:
```
>>> import pandas as pd
>>> s = pd.Series([0, 1, pd.np.nan, 3, 4])
>>> s.interpolate(method='spline')
Traceback (most recent call last):
...
ValueError: invalid method 'spline' to interpolate.
```

This problem was reported as issues #10633 and #24014.

After this change, a specific and correct exception (previously caught and discarded internally) is raised:
```
>>> import pandas as pd
>>> s = pd.Series([0, 1, pd.np.nan, 3, 4])
>>> s.interpolate(method='spline')
...
ValueError: You must specify the order of the spline or polynomial.
```

In addition, light validation is now performed on the `order` parameter before it is passed to a `scipy` class.  Previously, `pandas` would check if `order` was truthy in the Python sense.  If `order` was non-zero and invalid, a scipy error would propagate to the user:
```
>>> s.interpolate(method='spline', order=-1)
Traceback (most recent call last):
...
dfitpack.error: (1<=k && k<=5) failed for 3rd argument k: fpcurf0:k=-1
```

After this change, a more understandable exception is raised in this case:
```
>>> s.interpolate(method='spline', order=-1)
Traceback (most recent call last):
...
ValueError: order needs to be specified and greater than 0
```