### PR TITLE
TST: Check pytables<3.5.1 when skipping

### DIFF
--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -38,7 +38,8 @@ tables = pytest.importorskip('tables')
 # remove when gh-24839 is fixed; this affects numpy 1.16
 # and pytables 3.4.4
 xfail_non_writeable = pytest.mark.xfail(
-    LooseVersion(np.__version__) >= LooseVersion('1.16'),
+    LooseVersion(np.__version__) >= LooseVersion('1.16') and
+    LooseVersion(tables.__version__) < LooseVersion('3.5.1'),
     reason=('gh-25511, gh-24839. pytables needs a '
             'release beyong 3.4.4 to support numpy 1.16x'))
 

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -118,6 +118,7 @@ def test_pandas_datareader():
 @pytest.mark.filterwarnings("ignore:The 'warn':DeprecationWarning")
 @pytest.mark.filterwarnings("ignore:pandas.util:DeprecationWarning")
 @pytest.mark.filterwarnings("ignore:can't resolve:ImportWarning")
+@pytest.mark.skip(reason="gh-25778: geopandas stack issue")
 def test_geopandas():
 
     geopandas = import_module('geopandas')  # noqa


### PR DESCRIPTION
`3.5.1` was made available on `conda`, causing `xfail_non_writeable` tests to fail.

Note that this is just to get `master` to pass again (started failing when #25751 was merged).

This new release of `pytables`, however, brings up the question of how we want to proceed with #24839, as it appears that all of our CI builds that install `pytables` will use this version now.

It seems a little early to declare that `3.5.1` is our minimum version, but it definitely looks like we *could* drop this `xfail` from our tests at some point in the near future.