### PR TITLE
Remove pandas.io.formats.css from MyPy Blacklist

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -155,9 +155,6 @@ ignore_errors=True
 [mypy-pandas.io.feather_format]
 ignore_errors=True
 
-[mypy-pandas.io.formats.css]
-ignore_errors=True
-
 [mypy-pandas.io.html]
 ignore_errors=True
 

--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -15,9 +15,6 @@ class CSSResolver(object):
 
     """
 
-    INITIAL_STYLE = {
-    }
-
     def __call__(self, declarations_str, inherited=None):
         """ the given declarations to atomic properties
 
@@ -69,7 +66,7 @@ class CSSResolver(object):
             if val == 'inherit':
                 val = inherited.get(prop, 'initial')
             if val == 'initial':
-                val = self.INITIAL_STYLE.get(prop)
+                val = None
 
             if val is None:
                 # we do not define a complete initial stylesheet

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -57,8 +57,7 @@ class CSSToExcelConverter(object):
 
     def __init__(self, inherited=None):
         if inherited is not None:
-            inherited = self.compute_css(inherited,
-                                         self.compute_css.INITIAL_STYLE)
+            inherited = self.compute_css(inherited)
 
         self.inherited = inherited
 


### PR DESCRIPTION
There was a seemingly unused class variable which was failing mypy due to a lack of annotation. On closer inspection however it doesn't appear that this was even used, so I figured deletion makes things simpler.

I suppose if this was subclassed it could have some effect but this isn't part of the exposed API

@jnothman if you have any thoughts or objections