### PR TITLE
CLN: remove unneeded inheritance from base object

### DIFF
--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -13,7 +13,7 @@ for imp in ['pandas.util', 'pandas.tools.hashing']:
         pass
 
 
-class Factorize(object):
+class Factorize:
 
     params = [[True, False], ['int', 'uint', 'float', 'string']]
     param_names = ['sort', 'dtype']
@@ -30,7 +30,7 @@ class Factorize(object):
         self.idx.factorize(sort=sort)
 
 
-class FactorizeUnique(object):
+class FactorizeUnique:
 
     params = [[True, False], ['int', 'uint', 'float', 'string']]
     param_names = ['sort', 'dtype']
@@ -48,7 +48,7 @@ class FactorizeUnique(object):
         self.idx.factorize(sort=sort)
 
 
-class Duplicated(object):
+class Duplicated:
 
     params = [['first', 'last', False], ['int', 'uint', 'float', 'string']]
     param_names = ['keep', 'dtype']
@@ -67,7 +67,7 @@ class Duplicated(object):
         self.idx.duplicated(keep=keep)
 
 
-class DuplicatedUniqueIndex(object):
+class DuplicatedUniqueIndex:
 
     params = ['int', 'uint', 'float', 'string']
     param_names = ['dtype']
@@ -86,7 +86,7 @@ class DuplicatedUniqueIndex(object):
         self.idx.duplicated()
 
 
-class Hashing(object):
+class Hashing:
 
     def setup_cache(self):
         N = 10**5
@@ -124,7 +124,7 @@ class Hashing(object):
         hashing.hash_pandas_object(df['dates'])
 
 
-class Quantile(object):
+class Quantile:
     params = [[0, 0.5, 1],
               ['linear', 'nearest', 'lower', 'higher', 'midpoint'],
               ['float', 'int', 'uint']]

--- a/asv_bench/benchmarks/attrs_caching.py
+++ b/asv_bench/benchmarks/attrs_caching.py
@@ -6,7 +6,7 @@ except ImportError:
     from pandas.util.decorators import cache_readonly
 
 
-class DataFrameAttributes(object):
+class DataFrameAttributes:
 
     def setup(self):
         self.df = DataFrame(np.random.randn(10, 6))
@@ -19,7 +19,7 @@ class DataFrameAttributes(object):
         self.df.index = self.cur_index
 
 
-class CacheReadonly(object):
+class CacheReadonly:
 
     def setup(self):
 

--- a/asv_bench/benchmarks/binary_ops.py
+++ b/asv_bench/benchmarks/binary_ops.py
@@ -7,7 +7,7 @@ except ImportError:
     import pandas.computation.expressions as expr
 
 
-class Ops(object):
+class Ops:
 
     params = [[True, False], ['default', 1]]
     param_names = ['use_numexpr', 'threads']
@@ -38,7 +38,7 @@ class Ops(object):
         expr.set_numexpr_threads()
 
 
-class Ops2(object):
+class Ops2:
 
     def setup(self):
         N = 10**3
@@ -88,7 +88,7 @@ class Ops2(object):
         self.df.dot(self.s)
 
 
-class Timeseries(object):
+class Timeseries:
 
     params = [None, 'US/Eastern']
     param_names = ['tz']
@@ -114,7 +114,7 @@ class Timeseries(object):
         self.s - self.s.shift()
 
 
-class AddOverflowScalar(object):
+class AddOverflowScalar:
 
     params = [1, -1, 0]
     param_names = ['scalar']
@@ -127,7 +127,7 @@ class AddOverflowScalar(object):
         checked_add_with_arr(self.arr, scalar)
 
 
-class AddOverflowArray(object):
+class AddOverflowArray:
 
     def setup(self):
         N = 10**6

--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -12,7 +12,7 @@ except ImportError:
         pass
 
 
-class Concat(object):
+class Concat:
 
     def setup(self):
         N = 10**5
@@ -28,7 +28,7 @@ class Concat(object):
         union_categoricals([self.a, self.b])
 
 
-class Constructor(object):
+class Constructor:
 
     def setup(self):
         N = 10**5
@@ -77,7 +77,7 @@ class Constructor(object):
         pd.Categorical(self.series)
 
 
-class ValueCounts(object):
+class ValueCounts:
 
     params = [True, False]
     param_names = ['dropna']
@@ -92,7 +92,7 @@ class ValueCounts(object):
         self.ts.value_counts(dropna=dropna)
 
 
-class Repr(object):
+class Repr:
 
     def setup(self):
         self.sel = pd.Series(['s1234']).astype('category')
@@ -101,7 +101,7 @@ class Repr(object):
         str(self.sel)
 
 
-class SetCategories(object):
+class SetCategories:
 
     def setup(self):
         n = 5 * 10**5
@@ -113,7 +113,7 @@ class SetCategories(object):
         self.ts.cat.set_categories(self.ts.cat.categories[::2])
 
 
-class RemoveCategories(object):
+class RemoveCategories:
 
     def setup(self):
         n = 5 * 10**5
@@ -125,7 +125,7 @@ class RemoveCategories(object):
         self.ts.cat.remove_categories(self.ts.cat.categories[::2])
 
 
-class Rank(object):
+class Rank:
 
     def setup(self):
         N = 10**5
@@ -162,7 +162,7 @@ class Rank(object):
         self.s_int_cat_ordered.rank()
 
 
-class Isin(object):
+class Isin:
 
     params = ['object', 'int64']
     param_names = ['dtype']
@@ -181,7 +181,7 @@ class Isin(object):
         self.series.isin(self.sample)
 
 
-class IsMonotonic(object):
+class IsMonotonic:
 
     def setup(self):
         N = 1000
@@ -201,7 +201,7 @@ class IsMonotonic(object):
         self.s.is_monotonic_decreasing
 
 
-class Contains(object):
+class Contains:
 
     def setup(self):
         N = 10**5
@@ -216,7 +216,7 @@ class Contains(object):
         self.key in self.c
 
 
-class CategoricalSlicing(object):
+class CategoricalSlicing:
 
     params = ['monotonic_incr', 'monotonic_decr', 'non_monotonic']
     param_names = ['index']
@@ -257,7 +257,7 @@ class CategoricalSlicing(object):
         self.data[self.data == self.cat_scalar]
 
 
-class Indexing(object):
+class Indexing:
 
     def setup(self):
         N = 10**5

--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -39,7 +39,7 @@ def list_of_lists_with_none(arr):
     return [[i, -i] for i in arr][:-1] + [None]
 
 
