### PR TITLE
PERF: fixed performance degration becasue doesn't slice values array in to_native_types of DateTimeBlock

### DIFF
--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -50,6 +50,24 @@ class ToCSVDatetime(BaseIO):
         self.data.to_csv(self.fname, date_format='%Y%m%d')
 
 
+class ToCSVDatetimeBig(BaseIO):
+
+    fname = '__test__.csv'
+    timeout = 1500
+    params = [1000, 10000, 100000]
+    param_names = ['obs']
+
+    def setup(self, obs):
+        d = '2018-11-29'
+        dt = '2018-11-26 11:18:27.0'
+        self.data = DataFrame({'dt': [np.datetime64(dt)] * obs,
+                               'd': [np.datetime64(d)] * obs,
+                               'r': [np.random.uniform()] * obs})
+
+    def time_frame(self, obs):
+        self.data.to_csv(self.fname)
+
+
 class StringIORewind(object):
 
     def data(self, stringio_object):

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -248,6 +248,7 @@ Performance Improvements
 - Improved performance of :meth:`pandas.core.groupby.GroupBy.quantile` (:issue:`20405`)
 - Improved performance of :meth:`read_csv` by faster tokenizing and faster parsing of small float numbers (:issue:`25784`)
 - Improved performance of :meth:`read_csv` by faster parsing of N/A and boolean values (:issue:`25804`)
+- Improved performance of :meth:DataFrame.`to_csv` when write datetime dtype data (:issue:`25708`)
 
 .. _whatsnew_0250.bug_fixes:
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2178,6 +2178,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
         i8values = self.values.view('i8')
 
         if slicer is not None:
+            values = values[..., slicer]
             i8values = i8values[..., slicer]
 
         from pandas.io.formats.format import _get_format_datetime64_from_values


### PR DESCRIPTION
- [x] closes #25708 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
Slicing in [line 2181](https://github.com/pandas-dev/pandas/blob/707c7201a744c48c835f719421e47480beee2184/pandas/core/internals/blocks.py#L2181) only slice of i8values that make a whole of values array is processed in _is_dates_only function. This change was from pull #24543
```python
        values = self.values
        i8values = self.values.view('i8')

        if slicer is not None:
            i8values = i8values[..., slicer]

        from pandas.io.formats.format import _get_format_datetime64_from_values
        fmt = _get_format_datetime64_from_values(values, date_format)
```