### PR TITLE
CLN: Remove long and integer_types from pandas.compat

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -7,7 +7,6 @@ Cross-compatible functions for Python 2 and 3.
 Key items to import for 2/3 compatible code:
 * iterators: reduce()
 * lists: lrange(), lmap(), lzip(), lfilter()
-* longs: long (int in Python 3)
 * iterable method compatibility: iteritems, iterkeys, itervalues
   * Uses the original method if available, otherwise uses items, keys, values.
 * types:
@@ -108,7 +107,6 @@ if PY3:
     # have to explicitly put builtins into the namespace
     intern = sys.intern
     reduce = functools.reduce
-    long = int
     unichr = chr
 
     # list-producing versions of the major Python iterating functions
@@ -172,7 +170,6 @@ else:
     # import iterator versions of these functions
     intern = intern
     reduce = reduce
-    long = long
     unichr = unichr
 
     # Python 2-builtin ranges produce lists
@@ -250,7 +247,6 @@ _EAW_MAP = {'Na': 1, 'N': 1, 'W': 2, 'F': 2, 'H': 1}
 
 if PY3:
     string_types = str,
-    integer_types = int,
     class_types = type,
     text_type = str
     binary_type = bytes
@@ -293,7 +289,6 @@ if PY3:
         return f
 else:
     string_types = basestring,
-    integer_types = (int, long)
     class_types = (type, types.ClassType)
     text_type = unicode
     binary_type = str

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1959,9 +1959,9 @@ class FloatBlock(FloatOrComplexBlock):
                     not issubclass(tipo.type, (np.datetime64, np.timedelta64)))
         return (
             isinstance(
-                element, (float, int, np.floating, np.int_, compat.long))
-            and not isinstance(element, (bool, np.bool_, datetime, timedelta,
-                                         np.datetime64, np.timedelta64)))
+                element, (float, int, np.floating, np.int_)) and
+            not isinstance(element, (bool, np.bool_, datetime, timedelta,
+                                     np.datetime64, np.timedelta64)))
 
     def to_native_types(self, slicer=None, na_rep='', float_format=None,
                         decimal='.', quoting=None, **kwargs):
@@ -2011,8 +2011,8 @@ class ComplexBlock(FloatOrComplexBlock):
         return (
             isinstance(
                 element,
-                (float, int, complex, np.float_, np.int_, compat.long))
-            and not isinstance(element, (bool, np.bool_)))
+                (float, int, complex, np.float_, np.int_)) and
+            not isinstance(element, (bool, np.bool_)))
 
     def should_store(self, value):
         return issubclass(value.dtype.type, np.complexfloating)

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from pandas._libs import algos, hashtable, lib
 from pandas._libs.hashtable import unique_label_indices
