### PR TITLE
Allows loc to create multiple new index

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -187,7 +187,7 @@ Interval
 Indexing
 ^^^^^^^^
 
--
+- loc creates required  missing columns and index if a list is passed except if a MultiIndex is used.
 -
 -
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -187,7 +187,7 @@ Interval
 Indexing
 ^^^^^^^^
 
-- loc creates required  missing columns and index if a list is passed except if a MultiIndex is used.
+- :meth:`loc` creates required  missing columns and index if a list is passed except if the axis is a :meth:`MultiIndex`, as this would lead to ambiguities.
 -
 -
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -481,14 +481,15 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                                 if k not in labels:
                                     self.obj[k] = _infer_fill_value(v)
                             new_indexer = tuple(
-                                    convert_missing_indexer(_idx)[0]
-                                    if isinstance(_idx, dict) else _idx
-                                    for _idx in indexer)
-                            new_indexer = self._get_setitem_indexer(new_indexer)
+                                convert_missing_indexer(_idx)[0]
+                                if isinstance(_idx, dict) else _idx
+                                for _idx in indexer)
+                            new_indexer = self._get_setitem_indexer(
+                                new_indexer)
                         else:
                             self.obj[key] = _infer_fill_value(value)
                             new_indexer = convert_from_missing_indexer_tuple(
-                                    indexer, self.obj.axes)
+                                indexer, self.obj.axes)
                         self._setitem_with_indexer(new_indexer, value)
 
                         return self.obj
@@ -510,7 +511,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     self.obj._is_copy = None
                     if idx_as_list:
                         nindexer.append(self._get_listlike_indexer(
-                                key, axis=i, raise_missing=True)[1])
+                            key, axis=i, raise_missing=True)[1])
                     else:
                         nindexer.append(labels.get_loc(key))
 
@@ -537,7 +538,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     self.obj._maybe_update_cacher(clear=True)
                     self.obj._is_copy = None
                     indexer = self._get_listlike_indexer(
-                                indexer, axis=0, raise_missing=True)[1]
+                        indexer, axis=0, raise_missing=True)[1]
 
                 # reindex the axis to the new value
                 # and set inplace

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -457,6 +457,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     # essentially this separates out the block that is needed
                     # to possibly be modified
                     if self.ndim > 1 and i == self.obj._info_axis_number:
+
                         # add the new item, and set the value
                         # must have all defined axes if we have a scalar
                         # or a list-like on the non-info axes if we have a
@@ -508,6 +509,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     self.obj._data = self.obj.reindex(labels, axis=i)._data
                     self.obj._maybe_update_cacher(clear=True)
                     self.obj._is_copy = None
+
                     if idx_as_list:
                         nindexer.append(self._get_listlike_indexer(
                             key, axis=i, raise_missing=True)[1])

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1411,13 +1411,13 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 inds, = obj.nonzero()
                 return inds
             else:
-                # When setting, missing keys are not allowed, even with .loc:
+                # When setting, missing keys are not allowed, except with .loc:
                 kwargs = {'raise_missing': True if is_setter else
                           raise_missing}
                 try:
                     return self._get_listlike_indexer(obj, axis, **kwargs)[1]
                 except KeyError:
-                    if is_setter:
+                    if is_setter and self.name == 'loc':
                         return {'key': obj}
                     raise
         else:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -500,10 +500,10 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                         # If use multilabel, can't create more than one axis
                         if can_use_idx_as_list(key, i):
 
-                            for k, v in get_key_value_list(
-                                    key, value, [0], 0):
+                            for k in key:
                                 if k not in labels:
