### PR TITLE
CLN: parse_date compat function

### DIFF
--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -624,7 +624,7 @@ def _guess_datetime_format(dt_str, dayfirst=False, dt_str_parse=du_parse,
         If True parses dates with the day first, eg 20/01/2005
         Warning: dayfirst=True is not strict, but will prefer to parse
         with day first (this is a known bug).
-    dt_str_parse : function, defaults to `compat.parse_date` (dateutil)
+    dt_str_parse : function, defaults to `dateutil.parser.parse`
         This function should take in a datetime string and return
         a `datetime.datetime` guess that the datetime string represents
     dt_str_split : function, defaults to `_DATEUTIL_LEXER_SPLIT` (dateutil)

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -138,16 +138,6 @@ def raise_with_traceback(exc, traceback=Ellipsis):
 raise_with_traceback.__doc__ = """Raise exception with existing traceback.
 If traceback is not passed, uses sys.exc_info() to get traceback."""
 
-
-# dateutil minimum version
-import dateutil
-
-if LooseVersion(dateutil.__version__) < LooseVersion('2.5'):
-    raise ImportError('dateutil 2.5.0 is the minimum required version')
-from dateutil import parser as _date_parser
-parse_date = _date_parser.parse
-
-
 # In Python 3.7, the private re._pattern_type is removed.
 # Python 3.5+ have typing.re.Pattern
 if PY36:

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1303,8 +1303,6 @@ class TestToDatetimeMisc(object):
     def test_string_na_nat_conversion(self, cache):
         # GH #999, #858
 
-        from pandas.compat import parse_date
-
         strings = np.array(['1/1/2000', '1/2/2000', np.nan,
                             '1/4/2000, 12:34:56'], dtype=object)
 
@@ -1313,7 +1311,7 @@ class TestToDatetimeMisc(object):
             if isna(val):
                 expected[i] = iNaT
             else:
-                expected[i] = parse_date(val)
+                expected[i] = parse(val)
 
         result = tslib.array_to_datetime(strings)[0]
         tm.assert_almost_equal(result, expected)

--- a/pandas/tests/io/parser/test_converters.py
+++ b/pandas/tests/io/parser/test_converters.py
@@ -6,10 +6,11 @@ for all of the parsers defined in parsers.py
 """
 from io import StringIO
 
+from dateutil.parser import parse
 import numpy as np
 import pytest
 
-from pandas.compat import lmap, parse_date
+from pandas.compat import lmap
 
 import pandas as pd
 from pandas import DataFrame, Index
@@ -28,7 +29,7 @@ foo,2,3,4,5
 
 @pytest.mark.parametrize("column", [3, "D"])
 @pytest.mark.parametrize("converter", [
-    parse_date,
+    parse,
     lambda x: int(x.split("/")[2])  # Produce integer.
 ])
 def test_converters(all_parsers, column, converter):

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -8,13 +8,14 @@ parsers defined in parsers.py
 from datetime import date, datetime
 from io import StringIO
 
+from dateutil.parser import parse
 import numpy as np
 import pytest
 import pytz
 
 from pandas._libs.tslib import Timestamp
 from pandas._libs.tslibs import parsing
-from pandas.compat import lrange, parse_date
+from pandas.compat import lrange
 from pandas.compat.numpy import np_array_datetime64_compat
 
 import pandas as pd
@@ -438,7 +439,7 @@ def test_parse_dates_custom_euro_format(all_parsers, kwargs):
 """
     if "dayfirst" in kwargs:
         df = parser.read_csv(StringIO(data), names=["time", "Q", "NTU"],
-                             date_parser=lambda d: parse_date(d, **kwargs),
+                             date_parser=lambda d: parse(d, **kwargs),
                              header=0, index_col=0, parse_dates=True,
                              na_values=["NA"])
         exp_index = Index([datetime(2010, 1, 31), datetime(2010, 2, 1),
@@ -450,7 +451,7 @@ def test_parse_dates_custom_euro_format(all_parsers, kwargs):
         msg = "got an unexpected keyword argument 'day_first'"
         with pytest.raises(TypeError, match=msg):
             parser.read_csv(StringIO(data), names=["time", "Q", "NTU"],
-                            date_parser=lambda d: parse_date(d, **kwargs),
+                            date_parser=lambda d: parse(d, **kwargs),
                             skiprows=[0], index_col=0, parse_dates=True,
                             na_values=["NA"])
 

--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -16,7 +16,11 @@ import re
 import os
 import argparse
 from collections import namedtuple
-from pandas.compat import lrange, parse_date
+
+from dateutil.parser import parse
+
+from pandas.compat import lrange
+
 try:
     import sh
 except ImportError:
@@ -107,7 +111,7 @@ def get_commit_info(c, fmt, sep='\t'):
 
 def get_commit_vitals(c, hlen=HASH_LEN):
     h, s, d = get_commit_info(c, '%H\t%s\t%ci', "\t")
-    return h[:hlen], s, parse_date(d)
+    return h[:hlen], s, parse(d)
 
 
 def file_filter(state, dirname, fnames):


### PR DESCRIPTION
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

More `compat/__init__.py` cleaning. 

Remove `parse_date` in favor of `dateutil.parser.parse` directly. pandas min dateutil version is 2.5.0 so the import check is unnecessary.