-class SeriesConstructors(object):
+class SeriesConstructors:
 
     param_names = ["data_fmt", "with_index", "dtype"]
     params = [[no_change,
@@ -68,7 +68,7 @@ class SeriesConstructors(object):
         Series(self.data, index=self.index)
 
 
-class SeriesDtypesConstructors(object):
+class SeriesDtypesConstructors:
 
     def setup(self):
         N = 10**4
@@ -90,7 +90,7 @@ class SeriesDtypesConstructors(object):
         Index(self.s)
 
 
-class MultiIndexConstructor(object):
+class MultiIndexConstructor:
 
     def setup(self):
         N = 10**4

--- a/asv_bench/benchmarks/dtypes.py
+++ b/asv_bench/benchmarks/dtypes.py
@@ -12,7 +12,7 @@ _numpy_dtypes = [np.dtype(dtype)
 _dtypes = _numpy_dtypes + extension_dtypes
 
 
-class Dtypes(object):
+class Dtypes:
     params = (_dtypes +
               list(map(lambda dt: dt.name, _dtypes)))
     param_names = ['dtype']
@@ -21,7 +21,7 @@ class Dtypes(object):
         pandas_dtype(dtype)
 
 
-class DtypesInvalid(object):
+class DtypesInvalid:
     param_names = ['dtype']
     params = ['scalar-string', 'scalar-int', 'list-string', 'array-string']
     data_dict = {'scalar-string': 'foo',

--- a/asv_bench/benchmarks/eval.py
+++ b/asv_bench/benchmarks/eval.py
@@ -6,7 +6,7 @@ except ImportError:
     import pandas.computation.expressions as expr
 
 
-class Eval(object):
+class Eval:
 
     params = [['numexpr', 'python'], [1, 'all']]
     param_names = ['engine', 'threads']
@@ -37,7 +37,7 @@ class Eval(object):
         expr.set_numexpr_threads()
 
 
-class Query(object):
+class Query:
 
     def setup(self):
         N = 10**6

--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -8,7 +8,7 @@ except ImportError:
     from pandas.core.datetools import * # noqa
 
 
-class FromDicts(object):
+class FromDicts:
 
     def setup(self):
         N, K = 5000, 50
@@ -41,7 +41,7 @@ class FromDicts(object):
         DataFrame(self.data2)
 
 
-class FromSeries(object):
+class FromSeries:
 
     def setup(self):
         mi = MultiIndex.from_product([range(100), range(100)])
@@ -51,7 +51,7 @@ class FromSeries(object):
         DataFrame(self.s)
 
 
-class FromDictwithTimestamp(object):
+class FromDictwithTimestamp:
 
     params = [Nano(1), Hour(1)]
     param_names = ['offset']
@@ -67,7 +67,7 @@ class FromDictwithTimestamp(object):
         DataFrame(self.d)
 
 
-class FromRecords(object):
+class FromRecords:
 
     params = [None, 1000]
     param_names = ['nrows']
@@ -81,7 +81,7 @@ class FromRecords(object):
         self.df = DataFrame.from_records(self.gen, nrows=nrows)
 
 
-class FromNDArray(object):
+class FromNDArray:
 
     def setup(self):
         N = 100000
@@ -91,7 +91,7 @@ class FromNDArray(object):
         self.df = DataFrame(self.data)
 
 
-class FromLists(object):
+class FromLists:
 
     goal_time = 0.2
 

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -7,7 +7,7 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-class GetNumericData(object):
+class GetNumericData:
 
     def setup(self):
         self.df = DataFrame(np.random.randn(10000, 25))
@@ -19,7 +19,7 @@ class GetNumericData(object):
         self.df._get_numeric_data()
 
 
-class Lookup(object):
+class Lookup:
 
     def setup(self):
         self.df = DataFrame(np.random.randn(10000, 8),
@@ -39,7 +39,7 @@ class Lookup(object):
         self.df.lookup(self.row_labels_all, self.col_labels_all)
 
 
-class Reindex(object):
+class Reindex:
 
     def setup(self):
         N = 10**3
@@ -65,7 +65,7 @@ class Reindex(object):
         self.df2.reindex(np.random.permutation(range(1200)))
 
 
-class Rename(object):
+class Rename:
 
     def setup(self):
         N = 10**3
@@ -95,7 +95,7 @@ class Rename(object):
         self.df.rename(index=self.dict_idx, columns=self.dict_idx)
 
 
-class Iteration(object):
+class Iteration:
 
     def setup(self):
         N = 1000
@@ -189,7 +189,7 @@ class Iteration(object):
             pass
 
 
-class ToString(object):
+class ToString:
 
     def setup(self):
         self.df = DataFrame(np.random.randn(100, 10))
@@ -198,7 +198,7 @@ class ToString(object):
         self.df.to_string()
 
 
-class ToHTML(object):
+class ToHTML:
 
     def setup(self):
         nrows = 500
@@ -210,7 +210,7 @@ class ToHTML(object):
         self.df2.to_html()
 
 
-class Repr(object):
+class Repr:
 
     def setup(self):
         nrows = 10000
@@ -235,7 +235,7 @@ class Repr(object):
         repr(self.df_wide)
 
 
-class MaskBool(object):
+class MaskBool:
 
     def setup(self):
         data = np.random.randn(1000, 500)
@@ -251,7 +251,7 @@ class MaskBool(object):
         self.bools.astype(float).mask(self.mask)
 
 
-class Isnull(object):
+class Isnull:
 
     def setup(self):
         N = 10**3
@@ -283,7 +283,7 @@ class Isnull(object):
         isnull(self.df_obj)
 
 
-class Fillna(object):
+class Fillna:
 
     params = ([True, False], ['pad', 'bfill'])
     param_names = ['inplace', 'method']
@@ -297,7 +297,7 @@ class Fillna(object):
         self.df.fillna(inplace=inplace, method=method)
 
 
-class Dropna(object):
+class Dropna:
 
     params = (['all', 'any'], [0, 1])
     param_names = ['how', 'axis']
@@ -317,7 +317,7 @@ class Dropna(object):
         self.df_mixed.dropna(how=how, axis=axis)
 
 
-class Count(object):
+class Count:
 
     params = [0, 1]
     param_names = ['axis']
@@ -345,7 +345,7 @@ class Count(object):
         self.df_mixed.count(axis=axis, level=1)
 
 
-class Apply(object):
+class Apply:
 
     def setup(self):
         self.df = DataFrame(np.random.randn(1000, 100))
@@ -373,7 +373,7 @@ class Apply(object):
         self.df3.apply(lambda x: x['A'] + x['B'], axis=1)
 
 
-class Dtypes(object):
+class Dtypes:
 
     def setup(self):
         self.df = DataFrame(np.random.randn(1000, 1000))
@@ -382,7 +382,7 @@ class Dtypes(object):
         self.df.dtypes
 
 
-class Equals(object):
+class Equals:
 
     def setup(self):
         N = 10**3
@@ -418,7 +418,7 @@ class Equals(object):
         self.object_df.equals(self.object_df_nan)
 
 
-class Interpolate(object):
+class Interpolate:
 
     params = [None, 'infer']
     param_names = ['downcast']
@@ -443,7 +443,7 @@ class Interpolate(object):
         self.df2.interpolate(downcast=downcast)
 
 
-class Shift(object):
+class Shift:
     # frame shift speedup issue-5609
     params = [0, 1]
     param_names = ['axis']
@@ -455,7 +455,7 @@ class Shift(object):
         self.df.shift(1, axis=axis)
 
 
-class Nunique(object):
+class Nunique:
 
     def setup(self):
         self.df = DataFrame(np.random.randn(10000, 1000))
@@ -464,7 +464,7 @@ class Nunique(object):
         self.df.nunique()
 
 
-class Duplicated(object):
+class Duplicated:
 
     def setup(self):
         n = (1 << 20)
@@ -482,7 +482,7 @@ class Duplicated(object):
         self.df2.duplicated()
 
 
-class XS(object):
+class XS:
 
     params = [0, 1]
     param_names = ['axis']
@@ -495,7 +495,7 @@ class XS(object):
         self.df.xs(self.N / 2, axis=axis)
 
 
-class SortValues(object):
+class SortValues:
 
     params = [True, False]
     param_names = ['ascending']
@@ -507,7 +507,7 @@ class SortValues(object):
         self.df.sort_values(by='A', ascending=ascending)
 
 
-class SortIndexByColumns(object):
+class SortIndexByColumns:
 
     def setup(self):
         N = 10000
@@ -520,7 +520,7 @@ class SortIndexByColumns(object):
         self.df.sort_values(by=['key1', 'key2'])
 
 
-class Quantile(object):
+class Quantile:
 
     params = [0, 1]
     param_names = ['axis']
@@ -532,7 +532,7 @@ class Quantile(object):
         self.df.quantile([0.1, 0.5], axis=axis)
 
 
-class GetDtypeCounts(object):
+class GetDtypeCounts:
     # 2807
     def setup(self):
         self.df = DataFrame(np.random.randn(10, 10000))
@@ -544,7 +544,7 @@ class GetDtypeCounts(object):
         self.df.info()
 
 
-class NSort(object):
+class NSort:
 
     params = ['first', 'last', 'all']
     param_names = ['keep']
@@ -566,7 +566,7 @@ class NSort(object):
         self.df.nsmallest(100, ['A', 'B'], keep=keep)
 
 
-class Describe(object):
+class Describe:
 
     def setup(self):
         self.df = DataFrame({

--- a/asv_bench/benchmarks/gil.py
+++ b/asv_bench/benchmarks/gil.py
@@ -26,7 +26,7 @@ except ImportError:
 from .pandas_vb_common import BaseIO
 
 
-class ParallelGroupbyMethods(object):
+class ParallelGroupbyMethods:
 
     params = ([2, 4, 8], ['count', 'last', 'max', 'mean', 'min', 'prod',
                           'sum', 'var'])
@@ -57,7 +57,7 @@ class ParallelGroupbyMethods(object):
             self.loop()
 
 
-class ParallelGroups(object):
+class ParallelGroups:
 
     params = [2, 4, 8]
     param_names = ['threads']
@@ -78,7 +78,7 @@ class ParallelGroups(object):
         self.get_groups()
 
 
-class ParallelTake1D(object):
+class ParallelTake1D:
 
     params = ['int64', 'float64']
     param_names = ['dtype']
@@ -99,7 +99,7 @@ class ParallelTake1D(object):
         self.parallel_take1d()
 
 
-class ParallelKth(object):
+class ParallelKth:
 
     number = 1
     repeat = 5
@@ -121,7 +121,7 @@ class ParallelKth(object):
         self.parallel_kth_smallest()
 
 
-class ParallelDatetimeFields(object):
+class ParallelDatetimeFields:
 
     def setup(self):
         if not have_real_test_parallel:
@@ -167,7 +167,7 @@ class ParallelDatetimeFields(object):
         run(self.period)
 
 
-class ParallelRolling(object):
+class ParallelRolling:
 
     params = ['median', 'mean', 'min', 'max', 'var', 'skew', 'kurt', 'std']
     param_names = ['method']
@@ -239,7 +239,7 @@ class ParallelReadCSV(BaseIO):
         self.parallel_read_csv()
 
 
-class ParallelFactorize(object):
+class ParallelFactorize:
 
     number = 1
     repeat = 5

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -21,7 +21,7 @@ method_blacklist = {
 }
 
 
-class ApplyDictReturn(object):
+class ApplyDictReturn:
     def setup(self):
         self.labels = np.arange(1000).repeat(10)
         self.data = Series(np.random.randn(len(self.labels)))
@@ -31,7 +31,7 @@ class ApplyDictReturn(object):
                                                         'last': x.values[-1]})
 
 
-class Apply(object):
+class Apply:
 
     def setup_cache(self):
         N = 10**4
@@ -63,7 +63,7 @@ class Apply(object):
         df.groupby('key').apply(self.df_copy_function)
 
 
-class Groups(object):
+class Groups:
 
     param_names = ['key']
     params = ['int64_small', 'int64_large', 'object_small', 'object_large']
@@ -87,7 +87,7 @@ class Groups(object):
         self.ser.groupby(self.ser).groups
 
 
-class GroupManyLabels(object):
+class GroupManyLabels:
 
     params = [1, 1000]
     param_names = ['ncols']
@@ -102,7 +102,7 @@ class GroupManyLabels(object):
         self.df.groupby(self.labels).sum()
 
 
-class Nth(object):
+class Nth:
 
     param_names = ['dtype']
     params = ['float32', 'float64', 'datetime', 'object']
@@ -140,7 +140,7 @@ class Nth(object):
         self.df['values'].groupby(self.df['key']).nth(0)
 
 
-class DateAttributes(object):
+class DateAttributes:
 
     def setup(self):
         rng = date_range('1/1/2000', '12/31/2005', freq='H')
@@ -151,7 +151,7 @@ class DateAttributes(object):
         len(self.ts.groupby([self.year, self.month, self.day]))
 
 
-class Int64(object):
+class Int64:
 
     def setup(self):
         arr = np.random.randint(-1 << 12, 1 << 12, (1 << 17, 5))
@@ -167,7 +167,7 @@ class Int64(object):
         self.df.groupby(self.cols).max()
 
 
-class CountMultiDtype(object):
+class CountMultiDtype:
 
     def setup_cache(self):
         n = 10000
@@ -193,7 +193,7 @@ class CountMultiDtype(object):
         df.groupby(['key1', 'key2']).count()
 
 
-class CountMultiInt(object):
+class CountMultiInt:
 
     def setup_cache(self):
         n = 10000
@@ -210,7 +210,7 @@ class CountMultiInt(object):
         df.groupby(['key1', 'key2']).nunique()
 
 
-class AggFunctions(object):
+class AggFunctions:
 
     def setup_cache(self):
         N = 10**5
@@ -240,7 +240,7 @@ class AggFunctions(object):
         df.groupby('key1').agg([sum, min, max])
 
 
-class GroupStrings(object):
+class GroupStrings:
 
     def setup(self):
         n = 2 * 10**5
@@ -255,7 +255,7 @@ class GroupStrings(object):
         self.df.groupby(list('abcd')).max()
 
 
-class MultiColumn(object):
+class MultiColumn:
 
     def setup_cache(self):
         N = 10**5
@@ -282,7 +282,7 @@ class MultiColumn(object):
         df.groupby(['key1', 'key2'])['data1'].agg(np.sum)
 
 
-class Size(object):
+class Size:
 
     def setup(self):
         n = 10**5
@@ -309,7 +309,7 @@ class Size(object):
         self.draws.groupby(self.cats).size()
 
 
-class GroupByMethods(object):
+class GroupByMethods:
 
     param_names = ['dtype', 'method', 'application']
     params = [['int', 'float', 'object', 'datetime'],
@@ -359,7 +359,7 @@ class GroupByMethods(object):
         self.as_field_method()
 
 
-class RankWithTies(object):
+class RankWithTies:
     # GH 21237
     param_names = ['dtype', 'tie_method']
     params = [['float64', 'float32', 'int64', 'datetime64'],
@@ -377,7 +377,7 @@ class RankWithTies(object):
         self.df.groupby('key').rank(method=tie_method)
 
 
-class Float32(object):
+class Float32:
     # GH 13335
     def setup(self):
         tmp1 = (np.random.random(10000) * 0.1).astype(np.float32)
@@ -390,7 +390,7 @@ class Float32(object):
         self.df.groupby(['a'])['b'].sum()
 
 
-class Categories(object):
+class Categories:
 
     def setup(self):
         N = 10**5
@@ -426,7 +426,7 @@ class Categories(object):
         self.df_extra_cat.groupby('a', sort=False)['b'].count()
 
 
-class Datelike(object):
+class Datelike:
     # GH 14338
     params = ['period_range', 'date_range', 'date_range_tz']
     param_names = ['grouper']
@@ -443,7 +443,7 @@ class Datelike(object):
         self.df.groupby(self.grouper).sum()
 
 
-class SumBools(object):
+class SumBools:
     # GH 2692
     def setup(self):
         N = 500
@@ -454,7 +454,7 @@ class SumBools(object):
         self.df.groupby('ii').sum()
 
 
-class SumMultiLevel(object):
+class SumMultiLevel:
     # GH 9049
     timeout = 120.0
 
@@ -468,7 +468,7 @@ class SumMultiLevel(object):
         self.df.groupby(level=[0, 1]).sum()
 
 
-class Transform(object):
+class Transform:
 
     def setup(self):
         n1 = 400
@@ -514,7 +514,7 @@ class Transform(object):
         self.df4.groupby(['jim', 'joe'])['jolie'].transform('max')
 
 
-class TransformBools(object):
+class TransformBools:
 
     def setup(self):
         N = 120000
@@ -528,7 +528,7 @@ class TransformBools(object):
         self.df['signal'].groupby(self.g).transform(np.mean)
 
 
-class TransformNaN(object):
+class TransformNaN:
     # GH 12737
     def setup(self):
         self.df_nans = DataFrame({'key': np.repeat(np.arange(1000), 10),

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -4,7 +4,7 @@ from pandas import (Series, date_range, DatetimeIndex, Index, RangeIndex,
                     Float64Index)
 
 
-class SetOperations(object):
+class SetOperations:
 
     params = (['datetime', 'date_string', 'int', 'strings'],
               ['intersection', 'union', 'symmetric_difference'])
@@ -29,7 +29,7 @@ class SetOperations(object):
         getattr(self.left, method)(self.right)
 
 
-class SetDisjoint(object):
+class SetDisjoint:
 
     def setup(self):
         N = 10**5
@@ -41,7 +41,7 @@ class SetDisjoint(object):
         self.datetime_left.difference(self.datetime_right)
 
 
-class Datetime(object):
+class Datetime:
 
     def setup(self):
         self.dr = date_range('20000101', freq='D', periods=10000)
@@ -50,7 +50,7 @@ class Datetime(object):
         self.dr._is_dates_only
 
 
-class Ops(object):
+class Ops:
 
     sample_time = 0.2
     params = ['float', 'int']
@@ -77,7 +77,7 @@ class Ops(object):
         self.index % 2
 
 
-class Range(object):
+class Range:
 
     def setup(self):
         self.idx_inc = RangeIndex(start=0, stop=10**7, step=3)
@@ -96,7 +96,7 @@ class Range(object):
         self.idx_inc.min()
 
 
-class IndexAppend(object):
+class IndexAppend:
 
     def setup(self):
 
@@ -125,7 +125,7 @@ class IndexAppend(object):
         self.obj_idx.append(self.object_idxs)
 
 
-class Indexing(object):
+class Indexing:
 
     params = ['String', 'Float', 'Int']
     param_names = ['dtype']
@@ -170,7 +170,7 @@ class Indexing(object):
         self.non_unique_sorted.get_loc(self.key)
 
 
-class Float64IndexMethod(object):
+class Float64IndexMethod:
     # GH 13166
     def setup(self):
         N = 100000

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -8,7 +8,7 @@ from pandas import (Series, DataFrame, MultiIndex,
                     IndexSlice, concat, date_range)
 
 
-class NumericSeriesIndexing(object):
+class NumericSeriesIndexing:
 
     params = [
         (Int64Index, UInt64Index, Float64Index),
@@ -79,7 +79,7 @@ class NumericSeriesIndexing(object):
         self.data.loc[:800000]
 
 
-class NonNumericSeriesIndexing(object):
+class NonNumericSeriesIndexing:
 
     params = [
         ('string', 'datetime'),
@@ -114,7 +114,7 @@ class NonNumericSeriesIndexing(object):
         self.s[[self.lbl]]
 
 
-class DataFrameStringIndexing(object):
+class DataFrameStringIndexing:
 
     def setup(self):
         index = tm.makeStringIndex(1000)
@@ -146,7 +146,7 @@ class DataFrameStringIndexing(object):
         self.df[self.bool_obj_indexer]
 
 
-class DataFrameNumericIndexing(object):
+class DataFrameNumericIndexing:
 
     def setup(self):
         self.idx_dupe = np.array(range(30)) * 99
@@ -170,7 +170,7 @@ class DataFrameNumericIndexing(object):
         self.df[self.bool_indexer]
 
 
-class Take(object):
+class Take:
 
     params = ['int', 'datetime']
     param_names = ['index']
@@ -187,7 +187,7 @@ class Take(object):
         self.s.take(self.indexer)
 
 
-class MultiIndexing(object):
+class MultiIndexing:
 
     def setup(self):
         mi = MultiIndex.from_product([range(1000), range(1000)])
@@ -215,7 +215,7 @@ class MultiIndexing(object):
         self.mdt.loc[self.idx, :]
 
 
-class IntervalIndexing(object):
+class IntervalIndexing:
 
     def setup_cache(self):
         idx = IntervalIndex.from_breaks(np.arange(1000001))
@@ -235,7 +235,7 @@ class IntervalIndexing(object):
         monotonic.loc[80000:]
 
 
-class CategoricalIndexIndexing(object):
+class CategoricalIndexIndexing:
 
     params = ['monotonic_incr', 'monotonic_decr', 'non_monotonic']
     param_names = ['index']
@@ -277,7 +277,7 @@ class CategoricalIndexIndexing(object):
         self.data.get_indexer(self.cat_list)
 
 
-class MethodLookup(object):
+class MethodLookup:
 
     def setup_cache(self):
         s = Series()
@@ -293,7 +293,7 @@ class MethodLookup(object):
         s.loc
 
 
-class GetItemSingleColumn(object):
+class GetItemSingleColumn:
 
     def setup(self):
         self.df_string_col = DataFrame(np.random.randn(3000, 1), columns=['A'])
@@ -306,7 +306,7 @@ class GetItemSingleColumn(object):
         self.df_int_col[0]
 
 
-class AssignTimeseriesIndex(object):
+class AssignTimeseriesIndex:
 
     def setup(self):
         N = 100000
@@ -317,7 +317,7 @@ class AssignTimeseriesIndex(object):
         self.df['date'] = self.df.index
 
 
-class InsertColumns(object):
+class InsertColumns:
 
     def setup(self):
         self.N = 10**3

--- a/asv_bench/benchmarks/indexing_engines.py
+++ b/asv_bench/benchmarks/indexing_engines.py
@@ -16,7 +16,7 @@ def _get_numeric_engines():
             if hasattr(libindex, engine_name)]
 
 
-class NumericEngineIndexing(object):
+class NumericEngineIndexing:
 
     params = [_get_numeric_engines(),
               ['monotonic_incr', 'monotonic_decr', 'non_monotonic'],
@@ -42,7 +42,7 @@ class NumericEngineIndexing(object):
         self.data.get_loc(2)
 
 
-class ObjectEngineIndexing(object):
+class ObjectEngineIndexing:
 
     params = [('monotonic_incr', 'monotonic_decr', 'non_monotonic')]
     param_names = ['index_type']

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -5,7 +5,7 @@ from pandas import DataFrame, Series, to_numeric
 from .pandas_vb_common import numeric_dtypes, lib
 
 
-class NumericInferOps(object):
+class NumericInferOps:
     # from GH 7332
     params = numeric_dtypes
     param_names = ['dtype']
@@ -31,7 +31,7 @@ class NumericInferOps(object):
         self.df['A'] % self.df['B']
 
 
-class DateInferOps(object):
+class DateInferOps:
     # from GH 7332
     def setup_cache(self):
         N = 5 * 10**5
@@ -49,7 +49,7 @@ class DateInferOps(object):
         df['timedelta'] + df['timedelta']
 
 
-class ToNumeric(object):
+class ToNumeric:
 
     params = ['ignore', 'coerce']
     param_names = ['errors']
@@ -70,7 +70,7 @@ class ToNumeric(object):
         to_numeric(self.str, errors=errors)
 
 
-class ToNumericDowncast(object):
+class ToNumericDowncast:
 
     param_names = ['dtype', 'downcast']
     params = [['string-float', 'string-int', 'string-nint', 'datetime64',
@@ -95,7 +95,7 @@ class ToNumericDowncast(object):
         to_numeric(self.data, downcast=downcast)
 
 
-class MaybeConvertNumeric(object):
+class MaybeConvertNumeric:
 
     def setup_cache(self):
         N = 10**6

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -50,7 +50,7 @@ class ToCSVDatetime(BaseIO):
         self.data.to_csv(self.fname, date_format='%Y%m%d')
 
 
-class StringIORewind(object):
+class StringIORewind:
 
     def data(self, stringio_object):
         stringio_object.seek(0)

--- a/asv_bench/benchmarks/io/excel.py
+++ b/asv_bench/benchmarks/io/excel.py
@@ -4,7 +4,7 @@ from pandas import DataFrame, date_range, ExcelWriter, read_excel
 import pandas.util.testing as tm
 
 
-class Excel(object):
+class Excel:
 
     params = ['openpyxl', 'xlsxwriter', 'xlwt']
     param_names = ['engine']

--- a/asv_bench/benchmarks/io/sas.py
+++ b/asv_bench/benchmarks/io/sas.py
@@ -3,7 +3,7 @@ import os
 from pandas import read_sas
 
 
-class SAS(object):
+class SAS:
 
     params = ['sas7bdat', 'xport']
     param_names = ['format']

--- a/asv_bench/benchmarks/io/sql.py
+++ b/asv_bench/benchmarks/io/sql.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, date_range, read_sql_query, read_sql_table
 from sqlalchemy import create_engine
 
 
-class SQL(object):
+class SQL:
 
     params = ['sqlalchemy', 'sqlite']
     param_names = ['connection']
@@ -38,7 +38,7 @@ class SQL(object):
         read_sql_query(self.query_all, self.con)
 
 
-class WriteSQLDtypes(object):
+class WriteSQLDtypes:
 
     params = (['sqlalchemy', 'sqlite'],
               ['float', 'float_with_nan', 'string', 'bool', 'int', 'datetime'])
@@ -71,7 +71,7 @@ class WriteSQLDtypes(object):
         read_sql_query(self.query_col, self.con)
 
 
-class ReadSQLTable(object):
+class ReadSQLTable:
 
     def setup(self):
         N = 10000
@@ -98,7 +98,7 @@ class ReadSQLTable(object):
                        parse_dates=['datetime_string'])
 
 
-class ReadSQLTableDtypes(object):
+class ReadSQLTableDtypes:
 
     params = ['float', 'float_with_nan', 'string', 'bool', 'int', 'datetime']
     param_names = ['dtype']

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -11,7 +11,7 @@ except ImportError:
     from pandas import ordered_merge as merge_ordered
 
 
-class Append(object):
+class Append:
 
     def setup(self):
         self.df1 = DataFrame(np.random.randn(10000, 4),
@@ -33,7 +33,7 @@ class Append(object):
         self.mdf1.append(self.mdf2)
 
 
-class Concat(object):
+class Concat:
 
     params = [0, 1]
     param_names = ['axis']
@@ -65,7 +65,7 @@ class Concat(object):
         concat(self.mixed_ndims, axis=axis)
 
 
-class ConcatDataFrames(object):
+class ConcatDataFrames:
 
     params = ([0, 1], [True, False])
     param_names = ['axis', 'ignore_index']
@@ -85,7 +85,7 @@ class ConcatDataFrames(object):
         concat(self.frame_f, axis=axis, ignore_index=ignore_index)
 
 
-class Join(object):
+class Join:
 
     params = [True, False]
     param_names = ['sort']
@@ -132,7 +132,7 @@ class Join(object):
         self.df_shuf.join(self.df_key2, on='key2', sort=sort)
 
 
-class JoinIndex(object):
+class JoinIndex:
 
     def setup(self):
         N = 50000
@@ -145,7 +145,7 @@ class JoinIndex(object):
         self.left.join(self.right, on='jim')
 
 
-class JoinNonUnique(object):
+class JoinNonUnique:
     # outer join of non-unique
     # GH 6329
     def setup(self):
@@ -162,7 +162,7 @@ class JoinNonUnique(object):
         self.fracofday * self.temp
 
 
-class Merge(object):
+class Merge:
 
     params = [True, False]
     param_names = ['sort']
@@ -196,7 +196,7 @@ class Merge(object):
         merge(self.df, self.df2, on='key1', sort=sort)
 
 
-class I8Merge(object):
+class I8Merge:
 
     params = ['inner', 'outer', 'left', 'right']
     param_names = ['how']
@@ -214,7 +214,7 @@ class I8Merge(object):
         merge(self.left, self.right, how=how)
 
 
-class MergeCategoricals(object):
+class MergeCategoricals:
 
     def setup(self):
         self.left_object = DataFrame(
@@ -237,7 +237,7 @@ class MergeCategoricals(object):
         merge(self.left_cat, self.right_cat, on='X')
 
 
-class MergeOrdered(object):
+class MergeOrdered:
 
     def setup(self):
         groups = tm.makeStringIndex(10).values
@@ -251,7 +251,7 @@ class MergeOrdered(object):
         merge_ordered(self.left, self.right, on='key', left_by='group')
 
 
-class MergeAsof(object):
+class MergeAsof:
     params = [['backward', 'forward', 'nearest']]
     param_names = ['direction']
 
@@ -306,7 +306,7 @@ class MergeAsof(object):
                    direction=direction)
 
 
-class Align(object):
+class Align:
 
     def setup(self):
         size = 5 * 10**5

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -5,7 +5,7 @@ import pandas.util.testing as tm
 from pandas import date_range, MultiIndex
 
 
-class GetLoc(object):
+class GetLoc:
 
     def setup(self):
         self.mi_large = MultiIndex.from_product(
@@ -40,7 +40,7 @@ class GetLoc(object):
             self.mi_small.get_loc((99, 'A', 'A'))
 
 
-class Duplicates(object):
+class Duplicates:
 
     def setup(self):
         size = 65536
@@ -54,7 +54,7 @@ class Duplicates(object):
         self.mi_unused_levels.remove_unused_levels()
 
 
-class Integer(object):
+class Integer:
 
     def setup(self):
         self.mi_int = MultiIndex.from_product([np.arange(1000),
@@ -72,7 +72,7 @@ class Integer(object):
         self.mi_int.is_monotonic
 
 
-class Duplicated(object):
+class Duplicated:
 
     def setup(self):
         n, k = 200, 5000
@@ -86,7 +86,7 @@ class Duplicated(object):
         self.mi.duplicated()
 
 
-class Sortlevel(object):
+class Sortlevel:
 
     def setup(self):
         n = 1182720
@@ -110,7 +110,7 @@ class Sortlevel(object):
         self.mi.sortlevel(1)
 
 
-class Values(object):
+class Values:
 
     def setup_cache(self):
 

--- a/asv_bench/benchmarks/offset.py
+++ b/asv_bench/benchmarks/offset.py
@@ -32,7 +32,7 @@ other_offsets = [pd.offsets.YearEnd(), pd.offsets.YearBegin(),
 offsets = non_apply + other_offsets
 
 
-class ApplyIndex(object):
+class ApplyIndex:
 
     params = other_offsets
     param_names = ['offset']
@@ -45,7 +45,7 @@ class ApplyIndex(object):
         offset.apply_index(self.rng)
 
 
-class OnOffset(object):
+class OnOffset:
 
     params = offsets
     param_names = ['offset']
@@ -61,7 +61,7 @@ class OnOffset(object):
             offset.onOffset(date)
 
 
-class OffsetSeriesArithmetic(object):
+class OffsetSeriesArithmetic:
 
     params = offsets
     param_names = ['offset']
@@ -76,7 +76,7 @@ class OffsetSeriesArithmetic(object):
             self.data + offset
 
 
-class OffsetDatetimeIndexArithmetic(object):
+class OffsetDatetimeIndexArithmetic:
 
     params = offsets
     param_names = ['offset']
@@ -90,7 +90,7 @@ class OffsetDatetimeIndexArithmetic(object):
             self.data + offset
 
 
-class OffestDatetimeArithmetic(object):
+class OffestDatetimeArithmetic:
 
     params = offsets
     param_names = ['offset']

--- a/asv_bench/benchmarks/pandas_vb_common.py
+++ b/asv_bench/benchmarks/pandas_vb_common.py
@@ -36,7 +36,7 @@ def setup(*args, **kwargs):
     np.random.seed(1234)
 
 
-class BaseIO(object):
+class BaseIO:
     """
     Base class for IO benchmarks
     """

--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -3,7 +3,7 @@ from pandas import (
 from pandas.tseries.frequencies import to_offset
 
 
-class PeriodProperties(object):
+class PeriodProperties:
 
     params = (['M', 'min'],
               ['year', 'month', 'day', 'hour', 'minute', 'second',
@@ -18,7 +18,7 @@ class PeriodProperties(object):
         getattr(self.per, attr)
 
 
-class PeriodUnaryMethods(object):
+class PeriodUnaryMethods:
 
     params = ['M', 'min']
     param_names = ['freq']
@@ -36,7 +36,7 @@ class PeriodUnaryMethods(object):
         self.per.asfreq('A')
 
 
-class PeriodConstructor(object):
+class PeriodConstructor:
     params = [['D'], [True, False]]
     param_names = ['freq', 'is_offset']
 
@@ -50,7 +50,7 @@ class PeriodConstructor(object):
         Period('2012-06-01', freq=freq)
 
 
-class PeriodIndexConstructor(object):
+class PeriodIndexConstructor:
 
     params = [['D'], [True, False]]
     param_names = ['freq', 'is_offset']
@@ -79,7 +79,7 @@ class PeriodIndexConstructor(object):
         PeriodIndex(self.daily_ints, freq=freq)
 
 
-class DataFramePeriodColumn(object):
+class DataFramePeriodColumn:
 
     def setup(self):
         self.rng = period_range(start='1/1/1990', freq='S', periods=20000)
@@ -94,7 +94,7 @@ class DataFramePeriodColumn(object):
         self.df.set_index('col2', append=True)
 
 
-class Algorithms(object):
+class Algorithms:
 
     params = ['index', 'series']
     param_names = ['typ']
@@ -115,7 +115,7 @@ class Algorithms(object):
         self.vector.value_counts()
 
 
-class Indexing(object):
+class Indexing:
 
     def setup(self):
         self.index = period_range(start='1985', periods=1000, freq='D')

--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -8,7 +8,7 @@ import matplotlib
 matplotlib.use('Agg')
 
 
-class SeriesPlotting(object):
+class SeriesPlotting:
     params = [['line', 'bar', 'area', 'barh', 'hist', 'kde', 'pie']]
     param_names = ['kind']
 
@@ -28,7 +28,7 @@ class SeriesPlotting(object):
         self.s.plot(kind=kind)
 
 
-class FramePlotting(object):
+class FramePlotting:
     params = [['line', 'bar', 'area', 'barh', 'hist', 'kde', 'pie', 'scatter',
                'hexbin']]
     param_names = ['kind']
@@ -52,7 +52,7 @@ class FramePlotting(object):
         self.df.plot(x='x', y='y', kind=kind)
 
 
-class TimeseriesPlotting(object):
+class TimeseriesPlotting:
 
     def setup(self):
         N = 2000
@@ -78,7 +78,7 @@ class TimeseriesPlotting(object):
         self.df.plot(table=True)
 
 
-class Misc(object):
+class Misc:
 
     def setup(self):
         N = 500

--- a/asv_bench/benchmarks/reindex.py
+++ b/asv_bench/benchmarks/reindex.py
@@ -5,7 +5,7 @@ from pandas import (DataFrame, Series, MultiIndex, Index, date_range,
 from .pandas_vb_common import lib
 
 
-class Reindex(object):
+class Reindex:
 
     def setup(self):
         rng = date_range(start='1/1/1970', periods=10000, freq='1min')
@@ -33,7 +33,7 @@ class Reindex(object):
         self.s.reindex(self.s_subset.index)
 
 
-class ReindexMethod(object):
+class ReindexMethod:
 
     params = [['pad', 'backfill'], [date_range, period_range]]
     param_names = ['method', 'constructor']
@@ -47,7 +47,7 @@ class ReindexMethod(object):
         self.ts.reindex(self.idx, method=method)
 
 
-class Fillna(object):
+class Fillna:
 
     params = ['pad', 'backfill']
     param_names = ['method']
@@ -66,7 +66,7 @@ class Fillna(object):
         self.ts_float32.fillna(method=method)
 
 
-class LevelAlign(object):
+class LevelAlign:
 
     def setup(self):
         self.index = MultiIndex(
@@ -86,7 +86,7 @@ class LevelAlign(object):
         self.df_level.reindex(self.index, level=1)
 
 
-class DropDuplicates(object):
+class DropDuplicates:
 
     params = [True, False]
     param_names = ['inplace']
@@ -130,7 +130,7 @@ class DropDuplicates(object):
         self.df_bool.drop_duplicates(inplace=inplace)
 
 
-class Align(object):
+class Align:
     # blog "pandas escaped the zoo"
     def setup(self):
         n = 50000
@@ -145,7 +145,7 @@ class Align(object):
         self.x + self.y
 
 
-class LibFastZip(object):
+class LibFastZip:
 
     def setup(self):
         N = 10000

--- a/asv_bench/benchmarks/replace.py
+++ b/asv_bench/benchmarks/replace.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 
-class FillNa(object):
+class FillNa:
 
     params = [True, False]
     param_names = ['inplace']
@@ -21,7 +21,7 @@ class FillNa(object):
         self.ts.replace(np.nan, 0.0, inplace=inplace)
 
 
-class ReplaceDict(object):
+class ReplaceDict:
 
     params = [True, False]
     param_names = ['inplace']
@@ -36,7 +36,7 @@ class ReplaceDict(object):
         self.s.replace(self.to_rep, inplace=inplace)
 
 
-class Convert(object):
+class Convert:
 
     params = (['DataFrame', 'Series'], ['Timestamp', 'Timedelta'])
     param_names = ['constructor', 'replace_data']

--- a/asv_bench/benchmarks/reshape.py
+++ b/asv_bench/benchmarks/reshape.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, MultiIndex, date_range, melt, wide_to_long
 import pandas as pd
 
 
-class Melt(object):
+class Melt:
 
     def setup(self):
         self.df = DataFrame(np.random.randn(10000, 3), columns=['A', 'B', 'C'])
@@ -17,7 +17,7 @@ class Melt(object):
         melt(self.df, id_vars=['id1', 'id2'])
 
 
-class Pivot(object):
+class Pivot:
 
     def setup(self):
         N = 10000
@@ -31,7 +31,7 @@ class Pivot(object):
         self.df.pivot('date', 'variable', 'value')
 
 
-class SimpleReshape(object):
+class SimpleReshape:
 
     def setup(self):
         arrays = [np.arange(100).repeat(100),
@@ -47,7 +47,7 @@ class SimpleReshape(object):
         self.df.unstack(1)
 
 
-class Unstack(object):
+class Unstack:
 
     params = ['int', 'category']
 
@@ -79,7 +79,7 @@ class Unstack(object):
         self.df2.unstack()
 
 
-class SparseIndex(object):
+class SparseIndex:
 
     def setup(self):
         NUM_ROWS = 1000
@@ -95,7 +95,7 @@ class SparseIndex(object):
         self.df.unstack()
 
 
-class WideToLong(object):
+class WideToLong:
 
     def setup(self):
         nyrs = 20
@@ -113,7 +113,7 @@ class WideToLong(object):
         wide_to_long(self.df, self.letters, i='id', j='year')
 
 
-class PivotTable(object):
+class PivotTable:
 
     def setup(self):
         N = 100000
@@ -140,7 +140,7 @@ class PivotTable(object):
                             margins=True)
 
 
-class Crosstab(object):
+class Crosstab:
 
     def setup(self):
         N = 100000
@@ -164,7 +164,7 @@ class Crosstab(object):
         pd.crosstab(self.vec1, self.vec2, normalize=True, margins=True)
 
 
-class GetDummies(object):
+class GetDummies:
     def setup(self):
         categories = list(string.ascii_letters[:12])
         s = pd.Series(np.random.choice(categories, size=1000000),
@@ -178,7 +178,7 @@ class GetDummies(object):
         pd.get_dummies(self.s, sparse=True)
 
 
-class Cut(object):
+class Cut:
     params = [[4, 10, 1000]]
     param_names = ['bins']
 

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 
 
-class Methods(object):
+class Methods:
 
     sample_time = 0.2
     params = (['DataFrame', 'Series'],
@@ -21,7 +21,7 @@ class Methods(object):
         getattr(self.roll, method)()
 
 
-class ExpandingMethods(object):
+class ExpandingMethods:
 
     sample_time = 0.2
     params = (['DataFrame', 'Series'],
@@ -39,7 +39,7 @@ class ExpandingMethods(object):
         getattr(self.expanding, method)()
 
 
-class EWMMethods(object):
+class EWMMethods:
 
     sample_time = 0.2
     params = (['DataFrame', 'Series'],
@@ -73,7 +73,7 @@ class VariableWindowMethods(Methods):
         self.roll = getattr(pd, constructor)(arr, index=index).rolling(window)
 
 
-class Pairwise(object):
+class Pairwise:
 
     sample_time = 0.2
     params = ([10, 1000, None],
@@ -94,7 +94,7 @@ class Pairwise(object):
         getattr(r, method)(self.df, pairwise=pairwise)
 
 
-class Quantile(object):
+class Quantile:
     sample_time = 0.2
     params = (['DataFrame', 'Series'],
               [10, 1000],
@@ -113,7 +113,7 @@ class Quantile(object):
         self.roll.quantile(percentile, interpolation=interpolation)
 
 
-class PeakMemFixed(object):
+class PeakMemFixed:
 
     def setup(self):
         N = 10

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -5,7 +5,7 @@ import pandas.util.testing as tm
 from pandas import Series, date_range, NaT
 
 
-class SeriesConstructor(object):
+class SeriesConstructor:
 
     params = [None, 'dict']
     param_names = ['data']
@@ -21,7 +21,7 @@ class SeriesConstructor(object):
         Series(data=self.data, index=self.idx)
 
 
-class IsIn(object):
+class IsIn:
 
     params = ['int64', 'uint64', 'object']
     param_names = ['dtype']
@@ -34,7 +34,7 @@ class IsIn(object):
         self.s.isin(self.values)
 
 
-class IsInFloat64(object):
+class IsInFloat64:
 
     def setup(self):
         self.small = Series([1, 2], dtype=np.float64)
@@ -55,7 +55,7 @@ class IsInFloat64(object):
         self.small.isin(self.few_different_values)
 
 
-class IsInForObjects(object):
+class IsInForObjects:
 
     def setup(self):
         self.s_nans = Series(np.full(10**4, np.nan)).astype(np.object)
@@ -92,7 +92,7 @@ class IsInForObjects(object):
         self.s_long_floats.isin(self.vals_long_floats)
 
 
-class NSort(object):
+class NSort:
 
     params = ['first', 'last', 'all']
     param_names = ['keep']
@@ -107,7 +107,7 @@ class NSort(object):
         self.s.nsmallest(3, keep=keep)
 
 
-class Dropna(object):
+class Dropna:
 
     params = ['int', 'datetime']
     param_names = ['dtype']
@@ -124,7 +124,7 @@ class Dropna(object):
         self.s.dropna()
 
 
-class SearchSorted(object):
+class SearchSorted:
 
     goal_time = 0.2
     params = ['int8', 'int16', 'int32', 'int64',
@@ -143,7 +143,7 @@ class SearchSorted(object):
         self.s.searchsorted(key)
 
 
-class Map(object):
+class Map:
 
     params = ['dict', 'Series']
     param_names = 'mapper'
@@ -158,7 +158,7 @@ class Map(object):
         self.s.map(self.map_data)
 
 
-class Clip(object):
+class Clip:
     params = [50, 1000, 10**5]
     param_names = ['n']
 
@@ -169,7 +169,7 @@ class Clip(object):
         self.s.clip(0, 1)
 
 
-class ValueCounts(object):
+class ValueCounts:
 
     params = ['int', 'uint', 'float', 'object']
     param_names = ['dtype']
@@ -181,7 +181,7 @@ class ValueCounts(object):
         self.s.value_counts()
 
 
-class Dir(object):
+class Dir:
 
     def setup(self):
         self.s = Series(index=tm.makeStringIndex(10000))
@@ -190,7 +190,7 @@ class Dir(object):
         dir(self.s)
 
 
-class SeriesGetattr(object):
+class SeriesGetattr:
     # https://github.com/pandas-dev/pandas/issues/19764
     def setup(self):
         self.s = Series(1,

--- a/asv_bench/benchmarks/sparse.py
+++ b/asv_bench/benchmarks/sparse.py
@@ -14,7 +14,7 @@ def make_array(size, dense_proportion, fill_value, dtype):
     return arr
 
 
-class SparseSeriesToFrame(object):
+class SparseSeriesToFrame:
 
     def setup(self):
         K = 50
@@ -31,7 +31,7 @@ class SparseSeriesToFrame(object):
         SparseDataFrame(self.series)
 
 
-class SparseArrayConstructor(object):
+class SparseArrayConstructor:
 
     params = ([0.1, 0.01], [0, np.nan],
               [np.int64, np.float64, np.object])
@@ -45,7 +45,7 @@ class SparseArrayConstructor(object):
         SparseArray(self.array, fill_value=fill_value, dtype=dtype)
 
 
-class SparseDataFrameConstructor(object):
+class SparseDataFrameConstructor:
 
     def setup(self):
         N = 1000
@@ -63,7 +63,7 @@ class SparseDataFrameConstructor(object):
         SparseDataFrame(self.dict)
 
 
-class FromCoo(object):
+class FromCoo:
 
     def setup(self):
         self.matrix = scipy.sparse.coo_matrix(([3.0, 1.0, 2.0],
@@ -74,7 +74,7 @@ class FromCoo(object):
         SparseSeries.from_coo(self.matrix)
 
 
-class ToCoo(object):
+class ToCoo:
 
     def setup(self):
         s = Series([np.nan] * 10000)
@@ -90,7 +90,7 @@ class ToCoo(object):
                        sort_labels=True)
 
 
-class Arithmetic(object):
+class Arithmetic:
 
     params = ([0.1, 0.01], [0, np.nan])
     param_names = ['dense_proportion', 'fill_value']
@@ -115,7 +115,7 @@ class Arithmetic(object):
         self.array1 / self.array2
 
 
-class ArithmeticBlock(object):
+class ArithmeticBlock:
 
     params = [np.nan, 0]
     param_names = ['fill_value']

--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -6,7 +6,7 @@ ops = ['mean', 'sum', 'median', 'std', 'skew', 'kurt', 'mad', 'prod', 'sem',
        'var']
 
 
-class FrameOps(object):
+class FrameOps:
 
     params = [ops, ['float', 'int'], [0, 1], [True, False]]
     param_names = ['op', 'dtype', 'axis', 'use_bottleneck']
@@ -24,7 +24,7 @@ class FrameOps(object):
         self.df_func(axis=axis)
 
 
-class FrameMultiIndexOps(object):
+class FrameMultiIndexOps:
 
     params = ([0, 1, [0, 1]], ops)
     param_names = ['level', 'op']
@@ -42,7 +42,7 @@ class FrameMultiIndexOps(object):
         self.df_func(level=level)
 
 
-class SeriesOps(object):
+class SeriesOps:
 
     params = [ops, ['float', 'int'], [True, False]]
     param_names = ['op', 'dtype', 'use_bottleneck']
@@ -60,7 +60,7 @@ class SeriesOps(object):
         self.s_func()
 
 
-class SeriesMultiIndexOps(object):
+class SeriesMultiIndexOps:
 
     params = ([0, 1, [0, 1]], ops)
     param_names = ['level', 'op']
@@ -78,7 +78,7 @@ class SeriesMultiIndexOps(object):
         self.s_func(level=level)
 
 
-class Rank(object):
+class Rank:
 
     params = [['DataFrame', 'Series'], [True, False]]
     param_names = ['constructor', 'pct']
@@ -94,7 +94,7 @@ class Rank(object):
         self.data.rank(pct=pct) / len(self.data)
 
 
-class Correlation(object):
+class Correlation:
 
     params = [['spearman', 'kendall', 'pearson'], [True, False]]
     param_names = ['method', 'use_bottleneck']
@@ -123,7 +123,7 @@ class Correlation(object):
         self.df.corrwith(self.df2, axis=1, method=method)
 
 
-class Covariance(object):
+class Covariance:
 
     params = [[True, False]]
     param_names = ['use_bottleneck']

--- a/asv_bench/benchmarks/strings.py
+++ b/asv_bench/benchmarks/strings.py
@@ -5,7 +5,7 @@ from pandas import Series, DataFrame
 import pandas.util.testing as tm
 
 
-class Methods(object):
+class Methods:
 
     def setup(self):
         self.s = Series(tm.makeStringIndex(10**5))
@@ -93,7 +93,7 @@ class Methods(object):
         self.s.str.zfill(10)
 
 
-class Repeat(object):
+class Repeat:
 
     params = ['int', 'array']
     param_names = ['repeats']
@@ -108,7 +108,7 @@ class Repeat(object):
         self.s.str.repeat(self.values)
 
 
-class Cat(object):
+class Cat:
 
     params = ([0, 3], [None, ','], [None, '-'], [0.0, 0.001, 0.15])
     param_names = ['other_cols', 'sep', 'na_rep', 'na_frac']
@@ -133,7 +133,7 @@ class Cat(object):
         self.s.str.cat(others=self.others, sep=sep, na_rep=na_rep)
 
 
-class Contains(object):
+class Contains:
 
     params = [True, False]
     param_names = ['regex']
@@ -145,7 +145,7 @@ class Contains(object):
         self.s.str.contains('A', regex=regex)
 
 
-class Split(object):
+class Split:
 
     params = [True, False]
     param_names = ['expand']
@@ -160,7 +160,7 @@ class Split(object):
         self.s.str.rsplit('--', expand=expand)
 
 
-class Dummies(object):
+class Dummies:
 
     def setup(self):
         self.s = Series(tm.makeStringIndex(10**5)).str.join('|')
@@ -169,7 +169,7 @@ class Dummies(object):
         self.s.str.get_dummies('|')
 
 
-class Encode(object):
+class Encode:
 
     def setup(self):
         self.ser = Series(tm.makeUnicodeIndex())
@@ -178,7 +178,7 @@ class Encode(object):
         self.ser.str.encode('utf-8').str.decode('utf-8')
 
 
-class Slice(object):
+class Slice:
 
     def setup(self):
         self.s = Series(['abcdefg', np.nan] * 500000)

--- a/asv_bench/benchmarks/timedelta.py
+++ b/asv_bench/benchmarks/timedelta.py
@@ -6,7 +6,7 @@ from pandas import (
     DataFrame, Series, Timedelta, Timestamp, timedelta_range, to_timedelta)
 
 
-class TimedeltaConstructor(object):
+class TimedeltaConstructor:
 
     def time_from_int(self):
         Timedelta(123456789)
@@ -34,7 +34,7 @@ class TimedeltaConstructor(object):
         Timedelta('nat')
 
 
-class ToTimedelta(object):
+class ToTimedelta:
 
     def setup(self):
         self.ints = np.random.randint(0, 60, size=10000)
@@ -54,7 +54,7 @@ class ToTimedelta(object):
         to_timedelta(self.str_seconds)
 
 
-class ToTimedeltaErrors(object):
+class ToTimedeltaErrors:
 
     params = ['coerce', 'ignore']
     param_names = ['errors']
@@ -68,7 +68,7 @@ class ToTimedeltaErrors(object):
         to_timedelta(self.arr, errors=errors)
 
 
-class TimedeltaOps(object):
+class TimedeltaOps:
 
     def setup(self):
         self.td = to_timedelta(np.arange(1000000))
@@ -78,7 +78,7 @@ class TimedeltaOps(object):
         self.td + self.ts
 
 
-class TimedeltaProperties(object):
+class TimedeltaProperties:
 
     def setup_cache(self):
         td = Timedelta(days=365, minutes=35, seconds=25, milliseconds=35)
@@ -97,7 +97,7 @@ class TimedeltaProperties(object):
         td.nanoseconds
 
 
-class DatetimeAccessor(object):
+class DatetimeAccessor:
 
     def setup_cache(self):
         N = 100000
@@ -120,7 +120,7 @@ class DatetimeAccessor(object):
         series.dt.nanoseconds
 
 
-class TimedeltaIndexing(object):
+class TimedeltaIndexing:
 
     def setup(self):
         self.index = timedelta_range(start='1985', periods=1000, freq='D')

--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -10,7 +10,7 @@ except ImportError:
     from pandas.tseries.converter import DatetimeConverter
 
 
-class DatetimeIndex(object):
+class DatetimeIndex:
 
     params = ['dst', 'repeated', 'tz_aware', 'tz_local', 'tz_naive']
     param_names = ['index_type']
@@ -60,7 +60,7 @@ class DatetimeIndex(object):
         self.index.to_pydatetime()
 
 
-class TzLocalize(object):
+class TzLocalize:
 
     params = [None, 'US/Eastern', 'UTC', dateutil.tz.tzutc()]
     param_names = 'tz'
@@ -80,7 +80,7 @@ class TzLocalize(object):
         self.index.tz_localize(tz, ambiguous='infer')
 
 
-class ResetIndex(object):
+class ResetIndex:
 
     params = [None, 'US/Eastern']
     param_names = 'tz'
@@ -93,7 +93,7 @@ class ResetIndex(object):
         self.df.reset_index()
 
 
-class Factorize(object):
+class Factorize:
 
     params = [None, 'Asia/Tokyo']
     param_names = 'tz'
@@ -107,7 +107,7 @@ class Factorize(object):
         self.dti.factorize()
 
 
-class InferFreq(object):
+class InferFreq:
 
     params = [None, 'D', 'B']
     param_names = ['freq']
@@ -123,7 +123,7 @@ class InferFreq(object):
         infer_freq(self.idx)
 
 
-class TimeDatetimeConverter(object):
+class TimeDatetimeConverter:
 
     def setup(self):
         N = 100000
@@ -133,7 +133,7 @@ class TimeDatetimeConverter(object):
         DatetimeConverter.convert(self.rng, None, None)
 
 
-class Iteration(object):
+class Iteration:
 
     params = [date_range, period_range]
     param_names = ['time_index']
@@ -153,7 +153,7 @@ class Iteration(object):
                 break
 
 
-class ResampleDataFrame(object):
+class ResampleDataFrame:
 
     params = ['max', 'mean', 'min']
     param_names = ['method']
@@ -167,7 +167,7 @@ class ResampleDataFrame(object):
         self.resample()
 
 
-class ResampleSeries(object):
+class ResampleSeries:
 
     params = (['period', 'datetime'], ['5min', '1D'], ['mean', 'ohlc'])
     param_names = ['index', 'freq', 'method']
@@ -187,7 +187,7 @@ class ResampleSeries(object):
         self.resample()
 
 
-class ResampleDatetetime64(object):
+class ResampleDatetetime64:
     # GH 7754
     def setup(self):
         rng3 = date_range(start='2000-01-01 00:00:00',
@@ -198,7 +198,7 @@ class ResampleDatetetime64(object):
         self.dt_ts.resample('1S').last()
 
 
-class AsOf(object):
+class AsOf:
 
     params = ['DataFrame', 'Series']
     param_names = ['constructor']
@@ -245,7 +245,7 @@ class AsOf(object):
         self.ts3.asof(self.date_last)
 
 
-class SortIndex(object):
+class SortIndex:
 
     params = [True, False]
     param_names = ['monotonic']
@@ -264,7 +264,7 @@ class SortIndex(object):
         self.s[:10000]
 
 
-class IrregularOps(object):
+class IrregularOps:
 
     def setup(self):
         N = 10**5
@@ -277,7 +277,7 @@ class IrregularOps(object):
         self.left + self.right
 
 
-class Lookup(object):
+class Lookup:
 
     def setup(self):
         N = 1500000
@@ -290,7 +290,7 @@ class Lookup(object):
         self.ts.index._cleanup()
 
 
-class ToDatetimeYYYYMMDD(object):
+class ToDatetimeYYYYMMDD:
 
     def setup(self):
         rng = date_range(start='1/1/2000', periods=10000, freq='D')
@@ -300,7 +300,7 @@ class ToDatetimeYYYYMMDD(object):
         to_datetime(self.stringsD, format='%Y%m%d')
 
 
-class ToDatetimeISO8601(object):
+class ToDatetimeISO8601:
 
     def setup(self):
         rng = date_range(start='1/1/2000', periods=20000, freq='H')
@@ -325,7 +325,7 @@ class ToDatetimeISO8601(object):
         to_datetime(self.strings_tz_space)
 
 
-class ToDatetimeNONISO8601(object):
+class ToDatetimeNONISO8601:
 
     def setup(self):
         N = 10000
@@ -342,7 +342,7 @@ class ToDatetimeNONISO8601(object):
         to_datetime(self.diff_offset)
 
 
-class ToDatetimeFormatQuarters(object):
+class ToDatetimeFormatQuarters:
 
     def setup(self):
         self.s = Series(['2Q2005', '2Q05', '2005Q1', '05Q1'] * 10000)
@@ -351,7 +351,7 @@ class ToDatetimeFormatQuarters(object):
         to_datetime(self.s)
 
 
-class ToDatetimeFormat(object):
+class ToDatetimeFormat:
 
     def setup(self):
         self.s = Series(['19MAY11', '19MAY11:00:00:00'] * 100000)
@@ -364,7 +364,7 @@ class ToDatetimeFormat(object):
         to_datetime(self.s, format='%d%b%y', exact=False)
 
 
-class ToDatetimeCache(object):
+class ToDatetimeCache:
 
     params = [True, False]
     param_names = ['cache']
@@ -392,7 +392,7 @@ class ToDatetimeCache(object):
         to_datetime(self.dup_string_with_tz, cache=cache)
 
 
-class DatetimeAccessor(object):
+class DatetimeAccessor:
 
     params = [None, 'US/Eastern', 'UTC', dateutil.tz.tzutc()]
     param_names = 'tz'

--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -6,7 +6,7 @@ import pytz
 from pandas import Timestamp
 
 
-class TimestampConstruction(object):
+class TimestampConstruction:
 
     def time_parse_iso8601_no_tz(self):
         Timestamp('2017-08-25 08:16:14')
@@ -30,7 +30,7 @@ class TimestampConstruction(object):
         Timestamp.fromtimestamp(1515448538)
 
 
-class TimestampProperties(object):
+class TimestampProperties:
     _tzs = [None, pytz.timezone('Europe/Amsterdam'), pytz.UTC,
             dateutil.tz.tzutc()]
     _freqs = [None, 'B']
@@ -92,7 +92,7 @@ class TimestampProperties(object):
         self.ts.month_name()
 
 
-class TimestampOps(object):
+class TimestampOps:
     params = [None, 'US/Eastern', pytz.UTC,
               dateutil.tz.tzutc()]
     param_names = ['tz']
@@ -130,7 +130,7 @@ class TimestampOps(object):
         self.ts.ceil('5T')
 
 
-class TimestampAcrossDst(object):
+class TimestampAcrossDst:
     def setup(self):
         dt = datetime.datetime(2016, 3, 27, 1)
         self.tzinfo = pytz.timezone('CET').localize(dt, is_dst=False).tzinfo

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -140,10 +140,6 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -R --include="*.py" --include="*.pyx" -E "(DEPRECATED|DEPRECATE|Deprecated)(:|,|\.)" pandas
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
-    MSG='Check for old-style classes' ; echo $MSG
-    invgrep -R --include="*.py" -E "class\s\S*[^)]:" pandas scripts
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
     MSG='Check for backticks incorrectly rendering because of missing spaces' ; echo $MSG
     invgrep -R --include="*.rst" -E "[a-zA-Z0-9]\`\`?[a-zA-Z0-9]" doc/source/
     RET=$(($RET + $?)) ; echo $MSG "DONE"

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -140,6 +140,10 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -R --include="*.py" --include="*.pyx" -E "(DEPRECATED|DEPRECATE|Deprecated)(:|,|\.)" pandas
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
+    MSG='Check for python2 new-style classes' ; echo $MSG
+    invgrep -R --include="*.py" -E "class\s\S*\(object\):" pandas scripts
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
+
     MSG='Check for backticks incorrectly rendering because of missing spaces' ; echo $MSG
     invgrep -R --include="*.rst" -E "[a-zA-Z0-9]\`\`?[a-zA-Z0-9]" doc/source/
     RET=$(($RET + $?)) ; echo $MSG "DONE"

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -773,7 +773,7 @@ Transitioning to ``pytest``
 
 .. code-block:: python
 
-    class TestReallyCoolFeature(object):
+    class TestReallyCoolFeature:
         pass
 
 Going forward, we are moving to a more *functional* style using the `pytest <http://docs.pytest.org/en/latest/>`__ framework, which offers a richer testing

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -26,7 +26,7 @@ decorate a class, providing the name of attribute to add. The class's
 .. code-block:: python
 
    @pd.api.extensions.register_dataframe_accessor("geo")
-   class GeoAccessor(object):
+   class GeoAccessor:
        def __init__(self, pandas_obj):
            self._validate(pandas_obj)
            self._obj = pandas_obj

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -177,7 +177,7 @@ def get_default_val(pat):
     return _get_registered_option(key).defval
 
 
-class DictWrapper(object):
+class DictWrapper:
     """ provide attribute-style access to a nested dict"""
 
     def __init__(self, d, prefix=""):
@@ -222,7 +222,7 @@ class DictWrapper(object):
 # of options, and option descriptions.
 
 
-class CallableDynamicDoc(object):
+class CallableDynamicDoc:
 
     def __init__(self, func, doc_tmpl):
         self.__doc_tmpl__ = doc_tmpl
@@ -379,7 +379,7 @@ options = DictWrapper(_global_config)
 # Functions for use by pandas developers, in addition to User - api
 
 
-class option_context(object):
+class option_context:
     """
     Context manager to temporarily set options in the `with` statement context.
 

--- a/pandas/_version.py
+++ b/pandas/_version.py
@@ -26,7 +26,7 @@ def get_keywords():
     return keywords
 
 
-class VersioneerConfig(object):
+class VersioneerConfig:
     pass
 
 

--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -27,7 +27,7 @@ from pandas.util._validators import (
     validate_args, validate_args_and_kwargs, validate_kwargs)
 
 
-class CompatValidator(object):
+class CompatValidator:
 
     def __init__(self, defaults, fname=None, method=None,
                  max_fname_arg_count=None):

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -10,7 +10,7 @@ import warnings
 from pandas.util._decorators import Appender
 
 
-class DirNamesMixin(object):
+class DirNamesMixin:
     _accessors = frozenset()
     _deprecations = frozenset(
         ['asobject', 'base', 'data', 'flags', 'itemsize', 'strides'])
@@ -44,7 +44,7 @@ class DirNamesMixin(object):
         return sorted(rv)
 
 
-class PandasDelegate(object):
+class PandasDelegate:
     """
     An abstract base class for delegating methods/properties.
     """
@@ -151,7 +151,7 @@ def delegate_names(delegate, accessors, typ, overwrite=False):
 # 1. We don't need to catch and re-raise AttributeErrors as RuntimeErrors
 # 2. We use a UserWarning instead of a custom Warning
 
-class CachedAccessor(object):
+class CachedAccessor:
     """
     Custom property-like object (descriptor) for caching accessors.
 
@@ -235,7 +235,7 @@ In your library code::
     import pandas as pd
 
     @pd.api.extensions.register_dataframe_accessor("geo")
-    class GeoAccessor(object):
+    class GeoAccessor:
         def __init__(self, pandas_obj):
             self._obj = pandas_obj
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1047,7 +1047,7 @@ def quantile(x, q, interpolation_method='fraction'):
 # select n        #
 # --------------- #
 
-class SelectN(object):
+class SelectN:
 
     def __init__(self, obj, n, keep):
         self.obj = obj

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -48,7 +48,7 @@ from pandas.core.tools.timedeltas import to_timedelta
 
 
 # Deprecation: xref gh-16747
-class TimeGrouper(object):
+class TimeGrouper:
 
     def __new__(cls, *args, **kwargs):
         from pandas.core.resample import TimeGrouper

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -31,7 +31,7 @@ def frame_apply(obj, func, axis=0, broadcast=None,
                  args=args, kwds=kwds)
 
 
-class FrameApply(object):
+class FrameApply:
 
     def __init__(self, obj, func, broadcast, raw, reduce, result_type,
                  ignore_failures, args, kwds):

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -29,7 +29,7 @@ _not_implemented_message = "{} does not implement {}."
 _extension_array_shared_docs = dict()
 
 
-class ExtensionArray(object):
+class ExtensionArray:
     """
     Abstract base class for custom 1-D array types.
 
@@ -964,7 +964,7 @@ class ExtensionArray(object):
             name=name, dtype=self.dtype))
 
 
-class ExtensionOpsMixin(object):
+class ExtensionOpsMixin:
     """
     A base class for linking the operators to their dunder names.
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -39,7 +39,7 @@ from pandas.tseries.offsets import DateOffset, Tick
 from .base import ExtensionArray, ExtensionOpsMixin
 
 
-class AttributesMixin(object):
+class AttributesMixin:
 
     @property
     def _attributes(self):
@@ -135,7 +135,7 @@ class AttributesMixin(object):
         raise AbstractMethodError(self)
 
 
-class DatelikeOps(object):
+class DatelikeOps:
     """
     Common ops for DatetimeIndex/PeriodIndex, but not TimedeltaIndex.
     """
@@ -181,7 +181,7 @@ class DatelikeOps(object):
         return Index(self._format_native_types(date_format=date_format))
 
 
-class TimelikeOps(object):
+class TimelikeOps:
     """
     Common ops for TimedeltaIndex/DatetimeIndex, but not PeriodIndex.
     """

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -32,7 +32,7 @@ _indexops_doc_kwargs = dict(klass='IndexOpsMixin', inplace='',
                             unique='IndexOpsMixin', duplicated='IndexOpsMixin')
 
 
-class StringMixin(object):
+class StringMixin:
     """
     Implements string methods so long as object defines a `__unicode__` method.
     """
@@ -110,7 +110,7 @@ class PandasObject(StringMixin, DirNamesMixin):
         return super(PandasObject, self).__sizeof__()
 
 
-class NoNewAttributesMixin(object):
+class NoNewAttributesMixin:
     """Mixin which prevents adding new attributes.
 
     Prevents additional attributes via xxx.attribute = "something" after a
@@ -153,7 +153,7 @@ class SpecificationError(GroupByError):
     pass
 
 
-class SelectionMixin(object):
+class SelectionMixin:
     """
     mixin implementing the selection & aggregation interface on a group-like
     object sub-classes need to define: obj, exclusions
@@ -645,7 +645,7 @@ class SelectionMixin(object):
         return self._builtin_table.get(arg, arg)
 
 
-class IndexOpsMixin(object):
+class IndexOpsMixin:
     """ common ops mixin to support a unified interface / docs for Series /
     Index
     """

--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -35,7 +35,7 @@ def _check_ne_builtin_clash(expr):
                                      .format(expr=expr, s=s))
 
 
-class AbstractEngine(object):
+class AbstractEngine:
 
     """Object serving as a base class for all engines."""
 

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -541,7 +541,7 @@ class MathCall(Op):
         return pprint_thing('{0}({1})'.format(self.op, ','.join(operands)))
 
 
-class FuncNode(object):
+class FuncNode:
     def __init__(self, name):
         from pandas.core.computation.check import (_NUMEXPR_INSTALLED,
                                                    _NUMEXPR_VERSION)

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -572,7 +572,7 @@ class Expr(expr.Expr):
         return self.condition, self.filter
 
 
-class TermValue(object):
+class TermValue:
 
     """ hold a term value the we use to construct a condition/filter """
 

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -8,7 +8,7 @@ from pandas.errors import AbstractMethodError
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 
 
-class _DtypeOpsMixin(object):
+class _DtypeOpsMixin:
     # Not all of pandas' extension dtypes are compatibile with
     # the new ExtensionArray interface. This means PandasExtensionDtype
     # can't subclass ExtensionDtype yet, as is_extension_array_dtype would

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -39,7 +39,7 @@ def register_extension_dtype(cls):
     return cls
 
 
-class Registry(object):
+class Registry:
     """
     Registry for dtype inference
 

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -11,7 +11,7 @@ from pandas.util._decorators import make_signature
 from pandas.core.dtypes.common import is_list_like, is_scalar
 
 
-class GroupByMixin(object):
+class GroupByMixin:
     """
     Provide the groupby facilities to the mixed object.
     """

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -25,7 +25,7 @@ from pandas.core.series import Series
 from pandas.io.formats.printing import pprint_thing
 
 
-class Grouper(object):
+class Grouper:
     """
     A Grouper allows the user to specify a groupby instruction for a target
     object
@@ -204,7 +204,7 @@ class Grouper(object):
         return "{}({})".format(cls_name, attrs)
 
 
-class Grouping(object):
+class Grouping:
 
     """
     Holds the grouping information for a single key

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -87,7 +87,7 @@ def generate_bins_generic(values, binner, closed):
     return bins
 
 
-class BaseGrouper(object):
+class BaseGrouper:
     """
     This is an internal Grouper class, which actually holds
     the generated groups
@@ -808,7 +808,7 @@ def _is_indexed_like(obj, axes):
 # Splitting / application
 
 
-class DataSplitter(object):
+class DataSplitter:
 
     def __init__(self, data, labels, ngroups, axis=0):
         self.data = data

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -35,7 +35,7 @@ _NS = slice(None, None)
 
 
 # the public IndexSlicerMaker
-class _IndexSlice(object):
+class _IndexSlice:
     """
     Create an object to more easily perform multi-index slicing
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1519,7 +1519,7 @@ class Block(PandasObject):
         return self
 
 
-class NonConsolidatableMixIn(object):
+class NonConsolidatableMixIn:
     """ hold methods for the nonconsolidatable blocks """
     _can_consolidate = False
     _verify_integrity = False
@@ -2033,7 +2033,7 @@ class IntBlock(NumericBlock):
         return is_integer_dtype(value) and value.dtype == self.dtype
 
 
-class DatetimeLikeBlockMixin(object):
+class DatetimeLikeBlockMixin:
     """Mixin class for DatetimeBlock, DatetimeTZBlock, and TimedeltaBlock."""
 
     @property

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -99,7 +99,7 @@ def get_mgr_concatenation_plan(mgr, indexers):
     return plan
 
 
-class JoinUnit(object):
+class JoinUnit:
 
     def __init__(self, block, shape, indexers=None):
         # Passing shape explicitly is required for cases when block is None.

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -54,7 +54,7 @@ def set_use_bottleneck(v=True):
 set_use_bottleneck(get_option('compute.use_bottleneck'))
 
 
-class disallow(object):
+class disallow:
 
     def __init__(self, *dtypes):
         super(disallow, self).__init__()
@@ -86,7 +86,7 @@ class disallow(object):
         return _f
 
 
-class bottleneck_switch(object):
+class bottleneck_switch:
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -229,7 +229,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     return op.get_result()
 
 
-class _Concatenator(object):
+class _Concatenator:
     """
     Orchestrates a concatenation operation for BlockManagers
     """

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -469,7 +469,7 @@ def merge_asof(left, right, on=None,
 
 # TODO: transformations??
 # TODO: only copy DataFrames when modification necessary
-class _MergeOperation(object):
+class _MergeOperation:
     """
     Perform a database (SQL) merge operation between two DataFrame objects
     using either columns as keys or their row indexes

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -24,7 +24,7 @@ from pandas.core.sorting import (
     get_group_index)
 
 
-class _Unstacker(object):
+class _Unstacker:
     """
     Helper class to unstack data / pivot with multi-level index
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -283,7 +283,7 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
     return indexer
 
 
-class _KeyMapper(object):
+class _KeyMapper:
 
     """
     Ease my suffering. Map compressed group id -> key tuple

--- a/pandas/io/clipboard/clipboards.py
+++ b/pandas/io/clipboard/clipboards.py
@@ -124,7 +124,7 @@ def init_klipper_clipboard():
 
 
 def init_no_clipboard():
-    class ClipboardUnavailable(object):
+    class ClipboardUnavailable:
 
         def __call__(self, *args, **kwargs):
             raise PyperclipException(EXCEPT_MSG)

--- a/pandas/io/clipboard/windows.py
+++ b/pandas/io/clipboard/windows.py
@@ -9,7 +9,7 @@ import time
 from .exceptions import PyperclipWindowsException
 
 
-class CheckedCall(object):
+class CheckedCall:
 
     def __init__(self, f):
         super(CheckedCall, self).__setattr__("f", f)

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -37,7 +37,7 @@ _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard('')
 
 
-class BaseIterator(object):
+class BaseIterator:
     """Subclass this and provide a "__next__()" method to obtain an iterator.
     Useful only when the object being iterated is non-reusable (e.g. OK for a
     parser, not for an in-memory table, yes for its iterator)."""

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -329,7 +329,7 @@ def read_excel(io,
 
 
 @add_metaclass(abc.ABCMeta)
-class _BaseExcelReader(object):
+class _BaseExcelReader:
 
     @property
     @abc.abstractmethod
@@ -488,7 +488,7 @@ class _BaseExcelReader(object):
 
 
 @add_metaclass(abc.ABCMeta)
-class ExcelWriter(object):
+class ExcelWriter:
     """
     Class for writing DataFrame objects into excel sheets, default is to use
     xlwt for xls, openpyxl for xlsx.  See DataFrame.to_excel for typical usage.
@@ -732,7 +732,7 @@ class ExcelWriter(object):
         return self.save()
 
 
-class ExcelFile(object):
+class ExcelFile:
     """
     Class for parsing tabular excel sheets into DataFrame objects.
     Uses xlrd. See read_excel for more documentation

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -4,7 +4,7 @@ from pandas.io.excel._base import ExcelWriter
 from pandas.io.excel._util import _validate_freeze_panes
 
 
-class _XlsxStyler(object):
+class _XlsxStyler:
     # Map from openpyxl-oriented styles to flatter xlsxwriter representation
     # Ordering necessary for both determinism and because some are keyed by
     # prefixes of others.

--- a/pandas/io/formats/css.py
+++ b/pandas/io/formats/css.py
@@ -10,7 +10,7 @@ class CSSWarning(UserWarning):
     pass
 
 
-class CSSResolver(object):
+class CSSResolver:
     """A callable for parsing and resolving CSS to atomic properties
 
     """

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -21,7 +21,7 @@ from pandas.io.common import (
     UnicodeWriter, _get_handle, _infer_compression, get_filepath_or_buffer)
 
 
-class CSVFormatter(object):
+class CSVFormatter:
 
     def __init__(self, obj, path_or_buf=None, sep=",", na_rep='',
                  float_format=None, cols=None, header=True, index=True,

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -20,7 +20,7 @@ from pandas.io.formats.format import get_level_lengths
 from pandas.io.formats.printing import pprint_thing
 
 
-class ExcelCell(object):
+class ExcelCell:
     __fields__ = ('row', 'col', 'val', 'style', 'mergestart', 'mergeend')
     __slots__ = __fields__
 
@@ -34,7 +34,7 @@ class ExcelCell(object):
         self.mergeend = mergeend
 
 
-class CSSToExcelConverter(object):
+class CSSToExcelConverter:
     """A callable for converting CSS declarations to ExcelWriter styles
 
     Supports parts of CSS 2.2, with minimal CSS 3.0 support (e.g. text-shadow),
@@ -308,7 +308,7 @@ class CSSToExcelConverter(object):
         return {'format_code': props.get('number-format')}
 
 
-class ExcelFormatter(object):
+class ExcelFormatter:
     """
     Class for formatting a DataFrame to a list of ExcelCells,
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -103,7 +103,7 @@ return_docstring = """
     """
 
 
-class CategoricalFormatter(object):
+class CategoricalFormatter:
 
     def __init__(self, categorical, buf=None, length=True, na_rep='NaN',
                  footer=True):
@@ -157,7 +157,7 @@ class CategoricalFormatter(object):
         return str('\n'.join(result))
 
 
-class SeriesFormatter(object):
+class SeriesFormatter:
 
     def __init__(self, series, buf=None, length=True, header=True, index=True,
                  na_rep='NaN', name=False, float_format=None, dtype=True,
@@ -290,7 +290,7 @@ class SeriesFormatter(object):
         return str(''.join(result))
 
 
-class TextAdjustment(object):
+class TextAdjustment:
 
     def __init__(self):
         self.encoding = get_option("display.encoding")
@@ -351,7 +351,7 @@ def _get_adjustment():
         return TextAdjustment()
 
 
-class TableFormatter(object):
+class TableFormatter:
 
     is_truncated = False
     show_dimensions = None
@@ -913,7 +913,7 @@ def format_array(values, formatter, float_format=None, na_rep='NaN',
     return fmt_obj.get_result()
 
 
-class GenericArrayFormatter(object):
+class GenericArrayFormatter:
 
     def __init__(self, values, digits=7, formatter=None, na_rep='NaN',
                  space=12, float_format=None, justify='right', decimal='.',
@@ -1469,7 +1469,7 @@ def _has_names(index):
         return index.name is not None
 
 
-class EngFormatter(object):
+class EngFormatter:
     """
     Formats float values according to engineering format.
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -52,7 +52,7 @@ def _mpl(func):
         raise ImportError(no_mpl_message.format(func.__name__))
 
 
-class Styler(object):
+class Styler:
     """
     Helps style a DataFrame or Series according to the data with HTML and CSS.
 

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -139,7 +139,7 @@ def _read(obj):
     return text
 
 
-class _HtmlFrameParser(object):
+class _HtmlFrameParser:
     """Base class for parsers that parse HTML into DataFrames.
 
     Parameters

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -76,7 +76,7 @@ def to_json(path_or_buf, obj, orient=None, date_format='epoch',
         path_or_buf.write(s)
 
 
-class Writer(object):
+class Writer:
     def __init__(self, obj, orient, date_format, double_precision,
                  ensure_ascii, date_unit, index, default_handler=None):
         self.obj = obj
@@ -615,7 +615,7 @@ class JsonReader(BaseIterator):
         raise StopIteration
 
 
-class Parser(object):
+class Parser:
 
     _STAMP_UNITS = ('s', 'ms', 'us', 'ns')
     _MIN_STAMPS = {

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -777,7 +777,7 @@ class Unpacker(_Unpacker):
                                        ext_hook=ext_hook)
 
 
-class Iterator(object):
+class Iterator:
 
     """ manage the unpacking iteration,
         close the file on completion """

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -42,7 +42,7 @@ def get_engine(engine):
         return FastParquetImpl()
 
 
-class BaseImpl(object):
+class BaseImpl:
 
     api = None  # module
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1351,7 +1351,7 @@ def _validate_parse_dates_arg(parse_dates):
     return parse_dates
 
 
-class ParserBase(object):
+class ParserBase:
 
     def __init__(self, kwds):
         self.names = kwds.get('names')

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1410,7 +1410,7 @@ class HDFStore(StringMixin):
         return s.read(**kwargs)
 
 
-class TableIterator(object):
+class TableIterator:
 
     """ define the iteration interface on a table
 
@@ -4618,7 +4618,7 @@ def _need_convert(kind):
     return False
 
 
-class Selection(object):
+class Selection:
 
     """
     Carries out a selection operation on a tables.Table object.

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -27,11 +27,11 @@ from pandas.io.sas._sas import Parser
 import pandas.io.sas.sas_constants as const
 
 
-class _subheader_pointer(object):
+class _subheader_pointer:
     pass
 
 
-class _column(object):
+class _column:
     pass
 
 

--- a/pandas/io/sas/sas_constants.py
+++ b/pandas/io/sas/sas_constants.py
@@ -102,7 +102,7 @@ encoding_names = {29: "latin1", 20: "utf-8", 33: "cyrillic", 60: "wlatin2",
                   61: "wcyrillic", 62: "wlatin1", 90: "ebcdic870"}
 
 
-class SASIndex(object):
+class SASIndex:
     row_size_index = 0
     column_size_index = 1
     subheader_counts_index = 2

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -592,7 +592,7 @@ def _cast_to_stata_types(data):
     return data
 
 
-class StataValueLabel(object):
+class StataValueLabel:
     """
     Parse a categorical column and prepare formatted output
 
@@ -833,7 +833,7 @@ class StataMissingValue(StringMixin):
         return value
 
 
-class StataParser(object):
+class StataParser:
 
     def __init__(self):
 
@@ -2483,7 +2483,7 @@ def _pad_bytes_new(name, length):
     return name + b'\x00' * (length - len(name))
 
 
-class StataStrLWriter(object):
+class StataStrLWriter:
     """
     Converter for Stata StrLs
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -60,7 +60,7 @@ def _gcf():
     return plt.gcf()
 
 
-class MPLPlot(object):
+class MPLPlot:
     """
     Base class for assembling a pandas plot using matplotlib
 

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -4,7 +4,7 @@ from pandas import api
 from pandas.util import testing as tm
 
 
-class Base(object):
+class Base:
 
     def check(self, namespace, expected, ignored=None):
         # see which names are in the namespace, minus optional
@@ -133,7 +133,7 @@ class TestTesting(Base):
         self.check(testing, self.funcs)
 
 
-class TestTopLevelDeprecations(object):
+class TestTopLevelDeprecations:
 
     # top-level API deprecations
     # GH 13790
@@ -144,7 +144,7 @@ class TestTopLevelDeprecations(object):
             pd.TimeGrouper(freq='D')
 
 
-class TestCDateRange(object):
+class TestCDateRange:
 
     def test_deprecation_cdaterange(self):
         # GH17596

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -38,7 +38,7 @@ def assert_all(obj):
 # ------------------------------------------------------------------
 # Comparisons
 
-class TestDatetime64DataFrameComparison(object):
+class TestDatetime64DataFrameComparison:
     @pytest.mark.parametrize('timestamps', [
         [pd.Timestamp('2012-01-01 13:00:00+00:00')] * 2,
         [pd.Timestamp('2012-01-01 13:00:00')] * 2])
@@ -58,7 +58,7 @@ class TestDatetime64DataFrameComparison(object):
         tm.assert_frame_equal(result, expected)
 
 
-class TestDatetime64SeriesComparison(object):
+class TestDatetime64SeriesComparison:
     # TODO: moved from tests.series.test_operators; needs cleanup
 
     @pytest.mark.parametrize('pair', [
@@ -337,7 +337,7 @@ class TestDatetime64SeriesComparison(object):
         # comparison with the Series on the left-hand side
 
 
-class TestDatetimeIndexComparisons(object):
+class TestDatetimeIndexComparisons:
 
     # TODO: moved from tests.indexes.test_base; parametrize and de-duplicate
     @pytest.mark.parametrize("op", [
@@ -789,7 +789,7 @@ class TestDatetimeIndexComparisons(object):
 # ------------------------------------------------------------------
 # Arithmetic
 
-class TestDatetime64Arithmetic(object):
+class TestDatetime64Arithmetic:
     # This class is intended for "finished" tests that are fully parametrized
     #  over DataFrame/Series/Index/DatetimeArray
 
@@ -1125,7 +1125,7 @@ class TestDatetime64Arithmetic(object):
             per - dtarr
 
 
-class TestDatetime64DateOffsetArithmetic(object):
+class TestDatetime64DateOffsetArithmetic:
 
     # -------------------------------------------------------------
     # Tick DateOffsets
@@ -1437,7 +1437,7 @@ class TestDatetime64DateOffsetArithmetic(object):
         tm.assert_equal(res, expected)
 
 
-class TestDatetime64OverflowHandling(object):
+class TestDatetime64OverflowHandling:
     # TODO: box + de-duplicate
 
     def test_dt64_overflow_masking(self, box_with_array):
@@ -1555,7 +1555,7 @@ class TestDatetime64OverflowHandling(object):
             tmax - t2
 
 
-class TestTimestampSeriesArithmetic(object):
+class TestTimestampSeriesArithmetic:
 
     def test_empty_series_add_sub(self):
         # GH#13844
@@ -1843,7 +1843,7 @@ class TestTimestampSeriesArithmetic(object):
             td2 - dt2
 
 
-class TestDatetimeIndexArithmetic(object):
+class TestDatetimeIndexArithmetic:
 
     # -------------------------------------------------------------
     # Binary operations DatetimeIndex and int

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -19,7 +19,7 @@ import pandas.util.testing as tm
 # Comparisons
 
 
-class TestNumericComparisons(object):
+class TestNumericComparisons:
     def test_operator_series_comparison_zerorank(self):
         # GH#13006
         result = np.float64(0) > pd.Series([1, 2, 3])
@@ -60,7 +60,7 @@ class TestNumericComparisons(object):
 # ------------------------------------------------------------------
 # Numeric dtypes Arithmetic with Timedelta Scalar
 
-class TestNumericArraylikeArithmeticWithTimedeltaLike(object):
+class TestNumericArraylikeArithmeticWithTimedeltaLike:
 
     # TODO: also check name retentention
     @pytest.mark.parametrize('box_cls', [np.array, pd.Index, pd.Series])
@@ -185,7 +185,7 @@ class TestNumericArraylikeArithmeticWithTimedeltaLike(object):
 # ------------------------------------------------------------------
 # Arithmetic
 
-class TestDivisionByZero(object):
+class TestDivisionByZero:
 
     def test_div_zero(self, zero, numeric_idx):
         idx = numeric_idx
@@ -395,7 +395,7 @@ class TestDivisionByZero(object):
         assert not res.fillna(0).equals(res2.fillna(0))
 
 
-class TestMultiplicationDivision(object):
+class TestMultiplicationDivision:
     # __mul__, __rmul__, __div__, __rdiv__, __floordiv__, __rfloordiv__
     # for non-timestamp/timedelta/period dtypes
 
@@ -627,7 +627,7 @@ class TestMultiplicationDivision(object):
             tm.assert_series_equal(result, expected)
 
 
-class TestAdditionSubtraction(object):
+class TestAdditionSubtraction:
     # __add__, __sub__, __radd__, __rsub__, __iadd__, __isub__
     # for non-timestamp/timedelta/period dtypes
 
@@ -834,7 +834,7 @@ class TestAdditionSubtraction(object):
         check(tser, 5)
 
 
-class TestUFuncCompat(object):
+class TestUFuncCompat:
 
     @pytest.mark.parametrize('holder', [pd.Int64Index, pd.UInt64Index,
                                         pd.Float64Index, pd.RangeIndex,
@@ -894,7 +894,7 @@ class TestUFuncCompat(object):
         tm.assert_equal(result, exp)
 
 
-class TestObjectDtypeEquivalence(object):
+class TestObjectDtypeEquivalence:
     # Tests that arithmetic operations match operations executed elementwise
 
     @pytest.mark.parametrize('dtype', [None, object])
@@ -937,7 +937,7 @@ class TestObjectDtypeEquivalence(object):
         tm.assert_series_equal(result.astype(float), expected)
 
 
-class TestNumericArithmeticUnsorted(object):
+class TestNumericArithmeticUnsorted:
     # Tests in this class have been moved from type-specific test modules
     #  but not yet sorted, parametrized, and de-duplicated
 

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -17,7 +17,7 @@ import pandas.util.testing as tm
 # Comparisons
 
 
-class TestObjectComparisons(object):
+class TestObjectComparisons:
 
     def test_comparison_object_numeric_nas(self):
         ser = Series(np.random.randn(10), dtype=object)
@@ -71,7 +71,7 @@ class TestObjectComparisons(object):
 # ------------------------------------------------------------------
 # Arithmetic
 
-class TestArithmetic(object):
+class TestArithmetic:
 
     # TODO: parametrize
     def test_pow_ops_object(self):

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -21,7 +21,7 @@ from pandas.tseries.frequencies import to_offset
 # Comparisons
 
 
-class TestPeriodIndexComparisons(object):
+class TestPeriodIndexComparisons:
 
     @pytest.mark.parametrize("other", ["2017", 2017])
     def test_eq(self, other):
@@ -260,7 +260,7 @@ class TestPeriodIndexComparisons(object):
         tm.assert_numpy_array_equal(pd.NaT > left, expected)
 
 
-class TestPeriodSeriesComparisons(object):
+class TestPeriodSeriesComparisons:
     def test_cmp_series_period_series_mixed_freq(self):
         # GH#13200
         base = Series([Period('2011', freq='A'),
@@ -292,7 +292,7 @@ class TestPeriodSeriesComparisons(object):
         tm.assert_series_equal(base <= ser, exp)
 
 
-class TestPeriodIndexSeriesComparisonConsistency(object):
+class TestPeriodIndexSeriesComparisonConsistency:
     """ Test PeriodIndex and Period Series Ops consistency """
     # TODO: needs parametrization+de-duplication
 
@@ -388,7 +388,7 @@ class TestPeriodIndexSeriesComparisonConsistency(object):
 # ------------------------------------------------------------------
 # Arithmetic
 
-class TestPeriodFrameArithmetic(object):
+class TestPeriodFrameArithmetic:
 
     def test_ops_frame_period(self):
         # GH#13043
@@ -420,7 +420,7 @@ class TestPeriodFrameArithmetic(object):
         tm.assert_frame_equal(df - df2, -1 * exp)
 
 
-class TestPeriodIndexArithmetic(object):
+class TestPeriodIndexArithmetic:
     # ---------------------------------------------------------------
     # __add__/__sub__ with PeriodIndex
     # PeriodIndex + other is defined for integers and timedelta-like others
@@ -967,7 +967,7 @@ class TestPeriodIndexArithmetic(object):
             other - obj
 
 
-class TestPeriodSeriesArithmetic(object):
+class TestPeriodSeriesArithmetic:
     def test_ops_series_timedelta(self):
         # GH#13043
         ser = pd.Series([pd.Period('2015-01-01', freq='D'),
@@ -1011,7 +1011,7 @@ class TestPeriodSeriesArithmetic(object):
         tm.assert_series_equal(ser - s2, -1 * expected)
 
 
-class TestPeriodIndexSeriesMethods(object):
+class TestPeriodIndexSeriesMethods:
     """ Test PeriodIndex and Period Series Ops consistency """
 
     def _check(self, values, func, expected):

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -31,7 +31,7 @@ def get_upcast_box(box, vector):
 # ------------------------------------------------------------------
 # Timedelta64[ns] dtype Comparisons
 
-class TestTimedelta64ArrayComparisons(object):
+class TestTimedelta64ArrayComparisons:
     # TODO: All of these need to be parametrized over box
 
     def test_compare_timedelta_series(self):
@@ -157,7 +157,7 @@ class TestTimedelta64ArrayComparisons(object):
 # ------------------------------------------------------------------
 # Timedelta64[ns] dtype Arithmetic Operations
 
-class TestTimedelta64ArithmeticUnsorted(object):
+class TestTimedelta64ArithmeticUnsorted:
     # Tests moved from type-specific test files but not
     #  yet sorted/parametrized/de-duplicated
 
@@ -442,7 +442,7 @@ class TestTimedelta64ArithmeticUnsorted(object):
         tm.assert_index_equal(result2, result3)
 
 
-class TestAddSubNaTMasking(object):
+class TestAddSubNaTMasking:
     # TODO: parametrize over boxes
 
     def test_tdi_add_timestamp_nat_masking(self):
@@ -502,7 +502,7 @@ class TestAddSubNaTMasking(object):
         tm.assert_index_equal(result, exp)
 
 
-class TestTimedeltaArraylikeAddSubOps(object):
+class TestTimedeltaArraylikeAddSubOps:
     # Tests for timedelta64[ns] __add__, __sub__, __radd__, __rsub__
 
     # TODO: moved from frame tests; needs parametrization/de-duplication
@@ -1399,7 +1399,7 @@ class TestTimedeltaArraylikeAddSubOps(object):
                 anchored - tdi
 
 
-class TestTimedeltaArraylikeMulDivOps(object):
+class TestTimedeltaArraylikeMulDivOps:
     # Tests for timedelta64[ns]
     # __mul__, __rmul__, __div__, __rdiv__, __floordiv__, __rfloordiv__
 
@@ -1990,7 +1990,7 @@ class TestTimedeltaArraylikeMulDivOps(object):
             tm.assert_equal(result, expected)
 
 
-class TestTimedeltaArraylikeInvalidArithmeticOps(object):
+class TestTimedeltaArraylikeInvalidArithmeticOps:
 
     def test_td64arr_pow_invalid(self, scalar_td, box_with_array):
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)

--- a/pandas/tests/arrays/categorical/common.py
+++ b/pandas/tests/arrays/categorical/common.py
@@ -3,7 +3,7 @@
 from pandas import Categorical
 
 
-class TestCategorical(object):
+class TestCategorical:
 
     def setup_method(self, method):
         self.factor = Categorical(['a', 'b', 'b', 'a', 'a', 'c', 'c', 'c'],

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -71,7 +71,7 @@ def test_isin_empty(empty):
     tm.assert_numpy_array_equal(expected, result)
 
 
-class TestTake(object):
+class TestTake:
     # https://github.com/pandas-dev/pandas/issues/20664
 
     def test_take_warns(self):

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -12,7 +12,7 @@ from pandas.api.types import is_scalar
 import pandas.util.testing as tm
 
 
-class TestCategoricalAnalytics(object):
+class TestCategoricalAnalytics:
 
     def test_min_max(self):
 

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -9,7 +9,7 @@ from pandas.tests.arrays.categorical.common import TestCategorical
 import pandas.util.testing as tm
 
 
-class TestCategoricalAPI(object):
+class TestCategoricalAPI:
 
     def test_ordered_api(self):
         # GH 9347
@@ -448,7 +448,7 @@ class TestCategoricalAPIWithFactor(TestCategorical):
         tm.assert_index_equal(cat.categories, Index(['a', 'b', 'c', 'd']))
 
 
-class TestPrivateCategoricalAPI(object):
+class TestPrivateCategoricalAPI:
 
     def test_codes_immutable(self):
 

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -16,7 +16,7 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-class TestCategoricalConstructors(object):
+class TestCategoricalConstructors:
 
     def test_validate_ordered(self):
         # see gh-14058

--- a/pandas/tests/arrays/categorical/test_dtypes.py
+++ b/pandas/tests/arrays/categorical/test_dtypes.py
@@ -8,7 +8,7 @@ from pandas import Categorical, CategoricalIndex, Index, Series, Timestamp
 import pandas.util.testing as tm
 
 
-class TestCategoricalDtypes(object):
+class TestCategoricalDtypes:
 
     def test_is_equal_dtype(self):
 

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -84,7 +84,7 @@ class TestCategoricalIndexingWithFactor(TestCategorical):
             target[mask] = other[mask]
 
 
-class TestCategoricalIndexing(object):
+class TestCategoricalIndexing:
 
     def test_getitem_listlike(self):
 

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -12,7 +12,7 @@ from pandas import Categorical, Index, isna
 import pandas.util.testing as tm
 
 
-class TestCategoricalMissing(object):
+class TestCategoricalMissing:
 
     def test_na_flags_int_categories(self):
         # #1457

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -127,7 +127,7 @@ class TestCategoricalOpsWithFactor(TestCategorical):
         tm.assert_numpy_array_equal(res, exp)
 
 
-class TestCategoricalOps(object):
+class TestCategoricalOps:
 
     def test_compare_frame(self):
         # GH#24282 check that Categorical.__cmp__(DataFrame) defers to frame

--- a/pandas/tests/arrays/categorical/test_repr.py
+++ b/pandas/tests/arrays/categorical/test_repr.py
@@ -18,7 +18,7 @@ class TestCategoricalReprWithFactor(TestCategorical):
         assert actual == expected
 
 
-class TestCategoricalRepr(object):
+class TestCategoricalRepr:
 
     def test_big_print(self):
         factor = Categorical([0, 1, 2, 0, 1, 2] * 100, ['a', 'b', 'c'],

--- a/pandas/tests/arrays/categorical/test_sorting.py
+++ b/pandas/tests/arrays/categorical/test_sorting.py
@@ -7,7 +7,7 @@ from pandas import Categorical, Index
 import pandas.util.testing as tm
 
 
-class TestCategoricalSort(object):
+class TestCategoricalSort:
 
     def test_argsort(self):
         c = Categorical([5, 3, 1, 4, 2], ordered=True)

--- a/pandas/tests/arrays/categorical/test_subclass.py
+++ b/pandas/tests/arrays/categorical/test_subclass.py
@@ -4,7 +4,7 @@ from pandas import Categorical
 import pandas.util.testing as tm
 
 
-class TestCategoricalSubclassing(object):
+class TestCategoricalSubclassing:
 
     def test_constructor(self):
         sc = tm.SubclassedCategorical(['a', 'b', 'c'])

--- a/pandas/tests/arrays/categorical/test_warnings.py
+++ b/pandas/tests/arrays/categorical/test_warnings.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 
-class TestCategoricalWarnings(object):
+class TestCategoricalWarnings:
     def test_tab_complete_warning(self, ip):
         # https://github.com/pandas-dev/pandas/issues/16409
         pytest.importorskip('IPython', minversion="6.0.0")

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -24,7 +24,7 @@ def left_right_dtypes(request):
     return request.param
 
 
-class TestMethods(object):
+class TestMethods:
 
     @pytest.mark.parametrize('new_closed', [
         'left', 'right', 'both', 'neither'])
@@ -47,7 +47,7 @@ class TestMethods(object):
             ser.where([True, False, True], other=other)
 
 
-class TestSetitem(object):
+class TestSetitem:
 
     def test_set_na(self, left_right_dtypes):
         left, right = left_right_dtypes

--- a/pandas/tests/arrays/interval/test_ops.py
+++ b/pandas/tests/arrays/interval/test_ops.py
@@ -27,7 +27,7 @@ def start_shift(request):
     return request.param
 
 
-class TestOverlaps(object):
+class TestOverlaps:
 
     def test_overlaps_interval(
             self, constructor, start_shift, closed, other_closed):

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -8,7 +8,7 @@ from pandas.core.sparse.api import SparseDtype
 import pandas.util.testing as tm
 
 
-class TestSparseArrayArithmetics(object):
+class TestSparseArrayArithmetics:
 
     _base = np.array
     _klass = pd.SparseArray

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -20,7 +20,7 @@ def kind(request):
     return request.param
 
 
-class TestSparseArray(object):
+class TestSparseArray:
 
     def setup_method(self, method):
         self.arr_data = np.array([np.nan, np.nan, 1, 2, 3,
@@ -814,7 +814,7 @@ class TestSparseArray(object):
         tm.assert_numpy_array_equal(expected, result)
 
 
-class TestSparseArrayAnalytics(object):
+class TestSparseArrayAnalytics:
 
     @pytest.mark.parametrize('data,pos,neg', [
         ([True, True, True], True, False),
@@ -1071,7 +1071,7 @@ class TestSparseArrayAnalytics(object):
         assert arr.npoints == 1
 
 
-class TestAccessor(object):
+class TestAccessor:
 
     @pytest.mark.parametrize('attr', [
         'npoints', 'density', 'fill_value', 'sp_values',

--- a/pandas/tests/arrays/sparse/test_libsparse.py
+++ b/pandas/tests/arrays/sparse/test_libsparse.py
@@ -42,7 +42,7 @@ def check_cases(_check_case):
     _check_case([], [], [], [], [], [])
 
 
-class TestSparseIndexUnion(object):
+class TestSparseIndexUnion:
 
     def test_index_make_union(self):
         def _check_case(xloc, xlen, yloc, ylen, eloc, elen):
@@ -190,7 +190,7 @@ class TestSparseIndexUnion(object):
             a.make_union(b)
 
 
-class TestSparseIndexIntersect(object):
+class TestSparseIndexIntersect:
 
     @td.skip_if_windows
     def test_intersect(self):
@@ -242,7 +242,7 @@ class TestSparseIndexIntersect(object):
             assert case.intersect(case).equals(case)
 
 
-class TestSparseIndexCommon(object):
+class TestSparseIndexCommon:
 
     def test_int_internal(self):
         idx = _make_index(4, np.array([2, 3], dtype=np.int32), kind='integer')
@@ -390,7 +390,7 @@ class TestSparseIndexCommon(object):
         # corner cases
 
 
-class TestBlockIndex(object):
+class TestBlockIndex:
 
     def test_block_internal(self):
         idx = _make_index(4, np.array([2, 3], dtype=np.int32), kind='block')
@@ -477,7 +477,7 @@ class TestBlockIndex(object):
         assert index.to_block_index() is index
 
 
-class TestIntIndex(object):
+class TestIntIndex:
 
     def test_check_integrity(self):
 
@@ -562,7 +562,7 @@ class TestIntIndex(object):
         assert index.to_int_index() is index
 
 
-class TestSparseOperators(object):
+class TestSparseOperators:
 
     def _op_tests(self, sparse_op, python_op):
         def _check_case(xloc, xlen, yloc, ylen, eloc, elen):

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -257,7 +257,7 @@ def test_array_not_registered(registry_without_decimal):
     tm.assert_equal(result, expected)
 
 
-class TestArrayAnalytics(object):
+class TestArrayAnalytics:
     def test_searchsorted(self, string_dtype):
         arr = pd.array(['a', 'b', 'c'], dtype=string_dtype)
 

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -54,7 +54,7 @@ def timedelta_index(request):
     return pd.TimedeltaIndex(['1 Day', '3 Hours', 'NaT'])
 
 
-class SharedTests(object):
+class SharedTests:
     index_cls = None
 
     def test_compare_len1_raises(self):

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -15,7 +15,7 @@ from pandas.core.arrays.datetimes import sequence_to_dt64ns
 import pandas.util.testing as tm
 
 
-class TestDatetimeArrayConstructor(object):
+class TestDatetimeArrayConstructor:
     def test_freq_validation(self):
         # GH#24623 check that invalid instances cannot be created with the
         #  public constructor
@@ -85,7 +85,7 @@ class TestDatetimeArrayConstructor(object):
         assert arr._data is not data
 
 
-class TestDatetimeArrayComparisons(object):
+class TestDatetimeArrayComparisons:
     # TODO: merge this into tests/arithmetic/test_datetime64 once it is
     #  sufficiently robust
 
@@ -118,7 +118,7 @@ class TestDatetimeArrayComparisons(object):
             tm.assert_numpy_array_equal(result, expected)
 
 
-class TestDatetimeArray(object):
+class TestDatetimeArray:
     def test_astype_to_same(self):
         arr = DatetimeArray._from_sequence(['2000'], tz='US/Central')
         result = arr.astype(DatetimeTZDtype(tz="US/Central"), copy=False)
@@ -240,7 +240,7 @@ class TestDatetimeArray(object):
         tm.assert_numpy_array_equal(result, expected)
 
 
-class TestSequenceToDT64NS(object):
+class TestSequenceToDT64NS:
 
     def test_tz_dtype_mismatch_raises(self):
         arr = DatetimeArray._from_sequence(['2000'], tz='US/Central')
@@ -254,7 +254,7 @@ class TestSequenceToDT64NS(object):
         tm.assert_numpy_array_equal(arr._data, result)
 
 
-class TestReductions(object):
+class TestReductions:
 
     @pytest.mark.parametrize("tz", [None, "US/Central"])
     def test_min_max(self, tz):

--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -94,7 +94,7 @@ def test_repr_array_long():
     assert result == expected
 
 
-class TestConstructors(object):
+class TestConstructors:
 
     def test_from_dtype_from_float(self, data):
         # construct from our dtype & string dtype
@@ -365,7 +365,7 @@ class TestComparisonOps(BaseOpsUtil):
         self._compare_other(data, op_name, other)
 
 
-class TestCasting(object):
+class TestCasting:
     pass
 
     @pytest.mark.parametrize('dropna', [True, False])

--- a/pandas/tests/arrays/test_period.py
+++ b/pandas/tests/arrays/test_period.py
@@ -281,7 +281,7 @@ def test_repr_large():
 # ----------------------------------------------------------------------------
 # Reductions
 
-class TestReductions(object):
+class TestReductions:
 
     def test_min_max(self):
         arr = period_array([

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -8,7 +8,7 @@ from pandas.core.arrays import TimedeltaArray
 import pandas.util.testing as tm
 
 
-class TestTimedeltaArrayConstructor(object):
+class TestTimedeltaArrayConstructor:
     def test_only_1dim_accepted(self):
         # GH#25282
         arr = np.array([0, 1, 2, 3], dtype='m8[h]').astype('m8[ns]')
@@ -62,7 +62,7 @@ class TestTimedeltaArrayConstructor(object):
         assert arr._data.base is not data
 
 
-class TestTimedeltaArray(object):
+class TestTimedeltaArray:
     def test_np_sum(self):
         # GH#25282
         vals = np.arange(5, dtype=np.int64).view('m8[h]').astype('m8[ns]')
@@ -130,7 +130,7 @@ class TestTimedeltaArray(object):
         assert a.freq is None
 
 
-class TestReductions(object):
+class TestReductions:
 
     def test_min_max(self):
         arr = TimedeltaArray._from_sequence([

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -110,7 +110,7 @@ _good_arith_ops = set(_arith_ops_syms).difference(_special_case_arith_ops_syms)
 
 
 @td.skip_if_no_ne
-class TestEvalNumexprPandas(object):
+class TestEvalNumexprPandas:
 
     @classmethod
     def setup_class(cls):
@@ -784,7 +784,7 @@ f = lambda *args, **kwargs: np.random.randn()
 # gh-12388: Typecasting rules consistency with python
 
 
-class TestTypeCasting(object):
+class TestTypeCasting:
     @pytest.mark.parametrize('op', ['+', '-', '*', '**', '/'])
     # maybe someday... numexpr has too many upcasting rules now
     # chain(*(np.sctypes[x] for x in ['uint', 'int', 'float']))
@@ -817,7 +817,7 @@ def should_warn(*args):
     return not_mono and only_one_dt
 
 
-class TestAlignment(object):
+class TestAlignment:
 
     index_types = 'i', 'u', 'dt'
     lhs_index_types = index_types + ('s',)  # 'p'
@@ -1061,7 +1061,7 @@ class TestAlignment(object):
 # Slightly more complex ops
 
 @td.skip_if_no_ne
-class TestOperationsNumExprPandas(object):
+class TestOperationsNumExprPandas:
 
     @classmethod
     def setup_class(cls):
@@ -1588,7 +1588,7 @@ class TestOperationsPythonPandas(TestOperationsNumExprPandas):
 
 
 @td.skip_if_no_ne
-class TestMathPythonPython(object):
+class TestMathPythonPython:
 
     @classmethod
     def setup_class(cls):
@@ -1734,7 +1734,7 @@ class TestMathNumExprPython(TestMathPythonPython):
 _var_s = randn(10)
 
 
-class TestScope(object):
+class TestScope:
 
     def test_global_scope(self, engine, parser):
         e = '_var_s * 2'
@@ -1882,7 +1882,7 @@ def test_negate_lt_eq_le(engine, parser):
         tm.assert_frame_equal(result, expected)
 
 
-class TestValidate(object):
+class TestValidate:
 
     def test_validate_bool_args(self):
         invalid_values = [1, "True", [1, 2, 3], 5.0]

--- a/pandas/tests/config/test_config.py
+++ b/pandas/tests/config/test_config.py
@@ -9,7 +9,7 @@ from pandas._config.config import OptionError
 import pandas as pd
 
 
-class TestConfig(object):
+class TestConfig:
 
     @classmethod
     def setup_class(cls):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -29,7 +29,7 @@ def to_numpy_dtypes(dtypes):
     return [getattr(np, dt) for dt in dtypes if isinstance(dt, str)]
 
 
-class TestPandasDtype(object):
+class TestPandasDtype:
 
     # Passing invalid dtype, both as a string or object, must raise TypeError
     # Per issue GH15520

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -20,7 +20,7 @@ from pandas.core.sparse.api import SparseDtype
 import pandas.util.testing as tm
 
 
-class Base(object):
+class Base:
 
     def setup_method(self, method):
         self.dtype = self.create()
@@ -646,7 +646,7 @@ class TestIntervalDtype(Base):
         assert len(IntervalDtype._cache) == 0
 
 
-class TestCategoricalDtypeParametrized(object):
+class TestCategoricalDtypeParametrized:
 
     @pytest.mark.parametrize('categories', [
         list('abcd'),

--- a/pandas/tests/dtypes/test_generic.py
+++ b/pandas/tests/dtypes/test_generic.py
@@ -10,7 +10,7 @@ import pandas as pd
 from pandas.util import testing as tm
 
 
-class TestABCClasses(object):
+class TestABCClasses:
     tuples = [[1, 2, 2], ['red', 'blue', 'red']]
     multi_index = pd.MultiIndex.from_arrays(tuples, names=('number', 'color'))
     datetime_index = pd.to_datetime(['2000/1/1', '2010/1/1'])

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -111,7 +111,7 @@ def test_is_sequence():
     assert (not is_seq("abcd"))
     assert (not is_seq(np.int64))
 
-    class A(object):
+    class A:
 
         def __getitem__(self):
             return 1
@@ -175,7 +175,7 @@ def test_is_dict_like_fails(ll):
 @pytest.mark.parametrize("has_getitem", [True, False])
 @pytest.mark.parametrize("has_contains", [True, False])
 def test_is_dict_like_duck_type(has_keys, has_getitem, has_contains):
-    class DictLike(object):
+    class DictLike:
         def __init__(self, d):
             self.d = d
 
@@ -199,7 +199,7 @@ def test_is_dict_like_duck_type(has_keys, has_getitem, has_contains):
 
 
 def test_is_file_like():
-    class MockFile(object):
+    class MockFile:
         pass
 
     is_file = inference.is_file_like
@@ -253,13 +253,13 @@ def test_is_names_tuple_fails(ll):
 def test_is_hashable():
 
     # all new-style classes are hashable by default
-    class HashableClass(object):
+    class HashableClass:
         pass
 
-    class UnhashableClass1(object):
+    class UnhashableClass1:
         __hash__ = None
 
-    class UnhashableClass2(object):
+    class UnhashableClass2:
 
         def __hash__(self):
             raise TypeError("Not hashable")
@@ -315,7 +315,7 @@ def test_is_recompilable_fails(ll):
     assert not inference.is_re_compilable(ll)
 
 
-class TestInference(object):
+class TestInference:
 
     def test_infer_dtype_bytes(self):
         compare = 'bytes'
@@ -497,7 +497,7 @@ class TestInference(object):
         tm.assert_numpy_array_equal(result, array)
 
 
-class TestTypeInference(object):
+class TestTypeInference:
 
     # Dummy class used for testing with Python objects
     class Dummy():
@@ -1084,7 +1084,7 @@ class TestTypeInference(object):
         assert result == 'categorical'
 
 
-class TestNumberScalar(object):
+class TestNumberScalar:
 
     def test_is_number(self):
 
@@ -1227,7 +1227,7 @@ class TestNumberScalar(object):
         assert not is_timedelta64_ns_dtype(tdi.astype('timedelta64[h]'))
 
 
-class TestIsScalar(object):
+class TestIsScalar:
 
     def test_is_scalar_builtin_scalars(self):
         assert is_scalar(None)

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -53,7 +53,7 @@ def test_notna_notnull(notna_f):
             assert (isinstance(notna_f(s), Series))
 
 
-class TestIsNA(object):
+class TestIsNA:
 
     def test_0d_array(self):
         assert isna(np.array(np.nan))
@@ -337,7 +337,7 @@ def test_na_value_for_dtype(dtype, na_value):
     assert result is na_value
 
 
-class TestNAObj(object):
+class TestNAObj:
 
     _1d_methods = ['isnaobj', 'isnaobj_old']
     _2d_methods = ['isnaobj2d', 'isnaobj2d_old']
@@ -435,7 +435,7 @@ never_na_vals = [
 ]
 
 
-class TestLibMissing(object):
+class TestLibMissing:
     def test_checknull(self):
         for value in na_vals:
             assert libmissing.checknull(value)

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -26,7 +26,7 @@ def data_missing():
     return ArrowBoolArray.from_scalars([None, True])
 
 
-class BaseArrowTests(object):
+class BaseArrowTests:
     pass
 
 

--- a/pandas/tests/extension/base/base.py
+++ b/pandas/tests/extension/base/base.py
@@ -1,7 +1,7 @@
 import pandas.util.testing as tm
 
 
-class BaseExtensionTests(object):
+class BaseExtensionTests:
     assert_equal = staticmethod(tm.assert_equal)
     assert_series_equal = staticmethod(tm.assert_series_equal)
     assert_frame_equal = staticmethod(tm.assert_frame_equal)

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -65,7 +65,7 @@ def data_for_grouping():
     return DecimalArray([b, b, na, na, a, a, b, c])
 
 
-class BaseDecimal(object):
+class BaseDecimal:
 
     def assert_series_equal(self, left, right, *args, **kwargs):
         def convert(x):
@@ -149,7 +149,7 @@ class TestMissing(BaseDecimal, base.BaseMissingTests):
     pass
 
 
-class Reduce(object):
+class Reduce:
 
     def check_reduce(self, s, op_name, skipna):
 

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -71,7 +71,7 @@ def data_for_grouping():
     ])
 
 
-class BaseJSON(object):
+class BaseJSON:
     # NumPy doesn't handle an array of equal-length UserDicts.
     # The default assert_series_equal eventually does a
     # Series.values, which raises. We work around it by

--- a/pandas/tests/extension/test_common.py
+++ b/pandas/tests/extension/test_common.py
@@ -35,7 +35,7 @@ class DummyArray(ExtensionArray):
         return np.array(self, dtype=dtype, copy=copy)
 
 
-class TestExtensionArrayDtype(object):
+class TestExtensionArrayDtype:
 
     @pytest.mark.parametrize('values', [
         pd.Categorical([]),

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -74,7 +74,7 @@ def na_value():
 
 
 # ----------------------------------------------------------------------------
-class BaseDatetimeTests(object):
+class BaseDatetimeTests:
     pass
 
 

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -70,7 +70,7 @@ def data_for_grouping():
     return IntervalArray.from_tuples([b, b, None, None, a, a, b, c])
 
 
-class BaseInterval(object):
+class BaseInterval:
     pass
 
 

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -136,7 +136,7 @@ def skip_numpy_object(dtype):
 skip_nested = pytest.mark.usefixtures('skip_numpy_object')
 
 
-class BaseNumPyTests(object):
+class BaseNumPyTests:
     pass
 
 

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -54,7 +54,7 @@ def na_value():
     return pd.NaT
 
 
-class BasePeriodTests(object):
+class BasePeriodTests:
     pass
 
 

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -81,7 +81,7 @@ def data_for_grouping(request):
                        fill_value=request.param)
 
 
-class BaseSparseTests(object):
+class BaseSparseTests:
 
     def _check_unsupported(self, data):
         if data.dtype == SparseDtype(int, 0):

--- a/pandas/tests/frame/common.py
+++ b/pandas/tests/frame/common.py
@@ -18,7 +18,7 @@ _mixed_frame = _frame.copy()
 _mixed_frame['foo'] = 'bar'
 
 
-class TestData(object):
+class TestData:
 
     @cache_readonly
     def frame(self):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -300,7 +300,7 @@ class TestDataFrameAlterAxes():
     def test_set_index_custom_label_type(self):
         # GH 24969
 
-        class Thing(object):
+        class Thing:
             def __init__(self, name, color):
                 self.name = name
                 self.color = color
@@ -1376,7 +1376,7 @@ class TestDataFrameAlterAxes():
         tm.assert_frame_equal(result, expected)
 
 
-class TestIntervalIndex(object):
+class TestIntervalIndex:
 
     def test_setitem(self):
 

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -231,7 +231,7 @@ def assert_bool_op_api(opname, bool_frame_with_na, float_string_frame,
         getattr(bool_frame_with_na, opname)(axis=1, bool_only=False)
 
 
-class TestDataFrameAnalytics(object):
+class TestDataFrameAnalytics:
 
     # ---------------------------------------------------------------------
     # Correlation and covariance
@@ -2242,7 +2242,7 @@ def df_main_dtypes():
                  'timedelta'])
 
 
-class TestNLargestNSmallest(object):
+class TestNLargestNSmallest:
 
     dtype_error_msg_template = ("Column {column!r} has dtype {dtype}, cannot "
                                 "use method {method!r} with this dtype")

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -16,7 +16,7 @@ from pandas.util.testing import (
     assert_almost_equal, assert_frame_equal, assert_series_equal)
 
 
-class SharedWithSparse(object):
+class SharedWithSparse:
     """
     A collection of tests DataFrame and SparseDataFrame can share.
 

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -579,7 +579,7 @@ class TestDataFrameApply():
         tm.assert_frame_equal(result, expected)
 
 
-class TestInferOutputShape(object):
+class TestInferOutputShape:
     # the user has supplied an opaque UDF where
     # they are transforming the input that requires
     # us to infer the output

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -14,7 +14,7 @@ import pandas.util.testing as tm
 # Comparisons
 
 
-class TestFrameComparisons(object):
+class TestFrameComparisons:
     # Specifically _not_ flex-comparisons
 
     def test_comparison_invalid(self):
@@ -138,7 +138,7 @@ class TestFrameComparisons(object):
         tm.assert_frame_equal(df[-mask_b], df.loc[1:1, :])
 
 
-class TestFrameFlexComparisons(object):
+class TestFrameFlexComparisons:
     # TODO: test_bool_flex_frame needs a better name
     def test_bool_flex_frame(self):
         data = np.random.randn(5, 3)
@@ -291,7 +291,7 @@ class TestFrameFlexComparisons(object):
 # -------------------------------------------------------------------
 # Arithmetic
 
-class TestFrameFlexArithmetic(object):
+class TestFrameFlexArithmetic:
 
     def test_df_add_td64_columnwise(self):
         # GH 22534 Check that column-wise addition broadcasts correctly
@@ -445,7 +445,7 @@ class TestFrameFlexArithmetic(object):
             df_len0.sub(df['A'], axis=None, fill_value=3)
 
 
-class TestFrameArithmetic(object):
+class TestFrameArithmetic:
     def test_df_add_2d_array_rowlike_broadcasts(self):
         # GH#23000
         arr = np.arange(6).reshape(3, 2)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2215,7 +2215,7 @@ class TestDataFrameConstructors(TestData):
             DataFrame.from_records(df, index=2)
 
     def test_from_records_non_tuple(self):
-        class Record(object):
+        class Record:
 
             def __init__(self, *args):
                 self.args = args

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -337,7 +337,7 @@ class TestDataFrameConvertTo(TestData):
 
     def test_to_records_dict_like(self):
         # see gh-18146
-        class DictLike(object):
+        class DictLike:
             def __init__(self, **kwargs):
                 self.d = kwargs.copy()
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3363,7 +3363,7 @@ class TestDataFrameIndexingUInt64(TestData):
         assert_frame_equal(result, expected)
 
 
-class TestDataFrameIndexingCategorical(object):
+class TestDataFrameIndexingCategorical:
 
     def test_assignment(self):
         # assignment

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -15,7 +15,7 @@ from pandas.util.testing import (
     assert_frame_equal, assert_numpy_array_equal, assert_series_equal)
 
 
-class TestDataFrameUnaryOperators(object):
+class TestDataFrameUnaryOperators:
     # __pos__, __neg__, __inv__
 
     @pytest.mark.parametrize('df,expected', [
@@ -88,7 +88,7 @@ class TestDataFrameUnaryOperators(object):
             (+ df['a'])
 
 
-class TestDataFrameLogicalOperators(object):
+class TestDataFrameLogicalOperators:
     # &, |, ^
 
     def test_logical_ops_empty_frame(self):
@@ -203,7 +203,7 @@ class TestDataFrameLogicalOperators(object):
         assert_series_equal(result, expected)
 
 
-class TestDataFrameOperators(object):
+class TestDataFrameOperators:
 
     @pytest.mark.parametrize('op', [operator.add, operator.sub,
                                     operator.mul, operator.truediv])

--- a/pandas/tests/frame/test_period.py
+++ b/pandas/tests/frame/test_period.py
@@ -14,7 +14,7 @@ def _permute(obj):
     return obj.take(np.random.permutation(len(obj)))
 
 
-class TestPeriodIndex(object):
+class TestPeriodIndex:
 
     def test_as_frame_columns(self):
         rng = period_range('1/1/2000', periods=5)

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -34,7 +34,7 @@ def skip_if_no_pandas_parser(parser):
         pytest.skip("cannot evaluate with parser {0!r}".format(parser))
 
 
-class TestCompat(object):
+class TestCompat:
 
     def setup_method(self, method):
         self.df = DataFrame({'A': [1, 2, 3]})
@@ -158,7 +158,7 @@ class TestDataFrameEval(TestData):
                 dict1['a'] + dict2['b'])
 
 
-class TestDataFrameQueryWithMultiIndex(object):
+class TestDataFrameQueryWithMultiIndex:
 
     def test_query_with_named_multiindex(self, parser, engine):
         skip_if_no_pandas_parser(parser)
@@ -354,7 +354,7 @@ class TestDataFrameQueryWithMultiIndex(object):
 
 
 @td.skip_if_no_ne
-class TestDataFrameQueryNumExprPandas(object):
+class TestDataFrameQueryNumExprPandas:
 
     @classmethod
     def setup_class(cls):
@@ -831,7 +831,7 @@ class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
         assert_frame_equal(expected, result)
 
 
-class TestDataFrameQueryStrings(object):
+class TestDataFrameQueryStrings:
 
     def test_str_query_method(self, parser, engine):
         df = DataFrame(np.random.randn(10, 1), columns=['b'])
@@ -1004,7 +1004,7 @@ class TestDataFrameQueryStrings(object):
         assert_frame_equal(e, r)
 
 
-class TestDataFrameEvalWithFrame(object):
+class TestDataFrameEvalWithFrame:
 
     def setup_method(self, method):
         self.frame = DataFrame(np.random.randn(10, 3), columns=list('abc'))
@@ -1031,7 +1031,7 @@ class TestDataFrameEvalWithFrame(object):
             df.eval('a {0} b'.format(op), engine=engine, parser=parser)
 
 
-class TestDataFrameQueryBacktickQuoting(object):
+class TestDataFrameQueryBacktickQuoting:
 
     @pytest.fixture(scope='class')
     def df(self):

--- a/pandas/tests/frame/test_timezones.py
+++ b/pandas/tests/frame/test_timezones.py
@@ -18,7 +18,7 @@ from pandas.core.indexes.datetimes import date_range
 import pandas.util.testing as tm
 
 
-class TestDataFrameTimezones(object):
+class TestDataFrameTimezones:
 
     def test_frame_values_with_tz(self):
         tz = "US/Central"

--- a/pandas/tests/frame/test_validate.py
+++ b/pandas/tests/frame/test_validate.py
@@ -8,7 +8,7 @@ def dataframe():
     return DataFrame({'a': [1, 2], 'b': [3, 4]})
 
 
-class TestDataFrameValidate(object):
+class TestDataFrameValidate:
     """Tests for error handling related to data types of method arguments."""
 
     @pytest.mark.parametrize("func", ["query", "eval", "set_index",

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -15,7 +15,7 @@ from pandas.util.testing import assert_frame_equal, assert_series_equal
 # Generic types test cases
 
 
-class Generic(object):
+class Generic:
 
     @property
     def _ndim(self):
@@ -578,7 +578,7 @@ class Generic(object):
             tm.assert_series_equal(res, Series(exp))
 
 
-class TestNDFrame(object):
+class TestNDFrame:
     # tests that don't fit elsewhere
 
     def test_sample(sel):

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -361,7 +361,7 @@ def test_agg_callables():
     # GH 7929
     df = DataFrame({'foo': [1, 2], 'bar': [3, 4]}).astype(np.int64)
 
-    class fn_class(object):
+    class fn_class:
 
         def __call__(self, x):
             return sum(x)

--- a/pandas/tests/groupby/test_bin_groupby.py
+++ b/pandas/tests/groupby/test_bin_groupby.py
@@ -48,7 +48,7 @@ def test_series_bin_grouper():
     assert_almost_equal(counts, exp_counts)
 
 
-class TestBinGroupers(object):
+class TestBinGroupers:
 
     def setup_method(self, method):
         self.obj = np.random.randn(10, 1)
@@ -121,11 +121,11 @@ def test_group_ohlc():
     _check('float64')
 
 
-class TestMoments(object):
+class TestMoments:
     pass
 
 
-class TestReducer(object):
+class TestReducer:
 
     def test_int_index(self):
         from pandas.core.series import Series

--- a/pandas/tests/groupby/test_counting.py
+++ b/pandas/tests/groupby/test_counting.py
@@ -8,7 +8,7 @@ from pandas import DataFrame, MultiIndex, Period, Series, Timedelta, Timestamp
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
-class TestCounting(object):
+class TestCounting:
 
     def test_cumcount(self):
         df = DataFrame([['a'], ['a'], ['a'], ['b'], ['a']], columns=['A'])

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1041,7 +1041,7 @@ def test_count_uses_size_on_exception():
     class RaisingObjectException(Exception):
         pass
 
-    class RaisingObject(object):
+    class RaisingObject:
 
         def __init__(self, msg='I will raise inside Cython'):
             super(RaisingObject, self).__init__()

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -20,7 +20,7 @@ from pandas.util.testing import (
 # --------------------------------
 
 
-class TestSelection(object):
+class TestSelection:
 
     def test_select_bad_cols(self):
         df = DataFrame([[1, 2]], columns=['A', 'B'])

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -15,7 +15,7 @@ from pandas.util import testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
-class TestGroupBy(object):
+class TestGroupBy:
 
     def test_groupby_with_timegrouper(self):
         # GH 4161

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -17,7 +17,7 @@ from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 import pandas.util.testing as tm
 
 
-class Base(object):
+class Base:
     """ base class for index sub-class tests """
     _holder = None
     _compat_props = ['shape', 'ndim', 'size', 'nbytes']

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -11,7 +11,7 @@ from pandas import DatetimeIndex, Series, date_range
 import pandas.util.testing as tm
 
 
-class TestDatetimeIndexArithmetic(object):
+class TestDatetimeIndexArithmetic:
 
     # -------------------------------------------------------------
     # DatetimeIndex.shift is used in integer addition

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -13,7 +13,7 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-class TestDatetimeIndex(object):
+class TestDatetimeIndex:
 
     def test_astype(self):
         # GH 13149, GH 13209
@@ -245,7 +245,7 @@ class TestDatetimeIndex(object):
         tm.assert_index_equal(result, expected)
 
 
-class TestToPeriod(object):
+class TestToPeriod:
 
     def setup_method(self, method):
         data = [Timestamp('2007-01-01 10:11:12.123456Z'),

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -17,7 +17,7 @@ from pandas.core.arrays import DatetimeArray, period_array
 import pandas.util.testing as tm
 
 
-class TestDatetimeIndex(object):
+class TestDatetimeIndex:
 
     @pytest.mark.parametrize('dt_cls', [DatetimeIndex,
                                         DatetimeArray._from_sequence])
@@ -667,7 +667,7 @@ class TestDatetimeIndex(object):
             pd.DatetimeIndex(['2000'], dtype='datetime64[us]')
 
 
-class TestTimeSeries(object):
+class TestTimeSeries:
 
     def test_dti_constructor_preserve_dti_freq(self):
         rng = date_range('1/1/2000', '1/2/2000', freq='5min')

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -23,7 +23,7 @@ from pandas.tseries.offsets import (
 START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 
-class TestTimestampEquivDateRange(object):
+class TestTimestampEquivDateRange:
     # Older tests in TestTimeSeries constructed their `stamp` objects
     # using `date_range` instead of the `Timestamp` constructor.
     # TestTimestampEquivDateRange checks that these are equivalent in the
@@ -598,7 +598,7 @@ class TestDateRanges(TestData):
         tm.assert_index_equal(result, expected)
 
 
-class TestGenRangeGeneration(object):
+class TestGenRangeGeneration:
 
     def test_generate(self):
         rng1 = list(generate_range(START, END, offset=BDay()))
@@ -666,7 +666,7 @@ class TestGenRangeGeneration(object):
             pd.date_range(start, end, freq=BDay())
 
 
-class TestBusinessDateRange(object):
+class TestBusinessDateRange:
 
     def test_constructor(self):
         bdate_range(START, END, freq=BDay())
@@ -741,7 +741,7 @@ class TestBusinessDateRange(object):
         tm.assert_index_equal(result, expected)
 
 
-class TestCustomDateRange(object):
+class TestCustomDateRange:
 
     def test_constructor(self):
         bdate_range(START, END, freq=CDay())

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -15,7 +15,7 @@ from pandas.util.testing import assert_almost_equal
 randn = np.random.randn
 
 
-class TestDatetimeIndex(object):
+class TestDatetimeIndex:
 
     def test_roundtrip_pickle_with_tz(self):
 

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -51,7 +51,7 @@ def test_to_native_types():
     tm.assert_numpy_array_equal(result, expected)
 
 
-class TestDatetimeIndexRendering(object):
+class TestDatetimeIndexRendering:
     def test_dti_repr_short(self):
         dr = pd.date_range(start='1/1/2012', periods=1)
         repr(dr)

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -13,7 +13,7 @@ from pandas.tseries.offsets import BDay, CDay
 START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 
-class TestGetItem(object):
+class TestGetItem:
     def test_ellipsis(self):
         # GH#21282
         idx = pd.date_range('2011-01-01', '2011-01-31', freq='D',
@@ -107,7 +107,7 @@ class TestGetItem(object):
         tm.assert_numpy_array_equal(values, expected)
 
 
-class TestWhere(object):
+class TestWhere:
     def test_where_other(self):
         # other is ndarray or Index
         i = pd.date_range('20130101', periods=3, tz='US/Eastern')
@@ -140,7 +140,7 @@ class TestWhere(object):
         tm.assert_index_equal(result, expected)
 
 
-class TestTake(object):
+class TestTake:
     def test_take(self):
         # GH#10295
         idx1 = pd.date_range('2011-01-01', '2011-01-31', freq='D', name='idx')
@@ -284,7 +284,7 @@ class TestTake(object):
             idx.take(np.array([1, -5]))
 
 
-class TestDatetimeIndex(object):
+class TestDatetimeIndex:
     @pytest.mark.parametrize('null', [None, np.nan, pd.NaT])
     @pytest.mark.parametrize('tz', [None, 'UTC', 'US/Eastern'])
     def test_insert_nat(self, tz, null):

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -11,7 +11,7 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-class TestTimeSeries(object):
+class TestTimeSeries:
 
     def test_pass_datetimeindex_to_index(self):
         # Bugs in #1396
@@ -88,7 +88,7 @@ class TestTimeSeries(object):
         tm.assert_index_equal(idx, exp)
 
 
-class TestDatetime64(object):
+class TestDatetime64:
 
     def test_datetimeindex_accessors(self):
         dti_naive = pd.date_range(freq='D', start=datetime(1998, 1, 1),

--- a/pandas/tests/indexes/datetimes/test_missing.py
+++ b/pandas/tests/indexes/datetimes/test_missing.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 
-class TestDatetimeIndex(object):
+class TestDatetimeIndex:
 
     @pytest.mark.parametrize('tz', ['US/Eastern', 'Asia/Tokyo'])
     def test_fillna_datetime64(self, tz):

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -390,7 +390,7 @@ class TestDatetimeIndexOps(Ops):
             idx.offset = BDay()
 
 
-class TestBusinessDatetimeIndex(object):
+class TestBusinessDatetimeIndex:
 
     def setup_method(self, method):
         self.rng = bdate_range(START, END)
@@ -449,7 +449,7 @@ class TestBusinessDatetimeIndex(object):
         assert not t1.identical(t2v)
 
 
-class TestCustomDatetimeIndex(object):
+class TestCustomDatetimeIndex:
     def setup_method(self, method):
         self.rng = bdate_range(START, END, freq='C')
 

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -13,7 +13,7 @@ from pandas.core.indexing import IndexingError
 from pandas.util import testing as tm
 
 
-class TestSlicing(object):
+class TestSlicing:
     def test_dti_slicing(self):
         dti = date_range(start='1/1/2005', end='12/1/2005', freq='M')
         dti2 = dti[[1, 3, 5]]

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -16,7 +16,7 @@ import pandas.util.testing as tm
 from pandas.tseries.frequencies import to_offset
 
 
-class TestDatetimeIndexOps(object):
+class TestDatetimeIndexOps:
     def test_dti_time(self):
         rng = date_range('1/1/2000', freq='12min', periods=10)
         result = pd.Index(rng).time
@@ -254,7 +254,7 @@ class TestDatetimeIndexOps(object):
         tm.assert_index_equal(result, expected)
 
 
-class TestDateTimeIndexToJulianDate(object):
+class TestDateTimeIndexToJulianDate:
 
     def test_1700(self):
         dr = date_range(start=Timestamp('1710-10-01'), periods=5, freq='D')

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -16,7 +16,7 @@ from pandas.tseries.offsets import BMonthEnd, Minute, MonthEnd
 START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 
-class TestDatetimeIndexSetOps(object):
+class TestDatetimeIndexSetOps:
     tz = [None, 'UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/Asia/Singapore',
           'dateutil/US/Pacific']
 
@@ -318,7 +318,7 @@ class TestDatetimeIndexSetOps(object):
         assert rs.is_monotonic
 
 
-class TestBusinessDatetimeIndex(object):
+class TestBusinessDatetimeIndex:
 
     def setup_method(self, method):
         self.rng = bdate_range(START, END)
@@ -472,7 +472,7 @@ class TestBusinessDatetimeIndex(object):
         early_dr.union(late_dr, sort=sort)
 
 
-class TestCustomDatetimeIndex(object):
+class TestCustomDatetimeIndex:
 
     def setup_method(self, method):
         self.rng = bdate_range(START, END, freq='C')

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -43,7 +43,7 @@ fixed_off = FixedOffset(-420, '-07:00')
 fixed_off_no_name = FixedOffset(-330, None)
 
 
-class TestDatetimeIndexTimezones(object):
+class TestDatetimeIndexTimezones:
     # -------------------------------------------------------------
     # DatetimeIndex.tz_convert
     def test_tz_convert_nat(self):
@@ -1092,7 +1092,7 @@ class TestDatetimeIndexTimezones(object):
             assert ts == index[i]
 
 
-class TestDateRange(object):
+class TestDateRange:
     """Tests for date_range with timezones"""
     def test_hongkong_tz_convert(self):
         # GH#1673 smoke test
@@ -1145,7 +1145,7 @@ class TestDateRange(object):
         assert stamp == rng[1]
 
 
-class TestToDatetime(object):
+class TestToDatetime:
     """Tests for the to_datetime constructor with timezones"""
     def test_to_datetime_utc(self):
         arr = np.array([dateutil.parser.parse('2012-06-13T01:39:00Z')],

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -30,7 +30,7 @@ from pandas.util import testing as tm
 from pandas.util.testing import assert_series_equal
 
 
-class TestTimeConversionFormats(object):
+class TestTimeConversionFormats:
 
     @pytest.mark.parametrize('cache', [True, False])
     def test_to_datetime_format(self, cache):
@@ -243,7 +243,7 @@ class TestTimeConversionFormats(object):
         tm.assert_index_equal(result, expected)
 
 
-class TestToDatetime(object):
+class TestToDatetime:
     @pytest.mark.parametrize("s, _format, dt", [
         ['2015-1-1', '%G-%V-%u', datetime(2014, 12, 29, 0, 0)],
         ['2015-1-4', '%G-%V-%u', datetime(2015, 1, 1, 0, 0)],
@@ -824,7 +824,7 @@ class TestToDatetime(object):
         assert result == expected
 
 
-class TestToDatetimeUnit(object):
+class TestToDatetimeUnit:
     @pytest.mark.parametrize('cache', [True, False])
     def test_unit(self, cache):
         # GH 11758
@@ -1147,7 +1147,7 @@ class TestToDatetimeUnit(object):
         tm.assert_index_equal(result, expected)
 
 
-class TestToDatetimeMisc(object):
+class TestToDatetimeMisc:
     def test_to_datetime_barely_out_of_bounds(self):
         # GH#19529
         # GH#19382 close enough to bounds that dropping nanos would result
@@ -1396,7 +1396,7 @@ class TestToDatetimeMisc(object):
         tm.assert_index_equal(expected, idx6)
 
 
-class TestGuessDatetimeFormat(object):
+class TestGuessDatetimeFormat:
 
     @td.skip_if_not_us_locale
     def test_guess_datetime_format_for_array(self):
@@ -1419,7 +1419,7 @@ class TestGuessDatetimeFormat(object):
         assert format_for_string_of_nans is None
 
 
-class TestToDatetimeInferFormat(object):
+class TestToDatetimeInferFormat:
 
     @pytest.mark.parametrize('cache', [True, False])
     def test_to_datetime_infer_datetime_format_consistent_format(self, cache):
@@ -1498,7 +1498,7 @@ class TestToDatetimeInferFormat(object):
                                               cache=cache), expected)
 
 
-class TestDaysInMonth(object):
+class TestDaysInMonth:
     # tests for issue #10154
 
     @pytest.mark.parametrize('cache', [True, False])
@@ -1544,7 +1544,7 @@ class TestDaysInMonth(object):
                            format="%Y-%m-%d", cache=cache) == '2015-04-31'
 
 
-class TestDatetimeParsingWrappers(object):
+class TestDatetimeParsingWrappers:
 
     @pytest.mark.parametrize('date_str,expected', list({
         '2011-01-01': datetime(2011, 1, 1),
@@ -1857,7 +1857,7 @@ def julian_dates():
     return pd.date_range('2014-1-1', periods=10).to_julian_date().values
 
 
-class TestOrigin(object):
+class TestOrigin:
 
     def test_to_basic(self, julian_dates):
         # gh-11276, gh-11745

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -9,7 +9,7 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-class Base(object):
+class Base:
     """Tests common to IntervalIndex with any subtype"""
 
     def test_astype_idempotent(self, index):

--- a/pandas/tests/indexes/interval/test_construction.py
+++ b/pandas/tests/indexes/interval/test_construction.py
@@ -21,7 +21,7 @@ def name(request):
     return request.param
 
 
-class Base(object):
+class Base:
     """
     Common tests for all variations of IntervalIndex construction. Input data
     to be supplied in breaks format, then converted by the subclass method

--- a/pandas/tests/indexes/interval/test_interval_new.py
+++ b/pandas/tests/indexes/interval/test_interval_new.py
@@ -7,7 +7,7 @@ import pandas.util.testing as tm
 pytestmark = pytest.mark.skip(reason="new indexing tests for issue 16316")
 
 
-class TestIntervalIndex(object):
+class TestIntervalIndex:
 
     @pytest.mark.parametrize("side", ['right', 'left', 'both', 'neither'])
     def test_get_loc_interval(self, closed, side):

--- a/pandas/tests/indexes/interval/test_interval_range.py
+++ b/pandas/tests/indexes/interval/test_interval_range.py
@@ -18,7 +18,7 @@ def name(request):
     return request.param
 
 
-class TestIntervalRange(object):
+class TestIntervalRange:
 
     @pytest.mark.parametrize('freq, periods', [
         (1, 100), (2.5, 40), (5, 20), (25, 4)])

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -47,7 +47,7 @@ def tree(request, leaf_size):
     return IntervalTree(left, left + 2, leaf_size=leaf_size)
 
 
-class TestIntervalTree(object):
+class TestIntervalTree:
 
     def test_get_loc(self, tree):
         result = tree.get_loc(1)

--- a/pandas/tests/indexes/period/test_arithmetic.py
+++ b/pandas/tests/indexes/period/test_arithmetic.py
@@ -8,7 +8,7 @@ from pandas import PeriodIndex, period_range
 import pandas.util.testing as tm
 
 
-class TestPeriodIndexArithmetic(object):
+class TestPeriodIndexArithmetic:
     # ---------------------------------------------------------------
     # PeriodIndex.shift is used by __add__ and __sub__
 

--- a/pandas/tests/indexes/period/test_asfreq.py
+++ b/pandas/tests/indexes/period/test_asfreq.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, PeriodIndex, Series, period_range
 from pandas.util import testing as tm
 
 
-class TestPeriodIndex(object):
+class TestPeriodIndex:
 
     def test_asfreq(self):
         pi1 = period_range(freq='A', start='1/1/2001', end='1/1/2001')

--- a/pandas/tests/indexes/period/test_astype.py
+++ b/pandas/tests/indexes/period/test_astype.py
@@ -8,7 +8,7 @@ from pandas import Index, Int64Index, NaT, Period, PeriodIndex, period_range
 import pandas.util.testing as tm
 
 
-class TestPeriodIndexAsType(object):
+class TestPeriodIndexAsType:
     @pytest.mark.parametrize('dtype', [
         float, 'timedelta64', 'timedelta64[ns]'])
     def test_astype_raises(self, dtype):

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -13,7 +13,7 @@ import pandas.core.indexes.period as period
 import pandas.util.testing as tm
 
 
-class TestPeriodIndex(object):
+class TestPeriodIndex:
 
     def setup_method(self, method):
         pass
@@ -527,7 +527,7 @@ class TestPeriodIndex(object):
         tm.assert_index_equal(res, expected)
 
 
-class TestSeriesPeriod(object):
+class TestSeriesPeriod:
 
     def setup_method(self, method):
         self.series = Series(period_range('2000-01-01', periods=10, freq='D'))

--- a/pandas/tests/indexes/period/test_formats.py
+++ b/pandas/tests/indexes/period/test_formats.py
@@ -48,7 +48,7 @@ def test_to_native_types():
     tm.assert_numpy_array_equal(result, expected)
 
 
-class TestPeriodIndexRendering(object):
+class TestPeriodIndexRendering:
 
     def test_frame_repr(self):
         df = pd.DataFrame({"A": [1, 2, 3]},

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -12,7 +12,7 @@ from pandas import (
 from pandas.util import testing as tm
 
 
-class TestGetItem(object):
+class TestGetItem:
     def test_ellipsis(self):
         # GH#21282
         idx = period_range('2011-01-01', '2011-01-31', freq='D',
@@ -199,7 +199,7 @@ class TestGetItem(object):
                     s[v]
 
 
-class TestWhere(object):
+class TestWhere:
     @pytest.mark.parametrize('klass', [list, tuple, np.array, Series])
     def test_where(self, klass):
         i = period_range('20130101', periods=5, freq='D')
@@ -233,7 +233,7 @@ class TestWhere(object):
         tm.assert_index_equal(result, i2)
 
 
-class TestTake(object):
+class TestTake:
     def test_take(self):
         # GH#10295
         idx1 = pd.period_range('2011-01-01', '2011-01-31', freq='D',
@@ -332,7 +332,7 @@ class TestTake(object):
             idx.take(np.array([1, -5]))
 
 
-class TestIndexing(object):
+class TestIndexing:
 
     def test_get_loc_msg(self):
         idx = period_range('2000-1-1', freq='A', periods=10)

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, Period, Series, period_range
 from pandas.util import testing as tm
 
 
-class TestPeriodIndex(object):
+class TestPeriodIndex:
 
     def setup_method(self, method):
         pass

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -4,7 +4,7 @@ from pandas import NaT, Period, PeriodIndex, date_range, period_range
 import pandas.util.testing as tm
 
 
-class TestPeriodRange(object):
+class TestPeriodRange:
 
     @pytest.mark.parametrize('freq', ['D', 'W', 'M', 'Q', 'A'])
     def test_construction_from_string(self, freq):

--- a/pandas/tests/indexes/period/test_scalar_compat.py
+++ b/pandas/tests/indexes/period/test_scalar_compat.py
@@ -5,7 +5,7 @@ from pandas import Timedelta, date_range, period_range
 import pandas.util.testing as tm
 
 
-class TestPeriodIndexOps(object):
+class TestPeriodIndexOps:
     def test_start_time(self):
         index = period_range(freq='M', start='2016-01-01', end='2016-05-31')
         expected_index = date_range('2016-01-01', end='2016-05-31', freq='MS')

--- a/pandas/tests/indexes/period/test_setops.py
+++ b/pandas/tests/indexes/period/test_setops.py
@@ -11,7 +11,7 @@ def _permute(obj):
     return obj.take(np.random.permutation(len(obj)))
 
 
-class TestPeriodIndex(object):
+class TestPeriodIndex:
 
     def test_joins(self, join_type):
         index = period_range('1/1/2000', '1/20/2000', freq='D')

--- a/pandas/tests/indexes/period/test_tools.py
+++ b/pandas/tests/indexes/period/test_tools.py
@@ -14,7 +14,7 @@ import pandas.core.indexes.period as period
 import pandas.util.testing as tm
 
 
-class TestPeriodRepresentation(object):
+class TestPeriodRepresentation:
     """
     Wish to match NumPy units
     """
@@ -54,7 +54,7 @@ class TestPeriodRepresentation(object):
         repr(period)
 
 
-class TestPeriodIndex(object):
+class TestPeriodIndex:
     def test_to_timestamp(self):
         index = period_range(freq='A', start='1/1/2001', end='12/1/2009')
         series = Series(1, index=index, name='foo')
@@ -227,7 +227,7 @@ class TestPeriodIndex(object):
             pidx.searchsorted(pd.Period('2014-01-01', freq='5D'))
 
 
-class TestPeriodIndexConversion(object):
+class TestPeriodIndexConversion:
     def test_tolist(self):
         index = period_range(freq='A', start='1/1/2001', end='12/1/2009')
         rs = index.tolist()

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -221,7 +221,7 @@ class TestIndex(Base):
         # GH 5460#issuecomment-44474502
         # it should be possible to convert any object that satisfies the numpy
         # ndarray interface directly into an Index
-        class ArrayLike(object):
+        class ArrayLike:
             def __init__(self, array):
                 self.array = array
 
@@ -2406,7 +2406,7 @@ class TestMixedIntIndex(Base):
         tm.assert_index_equal(result, expected)
 
 
-class TestIndexUtils(object):
+class TestIndexUtils:
 
     @pytest.mark.parametrize('data, names, expected', [
         ([[1, 2, 3]], None, Index([1, 2, 3])),

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -17,7 +17,7 @@ from pandas import CategoricalIndex, MultiIndex, RangeIndex
 import pandas.util.testing as tm
 
 
-class TestCommon(object):
+class TestCommon:
 
     def test_droplevel(self, indices):
         # GH 21115

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -25,7 +25,7 @@ def freq(request):
     return request.param
 
 
-class TestTimedeltaIndexArithmetic(object):
+class TestTimedeltaIndexArithmetic:
     # Addition and Subtraction Operations
 
     # -------------------------------------------------------------

--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -10,7 +10,7 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-class TestTimedeltaIndex(object):
+class TestTimedeltaIndex:
     def test_astype_object(self):
         idx = timedelta_range(start='1 days', periods=4, freq='D', name='idx')
         expected_list = [Timedelta('1 days'), Timedelta('2 days'),

--- a/pandas/tests/indexes/timedeltas/test_construction.py
+++ b/pandas/tests/indexes/timedeltas/test_construction.py
@@ -9,7 +9,7 @@ from pandas.core.arrays import TimedeltaArray
 import pandas.util.testing as tm
 
 
-class TestTimedeltaIndex(object):
+class TestTimedeltaIndex:
 
     def test_verify_integrity_deprecated(self):
         # GH#23919

--- a/pandas/tests/indexes/timedeltas/test_formats.py
+++ b/pandas/tests/indexes/timedeltas/test_formats.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pandas import TimedeltaIndex
 
 
-class TestTimedeltaIndexRendering(object):
+class TestTimedeltaIndexRendering:
     @pytest.mark.parametrize('method', ['__repr__', '__unicode__', '__str__'])
     def test_representation(self, method):
         idx1 = TimedeltaIndex([], freq='D')

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -8,7 +8,7 @@ from pandas import Index, Timedelta, TimedeltaIndex, timedelta_range
 import pandas.util.testing as tm
 
 
-class TestGetItem(object):
+class TestGetItem:
     def test_ellipsis(self):
         # GH#21282
         idx = timedelta_range('1 day', '31 day', freq='D', name='idx')
@@ -59,12 +59,12 @@ class TestGetItem(object):
             tdi.get_loc(key)
 
 
-class TestWhere(object):
+class TestWhere:
     # placeholder for symmetry with DatetimeIndex and PeriodIndex tests
     pass
 
 
-class TestTake(object):
+class TestTake:
     def test_take(self):
         # GH 10295
         idx1 = timedelta_range('1 day', '31 day', freq='D', name='idx')
@@ -168,7 +168,7 @@ class TestTake(object):
             idx.take(np.array([1, -5]))
 
 
-class TestTimedeltaIndex(object):
+class TestTimedeltaIndex:
 
     def test_insert(self):
 

--- a/pandas/tests/indexes/timedeltas/test_partial_slicing.py
+++ b/pandas/tests/indexes/timedeltas/test_partial_slicing.py
@@ -6,7 +6,7 @@ from pandas import Series, Timedelta, timedelta_range
 from pandas.util.testing import assert_series_equal
 
 
-class TestSlicing(object):
+class TestSlicing:
     def test_slice_keeps_name(self):
         # GH4226
         dr = pd.timedelta_range('1d', '5d', freq='H', name='timebucket')

--- a/pandas/tests/indexes/timedeltas/test_scalar_compat.py
+++ b/pandas/tests/indexes/timedeltas/test_scalar_compat.py
@@ -11,7 +11,7 @@ from pandas import Index, Series, Timedelta, TimedeltaIndex, timedelta_range
 import pandas.util.testing as tm
 
 
-class TestVectorizedTimedelta(object):
+class TestVectorizedTimedelta:
     def test_tdi_total_seconds(self):
         # GH#10939
         # test index

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -5,7 +5,7 @@ from pandas import Int64Index, TimedeltaIndex, timedelta_range
 import pandas.util.testing as tm
 
 
-class TestTimedeltaIndex(object):
+class TestTimedeltaIndex:
 
     def test_union(self):
 

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -338,7 +338,7 @@ class TestTimedeltaIndex(DatetimeLike):
         assert re.match(msg, str(w[0].message))
 
 
-class TestTimeSeries(object):
+class TestTimeSeries:
 
     def test_series_box_timedelta(self):
         rng = timedelta_range('1 day 1 s', periods=5, freq='h')

--- a/pandas/tests/indexes/timedeltas/test_timedelta_range.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta_range.py
@@ -8,7 +8,7 @@ import pandas.util.testing as tm
 from pandas.tseries.offsets import Day, Second
 
 
-class TestTimedeltas(object):
+class TestTimedeltas:
 
     def test_timedelta_range(self):
 

--- a/pandas/tests/indexes/timedeltas/test_tools.py
+++ b/pandas/tests/indexes/timedeltas/test_tools.py
@@ -11,7 +11,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_series_equal
 
 
-class TestTimedeltas(object):
+class TestTimedeltas:
 
     def test_to_timedelta(self):
         def conv(v):

--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -29,7 +29,7 @@ def _axify(obj, key, axis):
     return tuple(axes)
 
 
-class Base(object):
+class Base:
     """ indexing comprehensive base class """
 
     _objs = {'series', 'frame'}

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, Interval, IntervalIndex, Series
 import pandas.util.testing as tm
 
 
-class TestIntervalIndex(object):
+class TestIntervalIndex:
 
     def setup_method(self, method):
         self.s = Series(np.arange(5), IntervalIndex.from_breaks(np.arange(6)))

--- a/pandas/tests/indexing/interval/test_interval_new.py
+++ b/pandas/tests/indexing/interval/test_interval_new.py
@@ -7,7 +7,7 @@ import pandas.util.testing as tm
 pytestmark = pytest.mark.skip(reason="new indexing tests for issue 16316")
 
 
-class TestIntervalIndex(object):
+class TestIntervalIndex:
 
     def setup_method(self, method):
         self.s = Series(np.arange(5), IntervalIndex.from_breaks(np.arange(6)))

--- a/pandas/tests/indexing/multiindex/test_ix.py
+++ b/pandas/tests/indexing/multiindex/test_ix.py
@@ -10,7 +10,7 @@ from pandas.util import testing as tm
 
 
 @pytest.mark.filterwarnings("ignore:\\n.ix:DeprecationWarning")
-class TestMultiIndexIx(object):
+class TestMultiIndexIx:
 
     def test_frame_setitem_ix(self, multiindex_dataframe_random_data):
         frame = multiindex_dataframe_random_data

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -25,7 +25,7 @@ def frame_random_data_integer_multi_index():
 
 
 @pytest.mark.filterwarnings("ignore:\\n.ix:DeprecationWarning")
-class TestMultiIndexLoc(object):
+class TestMultiIndexLoc:
 
     def test_loc_getitem_series(self):
         # GH14730

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -10,7 +10,7 @@ from pandas import DataFrame, Index, MultiIndex, Series
 from pandas.util import testing as tm
 
 
-class TestMultiIndexBasic(object):
+class TestMultiIndexBasic:
 
     def test_multiindex_perf_warn(self):
 

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -7,7 +7,7 @@ from pandas import DataFrame, MultiIndex
 from pandas.util import testing as tm
 
 
-class TestMultiIndexPartial(object):
+class TestMultiIndexPartial:
 
     def test_getitem_partial_int(self):
         # GH 12416

--- a/pandas/tests/indexing/multiindex/test_set_ops.py
+++ b/pandas/tests/indexing/multiindex/test_set_ops.py
@@ -4,7 +4,7 @@ from pandas import DataFrame, MultiIndex, Series
 from pandas.util import testing as tm
 
 
-class TestMultiIndexSetOps(object):
+class TestMultiIndexSetOps:
 
     def test_multiindex_symmetric_difference(self):
         # GH 13490

--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -12,7 +12,7 @@ from pandas.util import testing as tm
 
 
 @pytest.mark.filterwarnings("ignore:\\n.ix:DeprecationWarning")
-class TestMultiIndexSetItem(object):
+class TestMultiIndexSetItem:
 
     def test_setitem_multiindex(self):
         with catch_warnings(record=True):

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -13,7 +13,7 @@ from pandas.util import testing as tm
 
 
 @pytest.mark.filterwarnings("ignore:\\n.ix:DeprecationWarning")
-class TestMultiIndexSlicers(object):
+class TestMultiIndexSlicers:
 
     def test_per_axis_per_level_getitem(self):
 

--- a/pandas/tests/indexing/multiindex/test_sorted.py
+++ b/pandas/tests/indexing/multiindex/test_sorted.py
@@ -7,7 +7,7 @@ from pandas import DataFrame, MultiIndex, Series
 from pandas.util import testing as tm
 
 
-class TestMultiIndexSorted(object):
+class TestMultiIndexSorted:
     def test_getitem_multilevel_index_tuple_not_sorted(self):
         index_columns = list("abc")
         df = DataFrame([[0, 1, 0, "x"], [0, 0, 1, "y"]],

--- a/pandas/tests/indexing/test_callable.py
+++ b/pandas/tests/indexing/test_callable.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 
-class TestIndexingCallable(object):
+class TestIndexingCallable:
 
     def test_frame_loc_ix_callable(self):
         # GH 11485

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -15,7 +15,7 @@ from pandas.util import testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
-class TestCategoricalIndex(object):
+class TestCategoricalIndex:
 
     def setup_method(self, method):
 

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -8,7 +8,7 @@ from pandas.core import common as com
 from pandas.util import testing as tm
 
 
-class TestCaching(object):
+class TestCaching:
 
     def test_slice_consolidate_invalidate_item_cache(self):
 
@@ -88,7 +88,7 @@ class TestCaching(object):
         tm.assert_series_equal(out['A'], expected['A'])
 
 
-class TestChaining(object):
+class TestChaining:
 
     def test_setitem_chained_setfault(self):
 

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -36,7 +36,7 @@ def check_comprehensiveness(request):
     yield
 
 
-class CoercionBase(object):
+class CoercionBase:
 
     klasses = ['index', 'series']
     dtypes = ['object', 'int64', 'float64', 'complex128', 'bool',

--- a/pandas/tests/indexing/test_datetime.py
+++ b/pandas/tests/indexing/test_datetime.py
@@ -8,7 +8,7 @@ from pandas import DataFrame, Index, Series, Timestamp, date_range
 from pandas.util import testing as tm
 
 
-class TestDatetimeIndex(object):
+class TestDatetimeIndex:
 
     def test_setitem_with_datetime_tz(self):
         # 16889

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -13,7 +13,7 @@ from pandas.util.testing import assert_almost_equal, assert_series_equal
 ignore_ix = pytest.mark.filterwarnings("ignore:\\n.ix:DeprecationWarning")
 
 
-class TestFloatIndexers(object):
+class TestFloatIndexers:
 
     def check(self, result, original, indexer, getitem):
         """

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -412,7 +412,7 @@ class TestFancy(Base):
         tm.assert_frame_equal(result, df)
 
         # ix with an object
-        class TO(object):
+        class TO:
 
             def __init__(self, value):
                 self.value = value
@@ -862,7 +862,7 @@ class TestMisc(Base):
         assert wr() is None
 
 
-class TestSeriesNoneCoercion(object):
+class TestSeriesNoneCoercion:
     EXPECTED_RESULTS = [
         # For numeric series, we should coerce to NaN.
         ([1, 2, 3], [np.nan, 2, 3]),
@@ -909,7 +909,7 @@ class TestSeriesNoneCoercion(object):
             tm.assert_series_equal(start_series, expected_series)
 
 
-class TestDataframeNoneCoercion(object):
+class TestDataframeNoneCoercion:
     EXPECTED_SINGLE_ROW_RESULTS = [
         # For numeric series, we should coerce to NaN.
         ([1, 2, 3], [np.nan, 2, 3]),

--- a/pandas/tests/indexing/test_indexing_engines.py
+++ b/pandas/tests/indexing/test_indexing_engines.py
@@ -5,7 +5,7 @@ from pandas._libs import algos as libalgos, index as libindex
 import pandas.util.testing as tm
 
 
-class TestNumericEngine(object):
+class TestNumericEngine:
     def test_is_monotonic(self, numeric_indexing_engine_type_and_dtype):
         engine_type, dtype = numeric_indexing_engine_type_and_dtype
         num = 1000
@@ -88,7 +88,7 @@ class TestNumericEngine(object):
         tm.assert_numpy_array_equal(result, expected)
 
 
-class TestObjectEngine(object):
+class TestObjectEngine:
     engine_type = libindex.ObjectEngine
     dtype = np.object_
     values = list('abc')

--- a/pandas/tests/indexing/test_indexing_slow.py
+++ b/pandas/tests/indexing/test_indexing_slow.py
@@ -6,7 +6,7 @@ from pandas import DataFrame
 import pandas.util.testing as tm
 
 
-class TestIndexingSlow(object):
+class TestIndexingSlow:
 
     @pytest.mark.slow
     def test_large_dataframe_indexing(self):

--- a/pandas/tests/indexing/test_ix.py
+++ b/pandas/tests/indexing/test_ix.py
@@ -24,7 +24,7 @@ def test_ix_deprecation():
 
 
 @pytest.mark.filterwarnings("ignore:\\n.ix:DeprecationWarning")
-class TestIX(object):
+class TestIX:
 
     def test_ix_loc_setitem_consistency(self):
 

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -14,7 +14,7 @@ from pandas import DataFrame, Index, Series, date_range
 from pandas.util import testing as tm
 
 
-class TestPartialSetting(object):
+class TestPartialSetting:
 
     @pytest.mark.filterwarnings("ignore:\\n.ix:DeprecationWarning")
     def test_partial_setting(self):

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -5,7 +5,7 @@ import pandas as pd
 from pandas.util import testing as tm
 
 
-class TestTimedeltaIndexing(object):
+class TestTimedeltaIndexing:
     def test_boolean_indexing(self):
         # GH 14946
         df = pd.DataFrame({'x': range(10)})

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -193,7 +193,7 @@ def create_mgr(descr, item_shape=None):
                         [mgr_items] + [np.arange(n) for n in item_shape])
 
 
-class TestBlock(object):
+class TestBlock:
 
     def setup_method(self, method):
         # self.fblock = get_float_ex()  # a,c,e
@@ -295,7 +295,7 @@ class TestBlock(object):
                                         dtype=block.values.dtype)
 
 
-class TestDatetimeBlock(object):
+class TestDatetimeBlock:
 
     def test_try_coerce_arg(self):
         block = create_block('datetime', [0])
@@ -313,7 +313,7 @@ class TestDatetimeBlock(object):
             assert pd.Timestamp('2010-10-10') == pd.Timestamp(coerced)
 
 
-class TestBlockManager(object):
+class TestBlockManager:
 
     def test_constructor_corner(self):
         pass
@@ -834,7 +834,7 @@ class TestBlockManager(object):
                 bm1.replace_list([1], [2], inplace=value)
 
 
-class TestIndexing(object):
+class TestIndexing:
     # Nosetests-style data-driven tests.
     #
     # This test applies different indexing routines to block managers and
@@ -1037,7 +1037,7 @@ class TestIndexing(object):
     # reindex_indexer(new_labels, indexer, axis)
 
 
-class TestBlockPlacement(object):
+class TestBlockPlacement:
 
     def test_slice_len(self):
         assert len(BlockPlacement(slice(0, 4))) == 4
@@ -1179,7 +1179,7 @@ class TestBlockPlacement(object):
                 BlockPlacement(slice(2, None, -1)).add(-1)
 
 
-class DummyElement(object):
+class DummyElement:
     def __init__(self, value, dtype):
         self.value = value
         self.dtype = np.dtype(dtype)
@@ -1204,7 +1204,7 @@ class DummyElement(object):
         return bool(self.value)
 
 
-class TestCanHoldElement(object):
+class TestCanHoldElement:
     @pytest.mark.parametrize('value, dtype', [
         (1, 'i8'),
         (1.0, 'f8'),

--- a/pandas/tests/io/formats/test_console.py
+++ b/pandas/tests/io/formats/test_console.py
@@ -3,7 +3,7 @@ import pytest
 from pandas._config import detect_console_encoding
 
 
-class MockEncoding(object):  # TODO(py27): replace with mock
+class MockEncoding:  # TODO(py27): replace with mock
     """
     Used to add a side effect when accessing the 'encoding' property. If the
     side effect is a str in nature, the value will be returned. Otherwise, the

--- a/pandas/tests/io/formats/test_eng_formatting.py
+++ b/pandas/tests/io/formats/test_eng_formatting.py
@@ -7,7 +7,7 @@ from pandas.util import testing as tm
 import pandas.io.formats.format as fmt
 
 
-class TestEngFormatter(object):
+class TestEngFormatter:
 
     def test_eng_float_formatter(self):
         df = DataFrame({'A': [1.41, 141., 14100, 1410000.]})

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -103,7 +103,7 @@ def has_expanded_repr(df):
     return False
 
 
-class TestDataFrameFormatting(object):
+class TestDataFrameFormatting:
 
     def setup_method(self, method):
         self.warn_filters = warnings.filters
@@ -1719,7 +1719,7 @@ c  10  11  12  13  14\
         If the test fails, it at least won't hang.
         """
 
-        class A(object):
+        class A:
             def __getitem__(self, key):
                 return 3  # obviously simplified
 
@@ -1772,7 +1772,7 @@ def gen_series_formatting():
     return test_sers
 
 
-class TestSeriesFormatting(object):
+class TestSeriesFormatting:
 
     def setup_method(self, method):
         self.ts = tm.makeTimeSeries()
@@ -2355,7 +2355,7 @@ def _three_digit_exp():
     return '{x:.4g}'.format(x=1.7e8) == '1.7e+008'
 
 
-class TestFloatArrayFormatter(object):
+class TestFloatArrayFormatter:
 
     def test_misc(self):
         obj = fmt.FloatArrayFormatter(np.array([], dtype=np.float64))
@@ -2441,7 +2441,7 @@ class TestFloatArrayFormatter(object):
             assert str(df) == '            x\n0  1.2346e+04\n1  2.0000e+06'
 
 
-class TestRepr_timedelta64(object):
+class TestRepr_timedelta64:
 
     def test_none(self):
         delta_1d = pd.to_timedelta(1, unit='D')
@@ -2507,7 +2507,7 @@ class TestRepr_timedelta64(object):
         assert drepr(-delta_1d + delta_1ns) == "-1 days +00:00:00.000000001"
 
 
-class TestTimedelta64Formatter(object):
+class TestTimedelta64Formatter:
 
     def test_days(self):
         x = pd.to_timedelta(list(range(5)) + [pd.NaT], unit='D')
@@ -2553,7 +2553,7 @@ class TestTimedelta64Formatter(object):
         assert result[0].strip() == "'0 days'"
 
 
-class TestDatetime64Formatter(object):
+class TestDatetime64Formatter:
 
     def test_mixed(self):
         x = Series([datetime(2013, 1, 1), datetime(2013, 1, 1, 12), pd.NaT])
@@ -2634,7 +2634,7 @@ class TestDatetime64Formatter(object):
         assert result == ['10:10', '12:12']
 
 
-class TestNaTFormatting(object):
+class TestNaTFormatting:
 
     def test_repr(self):
         assert repr(pd.NaT) == "NaT"
@@ -2643,7 +2643,7 @@ class TestNaTFormatting(object):
         assert str(pd.NaT) == "NaT"
 
 
-class TestDatetimeIndexFormat(object):
+class TestDatetimeIndexFormat:
 
     def test_datetime(self):
         formatted = pd.to_datetime([datetime(2003, 1, 1, 12), pd.NaT]).format()
@@ -2670,7 +2670,7 @@ class TestDatetimeIndexFormat(object):
         assert formatted[1] == "UT"
 
 
-class TestDatetimeIndexUnicode(object):
+class TestDatetimeIndexUnicode:
 
     def test_dates(self):
         text = str(pd.to_datetime([datetime(2013, 1, 1), datetime(2014, 1, 1)
@@ -2685,7 +2685,7 @@ class TestDatetimeIndexUnicode(object):
         assert "'2014-01-01 00:00:00']" in text
 
 
-class TestStringRepTimestamp(object):
+class TestStringRepTimestamp:
 
     def test_no_tz(self):
         dt_date = datetime(2013, 1, 2)

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -33,7 +33,7 @@ def test_repr_binary_type():
     assert res == b
 
 
-class TestFormattBase(object):
+class TestFormattBase:
 
     def test_adjoin(self):
         data = [['a', 'b', 'c'], ['dd', 'ee', 'ff'], ['ggg', 'hhh', 'iii']]
@@ -121,7 +121,7 @@ c        ff         いいい"""
         assert adjoined == expected
 
 
-class TestTableSchemaRepr(object):
+class TestTableSchemaRepr:
 
     @classmethod
     def setup_class(cls):

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -15,7 +15,7 @@ jinja2 = pytest.importorskip('jinja2')
 from pandas.io.formats.style import Styler, _get_level_lengths  # noqa  # isort:skip
 
 
-class TestStyler(object):
+class TestStyler:
 
     def setup_method(self, method):
         np.random.seed(24)
@@ -1219,7 +1219,7 @@ class TestStyler(object):
 
 
 @td.skip_if_no_mpl
-class TestStylerMatplotlibDep(object):
+class TestStylerMatplotlibDep:
 
     def test_background_gradient(self):
         df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -11,7 +11,7 @@ from pandas import DataFrame, compat
 from pandas.util import testing as tm
 
 
-class TestToCSV(object):
+class TestToCSV:
 
     @pytest.mark.xfail((3, 6, 5) > sys.version_info >= (3, 5),
                        reason=("Python csv library bug "

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -13,7 +13,7 @@ def frame():
     return DataFrame(tm.getSeriesData())
 
 
-class TestToLatex(object):
+class TestToLatex:
 
     def test_to_latex_filename(self, frame):
         with tm.ensure_clean('test.tex') as path:

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -17,7 +17,7 @@ from pandas.io.json.table_schema import (
     convert_pandas_type_to_json_field, set_default_names)
 
 
-class TestBuildSchema(object):
+class TestBuildSchema:
 
     def setup_method(self, method):
         self.df = DataFrame(
@@ -85,7 +85,7 @@ class TestBuildSchema(object):
         assert result == expected
 
 
-class TestTableSchemaType(object):
+class TestTableSchemaType:
 
     @pytest.mark.parametrize('int_type', [
         np.int, np.int16, np.int32, np.int64])
@@ -172,7 +172,7 @@ class TestTableSchemaType(object):
         assert as_json_table_type(CategoricalDtype()) == 'any'
 
 
-class TestTableOrient(object):
+class TestTableOrient:
 
     def setup_method(self, method):
         self.df = DataFrame(
@@ -491,7 +491,7 @@ class TestTableOrient(object):
         assert result == ['level_0', 'level_1', 0, 1, 2, 3]
 
 
-class TestTableOrientReader(object):
+class TestTableOrientReader:
 
     @pytest.mark.parametrize("index_nm", [
         None,

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -85,7 +85,7 @@ def missing_metadata():
     ]
 
 
-class TestJSONNormalize(object):
+class TestJSONNormalize:
 
     def test_simple_records(self):
         recs = [{'a': 1, 'b': 2, 'c': 3},
@@ -295,7 +295,7 @@ class TestJSONNormalize(object):
         tm.assert_frame_equal(result, expected)
 
 
-class TestNestedToRecord(object):
+class TestNestedToRecord:
 
     def test_flat_stays_flat(self):
         recs = [dict(flat1=1, flat2=2),

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -37,7 +37,7 @@ _cat_frame['sort'] = np.arange(len(_cat_frame), dtype='int64')
 _mixed_frame = _frame.copy()
 
 
-class TestPandasContainer(object):
+class TestPandasContainer:
 
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, datapath):
@@ -535,7 +535,7 @@ class TestPandasContainer(object):
     def test_frame_nonprintable_bytes(self):
         # GH14256: failing column caused segfaults, if it is not the last one
 
-        class BinaryThing(object):
+        class BinaryThing:
 
             def __init__(self, hexed):
                 self.hexed = hexed

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -58,7 +58,7 @@ def numpy(request):
     return request.param
 
 
-class TestUltraJSONTests(object):
+class TestUltraJSONTests:
 
     @pytest.mark.skipif(compat.is_platform_32bit(),
                         reason="not compliant on 32-bit, xref #15865")
@@ -440,11 +440,11 @@ class TestUltraJSONTests(object):
     def test_encode_recursion_max(self):
         # 8 is the max recursion depth
 
-        class O2(object):
+        class O2:
             member = 0
             pass
 
-        class O1(object):
+        class O1:
             member = 0
             pass
 
@@ -568,7 +568,7 @@ class TestUltraJSONTests(object):
         assert "[1,2,3]" == f.getvalue()
 
     def test_dump_to_file_like(self):
-        class FileLike(object):
+        class FileLike:
 
             def __init__(self):
                 self.bytes = ''
@@ -596,7 +596,7 @@ class TestUltraJSONTests(object):
                                     ujson.load(f, numpy=True))
 
     def test_load_file_like(self):
-        class FileLike(object):
+        class FileLike:
 
             def read(self):
                 try:
@@ -627,7 +627,7 @@ class TestUltraJSONTests(object):
             ujson.encode(12839128391289382193812939)
 
     def test_encode_numeric_overflow_nested(self):
-        class Nested(object):
+        class Nested:
             x = 12839128391289382193812939
 
         for _ in range(0, 100):
@@ -662,7 +662,7 @@ class TestUltraJSONTests(object):
     def test_to_dict(self):
         d = {"key": 31337}
 
-        class DictTest(object):
+        class DictTest:
             def toDict(self):
                 return d
 
@@ -674,7 +674,7 @@ class TestUltraJSONTests(object):
 
     def test_default_handler(self):
 
-        class _TestObject(object):
+        class _TestObject:
 
             def __init__(self, val):
                 self.val = val
@@ -722,7 +722,7 @@ class TestUltraJSONTests(object):
                 ujson.decode(ujson.encode(obj_list, default_handler=str)))
 
 
-class TestNumpyJSONTests(object):
+class TestNumpyJSONTests:
 
     @pytest.mark.parametrize("bool_input", [True, False])
     def test_bool(self, bool_input):
@@ -885,7 +885,7 @@ class TestNumpyJSONTests(object):
         assert (np.array(["a", "b"]) == output[2]).all()
 
 
-class TestPandasJSONTests(object):
+class TestPandasJSONTests:
 
     def test_dataframe(self, orient, numpy):
         if orient == "records" and numpy:

--- a/pandas/tests/io/msgpack/test_except.py
+++ b/pandas/tests/io/msgpack/test_except.py
@@ -11,7 +11,7 @@ class DummyException(Exception):
     pass
 
 
-class TestExceptions(object):
+class TestExceptions:
 
     def test_raise_on_find_unsupported_value(self):
         msg = "can\'t serialize datetime"

--- a/pandas/tests/io/msgpack/test_limits.py
+++ b/pandas/tests/io/msgpack/test_limits.py
@@ -4,7 +4,7 @@ import pytest
 from pandas.io.msgpack import ExtType, Packer, Unpacker, packb, unpackb
 
 
-class TestLimits(object):
+class TestLimits:
 
     def test_integer(self):
         x = -(2 ** 63)

--- a/pandas/tests/io/msgpack/test_obj.py
+++ b/pandas/tests/io/msgpack/test_obj.py
@@ -9,7 +9,7 @@ class DecodeError(Exception):
     pass
 
 
-class TestObj(object):
+class TestObj:
 
     def _arr_to_str(self, arr):
         return ''.join(str(c) for c in arr)

--- a/pandas/tests/io/msgpack/test_pack.py
+++ b/pandas/tests/io/msgpack/test_pack.py
@@ -8,7 +8,7 @@ import pytest
 from pandas.io.msgpack import Packer, Unpacker, packb, unpackb
 
 
-class TestPack(object):
+class TestPack:
 
     def check(self, data, use_list=False):
         re = unpackb(packb(data), use_list=use_list)

--- a/pandas/tests/io/msgpack/test_sequnpack.py
+++ b/pandas/tests/io/msgpack/test_sequnpack.py
@@ -6,7 +6,7 @@ import pytest
 from pandas.io.msgpack import BufferFull, OutOfData, Unpacker
 
 
-class TestPack(object):
+class TestPack:
 
     def test_partial_data(self):
         unpacker = Unpacker()

--- a/pandas/tests/io/msgpack/test_unpack.py
+++ b/pandas/tests/io/msgpack/test_unpack.py
@@ -6,7 +6,7 @@ import pytest
 from pandas.io.msgpack import ExtType, OutOfData, Unpacker, packb
 
 
-class TestUnpack(object):
+class TestUnpack:
 
     def test_unpack_array_header_from_file(self):
         f = BytesIO(packb([1, 2, 3, 4]))

--- a/pandas/tests/io/parser/conftest.py
+++ b/pandas/tests/io/parser/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from pandas import read_csv, read_table
 
 
-class BaseParser(object):
+class BaseParser:
     engine = None
     low_memory = True
     float_precision_choices = []

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -1792,7 +1792,7 @@ def test_file_handles_with_open(all_parsers, csv1):
 
 def test_invalid_file_buffer_class(all_parsers):
     # see gh-15337
-    class InvalidBuffer(object):
+    class InvalidBuffer:
         pass
 
     parser = all_parsers

--- a/pandas/tests/io/parser/test_dialect.py
+++ b/pandas/tests/io/parser/test_dialect.py
@@ -65,7 +65,7 @@ pear:tomato
 
 
 def test_invalid_dialect(all_parsers):
-    class InvalidDialect(object):
+    class InvalidDialect:
         pass
 
     data = "a\n1"

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -54,7 +54,7 @@ def tips_df(datapath):
 
 @pytest.mark.usefixtures("s3_resource")
 @td.skip_if_not_us_locale()
-class TestS3(object):
+class TestS3:
 
     def test_parse_public_s3_bucket(self, tips_df):
         pytest.importorskip('s3fs')

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -21,7 +21,7 @@ from pandas.util.testing import assert_frame_equal
 from pandas.io.parsers import TextFileReader, read_csv
 
 
-class TestTextReader(object):
+class TestTextReader:
 
     @pytest.fixture(autouse=True)
     def setup_method(self, datapath):

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -25,7 +25,7 @@ def python_engine(request):
     return request.param
 
 
-class TestUnsupportedFeatures(object):
+class TestUnsupportedFeatures:
 
     def test_mangle_dupe_cols_false(self):
         # see gh-12935
@@ -109,7 +109,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
     def test_python_engine_file_no_next(self, python_engine):
         # see gh-16530
-        class NoNextBuffer(object):
+        class NoNextBuffer:
             def __init__(self, csv_data):
                 self.data = csv_data
 
@@ -126,7 +126,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
             read_csv(NoNextBuffer(data), engine=python_engine)
 
 
-class TestDeprecatedFeatures(object):
+class TestDeprecatedFeatures:
 
     @pytest.mark.parametrize("engine", ["c", "python"])
     @pytest.mark.parametrize("kwargs", [{"tupleize_cols": True},

--- a/pandas/tests/io/sas/test_sas.py
+++ b/pandas/tests/io/sas/test_sas.py
@@ -6,7 +6,7 @@ from pandas import read_sas
 import pandas.util.testing as tm
 
 
-class TestSas(object):
+class TestSas:
 
     def test_sas_buffer_format(self):
         # see gh-14947

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -13,7 +13,7 @@ import pandas.util.testing as tm
 
 # https://github.com/cython/cython/issues/1720
 @pytest.mark.filterwarnings("ignore:can't resolve package:ImportWarning")
-class TestSAS7BDAT(object):
+class TestSAS7BDAT:
 
     @pytest.fixture(autouse=True)
     def setup_method(self, datapath):

--- a/pandas/tests/io/sas/test_xport.py
+++ b/pandas/tests/io/sas/test_xport.py
@@ -20,7 +20,7 @@ def numeric_as_float(data):
             data[v] = data[v].astype(np.float64)
 
 
-class TestXport(object):
+class TestXport:
 
     @pytest.fixture(autouse=True)
     def setup_method(self, datapath):

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -120,7 +120,7 @@ def test_mock_clipboard(mock_clipboard):
 @pytest.mark.skipif(not _DEPS_INSTALLED,
                     reason="clipboard primitives not installed")
 @pytest.mark.usefixtures("mock_clipboard")
-class TestClipboard(object):
+class TestClipboard:
 
     def check_round_trip_frame(self, data, excel=None, sep=None,
                                encoding=None):

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -16,7 +16,7 @@ import pandas.util.testing as tm
 import pandas.io.common as icom
 
 
-class CustomFSPath(object):
+class CustomFSPath:
     """For testing fspath on unknown objects"""
     def __init__(self, path):
         self.path = path
@@ -45,7 +45,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # https://github.com/cython/cython/issues/1720
 @pytest.mark.filterwarnings("ignore:can't resolve package:ImportWarning")
-class TestCommonIOCapabilities(object):
+class TestCommonIOCapabilities:
     data1 = """index,A,B,C,D
 foo,2,3,4,5
 bar,7,8,9,10
@@ -300,7 +300,7 @@ def mmap_file(datapath):
     return datapath('io', 'data', 'test_mmap.csv')
 
 
-class TestMMapWrapper(object):
+class TestMMapWrapper:
 
     def test_constructor_bad_file(self, mmap_file):
         non_file = StringIO('I am not a file')

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -50,7 +50,7 @@ def ignore_xlrd_time_clock_warning():
 
 
 @td.skip_if_no('xlrd', '1.0.0')
-class SharedItems(object):
+class SharedItems:
 
     @pytest.fixture(autouse=True)
     def setup_method(self, datapath):
@@ -2327,7 +2327,7 @@ class TestXlsxWriterTests(_WriterBase):
                 ExcelWriter(f, engine=engine, mode='a')
 
 
-class TestExcelWriterEngineTests(object):
+class TestExcelWriterEngineTests:
 
     @pytest.mark.parametrize('klass,ext', [
         pytest.param(_XlsxWriter, '.xlsx', marks=pytest.mark.skipif(
@@ -2543,7 +2543,7 @@ def test_styler_to_excel(engine):
 
 @td.skip_if_no('openpyxl')
 @pytest.mark.skipif(not PY36, reason='requires fspath')
-class TestFSPath(object):
+class TestFSPath:
 
     def test_excelfile_fspath(self):
         with tm.ensure_clean('foo.xlsx') as path:

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -17,7 +17,7 @@ pyarrow_version = LooseVersion(pyarrow.__version__)
 
 
 @pytest.mark.single
-class TestFeather(object):
+class TestFeather:
 
     def check_error_on_write(self, df, exc):
         # check that we are raising the exception

--- a/pandas/tests/io/test_gbq.py
+++ b/pandas/tests/io/test_gbq.py
@@ -103,7 +103,7 @@ def test_read_gbq_without_dialect_warns_future_change(monkeypatch):
 
 
 @pytest.mark.single
-class TestToGBQIntegrationWithServiceAccountKeyPath(object):
+class TestToGBQIntegrationWithServiceAccountKeyPath:
 
     @classmethod
     def setup_class(cls):

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -81,7 +81,7 @@ def test_same_ordering(datapath):
         not td.safe_import('lxml'), reason='No bs4')),
     pytest.param('lxml', marks=pytest.mark.skipif(
         not td.safe_import('lxml'), reason='No lxml'))], scope="class")
-class TestReadHtml(object):
+class TestReadHtml:
 
     @pytest.fixture(autouse=True)
     def set_files(self, datapath):
@@ -1109,7 +1109,7 @@ class TestReadHtml(object):
     def test_parse_failure_rewinds(self):
         # Issue #17975
 
-        class MockFile(object):
+        class MockFile:
             def __init__(self, data):
                 self.data = data
                 self.at_end = False

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -85,7 +85,7 @@ def check_arbitrary(a, b):
 
 
 @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
-class TestPackers(object):
+class TestPackers:
 
     def setup_method(self, method):
         self.path = '__%s__.msg' % tm.rands(10)
@@ -148,7 +148,7 @@ class TestAPI(TestPackers):
 
     def test_invalid_arg(self):
         # GH10369
-        class A(object):
+        class A:
 
             def __init__(self):
                 self.read = 0
@@ -841,7 +841,7 @@ def legacy_packer(request, datapath):
 
 
 @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
-class TestMsgpack(object):
+class TestMsgpack:
     """
     How to add msgpack tests:
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -220,7 +220,7 @@ def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
             tm.assert_frame_equal(result, df[['a', 'd']])
 
 
-class Base(object):
+class Base:
 
     def check_error_on_write(self, df, engine, exc):
         # check that we are raising the exception on writing

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -289,7 +289,7 @@ def get_random_path():
     return '__%s__.pickle' % tm.rands(10)
 
 
-class TestCompression(object):
+class TestCompression:
 
     _compression_to_extension = {
         None: ".none",
@@ -427,7 +427,7 @@ class TestCompression(object):
 # test pickle compression
 # ---------------------
 
-class TestProtocol(object):
+class TestProtocol:
 
     @pytest.mark.parametrize('protocol', [-1, 0, 1, 2])
     def test_read(self, protocol, get_random_path):

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -129,7 +129,7 @@ def _maybe_remove(store, key):
         pass
 
 
-class Base(object):
+class Base:
 
     @classmethod
     def setup_class(cls):

--- a/pandas/tests/io/test_s3.py
+++ b/pandas/tests/io/test_s3.py
@@ -7,7 +7,7 @@ from pandas import read_csv
 from pandas.io.common import is_s3_url
 
 
-class TestS3URL(object):
+class TestS3URL:
 
     def test_is_s3_url(self):
         assert is_s3_url("s3://pandas/somethingelse.com")

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -177,7 +177,7 @@ SQL_STRINGS = {
 }
 
 
-class MixInBase(object):
+class MixInBase:
 
     def teardown_method(self, method):
         # if setup fails, there may not be a connection to close.
@@ -239,7 +239,7 @@ class SQLAlchemyMixIn(MixInBase):
         pass
 
 
-class PandasSQLTest(object):
+class PandasSQLTest:
     """
     Base class with common private methods for SQLAlchemy and fallback cases.
 
@@ -1034,7 +1034,7 @@ class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):
         assert all_names == {'Iris-setosa'}
 
 
-class _EngineToConnMixin(object):
+class _EngineToConnMixin:
     """
     A mixin that causes setup_connect to create a conn rather than an engine.
     """
@@ -1734,7 +1734,7 @@ class _TestSQLAlchemyConn(_EngineToConnMixin, _TestSQLAlchemy):
             "Nested transactions rollbacks don't work with Pandas")
 
 
-class _TestSQLiteAlchemy(object):
+class _TestSQLiteAlchemy:
     """
     Test the sqlalchemy backend against an in-memory sqlite database.
 
@@ -1782,7 +1782,7 @@ class _TestSQLiteAlchemy(object):
             assert len(w) == 0
 
 
-class _TestMySQLAlchemy(object):
+class _TestMySQLAlchemy:
     """
     Test the sqlalchemy backend against an MySQL database.
 
@@ -1849,7 +1849,7 @@ class _TestMySQLAlchemy(object):
         tm.assert_frame_equal(df, res2)
 
 
-class _TestPostgreSQLAlchemy(object):
+class _TestPostgreSQLAlchemy:
     """
     Test the sqlalchemy backend against an PostgreSQL database.
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -36,7 +36,7 @@ def parsed_114(dirpath):
     return parsed_114
 
 
-class TestStata(object):
+class TestStata:
 
     @pytest.fixture(autouse=True)
     def setup_method(self, datapath):

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -27,7 +27,7 @@ This is a common base class used for various plotting tests
 
 
 @td.skip_if_no_mpl
-class TestPlotBase(object):
+class TestPlotBase:
 
     def setup_method(self, method):
 

--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -23,7 +23,7 @@ def test_timtetonum_accepts_unicode():
     assert (converter.time2num("00:01") == converter.time2num("00:01"))
 
 
-class TestRegistration(object):
+class TestRegistration:
 
     def test_register_by_default(self):
         # Run in subprocess to ensure a clean state
@@ -143,7 +143,7 @@ class TestRegistration(object):
                 str(w[0].message))
 
 
-class TestDateTimeConverter(object):
+class TestDateTimeConverter:
 
     def setup_method(self, method):
         self.dtc = converter.DatetimeConverter()
@@ -283,12 +283,12 @@ class TestDateTimeConverter(object):
         assert (np.array(result) == expected).all()
 
 
-class TestPeriodConverter(object):
+class TestPeriodConverter:
 
     def setup_method(self, method):
         self.pc = converter.PeriodConverter()
 
-        class Axis(object):
+        class Axis:
             pass
 
         self.axis = Axis()

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -35,7 +35,7 @@ def get_objs():
 objs = get_objs()
 
 
-class TestReductions(object):
+class TestReductions:
 
     @pytest.mark.parametrize('opname', ['max', 'min'])
     @pytest.mark.parametrize('obj', objs)
@@ -152,7 +152,7 @@ class TestReductions(object):
         tm.assert_series_equal(result, expected)
 
 
-class TestIndexReductions(object):
+class TestIndexReductions:
     # Note: the name TestIndexReductions indicates these tests
     #  were moved from a Index-specific test file, _not_ that these tests are
     #  intended long-term to be Index-specific
@@ -414,7 +414,7 @@ class TestIndexReductions(object):
         assert ci.max() == 'b'
 
 
-class TestSeriesReductions(object):
+class TestSeriesReductions:
     # Note: the name TestSeriesReductions indicates these tests
     #  were moved from a series-specific test file, _not_ that these tests are
     #  intended long-term to be series-specific
@@ -864,7 +864,7 @@ class TestSeriesReductions(object):
             np.isnan(s.idxmax(skipna=False))
 
 
-class TestDatetime64SeriesReductions(object):
+class TestDatetime64SeriesReductions:
     # Note: the name TestDatetime64SeriesReductions indicates these tests
     #  were moved from a series-specific test file, _not_ that these tests are
     #  intended long-term to be series-specific
@@ -921,7 +921,7 @@ class TestDatetime64SeriesReductions(object):
         assert result == exp
 
 
-class TestCategoricalSeriesReductions(object):
+class TestCategoricalSeriesReductions:
     # Note: the name TestCategoricalSeriesReductions indicates these tests
     #  were moved from a series-specific test file, _not_ that these tests are
     #  intended long-term to be series-specific
@@ -984,7 +984,7 @@ class TestCategoricalSeriesReductions(object):
         assert _max == "a"
 
 
-class TestSeriesMode(object):
+class TestSeriesMode:
     # Note: the name TestSeriesMode indicates these tests
     #  were moved from a series-specific test file, _not_ that these tests are
     #  intended long-term to be series-specific

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -15,7 +15,7 @@ from pandas import DataFrame, Series
 import pandas.util.testing as tm
 
 
-class TestSeriesStatReductions(object):
+class TestSeriesStatReductions:
     # Note: the name TestSeriesStatReductions indicates these tests
     #  were moved from a series-specific test file, _not_ that these tests are
     #  intended long-term to be series-specific

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -210,7 +210,7 @@ def test_resample_how_callables():
     def fn(x, a=1):
         return str(type(x))
 
-    class FnClass(object):
+    class FnClass:
 
         def __call__(self, x):
             return str(type(x))

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -32,7 +32,7 @@ def _series_name():
     return 'pi'
 
 
-class TestPeriodIndex(object):
+class TestPeriodIndex:
 
     @pytest.mark.parametrize('freq', ['2D', '1H', '2H'])
     @pytest.mark.parametrize('kind', ['period', None, 'timestamp'])

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -14,7 +14,7 @@ from pandas.util.testing import assert_frame_equal
 a_ = np.array
 
 
-class TestJoin(object):
+class TestJoin:
 
     def setup_method(self, method):
         # aggregate multiple columns

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -85,7 +85,7 @@ def series_of_dtype_all_na(request):
     return request.param
 
 
-class TestMerge(object):
+class TestMerge:
 
     def setup_method(self, method):
         # aggregate multiple columns
@@ -1080,7 +1080,7 @@ def _check_merge(x, y):
         assert_frame_equal(result, expected, check_names=False)
 
 
-class TestMergeDtypes(object):
+class TestMergeDtypes:
 
     @pytest.mark.parametrize('right_vals', [
         ['foo', 'bar'],
@@ -1280,7 +1280,7 @@ def right():
          'Z': [1, 2]})
 
 
-class TestMergeCategorical(object):
+class TestMergeCategorical:
 
     def test_identical(self, left):
         # merging on the same, should preserve dtypes
@@ -1513,7 +1513,7 @@ def right_df():
     return DataFrame({'b': [300, 100, 200]}, index=[3, 1, 2])
 
 
-class TestMergeOnIndexes(object):
+class TestMergeOnIndexes:
 
     @pytest.mark.parametrize(
         "how, sort, expected",

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -8,7 +8,7 @@ from pandas.core.reshape.merge import MergeError
 from pandas.util.testing import assert_frame_equal
 
 
-class TestAsOfMerge(object):
+class TestAsOfMerge:
 
     def read_data(self, datapath, name, dedupe=False):
         path = datapath('reshape', 'merge', 'data', name)

--- a/pandas/tests/reshape/merge/test_merge_ordered.py
+++ b/pandas/tests/reshape/merge/test_merge_ordered.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, merge_ordered
 from pandas.util.testing import assert_frame_equal
 
 
-class TestMergeOrdered(object):
+class TestMergeOrdered:
 
     def setup_method(self, method):
         self.left = DataFrame({'key': ['a', 'c', 'e'],

--- a/pandas/tests/reshape/merge/test_multi.py
+++ b/pandas/tests/reshape/merge/test_multi.py
@@ -76,7 +76,7 @@ def idx_cols_multi():
     return ['Origin', 'Destination', 'Period', 'TripPurp', 'LinkType']
 
 
-class TestMergeMulti(object):
+class TestMergeMulti:
 
     def setup_method(self):
         self.index = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux'],
@@ -581,7 +581,7 @@ class TestMergeMulti(object):
         tm.assert_frame_equal(result, expected)
 
 
-class TestJoinMultiMulti(object):
+class TestJoinMultiMulti:
 
     def test_join_multi_multi(self, left_multi, right_multi, join_type,
                               on_cols_multi, idx_cols_multi):

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -39,7 +39,7 @@ def sort_with_none(request):
     return request.param
 
 
-class ConcatenateBase(object):
+class ConcatenateBase:
 
     def setup_method(self, method):
         self.frame = DataFrame(tm.getSeriesData())
@@ -1728,7 +1728,7 @@ class TestConcatenate(ConcatenateBase):
         assert_frame_equal(
             concat(deque((df1, df2)), ignore_index=True), expected)
 
-        class CustomIterator1(object):
+        class CustomIterator1:
 
             def __len__(self):
                 return 2

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -8,7 +8,7 @@ from pandas import DataFrame, lreshape, melt, wide_to_long
 import pandas.util.testing as tm
 
 
-class TestMelt(object):
+class TestMelt:
 
     def setup_method(self, method):
         self.df = tm.makeTimeDataFrame()[:10]
@@ -281,7 +281,7 @@ class TestMelt(object):
             multi.melt(['A'], ['F'], col_level=0)
 
 
-class TestLreshape(object):
+class TestLreshape:
 
     def test_pairs(self):
         data = {'birthdt': ['08jan2009', '20dec2008', '30dec2008', '21dec2008',
@@ -355,7 +355,7 @@ class TestLreshape(object):
             lreshape(df, spec)
 
 
-class TestWideToLong(object):
+class TestWideToLong:
 
     def test_simple(self):
         np.random.seed(123)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -21,7 +21,7 @@ def dropna(request):
     return request.param
 
 
-class TestPivotTable(object):
+class TestPivotTable:
 
     def setup_method(self, method):
         self.data = DataFrame({'A': ['foo', 'foo', 'foo', 'foo',
@@ -1338,7 +1338,7 @@ class TestPivotTable(object):
         tm.assert_frame_equal(result, expected)
 
 
-class TestCrosstab(object):
+class TestCrosstab:
 
     def setup_method(self, method):
         df = DataFrame({'A': ['foo', 'foo', 'foo', 'foo',

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -14,7 +14,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal
 
 
-class TestGetDummies(object):
+class TestGetDummies:
 
     @pytest.fixture
     def df(self):
@@ -584,7 +584,7 @@ class TestGetDummies(object):
         tm.assert_frame_equal(result, expected)
 
 
-class TestCategoricalReshape(object):
+class TestCategoricalReshape:
 
     def test_reshaping_multi_index_categorical(self):
 
@@ -611,7 +611,7 @@ class TestCategoricalReshape(object):
         tm.assert_frame_equal(result, expected)
 
 
-class TestMakeAxisDummies(object):
+class TestMakeAxisDummies:
 
     def test_preserve_categorical_dtype(self):
         # GH13854

--- a/pandas/tests/reshape/test_union_categoricals.py
+++ b/pandas/tests/reshape/test_union_categoricals.py
@@ -8,7 +8,7 @@ from pandas import Categorical, CategoricalIndex, Series
 from pandas.util import testing as tm
 
 
-class TestUnionCategoricals(object):
+class TestUnionCategoricals:
 
     def test_union_categorical(self):
         # GH 13361

--- a/pandas/tests/reshape/test_util.py
+++ b/pandas/tests/reshape/test_util.py
@@ -6,7 +6,7 @@ from pandas.core.reshape.util import cartesian_product
 import pandas.util.testing as tm
 
 
-class TestCartesianProduct(object):
+class TestCartesianProduct:
 
     def test_simple(self):
         x, y = list('ABC'), [1, 22]

--- a/pandas/tests/scalar/interval/test_interval.py
+++ b/pandas/tests/scalar/interval/test_interval.py
@@ -10,7 +10,7 @@ def interval():
     return Interval(0, 1)
 
 
-class TestInterval(object):
+class TestInterval:
 
     def test_properties(self, interval):
         assert interval.closed == 'right'

--- a/pandas/tests/scalar/interval/test_ops.py
+++ b/pandas/tests/scalar/interval/test_ops.py
@@ -16,7 +16,7 @@ def start_shift(request):
     return request.param
 
 
-class TestOverlaps(object):
+class TestOverlaps:
 
     def test_overlaps_self(self, start_shift, closed):
         start, shift = start_shift

--- a/pandas/tests/scalar/period/test_asfreq.py
+++ b/pandas/tests/scalar/period/test_asfreq.py
@@ -7,7 +7,7 @@ from pandas.errors import OutOfBoundsDatetime
 from pandas import Period, offsets
 
 
-class TestFreqConversion(object):
+class TestFreqConversion:
     """Test frequency conversion of date objects"""
     @pytest.mark.parametrize('freq', ['A', 'Q', 'M', 'W', 'B', 'D'])
     def test_asfreq_near_zero(self, freq):

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -18,7 +18,7 @@ import pandas.core.indexes.period as period
 import pandas.util.testing as tm
 
 
-class TestPeriodConstruction(object):
+class TestPeriodConstruction:
     def test_construction(self):
         i1 = Period('1/1/2005', freq='M')
         i2 = Period('Jan 2005')
@@ -472,7 +472,7 @@ class TestPeriodConstruction(object):
             Period('2011-01', freq='1D1W')
 
 
-class TestPeriodMethods(object):
+class TestPeriodMethods:
     def test_round_trip(self):
         p = Period('2000Q1')
         new_p = tm.round_trip_pickle(p)
@@ -655,7 +655,7 @@ class TestPeriodMethods(object):
         assert isinstance(res, str)
 
 
-class TestPeriodProperties(object):
+class TestPeriodProperties:
     "Test properties such as year, month, weekday, etc...."
 
     @pytest.mark.parametrize('freq', ['A', 'M', 'D', 'H'])
@@ -923,7 +923,7 @@ class TestPeriodProperties(object):
                       minute=0, second=0).days_in_month == 29
 
 
-class TestPeriodField(object):
+class TestPeriodField:
 
     def test_get_period_field_array_raises_on_out_of_range(self):
         msg = "Buffer dtype mismatch, expected 'int64_t' but got 'double'"
@@ -931,7 +931,7 @@ class TestPeriodField(object):
             libperiod.get_period_field_arr(-1, np.empty(1), 0)
 
 
-class TestComparisons(object):
+class TestComparisons:
 
     def setup_method(self, method):
         self.january1 = Period('2000-01', 'M')
@@ -1016,7 +1016,7 @@ class TestComparisons(object):
             assert not left >= right
 
 
-class TestArithmetic(object):
+class TestArithmetic:
 
     def test_sub_delta(self):
         left, right = Period('2011', freq='A'), Period('2007', freq='A')

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -14,7 +14,7 @@ from pandas.core import ops
 import pandas.util.testing as tm
 
 
-class TestTimedeltaAdditionSubtraction(object):
+class TestTimedeltaAdditionSubtraction:
     """
     Tests for Timedelta methods:
 
@@ -240,7 +240,7 @@ class TestTimedeltaAdditionSubtraction(object):
         tm.assert_numpy_array_equal(res, exp)
 
 
-class TestTimedeltaMultiplicationDivision(object):
+class TestTimedeltaMultiplicationDivision:
     """
     Tests for Timedelta methods:
 

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -13,7 +13,7 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-class TestTimedeltaArithmetic(object):
+class TestTimedeltaArithmetic:
 
     def test_arithmetic_overflow(self):
         with pytest.raises(OverflowError):
@@ -50,7 +50,7 @@ class TestTimedeltaArithmetic(object):
             assert left != right
 
     def test_ops_notimplemented(self):
-        class Other(object):
+        class Other:
             pass
 
         other = Other()
@@ -76,7 +76,7 @@ class TestTimedeltaArithmetic(object):
         assert abs(-td) == Timedelta('10d')
 
 
-class TestTimedeltaComparison(object):
+class TestTimedeltaComparison:
     def test_compare_tick(self, tick_classes):
         cls = tick_classes
 
@@ -131,7 +131,7 @@ class TestTimedeltaComparison(object):
         Make sure non supported operations on Timedelta returns NonImplemented
         and yields to other operand (GH#20829).
         """
-        class CustomClass(object):
+        class CustomClass:
 
             def __init__(self, cmp_result=None):
                 self.cmp_result = cmp_result
@@ -174,7 +174,7 @@ class TestTimedeltaComparison(object):
             t < val
 
 
-class TestTimedeltas(object):
+class TestTimedeltas:
 
     @pytest.mark.parametrize("unit, value, expected", [
         ('us', 9.999, 9999), ('ms', 9.999999, 9999999),

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -11,7 +11,7 @@ from pandas.tseries import offsets
 from pandas.tseries.frequencies import to_offset
 
 
-class TestTimestampArithmetic(object):
+class TestTimestampArithmetic:
     def test_overflow_offset(self):
         # no overflow expected
 

--- a/pandas/tests/scalar/timestamp/test_comparisons.py
+++ b/pandas/tests/scalar/timestamp/test_comparisons.py
@@ -8,7 +8,7 @@ import pytest
 from pandas import Timestamp
 
 
-class TestTimestampComparison(object):
+class TestTimestampComparison:
     def test_comparison_object_array(self):
         # GH#15183
         ts = Timestamp('2011-01-03 00:00:00-0500', tz='US/Eastern')
@@ -162,7 +162,7 @@ def test_rich_comparison_with_unsupported_type():
     # Comparisons with unsupported objects should return NotImplemented
     # (it previously raised TypeError, see #24011)
 
-    class Inf(object):
+    class Inf:
         def __lt__(self, o):
             return False
 

--- a/pandas/tests/scalar/timestamp/test_rendering.py
+++ b/pandas/tests/scalar/timestamp/test_rendering.py
@@ -10,7 +10,7 @@ import pytz  # noqa  # a test below uses pytz but only inside a `eval` call
 from pandas import Timestamp
 
 
-class TestTimestampRendering(object):
+class TestTimestampRendering:
 
     # dateutil zone change (only matters for repr)
     if LooseVersion(dateutil.__version__) >= LooseVersion('2.6.0'):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -24,7 +24,7 @@ import pandas.util.testing as tm
 from pandas.tseries import offsets
 
 
-class TestTimestampProperties(object):
+class TestTimestampProperties:
 
     def test_properties_business(self):
         ts = Timestamp('2017-10-01', freq='B')
@@ -192,7 +192,7 @@ class TestTimestampProperties(object):
         assert dt.resolution == Timedelta(nanoseconds=1)
 
 
-class TestTimestampConstructors(object):
+class TestTimestampConstructors:
 
     def test_constructor(self):
         base_str = '2014-07-01 09:00'
@@ -616,7 +616,7 @@ class TestTimestampConstructors(object):
         assert result == expected
 
 
-class TestTimestamp(object):
+class TestTimestamp:
 
     def test_tz(self):
         tstr = '2014-02-01 09:00'
@@ -787,7 +787,7 @@ class TestTimestamp(object):
         assert t2.tz_convert(tz='UTC').freq == t2.freq
 
 
-class TestTimestampNsOperations(object):
+class TestTimestampNsOperations:
 
     def setup_method(self, method):
         self.timestamp = Timestamp(datetime.utcnow())
@@ -874,7 +874,7 @@ class TestTimestampNsOperations(object):
         assert t.nanosecond == 10
 
 
-class TestTimestampToJulianDate(object):
+class TestTimestampToJulianDate:
 
     def test_compare_1700(self):
         r = Timestamp('1700-06-23').to_julian_date()
@@ -897,7 +897,7 @@ class TestTimestampToJulianDate(object):
         assert r == 2451769.0416666666666666
 
 
-class TestTimestampConversion(object):
+class TestTimestampConversion:
     def test_conversion(self):
         # GH#9255
         ts = Timestamp('2000-01-01')

--- a/pandas/tests/scalar/timestamp/test_timezones.py
+++ b/pandas/tests/scalar/timestamp/test_timezones.py
@@ -19,7 +19,7 @@ from pandas import NaT, Timestamp
 import pandas.util.testing as tm
 
 
-class TestTimestampTZOperations(object):
+class TestTimestampTZOperations:
     # --------------------------------------------------------------
     # Timestamp.tz_localize
 

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -17,7 +17,7 @@ import pandas.util.testing as tm
 from pandas.tseries.frequencies import to_offset
 
 
-class TestTimestampUnaryOps(object):
+class TestTimestampUnaryOps:
 
     # --------------------------------------------------------------
     # Timestamp.round

--- a/pandas/tests/series/common.py
+++ b/pandas/tests/series/common.py
@@ -6,7 +6,7 @@ import pandas.util.testing as tm
 _ts = tm.makeTimeSeries()
 
 
-class TestData(object):
+class TestData:
 
     @cache_readonly
     def ts(self):

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -10,7 +10,7 @@ from pandas import DataFrame, Index, MultiIndex, RangeIndex, Series
 import pandas.util.testing as tm
 
 
-class TestSeriesAlterAxes(object):
+class TestSeriesAlterAxes:
 
     def test_setindex(self, string_series):
         # wrong type

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -21,7 +21,7 @@ from pandas.util.testing import (
     assert_series_equal)
 
 
-class TestSeriesAnalytics(object):
+class TestSeriesAnalytics:
 
     def test_describe(self):
         s = Series([0, 1, 2, 3, 4], name='int_data')
@@ -1211,7 +1211,7 @@ def assert_check_nselect_boundary(vals, dtype, method):
     tm.assert_series_equal(result, expected)
 
 
-class TestNLargestNSmallest(object):
+class TestNLargestNSmallest:
 
     @pytest.mark.parametrize(
         "r", [Series([3., 2, 1, 2, '5'], dtype='object'),
@@ -1331,7 +1331,7 @@ class TestNLargestNSmallest(object):
         assert_series_equal(result, expected)
 
 
-class TestCategoricalSeriesAnalytics(object):
+class TestCategoricalSeriesAnalytics:
 
     def test_count(self):
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -22,7 +22,7 @@ import pandas.io.formats.printing as printing
 from .common import TestData
 
 
-class SharedWithSparse(object):
+class SharedWithSparse:
     """
     A collection of tests Series and SparseSeries can share.
 
@@ -499,7 +499,7 @@ class TestSeriesMisc(TestData, SharedWithSparse):
         assert s.size == 9
 
 
-class TestCategoricalSeries(object):
+class TestCategoricalSeries:
 
     @pytest.mark.parametrize(
         "method",

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -14,7 +14,7 @@ def _permute(obj):
     return obj.take(np.random.permutation(len(obj)))
 
 
-class TestSeriesFlexArithmetic(object):
+class TestSeriesFlexArithmetic:
     @pytest.mark.parametrize(
         'ts',
         [
@@ -55,7 +55,7 @@ class TestSeriesFlexArithmetic(object):
             tm.assert_almost_equal(result, expected)
 
 
-class TestSeriesArithmetic(object):
+class TestSeriesArithmetic:
     # Some of these may end up in tests/arithmetic, but are not yet sorted
 
     def test_add_series_with_period_index(self):
@@ -78,7 +78,7 @@ class TestSeriesArithmetic(object):
 # ------------------------------------------------------------------
 # Comparisons
 
-class TestSeriesFlexComparison(object):
+class TestSeriesFlexComparison:
     def test_comparison_flex_basic(self):
         left = pd.Series(np.random.randn(10))
         right = pd.Series(np.random.randn(10))
@@ -106,7 +106,7 @@ class TestSeriesFlexComparison(object):
                 getattr(left, op)(right, axis=1)
 
 
-class TestSeriesComparison(object):
+class TestSeriesComparison:
     def test_comparison_different_length(self):
         a = Series(['a', 'b', 'c'])
         b = Series(['b', 'a'])

--- a/pandas/tests/series/test_block_internals.py
+++ b/pandas/tests/series/test_block_internals.py
@@ -6,7 +6,7 @@ import pandas as pd
 # structure
 
 
-class TestSeriesBlockInternals(object):
+class TestSeriesBlockInternals:
 
     def test_setitem_invalidates_datetime_index_freq(self):
         # GH#24096 altering a datetime64tz Series inplace invalidates the

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -11,7 +11,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
-class TestSeriesCombine(object):
+class TestSeriesCombine:
 
     def test_append(self, datetime_series, string_series, object_series):
         appendedSeries = string_series.append(object_series)
@@ -277,7 +277,7 @@ class TestSeriesCombine(object):
         assert_series_equal(rs, xp)
 
 
-class TestTimeseries(object):
+class TestTimeseries:
 
     def test_append_concat(self):
         rng = date_range('5/8/2012 1:45', periods=10, freq='5T')

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -24,7 +24,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_series_equal
 
 
-class TestSeriesConstructors(object):
+class TestSeriesConstructors:
 
     @pytest.mark.parametrize('constructor,check_index_type', [
         # NOTE: some overlap with test_constructor_empty but that test does not

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -17,7 +17,7 @@ from pandas.api.types import CategoricalDtype
 import pandas.util.testing as tm
 
 
-class TestSeriesDtypes(object):
+class TestSeriesDtypes:
 
     def test_dt64_series_astype_object(self):
         dt64ser = Series(date_range('20130101', periods=3))

--- a/pandas/tests/series/test_duplicates.py
+++ b/pandas/tests/series/test_duplicates.py
@@ -75,7 +75,7 @@ def test_is_unique(data, expected):
 
 def test_is_unique_class_ne(capsys):
     # GH 20661
-    class Foo(object):
+    class Foo:
         def __init__(self, val):
             self._value = val
 

--- a/pandas/tests/series/test_internals.py
+++ b/pandas/tests/series/test_internals.py
@@ -11,7 +11,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_series_equal
 
 
-class TestSeriesInternals(object):
+class TestSeriesInternals:
 
     def test_convert_objects(self):
 

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -17,7 +17,7 @@ from pandas.util.testing import (
 from .common import TestData
 
 
-class TestSeriesLogicalOps(object):
+class TestSeriesLogicalOps:
     @pytest.mark.parametrize('bool_op', [operator.and_,
                                          operator.or_, operator.xor])
     def test_bool_operators_with_nas(self, bool_op):
@@ -356,7 +356,7 @@ class TestSeriesLogicalOps(object):
         assert_frame_equal(s4.to_frame() | s3.to_frame(), exp)
 
 
-class TestSeriesComparisons(object):
+class TestSeriesComparisons:
     def test_comparisons(self):
         left = np.random.randn(10)
         right = np.random.randn(10)
@@ -566,7 +566,7 @@ class TestSeriesComparisons(object):
         assert_series_equal(result, expected)
 
 
-class TestSeriesFlexComparisonOps(object):
+class TestSeriesFlexComparisonOps:
 
     def test_comparison_flex_alignment(self):
         left = Series([1, 3, 2], index=list('abc'))
@@ -747,7 +747,7 @@ class TestSeriesOperators(TestData):
         assert_series_equal(result[1], expected[1])
 
 
-class TestSeriesUnaryOps(object):
+class TestSeriesUnaryOps:
     # __neg__, __pos__, __inv__
 
     def test_neg(self):

--- a/pandas/tests/series/test_period.py
+++ b/pandas/tests/series/test_period.py
@@ -7,7 +7,7 @@ from pandas.core.arrays import PeriodArray
 import pandas.util.testing as tm
 
 
-class TestSeriesPeriod(object):
+class TestSeriesPeriod:
 
     def setup_method(self, method):
         self.series = Series(period_range('2000-01-01', periods=10, freq='D'))

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -198,7 +198,7 @@ class TestSeriesRepr(TestData):
         assert repr(s) == exp
 
 
-class TestCategoricalRepr(object):
+class TestCategoricalRepr:
 
     def test_categorical_repr_unicode(self):
         # see gh-21002

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -6,7 +6,7 @@ from pandas import SparseDtype
 import pandas.util.testing as tm
 
 
-class TestSeriesSubclassing(object):
+class TestSeriesSubclassing:
 
     def test_indexing_sliced(self):
         s = tm.SubclassedSeries([1, 2, 3, 4], index=list('abcd'))
@@ -40,7 +40,7 @@ class TestSeriesSubclassing(object):
         tm.assert_frame_equal(res, exp)
 
 
-class TestSparseSeriesSubclassing(object):
+class TestSparseSeriesSubclassing:
 
     def test_subclass_sparse_slice(self):
         # int64

--- a/pandas/tests/series/test_timezones.py
+++ b/pandas/tests/series/test_timezones.py
@@ -17,7 +17,7 @@ from pandas.core.indexes.datetimes import date_range
 import pandas.util.testing as tm
 
 
-class TestSeriesTimezones(object):
+class TestSeriesTimezones:
     # -----------------------------------------------------------------
     # Series.tz_localize
     def test_series_tz_localize(self):

--- a/pandas/tests/series/test_validate.py
+++ b/pandas/tests/series/test_validate.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-class TestSeriesValidate(object):
+class TestSeriesValidate:
     """Tests for error handling related to data types of method arguments."""
 
     @pytest.mark.parametrize("func", ["reset_index", "_set_name",

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -212,7 +212,7 @@ class TestSparseDataFrame(SharedWithSparse):
 
     def test_constructor_from_unknown_type(self):
         # GH 19393
-        class Unknown(object):
+        class Unknown:
             pass
         with pytest.raises(TypeError,
                            match=('SparseDataFrame called with unknown type '
@@ -1283,7 +1283,7 @@ class TestSparseDataFrame(SharedWithSparse):
         tm.assert_frame_equal(expected, result)
 
 
-class TestSparseDataFrameArithmetic(object):
+class TestSparseDataFrameArithmetic:
 
     def test_numeric_op_scalar(self):
         df = pd.DataFrame({'A': [nan, nan, 0, 1, ],
@@ -1312,7 +1312,7 @@ class TestSparseDataFrameArithmetic(object):
         tm.assert_frame_equal(res.to_dense(), df != 0)
 
 
-class TestSparseDataFrameAnalytics(object):
+class TestSparseDataFrameAnalytics:
 
     def test_cumsum(self, float_frame):
         expected = SparseDataFrame(float_frame.to_dense().cumsum())

--- a/pandas/tests/sparse/frame/test_to_csv.py
+++ b/pandas/tests/sparse/frame/test_to_csv.py
@@ -5,7 +5,7 @@ from pandas import SparseDataFrame, read_csv
 from pandas.util import testing as tm
 
 
-class TestSparseDataFrameToCsv(object):
+class TestSparseDataFrameToCsv:
     fill_values = [np.nan, 0, None, 1]
 
     @pytest.mark.parametrize('fill_value', fill_values)

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -1032,7 +1032,7 @@ class TestSparseSeries(SharedWithSparse):
         assert sparse_usage < dense_usage
 
 
-class TestSparseHandlingMultiIndexes(object):
+class TestSparseHandlingMultiIndexes:
 
     def setup_method(self, method):
         miindex = pd.MultiIndex.from_product(
@@ -1062,7 +1062,7 @@ class TestSparseHandlingMultiIndexes(object):
 @pytest.mark.filterwarnings(
     "ignore:the matrix subclass:PendingDeprecationWarning"
 )
-class TestSparseSeriesScipyInteraction(object):
+class TestSparseSeriesScipyInteraction:
     # Issue 8048: add SparseSeries coo methods
 
     def setup_method(self, method):
@@ -1425,7 +1425,7 @@ def _dense_series_compare(s, f):
     tm.assert_series_equal(result.to_dense(), dense_result)
 
 
-class TestSparseSeriesAnalytics(object):
+class TestSparseSeriesAnalytics:
 
     def setup_method(self, method):
         arr, index = _test_data1()

--- a/pandas/tests/sparse/test_combine_concat.py
+++ b/pandas/tests/sparse/test_combine_concat.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 
-class TestSparseArrayConcat(object):
+class TestSparseArrayConcat:
     @pytest.mark.parametrize('kind', ['integer', 'block'])
     def test_basic(self, kind):
         a = pd.SparseArray([1, 0, 0, 2], kind=kind)
@@ -35,7 +35,7 @@ class TestSparseArrayConcat(object):
         assert result.kind == kind
 
 
-class TestSparseSeriesConcat(object):
+class TestSparseSeriesConcat:
 
     @pytest.mark.parametrize('kind', [
         'integer',
@@ -176,7 +176,7 @@ class TestSparseSeriesConcat(object):
         tm.assert_series_equal(res, exp)
 
 
-class TestSparseDataFrameConcat(object):
+class TestSparseDataFrameConcat:
 
     def setup_method(self, method):
 

--- a/pandas/tests/sparse/test_format.py
+++ b/pandas/tests/sparse/test_format.py
@@ -10,7 +10,7 @@ import pandas.util.testing as tm
 use_32bit_repr = is_platform_windows() or is_platform_32bit()
 
 
-class TestSparseSeriesFormatting(object):
+class TestSparseSeriesFormatting:
 
     @property
     def dtype_format_for_platform(self):
@@ -106,7 +106,7 @@ class TestSparseSeriesFormatting(object):
             assert result == exp
 
 
-class TestSparseDataFrameFormatting(object):
+class TestSparseDataFrameFormatting:
 
     def test_sparse_frame(self):
         # GH 13110

--- a/pandas/tests/sparse/test_groupby.py
+++ b/pandas/tests/sparse/test_groupby.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 
-class TestSparseGroupBy(object):
+class TestSparseGroupBy:
 
     def setup_method(self, method):
         self.dense = pd.DataFrame({'A': ['foo', 'bar', 'foo', 'bar',

--- a/pandas/tests/sparse/test_indexing.py
+++ b/pandas/tests/sparse/test_indexing.py
@@ -6,7 +6,7 @@ from pandas.core.sparse.api import SparseDtype
 import pandas.util.testing as tm
 
 
-class TestSparseSeriesIndexing(object):
+class TestSparseSeriesIndexing:
 
     def setup_method(self, method):
         self.orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
@@ -599,7 +599,7 @@ class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
         assert sparse is not res
 
 
-class TestSparseDataFrameIndexing(object):
+class TestSparseDataFrameIndexing:
 
     def test_getitem(self):
         orig = pd.DataFrame([[1, np.nan, np.nan],
@@ -976,7 +976,7 @@ class TestSparseDataFrameIndexing(object):
         tm.assert_sp_frame_equal(res, exp)
 
 
-class TestMultitype(object):
+class TestMultitype:
 
     def setup_method(self, method):
         self.cols = ['string', 'int', 'float', 'object']

--- a/pandas/tests/sparse/test_pivot.py
+++ b/pandas/tests/sparse/test_pivot.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 
-class TestPivotTable(object):
+class TestPivotTable:
 
     def setup_method(self, method):
         self.dense = pd.DataFrame({'A': ['foo', 'bar', 'foo', 'bar',

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -28,7 +28,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_almost_equal
 
 
-class TestMatch(object):
+class TestMatch:
 
     def test_ints(self):
         values = np.array([0, 2, 1])
@@ -64,7 +64,7 @@ class TestMatch(object):
         tm.assert_series_equal(result, expected)
 
 
-class TestFactorize(object):
+class TestFactorize:
 
     def test_basic(self):
 
@@ -341,7 +341,7 @@ class TestFactorize(object):
         tm.assert_numpy_array_equal(uniques, expected_uniques)
 
 
-class TestUnique(object):
+class TestUnique:
 
     def test_ints(self):
         arr = np.random.randint(0, 100, size=50)
@@ -604,7 +604,7 @@ class TestUnique(object):
         assert a[1] is unique_nulls_fixture2
 
 
-class TestIsin(object):
+class TestIsin:
 
     def test_invalid(self):
 
@@ -720,7 +720,7 @@ class TestIsin(object):
         # the user however could define a custom class
         # with similar behavior, then we at least should
         # fall back to usual python's behavior: "a in [a] == True"
-        class LikeNan(object):
+        class LikeNan:
             def __eq__(self):
                 return False
 
@@ -804,7 +804,7 @@ class TestIsin(object):
         tm.assert_numpy_array_equal(result, expected)
 
 
-class TestValueCounts(object):
+class TestValueCounts:
 
     def test_value_counts(self):
         np.random.seed(1234)
@@ -993,7 +993,7 @@ class TestValueCounts(object):
             tm.assert_series_equal(result, expected)
 
 
-class TestDuplicated(object):
+class TestDuplicated:
 
     def test_duplicated_with_nas(self):
         keys = np.array([0, 1, np.nan, 0, 2, np.nan], dtype=object)
@@ -1160,7 +1160,7 @@ class TestDuplicated(object):
         tm.assert_numpy_array_equal(result, expected)
 
 
-class GroupVarTestMixin(object):
+class GroupVarTestMixin:
 
     def test_group_var_generic_1d(self):
         prng = RandomState(1234)
@@ -1275,7 +1275,7 @@ class TestGroupVarFloat32(GroupVarTestMixin):
     rtol = 1e-2
 
 
-class TestHashTable(object):
+class TestHashTable:
 
     def test_lookup_nan(self, writable):
         xs = np.array([2.718, 3.14, np.nan, -7, 5, 2, 3])
@@ -1469,7 +1469,7 @@ def test_unique_label_indices():
                                 check_dtype=False)
 
 
-class TestRank(object):
+class TestRank:
 
     @td.skip_if_no_scipy
     def test_scipy_compat(self):
@@ -1548,7 +1548,7 @@ def test_arrmap():
     assert (result.dtype == np.bool_)
 
 
-class TestTseriesUtil(object):
+class TestTseriesUtil:
 
     def test_combineFunc(self):
         pass
@@ -1758,7 +1758,7 @@ def test_int64_add_overflow():
                                b_mask=np.array([False, True]))
 
 
-class TestMode(object):
+class TestMode:
 
     def test_no_mode(self):
         exp = Series([], dtype=np.float64)

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -27,7 +27,7 @@ from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 import pandas.util.testing as tm
 
 
-class CheckStringMixin(object):
+class CheckStringMixin:
 
     def test_string_methods_dont_fail(self):
         repr(self.container)
@@ -42,7 +42,7 @@ class CheckStringMixin(object):
         bytes(self.unicode_container)
 
 
-class CheckImmutable(object):
+class CheckImmutable:
     mutable_regex = re.compile('does not support mutable operations')
 
     def check_mutable_error(self, *args, **kwargs):
@@ -87,9 +87,9 @@ class CheckImmutable(object):
         assert result == expected
 
 
-class TestPandasDelegate(object):
+class TestPandasDelegate:
 
-    class Delegator(object):
+    class Delegator:
         _properties = ['foo']
         _methods = ['bar']
 
@@ -149,7 +149,7 @@ class TestPandasDelegate(object):
         sys.getsizeof(delegate)
 
 
-class Ops(object):
+class Ops:
 
     def _allow_na_ops(self, obj):
         """Whether to skip test cases including NaN"""
@@ -979,7 +979,7 @@ class TestTranspose(Ops):
                 np.transpose(obj, axes=1)
 
 
-class TestNoNewAttributesMixin(object):
+class TestNoNewAttributesMixin:
 
     def test_mixin(self):
         class T(NoNewAttributesMixin):
@@ -1001,7 +1001,7 @@ class TestNoNewAttributesMixin(object):
         assert not hasattr(t, "b")
 
 
-class TestToIterable(object):
+class TestToIterable:
     # test that we convert an iterable to python types
 
     dtypes = [

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -22,7 +22,7 @@ def test_get_callable_name():
     part1 = partial(fn)
     part2 = partial(part1)
 
-    class somecall(object):
+    class somecall:
 
         def __call__(self):
             return x  # noqa

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -8,7 +8,7 @@ import re
 from pandas.compat import lmap, lrange, lzip, re_type
 
 
-class TestBuiltinIterators(object):
+class TestBuiltinIterators:
 
     @classmethod
     def check_results(cls, results, expecteds, lengths):

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -47,7 +47,7 @@ def test_error_rename():
         pass
 
 
-class Foo(object):
+class Foo:
     @classmethod
     def classmethod(cls):
         raise AbstractMethodError(cls, methodtype='classmethod')

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -33,7 +33,7 @@ _integer2 = DataFrame(np.random.randint(1, 100, size=(101, 4)),
 
 
 @pytest.mark.skipif(not expr._USE_NUMEXPR, reason='not using numexpr')
-class TestExpressions(object):
+class TestExpressions:
 
     def setup_method(self, method):
 

--- a/pandas/tests/test_join.py
+++ b/pandas/tests/test_join.py
@@ -9,7 +9,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_almost_equal, assert_frame_equal
 
 
-class TestIndexer(object):
+class TestIndexer:
 
     def test_outer_join_indexer(self):
         typemap = [('int32', _join.outer_join_indexer_int32),

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -9,7 +9,7 @@ from pandas import Index
 import pandas.util.testing as tm
 
 
-class TestMisc(object):
+class TestMisc:
 
     def test_max_len_string_array(self):
 
@@ -42,7 +42,7 @@ class TestMisc(object):
         tm.assert_numpy_array_equal(np.array(out), expected)
 
 
-class TestIndexing(object):
+class TestIndexing:
 
     def test_maybe_indices_to_slice_left_edge(self):
         target = np.arange(100)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -23,7 +23,7 @@ AGG_FUNCTIONS = ['sum', 'prod', 'min', 'max', 'median', 'mean', 'skew', 'mad',
                  'std', 'var', 'sem']
 
 
-class Base(object):
+class Base:
 
     def setup_method(self, method):
 

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -18,7 +18,7 @@ import pandas.util.testing as tm
 use_bn = nanops._USE_BOTTLENECK
 
 
-class TestnanopsDataFrame(object):
+class TestnanopsDataFrame:
 
     def setup_method(self, method):
         np.random.seed(11235)
@@ -713,7 +713,7 @@ class TestnanopsDataFrame(object):
         assert not nanops._bn_ok_dtype(self.arr_obj.dtype, 'test')
 
 
-class TestEnsureNumeric(object):
+class TestEnsureNumeric:
 
     def test_numeric_values(self):
         # Test integer
@@ -761,7 +761,7 @@ class TestEnsureNumeric(object):
             nanops._ensure_numeric([])
 
 
-class TestNanvarFixedValues(object):
+class TestNanvarFixedValues:
 
     # xref GH10242
 
@@ -874,7 +874,7 @@ class TestNanvarFixedValues(object):
         return np.random.RandomState(1234)
 
 
-class TestNanskewFixedValues(object):
+class TestNanskewFixedValues:
 
     # xref GH 11974
 
@@ -924,7 +924,7 @@ class TestNanskewFixedValues(object):
         return np.random.RandomState(1234)
 
 
-class TestNankurtFixedValues(object):
+class TestNankurtFixedValues:
 
     # xref GH 11974
 
@@ -974,7 +974,7 @@ class TestNankurtFixedValues(object):
         return np.random.RandomState(1234)
 
 
-class TestDatetime64NaNOps(object):
+class TestDatetime64NaNOps:
     @pytest.mark.parametrize('tz', [None, 'UTC'])
     @pytest.mark.xfail(reason="disabled")
     # Enabling mean changes the behavior of DataFrame.mean

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -20,7 +20,7 @@ def ensure_removed(obj, attr):
         obj._accessors.discard(attr)
 
 
-class MyAccessor(object):
+class MyAccessor:
 
     def __init__(self, obj):
         self.obj = obj
@@ -81,7 +81,7 @@ def test_raises_attribute_error():
     with ensure_removed(pd.Series, 'bad'):
 
         @pd.api.extensions.register_series_accessor("bad")
-        class Bad(object):
+        class Bad:
             def __init__(self, data):
                 raise AttributeError("whoops")
 

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -15,7 +15,7 @@ from pandas.util import testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
-class TestSorting(object):
+class TestSorting:
 
     @pytest.mark.slow
     def test_int64_overflow(self):
@@ -188,7 +188,7 @@ class TestSorting(object):
             nargsort(data)
 
 
-class TestMerge(object):
+class TestMerge:
 
     @pytest.mark.slow
     def test_int64_overflow_issues(self):
@@ -340,7 +340,7 @@ def test_decons():
     testit(label_list, shape)
 
 
-class TestSafeSort(object):
+class TestSafeSort:
 
     def test_basic_sort(self):
         values = [3, 1, 2, 0, 4]

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -159,7 +159,7 @@ def any_allowed_skipna_inferred_dtype(request):
     return inferred_dtype, values
 
 
-class TestStringMethods(object):
+class TestStringMethods:
 
     def test_api(self):
 

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -65,7 +65,7 @@ def dtype_fill_out_dtype(request):
     return request.param
 
 
-class TestTake(object):
+class TestTake:
     # Standard incompatible fill error.
     fill_error = re.compile("Incompatible type for fill_value")
 
@@ -422,7 +422,7 @@ class TestTake(object):
         tm.assert_numpy_array_equal(result, expected)
 
 
-class TestExtensionTake(object):
+class TestExtensionTake:
     # The take method found in pd.api.extensions
 
     def test_bounds_check_large(self):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -47,7 +47,7 @@ def win_types_special(request):
     return request.param
 
 
-class Base(object):
+class Base:
 
     _nan_locs = np.arange(20, 40)
     _inf_locs = np.array([])
@@ -846,7 +846,7 @@ class TestEWM(Base):
 #
 # further note that we are only checking rolling for fully dtype
 # compliance (though both expanding and ewm inherit)
-class Dtype(object):
+class Dtype:
     window = 2
 
     funcs = {
@@ -1900,7 +1900,7 @@ class TestMoments(Base):
         assert result2.dtype == np.float_
 
 
-class TestPairwise(object):
+class TestPairwise:
 
     # GH 7738
     df1s = [DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[0, 1]),
@@ -3274,7 +3274,7 @@ class TestMomentsConsistency(Base):
             assert result.dtypes[0] == np.dtype("f8")
 
 
-class TestGrouperGrouping(object):
+class TestGrouperGrouping:
 
     def setup_method(self, method):
         self.series = Series(np.arange(10))
@@ -3443,7 +3443,7 @@ class TestGrouperGrouping(object):
         tm.assert_frame_equal(result, expected)
 
 
-class TestRollingTS(object):
+class TestRollingTS:
 
     # rolling time-series friendly
     # xref GH13327

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -31,7 +31,7 @@ from pandas.tseries.offsets import (
 from .common import assert_offset_equal, assert_onOffset
 
 
-class WeekDay(object):
+class WeekDay:
     # TODO: Remove: This is not used outside of tests
     MON = 0
     TUE = 1
@@ -58,7 +58,7 @@ def test_to_M8():
 #####
 
 
-class Base(object):
+class Base:
     _offset = None
     d = Timestamp(datetime(2008, 1, 2))
 
@@ -1868,7 +1868,7 @@ class TestCustomBusinessDay(Base):
         assert cday == cday0_14_1
 
 
-class CustomBusinessMonthBase(object):
+class CustomBusinessMonthBase:
 
     def setup_method(self, method):
         self.d = datetime(2008, 1, 1)
@@ -2785,7 +2785,7 @@ def test_Easter():
                         datetime(2008, 3, 23))
 
 
-class TestOffsetNames(object):
+class TestOffsetNames:
 
     def test_get_offset_name(self):
         assert BDay().freqstr == 'B'
@@ -2825,7 +2825,7 @@ def test_get_offset_legacy():
             get_offset(name)
 
 
-class TestOffsetAliases(object):
+class TestOffsetAliases:
 
     def setup_method(self, method):
         _offset_map.clear()
@@ -2884,7 +2884,7 @@ def test_freq_offsets():
     assert (off.freqstr == 'B-30Min')
 
 
-class TestReprNames(object):
+class TestReprNames:
 
     def test_str_for_named_is_name(self):
         # look at all the amazing combinations!
@@ -2909,7 +2909,7 @@ def get_utc_offset_hours(ts):
     return (o.days * 24 * 3600 + o.seconds) / 3600.0
 
 
-class TestDST(object):
+class TestDST:
     """
     test DateOffset additions over Daylight Savings Time
     """

--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -132,7 +132,7 @@ def test_assert_almost_equal_dict_like_object(val):
     dict_val = 1
     real_dict = dict(a=val)
 
-    class DictLikeObj(object):
+    class DictLikeObj:
         def keys(self):
             return "a",
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -253,7 +253,7 @@ def infer_freq(index, warn=True):
     return inferer.get_freq()
 
 
-class _FrequencyInferer(object):
+class _FrequencyInferer:
     """
     Not sure if I can avoid the state machine here
     """

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -122,7 +122,7 @@ def after_nearest_workday(dt):
     return next_workday(nearest_workday(dt))
 
 
-class Holiday(object):
+class Holiday:
     """
     Class that defines a holiday with start/end dates and rules
     for observance.
@@ -325,7 +325,7 @@ class HolidayCalendarMetaClass(type):
 
 
 @add_metaclass(HolidayCalendarMetaClass)
-class AbstractHolidayCalendar(object):
+class AbstractHolidayCalendar:
     """
     Abstract interface to create holidays following certain rules.
     """

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -410,7 +410,7 @@ class SingleConstructorOffset(DateOffset):
         return cls()
 
 
-class _CustomMixin(object):
+class _CustomMixin:
     """
     Mixin for classes that define and validate calendar, holidays,
     and weekdays attributes.
@@ -428,7 +428,7 @@ class _CustomMixin(object):
         object.__setattr__(self, "calendar", calendar)
 
 
-class BusinessMixin(object):
+class BusinessMixin:
     """
     Mixin to business types to provide related functions.
     """
@@ -1414,7 +1414,7 @@ class Week(DateOffset):
         return cls(weekday=weekday)
 
 
-class _WeekOfMonthMixin(object):
+class _WeekOfMonthMixin:
     """
     Mixin for methods common to WeekOfMonth and LastWeekOfMonth.
     """

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -218,7 +218,7 @@ def rewrite_axis_style_signature(name, extra_params):
 # module http://matplotlib.org/users/license.html
 
 
-class Substitution(object):
+class Substitution:
     """
     A decorator to take a function's docstring and perform string
     substitution on it.
@@ -279,7 +279,7 @@ class Substitution(object):
         return result
 
 
-class Appender(object):
+class Appender:
     """
     A function decorator that will append an addendum to the docstring
     of the target function.

--- a/pandas/util/_depr_module.py
+++ b/pandas/util/_depr_module.py
@@ -7,7 +7,7 @@ import importlib
 import warnings
 
 
-class _DeprecatedModule(object):
+class _DeprecatedModule:
     """ Class for mocking deprecated modules.
 
     Parameters

--- a/pandas/util/_doctools.py
+++ b/pandas/util/_doctools.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 
 
-class TablePlotter(object):
+class TablePlotter:
     """
     Layout some DataFrames in vertical/horizontal layout for explanation.
     Used in merging.rst

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2263,7 +2263,7 @@ item assignment"
         return manager
 
 
-class _AssertRaisesContextmanager(object):
+class _AssertRaisesContextmanager:
     """
     Context manager behind `assert_raises_regex`.
     """
@@ -2458,7 +2458,7 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
             )
 
 
-class RNGContext(object):
+class RNGContext:
     """
     Context manager to set the numpy random number generator speed. Returns
     to the original value upon exiting the context manager.

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -10,7 +10,7 @@ import validate_docstrings
 validate_one = validate_docstrings.validate_one
 
 
-class GoodDocStrings(object):
+class GoodDocStrings:
     """
     Collection of good doc strings.
 
@@ -253,7 +253,7 @@ class GoodDocStrings(object):
             return None
 
 
-class BadGenericDocStrings(object):
+class BadGenericDocStrings:
     """Everything here has a bad docstring
     """
 
@@ -445,7 +445,7 @@ class BadGenericDocStrings(object):
         pass
 
 
-class BadSummaries(object):
+class BadSummaries:
 
     def wrong_line(self):
         """Exists on the wrong line"""
@@ -484,7 +484,7 @@ class BadSummaries(object):
         """
 
 
-class BadParameters(object):
+class BadParameters:
     """
     Everything here has a problem with its Parameters section.
     """
@@ -611,7 +611,7 @@ class BadParameters(object):
         pass
 
 
-class BadReturns(object):
+class BadReturns:
 
     def return_not_documented(self):
         """
@@ -694,7 +694,7 @@ class BadReturns(object):
         return "Hello", "World!"
 
 
-class BadSeeAlso(object):
+class BadSeeAlso:
 
     def desc_no_period(self):
         """
@@ -732,7 +732,7 @@ class BadSeeAlso(object):
         pass
 
 
-class BadExamples(object):
+class BadExamples:
 
     def unused_import(self):
         """
@@ -770,7 +770,7 @@ class BadExamples(object):
         pass
 
 
-class TestValidator(object):
+class TestValidator:
 
     def _import_path(self, klass=None, func=None):
         """
@@ -951,7 +951,7 @@ class TestValidator(object):
         assert len(result) == 0
 
 
-class TestApiItems(object):
+class TestApiItems:
     @property
     def api_doc(self):
         return io.StringIO(textwrap.dedent('''
@@ -1027,7 +1027,7 @@ class TestApiItems(object):
         assert result[idx][3] == subsection
 
 
-class TestDocstringClass(object):
+class TestDocstringClass:
     @pytest.mark.parametrize('name, expected_obj',
                              [('pandas.isnull', pd.isnull),
                               ('pandas.DataFrame', pd.DataFrame),
@@ -1053,7 +1053,7 @@ class TestDocstringClass(object):
             validate_docstrings.Docstring(invalid_name)
 
 
-class TestMainFunction(object):
+class TestMainFunction:
     def test_exit_status_for_validate_one(self, monkeypatch):
         monkeypatch.setattr(
             validate_docstrings, 'validate_one', lambda func_name: {

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -223,7 +223,7 @@ def get_api_items(api_doc_fd):
         previous_line = line
 
 
-class Docstring(object):
+class Docstring:
     def __init__(self, name):
         self.name = name
         obj = self._load_obj(name)


### PR DESCRIPTION
- [x] xref #25725

Bit of a tedious whopper to review (sorry), but this PR removes all instances of inheriting from the base ``object`` from the code base, as dropping Python2 support means that this particular idiom is no longer needed. 

Additionally, as part of the above, I've removed the check in code_checks.sh that classes must inherit, as that is no longer a requirement after dropping Python2. I don't think a different check is possible to do now, but I can change instead of delete the check if anyone thinks that would make sense.
