### PR TITLE
BUG: Fix index type casting in read_json with orient='table' and float index (#25433)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -194,6 +194,7 @@ I/O
 
 - Fixed bug in missing text when using :meth:`to_clipboard` if copying utf-16 characters in Python 3 on Windows (:issue:`25040`)
 - Bug in :func:`read_json` for ``orient='table'`` when it tries to infer dtypes by default, which is not applicable as dtypes are already defined in the JSON schema (:issue:`21345`)
+- Bug in :func:`read_json` for ``orient='table'`` and float index, as it infers index dtype by default, which is not applicable because index dtype is already defined in the JSON schema (:issue:`25433`)
 -
 -
 -

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -195,6 +195,7 @@ I/O
 - Fixed bug in missing text when using :meth:`to_clipboard` if copying utf-16 characters in Python 3 on Windows (:issue:`25040`)
 - Bug in :func:`read_json` for ``orient='table'`` when it tries to infer dtypes by default, which is not applicable as dtypes are already defined in the JSON schema (:issue:`21345`)
 - Bug in :func:`read_json` for ``orient='table'`` and float index, as it infers index dtype by default, which is not applicable because index dtype is already defined in the JSON schema (:issue:`25433`)
+- Bug in :func:`read_json` for ``orient='table'`` and string of float column names, as it makes a column name type conversion to Timestamp, which is not applicable because column names are already defined in the JSON schema (:issue:`25435`)
 -
 -
 -

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -227,7 +227,7 @@ class JSONTableWriter(FrameWriter):
 
 
 def read_json(path_or_buf=None, orient=None, typ='frame', dtype=None,
-              convert_axes=True, convert_dates=True, keep_default_dates=True,
+              convert_axes=None, convert_dates=True, keep_default_dates=True,
               numpy=False, precise_float=False, date_unit=None, encoding=None,
               lines=False, chunksize=None, compression='infer'):
     """
@@ -289,6 +289,13 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=None,
 
     convert_axes : boolean, default True
         Try to convert the axes to the proper dtypes.
+
+        Not applicable with ``orient='table'``.
+
+        .. versionchanged:: 0.25
+
+           Not applicable with ``orient='table'``.
+
     convert_dates : boolean, default True
         List of columns to parse for dates; If True, then try to parse
         datelike columns default is True; a column label is datelike if
@@ -417,8 +424,12 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=None,
 
     if orient == 'table' and dtype:
         raise ValueError("cannot pass both dtype and orient='table'")
+    if orient == 'table' and convert_axes:
+        raise ValueError("cannot pass both convert_axes and orient='table'")
 
     dtype = orient != 'table' if dtype is None else dtype
+    if convert_axes is None:
+        convert_axes = orient != 'table'
 
     compression = _infer_compression(path_or_buf, compression)
     filepath_or_buffer, _, compression, should_close = get_filepath_or_buffer(

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -281,18 +281,14 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=None,
         If True, infer dtypes; if a dict of column to dtype, then use those;
         if False, then don't infer dtypes at all, applies only to the data.
 
-        Not applicable with ``orient='table'``.
-
-        .. versionchanged:: 0.25
+        .. versionchanged:: 0.25.0
 
            Not applicable with ``orient='table'``.
 
     convert_axes : boolean, default True
         Try to convert the axes to the proper dtypes.
 
-        Not applicable with ``orient='table'``.
-
-        .. versionchanged:: 0.25
+        .. versionchanged:: 0.25.0
 
            Not applicable with ``orient='table'``.
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -277,20 +277,24 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=None,
            'table' as an allowed value for the ``orient`` argument
 
     typ : type of object to recover (series or frame), default 'frame'
-    dtype : boolean or dict, default True
+    dtype : boolean or dict, default None
         If True, infer dtypes; if a dict of column to dtype, then use those;
         if False, then don't infer dtypes at all, applies only to the data.
 
+        For all ``orient`` values except ``'table'``, default is True.
+
         .. versionchanged:: 0.25.0
 
-           Not applicable with ``orient='table'``.
+           Not applicable for ``orient='table'``.
 
-    convert_axes : boolean, default True
+    convert_axes : boolean, default None
         Try to convert the axes to the proper dtypes.
 
+        For all ``orient`` values except ``'table'``, default is True.
+
         .. versionchanged:: 0.25.0
 
-           Not applicable with ``orient='table'``.
+           Not applicable for ``orient='table'``.
 
     convert_dates : boolean, default True
         List of columns to parse for dates; If True, then try to parse
@@ -423,9 +427,10 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=None,
     if orient == 'table' and convert_axes:
         raise ValueError("cannot pass both convert_axes and orient='table'")
 
-    dtype = orient != 'table' if dtype is None else dtype
-    if convert_axes is None:
-        convert_axes = orient != 'table'
+    if dtype is None and orient != 'table':
+        dtype = True
+    if convert_axes is None and orient != 'table':
+        convert_axes = True
 
     compression = _infer_compression(path_or_buf, compression)
     filepath_or_buffer, _, compression, should_close = get_filepath_or_buffer(
@@ -699,7 +704,7 @@ class Parser(object):
 
         # don't try to coerce, unless a force conversion
         if use_dtypes:
-            if self.dtype is False:
+            if not self.dtype:
                 return data, False
             elif self.dtype is True:
                 pass

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -564,17 +564,11 @@ class TestTableOrientReader(object):
         result = pd.read_json(out, orient="table")
         tm.assert_frame_equal(df, result)
 
-    @pytest.mark.parametrize("strict_check", [
-        pytest.param(True, marks=pytest.mark.xfail),
-        False
-    ])
-    def test_empty_frame_roundtrip(self, strict_check):
+    def test_empty_frame_roundtrip(self):
         # GH 21287
         df = pd.DataFrame([], columns=['a', 'b', 'c'])
         expected = df.copy()
         out = df.to_json(orient='table')
         result = pd.read_json(out, orient='table')
         # TODO: When DF coercion issue (#21345) is resolved tighten type checks
-        tm.assert_frame_equal(expected, result,
-                              check_dtype=strict_check,
-                              check_index_type=strict_check)
+        tm.assert_frame_equal(expected, result)

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -570,5 +570,4 @@ class TestTableOrientReader(object):
         expected = df.copy()
         out = df.to_json(orient='table')
         result = pd.read_json(out, orient='table')
-        # TODO: When DF coercion issue (#21345) is resolved tighten type checks
         tm.assert_frame_equal(expected, result)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1202,6 +1202,14 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         assert size_before == size_after
 
+    @pytest.mark.parametrize('index', [None, [1., 2.], ['1', '2'],
+                                       ['1.', '2.']])
+    def test_from_json_to_json_table_index(self, index):
+        expected = DataFrame({'a': [1, 2]}, index=index)
+        dfjson = expected.to_json(orient='table')
+        result = pd.read_json(dfjson, orient='table')
+        assert_frame_equal(result, expected)
+
     def test_from_json_to_json_table_dtypes(self):
         # GH21345
         expected = pd.DataFrame({'a': [1, 2], 'b': [3., 4.], 'c': ['5', '6']})

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1202,10 +1202,12 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         assert size_before == size_after
 
-    @pytest.mark.parametrize('index', [None, [1., 2.], ['1', '2'],
-                                       ['1.', '2.']])
-    def test_from_json_to_json_table_index(self, index):
-        expected = DataFrame({'a': [1, 2]}, index=index)
+    @pytest.mark.parametrize('index', [None, [1, 2], [1., 2.], ['a', 'b'],
+                                       ['1', '2'], ['1.', '2.']])
+    @pytest.mark.parametrize('columns', [['a', 'b'], ['1', '2'], ['1.', '2.']])
+    def test_from_json_to_json_table_index_and_columns(self, index, columns):
+        # GH25433 GH25435
+        expected = DataFrame([[1, 2], [3, 4]], index=index, columns=columns)
         dfjson = expected.to_json(orient='table')
         result = pd.read_json(dfjson, orient='table')
         assert_frame_equal(result, expected)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -194,7 +194,7 @@ class TestPandasContainer(object):
             else:
                 unser = unser.sort_index()
 
-            if dtype is False:
+            if not dtype:
                 check_dtype = False
 
             if not convert_axes and df.index.dtype.type == np.datetime64:

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1224,14 +1224,16 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         # GH21345
         df = pd.DataFrame({'a': [1, 2], 'b': [3., 4.], 'c': ['5', '6']})
         dfjson = df.to_json(orient='table')
-        with pytest.raises(ValueError):
+        msg = "cannot pass both dtype and orient='table'"
+        with pytest.raises(ValueError, match=msg):
             pd.read_json(dfjson, orient='table', dtype=dtype)
 
     def test_read_json_table_convert_axes_raises(self):
         # GH25433 GH25435
         df = DataFrame([[1, 2], [3, 4]], index=[1., 2.], columns=['1.', '2.'])
         dfjson = df.to_json(orient='table')
-        with pytest.raises(ValueError):
+        msg = "cannot pass both convert_axes and orient='table'"
+        with pytest.raises(ValueError, match=msg):
             pd.read_json(dfjson, orient='table', convert_axes=True)
 
     @pytest.mark.parametrize('data, expected', [

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1227,6 +1227,13 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         with pytest.raises(ValueError):
             pd.read_json(dfjson, orient='table', dtype=dtype)
 
+    def test_read_json_table_convert_axes_raises(self):
+        # GH25433 GH25435
+        df = DataFrame([[1, 2], [3, 4]], index=[1., 2.], columns=['1.', '2.'])
+        dfjson = df.to_json(orient='table')
+        with pytest.raises(ValueError):
+            pd.read_json(dfjson, orient='table', convert_axes=True)
+
     @pytest.mark.parametrize('data, expected', [
         (DataFrame([[1, 2], [4, 5]], columns=['a', 'b']),
             {'columns': ['a', 'b'], 'data': [[1, 2], [4, 5]]}),


### PR DESCRIPTION
closes #25433
closes #25435
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
