### PR TITLE
CLN: Remove collections.abc classes from pandas.compat

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -111,8 +111,10 @@ fi
 if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
 
     # Check for imports from pandas.core.common instead of `import pandas.core.common as com`
+    # Check for imports from collections.abc instead of `from collections import abc`
     MSG='Check for non-standard imports' ; echo $MSG
     invgrep -R --include="*.py*" -E "from pandas.core.common import " pandas
+    invgrep -R --include="*.py*" -E "from collections.abc import " pandas
     # invgrep -R --include="*.py*" -E "from numpy import nan " pandas  # GH#24822 not yet implemented since the offending imports have not all been removed
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -29,7 +29,6 @@ import types
 import struct
 import inspect
 from collections import namedtuple
-import collections
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] >= 3
@@ -106,16 +105,6 @@ if PY3:
 
     def lfilter(*args, **kwargs):
         return list(filter(*args, **kwargs))
-
-    Hashable = collections.abc.Hashable
-    Iterable = collections.abc.Iterable
-    Iterator = collections.abc.Iterator
-    Mapping = collections.abc.Mapping
-    MutableMapping = collections.abc.MutableMapping
-    Sequence = collections.abc.Sequence
-    Sized = collections.abc.Sized
-    Set = collections.abc.Set
-
 else:
     # Python 2
     _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
@@ -137,15 +126,6 @@ else:
     lzip = builtins.zip
     lmap = builtins.map
     lfilter = builtins.filter
-
-    Hashable = collections.Hashable
-    Iterable = collections.Iterable
-    Iterator = collections.Iterator
-    Mapping = collections.Mapping
-    MutableMapping = collections.MutableMapping
-    Sequence = collections.Sequence
-    Sized = collections.Sized
-    Set = collections.Set
 
 if PY2:
     def iteritems(obj, **kw):

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1,6 +1,7 @@
 """
 SparseArray data structure
 """
+from collections.abc import Mapping
 import numbers
 import operator
 import re
@@ -1377,7 +1378,7 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
         if isinstance(mapper, ABCSeries):
             mapper = mapper.to_dict()
 
-        if isinstance(mapper, compat.Mapping):
+        if isinstance(mapper, Mapping):
             fill_value = mapper.get(self.fill_value, self.fill_value)
             sp_values = [mapper.get(x, None) for x in self.sp_values]
         else:

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1,7 +1,7 @@
 """
 SparseArray data structure
 """
-from collections.abc import Mapping
+from collections import abc
 import numbers
 import operator
 import re
@@ -1378,7 +1378,7 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
         if isinstance(mapper, ABCSeries):
             mapper = mapper.to_dict()
 
-        if isinstance(mapper, Mapping):
+        if isinstance(mapper, abc.Mapping):
             fill_value = mapper.get(self.fill_value, self.fill_value)
             sp_values = [mapper.get(x, None) for x in self.sp_values]
         else:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -6,6 +6,7 @@ Note: pandas.core.common is *not* part of the public API.
 
 import collections
 from collections import OrderedDict
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from functools import partial
 import inspect
@@ -14,7 +15,6 @@ from typing import Any
 import numpy as np
 
 from pandas._libs import lib, tslibs
-import pandas.compat as compat
 from pandas.compat import PY36, iteritems
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
@@ -374,13 +374,13 @@ def standardize_mapping(into):
 
     Parameters
     ----------
-    into : instance or subclass of collections.Mapping
+    into : instance or subclass of collections.abc.Mapping
         Must be a class, an initialized collections.defaultdict,
-        or an instance of a collections.Mapping subclass.
+        or an instance of a collections.abc.Mapping subclass.
 
     Returns
     -------
-    mapping : a collections.Mapping subclass or other constructor
+    mapping : a collections.abc.Mapping subclass or other constructor
         a callable object that can accept an iterator to create
         the desired Mapping.
 
@@ -394,7 +394,7 @@ def standardize_mapping(into):
             return partial(
                 collections.defaultdict, into.default_factory)
         into = type(into)
