### PR TITLE
GH26139, DOC: Explicit statement of default complevel for HDFStore

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -422,7 +422,7 @@ class HDFStore(StringMixin):
             It is similar to ``'a'``, but the file must already exist.
     complevel : int, 0-9, default None
             Specifies a compression level for data.
-            A value of 0 disables compression.
+            A value of 0 or None disables compression.
     complib : {'zlib', 'lzo', 'bzip2', 'blosc'}, default 'zlib'
             Specifies the compression library to be used.
             As of v0.20.2 these additional compressors for Blosc are supported


### PR DESCRIPTION
State what `None` complevel in `HDFStore` means explicitly.

- [x] closes #26139

