### PR TITLE
Incorrect example in wide_to_long docstring

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -233,6 +233,7 @@ if [[ -z "$CHECK" || "$CHECK" == "doctests" ]]; then
         pandas/core/reshape/pivot.py \
         pandas/core/reshape/reshape.py \
         pandas/core/reshape/tile.py \
+        pandas/core/reshape/melt.py \
         -k"-crosstab -pivot_table -cut"
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -386,7 +386,7 @@ def wide_to_long(df, stubnames, i, j, sep="", suffix=r'\d+'):
     8      3      3     2.1     2.9
 
     >>> l = pd.wide_to_long(df, stubnames='ht', i=['famid', 'birth'], j='age',
-                            sep='_', suffix='\w')
+                            sep='_', suffix='\w+')
     >>> l
     ... # doctest: +NORMALIZE_WHITESPACE
                       ht

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -386,7 +386,7 @@ def wide_to_long(df, stubnames, i, j, sep="", suffix=r'\d+'):
     8      3      3     2.1     2.9
 
     >>> l = pd.wide_to_long(df, stubnames='ht', i=['famid', 'birth'], j='age',
-                            sep='_', suffix='\w+')
+    ...                        sep='_', suffix='\w+')
     >>> l
     ... # doctest: +NORMALIZE_WHITESPACE
                       ht


### PR DESCRIPTION
- [x] closes #25733
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
