### PR TITLE
BUG: Fix passing of numeric_only argument for categorical reduce

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -25,7 +25,7 @@ Fixed Regressions
 - Fixed regression in :meth:`DataFrame.apply` causing ``RecursionError`` when ``dict``-like classes were passed as argument. (:issue:`25196`)
 
 - Fixed regression in :meth:`DataFrame.duplicated()`, where empty dataframe was not returning a boolean dtyped Series. (:issue:`25184`)
-- Fixed regression in :meth:`Series.min` and :meth:`Series.max` where ``numeric_only=True`` was ignored when the `Series` contained `Categorical` data (:issue:`25299`)
+- Fixed regression in :meth:`Series.min` and :meth:`Series.max` where ``numeric_only=True`` was ignored when the ``Series`` contained ```Categorical`` data (:issue:`25299`)
 
 .. _whatsnew_0242.enhancements:
 

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -25,7 +25,7 @@ Fixed Regressions
 - Fixed regression in :meth:`DataFrame.apply` causing ``RecursionError`` when ``dict``-like classes were passed as argument. (:issue:`25196`)
 
 - Fixed regression in :meth:`DataFrame.duplicated()`, where empty dataframe was not returning a boolean dtyped Series. (:issue:`25184`)
-- Fixed regression in :meth:`Categorical.min` and :meth:`Categorical.max` where ``numeric_only=True`` was ignored (:issue:`25299`)
+- Fixed regression in :meth:`Series.min` and :meth:`Series.max` where ``numeric_only=True`` was ignored when the `Series` contained `Categorical` data (:issue:`25299`)
 
 .. _whatsnew_0242.enhancements:
 

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -25,6 +25,7 @@ Fixed Regressions
 - Fixed regression in :meth:`DataFrame.apply` causing ``RecursionError`` when ``dict``-like classes were passed as argument. (:issue:`25196`)
 
 - Fixed regression in :meth:`DataFrame.duplicated()`, where empty dataframe was not returning a boolean dtyped Series. (:issue:`25184`)
+- Fixed regression in :meth:`Categorical.min` and :meth:`Categorical.max` where ``numeric_only=True`` was ignored (:issue:`25299`)
 
 .. _whatsnew_0242.enhancements:
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2172,7 +2172,7 @@ class Categorical(ExtensionArray, PandasObject):
         return result
 
     # reduction ops #
-    def _reduce(self, name, axis=0, skipna=True, **kwargs):
+    def _reduce(self, name, axis=0, **kwargs):
         func = getattr(self, name, None)
         if func is None:
             msg = 'Categorical cannot perform the operation {op}'

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3678,8 +3678,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         if axis is not None:
             self._get_axis_number(axis)
 
-        # dispatch to ExtensionArray interface
-        if isinstance(delegate, ExtensionArray):
+        if isinstance(delegate, Categorical):
+            # TODO deprecate numeric_only argument for Categorical and use
+            # skipna as well
+            return delegate._reduce(name, numeric_only=numeric_only, **kwds)
+        elif isinstance(delegate, ExtensionArray):
+            # dispatch to ExtensionArray interface
             return delegate._reduce(name, skipna=skipna, **kwds)
         elif is_datetime64_dtype(delegate):
             # use DatetimeIndex implementation to handle skipna correctly

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3680,7 +3680,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         if isinstance(delegate, Categorical):
             # TODO deprecate numeric_only argument for Categorical and use
-            # skipna as well
+            # skipna as well, see GH25303
             return delegate._reduce(name, numeric_only=numeric_only, **kwds)
         elif isinstance(delegate, ExtensionArray):
             # dispatch to ExtensionArray interface

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -960,6 +960,18 @@ class TestCategoricalSeriesReductions(object):
         assert np.isnan(_min)
         assert _max == 1
 
+        cat = Series(Categorical(
+            ["a", "b", np.nan, "a"], categories=['b', 'a'], ordered=True))
+        _min = cat.min(numeric_only=True)
+        _max = cat.max(numeric_only=True)
+        assert _min == "b"
+        assert _max == "a"
+
+        _min = cat.min(numeric_only=False)
+        _max = cat.max(numeric_only=False)
+        assert np.isnan(_min)
+        assert _max == "a"
+
 
 class TestSeriesMode(object):
     # Note: the name TestSeriesMode indicates these tests

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -960,8 +960,17 @@ class TestCategoricalSeriesReductions(object):
         assert np.isnan(_min)
         assert _max == 1
 
+    def test_min_max_numeric_only(self):
+        # TODO deprecate numeric_only argument for Categorical and use
+        # skipna as well, see GH25303
         cat = Series(Categorical(
             ["a", "b", np.nan, "a"], categories=['b', 'a'], ordered=True))
+
+        _min = cat.min()
+        _max = cat.max()
+        assert np.isnan(_min)
+        assert _max == "a"
+
         _min = cat.min(numeric_only=True)
         _max = cat.max(numeric_only=True)
         assert _min == "b"


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/issues/25303 and https://github.com/pandas-dev/pandas/issues/25299

- [x] closes https://github.com/pandas-dev/pandas/issues/25299
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
