### PR TITLE
PERF: speed up MPLPlot._apply_axis_properties by skipping expensive tick enumeration where feasible

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -468,12 +468,20 @@ class MPLPlot(object):
                 self.axes[0].set_title(self.title)
 
     def _apply_axis_properties(self, axis, rot=None, fontsize=None):
-        labels = axis.get_majorticklabels() + axis.get_minorticklabels()
-        for label in labels:
-            if rot is not None:
-                label.set_rotation(rot)
-            if fontsize is not None:
-                label.set_fontsize(fontsize)
+        """ Tick creation within matplotlib is reasonably expensive and is
+            internally deferred until accessed as Ticks are created/destroyed
+            multiple times per draw. It's therefore beneficial for us to avoid
+            accessing unless we will act on the Tick.
+        """
+
+        if rot is not None or fontsize is not None:
+            # rot=0 is a valid setting, hence the explicit None check
+            labels = axis.get_majorticklabels() + axis.get_minorticklabels()
+            for label in labels:
+                if rot is not None:
+                    label.set_rotation(rot)
+                if fontsize is not None:
+                    label.set_fontsize(fontsize)
 
     @property
     def legend_title(self):


### PR DESCRIPTION
This issue likely originates in `matplotlib`, as it seems enumeration of `axis.majorTicks` frequently requires re-creating all of the ticks. We sidestep that here by only enumerating the labels if we will mutate them; in particular, this is beneficial to `MPLPlot._post_plot_logic_common()`.

```
asv compare upstream/master HEAD -s --sort ratio

Benchmarks that have improved:

       before           after         ratio
     [63755498]       [eb051291]
     <plot_perf~1>       <plot_perf>
-      67.0±0.8ms       57.4±0.4ms     0.86  plotting.FramePlotting.time_frame_plot('hexbin')
-        61.1±2ms       50.3±0.7ms     0.82  plotting.FramePlotting.time_frame_plot('scatter')
-      48.3±0.2ms       39.6±0.2ms     0.82  plotting.TimeseriesPlotting.time_plot_regular_compat
-        52.3±2ms       42.2±0.4ms     0.81  plotting.TimeseriesPlotting.time_plot_irregular

Benchmarks that have stayed the same:

       before           after         ratio
     [63755498]       [eb051291]
     <plot_perf~1>       <plot_perf>
          171±4ms          175±5ms     1.02  plotting.SeriesPlotting.time_series_plot('hist')
       92.9±0.2ms       94.1±0.2ms     1.01  plotting.SeriesPlotting.time_series_plot('pie')
        143±0.2ms        144±0.2ms     1.01  plotting.FramePlotting.time_frame_plot('pie')
          851±6ms          844±6ms     0.99  plotting.FramePlotting.time_frame_plot('kde')
       1.97±0.02s       1.94±0.01s     0.99  plotting.TimeseriesPlotting.time_plot_table
        1.20±0.1s        1.18±0.1s     0.99  plotting.Misc.time_plot_andrews_curves
         80.1±5ms         78.7±6ms     0.98  plotting.SeriesPlotting.time_series_plot('line')
         736±10ms         723±10ms     0.98  plotting.SeriesPlotting.time_series_plot('kde')
        193±0.2ms          190±1ms     0.98  plotting.FramePlotting.time_frame_plot('barh')
       87.6±0.3ms       85.7±0.3ms     0.98  plotting.SeriesPlotting.time_series_plot('bar')
          208±5ms          203±3ms     0.98  plotting.FramePlotting.time_frame_plot('area')
       87.5±0.4ms       85.5±0.6ms     0.98  plotting.SeriesPlotting.time_series_plot('barh')
          199±5ms          192±2ms     0.96  plotting.SeriesPlotting.time_series_plot('area')
        196±0.8ms        189±0.4ms     0.96  plotting.FramePlotting.time_frame_plot('bar')
       91.3±0.4ms        86.9±10ms     0.95  plotting.FramePlotting.time_frame_plot('line')
          201±2ms          191±3ms     0.95  plotting.FramePlotting.time_frame_plot('hist')
       83.5±0.2ms         76.7±1ms     0.92  plotting.TimeseriesPlotting.time_plot_regular

```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
