### PR TITLE
CLN: rename test method parameter name 'object' to 'self'

### DIFF
--- a/pandas/tests/arrays/categorical/test_warnings.py
+++ b/pandas/tests/arrays/categorical/test_warnings.py
@@ -18,14 +18,14 @@ class TestCategoricalWarnings(object):
             with provisionalcompleter('ignore'):
                 list(ip.Completer.completions('c.', 1))
 
-    def test_CategoricalAccessor_categorical_deprecation(object):
+    def test_CategoricalAccessor_categorical_deprecation(self):
         with tm.assert_produces_warning(FutureWarning):
             pd.Series(['a', 'b'], dtype='category').cat.categorical
 
-    def test_CategoricalAccessor_name_deprecation(object):
+    def test_CategoricalAccessor_name_deprecation(self):
         with tm.assert_produces_warning(FutureWarning):
             pd.Series(['a', 'b'], dtype='category').cat.name
 
-    def test_CategoricalAccessor_index_deprecation(object):
+    def test_CategoricalAccessor_index_deprecation(self):
         with tm.assert_produces_warning(FutureWarning):
             pd.Series(['a', 'b'], dtype='category').cat.index


### PR DESCRIPTION
As part of #26128, I saw that in three test methods, their first parameter has been named ``object`` rather than ``self``. This rectifies that.