### PR TITLE
ENH: .to_latex(longtable=True) latex caption and label support

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2740,9 +2740,9 @@ class NDFrame(PandasObject, SelectionMixin):
     def to_latex(self, buf=None, columns=None, col_space=None, header=True,
                  index=True, na_rep='NaN', formatters=None, float_format=None,
                  sparsify=None, index_names=True, bold_rows=False,
-                 column_format=None, longtable=None, escape=None,
-                 encoding=None, decimal='.', multicolumn=None,
-                 multicolumn_format=None, multirow=None):
+                 column_format=None, longtable=None, lt_caption=None,
+                 lt_label=None, escape=None, encoding=None, decimal='.',
+                 multicolumn=None, multicolumn_format=None, multirow=None):
         r"""
         Render an object to a LaTeX tabular environment table.
 
@@ -2790,6 +2790,10 @@ class NDFrame(PandasObject, SelectionMixin):
             By default, the value will be read from the pandas config
             module. Use a longtable environment instead of tabular. Requires
             adding a \usepackage{longtable} to your LaTeX preamble.
+        lt_caption : str, optional
+            The caption to use when longtable is True
+        lt_label : str, optional
+            The label to use with \ref{} when longtable is True
         escape : bool, optional
             By default, the value will be read from the pandas config
             module. When set to False prevents from escaping latex special
@@ -2863,6 +2867,7 @@ class NDFrame(PandasObject, SelectionMixin):
                                        index_names=index_names,
                                        escape=escape, decimal=decimal)
         formatter.to_latex(column_format=column_format, longtable=longtable,
+                           lt_caption=lt_caption, lt_label=lt_label,
                            encoding=encoding, multicolumn=multicolumn,
                            multicolumn_format=multicolumn_format,
                            multirow=multirow)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -679,16 +679,17 @@ class DataFrameFormatter(TableFormatter):
             st = ed
         return '\n\n'.join(str_lst)
 
-    def to_latex(self, column_format=None, longtable=False, encoding=None,
-                 multicolumn=False, multicolumn_format=None, multirow=False):
+    def to_latex(self, column_format=None, longtable=False, lt_caption=None,
+                 lt_label=None, encoding=None, multicolumn=False,
+                 multicolumn_format=None, multirow=False):
         """
         Render a DataFrame to a LaTeX tabular/longtable environment output.
         """
 
         from pandas.io.formats.latex import LatexFormatter
         latex_renderer = LatexFormatter(self, column_format=column_format,
-                                        longtable=longtable,
-                                        multicolumn=multicolumn,
+                                        longtable=longtable, lt_caption=lt_caption,
+                                        lt_label=lt_label, multicolumn=multicolumn,
                                         multicolumn_format=multicolumn_format,
                                         multirow=multirow)
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -688,8 +688,10 @@ class DataFrameFormatter(TableFormatter):
 
         from pandas.io.formats.latex import LatexFormatter
         latex_renderer = LatexFormatter(self, column_format=column_format,
-                                        longtable=longtable, lt_caption=lt_caption,
-                                        lt_label=lt_label, multicolumn=multicolumn,
+                                        longtable=longtable,
+                                        lt_caption=lt_caption,
+                                        lt_label=lt_label,
+                                        multicolumn=multicolumn,
                                         multicolumn_format=multicolumn_format,
                                         multirow=multirow)
 

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -4,6 +4,8 @@ Module for formatting output data in Latex.
 """
 from __future__ import print_function
 
+from warnings import warn
+
 import numpy as np
 
 from pandas.compat import map, range, u, zip
