### PR TITLE
BUG: secondary y axis could not be set to log scale (#25545)

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -90,7 +90,7 @@ Bug Fixes
 
 **Visualization**
 
--
+- Bug in :meth:`Series.plot` where a secondary y axis could not be set to log scale (:issue:`25545`)
 -
 -
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -287,6 +287,9 @@ class MPLPlot(object):
 
             if not self._has_plotted_object(orig_ax):  # no data on left y
                 orig_ax.get_yaxis().set_visible(False)
+
+            if self.logy or self.loglog:
+                new_ax.set_yscale('log')
             return new_ax
 
     def _setup_subplots(self):

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -571,6 +571,18 @@ class TestSeriesPlots(TestPlotBase):
         tm.close()
 
     @pytest.mark.slow
+    def test_secondary_logy(self):
+        # GH 25545
+        s1 = Series(np.random.randn(30))
+        s2 = Series(np.random.randn(30))
+
+        ax1 = s1.plot(logy=True)
+        ax2 = s2.plot(secondary_y=True, logy=True)
+
+        assert ax1.get_yscale() == 'log'
+        assert ax2.get_yscale() == 'log'
+
+    @pytest.mark.slow
     def test_plot_fails_with_dupe_color_and_style(self):
         x = Series(randn(2))
         with pytest.raises(ValueError):


### PR DESCRIPTION
- [x] closes #25545
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
