### PR TITLE
WIP, MAINT: upstream timedelta64 changes

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1181,7 +1181,7 @@ class Timedelta(_Timedelta):
 
             kwargs = {key: _to_py_int_float(kwargs[key]) for key in kwargs}
 
-            nano = kwargs.pop('nanoseconds', 0)
+            nano = np.timedelta64(kwargs.pop('nanoseconds', 0), 'ns')
             try:
                 value = nano + convert_to_timedelta64(timedelta(**kwargs),
                                                       'ns')

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -2137,7 +2137,8 @@ class TestDatetimeIndexArithmetic(object):
         #                   'us': 1}
 
         def timedelta64(*args):
-            return sum(starmap(np.timedelta64, zip(args, intervals)))
+            # see casting notes in NumPy gh-12927
+            return np.sum(list(starmap(np.timedelta64, zip(args, intervals))))
 
         for d, h, m, s, us in product(*([range(2)] * 5)):
             nptd = timedelta64(d, h, m, s, us)


### PR DESCRIPTION
**Background:** In NumPy, I've been working to expand the operations supported for `np.timedelta64` (`m8`) operands, adding support for modulus, floordiv and divmod operations. Historically, we've allowed casting from integer and bool types to `m8`, which may seem innocent enough, but is arguably sloppy from a units perspective.

Furthermore, with the introduction of new `m8` operation support, signed and unsigned integers are now able to interconvert in [undesirable ways](https://github.com/numpy/numpy/issues/12927) by sneaking through casts to `m8`. So, core devs have suggested [prohibiting casts from int / bool types to `m8`](https://github.com/numpy/numpy/pull/13061). A prime concern here for me is the effect on downstream libraries that are known to heavily use datetime operations, like `pandas`.

**Feedback**: It would be great to get some feedback here from the `pandas` perspective. To get the discussion started, I've opened this PR with some perhaps crude changes that allow the `pandas` master branch test suite to pass for me locally (via `./test_fash.sh` anyway) with the NumPy feature branch linked above. 

How disruptive is this for you? Will we need to issue warnings / deprecate? Should we just not do this at all?