### PR TITLE
CLN: typing/mypy cleanup: Small fixes to make stubgen happy

### DIFF
--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -710,7 +710,7 @@ def _raise_on_incompatible(left, right):
 # Constructor Helpers
 
 def period_array(data, freq=None, copy=False):
-    # type: (Sequence[Optional[Period]], Optional[Tick]) -> PeriodArray
+    # type: (Sequence[Optional[Period]], Optional[Tick], bool) -> PeriodArray
     """
     Construct a new PeriodArray from a sequence of Period scalars.
 

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -397,6 +397,7 @@ def _get_fill(arr):
 
 
 def _sparse_array_op(left, right, op, name):
+    # type: (SparseArray, SparseArray, Callable, str) -> Any
     """
     Perform a binary operation between two arrays.
 
@@ -413,7 +414,6 @@ def _sparse_array_op(left, right, op, name):
     -------
     SparseArray
     """
-    # type: (SparseArray, SparseArray, Callable, str) -> Any
     if name.startswith('__'):
         # For lookups in _libs.sparse we need non-dunder op name
         name = name[2:-2]

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1041,7 +1041,7 @@ class GroupBy(_GroupBy):
         """
 
         def objs_to_bool(vals):
-            # type: np.ndarray -> (np.ndarray, typing.Type)
+            # type: (np.ndarray) -> (np.ndarray, typing.Type)
             if is_object_dtype(vals):
                 vals = np.array([bool(x) for x in vals])
             else:
@@ -1743,7 +1743,7 @@ class GroupBy(_GroupBy):
         """
 
         def pre_processor(vals):
-            # type: np.ndarray -> (np.ndarray, Optional[typing.Type])
+            # type: (np.ndarray) -> (np.ndarray, Optional[typing.Type])
             if is_object_dtype(vals):
                 raise TypeError("'quantile' cannot be performed against "
                                 "'object' dtypes!")

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1827,13 +1827,13 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
             placement=self.mgr_locs)
 
     def shift(self, periods, axis=0, fill_value=None):
+        # type: (int, Optional[BlockPlacement], Any) -> List[ExtensionBlock]
         """
         Shift the block by `periods`.
 
         Dispatches to underlying ExtensionArray and re-boxes in an
         ExtensionBlock.
         """
-        # type: (int, Optional[BlockPlacement]) -> List[ExtensionBlock]
         return [
             self.make_block_same_class(
                 self.values.shift(periods=periods, fill_value=fill_value),


### PR DESCRIPTION
No code changes, just moved a few comments, and fixed a few broken types.

This patch allows stubgen to run over the pandas codebase without generating errors