### PR TITLE
Unpin pycodestyle

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - hypothesis>=3.82
   - isort
   - moto
-  - pycodestyle=2.4
+  - pycodestyle
   - pytest>=4.0.2
   - pytest-mock
   - sphinx

--- a/pandas/_libs/__init__.py
+++ b/pandas/_libs/__init__.py
@@ -2,4 +2,4 @@
 # flake8: noqa
 
 from .tslibs import (
-    iNaT, NaT, Timestamp, Timedelta, OutOfBoundsDatetime, Period)
+    iNaT, NaT, NaTType, Timestamp, Timedelta, OutOfBoundsDatetime, Period)

--- a/pandas/_libs/tslibs/__init__.py
+++ b/pandas/_libs/tslibs/__init__.py
@@ -2,7 +2,7 @@
 # flake8: noqa
 
 from .conversion import normalize_date, localize_pydatetime, tz_convert_single
-from .nattype import NaT, iNaT, is_null_datetimelike
+from .nattype import NaT, NaTType, iNaT, is_null_datetimelike
 from .np_datetime import OutOfBoundsDatetime
 from .period import Period, IncompatibleFrequency
 from .timestamps import Timestamp

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -353,7 +353,7 @@ class NaTType(_NaT):
 
         .. versionadded:: 0.23.0
         """)
-    day_name = _make_nan_func('day_name', # noqa:E128
+    day_name = _make_nan_func('day_name',  # noqa:E128
         """
         Return the day name of the Timestamp with specified locale.
 

--- a/pandas/core/arrays/array_.py
+++ b/pandas/core/arrays/array_.py
@@ -1,7 +1,12 @@
+from typing import Optional, Sequence, Union
+
+import numpy as np
+
 from pandas._libs import lib, tslibs
 
 from pandas.core.dtypes.common import (
-    is_datetime64_ns_dtype, is_extension_array_dtype, is_timedelta64_ns_dtype)
+    ExtensionDtype, is_datetime64_ns_dtype, is_extension_array_dtype,
+    is_timedelta64_ns_dtype)
 from pandas.core.dtypes.dtypes import registry
 
 from pandas import compat

--- a/pandas/core/arrays/array_.py
+++ b/pandas/core/arrays/array_.py
@@ -5,9 +5,8 @@ import numpy as np
 from pandas._libs import lib, tslibs
 
 from pandas.core.dtypes.common import (
-    ExtensionDtype, is_datetime64_ns_dtype, is_extension_array_dtype,
-    is_timedelta64_ns_dtype)
-from pandas.core.dtypes.dtypes import registry
+    is_datetime64_ns_dtype, is_extension_array_dtype, is_timedelta64_ns_dtype)
+from pandas.core.dtypes.dtypes import ExtensionDtype, registry
 
 from pandas import compat
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -15,7 +15,8 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution
 
-from pandas.core.dtypes.common import ExtensionDtype, is_list_like
+from pandas.core.dtypes.common import is_list_like
+from pandas.core.dtypes.dtypes import ExtensionDtype
 from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
 from pandas.core.dtypes.missing import isna
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -6,6 +6,7 @@
    without warning.
 """
 import operator
+from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -14,7 +15,7 @@ from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution
 
-from pandas.core.dtypes.common import is_list_like
+from pandas.core.dtypes.common import ExtensionDtype, is_list_like
 from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
 from pandas.core.dtypes.missing import isna
 
@@ -365,7 +366,7 @@ class ExtensionArray(object):
         raise AbstractMethodError(self)
 
     def _values_for_argsort(self):
-        # type: () -> ndarray
+        # type: () -> np.ndarray
         """
         Return values for sorting.
 
@@ -597,7 +598,7 @@ class ExtensionArray(object):
         return arr.searchsorted(value, side=side, sorter=sorter)
 
     def _values_for_factorize(self):
-        # type: () -> Tuple[ndarray, Any]
+        # type: () -> Tuple[np.ndarray, Any]
         """
         Return an array and missing value suitable for factorization.
 
@@ -622,7 +623,7 @@ class ExtensionArray(object):
         return self.astype(object), np.nan
 
     def factorize(self, na_sentinel=-1):
-        # type: (int) -> Tuple[ndarray, ExtensionArray]
+        # type: (int) -> Tuple[np.ndarray, ExtensionArray]
         """
         Encode the extension array as an enumerated type.
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -2,10 +2,11 @@
 from datetime import datetime, timedelta
 import operator
 import warnings
