### PR TITLE
BUG: Preserve name in DatetimeIndex.snap

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -31,7 +31,6 @@ Fixed Regressions
 - Fixed regression in ``IntervalDtype`` construction where passing an incorrect string with 'Interval' as a prefix could result in a ``RecursionError``. (:issue:`25338`)
 - Fixed regression in :class:`Categorical`, where constructing it from a categorical ``Series`` and an explicit ``categories=`` that differed from that in the ``Series`` created an invalid object which could trigger segfaults. (:issue:`25318`)
 - Fixed pip installing from source into an environment without NumPy (:issue:`25193`)
-- Fixed name preserving bug of :meth:`DatetimeIndex.snap` (:issue:`25575`)
 
 .. _whatsnew_0242.enhancements:
 

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -31,6 +31,7 @@ Fixed Regressions
 - Fixed regression in ``IntervalDtype`` construction where passing an incorrect string with 'Interval' as a prefix could result in a ``RecursionError``. (:issue:`25338`)
 - Fixed regression in :class:`Categorical`, where constructing it from a categorical ``Series`` and an explicit ``categories=`` that differed from that in the ``Series`` created an invalid object which could trigger segfaults. (:issue:`25318`)
 - Fixed pip installing from source into an environment without NumPy (:issue:`25193`)
+- Fixed name preserving bug of :meth:`DatetimeIndex.snap` (:issue:`25575`)
 
 .. _whatsnew_0242.enhancements:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -86,7 +86,7 @@ Other API Changes
 - :class:`DatetimeTZDtype` will now standardize pytz timezones to a common timezone instance (:issue:`24713`)
 - ``Timestamp`` and ``Timedelta`` scalars now implement the :meth:`to_numpy` method as aliases to :meth:`Timestamp.to_datetime64` and :meth:`Timedelta.to_timedelta64`, respectively. (:issue:`24653`)
 - :meth:`Timestamp.strptime` will now rise a ``NotImplementedError`` (:issue:`25016`)
--
+- Bug in :meth:`DatetimeIndex.snap` which didn't preserving the ``name`` of the input :class:`Index` (:issue:`25575`)
 
 .. _whatsnew_0250.deprecations:
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -787,7 +787,8 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
             snapped[i] = s
 
         # we know it conforms; skip check
-        return DatetimeIndex._simple_new(snapped, name=self.name, freq=freq)
+        return DatetimeIndex._simple_new(snapped, name=self.name, tz=self.tz,
+                                         freq=freq)
 
     def join(self, other, how='left', level=None, return_indexers=False,
              sort=False):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -787,8 +787,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
             snapped[i] = s
 
         # we know it conforms; skip check
-        return DatetimeIndex._simple_new(snapped, freq=freq)
-        # TODO: what about self.name?  tz? if so, use shallow_copy?
+        return DatetimeIndex._simple_new(snapped, name=self.name, freq=freq)
 
     def join(self, other, how='left', level=None, return_indexers=False,
              sort=False):

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -52,6 +52,7 @@ def test_fancy_setitem():
     assert (s[48:54] == -3).all()
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize('tz', [None, 'Asia/Shanghai', 'Europe/Berlin'])
 @pytest.mark.parametrize('name', [None, 'my_dti'])
 def test_dti_snap(name, tz):

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -52,22 +52,24 @@ def test_fancy_setitem():
     assert (s[48:54] == -3).all()
 
 
-def test_dti_snap():
+@pytest.mark.parametrize('tz', [None, 'Asia/Shanghai', 'Europe/Berlin'])
+@pytest.mark.parametrize('name', [None, 'my_dti'])
+def test_dti_snap(name, tz):
     dti = DatetimeIndex(['1/1/2002', '1/2/2002', '1/3/2002', '1/4/2002',
                          '1/5/2002', '1/6/2002', '1/7/2002'],
-                        name='my_dti', tz='Asia/Shanghai', freq='D')
+                        name=name, tz=tz, freq='D')
 
     result = dti.snap(freq='W-MON')
-    expected = date_range('12/31/2001', '1/7/2002', name='my_dti',
-                          tz='Asia/Shanghai', freq='w-mon')
+    expected = date_range('12/31/2001', '1/7/2002',
+                          name=name, tz=tz, freq='w-mon')
     expected = expected.repeat([3, 4])
     tm.assert_index_equal(result, expected)
     assert result.tz == expected.tz
 
     result = dti.snap(freq='B')
 
-    expected = date_range('1/1/2002', '1/7/2002', name='my_dti',
-                          tz='Asia/Shanghai', freq='b')
+    expected = date_range('1/1/2002', '1/7/2002',
+                          name=name, tz=tz, freq='b')
     expected = expected.repeat([1, 1, 1, 2, 2])
     tm.assert_index_equal(result, expected)
     assert result.tz == expected.tz

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -54,12 +54,14 @@ def test_fancy_setitem():
 
 def test_dti_snap():
     dti = DatetimeIndex(['1/1/2002', '1/2/2002', '1/3/2002', '1/4/2002',
-                         '1/5/2002', '1/6/2002', '1/7/2002'], freq='D')
+                         '1/5/2002', '1/6/2002', '1/7/2002'],
+                        name='my_dti', freq='D')
 
     res = dti.snap(freq='W-MON')
-    exp = date_range('12/31/2001', '1/7/2002', freq='w-mon')
+    exp = date_range('12/31/2001', '1/7/2002', name='my_dti', freq='w-mon')
     exp = exp.repeat([3, 4])
     assert (res == exp).all()
+    assert res.name == exp.name
 
     res = dti.snap(freq='B')
 

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -55,19 +55,22 @@ def test_fancy_setitem():
 def test_dti_snap():
     dti = DatetimeIndex(['1/1/2002', '1/2/2002', '1/3/2002', '1/4/2002',
                          '1/5/2002', '1/6/2002', '1/7/2002'],
-                        name='my_dti', freq='D')
+                        name='my_dti', tz='Asia/Shanghai', freq='D')
 
-    res = dti.snap(freq='W-MON')
-    exp = date_range('12/31/2001', '1/7/2002', name='my_dti', freq='w-mon')
-    exp = exp.repeat([3, 4])
-    assert (res == exp).all()
-    assert res.name == exp.name
+    result = dti.snap(freq='W-MON')
+    expected = date_range('12/31/2001', '1/7/2002', name='my_dti',
+                          tz='Asia/Shanghai', freq='w-mon')
+    expected = expected.repeat([3, 4])
+    tm.assert_index_equal(result, expected)
+    assert result.tz == expected.tz
 
-    res = dti.snap(freq='B')
+    result = dti.snap(freq='B')
 
-    exp = date_range('1/1/2002', '1/7/2002', freq='b')
-    exp = exp.repeat([1, 1, 1, 2, 2])
-    assert (res == exp).all()
+    expected = date_range('1/1/2002', '1/7/2002', name='my_dti',
+                          tz='Asia/Shanghai', freq='b')
+    expected = expected.repeat([1, 1, 1, 2, 2])
+    tm.assert_index_equal(result, expected)
+    assert result.tz == expected.tz
 
 
 def test_dti_reset_index_round_trip():


### PR DESCRIPTION
Use self.name to construct the result of `DatetimeIndex.snap`, fix #25575.

- [x] closes #25575
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
