### PR TITLE
CLN: Remove redundant definitions in pandas.compat (filter, map, range, etc.)

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -698,7 +698,7 @@ cdef class TextReader:
 
             if ptr == NULL:
                 if not os.path.exists(source):
-                    raise compat.FileNotFoundError(
+                    raise FileNotFoundError(
                         ENOENT,
                         'File {source} does not exist'.format(source=source),
                         source)

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -5,7 +5,7 @@ compat
 Cross-compatible functions for Python 2 and 3.
 
 Key items to import for 2/3 compatible code:
-* iterators: range(), map(), zip(), filter(), reduce()
+* iterators: reduce()
 * lists: lrange(), lmap(), lzip(), lfilter()
 * unicode: u() [no unicode builtin in Python 3]
 * longs: long (int in Python 3)
@@ -298,9 +298,6 @@ if PY3:
             name=name)
         f.__module__ = cls.__module__
         return f
-
-    ResourceWarning = ResourceWarning
-
 else:
     string_types = basestring,
     integer_types = (int, long)
@@ -355,9 +352,6 @@ else:
         """ Bind the name attributes of the function """
         f.__name__ = name
         return f
-
-    class ResourceWarning(Warning):
-        pass
 
 string_and_binary_types = string_types + (binary_type,)
 

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -107,18 +107,10 @@ if PY3:
         return data.start, data.stop, data.step
 
     # have to explicitly put builtins into the namespace
-    range = range
-    map = map
-    zip = zip
-    filter = filter
     intern = sys.intern
     reduce = functools.reduce
     long = int
     unichr = chr
-
-    # This was introduced in Python 3.3, but we don't support
-    # Python 3.x < 3.5, so checking PY3 is safe.
-    FileNotFoundError = FileNotFoundError
 
     # list-producing versions of the major Python iterating functions
     def lrange(*args, **kwargs):
@@ -147,8 +139,6 @@ if PY3:
 else:
     # Python 2
     _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
-
-    FileNotFoundError = IOError
 
     def isidentifier(s, dotted=False):
         return bool(_name_re.match(s))
@@ -181,11 +171,7 @@ else:
         return start, stop, step
 
     # import iterator versions of these functions
-    range = xrange
     intern = intern
-    zip = itertools.izip
-    filter = itertools.ifilter
-    map = itertools.imap
     reduce = reduce
     long = long
     unichr = unichr
@@ -217,7 +203,6 @@ if PY2:
     def itervalues(obj, **kw):
         return obj.itervalues(**kw)
 
-    next = lambda it: it.next()
 else:
     def iteritems(obj, **kw):
         return iter(obj.items(**kw))
@@ -227,8 +212,6 @@ else:
 
     def itervalues(obj, **kw):
         return iter(obj.values(**kw))
-
-    next = next
 
 
 def bind_method(cls, name, func):

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 
 from pandas._libs import lib
