### PR TITLE
PERF: avoid copy of dataframe while writing to SQL DBs

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -623,7 +623,7 @@ class SQLTable(PandasObject):
                     "duplicate name in index/columns: {0}".format(err))
         else:
             if start_index == 0 and end_index == len(self.frame.index):
-                #avoid unnecessary copy by avoiding slicing
+                # avoid unnecessary copy by avoiding slicing
                 temp = self.frame
             else:
                 temp = self.frame[start_index:end_index]


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] This change avoids making an entire copy of the dataframe while writing to SQL DBs with a chunksize. Instead we convert slices of the dataframe into a data list and write to the DB. Saves significant memory when writing large dataframes to SQL DBs. 
