### PR TITLE
CLN: remove compat.add_metaclass

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -6,8 +6,6 @@ Cross-compatible functions for different versions of Python.
 
 Key items to import for compatible code:
 * lists: lrange(), lmap(), lzip()
-* add_metaclass(metaclass) - class decorator that recreates class with with the
-  given metaclass instead (and avoids intermediary class creation)
 
 Other items:
 * platform checker
@@ -64,20 +62,6 @@ def set_function_name(f, name, cls):
         name=name)
     f.__module__ = cls.__module__
     return f
-
-
-def add_metaclass(metaclass):
-    """
-    Class decorator for creating a class with a metaclass.
-    """
-    def wrapper(cls):
-        orig_vars = cls.__dict__.copy()
-        orig_vars.pop('__dict__', None)
-        orig_vars.pop('__weakref__', None)
-        for slots_var in orig_vars.get('__slots__', ()):
-            orig_vars.pop(slots_var)
-        return metaclass(cls.__name__, cls.__bases__, orig_vars)
-    return wrapper
 
 
 def raise_with_traceback(exc, traceback=Ellipsis):

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -8,7 +8,6 @@ import warnings
 from pandas._config import config
 
 import pandas.compat as compat
-from pandas.compat import add_metaclass
 from pandas.errors import EmptyDataError
 from pandas.util._decorators import Appender, deprecate_kwarg
 
@@ -328,8 +327,7 @@ def read_excel(io,
         **kwds)
 
 
-@add_metaclass(abc.ABCMeta)
-class _BaseExcelReader:
+class _BaseExcelReader(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
@@ -487,8 +485,7 @@ class _BaseExcelReader:
             return output[asheetname]
 
 
-@add_metaclass(abc.ABCMeta)
-class ExcelWriter:
+class ExcelWriter(metaclass=abc.ABCMeta):
     """
     Class for writing DataFrame objects into excel sheets, default is to use
     xlwt for xls, openpyxl for xlsx.  See DataFrame.to_excel for typical usage.

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -5,7 +5,6 @@ import warnings
 from dateutil.relativedelta import FR, MO, SA, SU, TH, TU, WE  # noqa
 import numpy as np
 
-from pandas.compat import add_metaclass
 from pandas.errors import PerformanceWarning
 
 from pandas import DateOffset, Series, Timestamp, date_range
@@ -324,12 +323,10 @@ class HolidayCalendarMetaClass(type):
         return calendar_class
 
 
-@add_metaclass(HolidayCalendarMetaClass)
-class AbstractHolidayCalendar:
+class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
     """
     Abstract interface to create holidays following certain rules.
     """
-    __metaclass__ = HolidayCalendarMetaClass
     rules = []  # type: List[Holiday]
     start_date = Timestamp(datetime(1970, 1, 1))
     end_date = Timestamp(datetime(2030, 12, 31))


### PR DESCRIPTION
- [x] xref #25725 

This removes the ``compat.add_metaclass`` function from the code base and replaces it with a metaclass parameter in class instation.

I don't understand why ``ExcelWriter`` needs to use a abc.ABCMeta metaclass, as the class is being used directly in the code base and I thought abstract classes couldn't be instantiated, but needed subclassing. I've kept abc.ABCMeta metaclass in ``ExcelWriter``, but would appreciate advice.