### PR TITLE
CLN: replace usage internally of .iteritems with .items

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -115,15 +115,15 @@ class Iteration:
         )
         self.df4 = DataFrame(np.random.randn(N * 1000, 10))
 
-    def time_iteritems(self):
+    def time_items(self):
         # (monitor no-copying behaviour)
         if hasattr(self.df, "_item_cache"):
             self.df._item_cache.clear()
-        for name, col in self.df.iteritems():
+        for name, col in self.df.items():
             pass
 
-    def time_iteritems_cached(self):
-        for name, col in self.df.iteritems():
+    def time_items_cached(self):
+        for name, col in self.df.items():
             pass
 
     def time_iteritems_indexing(self):

--- a/doc/source/development/contributing_docstring.rst
+++ b/doc/source/development/contributing_docstring.rst
@@ -522,7 +522,7 @@ examples:
 * ``loc`` and ``iloc``, as they do the same, but in one case providing indices
   and in the other positions
 * ``max`` and ``min``, as they do the opposite
-* ``iterrows``, ``itertuples`` and ``iteritems``, as it is easy that a user
+* ``iterrows``, ``itertuples`` and ``items``, as it is easy that a user
   looking for the method to iterate over columns ends up in the method to
   iterate over rows, and vice-versa
 * ``fillna`` and ``dropna``, as both methods are used to handle missing values

--- a/doc/source/getting_started/basics.rst
+++ b/doc/source/getting_started/basics.rst
@@ -1475,7 +1475,7 @@ Thus, for example, iterating over a DataFrame gives you the column names:
        print(col)
 
 
-Pandas objects also have the dict-like :meth:`~DataFrame.iteritems` method to
+Pandas objects also have the dict-like :meth:`~DataFrame.items` method to
 iterate over the (key, value) pairs.
 
 To iterate over the rows of a DataFrame, you can use the following methods:
@@ -1524,10 +1524,10 @@ To iterate over the rows of a DataFrame, you can use the following methods:
 
     df
 
-iteritems
+items
 ~~~~~~~~~
 
-Consistent with the dict-like interface, :meth:`~DataFrame.iteritems` iterates
+Consistent with the dict-like interface, :meth:`~DataFrame.items` iterates
 through key-value pairs:
 
 * **Series**: (index, scalar value) pairs
@@ -1537,7 +1537,7 @@ For example:
 
 .. ipython:: python
 
-   for label, ser in df.iteritems():
+   for label, ser in df.items():
        print(label)
        print(ser)
 

--- a/doc/source/getting_started/basics.rst
+++ b/doc/source/getting_started/basics.rst
@@ -1525,7 +1525,7 @@ To iterate over the rows of a DataFrame, you can use the following methods:
     df
 
 items
-~~~~~~~~~
+~~~~~
 
 Consistent with the dict-like interface, :meth:`~DataFrame.items` iterates
 through key-value pairs:

--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -68,7 +68,7 @@ Indexing, iteration
    DataFrame.__iter__
    DataFrame.items
    DataFrame.keys
-   DataFrame.iteritems
+   DataFrame.items
    DataFrame.iterrows
    DataFrame.itertuples
    DataFrame.lookup

--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -67,8 +67,8 @@ Indexing, iteration
    DataFrame.insert
    DataFrame.__iter__
    DataFrame.items
+   DataFrame.iteritems
    DataFrame.keys
-   DataFrame.items
    DataFrame.iterrows
    DataFrame.itertuples
    DataFrame.lookup

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -77,6 +77,7 @@ Indexing, iteration
    Series.iloc
    Series.__iter__
    Series.items
+   Series.iteritems
    Series.keys
    Series.pop
    Series.item

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -76,7 +76,6 @@ Indexing, iteration
    Series.loc
    Series.iloc
    Series.__iter__
-   Series.iteritems
    Series.items
    Series.keys
    Series.pop

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -886,7 +886,6 @@ Other deprecations
 - :meth:`Index.item` and :meth:`Series.item` is deprecated. (:issue:`18262`)
 - The default value ``ordered=None`` in :class:`~pandas.api.types.CategoricalDtype` has been deprecated in favor of ``ordered=False``. When converting between categorical types ``ordered=True`` must be explicitly passed in order to be preserved. (:issue:`26336`)
 - :meth:`Index.contains` is deprecated. Use ``key in index`` (``__contains__``) instead (:issue:`17753`).
