### PR TITLE
CLN: Remove PY35 flag from pandas.compat

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -25,7 +25,6 @@ import struct
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] >= 3
-PY35 = sys.version_info >= (3, 5)
 PY36 = sys.version_info >= (3, 6)
 PY37 = sys.version_info >= (3, 7)
 PYPY = platform.python_implementation() == 'PyPy'

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import (
-    PY35, PY36, is_platform_little_endian, is_platform_windows, lrange)
+    PY36, is_platform_little_endian, is_platform_windows, lrange)
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import is_categorical_dtype
@@ -4027,8 +4027,8 @@ class TestHDFStore(Base):
             d2 = store['detector/readout']
             assert isinstance(d2, DataFrame)
 
-    @pytest.mark.skipif(PY35 and is_platform_windows(),
-                        reason="native2 read fails oddly on windows / 3.5")
+    @pytest.mark.skipif(is_platform_windows(),
+                        reason="native2 read fails oddly on windows")
     def test_pytables_native2_read(self, datapath):
         with ensure_clean_store(
                 datapath('io', 'data', 'legacy_hdf', 'pytables_native2.h5'),


### PR DESCRIPTION
- [X] xref #25725
- [X] tests passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

The `PY35` flag is always `True` after dropping Python 2, as Python 3.5 is now the lowest supported version.
