### PR TITLE
PERF: Improve performance of hash sets in read_csv

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -176,6 +176,7 @@ Performance Improvements
   int8/int16/int32 and the searched key is within the integer bounds for the dtype (:issue:`22034`)
 - Improved performance of :meth:`pandas.core.groupby.GroupBy.quantile` (:issue:`20405`)
 - Improved performance of :meth:`read_csv` by faster tokenizing and faster parsing of small float numbers (:issue:`25784`)
+- Improved performance of :meth:`read_csv` by faster parsing of N/A and boolean values (:issue:`25804`)
 
 .. _whatsnew_0250.bug_fixes:
 

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -56,6 +56,16 @@ cdef extern from "khash_python.h":
 
     bint kh_exist_str(kh_str_t*, khiter_t) nogil
 
+    ctypedef struct kh_str_starts_t:
+        kh_str_t *table
+        char starts[256]
+
+    kh_str_starts_t* kh_init_str_starts() nogil
+    khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key, int* ret) nogil
+    khint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) nogil
+    void kh_destroy_str_starts(kh_str_starts_t*) nogil
+    void kh_resize_str_starts(kh_str_starts_t*, khint_t) nogil
+
     ctypedef struct kh_int64_t:
         khint_t n_buckets, size, n_occupied, upper_bound
         uint32_t *flags

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -61,7 +61,8 @@ cdef extern from "khash_python.h":
         int starts[256]
 
     kh_str_starts_t* kh_init_str_starts() nogil
-    khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key, int* ret) nogil
+    khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key,
+                                                            int* ret) nogil
     khint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) nogil
     void kh_destroy_str_starts(kh_str_starts_t*) nogil
     void kh_resize_str_starts(kh_str_starts_t*, khint_t) nogil

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -62,7 +62,7 @@ cdef extern from "khash_python.h":
 
     kh_str_starts_t* kh_init_str_starts() nogil
     khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key,
-                                                            int* ret) nogil
+                                   int* ret) nogil
     khint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) nogil
     void kh_destroy_str_starts(kh_str_starts_t*) nogil
     void kh_resize_str_starts(kh_str_starts_t*, khint_t) nogil

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -58,7 +58,7 @@ cdef extern from "khash_python.h":
 
     ctypedef struct kh_str_starts_t:
         kh_str_t *table
-        char starts[256]
+        int starts[256]
 
     kh_str_starts_t* kh_init_str_starts() nogil
     khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key, int* ret) nogil

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -44,7 +44,8 @@ from pandas._libs.khash cimport (
     kh_put_float64, kh_init_float64, kh_resize_float64,
     kh_strbox_t, kh_put_strbox, kh_get_strbox, kh_init_strbox,
     kh_destroy_strbox,
-    kh_str_starts_t, kh_put_str_starts_item, kh_init_str_starts, kh_get_str_starts_item, kh_destroy_str_starts, kh_resize_str_starts)
+    kh_str_starts_t, kh_put_str_starts_item, kh_init_str_starts,
+    kh_get_str_starts_item, kh_destroy_str_starts, kh_resize_str_starts)
 
 import pandas.compat as compat
 from pandas.core.dtypes.common import (

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -235,9 +235,9 @@ cdef extern from "parser/tokenizer.h":
                            uint64_t uint_max, int *error, char tsep) nogil
 
     float64_t xstrtod(const char *p, char **q, char decimal, char sci,
-                      char tsep, int skip_trailing, int *_error) nogil
+                      char tsep, int skip_trailing, int *error) nogil
     float64_t precise_xstrtod(const char *p, char **q, char decimal, char sci,
-                              char tsep, int skip_trailing, int *_error) nogil
+                              char tsep, int skip_trailing, int *error) nogil
     float64_t round_trip(const char *p, char **q, char decimal, char sci,
                          char tsep, int skip_trailing) nogil
 
@@ -1777,7 +1777,7 @@ cdef inline int _try_double_nogil(parser_t *parser,
                                   float64_t NA, float64_t *data,
                                   int *na_count) nogil:
     cdef:
-        int _error,
+        int error = 0,
         Py_ssize_t i, lines = line_end - line_start
         coliter_t it
         const char *word = NULL
@@ -1797,8 +1797,9 @@ cdef inline int _try_double_nogil(parser_t *parser,
                 data[0] = NA
             else:
                 data[0] = double_converter(word, &p_end, parser.decimal,
-                                           parser.sci, parser.thousands, 1, &_error)
-                if _error != 0 or p_end == word or p_end[0]:
+                                           parser.sci, parser.thousands, 1, &error)
+                if error != 0 or p_end == word or p_end[0]:
+                    error = 0
                     if (strcasecmp(word, cinf) == 0 or
                             strcasecmp(word, cposinf) == 0):
                         data[0] = INF
