### PR TITLE
DOC: fix See Also constructs

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1097,7 +1097,8 @@ class GroupBy(_GroupBy):
         # defined here for API doc
         raise NotImplementedError
 
-    @Substitution(name='groupby', see_also=_common_see_also)
+    @Substitution(name='groupby')
+    @Substitution(see_also=_common_see_also)
     def mean(self, *args, **kwargs):
         """
         Compute mean of groups, excluding missing values.
@@ -1543,7 +1544,8 @@ class GroupBy(_GroupBy):
         return self._fill('bfill', limit=limit)
     bfill = backfill
 
-    @Substitution(name='groupby', see_also=_common_see_also)
+    @Substitution(name='groupby')
+    @Substitution(see_also=_common_see_also)
     def nth(self, n, dropna=None):
         """
         Take the nth row from each group if n is an int, or a subset of rows
@@ -2130,7 +2132,8 @@ class GroupBy(_GroupBy):
         shifted = fill_grp.shift(periods=periods, freq=freq)
         return (filled / shifted) - 1
 
-    @Substitution(name='groupby', see_also=_common_see_also)
+    @Substitution(name='groupby')
+    @Substitution(see_also=_common_see_also)
     def head(self, n=5):
         """
         Return first n rows of each group.
@@ -2156,7 +2159,8 @@ class GroupBy(_GroupBy):
         mask = self._cumcount_array() < n
         return self._selected_obj[mask]
 
-    @Substitution(name='groupby', see_also=_common_see_also)
+    @Substitution(name='groupby')
+    @Substitution(see_also=_common_see_also)
     def tail(self, n=5):
         """
         Return last n rows of each group.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3625,7 +3625,6 @@ class Index(IndexOpsMixin, PandasObject):
         Index.array : Reference to the underlying data.
         Index.to_numpy : A NumPy array representing the underlying data.
 
-        Return the underlying data as an ndarray.
         """
         return self._data.view(np.ndarray)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3624,7 +3624,6 @@ class Index(IndexOpsMixin, PandasObject):
         --------
         Index.array : Reference to the underlying data.
         Index.to_numpy : A NumPy array representing the underlying data.
-
         """
         return self._data.view(np.ndarray)
 


### PR DESCRIPTION
I am testing the numpydoc master version (almost to be released as 0.9, see https://github.com/numpy/numpydoc/issues/203), and it got a bit more strict on misformatted See Also sections. This PR fixes that.