### PR TITLE
Document the behavior of `axis=None` with `style.background_gradient`

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -894,9 +894,10 @@ class Styler(object):
             matplotlib colormap
         low, high : float
             compress the range by these values.
-        axis : int or str
-            0 or 'index' for columnwise, 1 or 'columns' for rowwise, or
-            ``None`` for tablewise
+        axis : int, str or None
+            apply to each column (``axis=0`` or ``'index'``) or to each row
+            (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
+            with ``axis=None``.
         subset : IndexSlice
             a valid slice for ``data`` to limit the style application to
         text_color_threshold : float or int
@@ -1152,9 +1153,10 @@ class Styler(object):
         subset : IndexSlice, default None
             a valid slice for ``data`` to limit the style application to
         color : str, default 'yellow'
-        axis : int, str, or None; default 0
-            0 or 'index' for columnwise (default), 1 or 'columns' for rowwise,
-            or ``None`` for tablewise
+        axis : int, str or None
+            apply to each column (``axis=0`` or ``'index'``) or to each row
+            (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
+            with ``axis=None``.
 
         Returns
         -------
@@ -1172,9 +1174,10 @@ class Styler(object):
         subset : IndexSlice, default None
             a valid slice for ``data`` to limit the style application to
         color : str, default 'yellow'
-        axis : int, str, or None; default 0
-            0 or 'index' for columnwise (default), 1 or 'columns' for rowwise,
-            or ``None`` for tablewise
+        axis : int, str or None
+            apply to each column (``axis=0`` or ``'index'``) or to each row
+            (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
+            with ``axis=None``.
 
         Returns
         -------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -899,7 +899,7 @@ class Styler(object):
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
         subset : IndexSlice
-            a valid slice for ``data`` to limit the style application to
+            a valid slice for ``data`` to limit the style application to.
         text_color_threshold : float or int
             luminance threshold for determining text color. Facilitates text
             visibility across varying background colors. From 0 to 1.
@@ -1151,7 +1151,7 @@ class Styler(object):
         Parameters
         ----------
         subset : IndexSlice, default None
-            a valid slice for ``data`` to limit the style application to
+            a valid slice for ``data`` to limit the style application to.
         color : str, default 'yellow'
         axis : int, str or None, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
@@ -1172,7 +1172,7 @@ class Styler(object):
         Parameters
         ----------
         subset : IndexSlice, default None
-            a valid slice for ``data`` to limit the style application to
+            a valid slice for ``data`` to limit the style application to.
         color : str, default 'yellow'
         axis : int, str or None, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -576,7 +576,7 @@ class Styler(object):
             on ``axis``), and return an object with the same shape.
             Must return a DataFrame with identical index and
             column labels when ``axis=None``
-        axis : int, str or None
+        axis : int, str or None, default 0
             apply to each column (``axis=0`` or ``'index'``)
             or to each row (``axis=1`` or ``'columns'``) or
             to the entire DataFrame at once with ``axis=None``
@@ -894,7 +894,7 @@ class Styler(object):
             matplotlib colormap
         low, high : float
             compress the range by these values.
-        axis : int, str or None
+        axis : int, str or None, default 0
             apply to each column (``axis=0`` or ``'index'``) or to each row
             (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
             with ``axis=None``.
@@ -1153,7 +1153,7 @@ class Styler(object):
         subset : IndexSlice, default None
             a valid slice for ``data`` to limit the style application to
         color : str, default 'yellow'
-        axis : int, str or None
+        axis : int, str or None, default 0
             apply to each column (``axis=0`` or ``'index'``) or to each row
             (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
             with ``axis=None``.
@@ -1174,7 +1174,7 @@ class Styler(object):
         subset : IndexSlice, default None
             a valid slice for ``data`` to limit the style application to
         color : str, default 'yellow'
-        axis : int, str or None
+        axis : int, str or None, default 0
             apply to each column (``axis=0`` or ``'index'``) or to each row
             (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
             with ``axis=None``.

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -576,7 +576,7 @@ class Styler(object):
             on ``axis``), and return an object with the same shape.
             Must return a DataFrame with identical index and
             column labels when ``axis=None``
-        axis : int, str or None, default 0
+        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
@@ -894,7 +894,7 @@ class Styler(object):
             matplotlib colormap
         low, high : float
             compress the range by these values.
-        axis : int, str or None, default 0
+        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
@@ -1083,7 +1083,7 @@ class Styler(object):
         ----------
         subset : IndexSlice, optional
             A valid slice for `data` to limit the style application to.
-        axis : int, str or None, default 0
+        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
@@ -1153,7 +1153,7 @@ class Styler(object):
         subset : IndexSlice, default None
             a valid slice for ``data`` to limit the style application to.
         color : str, default 'yellow'
-        axis : int, str or None, default 0
+        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
@@ -1174,7 +1174,7 @@ class Styler(object):
         subset : IndexSlice, default None
             a valid slice for ``data`` to limit the style application to.
         color : str, default 'yellow'
-        axis : int, str or None, default 0
+        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -895,7 +895,8 @@ class Styler(object):
         low, high : float
             compress the range by these values.
         axis : int or str
-            1 or 'columns' for columnwise, 0 or 'index' for rowwise
+            0 or 'index' for columnwise, 1 or 'columns' for rowwise, or
+            ``None`` for tablewise
         subset : IndexSlice
             a valid slice for ``data`` to limit the style application to
         text_color_threshold : float or int

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -577,9 +577,9 @@ class Styler(object):
             Must return a DataFrame with identical index and
             column labels when ``axis=None``
         axis : int, str or None, default 0
-            apply to each column (``axis=0`` or ``'index'``)
-            or to each row (``axis=1`` or ``'columns'``) or
-            to the entire DataFrame at once with ``axis=None``
+            apply to each column (``axis=0`` or ``'index'``), to each row
+            (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
+            with ``axis=None``.
         subset : IndexSlice
             a valid indexer to limit ``data`` to *before* applying the
             function. Consider using a pandas.IndexSlice
@@ -895,8 +895,8 @@ class Styler(object):
         low, high : float
             compress the range by these values.
         axis : int, str or None, default 0
-            apply to each column (``axis=0`` or ``'index'``) or to each row
-            (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
+            apply to each column (``axis=0`` or ``'index'``), to each row
+            (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
         subset : IndexSlice
             a valid slice for ``data`` to limit the style application to
@@ -1084,9 +1084,9 @@ class Styler(object):
         subset : IndexSlice, optional
             A valid slice for `data` to limit the style application to.
         axis : int, str or None, default 0
-            Apply to each column (`axis=0` or `'index'`)
-            or to each row (`axis=1` or `'columns'`) or
-            to the entire DataFrame at once with `axis=None`.
+            apply to each column (``axis=0`` or ``'index'``), to each row
+            (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
+            with ``axis=None``.
         color : str or 2-tuple/list
             If a str is passed, the color is the same for both
             negative and positive numbers. If 2-tuple/list is used, the
@@ -1154,8 +1154,8 @@ class Styler(object):
             a valid slice for ``data`` to limit the style application to
         color : str, default 'yellow'
         axis : int, str or None, default 0
-            apply to each column (``axis=0`` or ``'index'``) or to each row
-            (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
+            apply to each column (``axis=0`` or ``'index'``), to each row
+            (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
 
         Returns
@@ -1175,8 +1175,8 @@ class Styler(object):
             a valid slice for ``data`` to limit the style application to
         color : str, default 'yellow'
         axis : int, str or None, default 0
-            apply to each column (``axis=0`` or ``'index'``) or to each row
-            (``axis=1`` or ``'columns'``) or to the entire DataFrame at once
+            apply to each column (``axis=0`` or ``'index'``), to each row
+            (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
 
         Returns

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -576,7 +576,7 @@ class Styler(object):
             on ``axis``), and return an object with the same shape.
             Must return a DataFrame with identical index and
             column labels when ``axis=None``
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
+        axis : {0 or 'index', 1 or 'columns', None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
@@ -894,7 +894,7 @@ class Styler(object):
             matplotlib colormap
         low, high : float
             compress the range by these values.
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
+        axis : {0 or 'index', 1 or 'columns', None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
@@ -1083,7 +1083,7 @@ class Styler(object):
         ----------
         subset : IndexSlice, optional
             A valid slice for `data` to limit the style application to.
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
+        axis : {0 or 'index', 1 or 'columns', None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
@@ -1153,7 +1153,7 @@ class Styler(object):
         subset : IndexSlice, default None
             a valid slice for ``data`` to limit the style application to.
         color : str, default 'yellow'
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
+        axis : {0 or 'index', 1 or 'columns', None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.
@@ -1174,7 +1174,7 @@ class Styler(object):
         subset : IndexSlice, default None
             a valid slice for ``data`` to limit the style application to.
         color : str, default 'yellow'
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
+        axis : {0 or 'index', 1 or 'columns', None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
             with ``axis=None``.


### PR DESCRIPTION
Add docstring entry for using `axis=None`with `style.background_gradient`, which was added in #21259. Also reword to be in numerical order and consistent with how `highlight_max` and `highligh_min` defines column-wise and row-wise.

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
