### PR TITLE
CI: Add 'conda list' for azure/posix after activate 'pandas-dev'

### DIFF
--- a/ci/incremental/setup_conda_environment.cmd
+++ b/ci/incremental/setup_conda_environment.cmd
@@ -16,6 +16,7 @@ conda remove --all -q -y -n pandas-dev
 conda env create --file=ci\deps\azure-windows-%CONDA_PY%.yaml
 
 call activate pandas-dev
+@rem Display pandas-dev environment (for debugging)
 conda list
 
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/ci/incremental/setup_conda_environment.sh
+++ b/ci/incremental/setup_conda_environment.sh
@@ -23,6 +23,9 @@ set +v
 source activate pandas-dev
 set -v
 
+# Display pandas-dev environment (for debugging)
+conda list
+
 # remove any installed pandas package
 # w/o removing anything else
 echo

--- a/ci/install_travis.sh
+++ b/ci/install_travis.sh
@@ -100,6 +100,7 @@ pip list --format columns |grep pandas
 echo "[running setup.py develop]"
 python setup.py develop  || exit 1
 
+# Display pandas-dev environment (for debugging)
 echo
 echo "[show environment]"
 conda list


### PR DESCRIPTION
Running into debugging problems in #24984 because `conda list` is never called after installing the `pandas-dev` environment.

It seems that this is just missing in azure/posix (I reflected the comment in other locations not least to show where else this is already done).