### PR TITLE
CLN: pylint references

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -1,5 +1,3 @@
-# pylint: disable-msg=W0614,W0401,W0611,W0622
-
 # flake8: noqa
 
 __docformat__ = 'restructuredtext'

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -14,7 +14,6 @@ Key items to import for compatible code:
 Other items:
 * platform checker
 """
-# pylint disable=W0611
 # flake8: noqa
 
 import re

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -1,5 +1,3 @@
-
-# pylint: disable=W0614,W0401,W0611
 # flake8: noqa
 
 import numpy as np

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1101,W0232
-
 from shutil import get_terminal_size
 import textwrap
 from warnings import warn

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1101
-# pylint: disable=W0212,W0703,W0622
 """
 DataFrame
 ---------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0231,E1101
 import collections
 from datetime import timedelta
 import functools

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1,4 +1,3 @@
-# pylint: disable=E1101
 from datetime import datetime, time, timedelta
 import operator
 import warnings

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1,4 +1,3 @@
-# pylint: disable=E1101,E1103,W0232
 from collections import OrderedDict
 import datetime
 from sys import getsizeof

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -1,4 +1,3 @@
-# pylint: disable=E1101,E1103,W0232
 from datetime import datetime, timedelta
 import warnings
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0223
 import textwrap
 import warnings
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1,7 +1,6 @@
 """
 Contains data structures designed for manipulating panel (3-dimensional) data
 """
-# pylint: disable=E1103,W0231,W0212,W0621
 from collections import OrderedDict
 import warnings
 

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1101,E1103
-# pylint: disable=W0703,W0622,W0613,W0201
 import re
 
 import numpy as np

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -1,4 +1,3 @@
-# pylint: disable=E1103
 import numpy as np
 
 from pandas.compat import lrange

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1101,E1103
-# pylint: disable=W0703,W0622,W0613,W0201
 from functools import partial
 import itertools
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -51,10 +51,6 @@ from pandas.core.tools.datetimes import to_datetime
 import pandas.io.formats.format as fmt
 import pandas.plotting._core as gfx
 
