### PR TITLE
BUG: reading windows utf8 filenames in py3.6

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -175,6 +175,7 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+- Bug in `TextReader()` not properly working with UTF8 on Windows on Python 3.6+ (fix for :issue:`15086` instead of a workaround)
 
 Categorical
 ^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -175,7 +175,6 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
-- Bug in `TextReader()` not properly working with UTF8 on Windows on Python 3.6+ (fix for :issue:`15086` instead of a workaround)
 
 Categorical
 ^^^^^^^^^^^
@@ -272,6 +271,7 @@ I/O
 - Bug in :func:`json_normalize` for ``errors='ignore'`` where missing values in the input data, were filled in resulting ``DataFrame`` with the string "nan" instead of ``numpy.nan`` (:issue:`25468`)
 - :meth:`DataFrame.to_html` now raises ``TypeError`` when using an invalid type for the ``classes`` parameter instead of ``AsseertionError`` (:issue:`25608`)
 - Bug in :meth:`DataFrame.to_string` and :meth:`DataFrame.to_latex` that would lead to incorrect output when the ``header`` keyword is used (:issue:`16718`)
+- Bug in :func:`read_csv` not properly interpreting the UTF8 encoded filenames on Windows on Python 3.6+ (:issue:`15086`)
 -
 
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -678,11 +678,7 @@ cdef class TextReader:
 
         if isinstance(source, basestring):
             if not isinstance(source, bytes):
-                if compat.PY36 and compat.is_platform_windows():
-                    # see gh-15086.
-                    encoding = "mbcs"
-                else:
-                    encoding = sys.getfilesystemencoding() or "utf-8"
+                encoding = sys.getfilesystemencoding() or "utf-8"
 
                 source = source.encode(encoding)
 

--- a/pandas/_libs/src/parser/io.c
+++ b/pandas/_libs/src/parser/io.c
@@ -49,7 +49,8 @@ void *new_file_source(char *fname, size_t buffer_size) {
             free(fs);
             return NULL;
         }
-        if (MultiByteToWideChar(CP_UTF8, 0, fname, -1, wname, required) < required) {
+        if (MultiByteToWideChar(CP_UTF8, 0, fname, -1, wname, required) <
+                                                                required) {
             free(wname);
             free(fs);
             return NULL;

--- a/pandas/_libs/src/parser/io.c
+++ b/pandas/_libs/src/parser/io.c
@@ -17,6 +17,11 @@ The full license is in the LICENSE file, distributed with this software.
 #define O_BINARY 0
 #endif  // O_BINARY
 
+#if PY_VERSION_HEX >= 0x03060000 && defined(_WIN32)
+#define USE_WIN_UTF16
+#include <Windows.h>
+#endif
+
 /*
   On-disk FILE, uncompressed
 */
@@ -27,7 +32,34 @@ void *new_file_source(char *fname, size_t buffer_size) {
         return NULL;
     }
 
+#ifdef USE_WIN_UTF16
+    // Fix gh-15086 properly - convert UTF8 to UTF16 that Windows widechar API
+    // accepts. This is needed because UTF8 might _not_ be convertible to MBCS
+    // for some conditions, as MBCS is locale-dependent, and not all unicode
+    // symbols can be expressed in it.
+    {
+        wchar_t* wname = NULL;
+        int required = MultiByteToWideChar(CP_UTF8, 0, fname, -1, NULL, 0);
+        if (required == 0) {
+            free(fs);
+            return NULL;
+        }
+        wname = (wchar_t*)malloc(required * sizeof(wchar_t));
+        if (wname == NULL) {
+            free(fs);
+            return NULL;
+        }
+        if (MultiByteToWideChar(CP_UTF8, 0, fname, -1, wname, required) < required) {
+            free(wname);
+            free(fs);
+            return NULL;
+        }
+        fs->fd = _wopen(wname, O_RDONLY | O_BINARY);
+        free(wname);
+    }
+#else
     fs->fd = open(fname, O_RDONLY | O_BINARY);
+#endif
     if (fs->fd == -1) {
         free(fs);
         return NULL;

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -5,8 +5,8 @@ Tests that work on both the Python and C engines but do not have a
 specific classification into the other test modules.
 """
 
-import sys
 import codecs
+import ctypes
 from collections import OrderedDict
 import csv
 from datetime import datetime
@@ -1905,15 +1905,14 @@ def test_suppress_error_output(all_parsers, capsys):
     assert captured.err == ""
 
 
-def __should_skip_utf8_test():
+def __windows_ansi_encoding_not_cp1252():
     if compat.is_platform_windows():
-        import ctypes
         ansi_codepage = ctypes.cdll.kernel32.GetACP()
-        return ansi_codepage != 1252 and sys.version_info < (3, 6)
+        return ansi_codepage != 1252 and not compat.PY36
     return False
 
-@pytest.mark.skipif(__should_skip_utf8_test(),
-                    reason="Python < 3.6 won't pass on non-1252 codepage")
+@pytest.mark.skipif(__windows_ansi_encoding_not_cp1252(),
+                    reason="On Python < 3.6 won't pass on non-1252 codepage")
 def test_filename_with_special_chars(all_parsers):
     # see gh-15086.
     parser = all_parsers

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -6,7 +6,6 @@ specific classification into the other test modules.
 """
 
 import codecs
-import ctypes
 from collections import OrderedDict
 import csv
 from datetime import datetime
@@ -1905,20 +1904,15 @@ def test_suppress_error_output(all_parsers, capsys):
     assert captured.err == ""
 
 
-def __windows_ansi_encoding_not_cp1252():
-    if compat.is_platform_windows():
-        ansi_codepage = ctypes.cdll.kernel32.GetACP()
-        return ansi_codepage != 1252 and not compat.PY36
-    return False
-
-@pytest.mark.skipif(__windows_ansi_encoding_not_cp1252(),
-                    reason="On Python < 3.6 won't pass on non-1252 codepage")
-def test_filename_with_special_chars(all_parsers):
+@pytest.mark.skipif(compat.is_platform_windows() and not compat.PY36,
+                    reason="On Python < 3.6 won't pass on Windows")
+@pytest.mark.parametrize("filename", ["sé-es-vé.csv", "ru-sй.csv"])
+def test_filename_with_special_chars(all_parsers, filename):
     # see gh-15086.
     parser = all_parsers
     df = DataFrame({"a": [1, 2, 3]})
 
-    with tm.ensure_clean("sé-es-vé-sй.csv") as path:
+    with tm.ensure_clean(filename) as path:
         df.to_csv(path, index=False)
 
         result = parser.read_csv(path)


### PR DESCRIPTION
- [x] closes #15086 properly
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Test that was added in prior fix was failing on my machine, where my locale was set to `CP-1251` (which apparently cannot handle some unicode symbols in the test even when using MBCS, as MBCS encoding is locale-dependent).

This PR fixes the issue removing the workaround by switching to converting UTF8 to UTF16 and using Win32 Unicode file API (much like Python >= 3.6 does internally).

P.S. This as a bonus adds possibility to use `\\?\C\long\file\name` addressing if desired to overcome 260 symbols limitation on path length.