-- ``DataFrame.iteritems`` and ``Series.iteritems`` have been deprecated. :attr:`DataFrame.items` and :attr:`Series.items` provide the exact same functionality and should be used instead (:issue:`26114`).
 - :meth:`DataFrame.get_dtype_counts` is deprecated. (:issue:`18262`)
 - :meth:`Categorical.ravel` will return a :class:`Categorical` instead of a ``np.ndarray`` (:issue:`27199`)
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -886,8 +886,10 @@ Other deprecations
 - :meth:`Index.item` and :meth:`Series.item` is deprecated. (:issue:`18262`)
 - The default value ``ordered=None`` in :class:`~pandas.api.types.CategoricalDtype` has been deprecated in favor of ``ordered=False``. When converting between categorical types ``ordered=True`` must be explicitly passed in order to be preserved. (:issue:`26336`)
 - :meth:`Index.contains` is deprecated. Use ``key in index`` (``__contains__``) instead (:issue:`17753`).
+- ``DataFrame.iteritems`` and ``Series.iteritems`` have been deprecated. :attr:`DataFrame.items` and :attr:`Series.items` provide the exact same functionality and should be used instead (:issue:`26114`).
 - :meth:`DataFrame.get_dtype_counts` is deprecated. (:issue:`18262`)
 - :meth:`Categorical.ravel` will return a :class:`Categorical` instead of a ``np.ndarray`` (:issue:`27199`)
+
 
 .. _whatsnew_0250.prior_deprecations:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -771,15 +771,15 @@ class DataFrame(NDFrame):
 
         return Styler(self)
 
-    def items(self):
-        r"""
+    _shared_docs[
+        "items"
+    ] = r"""
         Iterator over (column name, Series) pairs.
 
         Iterates over the DataFrame columns, returning a tuple with
         the column name and the content as a Series.
 
-        Yields
-        ------
+        %s
         label : object
             The column names for the DataFrame being iterated over.
         content : Series
@@ -819,6 +819,9 @@ class DataFrame(NDFrame):
         koala    80000
         Name: population, dtype: int64
         """
+
+    @Appender(_shared_docs["items"] % "Yields\n        ------")
+    def items(self):
         if self.columns.is_unique and hasattr(self, "_item_cache"):
             for k in self.columns:
                 yield k, self._get_item_cache(k)
@@ -826,10 +829,9 @@ class DataFrame(NDFrame):
             for i, k in enumerate(self.columns):
                 yield k, self._ixs(i, axis=1)
 
-    @Appender(items.__doc__)
+    @Appender(_shared_docs["items"] % "Returns\n        -------")
     def iteritems(self):
-        for key, value in self.items():
-            yield key, value
+        return self.items()
 
     def iterrows(self):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -826,9 +826,10 @@ class DataFrame(NDFrame):
             for i, k in enumerate(self.columns):
                 yield k, self._ixs(i, axis=1)
 
-    @Appender(items.__doc)
+    @Appender(items.__doc__)
     def iteritems(self):
-        return self.items()
+        for key, value in self.items():
+            yield key, value
 
     def iterrows(self):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -771,7 +771,7 @@ class DataFrame(NDFrame):
 
         return Styler(self)
 
-    def iteritems(self):
+    def items(self):
         r"""
         Iterator over (column name, Series) pairs.
 
@@ -802,7 +802,7 @@ class DataFrame(NDFrame):
         panda 	bear 	  1864
         polar 	bear 	  22000
         koala 	marsupial 80000
-        >>> for label, content in df.iteritems():
+        >>> for label, content in df.items():
         ...     print('label:', label)
         ...     print('content:', content, sep='\n')
         ...
@@ -826,6 +826,10 @@ class DataFrame(NDFrame):
             for i, k in enumerate(self.columns):
                 yield k, self._ixs(i, axis=1)
 
+    @Appender(items.__doc)
+    def iteritems(self):
+        return self.items()
+
     def iterrows(self):
         """
         Iterate over DataFrame rows as (index, Series) pairs.
@@ -843,7 +847,7 @@ class DataFrame(NDFrame):
         See Also
         --------
         itertuples : Iterate over DataFrame rows as namedtuples of the values.
-        iteritems : Iterate over (column name, Series) pairs.
+        items : Iterate over (column name, Series) pairs.
 
         Notes
         -----
@@ -901,7 +905,7 @@ class DataFrame(NDFrame):
         --------
         DataFrame.iterrows : Iterate over DataFrame rows as (index, Series)
             pairs.
-        DataFrame.iteritems : Iterate over (column name, Series) pairs.
+        DataFrame.items : Iterate over (column name, Series) pairs.
 
         Notes
         -----
@@ -957,8 +961,6 @@ class DataFrame(NDFrame):
 
         # fallback to regular tuples
         return zip(*arrays)
-
-    items = iteritems
 
     def __len__(self):
         """
