### PR TITLE
BUG: Replace internal use of loc with reindex in DataFrame append

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -330,7 +330,7 @@ Indexing
 ^^^^^^^^
 
 - Improved exception message when calling :meth:`DataFrame.iloc` with a list of non-numeric objects (:issue:`25753`).
--
+- Bug in which :meth:`DataFrame.append` produced an erroneous warning indicating that a ``KeyError`` will be thrown in the future when the data to be appended contains new columns (:issue:`22252`).
 -
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6720,7 +6720,7 @@ class DataFrame(NDFrame):
         elif isinstance(other, list) and not isinstance(other[0], DataFrame):
             other = DataFrame(other)
             if (self.columns.get_indexer(other.columns) >= 0).all():
-                other = other.loc[:, self.columns]
+                other = other.reindex(columns=self.columns)
 
         from pandas.core.reshape.concat import concat
         if isinstance(other, (list, tuple)):

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -167,6 +167,21 @@ class TestDataFrameConcatCommon():
         expected = df.append(DataFrame(dicts), ignore_index=True, sort=True)
         assert_frame_equal(result, expected)
 
+    def test_append_missing_cols(self):
+        # GH22252
+        # exercise the conditional branch in append method where the data
+        # to be appended is a list and does not contain all columns that are in
+        # the target DataFrame
+        df = DataFrame(np.random.randn(5, 4),
+                       columns=['foo', 'bar', 'baz', 'qux'])
+
+        dicts = [{'foo': 9}, {'bar': 10}]
+        with tm.assert_produces_warning(None):
+            result = df.append(dicts, ignore_index=True, sort=True)
+
+        expected = df.append(DataFrame(dicts), ignore_index=True, sort=True)
+        assert_frame_equal(result, expected)
+
     def test_append_empty_dataframe(self):
 
         # Empty df append empty df


### PR DESCRIPTION
The issue here was that the DataFrame append method was using .loc, which only throws a warning now, but would eventually throw a KeyError whenever that went into effect. Just swapped out that use of .loc for .reindex.

- [x] closes #22252
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
