### PR TITLE
CLN: Remove unused test code

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -23,14 +23,12 @@ from pandas.core.computation.expr import PandasExprVisitor, PythonExprVisitor
 from pandas.core.computation.expressions import (
     _NUMEXPR_INSTALLED, _USE_NUMEXPR)
 from pandas.core.computation.ops import (
-    _arith_ops_syms, _binary_math_ops, _binary_ops_dict, _bool_ops_syms,
+    _arith_ops_syms, _binary_math_ops, _binary_ops_dict,
     _special_case_arith_ops_syms, _unary_math_ops)
 import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_frame_equal, assert_numpy_array_equal, assert_produces_warning,
     assert_series_equal, makeCustomDataframe as mkdf, randbool)
-
-_series_frame_incompatible = _bool_ops_syms
 
 
 @pytest.fixture(params=(

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -159,12 +159,12 @@ class TestEvalNumexprPandas(object):
         del self.pandas_rhses, self.pandas_lhses, self.current_engines
 
     @pytest.mark.slow
-    def test_complex_cmp_ops(self):
-        cmp_ops = ('!=', '==', '<=', '>=', '<', '>')
-        cmp2_ops = ('>', '<')
-        for lhs, cmp1, rhs, binop, cmp2 in product(self.lhses, cmp_ops,
-                                                   self.rhses, self.bin_ops,
-                                                   cmp2_ops):
+    @pytest.mark.parametrize('cmp1', ['!=', '==', '<=', '>=', '<', '>'],
+                             ids=['ne', 'eq', 'le', 'ge', 'lt', 'gt'])
+    @pytest.mark.parametrize('cmp2', ['>', '<'], ids=['gt', 'lt'])
+    def test_complex_cmp_ops(self, cmp1, cmp2):
+        for lhs, rhs, binop in product(
+                self.lhses, self.rhses, self.bin_ops):
             lhs_new = _eval_single_bin(lhs, cmp1, rhs, self.engine)
             rhs_new = _eval_single_bin(lhs, cmp2, rhs, self.engine)
             expected = _eval_single_bin(


### PR DESCRIPTION
cc @WillAyd same code as cleaned in #25647 

intention originally to just deal with the commented out instance of `pytest.raises` for #24332 but may have gone too far!
