### PR TITLE
CLN (PY2): Remove DataFrame/Series.timetuple

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -258,10 +258,6 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
                              'normalize', 'strftime', 'round', 'floor',
                              'ceil', 'month_name', 'day_name']
 
-    # dummy attribute so that datetime.__eq__(DatetimeArray) defers
-    # by returning NotImplemented
-    timetuple = None
-
     # Needed so that Timestamp.__richcmp__(DateTimeArray) operates pointwise
     ndim = 1
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -118,10 +118,6 @@ class NDFrame(PandasObject, SelectionMixin):
     _metadata = []
     _is_copy = None
 
-    # dummy attribute so that datetime.__eq__(Series/DataFrame) defers
-    # by returning NotImplemented
-    timetuple = None
-
     # ----------------------------------------------------------------------
     # Constructors
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -241,10 +241,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     _comparables = ['name', 'freqstr', 'tz']
     _attributes = ['name', 'tz', 'freq']
 
-    # dummy attribute so that datetime.__eq__(DatetimeArray) defers
-    # by returning NotImplemented
-    timetuple = None
-
     _is_numeric_dtype = False
     _infer_as_myclass = True
 


### PR DESCRIPTION
I was looking at the sphinx doc build warnings, and of them was complaining about the `DataFrame/Series.timetuple` attribute. This dummy `timetuple` attribute was added in https://github.com/pandas-dev/pandas/pull/24056, to fix comparison with `datetime.datetime`. 

Apart from the doc build problem (which can probably be fixed in another way as well), this also adds yet another (and for the rest useless / undocumented) attribute to our main classes.

But from a quick test (at least on linux with python 3.7, with Series) this is not needed to make it work. So removing again to see what travis/azure say.

@jbrockmendel do you remember the context of adding this?