### PR TITLE
Update documentation of read_csv to explain that index_col can be a string containg a column name

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -111,9 +111,13 @@ names : array-like, default ``None``
   explicitly pass ``header=None``. Duplicates in this list will cause
   a ``UserWarning`` to be issued.
 index_col : int, str, sequence of int / str, or False, default ``None``
-  Column(s) to use as the row labels of the ``DataFrame``, either given as string name or column index.
-  If a sequence of int / str is given, a MultiIndex is used.
-  (Note: ``index_col=False`` can be used to force pandas to *not* use the first column as the index, e.g. when you have a malformed file with delimiters at the end of each line.)
+  Column(s) to use as the row labels of the ``DataFrame``, either given as
+  string name or column index. If a sequence of int / str is given, a
+  MultiIndex is used.
+  
+  Note: ``index_col=False`` can be used to force pandas to *not* use the first
+  column as the index, e.g. when you have a malformed file with delimiters at
+  the end of each line.
 usecols : list-like or callable, default ``None``
   Return a subset of the columns. If list-like, all elements must either
   be positional (i.e. integer indices into the document columns) or strings

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -114,7 +114,7 @@ index_col : int, str, sequence of int / str, or False, default ``None``
   Column(s) to use as the row labels of the ``DataFrame``, either given as
   string name or column index. If a sequence of int / str is given, a
   MultiIndex is used.
-  
+
   Note: ``index_col=False`` can be used to force pandas to *not* use the first
   column as the index, e.g. when you have a malformed file with delimiters at
   the end of each line.

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -110,9 +110,9 @@ names : array-like, default ``None``
   List of column names to use. If file contains no header row, then you should
   explicitly pass ``header=None``. Duplicates in this list will cause
   a ``UserWarning`` to be issued.
-index_col : int/string or sequence of int/string or ``False``, default ``None``
+index_col : int, str, sequence of int / str, or False, default ``None``
   Column(s) to use as the row labels of the ``DataFrame``, either given as string name or column index.
-  If a sequence of int/string is given, a MultiIndex is used.
+  If a sequence of int / str is given, a MultiIndex is used.
   Columns used for the index (row names) are dropped from the actual columns of the input dataframe.
   They are accessible via ``.index``.
   (Note: ``index_col=False`` can be used to force pandas to *not* use the first column as the index, e.g. when you have a malformed file with delimiters at the end of each line.)

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -113,8 +113,6 @@ names : array-like, default ``None``
 index_col : int, str, sequence of int / str, or False, default ``None``
   Column(s) to use as the row labels of the ``DataFrame``, either given as string name or column index.
   If a sequence of int / str is given, a MultiIndex is used.
-  Columns used for the index (row names) are dropped from the actual columns of the input dataframe.
-  They are accessible via ``.index``.
   (Note: ``index_col=False`` can be used to force pandas to *not* use the first column as the index, e.g. when you have a malformed file with delimiters at the end of each line.)
 usecols : list-like or callable, default ``None``
   Return a subset of the columns. If list-like, all elements must either

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -110,11 +110,12 @@ names : array-like, default ``None``
   List of column names to use. If file contains no header row, then you should
   explicitly pass ``header=None``. Duplicates in this list will cause
   a ``UserWarning`` to be issued.
-index_col :  int or sequence or ``False``, default ``None``
-  Column to use as the row labels of the ``DataFrame``. If a sequence is given, a
-  MultiIndex is used. If you have a malformed file with delimiters at the end of
-  each line, you might consider ``index_col=False`` to force pandas to *not* use
-  the first column as the index (row names).
+index_col : int/string or sequence of int/string or ``False``, default ``None``
+  Column(s) to use as the row labels of the ``DataFrame``, either given as string name or column index.
+  If a sequence of int/string is given, a MultiIndex is used.
+  Columns used for the index (row names) are dropped from the actual columns of the input dataframe.
+  They are accessible via ``.index``.
+  (Note: ``index_col=False`` can be used to force pandas to *not* use the first column as the index, e.g. when you have a malformed file with delimiters at the end of each line.)
 usecols : list-like or callable, default ``None``
   Return a subset of the columns. If list-like, all elements must either
   be positional (i.e. integer indices into the document columns) or strings

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -102,9 +102,9 @@ names : array-like, optional
     List of column names to use. If file contains no header row, then you
     should explicitly pass ``header=None``. Duplicates in this list will cause
     a ``UserWarning`` to be issued.
-index_col : int/string or sequence of int/string or ``False``, default ``None``
+index_col : int, str, sequence of int / str, or False, default ``None``
   Column(s) to use as the row labels of the ``DataFrame``, either given as
-  string name or column index. If a sequence of int/string is given, a
+  string name or column index. If a sequence of int / str is given, a
   MultiIndex is used. Columns used for the index (row names) are dropped from
   the actual columns of the input dataframe. They are accessible via
   ``.index``. (Note: ``index_col=False`` can be used to force pandas to *not*

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -102,11 +102,14 @@ names : array-like, optional
     List of column names to use. If file contains no header row, then you
     should explicitly pass ``header=None``. Duplicates in this list will cause
     a ``UserWarning`` to be issued.
-index_col : int, sequence or bool, optional
-    Column to use as the row labels of the DataFrame. If a sequence is given, a
-    MultiIndex is used. If you have a malformed file with delimiters at the end
-    of each line, you might consider ``index_col=False`` to force pandas to
-    not use the first column as the index (row names).
+index_col : int/string or sequence of int/string or ``False``, default ``None``
+  Column(s) to use as the row labels of the ``DataFrame``, either given as
+  string name or column index. If a sequence of int/string is given, a
+  MultiIndex is used. Columns used for the index (row names) are dropped from
+  the actual columns of the input dataframe. They are accessible via
+  ``.index``. (Note: ``index_col=False`` can be used to force pandas to *not*
+  use the first column as the index, e.g. when you have a malformed file with
+  delimiters at the end of each line.)
 usecols : list-like or callable, optional
     Return a subset of the columns. If list-like, all elements must either
     be positional (i.e. integer indices into the document columns) or strings

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -105,9 +105,7 @@ names : array-like, optional
 index_col : int, str, sequence of int / str, or False, default ``None``
   Column(s) to use as the row labels of the ``DataFrame``, either given as
   string name or column index. If a sequence of int / str is given, a
-  MultiIndex is used. Columns used for the index (row names) are dropped from
-  the actual columns of the input dataframe. They are accessible via
-  ``.index``.
+  MultiIndex is used.
 
   Note: ``index_col=False`` can be used to force pandas to *not* use the first
   column as the index, e.g. when you have a malformed file with delimiters at

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -107,9 +107,11 @@ index_col : int, str, sequence of int / str, or False, default ``None``
   string name or column index. If a sequence of int / str is given, a
   MultiIndex is used. Columns used for the index (row names) are dropped from
   the actual columns of the input dataframe. They are accessible via
-  ``.index``. (Note: ``index_col=False`` can be used to force pandas to *not*
-  use the first column as the index, e.g. when you have a malformed file with
-  delimiters at the end of each line.)
+  ``.index``.
+
+  Note: ``index_col=False`` can be used to force pandas to *not* use the first
+  column as the index, e.g. when you have a malformed file with delimiters at
+  the end of each line.
 usecols : list-like or callable, optional
     Return a subset of the columns. If list-like, all elements must either
     be positional (i.e. integer indices into the document columns) or strings


### PR DESCRIPTION
Uses the suggestion from #22276 and closes #22276.