### PR TITLE
CLN: remove util._doctools._WritableDoc

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -7,10 +7,8 @@ from pandas._config import get_option
 
 from pandas._libs.interval import (
     Interval, IntervalMixin, intervals_to_interval_bounds)
-from pandas.compat import add_metaclass
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender
-from pandas.util._doctools import _WritableDoc
 
 from pandas.core.dtypes.cast import maybe_convert_platform
 from pandas.core.dtypes.common import (
@@ -127,7 +125,6 @@ for more.
     :meth:`IntervalArray.from_breaks`, and :meth:`IntervalArray.from_tuples`.
     """),
 ))
-@add_metaclass(_WritableDoc)
 class IntervalArray(IntervalMixin, ExtensionArray):
     dtype = IntervalDtype()
     ndim = 1

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -8,9 +8,7 @@ from pandas._config import get_option
 
 from pandas._libs import Timedelta, Timestamp
 from pandas._libs.interval import Interval, IntervalMixin, IntervalTree
-from pandas.compat import add_metaclass
 from pandas.util._decorators import Appender, cache_readonly
-from pandas.util._doctools import _WritableDoc
 from pandas.util._exceptions import rewrite_exception
 
 from pandas.core.dtypes.cast import (
@@ -126,7 +124,6 @@ def _new_IntervalIndex(cls, d):
     """),
 
 ))
-@add_metaclass(_WritableDoc)
 class IntervalIndex(IntervalMixin, Index):
     _typ = 'intervalindex'
     _comparables = ['name']

--- a/pandas/util/_doctools.py
+++ b/pandas/util/_doctools.py
@@ -163,14 +163,6 @@ class TablePlotter:
         ax.axis('off')
 
 
-class _WritableDoc(type):
-    # Remove this when Python2 support is dropped
-    # __doc__ is not mutable for new-style classes in Python2, which means
-    # we can't use @Appender to share class docstrings. This can be used
-    # with `add_metaclass` to make cls.__doc__ mutable.
-    pass
-
-
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
 


### PR DESCRIPTION
- [x] xref #25725 

Removes the metaclass ``_WritableDoc`` from the code base.