### PR TITLE
BUG: StringIO fail import for asv benchmarks

### DIFF
--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -4,7 +4,7 @@ import string
 import numpy as np
 import pandas.util.testing as tm
 from pandas import DataFrame, Categorical, date_range, read_csv
-from pandas.compat import cStringIO as StringIO
+from io import StringIO
 
 from ..pandas_vb_common import BaseIO
 

--- a/asv_bench/benchmarks/io/excel.py
+++ b/asv_bench/benchmarks/io/excel.py
@@ -1,6 +1,6 @@
+from io import BytesIO
 import numpy as np
 from pandas import DataFrame, date_range, ExcelWriter, read_excel
-from pandas.compat import BytesIO
 import pandas.util.testing as tm
 
 


### PR DESCRIPTION
- [x] closes N/A
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Fix StringIO import after #25954 PR