### PR TITLE
Backport PR #25584 on branch 0.24.x (BUG: Redefine IndexOpsMixin.size, fix #25580)

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -102,7 +102,8 @@ Bug Fixes
 - Bug in :meth:`Series.is_unique` where single occurrences of ``NaN`` were not considered unique (:issue:`25180`)
 - Bug in :func:`merge` when merging an empty ``DataFrame`` with an ``Int64`` column or a non-empty ``DataFrame`` with an ``Int64`` column that is all ``NaN`` (:issue:`25183`)
 - Bug in ``IntervalTree`` where a ``RecursionError`` occurs upon construction due to an overflow when adding endpoints, which also causes :class:`IntervalIndex` to crash during indexing operations (:issue:`25485`)
--
+- Bug in :attr:`Series.size` raising for some extension-array-backed ``Series``, rather than returning the size (:issue:`25580`)
+- Bug in resampling raising for nullable integer-dtype columns (:issue:`25580`)
 
 .. _whatsnew_0242.contributors:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -761,7 +761,7 @@ class IndexOpsMixin(object):
         """
         Return the number of elements in the underlying data.
         """
-        return self._values.size
+        return len(self._values)
 
     @property
     def flags(self):

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -102,6 +102,18 @@ def test_resample_basic(series, closed, expected):
     assert_series_equal(result, expected)
 
 
+def test_resample_integerarray():
+    # GH 25580, resample on IntegerArray
+    ts = pd.Series(range(9),
+                   index=pd.date_range('1/1/2000', periods=9, freq='T'),
+                   dtype='Int64')
+    result = ts.resample('3T').sum()
+    expected = Series([3, 12, 21],
+                      index=pd.date_range('1/1/2000', periods=3, freq='3T'),
+                      dtype="Int64")
+    assert_series_equal(result, expected)
+
+
 def test_resample_basic_grouper(series):
     s = series
     result = s.resample('5Min').last()

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -493,6 +493,13 @@ class TestSeriesMisc(TestData, SharedWithSparse):
             with provisionalcompleter('ignore'):
                 list(ip.Completer.completions('s.', 1))
 
+    def test_integer_series_size(self):
+        # GH 25580
+        s = Series(range(9))
+        assert s.size == 9
+        s = Series(range(9), dtype="Int64")
+        assert s.size == 9
+
 
 class TestCategoricalSeries(object):
 


### PR DESCRIPTION
Manual backport of https://github.com/pandas-dev/pandas/pull/25584