### PR TITLE
API: concat on sparse values

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -64,6 +64,42 @@ is respected in indexing. (:issue:`24076`, :issue:`16785`)
     df = pd.DataFrame([0], index=pd.DatetimeIndex(['2019-01-01'], tz='US/Pacific'))
     df['2019-01-01 12:00:00+04:00':'2019-01-01 13:00:00+04:00']
 
+Concatenating Sparse Values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When passed DataFrames whose values are sparse, :func:`concat` will now return a
+Series or DataFrame with sparse values, rather than a ``SparseDataFrame`` (:issue:`25702`).
+
+.. ipython:: python
+
+   df = pd.DataFrame({"A": pd.SparseArray([0, 1])})
+
+*Previous Behavior:*
+
+.. code-block:: ipython
+
+   In [2]: type(pd.concat([df, df]))
+   pandas.core.sparse.frame.SparseDataFrame
+
+*New Behavior:*
+
+.. ipython:: python
+
+   type(pd.concat([df, df]))
+
+
+This now matches the existing behavior of :class:`concat` on ``Series`` with sparse values.
+:func:`concat` will continue to return a ``SparseDataFrame`` when all the values
+are instances of ``SparseDataFrame``.
+
+This change also affects routines using :func:`concat` internally, like :func:`get_dummies`,
+which now returns a :class:`DataFrame` in all cases (previously a ``SparseDataFrame`` was
+returned if all the columns were dummy encoded, and a :class:`DataFrame` otherwise).
+
+Providing any ``SparseSeries`` or ``SparseDataFrame`` to :func:`concat` will
+cause a ``SparseSeries`` or ``SparseDataFrame`` to be returned, as before.
+
+
 .. _whatsnew_0250.api_breaking.deps:
 
 Increased minimum versions for dependencies

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -89,8 +89,7 @@ def _get_frame_result_type(result, objs):
     """
 
     if (result.blocks and (
-            all(is_sparse(b) for b in result.blocks) or
-            all(isinstance(obj, ABCSparseDataFrame) for obj in objs))):
+            any(isinstance(obj, ABCSparseDataFrame) for obj in objs))):
         from pandas.core.sparse.api import SparseDataFrame
         return SparseDataFrame
     else:

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -577,6 +577,16 @@ class TestGetDummies(object):
 
         tm.assert_frame_equal(result, expected)
 
+    def test_get_dummies_all_sparse(self):
+        df = pd.DataFrame({"A": [1, 2]})
+        result = pd.get_dummies(df, columns=['A'], sparse=True)
+        dtype = SparseDtype('uint8', 0)
+        expected = pd.DataFrame({
+            'A_1': SparseArray([1, 0], dtype=dtype),
+            'A_2': SparseArray([0, 1], dtype=dtype),
+        })
+        tm.assert_frame_equal(result, expected)
+
 
 class TestCategoricalReshape(object):
 


### PR DESCRIPTION
API breaking change to `concat(List[DataFrame[Sparse]])` to
return a DataFrame with sparse values, rather than a SparseDataFrame.

Doing an outright break, rather than deprecation, because I have a
followup PR deprecating SparseDataFrame. We hit this internally in
a few places (e.g. get_dummies on all-sparse data).

Closes https://github.com/pandas-dev/pandas/issues/25702

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
