### PR TITLE
BUG: Improve col_space in to_html to allow css length strings (#25941)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -361,6 +361,7 @@ I/O
 - Bug in ``read_csv`` which would not raise ``ValueError`` if a column index in ``usecols`` was out of bounds (:issue:`25623`)
 - Improved the explanation for the failure when value labels are repeated in Stata dta files and suggested work-arounds (:issue:`25772`)
 - Improved :meth:`pandas.read_stata` and :class:`pandas.io.stata.StataReader` to read incorrectly formatted 118 format files saved by Stata (:issue:`25960`)
+- Improved the ``col_space`` parameter in :meth:`DataFrame.to_html` to accept a string so CSS length values can be set correctly (:issue:`25941`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -663,7 +663,9 @@ class DataFrame(NDFrame):
 
     @Substitution(header='Write out the column names. If a list of strings '
                          'is given, it is assumed to be aliases for the '
-                         'column names')
+                         'column names',
+                  col_space_type='int',
+                  col_space='The minimum width of each column')
     @Substitution(shared_params=fmt.common_docstring,
                   returns=fmt.return_docstring)
     def to_string(self, buf=None, columns=None, col_space=None, header=True,
@@ -2149,7 +2151,10 @@ class DataFrame(NDFrame):
                    compression=compression, index=index,
                    partition_cols=partition_cols, **kwargs)
 
-    @Substitution(header='Whether to print column labels, default True')
+    @Substitution(header='Whether to print column labels, default True',
+                  col_space_type='str or int',
+                  col_space='The minimum width of each column in CSS length '
+                            'units.  An int is assumed to be px units')
     @Substitution(shared_params=fmt.common_docstring,
                   returns=fmt.return_docstring)
     def to_html(self, buf=None, columns=None, col_space=None, header=True,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2154,7 +2154,9 @@ class DataFrame(NDFrame):
     @Substitution(header='Whether to print column labels, default True',
                   col_space_type='str or int',
                   col_space='The minimum width of each column in CSS length '
-                            'units.  An int is assumed to be px units')
+                            'units.  An int is assumed to be px units.\n\n'
+                            '            .. versionadded:: 0.25.0\n'
+                            '            Abillity to use str')
     @Substitution(shared_params=fmt.common_docstring,
                   returns=fmt.return_docstring)
     def to_html(self, buf=None, columns=None, col_space=None, header=True,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2156,7 +2156,7 @@ class DataFrame(NDFrame):
                   col_space='The minimum width of each column in CSS length '
                             'units.  An int is assumed to be px units.\n\n'
                             '            .. versionadded:: 0.25.0\n'
-                            '            Abillity to use str')
+                            '                Abillity to use str')
     @Substitution(shared_params=fmt.common_docstring,
                   returns=fmt.return_docstring)
     def to_html(self, buf=None, columns=None, col_space=None, header=True,

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -45,8 +45,8 @@ common_docstring = """
             Buffer to write to.
         columns : sequence, optional, default None
             The subset of columns to write. Writes all columns by default.
-        col_space : int, optional
-            The minimum width of each column.
+        col_space : %(col_space_type)s, optional
+            %(col_space)s.
         header : bool, optional
             %(header)s.
         index : bool, optional, default True

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -87,14 +87,26 @@ class HTMLFormatter(TableFormatter):
 
     def write_th(self, s, header=False, indent=0, tags=None):
         """
-        Return a formatted <th> cell.
+        Method for writting a formatted <th> cell.
 
-        Most tags are passed in as a parameter, but if col_space is set
-        then that value is used for min-width.
+        If col_space is set on the formatter then that is used for
+        the value of min-width.
 
-        Since min-width is only set inside <thead>, this function also takes
-        the 'header' parameter.  If 'header' is True, min-width needs to be
-        set as it is for use inside <thead>
+        Parameters
+        ----------
+        s : object
+            The data to be written inside the cell.
+        header : boolean, default False
+            Set to True if the <th> is for use inside <thead>.  This will
+            cause min-width to be set if there is one.
+        indent : int, default 0
+            The indentation level of the cell.
+        tags : string, default None
+            Tags to include in the cell.
+
+        Returns
+        -------
+        A written <th> cell.
         """
         if header and self.fmt.col_space is not None:
             if isinstance(self.fmt.col_space, int):

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -86,6 +86,8 @@ class HTMLFormatter(TableFormatter):
         self.elements.append(' ' * indent + rs)
 
     def write_th(self, s, header=False, indent=0, tags=None):
+        # header=False is for use of this function inside <tbody>
+        # header is set to True for use inside <thead>
         if header and self.fmt.col_space is not None:
             if isinstance(self.fmt.col_space, int):
                 self.fmt.col_space = ('{colspace}px'
@@ -140,7 +142,7 @@ class HTMLFormatter(TableFormatter):
         for i, s in enumerate(line):
             val_tag = tags.get(i, None)
             if header or (self.bold_rows and i < nindex_levels):
-                self.write_th(s, header=header, indent=indent, tags=val_tag)
+                self.write_th(s, indent=indent, header=header, tags=val_tag)
             else:
                 self.write_td(s, indent, tags=val_tag)
 

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -96,7 +96,6 @@ class HTMLFormatter(TableFormatter):
         the 'header' parameter.  If 'header' is True, min-width needs to be
         set as it is for use inside <thead>
         """
-        
         if header and self.fmt.col_space is not None:
             if isinstance(self.fmt.col_space, int):
                 self.fmt.col_space = ('{colspace}px'

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -46,6 +46,9 @@ class HTMLFormatter(TableFormatter):
         self.border = border
         self.table_id = self.fmt.table_id
         self.render_links = self.fmt.render_links
+        if isinstance(self.fmt.col_space, int):
+            self.fmt.col_space = ('{colspace}px'
+                                  .format(colspace=self.fmt.col_space))
 
     @property
     def show_row_idx_names(self):
@@ -109,9 +112,6 @@ class HTMLFormatter(TableFormatter):
         A written <th> cell.
         """
         if header and self.fmt.col_space is not None:
-            if isinstance(self.fmt.col_space, int):
-                self.fmt.col_space = ('{colspace}px'
-                                      .format(colspace=self.fmt.col_space))
             tags = (tags or "")
             tags += ('style="min-width: {colspace};"'
                      .format(colspace=self.fmt.col_space))

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -96,6 +96,7 @@ class HTMLFormatter(TableFormatter):
         the 'header' parameter.  If 'header' is True, min-width needs to be
         set as it is for use inside <thead>
         """
+        
         if header and self.fmt.col_space is not None:
             if isinstance(self.fmt.col_space, int):
                 self.fmt.col_space = ('{colspace}px'

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -85,8 +85,11 @@ class HTMLFormatter(TableFormatter):
         rs = pprint_thing(s)
         self.elements.append(' ' * indent + rs)
 
-    def write_th(self, s, indent=0, tags=None):
-        if self.fmt.col_space is not None and self.fmt.col_space > 0:
+    def write_th(self, s, header=False, indent=0, tags=None):
+        if header and self.fmt.col_space is not None:
+            if isinstance(self.fmt.col_space, int):
+                self.fmt.col_space = ('{colspace}px'
+                                      .format(colspace=self.fmt.col_space))
             tags = (tags or "")
             tags += ('style="min-width: {colspace};"'
                      .format(colspace=self.fmt.col_space))
@@ -137,7 +140,7 @@ class HTMLFormatter(TableFormatter):
         for i, s in enumerate(line):
             val_tag = tags.get(i, None)
             if header or (self.bold_rows and i < nindex_levels):
-                self.write_th(s, indent, tags=val_tag)
+                self.write_th(s, header=header, indent=indent, tags=val_tag)
             else:
                 self.write_td(s, indent, tags=val_tag)
 

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -86,8 +86,16 @@ class HTMLFormatter(TableFormatter):
         self.elements.append(' ' * indent + rs)
 
     def write_th(self, s, header=False, indent=0, tags=None):
-        # header=False is for use of this function inside <tbody>
-        # header is set to True for use inside <thead>
+        """
+        Return a formatted <th> cell.
+
+        Most tags are passed in as a parameter, but if col_space is set
+        then that value is used for min-width.
+
+        Since min-width is only set inside <thead>, this function also takes
+        the 'header' parameter.  If 'header' is True, min-width needs to be
+        set as it is for use inside <thead>
+        """
         if header and self.fmt.col_space is not None:
             if isinstance(self.fmt.col_space, int):
                 self.fmt.col_space = ('{colspace}px'

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -644,12 +644,15 @@ def test_to_html_round_column_headers():
     assert "0.55555" in html
     assert "0.556" in notebook
 
-
-def test_to_html_with_col_space_percent():
+@pytest.mark.parametrize("unit", ['100px', '10%', '5em', 150])
+def test_to_html_with_col_space_units(unit):
     # GH 25941
     df = DataFrame(np.random.random(size=(1, 3)))
-    result = df.to_html(col_space='100%')
+    result = df.to_html(col_space=unit)
     result = result.split('tbody')[0]
     hdrs = [x for x in result.split("\n") if re.search(r"<th[>\s]", x)]
+    if isinstance(unit, int):
+        unit = str(unit) + 'px'
     for h in hdrs:
-        assert "min-width: 100%" in h
+        expected = '<th style="min-width: {unit};">'.format(unit=unit)
+        assert expected in h

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -643,3 +643,13 @@ def test_to_html_round_column_headers():
         notebook = df.to_html(notebook=True)
     assert "0.55555" in html
     assert "0.556" in notebook
+
+
+def test_to_html_with_col_space_percent():
+    # GH 25941
+    df = DataFrame(np.random.random(size=(1, 3)))
+    result = df.to_html(col_space='100%')
+    result = result.split('tbody')[0]
+    hdrs = [x for x in result.split("\n") if re.search(r"<th[>\s]", x)]
+    for h in hdrs:
+        assert "min-width: 100%" in h

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -644,6 +644,7 @@ def test_to_html_round_column_headers():
     assert "0.55555" in html
     assert "0.556" in notebook
 
+
 @pytest.mark.parametrize("unit", ['100px', '10%', '5em', 150])
 def test_to_html_with_col_space_units(unit):
     # GH 25941


### PR DESCRIPTION
- [x] closes #25941
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Adds the ability to pass a string as the `col_space` parameter in `to_html`.

For backwards compatibility and similarity for other `to_*` functions, I kept in the ability to pass an `int`.  The `int` is automatically turned into `px` units (I chose `px` because that is the default if you put a unit-less CSS length into chrome).  If you want that removed and to always expect a string, let me know.