@@ -2634,7 +2636,7 @@ class DataFrame(NDFrame):
         5216
         """
         result = Series(
-            [c.memory_usage(index=False, deep=deep) for col, c in self.iteritems()],
+            [c.memory_usage(index=False, deep=deep) for col, c in self.items()],
             index=self.columns,
         )
         if index:
@@ -4955,7 +4957,7 @@ class DataFrame(NDFrame):
         if not diff.empty:
             raise KeyError(diff)
 
-        vals = (col.values for name, col in self.iteritems() if name in subset)
+        vals = (col.values for name, col in self.items() if name in subset)
         labels, shape = map(list, zip(*map(f, vals)))
 
         ids = get_group_index(labels, shape, sort=False, xnull=False)
@@ -7343,7 +7345,7 @@ class DataFrame(NDFrame):
         from pandas.core.reshape.concat import concat
 
         def _dict_round(df, decimals):
-            for col, vals in df.iteritems():
+            for col, vals in df.items():
                 try:
                     yield _series_round(vals, decimals[col])
                 except KeyError:
@@ -7363,7 +7365,7 @@ class DataFrame(NDFrame):
             new_cols = [col for col in _dict_round(self, decimals)]
         elif is_integer(decimals):
             # Dispatch to Series.round
-            new_cols = [_series_round(v, decimals) for _, v in self.iteritems()]
+            new_cols = [_series_round(v, decimals) for _, v in self.items()]
         else:
             raise TypeError("decimals must be an integer, a dict-like or a " "Series")
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1940,6 +1940,10 @@ class NDFrame(PandasObject, SelectionMixin):
         """Iterate over (label, values) on info axis
 
         This is index for Series and columns for DataFrame.
+
+        Returns
+        -------
+        Generator
         """
         for h in self._info_axis:
             yield h, self[h]

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -494,7 +494,7 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         from pandas.core.computation.common import _remove_spaces_column_name
 
-        return {_remove_spaces_column_name(k): v for k, v in self.iteritems()}
+        return {_remove_spaces_column_name(k): v for k, v in self.items()}
 
     @property
     def _info_axis(self):
@@ -1936,14 +1936,17 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         return self._info_axis
 
-    def iteritems(self):
-        """
-        Iterate over (label, values) on info axis
+    def items(self):
+        """Iterate over (label, values) on info axis
 
-        This is index for Series, columns for DataFrame and so on.
+        This is index for Series and columns for DataFrame.
         """
         for h in self._info_axis:
             yield h, self[h]
+
+    @Appender(items.__doc__)
+    def iteritems(self):
+        return self.items()
 
     def __len__(self):
         """Returns length of info axis"""
@@ -5912,7 +5915,7 @@ class NDFrame(PandasObject, SelectionMixin):
                         "key in a dtype mappings argument."
                     )
             results = []
