### PR TITLE
Suppress incorrect warning in nargsort for timezone-aware DatetimeIndex

### DIFF
--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -1,4 +1,5 @@
 """ miscellaneous sorting / groupby utilities """
+import warnings
 
 import numpy as np
 
@@ -254,7 +255,13 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
             sorted_idx = np.roll(sorted_idx, cnt_null)
         return sorted_idx
 
-    items = np.asanyarray(items)
+    with warnings.catch_warnings():
+        # https://github.com/pandas-dev/pandas/issues/25439
+        # can be removed once ExtensionArrays are properly handled by nargsort
+        warnings.filterwarnings(
+            "ignore", category=FutureWarning,
+            message="Converting timezone-aware DatetimeArray to")
+        items = np.asanyarray(items)
     idx = np.arange(len(items))
     mask = isna(items)
     non_nans = items[~mask]

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -9,7 +9,8 @@ import pytest
 
 from pandas.compat import PY2
 
-from pandas import DataFrame, MultiIndex, Series, compat, concat, merge
+from pandas import (
+    DataFrame, MultiIndex, Series, compat, concat, merge, to_datetime)
 from pandas.core import common as com
 from pandas.core.sorting import (
     decons_group_index, get_group_index, is_int64_overflow_possible,
@@ -182,6 +183,13 @@ class TestSorting(object):
                           na_position='first')
         exp = list(range(5)) + list(range(105, 110)) + list(range(104, 4, -1))
         tm.assert_numpy_array_equal(result, np.array(exp), check_dtype=False)
+
+    def test_nargsort_datetimearray_warning(self):
+        # https://github.com/pandas-dev/pandas/issues/25439
+        # can be removed once the FutureWarning for np.array(DTA) is removed
+        data = to_datetime([0, 2, 0, 1]).tz_localize('Europe/Brussels')
+        with tm.assert_produces_warning(None):
+            nargsort(data)
 
 
 class TestMerge(object):


### PR DESCRIPTION
Closes #25439, alternative to https://github.com/pandas-dev/pandas/pull/25595 for 0.24.2