### PR TITLE
BUG: update cython to fix segfault accessing __kwdefaults__

### DIFF
--- a/ci/deps/azure-35-compat.yaml
+++ b/ci/deps/azure-35-compat.yaml
@@ -18,7 +18,7 @@ dependencies:
   - xlsxwriter=0.7.7
   - xlwt=1.0.0
   # universal
-  - cython=0.28.2
+  - cython=0.29.7
   - hypothesis>=3.58.0
   - pytest-xdist
   - pytest-mock

--- a/ci/deps/azure-36-locale.yaml
+++ b/ci/deps/azure-36-locale.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - beautifulsoup4==4.5.1
   - bottleneck=1.2.*
-  - cython=0.28.2
+  - cython=0.29.7
   - lxml
   - matplotlib=2.2.2
   - numpy=1.14.*

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - beautifulsoup4
-  - cython>=0.28.2
+  - cython>=0.29.7
   - gcsfs
   - html5lib
   - ipython

--- a/ci/deps/azure-37-locale.yaml
+++ b/ci/deps/azure-37-locale.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - beautifulsoup4
-  - cython>=0.28.2
+  - cython>=0.29.7
   - html5lib
   - ipython
   - jinja2

--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.7.*
   - pytz
-  - Cython>=0.28.2
+  - Cython>=0.29.7
   # universal
   - pytest>=4.0.2
   - pytest-xdist

--- a/ci/deps/azure-macos-35.yaml
+++ b/ci/deps/azure-macos-35.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - beautifulsoup4
   - bottleneck
-  - cython>=0.28.2
+  - cython>=0.29.7
   - html5lib
   - jinja2
   - lxml

--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -22,7 +22,7 @@ dependencies:
   - xlsxwriter
   - xlwt
   # universal
-  - cython>=0.28.2
+  - cython>=0.29.7
   - pytest>=4.0.2
   - pytest-xdist
   - pytest-mock

--- a/ci/deps/azure-windows-37.yaml
+++ b/ci/deps/azure-windows-37.yaml
@@ -24,7 +24,7 @@ dependencies:
   - xlsxwriter
   - xlwt
   # universal
-  - cython>=0.28.2
+  - cython>=0.29.7
   - pytest>=4.0.2
   - pytest-xdist
   - pytest-mock

--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - beautifulsoup4
   - botocore>=1.11
-  - cython>=0.28.2
+  - cython>=0.29.7
   - dask
   - fastparquet>=0.2.1
   - gcsfs

--- a/ci/deps/travis-36-doc.yaml
+++ b/ci/deps/travis-36-doc.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - beautifulsoup4
   - bottleneck
-  - cython>=0.28.2
+  - cython>=0.29.7
   - fastparquet>=0.2.1
   - gitpython
   - html5lib

--- a/ci/deps/travis-36-locale.yaml
+++ b/ci/deps/travis-36-locale.yaml
@@ -6,7 +6,7 @@ dependencies:
   - beautifulsoup4
   - blosc=1.14.3
   - python-blosc
-  - cython>=0.28.2
+  - cython>=0.29.7
   - fastparquet=0.2.1
   - gcsfs=0.1.0
   - html5lib

--- a/ci/deps/travis-36-slow.yaml
+++ b/ci/deps/travis-36-slow.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - beautifulsoup4
-  - cython>=0.28.2
+  - cython>=0.29.7
   - html5lib
   - lxml
   - matplotlib

--- a/ci/deps/travis-37.yaml
+++ b/ci/deps/travis-37.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.7.*
   - botocore>=1.11
-  - cython>=0.28.2
+  - cython>=0.29.7
   - numpy
   - python-dateutil
   - nomkl

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 
   # development
   - asv
-  - cython>=0.28.2
+  - cython>=0.29.7
   - flake8
   - flake8-comprehensions
   - flake8-rst>=0.6.0,<=0.7.0

--- a/pandas/tests/test_cython.py
+++ b/pandas/tests/test_cython.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import inspect
+
+import pytest
+
+
+def check_accessible(x, depth=0):
+    if depth == 0:
+        return
+
+    for _, member in inspect.getmembers(x):
+        check_accessible(member, depth - 1)
+
+
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_libs():
+    import pandas._libs as libs
+    check_accessible(libs, 3)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ numpy>=1.15
 python-dateutil>=2.5.0
 pytz
 asv
-cython>=0.28.2
+cython>=0.29.7
 flake8
 flake8-comprehensions
 flake8-rst>=0.6.0,<=0.7.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools_kwargs = {
 }
 
 
-min_cython_ver = '0.28.2'
+min_cython_ver = '0.29.7'
 try:
     import Cython
     ver = Cython.__version__


### PR DESCRIPTION
- [x] closes #26127
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This ups the cython minimum version to fix bugs as seen in #26127. I've added a test which goes through the members of `_libs` to check that they don't segfault when accessed. If you manually install 0.28.2 and run the test, you'll see it segfault.

I'm not sure how to place this change in the "whatsnow", so I'd be happy if I could get some advice there (and anywhere else I've gone wrong, of course).