### PR TITLE
remove unnecessary check_output copy/pasted code

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -427,44 +427,9 @@ def close(fignum=None):
 # locale utilities
 
 
-def check_output(*popenargs, **kwargs):
-    # shamelessly taken from Python 2.7 source
-    r"""Run command with arguments and return its output as a byte string.
-
-    If the exit code was non-zero it raises a CalledProcessError.  The
-    CalledProcessError object will have the return code in the returncode
-    attribute and output in the output attribute.
-
-    The arguments are the same as for the Popen constructor.  Example:
-
-    >>> check_output(["ls", "-l", "/dev/null"])
-    'crw-rw-rw- 1 root root 1, 3 Oct 18  2007 /dev/null\n'
-
-    The stdout argument is not allowed as it is used internally.
-    To capture standard error in the result, use stderr=STDOUT.
-
-    >>> check_output(["/bin/sh", "-c",
-    ...               "ls -l non_existent_file ; exit 0"],
-    ...              stderr=STDOUT)
-    'ls: non_existent_file: No such file or directory\n'
-    """
-    if 'stdout' in kwargs:
-        raise ValueError('stdout argument not allowed, it will be overridden.')
-    process = subprocess.Popen(stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                               *popenargs, **kwargs)
-    output, unused_err = process.communicate()
-    retcode = process.poll()
-    if retcode:
-        cmd = kwargs.get("args")
-        if cmd is None:
-            cmd = popenargs[0]
-        raise subprocess.CalledProcessError(retcode, cmd, output=output)
-    return output
-
-
 def _default_locale_getter():
     try:
-        raw_locales = check_output(['locale -a'], shell=True)
+        raw_locales = subprocess.check_output(['locale -a'], shell=True)
     except subprocess.CalledProcessError as e:
         raise type(e)("{exception}, the 'locale -a' command cannot be found "
                       "on your system".format(exception=e))


### PR DESCRIPTION
It isn't clear to me why this is needed.  Maybe the CI will fail, in which case I'll just add a comment in the code explaining why it is needed.