### PR TITLE
Safe version of ascii macros, add missing tolower_ascii

### DIFF
--- a/pandas/_libs/src/headers/portable.h
+++ b/pandas/_libs/src/headers/portable.h
@@ -7,8 +7,8 @@
 
 // GH-23516 - works around locale perf issues
 // from MUSL libc, MIT Licensed - see LICENSES
-#define isdigit_ascii(c) ((unsigned)c - '0' < 10)
-#define isspace_ascii(c) (c == ' ' || (unsigned)c-'\t' < 5)
-#define toupper_ascii(c) (((unsigned)c-'a' < 26) ? (c & 0x5f) : c)
+#define isdigit_ascii(c) (((unsigned)(c) - '0') < 10u)
+#define isspace_ascii(c) (((c) == ' ') || (((unsigned)(c) - '\t') < 5))
+#define toupper_ascii(c) ((((unsigned)(c) - 'a') < 26) ? ((c) & 0x5f) : (c))
 
 #endif

--- a/pandas/_libs/src/headers/portable.h
+++ b/pandas/_libs/src/headers/portable.h
@@ -10,5 +10,6 @@
 #define isdigit_ascii(c) (((unsigned)(c) - '0') < 10u)
 #define isspace_ascii(c) (((c) == ' ') || (((unsigned)(c) - '\t') < 5))
 #define toupper_ascii(c) ((((unsigned)(c) - 'a') < 26) ? ((c) & 0x5f) : (c))
+#define tolower_ascii(c) ((((unsigned)(c) - 'A') < 26) ? ((c) | 0x20) : (c))
 
 #endif


### PR DESCRIPTION
- [x] fixes a warning introduced in #23981
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Using unparenthesized macro parameters is dangerous, so wrap `c` in braces.

Example warning fixed by adding `tolower_ascii()`:

```
In file included from pandas/_libs/lib.c:643:0:
pandas/_libs/src/parse_helper.h: In function ‘lowercase’:
pandas/_libs/src/parse_helper.h:141:26: warning: implicit declaration of function ‘tolower_ascii’; did you mean ‘toupper_ascii’? [-Wimplicit-function-declaration]
     for (; *p; ++p) *p = tolower_ascii(*p);
                          ^~~~~~~~~~~~~
                          toupper_ascii
```