### PR TITLE
DEP: add pytest-mock to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - isort
   - moto
   - pytest>=4.0
+  - pytest-mock
   - sphinx
   - numpydoc
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ hypothesis>=3.82
 isort
 moto
 pytest>=4.0
+pytest-mock
 sphinx
 numpydoc
 beautifulsoup4>=4.2.1


### PR DESCRIPTION
Ran into errors when trying to run the test suite in a freshly installed conda environment. There's an error being caused by the fact that #25346 added `pytest-mock` as a dependency in all the CI jobs (to be able to use the `mocker` fixture), but didn't adapt `environment.yml`. This PR fixes that.
