### PR TITLE
DOC: Fix typo in docstring of DataFrame.memory_usage 

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2468,8 +2468,8 @@ class DataFrame(NDFrame):
         ----------
         index : bool, default True
             Specifies whether to include the memory usage of the DataFrame's
-            index in returned Series. If ``index=True`` the memory usage of the
-            index the first item in the output.
+            index in returned Series. If ``index=True``, the memory usage of 
+            the index is the first item in the output.
         deep : bool, default False
             If True, introspect the data deeply by interrogating
             `object` dtypes for system-level memory consumption, and include

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2468,7 +2468,7 @@ class DataFrame(NDFrame):
         ----------
         index : bool, default True
             Specifies whether to include the memory usage of the DataFrame's
-            index in returned Series. If ``index=True``, the memory usage of 
+            index in returned Series. If ``index=True``, the memory usage of
             the index is the first item in the output.
         deep : bool, default False
             If True, introspect the data deeply by interrogating


### PR DESCRIPTION
Cherry picked commit from #25761 and removed trailing whitespace.

@jorisvandenbossche if you don't mind taking a look