### PR TITLE
fixed geo accessor example in extending.rst

### DIFF
--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -33,10 +33,9 @@ decorate a class, providing the name of attribute to add. The class's
 
        @staticmethod
        def _validate(obj):
-           # verify each column name contains 'lat' or 'lon'
-           for col in obj.columns:
-               if 'lat' not in col and 'lon' not in col:
-                   raise AttributeError("Must have 'lat' and 'lon'.")
+           # verify there is a column latitude and a column longitude
+           if 'latitude' not in obj.columns or 'longitude' not in obj.columns:
+               raise AttributeError("Must have 'latitude' and 'longitude'.")
 
        @property
        def center(self):

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -33,8 +33,10 @@ decorate a class, providing the name of attribute to add. The class's
 
        @staticmethod
        def _validate(obj):
-           if 'lat' not in obj.columns or 'lon' not in obj.columns:
-               raise AttributeError("Must have 'lat' and 'lon'.")
+           # verify each column name contains 'lat' or 'lon'
+           for col in obj.columns:
+               if 'lat' not in col and 'lon' not in col:
+                   raise AttributeError("Must have 'lat' and 'lon'.")
 
        @property
        def center(self):


### PR DESCRIPTION
The previous code was incompatible with the following paragraph. See the second block of code in https://pandas.pydata.org/pandas-docs/stable/development/extending.html#registering-custom-accessors

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


<details>



```python
import pandas as pd
import numpy as np
```

# Before

## Register the DataFrame accessor "geo"


```python
@pd.api.extensions.register_dataframe_accessor("geo")
class GeoAccessor(object):
    def __init__(self, pandas_obj):
        self._validate(pandas_obj)
        self._obj = pandas_obj

    @staticmethod
    def _validate(obj):
        if 'lat' not in obj.columns or 'lon' not in obj.columns:
            raise AttributeError("Must have 'lat' and 'lon'.")

    @property
    def center(self):
        # return the geographic center point of this DataFrame
        lat = self._obj.latitude
        lon = self._obj.longitude
        return (float(lon.mean()), float(lat.mean()))

    def plot(self):
        # plot this array's data on a map, e.g., using Cartopy
        pass
```

## Test the DataFrame accessor "geo"


```python
ds = pd.DataFrame({'longitude': np.linspace(0, 10),
                   'latitude': np.linspace(0, 20)})
ds.geo.center
```


    ---------------------------------------------------------------------------

    AttributeError                            Traceback (most recent call last)

    <ipython-input-3-71f0445704bc> in <module>()
          1 ds = pd.DataFrame({'longitude': np.linspace(0, 10),
          2                    'latitude': np.linspace(0, 20)})
    ----> 3 ds.geo.center
    

    ~\Anaconda3\lib\site-packages\pandas\core\generic.py in __getattr__(self, name)
       5061         if (name in self._internal_names_set or name in self._metadata or
       5062                 name in self._accessors):
    -> 5063             return object.__getattribute__(self, name)
       5064         else:
       5065             if self._info_axis._can_hold_identifiers_and_holds_name(name):
    

    ~\Anaconda3\lib\site-packages\pandas\core\accessor.py in __get__(self, obj, cls)
        169             # we're accessing the attribute of the class, i.e., Dataset.geo
        170             return self._accessor
    --> 171         accessor_obj = self._accessor(obj)
        172         # Replace the property with the accessor object. Inspired by:
        173         # http://www.pydanny.com/cached-property.html
    

    <ipython-input-2-114caa965d3b> in __init__(self, pandas_obj)
          2 class GeoAccessor(object):
          3     def __init__(self, pandas_obj):
    ----> 4         self._validate(pandas_obj)
          5         self._obj = pandas_obj
          6 
    

    <ipython-input-2-114caa965d3b> in _validate(obj)
          8     def _validate(obj):
          9         if 'lat' not in obj.columns or 'lon' not in obj.columns:
    ---> 10             raise AttributeError("Must have 'lat' and 'lon'.")
         11 
         12     @property
    

    AttributeError: Must have 'lat' and 'lon'.


# After

## Register the DataFrame accessor "geo"


```python
@pd.api.extensions.register_dataframe_accessor("geo")
class GeoAccessor(object):
    def __init__(self, pandas_obj):
        self._validate(pandas_obj)
        self._obj = pandas_obj

    @staticmethod
    def _validate(obj):
       # verify each column name contains 'lat' or 'lon'
       for col in obj.columns:
            if 'lat' not in col and 'lon' not in col:
                raise AttributeError("Must have 'lat' and 'lon'.")

    @property
    def center(self):
        # return the geographic center point of this DataFrame
        lat = self._obj.latitude
        lon = self._obj.longitude
        return (float(lon.mean()), float(lat.mean()))

    def plot(self):
        # plot this array's data on a map, e.g., using Cartopy
        pass
```
      
    

## Test the DataFrame accessor "geo"


```python
ds = pd.DataFrame({'longitude': np.linspace(0, 10),
                   'latitude': np.linspace(0, 20)})
ds.geo.center
```




    (5.0, 10.0)


</details>
