### PR TITLE
CLN: PY3 compat signature

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -24,8 +24,6 @@ import sys
 import platform
 import types
 import struct
-import inspect
-from collections import namedtuple
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] >= 3
@@ -64,32 +62,6 @@ if PY3:
     def bytes_to_str(b, encoding=None):
         return b.decode(encoding or 'utf-8')
 
-    # The signature version below is directly copied from Django,
-    # https://github.com/django/django/pull/4846
-    def signature(f):
-        sig = inspect.signature(f)
-        args = [
-            p.name for p in sig.parameters.values()
-            if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-        ]
-        varargs = [
-            p.name for p in sig.parameters.values()
-            if p.kind == inspect.Parameter.VAR_POSITIONAL
-        ]
-        varargs = varargs[0] if varargs else None
-        keywords = [
-            p.name for p in sig.parameters.values()
-            if p.kind == inspect.Parameter.VAR_KEYWORD
-        ]
-        keywords = keywords[0] if keywords else None
-        defaults = [
-            p.default for p in sig.parameters.values()
-            if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-            and p.default is not p.empty
-        ] or None
-        argspec = namedtuple('Signature', ['args', 'defaults',
-                                           'varargs', 'keywords'])
-        return argspec(args, defaults, varargs, keywords)
 else:
     # Python 2
     _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
@@ -102,9 +74,6 @@ else:
 
     def bytes_to_str(b, encoding='ascii'):
         return b
-
-    def signature(f):
-        return inspect.getargspec(f)
 
 if PY2:
     def iteritems(obj, **kw):

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1,9 +1,9 @@
+import inspect
 import warnings
 
 import numpy as np
 
 from pandas._libs import reduction
-import pandas.compat as compat
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
@@ -123,7 +123,7 @@ class FrameApply(object):
             # Some methods (shift, etc.) require the axis argument, others
             # don't, so inspect and insert if necessary.
             func = getattr(self.obj, self.f)
-            sig = compat.signature(func)
+            sig = inspect.getfullargspec(func)
             if 'axis' in sig.args:
                 self.kwds['axis'] = self.axis
             return func(*self.args, **self.kwds)

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -2,6 +2,7 @@
 """
 Tests for statistical reductions of 2nd moment or higher: var, skew, kurt, ...
 """
+import inspect
 
 import numpy as np
 import pytest
@@ -10,7 +11,7 @@ from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd
-from pandas import DataFrame, Series, compat
+from pandas import DataFrame, Series
 import pandas.util.testing as tm
 
 
@@ -75,7 +76,7 @@ class TestSeriesStatReductions(object):
                 f(string_series_, axis=1)
 
             # Unimplemented numeric_only parameter.
-            if 'numeric_only' in compat.signature(f).args:
+            if 'numeric_only' in inspect.getfullargspec(f).args:
                 with pytest.raises(NotImplementedError, match=name):
                     f(string_series_, numeric_only=True)
 

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -346,6 +346,6 @@ def make_signature(func):
         args.append(var if default == '' else var + '=' + repr(default))
     if spec.varargs:
         args.append('*' + spec.varargs)
-    if spec.keywords:
+    if spec.varkw:
         args.append('**' + spec.varkw)
     return args, spec.args

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -4,7 +4,6 @@ from textwrap import dedent
 import warnings
 
 from pandas._libs.properties import cache_readonly  # noqa
-from pandas.compat import signature
 
 
 def deprecate(name, alternative, version, alt_name=None,

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -335,7 +335,7 @@ def make_signature(func):
     (['a', 'b', 'c=2'], ['a', 'b', 'c'])
     """
 
-    spec = signature(func)
+    spec = inspect.getfullargspec(func)
     if spec.defaults is None:
         n_wo_defaults = len(spec.args)
         defaults = ('',) * n_wo_defaults
@@ -348,5 +348,5 @@ def make_signature(func):
     if spec.varargs:
         args.append('*' + spec.varargs)
     if spec.keywords:
-        args.append('**' + spec.keywords)
+        args.append('**' + spec.varkw)
     return args, spec.args

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -50,7 +50,6 @@ BASE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 sys.path.insert(0, os.path.join(BASE_PATH))
 import pandas
-from pandas.compat import signature
 
 sys.path.insert(1, os.path.join(BASE_PATH, 'doc', 'sphinxext'))
 from numpydoc.docscrape import NumpyDocString
@@ -420,7 +419,7 @@ class Docstring(object):
                 # accessor classes have a signature but don't want to show this
                 return tuple()
         try:
-            sig = signature(self.obj)
+            sig = inspect.getfullargspec(self.obj)
         except (TypeError, ValueError):
             # Some objects, mainly in C extensions do not support introspection
             # of the signature
@@ -428,8 +427,8 @@ class Docstring(object):
         params = sig.args
         if sig.varargs:
             params.append("*" + sig.varargs)
-        if sig.keywords:
-            params.append("**" + sig.keywords)
+        if sig.varkw:
+            params.append("**" + sig.varkw)
         params = tuple(params)
         if params and params[0] in ('self', 'cls'):
             return params[1:]


### PR DESCRIPTION
- [x] xref #25725
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Replace `compat.signature` for `inspect.getfullargspec`