### PR TITLE
ENH: Add parameter to download BigQuery results with the BigQuery Storage API

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -364,6 +364,7 @@ I/O
 - Improved the explanation for the failure when value labels are repeated in Stata dta files and suggested work-arounds (:issue:`25772`)
 - Improved :meth:`pandas.read_stata` and :class:`pandas.io.stata.StataReader` to read incorrectly formatted 118 format files saved by Stata (:issue:`25960`)
 - Fixed bug in loading objects from S3 that contain ``#`` characters in the URL (:issue:`25945`)
+- Adds ``use_bqstorage_api`` parameter to :func:`read_gbq` to speed up downloads of large data frames. This feature requires version 0.10.0 of the ``pandas-gbq`` library as well as the ``google-cloud-bigquery-storage`` and ``fastavro`` libraries. (:issue:`26104`)
 
 Plotting
 ^^^^^^^^


### PR DESCRIPTION
pandas-gbq 0.10.0 adds a new `use_bqstorage_api` parameter to speed up downloads of large dataframes.

- [ ] ~closes #xxxx~
- [x] tests added / passed

```
$ pytest pandas/tests/io/test_gbq.py
=============================== test session starts ================================
platform darwin -- Python 3.6.4, pytest-4.4.1, py-1.5.3, pluggy-0.9.0
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/swast/src/pandas/pandas/.hypothesis/examples')
rootdir: /Users/swast/src/pandas/pandas, inifile: setup.cfg
plugins: xdist-1.22.2, forked-0.2, cov-2.5.1, hypothesis-3.70.3
collected 1 item                                                                   

pandas/tests/io/test_gbq.py .                                                [100%]

============================= 1 passed in 9.84 seconds =============================
```

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
