### PR TITLE
BUG: Fix loading files from S3 with # characters in URL (GH25945)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -356,6 +356,7 @@ I/O
 - Bug in :func:`read_hdf` not properly closing store after a ``KeyError`` is raised (:issue:`25766`)
 - Bug in ``read_csv`` which would not raise ``ValueError`` if a column index in ``usecols`` was out of bounds (:issue:`25623`)
 - Improved :meth:`pandas.read_stata` and :class:`pandas.io.stata.StataReader` to read incorrectly formatted 118 format files saved by Stata (:issue:`25960`)
+- Fixed bug in loading objects from S3 that contain ``#`` characters in the URL (:issue:`25945`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse as parse_url
 
 def _strip_schema(url):
     """Returns the url without the s3:// part"""
-    result = parse_url(url)
+    result = parse_url(url, allow_fragments=False)
     return result.netloc + result.path
 
 

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -59,6 +59,7 @@ def s3_resource(tips_file, jsonl_file):
         moto = pytest.importorskip('moto')
 
         test_s3_files = [
+            ('tips#1.csv', tips_file),
             ('tips.csv', tips_file),
             ('tips.csv.gz', tips_file + '.gz'),
             ('tips.csv.bz2', tips_file + '.bz2'),

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -198,3 +198,8 @@ class TestS3(object):
             read_csv("s3://pandas-test/large-file.csv", nrows=5)
             # log of fetch_range (start, stop)
             assert ((0, 5505024) in {x.args[-2:] for x in caplog.records})
+
+    def test_read_s3_with_hash_in_key(self, tips_df):
+        # GH 25945
+        result = read_csv('s3://pandas-test/tips#1.csv')
+        tm.assert_frame_equal(tips_df, result)


### PR DESCRIPTION
This fixes loading files with URLs such as s3://bucket/key#1.csv.  The part
from the # on was being lost because it was considered to be a URL fragment.
The fix disables URL fragment parsing as it doesn't make sense for S3 URLs.

- [x] closes #25945 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
