### PR TITLE
CLN: Remove __future__ imports

### DIFF
--- a/doc/sphinxext/announce.py
+++ b/doc/sphinxext/announce.py
@@ -33,8 +33,6 @@ From the bash command line with $GITHUB token.
     $ ./scripts/announce.py $GITHUB v1.11.0..v1.11.1 > announce.rst
 
 """
-from __future__ import division, print_function
-
 import codecs
 import os
 import re

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -2,8 +2,6 @@
 Generic data algorithms. This module is experimental at the moment and not
 intended for public consumption
 """
-from __future__ import division
-
 from textwrap import dedent
 from warnings import catch_warnings, simplefilter, warn
 

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1,8 +1,6 @@
 """
 SparseArray data structure
 """
-from __future__ import division
-
 import numbers
 import operator
 import re

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
-
 from datetime import timedelta
 import textwrap
 import warnings

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10,8 +10,6 @@ Similar to its R counterpart, data.frame, except providing automatic data
 alignment and a host of useful data manipulation methods having to do with the
 labeling information
 """
-from __future__ import division
-
 import collections
 from collections import OrderedDict
 import functools

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1,6 +1,4 @@
 # pylint: disable=E1101
-from __future__ import division
-
 from datetime import datetime, time, timedelta
 import operator
 import warnings

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -3,9 +3,6 @@ Arithmetic operations for PandasObjects
 
 This is not a public API.
 """
-# necessary to enforce truediv in Python 2.X
-from __future__ import division
-
 import datetime
 import operator
 import textwrap

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -2,8 +2,6 @@
 Contains data structures designed for manipulating panel (3-dimensional) data
 """
 # pylint: disable=E1103,W0231,W0212,W0621
-from __future__ import division
-
 from collections import OrderedDict
 import warnings
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1,8 +1,6 @@
 """
 Data structure for 1-dimensional cross-sectional and time series data
 """
-from __future__ import division
-
 from collections import OrderedDict
 from textwrap import dedent
 import warnings

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -2,8 +2,6 @@
 Data structures for sparse float data. Life is made simpler by dealing only
 with float64 data
 """
-from __future__ import division
-
 import warnings
 
 import numpy as np

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -2,8 +2,6 @@
 Provide a generic structure to support window functions,
 similar to how we have a Groupby object.
 """
-from __future__ import division
-
 from collections import defaultdict
 from datetime import timedelta
 from textwrap import dedent

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -3,8 +3,6 @@
 Module for formatting output data into CSV files.
 """
 
-from __future__ import print_function
-
 import csv as csvlib
 import os
 import warnings

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -4,8 +4,6 @@ Internal module for formatting output data in csv, html,
 and latex files. This module also applies to display formatting.
 """
 
-from __future__ import print_function
-
 from functools import partial
 
 import numpy as np

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -3,8 +3,6 @@
 Module for formatting output data in HTML.
 """
 
-from __future__ import print_function
-
 from collections import OrderedDict
 from textwrap import dedent
 

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -2,8 +2,6 @@
 """
 Module for formatting output data in Latex.
 """
-from __future__ import print_function
-
 import numpy as np
 
 from pandas.core.dtypes.generic import ABCMultiIndex

