### PR TITLE
#25707 - Fixed flakiness in stata write test

### DIFF
--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -251,7 +251,7 @@ bar2,12,13,14,15
         ('to_latex', {}, 'os'),
         ('to_msgpack', {}, 'os'),
         ('to_pickle', {}, 'os'),
-        ('to_stata', {}, 'os'),
+        ('to_stata', {'time_stamp': pd.to_datetime('2019-01-01 00:00')}, 'os'),
     ])
     def test_write_fspath_all(self, writer_name, writer_kwargs, module):
         p1 = tm.ensure_clean('string')


### PR DESCRIPTION
This is my first contribution, so please be gentle.
 
For future reference, this error occurs when the two files are written in different minutes. I couldn't break the comparison by feeding the test datetime objects that only changed the seconds, so I assume only the date, hours, and minutes, are encoded. 

Anyway, we can't pass `False` as a keyword argument for `time_stamp`. It defaults to `None`, which internally uses the current timestamp, but otherwise expects a datetime.

For testing purposes, it suffice to pass the same arbitrary timestamp as a keyword. That way it encodes the same timestamp into each file, regardless of when the test runs and how long it takes.

Instead of `False`, we could use a keyword argument like this: `{'time_stamp': pd.to_datetime('2019-01-01 00:00')}`
