### PR TITLE
TST: Fix test_stringified_slice_with_tz failure

### DIFF
--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -100,8 +100,7 @@ class TestDatetimeIndex(object):
 
     def test_stringified_slice_with_tz(self):
         # GH#2658
-        import datetime
-        start = datetime.datetime.now()
+        start = '2013-01-07'
         idx = date_range(start=start, freq="1d", periods=10, tz='US/Eastern')
         df = DataFrame(lrange(10), index=idx)
         df["2013-01-14 23:44:34.437768-05:00":]  # no exception here


### PR DESCRIPTION
- [x] closes #25492
- [x] tests added / passed

This test shouldn't need to depend on `datetime.now`
