### PR TITLE
BUG: Cleaner exception when `.iloc` called with non-integer list

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -204,7 +204,7 @@ Interval
 Indexing
 ^^^^^^^^
 
-- Added an exception message when calling :meth:`DataFrame.iloc` with a list of non-numeric objects (:issue:`25753`).
+- Improved exception message when calling :meth:`DataFrame.iloc` with a list of non-numeric objects (:issue:`25753`).
 -
 -
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -204,7 +204,7 @@ Interval
 Indexing
 ^^^^^^^^
 
--
+- Added an exception message when calling :meth:`DataFrame.iloc` with a list of non-integer objects.
 -
 -
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -204,7 +204,7 @@ Interval
 Indexing
 ^^^^^^^^
 
-- Added an exception message when calling :meth:`DataFrame.iloc` with a list of non-numeric objects.
+- Added an exception message when calling :meth:`DataFrame.iloc` with a list of non-numeric objects (:issue:`25753`).
 -
 -
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -204,7 +204,7 @@ Interval
 Indexing
 ^^^^^^^^
 
-- Added an exception message when calling :meth:`DataFrame.iloc` with a list of non-integer objects.
+- Added an exception message when calling :meth:`DataFrame.iloc` with a list of non-numeric objects.
 -
 -
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2080,8 +2080,8 @@ class _iLocIndexer(_LocationIndexer):
             len_axis = len(self.obj._get_axis(axis))
 
             if not np.issubdtype(arr.dtype, np.number):
-                raise IndexError(".iloc requires integer indexers, found "
-                                 "type {dtype}".format(dtype=arr.dtype))
+                raise IndexError(".iloc requires integer indexers, got "
+                                 "{arr}".format(arr=arr))
 
             if len(arr) and (arr.max() >= len_axis or arr.min() < -len_axis):
                 raise IndexError("positional indexers are out-of-bounds")

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2079,7 +2079,7 @@ class _iLocIndexer(_LocationIndexer):
             arr = np.array(key)
             len_axis = len(self.obj._get_axis(axis))
 
-            if not np.issubdtype(arr.dtype, np.int):
+            if not np.issubdtype(arr.dtype, np.number):
                 raise IndexError(".iloc requires integer indexers, found "
                                  "type {dtype}".format(dtype=arr.dtype))
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -13,7 +13,7 @@ from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.common import (
     ensure_platform_int, is_float, is_integer, is_integer_dtype, is_iterator,
-    is_list_like, is_scalar, is_sequence, is_sparse)
+    is_list_like, is_scalar, is_sequence, is_sparse, is_numeric_dtype)
 from pandas.core.dtypes.generic import ABCDataFrame, ABCPanel, ABCSeries
 from pandas.core.dtypes.missing import _infer_fill_value, isna
 
@@ -2079,7 +2079,7 @@ class _iLocIndexer(_LocationIndexer):
             len_axis = len(self.obj._get_axis(axis))
 
             # check that the key has a numeric dtype
-            if not np.issubdtype(arr.dtype, np.number):
+            if not is_numeric_dtype(arr.dtype):
                 raise IndexError(".iloc requires numeric indexers, got "
                                  "{arr}".format(arr=arr))
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2075,14 +2075,15 @@ class _iLocIndexer(_LocationIndexer):
             # so don't treat a tuple as a valid indexer
             raise IndexingError('Too many indexers')
         elif is_list_like_indexer(key):
-            # check that the key does not exceed the maximum size of the index
             arr = np.array(key)
             len_axis = len(self.obj._get_axis(axis))
 
+            # check that the key has a numeric dtype
             if not np.issubdtype(arr.dtype, np.number):
-                raise IndexError(".iloc requires integer indexers, got "
+                raise IndexError(".iloc requires numeric indexers, got "
                                  "{arr}".format(arr=arr))
 
+            # check that the key does not exceed the maximum size of the index
             if len(arr) and (arr.max() >= len_axis or arr.min() < -len_axis):
                 raise IndexError("positional indexers are out-of-bounds")
         else:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2079,6 +2079,10 @@ class _iLocIndexer(_LocationIndexer):
             arr = np.array(key)
             len_axis = len(self.obj._get_axis(axis))
 
+            if not np.issubdtype(arr.dtype, np.int):
+                raise IndexError(".iloc requires integer indexers, found "
+                                 "type {dtype}".format(dtype=arr.dtype))
+
             if len(arr) and (arr.max() >= len_axis or arr.min() < -len_axis):
                 raise IndexError("positional indexers are out-of-bounds")
         else:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -13,7 +13,7 @@ from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.common import (
     ensure_platform_int, is_float, is_integer, is_integer_dtype, is_iterator,
-    is_list_like, is_scalar, is_sequence, is_sparse, is_numeric_dtype)
+    is_list_like, is_numeric_dtype, is_scalar, is_sequence, is_sparse)
 from pandas.core.dtypes.generic import ABCDataFrame, ABCPanel, ABCSeries
 from pandas.core.dtypes.missing import _infer_fill_value, isna
 

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -118,39 +118,20 @@ class TestiLoc(Base):
         with pytest.raises(IndexError, match=msg):
             dfl.iloc[:, 4]
 