-from pandas.compat import PY3, long, string_types
+from pandas.compat import PY3, string_types
 
 from pandas.core.dtypes.cast import infer_dtype_from_array
 from pandas.core.dtypes.common import (
@@ -45,9 +45,9 @@ def get_group_index(labels, shape, sort, xnull):
     labels are equal at all location.
     """
     def _int64_cut_off(shape):
-        acc = long(1)
+        acc = 1
         for i, mul in enumerate(shape):
-            acc *= long(mul)
+            acc *= int(mul)
             if not acc < _INT64_MAX:
                 return i
         return len(shape)
@@ -122,9 +122,9 @@ def get_compressed_ids(labels, sizes):
 
 
 def is_int64_overflow_possible(shape):
-    the_prod = long(1)
+    the_prod = 1
     for x in shape:
-        the_prod *= long(x)
+        the_prod *= int(x)
 
     return the_prod >= _INT64_MAX
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import pandas._libs.json as json
 from pandas._libs.tslibs import iNaT
-from pandas.compat import StringIO, long, to_str
+from pandas.compat import StringIO, to_str
 from pandas.errors import AbstractMethodError
 
 from pandas.core.dtypes.common import is_period_dtype
@@ -619,10 +619,10 @@ class Parser(object):
 
     _STAMP_UNITS = ('s', 'ms', 'us', 'ns')
     _MIN_STAMPS = {
-        's': long(31536000),
-        'ms': long(31536000000),
-        'us': long(31536000000000),
-        'ns': long(31536000000000000)}
+        's': 31536000,
+        'ms': 31536000000,
+        'us': 31536000000000,
+        'ns': 31536000000000000}
 
     def __init__(self, json, orient, dtype=None, convert_axes=True,
                  convert_dates=True, keep_default_dates=False, numpy=False,

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -765,9 +765,9 @@ class StataMissingValue(StringMixin):
     bases = (101, 32741, 2147483621)
     for b in bases:
         # Conversion to long to avoid hash issues on 32 bit platforms #8968
-        MISSING_VALUES[compat.long(b)] = '.'
+        MISSING_VALUES[b] = '.'
         for i in range(1, 27):
-            MISSING_VALUES[compat.long(i + b)] = '.' + chr(96 + i)
+            MISSING_VALUES[i + b] = '.' + chr(96 + i)
 
     float32_base = b'\x00\x00\x00\x7f'
     increment = struct.unpack('<i', b'\x00\x08\x00\x00')[0]
@@ -798,8 +798,8 @@ class StataMissingValue(StringMixin):
 
     def __init__(self, value):
         self._value = value
-        # Conversion to long to avoid hash issues on 32 bit platforms #8968
-        value = compat.long(value) if value < 2147483648 else float(value)
+        # Conversion to int to avoid hash issues on 32 bit platforms #8968
+        value = int(value) if value < 2147483648 else float(value)
         self._str = self.MISSING_VALUES[value]
 
     string = property(lambda self: self._str,

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -2,8 +2,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import long
-
 import pandas as pd
 import pandas.util.testing as tm
 
@@ -32,7 +30,7 @@ zeros = [box_cls([0] * 5, dtype=dtype)
          for dtype in [np.int64, np.uint64, np.float64]]
 zeros.extend([np.array(0, dtype=dtype)
               for dtype in [np.int64, np.uint64, np.float64]])
-zeros.extend([0, 0.0, long(0)])
+zeros.extend([0, 0.0])
 
 
 @pytest.fixture(params=zeros)

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -674,7 +674,7 @@ class TestPeriodIndexArithmetic(object):
     def test_pi_sub_isub_int(self, one):
         """
         PeriodIndex.__sub__ and __isub__ with several representations of
-        the integer 1, e.g. int, long, np.int64, np.uint8, ...
+        the integer 1, e.g. int, np.int64, np.uint8, ...
         """
         rng = pd.period_range('2000-01-01 09:00', freq='H', periods=10)
         result = rng - one

--- a/pandas/tests/arrays/categorical/test_dtypes.py
+++ b/pandas/tests/arrays/categorical/test_dtypes.py
@@ -2,8 +2,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import long
-
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 from pandas import Categorical, CategoricalIndex, Index, Series, Timestamp
@@ -165,10 +163,9 @@ class TestCategoricalDtypes(object):
 
     def test_iter_python_types(self):
         # GH-19909
-        # TODO(Py2): Remove long
         cat = Categorical([1, 2])
-        assert isinstance(list(cat)[0], (int, long))
-        assert isinstance(cat.tolist()[0], (int, long))
+        assert isinstance(list(cat)[0], int)
+        assert isinstance(cat.tolist()[0], int)
 
     def test_iter_python_types_datetime(self):
         cat = Categorical([Timestamp('2017-01-01'),

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -2,8 +2,6 @@
 import numpy as np
 import pytest
 
-import pandas.compat as compat
-
 import pandas as pd
 from pandas.core.arrays import DatetimeArray, PeriodArray, TimedeltaArray
 import pandas.util.testing as tm
@@ -133,10 +131,10 @@ class SharedTests(object):
         data = np.arange(10, dtype='i8') * 24 * 3600 * 10**9
         arr = self.array_cls(data, freq='D')
         result = arr._unbox_scalar(arr[0])
-        assert isinstance(result, (int, compat.long))
+        assert isinstance(result, int)
 
         result = arr._unbox_scalar(pd.NaT)
-        assert isinstance(result, (int, compat.long))
+        assert isinstance(result, int)
 
         with pytest.raises(ValueError):
             arr._unbox_scalar('foo')

--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -509,7 +509,6 @@ def test_conversions(data_missing):
         if pd.isnull(r):
             assert pd.isnull(e)
         elif is_integer(r):
-            # PY2 can be int or long
             assert r == e
             assert is_integer(e)
         else:

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -9,7 +9,7 @@ import pydoc
 import numpy as np
 import pytest
 
-from pandas.compat import long, lrange
+from pandas.compat import lrange
 
 import pandas as pd
 from pandas import (
@@ -242,7 +242,7 @@ class SharedWithSparse(object):
                          'ints': lrange(5)}, columns=['floats', 'ints'])
 
         for tup in df.itertuples(index=False):
-            assert isinstance(tup[1], (int, long))
+            assert isinstance(tup[1], int)
 
         df = self.klass(data={"a": [1, 2, 3], "b": [4, 5, 6]})
         dfaa = df[['a', 'a']]
@@ -250,7 +250,7 @@ class SharedWithSparse(object):
         assert (list(dfaa.itertuples()) ==
                 [(0, 1, 1), (1, 2, 2), (2, 3, 3)])
 
-        # repr with be int/long on 32-bit/windows
+        # repr with int on 32-bit/windows
         if not (compat.is_platform_windows() or compat.is_platform_32bit()):
             assert (repr(list(df.itertuples(name=None))) ==
                     '[(0, 1, 4), (1, 2, 5), (2, 3, 6)]')

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -11,8 +11,7 @@ import numpy as np
 import numpy.ma as ma
 import pytest
 
-from pandas.compat import (
-    PY36, is_platform_little_endian, lmap, long, lrange, lzip)
+from pandas.compat import PY36, is_platform_little_endian, lmap, lrange, lzip
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import is_integer_dtype
@@ -193,9 +192,8 @@ class TestDataFrameConstructors(TestData):
 
         # see gh-2355
         data_scores = [(6311132704823138710, 273), (2685045978526272070, 23),
-                       (8921811264899370420, 45),
-                       (long(17019687244989530680), 270),
-                       (long(9930107427299601010), 273)]
+                       (8921811264899370420, 45), (17019687244989530680, 270),
+                       (9930107427299601010, 273)]
         dtype = [('uid', 'u8'), ('score', 'u8')]
         data = np.zeros((len(data_scores),), dtype=dtype)
         data[:] = data_scores

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -8,8 +8,6 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas.compat import long
-
 from pandas import (
     CategoricalDtype, DataFrame, MultiIndex, Series, Timestamp, compat,
     date_range)
@@ -472,7 +470,7 @@ class TestDataFrameConvertTo(TestData):
         # make sure that we are boxing properly
         df = DataFrame({'a': [1, 2], 'b': [.1, .2]})
         result = df.to_dict(orient=orient)
-        assert isinstance(item_getter(result, 'a', 0), (int, long))
+        assert isinstance(item_getter(result, 'a', 0), int)
         assert isinstance(item_getter(result, 'b', 0), float)
 
     def test_frame_to_dict_tz(self):

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import iNaT
-from pandas.compat import long, lrange, lzip
+from pandas.compat import lrange, lzip
 
 from pandas.core.dtypes.common import is_float_dtype, is_integer, is_scalar
 from pandas.core.dtypes.dtypes import CategoricalDtype
@@ -2560,19 +2560,14 @@ class TestDataFrameIndexing(TestData):
 
     def test_boolean_indexing_mixed(self):
         df = DataFrame({
-            long(0): {35: np.nan, 40: np.nan, 43: np.nan,
-                      49: np.nan, 50: np.nan},
-            long(1): {35: np.nan,
-                      40: 0.32632316859446198,
-                      43: np.nan,
-                      49: 0.32632316859446198,
-                      50: 0.39114724480578139},
-            long(2): {35: np.nan, 40: np.nan, 43: 0.29012581014105987,
-                      49: np.nan, 50: np.nan},
-            long(3): {35: np.nan, 40: np.nan, 43: np.nan, 49: np.nan,
-                      50: np.nan},
-            long(4): {35: 0.34215328467153283, 40: np.nan, 43: np.nan,
-                      49: np.nan, 50: np.nan},
+            0: {35: np.nan, 40: np.nan, 43: np.nan, 49: np.nan, 50: np.nan},
+            1: {35: np.nan, 40: 0.32632316859446198, 43: np.nan,
+                49: 0.32632316859446198, 50: 0.39114724480578139},
+            2: {35: np.nan, 40: np.nan, 43: 0.29012581014105987, 49: np.nan,
+                50: np.nan},
+            3: {35: np.nan, 40: np.nan, 43: np.nan, 49: np.nan, 50: np.nan},
+            4: {35: 0.34215328467153283, 40: np.nan, 43: np.nan, 49: np.nan,
+                50: np.nan},
             'y': {35: 0, 40: 0, 43: 0, 49: 0, 50: 1}})
 
         # mixed int/float ok

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -770,7 +770,7 @@ def test_empty_groups_corner(mframe):
 
 def test_nonsense_func():
     df = DataFrame([0])
-    msg = r"unsupported operand type\(s\) for \+: '(int|long)' and 'str'"
+    msg = r"unsupported operand type\(s\) for \+: 'int' and 'str'"
     with pytest.raises(TypeError, match=msg):
         df.groupby(lambda x: x + 'foo')
 

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import long, lrange
+from pandas.compat import lrange
 
 import pandas as pd
 from pandas import (
@@ -396,7 +396,7 @@ class TestGrouping():
         lst = [['count', 'values'], ['to filter', '']]
         midx = MultiIndex.from_tuples(lst)
 
-        df = DataFrame([[long(1), 'A']], columns=midx)
+        df = DataFrame([[1, 'A']], columns=midx)
 
         grouped = df.groupby('to filter').groups
         assert grouped['A'] == [0]
@@ -404,13 +404,13 @@ class TestGrouping():
         grouped = df.groupby([('to filter', '')]).groups
         assert grouped['A'] == [0]
 
-        df = DataFrame([[long(1), 'A'], [long(2), 'B']], columns=midx)
+        df = DataFrame([[1, 'A'], [2, 'B']], columns=midx)
 
         expected = df.groupby('to filter').groups
         result = df.groupby([('to filter', '')]).groups
         assert result == expected
 
-        df = DataFrame([[long(1), 'A'], [long(2), 'A']], columns=midx)
+        df = DataFrame([[1, 'A'], [2, 'A']], columns=midx)
 
         expected = df.groupby('to filter').groups
         result = df.groupby([('to filter', '')]).groups

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import long, lzip
+from pandas.compat import lzip
 
 import pandas as pd
 from pandas.core.indexes.api import Index, MultiIndex
@@ -39,7 +39,7 @@ zeros = [box([0] * 5, dtype=dtype)
          for dtype in [np.int64, np.uint64, np.float64]]
 zeros.extend([np.array(0, dtype=dtype)
               for dtype in [np.int64, np.uint64, np.float64]])
-zeros.extend([0, 0.0, long(0)])
+zeros.extend([0, 0.0])
 
 
 @pytest.fixture(params=zeros)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -9,7 +9,6 @@ import pytest
 import pytz
 from pytz import timezone
 
-import pandas.compat as compat
 from pandas.errors import OutOfBoundsDatetime
 import pandas.util._test_decorators as td
 
@@ -335,12 +334,11 @@ class TestDateRanges(TestData):
         with pytest.raises(ValueError, match=msg):
             date_range()
 
-    @pytest.mark.parametrize('f', [compat.long, int])
-    def test_compat_replace(self, f):
+    def test_compat_replace(self):
         # https://github.com/statsmodels/statsmodels/issues/3349
         # replace should take ints/longs for compat
         result = date_range(Timestamp('1960-04-01 00:00:00', freq='QS-JAN'),
-                            periods=f(76), freq='QS-JAN')
+                            periods=76, freq='QS-JAN')
         assert len(result) == 76
 
     def test_catch_infinite_loop(self):

--- a/pandas/tests/indexes/multi/test_compat.py
+++ b/pandas/tests/indexes/multi/test_compat.py
@@ -4,8 +4,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import long
-
 from pandas import MultiIndex
 import pandas.util.testing as tm
 
@@ -87,7 +85,7 @@ def test_inplace_mutation_resets_values():
     # Make sure label setting works too
     codes2 = [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]
     exp_values = np.empty((6,), dtype=object)
-    exp_values[:] = [(long(1), 'a')] * 6
+    exp_values[:] = [(1, 'a')] * 6
 
     # Must be 1d array of tuples
     assert exp_values.shape == (6,)

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -963,7 +963,7 @@ class TestAppend(ConcatenateBase):
                         name=2)
         msg = ("the other index needs to be an IntervalIndex too, but was"
                r" type {}|"
-               r"object of type '(int|long|float|Timestamp)' has no len\(\)|"
+               r"object of type '(int|float|Timestamp)' has no len\(\)|"
                "Expected tuple, got str")
         with pytest.raises(TypeError, match=msg.format(
                 index_can_append.__class__.__name__)):
@@ -973,9 +973,9 @@ class TestAppend(ConcatenateBase):
                           columns=index_cannot_append_with_other)
         ser = pd.Series([7, 8, 9], index=index_can_append, name=2)
         msg = (r"unorderable types: (Interval|int)\(\) > "
-               r"(int|long|float|str)\(\)|"
-               r"Expected tuple, got (int|long|float|str)|"
-               r"Cannot compare type 'Timestamp' with type '(int|long)'|"
+               r"(int|float|str)\(\)|"
+               r"Expected tuple, got (int|float|str)|"
+               r"Cannot compare type 'Timestamp' with type 'int'|"
                r"'>' not supported between instances of 'int' and 'str'")
         with pytest.raises(TypeError, match=msg):
             df.append(ser)

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import NaT, iNaT
-import pandas.compat as compat
 
 import pandas as pd
 from pandas import (
@@ -240,8 +239,8 @@ class TestTimedeltas(object):
 
     def test_fields(self):
         def check(value):
-            # that we are int/long like
-            assert isinstance(value, (int, compat.long))
+            # that we are int
+            assert isinstance(value, int)
 
         # compat to datetime.timedelta
         rng = to_timedelta('1 days, 10:11:12')

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -4,8 +4,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from pandas.compat import long
-
 from pandas import Timedelta, Timestamp
 import pandas.util.testing as tm
 
@@ -63,7 +61,7 @@ class TestTimestampArithmetic(object):
             stamp - offset_overflow
 
     def test_delta_preserve_nanos(self):
-        val = Timestamp(long(1337299200000000123))
+        val = Timestamp(1337299200000000123)
         result = val + timedelta(1)
         assert result.nanosecond == val.nanosecond
 

--- a/pandas/tests/scalar/timestamp/test_comparisons.py
+++ b/pandas/tests/scalar/timestamp/test_comparisons.py
@@ -5,8 +5,6 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import long
-
 from pandas import Timestamp
 
 
@@ -38,7 +36,7 @@ class TestTimestampComparison(object):
 
     def test_comparison(self):
         # 5-18-2012 00:00:00.000
-        stamp = long(1337299200000000000)
+        stamp = 1337299200000000000
 
         val = Timestamp(stamp)
 
@@ -72,7 +70,6 @@ class TestTimestampComparison(object):
         assert not val == 'foo'
         assert not val == 10.0
         assert not val == 1
-        assert not val == long(1)
         assert not val == []
         assert not val == {'foo': 1}
         assert not val == np.float64(1)
@@ -81,7 +78,6 @@ class TestTimestampComparison(object):
         assert val != 'foo'
         assert val != 10.0
         assert val != 1
-        assert val != long(1)
         assert val != []
         assert val != {'foo': 1}
         assert val != np.float64(1)

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -14,7 +14,6 @@ from pytz import timezone, utc
 
 from pandas._libs.tslibs import conversion
 from pandas._libs.tslibs.timezones import dateutil_gettz as gettz, get_timezone
-from pandas.compat import long
 from pandas.compat.numpy import np_datetime64_compat
 from pandas.errors import OutOfBoundsDatetime
 import pandas.util._test_decorators as td
@@ -48,8 +47,8 @@ class TestTimestampProperties(object):
 
     def test_fields(self):
         def check(value, equal):
-            # that we are int/long like
-            assert isinstance(value, (int, long))
+            # that we are int like
+            assert isinstance(value, int)
             assert value == equal
 
         # GH 10050
@@ -699,18 +698,17 @@ class TestTimestamp(object):
 
     @pytest.mark.parametrize('value, check_kwargs', [
         [946688461000000000, {}],
-        [946688461000000000 / long(1000), dict(unit='us')],
-        [946688461000000000 / long(1000000), dict(unit='ms')],
-        [946688461000000000 / long(1000000000), dict(unit='s')],
+        [946688461000000000 / 1000, dict(unit='us')],
+        [946688461000000000 / 1000000, dict(unit='ms')],
+        [946688461000000000 / 1000000000, dict(unit='s')],
         [10957, dict(unit='D', h=0)],
-        [(946688461000000000 + 500000) / long(1000000000),
+        [(946688461000000000 + 500000) / 1000000000,
          dict(unit='s', us=499, ns=964)],
-        [(946688461000000000 + 500000000) / long(1000000000),
+        [(946688461000000000 + 500000000) / 1000000000,
          dict(unit='s', us=500000)],
-        [(946688461000000000 + 500000) / long(1000000),
-         dict(unit='ms', us=500)],
-        [(946688461000000000 + 500000) / long(1000), dict(unit='us', us=500)],
-        [(946688461000000000 + 500000000) / long(1000000),
+        [(946688461000000000 + 500000) / 1000000, dict(unit='ms', us=500)],
+        [(946688461000000000 + 500000) / 1000, dict(unit='us', us=500)],
+        [(946688461000000000 + 500000000) / 1000000,
          dict(unit='ms', us=500000)],
         [946688461000000000 / 1000.0 + 5, dict(unit='us', us=5)],
         [946688461000000000 / 1000.0 + 5000, dict(unit='us', us=5000)],

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -11,7 +11,7 @@ import pytest
 
 from pandas._libs import lib
 from pandas._libs.tslib import iNaT
-from pandas.compat import PY36, long, lrange
+from pandas.compat import PY36, lrange
 
 from pandas.core.dtypes.common import (
     is_categorical_dtype, is_datetime64tz_dtype)
@@ -45,7 +45,6 @@ class TestSeriesConstructors():
         # Coercion
         assert float(Series([1.])) == 1.0
         assert int(Series([1.])) == 1
-        assert long(Series([1.])) == 1
 
     def test_constructor(self, datetime_series):
         empty_series = Series()

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -74,7 +74,7 @@ class TestSeriesDtypes(object):
     @pytest.mark.parametrize("dtype", [int, np.int8, np.int64])
     def test_astype_cast_object_int_fail(self, dtype):
         arr = Series(["car", "house", "tree", "1"])
-        msg = r"invalid literal for (int|long)\(\) with base 10: 'car'"
+        msg = r"invalid literal for int\(\) with base 10: 'car'"
         with pytest.raises(ValueError, match=msg):
             arr.astype(dtype)
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import iNaT
-from pandas.compat import PYPY, StringIO, long
+from pandas.compat import PYPY, StringIO
 from pandas.compat.numpy import np_array_datetime64_compat
 
 from pandas.core.dtypes.common import (
@@ -1006,14 +1006,14 @@ class TestToIterable(object):
     # test that we convert an iterable to python types
 
     dtypes = [
-        ('int8', (int, long)),
-        ('int16', (int, long)),
-        ('int32', (int, long)),
-        ('int64', (int, long)),
-        ('uint8', (int, long)),
-        ('uint16', (int, long)),
-        ('uint32', (int, long)),
-        ('uint64', (int, long)),
+        ('int8', int),
+        ('int16', int),
+        ('int32', int),
+        ('int64', int),
+        ('uint8', int),
+        ('uint16', int),
+        ('uint32', int),
+        ('uint64', int),
         ('float16', float),
         ('float32', float),
         ('float64', float),
@@ -1046,9 +1046,9 @@ class TestToIterable(object):
         'dtype, rdtype, obj',
         [
             ('object', object, 'a'),
-            ('object', (int, long), 1),
+            ('object', int, 1),
             ('category', object, 'a'),
-            ('category', (int, long), 1)])
+            ('category', int, 1)])
     @pytest.mark.parametrize(
         'method',
         [
@@ -1083,8 +1083,8 @@ class TestToIterable(object):
     @pytest.mark.parametrize(
         'dtype, rdtype',
         dtypes + [
-            ('object', (int, long)),
-            ('category', (int, long))])
+            ('object', int),
+            ('category', int)])
     @pytest.mark.parametrize('typ', [Series, Index])
     @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
     # TODO(GH-24559): Remove the filterwarnings

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import iNaT
-from pandas.compat import long
 
 import pandas.core.algorithms as algos
 import pandas.util.testing as tm
@@ -353,8 +352,7 @@ class TestTake(object):
 
     def test_2d_datetime64(self):
         # 2005/01/01 - 2006/01/01
-        arr = np.random.randint(
-            long(11045376), long(11360736), (5, 3)) * 100000000000
+        arr = np.random.randint(11045376, 11360736, (5, 3)) * 100000000000
         arr = arr.view(dtype='datetime64[ns]')
         indexer = [0, 2, -1, 1, -1]
 

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -4,8 +4,6 @@ import numpy as np
 from numpy import iinfo
 import pytest
 
-import pandas.compat as compat
-
 import pandas as pd
 from pandas import DataFrame, Index, Series, to_numeric
 from pandas.util import testing as tm
@@ -280,8 +278,7 @@ def test_really_large_in_arr(large_val, signed, transform,
                 expected.append(extra_elt)
                 exp_dtype = object
         else:
-            exp_dtype = float if isinstance(exp_val, (
-                int, compat.long, float)) else object
+            exp_dtype = float if isinstance(exp_val, (int, float)) else object
 
         tm.assert_almost_equal(result, np.array(expected, dtype=exp_dtype))
 


### PR DESCRIPTION
- [X] xref #25725
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Another incremental step in removing Python 2.  Doesn't look like `integer_types` was actually used anywhere.  Otherwise mostly `long` --> `int`, or just removing `long` as the argument was already an `int` in Python 3.