-    if not issubclass(into, compat.Mapping):
+    if not issubclass(into, Mapping):
         raise TypeError('unsupported type: {into}'.format(into=into))
     elif into == collections.defaultdict:
         raise TypeError(
@@ -471,7 +471,7 @@ def _get_rename_function(mapper):
     Returns a function that will map names/labels, dependent if mapper
     is a dict, Series or just a function.
     """
-    if isinstance(mapper, (compat.Mapping, ABCSeries)):
+    if isinstance(mapper, (Mapping, ABCSeries)):
 
         def f(x):
             if x in mapper:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -5,8 +5,7 @@ Note: pandas.core.common is *not* part of the public API.
 """
 
 import collections
-from collections import OrderedDict
-from collections.abc import Mapping
+from collections import OrderedDict, abc
 from datetime import datetime, timedelta
 from functools import partial
 import inspect
@@ -394,7 +393,7 @@ def standardize_mapping(into):
             return partial(
                 collections.defaultdict, into.default_factory)
         into = type(into)
-    if not issubclass(into, Mapping):
+    if not issubclass(into, abc.Mapping):
         raise TypeError('unsupported type: {into}'.format(into=into))
     elif into == collections.defaultdict:
         raise TypeError(
@@ -471,7 +470,7 @@ def _get_rename_function(mapper):
     Returns a function that will map names/labels, dependent if mapper
     is a dict, Series or just a function.
     """
-    if isinstance(mapper, (Mapping, ABCSeries)):
+    if isinstance(mapper, (abc.Mapping, ABCSeries)):
 
         def f(x):
             if x in mapper:

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -1,6 +1,6 @@
 """ basic inference routines """
 
-from collections.abc import Iterable, Set
+from collections import abc
 from numbers import Number
 import re
 
@@ -112,7 +112,7 @@ def _iterable_not_string(obj):
     False
     """
 
-    return isinstance(obj, Iterable) and not isinstance(obj, str)
+    return isinstance(obj, abc.Iterable) and not isinstance(obj, str)
 
 
 def is_iterator(obj):
@@ -287,7 +287,7 @@ def is_list_like(obj, allow_sets=True):
     False
     """
 
-    return (isinstance(obj, Iterable) and
+    return (isinstance(obj, abc.Iterable) and
             # we do not count strings/unicode/bytes as list-like
             not isinstance(obj, (str, bytes)) and
 
@@ -295,7 +295,7 @@ def is_list_like(obj, allow_sets=True):
             not (isinstance(obj, np.ndarray) and obj.ndim == 0) and
 
             # exclude sets if allow_sets is False
-            not (allow_sets is False and isinstance(obj, Set)))
+            not (allow_sets is False and isinstance(obj, abc.Set)))
 
 
 def is_array_like(obj):

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -1,14 +1,13 @@
 """ basic inference routines """
 
+from collections.abc import Iterable, Set
 from numbers import Number
 import re
 
 import numpy as np
 
 from pandas._libs import lib
-from pandas.compat import PY2, Set, re_type
-
-from pandas import compat
+from pandas.compat import PY2, re_type
 
 is_bool = lib.is_bool
 
@@ -113,7 +112,7 @@ def _iterable_not_string(obj):
     False
     """
 
-    return isinstance(obj, compat.Iterable) and not isinstance(obj, str)
+    return isinstance(obj, Iterable) and not isinstance(obj, str)
 
 
 def is_iterator(obj):
@@ -288,7 +287,7 @@ def is_list_like(obj, allow_sets=True):
     False
     """
 
-    return (isinstance(obj, compat.Iterable) and
+    return (isinstance(obj, Iterable) and
             # we do not count strings/unicode/bytes as list-like
             not isinstance(obj, (str, bytes)) and
 
@@ -436,8 +435,8 @@ def is_named_tuple(obj):
 def is_hashable(obj):
     """Return True if hash(obj) will succeed, False otherwise.
 
-    Some types will pass a test against collections.Hashable but fail when they
-    are actually hashed with hash().
+    Some types will pass a test against collections.abc.Hashable but fail when
+    they are actually hashed with hash().
 
     Distinguish between these and other types by trying the call to hash() and
     seeing if they raise TypeError.
@@ -445,14 +444,14 @@ def is_hashable(obj):
     Examples
     --------
     >>> a = ([],)
-    >>> isinstance(a, collections.Hashable)
+    >>> isinstance(a, collections.abc.Hashable)
     True
     >>> is_hashable(a)
     False
     """
-    # Unfortunately, we can't use isinstance(obj, collections.Hashable), which
-    # can be faster than calling hash. That is because numpy scalars on Python
-    # 3 fail this test.
+    # Unfortunately, we can't use isinstance(obj, collections.abc.Hashable),
+    # which can be faster than calling hash. That is because numpy scalars
+    # fail this test.
 
     # Reconsider this decision once this numpy bug is fixed:
     # https://github.com/numpy/numpy/issues/5562

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11,8 +11,7 @@ alignment and a host of useful data manipulation methods having to do with the
 labeling information
 """
 import collections
-from collections import OrderedDict
-from collections.abc import Iterable, Iterator, Sequence
+from collections import OrderedDict, abc
 import functools
 import itertools
 import sys
@@ -426,9 +425,9 @@ class DataFrame(NDFrame):
                                    copy=copy)
 
         # For data is list-like, or Iterable (will consume into list)
-        elif (isinstance(data, Iterable) and
+        elif (isinstance(data, abc.Iterable) and
               not isinstance(data, (str, bytes))):
-            if not isinstance(data, Sequence):
+            if not isinstance(data, abc.Sequence):
                 data = list(data)
             if len(data) > 0:
                 if is_list_like(data[0]) and getattr(data[0], 'ndim', 1) == 1:
@@ -4166,7 +4165,7 @@ class DataFrame(NDFrame):
         missing = []
         for col in keys:
             if isinstance(col, (ABCIndexClass, ABCSeries, np.ndarray,
-                                list, Iterator)):
+                                list, abc.Iterator)):
                 # arrays are fine as long as they are one-dimensional
                 # iterators get converted to list below
                 if getattr(col, 'ndim', 1) != 1:
