### PR TITLE
CLN: collect ordered fixtures in pandas.conftest

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -127,7 +127,7 @@ def observed(request):
 
 
 @pytest.fixture(params=[True, False, None])
-def ordered(request):
+def ordered_fixture(request):
     """Boolean 'ordered' parameter for Categorical."""
     return request.param
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -126,6 +126,12 @@ def observed(request):
     return request.param
 
 
+@pytest.fixture(params=[True, False, None])
+def ordered(request):
+    """Boolean 'ordered' parameter for Categorical."""
+    return request.param
+
+
 _all_arithmetic_operators = ['__add__', '__radd__',
                              '__sub__', '__rsub__',
                              '__mul__', '__rmul__',

--- a/pandas/tests/arrays/categorical/conftest.py
+++ b/pandas/tests/arrays/categorical/conftest.py
@@ -5,9 +5,3 @@ import pytest
 def allow_fill(request):
     """Boolean 'allow_fill' parameter for Categorical.take"""
     return request.param
-
-
-@pytest.fixture(params=[True, False])
-def ordered(request):
-    """Boolean 'ordered' parameter for Categorical."""
-    return request.param

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -96,20 +96,20 @@ class TestTake(object):
         with pytest.raises(IndexError):
             cat.take([0], allow_fill=allow_fill)
 
-    def test_positional_take(self, ordered):
+    def test_positional_take(self, ordered_fixture):
         cat = pd.Categorical(['a', 'a', 'b', 'b'], categories=['b', 'a'],
-                             ordered=ordered)
+                             ordered=ordered_fixture)
         result = cat.take([0, 1, 2], allow_fill=False)
         expected = pd.Categorical(['a', 'a', 'b'], categories=cat.categories,
-                                  ordered=ordered)
+                                  ordered=ordered_fixture)
         tm.assert_categorical_equal(result, expected)
 
-    def test_positional_take_unobserved(self, ordered):
+    def test_positional_take_unobserved(self, ordered_fixture):
         cat = pd.Categorical(['a', 'b'], categories=['a', 'b', 'c'],
-                             ordered=ordered)
+                             ordered=ordered_fixture)
         result = cat.take([1, 0], allow_fill=False)
         expected = pd.Categorical(['b', 'a'], categories=cat.categories,
-                                  ordered=ordered)
+                                  ordered=ordered_fixture)
         tm.assert_categorical_equal(result, expected)
 
     def test_take_allow_fill(self):

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -20,11 +20,6 @@ from pandas.core.sparse.api import SparseDtype
 import pandas.util.testing as tm
 
 
-@pytest.fixture(params=[True, False, None])
-def ordered(request):
-    return request.param
-
-
 class Base(object):
 
     def setup_method(self, method):

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -654,10 +654,10 @@ class TestCategoricalDtypeParametrized(object):
         ['a', 'b', 10, 2, 1.3, True],
         [True, False],
         pd.date_range('2017', periods=4)])
-    def test_basic(self, categories, ordered):
-        c1 = CategoricalDtype(categories, ordered=ordered)
+    def test_basic(self, categories, ordered_fixture):
+        c1 = CategoricalDtype(categories, ordered=ordered_fixture)
         tm.assert_index_equal(c1.categories, pd.Index(categories))
-        assert c1.ordered is ordered
+        assert c1.ordered is ordered_fixture
 
     def test_order_matters(self):
         categories = ['a', 'b']
@@ -678,7 +678,7 @@ class TestCategoricalDtypeParametrized(object):
         tm.assert_index_equal(result.categories, pd.Index(['a', 'b', 'c']))
         assert result.ordered is None
 
-    def test_equal_but_different(self, ordered):
+    def test_equal_but_different(self, ordered_fixture):
         c1 = CategoricalDtype([1, 2, 3])
         c2 = CategoricalDtype([1., 2., 3.])
         assert c1 is not c2
@@ -743,8 +743,9 @@ class TestCategoricalDtypeParametrized(object):
 
     @pytest.mark.parametrize('categories', [list('abc'), None])
     @pytest.mark.parametrize('other', ['category', 'not a category'])
-    def test_categorical_equality_strings(self, categories, ordered, other):
-        c1 = CategoricalDtype(categories, ordered)
+    def test_categorical_equality_strings(self, categories, ordered_fixture,
+                                          other):
+        c1 = CategoricalDtype(categories, ordered_fixture)
         result = c1 == other
         expected = other == 'category'
         assert result is expected
@@ -788,12 +789,12 @@ class TestCategoricalDtypeParametrized(object):
             c1, categories=[1, 2], ordered=False)
         assert result == CategoricalDtype([1, 2], ordered=False)
 
-    def test_str_vs_repr(self, ordered):
-        c1 = CategoricalDtype(['a', 'b'], ordered=ordered)
+    def test_str_vs_repr(self, ordered_fixture):
+        c1 = CategoricalDtype(['a', 'b'], ordered=ordered_fixture)
         assert str(c1) == 'category'
         # Py2 will have unicode prefixes
         pat = r"CategoricalDtype\(categories=\[.*\], ordered={ordered}\)"
-        assert re.match(pat.format(ordered=ordered), repr(c1))
+        assert re.match(pat.format(ordered=ordered_fixture), repr(c1))
 
     def test_categorical_categories(self):
         # GH17884