+from typing import Any, Sequence, Tuple, Union
 
 import numpy as np
 
-from pandas._libs import NaT, algos, iNaT, lib
+from pandas._libs import NaT, NaTType, algos, iNaT, lib, Timestamp
 from pandas._libs.tslibs.period import (
     DIFFERENT_FREQ, IncompatibleFrequency, Period)
 from pandas._libs.tslibs.timedeltas import Timedelta, delta_to_nanoseconds
@@ -350,7 +351,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
 
     @property
     def asi8(self):
-        # type: () -> ndarray
+        # type: () -> np.ndarray
         """
         Integer representation of the values.
 
@@ -461,10 +462,10 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
     def __setitem__(
             self,
             key,    # type: Union[int, Sequence[int], Sequence[bool], slice]
-            value,  # type: Union[NaTType, Scalar, Sequence[Scalar]]
+            value,  # type: Union[NaTType, Any, Sequence[Any]]
     ):
         # type: (...) -> None
-        # I'm fudging the types a bit here. The "Scalar" above really depends
+        # I'm fudging the types a bit here. "Any" above really depends
         # on type(self). For PeriodArray, it's Period (or stuff coercible
         # to a period in from_sequence). For DatetimeArray, it's Timestamp...
         # I don't know if mypy can do that, possibly with Generics.

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 import operator
-import warnings
 from typing import Any, Sequence, Tuple, Union
+import warnings
 
 import numpy as np
 
-from pandas._libs import NaT, NaTType, algos, iNaT, lib, Timestamp
+from pandas._libs import NaT, NaTType, Timestamp, algos, iNaT, lib
 from pandas._libs.tslibs.period import (
     DIFFERENT_FREQ, IncompatibleFrequency, Period)
 from pandas._libs.tslibs.timedeltas import Timedelta, delta_to_nanoseconds

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2,6 +2,7 @@
 from datetime import datetime, time, timedelta
 import textwrap
 import warnings
+from typing import Union
 
 import numpy as np
 from pytz import utc

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, time, timedelta
 import textwrap
-import warnings
 from typing import Union
+import warnings
 
 import numpy as np
 from pytz import utc

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -510,7 +510,7 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
         return Series(array, index=index)
 
     def _values_for_argsort(self):
-        # type: () -> ndarray
+        # type: () -> np.ndarray
         """Return values for sorting.
 
         Returns

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from datetime import timedelta
 import operator
