### PR TITLE
CLN: remove abc.abstractproperty from code base

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -600,14 +600,16 @@ class ExcelWriter:
     curr_sheet = None
     path = None
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def supported_extensions(self):
-        "extensions that writer engine supports"
+        """Extensions that writer engine supports."""
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def engine(self):
-        "name of engine"
+        """Name of engine."""
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
- [x] xref #25725 
- [x] xref #26165

While doing #26165 I discovered some uses of ``abc.abstractproperty`` in the codebase. This propery was deprecated in Python 3.3 and superseeded by using ``abc.abstractmethod`` and ``property`` together instead (see [python abc.abstractproperty docs](https://docs.python.org/3.7/library/abc.html#abc.abstractproperty)). I've therefore removed the uses of ``abc.abstractproperty`` from the code base.
