### PR TITLE
BUG: Preserve index order when constructing DataFrame from dict

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -305,7 +305,7 @@ Conversion
 ^^^^^^^^^^
 
 - Bug in :func:`DataFrame.astype()` when passing a dict of columns and types the `errors` parameter was ignored. (:issue:`25905`)
--
+- Bug in constructing :class:`DataFrame` from dict, where the index would be sorted instead of using the dict insertion order. (:issue:`24859`)
 -
 
 Strings

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -305,7 +305,7 @@ Conversion
 ^^^^^^^^^^
 
 - Bug in :func:`DataFrame.astype()` when passing a dict of columns and types the `errors` parameter was ignored. (:issue:`25905`)
-- Bug in constructing :class:`DataFrame` from dict, where the index would be sorted instead of using the dict insertion order. (:issue:`24859`)
+- Bug in :class:`DataFrame` construction from dict, where the index would be sorted instead of using dict insertion order. (:issue:`24859`)
 -
 
 Strings

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6304,11 +6304,11 @@ class DataFrame(NDFrame):
 
     Different aggregations per column.
 
-    >>> df.agg({'A' : ['sum', 'min'], 'B' : ['min', 'max']})
-            A    B
-    max   NaN  8.0
-    min   1.0  2.0
-    sum  12.0  NaN
+    >>> df.agg({'A' : ['max', 'min'], 'B' : ['min', 'sum']})
+           A     B
+    max  7.0   NaN
+    min  1.0   2.0
+    sum  NaN  15.0
 
     Aggregate over the columns.
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -146,7 +146,8 @@ def _union_indexes(indexes, sort=True):
     if len(indexes) == 1:
         result = indexes[0]
         if isinstance(result, list):
-            result = Index(sorted(result))
+            result = sorted(result) if sort else result
+            result = Index(result)
         return result
 
     indexes, kind = _sanitize_and_check(indexes)

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -9,7 +9,7 @@ import numpy.ma as ma
 
 from pandas._libs import lib
 from pandas._libs.tslibs import IncompatibleFrequency
-from pandas.compat import lmap, lrange, raise_with_traceback
+from pandas.compat import PY36, lmap, lrange, raise_with_traceback
 
 from pandas.core.dtypes.cast import (
     construct_1d_arraylike_from_scalar, construct_1d_ndarray_preserving_na,
@@ -301,7 +301,7 @@ def extract_index(data):
                              ' an index')
 
         if have_series or have_dicts:
-            index = _union_indexes(indexes, sort=False)
+            index = _union_indexes(indexes, sort=not PY36)
 
         if have_raw_arrays:
             lengths = list(set(raw_lengths))

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -301,7 +301,7 @@ def extract_index(data):
                              ' an index')
 
         if have_series or have_dicts:
-            index = _union_indexes(indexes)
+            index = _union_indexes(indexes, sort=False)
 
         if have_raw_arrays:
             lengths = list(set(raw_lengths))

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -620,10 +620,9 @@ class TestDataFrameAlterAxes():
 
         # index
         data = {
-            'A': {'foo': 0, 'bar': 1}
+            'A': {'bar': 0, 'foo': 1}
         }
 
-        # gets sorted alphabetical
         df = DataFrame(data)
         renamed = df.rename(index={'foo': 'bar', 'bar': 'foo'})
         tm.assert_index_equal(renamed.index, Index(['foo', 'bar']))

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1111,7 +1111,6 @@ class TestDataFrameConstructors(TestData):
 
         sdict = OrderedDict(zip(['x', 'Unnamed 0'], data))
         expected = DataFrame.from_dict(sdict, orient='index')
-
         result = result if PY36 else result.sort_index()
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -479,7 +479,8 @@ class TestDataFrameConstructors(TestData):
             dct.update(v.to_dict())
             data[k] = dct
         frame = DataFrame(data)
-        tm.assert_frame_equal(self.frame.sort_index(), frame)
+        old_frame = self.frame if PY36 else self.frame.sort_index()
+        tm.assert_frame_equal(old_frame, frame)
 
     def test_constructor_dict_block(self):
         expected = np.array([[4., 3., 2., 1.]])
@@ -1110,7 +1111,8 @@ class TestDataFrameConstructors(TestData):
 
         sdict = OrderedDict(zip(['x', 'Unnamed 0'], data))
         expected = DataFrame.from_dict(sdict, orient='index')
-        tm.assert_frame_equal(result.sort_index(), expected)
+
+        tm.assert_frame_equal(result if PY36 else result.sort_index(), expected)
 
         # none named
         data = [OrderedDict([['a', 1.5], ['b', 3], ['c', 4], ['d', 6]]),
@@ -1245,7 +1247,7 @@ class TestDataFrameConstructors(TestData):
     def test_constructor_orient(self):
         data_dict = self.mixed_frame.T._series
         recons = DataFrame.from_dict(data_dict, orient='index')
-        expected = self.mixed_frame.sort_index()
+        expected = self.mixed_frame if PY36 else self.mixed_frame.sort_index()
         tm.assert_frame_equal(recons, expected)
 
         # dict of sequence

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1112,7 +1112,8 @@ class TestDataFrameConstructors(TestData):
         sdict = OrderedDict(zip(['x', 'Unnamed 0'], data))
         expected = DataFrame.from_dict(sdict, orient='index')
 
-        tm.assert_frame_equal(result if PY36 else result.sort_index(), expected)
+        result = result if PY36 else result.sort_index()
+        tm.assert_frame_equal(result, expected)
 
         # none named
         data = [OrderedDict([['a', 1.5], ['b', 3], ['c', 4], ['d', 6]]),

--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -140,8 +140,8 @@ class TestMultiIndexSetItem(object):
         # http://stackoverflow.com/questions/24572040/pandas-access-the-level-of-multiindex-for-inplace-operation
         df_orig = DataFrame.from_dict({'price': {
             ('DE', 'Coal', 'Stock'): 2,
-            ('DE', 'Gas', 'Stock'): 4,
             ('DE', 'Elec', 'Demand'): 1,
+            ('DE', 'Gas', 'Stock'): 4,
             ('FR', 'Gas', 'Stock'): 5,
             ('FR', 'Solar', 'SupIm'): 0,
             ('FR', 'Wind', 'SupIm'): 0

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1588,7 +1588,7 @@ class TestConcatenate(ConcatenateBase):
         s = Series(randn(3), index=['c', 'a', 'b'], name='A')
         s2 = Series(randn(4), index=['d', 'a', 'b', 'c'], name='B')
         result = concat([s, s2], axis=1, sort=sort)
-        expected = DataFrame({'A': s, 'B': s2})
+        expected = DataFrame({'A': s, 'B': s2}).sort_index()
         assert_frame_equal(result, expected)
 
     def test_concat_series_axis1_names_applied(self):


### PR DESCRIPTION
- [x] closes #24859
- [x] tests added / passed
    (no new tests added)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This resolves the issue of `pd.DataFrame(dict)` or `pd.DataFrame.from_dict(dict)` not preserving the order of the index specified in `dict`.

This required fixing up tests that relied on alphabetical ordering. The changes to these tests also test for this new preserved ordering; let me know if I should add an additional explicit test.