-            for col_name, col in self.iteritems():
+            for col_name, col in self.items():
                 if col_name in dtype:
                     results.append(
                         col.astype(
@@ -10328,7 +10331,7 @@ class NDFrame(PandasObject, SelectionMixin):
         else:
             data = self.select_dtypes(include=include, exclude=exclude)
 
-        ldesc = [describe_1d(s) for _, s in data.iteritems()]
+        ldesc = [describe_1d(s) for _, s in data.items()]
         # set a convenient order for rows
         names = []
         ldesc_indexes = sorted((x.index for x in ldesc), key=len)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -601,7 +601,7 @@ class MultiIndex(Index):
         if not isinstance(df, ABCDataFrame):
             raise TypeError("Input must be a DataFrame")
 
-        column_names, columns = zip(*df.iteritems())
+        column_names, columns = zip(*df.items())
         names = column_names if names is None else names
         return cls.from_arrays(columns, sortorder=sortorder, names=names)
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -272,7 +272,7 @@ def _compute_grand_margin(data, values, aggfunc, margins_name="All"):
 
     if values:
         grand_margin = {}
-        for k, v in data[values].iteritems():
+        for k, v in data[values].items():
             try:
                 if isinstance(aggfunc, str):
                     grand_margin[k] = getattr(v, aggfunc)()

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -478,7 +478,7 @@ def _unstack_extension_series(series, level, fill_value):
     out = []
     values = extract_array(series, extract_numpy=False)
 
-    for col, indices in result.iteritems():
+    for col, indices in result.items():
         out.append(
             Series(
                 values.take(indices.values, allow_fill=True, fill_value=fill_value),
@@ -544,7 +544,7 @@ def stack(frame, level=-1, dropna=True):
         if is_extension_array_dtype(dtype):
             arr = dtype.construct_array_type()
             new_values = arr._concat_same_type(
-                [col._values for _, col in frame.iteritems()]
+                [col._values for _, col in frame.items()]
             )
             new_values = _reorder_for_extension_array_stack(new_values, N, K)
         else:
@@ -695,7 +695,7 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
                 subset = this[this.columns[loc]]
 
                 value_slice = dtype.construct_array_type()._concat_same_type(
-                    [x._values for _, x in subset.iteritems()]
+                    [x._values for _, x in subset.items()]
                 )
                 N, K = this.shape
                 idx = np.arange(N * K).reshape(K, N).T.ravel()
@@ -909,7 +909,7 @@ def get_dummies(
             # columns to prepend to result.
             with_dummies = [data.select_dtypes(exclude=dtypes_to_encode)]
 
-        for (col, pre, sep) in zip(data_to_encode.iteritems(), prefix, prefix_sep):
+        for (col, pre, sep) in zip(data_to_encode.items(), prefix, prefix_sep):
             # col is (column_name, column), use just column data here
             dummy = _get_dummies_1d(
                 col[1],

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1692,13 +1692,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     # ----------------------------------------------------------------------
 
-    def iteritems(self):
+    def items(self):
         """
         Lazily iterate over (index, value) tuples.
 
         This method returns an iterable tuple (index, value). This is
-        convenient if you want to create a lazy iterator. Note that the
-        methods Series.items and Series.iteritems are the same methods.
+        convenient if you want to create a lazy iterator.
 
         Returns
         -------
@@ -1708,12 +1707,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        DataFrame.iteritems : Equivalent to Series.iteritems for DataFrame.
+        DataFrame.items : Equivalent to Series.items for DataFrame.
 
         Examples
         --------
         >>> s = pd.Series(['A', 'B', 'C'])
-        >>> for index, value in s.iteritems():
+        >>> for index, value in s.items():
         ...     print("Index : {}, Value : {}".format(index, value))
         Index : 0, Value : A
         Index : 1, Value : B
@@ -1721,7 +1720,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         return zip(iter(self.index), iter(self))
 
-    items = iteritems
+    @Appender(generic._shared_docs["iteritems"] % _shared_doc_kwargs)
+    def iteritems(self):
+        return self.items()
 
     # ----------------------------------------------------------------------
     # Misc public methods

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1720,7 +1720,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         return zip(iter(self.index), iter(self))
 
-    @Appender(generic._shared_docs["iteritems"] % _shared_doc_kwargs)
+    @Appender(items.__doc__)
     def iteritems(self):
         return self.items()
 

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -695,7 +695,7 @@ class SparseDataFrame(DataFrame):
         need_mask = mask.any()
 
         new_series = {}
-        for col, series in self.iteritems():
+        for col, series in self.items():
             if mask.all():
                 continue
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -998,7 +998,7 @@ def str_extractall(arr, pat, flags=0):
     index_list = []
     is_mi = arr.index.nlevels > 1
 
-    for subject_key, subject in arr.iteritems():
+    for subject_key, subject in arr.items():
         if isinstance(subject, str):
 
             if not is_mi:

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -113,7 +113,7 @@ def hash_pandas_object(
         h = Series(h, index=obj.index, dtype="uint64", copy=False)
 
     elif isinstance(obj, ABCDataFrame):
-        hashes = (hash_array(series.values) for _, series in obj.iteritems())
+        hashes = (hash_array(series.values) for _, series in obj.items())
         num_items = len(obj.columns)
         if index:
             index_hash_generator = (

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -538,7 +538,7 @@ class Styler:
         matter.
         """
         for row_label, v in attrs.iterrows():
-            for col_label, col in v.iteritems():
+            for col_label, col in v.items():
                 i = self.index.get_indexer([row_label])[0]
                 j = self.columns.get_indexer([col_label])[0]
                 for pair in col.rstrip(";").split(";"):

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -1105,7 +1105,7 @@ class FrameParser(Parser):
 
         needs_new_obj = False
         new_obj = dict()
-        for i, (col, c) in enumerate(self.obj.iteritems()):
+        for i, (col, c) in enumerate(self.obj.items()):
             if filt(col, c):
                 new_data, result = f(col, c)
                 if result:

--- a/pandas/io/json/_table_schema.py
+++ b/pandas/io/json/_table_schema.py
@@ -249,7 +249,7 @@ def build_table_schema(data, index=True, primary_key=None, version=True):
             fields.append(convert_pandas_type_to_json_field(data.index))
 
     if data.ndim > 1:
-        for column, s in data.iteritems():
+        for column, s in data.items():
             fields.append(convert_pandas_type_to_json_field(s))
     else:
         fields.append(convert_pandas_type_to_json_field(data))

--- a/pandas/io/msgpack/_packer.pyx
+++ b/pandas/io/msgpack/_packer.pyx
@@ -194,7 +194,7 @@ cdef class Packer:
                     raise ValueError("dict is too large")
                 ret = msgpack_pack_map(&self.pk, L)
                 if ret == 0:
-                    for k, v in d.iteritems():
+                    for k, v in d.items():
                         ret = self._pack(k, nest_limit - 1)
                         if ret != 0: break
                         ret = self._pack(v, nest_limit - 1)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -108,7 +108,7 @@ def _parse_date_columns(data_frame, parse_dates):
     # we want to coerce datetime64_tz dtypes for now to UTC
     # we could in theory do a 'nice' conversion from a FixedOffset tz
     # GH11216
-    for col_name, df_col in data_frame.iteritems():
+    for col_name, df_col in data_frame.items():
         if is_datetime64tz_dtype(df_col) or col_name in parse_dates:
             try:
                 fmt = parse_dates[col_name]

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2302,7 +2302,7 @@ class StataWriter(StataParser):
     def _set_formats_and_types(self, data, dtypes):
         self.typlist = []
         self.fmtlist = []
-        for col, dtype in dtypes.iteritems():
+        for col, dtype in dtypes.items():
             self.fmtlist.append(_dtype_to_default_stata_fmt(dtype, data[col]))
             self.typlist.append(_dtype_to_stata_type(dtype, data[col]))
 
@@ -3168,7 +3168,7 @@ class StataWriter117(StataWriter):
     def _set_formats_and_types(self, data, dtypes):
         self.typlist = []
         self.fmtlist = []
-        for col, dtype in dtypes.iteritems():
+        for col, dtype in dtypes.items():
             force_strl = col in self._convert_strl
             fmt = _dtype_to_default_stata_fmt(
                 dtype, data[col], dta_version=117, force_strl=force_strl

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -258,7 +258,7 @@ class MPLPlot:
         # else:
         #     columns = data.columns
 
-        for col, values in data.iteritems():
+        for col, values in data.items():
             if keep_index is True:
                 yield col, values
             else:

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -319,7 +319,7 @@ class SharedWithSparse:
         for row, s in df.iterrows():
             str(s)
 
-        for c, col in df.iteritems():
+        for c, col in df.items():
             str(s)
 
     def test_len(self, float_frame):
@@ -430,7 +430,7 @@ class SharedWithSparse:
         expected = "              X\nNaT        a  1\n2013-01-01 b  2"
         assert result == expected
 
-    def test_iteritems_names(self, float_string_frame):
+    def test_items_names(self, float_string_frame):
         for k, v in float_string_frame.items():
             assert v.name == k
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -2712,7 +2712,7 @@ class TestDataFrameIndexing(TestData):
             other1 = _safe_add(df)
             rs = df.where(cond, other1)
             rs2 = df.where(cond.values, other1)
-            for k, v in rs.iteritems():
+            for k, v in rs.items():
                 exp = Series(np.where(cond[k], df[k], other1[k]), index=v.index)
                 assert_series_equal(v, exp, check_names=False)
             assert_frame_equal(rs, rs2)

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -281,7 +281,7 @@ class TestDataFrameOperators:
             result = getattr(df, op)(x, level="third", axis=0)
 
             expected = pd.concat(
-                [opa(df.loc[idx[:, :, i], :], v) for i, v in x.iteritems()]
+                [opa(df.loc[idx[:, :, i], :], v) for i, v in x.items()]
             ).sort_index()
             assert_frame_equal(result, expected)
 
@@ -289,7 +289,7 @@ class TestDataFrameOperators:
             result = getattr(df, op)(x, level="second", axis=0)
 
             expected = (
-                pd.concat([opa(df.loc[idx[:, i], :], v) for i, v in x.iteritems()])
+                pd.concat([opa(df.loc[idx[:, i], :], v) for i, v in x.items()])
                 .reindex_like(df)
                 .sort_index()
             )

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -842,7 +842,7 @@ class TestMisc(Base):
 
     def test_float_index_at_iat(self):
         s = Series([1, 2, 3], index=[0.1, 0.2, 0.3])
-        for el, item in s.iteritems():
+        for el, item in s.items():
             assert s.at[el] == item
         for i in range(len(s)):
             assert s.iat[i] == i + 1

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -198,7 +198,7 @@ class TestScalar(Base):
     def test_mixed_index_at_iat_loc_iloc_series(self):
         # GH 19860
         s = Series([1, 2, 3, 4, 5], index=["a", "b", "c", 1, 2])
-        for el, item in s.iteritems():
+        for el, item in s.items():
             assert s.at[el] == s.loc[el] == item
         for i in range(len(s)):
             assert s.iat[i] == s.iloc[i] == i + 1
@@ -214,7 +214,7 @@ class TestScalar(Base):
             [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]], columns=["a", "b", "c", 1, 2]
         )
         for rowIdx, row in df.iterrows():
-            for el, item in row.iteritems():
+            for el, item in row.items():
                 assert df.at[rowIdx, el] == df.loc[rowIdx, el] == item
 
         for row in range(2):

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -380,7 +380,7 @@ class TestReadHtml:
         dfs = self.read_html(macau_data, index_col=0, attrs={"class": "style1"})
         df = dfs[all_non_nan_table_index]
 
-        assert not any(s.isna().any() for _, s in df.iteritems())
+        assert not any(s.isna().any() for _, s in df.items())
 
     @pytest.mark.slow
     def test_thousands_macau_index_col(self, datapath):
@@ -389,7 +389,7 @@ class TestReadHtml:
         dfs = self.read_html(macau_data, index_col=0, header=0)
         df = dfs[all_non_nan_table_index]
 
-        assert not any(s.isna().any() for _, s in df.iteritems())
+        assert not any(s.isna().any() for _, s in df.items())
 
     def test_empty_tables(self):
         """

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -336,10 +336,10 @@ class TestSeriesMisc(TestData, SharedWithSparse):
         tm.assert_almost_equal(self.ts.values, self.ts, check_dtype=False)
 
     def test_iteritems(self):
-        for idx, val in self.series.items():
+        for idx, val in self.series.iteritems():
             assert val == self.series[idx]
 
-        for idx, val in self.ts.items():
+        for idx, val in self.ts.iteritems():
             assert val == self.ts[idx]
 
         # assert is lazy (genrators don't define reverse, lists do)

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -259,5 +259,5 @@ class TestSeriesIO:
             Series(datetime_series.to_dict(mapping), name="ts"), datetime_series
         )
         from_method = Series(datetime_series.to_dict(collections.Counter))
-        from_constructor = Series(collections.Counter(datetime_series.iteritems()))
+        from_constructor = Series(collections.Counter(datetime_series.items()))
         tm.assert_series_equal(from_method, from_constructor)

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1107,13 +1107,13 @@ class TestToIterable:
     @pytest.mark.parametrize("dtype, rdtype", dtypes)
     def test_iterable_items(self, dtype, rdtype):
         # gh-13258
-        # test items / iteritems yields the correct boxed scalars
+        # test if items yields the correct boxed scalars
         # this only applies to series
         s = Series([1], dtype=dtype)
         _, result = list(s.items())[0]
         assert isinstance(result, rdtype)
 
-        _, result = list(s.iteritems())[0]
+        _, result = list(s.items())[0]
         assert isinstance(result, rdtype)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] xref #25725
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Now that Python2 is being removed, ``.iteritems`` should be deprecated, and ``.items`` should be used instead.

EDIT: This PR ended up not deprecating .iteritems, but only change its usage internally with using .items