### PR TITLE
BUG: DatetimeIndex.to_frame does not drop timezone information

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -208,6 +208,7 @@ Timedelta
 Timezones
 ^^^^^^^^^
 
+- Bug in :func:`DatetimeIndex.to_frame` where timezone aware data would be converted to timezone naive data (:issue:`25809`)
 - Bug in :func:`to_datetime` with ``utc=True`` and datetime strings that would apply previously parsed UTC offsets to subsequent arguments (:issue:`24992`)
 - Bug in :func:`Timestamp.tz_localize` and :func:`Timestamp.tz_convert` does not propagate ``freq`` (:issue:`25241`)
 - Bug in :func:`Series.at` where setting :class:`Timestamp` with timezone raises ``TypeError`` (:issue:`25506`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1208,7 +1208,7 @@ class Index(IndexOpsMixin, PandasObject):
         from pandas import DataFrame
         if name is None:
             name = self.name or 0
-        result = DataFrame({name: self.values.copy()})
+        result = DataFrame({name: self._values.copy()})
 
         if index:
             result.index = self

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -85,6 +85,14 @@ class Base(object):
         df = idx.to_frame(index=False, name=idx_name)
         assert df.index is not idx
 
+    def test_to_frame_datetime_tz(self):
+        # GH 25809
+        idx = pd.date_range(start='2019-01-01', end='2019-01-30', freq='D')
+        idx = idx.tz_localize('UTC')
+        result = idx.to_frame()
+        expected = pd.DataFrame(idx, index=idx)
+        tm.assert_frame_equal(result, expected)
+
     def test_shift(self):
 
         # GH8083 test the base class for shift


### PR DESCRIPTION
- [x] closes #25809
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
