### PR TITLE
REF: use _constructor and ABCFoo to avoid runtime imports

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -8,7 +8,8 @@ import pytz
 from pandas._libs.interval import Interval
 from pandas._libs.tslibs import NaT, Period, Timestamp, timezones
 
-from pandas.core.dtypes.generic import ABCCategoricalIndex, ABCIndexClass
+from pandas.core.dtypes.generic import (
+    ABCCategoricalIndex, ABCDateOffset, ABCIndexClass)
 
 from pandas import compat
 
@@ -758,8 +759,7 @@ class PeriodDtype(ExtensionDtype, PandasExtensionDtype):
             # empty constructor for pickle compat
             return object.__new__(cls)
 
-        from pandas.tseries.offsets import DateOffset
-        if not isinstance(freq, DateOffset):
+        if not isinstance(freq, ABCDateOffset):
             freq = cls._parse_dtype_strict(freq)
 
         try:
@@ -790,12 +790,10 @@ class PeriodDtype(ExtensionDtype, PandasExtensionDtype):
         Strict construction from a string, raise a TypeError if not
         possible
         """
-        from pandas.tseries.offsets import DateOffset
-
         if (isinstance(string, compat.string_types) and
             (string.startswith('period[') or
              string.startswith('Period[')) or
-                isinstance(string, DateOffset)):
+                isinstance(string, ABCDateOffset)):
             # do not parse string like U as period[U]
             # avoid tuple to be regarded as freq
             try:

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -221,8 +221,8 @@ def _isna_ndarraylike(obj):
 
     # box
     if isinstance(obj, ABCSeries):
-        from pandas import Series
-        result = Series(result, index=obj.index, name=obj.name, copy=False)
+        result = obj._constructor(
+            result, index=obj.index, name=obj.name, copy=False)
 
     return result
 
@@ -250,8 +250,8 @@ def _isna_ndarraylike_old(obj):
 
     # box
     if isinstance(obj, ABCSeries):
-        from pandas import Series
-        result = Series(result, index=obj.index, name=obj.name, copy=False)
+        result = obj._constructor(
+            result, index=obj.index, name=obj.name, copy=False)
 
     return result
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -588,9 +588,8 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
         if not cache_array.empty:
             result = arg.map(cache_array)
         else:
-            from pandas import Series
             values = convert_listlike(arg._values, True, format)
-            result = Series(values, index=arg.index, name=arg.name)
+            result = arg._constructor(values, index=arg.index, name=arg.name)
     elif isinstance(arg, (ABCDataFrame, compat.MutableMapping)):
         result = _assemble_from_unit_mappings(arg, errors, box, tz)
     elif isinstance(arg, ABCIndexClass):
@@ -827,7 +826,6 @@ def to_time(arg, format=None, infer_time_format=False, errors='raise'):
     -------
     datetime.time
     """
-    from pandas.core.series import Series
 
     def _convert_listlike(arg, format):
 
@@ -892,9 +890,9 @@ def to_time(arg, format=None, infer_time_format=False, errors='raise'):
         return arg
     elif isinstance(arg, time):
         return arg
-    elif isinstance(arg, Series):
+    elif isinstance(arg, ABCSeries):
         values = _convert_listlike(arg._values, format)
-        return Series(values, index=arg.index, name=arg.name)
+        return arg._constructor(values, index=arg.index, name=arg.name)
     elif isinstance(arg, ABCIndexClass):
         return _convert_listlike(arg, format)
     elif is_list_like(arg):

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -6,12 +6,12 @@ import warnings
 
 import numpy as np
 
+from pandas._libs.tslibs import NaT
 from pandas._libs.tslibs.timedeltas import Timedelta, parse_timedelta_unit
 
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
 
-import pandas as pd
 from pandas.core.arrays.timedeltas import sequence_to_td64ns
 
 
@@ -100,10 +100,9 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     if arg is None:
         return arg
     elif isinstance(arg, ABCSeries):
-        from pandas import Series
         values = _convert_listlike(arg._values, unit=unit,
                                    box=False, errors=errors)
-        return Series(values, index=arg.index, name=arg.name)
+        return arg._constructor(values, index=arg.index, name=arg.name)
     elif isinstance(arg, ABCIndexClass):
         return _convert_listlike(arg, unit=unit, box=box,
                                  errors=errors, name=arg.name)
@@ -136,7 +135,7 @@ def _coerce_scalar_to_timedelta_type(r, unit='ns', box=True, errors='raise'):
             return r
 
         # coerce
-        result = pd.NaT
+        result = NaT
 
     return result
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
