### PR TITLE
CI: add __init__.py to isort skip list

### DIFF
--- a/ci/deps/azure-27-compat.yaml
+++ b/ci/deps/azure-27-compat.yaml
@@ -21,6 +21,7 @@ dependencies:
   - pytest
   - pytest-xdist
   - pytest-mock
+  - isort
   - pip:
     - html5lib==1.0b2
     - beautifulsoup4==4.2.1

--- a/ci/deps/azure-27-locale.yaml
+++ b/ci/deps/azure-27-locale.yaml
@@ -24,6 +24,7 @@ dependencies:
   - pytest-xdist
   - pytest-mock
   - hypothesis>=3.58.0
+  - isort
   - pip:
     - html5lib==1.0b2
     - beautifulsoup4==4.2.1

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -30,5 +30,6 @@ dependencies:
   - pytest-xdist
   - pytest-mock
   - moto
+  - isort
   - pip:
     - hypothesis>=3.58.0

--- a/ci/deps/azure-37-locale.yaml
+++ b/ci/deps/azure-37-locale.yaml
@@ -28,6 +28,7 @@ dependencies:
   - pytest
   - pytest-xdist
   - pytest-mock
+  - isort
   - pip:
     - hypothesis>=3.58.0
     - moto  # latest moto in conda-forge fails with 3.7, move to conda dependencies when this is fixed

--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pytest-xdist
   - pytest-mock
   - hypothesis>=3.58.0
+  - isort
   - pip:
     - "git+git://github.com/dateutil/dateutil.git"
     - "-f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"

--- a/ci/deps/azure-macos-35.yaml
+++ b/ci/deps/azure-macos-35.yaml
@@ -25,6 +25,7 @@ dependencies:
   - pytest
   - pytest-xdist
   - pytest-mock
+  - isort
   - pip:
     - python-dateutil==2.5.3
     - hypothesis>=3.58.0

--- a/ci/deps/azure-windows-27.yaml
+++ b/ci/deps/azure-windows-27.yaml
@@ -30,3 +30,4 @@ dependencies:
   - pytest-mock
   - moto
   - hypothesis>=3.58.0
+  - isort

--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -27,3 +27,4 @@ dependencies:
   - pytest-xdist
   - pytest-mock
   - hypothesis>=3.58.0
+  - isort

--- a/ci/deps/travis-27.yaml
+++ b/ci/deps/travis-27.yaml
@@ -44,6 +44,7 @@ dependencies:
   - pytest-mock
   - moto==1.3.4
   - hypothesis>=3.58.0
+  - isort
   - pip:
     - backports.lzma
     - pandas-gbq

--- a/ci/deps/travis-36-doc.yaml
+++ b/ci/deps/travis-36-doc.yaml
@@ -43,3 +43,4 @@ dependencies:
   # universal
   - pytest
   - pytest-xdist
+  - isort

--- a/ci/deps/travis-36-locale.yaml
+++ b/ci/deps/travis-36-locale.yaml
@@ -32,5 +32,6 @@ dependencies:
   - pytest-xdist
   - pytest-mock
   - moto
+  - isort
   - pip:
     - hypothesis>=3.58.0

--- a/ci/deps/travis-36-slow.yaml
+++ b/ci/deps/travis-36-slow.yaml
@@ -30,3 +30,4 @@ dependencies:
   - pytest-mock
   - moto
   - hypothesis>=3.58.0
+  - isort

--- a/ci/deps/travis-36.yaml
+++ b/ci/deps/travis-36.yaml
@@ -38,6 +38,7 @@ dependencies:
   - pytest-cov
   - pytest-mock
   - hypothesis>=3.58.0
+  - isort
   - pip:
     - brotlipy
     - coverage

--- a/ci/deps/travis-37.yaml
+++ b/ci/deps/travis-37.yaml
@@ -17,5 +17,6 @@ dependencies:
   - pytest-mock
   - hypothesis>=3.58.0
   - s3fs
+  - isort
   - pip:
     - moto

--- a/setup.cfg
+++ b/setup.cfg
@@ -152,3 +152,23 @@ skip=
     asv_bench/benchmarks/dtypes.py
     asv_bench/benchmarks/strings.py
     asv_bench/benchmarks/period.py
+    pandas/__init__.py
+    pandas/plotting/__init__.py
+    pandas/tests/extension/decimal/__init__.py
+    pandas/tests/extension/base/__init__.py
+    pandas/io/msgpack/__init__.py
+    pandas/io/json/__init__.py
+    pandas/io/clipboard/__init__.py
+    pandas/io/excel/__init__.py
+    pandas/compat/__init__.py
+    pandas/compat/numpy/__init__.py
+    pandas/core/arrays/__init__.py
+    pandas/core/groupby/__init__.py
+    pandas/core/internals/__init__.py
+    pandas/api/__init__.py
+    pandas/api/extensions/__init__.py
+    pandas/api/types/__init__.py
+    pandas/_libs/__init__.py
+    pandas/_libs/tslibs/__init__.py
+    pandas/util/__init__.py
+    pandas/arrays/__init__.py


### PR DESCRIPTION
4.3.5 - February 24, 2019 - last Python 2.7 Maintenance Release
This is the final Python 2.x release of isort, and includes the following major changes:

Potentially Interface Breaking:

The -r option for removing imports has been renamed -rm to avoid accidental deletions and confusion with the -rc recursive option.
__init__.py has been removed from the default ignore list. The default ignore list is now empty - with all items needing to be explicitly ignored....