### PR TITLE
DOC: fix docstring for pandas.read_parquet

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -260,8 +260,8 @@ def read_parquet(path, engine='auto', columns=None, **kwargs):
 
     Parameters
     ----------
-    path : string
-        File path
+    path : str
+        File path.
     engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
         Parquet library to use. If 'auto', then the option
         ``io.parquet.engine`` is used. The default ``io.parquet.engine``
@@ -277,6 +277,17 @@ def read_parquet(path, engine='auto', columns=None, **kwargs):
     Returns
     -------
     DataFrame
+        A parquet file is returned as two-dimensional data structure with
+        labeled axes.
+
+    See Also
+    --------
+    to_parquet : Write DataFrame to a parquet file.
+    read_csv : Read a comma-separated values (csv) file into DataFrame.
+
+    Examples
+    --------
+    >>> pd.read_parquet('data.parquet')  # doctest: +SKIP
     """
 
     impl = get_engine(engine)

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -282,7 +282,7 @@ def read_parquet(path, engine='auto', columns=None, **kwargs):
 
     See Also
     --------
-    to_parquet : Write DataFrame to a parquet file.
+    DataFrame.to_parquet : Write DataFrame to a parquet file.
     read_csv : Read a comma-separated values (csv) file into DataFrame.
 
     Examples

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -277,7 +277,7 @@ def read_parquet(path, engine='auto', columns=None, **kwargs):
     Returns
     -------
     DataFrame
-        A parquet file is returned as two-dimensional data structure with
+        DataFrame with appropriate data.
         labeled axes.
 
     See Also

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -278,7 +278,6 @@ def read_parquet(path, engine='auto', columns=None, **kwargs):
     -------
     DataFrame
         DataFrame with appropriate data.
-        labeled axes.
 
     See Also
     --------


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

```
################################################################################
####################### Docstring (pandas.read_parquet)  #######################
################################################################################

Load a parquet object from the file path, returning a DataFrame.

.. versionadded 0.21.0

Parameters
----------
path : str
    File path.
engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
    Parquet library to use. If 'auto', then the option
    ``io.parquet.engine`` is used. The default ``io.parquet.engine``
    behavior is to try 'pyarrow', falling back to 'fastparquet' if
    'pyarrow' is unavailable.
columns : list, default=None
    If not None, only these columns will be read from the file.

    .. versionadded 0.21.1
**kwargs
    Any additional kwargs are passed to the engine.

Returns
-------
DataFrame
    A parquet file is returned as two-dimensional data structure with
    labeled axes.

See Also
--------
to_parquet : Write DataFrame to a parquet file.
read_csv : Read a comma-separated values (csv) file into DataFrame.

Examples
--------
>>> pd.read_parquet('data.parquet')  # doctest: +SKIP

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.read_parquet" correct. :)
```