### PR TITLE
Add obj=obj to get it in failing assert messages

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1263,7 +1263,7 @@ def assert_series_equal(left, right, check_dtype=True,
                 not check_categorical):
             pass
         else:
-            assert_attr_equal('dtype', left, right)
+            assert_attr_equal('dtype', left, right, obj=obj)
 
     if check_exact:
         assert_numpy_array_equal(left.get_values(), right.get_values(),


### PR DESCRIPTION
Adding obj=obj in this call to assert_attr_equal helps make failing test cases more easily debuggable. This follows the pattern elsewhere in this same file of other calls to assert_attr_equal and related methods.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
