### PR TITLE
Fixed regression of Multi index with NaN

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -199,6 +199,7 @@ Missing
 
 - Fixed misleading exception message in :meth:`Series.missing` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 - Fixed class type displayed in exception message in :meth:`DataFrame.dropna` if invalid ``axis`` parameter passed (:issue:`25555`)
+- Fixed MultiIndex bug copying values incorrectly when adding values to index, in case `NaN` is included in the index (:issue:`22247`)
 -
 
 MultiIndex


### PR DESCRIPTION
- [x] closes #22247
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
As pull #19074 changed compute of hashtable from `self.values` to `self.codes` and `self.levels`, NaN values doesn't cover.
I just simply fixed this regression the special case, by check return value from the hashtable.