### PR TITLE
Draft implementation

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1,5 +1,6 @@
 from datetime import datetime, time
 from functools import partial
+import numbers
 
 import numpy as np
 
@@ -398,6 +399,19 @@ def _adjust_to_origin(arg, origin, unit):
     return arg
 
 
+def _contains_numbers(arg):
+    """Returns True if argument is a number or is an iterable containing some numbers"""
+    # deal with case where input is a number or a list of numbers
+    arr = np.asarray(arg)
+    if np.issubdtype(arr.dtype, np.number):
+        return True
+    elif np.isscalar(arr) and np.issubdtype(x, np.number):
+        return True
+    else:
+        # inefficient
+        return any(isinstance(x, numbers.Number) for x in arg)
+
+
 def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
                 utc=None, box=True, format=None, exact=True,
                 unit=None, infer_datetime_format=False, origin='unix',
@@ -569,6 +583,9 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
 
     if origin != 'unix':
         arg = _adjust_to_origin(arg, origin, unit)
+
+    if _contains_numbers(arg) and units is None:
+        raise ValueError('When supplying numbers the unit must be specified.')
 
     tz = 'utc' if utc else None
     convert_listlike = partial(_convert_listlike_datetimes, tz=tz, unit=unit,

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -400,12 +400,14 @@ def _adjust_to_origin(arg, origin, unit):
 
 
 def _contains_numbers(arg):
-    """Returns True if argument is a number or is an iterable containing some numbers"""
+    """Returns True if argument is a number or an iterable containing
+    some numbers.
+    """
     # deal with case where input is a number or a list of numbers
     arr = np.asarray(arg)
     if np.issubdtype(arr.dtype, np.number):
         return True
-    elif np.isscalar(arr) and np.issubdtype(x, np.number):
+    elif np.isscalar(arr) and np.issubdtype(arr, np.number):
         return True
     else:
         # inefficient
@@ -584,7 +586,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
     if origin != 'unix':
         arg = _adjust_to_origin(arg, origin, unit)
 
-    if _contains_numbers(arg) and units is None:
+    if _contains_numbers(arg) and unit is None:
         raise ValueError('When supplying numbers the unit must be specified.')
 
     tz = 'utc' if utc else None


### PR DESCRIPTION
Raises a ValueError when the input to to_datetime contains some numbers
but the unit isn't supplied.

- [X] closes #15836
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