-from pandas.compat import range, set_function_name, string_types
+from pandas.compat import set_function_name, string_types
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.base import ExtensionDtype

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -934,14 +934,14 @@ def _range_from_fields(year=None, month=None, quarter=None, day=None,
                 raise AssertionError("base must equal FR_QTR")
 
         year, quarter = _make_field_arrays(year, quarter)
-        for y, q in compat.zip(year, quarter):
+        for y, q in zip(year, quarter):
             y, m = libperiod.quarter_to_myear(y, q, freq)
             val = libperiod.period_ordinal(y, m, 1, 1, 1, 1, 0, 0, base)
             ordinals.append(val)
     else:
         base, mult = libfrequencies.get_freq_code(freq)
         arrays = _make_field_arrays(year, month, day, hour, minute, second)
-        for y, mth, d, h, mn, s in compat.zip(*arrays):
+        for y, mth, d, h, mn, s in zip(*arrays):
             ordinals.append(libperiod.period_ordinal(
                 y, mth, d, h, mn, s, 0, 0, base))
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import pandas._libs.lib as lib
 import pandas.compat as compat
-from pandas.compat import PYPY, builtins, map, range
+from pandas.compat import PYPY, builtins
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, cache_readonly

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -6,7 +6,6 @@ import warnings
 
 import numpy as np
 
-from pandas.compat import range, zip
 from pandas.errors import PerformanceWarning
 
 import pandas as pd

--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -4,8 +4,6 @@ Engine classes for :func:`~pandas.eval`
 
 import abc
 
-from pandas.compat import map
-
 from pandas import compat
 from pandas.core.computation.align import _align, _reconstruct_object
 from pandas.core.computation.ops import (

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -9,7 +9,7 @@ import tokenize
 
 import numpy as np
 
-from pandas.compat import StringIO, lmap, map, reduce, string_types, zip
+from pandas.compat import StringIO, lmap, reduce, string_types
 
 import pandas as pd
 from pandas import compat

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -12,7 +12,7 @@ import sys
 import numpy as np
 
 from pandas._libs.tslibs import Timestamp
-from pandas.compat import DeepChainMap, StringIO, map
+from pandas.compat import DeepChainMap, StringIO
 
 from pandas.core.base import StringMixin
 import pandas.core.computation as compu

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -33,9 +33,9 @@ from pandas.util._validators import (validate_bool_kwarg,
                                      validate_axis_style_args)
 
 from pandas import compat
-from pandas.compat import (range, map, zip, lmap, lzip, StringIO, u,
-                           PY36, raise_with_traceback, Iterator,
-                           string_and_binary_types)
+from pandas.compat import (
+    PY36, Iterator, StringIO, lmap, lzip, raise_with_traceback,
+    string_and_binary_types, u)
 from pandas.compat.numpy import function as nv
 from pandas.core.dtypes.cast import (
     maybe_upcast,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -14,8 +14,8 @@ import numpy as np
 from pandas._libs import Timestamp, iNaT, properties
 import pandas.compat as compat
 from pandas.compat import (
-    cPickle as pkl, isidentifier, lrange, lzip, map, set_function_name,
-    string_types, to_str, zip)
+    cPickle as pkl, isidentifier, lrange, lzip, set_function_name,
+    string_types, to_str)
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import (

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from pandas._libs import Timestamp, lib
 import pandas.compat as compat
-from pandas.compat import lzip, map
+from pandas.compat import lzip
 from pandas.compat.numpy import _np_version_under1p13
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from pandas._libs import Timestamp, groupby as libgroupby
 import pandas.compat as compat
-from pandas.compat import range, set_function_name, zip
+from pandas.compat import set_function_name
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, cache_readonly

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -8,7 +8,6 @@ import warnings
 import numpy as np
 
 import pandas.compat as compat
-from pandas.compat import zip
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -11,7 +11,7 @@ import collections
 import numpy as np
 
 from pandas._libs import NaT, groupby as libgroupby, iNaT, lib, reduction
-from pandas.compat import lzip, range, zip
+from pandas.compat import lzip
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -12,7 +12,7 @@ from pandas._libs.lib import is_datetime_array
 from pandas._libs.tslibs import OutOfBoundsDatetime, Timedelta, Timestamp
 from pandas._libs.tslibs.timezones import tz_compare
 import pandas.compat as compat
-from pandas.compat import range, set_function_name, u
+from pandas.compat import set_function_name, u
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, Substitution, cache_readonly
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -9,7 +9,7 @@ import numpy as np
 from pandas._libs import (
     Timestamp, algos as libalgos, index as libindex, lib, tslibs)
 import pandas.compat as compat
-from pandas.compat import lrange, lzip, map, range, zip
+from pandas.compat import lrange, lzip
 from pandas.compat.numpy import function as nv
 from pandas.errors import PerformanceWarning, UnsortedIndexError
 from pandas.util._decorators import Appender, cache_readonly, deprecate_kwarg

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pandas._libs import index as libindex, lib
 import pandas.compat as compat
-from pandas.compat import get_range_parameters, lrange, range
+from pandas.compat import get_range_parameters, lrange
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, cache_readonly
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -7,7 +7,6 @@ import numpy as np
 from pandas._libs.indexing import _NDFrameIndexerBase
 from pandas._libs.lib import item_from_zerodim
 import pandas.compat as compat
-from pandas.compat import range, zip
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -11,7 +11,6 @@ import numpy as np
 from pandas._libs import internals as libinternals, lib, tslib, tslibs
 from pandas._libs.tslibs import Timedelta, conversion, is_null_datetimelike
 import pandas.compat as compat
-from pandas.compat import range, zip
 from pandas.util._validators import validate_bool_kwarg
 
 from pandas.core.dtypes.cast import (

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -11,7 +11,7 @@ from pandas._libs import lib
 from pandas._libs.tslibs import IncompatibleFrequency
 import pandas.compat as compat
 from pandas.compat import (
-    get_range_parameters, lmap, lrange, raise_with_traceback, range)
+    get_range_parameters, lmap, lrange, raise_with_traceback)
 
 from pandas.core.dtypes.cast import (
     construct_1d_arraylike_from_scalar, construct_1d_ndarray_preserving_na,

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -9,7 +9,6 @@ from typing import List, Optional, Union
 import numpy as np
 
 from pandas._libs import internals as libinternals, lib
-from pandas.compat import map, range, zip
 from pandas.util._validators import validate_bool_kwarg
 
 from pandas.core.dtypes.cast import (

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -7,7 +7,7 @@ import operator
 import numpy as np
 
 from pandas._libs import algos, lib
-from pandas.compat import range, string_types
+from pandas.compat import string_types
 
 from pandas.core.dtypes.cast import infer_dtype_from_array
 from pandas.core.dtypes.common import (

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -10,7 +10,7 @@ import warnings
 import numpy as np
 
 import pandas.compat as compat
-from pandas.compat import map, range, u, zip
+from pandas.compat import u
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, Substitution, deprecate_kwarg
 from pandas.util._validators import validate_axis_style_args

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from pandas._libs import hashtable as libhashtable, join as libjoin, lib
 import pandas.compat as compat
-from pandas.compat import filter, lzip, map, range, zip
+from pandas.compat import lzip
 from pandas.errors import MergeError
 from pandas.util._decorators import Appender, Substitution
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -1,7 +1,7 @@
 # pylint: disable=E1103
 import numpy as np
 
-from pandas.compat import lrange, range, zip
+from pandas.compat import lrange
 from pandas.util._decorators import Appender, Substitution
 
 from pandas.core.dtypes.cast import maybe_downcast_to_dtype

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pandas._libs import algos as _algos, reshape as _reshape
 from pandas._libs.sparse import IntIndex
-from pandas.compat import PY2, range, text_type, u, zip
+from pandas.compat import PY2, text_type, u
 
 from pandas.core.dtypes.cast import maybe_promote
 from pandas.core.dtypes.common import (

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from pandas._libs import iNaT, index as libindex, lib, tslibs
 import pandas.compat as compat
-from pandas.compat import PY36, StringIO, u, zip
+from pandas.compat import PY36, StringIO, u
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, Substitution, deprecate
 from pandas.util._validators import validate_bool_kwarg

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas._libs.lib as lib
 import pandas._libs.ops as libops
 import pandas.compat as compat
-from pandas.compat import zip
 from pandas.util._decorators import Appender, deprecate_kwarg
 
 from pandas.core.dtypes.common import (

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -8,7 +8,6 @@ from pandas._libs.tslibs import Timestamp, conversion, parsing
 from pandas._libs.tslibs.parsing import (  # noqa
     DateParseError, _format_is_iso, _guess_datetime_format, parse_time_string)
 from pandas._libs.tslibs.strptime import array_strptime
-from pandas.compat import zip
 from pandas.util._decorators import deprecate_kwarg
 
 from pandas.core.dtypes.common import (

--- a/pandas/io/date_converters.py
+++ b/pandas/io/date_converters.py
@@ -2,7 +2,6 @@
 import numpy as np
 
 from pandas._libs.tslibs import parsing
-from pandas.compat import map, range
 
 
 def parse_date_time(date_col, time_col):

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -6,7 +6,7 @@ from textwrap import fill
 import warnings
 
 import pandas.compat as compat
-from pandas.compat import add_metaclass, range, string_types, u
+from pandas.compat import add_metaclass, string_types, u
 from pandas.errors import EmptyDataError
 from pandas.util._decorators import Appender, deprecate_kwarg
 

--- a/pandas/io/excel/_util.py
+++ b/pandas/io/excel/_util.py
@@ -1,7 +1,7 @@
 import warnings
 
 import pandas.compat as compat
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 from pandas.core.dtypes.common import is_integer, is_list_like
 

--- a/pandas/io/excel/_xlrd.py
+++ b/pandas/io/excel/_xlrd.py
@@ -5,7 +5,6 @@ from io import UnsupportedOperation
 import numpy as np
 
 import pandas.compat as compat
-from pandas.compat import range, zip
 
 from pandas.io.common import _is_url, _urlopen, get_filepath_or_buffer
 from pandas.io.excel._base import _BaseExcelReader

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -2,7 +2,6 @@
 
 from distutils.version import LooseVersion
 
-from pandas.compat import range
 from pandas.util._decorators import deprecate_kwarg
 
 from pandas import DataFrame, Int64Index, RangeIndex

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 import numpy as np
 
 from pandas._libs import writers as libwriters
-from pandas.compat import StringIO, range, zip
+from pandas.compat import StringIO
 
 from pandas.core.dtypes.generic import (
     ABCDatetimeIndex, ABCIndexClass, ABCMultiIndex, ABCPeriodIndex)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -13,7 +13,7 @@ import numpy as np
 from pandas._libs import lib
 from pandas._libs.tslib import format_array_from_datetime
 from pandas._libs.tslibs import NaT, Timedelta, Timestamp, iNaT
-from pandas.compat import StringIO, lzip, map, u, zip
+from pandas.compat import StringIO, lzip, u
 
 from pandas.core.dtypes.common import (
     is_categorical_dtype, is_datetime64_dtype, is_datetime64tz_dtype,

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 from collections import OrderedDict
 from textwrap import dedent
 
-from pandas.compat import lzip, map, range, u, unichr, zip
+from pandas.compat import lzip, u, unichr
 
 from pandas.core.dtypes.generic import ABCMultiIndex
 

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import numpy as np
 
-from pandas.compat import map, range, u, zip
+from pandas.compat import u
 
 from pandas.core.dtypes.generic import ABCMultiIndex
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -12,7 +12,6 @@ from uuid import uuid1
 
 import numpy as np
 
-from pandas.compat import range
 from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.common import is_float, is_string_like

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -19,8 +19,7 @@ import pandas._libs.ops as libops
 import pandas._libs.parsers as parsers
 from pandas._libs.tslibs import parsing
 import pandas.compat as compat
-from pandas.compat import (
-    PY3, StringIO, lrange, lzip, map, range, string_types, u, zip)
+from pandas.compat import PY3, StringIO, lrange, lzip, string_types, u
 from pandas.errors import (
     AbstractMethodError, EmptyDataError, ParserError, ParserWarning)
 from pandas.util._decorators import Appender
@@ -1147,7 +1146,7 @@ class TextFileReader(BaseIterator):
         if index is None:
             if col_dict:
                 # Any column is actually fine:
-                new_rows = len(compat.next(compat.itervalues(col_dict)))
+                new_rows = len(next(compat.itervalues(col_dict)))
                 index = RangeIndex(self._currow, self._currow + new_rows)
             else:
                 new_rows = 0

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from pandas._libs import lib, writers as libwriters
 from pandas._libs.tslibs import timezones
-from pandas.compat import PY3, filter, lrange, range, string_types
+from pandas.compat import PY3, lrange, string_types
 from pandas.errors import PerformanceWarning
 
 from pandas.core.dtypes.common import (
@@ -351,7 +351,7 @@ def read_hdf(path_or_buf, key=None, mode='r', **kwargs):
             exists = False
 
         if not exists:
-            raise compat.FileNotFoundError(
+            raise FileNotFoundError(
                 'File {path} does not exist'.format(path=path_or_buf))
 
         store = HDFStore(path_or_buf, mode=mode, **kwargs)

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -28,7 +28,7 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
     fs = s3fs.S3FileSystem(anon=False)
     try:
         filepath_or_buffer = fs.open(_strip_schema(filepath_or_buffer), mode)
-    except (compat.FileNotFoundError, NoCredentialsError):
+    except (FileNotFoundError, NoCredentialsError):
         # boto3 has troubles when trying to access a public file
         # when credentialed...
         # An OSError is raised if you have credentials, but they

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -15,8 +15,7 @@ import warnings
 import numpy as np
 
 import pandas._libs.lib as lib
-from pandas.compat import (
-    map, raise_with_traceback, string_types, text_type, zip)
+from pandas.compat import raise_with_traceback, string_types, text_type
 
 from pandas.core.dtypes.common import (
     is_datetime64tz_dtype, is_dict_like, is_list_like)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -23,8 +23,7 @@ import numpy as np
 from pandas._libs.lib import infer_dtype
 from pandas._libs.tslibs import NaT, Timestamp
 from pandas._libs.writers import max_len_string_array
-from pandas.compat import (
-    BytesIO, ResourceWarning, lmap, lrange, lzip, string_types, text_type)
+from pandas.compat import BytesIO, lmap, lrange, lzip, string_types, text_type
 from pandas.util._decorators import Appender, deprecate_kwarg
 
 from pandas.core.dtypes.common import (

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -24,8 +24,7 @@ from pandas._libs.lib import infer_dtype
 from pandas._libs.tslibs import NaT, Timestamp
 from pandas._libs.writers import max_len_string_array
 from pandas.compat import (
-    BytesIO, ResourceWarning, lmap, lrange, lzip, range, string_types,
-    text_type, zip)
+    BytesIO, ResourceWarning, lmap, lrange, lzip, string_types, text_type)
 from pandas.util._decorators import Appender, deprecate_kwarg
 
 from pandas.core.dtypes.common import (

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -10,7 +10,7 @@ import warnings
 import numpy as np
 
 import pandas.compat as compat
-from pandas.compat import lrange, map, range, string_types, zip
+from pandas.compat import lrange, string_types
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, cache_readonly
 

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import numpy as np
 
-from pandas.compat import lmap, lrange, range, zip
+from pandas.compat import lmap, lrange
 from pandas.util._decorators import deprecate_kwarg
 
 from pandas.core.dtypes.missing import notna

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -7,8 +7,6 @@ import warnings
 
 import numpy as np
 
-from pandas.compat import range
-
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.sparse import IntIndex
-from pandas.compat import range
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -9,7 +9,7 @@ import pydoc
 import numpy as np
 import pytest
 
-from pandas.compat import long, lrange, range
+from pandas.compat import long, lrange
 
 import pandas as pd
 from pandas import (

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -6,8 +6,6 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas.tests.frame.common import _check_mixed_float, _check_mixed_int
 import pandas.util.testing as tm

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -12,7 +12,7 @@ import numpy.ma as ma
 import pytest
 
 from pandas.compat import (
-    PY36, is_platform_little_endian, lmap, long, lrange, lzip, range, zip)
+    PY36, is_platform_little_endian, lmap, long, lrange, lzip)
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import is_integer_dtype

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import iNaT
-from pandas.compat import long, lrange, lzip, map, range, zip
+from pandas.compat import long, lrange, lzip
 
 from pandas.core.dtypes.common import is_float_dtype, is_integer, is_scalar
 from pandas.core.dtypes.dtypes import CategoricalDtype

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import numpy as np
 import pytest
 
-from pandas.compat import PY36, lrange, range
+from pandas.compat import PY36, lrange
 
 from pandas import DataFrame, Index, MultiIndex, Series
 import pandas.util.testing as tm

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -8,8 +8,6 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, compat
 import pandas.core.common as com

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -7,7 +7,7 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, lrange, range, zip
+from pandas.compat import StringIO, lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -8,7 +8,7 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, lrange, range, zip
+from pandas.compat import StringIO, lrange
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, compat, date_range

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, lmap, lrange, range, u
+from pandas.compat import StringIO, lmap, lrange, u
 from pandas.errors import ParserError
 
 import pandas as pd

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -8,7 +8,6 @@ from operator import methodcaller
 import numpy as np
 import pytest
 
-from pandas.compat import range
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -6,8 +6,6 @@ from copy import copy, deepcopy
 import numpy as np
 import pytest
 
-from pandas.compat import range, zip
-
 from pandas.core.dtypes.common import is_scalar
 
 import pandas as pd

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -7,7 +7,6 @@ from operator import methodcaller
 import numpy as np
 import pytest
 
-from pandas.compat import range
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/groupby/test_counting.py
+++ b/pandas/tests/groupby/test_counting.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import numpy as np
 import pytest
 
-from pandas.compat import product as cart_product, range
+from pandas.compat import product as cart_product
 
 from pandas import DataFrame, MultiIndex, Period, Series, Timedelta, Timestamp
 from pandas.util.testing import assert_frame_equal, assert_series_equal

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, lmap, lrange, lzip, map, range, zip
+from pandas.compat import StringIO, lmap, lrange, lzip
 from pandas.errors import PerformanceWarning
 
 import pandas as pd

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -12,7 +12,7 @@ import pytest
 import pytz
 
 from pandas._libs.tslibs import conversion, timezones
-from pandas.compat import lrange, zip
+from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import Timestamp
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 

--- a/pandas/tests/indexes/multi/test_conversion.py
+++ b/pandas/tests/indexes/multi/test_conversion.py
@@ -5,8 +5,6 @@ from collections import OrderedDict
 import numpy as np
 import pytest
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas import DataFrame, MultiIndex, date_range
 import pandas.util.testing as tm

--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from pandas._libs import hashtable
-from pandas.compat import range, u
+from pandas.compat import u
 
 from pandas import DatetimeIndex, MultiIndex
 import pandas.util.testing as tm

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, lzip, range
+from pandas.compat import lrange, lzip
 
 import pandas as pd
 from pandas import Index, MultiIndex, Series

--- a/pandas/tests/indexes/multi/test_format.py
+++ b/pandas/tests/indexes/multi/test_format.py
@@ -5,7 +5,7 @@ import warnings
 
 import pytest
 
-from pandas.compat import range, u
+from pandas.compat import u
 
 import pandas as pd
 from pandas import MultiIndex, compat

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -4,8 +4,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas import CategoricalIndex, Index, MultiIndex
 import pandas.util.testing as tm

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -5,7 +5,7 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import Timestamp
-from pandas.compat import PY36, StringIO, lrange, lzip, range, u, zip
+from pandas.compat import PY36, StringIO, lrange, lzip, u
 from pandas.compat.numpy import np_datetime64_compat
 
 from pandas.core.dtypes.common import is_unsigned_integer_dtype

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from pandas._libs import index as libindex
-from pandas.compat import range
 
 from pandas.core.dtypes.dtypes import CategoricalDtype
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import Timestamp
-from pandas.compat import range
 
 import pandas as pd
 from pandas import Float64Index, Index, Int64Index, Series, UInt64Index

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from pandas.compat import range, u
+from pandas.compat import u
 
 import pandas as pd
 from pandas import Float64Index, Index, Int64Index, RangeIndex, Series

--- a/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, lzip, range
+from pandas.compat import lrange, lzip
 
 from pandas import DataFrame, MultiIndex, Series
 from pandas.core import common as com

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import u, zip
+from pandas.compat import u
 
 from pandas import DataFrame, Index, MultiIndex, Series
 from pandas.core.indexing import IndexingError

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -10,7 +10,7 @@ import weakref
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 from pandas.core.dtypes.common import is_float_dtype, is_integer_dtype
 

--- a/pandas/tests/indexing/test_indexing_engines.py
+++ b/pandas/tests/indexing/test_indexing_engines.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from pandas._libs import algos as libalgos, index as libindex
 
-from pandas import compat
 import pandas.util.testing as tm
 
 
@@ -69,7 +68,7 @@ class TestNumericEngine(object):
         arr = np.array([1, 5, 10], dtype=dtype)
         engine = engine_type(lambda: arr, len(arr))
 
-        new = np.array(compat.range(12), dtype=dtype)
+        new = np.arange(12, dtype=dtype)
         result = engine.get_backfill_indexer(new)
 
         expected = libalgos.backfill(arr, new)
@@ -82,7 +81,7 @@ class TestNumericEngine(object):
         arr = np.array([1, 5, 10], dtype=dtype)
         engine = engine_type(lambda: arr, len(arr))
 
-        new = np.array(compat.range(12), dtype=dtype)
+        new = np.arange(12, dtype=dtype)
         result = engine.get_pad_indexer(new)
 
         expected = libalgos.pad(arr, new)

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.internals import BlockPlacement
-from pandas.compat import lrange, u, zip
+from pandas.compat import lrange, u
 
 import pandas as pd
 from pandas import (

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -22,8 +22,7 @@ import pytz
 
 import pandas.compat as compat
 from pandas.compat import (
-    StringIO, is_platform_32bit, is_platform_windows, lrange, lzip, range, u,
-    zip)
+    StringIO, is_platform_32bit, is_platform_windows, lrange, lzip, u)
 
 import pandas as pd
 from pandas import (

--- a/pandas/tests/io/generate_legacy_storage_files.py
+++ b/pandas/tests/io/generate_legacy_storage_files.py
@@ -290,7 +290,7 @@ def write_legacy_pickles(output_dir):
 
     # make sure we are < 0.13 compat (in py3)
     try:
-        from pandas.compat import zip, cPickle as pickle  # noqa
+        from pandas.compat import cPickle as pickle  # noqa
     except ImportError:
         import pickle
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, is_platform_32bit, lrange, range
+from pandas.compat import StringIO, is_platform_32bit, lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -20,7 +20,7 @@ import pytz
 import pandas._libs.json as ujson
 from pandas._libs.tslib import Timestamp
 import pandas.compat as compat
-from pandas.compat import StringIO, range, u
+from pandas.compat import StringIO, u
 
 from pandas import DataFrame, DatetimeIndex, Index, NaT, Series, date_range
 import pandas.util.testing as tm

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -15,7 +15,7 @@ import tarfile
 import numpy as np
 import pytest
 
-from pandas.compat import BytesIO, StringIO, lrange, range
+from pandas.compat import BytesIO, StringIO, lrange
 from pandas.errors import ParserError
 import pandas.util._test_decorators as td
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import Timestamp
-from pandas.compat import BytesIO, StringIO, lrange, range, u
+from pandas.compat import BytesIO, StringIO, lrange, u
 from pandas.errors import DtypeWarning, EmptyDataError, ParserError
 
 from pandas import DataFrame, Index, MultiIndex, Series, compat, concat
@@ -892,7 +892,7 @@ def test_nonexistent_path(all_parsers):
 
     msg = ("does not exist" if parser.engine == "c"
            else r"\[Errno 2\]")
-    with pytest.raises(compat.FileNotFoundError, match=msg) as e:
+    with pytest.raises(FileNotFoundError, match=msg) as e:
         parser.read_csv(path)
 
         filename = e.value.filename

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -11,7 +11,7 @@ from multiprocessing.pool import ThreadPool
 
 import numpy as np
 
-from pandas.compat import BytesIO, range
+from pandas.compat import BytesIO
 
 import pandas as pd
 from pandas import DataFrame

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -8,7 +8,7 @@ parsing for all of the parsers defined in parsers.py
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, range
+from pandas.compat import StringIO
 
 from pandas import DataFrame, Index, MultiIndex
 import pandas.util.testing as tm

--- a/pandas/tests/io/parser/test_skiprows.py
+++ b/pandas/tests/io/parser/test_skiprows.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from pandas.compat import StringIO, lrange, range
+from pandas.compat import StringIO, lrange
 from pandas.errors import EmptyDataError
 
 from pandas import DataFrame, Index

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -14,7 +14,7 @@ import pytest
 import pandas._libs.parsers as parser
 from pandas._libs.parsers import TextReader
 import pandas.compat as compat
-from pandas.compat import BytesIO, StringIO, map
+from pandas.compat import BytesIO, StringIO
 
 from pandas import DataFrame
 import pandas.util.testing as tm

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-from pandas.compat import FileNotFoundError, StringIO, is_platform_windows
+from pandas.compat import StringIO, is_platform_windows
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy import nan
 import pytest
 
-from pandas.compat import PY36, BytesIO, iteritems, map, range, u
+from pandas.compat import PY36, BytesIO, iteritems, u
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/io/test_gbq.py
+++ b/pandas/tests/io/test_gbq.py
@@ -6,8 +6,6 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas import DataFrame
 import pandas.util.testing as tm

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -9,8 +9,7 @@ import numpy as np
 from numpy.random import rand
 import pytest
 
-from pandas.compat import (
-    BytesIO, StringIO, is_platform_windows, map, reload, zip)
+from pandas.compat import BytesIO, StringIO, is_platform_windows, reload
 from pandas.errors import ParserError
 import pandas.util._test_decorators as td
 

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -11,7 +11,7 @@ import pytest
 
 from pandas.compat import (
     PY35, PY36, BytesIO, is_platform_little_endian, is_platform_windows,
-    lrange, range, text_type, u)
+    lrange, text_type, u)
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import is_categorical_dtype
@@ -19,8 +19,8 @@ from pandas.core.dtypes.common import is_categorical_dtype
 import pandas as pd
 from pandas import (
     Categorical, DataFrame, DatetimeIndex, Index, Int64Index, MultiIndex,
-    RangeIndex, Series, Timestamp, bdate_range, compat, concat, date_range,
-    isna, timedelta_range)
+    RangeIndex, Series, Timestamp, bdate_range, concat, date_range, isna,
+    timedelta_range)
 import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_frame_equal, assert_series_equal, set_timezone)
@@ -301,8 +301,7 @@ class TestHDFStore(Base):
 
         # File path doesn't exist
         path = ""
-        pytest.raises(compat.FileNotFoundError,
-                      read_hdf, path, 'df')
+        pytest.raises(FileNotFoundError, read_hdf, path, 'df')
 
     def test_api_default_format(self):
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -28,7 +28,7 @@ import numpy as np
 import pytest
 
 import pandas.compat as compat
-from pandas.compat import PY36, lrange, range, string_types
+from pandas.compat import PY36, lrange, string_types
 
 from pandas.core.dtypes.common import (
     is_datetime64_dtype, is_datetime64tz_dtype)

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 
 import pandas.compat as compat
-from pandas.compat import ResourceWarning, iterkeys
+from pandas.compat import iterkeys
 
 from pandas.core.dtypes.common import is_categorical_dtype
 

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy import random
 import pytest
 
-from pandas.compat import iteritems, zip
+from pandas.compat import iteritems
 from pandas.util._decorators import cache_readonly
 import pandas.util._test_decorators as td
 

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy import random
 import pytest
 
-from pandas.compat import lzip, range
+from pandas.compat import lzip
 import pandas.util._test_decorators as td
 
 from pandas import DataFrame, MultiIndex, Series

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -6,7 +6,7 @@ import sys
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, zip
+from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 from pandas import DataFrame, Index, NaT, Series, isna

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.random import rand, randn
 import pytest
 
-from pandas.compat import lmap, lrange, lzip, range, u, zip
+from pandas.compat import lmap, lrange, lzip, u
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.api import is_list_like

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.random import randn
 import pytest
 
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -3,8 +3,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from pandas.compat import range, zip
-
 import pandas as pd
 from pandas import DataFrame, Series
 from pandas.core.groupby.groupby import DataError

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas.compat import StringIO, range
+from pandas.compat import StringIO
 from pandas.errors import UnsupportedFunctionCall
 
 import pandas as pd

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -7,7 +7,7 @@ import pytz
 
 from pandas._libs.tslibs.ccalendar import DAYS, MONTHS
 from pandas._libs.tslibs.period import IncompatibleFrequency
-from pandas.compat import lrange, range, zip
+from pandas.compat import lrange
 
 import pandas as pd
 from pandas import DataFrame, Series, Timestamp

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -6,8 +6,6 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas import DataFrame, Series
 from pandas.core.indexes.datetimes import date_range

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -4,8 +4,6 @@ from textwrap import dedent
 
 import numpy as np
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas import DataFrame, Series, Timestamp
 from pandas.core.indexes.datetimes import date_range

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -5,8 +5,6 @@ import numpy as np
 from numpy import nan
 import pytest
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas import DataFrame, lreshape, melt, wide_to_long
 import pandas.util.testing as tm

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timedelta
 import numpy as np
 import pytest
 
-from pandas.compat import product, range
+from pandas.compat import product
 
 import pandas as pd
 from pandas import (

--- a/pandas/tests/reshape/test_qcut.py
+++ b/pandas/tests/reshape/test_qcut.py
@@ -3,8 +3,6 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import zip
-
 from pandas import (
     Categorical, DatetimeIndex, Interval, IntervalIndex, NaT, Series,
     TimedeltaIndex, Timestamp, cut, date_range, isna, qcut, timedelta_range)

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -8,7 +8,7 @@ from numpy import nan
 import pytest
 
 import pandas.compat as compat
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 import pandas as pd
 from pandas import Categorical, Series, date_range, isna

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -4,7 +4,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 from pandas.core.dtypes.common import is_integer
 

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -8,7 +8,7 @@ import pytest
 
 from pandas._libs import iNaT
 import pandas._libs.index as _index
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex, NaT, Series, Timestamp, date_range

--- a/pandas/tests/series/indexing/test_iloc.py
+++ b/pandas/tests/series/indexing/test_iloc.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 from pandas import Series
 from pandas.util.testing import assert_almost_equal, assert_series_equal

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 from pandas.core.dtypes.common import is_scalar
 

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -4,7 +4,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 
 import pandas as pd
 from pandas import DataFrame, Index, Series

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from pandas.compat import lrange, range, zip
+from pandas.compat import lrange
 
 from pandas import DataFrame, Index, MultiIndex, RangeIndex, Series
 import pandas.util.testing as tm

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy import nan
 import pytest
 
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import pandas.compat as compat
-from pandas.compat import isidentifier, lzip, range, string_types
+from pandas.compat import isidentifier, lzip, string_types
 
 import pandas as pd
 from pandas import (

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -11,7 +11,7 @@ import pytest
 
 from pandas._libs import lib
 from pandas._libs.tslib import iNaT
-from pandas.compat import PY36, long, lrange, range, zip
+from pandas.compat import PY36, long, lrange
 
 from pandas.core.dtypes.common import (
     is_categorical_dtype, is_datetime64tz_dtype)

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -10,7 +10,7 @@ import pytest
 
 from pandas._libs.tslibs import iNaT
 import pandas.compat as compat
-from pandas.compat import lrange, range, u
+from pandas.compat import lrange, u
 
 import pandas as pd
 from pandas import (

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -10,7 +10,6 @@ import pytest
 import pytz
 
 from pandas._libs.tslib import iNaT
-from pandas.compat import range
 from pandas.errors import PerformanceWarning
 import pandas.util._test_decorators as td
 

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -7,8 +7,6 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import range
-
 import pandas as pd
 from pandas import (
     Categorical, DataFrame, Index, Series, bdate_range, date_range, isna)

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 
-from pandas.compat import lrange, range, u
+from pandas.compat import lrange, u
 
 import pandas as pd
 from pandas import (

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -8,7 +8,7 @@ from numpy import nan
 import pytest
 
 from pandas._libs.sparse import BlockIndex, IntIndex
-from pandas.compat import PY36, range
+from pandas.compat import PY36
 from pandas.errors import PerformanceWarning
 import pandas.util._test_decorators as td
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -11,7 +11,7 @@ import pytest
 
 from pandas._libs import (
     algos as libalgos, groupby as libgroupby, hashtable as ht)
-from pandas.compat import lrange, range
+from pandas.compat import lrange
 from pandas.compat.numpy import np_array_datetime64_compat
 import pandas.util._test_decorators as td
 

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -8,66 +8,51 @@ import re
 import pytest
 
 from pandas.compat import (
-    builtins, filter, get_range_parameters, iteritems, iterkeys, itervalues,
-    lfilter, lmap, lrange, lzip, map, next, range, re_type, zip)
+    builtins, get_range_parameters, iteritems, iterkeys, itervalues, lfilter,
+    lmap, lrange, lzip, re_type)
 
 
 class TestBuiltinIterators(object):
 
     @classmethod
-    def check_result(cls, actual, expected, lengths):
-        for (iter_res, list_res), exp, length in zip(actual, expected,
-                                                     lengths):
-            assert not isinstance(iter_res, list)
-            assert isinstance(list_res, list)
+    def check_results(cls, results, expecteds, lengths):
+        for result, expected, length in zip(results, expecteds, lengths):
+            assert isinstance(result, list)
+            assert len(result) == length
+            assert result == expected
 
-            iter_res = list(iter_res)
-
-            assert len(list_res) == length
-            assert len(iter_res) == length
-            assert iter_res == exp
-            assert list_res == exp
-
-    def test_range(self):
-        actual1 = range(10)
-        actual2 = lrange(10)
-        actual = [actual1, actual2],
-        expected = list(builtins.range(10)),
+    def test_lrange(self):
+        results = lrange(10),
+        expecteds = list(builtins.range(10)),
         lengths = 10,
 
-        actual1 = range(1, 10, 2)
-        actual2 = lrange(1, 10, 2)
-        actual += [actual1, actual2],
+        results += lrange(1, 10, 2),
         lengths += 5,
-        expected += list(builtins.range(1, 10, 2)),
-        self.check_result(actual, expected, lengths)
+        expecteds += list(builtins.range(1, 10, 2)),
+        self.check_results(results, expecteds, lengths)
 
-    def test_map(self):
+    def test_lmap(self):
         func = lambda x, y, z: x + y + z
         lst = [builtins.range(10), builtins.range(10), builtins.range(10)]
-        actual1 = map(func, *lst)
-        actual2 = lmap(func, *lst)
-        actual = [actual1, actual2],
-        expected = list(builtins.map(func, *lst)),
+        results = lmap(func, *lst),
+        expecteds = list(builtins.map(func, *lst)),
         lengths = 10,
-        self.check_result(actual, expected, lengths)
+        self.check_results(results, expecteds, lengths)
 
-    def test_filter(self):
+    def test_lfilter(self):
         func = lambda x: x
         lst = list(builtins.range(10))
-        actual1 = filter(func, lst)
-        actual2 = lfilter(func, lst)
-        actual = [actual1, actual2],
+        results = lfilter(lambda x: x, lst),
         lengths = 9,
-        expected = list(builtins.filter(func, lst)),
-        self.check_result(actual, expected, lengths)
+        expecteds = list(builtins.filter(func, lst)),
+        self.check_results(results, expecteds, lengths)
 
-    def test_zip(self):
+    def test_lzip(self):
         lst = [builtins.range(10), builtins.range(10), builtins.range(10)]
-        actual = [zip(*lst), lzip(*lst)],
-        expected = list(builtins.zip(*lst)),
+        results = lzip(*lst),
+        expecteds = list(builtins.zip(*lst)),
         lengths = 10,
-        self.check_result(actual, expected, lengths)
+        self.check_results(results, expecteds, lengths)
 
     def test_dict_iterators(self):
         assert next(itervalues({1: 2})) == 2

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -9,8 +9,7 @@ from numpy.random import randn
 import pytest
 import pytz
 
-from pandas.compat import (
-    StringIO, lrange, lzip, product as cart_product, range, u, zip)
+from pandas.compat import StringIO, lrange, lzip, product as cart_product, u
 
 from pandas.core.dtypes.common import is_float_dtype, is_integer_dtype
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -10,7 +10,7 @@ from numpy.random import randint
 import pytest
 
 import pandas.compat as compat
-from pandas.compat import range, u
+from pandas.compat import u
 
 from pandas import DataFrame, Index, MultiIndex, Series, concat, isna, notna
 import pandas.core.strings as strings

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -8,7 +8,6 @@ import numpy as np
 from numpy.random import randn
 import pytest
 
-from pandas.compat import range, zip
 from pandas.errors import UnsupportedFunctionCall
 import pandas.util._test_decorators as td
 

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -6,7 +6,7 @@ import pytest
 from pandas._libs.tslibs.ccalendar import DAYS, MONTHS
 from pandas._libs.tslibs.frequencies import INVALID_FREQ_ERR_MSG
 import pandas.compat as compat
-from pandas.compat import is_platform_windows, range
+from pandas.compat import is_platform_windows
 
 from pandas import (
     DatetimeIndex, Index, Series, Timestamp, date_range, period_range)

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -11,7 +11,6 @@ from pandas._libs.tslibs.frequencies import (
 import pandas._libs.tslibs.offsets as liboffsets
 from pandas._libs.tslibs.offsets import ApplyTypeError
 import pandas.compat as compat
-from pandas.compat import range
 from pandas.compat.numpy import np_datetime64_compat
 
 from pandas.core.indexes.datetimes import DatetimeIndex, _to_M8, date_range

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -16,7 +16,6 @@ import pandas._libs.tslibs.resolution as libresolution
 from pandas._libs.tslibs.resolution import Resolution
 from pandas._libs.tslibs.timezones import UTC
 import pandas.compat as compat
-from pandas.compat import zip
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -14,7 +14,6 @@ from pandas._libs.tslibs.offsets import (
     ApplyTypeError, BaseOffset, _get_calendar, _is_normalized, _to_dt64,
     apply_index_wraps, as_datetime, roll_yearday, shift_month)
 import pandas.compat as compat
-from pandas.compat import range
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -50,7 +50,7 @@ K = 4
 _RAISE_NETWORK_ERROR_DEFAULT = False
 
 # set testing_mode
-_testing_mode_warnings = (DeprecationWarning, compat.ResourceWarning)
+_testing_mode_warnings = (DeprecationWarning, ResourceWarning)
 
 
 def set_testing_mode():

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -23,8 +23,8 @@ from pandas._config.localization import (  # noqa:F401
 from pandas._libs import testing as _testing
 import pandas.compat as compat
 from pandas.compat import (
-    PY2, PY3, httplib, lmap, lrange, lzip, map, raise_with_traceback, range,
-    string_types, u, unichr, zip)
+    PY2, PY3, httplib, lmap, lrange, lzip, raise_with_traceback, string_types,
+    u, unichr)
 
 from pandas.core.dtypes.common import (
     is_bool, is_categorical_dtype, is_datetime64_dtype, is_datetime64tz_dtype,

--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -17,7 +17,7 @@ import re
 import os
 import argparse
 from collections import namedtuple
-from pandas.compat import lrange, map, string_types, text_type, parse_date
+from pandas.compat import lrange, string_types, text_type, parse_date
 try:
     import sh
 except ImportError:


### PR DESCRIPTION
- [X] xref #25725
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Some more low hanging fruit in the Python 2 removal process.  This should remove all references to the following functions in `pandas.compat` which are redundantly defined for Python 3:
  - `filter`
  - `map`
  - `range`
  - `zip`
  - `next`
  - `FileNotFoundError`
  - `ResourceWarning`