### PR TITLE
#14873: test for groupby.agg coercing booleans

### DIFF
--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -286,3 +286,20 @@ def test_multi_function_flexible_mix(df):
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
         result = grouped.aggregate(d)
     tm.assert_frame_equal(result, expected)
+
+
+def test_groupby_agg_coercing_bools():
+    # issue 14873
+    dat = pd.DataFrame(
+        {'a': [1, 1, 2, 2], 'b': [0, 1, 2, 3], 'c': [None, None, 1, 1]})
+    gp = dat.groupby('a')
+
+    index = Index([1, 2], name='a')
+
+    result = gp['b'].aggregate(lambda x: (x != 0).all())
+    expected = Series([False, True], index=index, name='b')
+    tm.assert_series_equal(result, expected)
+
+    result = gp['c'].aggregate(lambda x: x.isnull().all())
+    expected = Series([True, False], index=index, name='c')
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #14873 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

The referenced issue seems to be solved in the current master. So added a test for the edge case.