### PR TITLE
BUG: Fix #16363 - Prevent visit_BinOp from accessing value on UnaryOp

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -228,7 +228,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
-- Bug in :meth:`~pandas.eval` when comparing floats with scalar operators that don't have a 'value' attribute (e.g., unary operators) (:issue:`25928`)
+
 
 Categorical
 ^^^^^^^^^^^
@@ -269,7 +269,7 @@ Numeric
 - Bug in error messages in :meth:`DataFrame.corr` and :meth:`Series.corr`. Added the possibility of using a callable. (:issue:`25729`)
 - Bug in :meth:`Series.divmod` and :meth:`Series.rdivmod` which would raise an (incorrect) ``ValueError`` rather than return a pair of :class:`Series` objects as result (:issue:`25557`)
 - Raises a helpful exception when a non-numeric index is sent to :meth:`interpolate` with methods which require numeric index. (:issue:`21662`)
--
+- Bug in :meth:`~pandas.eval` when comparing floats with scalar operators, for example: ``x < -0.1`` (:issue:`25928`)
 -
 
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -228,6 +228,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in :meth:`~pandas.eval` when comparing floats with scalar operators that don't have a 'value' attribute (e.g., unary operators) (:issue:`25928`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -418,11 +418,13 @@ class BaseExprVisitor(ast.NodeVisitor):
 
     def _maybe_downcast_constants(self, left, right):
         f32 = np.dtype(np.float32)
-        if left.is_scalar and not right.is_scalar and right.return_type == f32:
+        if (left.is_scalar and hasattr(left, 'value') and
+                not right.is_scalar and right.return_type == f32):
             # right is a float32 array, left is a scalar
             name = self.env.add_tmp(np.float32(left.value))
             left = self.term_type(name, self.env)
-        if right.is_scalar and not left.is_scalar and left.return_type == f32:
+        if (right.is_scalar and hasattr(right, 'value') and
+                not left.is_scalar and left.return_type == f32):
             # left is a float32 array, right is a scalar
             name = self.env.add_tmp(np.float32(right.value))
             right = self.term_type(name, self.env)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -614,6 +614,9 @@ class TestEvalNumexprPandas(object):
         res = df.eval('x < -0.1')
         assert res.values == np.array([False])
 
+        res = df.eval('-5 > x')
+        assert res.values == np.array([False])
+
     def test_disallow_scalar_bool_ops(self):
         exprs = '1 or 2', '1 and 2'
         exprs += 'a and b', 'a or b'

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -608,9 +608,10 @@ class TestEvalNumexprPandas(object):
                       -False, False, ~False, +False,
                       -37, 37, ~37, +37], dtype=np.object_))
 
-    def test_float_comparison_bin_op(self):
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    def test_float_comparison_bin_op(self, dtype):
         # GH 16363
-        df = pd.DataFrame({'x': np.array([0], dtype=np.float32)})
+        df = pd.DataFrame({'x': np.array([0], dtype=dtype)})
         res = df.eval('x < -0.1')
         assert res.values == np.array([False])
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -608,6 +608,12 @@ class TestEvalNumexprPandas(object):
                       -False, False, ~False, +False,
                       -37, 37, ~37, +37], dtype=np.object_))
 
+    def test_float_comparison_bin_op(self):
+        # GH 16363
+        df = pd.DataFrame({'x': np.array([0], dtype=np.float32)})
+        res = df.eval('x < -0.1')
+        assert np.array_equal(res, np.array([False])), res
+
     def test_disallow_scalar_bool_ops(self):
         exprs = '1 or 2', '1 and 2'
         exprs += 'a and b', 'a or b'

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -612,7 +612,7 @@ class TestEvalNumexprPandas(object):
         # GH 16363
         df = pd.DataFrame({'x': np.array([0], dtype=np.float32)})
         res = df.eval('x < -0.1')
-        assert np.array_equal(res, np.array([False])), res
+        assert np.array_equal(res, np.array([False]))
 
     def test_disallow_scalar_bool_ops(self):
         exprs = '1 or 2', '1 and 2'

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -612,7 +612,7 @@ class TestEvalNumexprPandas(object):
         # GH 16363
         df = pd.DataFrame({'x': np.array([0], dtype=np.float32)})
         res = df.eval('x < -0.1')
-        assert np.array_equal(res, np.array([False]))
+        assert res.values == np.array([False])
 
     def test_disallow_scalar_bool_ops(self):
         exprs = '1 or 2', '1 and 2'


### PR DESCRIPTION
- [x] closes #16363
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Checking `hasattr(side, 'value')` resolves the bug and is consistent with the way that other methods of the `BaseExprVisitor` class work (e.g., both `visit_Call_35` and `visit_Call_legacy` check for 'value').