### PR TITLE
CLN: (re-)enable infer_dtype to catch complex

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -939,6 +939,7 @@ _TYPE_MAP = {
     'float32': 'floating',
     'float64': 'floating',
     'f': 'floating',
+    'complex64': 'complex',
     'complex128': 'complex',
     'c': 'complex',
     'string': 'string' if PY2 else 'bytes',
@@ -1304,6 +1305,9 @@ def infer_dtype(value: object, skipna: object=None) -> str:
 
     elif is_decimal(val):
         return 'decimal'
+
+    elif is_complex(val):
+        return 'complex'
 
     elif util.is_float_object(val):
         if is_float_array(values):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -618,6 +618,30 @@ class TestTypeInference(object):
         result = lib.infer_dtype(arr, skipna=True)
         assert result == 'decimal'
 
+    def test_complex(self):
+        # gets cast to complex on array construction
+        arr = np.array([1.0, 2.0, 1 + 1j])
+        result = lib.infer_dtype(arr, skipna=True)
+        assert result == 'complex'
+
+        arr = np.array([1.0, 2.0, 1 + 1j], dtype='O')
+        result = lib.infer_dtype(arr, skipna=True)
+        assert result == 'mixed'
+
+        # gets cast to complex on array construction
+        arr = np.array([1, np.nan, 1 + 1j])
+        result = lib.infer_dtype(arr, skipna=True)
+        assert result == 'complex'
+
+        arr = np.array([1.0, np.nan, 1 + 1j], dtype='O')
+        result = lib.infer_dtype(arr, skipna=True)
+        assert result == 'mixed'
+
+        # complex with nans stays complex
+        arr = np.array([1 + 1j, np.nan, 3 + 3j], dtype='O')
+        result = lib.infer_dtype(arr, skipna=True)
+        assert result == 'complex'
+
     def test_string(self):
         pass
 

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -618,28 +618,35 @@ class TestTypeInference(object):
         result = lib.infer_dtype(arr, skipna=True)
         assert result == 'decimal'
 
-    def test_complex(self):
+    # complex is compatible with nan, so skipna has no effect
+    @pytest.mark.parametrize('skipna', [True, False])
+    def test_complex(self, skipna):
         # gets cast to complex on array construction
         arr = np.array([1.0, 2.0, 1 + 1j])
-        result = lib.infer_dtype(arr, skipna=True)
+        result = lib.infer_dtype(arr, skipna=skipna)
         assert result == 'complex'
 
         arr = np.array([1.0, 2.0, 1 + 1j], dtype='O')
-        result = lib.infer_dtype(arr, skipna=True)
+        result = lib.infer_dtype(arr, skipna=skipna)
         assert result == 'mixed'
 
         # gets cast to complex on array construction
         arr = np.array([1, np.nan, 1 + 1j])
-        result = lib.infer_dtype(arr, skipna=True)
+        result = lib.infer_dtype(arr, skipna=skipna)
         assert result == 'complex'
 
         arr = np.array([1.0, np.nan, 1 + 1j], dtype='O')
-        result = lib.infer_dtype(arr, skipna=True)
+        result = lib.infer_dtype(arr, skipna=skipna)
         assert result == 'mixed'
 
         # complex with nans stays complex
         arr = np.array([1 + 1j, np.nan, 3 + 3j], dtype='O')
-        result = lib.infer_dtype(arr, skipna=True)
+        result = lib.infer_dtype(arr, skipna=skipna)
+        assert result == 'complex'
+
+        # test smaller complex dtype; will pass through _try_infer_map fastpath
+        arr = np.array([1 + 1j, np.nan, 3 + 3j], dtype=np.complex64)
+        result = lib.infer_dtype(arr, skipna=skipna)
         assert result == 'complex'
 
     def test_string(self):


### PR DESCRIPTION
- [x] takes a small bite out of #23554
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

`complex` should already be inferred according to the docstring, but isn't. I'm hitting this while working on my PR for #23833 so splitting that off as a separate change.
