### PR TITLE
CLN: replace %s syntax with .format in pandas.core.indexes

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1411,8 +1411,8 @@ class Index(IndexOpsMixin, PandasObject):
         if isinstance(level, int):
             if level < 0 and level != -1:
                 raise IndexError("Too many levels: Index has only 1 level,"
-                                 " {level} is not a valid level number"
-                                 "".format(level=level))
+                                 " {level} is not a valid level"
+                                 " number".format(level=level))
             elif level > 0:
                 raise IndexError("Too many levels: Index has only 1 level, not"
                                  " {level}".format(level=(level + 1)))

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -927,14 +927,15 @@ class Index(IndexOpsMixin, PandasObject):
         attrs = self._format_attrs()
         space = self._format_space()
 
-        prepr = (",%s" %
-                 space).join("%s=%s" % (k, v) for k, v in attrs)
+        prepr = (",{space}".format(space=space)).join(
+            "{k}={v}".format(k=k, v=v) for k, v in attrs)
 
         # no data provided, just attributes
         if data is None:
             data = ''
 
-        res = "%s(%s%s)" % (klass, data, prepr)
+        res = "{klass}({data}{prepr})".format(
+            klass=klass, data=data, prepr=prepr)
 
         return res
 
@@ -1410,14 +1411,14 @@ class Index(IndexOpsMixin, PandasObject):
         if isinstance(level, int):
             if level < 0 and level != -1:
                 raise IndexError("Too many levels: Index has only 1 level,"
-                                 " %d is not a valid level number" % (level, ))
+                                 " {level} is not a valid level number"
+                                 "".format(level=level))
             elif level > 0:
-                raise IndexError("Too many levels:"
-                                 " Index has only 1 level, not %d" %
-                                 (level + 1))
+                raise IndexError("Too many levels: Index has only 1 level, not"
+                                 " {level}".format(level=(level + 1)))
         elif level != self.name:
-            raise KeyError('Level %s must be same as name (%s)' %
-                           (level, self.name))
+            raise KeyError("Level {level} must be same as name ({name})"
+                           "".format(level=level, name=self.name))
 
     def _get_level_number(self, level):
         self._validate_index_level(level)
@@ -4808,8 +4809,9 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 slc = lib.maybe_indices_to_slice(slc.astype('i8'), len(self))
             if isinstance(slc, np.ndarray):
-                raise KeyError("Cannot get %s slice bound for non-unique "
-                               "label: %r" % (side, original_label))
+                raise KeyError("Cannot get {side} slice bound for non-unique "
+                               "label: {original_label!r}".format(
+                                   side=side, original_label=original_label))
 
         if isinstance(slc, slice):
             if side == 'left':

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -113,8 +113,8 @@ class FrozenList(PandasObject, list):
                             escape_chars=('\t', '\r', '\n'))
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__,
-                           str(self))
+        return "{class_name}({list!s})".format(
+            class_name=self.__class__.__name__, list=self)
 
     __setitem__ = __setslice__ = __delitem__ = __delslice__ = _disabled
     pop = append = extend = remove = sort = insert = _disabled
@@ -155,7 +155,8 @@ class FrozenNDArray(PandasObject, np.ndarray):
         """
         prepr = pprint_thing(self, escape_chars=('\t', '\r', '\n'),
                              quote_strings=True)
-        return "%s(%s, dtype='%s')" % (type(self).__name__, prepr, self.dtype)
+        return "{ctype}({prepr}, dtype='{dtype}')".format(
+            ctype=type(self).__name__, prepr=prepr, dtype=self.dtype)
 
     @deprecate_kwarg(old_arg_name="v", new_arg_name="value")
     def searchsorted(self, value, side="left", sorter=None):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -278,10 +278,11 @@ class MultiIndex(Index):
                 raise ValueError("Unequal code lengths: %s" %
                                  ([len(code_) for code_ in codes]))
             if len(level_codes) and level_codes.max() >= len(level):
-                raise ValueError("On level %d, code max (%d) >= length of"
-                                 " level  (%d). NOTE: this index is in an"
-                                 " inconsistent state" % (i, level_codes.max(),
-                                                          len(level)))
+                raise ValueError("On level {index}, code max ({max}) >= "
+                                 "length of level  ({length}). NOTE: this "
+                                 "index is in an inconsistent state".format(
+                                     index=i, max=level_codes.max(),
+                                     length=len(level)))
             if not level.is_unique:
                 raise ValueError("Level values must be unique: {values} on "
                                  "level {level}".format(
@@ -923,7 +924,8 @@ class MultiIndex(Index):
         return attrs
 
     def _format_space(self):
-        return "\n%s" % (' ' * (len(self.__class__.__name__) + 1))
+        return "\n{space}".format(
+            space=(' ' * (len(self.__class__.__name__) + 1)))
 
     def _format_data(self, name=None):
         # we are formatting thru the attributes


### PR DESCRIPTION
progress towards #16130

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