-                                    self.obj[k] = _infer_fill_value(v)
+                                    # The dtype will be set later
+                                    self.obj[k] = np.nan
 
                             new_indexer = tuple(
                                 convert_missing_indexer(_idx)[0]

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -328,106 +328,6 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     take_split_path = True
                     break
 
-        def can_do_equal_len(labels, value, plane_indexer, lplane_indexer):
-            """ return True if we have an equal len settable """
-            if (not len(labels) == 1 or not np.iterable(value) or
-                    is_scalar(plane_indexer[0])):
-                return False
-
-            item = labels[0]
-            index = self.obj[item].index
-
-            values_len = len(value)
-            # equal len list/ndarray
-            if len(index) == values_len:
-                return True
-            elif lplane_indexer == values_len:
-                return True
-
-            return False
-
-        def get_key_value_list(labels, value, plane_indexer, lplane_indexer):
-            """Splits the value and labels in corresponding groups"""
-            # we need an iterable, with a ndim of at least 1
-            # eg. don't pass through np.array(0)
-            if not(is_list_like_indexer(value) and
-                   getattr(value, 'ndim', 1) > 0):
-                return [(item, value) for item in labels]
-
-            # we have an equal len Frame
-            if isinstance(value, ABCDataFrame) and value.ndim > 1:
-                sub_indexer = list(indexer)
-                multiindex_indexer = isinstance(labels, MultiIndex)
-
-                ret = []
-                for item in labels:
-                    if item in value:
-                        sub_indexer[info_axis] = item
-                        v = self._align_series(
-                            tuple(sub_indexer), value[item],
-                            multiindex_indexer)
-                    else:
-                        v = np.nan
-                    ret.append((item, v))
-                return ret
-
-            # we have an equal len ndarray/convertible to our labels
-            # hasattr first, to avoid coercing to ndarray without reason.
-            # But we may be relying on the ndarray coercion to check ndim.
-            # Why not just convert to an ndarray earlier on if needed?
-            elif ((hasattr(value, 'ndim') and value.ndim == 2)
-                  or (not hasattr(value, 'ndim') and
-                      np.array(value).ndim) == 2):
-
-                # note that this coerces the dtype if we are mixed
-                # GH 7551
-                value = np.array(value, dtype=object)
-                if len(labels) != value.shape[1]:
-                    raise ValueError('Must have equal len keys and value '
-                                     'when setting with an ndarray')
-
-                # setting with a list, recoerces
-                return [(item, value[:, i].tolist())
-                        for i, item in enumerate(labels)]
-
-            # we have an equal len list/ndarray
-            elif can_do_equal_len(labels, value,
-                                  plane_indexer, lplane_indexer):
-                return [(labels[0], value)]
-
-            # per label values
-            else:
-
-                if len(labels) != len(value):
-                    raise ValueError('Must have equal len keys and value '
-                                     'when setting with an iterable')
-                return [(item, v) for item, v in zip(labels, value)]
-
-        def get_plane_indexer(indexer, value, labels):
-            """Get Plane indexer and corresponding length"""
-            # if we have a partial multiindex, then need to adjust the plane
-            # indexer here
-            if (len(labels) == 1 and
-                    isinstance(self.obj[labels[0]].axes[0], MultiIndex)):
-                item = labels[0]
-                obj = self.obj[item]
-                index = obj.index
-                idx = indexer[:info_axis][0]
-
-                plane_indexer = tuple([idx]) + indexer[info_axis + 1:]
-                lplane_indexer = length_of_indexer(plane_indexer[0], index)
-
-            # non-mi
-            else:
-                plane_indexer = indexer[:info_axis] + indexer[info_axis + 1:]
-                if info_axis > 0:
-                    plane_axis = self.obj.axes[:info_axis][0]
-                    lplane_indexer = length_of_indexer(plane_indexer[0],
-                                                       plane_axis)
-                else:
-                    lplane_indexer = 0
-            return plane_indexer, lplane_indexer
-
         if isinstance(indexer, tuple):
             nindexer = []
             for i, idx in enumerate(indexer):
@@ -557,9 +457,6 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 elif self.ndim >= 3:
                     return self.obj.__setitem__(indexer, value)
 
-        # set
-        item_labels = self.obj._get_axis(info_axis)
-
         # align and set the values
         if take_split_path:
 
@@ -569,16 +466,11 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             if isinstance(value, ABCSeries):
                 value = self._align_series(indexer, value)
 
-            info_idx = indexer[info_axis]
-            if is_integer(info_idx):
-                info_idx = [info_idx]
-            labels = item_labels[info_idx]
-
-            plane_indexer, lplane_indexer = get_plane_indexer(
-                indexer, value, labels)
+            plane_indexer, lplane_indexer = self._get_plane_indexer(indexer)
 
             # require that we are setting the right number of values that
             # we are indexing
+            labels = self._get_labels(indexer)
             if (len(labels) == 1 and
                     isinstance(self.obj[labels[0]].axes[0], MultiIndex) and
                     (is_list_like_indexer(value) and np.iterable(value) and
@@ -630,8 +522,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 # reset the sliced object if unique
                 self.obj[item] = s
 
-            for (item, v) in get_key_value_list(labels, value,
-                                                plane_indexer, lplane_indexer):
+            for (item, v) in self._get_key_value_list(indexer, value):
                 setter(item, v)
 
         else:
@@ -641,6 +532,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 # if we are setting on the info axis ONLY
                 # set using those methods to avoid block-splitting
                 # logic here
+                item_labels = self.obj._get_axis(info_axis)
                 if (len(indexer) > info_axis and
                         is_integer(indexer[info_axis]) and
                         all(com.is_null_slice(idx)
@@ -670,6 +562,127 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             self.obj._data = self.obj._data.setitem(indexer=indexer,
                                                     value=value)
             self.obj._maybe_update_cacher(clear=True)
+
+    def _can_do_equal_len(self, indexer, value):
+        """return True if we have an equal len settable"""
+        labels = self._get_labels(indexer)
+        plane_indexer, lplane_indexer = self._get_plane_indexer(indexer)
+        if (not len(labels) == 1 or not np.iterable(value) or
+                is_scalar(plane_indexer[0])):
+            return False
+
+        item = labels[0]
+        index = self.obj[item].index
+
+        values_len = len(value)
+        # equal len list/ndarray
+        if len(index) == values_len:
+            return True
+
+        if lplane_indexer == values_len:
+            return True
+
+        return False
+
+    def _get_key_value_list(self, indexer, value):
+        """Splits the value into a key value list to match the indexer"""
+        # we need an iterable, with a ndim of at least 1
+        # eg. don't pass through np.array(0)
+        info_axis = self.obj._info_axis_number
+        labels = self._get_labels(indexer)
+
+        if not(is_list_like_indexer(value) and
+               getattr(value, 'ndim', 1) > 0):
+            return [(item, value) for item in labels]
+
+        # we have an equal len Frame
+        if isinstance(value, ABCDataFrame) and value.ndim > 1:
+            sub_indexer = list(indexer)
+            multiindex_indexer = isinstance(labels, MultiIndex)
+
+            ret = []
+            for item in labels:
+                if item in value:
+                    sub_indexer[info_axis] = item
+                    value = self._align_series(
+                        tuple(sub_indexer), value[item],
+                        multiindex_indexer)
+                else:
+                    value = np.nan
+                ret.append((item, value))
+            return ret
+
+        # we have an equal len ndarray/convertible to our labels
+        # hasattr first, to avoid coercing to ndarray without reason.
+        # But we may be relying on the ndarray coercion to check ndim.
+        # Why not just convert to an ndarray earlier on if needed?
+        elif ((hasattr(value, 'ndim') and value.ndim == 2)
+              or (not hasattr(value, 'ndim') and
+                  np.array(value).ndim) == 2):
+
+            # note that this coerces the dtype if we are mixed
+            # GH 7551
+            value = np.array(value, dtype=object)
+            if len(labels) != value.shape[1]:
+                raise ValueError('Must have equal len keys and value '
+                                 'when setting with an ndarray')
+
+            # setting with a list, recoerces
+            return [(item, value[:, i].tolist())
+                    for i, item in enumerate(labels)]
+
+        # we have an equal len list/ndarray
+        elif self._can_do_equal_len(indexer, value):
+            return [(labels[0], value)]
+
+        # per label values
+        else:
+
+            if len(labels) != len(value):
+                raise ValueError('Must have equal len keys and value '
+                                 'when setting with an iterable')
+            return [(item, v) for item, v in zip(labels, value)]
+
+    def _get_labels(self, indexer):
+        """
+        Get Labels from an indexer
+        """
+        info_axis = self.obj._info_axis_number
+        item_labels = self.obj._get_axis(info_axis)
+        info_idx = indexer[info_axis]
+        if is_integer(info_idx):
+            info_idx = [info_idx]
+        return item_labels[info_idx]
+
+    def _get_plane_indexer(self, indexer):
+        """
+        Get Plane indexer and corresponding length from indexer
+        """
+        # if we have a partial multiindex, then need to adjust the plane
+        # indexer here
+        info_axis = self.obj._info_axis_number
+        labels = self._get_labels(indexer)
+    
+        if (len(labels) == 1 and
+                isinstance(self.obj[labels[0]].axes[0], MultiIndex)):
+            item = labels[0]
+            obje = self.obj[item]
+            index = obje.index
+            idx = indexer[:info_axis][0]
+    
+            plane_indexer = tuple([idx]) + indexer[info_axis + 1:]
+            lplane_indexer = length_of_indexer(plane_indexer[0], index)
+    
+        # non-mi
+        else:
+            plane_indexer = indexer[:info_axis] + indexer[info_axis + 1:]
+            if info_axis > 0:
+                plane_axis = self.obj.axes[:info_axis][0]
+                lplane_indexer = length_of_indexer(plane_indexer[0],
+                                                   plane_axis)
+            else:
+                lplane_indexer = 0
+        return plane_indexer, lplane_indexer
 
     def _align_series(self, indexer, ser, multiindex_indexer=False):
         """

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -662,17 +662,17 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         # indexer here
         info_axis = self.obj._info_axis_number
         labels = self._get_labels(indexer)
-    
+
         if (len(labels) == 1 and
                 isinstance(self.obj[labels[0]].axes[0], MultiIndex)):
             item = labels[0]
             obje = self.obj[item]
             index = obje.index
             idx = indexer[:info_axis][0]
-    
+
             plane_indexer = tuple([idx]) + indexer[info_axis + 1:]
             lplane_indexer = length_of_indexer(plane_indexer[0], index)
-    
+
         # non-mi
         else:
             plane_indexer = indexer[:info_axis] + indexer[info_axis + 1:]

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -449,8 +449,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     # and set inplace
                     key, _ = convert_missing_indexer(idx)
 
-                    idx_as_list = (is_list_like_indexer(key) and not
-                                   isinstance(self.obj.axes[i], MultiIndex))
+                    idx_as_list = can_use_idx_as_list(key, i)
 
                     # if this is the items axes, then take the main missing
                     # path first
@@ -524,8 +523,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             indexer, missing = convert_missing_indexer(indexer)
 
             if missing:
-                if (is_list_like_indexer(indexer) and
-                        not isinstance(self.obj.axes[0], MultiIndex)):
+                if can_use_idx_as_list(indexer, 0):
                     # reindex the axis
                     # make sure to clear the cache because we are
                     # just replacing the block manager here

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -504,17 +504,15 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                                 if k not in labels:
                                     # The dtype will be set later
                                     self.obj[k] = np.nan
-
-                            new_indexer = tuple(
-                                convert_missing_indexer(_idx)[0]
-                                if isinstance(_idx, dict) else _idx
-                                for _idx in indexer)
-                            new_indexer = self._get_setitem_indexer(
-                                new_indexer)
                         else:
                             self.obj[key] = _infer_fill_value(value)
-                            new_indexer = convert_from_missing_indexer_tuple(
-                                indexer, self.obj.axes)
+
+                        new_indexer = tuple(
+                            convert_missing_indexer(_idx)[0]
+                            if isinstance(_idx, dict) else _idx
+                            for _idx in indexer)
+                        new_indexer = self._get_setitem_indexer(
+                            new_indexer)
                         self._setitem_with_indexer(new_indexer, value)
 
                         return self.obj

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1092,8 +1092,7 @@ class TestDataFrameIndexing(TestData):
             simplefilter("ignore", DeprecationWarning)
 
             # labels that aren't contained
-            with pytest.raises(KeyError,
-                               match=r"\[1\] not in index"):
+            with pytest.raises(KeyError,  match=r"\[1\] not in index"):
                 df.ix[[0, 1, 2], [2, 3, 4]] = 5
 
             # try to set indices not contained in frame

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1092,7 +1092,7 @@ class TestDataFrameIndexing(TestData):
             simplefilter("ignore", DeprecationWarning)
 
             # labels that aren't contained
-            with pytest.raises(KeyError,  match=r"\[1\] not in index"):
+            with pytest.raises(KeyError, match=r"\[1\] not in index"):
                 df.ix[[0, 1, 2], [2, 3, 4]] = 5
 
             # try to set indices not contained in frame

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1093,14 +1093,16 @@ class TestDataFrameIndexing(TestData):
 
             # labels that aren't contained
             with pytest.raises(KeyError,
-                               match=r"\[0, 1, 2\] not all in index"):
+                               match=r"\[1\] not in index"):
                 df.ix[[0, 1, 2], [2, 3, 4]] = 5
 
             # try to set indices not contained in frame
-            msg = (r"\['foo', 'bar', 'baz'\] not all in index")
+            msg = (r"None of \[Index\(\['foo', 'bar', 'baz'\],"
+                   r" dtype='object'\)\] are in the \[index\]")
             with pytest.raises(KeyError, match=msg):
                 self.frame.ix[['foo', 'bar', 'baz']] = 1
-            msg = (r"\['E'\] not all in index")
+            msg = (r"None of \[Index\(\['E'\], dtype='object'\)\] are in the"
+                   r" \[columns\]")
             with pytest.raises(KeyError, match=msg):
                 self.frame.ix[:, ['E']] = 1
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1092,7 +1092,8 @@ class TestDataFrameIndexing(TestData):
             simplefilter("ignore", DeprecationWarning)
 
             # labels that aren't contained
-            with pytest.raises(KeyError, match=r"\[0, 1, 2\] not all in index"):
+            with pytest.raises(KeyError,
+                               match=r"\[0, 1, 2\] not all in index"):
                 df.ix[[0, 1, 2], [2, 3, 4]] = 5
 
             # try to set indices not contained in frame

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1092,16 +1092,14 @@ class TestDataFrameIndexing(TestData):
             simplefilter("ignore", DeprecationWarning)
 
             # labels that aren't contained
-            with pytest.raises(KeyError, match=r"\[1\] not in index"):
+            with pytest.raises(KeyError, match=r"\[0, 1, 2\] not all in index"):
                 df.ix[[0, 1, 2], [2, 3, 4]] = 5
 
             # try to set indices not contained in frame
-            msg = (r"None of \[Index\(\['foo', 'bar', 'baz'\],"
-                   r" dtype='object'\)\] are in the \[index\]")
+            msg = (r"\['foo', 'bar', 'baz'\] not all in index")
             with pytest.raises(KeyError, match=msg):
                 self.frame.ix[['foo', 'bar', 'baz']] = 1
-            msg = (r"None of \[Index\(\['E'\], dtype='object'\)\] are in the"
-                   r" \[columns\]")
+            msg = (r"\['E'\] not all in index")
             with pytest.raises(KeyError, match=msg):
                 self.frame.ix[:, ['E']] = 1
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -256,8 +256,8 @@ class TestLoc(Base):
 
         del s['a']
 
-        with pytest.raises(KeyError, match=msg):
-            s.loc[[-2]] = 0
+        s.loc[[-2]] = 0
+        tm.assert_series_equal(Series([1., 3, 0], index=[1, -1, -2]), s)
 
         # inconsistency between .loc[values] and .loc[values,:]
         # GH 7999
@@ -741,16 +741,17 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         df.loc[0, 'x'] = expected.loc[0, 'x']
         tm.assert_frame_equal(df, expected)
 
+        data = [1, 2]
+        df = DataFrame(columns=['x', 'y'],
+                       dtype=np.float)
+        df.loc[[0, 1], 'x'] = data
+        expected = DataFrame({'x': [1., 2.], 'y': [np.nan, np.nan]})
+        tm.assert_frame_equal(df, expected)
+
     def test_loc_setitem_empty_append_raises(self):
         # GH6173, various appends to an empty dataframe
-
         data = [1, 2]
         df = DataFrame(columns=['x', 'y'])
-        msg = (r"None of \[Int64Index\(\[0, 1\], dtype='int64'\)\] "
-               r"are in the \[index\]")
-        with pytest.raises(KeyError, match=msg):
-            df.loc[[0, 1], 'x'] = data
-
         msg = "cannot copy sequence with size 2 to array axis with dimension 0"
         with pytest.raises(ValueError, match=msg):
             df.loc[0:2, 'x'] = data

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -761,6 +761,12 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         df.loc[[5, 6], ['a', 'b']] = expected
         tm.assert_frame_equal(df, expected)
 
+        df = pd.DataFrame()
+        df.loc[('a', 'b'), 'c'] = 1
+
+        expected = pd.DataFrame([1., 1.], columns=['c'], index=['a', 'b'])
+        tm.assert_frame_equal(df, expected)
+
     def test_loc_setitem_empty_append_raises(self):
         # GH6173, various appends to an empty dataframe
 

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -750,6 +750,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
     def test_loc_setitem_empty_append_raises(self):
         # GH6173, various appends to an empty dataframe
+
         data = [1, 2]
         df = DataFrame(columns=['x', 'y'])
         msg = "cannot copy sequence with size 2 to array axis with dimension 0"

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -748,6 +748,19 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         expected = DataFrame({'x': [1., 2.], 'y': [np.nan, np.nan]})
         tm.assert_frame_equal(df, expected)
 
+        df = pd.DataFrame()
+        s = pd.Series({'float': 1.2, 'str': 'a'})
+        df.loc[1, ['str', 'float']] = s
+
+        expected = pd.DataFrame({'str': 'a', 'float': 1.2},
+                                index=[1])
+        tm.assert_frame_equal(df, expected)
+
+        df = pd.DataFrame()
+        expected = pd.DataFrame({'a': [1, 2], 'b': [3, 4]}, index=[5, 6])
+        df.loc[[5, 6], ['a', 'b']] = expected
+        tm.assert_frame_equal(df, expected)
+
     def test_loc_setitem_empty_append_raises(self):
         # GH6173, various appends to an empty dataframe
 

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -102,9 +102,9 @@ def test_loc_setitem_boolean(test_data):
 def test_loc_setitem_corner(test_data):
     inds = list(test_data.series.index[[5, 8, 12]])
     test_data.series.loc[inds] = 5
-    msg = r"\['foo'\] not in index"
-    with pytest.raises(KeyError, match=msg):
-        test_data.series.loc[inds + ['foo']] = 5
+    test_data.series.loc[inds + ['foo']] = 5
+    assert test_data.series.loc['foo'] == 5
+    assert test_data.series.loc[inds[0]] == 5
 
 
 def test_basic_setitem_with_labels(test_data):


### PR DESCRIPTION
- [x] closes #25594
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Starting in 0.21.0, using .loc or [] with a list with one or more missing labels, is deprecated. In the doc, only getting is shown:
https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-with-list-with-missing-labels-is-deprecated

As argued in #25594, this should not be the case for setting. This PR is therefore adding the possibility of adding index and columns when setting with array-like index.

If the axis is a MultiIndex, the expected result is not trivial, and is therefore not covered in this PR.