@@ -4213,7 +4212,7 @@ class DataFrame(NDFrame):
             elif isinstance(col, (list, np.ndarray)):
                 arrays.append(col)
                 names.append(None)
-            elif isinstance(col, Iterator):
+            elif isinstance(col, abc.Iterator):
                 arrays.append(list(col))
                 names.append(None)
             # from here, col can only be a column label

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12,6 +12,7 @@ labeling information
 """
 import collections
 from collections import OrderedDict
+from collections.abc import Iterable, Iterator, Sequence
 import functools
 import itertools
 import sys
@@ -33,8 +34,7 @@ from pandas.util._validators import (validate_bool_kwarg,
                                      validate_axis_style_args)
 
 from pandas import compat
-from pandas.compat import (
-    PY36, Iterator, StringIO, lmap, lzip, raise_with_traceback)
+from pandas.compat import PY36, StringIO, lmap, lzip, raise_with_traceback
 from pandas.compat.numpy import function as nv
 from pandas.core.dtypes.cast import (
     maybe_upcast,
@@ -426,9 +426,9 @@ class DataFrame(NDFrame):
                                    copy=copy)
 
         # For data is list-like, or Iterable (will consume into list)
-        elif (isinstance(data, compat.Iterable) and
+        elif (isinstance(data, Iterable) and
               not isinstance(data, (str, bytes))):
-            if not isinstance(data, compat.Sequence):
+            if not isinstance(data, Sequence):
                 data = list(data)
             if len(data) > 0:
                 if is_list_like(data[0]) and getattr(data[0], 'ndim', 1) == 1:
@@ -1203,7 +1203,7 @@ class DataFrame(NDFrame):
             indicates `split`.
 
         into : class, default dict
-            The collections.Mapping subclass used for all Mappings
+            The collections.abc.Mapping subclass used for all Mappings
             in the return value.  Can be the actual class or an empty
             instance of the mapping type you want.  If you want a
             collections.defaultdict, you must pass it initialized.
@@ -1212,8 +1212,8 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        dict, list or collections.Mapping
-            Return a collections.Mapping object representing the DataFrame.
+        dict, list or collections.abc.Mapping
+            Return a collections.abc.Mapping object representing the DataFrame.
             The resulting transformation depends on the `orient` parameter.
 
         See Also
@@ -4080,7 +4080,7 @@ class DataFrame(NDFrame):
             the same length as the calling DataFrame, or a list containing an
             arbitrary combination of column keys and arrays. Here, "array"
             encompasses :class:`Series`, :class:`Index`, ``np.ndarray``, and
-            instances of :class:`abc.Iterator`.
+            instances of :class:`~collections.abc.Iterator`.
         drop : bool, default True
             Delete columns to be used as the new index.
         append : bool, default False

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -7,6 +7,7 @@ which here returns a DataFrameGroupBy object.
 """
 
 import collections