-# pylint: disable=E1101,E1103
-# pylint: disable=W0703,W0622,W0613,W0201
-
-
 __all__ = ['Series']
 
 _shared_doc_kwargs = dict(

--- a/pandas/core/sparse/api.py
+++ b/pandas/core/sparse/api.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0611
 # flake8: noqa
 from pandas.core.arrays.sparse import SparseArray, SparseDtype
 from pandas.core.sparse.frame import SparseDataFrame

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -30,7 +30,6 @@ import pandas.core.ops as ops
 from pandas.core.series import Series
 from pandas.core.sparse.series import SparseSeries
 
-
 _shared_doc_kwargs = dict(klass='SparseDataFrame')
 
 

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -30,8 +30,6 @@ import pandas.core.ops as ops
 from pandas.core.series import Series
 from pandas.core.sparse.series import SparseSeries
 
-# pylint: disable=E1101,E1103,W0231,E0202
-
 
 _shared_doc_kwargs = dict(klass='SparseDataFrame')
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -2,9 +2,6 @@
 Data structures for sparse float data. Life is made simpler by dealing only
 with float64 data
 """
-
-# pylint: disable=E1101,E1103,W0231
-
 from collections import abc
 import warnings
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -35,8 +35,6 @@ from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.io.common import _expand_user, _stringify_path
 from pandas.io.formats.printing import adjoin, justify, pprint_thing
 
-# pylint: disable=W0141
-
 
 common_docstring = """
         Parameters

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -35,7 +35,6 @@ from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.io.common import _expand_user, _stringify_path
 from pandas.io.formats.printing import adjoin, justify, pprint_thing
 
-
 common_docstring = """
         Parameters
         ----------

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -1,4 +1,3 @@
-# pylint: disable-msg=E1101,W0613,W0603
 from io import StringIO
 from itertools import islice
 import os

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1,4 +1,3 @@
-# pylint: disable-msg=E1101,W0613,W0603
 """
 High level interface to PyTables for reading and writing pandas data structures
 to disk

--- a/pandas/plotting/_compat.py
+++ b/pandas/plotting/_compat.py
@@ -1,5 +1,4 @@
 # being a bit too dynamic
-# pylint: disable=E1101
 from distutils.version import LooseVersion
 import operator
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1,5 +1,4 @@
 # being a bit too dynamic
-# pylint: disable=E1101
 from collections import namedtuple
 import re
 from typing import List, Optional, Type

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -1,5 +1,4 @@
 # being a bit too dynamic
-# pylint: disable=E1101
 import numpy as np
 
 from pandas.compat import lmap, lrange

--- a/pandas/plotting/_style.py
+++ b/pandas/plotting/_style.py
@@ -1,5 +1,4 @@
 # being a bit too dynamic
-# pylint: disable=E1101
 from contextlib import contextmanager
 import warnings
 

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -1,5 +1,4 @@
 # being a bit too dynamic
-# pylint: disable=E1101
 from math import ceil
 import warnings
 

--- a/pandas/tests/extension/test_external_block.py
+++ b/pandas/tests/extension/test_external_block.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=W0102
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-# pylint: disable-msg=W0612,E1101
 from copy import deepcopy
 import pydoc
 

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=E1101,W0612
-
 from copy import deepcopy
 from distutils.version import LooseVersion
 from operator import methodcaller

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=E1101,W0612
-
 from copy import copy, deepcopy
 
 import numpy as np

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=E1101,W0612
-
 from distutils.version import LooseVersion
 from operator import methodcaller
 

--- a/pandas/tests/indexing/test_callable.py
+++ b/pandas/tests/indexing/test_callable.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=W0612,E1101
-
 import numpy as np
 
 import pandas as pd

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=W0612,E1101
-
 """ test fancy indexing & misc """
 
 from datetime import datetime

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=W0102
 from collections import OrderedDict
 from datetime import date, datetime
 from distutils.version import LooseVersion

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=W0612,E1101
 from collections import OrderedDict
 from datetime import timedelta
 from io import StringIO

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1101,E1103,W0232
-
 """
 manage legacy pickle tests
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=E1101
-
 from collections import OrderedDict
 import datetime as dt
 from datetime import datetime

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1101
-
 from collections import OrderedDict
 from datetime import datetime
 

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1101
-
 from textwrap import dedent
 
 import numpy as np

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1103
-
 import numpy as np
 from numpy.random import randn
 import pytest

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1103
-
 from collections import OrderedDict
 from datetime import date, datetime
 import random

--- a/pandas/tests/reshape/merge/test_multi.py
+++ b/pandas/tests/reshape/merge/test_multi.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1103
-
 from collections import OrderedDict
 
 import numpy as np

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=W0612,E1101
-
 import numpy as np
 from numpy import nan
 import pytest

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=W0612,E1101
-
 from collections import OrderedDict
 
 import numpy as np

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime
 
 import numpy as np

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime, timedelta
 
 import numpy as np

--- a/pandas/tests/series/indexing/test_iloc.py
+++ b/pandas/tests/series/indexing/test_iloc.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 import numpy as np
 
 from pandas.compat import lrange

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 """ test get/set & misc """
 
 from datetime import timedelta

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime
 
 import numpy as np

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from itertools import product
 import operator
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
 from collections import OrderedDict
 import pydoc
 import warnings

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from collections import Counter, OrderedDict, defaultdict
 from itertools import chain
 

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime
 
 import numpy as np

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from collections import OrderedDict
 from datetime import datetime, timedelta
 

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 import calendar
 from datetime import date, datetime, time
 import locale

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime, timedelta
 from importlib import reload
 import string

--- a/pandas/tests/series/test_internals.py
+++ b/pandas/tests/series/test_internals.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime
 
 import numpy as np

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 import collections
 from datetime import datetime
 from io import StringIO

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime, timedelta
 
 import numpy as np

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime, timedelta
 import operator
 

--- a/pandas/tests/series/test_quantile.py
+++ b/pandas/tests/series/test_quantile.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime, timedelta
 
 import numpy as np

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
 import numpy as np
 
 import pandas as pd

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime, time, timedelta
 from io import StringIO
 from itertools import product

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -1,5 +1,3 @@
-# pylint: disable-msg=E1101,W0612
-
 import operator
 
 import numpy as np

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -1,5 +1,3 @@
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime
 import operator
 

--- a/pandas/tests/sparse/test_combine_concat.py
+++ b/pandas/tests/sparse/test_combine_concat.py
@@ -1,4 +1,3 @@
-# pylint: disable-msg=E1101,W0612
 import itertools
 
 import numpy as np

--- a/pandas/tests/sparse/test_indexing.py
+++ b/pandas/tests/sparse/test_indexing.py
@@ -1,5 +1,3 @@
-# pylint: disable-msg=E1101,W0612
-
 import numpy as np
 import pytest
 

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -14,9 +14,6 @@ from pandas.util.testing import (
 
 from pandas.io.formats.printing import pprint_thing
 
-# pylint: disable-msg=W0612,E1101
-
-
 _frame = DataFrame(randn(10000, 4), columns=list('ABCD'), dtype='float64')
 _frame2 = DataFrame(randn(100, 4), columns=list('ABCD'), dtype='float64')
 _mixed = DataFrame({'A': _frame['A'].copy(),

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=W0612,E1101,W0141
 import datetime
 from io import StringIO
 import itertools

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable-msg=E1101,W0612
-
 from datetime import datetime, timedelta
 import re
 


### PR DESCRIPTION
Removing leftover `pylint` references since we exclusively use `flake8` for style checking.