### PR TITLE
DOC: import StringIO from io instead of pandas.compat

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -1045,7 +1045,7 @@ Option 1: pass rows explicitly to skip rows
 
 .. ipython:: python
 
-    from pandas.compat import StringIO
+    from io import StringIO
 
     pd.read_csv(StringIO(data), sep=';', skiprows=[11, 12],
                 index_col=0, parse_dates=True, header=10)

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -137,7 +137,7 @@ usecols : list-like or callable, default ``None``
 
   .. ipython:: python
 
-     from pandas.compat import StringIO, BytesIO
+     from io import StringIO, BytesIO
      data = ('col1,col2,col3\n'
              'a,b,1\n'
              'a,b,2\n'

--- a/doc/source/whatsnew/v0.19.0.rst
+++ b/doc/source/whatsnew/v0.19.0.rst
@@ -192,7 +192,7 @@ default of the index) in a DataFrame.
 .. ipython:: python
    :suppress:
 
-   from pandas.compat import StringIO
+   from io import StringIO
 
 :ref:`Duplicate column names <io.dupe_names>` are now supported in :func:`read_csv` whether
 they are in the file or passed in as the ``names`` parameter (:issue:`7160`, :issue:`9424`)

--- a/doc/source/whatsnew/v0.20.0.rst
+++ b/doc/source/whatsnew/v0.20.0.rst
@@ -119,7 +119,7 @@ fixed-width text files and :func:`read_excel` for parsing Excel files, now accep
 .. ipython:: python
    :suppress:
 
-   from pandas.compat import StringIO
+   from io import StringIO
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.21.0.rst
+++ b/doc/source/whatsnew/v0.21.0.rst
@@ -194,7 +194,7 @@ be strings.
 .. ipython:: python
    :suppress:
 
-   from pandas.compat import StringIO
+   from io import StringIO
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -567,7 +567,7 @@ missing indicator, ``np.nan``. (:issue:`20377`)
 .. ipython:: python
    :suppress:
 
-   from pandas.compat import StringIO
+   from pandas.io import StringIO
 
 *Previous Behavior*:
 


### PR DESCRIPTION
Doc follow-up on https://github.com/pandas-dev/pandas/pull/25954