+from typing import Any, Callable, Optional, Sequence, Union
 
 import numpy as np
 
 from pandas._libs.tslibs import (
-    NaT, frequencies as libfrequencies, iNaT, period as libperiod)
+    NaT, NaTType, frequencies as libfrequencies, iNaT, period as libperiod)
 from pandas._libs.tslibs.fields import isleapyear_arr
 from pandas._libs.tslibs.period import (
     DIFFERENT_FREQ, IncompatibleFrequency, Period, get_period_field_arr,
@@ -23,7 +24,7 @@ from pandas.core.dtypes.generic import (
 from pandas.core.dtypes.missing import isna, notna
 
 import pandas.core.algorithms as algos
-from pandas.core.arrays import datetimelike as dtl
+from pandas.core.arrays import datetimelike as dtl, ExtensionArray
 import pandas.core.common as com
 
 from pandas.tseries import frequencies
@@ -536,11 +537,14 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
     @Appender(dtl.DatetimeLikeArrayMixin._addsub_int_array.__doc__)
     def _addsub_int_array(
             self,
-            other,   # type: Union[Index, ExtensionArray, np.ndarray[int]]
-            op      # type: Callable[Any, Any]
+            other,      # type: Union[ExtensionArray, np.ndarray[int]]
+            op          # type: Callable[Any, Any]
     ):
         # type: (...) -> PeriodArray
 
+        # TODO: ABCIndexClass is a valid type for other but had to be excluded
+        # due to length of Py2 compatability comment; add back in once migrated
+        # to Py3 syntax
         assert op in [operator.add, operator.sub]
         if op is operator.sub:
             other = -other

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -24,7 +24,7 @@ from pandas.core.dtypes.generic import (
 from pandas.core.dtypes.missing import isna, notna
 
 import pandas.core.algorithms as algos
-from pandas.core.arrays import datetimelike as dtl, ExtensionArray
+from pandas.core.arrays import ExtensionArray, datetimelike as dtl
 import pandas.core.common as com
 
 from pandas.tseries import frequencies

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -6,8 +6,8 @@ from __future__ import division
 import numbers
 import operator
 import re
-import warnings
 from typing import Any, Callable, Union
+import warnings
 
 import numpy as np
 

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -7,12 +7,13 @@ import numbers
 import operator
 import re
 import warnings
+from typing import Any, Callable, Union
 
 import numpy as np
 
 from pandas._libs import index as libindex, lib
 import pandas._libs.sparse as splib
-from pandas._libs.sparse import BlockIndex, IntIndex
+from pandas._libs.sparse import BlockIndex, IntIndex, SparseIndex
 from pandas._libs.tslibs import NaT
 import pandas.compat as compat
 from pandas.compat.numpy import function as nv
@@ -372,7 +373,7 @@ _sparray_doc_kwargs = dict(klass='SparseArray')
 
 
 def _get_fill(arr):
-    # type: (SparseArray) -> ndarray
+    # type: (SparseArray) -> np.ndarray
     """
     Create a 0-dim ndarray containing the fill value
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -15,7 +15,6 @@ from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, cache_readonly
 from pandas.util._validators import validate_bool_kwarg
 
-from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.common import (
     is_datetime64_ns_dtype, is_datetime64tz_dtype, is_datetimelike,
     is_extension_array_dtype, is_extension_type, is_list_like, is_object_dtype,
@@ -25,6 +24,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core import algorithms, common as com
 from pandas.core.accessor import DirNamesMixin
+from pandas.core.arrays import ExtensionArray
 import pandas.core.nanops as nanops
 
 _shared_docs = dict()

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -19,6 +19,7 @@ from pandas.core.dtypes.common import (
     is_datetime64_ns_dtype, is_datetime64tz_dtype, is_datetimelike,
     is_extension_array_dtype, is_extension_type, is_list_like, is_object_dtype,
     is_scalar, is_timedelta64_ns_dtype)
+from pandas.core.dtypes.dtypes import ExtensionArray
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.missing import isna
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -15,11 +15,11 @@ from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, cache_readonly
 from pandas.util._validators import validate_bool_kwarg
 
+from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.common import (
     is_datetime64_ns_dtype, is_datetime64tz_dtype, is_datetimelike,
     is_extension_array_dtype, is_extension_type, is_list_like, is_object_dtype,
     is_scalar, is_timedelta64_ns_dtype)
-from pandas.core.dtypes.dtypes import ExtensionArray
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.missing import isna
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -8,6 +8,7 @@ import collections
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from functools import partial
+from typing import Any
 import inspect
 
 import numpy as np

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -8,8 +8,8 @@ import collections
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from functools import partial
-from typing import Any
 import inspect
+from typing import Any
 
 import numpy as np
 

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -1,4 +1,6 @@
 """Extend pandas with custom array types"""
+from typing import List, Optional, Type
+
 import numpy as np
 
 from pandas.errors import AbstractMethodError
@@ -211,7 +213,7 @@ class ExtensionDtype(_DtypeOpsMixin):
 
     @property
     def type(self):
-        # type: () -> type
+        # type: () -> Type
         """
         The scalar type for the array, e.g. ``int``
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -937,7 +937,7 @@ class IntervalDtype(PandasExtensionDtype, ExtensionDtype):
 
         if (string.lower() == 'interval' or
            cls._match.search(string) is not None):
-                return cls(string)
+            return cls(string)
 
         msg = ('Incorrectly formatted string passed to constructor. '
                'Valid formats include Interval or Interval[dtype] '

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -19,6 +19,7 @@ import itertools
 import sys
 import warnings
 from textwrap import dedent
+from typing import List, Union
 
 import numpy as np
 import numpy.ma as ma

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -12,8 +12,8 @@ from contextlib import contextmanager
 import datetime
 from functools import partial, wraps
 import types
-import warnings
 from typing import Optional, Type
+import warnings
 
 import numpy as np
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -13,6 +13,7 @@ import datetime
 from functools import partial, wraps
 import types
 import warnings
+from typing import Optional, Type
 
 import numpy as np
 
@@ -1040,7 +1041,7 @@ class GroupBy(_GroupBy):
         """
 
         def objs_to_bool(vals):
-            # type: (np.ndarray) -> (np.ndarray, typing.Type)
+            # type: (np.ndarray) -> (np.ndarray, Type)
             if is_object_dtype(vals):
                 vals = np.array([bool(x) for x in vals])
             else:
@@ -1049,7 +1050,7 @@ class GroupBy(_GroupBy):
             return vals.view(np.uint8), np.bool
 
         def result_to_bool(result, inference):
-            # type: (np.ndarray, typing.Type) -> np.ndarray
+            # type: (np.ndarray, Type) -> np.ndarray
             return result.astype(inference, copy=False)
 
         return self._get_cythonized_result('group_any_all', self.grouper,
@@ -1738,7 +1739,7 @@ class GroupBy(_GroupBy):
         """
 
         def pre_processor(vals):
-            # type: (np.ndarray) -> (np.ndarray, Optional[typing.Type])
+            # type: (np.ndarray) -> (np.ndarray, Optional[Type])
             if is_object_dtype(vals):
                 raise TypeError("'quantile' cannot be performed against "
                                 "'object' dtypes!")
@@ -1753,7 +1754,7 @@ class GroupBy(_GroupBy):
             return vals, inference
 
         def post_processor(vals, inference):
-            # type: (np.ndarray, Optional[typing.Type]) -> np.ndarray
+            # type: (np.ndarray, Optional[Type]) -> np.ndarray
             if inference:
                 # Check for edge case
                 if not (is_integer_dtype(inference) and
@@ -2016,7 +2017,7 @@ class GroupBy(_GroupBy):
             Function to be applied to result of Cython function. Should accept
             an array of values as the first argument and type inferences as its
             second argument, i.e. the signature should be
-            (ndarray, typing.Type).
+            (ndarray, Type).
         **kwargs : dict
             Extra arguments to be passed back to Cython funcs
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import operator
 from textwrap import dedent
 import warnings
+from typing import Union
 
 import numpy as np
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 import operator
 from textwrap import dedent
-import warnings
 from typing import Union
+import warnings
 
 import numpy as np
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 import re
 import warnings
+from typing import Any, List
 
 import numpy as np
 
@@ -1826,8 +1827,11 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
                                  limit=limit),
             placement=self.mgr_locs)
 
-    def shift(self, periods, axis=0, fill_value=None):
-        # type: (int, Optional[BlockPlacement], Any) -> List[ExtensionBlock]
+    def shift(self,
+              periods,                  # type: int
+              axis=0,                   # type: libinternals.BlockPlacement
+              fill_value=None):         # type: Any
+        # type: (...) -> List[ExtensionBlock]
         """
         Shift the block by `periods`.
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -3,8 +3,8 @@ from datetime import date, datetime, timedelta
 import functools
 import inspect
 import re
-import warnings
 from typing import Any, List
+import warnings
 
 import numpy as np
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -9,7 +9,6 @@ from typing import List, Optional, Union
 import numpy as np
 
 from pandas._libs import internals as libinternals, lib
-from pandas.api.extensions import ExtensionDtype
 from pandas.compat import map, range, zip
 from pandas.util._validators import validate_bool_kwarg
 
@@ -19,6 +18,7 @@ from pandas.core.dtypes.cast import (
 from pandas.core.dtypes.common import (
     _NS_DTYPE, is_datetimelike_v_numeric, is_extension_array_dtype,
     is_extension_type, is_list_like, is_numeric_v_string_like, is_scalar)
+from pandas.core.dtypes.dtypes import ExtensionDtype
 import pandas.core.dtypes.concat as _concat
 from pandas.core.dtypes.generic import ABCExtensionArray, ABCSeries
 from pandas.core.dtypes.missing import isna

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -4,10 +4,12 @@ from functools import partial
 import itertools
 import operator
 import re
+from typing import List, Optional, Union
 
 import numpy as np
 
 from pandas._libs import internals as libinternals, lib
+from pandas.api.extensions import ExtensionDtype
 from pandas.compat import map, range, zip
 from pandas.util._validators import validate_bool_kwarg
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -18,8 +18,8 @@ from pandas.core.dtypes.cast import (
 from pandas.core.dtypes.common import (
     _NS_DTYPE, is_datetimelike_v_numeric, is_extension_array_dtype,
     is_extension_type, is_list_like, is_numeric_v_string_like, is_scalar)
-from pandas.core.dtypes.dtypes import ExtensionDtype
 import pandas.core.dtypes.concat as _concat
+from pandas.core.dtypes.dtypes import ExtensionDtype
 from pandas.core.dtypes.generic import ABCExtensionArray, ABCSeries
 from pandas.core.dtypes.missing import isna
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -440,7 +440,6 @@ class DataFrameFormatter(TableFormatter):
         max_rows = self.max_rows
 
         if max_cols == 0 or max_rows == 0:  # assume we are in the terminal
-                                            # (why else = 0)
             (w, h) = get_terminal_size()
             self.w = w
             self.h = h

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -201,7 +201,8 @@ class TestDataFrameAlterAxes():
         # need to adapt first drop for case that both keys are 'A' --
         # cannot drop the same column twice;
         # use "is" because == would give ambiguous Boolean error for containers
-        first_drop = False if (keys[0] is 'A' and keys[1] is 'A') else drop
+        first_drop = False if (
+            keys[0] is 'A' and keys[1] is 'A') else drop  # noqa: F632
 
         # to test against already-tested behaviour, we add sequentially,
         # hence second append always True; must wrap keys in list, otherwise
@@ -1272,7 +1273,7 @@ class TestDataFrameAlterAxes():
             df.rename(id, mapper=id)
 
     def test_reindex_api_equivalence(self):
-            # equivalence of the labels/axis and index/columns API's
+        # equivalence of the labels/axis and index/columns API's
         df = DataFrame([[1, 2, 3], [3, 4, 5], [5, 6, 7]],
                        index=['a', 'b', 'c'],
                        columns=['d', 'e', 'f'])

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -9,7 +9,7 @@ from pandas.util import testing as tm
 
 
 def test_apply_issues():
-        # GH 5788
+    # GH 5788
 
     s = """2011.05.16,00:00,1.40893
 2011.05.16,01:00,1.40760

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -649,17 +649,17 @@ class TestGetGroup():
         tm.assert_frame_equal(df.groupby('a').nth(1), exp)
 
     def test_gb_key_len_equal_axis_len(self):
-            # GH16843
-            # test ensures that index and column keys are recognized correctly
-            # when number of keys equals axis length of groupby
-            df = pd.DataFrame([['foo', 'bar', 'B', 1],
-                               ['foo', 'bar', 'B', 2],
-                               ['foo', 'baz', 'C', 3]],
-                              columns=['first', 'second', 'third', 'one'])
-            df = df.set_index(['first', 'second'])
-            df = df.groupby(['first', 'second', 'third']).size()
-            assert df.loc[('foo', 'bar', 'B')] == 2
-            assert df.loc[('foo', 'baz', 'C')] == 1
+        # GH16843
+        # test ensures that index and column keys are recognized correctly
+        # when number of keys equals axis length of groupby
+        df = pd.DataFrame([['foo', 'bar', 'B', 1],
+                           ['foo', 'bar', 'B', 2],
+                           ['foo', 'baz', 'C', 3]],
+                          columns=['first', 'second', 'third', 'one'])
+        df = df.set_index(['first', 'second'])
+        df = df.groupby(['first', 'second', 'third']).size()
+        assert df.loc[('foo', 'bar', 'B')] == 2
+        assert df.loc[('foo', 'baz', 'C')] == 1
 
 
 # groups & iteration

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -159,7 +159,7 @@ class TestIntervalTree(object):
         left, right = np.arange(3), np.arange(1, 4)
         tree = IntervalTree(left[order], right[order], closed=closed)
         result = tree.is_overlapping
-        expected = closed is 'both'
+        expected = closed == 'both'
         assert result is expected
 
     @pytest.mark.parametrize('left, right', [

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2387,8 +2387,8 @@ class TestHDFStore(Base):
     @pytest.mark.parametrize(
         'dtype', [np.int64, np.float64, np.object, 'm8[ns]', 'M8[ns]'])
     def test_empty_series(self, dtype):
-            s = Series(dtype=dtype)
-            self._check_roundtrip(s, tm.assert_series_equal)
+        s = Series(dtype=dtype)
+        self._check_roundtrip(s, tm.assert_series_equal)
 
     def test_can_serialize_dates(self):
 

--- a/pandas/tests/series/test_rank.py
+++ b/pandas/tests/series/test_rank.py
@@ -421,10 +421,10 @@ class TestSeriesRank(TestData):
     ([1, 1, 3, 3, 5, 5], [1. / 3, 1. / 3, 2. / 3, 2. / 3, 3. / 3, 3. / 3]),
     ([-5, -4, -3, -2, -1], [1. / 5, 2. / 5, 3. / 5, 4. / 5, 5. / 5])])
 def test_rank_dense_pct(dtype, ser, exp):
-        s = Series(ser).astype(dtype)
-        result = s.rank(method='dense', pct=True)
-        expected = Series(exp).astype(result.dtype)
-        assert_series_equal(result, expected)
+    s = Series(ser).astype(dtype)
+    result = s.rank(method='dense', pct=True)
+    expected = Series(exp).astype(result.dtype)
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize('dtype', ['O', 'f8', 'i8'])
@@ -439,10 +439,10 @@ def test_rank_dense_pct(dtype, ser, exp):
     ([1, 1, 3, 3, 5, 5], [1. / 6, 1. / 6, 3. / 6, 3. / 6, 5. / 6, 5. / 6]),
     ([-5, -4, -3, -2, -1], [1. / 5, 2. / 5, 3. / 5, 4. / 5, 5. / 5])])
 def test_rank_min_pct(dtype, ser, exp):
-        s = Series(ser).astype(dtype)
-        result = s.rank(method='min', pct=True)
-        expected = Series(exp).astype(result.dtype)
-        assert_series_equal(result, expected)
+    s = Series(ser).astype(dtype)
+    result = s.rank(method='min', pct=True)
+    expected = Series(exp).astype(result.dtype)
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize('dtype', ['O', 'f8', 'i8'])
@@ -457,10 +457,10 @@ def test_rank_min_pct(dtype, ser, exp):
     ([1, 1, 3, 3, 5, 5], [2. / 6, 2. / 6, 4. / 6, 4. / 6, 6. / 6, 6. / 6]),
     ([-5, -4, -3, -2, -1], [1. / 5, 2. / 5, 3. / 5, 4. / 5, 5. / 5])])
 def test_rank_max_pct(dtype, ser, exp):