--- a/pandas/io/formats/terminal.py
+++ b/pandas/io/formats/terminal.py
@@ -11,8 +11,6 @@ Harco Kuppens (http://stackoverflow.com/users/825214/harco-kuppens)
 It is mentioned in the stackoverflow response that this code works
 on linux, os x, windows and cygwin (windows).
 """
-from __future__ import print_function
-
 import os
 import shutil
 import subprocess

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2,8 +2,6 @@
 Module contains tools for processing files into DataFrames or other objects
 """
 
-from __future__ import print_function
-
 from collections import defaultdict
 import csv
 import datetime

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -4,8 +4,6 @@ Collection of query wrappers / abstractions to both facilitate data
 retrieval and to reduce dependency on DB-specific API.
 """
 
-from __future__ import division, print_function
-
 from contextlib import contextmanager
 from datetime import date, datetime, time
 from functools import partial

--- a/pandas/plotting/_compat.py
+++ b/pandas/plotting/_compat.py
@@ -1,7 +1,5 @@
 # being a bit too dynamic
 # pylint: disable=E1101
-from __future__ import division
-
 from distutils.version import LooseVersion
 import operator
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1,7 +1,5 @@
 # being a bit too dynamic
 # pylint: disable=E1101
-from __future__ import division
-
 from collections import namedtuple
 from distutils.version import LooseVersion
 import re

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -1,7 +1,5 @@
 # being a bit too dynamic
 # pylint: disable=E1101
-from __future__ import division
-
 import numpy as np
 
 from pandas.compat import lmap, lrange

--- a/pandas/plotting/_style.py
+++ b/pandas/plotting/_style.py
@@ -1,7 +1,5 @@
 # being a bit too dynamic
 # pylint: disable=E1101
-from __future__ import division
-
 from contextlib import contextmanager
 import warnings
 

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -1,7 +1,5 @@
 # being a bit too dynamic
 # pylint: disable=E1101
-from __future__ import division
-
 from math import ceil
 import warnings
 

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import datetime, timedelta
 import inspect
 

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 # pylint: disable-msg=W0612,E1101
 from copy import deepcopy
 import pydoc

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from collections import OrderedDict
 from datetime import datetime
 from itertools import chain

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import datetime
 
 import numpy as np

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import datetime, timedelta
 import itertools
 

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import datetime
 
 import numpy as np

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from collections import OrderedDict
 from datetime import datetime, timedelta
 import functools

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from collections import OrderedDict
 from datetime import timedelta
 

--- a/pandas/tests/frame/test_duplicates.py
+++ b/pandas/tests/frame/test_duplicates.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import date, datetime, time, timedelta
 from warnings import catch_warnings, simplefilter
 

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import datetime
 from distutils.version import LooseVersion
 

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from decimal import Decimal
 import operator
 

--- a/pandas/tests/frame/test_quantile.py
+++ b/pandas/tests/frame/test_quantile.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import operator
 
 import numpy as np

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import datetime
 import re
 

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import datetime, timedelta
 import re
 import sys

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import datetime
 import itertools
 

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import random
 
 import numpy as np

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 from datetime import datetime, time
 
 import numpy as np

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import csv
 import os
 

--- a/pandas/tests/groupby/aggregate/test_cython.py
+++ b/pandas/tests/groupby/aggregate/test_cython.py
@@ -4,8 +4,6 @@
 test cython .agg behavior
 """
 
-from __future__ import print_function
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -4,8 +4,6 @@
 test all other .agg behavior
 """
 
-from __future__ import print_function
-
 from collections import OrderedDict
 import datetime as dt
 from functools import partial

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 from datetime import datetime
 
 import numpy as np

--- a/pandas/tests/groupby/test_counting.py
+++ b/pandas/tests/groupby/test_counting.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/groupby/test_filters.py
+++ b/pandas/tests/groupby/test_filters.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 from collections import OrderedDict, defaultdict
 from datetime import datetime
 from decimal import Decimal

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/indexes/interval/test_construction.py
+++ b/pandas/tests/indexes/interval/test_construction.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from functools import partial
 
 import numpy as np

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from itertools import permutations
 import re
 

--- a/pandas/tests/indexes/interval/test_interval_new.py
+++ b/pandas/tests/indexes/interval/test_interval_new.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/indexes/interval/test_interval_range.py
+++ b/pandas/tests/indexes/interval/test_interval_range.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from datetime import timedelta
 
 import numpy as np

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from itertools import permutations
 
 import numpy as np

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -4,8 +4,6 @@
 Test output formatting for Series/DataFrame, including to_string & reprs
 """
 
-from __future__ import print_function
-
 from datetime import datetime
 import itertools
 from operator import methodcaller

--- a/pandas/tests/io/generate_legacy_storage_files.py
+++ b/pandas/tests/io/generate_legacy_storage_files.py
@@ -34,8 +34,6 @@ run under the older AND the newer version.
 
 """
 
-from __future__ import print_function
-
 from datetime import timedelta
 from distutils.version import LooseVersion
 import os

--- a/pandas/tests/io/msgpack/test_extension.py
+++ b/pandas/tests/io/msgpack/test_extension.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import array
 
 import pandas.io.msgpack as msgpack

--- a/pandas/tests/io/msgpack/test_limits.py
+++ b/pandas/tests/io/msgpack/test_limits.py
@@ -1,7 +1,4 @@
 # coding: utf-8
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
-
 import pytest
 
 from pandas.io.msgpack import ExtType, Packer, Unpacker, packb, unpackb

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -5,8 +5,6 @@ Tests multithreading behaviour for reading and
 parsing files for each parser defined in parsers.py
 """
 
-from __future__ import division
-
 from multiprocessing.pool import ThreadPool
 
 import numpy as np

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from functools import partial
 import os
 import re

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -17,8 +17,6 @@ The SQL tests are broken down in different classes:
 
 """
 
-from __future__ import print_function
-
 import csv
 from datetime import date, datetime, time
 import sqlite3

--- a/pandas/tests/scalar/interval/test_interval.py
+++ b/pandas/tests/scalar/interval/test_interval.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/sparse/test_format.py
+++ b/pandas/tests/sparse/test_format.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import numpy as np
 
 from pandas.compat import is_platform_32bit, is_platform_windows

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 from datetime import datetime, timedelta
 import re
 import sys

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import operator
 import re
 

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function
-
 from functools import partial
 import warnings
 

--- a/pandas/tests/tseries/offsets/test_ticks.py
+++ b/pandas/tests/tseries/offsets/test_ticks.py
@@ -2,8 +2,6 @@
 """
 Tests for offsets.Tick and subclasses
 """
-from __future__ import division
-
 from datetime import datetime, timedelta
 
 from hypothesis import assume, example, given, settings, strategies as st

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from collections import Counter
 from contextlib import contextmanager
 from datetime import datetime

--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -11,7 +11,6 @@ files will probably erase them.
 Usage::
     $ ./find_commits_touching_func.py  (see arguments below)
 """
-from __future__ import print_function
 import logging
 import re
 import os

--- a/scripts/merge-pr.py
+++ b/scripts/merge-pr.py
@@ -22,8 +22,6 @@
 #   usage: ./apache-pr-merge.py    (see config env vars below)
 #
 # Lightly modified from version of this script in incubator-parquet-format
-from __future__ import print_function
-
 from subprocess import check_output
 from requests.auth import HTTPBasicAuth
 import requests

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,7 +339,6 @@ domain.
 
 """
 
-from __future__ import print_function
 try:
     import configparser
 except ImportError:


### PR DESCRIPTION
- [X] xref #25725
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Not needed after dropping Python 2.