### PR TITLE
BUG: Fix RecursionError during IntervalTree construction

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -98,6 +98,7 @@ Bug Fixes
 
 - Bug in :meth:`Series.is_unique` where single occurrences of ``NaN`` were not considered unique (:issue:`25180`)
 - Bug in :func:`merge` when merging an empty ``DataFrame`` with an ``Int64`` column or a non-empty ``DataFrame`` with an ``Int64`` column that is all ``NaN`` (:issue:`25183`)
+- Bug in ``IntervalTree`` where a ``RecursionError`` occurs upon construction due to an overflow when adding endpoints, which also causes :class:`IntervalIndex` to crash during indexing operations (:issue:`25485`)
 -
 
 .. _whatsnew_0.242.contributors:

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -284,7 +284,7 @@ cdef class {{dtype_title}}Closed{{closed_title}}IntervalNode:
         else:
             # calculate a pivot so we can create child nodes
             self.is_leaf_node = False
-            self.pivot = np.median(left + right) / 2
+            self.pivot = np.median(left / 2 + right / 2)
             left_set, right_set, center_set = self.classify_intervals(
                 left, right)
 

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -171,3 +171,13 @@ class TestIntervalTree(object):
         # GH 23309
         tree = IntervalTree(left, right, closed=closed)
         assert tree.is_overlapping is False
+
+    def test_construction_overflow(self):
+        # GH 25485
+        left, right = np.arange(101), [np.iinfo(np.int64).max] * 101
+        tree = IntervalTree(left, right)
+
+        # pivot should be average of left/right medians
+        result = tree.root.pivot
+        expected = (50 + np.iinfo(np.int64).max) / 2
+        assert result == expected


### PR DESCRIPTION
- [X] closes #25485
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Credit to @kingsykes for identifying the issue and determining the fix.