### PR TITLE
BUG: Respect na_rep in DataFrame.to_latex() when used with formatters (#9046)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -355,7 +355,6 @@ I/O
 - Improved performance in :meth:`pandas.read_stata` and :class:`pandas.io.stata.StataReader` when converting columns that have missing values (:issue:`25772`)
 - Bug in :func:`read_hdf` not properly closing store after a ``KeyError`` is raised (:issue:`25766`)
 - Bug in ``read_csv`` which would not raise ``ValueError`` if a column index in ``usecols`` was out of bounds (:issue:`25623`)
-- Bug in :meth:`DataFrame.to_latex` that would ignore `na_rep` if the `formatters` argument was used (:issue:`9046`)
 - Bug in :meth:`DataFrame.to_latex` that would ignore ``na_rep`` if the ``formatters`` argument was used (:issue:`9046`)
 -
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -355,6 +355,10 @@ I/O
 - Improved performance in :meth:`pandas.read_stata` and :class:`pandas.io.stata.StataReader` when converting columns that have missing values (:issue:`25772`)
 - Bug in :func:`read_hdf` not properly closing store after a ``KeyError`` is raised (:issue:`25766`)
 - Bug in ``read_csv`` which would not raise ``ValueError`` if a column index in ``usecols`` was out of bounds (:issue:`25623`)
+- Bug in :meth:`DataFrame.to_latex` that would ignore `na_rep` if the `formatters` argument was used (:issue:`9046`)
+- Bug in :meth:`DataFrame.to_latex` that would ignore ``na_rep`` if the ``formatters`` argument was used (:issue:`9046`)
+-
+
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1063,7 +1063,10 @@ class FloatArrayFormatter(GenericArrayFormatter):
         """
 
         if self.formatter is not None:
-            return np.array([self.formatter(x) for x in self.values])
+            out = np.array([self.formatter(x) for x in self.values])
+            mask = isna(self.values)
+            out[mask] = self.na_rep
+            return out
 
         if self.fixed_width:
             threshold = get_option("display.chop_threshold")
@@ -1142,7 +1145,8 @@ class FloatArrayFormatter(GenericArrayFormatter):
     def _format_strings(self):
         # shortcut
         if self.formatter is not None:
-            return [self.formatter(x) for x in self.values]
+            return [self.formatter(x) if not isna(x) else self.na_rep
+                    for x in self.values]
 
         return list(self.get_result_as_array())
 

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -743,3 +743,20 @@ a & b &    &    \\
 \end{tabular}
 """
         assert observed == expected
+
+    def test_to_latex_na_rep_formatters(self):
+        # GH 9046
+        df = pd.DataFrame({'a': [0, 1, 2], 'b': [0.1, None, 0.2]})
+        observed = df.to_latex(
+            formatters={'b': '{:0.4f}'.format}, na_rep='-')
+        expected = r"""\begin{tabular}{lrr}
+\toprule
+{} &  a &      b \\
+\midrule
+0 &  0 & 0.1000 \\
+1 &  1 &      - \\
+2 &  2 & 0.2000 \\
+\bottomrule
+\end{tabular}
+"""
+        assert observed == expected


### PR DESCRIPTION
- [x] closes #9046
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

A very old issue so low priority! 

I'd be tempted to remove the shortcut in `_format_strings()` since I'd guess in most cases it doesn't really save much time. 