### PR TITLE
CI: exclude asv env directory from isort and tailing whitespace checks

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -175,9 +175,9 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     set -o pipefail
     if [[ "$AZURE" == "true" ]]; then
         # we exclude all c/cpp files as the c/cpp files of pandas code base are tested when Linting .c and .h files
-        ! grep -n '--exclude=*.'{svg,c,cpp,html} -RI "\s$" * | awk -F ":" '{print "##vso[task.logissue type=error;sourcepath=" $1 ";linenumber=" $2 ";] Tailing whitespaces found: " $3}'
+        ! grep -n '--exclude=*.'{svg,c,cpp,html} --exclude-dir=env -RI "\s$" * | awk -F ":" '{print "##vso[task.logissue type=error;sourcepath=" $1 ";linenumber=" $2 ";] Tailing whitespaces found: " $3}'
     else
-        ! grep -n '--exclude=*.'{svg,c,cpp,html}  -RI "\s$" * | awk -F ":" '{print $1 ":" $2 ":Tailing whitespaces found: " $3}'
+        ! grep -n '--exclude=*.'{svg,c,cpp,html} --exclude-dir=env -RI "\s$" * | awk -F ":" '{print $1 ":" $2 ":Tailing whitespaces found: " $3}'
     fi
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ multi_line_output=4
 force_grid_wrap=0
 combine_as_imports=True
 force_sort_within_sections=True
+skip_glob=env,
 skip=
     pandas/core/api.py,
     pandas/core/frame.py,


### PR DESCRIPTION
When running `ci/code_checks.sh` on a local repository that has also been used to run `asv` benchmarks, a couple of the checks recurse into the `asv_bench/env` directory created for running benchmark environments. This massively increases the runtime and leads to linting errors on non-pandas packages, which is not informative.

This change simply adds `env` to the `isort` exclude list and the tailing whitespace `grep` call, which resolves the issue.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
