### PR TITLE
DOC: hardcode contributors for 0.24.x releases

### DIFF
--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -85,12 +85,12 @@ Contributors
 .. Including the contributors hardcoded for this release, as backporting with
    MeeseeksDev loses the commit authors
 
-A total of 7 people contributed patches to this release. People with a "+" by their names contributed a patch for the first time. 
+A total of 7 people contributed patches to this release. People with a "+" by their names contributed a patch for the first time.
 
 * Alex Buchkovsky
 * Roman Yurchak
 * h-vetinari
 * jbrockmendel
-* Jeremy Schendel 
+* Jeremy Schendel
 * Joris Van den Bossche
 * Tom Augspurger

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -82,4 +82,15 @@ Bug Fixes
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v0.24.0..v0.24.1
+.. Including the contributors hardcoded for this release, as backporting with
+   MeeseeksDev loses the commit authors
+
+A total of 7 people contributed patches to this release. People with a “+” by their names contributed a patch for the first time. 
+
+* Alex Buchkovsky
+* Roman Yurchak
+* h-vetinari
+* jbrockmendel
+* Jeremy Schendel 
+* Joris Van den Bossche
+* Tom Augspurger

--- a/doc/source/whatsnew/v0.24.1.rst
+++ b/doc/source/whatsnew/v0.24.1.rst
@@ -85,7 +85,7 @@ Contributors
 .. Including the contributors hardcoded for this release, as backporting with
    MeeseeksDev loses the commit authors
 
-A total of 7 people contributed patches to this release. People with a “+” by their names contributed a patch for the first time. 
+A total of 7 people contributed patches to this release. People with a "+" by their names contributed a patch for the first time. 
 
 * Alex Buchkovsky
 * Roman Yurchak

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -111,7 +111,7 @@ Contributors
 .. Including the contributors hardcoded for this release, as backporting with
    MeeseeksDev loses the commit authors
 
-A total of 24 people contributed patches to this release. People with a "+" by their names contributed a patch for the first time.
+A total of 25 people contributed patches to this release. People with a "+" by their names contributed a patch for the first time.
 
 * Albert Villanova del Moral
 * Arno Veenstra +
@@ -132,6 +132,7 @@ A total of 24 people contributed patches to this release. People with a "+" by t
 * Max Bolingbroke +
 * rbenes +
 * Sterling Paramore +
+* Tao He +
 * Thomas A Caswell
 * Tom Augspurger
 * Vibhu Agarwal +

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -108,4 +108,32 @@ Bug Fixes
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v0.24.1..v0.24.2
+.. Including the contributors hardcoded for this release, as backporting with
+   MeeseeksDev loses the commit authors
+
+A total of 24 people contributed patches to this release. People with a "+" by their names contributed a patch for the first time.
+
+* Albert Villanova del Moral
+* Arno Veenstra +
+* chris-b1
+* Devin Petersohn +
+* EternalLearner42 +
+* Flavien Lambert +
+* gfyoung
+* Gioia Ballin
+* jbrockmendel
+* Jeff Reback
+* Jeremy Schendel
+* Johan von Forstner +
+* Joris Van den Bossche
+* Josh
+* Justin Zheng
+* Matthew Roeschke
+* Max Bolingbroke +
+* rbenes +
+* Sterling Paramore +
+* Thomas A Caswell
+* Tom Augspurger
+* Vibhu Agarwal +
+* William Ayd
+* Zach Angell


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/24949#issuecomment-460170519

The actual contributors are not picked up by our `.. contributors::` sphinx extension, as the commit authors area lost in the backporting process using MeeseeksDev.

