### PR TITLE
BUG: pandas Timestamp tz_localize and tz_convert do not preserve `freq` attribute

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -93,7 +93,7 @@ Timezones
 ^^^^^^^^^
 
 - Bug in :func:`to_datetime` with ``utc=True`` and datetime strings that would apply previously parsed UTC offsets to subsequent arguments (:issue:`24992`)
--
+- Bug in :func:`tz_localize` and :func:`tz_convert` does not propagate freq if ``Timestamp`` is initiated with freq (:issue:`25241`)
 -
 
 Numeric

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -93,7 +93,7 @@ Timezones
 ^^^^^^^^^
 
 - Bug in :func:`to_datetime` with ``utc=True`` and datetime strings that would apply previously parsed UTC offsets to subsequent arguments (:issue:`24992`)
-- Bug in :func:`tz_localize` and :func:`tz_convert` does not propagate freq if ``Timestamp`` is initiated with freq (:issue:`25241`)
+- Bug in :func:`Timestamp.tz_localize` and :func:`Timestamp.tz_convert` does not propagate ``freq`` (:issue:`25241`)
 -
 
 Numeric

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1187,12 +1187,12 @@ class Timestamp(_Timestamp):
             value = tz_localize_to_utc(np.array([self.value], dtype='i8'), tz,
                                        ambiguous=ambiguous,
                                        nonexistent=nonexistent)[0]
-            return Timestamp(value, tz=tz)
+            return Timestamp(value, tz=self.tz)
         else:
             if tz is None:
                 # reset tz
                 value = tz_convert_single(self.value, UTC, self.tz)
-                return Timestamp(value, tz=None)
+                return Timestamp(value, tz=self.tz)
             else:
                 raise TypeError('Cannot localize tz-aware Timestamp, use '
                                 'tz_convert for conversions')
@@ -1222,7 +1222,7 @@ class Timestamp(_Timestamp):
                             'tz_localize to localize')
         else:
             # Same UTC timestamp, different time zone
-            return Timestamp(self.value, tz=tz)
+            return Timestamp(self.value, tz=self.tz)
 
     astimezone = tz_convert
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1187,12 +1187,12 @@ class Timestamp(_Timestamp):
             value = tz_localize_to_utc(np.array([self.value], dtype='i8'), tz,
                                        ambiguous=ambiguous,
                                        nonexistent=nonexistent)[0]
-            return Timestamp(value, tz=self.tz)
+            return Timestamp(value, tz=tz, freq=self.freq)
         else:
             if tz is None:
                 # reset tz
                 value = tz_convert_single(self.value, UTC, self.tz)
-                return Timestamp(value, tz=self.tz)
+                return Timestamp(value, tz=None, freq=self.freq)
             else:
                 raise TypeError('Cannot localize tz-aware Timestamp, use '
                                 'tz_convert for conversions')
@@ -1222,7 +1222,7 @@ class Timestamp(_Timestamp):
                             'tz_localize to localize')
         else:
             # Same UTC timestamp, different time zone
-            return Timestamp(self.value, tz=self.tz)
+            return Timestamp(self.value, tz=tz, freq=self.freq)
 
     astimezone = tz_convert
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1192,7 +1192,7 @@ class Timestamp(_Timestamp):
             if tz is None:
                 # reset tz
                 value = tz_convert_single(self.value, UTC, self.tz)
-                return Timestamp(value, tz=None, freq=self.freq)
+                return Timestamp(value, tz=tz, freq=self.freq)
             else:
                 raise TypeError('Cannot localize tz-aware Timestamp, use '
                                 'tz_convert for conversions')

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -825,6 +825,13 @@ class TestDatetimeIndexTimezones(object):
 
         assert ind.tz is not None
 
+    def test_dti_tz_conversion_freq(self, tz_naive_fixture):
+        # GH25241
+        t3 = DatetimeIndex(['2019-01-01 10:00'], freq='H')
+        assert t3.tz_localize(tz=tz_naive_fixture).freq == t3.freq
+        t4 = DatetimeIndex(['2019-01-02 12:00'], tz='UTC', freq='T')
+        assert t4.tz_convert(tz='UTC').freq == t4.freq
+
     def test_drop_dst_boundary(self):
         # see gh-18031
         tz = "Europe/Brussels"

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -789,9 +789,9 @@ class TestTimestamp(object):
 
         # freq propagation doesn't apply to DatetimeIndex
         t3 = DatetimeIndex(['2019-01-01 10:00'], freq='H')
