### PR TITLE
BUG: Fix memory leak in Rolling.min and Rolling.max (#25893)

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -113,4 +113,35 @@ class Quantile(object):
         self.roll.quantile(percentile, interpolation=interpolation)
 
 
+class PeakMemFixed(object):
+
+    params = (['max', 'min'])
+    param_names = ['method']
+
+    def setup(self, method):
+        N = 10**4
+        arr = 100 * np.random.random(N)
+        self.roll = pd.Series(arr).rolling(1000)
+
+    def peakmem_fixed(self, method):
+        for x in range(10000):
+            getattr(self.roll, method)()
+
+
+class PeakMemVariable(object):
+
+    params = (['max', 'min'])
+    param_names = ['method']
+
+    def setup(self, method):
+        N = 10**4
+        arr = (100 * np.random.random(N)).astype('int')
+        index = pd.date_range('2017-01-01', periods=N, freq='5s')
+        self.roll = pd.Series(arr, index=index).rolling('1d')
+
+    def peakmem_variable(self, method):
+        for x in range(10000):
+            getattr(self.roll, method)()
+
+
 from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -115,33 +115,35 @@ class Quantile(object):
 
 class PeakMemFixed(object):
 
-    params = (['max', 'min'])
-    param_names = ['method']
-
-    def setup(self, method):
+    def setup(self):
         N = 10**4
         arr = 100 * np.random.random(N)
         self.roll = pd.Series(arr).rolling(1000)
 
-    def peakmem_fixed(self, method):
-        for x in range(10000):
-            getattr(self.roll, method)()
+    def peakmem_fixed(self):
+        # GH 25926
+        # This is to detect memory leaks in rolling operations.
+        # To save time, this is only ran 1000 times, and will
+        # only detect larger memory leaks
+        for x in range(1000):
+            self.roll.max()
 
 
 class PeakMemVariable(object):
 
-    params = (['max', 'min'])
-    param_names = ['method']
-
-    def setup(self, method):
+    def setup(self):
         N = 10**4
         arr = (100 * np.random.random(N)).astype('int')
         index = pd.date_range('2017-01-01', periods=N, freq='5s')
         self.roll = pd.Series(arr, index=index).rolling('1d')
 
-    def peakmem_variable(self, method):
-        for x in range(10000):
-            getattr(self.roll, method)()
+    def peakmem_variable(self):
+        # GH 25926
+        # This is to detect memory leaks in rolling operations.
+        # To save time, this is only ran 1000 times, and will
+        # only detect larger memory leaks
+        for x in range(1000):
+            self.roll.max()
 
 
 from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -116,33 +116,16 @@ class Quantile(object):
 class PeakMemFixed(object):
 
     def setup(self):
-        N = 10**4
+        N = 10
         arr = 100 * np.random.random(N)
-        self.roll = pd.Series(arr).rolling(1000)
+        self.roll = pd.Series(arr).rolling(10)
 
     def peakmem_fixed(self):
         # GH 25926
         # This is to detect memory leaks in rolling operations.
-        # To save time, this is only ran 1000 times, and will
-        # only detect larger memory leaks
-        for x in range(1000):
-            self.roll.max()
-
-
-class PeakMemVariable(object):
-
-    def setup(self):
-        N = 10**4
-        arr = (100 * np.random.random(N)).astype('int')
-        index = pd.date_range('2017-01-01', periods=N, freq='5s')
-        self.roll = pd.Series(arr, index=index).rolling('1d')
-
-    def peakmem_variable(self):
-        # GH 25926
-        # This is to detect memory leaks in rolling operations.
-        # To save time, this is only ran 1000 times, and will
-        # only detect larger memory leaks
-        for x in range(1000):
+        # To save time this is only ran on one method.
+        # 6000 iterations is enough for most types of leaks to be detected
+        for x in range(6000):
             self.roll.max()
 
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -372,6 +372,7 @@ Groupby/Resample/Rolling
 - Bug in :func:`pandas.core.groupby.GroupBy.agg` when applying a aggregation function to timezone aware data (:issue:`23683`)
 - Bug in :func:`pandas.core.groupby.GroupBy.first` and :func:`pandas.core.groupby.GroupBy.last` where timezone information would be dropped (:issue:`21603`)
 - Ensured that ordering of outputs in ``groupby`` aggregation functions is consistent across all versions of Python (:issue:`25692`)
+- Bug in :meth:`pandas.core.window.Rolling.min` and :meth:`pandas.core.window.Rolling.max` that caused a memory leak (:issue:`25893`)
 
 
 Reshaping

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1263,12 +1263,12 @@ cdef _roll_min_max(ndarray[numeric] values, int64_t win, int64_t minp,
         return _roll_min_max_variable(values, starti, endi, N, win, minp,
                                       is_max)
     else:
-        return _roll_min_max_fixed(values, starti, endi, N, win, minp, is_max)
+        return _roll_min_max_fixed(values, N, win, minp, is_max)
 
 
 cdef _roll_min_max_variable(ndarray[numeric] values,
-                            int64_t[:] starti,
-                            int64_t[:] endi,
+                            const int64_t[:] starti,
+                            const int64_t[:] endi,
                             int64_t N,
                             int64_t win,
                             int64_t minp,
@@ -1349,8 +1349,6 @@ cdef _roll_min_max_variable(ndarray[numeric] values,
 
 
 cdef _roll_min_max_fixed(ndarray[numeric] values,
-                         int64_t[:] starti,
-                         int64_t[:] endi,
                          int64_t N,
                          int64_t win,
                          int64_t minp,

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1251,7 +1251,7 @@ cdef _roll_min_max(ndarray[numeric] values, int64_t win, int64_t minp,
     ignoring NaNs.
     """
     cdef:
-        int64_t[:] starti, endi
+        ndarray[int64_t] starti, endi
         int64_t N
         bint is_variable
 
@@ -1267,8 +1267,8 @@ cdef _roll_min_max(ndarray[numeric] values, int64_t win, int64_t minp,
 
 
 cdef _roll_min_max_variable(ndarray[numeric] values,
-                            const int64_t[:] starti,
-                            const int64_t[:] endi,
+                            ndarray[int64_t] starti,
+                            ndarray[int64_t] endi,
                             int64_t N,
                             int64_t win,
                             int64_t minp,

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1251,7 +1251,7 @@ cdef _roll_min_max(ndarray[numeric] values, int64_t win, int64_t minp,
     ignoring NaNs.
     """
     cdef:
-        ndarray[int64_t] starti, endi
+        int64_t[:] starti, endi
         int64_t N
         bint is_variable
 
@@ -1267,8 +1267,8 @@ cdef _roll_min_max(ndarray[numeric] values, int64_t win, int64_t minp,
 
 
 cdef _roll_min_max_variable(ndarray[numeric] values,
-                            ndarray[int64_t] starti,
-                            ndarray[int64_t] endi,
+                            int64_t[:] starti,
+                            int64_t[:] endi,
                             int64_t N,
                             int64_t win,
                             int64_t minp,
@@ -1349,8 +1349,8 @@ cdef _roll_min_max_variable(ndarray[numeric] values,
 
 
 cdef _roll_min_max_fixed(ndarray[numeric] values,
-                         ndarray[int64_t] starti,
-                         ndarray[int64_t] endi,
+                         int64_t[:] starti,
+                         int64_t[:] endi,
                          int64_t N,
                          int64_t win,
                          int64_t minp,


### PR DESCRIPTION
- [x] closes #25893
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This fixes an issue that caused a memory leak in `window._roll_min_max`.  Apparently, when you pass an ndarray as an argument that you `cdef`ed in the calling function, that memory never gets released.  This is not an issue unique to pandas, as evidenced by [this stackflow question](https://stackoverflow.com/questions/29247373/memory-leak-calling-cython-function-with-large-numpy-array-parameters).  It may be a numpy bug.

There are a few potential fixes for this:
- Moving everything into one function
- Pass pointers to the functions
- Use [memoryviews](https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html#memoryviews)

As memoryviews is the least disruptive change and is just as performant as what was already being used, that's what I went with for this fix.

I did not add a test with this PR, as determining memory usage is platform specific (and rather wonky) unless you use a library like `psutils`, and even with that may have problems.