### PR TITLE
TST: Test for private modules exposed via API 

### DIFF
--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -11,7 +11,7 @@ class Base(object):
         # ignored ones
         # compare vs the expected
 
-        result = sorted(f for f in dir(namespace) if not f.startswith('_'))
+        result = sorted(f for f in dir(namespace) if not f.startswith('__'))
         if ignored is not None:
             result = sorted(list(set(result) - set(ignored)))
 
@@ -93,6 +93,12 @@ class TestPDApi(Base):
     # these are already deprecated; awaiting removal
     deprecated_funcs = []
 
+    # private modules in pandas namespace
+    private_modules = ['_config', '_hashtable', '_lib', '_libs',
+                       '_np_version_under1p14', '_np_version_under1p15',
+                       '_np_version_under1p16', '_np_version_under1p17',
+                       '_tslib', '_typing', '_version']
+
     def test_api(self):
 
         self.check(pd,
@@ -103,7 +109,7 @@ class TestPDApi(Base):
                    self.funcs + self.funcs_option +
                    self.funcs_read + self.funcs_to +
                    self.deprecated_funcs_in_future +
-                   self.deprecated_funcs,
+                   self.deprecated_funcs + self.private_modules,
                    self.ignored)
 
 


### PR DESCRIPTION
- [x] closes #25930
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
