### PR TITLE
BUG: Series/DataFrame with IntervalIndex doesn't display NaN in index

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -315,7 +315,7 @@ Interval
 ^^^^^^^^
 
 - Construction of :class:`Interval` is restricted to numeric, :class:`Timestamp` and :class:`Timedelta` endpoints (:issue:`23013`)
--
+- Fixed bug in :class:`Series`/:class:`DataFrame` not displaying ``NaN`` in :class:`IntervalIndex` with missing values (:issue:`25984`)
 -
 
 Indexing

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1015,7 +1015,7 @@ class IntervalIndex(IntervalMixin, Index):
     def _format_with_header(self, header, **kwargs):
         return header + list(self._format_native_types(**kwargs))
 
-    def _format_native_types(self, na_rep='', quoting=None, **kwargs):
+    def _format_native_types(self, na_rep='NaN', quoting=None, **kwargs):
         """ actually format my specific types """
         from pandas.io.formats.format import ExtensionArrayFormatter
         return ExtensionArrayFormatter(values=self,

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -378,6 +378,23 @@ class TestIntervalIndex(Base):
         )
         assert result == expected
 
+    @pytest.mark.parametrize('constructor,expected', [
+        (pd.Series, ('(0.0, 1.0]    a\n'
+                     'NaN           b\n'
+                     '(2.0, 3.0]    c\n'
+                     'dtype: object')),
+        (pd.DataFrame, ('            0\n'
+                        '(0.0, 1.0]  a\n'
+                        'NaN         b\n'
+                        '(2.0, 3.0]  c'))
+    ])
+    def test_repr_missing(self, constructor, expected):
+        # GH 25984
+        index = IntervalIndex.from_tuples([(0, 1), np.nan, (2, 3)])
+        obj = constructor(list('abc'), index=index)
+        result = repr(obj)
+        assert result == expected
+
         # TODO: check this behavior is consistent with test_interval_new.py
     def test_get_item(self, closed):
         i = IntervalIndex.from_arrays((0, 1, np.nan), (1, 2, np.nan),


### PR DESCRIPTION
- [x] closes #25984
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
