### PR TITLE
CLN: Removed second version of xstrtod in parser_helper.h

### DIFF
--- a/pandas/_libs/src/parse_helper.h
+++ b/pandas/_libs/src/parse_helper.h
@@ -10,21 +10,19 @@ The full license is in the LICENSE file, distributed with this software.
 #ifndef PANDAS__LIBS_SRC_PARSE_HELPER_H_
 #define PANDAS__LIBS_SRC_PARSE_HELPER_H_
 
-#include <errno.h>
 #include <float.h>
 #include "inline_helper.h"
 #include "headers/portable.h"
-
-static double xstrtod(const char *p, char **q, char decimal, char sci,
-                      int skip_trailing, int *maybe_int);
+#include "parser/tokenizer.h"
 
 int to_double(char *item, double *p_value, char sci, char decimal,
               int *maybe_int) {
     char *p_end = NULL;
+    int error = 0;
 
-    *p_value = xstrtod(item, &p_end, decimal, sci, 1, maybe_int);
+    *p_value = xstrtod(item, &p_end, decimal, sci, '\0', 1, &error, maybe_int);
 
-    return (errno == 0) && (!*p_end);
+    return (error == 0) && (!*p_end);
 }
 
 #if PY_VERSION_HEX < 0x02060000
@@ -82,60 +80,7 @@ parsingerror:
     PyErr_Format(PyExc_ValueError, "Unable to parse string \"%s\"", data);
     Py_XDECREF(tmp);
     return -1;
-
-    /*
-    #if PY_VERSION_HEX >= 0x03000000
-      return PyFloat_FromString(str);
-    #else
-      return PyFloat_FromString(str, NULL);
-    #endif
-    */
 }
