### PR TITLE
Skipped flaky part of test_time

### DIFF
--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1105,7 +1105,7 @@ class TestTSPlot(TestPlotBase):
                 assert xp == rs
 
     @pytest.mark.slow
-    @pytest.mark.xfail(reason="Unreliable test")
+    @pytest.mark.xfail(strict=False, reason="Unreliable test")
     def test_time_change_xlim(self):
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1105,7 +1105,7 @@ class TestTSPlot(TestPlotBase):
                 assert xp == rs
 
     @pytest.mark.slow
-    @pytest.mark.skip(reason="Unreliable test")
+    @pytest.mark.xfail(reason="Unreliable test")
     def test_time_change_xlim(self):
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1104,6 +1104,33 @@ class TestTSPlot(TestPlotBase):
                     xp = time(h, m, s).strftime('%H:%M')
                 assert xp == rs
 
+    @pytest.mark.slow
+    @pytest.mark.skip(reason="Unreliable test")
+    def test_time_change_xlim(self):
+        t = datetime(1, 1, 1, 3, 30, 0)
+        deltas = np.random.randint(1, 20, 3).cumsum()
+        ts = np.array([(t + timedelta(minutes=int(x))).time() for x in deltas])
+        df = DataFrame({'a': np.random.randn(len(ts)),
+                        'b': np.random.randn(len(ts))},
+                       index=ts)
+        fig, ax = self.plt.subplots()
+        df.plot(ax=ax)
+
+        # verify tick labels
+        fig.canvas.draw()
+        ticks = ax.get_xticks()
+        labels = ax.get_xticklabels()
+        for t, l in zip(ticks, labels):
+            m, s = divmod(int(t), 60)
+            h, m = divmod(m, 60)
+            rs = l.get_text()
+            if len(rs) > 0:
+                if s != 0:
+                    xp = time(h, m, s).strftime('%H:%M:%S')
+                else:
+                    xp = time(h, m, s).strftime('%H:%M')
+                assert xp == rs
+
         # change xlim
         ax.set_xlim('1:30', '5:00')
 


### PR DESCRIPTION
Workaround for #25875 to get CI passing - I kept intact the working part of the test and split off the failing piece into a separate test, which may be more explicit anyway

Haven't been able to reproduce this locally so plan to either keep the original issue open or create a new one for a more permanent fix, which may require a total refactor of the test

@gfyoung 