### PR TITLE
WIP: Panel Transpose Cleanup

### DIFF
--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -282,23 +282,6 @@ validate_transpose = CompatValidator(TRANSPOSE_DEFAULTS, fname='transpose',
                                      method='both', max_fname_arg_count=0)
 
 
-def validate_transpose_for_generic(inst, kwargs):
-    try:
-        validate_transpose(tuple(), kwargs)
-    except ValueError as e:
-        klass = type(inst).__name__
-        msg = str(e)
-
-        # the Panel class actual relies on the 'axes' parameter if called
-        # via the 'numpy' library, so let's make sure the error is specific
-        # about saying that the parameter is not supported for particular
-        # implementations of 'transpose'
-        if "the 'axes' parameter is not supported" in msg:
-            msg += " for {klass} instances".format(klass=klass)
-
-        raise ValueError(msg)
-
-
 def validate_window_func(name, args, kwargs):
     numpy_args = ('axis', 'dtype', 'out')
     msg = ("numpy operations are not "

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2545,7 +2545,7 @@ class DataFrame(NDFrame):
                             index=['Index']).append(result)
         return result
 
-    def transpose(self, *args, **kwargs):
+    def transpose(self, copy=False):
         """
         Transpose index and columns.
 
@@ -2558,9 +2558,6 @@ class DataFrame(NDFrame):
         copy : bool, default False
             If True, the underlying data is copied. Otherwise (default), no
             copy is made if possible.
-        *args, **kwargs
-            Additional keywords have no effect but might be accepted for
-            compatibility with numpy.
 
         Returns
         -------
@@ -2640,8 +2637,7 @@ class DataFrame(NDFrame):
         1    object
         dtype: object
         """
-        nv.validate_transpose(args, dict())
-        return super(DataFrame, self).transpose(1, 0, **kwargs)
+        return super().transpose(copy)
 
     T = property(transpose)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -651,50 +651,6 @@ class NDFrame(PandasObject, SelectionMixin):
         self._data.set_axis(axis, labels)
         self._clear_item_cache()
 
-    def transpose(self, *args, **kwargs):
-        """
-        Permute the dimensions of the %(klass)s
-
-        Parameters
-        ----------
-        args : %(args_transpose)s
-        copy : boolean, default False
-            Make a copy of the underlying data. Mixed-dtype data will
-            always result in a copy
-        **kwargs
-            Additional keyword arguments will be passed to the function.
-
-        Returns
-        -------
-        y : same as input
-
-        Examples
-        --------
-        >>> p.transpose(2, 0, 1)
-        >>> p.transpose(2, 0, 1, copy=True)
-        """
-
-        # construct the args
-        axes, kwargs = self._construct_axes_from_arguments(args, kwargs,
-                                                           require_all=True)
-        axes_names = tuple(self._get_axis_name(axes[a])
-                           for a in self._AXIS_ORDERS)
-        axes_numbers = tuple(self._get_axis_number(axes[a])
-                             for a in self._AXIS_ORDERS)
-
-        # we must have unique axes
-        if len(axes) != len(set(axes)):
-            raise ValueError('Must specify %s unique axes' % self._AXIS_LEN)
-
-        new_axes = self._construct_axes_dict_from(self, [self._get_axis(x)
-                                                         for x in axes_names])
-        new_values = self.values.transpose(axes_numbers)
-        if kwargs.pop('copy', None) or (len(args) and args[-1]):
-            new_values = new_values.copy()
-
-        nv.validate_transpose_for_generic(self, kwargs)
-        return self._constructor(new_values, **new_axes).__finalize__(self)
-
     def swapaxes(self, axis1, axis2, copy=True):
         """
         Interchange axes and swap values axes appropriately.

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1265,25 +1265,6 @@ class Panel(NDFrame):
                                                fill_value=fill_value)
 
     @Substitution(**_shared_doc_kwargs)
-    @Appender(NDFrame.transpose.__doc__)
-    def transpose(self, *args, **kwargs):
-        # check if a list of axes was passed in instead as a
-        # single *args element
-        if (len(args) == 1 and hasattr(args[0], '__iter__') and
-                not is_string_like(args[0])):
-            axes = args[0]
-        else:
-            axes = args
-
-        if 'axes' in kwargs and axes:
-            raise TypeError("transpose() got multiple values for "
-                            "keyword argument 'axes'")
-        elif not axes:
-            axes = kwargs.pop('axes', ())
-
-        return super(Panel, self).transpose(*axes, **kwargs)
-
-    @Substitution(**_shared_doc_kwargs)
     @Appender(NDFrame.fillna.__doc__)
     def fillna(self, value=None, method=None, axis=None, inplace=False,
                limit=None, downcast=None, **kwargs):


### PR DESCRIPTION
Progress towards #25632 

Prefacing this PR with the statement that this is pretty wonky, but I would consider that largely an artifact of cleaning up the existing code base. 

Right now `transpose` is defined in `NDFrame` but is only used by `DataFrame` and `Panel`, as `Series` objects end up using a separate `transpose` defined in `IndexOpsMixin`. 

There are duplicate calls to `validate_transpose*` with various signatures that aren't well defined, and everything is passed rather ambiguously via args and kwargs which makes validation rather difficult.

Existing validation is arguably rough. Here's a sample call and response on master:

```python-traceback
>>> df = pd.DataFrame(np.ones((2, 2)))
>>> df.transpose('foo')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/williamayd/clones/pandas/pandas/core/frame.py", line 2643, in transpose
    nv.validate_transpose(args, dict())
  File "/Users/williamayd/clones/pandas/pandas/compat/numpy/function.py", line 55, in __call__
    self.defaults)
  File "/Users/williamayd/clones/pandas/pandas/util/_validators.py", line 218, in validate_args_and_kwargs
    validate_kwargs(fname, kwargs, compat_args)
  File "/Users/williamayd/clones/pandas/pandas/util/_validators.py", line 157, in validate_kwargs
    _check_for_default_values(fname, kwds, compat_args)
  File "/Users/williamayd/clones/pandas/pandas/util/_validators.py", line 69, in _check_for_default_values
    format(fname=fname, arg=key)))
ValueError: the 'axes' parameter is not supported in the pandas implementation of transpose()
```

As you can see the error message mentions the 'axes' parameter, but that isn't part of the signature of `transpose` and is instead ambiguously defined based off of args.

What I've done here is removed the Panel implementation and tried to make the `NDFrame` implementation more explicit. Because it's only used by `DataFrame` however, an alternate and arguably preferable implementation would be to raise `NotImplementedError` in `NDFrame` and handle everything in the `DataFrame` implementation once Panel is gone