-    def test_iloc_non_integer(self):
-
-        # iloc should throw IndexError if non-numeric list is passed
-        df = DataFrame(np.random.random_sample((20, 5)), columns=list('ABCDE'))
-
+    @pytest.mark.parametrize("index,columns", [(np.arange(20), list('ABCDE'))])
+    @pytest.mark.parametrize("index_vals,column_vals", [
+        ([slice(None), ['A', 'D']]),
+        (['1', '2'], slice(None)),
+        ([pd.datetime(2019, 1, 1)], slice(None))])
+    def test_iloc_non_integer_raises(self, index, columns,
+                                     index_vals, column_vals):
+        # GH 25753
+        df = DataFrame(np.random.randn(len(index), len(columns)),
+                       index=index,
+                       columns=columns)
         msg = '.iloc requires integer indexers, got'
         with pytest.raises(IndexError, match=msg):
-            df.iloc[:, ['A', 'D']]
-        with pytest.raises(IndexError, match=msg):
-            df.iloc[['1', '2'], :]
-        with pytest.raises(IndexError, match=msg):
-            df.iloc[[pd.datetime(2019, 1, 1)], :]
-
-        # Numeric or booleans should not raise errors
-        result = df.iloc[:, [0, 1]]
-        expected = df.loc[:, ['A', 'B']]
-        tm.assert_frame_equal(result, expected)
-
-        result = df.iloc[[0, 1], [0, 1, 3]]
-        expected = df.loc[[0, 1], ['A', 'B', 'D']]
-        tm.assert_frame_equal(result, expected)
-
-        result = df.iloc[:, [True, False, False, True]]
-        expected = df.loc[:, ['A', 'D']]
-        tm.assert_frame_equal(result, expected)
-
-        result = df.iloc[:, [0, 0.5]]
-        expected = df.loc[:, ['A', 'A']]
-        tm.assert_frame_equal(result, expected)
-
-        result = df.iloc[[True, False, True], :]
-        expected = df.loc[[0, 2], :]
-        tm.assert_frame_equal(result, expected)
+            df.iloc[index_vals, column_vals]
 
     def test_iloc_getitem_int(self):
 

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -129,7 +129,7 @@ class TestiLoc(Base):
         df = DataFrame(np.random.randn(len(index), len(columns)),
                        index=index,
                        columns=columns)
-        msg = '.iloc requires integer indexers, got'
+        msg = '.iloc requires numeric indexers, got'
         with pytest.raises(IndexError, match=msg):
             df.iloc[index_vals, column_vals]
 

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -118,6 +118,40 @@ class TestiLoc(Base):
         with pytest.raises(IndexError, match=msg):
             dfl.iloc[:, 4]
 
+    def test_iloc_non_integer(self):
+
+        # iloc should throw IndexError if non-numeric list is passed
+        df = DataFrame(np.random.random_sample((20, 5)), columns=list('ABCDE'))
+
+        msg = '.iloc requires integer indexers, got'
+        with pytest.raises(IndexError, match=msg):
+            df.iloc[:, ['A', 'D']]
+        with pytest.raises(IndexError, match=msg):
+            df.iloc[['1', '2'], :]
+        with pytest.raises(IndexError, match=msg):
+            df.iloc[[pd.datetime(2019, 1, 1)], :]
+
+        # Numeric or booleans should not raise errors
+        result = df.iloc[:, [0, 1]]
+        expected = df.loc[:, ['A', 'B']]
+        tm.assert_frame_equal(result, expected)
+
+        result = df.iloc[[0, 1], [0, 1, 3]]
+        expected = df.loc[[0, 1], ['A', 'B', 'D']]
+        tm.assert_frame_equal(result, expected)
+
+        result = df.iloc[:, [True, False, False, True]]
+        expected = df.loc[:, ['A', 'D']]
+        tm.assert_frame_equal(result, expected)
+
+        result = df.iloc[:, [0, 0.5]]
+        expected = df.loc[:, ['A', 'A']]
+        tm.assert_frame_equal(result, expected)
+
+        result = df.iloc[[True, False, True], :]
+        expected = df.loc[[0, 2], :]
+        tm.assert_frame_equal(result, expected)
+
     def test_iloc_getitem_int(self):
 
         # integer


### PR DESCRIPTION
- [x] closes #25753
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Issue #25753 was raised requesting more verbose error messages when calling `loc` and `iloc` with mixed dtype arguments. In this pull request, I've added a new error message when calling `iloc` with a non-numeric dtype list-like object. 

This fixes numpy ultimately raising an ambiguous exception when, for example, calling `.iloc` with a list of string column names:
```
>>> print(data.iloc[['Colorado', 'Utah'], [3, 0, 1]])
Old:
TypeError: cannot perform reduce with flexible type
New:
IndexError: .iloc requires integer indexers, got ['Colorado' 'Utah']
```

However, the current exception when calling `.loc` with integer column names when the column names are actually strings I feel is already accurate:
```
>>> print(data.loc[['Colorado', 'Utah'], [3, 0, 1]])
KeyError: "None of [Int64Index([3, 0, 1], dtype='int64')] are in the [columns]"
```