### PR TITLE
Correct a typo of version number for interpolate()

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -335,7 +335,7 @@ examined :ref:`in the API <api.dataframe.missing>`.
 Interpolation
 ~~~~~~~~~~~~~
 
-.. versionadded:: 0.21.0
+.. versionadded:: 0.23.0
 
   The ``limit_area`` keyword argument was added.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6648,7 +6648,7 @@ class NDFrame(PandasObject, SelectionMixin):
               (interpolate).
             * 'outside': Only fill NaNs outside valid values (extrapolate).
 
-            .. versionadded:: 0.21.0
+            .. versionadded:: 0.23.0
 
         downcast : optional, 'infer' or None, defaults to None
             Downcast dtypes if possible.


### PR DESCRIPTION
Correct a typo of version number in the docstring of _shared_docs['interpolat e'] which is the docstring for pandas.core.resample.Resampler.interpolate, pandas.DataFrame.interpolate, panda s.Series.interpolate, and pandas.Panel.interpolate, and in documentation/user_guide/missing_data about the limit_area keyword argument in interpolate(). The reference can be found at https://github.com/pandas-dev/pandas/issue s/8000#issuecomment-465802842.




