### PR TITLE
TST: Skip IntervalTree construction overflow test on 32bit

### DIFF
--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -172,6 +172,7 @@ class TestIntervalTree(object):
         tree = IntervalTree(left, right, closed=closed)
         assert tree.is_overlapping is False
 
+    @pytest.mark.skipif(compat.is_platform_32bit(), reason='GH 23440')
     def test_construction_overflow(self):
         # GH 25485
         left, right = np.arange(101), [np.iinfo(np.int64).max] * 101


### PR DESCRIPTION
- [X] xref https://github.com/pandas-dev/pandas/pull/25498#issuecomment-469672734
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Skipping this test as it's failing on 32bit due to #23440.  Note that this is consistent with #23442 where a few other tests that are being skipped for the same reason.

cc @jreback 