+from collections.abc import Iterable
 import copy
 from functools import partial
 from textwrap import dedent
@@ -770,7 +771,7 @@ class SeriesGroupBy(GroupBy):
         if isinstance(func_or_funcs, str):
             return getattr(self, func_or_funcs)(*args, **kwargs)
 
-        if isinstance(func_or_funcs, compat.Iterable):
+        if isinstance(func_or_funcs, Iterable):
             # Catch instances of lists / tuples
             # but not the class list / tuple itself.
             ret = self._aggregate_multiple_funcs(func_or_funcs,

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -6,8 +6,7 @@ These are user facing as the result of the ``df.groupby(...)`` operations,
 which here returns a DataFrameGroupBy object.
 """
 
-import collections
-from collections.abc import Iterable
+from collections import OrderedDict, abc
 import copy
 from functools import partial
 from textwrap import dedent
@@ -227,7 +226,7 @@ class NDFrameGroupBy(GroupBy):
         axis = self.axis
         obj = self._obj_with_exclusions
 
-        result = collections.OrderedDict()
+        result = OrderedDict()
         if axis != obj._info_axis_number:
             try:
                 for name, data in self:
@@ -254,7 +253,7 @@ class NDFrameGroupBy(GroupBy):
         # only for axis==0
 
         obj = self._obj_with_exclusions
-        result = collections.OrderedDict()
+        result = OrderedDict()
         cannot_agg = []
         errors = None
         for item in obj:
@@ -771,7 +770,7 @@ class SeriesGroupBy(GroupBy):
         if isinstance(func_or_funcs, str):
             return getattr(self, func_or_funcs)(*args, **kwargs)
 
-        if isinstance(func_or_funcs, Iterable):
+        if isinstance(func_or_funcs, abc.Iterable):
             # Catch instances of lists / tuples
             # but not the class list / tuple itself.
             ret = self._aggregate_multiple_funcs(func_or_funcs,
@@ -835,7 +834,7 @@ class SeriesGroupBy(GroupBy):
                     columns.append(com.get_callable_name(f))
             arg = lzip(columns, arg)
 
-        results = collections.OrderedDict()
+        results = OrderedDict()
         for name, func in arg:
             obj = self
             if name in results:
@@ -912,7 +911,7 @@ class SeriesGroupBy(GroupBy):
                           name=self._selection_name)
 
     def _aggregate_named(self, func, *args, **kwargs):
-        result = collections.OrderedDict()
+        result = OrderedDict()
 
         for name, group in self:
             group.name = name
@@ -1508,7 +1507,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
     def _fill(self, direction, limit=None):
         """Overridden method to join grouped columns in output"""
         res = super(DataFrameGroupBy, self)._fill(direction, limit=limit)
-        output = collections.OrderedDict(
+        output = OrderedDict(
             (grp.name, grp.grouper) for grp in self.grouper.groupings)
 
         from pandas import concat

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -3,13 +3,13 @@ Functions for preparing various inputs passed to the DataFrame or Series
 constructors before passing them to a BlockManager.
 """
 from collections import OrderedDict
+from collections.abc import Mapping
 
 import numpy as np
 import numpy.ma as ma
 
 from pandas._libs import lib
 from pandas._libs.tslibs import IncompatibleFrequency
-import pandas.compat as compat
 from pandas.compat import lmap, lrange, raise_with_traceback
 
 from pandas.core.dtypes.cast import (
@@ -395,7 +395,7 @@ def to_arrays(data, columns, coerce_float=False, dtype=None):
     if isinstance(data[0], (list, tuple)):
         return _list_to_arrays(data, columns, coerce_float=coerce_float,
                                dtype=dtype)
-    elif isinstance(data[0], compat.Mapping):
+    elif isinstance(data[0], Mapping):
         return _list_of_dict_to_arrays(data, columns,
                                        coerce_float=coerce_float, dtype=dtype)
     elif isinstance(data[0], ABCSeries):

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -2,8 +2,7 @@
 Functions for preparing various inputs passed to the DataFrame or Series
 constructors before passing them to a BlockManager.
 """
-from collections import OrderedDict
-from collections.abc import Mapping
+from collections import OrderedDict, abc
 
 import numpy as np
 import numpy.ma as ma
@@ -395,7 +394,7 @@ def to_arrays(data, columns, coerce_float=False, dtype=None):
     if isinstance(data[0], (list, tuple)):
         return _list_to_arrays(data, columns, coerce_float=coerce_float,
                                dtype=dtype)
-    elif isinstance(data[0], Mapping):
+    elif isinstance(data[0], abc.Mapping):
         return _list_of_dict_to_arrays(data, columns,
                                        coerce_float=coerce_float, dtype=dtype)
     elif isinstance(data[0], ABCSeries):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2,6 +2,7 @@
 Data structure for 1-dimensional cross-sectional and time series data
 """
 from collections import OrderedDict
+from collections.abc import Iterable, Sized
 from shutil import get_terminal_size
 from textwrap import dedent
 import warnings
@@ -224,8 +225,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 raise TypeError("{0!r} type is unordered"
                                 "".format(data.__class__.__name__))
             # If data is Iterable but not list-like, consume into list.
-            elif (isinstance(data, compat.Iterable)
-                  and not isinstance(data, compat.Sized)):
+            elif (isinstance(data, Iterable) and not isinstance(data, Sized)):
                 data = list(data)
             else:
 
@@ -1496,7 +1496,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Parameters
         ----------
         into : class, default dict
-            The collections.Mapping subclass to use as the return
+            The collections.abc.Mapping subclass to use as the return
             object. Can be the actual class or an empty
             instance of the mapping type you want.  If you want a
             collections.defaultdict, you must pass it initialized.
@@ -1505,7 +1505,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        collections.Mapping
+        collections.abc.Mapping
             Key-value representation of Series.
 
         Examples

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1,8 +1,7 @@
 """
 Data structure for 1-dimensional cross-sectional and time series data
 """
-from collections import OrderedDict
-from collections.abc import Iterable, Sized
+from collections import OrderedDict, abc
 from shutil import get_terminal_size
 from textwrap import dedent
 import warnings
@@ -225,7 +224,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 raise TypeError("{0!r} type is unordered"
                                 "".format(data.__class__.__name__))
             # If data is Iterable but not list-like, consume into list.
-            elif (isinstance(data, Iterable) and not isinstance(data, Sized)):
+            elif (isinstance(data, abc.Iterable) and
+                  not isinstance(data, abc.Sized)):
                 data = list(data)
             else:
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -5,6 +5,7 @@ with float64 data
 
 # pylint: disable=E1101,E1103,W0231
 
+from collections.abc import Mapping
 import warnings
 
 import numpy as np
@@ -12,7 +13,6 @@ import numpy as np
 import pandas._libs.index as libindex
 import pandas._libs.sparse as splib
 from pandas._libs.sparse import BlockIndex, IntIndex
-import pandas.compat as compat
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, Substitution
 
@@ -82,7 +82,7 @@ class SparseSeries(Series):
             if index is not None:
                 data = data.reindex(index)
 
-        elif isinstance(data, compat.Mapping):
+        elif isinstance(data, Mapping):
             data, index = Series()._init_dict(data, index=index)
 
         elif is_scalar(data) and index is not None:

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -5,7 +5,7 @@ with float64 data
 
 # pylint: disable=E1101,E1103,W0231
 
-from collections.abc import Mapping
+from collections import abc
 import warnings
 
 import numpy as np
@@ -82,7 +82,7 @@ class SparseSeries(Series):
             if index is not None:
                 data = data.reindex(index)
 
-        elif isinstance(data, Mapping):
+        elif isinstance(data, abc.Mapping):
             data, index = Series()._init_dict(data, index=index)
 
         elif is_scalar(data) and index is not None:

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1,3 +1,4 @@
+from collections.abc import MutableMapping
 from datetime import datetime, time
 from functools import partial
 
@@ -17,7 +18,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.missing import notna
 
-from pandas import compat
 from pandas.core import algorithms
 
 
@@ -599,7 +599,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
         else:
             values = convert_listlike(arg._values, True, format)
             result = arg._constructor(values, index=arg.index, name=arg.name)
-    elif isinstance(arg, (ABCDataFrame, compat.MutableMapping)):
+    elif isinstance(arg, (ABCDataFrame, MutableMapping)):
         result = _assemble_from_unit_mappings(arg, errors, box, tz)
     elif isinstance(arg, ABCIndexClass):
         cache_array = _maybe_cache(arg, format, cache, convert_listlike)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1,4 +1,4 @@
-from collections.abc import MutableMapping
+from collections import abc
 from datetime import datetime, time
 from functools import partial
 
@@ -599,7 +599,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
         else:
             values = convert_listlike(arg._values, True, format)
             result = arg._constructor(values, index=arg.index, name=arg.name)
-    elif isinstance(arg, (ABCDataFrame, MutableMapping)):
+    elif isinstance(arg, (ABCDataFrame, abc.MutableMapping)):
         result = _assemble_from_unit_mappings(arg, errors, box, tz)
     elif isinstance(arg, ABCIndexClass):
         cache_array = _maybe_cache(arg, format, cache, convert_listlike)

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -3,7 +3,7 @@ HTML IO.
 
 """
 
-from collections.abc import Iterable
+from collections import abc
 from distutils.version import LooseVersion
 import numbers
 import os
@@ -857,7 +857,7 @@ def _validate_flavor(flavor):
         flavor = 'lxml', 'bs4'
     elif isinstance(flavor, str):
         flavor = flavor,
-    elif isinstance(flavor, Iterable):
+    elif isinstance(flavor, abc.Iterable):
         if not all(isinstance(flav, str) for flav in flavor):
             raise TypeError('Object of type {typ!r} is not an iterable of '
                             'strings'

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -3,12 +3,12 @@ HTML IO.
 
 """
 
+from collections.abc import Iterable
 from distutils.version import LooseVersion
 import numbers
 import os
 import re
 
-import pandas.compat as compat
 from pandas.compat import iteritems, lmap, lrange, raise_with_traceback
 from pandas.errors import AbstractMethodError, EmptyDataError
 
@@ -857,7 +857,7 @@ def _validate_flavor(flavor):
         flavor = 'lxml', 'bs4'
     elif isinstance(flavor, str):
         flavor = flavor,
-    elif isinstance(flavor, compat.Iterable):
+    elif isinstance(flavor, Iterable):
         if not all(isinstance(flav, str) for flav in flavor):
             raise TypeError('Object of type {typ!r} is not an iterable of '
                             'strings'

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -2,14 +2,13 @@
 # Arithmetc tests for DataFrame/Series/Index/Array classes that should
 # behave identically.
 # Specifically for numeric dtypes
+from collections.abc import Iterable
 from decimal import Decimal
 from itertools import combinations
 import operator
 
 import numpy as np
 import pytest
-
-from pandas.compat import Iterable
 
 import pandas as pd
 from pandas import Index, Series, Timedelta, TimedeltaIndex

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -2,7 +2,7 @@
 # Arithmetc tests for DataFrame/Series/Index/Array classes that should
 # behave identically.
 # Specifically for numeric dtypes
-from collections.abc import Iterable
+from collections import abc
 from decimal import Decimal
 from itertools import combinations
 import operator
@@ -807,7 +807,7 @@ class TestAdditionSubtraction(object):
     def test_divmod(self):
         def check(series, other):
             results = divmod(series, other)
-            if isinstance(other, Iterable) and len(series) != len(other):
+            if isinstance(other, abc.Iterable) and len(series) != len(other):
                 # if the lengths don't match, this is the test where we use
                 # `tser[::2]`. Pad every other value in `other_np` with nan.
                 other_np = []

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -280,7 +280,7 @@ def test_is_hashable():
     for i in abc_hashable_not_really_hashable:
         assert not inference.is_hashable(i)
 
-    # numpy.array is no longer collections.Hashable as of
+    # numpy.array is no longer collections.abc.Hashable as of
     # https://github.com/numpy/numpy/pull/5326, just test
     # is_hashable()
     assert not inference.is_hashable(np.array([]))

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -10,8 +10,7 @@ internally that specifically check for dicts, and does non-scalar things
 in that case. We *want* the dictionaries to be treated as scalars, so we
 hack around pandas by using UserDicts.
 """
-import collections
-from collections.abc import Iterable, Mapping, Sequence
+from collections import UserDict, abc
 import itertools
 import numbers
 import random
@@ -26,11 +25,11 @@ from pandas.core.arrays import ExtensionArray
 
 
 class JSONDtype(ExtensionDtype):
-    type = Mapping
+    type = abc.Mapping
     name = 'json'
 
     try:
-        na_value = collections.UserDict()
+        na_value = UserDict()
     except AttributeError:
         # source compatibility with Py2.
         na_value = {}
@@ -78,14 +77,14 @@ class JSONArray(ExtensionArray):
 
     @classmethod
     def _from_factorized(cls, values, original):
-        return cls([collections.UserDict(x) for x in values if x != ()])
+        return cls([UserDict(x) for x in values if x != ()])
 
     def __getitem__(self, item):
         if isinstance(item, numbers.Integral):
             return self.data[item]
         elif isinstance(item, np.ndarray) and item.dtype == 'bool':
             return self._from_sequence([x for x, m in zip(self, item) if m])
-        elif isinstance(item, Iterable):
+        elif isinstance(item, abc.Iterable):
             # fancy indexing
             return type(self)([self.data[i] for i in item])
         else:
@@ -96,7 +95,7 @@ class JSONArray(ExtensionArray):
         if isinstance(key, numbers.Integral):
             self.data[key] = value
         else:
-            if not isinstance(value, (type(self), Sequence)):
+            if not isinstance(value, (type(self), abc.Sequence)):
                 # broadcast value
                 value = itertools.cycle([value])
 
@@ -193,6 +192,6 @@ class JSONArray(ExtensionArray):
 
 def make_data():
     # TODO: Use a regular dict. See _NDFrameIndexer._setitem_with_indexer
-    return [collections.UserDict([
+    return [UserDict([
         (random.choice(string.ascii_letters), random.randint(0, 100))
         for _ in range(random.randint(0, 10))]) for _ in range(100)]

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -11,6 +11,7 @@ in that case. We *want* the dictionaries to be treated as scalars, so we
 hack around pandas by using UserDicts.
 """
 import collections
+from collections.abc import Iterable, Mapping, Sequence
 import itertools
 import numbers
 import random
@@ -21,12 +22,11 @@ import numpy as np
 
 from pandas.core.dtypes.base import ExtensionDtype
 
-from pandas import compat
 from pandas.core.arrays import ExtensionArray
 
 
 class JSONDtype(ExtensionDtype):
-    type = compat.Mapping
+    type = Mapping
     name = 'json'
 
     try:
@@ -85,7 +85,7 @@ class JSONArray(ExtensionArray):
             return self.data[item]
         elif isinstance(item, np.ndarray) and item.dtype == 'bool':
             return self._from_sequence([x for x, m in zip(self, item) if m])
-        elif isinstance(item, compat.Iterable):
+        elif isinstance(item, Iterable):
             # fancy indexing
             return type(self)([self.data[i] for i in item])
         else:
@@ -96,8 +96,7 @@ class JSONArray(ExtensionArray):
         if isinstance(key, numbers.Integral):
             self.data[key] = value
         else:
-            if not isinstance(value, (type(self),
-                                      compat.Sequence)):
+            if not isinstance(value, (type(self), Sequence)):
                 # broadcast value
                 value = itertools.cycle([value])
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import OrderedDict
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 import functools
 import itertools
@@ -973,7 +974,7 @@ class TestDataFrameConstructors(TestData):
         # GH 3783
         # collections.Squence like
 
-        class DummyContainer(compat.Sequence):
+        class DummyContainer(Sequence):
 
             def __init__(self, lst):
                 self._lst = lst

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from collections import OrderedDict
-from collections.abc import Sequence
+from collections import OrderedDict, abc
 from datetime import datetime, timedelta
 import functools
 import itertools
@@ -974,7 +973,7 @@ class TestDataFrameConstructors(TestData):
         # GH 3783
         # collections.Squence like
 
-        class DummyContainer(Sequence):
+        class DummyContainer(abc.Sequence):
 
             def __init__(self, lst):
                 self._lst = lst

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -2,6 +2,7 @@
 
 import collections
 from collections import OrderedDict, defaultdict
+from collections.abc import Mapping
 from datetime import datetime
 
 import numpy as np
@@ -119,7 +120,7 @@ class TestDataFrameConvertTo(TestData):
         import email
         from email.parser import Parser
 
-        compat.Mapping.register(email.message.Message)
+        Mapping.register(email.message.Message)
 
         headers = Parser().parsestr('From: <user@example.com>\n'
                                     'To: <someone_else@example.com>\n'

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import collections
-from collections import OrderedDict, defaultdict
-from collections.abc import Mapping
+from collections import OrderedDict, abc, defaultdict
 from datetime import datetime
 
 import numpy as np
@@ -120,7 +118,7 @@ class TestDataFrameConvertTo(TestData):
         import email
         from email.parser import Parser
 
-        Mapping.register(email.message.Message)
+        abc.Mapping.register(email.message.Message)
 
         headers = Parser().parsestr('From: <user@example.com>\n'
                                     'To: <someone_else@example.com>\n'
@@ -366,10 +364,7 @@ class TestDataFrameConvertTo(TestData):
                                        ("B", "<f4"), ("C", "O")])
         tm.assert_almost_equal(result, expected)
 
-    @pytest.mark.parametrize('mapping', [
-        dict,
-        collections.defaultdict(list),
-        collections.OrderedDict])
+    @pytest.mark.parametrize('mapping', [dict, defaultdict(list), OrderedDict])
     def test_to_dict(self, mapping):
         test_data = {
             'A': {'1': 1, '2': 2},
@@ -425,10 +420,7 @@ class TestDataFrameConvertTo(TestData):
             for k2, v2 in compat.iteritems(v):
                 assert (v2 == recons_data[k2][k])
 
-    @pytest.mark.parametrize('mapping', [
-        list,
-        collections.defaultdict,
-        []])
+    @pytest.mark.parametrize('mapping', [list, defaultdict, []])
     def test_to_dict_errors(self, mapping):
         # GH16122
         df = DataFrame(np.random.randn(3, 3))

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1,5 +1,4 @@
-from collections import OrderedDict, deque
-from collections.abc import Iterable
+from collections import OrderedDict, abc, deque
 import datetime as dt
 from datetime import datetime
 from decimal import Decimal
@@ -1743,7 +1742,7 @@ class TestConcatenate(ConcatenateBase):
         assert_frame_equal(pd.concat(CustomIterator1(),
                                      ignore_index=True), expected)
 
-        class CustomIterator2(Iterable):
+        class CustomIterator2(abc.Iterable):
 
             def __iter__(self):
                 yield df1

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict, deque
+from collections.abc import Iterable
 import datetime as dt
 from datetime import datetime
 from decimal import Decimal
@@ -10,7 +11,7 @@ import numpy as np
 from numpy.random import randn
 import pytest
 
-from pandas.compat import Iterable, StringIO, iteritems
+from pandas.compat import StringIO, iteritems
 
 from pandas.core.dtypes.dtypes import CategoricalDtype
 


### PR DESCRIPTION
- [X] xref #25725
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Removes the following from `pandas.compat` in favor of direct imports from `collections.abc`:
  - `Hashable`
  - `Iterable`
  - `Iterator`
  - `Mapping`
  - `MutableMapping`
  - `Sequence`
  - `Sized`
  - `Set`