### PR TITLE
Fix minor error in dynamic load function

### DIFF
--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -1018,8 +1018,10 @@ class TestDocstringClass(object):
 
     @pytest.mark.parametrize('invalid_name', ['panda', 'panda.DataFrame'])
     def test_raises_for_invalid_module_name(self, invalid_name):
-        # Note that the module names in this test are misspelled.
-        with pytest.raises(ImportError):
+        # When an invalid module name is supplied, an ImportError should be
+        # raised, and the message should contain the user-supplied name.
+        msg = 'No module can be imported.*{}'.format(invalid_name)
+        with pytest.raises(ImportError, match=msg):
             validate_docstrings.Docstring(invalid_name)
 
     @pytest.mark.parametrize('invalid_name',

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -1027,7 +1027,10 @@ class TestDocstringClass(object):
                              ['pandas.BadClassName',
                               'pandas.Series.bad_method_name'])
     def test_raises_for_invalid_attribute_name(self, invalid_name):
-        with pytest.raises(AttributeError):
+        name_components = invalid_name.split('.')
+        obj_name, invalid_attr_name = name_components[-2], name_components[-1]
+        msg = "'{}' has no attribute '{}'".format(obj_name, invalid_attr_name)
+        with pytest.raises(AttributeError, match=msg):
             validate_docstrings.Docstring(invalid_name)
 
 

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -4,7 +4,7 @@ import string
 import textwrap
 import pytest
 import numpy as np
-import pandas
+import pandas as pd
 
 import validate_docstrings
 validate_one = validate_docstrings.validate_one
@@ -1008,9 +1008,9 @@ class TestApiItems(object):
 
 class TestDocstringClass(object):
     @pytest.mark.parametrize('name, expected_obj',
-                             [('pandas.isnull', pandas.isnull),
-                              ('pandas.DataFrame', pandas.DataFrame),
-                              ('pandas.Series.sum', pandas.Series.sum)])
+                             [('pandas.isnull', pd.isnull),
+                              ('pandas.DataFrame', pd.DataFrame),
+                              ('pandas.Series.sum', pd.Series.sum)])
     def test_resolves_class_name(self, name, expected_obj):
         d = validate_docstrings.Docstring(name)
         assert d.obj is expected_obj

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -1007,12 +1007,11 @@ class TestApiItems(object):
 
 
 class TestDocstringClass(object):
-    @pytest.mark.parametrize('name_and_expected_obj',
+    @pytest.mark.parametrize('name, expected_obj',
                              [('pandas.isnull', pandas.isnull),
                               ('pandas.DataFrame', pandas.DataFrame),
                               ('pandas.Series.sum', pandas.Series.sum)])
-    def test_resolves_class_name(self, name_and_expected_obj):
-        name, expected_obj = name_and_expected_obj
+    def test_resolves_class_name(self, name, expected_obj):
         d = validate_docstrings.Docstring(name)
         assert d.obj is expected_obj
 

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -1017,9 +1017,7 @@ class TestDocstringClass(object):
 
     @pytest.mark.parametrize('invalid_name', ['panda', 'panda.DataFrame'])
     def test_raises_for_invalid_module_name(self, invalid_name):
-        # When an invalid module name is supplied, an ImportError should be
-        # raised, and the message should contain the user-supplied name.
-        msg = 'No module can be imported.*{}'.format(invalid_name)
+        msg = 'No module can be imported from "{}"'.format(invalid_name)
         with pytest.raises(ImportError, match=msg):
             validate_docstrings.Docstring(invalid_name)
 

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -4,6 +4,8 @@ import string
 import textwrap
 import pytest
 import numpy as np
+import pandas
+
 import validate_docstrings
 validate_one = validate_docstrings.validate_one
 
@@ -1002,6 +1004,30 @@ class TestApiItems(object):
     def test_item_subsection(self, idx, subsection):
         result = list(validate_docstrings.get_api_items(self.api_doc))
         assert result[idx][3] == subsection
+
+
+class TestDocstringClass(object):
+    @pytest.mark.parametrize('name_and_expected_obj',
+                             [('pandas.isnull', pandas.isnull),
+                              ('pandas.DataFrame', pandas.DataFrame),
+                              ('pandas.Series.sum', pandas.Series.sum)])
+    def test_resolves_class_name(self, name_and_expected_obj):
+        name, expected_obj = name_and_expected_obj
+        d = validate_docstrings.Docstring(name)
+        assert d.obj is expected_obj
+
+    @pytest.mark.parametrize('invalid_name', ['panda', 'panda.DataFrame'])
+    def test_raises_for_invalid_module_name(self, invalid_name):
+        # Note that the module names in this test are misspelled.
+        with pytest.raises(ImportError):
+            validate_docstrings.Docstring(invalid_name)
+
+    @pytest.mark.parametrize('invalid_name',
+                             ['pandas.BadClassName',
+                              'pandas.Series.bad_method_name'])
+    def test_raises_for_invalid_attribute_name(self, invalid_name):
+        with pytest.raises(AttributeError):
+            validate_docstrings.Docstring(invalid_name)
 
 
 class TestMainFunction(object):

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -267,7 +267,7 @@ class Docstring(object):
             else:
                 continue
 
-        if 'module' not in locals():
+        if 'obj' not in locals():
             raise ImportError('No module can be imported '
                               'from "{}"'.format(name))
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The `validate_docstrings.py` script dynamically loads modules/classes/functions from its command-line argument.

Currently, if the user supplies an invalid argument, an UnboundLocalError can be obtained:
```
Traceback (most recent call last):
...
File "./scripts/validate_docstrings.py", line 275, in _load_obj
    obj = getattr(obj, part)
UnboundLocalError: local variable 'obj' referenced before assignment
```

This PR fixes a check within the relevant function, so that a more informative error can be raised:
```
$ ./scripts/validate_docstrings.py tslibs.Timestamp
Traceback (most recent call last):
...
ImportError: No module can be imported from "tslibs.Timestamp"
```