@@ -805,8 +806,8 @@ class TestCategoricalDtypeParametrized(object):
     @pytest.mark.parametrize('new_categories', [
         list('abc'), list('cba'), list('wxyz'), None])
     @pytest.mark.parametrize('new_ordered', [True, False, None])
-    def test_update_dtype(self, ordered, new_categories, new_ordered):
-        dtype = CategoricalDtype(list('abc'), ordered)
+    def test_update_dtype(self, ordered_fixture, new_categories, new_ordered):
+        dtype = CategoricalDtype(list('abc'), ordered_fixture)
         new_dtype = CategoricalDtype(new_categories, new_ordered)
 
         expected_categories = new_dtype.categories
@@ -821,8 +822,8 @@ class TestCategoricalDtypeParametrized(object):
         tm.assert_index_equal(result.categories, expected_categories)
         assert result.ordered is expected_ordered
 
-    def test_update_dtype_string(self, ordered):
-        dtype = CategoricalDtype(list('abc'), ordered)
+    def test_update_dtype_string(self, ordered_fixture):
+        dtype = CategoricalDtype(list('abc'), ordered_fixture)
         expected_categories = dtype.categories
         expected_ordered = dtype.ordered
         result = dtype.update_dtype('category')

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1406,13 +1406,14 @@ class TestCategoricalSeriesAnalytics(object):
          pytest.param("datetime64[D]",
                       marks=pytest.mark.xfail(reason="GH#7996"))]
     )
-    def test_drop_duplicates_categorical_non_bool(self, dtype, ordered):
+    def test_drop_duplicates_categorical_non_bool(self, dtype,
+                                                  ordered_fixture):
         cat_array = np.array([1, 2, 3, 4, 5], dtype=np.dtype(dtype))
 
         # Test case 1
         input1 = np.array([1, 2, 3, 3], dtype=np.dtype(dtype))
         tc1 = Series(Categorical(input1, categories=cat_array,
-                                 ordered=ordered))
+                                 ordered=ordered_fixture))
 
         expected = Series([False, False, False, True])
         tm.assert_series_equal(tc1.duplicated(), expected)
@@ -1439,7 +1440,7 @@ class TestCategoricalSeriesAnalytics(object):
         # Test case 2
         input2 = np.array([1, 2, 3, 5, 3, 2, 4], dtype=np.dtype(dtype))
         tc2 = Series(Categorical(
-            input2, categories=cat_array, ordered=ordered)
+            input2, categories=cat_array, ordered=ordered_fixture)
         )
 
         expected = Series([False, False, False, False, True, True, False])
@@ -1464,9 +1465,10 @@ class TestCategoricalSeriesAnalytics(object):
         sc.drop_duplicates(keep=False, inplace=True)
         tm.assert_series_equal(sc, tc2[~expected])
 
-    def test_drop_duplicates_categorical_bool(self, ordered):
+    def test_drop_duplicates_categorical_bool(self, ordered_fixture):
         tc = Series(Categorical([True, False, True, False],
-                                categories=[True, False], ordered=ordered))
+                                categories=[True, False],
+                                ordered=ordered_fixture))
 
         expected = Series([False, False, True, True])
         tm.assert_series_equal(tc.duplicated(), expected)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1406,14 +1406,13 @@ class TestCategoricalSeriesAnalytics(object):
          pytest.param("datetime64[D]",
                       marks=pytest.mark.xfail(reason="GH#7996"))]
     )
-    @pytest.mark.parametrize("is_ordered", [True, False])
-    def test_drop_duplicates_categorical_non_bool(self, dtype, is_ordered):
+    def test_drop_duplicates_categorical_non_bool(self, dtype, ordered):
         cat_array = np.array([1, 2, 3, 4, 5], dtype=np.dtype(dtype))
 
         # Test case 1
         input1 = np.array([1, 2, 3, 3], dtype=np.dtype(dtype))
         tc1 = Series(Categorical(input1, categories=cat_array,
-                                 ordered=is_ordered))
+                                 ordered=ordered))
 
         expected = Series([False, False, False, True])
         tm.assert_series_equal(tc1.duplicated(), expected)
@@ -1440,7 +1439,7 @@ class TestCategoricalSeriesAnalytics(object):
         # Test case 2
         input2 = np.array([1, 2, 3, 5, 3, 2, 4], dtype=np.dtype(dtype))
         tc2 = Series(Categorical(
-            input2, categories=cat_array, ordered=is_ordered)
+            input2, categories=cat_array, ordered=ordered)
         )
 
         expected = Series([False, False, False, False, True, True, False])
@@ -1465,10 +1464,9 @@ class TestCategoricalSeriesAnalytics(object):
         sc.drop_duplicates(keep=False, inplace=True)
         tm.assert_series_equal(sc, tc2[~expected])
 
-    @pytest.mark.parametrize("is_ordered", [True, False])
-    def test_drop_duplicates_categorical_bool(self, is_ordered):
+    def test_drop_duplicates_categorical_bool(self, ordered):
         tc = Series(Categorical([True, False, True, False],
-                                categories=[True, False], ordered=is_ordered))
+                                categories=[True, False], ordered=ordered))
 
         expected = Series([False, False, True, True])
         tm.assert_series_equal(tc.duplicated(), expected)


### PR DESCRIPTION
Currently, ``Categorical .ordered``, ``CategoricaDtype.ordered`` and similar is tested using different fixtures + parametrization in some places. This PR collects the ordered fixtures/parametrizations and places a common ``ordered`` fixture in pandas.conftest.