### PR TITLE
Implement --with-debugging-symbols switch in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -413,6 +413,11 @@ else:
 # ----------------------------------------------------------------------
 # Preparation of compiler arguments
 
+debugging_symbols_requested = '--with-debugging-symbols' in sys.argv
+if debugging_symbols_requested:
+    sys.argv.remove('--with-debugging-symbols')
+
+
 if sys.byteorder == 'big':
     endian_macro = [('__BIG_ENDIAN__', '1')]
 else:
@@ -421,10 +426,16 @@ else:
 
 if is_platform_windows():
     extra_compile_args = []
+    extra_link_args = []
+    if debugging_symbols_requested:
+        extra_compile_args.append('/Z7')
+        extra_link_args.append('/DEBUG')
 else:
     # args to ignore warnings
     extra_compile_args = ['-Wno-unused-function']
-
+    extra_link_args = []
+    if debugging_symbols_requested:
+        extra_compile_args.append('-g')
 
 # For mac, ensure extensions are built for macos 10.9 when compiling on a
 # 10.9 system or above, overriding distuitls behaviour which is to target
@@ -688,7 +699,8 @@ for name, data in ext_data.items():
                     include_dirs=include,
                     language=data.get('language', 'c'),
                     define_macros=data.get('macros', macros),
-                    extra_compile_args=extra_compile_args)
+                    extra_compile_args=extra_compile_args,
+                    extra_link_args=extra_link_args)
 
     extensions.append(obj)
 
@@ -715,6 +727,7 @@ ujson_ext = Extension('pandas._libs.json',
                                     'pandas/_libs/src/datetime'],
                       extra_compile_args=(['-D_GNU_SOURCE'] +
                                           extra_compile_args),
+                      extra_link_args=extra_link_args,
                       define_macros=macros)
 
 
@@ -726,7 +739,9 @@ extensions.append(ujson_ext)
 _move_ext = Extension('pandas.util._move',
                       depends=[],
                       sources=['pandas/util/move.c'],
-                      define_macros=macros)
+                      define_macros=macros,
+                      extra_compile_args=extra_compile_args,
+                      extra_link_args=extra_link_args)
 extensions.append(_move_ext)
 
 # The build cache system does string matching below this point.


### PR DESCRIPTION
- [x] closes N/A
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This implements a switch that enables building Pandas with debugging symbols - useful for debugging or profiling native parts of the code.