### PR TITLE
BUG: GroupBy.size with all-null data raises ValueError

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -381,6 +381,7 @@ Groupby/Resample/Rolling
 - Bug in :meth:`pandas.core.groupby.DataFrameGroupBy.nunique` in which the names of column levels were lost (:issue:`23222`)
 - Bug in :func:`pandas.core.groupby.GroupBy.agg` when applying a aggregation function to timezone aware data (:issue:`23683`)
 - Bug in :func:`pandas.core.groupby.GroupBy.first` and :func:`pandas.core.groupby.GroupBy.last` where timezone information would be dropped (:issue:`21603`)
+- Bug in :func:`pandas.core.groupby.GroupBy.size` when grouping only NA values (:issue:`23050`)
 - Bug in :func:`Series.groupby` where using ``groupby`` with a :class:`MultiIndex` Series with a list of labels equal to the length of the series caused incorrect grouping (:issue:`25704`)
 - Ensured that ordering of outputs in ``groupby`` aggregation functions is consistent across all versions of Python (:issue:`25692`)
 - Ensured that result group order is correct when grouping on an ordered ``Categorical`` and specifying ``observed=True`` (:issue:`25871`, :issue:`25167`)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -246,7 +246,7 @@ class BaseGrouper(object):
         if ngroup:
             out = np.bincount(ids[ids != -1], minlength=ngroup)
         else:
-            out = ids
+            out = []
         return Series(out,
                       index=self.result_index,
                       dtype='int64')

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1089,11 +1089,14 @@ def test_size(df):
     out = Series(dtype='int64', index=Index([], name='A'))
     tm.assert_series_equal(df.groupby('A').size(), out)
 
+
+def test_size_groupby_all_null():
     # GH23050
     # Assert no 'Value Error : Length of passed values is 2, index implies 0'
     df = DataFrame({'A': [None, None]})  # all-null groups
-    out = Series(dtype='int64', index=Index([], name='A'))
-    tm.assert_series_equal(df.groupby('A').size(), out)
+    result = df.groupby('A').size()
+    expected = Series(dtype='int64', index=Index([], name='A'))
+    tm.assert_series_equal(result, expected)
 
 
 # quantile

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1089,6 +1089,12 @@ def test_size(df):
     out = Series(dtype='int64', index=Index([], name='A'))
     tm.assert_series_equal(df.groupby('A').size(), out)
 
+    # GH23050
+    # Assert no 'Value Error : Length of passed values is 2, index implies 0'
+    df = DataFrame({'A': [None, None]})  # all-null groups
+    out = Series(dtype='int64', index=Index([], name='A'))
+    tm.assert_series_equal(df.groupby('A').size(), out)
+
 
 # quantile
 # --------------------------------


### PR DESCRIPTION
- [x] closes #23050
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
