### PR TITLE
remove is_string_object

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -536,7 +536,7 @@ cpdef convert_scalar(ndarray arr, object value):
             return Timestamp(value).value
         elif value is None or value != value:
             return NPY_NAT
-        elif util.is_string_object(value):
+        elif isinstance(value, str):
             return Timestamp(value).value
         raise ValueError("cannot set a Timestamp with a non-timestamp")
 
@@ -547,7 +547,7 @@ cpdef convert_scalar(ndarray arr, object value):
             return Timedelta(value).value
         elif value is None or value != value:
             return NPY_NAT
-        elif util.is_string_object(value):
+        elif isinstance(value, str):
             return Timedelta(value).value
         raise ValueError("cannot set a Timedelta with a non-timedelta")
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1377,7 +1377,7 @@ def infer_datetimelike_array(arr: object) -> object:
 
     for i in range(n):
         v = arr[i]
-        if util.is_string_object(v):
+        if isinstance(v, str):
             objs.append(v)
 
             if len(objs) == 3:
@@ -2070,7 +2070,7 @@ def maybe_convert_objects(ndarray[object] objects, bint try_float=0,
             else:
                 seen.object_ = 1
                 break
-        elif try_float and not util.is_string_object(val):
+        elif try_float and not isinstance(val, str):
             # this will convert Decimal objects
             try:
                 floats[i] = float(val)

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -17,7 +17,7 @@ cnp.import_array()
 import pytz
 
 from pandas._libs.util cimport (
-    is_integer_object, is_float_object, is_string_object, is_datetime64_object)
+    is_integer_object, is_float_object, is_datetime64_object)
 
 
 from pandas._libs.tslibs.np_datetime cimport (
@@ -111,7 +111,7 @@ def ints_to_pydatetime(int64_t[:] arr, object tz=None, object freq=None,
     elif box == "timestamp":
         func_create = create_timestamp_from_ts
 
-        if is_string_object(freq):
+        if isinstance(freq, str):
             freq = to_offset(freq)
     elif box == "time":
         func_create = create_time_from_ts
@@ -383,7 +383,7 @@ def array_with_unit_to_datetime(ndarray values, object unit,
                             raise AssertionError
                         iresult[i] = NPY_NAT
 
-            elif is_string_object(val):
+            elif isinstance(val, str):
                 if len(val) == 0 or val in nat_strings:
                     iresult[i] = NPY_NAT
 
@@ -442,7 +442,7 @@ def array_with_unit_to_datetime(ndarray values, object unit,
                 except:
                     oresult[i] = val
 
-        elif is_string_object(val):
+        elif isinstance(val, str):
             if len(val) == 0 or val in nat_strings:
                 oresult[i] = NaT
 
@@ -569,7 +569,7 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                         except:
                             iresult[i] = NPY_NAT
 
-                elif is_string_object(val):
+                elif isinstance(val, str):
                     # string
                     seen_string = 1
 
@@ -660,7 +660,7 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                 if is_coerce:
                     iresult[i] = NPY_NAT
                     continue
-                elif require_iso8601 and is_string_object(val):
+                elif require_iso8601 and isinstance(val, str):
                     # GH#19382 for just-barely-OutOfBounds falling back to
                     # dateutil parser will return incorrect result because
                     # it will ignore nanoseconds
@@ -794,7 +794,7 @@ cdef array_to_datetime_object(ndarray[object] values, bint is_raise,
         val = values[i]
         if checknull_with_nat(val):
             oresult[i] = val
-        elif is_string_object(val):
+        elif isinstance(val, str):
             if len(val) == 0 or val in nat_strings:
                 oresult[i] = 'NaT'
                 continue

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -27,7 +27,7 @@ from pandas._libs.tslibs.np_datetime cimport (
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 
 from pandas._libs.tslibs.util cimport (
-    is_string_object, is_datetime64_object, is_integer_object, is_float_object)
+    is_datetime64_object, is_integer_object, is_float_object)
 
 from pandas._libs.tslibs.timedeltas cimport (cast_from_unit,
                                              delta_to_nanoseconds)
@@ -284,7 +284,7 @@ cdef convert_to_tsobject(object ts, object tz, object unit,
 
     obj = _TSObject()
 
-    if is_string_object(ts):
+    if isinstance(ts, str):
         return convert_str_to_tsobject(ts, tz, unit, dayfirst, yearfirst)
 
     if ts is None or ts is NaT:
@@ -430,7 +430,7 @@ cdef _TSObject convert_str_to_tsobject(object ts, object tz, object unit,
 
     obj = _TSObject()
 
-    assert is_string_object(ts)
+    assert isinstance(ts, str)
 
     if len(ts) == 0 or ts in nat_strings:
         ts = NaT
@@ -924,7 +924,7 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
                 result[i] = _tz_convert_tzlocal_utc(v, tz, to_utc=True)
         return result
 
-    if is_string_object(ambiguous):
+    if isinstance(ambiguous, str):
         if ambiguous == 'infer':
             infer_dst = True
         elif ambiguous == 'NaT':

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -4,7 +4,7 @@ import re
 cimport numpy as cnp
 cnp.import_array()
 
-from pandas._libs.tslibs.util cimport is_integer_object, is_string_object
+from pandas._libs.tslibs.util cimport is_integer_object
 
 from pandas._libs.tslibs.ccalendar import MONTH_NUMBERS
 
@@ -316,7 +316,7 @@ cpdef object get_freq(object freq):
     >>> get_freq('3A')
     1000
     """
-    if is_string_object(freq):
+    if isinstance(freq, str):
         base, mult = get_freq_code(freq)
         freq = base
     return freq

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -249,7 +249,7 @@ def _to_dt64(dt, dtype='datetime64'):
 
 
 def _validate_business_time(t_input):
-    if isinsatnce(t_input, str):
+    if isinstance(t_input, str):
         try:
             t = time.strptime(t_input, '%H:%M')
             return dt_time(hour=t.tm_hour, minute=t.tm_min)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -19,7 +19,7 @@ cnp.import_array()
 
 
 from pandas._libs.tslibs cimport util
-from pandas._libs.tslibs.util cimport is_string_object, is_integer_object
+from pandas._libs.tslibs.util cimport is_integer_object
 
 from pandas._libs.tslibs.ccalendar import MONTHS, DAYS
 from pandas._libs.tslibs.ccalendar cimport get_days_in_month, dayofweek
@@ -249,7 +249,7 @@ def _to_dt64(dt, dtype='datetime64'):
 
 
 def _validate_business_time(t_input):
-    if is_string_object(t_input):
+    if isinsatnce(t_input, str):
         try:
             t = time.strptime(t_input, '%H:%M')
             return dt_time(hour=t.tm_hour, minute=t.tm_min)
@@ -331,7 +331,7 @@ class _BaseOffset(object):
         raise AttributeError("DateOffset objects are immutable.")
 
     def __eq__(self, other):
-        if is_string_object(other):
+        if isinstance(other, str):
             try:
                 # GH#23524 if to_offset fails, we are dealing with an
                 #  incomparable type so == is False and != is True

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -29,7 +29,7 @@ cdef extern from "src/datetime/np_datetime.h":
                                            npy_datetimestruct *d) nogil
 
 cimport pandas._libs.tslibs.util as util
-from pandas._libs.tslibs.util cimport is_period_object, is_string_object
+from pandas._libs.tslibs.util cimport is_period_object
 
 from pandas._libs.tslibs.timestamps import Timestamp
 from pandas._libs.tslibs.timezones cimport is_utc, is_tzlocal, get_dst_info
@@ -2457,7 +2457,7 @@ class Period(_Period):
         elif is_null_datetimelike(value) or value in nat_strings:
             ordinal = NPY_NAT
 
-        elif is_string_object(value) or util.is_integer_object(value):
+        elif isinsance(value, str) or util.is_integer_object(value):
             if util.is_integer_object(value):
                 value = str(value)
             value = value.upper()

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2457,7 +2457,7 @@ class Period(_Period):
         elif is_null_datetimelike(value) or value in nat_strings:
             ordinal = NPY_NAT
 
-        elif isinsance(value, str) or util.is_integer_object(value):
+        elif isinstance(value, str) or util.is_integer_object(value):
             if util.is_integer_object(value):
                 value = str(value)
             value = value.upper()

--- a/pandas/_libs/tslibs/resolution.pyx
+++ b/pandas/_libs/tslibs/resolution.pyx
@@ -3,7 +3,7 @@
 import numpy as np
 from numpy cimport ndarray, int64_t, int32_t
 
-from pandas._libs.tslibs.util cimport is_string_object, get_nat
+from pandas._libs.tslibs.util cimport get_nat
 
 from pandas._libs.tslibs.np_datetime cimport (
     npy_datetimestruct, dt64_to_dtstruct)
@@ -123,7 +123,7 @@ def get_freq_group(freq):
     if getattr(freq, '_typ', None) == 'dateoffset':
         freq = freq.rule_code
 
-    if is_string_object(freq):
+    if isinstance(freq, str):
         base, mult = get_freq_code(freq)
         freq = base
     elif isinstance(freq, int):

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -30,8 +30,6 @@ from numpy cimport int64_t
 from pandas._libs.tslibs.np_datetime cimport (
     check_dts_bounds, dtstruct_to_dt64, npy_datetimestruct)
 
-from pandas._libs.tslibs.util cimport is_string_object
-
 from pandas._libs.tslibs.nattype cimport checknull_with_nat, NPY_NAT
 from pandas._libs.tslibs.nattype import nat_strings
 
@@ -136,7 +134,7 @@ def array_strptime(object[:] values, object fmt,
 
     for i in range(n):
         val = values[i]
-        if is_string_object(val):
+        if isinstance(val, str):
             if val in nat_strings:
                 iresult[i] = NPY_NAT
                 continue

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -24,7 +24,7 @@ PyDateTime_IMPORT
 cimport pandas._libs.tslibs.util as util
 from pandas._libs.tslibs.util cimport (
     is_timedelta64_object, is_datetime64_object, is_integer_object,
-    is_float_object, is_string_object)
+    is_float_object)
 
 from pandas._libs.tslibs.ccalendar import DAY_SECONDS
 
@@ -188,7 +188,7 @@ cdef convert_to_timedelta64(object ts, object unit):
         else:
             ts = cast_from_unit(ts, unit)
             ts = np.timedelta64(ts)
-    elif is_string_object(ts):
+    elif isinstance(ts, str):
         if len(ts) > 0 and ts[0] == 'P':
             ts = parse_iso_format_string(ts)
         else:
@@ -539,7 +539,7 @@ cdef bint _validate_ops_compat(other):
         return True
     elif PyDelta_Check(other) or is_timedelta64_object(other):
         return True
-    elif is_string_object(other):
+    elif isinstance(other, str):
         return True
     elif hasattr(other, 'delta'):
         return True
@@ -1206,7 +1206,7 @@ class Timedelta(_Timedelta):
 
         if isinstance(value, Timedelta):
             value = value.value
-        elif is_string_object(value):
+        elif isinstance(value, str):
             if len(value) > 0 and value[0] == 'P':
                 value = parse_iso_format_string(value)
             else:

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -18,7 +18,7 @@ PyDateTime_IMPORT
 
 from pandas._libs.tslibs.util cimport (
     is_datetime64_object, is_timedelta64_object, is_integer_object,
-    is_string_object, is_array, is_offset_object)
+    is_array, is_offset_object)
 
 cimport pandas._libs.tslibs.ccalendar as ccalendar
 from pandas._libs.tslibs.ccalendar import DAY_SECONDS
@@ -639,7 +639,7 @@ class Timestamp(_Timestamp):
         tz : str or timezone object, default None
             Timezone to localize to
         """
-        if is_string_object(tz):
+        if isinstance(tz, str):
             tz = maybe_get_tz(tz)
         return cls(datetime.now(tz))
 
@@ -748,7 +748,7 @@ class Timestamp(_Timestamp):
             # User passed tzinfo instead of tz; avoid silently ignoring
             tz, tzinfo = tzinfo, None
 
-        if is_string_object(ts_input):
+        if isinstance(ts_input, str):
             # User passed a date string to parse.
             # Check that the user didn't also pass a date attribute kwarg.
             if any(arg is not None for arg in _date_attributes):
@@ -1202,7 +1202,7 @@ class Timestamp(_Timestamp):
         if self.tzinfo is None:
             # tz naive, localize
             tz = maybe_get_tz(tz)
-            if not is_string_object(ambiguous):
+            if not isinstance(ambiguous, str):
                 ambiguous = [ambiguous]
             value = tz_localize_to_utc(np.array([self.value], dtype='i8'), tz,
                                        ambiguous=ambiguous,

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -20,8 +20,7 @@ from numpy cimport int64_t
 cnp.import_array()
 
 # ----------------------------------------------------------------------
-from pandas._libs.tslibs.util cimport (
-    is_string_object, is_integer_object, get_nat)
+from pandas._libs.tslibs.util cimport is_integer_object, get_nat
 
 cdef int64_t NPY_NAT = get_nat()
 cdef object utc_stdlib = timezone.utc
@@ -88,7 +87,7 @@ cpdef inline object maybe_get_tz(object tz):
     (Maybe) Construct a timezone object from a string. If tz is a string, use
     it to construct a timezone object. Otherwise, just return tz.
     """
-    if is_string_object(tz):
+    if isinstance(tz, str):
         if tz == 'tzlocal()':
             tz = _dateutil_tzlocal()
         elif tz.startswith('dateutil/'):

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -37,7 +37,6 @@ from numpy cimport int64_t
 
 cdef extern from "numpy/arrayobject.h":
     PyTypeObject PyFloatingArrType_Type
-    int _import_array() except -1
 
 cdef extern from "numpy/ndarrayobject.h":
     PyTypeObject PyTimedeltaArrType_Type
@@ -56,27 +55,8 @@ cdef inline int64_t get_nat():
     return NPY_MIN_INT64
 
 
-cdef inline int import_array() except -1:
-    _import_array()
-
-
 # --------------------------------------------------------------------
 # Type Checking
-
-cdef inline bint is_string_object(object obj) nogil:
-    """
-    Cython equivalent of `isinstance(val, compat.string_types)`
-
-    Parameters
-    ----------
-    val : object
-
-    Returns
-    -------
-    is_string : bool
-    """
-    return PyString_Check(obj) or PyUnicode_Check(obj)
-
 
 cdef inline bint is_integer_object(object obj) nogil:
     """


### PR DESCRIPTION
now that we're py3-only, `is_string_object(obj)` reduces to just `isinstance(obj, str)` which cython already optimizes.