### PR TITLE
BUG: Series.__setitem__ with datetimetz data

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -133,7 +133,7 @@ Interval
 Indexing
 ^^^^^^^^
 
--
+- Bug when setting a value to a :class:`Series` with timezone aware values and an :class:`Index` of tuples or strings (:issue:`12862`, :issue:`20441`)
 -
 -
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1047,7 +1047,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             self._maybe_update_cacher()
 
     def _set_with_engine(self, key, value):
-        values = self._values
+        if is_extension_array_dtype(self):
+            # GH 20441: set_value expects and ndarray, not ExtensionArray
+            values = self.values
+        else:
+            values = self._values
         try:
             self.index._engine.set_value(values, key, value)
             return

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -839,3 +839,24 @@ def test_head_tail(test_data):
     assert_series_equal(test_data.series.head(0), test_data.series[0:0])
     assert_series_equal(test_data.series.tail(), test_data.series[-5:])
     assert_series_equal(test_data.series.tail(0), test_data.series[0:0])
+
+
+def test_setitem_tuple_with_datetimetz():
+    # GH 20441
+    arr = pd.date_range('2017', periods=4, tz='US/Eastern')
+    index = [(0, 1), (0, 2), (0, 3), (0, 4)]
+    result = Series(arr, index=index)
+    expected = result.copy()
+    result[(0, 1)] = np.nan
+    expected.iloc[0] = np.nan
+    assert_series_equal(result, expected)
+
+
+def test_setitem_str_with_datetimetz():
+    # GH 12862
+    result = pd.Series()
+    result['foo'] = pd.to_datetime(1000).tz_localize('UTC')
+    result['bar'] = pd.to_datetime(1001).tz_localize('UTC')
+    expected = pd.Series(pd.to_datetime([1000, 1001], utc=True),
+                         index=['foo', 'bar'])
+    assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #12862
- [x] closes #20441
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
