### PR TITLE
TST: assert_produces_warning works with filterwarnings

### DIFF
--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -5,12 +5,19 @@ import pytest
 import pandas.util.testing as tm
 
 
-def f():
-    warnings.warn('f1', FutureWarning)
-    warnings.warn('f2', RuntimeWarning)
+def f(a=FutureWarning, b=RuntimeWarning):
+    warnings.warn('f1', a)
+    warnings.warn('f2', b)
 
 
 @pytest.mark.filterwarnings('ignore:f1:FutureWarning')
+@pytest.mark.filterwarnings('ignore:f2:RuntimeWarning')
 def test_assert_produces_warning_honors_filter():
-    with tm.assert_produces_warning(RuntimeWarning, filter_level=None):
+    with tm.assert_produces_warning(RuntimeWarning):
         f()
+
+
+@pytest.mark.filterwarnings('ignore:f1:FutureWarning')
+def test_assert_produces_warning_message():
+    with tm.assert_produces_warning(FutureWarning, message='f2'):
+        f(FutureWarning, FutureWarning)

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -5,13 +5,18 @@ import pytest
 import pandas.util.testing as tm
 
 
-def f(a=FutureWarning, b=RuntimeWarning):
-    warnings.warn('f1', a)
-    warnings.warn('f2', b)
+def f():
+    warnings.warn('f1', FutureWarning)
+    warnings.warn('f2', RuntimeWarning)
 
 
 @pytest.mark.filterwarnings('ignore:f1:FutureWarning')
-@pytest.mark.filterwarnings('ignore:f2:RuntimeWarning')
 def test_assert_produces_warning_honors_filter():
-    with tm.assert_produces_warning(RuntimeWarning):
+    # raise by default
+    with pytest.raises(AssertionError):
+        with tm.assert_produces_warning(RuntimeWarning):
+            f()
+
+    with tm.assert_produces_warning(RuntimeWarning,
+                                    raise_on_extra_warnings=False):
         f()

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -15,9 +15,3 @@ def f(a=FutureWarning, b=RuntimeWarning):
 def test_assert_produces_warning_honors_filter():
     with tm.assert_produces_warning(RuntimeWarning):
         f()
-
-
-@pytest.mark.filterwarnings('ignore:f1:FutureWarning')
-def test_assert_produces_warning_message():
-    with tm.assert_produces_warning(FutureWarning, message='f2'):
-        f(FutureWarning, FutureWarning)

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -1,0 +1,16 @@
+import warnings
+
+import pytest
+
+import pandas.util.testing as tm
+
+
+def f():
+    warnings.warn('f1', FutureWarning)
+    warnings.warn('f2', RuntimeWarning)
+
+
+@pytest.mark.filterwarnings('ignore:f1:FutureWarning')
+def test_assert_produces_warning_honors_filter():
+    with tm.assert_produces_warning(RuntimeWarning, filter_level=None):
+        f()

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2571,8 +2571,7 @@ class _AssertRaisesContextmanager(object):
 
 @contextmanager
 def assert_produces_warning(expected_warning=Warning, filter_level="always",
-                            clear=None, check_stacklevel=True,
-                            message=''):
+                            clear=None, check_stacklevel=True):
     """
     Context manager for running code expected to either raise a specific
     warning, or not raise any warnings. Verifies that the code raises the
@@ -2610,9 +2609,6 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
         If True, displays the line that called the function containing
         the warning to show were the function is called. Otherwise, the
         line that implements the function is displayed.
-    message : str, default ''
-        Use in the filter with `filter_level` and `expected_warning`
-        the control which warnings the filter applies to.
 
     Examples
     --------
@@ -2652,7 +2648,8 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
 
         saw_warning = False
         if expected_warning and filter_level:
-            warnings.filterwarnings(filter_level, message, expected_warning)
+            warnings.filterwarnings(filter_level, message='',
+                                    category=expected_warning)
         elif filter_level:
             # no expected warnings.
             warnings.simplefilter(filter_level)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2584,7 +2584,7 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
         The type of Exception raised. ``exception.Warning`` is the base
         class for all warnings. To check that no warning is returned,
         specify ``False`` or ``None``.
-    filter_level : str, default "always"
+    filter_level : str or None, default "always"
         Specifies whether warnings are ignored, displayed, or turned
         into errors.
         Valid values are:
@@ -2597,6 +2597,7 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
         * "module" - print the warning the first time it is generated
           from each module
         * "once" - print the warning the first time it is generated
+        * None - do not apply a new filter
 
     clear : str, default None
         If not ``None`` then remove any previously raised warnings from
@@ -2646,7 +2647,8 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
                     pass
 
         saw_warning = False
-        warnings.simplefilter(filter_level)
+        if filter_level:
+            warnings.simplefilter(filter_level)
         yield w
         extra_warnings = []
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2651,8 +2651,11 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
                     pass
 
         saw_warning = False
-        if filter_level:
+        if expected_warning and filter_level:
             warnings.filterwarnings(filter_level, message, expected_warning)
+        elif filter_level:
+            # no expected warnings.
+            warnings.simplefilter(filter_level)
         yield w
         extra_warnings = []
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2571,7 +2571,8 @@ class _AssertRaisesContextmanager(object):
 
 @contextmanager
 def assert_produces_warning(expected_warning=Warning, filter_level="always",
-                            clear=None, check_stacklevel=True):
+                            clear=None, check_stacklevel=True,
+                            message=''):
     """
     Context manager for running code expected to either raise a specific
     warning, or not raise any warnings. Verifies that the code raises the
@@ -2609,6 +2610,9 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
         If True, displays the line that called the function containing
         the warning to show were the function is called. Otherwise, the
         line that implements the function is displayed.
+    message : str, default ''
+        Use in the filter with `filter_level` and `expected_warning`
+        the control which warnings the filter applies to.
 
     Examples
     --------
@@ -2648,7 +2652,7 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
 
         saw_warning = False
         if filter_level:
-            warnings.simplefilter(filter_level)
+            warnings.filterwarnings(filter_level, message, expected_warning)
         yield w
         extra_warnings = []
 


### PR DESCRIPTION
Previously, assert_produces_warning did not play well with pytest's
filterwarnings.

```
===================================================================================== FAILURES ======================================================================================
____________________________________________________________________ test_assert_produces_warning_honors_filter _____________________________________________________________________

    @pytest.mark.filterwarnings('ignore:f1:FutureWarning')
    def test_assert_produces_warning_honors_filter():
        with tm.assert_produces_warning(RuntimeWarning):
>           f()

pandas/tests/util/test_assert_produces_warning.py:17:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <contextlib._GeneratorContextManager object at 0x11dd61128>, type = None, value = None, traceback = None

    def __exit__(self, type, value, traceback):
        if type is None:
            try:
>               next(self.gen)
E               AssertionError: Caused unexpected warning(s): [('FutureWarning', FutureWarning('f1'), '/Users/taugspurger/sandbox/pandas/pandas/tests/util/test_assert_produces_warni
ng.py', 10)].

/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py:119: AssertionError
============================================================================= 1 failed in 0.20 seconds ==============================================================================
```

Internally, `assert_produces_warning` sets a new `filter`, which
overrides any filters set by pytest. We allow for `filter_level=None` to
not set a filter.


This will be useful for the SparseDataFrame deprecation, where I'd like to just set a `pytest.mark.filterwarning` on the class, and not worry about catching individual warnings.