### PR TITLE
DOC: Use correct pandas when building documentation

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -323,7 +323,7 @@ def main():
     # the import of `python_path` correctly. The latter is used to resolve
     # the import within the module, injecting it into the global namespace
     os.environ['PYTHONPATH'] = args.python_path
-    sys.path.append(args.python_path)
+    sys.path.insert(0, args.python_path)
     globals()['pandas'] = importlib.import_module('pandas')
 
     # Set the matplotlib backend to the non-interactive Agg backend for all


### PR DESCRIPTION
This manifested itself in #25419 - when trying to build documentation the version of pandas that gets inserted into the globals of this module may have inadvertently been picked up from another install on the system. This prioritizes the version of pandas dictated by command line args