-        s = Series(ser).astype(dtype)
-        result = s.rank(method='max', pct=True)
-        expected = Series(exp).astype(result.dtype)
-        assert_series_equal(result, expected)
+    s = Series(ser).astype(dtype)
+    result = s.rank(method='max', pct=True)
+    expected = Series(exp).astype(result.dtype)
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize('dtype', ['O', 'f8', 'i8'])
@@ -476,10 +476,10 @@ def test_rank_max_pct(dtype, ser, exp):
      [1.5 / 6, 1.5 / 6, 3.5 / 6, 3.5 / 6, 5.5 / 6, 5.5 / 6]),
     ([-5, -4, -3, -2, -1], [1. / 5, 2. / 5, 3. / 5, 4. / 5, 5. / 5])])
 def test_rank_average_pct(dtype, ser, exp):
-        s = Series(ser).astype(dtype)
-        result = s.rank(method='average', pct=True)
-        expected = Series(exp).astype(result.dtype)
-        assert_series_equal(result, expected)
+    s = Series(ser).astype(dtype)
+    result = s.rank(method='average', pct=True)
+    expected = Series(exp).astype(result.dtype)
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize('dtype', ['f8', 'i8'])
@@ -494,16 +494,16 @@ def test_rank_average_pct(dtype, ser, exp):
     ([1, 1, 3, 3, 5, 5], [1. / 6, 2. / 6, 3. / 6, 4. / 6, 5. / 6, 6. / 6]),
     ([-5, -4, -3, -2, -1], [1. / 5, 2. / 5, 3. / 5, 4. / 5, 5. / 5])])
 def test_rank_first_pct(dtype, ser, exp):