-        assert t3.freq is None
+        assert t3.tz_localize(tz=tz_naive_fixture).freq is None
         t4 = DatetimeIndex(['2019-01-02 12:00'], tz='UTC', freq='T')
-        assert t4.freq is None
+        assert t4.tz_convert(tz='UTC').freq is None
 
 
 class TestTimestampNsOperations(object):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -19,7 +19,7 @@ from pandas.compat.numpy import np_datetime64_compat
 from pandas.errors import OutOfBoundsDatetime
 import pandas.util._test_decorators as td
 
-from pandas import DatetimeIndex, NaT, Period, Timedelta, Timestamp
+from pandas import NaT, Period, Timedelta, Timestamp
 import pandas.util.testing as tm
 
 from pandas.tseries import offsets
@@ -786,12 +786,6 @@ class TestTimestamp(object):
         assert t1.tz_localize(tz=tz_naive_fixture).freq == t1.freq
         t2 = Timestamp('2019-01-02 12:00', tz='UTC', freq='T')
         assert t2.tz_convert(tz='UTC').freq == t2.freq
-
-        # freq propagation error doesn't happen with DatetimeIndex
-        t3 = DatetimeIndex(['2019-01-01 10:00'], freq='H')
-        assert t3.tz_localize(tz=tz_naive_fixture).freq == t3.freq
-        t4 = DatetimeIndex(['2019-01-02 12:00'], tz='UTC', freq='T')
-        assert t4.tz_convert(tz='UTC').freq == t4.freq
 
 
 class TestTimestampNsOperations(object):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -19,7 +19,7 @@ from pandas.compat.numpy import np_datetime64_compat
 from pandas.errors import OutOfBoundsDatetime
 import pandas.util._test_decorators as td
 
-from pandas import NaT, Period, Timedelta, Timestamp, DatetimeIndex
+from pandas import DatetimeIndex, NaT, Period, Timedelta, Timestamp
 import pandas.util.testing as tm
 
 from pandas.tseries import offsets

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -785,7 +785,7 @@ class TestTimestamp(object):
         t1 = Timestamp('2019-01-01 10:00', freq='H')
         assert t1.tz_localize(tz=tz_naive_fixture).freq == t1.freq
         t2 = Timestamp('2019-01-02 12:00', tz='UTC', freq='T')
-        assert t2.tz_convert(tz='UTC') == t2
+        assert t2.tz_convert(tz='UTC').freq == t2.freq
 
 
 class TestTimestampNsOperations(object):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -780,6 +780,13 @@ class TestTimestamp(object):
         stamp = Timestamp(datetime(2011, 1, 1))
         assert d[stamp] == 5
 
+    def test_tz_convert_freq(self, tz_naive_fixture):
+        # GH25241
+        t1 = Timestamp('2019-01-01 10:00', freq='H')
+        assert t1.tz_localize(tz=tz_naive_fixture).freq == t1.freq
+        t2 = Timestamp('2019-01-02 12:00', tz='UTC', freq='T')
+        assert t2.tz_convert(tz='UTC') == t2
+
 
 class TestTimestampNsOperations(object):
 

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -19,7 +19,7 @@ from pandas.compat.numpy import np_datetime64_compat
 from pandas.errors import OutOfBoundsDatetime
 import pandas.util._test_decorators as td
 
-from pandas import NaT, Period, Timedelta, Timestamp
+from pandas import NaT, Period, Timedelta, Timestamp, DatetimeIndex
 import pandas.util.testing as tm
 
 from pandas.tseries import offsets
@@ -780,12 +780,18 @@ class TestTimestamp(object):
         stamp = Timestamp(datetime(2011, 1, 1))
         assert d[stamp] == 5
 
-    def test_tz_convert_freq(self, tz_naive_fixture):
+    def test_tz_conversion_freq(self, tz_naive_fixture):
         # GH25241
         t1 = Timestamp('2019-01-01 10:00', freq='H')
         assert t1.tz_localize(tz=tz_naive_fixture).freq == t1.freq
         t2 = Timestamp('2019-01-02 12:00', tz='UTC', freq='T')
         assert t2.tz_convert(tz='UTC').freq == t2.freq
+
+        # freq propagation doesn't apply to DatetimeIndex
+        t3 = DatetimeIndex('2019-01-01 10:00', freq='H')
+        assert t3.freq is None
+        t4 = DatetimeIndex('2019-01-02 12:00', tz='UTC', freq='T')
+        assert t4.freq is None
 
 
 class TestTimestampNsOperations(object):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -788,9 +788,9 @@ class TestTimestamp(object):
         assert t2.tz_convert(tz='UTC').freq == t2.freq
 
         # freq propagation doesn't apply to DatetimeIndex