@@ -1816,8 +1817,9 @@ cdef inline int _try_double_nogil(parser_t *parser,
         for i in range(lines):
             COLITER_NEXT(it, word)
             data[0] = double_converter(word, &p_end, parser.decimal,
-                                       parser.sci, parser.thousands, 1, &_error)
-            if _error != 0 or p_end == word or p_end[0]:
+                                       parser.sci, parser.thousands, 1, &error)
+            if error != 0 or p_end == word or p_end[0]:
+                error = 0
                 if (strcasecmp(word, cinf) == 0 or
                         strcasecmp(word, cposinf) == 0):
                     data[0] = INF

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -2085,7 +2085,7 @@ cdef kh_str_starts_t* kset_from_list(list values) except NULL:
 
         # None creeps in sometimes, which isn't possible here
         if not isinstance(val, bytes):
-            kh_destroy_str(table)
+            kh_destroy_str_starts(table)
             raise ValueError('Must be all encoded bytes')
 
         kh_put_str_starts_item(table, PyBytes_AsString(val), &ret)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1798,7 +1798,8 @@ cdef inline int _try_double_nogil(parser_t *parser,
                 data[0] = NA
             else:
                 data[0] = double_converter(word, &p_end, parser.decimal,
-                                           parser.sci, parser.thousands, 1, &error)
+                                           parser.sci, parser.thousands,
+                                           1, &error)
                 if error != 0 or p_end == word or p_end[0]:
                     error = 0
                     if (strcasecmp(word, cinf) == 0 or
@@ -2078,7 +2079,6 @@ cdef kh_str_starts_t* kset_from_list(list values) except NULL:
         object val
 
     table = kh_init_str_starts()
-
 
     for i in range(len(values)):
         val = values[i]

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -90,13 +90,15 @@ typedef struct {
 	int starts[256];
 } kh_str_starts_t;
 
-inline static kh_str_starts_t* kh_init_str_starts(void) {
+typedef kh_str_starts_t* p_kh_str_starts_t;
+
+p_kh_str_starts_t PANDAS_INLINE kh_init_str_starts(void) {
 	kh_str_starts_t *result = (kh_str_starts_t*)calloc(1, sizeof(kh_str_starts_t));
 	result->table = kh_init_str();
 	return result;
 }
 
-inline static khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key, int* ret) {
+khint_t PANDAS_INLINE kh_put_str_starts_item(kh_str_starts_t* table, char* key, int* ret) {
     khint_t result = kh_put_str(table->table, key, ret);
 	if (*ret != 0) {
 		table->starts[(unsigned char)key[0]] = 1;
@@ -104,7 +106,7 @@ inline static khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key, 
     return result;
 }
 
-inline static khint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) {
+khint_t PANDAS_INLINE kh_get_str_starts_item(kh_str_starts_t* table, char* key) {
     unsigned char ch = *key;
 	if (table->starts[ch]) {
 		if (ch == '\0' || kh_get_str(table->table, key) != table->table->n_buckets) return 1;
@@ -112,11 +114,11 @@ inline static khint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) 
     return 0;
 }
 
-inline static void kh_destroy_str_starts(kh_str_starts_t* table) {
+void PANDAS_INLINE kh_destroy_str_starts(kh_str_starts_t* table) {
 	kh_destroy_str(table->table);
 	free(table);
 }
 
-inline static void kh_resize_str_starts(kh_str_starts_t* table, khint_t val) {
+void PANDAS_INLINE kh_resize_str_starts(kh_str_starts_t* table, khint_t val) {
 	kh_resize_str(table->table, val);
 }

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -87,7 +87,7 @@ KHASH_MAP_INIT_STR(strbox, kh_pyobject_t)
 
 typedef struct {
 	kh_str_t *table;
-	char starts[256];
+	int starts[256];
 } kh_str_starts_t;
 
 inline static kh_str_starts_t* kh_init_str_starts(void) {
@@ -105,15 +105,16 @@ inline static khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key, 
 }
 
 inline static khint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) {
-    char ch = *key;
+    int ch = *key;
 	if (table->starts[ch]) {
 		if (ch == '\0' || kh_get_str(table->table, key) != table->table->n_buckets) return 1;
 	}
     return 0;
 }
 
-inline static void kh_destroy_str_starts(kh_str_starts_t* table) {//FIXME
+inline static void kh_destroy_str_starts(kh_str_starts_t* table) {
 	kh_destroy_str(table->table);
+	free(table);
 }
 
 inline static void kh_resize_str_starts(kh_str_starts_t* table, khint_t val) {

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -99,13 +99,13 @@ inline static kh_str_starts_t* kh_init_str_starts(void) {
 inline static khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key, int* ret) {
     khint_t result = kh_put_str(table->table, key, ret);
 	if (*ret != 0) {
-		table->starts[key[0]] = 1;
+		table->starts[(unsigned char)key[0]] = 1;
 	}
     return result;
 }
 
 inline static khint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) {
-    int ch = *key;
+    unsigned char ch = *key;
 	if (table->starts[ch]) {
 		if (ch == '\0' || kh_get_str(table->table, key) != table->table->n_buckets) return 1;
 	}

--- a/pandas/_libs/src/klib/khash_python.h
+++ b/pandas/_libs/src/klib/khash_python.h
@@ -84,3 +84,38 @@ KHASH_SET_INIT_PYOBJECT(pyset)
 #define kh_exist_pyset(h, k) (kh_exist(h, k))
 
 KHASH_MAP_INIT_STR(strbox, kh_pyobject_t)
+
+typedef struct {
+	kh_str_t *table;
+	char starts[256];
+} kh_str_starts_t;
+
+inline static kh_str_starts_t* kh_init_str_starts(void) {
+	kh_str_starts_t *result = (kh_str_starts_t*)calloc(1, sizeof(kh_str_starts_t));
+	result->table = kh_init_str();
+	return result;
+}
+
+inline static khint_t kh_put_str_starts_item(kh_str_starts_t* table, char* key, int* ret) {
+    khint_t result = kh_put_str(table->table, key, ret);
+	if (*ret != 0) {
+		table->starts[key[0]] = 1;
+	}
+    return result;
+}
+
+inline static khint_t kh_get_str_starts_item(kh_str_starts_t* table, char* key) {
+    char ch = *key;
+	if (table->starts[ch]) {
+		if (ch == '\0' || kh_get_str(table->table, key) != table->table->n_buckets) return 1;
+	}
+    return 0;
+}
+
+inline static void kh_destroy_str_starts(kh_str_starts_t* table) {//FIXME
+	kh_destroy_str(table->table);
+}
+
+inline static void kh_resize_str_starts(kh_str_starts_t* table, khint_t val) {
+	kh_resize_str(table->table, val);
+}

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1544,7 +1544,7 @@ int main(int argc, char *argv[]) {
 const int max_int_decimal_digits = (sizeof(unsigned int) * 8) / 4;
 
 double xstrtod(const char *str, char **endptr, char decimal, char sci,
-               char tsep, int skip_trailing, int *_error) {
+               char tsep, int skip_trailing, int *error) {
     double number;
     unsigned int i_number = 0;
     int exponent;
@@ -1555,7 +1555,6 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     int num_digits;
     int num_decimals;
 
-    *_error = 0;
 
     // Skip leading whitespace.
     while (isspace_ascii(*p)) p++;
@@ -1609,7 +1608,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (num_digits == 0) {
-        *_error = ERANGE;
+        *error = ERANGE;
         return 0.0;
     }
 
@@ -1646,7 +1645,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (exponent < DBL_MIN_EXP || exponent > DBL_MAX_EXP) {
-        *_error = ERANGE;
+        *error = ERANGE;
         return HUGE_VAL;
     }
 
@@ -1666,7 +1665,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (number == HUGE_VAL) {
-        *_error = ERANGE;
+        *error = ERANGE;
     }
 
     if (skip_trailing) {
@@ -1680,7 +1679,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
 }
 
 double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
-                       char tsep, int skip_trailing, int *_error) {
+                       char tsep, int skip_trailing, int *error) {
     double number;
     int exponent;
     int negative;
@@ -1722,7 +1721,6 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
         1e280, 1e281, 1e282, 1e283, 1e284, 1e285, 1e286, 1e287, 1e288, 1e289,
         1e290, 1e291, 1e292, 1e293, 1e294, 1e295, 1e296, 1e297, 1e298, 1e299,
         1e300, 1e301, 1e302, 1e303, 1e304, 1e305, 1e306, 1e307, 1e308};
-    *_error = 0;
 
     // Skip leading whitespace.
     while (isspace_ascii(*p)) p++;
@@ -1772,7 +1770,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (num_digits == 0) {
-        *_error = ERANGE;
+        *error = ERANGE;
         return 0.0;
     }
 
@@ -1809,7 +1807,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (exponent > 308) {
-        *_error = ERANGE;
+        *error = ERANGE;
         return HUGE_VAL;
     } else if (exponent > 0) {
         number *= e[exponent];
@@ -1822,7 +1820,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
         number /= e[-exponent];
     }
 
-    if (number == HUGE_VAL || number == -HUGE_VAL) *_error = ERANGE;
+    if (number == HUGE_VAL || number == -HUGE_VAL) *error = ERANGE;
 
     if (skip_trailing) {
         // Skip trailing whitespace.

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1544,7 +1544,7 @@ int main(int argc, char *argv[]) {
 const int max_int_decimal_digits = (sizeof(unsigned int) * 8) / 4;
 
 double xstrtod(const char *str, char **endptr, char decimal, char sci,
-               char tsep, int skip_trailing) {
+               char tsep, int skip_trailing, int *_error) {
     double number;
     unsigned int i_number = 0;
     int exponent;
@@ -1555,7 +1555,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     int num_digits;
     int num_decimals;
 
-    errno = 0;
+    *_error = 0;
 
     // Skip leading whitespace.
     while (isspace_ascii(*p)) p++;
@@ -1609,7 +1609,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (num_digits == 0) {
-        errno = ERANGE;
+        *_error = ERANGE;
         return 0.0;
     }
 
@@ -1646,7 +1646,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (exponent < DBL_MIN_EXP || exponent > DBL_MAX_EXP) {
-        errno = ERANGE;
+        *_error = ERANGE;
         return HUGE_VAL;
     }
 
@@ -1666,7 +1666,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (number == HUGE_VAL) {
-        errno = ERANGE;
+        *_error = ERANGE;
     }
 
     if (skip_trailing) {
@@ -1680,7 +1680,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
 }
 
 double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
-                       char tsep, int skip_trailing) {
+                       char tsep, int skip_trailing, int *_error) {
     double number;
     int exponent;
     int negative;
@@ -1722,7 +1722,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
         1e280, 1e281, 1e282, 1e283, 1e284, 1e285, 1e286, 1e287, 1e288, 1e289,
         1e290, 1e291, 1e292, 1e293, 1e294, 1e295, 1e296, 1e297, 1e298, 1e299,
         1e300, 1e301, 1e302, 1e303, 1e304, 1e305, 1e306, 1e307, 1e308};
-    errno = 0;
+    *_error = 0;
 
     // Skip leading whitespace.
     while (isspace_ascii(*p)) p++;
@@ -1772,7 +1772,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (num_digits == 0) {
-        errno = ERANGE;
+        *_error = ERANGE;
         return 0.0;
     }
 
@@ -1809,7 +1809,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (exponent > 308) {
-        errno = ERANGE;
+        *_error = ERANGE;
         return HUGE_VAL;
     } else if (exponent > 0) {
         number *= e[exponent];
@@ -1822,7 +1822,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
         number /= e[-exponent];
     }
 
-    if (number == HUGE_VAL || number == -HUGE_VAL) errno = ERANGE;
+    if (number == HUGE_VAL || number == -HUGE_VAL) *_error = ERANGE;
 
     if (skip_trailing) {
         // Skip trailing whitespace.

--- a/pandas/_libs/src/parser/tokenizer.h
+++ b/pandas/_libs/src/parser/tokenizer.h
@@ -260,9 +260,9 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int64_t int_max,
 int64_t str_to_int64(const char *p_item, int64_t int_min, int64_t int_max,
                      int *error, char tsep);
 double xstrtod(const char *p, char **q, char decimal, char sci, char tsep,
-               int skip_trailing, int *_error);
+               int skip_trailing, int *error);
 double precise_xstrtod(const char *p, char **q, char decimal, char sci,
-                       char tsep, int skip_trailing, int *_error);
+                       char tsep, int skip_trailing, int *error);
 double round_trip(const char *p, char **q, char decimal, char sci, char tsep,
                   int skip_trailing);
 int to_boolean(const char *item, uint8_t *val);

--- a/pandas/_libs/src/parser/tokenizer.h
+++ b/pandas/_libs/src/parser/tokenizer.h
@@ -260,9 +260,9 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int64_t int_max,
 int64_t str_to_int64(const char *p_item, int64_t int_min, int64_t int_max,
                      int *error, char tsep);
 double xstrtod(const char *p, char **q, char decimal, char sci, char tsep,
-               int skip_trailing);
+               int skip_trailing, int *_error);
 double precise_xstrtod(const char *p, char **q, char decimal, char sci,
-                       char tsep, int skip_trailing);
+                       char tsep, int skip_trailing, int *_error);
 double round_trip(const char *p, char **q, char decimal, char sci, char tsep,
                   int skip_trailing);
 int to_boolean(const char *item, uint8_t *val);


### PR DESCRIPTION
- [x] closes N/A
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Improved performance of checking of string presence in hashsets by:
1. implemented lookup table for first symbol of entries - this speeds up negative answers
2. increased size of hash table to reduce the probability of hash collision

Hash bucket increase is needed due to khash search algorithm - it computes a hash of key being searched, uses its last N bits where N corresponds to bucket size, and then does an open ended search over the table if collision happened with calling a comparison function over keys. When keys are strings (or, more precisely, `char*` things) comparison function is `strcmp()` which complexity is O(N), thus we want for collisions to be rare.
Most lookups of those sets happen when values are checked against N/A table which by default has 17 entries. Without the change bucket size is 32, thus hash collision probability is 17/32 (~53%), after the patch bucket size is 256 and collision probability is 6.6%.

I will add `asv` results and whatsnew later.