### PR TITLE
fix segfault when running with cython coverage enabled, xref cython#2879

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -138,11 +138,11 @@ cdef int64_t get_daytime_conversion_factor(int from_index, int to_index) nogil:
     return daytime_conversion_factor_matrix[row - 6][col - 6]
 
 
-cdef int64_t nofunc(int64_t ordinal, asfreq_info *af_info):
-    return np.iinfo(np.int32).min
+cdef int64_t nofunc(int64_t ordinal, asfreq_info *af_info) nogil:
+    return INT32_MIN
 
 
-cdef int64_t no_op(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t no_op(int64_t ordinal, asfreq_info *af_info) nogil:
     return ordinal
 
 
@@ -270,7 +270,8 @@ cdef int64_t DtoB_weekday(int64_t unix_date) nogil:
     return ((unix_date + 4) // 7) * 5 + ((unix_date + 4) % 7) - 4
 
 
-cdef int64_t DtoB(npy_datetimestruct *dts, int roll_back, int64_t unix_date):
+cdef int64_t DtoB(npy_datetimestruct *dts, int roll_back,
+                  int64_t unix_date) nogil:
     cdef:
         int day_of_week = dayofweek(dts.year, dts.month, dts.day)
 
@@ -286,21 +287,23 @@ cdef int64_t DtoB(npy_datetimestruct *dts, int roll_back, int64_t unix_date):
     return DtoB_weekday(unix_date)
 
 
-cdef inline int64_t upsample_daytime(int64_t ordinal, asfreq_info *af_info):
+cdef inline int64_t upsample_daytime(int64_t ordinal,
+                                     asfreq_info *af_info) nogil:
     if (af_info.is_end):
         return (ordinal + 1) * af_info.intraday_conversion_factor - 1
     else:
         return ordinal * af_info.intraday_conversion_factor
 
 
-cdef inline int64_t downsample_daytime(int64_t ordinal, asfreq_info *af_info):
+cdef inline int64_t downsample_daytime(int64_t ordinal,
+                                       asfreq_info *af_info) nogil:
     return ordinal // (af_info.intraday_conversion_factor)
 
 
 cdef inline int64_t transform_via_day(int64_t ordinal,
                                       asfreq_info *af_info,
                                       freq_conv_func first_func,
-                                      freq_conv_func second_func):
+                                      freq_conv_func second_func) nogil:
     cdef:
         int64_t result
 
@@ -313,7 +316,7 @@ cdef inline int64_t transform_via_day(int64_t ordinal,
 # Conversion _to_ Daily Freq
 
 cdef void AtoD_ym(int64_t ordinal, int64_t *year,
-                  int *month, asfreq_info *af_info):
+                  int *month, asfreq_info *af_info) nogil:
     year[0] = ordinal + 1970
     month[0] = 1
 
@@ -327,7 +330,7 @@ cdef void AtoD_ym(int64_t ordinal, int64_t *year,
             year[0] -= 1
 
 
-cdef int64_t asfreq_AtoDT(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_AtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int64_t unix_date, year
         int month
@@ -341,7 +344,7 @@ cdef int64_t asfreq_AtoDT(int64_t ordinal, asfreq_info *af_info):
 
 
 cdef void QtoD_ym(int64_t ordinal, int *year,
-                  int *month, asfreq_info *af_info):
+                  int *month, asfreq_info *af_info) nogil:
     year[0] = ordinal // 4 + 1970
     month[0] = (ordinal % 4) * 3 + 1
 
@@ -353,7 +356,7 @@ cdef void QtoD_ym(int64_t ordinal, int *year,
             year[0] -= 1
 
 
-cdef int64_t asfreq_QtoDT(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_QtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int64_t unix_date
         int year, month
@@ -366,12 +369,12 @@ cdef int64_t asfreq_QtoDT(int64_t ordinal, asfreq_info *af_info):
     return upsample_daytime(unix_date, af_info)
 
 
-cdef void MtoD_ym(int64_t ordinal, int *year, int *month):
+cdef void MtoD_ym(int64_t ordinal, int *year, int *month) nogil:
     year[0] = ordinal // 12 + 1970
     month[0] = ordinal % 12 + 1
 
 
-cdef int64_t asfreq_MtoDT(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_MtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int64_t unix_date
         int year, month
@@ -384,7 +387,7 @@ cdef int64_t asfreq_MtoDT(int64_t ordinal, asfreq_info *af_info):
     return upsample_daytime(unix_date, af_info)
 
 
-cdef int64_t asfreq_WtoDT(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_WtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
     ordinal = (ordinal * 7 + af_info.from_end - 4 +
                (7 - 1) * (af_info.is_end - 1))
     return upsample_daytime(ordinal, af_info)
@@ -393,7 +396,7 @@ cdef int64_t asfreq_WtoDT(int64_t ordinal, asfreq_info *af_info):
 # --------------------------------------------------------------------
 # Conversion _to_ BusinessDay Freq
 
-cdef int64_t asfreq_AtoB(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_AtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -404,7 +407,7 @@ cdef int64_t asfreq_AtoB(int64_t ordinal, asfreq_info *af_info):
     return DtoB(&dts, roll_back, unix_date)
 
 
-cdef int64_t asfreq_QtoB(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_QtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -415,7 +418,7 @@ cdef int64_t asfreq_QtoB(int64_t ordinal, asfreq_info *af_info):
     return DtoB(&dts, roll_back, unix_date)
 
 
-cdef int64_t asfreq_MtoB(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_MtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -426,7 +429,7 @@ cdef int64_t asfreq_MtoB(int64_t ordinal, asfreq_info *af_info):
     return DtoB(&dts, roll_back, unix_date)
 
 
-cdef int64_t asfreq_WtoB(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_WtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -437,7 +440,7 @@ cdef int64_t asfreq_WtoB(int64_t ordinal, asfreq_info *af_info):
     return DtoB(&dts, roll_back, unix_date)
 
 
-cdef int64_t asfreq_DTtoB(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_DTtoB(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int roll_back
         npy_datetimestruct dts
@@ -452,7 +455,7 @@ cdef int64_t asfreq_DTtoB(int64_t ordinal, asfreq_info *af_info):
 # ----------------------------------------------------------------------
 # Conversion _from_ Daily Freq
 
-cdef int64_t asfreq_DTtoA(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_DTtoA(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         npy_datetimestruct dts
 
@@ -464,7 +467,7 @@ cdef int64_t asfreq_DTtoA(int64_t ordinal, asfreq_info *af_info):
         return <int64_t>(dts.year - 1970)
 
 
-cdef int DtoQ_yq(int64_t ordinal, asfreq_info *af_info, int *year):
+cdef int DtoQ_yq(int64_t ordinal, asfreq_info *af_info, int *year) nogil:
     cdef:
         npy_datetimestruct dts
         int quarter
@@ -485,7 +488,7 @@ cdef int DtoQ_yq(int64_t ordinal, asfreq_info *af_info, int *year):
     return quarter
 
 
-cdef int64_t asfreq_DTtoQ(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_DTtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         int year, quarter
 
@@ -495,7 +498,7 @@ cdef int64_t asfreq_DTtoQ(int64_t ordinal, asfreq_info *af_info):
     return <int64_t>((year - 1970) * 4 + quarter - 1)
 
 
-cdef int64_t asfreq_DTtoM(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_DTtoM(int64_t ordinal, asfreq_info *af_info) nogil:
     cdef:
         npy_datetimestruct dts
 
@@ -504,7 +507,7 @@ cdef int64_t asfreq_DTtoM(int64_t ordinal, asfreq_info *af_info):
     return <int64_t>((dts.year - 1970) * 12 + dts.month - 1)
 
 
-cdef int64_t asfreq_DTtoW(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_DTtoW(int64_t ordinal, asfreq_info *af_info) nogil:
     ordinal = downsample_daytime(ordinal, af_info)
     return (ordinal + 3 - af_info.to_end) // 7 + 1
 
@@ -512,30 +515,30 @@ cdef int64_t asfreq_DTtoW(int64_t ordinal, asfreq_info *af_info):
 # --------------------------------------------------------------------
 # Conversion _from_ BusinessDay Freq
 
-cdef int64_t asfreq_BtoDT(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_BtoDT(int64_t ordinal, asfreq_info *af_info) nogil:
     ordinal = ((ordinal + 3) // 5) * 7 + (ordinal + 3) % 5 -3
     return upsample_daytime(ordinal, af_info)
 
 
-cdef int64_t asfreq_BtoA(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_BtoA(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_BtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_BtoQ(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_BtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_BtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_BtoM(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_BtoM(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_BtoDT,
                              <freq_conv_func>asfreq_DTtoM)
 
 
-cdef int64_t asfreq_BtoW(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_BtoW(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_BtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -544,25 +547,25 @@ cdef int64_t asfreq_BtoW(int64_t ordinal, asfreq_info *af_info):
 # ----------------------------------------------------------------------
 # Conversion _from_ Annual Freq
 
-cdef int64_t asfreq_AtoA(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_AtoA(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_AtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_AtoQ(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_AtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_AtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_AtoM(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_AtoM(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_AtoDT,
                              <freq_conv_func>asfreq_DTtoM)
 
 
-cdef int64_t asfreq_AtoW(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_AtoW(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_AtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -571,25 +574,25 @@ cdef int64_t asfreq_AtoW(int64_t ordinal, asfreq_info *af_info):
 # ----------------------------------------------------------------------
 # Conversion _from_ Quarterly Freq
 
-cdef int64_t asfreq_QtoQ(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_QtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_QtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_QtoA(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_QtoA(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_QtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_QtoM(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_QtoM(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_QtoDT,
                              <freq_conv_func>asfreq_DTtoM)
 
 
-cdef int64_t asfreq_QtoW(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_QtoW(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_QtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -598,19 +601,19 @@ cdef int64_t asfreq_QtoW(int64_t ordinal, asfreq_info *af_info):
 # ----------------------------------------------------------------------
 # Conversion _from_ Monthly Freq
 
-cdef int64_t asfreq_MtoA(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_MtoA(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_MtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_MtoQ(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_MtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_MtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_MtoW(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_MtoW(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_MtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -619,25 +622,25 @@ cdef int64_t asfreq_MtoW(int64_t ordinal, asfreq_info *af_info):
 # ----------------------------------------------------------------------
 # Conversion _from_ Weekly Freq
 
-cdef int64_t asfreq_WtoA(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_WtoA(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_WtoDT,
                              <freq_conv_func>asfreq_DTtoA)
 
 
-cdef int64_t asfreq_WtoQ(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_WtoQ(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_WtoDT,
                              <freq_conv_func>asfreq_DTtoQ)
 
 
-cdef int64_t asfreq_WtoM(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_WtoM(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_WtoDT,
                              <freq_conv_func>asfreq_DTtoM)
 
 
-cdef int64_t asfreq_WtoW(int64_t ordinal, asfreq_info *af_info):
+cdef int64_t asfreq_WtoW(int64_t ordinal, asfreq_info *af_info) nogil:
     return transform_via_day(ordinal, af_info,
                              <freq_conv_func>asfreq_WtoDT,
                              <freq_conv_func>asfreq_DTtoW)
@@ -971,7 +974,7 @@ cdef int get_yq(int64_t ordinal, int freq, int *quarter, int *year):
     return qtr_freq
 
 
-cdef inline int month_to_quarter(int month):
+cdef inline int month_to_quarter(int month) nogil:
     return (month - 1) // 3 + 1
 
 
@@ -1024,9 +1027,6 @@ def periodarr_to_dt64arr(int64_t[:] periodarr, int freq):
 
     with nogil:
         for i in range(l):
-            if periodarr[i] == NPY_NAT:
-                out[i] = NPY_NAT
-                continue
             out[i] = period_ordinal_to_dt64(periodarr[i], freq)
 
     return out.base  # .base to access underlying np.ndarray


### PR DESCRIPTION
We have several functions getting called inside a `with nogil:` block that aren't currently declared as `nogil`.  In the future cython should warn in this type of situation (cython#2879).