-        t3 = DatetimeIndex('2019-01-01 10:00', freq='H')
+        t3 = DatetimeIndex(['2019-01-01 10:00'], freq='H')
         assert t3.freq is None
-        t4 = DatetimeIndex('2019-01-02 12:00', tz='UTC', freq='T')
+        t4 = DatetimeIndex(['2019-01-02 12:00'], tz='UTC', freq='T')
         assert t4.freq is None
 
 

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -787,7 +787,7 @@ class TestTimestamp(object):
         t2 = Timestamp('2019-01-02 12:00', tz='UTC', freq='T')
         assert t2.tz_convert(tz='UTC').freq == t2.freq
 
-        # freq propagation doesn't apply to DatetimeIndex
+        # freq propagation error doesn't happen with DatetimeIndex
         t3 = DatetimeIndex(['2019-01-01 10:00'], freq='H')
         assert t3.tz_localize(tz=tz_naive_fixture).freq == t3.freq
         t4 = DatetimeIndex(['2019-01-02 12:00'], tz='UTC', freq='T')

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -789,9 +789,9 @@ class TestTimestamp(object):
 
         # freq propagation doesn't apply to DatetimeIndex
         t3 = DatetimeIndex(['2019-01-01 10:00'], freq='H')
-        assert t3.tz_localize(tz=tz_naive_fixture).freq is None
+        assert t3.tz_localize(tz=tz_naive_fixture).freq == t3.freq
         t4 = DatetimeIndex(['2019-01-02 12:00'], tz='UTC', freq='T')
-        assert t4.tz_convert(tz='UTC').freq is None
+        assert t4.tz_convert(tz='UTC').freq == t4.freq
 
 
 class TestTimestampNsOperations(object):

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -114,7 +114,8 @@ def test_getitem_get(test_data):
 
     # missing
     d = test_data.ts.index[0] - BDay()
-    with pytest.raises(KeyError, match=r"Timestamp\('1999-12-31 00:00:00', freq='B'\)"):
+    msg = r"Timestamp\('1999-12-31 00:00:00', freq='B'\)"
+    with pytest.raises(KeyError, match=msg):
         test_data.ts[d]
 
     # None

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -114,7 +114,7 @@ def test_getitem_get(test_data):
 
     # missing
     d = test_data.ts.index[0] - BDay()
-    with pytest.raises(KeyError, match=r"Timestamp\('1999-12-31 00:00:00'\)"):
+    with pytest.raises(KeyError, match=r"Timestamp\('1999-12-31 00:00:00', freq='B'\)"):
         test_data.ts[d]
 
     # None

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -66,12 +66,3 @@ def test_length_zero_copy(dtype, copy):
     arr = np.array([], dtype=dtype)
     result = conversion.ensure_datetime64ns(arr, copy=copy)
     assert result.base is (None if copy else arr)
-
-
-def test_tz_convert_freq():
-    import pandas as pd
-    import pytz
-    t1 = pd.Timestamp('2019-01-01 10:00', freq='H')
-    assert t1.tz_localize(pytz.utc).freq == t1.freq
-    t2 = pd.Timestamp('2019-01-02 12:00', tz=pytz.utc, freq='T')
-    assert t2.tz_convert(pytz.utc).freq == t2.freq

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -73,3 +73,5 @@ def test_tz_convert_freq():
     import pytz
     t1 = pd.Timestamp('2019-01-01 10:00', freq='H')
     assert t1.tz_localize(pytz.utc).freq == t1.freq
+    t2 = pd.Timestamp('2019-01-02 12:00', tz=pytz.utc, freq='T')
+    assert t2.tz_convert(pytz.utc).freq == t2.freq

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -66,3 +66,10 @@ def test_length_zero_copy(dtype, copy):
     arr = np.array([], dtype=dtype)
     result = conversion.ensure_datetime64ns(arr, copy=copy)
     assert result.base is (None if copy else arr)
+
+
+def test_tz_convert_freq():
+    import pandas as pd
+    import pytz
+    t1 = pd.Timestamp('2019-01-01 10:00', freq='H')
+    assert t1.tz_localize(pytz.utc).freq == t1.freq


### PR DESCRIPTION
- [ ] closes #25241
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