@@ -34,12 +36,15 @@ class LatexFormatter(TableFormatter):
     """
 
     def __init__(self, formatter, column_format=None, longtable=False,
-                 multicolumn=False, multicolumn_format=None, multirow=False):
+                 lt_caption=None, lt_label=None, multicolumn=False,
+                 multicolumn_format=None, multirow=False):
         self.fmt = formatter
         self.frame = self.fmt.frame
         self.bold_rows = self.fmt.kwds.get('bold_rows', False)
         self.column_format = column_format
         self.longtable = longtable
+        self.lt_caption = lt_caption
+        self.lt_label = lt_label
         self.multicolumn = multicolumn
         self.multicolumn_format = multicolumn_format
         self.multirow = multirow
@@ -113,6 +118,24 @@ class LatexFormatter(TableFormatter):
         else:
             buf.write('\\begin{{longtable}}{{{fmt}}}\n'
                       .format(fmt=column_format))
+
+            if self.lt_caption is None and self.lt_label is None:
+                pass
+            else:
+                if self.lt_caption is not None:
+                    buf.write('\\caption{{{}}}'.format(self.lt_caption))
+                else:
+                    pass
+
+                if self.lt_label is not None:
+                    buf.write('\\label{{{}}}'.format(self.lt_label))
+                else:
+                    warn('no LaTeX label has been provided; referencing with \\ref{} will not work')
+
+                # a double-backslash is required at the end of the line as discussed here:
+                # https://tex.stackexchange.com/questions/219138
+                buf.write('\\\\\n')
+
             buf.write('\\toprule\n')
 
         ilevels = self.frame.index.nlevels

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -130,9 +130,11 @@ class LatexFormatter(TableFormatter):
                 if self.lt_label is not None:
                     buf.write('\\label{{{}}}'.format(self.lt_label))
                 else:
-                    warn('no LaTeX label has been provided; referencing with \\ref{} will not work')
+                    warn('no LaTeX label has been provided; '
+                         'referencing with \\ref{} will not work')
 
-                # a double-backslash is required at the end of the line as discussed here:
+                # a double-backslash is required at the end of the line
+                # as discussed here:
                 # https://tex.stackexchange.com/questions/219138
                 buf.write('\\\\\n')
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

When creating a latex table with `DataFrame.to_latex(longtable=False)` the output is written inside a latex `tabular` environment and stored in some file like `pandas_tabular.tex`; the user can conveniently typeset the table in a main `report.tex` file complete with caption and label as follows:

```tex
\begin{table}
\caption{the caption}
\label{the label}
\input{pandas_tabular.tex}
\end{table}
```

This is good because the `pandas_tabular.tex` file can be re-created and the main `report.tex` simply needs to be recompiled to get the updated output.

The problem when creating a latex [longtable](https://ctan.org/pkg/longtable) with `DataFrame.to_latex(longtable=True)` is the caption and label need to go inside the latex `longtable` environment which is stored in a some file like `pandas_longtable.tex`.  The latex `longtable` environment does not go inside a `table` environment like the `tabular` environment does; this means that setting the caption and label requires the user to edit the `pandas_longtable.tex` file after its creation.  This does not support an automated workflow like we have with the `tabular` environment.

**This PR adds caption and label support to `DataFrame.to_latex(longtable=True)` with the arguments `lt_caption` and `lt_label`.  Example usage is described below.**  

The following python code creates some data in a `DataFrame` and writes it to disk in `tabular` and `longtable` latex environments:


```python
import numpy as np
import pandas as pd


# create some example data with more rows than would fit on a single page
df = pd.DataFrame(np.random.randn(60,3))

# write the first 5 rows to regular table in a latex tabular environment
df.head().to_latex(
    'pandas_tabular.tex',
)

# write the whole table in the latex longtable environment c/w caption and label
df.to_latex(
    'pandas_longtable.tex',
    longtable=True,
    lt_caption='table in \\texttt{longtable} environment',
    lt_label='tab:longtable',
)
```

The following latex code is contained in a main `report.tex` and is used to typset both tables:

```tex
\documentclass{article}

\usepackage{longtable}
\usepackage{booktabs}

\begin{document}

% typeset the table in the tabular environment
Table \ref{tab:tabular}	is a \texttt{tabular} and has 5 rows:
\begin{table}[h]	
\centering	
\caption{table in \texttt{tabular} environment}
\label{tab:tabular}
\input{pandas_tabular.tex}	
\end{table}

% typeset the table in the longtable environment
Table \ref{tab:longtable} is a \texttt{longtable} and has 60 rows:
\input{pandas_longtable.tex}
\end{document}
```

Using `DataFrame.to_latex(longtable=True)` with the new arguments `lt_caption` and `lt_label` means we don't have to edit `pandas_longtable.tex` after its creation to get the caption and label working.  This functionality also works with `Series.to_latex(longtable=True)`.

PDF output is shown below:

![image](https://user-images.githubusercontent.com/36767735/52894669-0cf2a100-316b-11e9-8003-54298d8982cb.png)