-        s = Series(ser).astype(dtype)
-        result = s.rank(method='first', pct=True)
-        expected = Series(exp).astype(result.dtype)
-        assert_series_equal(result, expected)
+    s = Series(ser).astype(dtype)
+    result = s.rank(method='first', pct=True)
+    expected = Series(exp).astype(result.dtype)
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.single
 @pytest.mark.high_memory
 def test_pct_max_many_rows():
-        # GH 18271
-        s = Series(np.arange(2**24 + 1))
-        result = s.rank(pct=True).max()
-        assert result == 1
+    # GH 18271
+    s = Series(np.arange(2**24 + 1))
+    result = s.rank(pct=True).max()
+    assert result == 1

--- a/pandas/tests/tslibs/test_api.py
+++ b/pandas/tests/tslibs/test_api.py
@@ -22,6 +22,7 @@ def test_namespace():
                   'timezones']
 
     api = ['NaT',
+           'NaTType',
            'iNaT',
            'is_null_datetimelike',
            'OutOfBoundsDatetime',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ gitpython
 hypothesis>=3.82
 isort
 moto
-pycodestyle==2.4
+pycodestyle
 pytest>=4.0.2
 pytest-mock
 sphinx


### PR DESCRIPTION
- [X] closes #25771
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Larger change than I would have hoped for but it's tough to split this up given the typing import errors get bundled in with F821 errors during LINTing that we certainly wouldn't want to ignore