-
-// ---------------------------------------------------------------------------
-// Implementation of xstrtod
-
-//
-// strtod.c
-//
-// Convert string to double
-//
-// Copyright (C) 2002 Michael Ringgaard. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the project nor the names of its contributors
-//    may be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-// LIABLE
-// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-// SUCH DAMAGE.
-//
-// -----------------------------------------------------------------------
-// Modifications by Warren Weckesser, March 2011:
-// * Rename strtod() to xstrtod().
-// * Added decimal and sci arguments.
-// * Skip trailing spaces.
-// * Commented out the other functions.
-//
 
 PANDAS_INLINE void lowercase(char *p) {
     for (; *p; ++p) *p = tolower_ascii(*p);
@@ -143,132 +88,6 @@ PANDAS_INLINE void lowercase(char *p) {
 
 PANDAS_INLINE void uppercase(char *p) {
     for (; *p; ++p) *p = toupper_ascii(*p);
-}
-
-static double xstrtod(const char *str, char **endptr, char decimal, char sci,
-                      int skip_trailing, int *maybe_int) {
-    double number;
-    int exponent;
-    int negative;
-    char *p = (char *)str;
-    double p10;
-    int n;
-    int num_digits;
-    int num_decimals;
-
-    errno = 0;
-    *maybe_int = 1;
-
-    // Skip leading whitespace
-    while (isspace(*p)) p++;
-
-    // Handle optional sign
-    negative = 0;
-    switch (*p) {
-        case '-':
-            negative = 1;  // Fall through to increment position
-        case '+':
-            p++;
-    }
-
-    number = 0.;
-    exponent = 0;
-    num_digits = 0;
-    num_decimals = 0;
-
-    // Process string of digits
-    while (isdigit_ascii(*p)) {
-        number = number * 10. + (*p - '0');
-        p++;
-        num_digits++;
-    }
-
-    // Process decimal part
-    if (*p == decimal) {
-        *maybe_int = 0;
-        p++;
-
-        while (isdigit_ascii(*p)) {
-            number = number * 10. + (*p - '0');
-            p++;
-            num_digits++;
-            num_decimals++;
-        }
-
-        exponent -= num_decimals;
-    }
-
-    if (num_digits == 0) {
-        errno = ERANGE;
-        return 0.0;
-    }
-
-    // Correct for sign
-    if (negative) number = -number;
-
-    // Process an exponent string
-    if (toupper_ascii(*p) == toupper_ascii(sci)) {
-        *maybe_int = 0;
-
-        // Handle optional sign
-        negative = 0;
-        switch (*++p) {
-            case '-':
-                negative = 1;  // Fall through to increment pos
-            case '+':
-                p++;
-        }
-
-        // Process string of digits
-        num_digits = 0;
-        n = 0;
-        while (isdigit_ascii(*p)) {
-            n = n * 10 + (*p - '0');
-            num_digits++;
-            p++;
-        }
-
-        if (negative)
-            exponent -= n;
-        else
-            exponent += n;
-
-        // If no digits, after the 'e'/'E', un-consume it
-        if (num_digits == 0) p--;
-    }
-
-    if (exponent < DBL_MIN_EXP || exponent > DBL_MAX_EXP) {
-        errno = ERANGE;
-        return HUGE_VAL;
-    }
-
-    // Scale the result
-    p10 = 10.;
-    n = exponent;
-    if (n < 0) n = -n;
-    while (n) {
-        if (n & 1) {
-            if (exponent < 0)
-                number /= p10;
-            else
-                number *= p10;
-        }
-        n >>= 1;
-        p10 *= p10;
-    }
-
-    if (number == HUGE_VAL) {
-        errno = ERANGE;
-    }
-
-    if (skip_trailing) {
-        // Skip trailing whitespace
-        while (isspace_ascii(*p)) p++;
-    }
-
-    if (endptr) *endptr = p;
-
-    return number;
 }
 
 #endif  // PANDAS__LIBS_SRC_PARSE_HELPER_H_

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1554,9 +1554,8 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     int n;
     int num_digits;
     int num_decimals;
-    int _maybe_int = 1;
 
-
+    if (maybe_int != NULL) *maybe_int = 1;
     // Skip leading whitespace.
     while (isspace_ascii(*p)) p++;
 
@@ -1596,7 +1595,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
 
     // Process decimal part.
     if (*p == decimal) {
-        _maybe_int = 0;
+        if (maybe_int != NULL) *maybe_int = 0;
         p++;
 
         while (isdigit_ascii(*p)) {
@@ -1619,7 +1618,7 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
 
     // Process an exponent string.
     if (toupper_ascii(*p) == toupper_ascii(sci)) {
-        _maybe_int = 0;
+        if (maybe_int != NULL) *maybe_int = 0;
 
         // Handle optional sign.
         negative = 0;
@@ -1678,7 +1677,6 @@ double xstrtod(const char *str, char **endptr, char decimal, char sci,
     }
 
     if (endptr) *endptr = p;
-    if (maybe_int) *maybe_int = _maybe_int;
     return number;
 }
 
@@ -1693,7 +1691,8 @@ double precise_xstrtod(const char *str, char **endptr, char decimal,
     int num_decimals;
     int max_digits = 17;
     int n;
-    int _maybe_int = 1;
+
+    if (maybe_int != NULL) *maybe_int = 1;
     // Cache powers of 10 in memory.
     static double e[] = {
         1.,    1e1,   1e2,   1e3,   1e4,   1e5,   1e6,   1e7,   1e8,   1e9,
@@ -1760,7 +1759,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal,
 
     // Process decimal part
     if (*p == decimal) {
-        _maybe_int = 0;
+        if (maybe_int != NULL) *maybe_int = 0;
         p++;
 
         while (num_digits < max_digits && isdigit_ascii(*p)) {
@@ -1786,7 +1785,7 @@ double precise_xstrtod(const char *str, char **endptr, char decimal,
 
     // Process an exponent string.
     if (toupper_ascii(*p) == toupper_ascii(sci)) {
-        _maybe_int = 0;
+        if (maybe_int != NULL) *maybe_int = 0;
 
         // Handle optional sign
         negative = 0;
@@ -1837,7 +1836,6 @@ double precise_xstrtod(const char *str, char **endptr, char decimal,
     }
 
     if (endptr) *endptr = p;
-    if (maybe_int) *maybe_int = _maybe_int;
     return number;
 }
 

--- a/pandas/_libs/src/parser/tokenizer.h
+++ b/pandas/_libs/src/parser/tokenizer.h
@@ -260,11 +260,12 @@ uint64_t str_to_uint64(uint_state *state, const char *p_item, int64_t int_max,
 int64_t str_to_int64(const char *p_item, int64_t int_min, int64_t int_max,
                      int *error, char tsep);
 double xstrtod(const char *p, char **q, char decimal, char sci, char tsep,
-               int skip_trailing, int *error);
-double precise_xstrtod(const char *p, char **q, char decimal, char sci,
-                       char tsep, int skip_trailing, int *error);
+               int skip_trailing, int *error, int *maybe_int);
+double precise_xstrtod(const char *p, char **q, char decimal,
+                       char sci, char tsep, int skip_trailing,
+                       int *error, int *maybe_int);
 double round_trip(const char *p, char **q, char decimal, char sci, char tsep,
-                  int skip_trailing);
+                  int skip_trailing, int *error, int *maybe_int);
 int to_boolean(const char *item, uint8_t *val);
 
 #endif  // PANDAS__LIBS_SRC_PARSER_TOKENIZER_H_

--- a/setup.py
+++ b/setup.py
@@ -559,7 +559,7 @@ ext_data = {
         'pyxfile': '_libs/lib',
         'include': common_include + ts_include,
         'depends': lib_depends + tseries_depends,
-        'sources':['pandas/_libs/src/parser/tokenizer.c']},
+        'sources': ['pandas/_libs/src/parser/tokenizer.c']},
     '_libs.missing': {
         'pyxfile': '_libs/missing',
         'include': common_include + ts_include,

--- a/setup.py
+++ b/setup.py
@@ -558,7 +558,8 @@ ext_data = {
     '_libs.lib': {
         'pyxfile': '_libs/lib',
         'include': common_include + ts_include,
-        'depends': lib_depends + tseries_depends},
+        'depends': lib_depends + tseries_depends,
+        'sources':['pandas/_libs/src/parser/tokenizer.c']},
     '_libs.missing': {
         'pyxfile': '_libs/missing',
         'include': common_include + ts_include,


### PR DESCRIPTION
- [x] closes #19361
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
