### PR TITLE
Add 0.24.1 and 0.24.2 to whatsnew index

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -16,6 +16,8 @@ Version 0.24
 .. toctree::
    :maxdepth: 2
 
+   v0.24.2
+   v0.24.1
    v0.24.0
 
 Version 0.23


### PR DESCRIPTION
For backport. Following up with an update including 0.25.0 (not for backport).

cc @jorisvandenbossche 