### PR TITLE
Implement helper method to get char* buffer from Python objects

### DIFF
--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -9,7 +9,7 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 # VectorData
 # ----------------------------------------------------------------------
 
-from pandas._libs.tslibs.util cimport get_string_data
+from pandas._libs.tslibs.util cimport get_string_data, get_string_data_checked
 
 {{py:
 
@@ -597,7 +597,7 @@ cdef class StringHashTable(HashTable):
         cdef:
             khiter_t k
             const char *v
-        get_string_data(val, &v, NULL)
+        get_string_data_checked(val, &v, NULL)
 
         k = kh_get_str(self.table, v)
         if k != self.table.n_buckets:
@@ -611,7 +611,7 @@ cdef class StringHashTable(HashTable):
             int ret = 0
             const char *v
 
-        get_string_data(val, &v, NULL)
+        get_string_data_checked(val, &v, NULL)
 
         k = kh_put_str(self.table, v, &ret)
         self.table.keys[k] = key
@@ -634,7 +634,7 @@ cdef class StringHashTable(HashTable):
         vecs = <const char **>malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
-            get_string_data(val, &v, NULL)
+            get_string_data_checked(val, &v, NULL)
             vecs[i] = v
 
         with nogil:
@@ -778,7 +778,7 @@ cdef class StringHashTable(HashTable):
                 labels[i] = na_sentinel
             else:
                 # if ignore_na is False, we also stringify NaN/None/etc.
-                get_string_data(val, &v, NULL)
+                get_string_data_checked(val, &v, NULL)
                 vecs[i] = v
 
         # compute

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -9,7 +9,7 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 # VectorData
 # ----------------------------------------------------------------------
 
-from pandas._libs.tslibs.util cimport get_string_data, get_string_data_checked
+from pandas._libs.tslibs.util cimport get_c_string
 
 {{py:
 
@@ -597,7 +597,7 @@ cdef class StringHashTable(HashTable):
         cdef:
             khiter_t k
             const char *v
-        v = get_string_data_checked(val, NULL)
+        v = get_c_string(val)
 
         k = kh_get_str(self.table, v)
         if k != self.table.n_buckets:
@@ -611,7 +611,7 @@ cdef class StringHashTable(HashTable):
             int ret = 0
             const char *v
 
-        v = get_string_data_checked(val, NULL)
+        v = get_c_string(val)
 
         k = kh_put_str(self.table, v, &ret)
         self.table.keys[k] = key
@@ -634,7 +634,7 @@ cdef class StringHashTable(HashTable):
         vecs = <const char **>malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
-            v = get_string_data_checked(val, NULL)
+            v = get_c_string(val)
             vecs[i] = v
 
         with nogil:
@@ -664,9 +664,9 @@ cdef class StringHashTable(HashTable):
             val = values[i]
 
             if isinstance(val, (str, unicode)):
-                v = get_string_data(val, NULL)
+                v = get_c_string(val)
             else:
-                v = get_string_data(self.na_string_sentinel, NULL)
+                v = get_c_string(self.na_string_sentinel)
             vecs[i] = v
 
         with nogil:
@@ -697,9 +697,9 @@ cdef class StringHashTable(HashTable):
             val = values[i]
 
             if isinstance(val, (str, unicode)):
-                v = get_string_data(val, NULL)
+                v = get_c_string(val)
             else:
-                v = get_string_data(self.na_string_sentinel, NULL)
+                v = get_c_string(self.na_string_sentinel)
             vecs[i] = v
 
         with nogil:
@@ -778,7 +778,7 @@ cdef class StringHashTable(HashTable):
                 labels[i] = na_sentinel
             else:
                 # if ignore_na is False, we also stringify NaN/None/etc.
-                v = get_string_data_checked(val, NULL)
+                v = get_c_string(val)
                 vecs[i] = v
 
         # compute

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -9,6 +9,8 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 # VectorData
 # ----------------------------------------------------------------------
 
+from pandas._libs.tslibs.util cimport get_string_data
+
 {{py:
 
 # name, dtype, arg
@@ -595,7 +597,7 @@ cdef class StringHashTable(HashTable):
         cdef:
             khiter_t k
             const char *v
-        v = util.get_c_string(val)
+        get_string_data(val, &v, NULL)
 
         k = kh_get_str(self.table, v)
         if k != self.table.n_buckets:
@@ -609,7 +611,7 @@ cdef class StringHashTable(HashTable):
             int ret = 0
             const char *v
 
-        v = util.get_c_string(val)
+        get_string_data(val, &v, NULL)
 
         k = kh_put_str(self.table, v, &ret)
         self.table.keys[k] = key
@@ -632,7 +634,7 @@ cdef class StringHashTable(HashTable):
         vecs = <const char **>malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
-            v = util.get_c_string(val)
+            get_string_data(val, &v, NULL)
             vecs[i] = v
 
         with nogil:
@@ -662,9 +664,9 @@ cdef class StringHashTable(HashTable):
             val = values[i]
 
             if isinstance(val, (str, unicode)):
-                v = util.get_c_string(val)
+                get_string_data(val, &v, NULL)
             else:
-                v = util.get_c_string(self.na_string_sentinel)
+                get_string_data(self.na_string_sentinel, &v, NULL)
             vecs[i] = v
 
         with nogil:
@@ -695,9 +697,9 @@ cdef class StringHashTable(HashTable):
             val = values[i]
 
             if isinstance(val, (str, unicode)):
-                v = util.get_c_string(val)
+                get_string_data(val, &v, NULL)
             else:
-                v = util.get_c_string(self.na_string_sentinel)
+                get_string_data(self.na_string_sentinel, &v, NULL)
             vecs[i] = v
 
         with nogil:
@@ -776,7 +778,7 @@ cdef class StringHashTable(HashTable):
                 labels[i] = na_sentinel
             else:
                 # if ignore_na is False, we also stringify NaN/None/etc.
-                v = util.get_c_string(val)
+                get_string_data(val, &v, NULL)
                 vecs[i] = v
 
         # compute

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -597,7 +597,7 @@ cdef class StringHashTable(HashTable):
         cdef:
             khiter_t k
             const char *v
-        get_string_data_checked(val, &v, NULL)
+        v = get_string_data_checked(val, NULL)
 
         k = kh_get_str(self.table, v)
         if k != self.table.n_buckets:
@@ -611,7 +611,7 @@ cdef class StringHashTable(HashTable):
             int ret = 0
             const char *v
 
-        get_string_data_checked(val, &v, NULL)
+        v = get_string_data_checked(val, NULL)
 
         k = kh_put_str(self.table, v, &ret)
         self.table.keys[k] = key
@@ -634,7 +634,7 @@ cdef class StringHashTable(HashTable):
         vecs = <const char **>malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
-            get_string_data_checked(val, &v, NULL)
+            v = get_string_data_checked(val, NULL)
             vecs[i] = v
 
         with nogil:
@@ -664,9 +664,9 @@ cdef class StringHashTable(HashTable):
             val = values[i]
 
             if isinstance(val, (str, unicode)):
-                get_string_data(val, &v, NULL)
+                v = get_string_data(val, NULL)
             else:
-                get_string_data(self.na_string_sentinel, &v, NULL)
+                v = get_string_data(self.na_string_sentinel, NULL)
             vecs[i] = v
 
         with nogil:
@@ -697,9 +697,9 @@ cdef class StringHashTable(HashTable):
             val = values[i]
 
             if isinstance(val, (str, unicode)):
-                get_string_data(val, &v, NULL)
+                v = get_string_data(val, NULL)
             else:
-                get_string_data(self.na_string_sentinel, &v, NULL)
+                v = get_string_data(self.na_string_sentinel, NULL)
             vecs[i] = v
 
         with nogil:
@@ -778,7 +778,7 @@ cdef class StringHashTable(HashTable):
                 labels[i] = na_sentinel
             else:
                 # if ignore_na is False, we also stringify NaN/None/etc.
-                get_string_data_checked(val, &v, NULL)
+                v = get_string_data_checked(val, NULL)
                 vecs[i] = v
 
         # compute

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -177,6 +177,6 @@ cdef inline int _string_to_dts(object val, npy_datetimestruct* dts,
         Py_ssize_t length
         const char* tmp
 
-    get_string_data_checked(val, &tmp, &length)
+    tmp = get_string_data_checked(val, &length)
     return parse_iso_8601_datetime(tmp, length,
                                    dts, out_local, out_tzoffset)

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -12,7 +12,7 @@ from cpython.datetime cimport (datetime, date,
 PyDateTime_IMPORT
 
 from numpy cimport int64_t
-from pandas._libs.tslibs.util cimport get_string_data
+from pandas._libs.tslibs.util cimport get_string_data_checked
 
 cdef extern from "src/datetime/np_datetime.h":
     int cmp_npy_datetimestruct(npy_datetimestruct *a,
@@ -177,8 +177,6 @@ cdef inline int _string_to_dts(object val, npy_datetimestruct* dts,
         Py_ssize_t length
         const char* tmp
 
-    if not get_string_data(val, &tmp, &length):
-        raise ValueError('Unable to parse %s' % str(val))
+    get_string_data_checked(val, &tmp, &length)
     return parse_iso_8601_datetime(tmp, length,
                                    dts, out_local, out_tzoffset)
-

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -33,7 +33,7 @@ cdef extern from "src/datetime/np_datetime.h":
     npy_datetimestruct _NS_MIN_DTS, _NS_MAX_DTS
 
 cdef extern from "src/datetime/np_datetime_strings.h":
-    int parse_iso_8601_datetime(char *str, int len,
+    int parse_iso_8601_datetime(const char *str, int len,
                                 npy_datetimestruct *out,
                                 int *out_local, int *out_tzoffset)
 
@@ -175,7 +175,7 @@ cdef inline int _string_to_dts(object val, npy_datetimestruct* dts,
                                int* out_local, int* out_tzoffset) except? -1:
     cdef:
         Py_ssize_t length
-        char *tmp
+        const char* tmp
 
     if not get_string_data(val, &tmp, &length):
         raise ValueError('Unable to parse %s' % str(val))

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -12,7 +12,7 @@ from cpython.datetime cimport (datetime, date,
 PyDateTime_IMPORT
 
 from numpy cimport int64_t
-from pandas._libs.tslibs.util cimport get_string_data_checked
+from pandas._libs.tslibs.util cimport get_c_string_buf_and_size
 
 cdef extern from "src/datetime/np_datetime.h":
     int cmp_npy_datetimestruct(npy_datetimestruct *a,
@@ -175,8 +175,8 @@ cdef inline int _string_to_dts(object val, npy_datetimestruct* dts,
                                int* out_local, int* out_tzoffset) except? -1:
     cdef:
         Py_ssize_t length
-        const char* tmp
+        const char* buf
 
-    tmp = get_string_data_checked(val, &length)
-    return parse_iso_8601_datetime(tmp, length,
+    buf = get_c_string_buf_and_size(val, &length)
+    return parse_iso_8601_datetime(buf, length,
                                    dts, out_local, out_tzoffset)

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
@@ -72,7 +72,7 @@ int parse_iso_8601_datetime(const char *str, int len,
     int year_leap = 0;
     int i, numdigits;
     const char *substr;
-    char sublen;
+    int sublen;
 
     /* If year-month-day are separated by a valid separator,
      * months/days without leading zeroes will be parsed
@@ -587,7 +587,8 @@ int get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base) {
  */
 int make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
                            NPY_DATETIMEUNIT base) {
-    char *substr = outstr, sublen = outlen;
+    char *substr = outstr;
+    int sublen = outlen;
     int tmplen;
 
     /*

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
@@ -66,12 +66,13 @@ This file implements string parsing and creation for NumPy datetime.
  *
  * Returns 0 on success, -1 on failure.
  */
-int parse_iso_8601_datetime(char *str, int len,
+int parse_iso_8601_datetime(const char *str, int len,
                             npy_datetimestruct *out,
                             int *out_local, int *out_tzoffset) {
     int year_leap = 0;
     int i, numdigits;
-    char *substr, sublen;
+    const char *substr;
+    char sublen;
 
     /* If year-month-day are separated by a valid separator,
      * months/days without leading zeroes will be parsed

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
@@ -54,7 +54,7 @@ This file implements string parsing and creation for NumPy datetime.
  * Returns 0 on success, -1 on failure.
  */
 int
-parse_iso_8601_datetime(char *str, int len,
+parse_iso_8601_datetime(const char *str, int len,
                         npy_datetimestruct *out,
                         int *out_local,
                         int *out_tzoffset);

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -232,10 +232,27 @@ cdef inline bint is_nan(object val):
     return (is_float_object(val) or is_complex_object(val)) and val != val
 
 
-cdef inline bint get_string_data(object s, char **buf, Py_ssize_t *length):
+cdef inline bint get_string_data(object s, const char **buf,
+                                 Py_ssize_t *length):
+    """
+    Extract internal char * buffer of unicode or bytes object `s` to `buf` with
+    getting length of this internal buffer, that save in `length`.
+    Return `False` if it failed to extract such buffer for whatever reason
+    otherwise return `True`
+
+    Parameters
+    ----------
+    s      : object
+    buf    : const char**
+    length : Py_ssize_t*
+    
+    Returns
+    -------
+    bint
+    """
     if PyUnicode_Check(s):
         buf[0] = PyUnicode_AsUTF8AndSize(s, length)
         return buf[0] != NULL
     if PyBytes_Check(s):
-        return PyBytes_AsStringAndSize(s, buf, length) == 0
+        return PyBytes_AsStringAndSize(s, <char**>buf, length) == 0
     return False

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -238,10 +238,10 @@ cdef inline bint is_nan(object val):
     return (is_float_object(val) or is_complex_object(val)) and val != val
 
 
-cdef inline const char* get_c_string_buf_and_size(object s,
+cdef inline const char* get_c_string_buf_and_size(object py_string,
                                                   Py_ssize_t *length):
     """
-    Extract internal char * buffer of unicode or bytes object `s` with
+    Extract internal char* buffer of unicode or bytes object `py_string` with
     getting length of this internal buffer saved in `length`.
 
     Notes
@@ -251,7 +251,7 @@ cdef inline const char* get_c_string_buf_and_size(object s,
 
     Parameters
     ----------
-    s      : object
+    py_string : object
     length : Py_ssize_t*
 
     Returns
@@ -261,12 +261,12 @@ cdef inline const char* get_c_string_buf_and_size(object s,
     cdef:
         const char *buf
 
-    if PyUnicode_Check(s):
-        buf = PyUnicode_AsUTF8AndSize(s, length)
+    if PyUnicode_Check(py_string):
+        buf = PyUnicode_AsUTF8AndSize(py_string, length)
     else:
-        PyBytes_AsStringAndSize(s, <char**>&buf, length)
+        PyBytes_AsStringAndSize(py_string, <char**>&buf, length)
     return buf
 
 
-cdef inline const char* get_c_string(object s):
-    return get_c_string_buf_and_size(s, NULL)
+cdef inline const char* get_c_string(object py_string):
+    return get_c_string_buf_and_size(py_string, NULL)

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -241,6 +241,11 @@ cdef inline bint get_string_data(object s, const char **buf,
     Return `False` if it failed to extract such buffer for whatever reason
     otherwise return `True`
 
+    Note
+    ----
+    python object owns memory, `buf` should not be freed
+    `length` can be NULL
+
     Parameters
     ----------
     s      : object

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -18,11 +18,14 @@ cdef extern from "Python.h":
     # Note: importing extern-style allows us to declare these as nogil
     # functions, whereas `from cpython cimport` does not.
     bint PyUnicode_Check(object obj) nogil
+    bint PyBytes_Check(object obj) nogil
     bint PyString_Check(object obj) nogil
     bint PyBool_Check(object obj) nogil
     bint PyFloat_Check(object obj) nogil
     bint PyComplex_Check(object obj) nogil
     bint PyObject_TypeCheck(object obj, PyTypeObject* type) nogil
+    bint PyBytes_AsStringAndSize(object obj, char** buf, Py_ssize_t* length) nogil
+    char* PyUnicode_AsUTF8AndSize(object obj, Py_ssize_t* length) nogil
 
 from numpy cimport int64_t
 
@@ -227,3 +230,12 @@ cdef inline bint is_nan(object val):
     is_nan : bool
     """
     return (is_float_object(val) or is_complex_object(val)) and val != val
+
+
+cdef inline bint get_string_data(object s, char **buf, Py_ssize_t *length):
+    if PyUnicode_Check(s):
+        buf[0] = PyUnicode_AsUTF8AndSize(s, length)
+        return buf[0] != NULL
+    if PyBytes_Check(s):
+        return PyBytes_AsStringAndSize(s, buf, length) == 0
+    return False

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -30,7 +30,8 @@ cdef extern from "Python.h":
     # unicode object was stored as non-utf8 and utf8 wasn't requested before.
     bint PyBytes_AsStringAndSize(object obj, char** buf,
                                  Py_ssize_t* length) except -1
-    char* PyUnicode_AsUTF8AndSize(object obj, Py_ssize_t* length) except NULL
+    const char* PyUnicode_AsUTF8AndSize(object obj,
+                                        Py_ssize_t* length) except NULL
 
 from numpy cimport int64_t
 

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -24,7 +24,8 @@ cdef extern from "Python.h":
     bint PyFloat_Check(object obj) nogil
     bint PyComplex_Check(object obj) nogil
     bint PyObject_TypeCheck(object obj, PyTypeObject* type) nogil
-    bint PyBytes_AsStringAndSize(object obj, char** buf, Py_ssize_t* length) nogil
+    bint PyBytes_AsStringAndSize(object obj, char** buf,
+                                 Py_ssize_t* length) nogil
     char* PyUnicode_AsUTF8AndSize(object obj, Py_ssize_t* length) nogil
 
 from numpy cimport int64_t
@@ -245,7 +246,7 @@ cdef inline bint get_string_data(object s, const char **buf,
     s      : object
     buf    : const char**
     length : Py_ssize_t*
-    
+
     Returns
     -------
     bint

--- a/pandas/_libs/util.pxd
+++ b/pandas/_libs/util.pxd
@@ -15,21 +15,6 @@ cdef extern from "numpy/arrayobject.h":
         NPY_ARRAY_F_CONTIGUOUS
 
 
-cdef extern from *:
-    """
-    // returns ASCII or UTF8 (py3) view on python str
-    // python object owns memory, should not be freed
-    static const char* get_c_string(PyObject* obj) {
-    #if PY_VERSION_HEX >= 0x03000000
-        return PyUnicode_AsUTF8(obj);
-    #else
-        return PyString_AsString(obj);
-    #endif
-    }
-    """
-    const char *get_c_string(object) except NULL
-
-
 cdef extern from "src/headers/stdint.h":
     enum: UINT8_MAX
     enum: UINT16_MAX

--- a/pandas/tests/tslibs/test_parse_iso8601.py
+++ b/pandas/tests/tslibs/test_parse_iso8601.py
@@ -62,13 +62,7 @@ def test_parsers_iso8601_invalid_offset_invalid():
         tslib._test_parse_iso8601(date_str)
 
 
-def test_parsers_iso8601_overflow():
-    # if use char sublen variable in parse_iso_8601_datetime, then overflow
-    # occurs and no exception is thrown
-    date_str = "2013-01-01 05:30:00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
-               "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
-               "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
-               "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
-               "aaaaaaaaaaaaaaaaaaaaaa"
-    with pytest.raises(ValueError):
-        tslib._test_parse_iso8601(date_str)
+def test_parsers_iso8601_leading_space():
+    date_str, expected = ("2013-1-1 5:30:00", datetime(2013, 1, 1, 5, 30))
+    actual = tslib._test_parse_iso8601(' ' * 200 + date_str)
+    assert actual == expected

--- a/pandas/tests/tslibs/test_parse_iso8601.py
+++ b/pandas/tests/tslibs/test_parse_iso8601.py
@@ -63,6 +63,7 @@ def test_parsers_iso8601_invalid_offset_invalid():
 
 
 def test_parsers_iso8601_leading_space():
+    # GH#25895 make sure isoparser doesn't overflow with long input
     date_str, expected = ("2013-1-1 5:30:00", datetime(2013, 1, 1, 5, 30))
     actual = tslib._test_parse_iso8601(' ' * 200 + date_str)
     assert actual == expected

--- a/pandas/tests/tslibs/test_parse_iso8601.py
+++ b/pandas/tests/tslibs/test_parse_iso8601.py
@@ -60,3 +60,15 @@ def test_parsers_iso8601_invalid_offset_invalid():
 
     with pytest.raises(ValueError, match=msg):
         tslib._test_parse_iso8601(date_str)
+
+
+def test_parsers_iso8601_overflow():
+    # if use char sublen variable in parse_iso_8601_datetime, then overflow
+    # occurs and no exception is thrown
+    date_str = "2013-01-01 05:30:00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
+               "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
+               "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
+               "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
+               "aaaaaaaaaaaaaaaaaaaaaa"
+    with pytest.raises(ValueError):
+        tslib._test_parse_iso8601(date_str)


### PR DESCRIPTION
- [x] closes N/A
- [x] tests added - `test_parsers_iso8601_leading_space`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is a follow-up PR for #25754 which adds a utility method for getting internal `char *` buffer from `unicode` or `bytes` Python object and switch at least some of usages to it.

Its advantages over what is built-in in Cython is saving at least one extra memory allocation (Cython internally calls Python C API that creates a new `char *` copy which is not needed for most `unicode` objects which are internally stored in `utf8` encoding), and it also obtains the length in one call.

cc @jbrockmendel 