### PR TITLE
Make Rolling.apply documentation clearer

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -953,7 +953,7 @@ class _Rolling_and_Expanding(_Rolling):
     ----------
     func : function
         Must produce a single value from an ndarray input if ``raw=True``
-        or a Series if ``raw=False``.
+        or a single value from a Series if ``raw=False``.
     raw : bool, default None
         * ``False`` : passes each row or column as a Series to the
           function.


### PR DESCRIPTION
Fix #25656 by making Rolling.apply documentation clearer (hope this is what @js3711 intended)
- [x] closes #25656 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
