### PR TITLE
BUG: DataFrame.join on tz-aware DatetimeIndex

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -77,7 +77,7 @@ Bug Fixes
 **Reshaping**
 
 -
--
+- Bug in :func:`DataFrame.join` when joining on a timezone aware :class:`DatetimeIndex` (:issue:`23931`)
 -
 
 **Visualization**

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -181,7 +181,6 @@ Reshaping
 - Bug in :func:`pandas.merge` adds a string of ``None`` if ``None`` is assigned in suffixes instead of remain the column name as-is (:issue:`24782`).
 - Bug in :func:`merge` when merging by index name would sometimes result in an incorrectly numbered index (:issue:`24212`)
 - :func:`to_records` now accepts dtypes to its `column_dtypes` parameter (:issue:`24895`)
-- Bug in :func:`DataFrame.join` when joining on a timezone aware :class:`DatetimeIndex` (:issue:`23931`)
 
 
 Sparse

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -181,7 +181,7 @@ Reshaping
 - Bug in :func:`pandas.merge` adds a string of ``None`` if ``None`` is assigned in suffixes instead of remain the column name as-is (:issue:`24782`).
 - Bug in :func:`merge` when merging by index name would sometimes result in an incorrectly numbered index (:issue:`24212`)
 - :func:`to_records` now accepts dtypes to its `column_dtypes` parameter (:issue:`24895`)
--
+- Bug in :func:`DataFrame.join` when joining on a timezone aware :class:`DatetimeIndex` (:issue:`23931`)
 
 
 Sparse

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -897,7 +897,6 @@ class _MergeOperation(object):
                         left_keys.append(left.index)
                         join_names.append(left.index.name)
         elif _any(self.left_on):
-
             for k in self.left_on:
                 if is_lkey(k):
                     left_keys.append(k)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -897,6 +897,7 @@ class _MergeOperation(object):
                         left_keys.append(left.index)
                         join_names.append(left.index.name)
         elif _any(self.left_on):
+
             for k in self.left_on:
                 if is_lkey(k):
                     left_keys.append(k)
@@ -909,7 +910,7 @@ class _MergeOperation(object):
                               in zip(self.right.index.levels,
                                      self.right.index.codes)]
             else:
-                right_keys = [self.right.index.values]
+                right_keys = [self.right.index._values]
         elif _any(self.right_on):
             for k in self.right_on:
                 if is_rkey(k):

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -682,6 +682,28 @@ class TestJoin(object):
         with pytest.raises(ValueError, match=msg):
             right.join(left, on=['abc', 'xy'], how=join_type)
 
+    def test_join_on_tz_aware_datetimeindex(self):
+        # GH 23931
+        df1 = pd.DataFrame(
+            {
+                'date': pd.date_range(start='2018-01-01', periods=5,
+                                      tz='America/Chicago'),
+                'vals': list('abcde')
+            }
+        )
+
+        df2 = pd.DataFrame(
+            {
+                'date': pd.date_range(start='2018-01-03', periods=5,
+                                      tz='America/Chicago'),
+                'vals_2': list('tuvwx')
+            }
+        )
+        result = df1.join(df2.set_index('date'), on='date')
+        expected = df1.copy()
+        expected['vals_2'] = pd.Series([np.nan] * len(expected), dtype=object)
+        assert_frame_equal(result, expected)
+
 
 def _check_join(left, right, result, join_col, how='left',
                 lsuffix='_x', rsuffix='_y'):


### PR DESCRIPTION
- [x] closes #23931
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
