### PR TITLE
CLN: Clean-up use of super() in instance methods.

### DIFF
--- a/asv_bench/benchmarks/io/stata.py
+++ b/asv_bench/benchmarks/io/stata.py
@@ -38,7 +38,7 @@ class Stata(BaseIO):
 
 class StataMissing(Stata):
     def setup(self, convert_dates):
-        super(StataMissing, self).setup(convert_dates)
+        super().setup(convert_dates)
         for i in range(10):
             missing_data = np.random.randn(self.N)
             missing_data[missing_data < 0] = np.nan

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -528,7 +528,7 @@ class TimeRE(dict):
             self.locale_time = locale_time
         else:
             self.locale_time = LocaleTime()
-        base = super(TimeRE, self)
+        base = super()
         base.__init__({
             # The " \d" part of the regex is to make %c from ANSI C work
             'd': r"(?P<d>3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9])",

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -144,7 +144,7 @@ class Unpickler(pkl._Unpickler):  # type: ignore
         # override superclass
         key = (module, name)
         module, name = _class_locations_map.get(key, key)
-        return super(Unpickler, self).find_class(module, name)
+        return super().find_class(module, name)
 
 
 Unpickler.dispatch = copy.copy(Unpickler.dispatch)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1159,7 +1159,7 @@ class SelectNFrame(SelectN):
     """
 
     def __init__(self, obj, n, keep, columns):
-        super(SelectNFrame, self).__init__(obj, n, keep)
+        super().__init__(obj, n, keep)
         if not is_list_like(columns) or isinstance(columns, tuple):
             columns = [columns]
         columns = list(columns)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -317,7 +317,7 @@ class FrameRowApply(FrameApply):
     axis = 0
 
     def apply_broadcast(self):
-        return super(FrameRowApply, self).apply_broadcast(self.obj)
+        return super().apply_broadcast(self.obj)
 
     @property
     def series_generator(self):
@@ -356,7 +356,7 @@ class FrameColumnApply(FrameApply):
     axis = 1
 
     def apply_broadcast(self):
-        result = super(FrameColumnApply, self).apply_broadcast(self.obj.T)
+        result = super().apply_broadcast(self.obj.T)
         return result.T
 
     @property

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1549,7 +1549,7 @@ class Categorical(ExtensionArray, PandasObject):
         array([3, 0, 1, 2])
         """
         # Keep the implementation here just for the docstring.
-        return super(Categorical, self).argsort(*args, **kwargs)
+        return super().argsort(*args, **kwargs)
 
     def sort_values(self, inplace=False, ascending=True, na_position='last'):
         """

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1381,9 +1381,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
         if op:
             return op(axis=axis, skipna=skipna, **kwargs)
         else:
-            return super(DatetimeLikeArrayMixin, self)._reduce(
-                name, skipna, **kwargs
-            )
+            return super()._reduce(name, skipna, **kwargs)
 
     def min(self, axis=None, skipna=True, *args, **kwargs):
         """

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -580,7 +580,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
             # The default for tz-aware is object, to preserve tz info
             dtype = object
 
-        return super(DatetimeArray, self).__array__(dtype=dtype)
+        return super().__array__(dtype=dtype)
 
     def __iter__(self):
         """
@@ -771,7 +771,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
         -------
         result : DatetimeArray
         """
-        new_values = super(DatetimeArray, self)._add_delta(delta)
+        new_values = super()._add_delta(delta)
         return type(self)._from_sequence(new_values, tz=self.tz, freq='infer')
 
     # -----------------------------------------------------------------

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -505,7 +505,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
 
         if is_period_dtype(dtype):
             return self.asfreq(dtype.freq)
-        return super(PeriodArray, self).astype(dtype, copy=copy)
+        return super().astype(dtype, copy=copy)
 
     @property
     def flags(self):
@@ -560,7 +560,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         # Note: when calling parent class's _add_timedeltalike_scalar,
         #  it will call delta_to_nanoseconds(delta).  Because delta here
         #  is an integer, delta_to_nanoseconds will return it unchanged.
-        result = super(PeriodArray, self)._add_timedeltalike_scalar(other.n)
+        result = super()._add_timedeltalike_scalar(other.n)
         return type(self)(result, freq=self.freq)
 
     def _add_timedeltalike_scalar(self, other):
@@ -584,7 +584,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         # Note: when calling parent class's _add_timedeltalike_scalar,
         #  it will call delta_to_nanoseconds(delta).  Because delta here
         #  is an integer, delta_to_nanoseconds will return it unchanged.
-        ordinals = super(PeriodArray, self)._add_timedeltalike_scalar(other)
+        ordinals = super()._add_timedeltalike_scalar(other)
         return ordinals
 
     def _add_delta_tdi(self, other):
@@ -620,7 +620,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
             # We cannot add timedelta-like to non-tick PeriodArray
             _raise_on_incompatible(self, other)
 
-        new_ordinals = super(PeriodArray, self)._add_delta(other)
+        new_ordinals = super()._add_delta(other)
         return type(self)(new_ordinals, freq=self.freq)
 
     def _check_timedeltalike_freq_compat(self, other):

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -118,7 +118,7 @@ class SparseDtype(ExtensionDtype):
     def __hash__(self):
         # Python3 doesn't inherit __hash__ when a base class overrides
         # __eq__, so we explicitly do it here.
-        return super(SparseDtype, self).__hash__()
+        return super().__hash__()
 
     def __eq__(self, other):
         # We have to override __eq__ to handle NA values in _metadata.

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -387,7 +387,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         -------
         result : TimedeltaArray
         """
-        new_values = super(TimedeltaArray, self)._add_delta(delta)
+        new_values = super()._add_delta(delta)
         return type(self)._from_sequence(new_values, freq='infer')
 
     def _add_datetime_arraylike(self, other):
@@ -427,9 +427,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
             # TimedeltaIndex can only operate with a subset of DateOffset
             # subclasses.  Incompatible classes will raise AttributeError,
             # which we re-raise as TypeError
-            return super(TimedeltaArray, self)._addsub_offset_array(
-                other, op
-            )
+            return super()._addsub_offset_array(other, op)
         except AttributeError:
             raise TypeError("Cannot add/subtract non-tick DateOffset to {cls}"
                             .format(cls=type(self).__name__))

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -107,7 +107,7 @@ class PandasObject(StringMixin, DirNamesMixin):
 
         # no memory_usage attribute, so fall back to
         # object's 'sizeof'
-        return super(PandasObject, self).__sizeof__()
+        return super().__sizeof__()
 
 
 class NoNewAttributesMixin:

--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -98,10 +98,10 @@ class NumExprEngine(AbstractEngine):
     has_neg_frac = True
 
     def __init__(self, expr):
-        super(NumExprEngine, self).__init__(expr)
+        super().__init__(expr)
 
     def convert(self):
-        return str(super(NumExprEngine, self).convert())
+        return str(super().convert())
 
     def _evaluate(self):
         import numexpr as ne
@@ -133,7 +133,7 @@ class PythonEngine(AbstractEngine):
     has_neg_frac = False
 
     def __init__(self, expr):
-        super(PythonEngine, self).__init__(expr)
+        super().__init__(expr)
 
     def evaluate(self):
         return self.expr()

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -694,15 +694,14 @@ class PandasExprVisitor(BaseExprVisitor):
                  preparser=partial(_preparse, f=_compose(
                      _replace_locals, _replace_booleans,
                      _clean_spaces_backtick_quoted_names))):
-        super(PandasExprVisitor, self).__init__(env, engine, parser, preparser)
+        super().__init__(env, engine, parser, preparser)
 
 
 @disallow(_unsupported_nodes | _python_not_supported | frozenset(['Not']))
 class PythonExprVisitor(BaseExprVisitor):
 
     def __init__(self, env, engine, parser, preparser=lambda x: x):
-        super(PythonExprVisitor, self).__init__(env, engine, parser,
-                                                preparser=preparser)
+        super().__init__(env, engine, parser, preparser=preparser)
 
 
 class Expr(StringMixin):

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -43,7 +43,7 @@ class UndefinedVariableError(NameError):
             msg = 'local variable {0!r} is not defined'
         else:
             msg = 'name {0!r} is not defined'
-        super(UndefinedVariableError, self).__init__(msg.format(name))
+        super().__init__(msg.format(name))
 
 
 class Term(StringMixin):
@@ -161,8 +161,7 @@ class Term(StringMixin):
 class Constant(Term):
 
     def __init__(self, value, env, side=None, encoding=None):
-        super(Constant, self).__init__(value, env, side=side,
-                                       encoding=encoding)
+        super().__init__(value, env, side=side, encoding=encoding)
 
     def _resolve_name(self):
         return self._name
@@ -329,7 +328,7 @@ class BinOp(Op):
     """
 
     def __init__(self, op, lhs, rhs, **kwargs):
-        super(BinOp, self).__init__(op, (lhs, rhs))
+        super().__init__(op, (lhs, rhs))
         self.lhs = lhs
         self.rhs = rhs
 
@@ -462,7 +461,7 @@ class Div(BinOp):
     """
 
     def __init__(self, lhs, rhs, truediv, *args, **kwargs):
-        super(Div, self).__init__('/', lhs, rhs, *args, **kwargs)
+        super().__init__('/', lhs, rhs, *args, **kwargs)
 
         if not isnumeric(lhs.return_type) or not isnumeric(rhs.return_type):
             raise TypeError("unsupported operand type(s) for {0}:"
@@ -498,7 +497,7 @@ class UnaryOp(Op):
     """
 
     def __init__(self, op, operand):
-        super(UnaryOp, self).__init__(op, (operand,))
+        super().__init__(op, (operand,))
         self.operand = operand
 
         try:
@@ -528,7 +527,7 @@ class UnaryOp(Op):
 class MathCall(Op):
 
     def __init__(self, func, args):
-        super(MathCall, self).__init__(func.name, args)
+        super().__init__(func.name, args)
         self.func = func
 
     def __call__(self, env):

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -26,8 +26,9 @@ class Scope(expr.Scope):
 
     def __init__(self, level, global_dict=None, local_dict=None,
                  queryables=None):
-        super(Scope, self).__init__(level + 1, global_dict=global_dict,
-                                    local_dict=local_dict)
+        super().__init__(level + 1,
+                         global_dict=global_dict,
+                         local_dict=local_dict)
         self.queryables = queryables or dict()
 
 
@@ -39,7 +40,7 @@ class Term(ops.Term):
         return supr_new(klass)
 
     def __init__(self, name, env, side=None, encoding=None):
-        super(Term, self).__init__(name, env, side=side, encoding=encoding)
+        super().__init__(name, env, side=side, encoding=encoding)
 
     def _resolve_name(self):
         # must be a queryables
@@ -63,8 +64,7 @@ class Term(ops.Term):
 class Constant(Term):
 
     def __init__(self, value, env, side=None, encoding=None):
-        super(Constant, self).__init__(value, env, side=side,
-                                       encoding=encoding)
+        super().__init__(value, env, side=side, encoding=encoding)
 
     def _resolve_name(self):
         return self._name
@@ -75,7 +75,7 @@ class BinOp(ops.BinOp):
     _max_selectors = 31
 
     def __init__(self, op, lhs, rhs, queryables, encoding):
-        super(BinOp, self).__init__(op, lhs, rhs)
+        super().__init__(op, lhs, rhs)
         self.queryables = queryables
         self.encoding = encoding
         self.filter = None
@@ -385,7 +385,7 @@ class ExprVisitor(BaseExprVisitor):
     term_type = Term
 
     def __init__(self, env, engine, parser, **kwargs):
-        super(ExprVisitor, self).__init__(env, engine, parser)
+        super().__init__(env, engine, parser)
         for bin_op in self.binary_ops:
             bin_node = self.binary_op_nodes_map[bin_op]
             setattr(self, 'visit_{node}'.format(node=bin_node),

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2630,7 +2630,7 @@ class DataFrame(NDFrame):
         dtype: object
         """
         nv.validate_transpose(args, dict())
-        return super(DataFrame, self).transpose(1, 0, **kwargs)
+        return super().transpose(1, 0, **kwargs)
 
     T = property(transpose)
 
@@ -3761,12 +3761,10 @@ class DataFrame(NDFrame):
     def align(self, other, join='outer', axis=None, level=None, copy=True,
               fill_value=None, method=None, limit=None, fill_axis=0,
               broadcast_axis=None):
-        return super(DataFrame, self).align(other, join=join, axis=axis,
-                                            level=level, copy=copy,
-                                            fill_value=fill_value,
-                                            method=method, limit=limit,
-                                            fill_axis=fill_axis,
-                                            broadcast_axis=broadcast_axis)
+        return super().align(other, join=join, axis=axis, level=level,
+                             copy=copy, fill_value=fill_value, method=method,
+                             limit=limit, fill_axis=fill_axis,
+                             broadcast_axis=broadcast_axis)
 
     @Substitution(**_shared_doc_kwargs)
     @Appender(NDFrame.reindex.__doc__)
@@ -3783,15 +3781,14 @@ class DataFrame(NDFrame):
         # Pop these, since the values are in `kwargs` under different names
         kwargs.pop('axis', None)
         kwargs.pop('labels', None)
-        return super(DataFrame, self).reindex(**kwargs)
+        return super().reindex(**kwargs)
 
     @Appender(_shared_docs['reindex_axis'] % _shared_doc_kwargs)
     def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
                      limit=None, fill_value=np.nan):
-        return super(DataFrame,
-                     self).reindex_axis(labels=labels, axis=axis,
-                                        method=method, level=level, copy=copy,
-                                        limit=limit, fill_value=fill_value)
+        return super().reindex_axis(labels=labels, axis=axis, method=method,
+                                    level=level, copy=copy, limit=limit,
+                                    fill_value=fill_value)
 
     def drop(self, labels=None, axis=0, index=None, columns=None,
              level=None, inplace=False, errors='raise'):
@@ -3917,10 +3914,9 @@ class DataFrame(NDFrame):
         falcon  speed   320.0   250.0
                 weight  1.0     0.8
         """
-        return super(DataFrame, self).drop(labels=labels, axis=axis,
-                                           index=index, columns=columns,
-                                           level=level, inplace=inplace,
-                                           errors=errors)
+        return super().drop(labels=labels, axis=axis, index=index,
+                            columns=columns, level=level, inplace=inplace,
+                            errors=errors)
 
     @rewrite_axis_style_signature('mapper', [('copy', True),
                                              ('inplace', False),
@@ -4029,29 +4025,27 @@ class DataFrame(NDFrame):
         # Pop these, since the values are in `kwargs` under different names
         kwargs.pop('axis', None)
         kwargs.pop('mapper', None)
-        return super(DataFrame, self).rename(**kwargs)
+        return super().rename(**kwargs)
 
     @Substitution(**_shared_doc_kwargs)
     @Appender(NDFrame.fillna.__doc__)
     def fillna(self, value=None, method=None, axis=None, inplace=False,
                limit=None, downcast=None, **kwargs):
-        return super(DataFrame,
-                     self).fillna(value=value, method=method, axis=axis,
-                                  inplace=inplace, limit=limit,
-                                  downcast=downcast, **kwargs)
+        return super().fillna(value=value, method=method, axis=axis,
+                              inplace=inplace, limit=limit, downcast=downcast,
+                              **kwargs)
 
     @Appender(_shared_docs['replace'] % _shared_doc_kwargs)
     def replace(self, to_replace=None, value=None, inplace=False, limit=None,
                 regex=False, method='pad'):
-        return super(DataFrame, self).replace(to_replace=to_replace,
-                                              value=value, inplace=inplace,
-                                              limit=limit, regex=regex,
-                                              method=method)
+        return super().replace(to_replace=to_replace, value=value,
+                               inplace=inplace, limit=limit, regex=regex,
+                               method=method)
 
     @Appender(_shared_docs['shift'] % _shared_doc_kwargs)
     def shift(self, periods=1, freq=None, axis=0, fill_value=None):
-        return super(DataFrame, self).shift(periods=periods, freq=freq,
-                                            axis=axis, fill_value=fill_value)
+        return super().shift(periods=periods, freq=freq, axis=axis,
+                             fill_value=fill_value)
 
     def set_index(self, keys, drop=True, append=False, inplace=False,
                   verify_integrity=False):
@@ -4479,19 +4473,19 @@ class DataFrame(NDFrame):
 
     @Appender(_shared_docs['isna'] % _shared_doc_kwargs)
     def isna(self):
-        return super(DataFrame, self).isna()
+        return super().isna()
 
     @Appender(_shared_docs['isna'] % _shared_doc_kwargs)
     def isnull(self):
-        return super(DataFrame, self).isnull()
+        return super().isnull()
 
     @Appender(_shared_docs['notna'] % _shared_doc_kwargs)
     def notna(self):
-        return super(DataFrame, self).notna()
+        return super().notna()
 
     @Appender(_shared_docs['notna'] % _shared_doc_kwargs)
     def notnull(self):
-        return super(DataFrame, self).notnull()
+        return super().notnull()
 
     def dropna(self, axis=0, how='any', thresh=None, subset=None,
                inplace=False):
@@ -6334,7 +6328,7 @@ class DataFrame(NDFrame):
                            ._aggregate(arg, *args, **kwargs))
             result = result.T if result is not None else result
             return result, how
-        return super(DataFrame, self)._aggregate(arg, *args, **kwargs)
+        return super()._aggregate(arg, *args, **kwargs)
 
     agg = aggregate
 
@@ -6343,7 +6337,7 @@ class DataFrame(NDFrame):
         axis = self._get_axis_number(axis)
         if axis == 1:
             return super(DataFrame, self.T).transform(func, *args, **kwargs).T
-        return super(DataFrame, self).transform(func, *args, **kwargs)
+        return super().transform(func, *args, **kwargs)
 
     def apply(self, func, axis=0, broadcast=None, raw=False, reduce=None,
               result_type=None, args=(), **kwds):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5144,7 +5144,7 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         additions = {c for c in self._info_axis.unique(level=0)[:100]
                      if isinstance(c, str) and c.isidentifier()}
-        return super(NDFrame, self)._dir_additions().union(additions)
+        return super()._dir_additions().union(additions)
 
     # ----------------------------------------------------------------------
     # Getting and setting elements

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -722,7 +722,7 @@ class SeriesGroupBy(GroupBy):
               .format(input='series',
                       examples=_apply_docs['series_examples']))
     def apply(self, func, *args, **kwargs):
-        return super(SeriesGroupBy, self).apply(func, *args, **kwargs)
+        return super().apply(func, *args, **kwargs)
 
     @Substitution(see_also=_agg_see_also_doc,
                   examples=_agg_examples_doc,
@@ -1290,7 +1290,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
                   axis='')
     @Appender(_shared_docs['aggregate'])
     def aggregate(self, arg, *args, **kwargs):
-        return super(DataFrameGroupBy, self).aggregate(arg, *args, **kwargs)
+        return super().aggregate(arg, *args, **kwargs)
 
     agg = aggregate
 
@@ -1471,7 +1471,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
 
     def _fill(self, direction, limit=None):
         """Overridden method to join grouped columns in output"""
-        res = super(DataFrameGroupBy, self)._fill(direction, limit=limit)
+        res = super()._fill(direction, limit=limit)
         output = OrderedDict(
             (grp.name, grp.grouper) for grp in self.grouper.groupings)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1995,7 +1995,7 @@ class Index(IndexOpsMixin, PandasObject):
     def unique(self, level=None):
         if level is not None:
             self._validate_index_level(level)
-        result = super(Index, self).unique()
+        result = super().unique()
         return self._shallow_copy(result)
 
     def drop_duplicates(self, keep='first'):
@@ -2044,7 +2044,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx.drop_duplicates(keep=False)
         Index(['cow', 'beetle', 'hippo'], dtype='object')
         """
-        return super(Index, self).drop_duplicates(keep=keep)
+        return super().drop_duplicates(keep=keep)
 
     def duplicated(self, keep='first'):
         """
@@ -2100,7 +2100,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx.duplicated(keep=False)
         array([ True, False,  True, False,  True])
         """
-        return super(Index, self).duplicated(keep=keep)
+        return super().duplicated(keep=keep)
 
     def get_duplicates(self):
         """
@@ -3699,7 +3699,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @Appender(IndexOpsMixin.memory_usage.__doc__)
     def memory_usage(self, deep=False):
-        result = super(Index, self).memory_usage(deep=deep)
+        result = super().memory_usage(deep=deep)
 
         # include our engine hashtable
         result += self._engine.sizeof(deep=deep)
@@ -4507,8 +4507,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
 
         from .multi import MultiIndex
-        new_values = super(Index, self)._map_values(
-            mapper, na_action=na_action)
+        new_values = super()._map_values(mapper, na_action=na_action)
 
         attributes = self._get_attributes_dict()
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -250,8 +250,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     def _shallow_copy(self, values=None, dtype=None, **kwargs):
         if dtype is None:
             dtype = self.dtype
-        return super(CategoricalIndex, self)._shallow_copy(
-            values=values, dtype=dtype, **kwargs)
+        return super()._shallow_copy(values=values, dtype=dtype, **kwargs)
 
     def _is_dtype_compat(self, other):
         """
@@ -397,7 +396,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             if dtype == self.dtype:
                 return self.copy() if copy else self
 
-        return super(CategoricalIndex, self).astype(dtype=dtype, copy=copy)
+        return super().astype(dtype=dtype, copy=copy)
 
     @cache_readonly
     def _isnan(self):
@@ -503,7 +502,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             pass
 
         # we might be a positional inexer
-        return super(CategoricalIndex, self).get_value(series, key)
+        return super().get_value(series, key)
 
     def _can_reindex(self, indexer):
         """ always allow reindexing """
@@ -666,8 +665,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         if self.categories._defer_to_indexing:
             return self.categories._convert_scalar_indexer(key, kind=kind)
 
-        return super(CategoricalIndex, self)._convert_scalar_indexer(
-            key, kind=kind)
+        return super()._convert_scalar_indexer(key, kind=kind)
 
     @Appender(_index_shared_docs['_convert_list_indexer'])
     def _convert_list_indexer(self, keyarr, kind=None):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -441,7 +441,7 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
         """
         Return a list of tuples of the (attr,formatted_value).
         """
-        attrs = super(DatetimeIndexOpsMixin, self)._format_attrs()
+        attrs = super()._format_attrs()
         for attrib in self._attributes:
             if attrib == 'freq':
                 freq = self.freqstr
@@ -475,8 +475,7 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
             elif kind in ['ix', 'getitem'] and is_flt:
                 self._invalid_indexer('index', key)
 
-        return (super(DatetimeIndexOpsMixin, self)
-                ._convert_scalar_indexer(key, kind=kind))
+        return super()._convert_scalar_indexer(key, kind=kind)
 
     @classmethod
     def _add_datetimelike_methods(cls):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -383,7 +383,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     def __setstate__(self, state):
         """Necessary for making this object picklable"""
         if isinstance(state, dict):
-            super(DatetimeIndex, self).__setstate__(state)
+            super().__setstate__(state)
 
         elif isinstance(state, tuple):
 
@@ -482,7 +482,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
         self._assert_can_do_setop(other)
 
         if len(other) == 0 or self.equals(other) or len(self) == 0:
-            return super(DatetimeIndex, self).union(other, sort=sort)
+            return super().union(other, sort=sort)
 
         if not isinstance(other, DatetimeIndex):
             try:

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -47,7 +47,7 @@ class FrozenList(PandasObject, list):
         """
         if isinstance(other, tuple):
             other = list(other)
-        return type(self)(super(FrozenList, self).__add__(other))
+        return type(self)(super().__add__(other))
 
     def difference(self, other):
         """
@@ -72,13 +72,13 @@ class FrozenList(PandasObject, list):
 
     # Python 2 compat
     def __getslice__(self, i, j):
-        return self.__class__(super(FrozenList, self).__getslice__(i, j))
+        return self.__class__(super().__getslice__(i, j))
 
     def __getitem__(self, n):
         # Python 3 compat
         if isinstance(n, slice):
-            return self.__class__(super(FrozenList, self).__getitem__(n))
-        return super(FrozenList, self).__getitem__(n)
+            return self.__class__(super().__getitem__(n))
+        return super().__getitem__(n)
 
     def __radd__(self, other):
         if isinstance(other, tuple):
@@ -88,12 +88,12 @@ class FrozenList(PandasObject, list):
     def __eq__(self, other):
         if isinstance(other, (tuple, FrozenList)):
             other = list(other)
-        return super(FrozenList, self).__eq__(other)
+        return super().__eq__(other)
 
     __req__ = __eq__
 
     def __mul__(self, other):
-        return self.__class__(super(FrozenList, self).__mul__(other))
+        return self.__class__(super().__mul__(other))
 
     __imul__ = __mul__
 
@@ -181,8 +181,7 @@ class FrozenNDArray(PandasObject, np.ndarray):
         except ValueError:
             pass
 
-        return super(FrozenNDArray, self).searchsorted(
-            value, side=side, sorter=sorter)
+        return super().searchsorted(value, side=side, sorter=sorter)
 
 
 def _ensure_frozen(array_like, categories, copy=False):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -406,7 +406,7 @@ class IntervalIndex(IntervalMixin, Index):
             new_values = self.values.astype(dtype, copy=copy)
         if is_interval_dtype(new_values):
             return self._shallow_copy(new_values.left, new_values.right)
-        return super(IntervalIndex, self).astype(dtype, copy=copy)
+        return super().astype(dtype, copy=copy)
 
     @cache_readonly
     def dtype(self):
@@ -527,8 +527,7 @@ class IntervalIndex(IntervalMixin, Index):
     @Appender(_index_shared_docs['_convert_scalar_indexer'])
     def _convert_scalar_indexer(self, key, kind=None):
         if kind == 'iloc':
-            return super(IntervalIndex, self)._convert_scalar_indexer(
-                key, kind=kind)
+            return super()._convert_scalar_indexer(key, kind=kind)
         return key
 
     def _maybe_cast_slice_bound(self, label, side, kind):
@@ -912,7 +911,7 @@ class IntervalIndex(IntervalMixin, Index):
     @Appender(_index_shared_docs['get_indexer_non_unique'] % _index_doc_kwargs)
     def get_indexer_non_unique(self, target):
         target = self._maybe_cast_indexed(ensure_index(target))
-        return super(IntervalIndex, self).get_indexer_non_unique(target)
+        return super().get_indexer_non_unique(target)
 
     @Appender(_index_shared_docs['where'])
     def where(self, cond, other=None):
@@ -987,7 +986,7 @@ class IntervalIndex(IntervalMixin, Index):
             msg = ('can only append two IntervalIndex objects '
                    'that are closed on the same side')
             raise ValueError(msg)
-        return super(IntervalIndex, self)._concat_same_dtype(to_concat, name)
+        return super()._concat_same_dtype(to_concat, name)
 
     @Appender(_index_shared_docs['take'] % _index_doc_kwargs)
     def take(self, indices, axis=0, allow_fill=True,

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1421,7 +1421,7 @@ class MultiIndex(Index):
     def unique(self, level=None):
 
         if level is None:
-            return super(MultiIndex, self).unique()
+            return super().unique()
         else:
             level = self._get_level_number(level)
             return self._get_level_values(level=level, unique=True)
@@ -2121,8 +2121,7 @@ class MultiIndex(Index):
             indexer is an ndarray or None if cannot convert
             keyarr are tuple-safe keys
         """
-        indexer, keyarr = super(MultiIndex, self)._convert_listlike_indexer(
-            keyarr, kind=kind)
+        indexer, keyarr = super()._convert_listlike_indexer(keyarr, kind=kind)
 
         # are we indexing a specific level
         if indexer is None and len(keyarr) and not isinstance(keyarr[0],
@@ -2181,7 +2180,7 @@ class MultiIndex(Index):
 
     @Appender(_index_shared_docs['get_indexer_non_unique'] % _index_doc_kwargs)
     def get_indexer_non_unique(self, target):
-        return super(MultiIndex, self).get_indexer_non_unique(target)
+        return super().get_indexer_non_unique(target)
 
     def reindex(self, target, method=None, level=None, limit=None,
                 tolerance=None):
@@ -2306,7 +2305,7 @@ class MultiIndex(Index):
         """
         # This function adds nothing to its parent implementation (the magic
         # happens in get_slice_bound method), but it adds meaningful doc.
-        return super(MultiIndex, self).slice_locs(start, end, step, kind=kind)
+        return super().slice_locs(start, end, step, kind=kind)
 
     def _partial_tup_index(self, tup, side='left'):
         if len(tup) > self.lexsort_depth:

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -68,8 +68,7 @@ class NumericIndex(Index):
         if values is not None and not self._can_hold_na:
             # Ensure we are not returning an Int64Index with float data:
             return self._shallow_copy_with_infer(values=values, **kwargs)
-        return (super(NumericIndex, self)._shallow_copy(values=values,
-                                                        **kwargs))
+        return super()._shallow_copy(values=values, **kwargs)
 
     def _convert_for_op(self, value):
         """ Convert value to be insertable to ndarray """
@@ -121,7 +120,7 @@ class NumericIndex(Index):
         # treat NA values as nans:
         if is_scalar(item) and isna(item):
             item = self._na_value
-        return super(NumericIndex, self).insert(loc, item)
+        return super().insert(loc, item)
 
 
 _num_index_shared_docs['class_descr'] = """
@@ -206,8 +205,7 @@ class Int64Index(IntegerIndex):
         # don't coerce ilocs to integers
         if kind != 'iloc':
             key = self._maybe_cast_indexer(key)
-        return (super(Int64Index, self)
-                ._convert_scalar_indexer(key, kind=kind))
+        return super()._convert_scalar_indexer(key, kind=kind)
 
     def _wrap_joined_index(self, joined, other):
         name = get_op_result_name(self, other)
@@ -260,8 +258,7 @@ class UInt64Index(IntegerIndex):
         # don't coerce ilocs to integers
         if kind != 'iloc':
             key = self._maybe_cast_indexer(key)
-        return (super(UInt64Index, self)
-                ._convert_scalar_indexer(key, kind=kind))
+        return super()._convert_scalar_indexer(key, kind=kind)
 
     @Appender(_index_shared_docs['_convert_arr_indexer'])
     def _convert_arr_indexer(self, keyarr):
@@ -332,7 +329,7 @@ class Float64Index(NumericIndex):
             # TODO(jreback); this can change once we have an EA Index type
             # GH 13149
             raise ValueError('Cannot convert NA to integer')
-        return super(Float64Index, self).astype(dtype, copy=copy)
+        return super().astype(dtype, copy=copy)
 
     @Appender(_index_shared_docs['_convert_scalar_indexer'])
     def _convert_scalar_indexer(self, key, kind=None):
@@ -350,8 +347,7 @@ class Float64Index(NumericIndex):
             return key
 
         if kind == 'iloc':
-            return super(Float64Index, self)._convert_slice_indexer(key,
-                                                                    kind=kind)
+            return super()._convert_slice_indexer(key, kind=kind)
 
         # translate to locations
         return self.slice_indexer(key.start, key.stop, key.step, kind=kind)
@@ -400,7 +396,7 @@ class Float64Index(NumericIndex):
             return False
 
     def __contains__(self, other):
-        if super(Float64Index, self).__contains__(other):
+        if super().__contains__(other):
             return True
 
         try:
@@ -431,12 +427,11 @@ class Float64Index(NumericIndex):
                     return nan_idxs
         except (TypeError, NotImplementedError):
             pass
-        return super(Float64Index, self).get_loc(key, method=method,
-                                                 tolerance=tolerance)
+        return super().get_loc(key, method=method, tolerance=tolerance)
 
     @cache_readonly
     def is_unique(self):
-        return super(Float64Index, self).is_unique and self._nan_idxs.size < 2
+        return super().is_unique and self._nan_idxs.size < 2
 
     @Appender(Index.isin.__doc__)
     def isin(self, values, level=None):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -524,7 +524,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
             return self.to_timestamp(how=how).tz_localize(tz)
 
         # TODO: should probably raise on `how` here, so we don't ignore it.
-        return super(PeriodIndex, self).astype(dtype, copy=copy)
+        return super().astype(dtype, copy=copy)
 
     @Substitution(klass='PeriodIndex')
     @Appender(_shared_docs['searchsorted'])
@@ -576,7 +576,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         s = com.values_from_object(series)
         try:
             return com.maybe_box(self,
-                                 super(PeriodIndex, self).get_value(s, key),
+                                 super().get_value(s, key),
                                  series, key)
         except (KeyError, IndexError):
             try:
@@ -634,7 +634,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         """
         wrap Index._get_unique_index to handle NaT
         """
-        res = super(PeriodIndex, self)._get_unique_index(dropna=dropna)
+        res = super()._get_unique_index(dropna=dropna)
         if dropna:
             res = res.dropna()
         return res
@@ -801,7 +801,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         return self._apply_meta(result)
 
     def _assert_can_do_setop(self, other):
-        super(PeriodIndex, self)._assert_can_do_setop(other)
+        super()._assert_can_do_setop(other)
 
         if not isinstance(other, PeriodIndex):
             raise ValueError('can only call with other PeriodIndex-ed objects')
@@ -828,7 +828,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         """Necessary for making this object picklable"""
 
         if isinstance(state, dict):
-            super(PeriodIndex, self).__setstate__(state)
+            super().__setstate__(state)
 
         elif isinstance(state, tuple):
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -366,7 +366,7 @@ class RangeIndex(Int64Index):
                     self._start == other._start and
                     self._step == other._step)
 
-        return super(RangeIndex, self).equals(other)
+        return super().equals(other)
 
     def intersection(self, other, sort=False):
         """
@@ -395,7 +395,7 @@ class RangeIndex(Int64Index):
             return self._get_reconciled_name_object(other)
 
         if not isinstance(other, RangeIndex):
-            return super(RangeIndex, self).intersection(other, sort=sort)
+            return super().intersection(other, sort=sort)
 
         if not len(self) or not len(other):
             return RangeIndex._simple_new(None)
@@ -485,7 +485,7 @@ class RangeIndex(Int64Index):
         """
         self._assert_can_do_setop(other)
         if len(other) == 0 or self.equals(other) or len(self) == 0:
-            return super(RangeIndex, self).union(other, sort=sort)
+            return super().union(other, sort=sort)
 
         if isinstance(other, RangeIndex) and sort is None:
             start_s, step_s = self._start, self._step
@@ -534,8 +534,7 @@ class RangeIndex(Int64Index):
             return self._int64index.join(other, how, level, return_indexers,
                                          sort)
 
-        return super(RangeIndex, self).join(other, how, level, return_indexers,
-                                            sort)
+        return super().join(other, how, level, return_indexers, sort)
 
     def _concat_same_dtype(self, indexes, name):
         return _concat._concat_rangeindex_same_dtype(indexes).rename(name)
@@ -554,7 +553,7 @@ class RangeIndex(Int64Index):
         """
         Conserve RangeIndex type for scalar and slice keys.
         """
-        super_getitem = super(RangeIndex, self).__getitem__
+        super_getitem = super().__getitem__
 
         if is_scalar(key):
             if not lib.is_integer(key):

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -258,7 +258,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, dtl.TimelikeOps, Int64Index,
     def __setstate__(self, state):
         """Necessary for making this object picklable"""
         if isinstance(state, dict):
-            super(TimedeltaIndex, self).__setstate__(state)
+            super().__setstate__(state)
         else:
             raise Exception("invalid pickle state")
     _unpickle_compat = __setstate__
@@ -346,7 +346,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, dtl.TimelikeOps, Int64Index,
         self._assert_can_do_setop(other)
 
         if len(other) == 0 or self.equals(other) or len(self) == 0:
-            return super(TimedeltaIndex, self).union(other)
+            return super().union(other)
 
         if not isinstance(other, TimedeltaIndex):
             try:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1414,7 +1414,7 @@ class _IXIndexer(_NDFrameIndexer):
     def __init__(self, name, obj):
         warnings.warn(self._ix_deprecation_warning,
                       DeprecationWarning, stacklevel=2)
-        super(_IXIndexer, self).__init__(name, obj)
+        super().__init__(name, obj)
 
     @Appender(_NDFrameIndexer._validate_key.__doc__)
     def _validate_key(self, key, axis):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1544,8 +1544,7 @@ class NonConsolidatableMixIn:
                 ndim = 1
             else:
                 ndim = 2
-        super(NonConsolidatableMixIn, self).__init__(values, placement,
-                                                     ndim=ndim)
+        super().__init__(values, placement, ndim=ndim)
 
     @property
     def shape(self):
@@ -1657,7 +1656,7 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
 
     def __init__(self, values, placement, ndim=None):
         values = self._maybe_coerce_values(values)
-        super(ExtensionBlock, self).__init__(values, placement, ndim)
+        super().__init__(values, placement, ndim)
 
     def _maybe_coerce_values(self, values):
         """Unbox to an extension array.
@@ -2066,8 +2065,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
 
     def __init__(self, values, placement, ndim=None):
         values = self._maybe_coerce_values(values)
-        super(DatetimeBlock, self).__init__(values,
-                                            placement=placement, ndim=ndim)
+        super().__init__(values, placement=placement, ndim=ndim)
 
     def _maybe_coerce_values(self, values):
         """Input validation for values passed to __init__. Ensure that
@@ -2109,7 +2107,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
             return self.make_block(values)
 
         # delegate
-        return super(DatetimeBlock, self)._astype(dtype=dtype, **kwargs)
+        return super()._astype(dtype=dtype, **kwargs)
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
@@ -2411,16 +2409,13 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
             if self.ndim > 1:
                 values = np.atleast_2d(values)
             return ObjectBlock(values, ndim=self.ndim, placement=placement)
-        return super(DatetimeTZBlock, self).concat_same_type(to_concat,
-                                                             placement)
+        return super().concat_same_type(to_concat, placement)
 
     def fillna(self, value, limit=None, inplace=False, downcast=None):
         # We support filling a DatetimeTZ with a `value` whose timezone
         # is different by coercing to object.
         try:
-            return super(DatetimeTZBlock, self).fillna(
-                value, limit, inplace, downcast
-            )
+            return super().fillna(value, limit, inplace, downcast)
         except (ValueError, TypeError):
             # different timezones, or a non-tz
             return self.astype(object).fillna(
@@ -2432,7 +2427,7 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
         # Need a dedicated setitem until #24020 (type promotion in setitem
         # for extension arrays) is designed and implemented.
         try:
-            return super(DatetimeTZBlock, self).setitem(indexer, value)
+            return super().setitem(indexer, value)
         except (ValueError, TypeError):
             newb = make_block(self.values.astype(object),
                               placement=self.mgr_locs,
@@ -2458,8 +2453,7 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
         if isinstance(values, TimedeltaArray):
             values = values._data
         assert isinstance(values, np.ndarray), type(values)
-        super(TimeDeltaBlock, self).__init__(values,
-                                             placement=placement, ndim=ndim)
+        super().__init__(values, placement=placement, ndim=ndim)
 
     @property
     def _holder(self):
@@ -2488,7 +2482,7 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
                           "instead.",
                           FutureWarning, stacklevel=6)
             value = Timedelta(value, unit='s')
-        return super(TimeDeltaBlock, self).fillna(value, **kwargs)
+        return super().fillna(value, **kwargs)
 
     def _try_coerce_args(self, values, other):
         """
@@ -2587,9 +2581,8 @@ class BoolBlock(NumericBlock):
         to_replace_values = np.atleast_1d(to_replace)
         if not np.can_cast(to_replace_values, bool):
             return self
-        return super(BoolBlock, self).replace(to_replace, value,
-                                              inplace=inplace, filter=filter,
-                                              regex=regex, convert=convert)
+        return super().replace(to_replace, value, inplace=inplace,
+                               filter=filter, regex=regex, convert=convert)
 
 
 class ObjectBlock(Block):
@@ -2601,8 +2594,7 @@ class ObjectBlock(Block):
         if issubclass(values.dtype.type, str):
             values = np.array(values, dtype=object)
 
-        super(ObjectBlock, self).__init__(values, ndim=ndim,
-                                          placement=placement)
+        super().__init__(values, ndim=ndim, placement=placement)
 
     @property
     def is_bool(self):
@@ -2731,10 +2723,8 @@ class ObjectBlock(Block):
                                         filter=filter, regex=True,
                                         convert=convert)
         elif not (either_list or regex):
-            return super(ObjectBlock, self).replace(to_replace, value,
-                                                    inplace=inplace,
-                                                    filter=filter, regex=regex,
-                                                    convert=convert)
+            return super().replace(to_replace, value, inplace=inplace,
+                                   filter=filter, regex=regex, convert=convert)
         elif both_lists:
             for to_rep, v in zip(to_replace, value):
                 result_blocks = []
@@ -2819,9 +2809,8 @@ class ObjectBlock(Block):
         else:
             # if the thing to replace is not a string or compiled regex call
             # the superclass method -> to_replace is some kind of object
-            return super(ObjectBlock, self).replace(to_replace, value,
-                                                    inplace=inplace,
-                                                    filter=filter, regex=regex)
+            return super().replace(to_replace, value, inplace=inplace,
+                                   filter=filter, regex=regex)
 
         new_values = self.values if inplace else self.values.copy()
 
@@ -2887,7 +2876,7 @@ class ObjectBlock(Block):
         A new block if there is anything to replace or the original block.
         """
         if mask.any():
-            block = super(ObjectBlock, self)._replace_coerce(
+            block = super()._replace_coerce(
                 to_replace=to_replace, value=value, inplace=inplace,
                 regex=regex, convert=convert, mask=mask)
             if convert:
@@ -2908,9 +2897,9 @@ class CategoricalBlock(ExtensionBlock):
         from pandas.core.arrays.categorical import _maybe_to_categorical
 
         # coerce to categorical if we can
-        super(CategoricalBlock, self).__init__(_maybe_to_categorical(values),
-                                               placement=placement,
-                                               ndim=ndim)
+        super().__init__(_maybe_to_categorical(values),
+                         placement=placement,
+                         ndim=ndim)
 
     @property
     def _holder(self):
@@ -2990,7 +2979,7 @@ class CategoricalBlock(ExtensionBlock):
         )
         try:
             # Attempt to do preserve categorical dtype.
-            result = super(CategoricalBlock, self).where(
+            result = super().where(
                 other, cond, align, errors, try_cast, axis, transpose
             )
         except (TypeError, ValueError):

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -57,7 +57,7 @@ set_use_bottleneck(get_option('compute.use_bottleneck'))
 class disallow:
 
     def __init__(self, *dtypes):
-        super(disallow, self).__init__()
+        super().__init__()
         self.dtypes = tuple(pandas_dtype(dtype).type for dtype in dtypes)
 
     def check(self, obj):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -284,7 +284,7 @@ class Panel(NDFrame):
         if isinstance(self._info_axis, MultiIndex):
             return self._getitem_multilevel(key)
         if not (is_list_like(key) or isinstance(key, slice)):
-            return super(Panel, self).__getitem__(key)
+            return super().__getitem__(key)
         return self.loc[key]
 
     def _getitem_multilevel(self, key):
@@ -1238,7 +1238,7 @@ class Panel(NDFrame):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", FutureWarning)
             # do not warn about constructing Panel when reindexing
-            result = super(Panel, self).reindex(**kwargs)
+            result = super().reindex(**kwargs)
         return result
 
     @Substitution(**_shared_doc_kwargs)
@@ -1248,16 +1248,15 @@ class Panel(NDFrame):
                       kwargs.pop('major', None))
         minor_axis = (minor_axis if minor_axis is not None else
                       kwargs.pop('minor', None))
-        return super(Panel, self).rename(items=items, major_axis=major_axis,
-                                         minor_axis=minor_axis, **kwargs)
+        return super().rename(items=items, major_axis=major_axis,
+                              minor_axis=minor_axis, **kwargs)
 
     @Appender(_shared_docs['reindex_axis'] % _shared_doc_kwargs)
     def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
                      limit=None, fill_value=np.nan):
-        return super(Panel, self).reindex_axis(labels=labels, axis=axis,
-                                               method=method, level=level,
-                                               copy=copy, limit=limit,
-                                               fill_value=fill_value)
+        return super().reindex_axis(labels=labels, axis=axis, method=method,
+                                    level=level, copy=copy, limit=limit,
+                                    fill_value=fill_value)
 
     @Substitution(**_shared_doc_kwargs)
     @Appender(NDFrame.transpose.__doc__)
@@ -1276,15 +1275,15 @@ class Panel(NDFrame):
         elif not axes:
             axes = kwargs.pop('axes', ())
 
-        return super(Panel, self).transpose(*axes, **kwargs)
+        return super().transpose(*axes, **kwargs)
 
     @Substitution(**_shared_doc_kwargs)
     @Appender(NDFrame.fillna.__doc__)
     def fillna(self, value=None, method=None, axis=None, inplace=False,
                limit=None, downcast=None, **kwargs):
-        return super(Panel, self).fillna(value=value, method=method, axis=axis,
-                                         inplace=inplace, limit=limit,
-                                         downcast=downcast, **kwargs)
+        return super().fillna(value=value, method=method, axis=axis,
+                              inplace=inplace, limit=limit, downcast=downcast,
+                              **kwargs)
 
     def count(self, axis='major'):
         """
@@ -1328,10 +1327,10 @@ class Panel(NDFrame):
         if freq:
             return self.tshift(periods, freq, axis=axis)
 
-        return super(Panel, self).slice_shift(periods, axis=axis)
+        return super().slice_shift(periods, axis=axis)
 
     def tshift(self, periods=1, freq=None, axis='major'):
-        return super(Panel, self).tshift(periods, freq, axis)
+        return super().tshift(periods, freq, axis)
 
     def join(self, other, how='left', lsuffix='', rsuffix=''):
         """
@@ -1565,7 +1564,7 @@ class Panel(NDFrame):
         NOT IMPLEMENTED: do not call this method, as sorting values is not
         supported for Panel objects and will raise an error.
         """
-        super(Panel, self).sort_values(*args, **kwargs)
+        super().sort_values(*args, **kwargs)
 
 
 Panel._setup_axes(axes=['items', 'major_axis', 'minor_axis'], info_axis=0,

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -112,7 +112,7 @@ class Resampler(_GroupBy):
         GroupBy.__iter__
         """
         self._set_binner()
-        return super(Resampler, self).__iter__()
+        return super().__iter__()
 
     @property
     def obj(self):
@@ -207,7 +207,7 @@ class Resampler(_GroupBy):
     """)
     @Appender(_pipe_template)
     def pipe(self, func, *args, **kwargs):
-        return super(Resampler, self).pipe(func, *args, **kwargs)
+        return super().pipe(func, *args, **kwargs)
 
     _agg_see_also_doc = dedent("""
     See Also
@@ -938,7 +938,7 @@ class _GroupByMixin(GroupByMixin):
         for attr in self._attributes:
             setattr(self, attr, kwargs.get(attr, getattr(parent, attr)))
 
-        super(_GroupByMixin, self).__init__(None)
+        super().__init__(None)
         self._groupby = groupby
         self._groupby.mutated = True
         self._groupby.grouper.mutated = True
@@ -1069,7 +1069,7 @@ class DatetimeIndexResampler(Resampler):
         return self._wrap_result(result)
 
     def _wrap_result(self, result):
-        result = super(DatetimeIndexResampler, self)._wrap_result(result)
+        result = super()._wrap_result(result)
 
         # we may have a different kind that we were asked originally
         # convert if needed
@@ -1097,11 +1097,11 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
     def _get_binner_for_time(self):
         if self.kind == 'timestamp':
-            return super(PeriodIndexResampler, self)._get_binner_for_time()
+            return super()._get_binner_for_time()
         return self.groupby._get_period_bins(self.ax)
 
     def _convert_obj(self, obj):
-        obj = super(PeriodIndexResampler, self)._convert_obj(obj)
+        obj = super()._convert_obj(obj)
 
         if self._from_selection:
             # see GH 14008, GH 12871
@@ -1133,7 +1133,7 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
         # we may need to actually resample as if we are timestamps
         if self.kind == 'timestamp':
-            return super(PeriodIndexResampler, self)._downsample(how, **kwargs)
+            return super()._downsample(how, **kwargs)
 
         how = self._is_cython_func(how) or how
         ax = self.ax
@@ -1177,8 +1177,8 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
         # we may need to actually resample as if we are timestamps
         if self.kind == 'timestamp':
-            return super(PeriodIndexResampler, self)._upsample(
-                method, limit=limit, fill_value=fill_value)
+            return super()._upsample(method, limit=limit,
+                                     fill_value=fill_value)
 
         self._set_binner()
         ax = self.ax
@@ -1329,7 +1329,7 @@ class TimeGrouper(Grouper):
         # always sort time groupers
         kwargs['sort'] = True
 
-        super(TimeGrouper, self).__init__(freq=freq, axis=axis, **kwargs)
+        super().__init__(freq=freq, axis=axis, **kwargs)
 
     def _get_resampler(self, obj, kind=None):
         """

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1386,7 +1386,7 @@ class _AsOfMerge(_OrderedMerge):
                                fill_method=fill_method)
 
     def _validate_specification(self):
-        super(_AsOfMerge, self)._validate_specification()
+        super()._validate_specification()
 
         # we only allow on to be a single item for on
         if len(self.left_on) != 1 and not self.left_index:
@@ -1441,7 +1441,7 @@ class _AsOfMerge(_OrderedMerge):
         # note this function has side effects
         (left_join_keys,
          right_join_keys,
-         join_names) = super(_AsOfMerge, self)._get_merge_keys()
+         join_names) = super()._get_merge_keys()
 
         # validate index types are the same
         for i, (lk, rk) in enumerate(zip(left_join_keys, right_join_keys)):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1714,7 +1714,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         [b, a, c]
         Categories (3, object): [a < b < c]
         """
-        result = super(Series, self).unique()
+        result = super().unique()
         return result
 
     def drop_duplicates(self, keep='first', inplace=False):
@@ -1789,7 +1789,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         5     hippo
         Name: animal, dtype: object
         """
-        return super(Series, self).drop_duplicates(keep=keep, inplace=inplace)
+        return super().drop_duplicates(keep=keep, inplace=inplace)
 
     def duplicated(self, keep='first'):
         """
@@ -1865,7 +1865,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         4     True
         dtype: bool
         """
-        return super(Series, self).duplicated(keep=keep)
+        return super().duplicated(keep=keep)
 
     def idxmin(self, axis=0, skipna=True, *args, **kwargs):
         """
@@ -3466,7 +3466,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         3  I am a rabbit
         dtype: object
         """
-        new_values = super(Series, self)._map_values(
+        new_values = super()._map_values(
             arg, na_action=na_action)
         return self._constructor(new_values,
                                  index=self.index).__finalize__(self)
@@ -3549,7 +3549,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def transform(self, func, axis=0, *args, **kwargs):
         # Validate the axis parameter
         self._get_axis_number(axis)
-        return super(Series, self).transform(func, *args, **kwargs)
+        return super().transform(func, *args, **kwargs)
 
     def apply(self, func, convert_dtype=True, args=(), **kwds):
         """
@@ -3745,11 +3745,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def align(self, other, join='outer', axis=None, level=None, copy=True,
               fill_value=None, method=None, limit=None, fill_axis=0,
               broadcast_axis=None):
-        return super(Series, self).align(other, join=join, axis=axis,
-                                         level=level, copy=copy,
-                                         fill_value=fill_value, method=method,
-                                         limit=limit, fill_axis=fill_axis,
-                                         broadcast_axis=broadcast_axis)
+        return super().align(other, join=join, axis=axis, level=level,
+                             copy=copy, fill_value=fill_value, method=method,
+                             limit=limit, fill_axis=fill_axis,
+                             broadcast_axis=broadcast_axis)
 
     def rename(self, index=None, **kwargs):
         """
@@ -3819,12 +3818,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                                            not is_dict_like(index))
         if non_mapping:
             return self._set_name(index, inplace=kwargs.get('inplace'))
-        return super(Series, self).rename(index=index, **kwargs)
+        return super().rename(index=index, **kwargs)
 
     @Substitution(**_shared_doc_kwargs)
     @Appender(generic.NDFrame.reindex.__doc__)
     def reindex(self, index=None, **kwargs):
-        return super(Series, self).reindex(index=index, **kwargs)
+        return super().reindex(index=index, **kwargs)
 
     def drop(self, labels=None, axis=0, index=None, columns=None,
              level=None, inplace=False, errors='raise'):
@@ -3914,30 +3913,29 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 length      0.3
         dtype: float64
         """
-        return super(Series, self).drop(labels=labels, axis=axis, index=index,
-                                        columns=columns, level=level,
-                                        inplace=inplace, errors=errors)
+        return super().drop(labels=labels, axis=axis, index=index,
+                            columns=columns, level=level, inplace=inplace,
+                            errors=errors)
 
     @Substitution(**_shared_doc_kwargs)
     @Appender(generic.NDFrame.fillna.__doc__)
     def fillna(self, value=None, method=None, axis=None, inplace=False,
                limit=None, downcast=None, **kwargs):
-        return super(Series, self).fillna(value=value, method=method,
-                                          axis=axis, inplace=inplace,
-                                          limit=limit, downcast=downcast,
-                                          **kwargs)
+        return super().fillna(value=value, method=method, axis=axis,
+                              inplace=inplace, limit=limit, downcast=downcast,
+                              **kwargs)
 
     @Appender(generic._shared_docs['replace'] % _shared_doc_kwargs)
     def replace(self, to_replace=None, value=None, inplace=False, limit=None,
                 regex=False, method='pad'):
-        return super(Series, self).replace(to_replace=to_replace, value=value,
-                                           inplace=inplace, limit=limit,
-                                           regex=regex, method=method)
+        return super().replace(to_replace=to_replace, value=value,
+                               inplace=inplace, limit=limit, regex=regex,
+                               method=method)
 
     @Appender(generic._shared_docs['shift'] % _shared_doc_kwargs)
     def shift(self, periods=1, freq=None, axis=0, fill_value=None):
-        return super(Series, self).shift(periods=periods, freq=freq, axis=axis,
-                                         fill_value=fill_value)
+        return super().shift(periods=periods, freq=freq, axis=axis,
+                             fill_value=fill_value)
 
     def reindex_axis(self, labels, axis=0, **kwargs):
         """
@@ -4004,7 +4002,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.memory_usage(deep=True)
         212
         """
-        v = super(Series, self).memory_usage(deep=deep)
+        v = super().memory_usage(deep=deep)
         if index:
             v += self.index.memory_usage(deep=deep)
         return v
@@ -4296,19 +4294,19 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     @Appender(generic._shared_docs['isna'] % _shared_doc_kwargs)
     def isna(self):
-        return super(Series, self).isna()
+        return super().isna()
 
     @Appender(generic._shared_docs['isna'] % _shared_doc_kwargs)
     def isnull(self):
-        return super(Series, self).isnull()
+        return super().isnull()
 
     @Appender(generic._shared_docs['notna'] % _shared_doc_kwargs)
     def notna(self):
-        return super(Series, self).notna()
+        return super().notna()
 
     @Appender(generic._shared_docs['notna'] % _shared_doc_kwargs)
     def notnull(self):
-        return super(Series, self).notnull()
+        return super().notnull()
 
     def dropna(self, axis=0, inplace=False, **kwargs):
         """

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -356,7 +356,7 @@ class SparseDataFrame(DataFrame):
         """
         Make a copy of this SparseDataFrame
         """
-        result = super(SparseDataFrame, self).copy(deep=deep)
+        result = super().copy(deep=deep)
         result._default_fill_value = self._default_fill_value
         result._default_kind = self._default_kind
         return result
@@ -382,10 +382,9 @@ class SparseDataFrame(DataFrame):
 
     def fillna(self, value=None, method=None, axis=0, inplace=False,
                limit=None, downcast=None):
-        new_self = super(SparseDataFrame,
-                         self).fillna(value=value, method=method, axis=axis,
-                                      inplace=inplace, limit=limit,
-                                      downcast=downcast)
+        new_self = super().fillna(value=value, method=method, axis=axis,
+                                  inplace=inplace, limit=limit,
+                                  downcast=downcast)
         if not inplace:
             self = new_self
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -85,7 +85,7 @@ class SparseSeries(Series):
         elif is_scalar(data) and index is not None:
             data = np.full(len(index), fill_value=data)
 
-        super(SparseSeries, self).__init__(
+        super().__init__(
             SparseArray(data,
                         sparse_index=sparse_index,
                         kind=kind,
@@ -293,7 +293,7 @@ class SparseSeries(Series):
         if is_integer(key) and key not in self.index:
             return self._get_val_at(key)
         else:
-            return super(SparseSeries, self).__getitem__(key)
+            return super().__getitem__(key)
 
     def _get_values(self, indexer):
         try:
@@ -464,9 +464,8 @@ class SparseSeries(Series):
     def reindex(self, index=None, method=None, copy=True, limit=None,
                 **kwargs):
         # TODO: remove?
-        return super(SparseSeries, self).reindex(index=index, method=method,
-                                                 copy=copy, limit=limit,
-                                                 **kwargs)
+        return super().reindex(index=index, method=method, copy=copy,
+                               limit=limit, **kwargs)
 
     def sparse_reindex(self, new_index):
         """

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -585,7 +585,7 @@ class Window(_Window):
     """
 
     def validate(self):
-        super(Window, self).validate()
+        super().validate()
 
         window = self.window
         if isinstance(window, (list, tuple, np.ndarray)):
@@ -773,7 +773,7 @@ class _GroupByMixin(GroupByMixin):
         self._groupby = groupby
         self._groupby.mutated = True
         self._groupby.grouper.mutated = True
-        super(GroupByMixin, self).__init__(obj, *args, **kwargs)
+        super().__init__(obj, *args, **kwargs)
 
     count = GroupByMixin._dispatch('count')
     corr = GroupByMixin._dispatch('corr', other=None, pairwise=None)
@@ -1565,7 +1565,7 @@ class Rolling(_Rolling_and_Expanding):
                              "or None".format(self.on))
 
     def validate(self):
-        super(Rolling, self).validate()
+        super().validate()
 
         # we allow rolling on a datetimelike index
         if ((self.obj.empty or self.is_datetimelike) and
@@ -1678,7 +1678,7 @@ class Rolling(_Rolling_and_Expanding):
                   axis='')
     @Appender(_shared_docs['aggregate'])
     def aggregate(self, arg, *args, **kwargs):
-        return super(Rolling, self).aggregate(arg, *args, **kwargs)
+        return super().aggregate(arg, *args, **kwargs)
 
     agg = aggregate
 
@@ -1690,61 +1690,60 @@ class Rolling(_Rolling_and_Expanding):
         if self.is_freq_type:
             return self._apply('roll_count', 'count')
 
-        return super(Rolling, self).count()
+        return super().count()
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['apply'])
     def apply(self, func, raw=None, args=(), kwargs={}):
-        return super(Rolling, self).apply(
-            func, raw=raw, args=args, kwargs=kwargs)
+        return super().apply(func, raw=raw, args=args, kwargs=kwargs)
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['sum'])
     def sum(self, *args, **kwargs):
         nv.validate_rolling_func('sum', args, kwargs)
-        return super(Rolling, self).sum(*args, **kwargs)
+        return super().sum(*args, **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_doc_template)
     @Appender(_shared_docs['max'])
     def max(self, *args, **kwargs):
         nv.validate_rolling_func('max', args, kwargs)
-        return super(Rolling, self).max(*args, **kwargs)
+        return super().max(*args, **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['min'])
     def min(self, *args, **kwargs):
         nv.validate_rolling_func('min', args, kwargs)
-        return super(Rolling, self).min(*args, **kwargs)
+        return super().min(*args, **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['mean'])
     def mean(self, *args, **kwargs):
         nv.validate_rolling_func('mean', args, kwargs)
-        return super(Rolling, self).mean(*args, **kwargs)
+        return super().mean(*args, **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['median'])
     def median(self, **kwargs):
-        return super(Rolling, self).median(**kwargs)
+        return super().median(**kwargs)
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['std'])
     def std(self, ddof=1, *args, **kwargs):
         nv.validate_rolling_func('std', args, kwargs)
-        return super(Rolling, self).std(ddof=ddof, **kwargs)
+        return super().std(ddof=ddof, **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['var'])
     def var(self, ddof=1, *args, **kwargs):
         nv.validate_rolling_func('var', args, kwargs)
-        return super(Rolling, self).var(ddof=ddof, **kwargs)
+        return super().var(ddof=ddof, **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_doc_template)
     @Appender(_shared_docs['skew'])
     def skew(self, **kwargs):
-        return super(Rolling, self).skew(**kwargs)
+        return super().skew(**kwargs)
 
     _agg_doc = dedent("""
     Examples
@@ -1774,27 +1773,24 @@ class Rolling(_Rolling_and_Expanding):
     @Substitution(name='rolling')
     @Appender(_shared_docs['kurt'])
     def kurt(self, **kwargs):
-        return super(Rolling, self).kurt(**kwargs)
+        return super().kurt(**kwargs)
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['quantile'])
     def quantile(self, quantile, interpolation='linear', **kwargs):
-        return super(Rolling, self).quantile(quantile=quantile,
-                                             interpolation=interpolation,
-                                             **kwargs)
+        return super().quantile(quantile=quantile, interpolation=interpolation,
+                                **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_doc_template)
     @Appender(_shared_docs['cov'])
     def cov(self, other=None, pairwise=None, ddof=1, **kwargs):
-        return super(Rolling, self).cov(other=other, pairwise=pairwise,
-                                        ddof=ddof, **kwargs)
+        return super().cov(other=other, pairwise=pairwise, ddof=ddof, **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_shared_docs['corr'])
     def corr(self, other=None, pairwise=None, **kwargs):
-        return super(Rolling, self).corr(other=other, pairwise=pairwise,
-                                         **kwargs)
+        return super().corr(other=other, pairwise=pairwise, **kwargs)
 
 
 class RollingGroupby(_GroupByMixin, Rolling):
@@ -1816,7 +1812,7 @@ class RollingGroupby(_GroupByMixin, Rolling):
         if self.on is not None:
             self._groupby.obj = self._groupby.obj.set_index(self._on)
             self.on = None
-        return super(RollingGroupby, self)._gotitem(key, ndim, subset=subset)
+        return super()._gotitem(key, ndim, subset=subset)
 
     def _validate_monotonic(self):
         """
@@ -1881,8 +1877,8 @@ class Expanding(_Rolling_and_Expanding):
 
     def __init__(self, obj, min_periods=1, center=False, axis=0,
                  **kwargs):
-        super(Expanding, self).__init__(obj=obj, min_periods=min_periods,
-                                        center=center, axis=axis)
+        super().__init__(obj=obj, min_periods=min_periods, center=center,
+                         axis=axis)
 
     @property
     def _constructor(self):
@@ -1956,68 +1952,68 @@ class Expanding(_Rolling_and_Expanding):
                   axis='')
     @Appender(_shared_docs['aggregate'])
     def aggregate(self, arg, *args, **kwargs):
-        return super(Expanding, self).aggregate(arg, *args, **kwargs)
+        return super().aggregate(arg, *args, **kwargs)
 
     agg = aggregate
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['count'])
     def count(self, **kwargs):
-        return super(Expanding, self).count(**kwargs)
+        return super().count(**kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['apply'])
     def apply(self, func, raw=None, args=(), kwargs={}):
-        return super(Expanding, self).apply(
+        return super().apply(
             func, raw=raw, args=args, kwargs=kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['sum'])
     def sum(self, *args, **kwargs):
         nv.validate_expanding_func('sum', args, kwargs)
-        return super(Expanding, self).sum(*args, **kwargs)
+        return super().sum(*args, **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_doc_template)
     @Appender(_shared_docs['max'])
     def max(self, *args, **kwargs):
         nv.validate_expanding_func('max', args, kwargs)
-        return super(Expanding, self).max(*args, **kwargs)
+        return super().max(*args, **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['min'])
     def min(self, *args, **kwargs):
         nv.validate_expanding_func('min', args, kwargs)
-        return super(Expanding, self).min(*args, **kwargs)
+        return super().min(*args, **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['mean'])
     def mean(self, *args, **kwargs):
         nv.validate_expanding_func('mean', args, kwargs)
-        return super(Expanding, self).mean(*args, **kwargs)
+        return super().mean(*args, **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['median'])
     def median(self, **kwargs):
-        return super(Expanding, self).median(**kwargs)
+        return super().median(**kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['std'])
     def std(self, ddof=1, *args, **kwargs):
         nv.validate_expanding_func('std', args, kwargs)
-        return super(Expanding, self).std(ddof=ddof, **kwargs)
+        return super().std(ddof=ddof, **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['var'])
     def var(self, ddof=1, *args, **kwargs):
         nv.validate_expanding_func('var', args, kwargs)
-        return super(Expanding, self).var(ddof=ddof, **kwargs)
+        return super().var(ddof=ddof, **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_doc_template)
     @Appender(_shared_docs['skew'])
     def skew(self, **kwargs):
-        return super(Expanding, self).skew(**kwargs)
+        return super().skew(**kwargs)
 
     _agg_doc = dedent("""
     Examples
@@ -2047,27 +2043,25 @@ class Expanding(_Rolling_and_Expanding):
     @Substitution(name='expanding')
     @Appender(_shared_docs['kurt'])
     def kurt(self, **kwargs):
-        return super(Expanding, self).kurt(**kwargs)
+        return super().kurt(**kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['quantile'])
     def quantile(self, quantile, interpolation='linear', **kwargs):
-        return super(Expanding, self).quantile(quantile=quantile,
-                                               interpolation=interpolation,
-                                               **kwargs)
+        return super().quantile(quantile=quantile,
+                                interpolation=interpolation,
+                                **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_doc_template)
     @Appender(_shared_docs['cov'])
     def cov(self, other=None, pairwise=None, ddof=1, **kwargs):
-        return super(Expanding, self).cov(other=other, pairwise=pairwise,
-                                          ddof=ddof, **kwargs)
+        return super().cov(other=other, pairwise=pairwise, ddof=ddof, **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_shared_docs['corr'])
     def corr(self, other=None, pairwise=None, **kwargs):
-        return super(Expanding, self).corr(other=other, pairwise=pairwise,
-                                           **kwargs)
+        return super().corr(other=other, pairwise=pairwise, **kwargs)
 
 
 class ExpandingGroupby(_GroupByMixin, Expanding):
@@ -2267,7 +2261,7 @@ class EWM(_Rolling):
                   axis='')
     @Appender(_shared_docs['aggregate'])
     def aggregate(self, arg, *args, **kwargs):
-        return super(EWM, self).aggregate(arg, *args, **kwargs)
+        return super().aggregate(arg, *args, **kwargs)
 
     agg = aggregate
 

--- a/pandas/io/clipboard/exceptions.py
+++ b/pandas/io/clipboard/exceptions.py
@@ -9,4 +9,4 @@ class PyperclipWindowsException(PyperclipException):
 
     def __init__(self, message):
         message += " ({err})".format(err=ctypes.WinError())
-        super(PyperclipWindowsException, self).__init__(message)
+        super().__init__(message)

--- a/pandas/io/clipboard/windows.py
+++ b/pandas/io/clipboard/windows.py
@@ -12,7 +12,7 @@ from .exceptions import PyperclipWindowsException
 class CheckedCall:
 
     def __init__(self, f):
-        super(CheckedCall, self).__setattr__("f", f)
+        super().__setattr__("f", f)
 
     def __call__(self, *args):
         ret = self.f(*args)

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -422,10 +422,10 @@ class BytesZipFile(zipfile.ZipFile, BytesIO):  # type: ignore
     def __init__(self, file, mode, compression=zipfile.ZIP_DEFLATED, **kwargs):
         if mode in ['wb', 'rb']:
             mode = mode.replace('b', '')
-        super(BytesZipFile, self).__init__(file, mode, compression, **kwargs)
+        super().__init__(file, mode, compression, **kwargs)
 
     def write(self, data):
-        super(BytesZipFile, self).writestr(self.filename, data)
+        super().writestr(self.filename, data)
 
     @property
     def closed(self):

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -10,7 +10,7 @@ class _OpenpyxlWriter(ExcelWriter):
         # Use the openpyxl module as the Excel writer.
         from openpyxl.workbook import Workbook
 
-        super(_OpenpyxlWriter, self).__init__(path, mode=mode, **engine_kwargs)
+        super().__init__(path, mode=mode, **engine_kwargs)
 
         if self.mode == 'a':  # Load from existing workbook
             from openpyxl import load_workbook

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -160,11 +160,11 @@ class _XlsxWriter(ExcelWriter):
         if mode == 'a':
             raise ValueError('Append mode is not supported with xlsxwriter!')
 
-        super(_XlsxWriter, self).__init__(path, engine=engine,
-                                          date_format=date_format,
-                                          datetime_format=datetime_format,
-                                          mode=mode,
-                                          **engine_kwargs)
+        super().__init__(path, engine=engine,
+                         date_format=date_format,
+                         datetime_format=datetime_format,
+                         mode=mode,
+                         **engine_kwargs)
 
         self.book = xlsxwriter.Workbook(path, **engine_kwargs)
 

--- a/pandas/io/excel/_xlwt.py
+++ b/pandas/io/excel/_xlwt.py
@@ -17,7 +17,7 @@ class _XlwtWriter(ExcelWriter):
         if mode == 'a':
             raise ValueError('Append mode is not supported with xlwt!')
 
-        super(_XlwtWriter, self).__init__(path, mode=mode, **engine_kwargs)
+        super().__init__(path, mode=mode, **engine_kwargs)
 
         if encoding is None:
             encoding = 'ascii'

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -309,7 +309,7 @@ class TextAdjustment:
 class EastAsianTextAdjustment(TextAdjustment):
 
     def __init__(self):
-        super(EastAsianTextAdjustment, self).__init__()
+        super().__init__()
         if get_option("display.unicode.ambiguous_as_wide"):
             self.ambiguous_width = 2
         else:
@@ -1160,7 +1160,7 @@ class IntArrayFormatter(GenericArrayFormatter):
 class Datetime64Formatter(GenericArrayFormatter):
 
     def __init__(self, values, nat_rep='NaT', date_format=None, **kwargs):
-        super(Datetime64Formatter, self).__init__(values, **kwargs)
+        super().__init__(values, **kwargs)
         self.nat_rep = nat_rep
         self.date_format = date_format
 
@@ -1346,7 +1346,7 @@ class Datetime64TZFormatter(Datetime64Formatter):
 class Timedelta64Formatter(GenericArrayFormatter):
 
     def __init__(self, values, nat_rep='NaT', box=False, **kwargs):
-        super(Timedelta64Formatter, self).__init__(values, **kwargs)
+        super().__init__(values, **kwargs)
         self.nat_rep = nat_rep
         self.box = box
 

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -540,6 +540,6 @@ class NotebookFormatter(HTMLFormatter):
     def render(self):
         self.write('<div>')
         self.write_style()
-        super(NotebookFormatter, self).render()
+        super().render()
         self.write('</div>')
         return self.elements

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -533,8 +533,7 @@ class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
     """
 
     def __init__(self, *args, **kwargs):
-        super(_BeautifulSoupHtml5LibFrameParser, self).__init__(*args,
-                                                                **kwargs)
+        super().__init__(*args, **kwargs)
         from bs4 import SoupStrainer
         self._strainer = SoupStrainer('table')
 
@@ -644,7 +643,7 @@ class _LxmlFrameParser(_HtmlFrameParser):
     """
 
     def __init__(self, *args, **kwargs):
-        super(_LxmlFrameParser, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _text_getter(self, obj):
         return obj.text_content()

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -128,10 +128,8 @@ class SeriesWriter(Writer):
                date_unit, iso_dates, default_handler):
         if not self.index and orient == 'split':
             obj = {"name": obj.name, "data": obj.values}
-        return super(SeriesWriter, self)._write(obj, orient,
-                                                double_precision,
-                                                ensure_ascii, date_unit,
-                                                iso_dates, default_handler)
+        return super()._write(obj, orient, double_precision, ensure_ascii,
+                              date_unit, iso_dates, default_handler)
 
 
 class FrameWriter(Writer):
@@ -155,10 +153,8 @@ class FrameWriter(Writer):
         if not self.index and orient == 'split':
             obj = obj.to_dict(orient='split')
             del obj["index"]
-        return super(FrameWriter, self)._write(obj, orient,
-                                               double_precision,
-                                               ensure_ascii, date_unit,
-                                               iso_dates, default_handler)
+        return super()._write(obj, orient, double_precision, ensure_ascii,
+                              date_unit, iso_dates, default_handler)
 
 
 class JSONTableWriter(FrameWriter):
@@ -172,9 +168,9 @@ class JSONTableWriter(FrameWriter):
         to know what the index is, forces orient to records, and forces
         date_format to 'iso'.
         """
-        super(JSONTableWriter, self).__init__(
-            obj, orient, date_format, double_precision, ensure_ascii,
-            date_unit, index, default_handler=default_handler)
+        super().__init__(obj, orient, date_format, double_precision,
+                         ensure_ascii, date_unit, index,
+                         default_handler=default_handler)
 
         if date_format != 'iso':
             msg = ("Trying to write with `orient='table'` and "
@@ -216,11 +212,8 @@ class JSONTableWriter(FrameWriter):
 
     def _write(self, obj, orient, double_precision, ensure_ascii,
                date_unit, iso_dates, default_handler):
-        data = super(JSONTableWriter, self)._write(obj, orient,
-                                                   double_precision,
-                                                   ensure_ascii, date_unit,
-                                                   iso_dates,
-                                                   default_handler)
+        data = super()._write(obj, orient, double_precision, ensure_ascii,
+                              date_unit, iso_dates, default_handler)
         serialized = '{{"schema": {schema}, "data": {data}}}'.format(
                      schema=dumps(self.schema), data=data)
         return serialized

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -751,12 +751,11 @@ class Packer(_Packer):
                  use_single_float=False,
                  autoreset=1,
                  use_bin_type=1):
-        super(Packer, self).__init__(default=default,
-                                     encoding=encoding,
-                                     unicode_errors=unicode_errors,
-                                     use_single_float=use_single_float,
-                                     autoreset=autoreset,
-                                     use_bin_type=use_bin_type)
+        super().__init__(default=default, encoding=encoding,
+                         unicode_errors=unicode_errors,
+                         use_single_float=use_single_float,
+                         autoreset=autoreset,
+                         use_bin_type=use_bin_type)
 
 
 class Unpacker(_Unpacker):
@@ -765,16 +764,16 @@ class Unpacker(_Unpacker):
                  object_hook=decode,
                  object_pairs_hook=None, list_hook=None, encoding='utf-8',
                  unicode_errors='strict', max_buffer_size=0, ext_hook=ExtType):
-        super(Unpacker, self).__init__(file_like=file_like,
-                                       read_size=read_size,
-                                       use_list=use_list,
-                                       object_hook=object_hook,
-                                       object_pairs_hook=object_pairs_hook,
-                                       list_hook=list_hook,
-                                       encoding=encoding,
-                                       unicode_errors=unicode_errors,
-                                       max_buffer_size=max_buffer_size,
-                                       ext_hook=ext_hook)
+        super().__init__(file_like=file_like,
+                         read_size=read_size,
+                         use_list=use_list,
+                         object_hook=object_hook,
+                         object_pairs_hook=object_pairs_hook,
+                         list_hook=list_hook,
+                         encoding=encoding,
+                         unicode_errors=unicode_errors,
+                         max_buffer_size=max_buffer_size,
+                         ext_hook=ext_hook)
 
 
 class Iterator:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1860,8 +1860,8 @@ class DataCol(IndexCol):
     def __init__(self, values=None, kind=None, typ=None,
                  cname=None, data=None, meta=None, metadata=None,
                  block=None, **kwargs):
-        super(DataCol, self).__init__(values=values, kind=kind, typ=typ,
-                                      cname=cname, **kwargs)
+        super().__init__(values=values, kind=kind, typ=typ, cname=cname,
+                         **kwargs)
         self.dtype = None
         self.dtype_attr = '{name}_dtype'.format(name=self.name)
         self.meta = meta
@@ -2848,7 +2848,7 @@ class SeriesFixed(GenericFixed):
         return Series(values, index=index, name=self.name)
 
     def write(self, obj, **kwargs):
-        super(SeriesFixed, self).write(obj, **kwargs)
+        super().write(obj, **kwargs)
         self.write_index('index', obj.index)
         self.write_array('values', obj.values)
         self.attrs.name = obj.name
@@ -2860,7 +2860,7 @@ class SparseFixed(GenericFixed):
         """
         we don't support start, stop kwds in Sparse
         """
-        kwargs = super(SparseFixed, self).validate_read(kwargs)
+        kwargs = super().validate_read(kwargs)
         if 'start' in kwargs or 'stop' in kwargs:
             raise NotImplementedError("start and/or stop are not supported "
                                       "in fixed Sparse reading")
@@ -2882,7 +2882,7 @@ class SparseSeriesFixed(SparseFixed):
                             name=self.name)
 
     def write(self, obj, **kwargs):
-        super(SparseSeriesFixed, self).write(obj, **kwargs)
+        super().write(obj, **kwargs)
         self.write_index('index', obj.index)
         self.write_index('sp_index', obj.sp_index)
         self.write_array('sp_values', obj.sp_values)
@@ -2910,7 +2910,7 @@ class SparseFrameFixed(SparseFixed):
 
     def write(self, obj, **kwargs):
         """ write it as a collection of individual sparse series """
-        super(SparseFrameFixed, self).write(obj, **kwargs)
+        super().write(obj, **kwargs)
         for name, ss in obj.items():
             key = 'sparse_series_{name}'.format(name=name)
             if key not in self.group._v_children:
@@ -2987,7 +2987,7 @@ class BlockManagerFixed(GenericFixed):
         return self.obj_type(BlockManager(blocks, axes))
 
     def write(self, obj, **kwargs):
-        super(BlockManagerFixed, self).write(obj, **kwargs)
+        super().write(obj, **kwargs)
         data = obj._data
         if not data.is_consolidated():
             data = data.consolidate()
@@ -3047,7 +3047,7 @@ class Table(Fixed):
     is_shape_reversed = False
 
     def __init__(self, *args, **kwargs):
-        super(Table, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.index_axes = []
         self.non_index_axes = []
         self.values_axes = []
@@ -4199,8 +4199,8 @@ class AppendableSeriesTable(AppendableFrameTable):
             name = obj.name or 'values'
             obj = DataFrame({name: obj}, index=obj.index)
             obj.columns = [name]
-        return super(AppendableSeriesTable, self).write(
-            obj=obj, data_columns=obj.columns.tolist(), **kwargs)
+        return super().write(obj=obj, data_columns=obj.columns.tolist(),
+                             **kwargs)
 
     def read(self, columns=None, **kwargs):
 
@@ -4209,7 +4209,7 @@ class AppendableSeriesTable(AppendableFrameTable):
             for n in self.levels:
                 if n not in columns:
                     columns.insert(0, n)
-        s = super(AppendableSeriesTable, self).read(columns=columns, **kwargs)
+        s = super().read(columns=columns, **kwargs)
         if is_multi_index:
             s.set_index(self.levels, inplace=True)
 
@@ -4233,7 +4233,7 @@ class AppendableMultiSeriesTable(AppendableSeriesTable):
         cols = list(self.levels)
         cols.append(name)
         obj.columns = cols
-        return super(AppendableMultiSeriesTable, self).write(obj=obj, **kwargs)
+        return super().write(obj=obj, **kwargs)
 
 
 class GenericTable(AppendableFrameTable):
@@ -4306,12 +4306,11 @@ class AppendableMultiFrameTable(AppendableFrameTable):
         for n in self.levels:
             if n not in data_columns:
                 data_columns.insert(0, n)
-        return super(AppendableMultiFrameTable, self).write(
-            obj=obj, data_columns=data_columns, **kwargs)
+        return super().write(obj=obj, data_columns=data_columns, **kwargs)
 
     def read(self, **kwargs):
 
-        df = super(AppendableMultiFrameTable, self).read(**kwargs)
+        df = super().read(**kwargs)
         df = df.set_index(self.levels)
 
         # remove names for 'level_%d'

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1279,7 +1279,7 @@ class SQLiteTable(SQLTable):
         # this will transform time(12,34,56,789) into '12:34:56.000789'
         # (this is what sqlalchemy does)
         sqlite3.register_adapter(time, lambda _: _.strftime("%H:%M:%S.%f"))
-        super(SQLiteTable, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def sql_schema(self):
         return str(";\n".join(self.table))

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -955,7 +955,7 @@ class StataReader(StataParser, BaseIterator):
                  convert_missing=False, preserve_dtypes=True,
                  columns=None, order_categoricals=True,
                  encoding=None, chunksize=None):
-        super(StataReader, self).__init__()
+        super().__init__()
         self.col_sizes = ()
 
         # Arguments to the reader (can be temporarily overridden in
@@ -1997,7 +1997,7 @@ class StataWriter(StataParser):
     def __init__(self, fname, data, convert_dates=None, write_index=True,
                  encoding="latin-1", byteorder=None, time_stamp=None,
                  data_label=None, variable_labels=None):
-        super(StataWriter, self).__init__()
+        super().__init__()
         self._convert_dates = {} if convert_dates is None else convert_dates
         self._write_index = write_index
         self._encoding = 'latin-1'
@@ -2750,11 +2750,10 @@ class StataWriter117(StataWriter):
         # Shallow copy since convert_strl might be modified later
         self._convert_strl = [] if convert_strl is None else convert_strl[:]
 
-        super(StataWriter117, self).__init__(fname, data, convert_dates,
-                                             write_index, byteorder=byteorder,
-                                             time_stamp=time_stamp,
-                                             data_label=data_label,
-                                             variable_labels=variable_labels)
+        super().__init__(fname, data, convert_dates, write_index,
+                         byteorder=byteorder, time_stamp=time_stamp,
+                         data_label=data_label,
+                         variable_labels=variable_labels)
         self._map = None
         self._strl_blob = None
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -883,7 +883,7 @@ class ScatterPlot(PlanePlot):
             # hide the matplotlib default for size, in case we want to change
             # the handling of this argument later
             s = 20
-        super(ScatterPlot, self).__init__(data, x, y, s=s, **kwargs)
+        super().__init__(data, x, y, s=s, **kwargs)
         if is_integer(c) and not self.data.columns.holds_integer():
             c = self.data.columns[c]
         self.c = c
@@ -940,7 +940,7 @@ class HexBinPlot(PlanePlot):
     _kind = 'hexbin'
 
     def __init__(self, data, x, y, C=None, **kwargs):
-        super(HexBinPlot, self).__init__(data, x, y, **kwargs)
+        super().__init__(data, x, y, **kwargs)
         if is_integer(C) and not self.data.columns.holds_integer():
             C = self.data.columns[C]
         self.C = C
@@ -1723,7 +1723,7 @@ class BoxPlot(LinePlot):
     @property
     def result(self):
         if self.return_type is None:
-            return super(BoxPlot, self).result
+            return super().result
         else:
             return self._return_obj
 

--- a/pandas/plotting/_style.py
+++ b/pandas/plotting/_style.py
@@ -110,29 +110,29 @@ class _Options(dict):
     def __init__(self, deprecated=False):
         self._deprecated = deprecated
         # self['xaxis.compat'] = False
-        super(_Options, self).__setitem__('xaxis.compat', False)
+        super().__setitem__('xaxis.compat', False)
 
     def __getitem__(self, key):
         key = self._get_canonical_key(key)
         if key not in self:
             raise ValueError(
                 '{key} is not a valid pandas plotting option'.format(key=key))
-        return super(_Options, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def __setitem__(self, key, value):
         key = self._get_canonical_key(key)
-        return super(_Options, self).__setitem__(key, value)
+        return super().__setitem__(key, value)
 
     def __delitem__(self, key):
         key = self._get_canonical_key(key)
         if key in self._DEFAULT_KEYS:
             raise ValueError(
                 'Cannot remove default parameter {key}'.format(key=key))
-        return super(_Options, self).__delitem__(key)
+        return super().__delitem__(key)
 
     def __contains__(self, key):
         key = self._get_canonical_key(key)
-        return super(_Options, self).__contains__(key)
+        return super().__contains__(key)
 
     def reset(self):
         """

--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -120,7 +120,7 @@ class TestConstructors:
 class TestArithmeticOps(BaseOpsUtil):
 
     def _check_divmod_op(self, s, op, other, exc=None):
-        super(TestArithmeticOps, self)._check_divmod_op(s, op, other, None)
+        super()._check_divmod_op(s, op, other, None)
 
     def _check_op(self, s, op_name, other, exc=None):
         op = self.get_op_from_name(op_name)

--- a/pandas/tests/extension/arrow/bool.py
+++ b/pandas/tests/extension/arrow/bool.py
@@ -82,7 +82,7 @@ class ArrowBoolArray(ExtensionArray):
             if copy:
                 return self.copy()
             return self
-        return super(ArrowBoolArray, self).astype(dtype, copy)
+        return super().astype(dtype, copy)
 
     @property
     def dtype(self):

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -47,7 +47,7 @@ class TestConstructors(BaseArrowTests, base.BaseConstructorsTests):
     # seems like some bug in isna on empty BoolArray returning floats.
     @pytest.mark.xfail(reason='bad is-na for empty data')
     def test_from_sequence_from_cls(self, data):
-        super(TestConstructors, self).test_from_sequence_from_cls(data)
+        super().test_from_sequence_from_cls(data)
 
 
 class TestReduce(base.BaseNoReduceTests):

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -262,8 +262,7 @@ def test_astype_dispatches(frame):
 class TestArithmeticOps(BaseDecimal, base.BaseArithmeticOpsTests):
 
     def check_opname(self, s, op_name, other, exc=None):
-        super(TestArithmeticOps, self).check_opname(s, op_name,
-                                                    other, exc=None)
+        super().check_opname(s, op_name, other, exc=None)
 
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
         op_name = all_arithmetic_operators
@@ -289,9 +288,7 @@ class TestArithmeticOps(BaseDecimal, base.BaseArithmeticOpsTests):
 
     def _check_divmod_op(self, s, op, other, exc=NotImplementedError):
         # We implement divmod
-        super(TestArithmeticOps, self)._check_divmod_op(
-            s, op, other, exc=None
-        )
+        super()._check_divmod_op(s, op, other, exc=None)
 
     def test_error(self):
         pass
@@ -300,8 +297,7 @@ class TestArithmeticOps(BaseDecimal, base.BaseArithmeticOpsTests):
 class TestComparisonOps(BaseDecimal, base.BaseComparisonOpsTests):
 
     def check_opname(self, s, op_name, other, exc=None):
-        super(TestComparisonOps, self).check_opname(s, op_name,
-                                                    other, exc=None)
+        super().check_opname(s, op_name, other, exc=None)
 
     def _compare_other(self, s, data, op_name, other):
         self.check_opname(s, op_name, other)

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -188,24 +188,21 @@ class TestMethods(BaseJSON, base.BaseMethodsTests):
 
     @unstable
     def test_argsort(self, data_for_sorting):
-        super(TestMethods, self).test_argsort(data_for_sorting)
+        super().test_argsort(data_for_sorting)
 
     @unstable
     def test_argsort_missing(self, data_missing_for_sorting):
-        super(TestMethods, self).test_argsort_missing(
-            data_missing_for_sorting)
+        super().test_argsort_missing(data_missing_for_sorting)
 
     @unstable
     @pytest.mark.parametrize('ascending', [True, False])
     def test_sort_values(self, data_for_sorting, ascending):
-        super(TestMethods, self).test_sort_values(
-            data_for_sorting, ascending)
+        super().test_sort_values(data_for_sorting, ascending)
 
     @unstable
     @pytest.mark.parametrize('ascending', [True, False])
     def test_sort_values_missing(self, data_missing_for_sorting, ascending):
-        super(TestMethods, self).test_sort_values_missing(
-            data_missing_for_sorting, ascending)
+        super().test_sort_values_missing(data_missing_for_sorting, ascending)
 
     @pytest.mark.skip(reason="combine for JSONArray not supported")
     def test_combine_le(self, data_repeated):
@@ -232,7 +229,7 @@ class TestMethods(BaseJSON, base.BaseMethodsTests):
 
     @pytest.mark.skip(reason="Can't compare dicts.")
     def test_searchsorted(self, data_for_sorting):
-        super(TestMethods, self).test_searchsorted(data_for_sorting)
+        super().test_searchsorted(data_for_sorting)
 
 
 class TestCasting(BaseJSON, base.BaseCastingTests):
@@ -274,9 +271,7 @@ class TestGroupby(BaseJSON, base.BaseGroupbyTests):
     @unstable
     @pytest.mark.parametrize('as_index', [True, False])
     def test_groupby_extension_agg(self, as_index, data_for_grouping):
-        super(TestGroupby, self).test_groupby_extension_agg(
-            as_index, data_for_grouping
-        )
+        super().test_groupby_extension_agg(as_index, data_for_grouping)
 
 
 class TestArithmeticOps(BaseJSON, base.BaseArithmeticOpsTests):
@@ -294,9 +289,7 @@ class TestArithmeticOps(BaseJSON, base.BaseArithmeticOpsTests):
         pass
 
     def _check_divmod_op(self, s, op, other, exc=NotImplementedError):
-        return super(TestArithmeticOps, self)._check_divmod_op(
-            s, op, other, exc=TypeError
-        )
+        return super()._check_divmod_op(s, op, other, exc=TypeError)
 
 
 class TestComparisonOps(BaseJSON, base.BaseComparisonOpsTests):

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -86,7 +86,7 @@ class TestInterface(base.BaseInterfaceTests):
     @pytest.mark.skip(reason="Memory usage doesn't match")
     def test_memory_usage(self, data):
         # Is this deliberate?
-        super(TestInterface, self).test_memory_usage(data)
+        super().test_memory_usage(data)
 
 
 class TestConstructors(base.BaseConstructorsTests):
@@ -105,12 +105,12 @@ class TestGetitem(base.BaseGetitemTests):
         # CategoricalDtype.type isn't "correct" since it should
         # be a parent of the elements (object). But don't want
         # to break things by changing.
-        super(TestGetitem, self).test_getitem_scalar(data)
+        super().test_getitem_scalar(data)
 
     @skip_take
     def test_take(self, data, na_value, na_cmp):
         # TODO remove this once Categorical.take is fixed
-        super(TestGetitem, self).test_take(data, na_value, na_cmp)
+        super().test_take(data, na_value, na_cmp)
 
     @skip_take
     def test_take_negative(self, data):
@@ -204,8 +204,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
 
         op_name = all_arithmetic_operators
         if op_name != '__rmod__':
-            super(TestArithmeticOps, self).test_arith_series_with_scalar(
-                data, op_name)
+            super().test_arith_series_with_scalar(data, op_name)
         else:
             pytest.skip('rmod never called when string is first argument')
 
@@ -220,9 +219,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
         pass
 
     def _check_divmod_op(self, s, op, other, exc=NotImplementedError):
-        return super(TestArithmeticOps, self)._check_divmod_op(
-            s, op, other, exc=TypeError
-        )
+        return super()._check_divmod_op(s, op, other, exc=TypeError)
 
 
 class TestComparisonOps(base.BaseComparisonOpsTests):

--- a/pandas/tests/extension/test_datetime.py
+++ b/pandas/tests/extension/test_datetime.py
@@ -109,7 +109,7 @@ class TestInterface(BaseDatetimeTests, base.BaseInterfaceTests):
             # np.asarray(DTA) is currently always tz-naive.
             pytest.skip("GH-23569")
         else:
-            super(TestInterface, self).test_array_interface(data)
+            super().test_array_interface(data)
 
 
 class TestArithmeticOps(BaseDatetimeTests, base.BaseArithmeticOpsTests):
@@ -122,9 +122,8 @@ class TestArithmeticOps(BaseDatetimeTests, base.BaseArithmeticOpsTests):
                               exc=None)
         else:
             # ... but not the rest.
-            super(TestArithmeticOps, self).test_arith_series_with_scalar(
-                data, all_arithmetic_operators
-            )
+            super().test_arith_series_with_scalar(data,
+                                                  all_arithmetic_operators)
 
     def test_add_series_with_extension_array(self, data):
         # Datetime + Datetime not implemented
@@ -140,9 +139,8 @@ class TestArithmeticOps(BaseDatetimeTests, base.BaseArithmeticOpsTests):
                               exc=None)
         else:
             # ... but not the rest.
-            super(TestArithmeticOps, self).test_arith_series_with_scalar(
-                data, all_arithmetic_operators
-            )
+            super().test_arith_series_with_scalar(data,
+                                                  all_arithmetic_operators)
 
     def test_error(self, data, all_arithmetic_operators):
         pass
@@ -197,7 +195,7 @@ class TestReshaping(BaseDatetimeTests, base.BaseReshapingTests):
         # concat(Series[datetimetz], Series[category]) uses a
         # plain np.array(values) on the DatetimeArray, which
         # drops the tz.
-        super(TestReshaping, self).test_concat_mixed_dtypes(data)
+        super().test_concat_mixed_dtypes(data)
 
     @pytest.mark.parametrize("obj", ["series", "frame"])
     def test_unstack(self, obj):

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -94,8 +94,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
 
     def check_opname(self, s, op_name, other, exc=None):
         # overwriting to indicate ops don't raise an error
-        super(TestArithmeticOps, self).check_opname(s, op_name,
-                                                    other, exc=None)
+        super().check_opname(s, op_name, other, exc=None)
 
     def _check_op(self, s, op, other, op_name, exc=NotImplementedError):
         if exc is None:
@@ -138,7 +137,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
                 op(s, other)
 
     def _check_divmod_op(self, s, op, other, exc=None):
-        super(TestArithmeticOps, self)._check_divmod_op(s, op, other, None)
+        super()._check_divmod_op(s, op, other, None)
 
     @pytest.mark.skip(reason="intNA does not error on ops")
     def test_error(self, data, all_arithmetic_operators):
@@ -149,8 +148,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
 class TestComparisonOps(base.BaseComparisonOpsTests):
 
     def check_opname(self, s, op_name, other, exc=None):
-        super(TestComparisonOps, self).check_opname(s, op_name,
-                                                    other, exc=None)
+        super().check_opname(s, op_name, other, exc=None)
 
     def _compare_other(self, s, data, op_name, other):
         self.check_opname(s, op_name, other)

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -159,4 +159,4 @@ class TestParsing(BaseInterval, base.BaseParsingTests):
     def test_EA_types(self, engine, data):
         expected_msg = r'.*must implement _from_sequence_of_strings.*'
         with pytest.raises(NotImplementedError, match=expected_msg):
-            super(TestParsing, self).test_EA_types(engine, data)
+            super().test_EA_types(engine, data)

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -145,7 +145,7 @@ class TestCasting(BaseNumPyTests, base.BaseCastingTests):
     @skip_nested
     def test_astype_str(self, data):
         # ValueError: setting an array element with a sequence
-        super(TestCasting, self).test_astype_str(data)
+        super().test_astype_str(data)
 
 
 class TestConstructors(BaseNumPyTests, base.BaseConstructorsTests):
@@ -157,7 +157,7 @@ class TestConstructors(BaseNumPyTests, base.BaseConstructorsTests):
     @skip_nested
     def test_array_from_scalars(self, data):
         # ValueError: PandasArray must be 1-dimensional.
-        super(TestConstructors, self).test_array_from_scalars(data)
+        super().test_array_from_scalars(data)
 
 
 class TestDtype(BaseNumPyTests, base.BaseDtypeTests):
@@ -173,12 +173,12 @@ class TestGetitem(BaseNumPyTests, base.BaseGetitemTests):
     @skip_nested
     def test_getitem_scalar(self, data):
         # AssertionError
-        super(TestGetitem, self).test_getitem_scalar(data)
+        super().test_getitem_scalar(data)
 
     @skip_nested
     def test_take_series(self, data):
         # ValueError: PandasArray must be 1-dimensional.
-        super(TestGetitem, self).test_take_series(data)
+        super().test_take_series(data)
 
 
 class TestGroupby(BaseNumPyTests, base.BaseGroupbyTests):
@@ -186,15 +186,15 @@ class TestGroupby(BaseNumPyTests, base.BaseGroupbyTests):
     def test_groupby_extension_apply(
             self, data_for_grouping, groupby_apply_op):
         # ValueError: Names should be list-like for a MultiIndex
-        super(TestGroupby, self).test_groupby_extension_apply(
-            data_for_grouping, groupby_apply_op)
+        super().test_groupby_extension_apply(data_for_grouping,
+                                             groupby_apply_op)
 
 
 class TestInterface(BaseNumPyTests, base.BaseInterfaceTests):
     @skip_nested
     def test_array_interface(self, data):
         # NumPy array shape inference
-        super(TestInterface, self).test_array_interface(data)
+        super().test_array_interface(data)
 
 
 class TestMethods(BaseNumPyTests, base.BaseMethodsTests):
@@ -207,56 +207,55 @@ class TestMethods(BaseNumPyTests, base.BaseMethodsTests):
     # We have a bool dtype, so the result is an ExtensionArray
     # but expected is not
     def test_combine_le(self, data_repeated):
-        super(TestMethods, self).test_combine_le(data_repeated)
+        super().test_combine_le(data_repeated)
 
     @skip_nested
     def test_combine_add(self, data_repeated):
         # Not numeric
-        super(TestMethods, self).test_combine_add(data_repeated)
+        super().test_combine_add(data_repeated)
 
     @skip_nested
     def test_shift_fill_value(self, data):
         # np.array shape inference. Shift implementation fails.
-        super(TestMethods, self).test_shift_fill_value(data)
+        super().test_shift_fill_value(data)
 
     @skip_nested
     @pytest.mark.parametrize('box', [pd.Series, lambda x: x])
     @pytest.mark.parametrize('method', [lambda x: x.unique(), pd.unique])
     def test_unique(self, data, box, method):
         # Fails creating expected
-        super(TestMethods, self).test_unique(data, box, method)
+        super().test_unique(data, box, method)
 
     @skip_nested
     def test_fillna_copy_frame(self, data_missing):
         # The "scalar" for this array isn't a scalar.
-        super(TestMethods, self).test_fillna_copy_frame(data_missing)
+        super().test_fillna_copy_frame(data_missing)
 
     @skip_nested
     def test_fillna_copy_series(self, data_missing):
         # The "scalar" for this array isn't a scalar.
-        super(TestMethods, self).test_fillna_copy_series(data_missing)
+        super().test_fillna_copy_series(data_missing)
 
     @skip_nested
     def test_hash_pandas_object_works(self, data, as_frame):
         # ndarray of tuples not hashable
-        super(TestMethods, self).test_hash_pandas_object_works(data, as_frame)
+        super().test_hash_pandas_object_works(data, as_frame)
 
     @skip_nested
     def test_searchsorted(self, data_for_sorting, as_series):
         # Test setup fails.
-        super(TestMethods, self).test_searchsorted(data_for_sorting, as_series)
+        super().test_searchsorted(data_for_sorting, as_series)
 
     @skip_nested
     def test_where_series(self, data, na_value, as_frame):
         # Test setup fails.
-        super(TestMethods, self).test_where_series(data, na_value, as_frame)
+        super().test_where_series(data, na_value, as_frame)
 
     @skip_nested
     @pytest.mark.parametrize("repeats", [0, 1, 2, [1, 2, 3]])
     def test_repeat(self, data, repeats, as_series, use_numpy):
         # Fails creating expected
-        super(TestMethods, self).test_repeat(
-            data, repeats, as_series, use_numpy)
+        super().test_repeat(data, repeats, as_series, use_numpy)
 
 
 @skip_nested
@@ -275,14 +274,10 @@ class TestArithmetics(BaseNumPyTests, base.BaseArithmeticOpsTests):
         pass
 
     def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
-        super(TestArithmetics, self).test_arith_series_with_scalar(
-            data, all_arithmetic_operators
-        )
+        super().test_arith_series_with_scalar(data, all_arithmetic_operators)
 
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
-        super(TestArithmetics, self).test_arith_series_with_array(
-            data, all_arithmetic_operators
-        )
+        super().test_arith_series_with_array(data, all_arithmetic_operators)
 
 
 class TestPrinting(BaseNumPyTests, base.BasePrintingTests):
@@ -309,23 +304,23 @@ class TestMissing(BaseNumPyTests, base.BaseMissingTests):
     @skip_nested
     def test_fillna_scalar(self, data_missing):
         # Non-scalar "scalar" values.
-        super(TestMissing, self).test_fillna_scalar(data_missing)
+        super().test_fillna_scalar(data_missing)
 
     @skip_nested
     def test_fillna_series_method(self, data_missing, fillna_method):
         # Non-scalar "scalar" values.
-        super(TestMissing, self).test_fillna_series_method(
+        super().test_fillna_series_method(
             data_missing, fillna_method)
 
     @skip_nested
     def test_fillna_series(self, data_missing):
         # Non-scalar "scalar" values.
-        super(TestMissing, self).test_fillna_series(data_missing)
+        super().test_fillna_series(data_missing)
 
     @skip_nested
     def test_fillna_frame(self, data_missing):
         # Non-scalar "scalar" values.
-        super(TestMissing, self).test_fillna_frame(data_missing)
+        super().test_fillna_frame(data_missing)
 
 
 class TestReshaping(BaseNumPyTests, base.BaseReshapingTests):
@@ -333,23 +328,22 @@ class TestReshaping(BaseNumPyTests, base.BaseReshapingTests):
     @pytest.mark.skip("Incorrect parent test")
     # not actually a mixed concat, since we concat int and int.
     def test_concat_mixed_dtypes(self, data):
-        super(TestReshaping, self).test_concat_mixed_dtypes(data)
+        super().test_concat_mixed_dtypes(data)
 
     @skip_nested
     def test_merge(self, data, na_value):
         # Fails creating expected
-        super(TestReshaping, self).test_merge(data, na_value)
+        super().test_merge(data, na_value)
 
     @skip_nested
     def test_merge_on_extension_array(self, data):
         # Fails creating expected
-        super(TestReshaping, self).test_merge_on_extension_array(data)
+        super().test_merge_on_extension_array(data)
 
     @skip_nested
     def test_merge_on_extension_array_duplicates(self, data):
         # Fails creating expected
-        super(TestReshaping, self).test_merge_on_extension_array_duplicates(
-            data)
+        super().test_merge_on_extension_array_duplicates(data)
 
 
 class TestSetitem(BaseNumPyTests, base.BaseSetitemTests):
@@ -357,61 +351,56 @@ class TestSetitem(BaseNumPyTests, base.BaseSetitemTests):
     @skip_nested
     def test_setitem_scalar_series(self, data, box_in_series):
         # AssertionError
-        super(TestSetitem, self).test_setitem_scalar_series(
-            data, box_in_series)
+        super().test_setitem_scalar_series(data, box_in_series)
 
     @skip_nested
     def test_setitem_sequence(self, data, box_in_series):
         # ValueError: shape mismatch: value array of shape (2,1) could not
         # be broadcast to indexing result of shape (2,)
-        super(TestSetitem, self).test_setitem_sequence(data, box_in_series)
+        super().test_setitem_sequence(data, box_in_series)
 
     @skip_nested
     def test_setitem_sequence_mismatched_length_raises(self, data, as_array):
         # ValueError: PandasArray must be 1-dimensional.
-        (super(TestSetitem, self).
-         test_setitem_sequence_mismatched_length_raises(data, as_array))
+        super().test_setitem_sequence_mismatched_length_raises(data, as_array)
 
     @skip_nested
     def test_setitem_sequence_broadcasts(self, data, box_in_series):
         # ValueError: cannot set using a list-like indexer with a different
         # length than the value
-        super(TestSetitem, self).test_setitem_sequence_broadcasts(
-            data, box_in_series)
+        super().test_setitem_sequence_broadcasts(data, box_in_series)
 
     @skip_nested
     def test_setitem_loc_scalar_mixed(self, data):
         # AssertionError
-        super(TestSetitem, self).test_setitem_loc_scalar_mixed(data)
+        super().test_setitem_loc_scalar_mixed(data)
 
     @skip_nested
     def test_setitem_loc_scalar_multiple_homogoneous(self, data):
         # AssertionError
-        super(TestSetitem, self).test_setitem_loc_scalar_multiple_homogoneous(
-            data)
+        super().test_setitem_loc_scalar_multiple_homogoneous(data)
 
     @skip_nested
     def test_setitem_iloc_scalar_mixed(self, data):
         # AssertionError
-        super(TestSetitem, self).test_setitem_iloc_scalar_mixed(data)
+        super().test_setitem_iloc_scalar_mixed(data)
 
     @skip_nested
     def test_setitem_iloc_scalar_multiple_homogoneous(self, data):
         # AssertionError
-        super(TestSetitem, self).test_setitem_iloc_scalar_multiple_homogoneous(
-            data)
+        super().test_setitem_iloc_scalar_multiple_homogoneous(data)
 
     @skip_nested
     @pytest.mark.parametrize('setter', ['loc', None])
     def test_setitem_mask_broadcast(self, data, setter):
         # ValueError: cannot set using a list-like indexer with a different
         # length than the value
-        super(TestSetitem, self).test_setitem_mask_broadcast(data, setter)
+        super().test_setitem_mask_broadcast(data, setter)
 
     @skip_nested
     def test_setitem_scalar_key_sequence_raise(self, data):
         # Failed: DID NOT RAISE <class 'ValueError'>
-        super(TestSetitem, self).test_setitem_scalar_key_sequence_raise(data)
+        super().test_setitem_scalar_key_sequence_raise(data)
 
 
 @skip_nested

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -93,9 +93,8 @@ class TestArithmeticOps(BasePeriodTests, base.BaseArithmeticOpsTests):
                               exc=None)
         else:
             # ... but not the rest.
-            super(TestArithmeticOps, self).test_arith_series_with_scalar(
-                data, all_arithmetic_operators
-            )
+            super().test_arith_series_with_scalar(
+                data, all_arithmetic_operators)
 
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
         if all_arithmetic_operators in self.implements:
@@ -104,14 +103,11 @@ class TestArithmeticOps(BasePeriodTests, base.BaseArithmeticOpsTests):
                               exc=None)
         else:
             # ... but not the rest.
-            super(TestArithmeticOps, self).test_arith_series_with_scalar(
-                data, all_arithmetic_operators
-            )
+            super().test_arith_series_with_scalar(
+                data, all_arithmetic_operators)
 
     def _check_divmod_op(self, s, op, other, exc=NotImplementedError):
-        super(TestArithmeticOps, self)._check_divmod_op(
-            s, op, other, exc=TypeError
-        )
+        super()._check_divmod_op(s, op, other, exc=TypeError)
 
     def test_add_series_with_extension_array(self, data):
         # we don't implement + for Period
@@ -168,4 +164,4 @@ class TestParsing(BasePeriodTests, base.BaseParsingTests):
     def test_EA_types(self, engine, data):
         expected_msg = r'.*must implement _from_sequence_of_strings.*'
         with pytest.raises(NotImplementedError, match=expected_msg):
-            super(TestParsing, self).test_EA_types(engine, data)
+            super().test_EA_types(engine, data)

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -121,23 +121,23 @@ class TestReshaping(BaseSparseTests, base.BaseReshapingTests):
 
     def test_concat_columns(self, data, na_value):
         self._check_unsupported(data)
-        super(TestReshaping, self).test_concat_columns(data, na_value)
+        super().test_concat_columns(data, na_value)
 
     def test_align(self, data, na_value):
         self._check_unsupported(data)
-        super(TestReshaping, self).test_align(data, na_value)
+        super().test_align(data, na_value)
 
     def test_align_frame(self, data, na_value):
         self._check_unsupported(data)
-        super(TestReshaping, self).test_align_frame(data, na_value)
+        super().test_align_frame(data, na_value)
 
     def test_align_series_frame(self, data, na_value):
         self._check_unsupported(data)
-        super(TestReshaping, self).test_align_series_frame(data, na_value)
+        super().test_align_series_frame(data, na_value)
 
     def test_merge(self, data, na_value):
         self._check_unsupported(data)
-        super(TestReshaping, self).test_merge(data, na_value)
+        super().test_merge(data, na_value)
 
 
 class TestGetitem(BaseSparseTests, base.BaseGetitemTests):
@@ -152,7 +152,7 @@ class TestGetitem(BaseSparseTests, base.BaseGetitemTests):
 
     def test_reindex(self, data, na_value):
         self._check_unsupported(data)
-        super(TestGetitem, self).test_reindex(data, na_value)
+        super().test_reindex(data, na_value)
 
 
 # Skipping TestSetitem, since we don't implement it.
@@ -178,15 +178,15 @@ class TestMissing(BaseSparseTests, base.BaseMissingTests):
 
     def test_fillna_limit_pad(self, data_missing):
         with tm.assert_produces_warning(PerformanceWarning):
-            super(TestMissing, self).test_fillna_limit_pad(data_missing)
+            super().test_fillna_limit_pad(data_missing)
 
     def test_fillna_limit_backfill(self, data_missing):
         with tm.assert_produces_warning(PerformanceWarning):
-            super(TestMissing, self).test_fillna_limit_backfill(data_missing)
+            super().test_fillna_limit_backfill(data_missing)
 
     def test_fillna_series_method(self, data_missing):
         with tm.assert_produces_warning(PerformanceWarning):
-            super(TestMissing, self).test_fillna_limit_backfill(data_missing)
+            super().test_fillna_limit_backfill(data_missing)
 
     @pytest.mark.skip(reason="Unsupported")
     def test_fillna_series(self):
@@ -290,12 +290,11 @@ class TestMethods(BaseSparseTests, base.BaseMethodsTests):
             # Right now this is upcasted to float, just like combine_first
             # for Series[int]
             pytest.skip("TODO(SparseArray.__setitem__ will preserve dtype.")
-        super(TestMethods, self).test_combine_first(data)
+        super().test_combine_first(data)
 
     def test_searchsorted(self, data_for_sorting, as_series):
         with tm.assert_produces_warning(PerformanceWarning):
-            super(TestMethods, self).test_searchsorted(data_for_sorting,
-                                                       as_series)
+            super().test_searchsorted(data_for_sorting, as_series)
 
 
 class TestCasting(BaseSparseTests, base.BaseCastingTests):
@@ -320,17 +319,11 @@ class TestArithmeticOps(BaseSparseTests, base.BaseArithmeticOpsTests):
 
     def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
         self._skip_if_different_combine(data)
-        super(TestArithmeticOps, self).test_arith_series_with_scalar(
-            data,
-            all_arithmetic_operators
-        )
+        super().test_arith_series_with_scalar(data, all_arithmetic_operators)
 
     def test_arith_series_with_array(self, data, all_arithmetic_operators):
         self._skip_if_different_combine(data)
-        super(TestArithmeticOps, self).test_arith_series_with_array(
-            data,
-            all_arithmetic_operators
-        )
+        super().test_arith_series_with_array(data, all_arithmetic_operators)
 
 
 class TestComparisonOps(BaseSparseTests, base.BaseComparisonOpsTests):
@@ -363,7 +356,7 @@ class TestComparisonOps(BaseSparseTests, base.BaseComparisonOpsTests):
 class TestPrinting(BaseSparseTests, base.BasePrintingTests):
     @pytest.mark.xfail(reason='Different repr', strict=True)
     def test_array_repr(self, data, size):
-        super(TestPrinting, self).test_array_repr(data, size)
+        super().test_array_repr(data, size)
 
 
 class TestParsing(BaseSparseTests, base.BaseParsingTests):
@@ -371,4 +364,4 @@ class TestParsing(BaseSparseTests, base.BaseParsingTests):
     def test_EA_types(self, engine, data):
         expected_msg = r'.*must implement _from_sequence_of_strings.*'
         with pytest.raises(NotImplementedError, match=expected_msg):
-            super(TestParsing, self).test_EA_types(engine, data)
+            super().test_EA_types(engine, data)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -31,7 +31,7 @@ class TestDataFrameSubclassing(TestData):
             """
 
             def __init__(self, *args, **kw):
-                super(CustomDataFrame, self).__init__(*args, **kw)
+                super().__init__(*args, **kw)
 
             @property
             def _constructor(self):

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1044,7 +1044,7 @@ def test_count_uses_size_on_exception():
     class RaisingObject:
 
         def __init__(self, msg='I will raise inside Cython'):
-            super(RaisingObject, self).__init__()
+            super().__init__()
             self.msg = msg
 
         def __eq__(self, other):

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -21,7 +21,7 @@ START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 class TestDatetimeIndexOps(Ops):
 
     def setup_method(self, method):
-        super(TestDatetimeIndexOps, self).setup_method(method)
+        super().setup_method(method)
         mask = lambda x: (isinstance(x, DatetimeIndex) or
                           isinstance(x, PeriodIndex))
         self.is_valid_objs = [o for o in self.objs if mask(o)]

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -358,11 +358,11 @@ class TestIntervalIndex(Base):
 
     @pytest.mark.skip(reason='not a valid repr as we use interval notation')
     def test_repr_max_seq_item_setting(self):
-        super(TestIntervalIndex, self).test_repr_max_seq_item_setting()
+        super().test_repr_max_seq_item_setting()
 
     @pytest.mark.skip(reason='not a valid repr as we use interval notation')
     def test_repr_roundtrip(self):
-        super(TestIntervalIndex, self).test_repr_roundtrip()
+        super().test_repr_roundtrip()
 
     def test_frame_repr(self):
         # https://github.com/pandas-dev/pandas/pull/24134/files

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -12,7 +12,7 @@ import pandas.util.testing as tm
 class TestPeriodIndexOps(Ops):
 
     def setup_method(self, method):
-        super(TestPeriodIndexOps, self).setup_method(method)
+        super().setup_method(method)
         mask = lambda x: (isinstance(x, DatetimeIndex) or
                           isinstance(x, PeriodIndex))
         self.is_valid_objs = [o for o in self.objs if mask(o)]

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -439,7 +439,7 @@ class TestPeriodIndex(DatetimeLike):
 
     @td.skip_if_32bit
     def test_ndarray_compat_properties(self):
-        super(TestPeriodIndex, self).test_ndarray_compat_properties()
+        super().test_ndarray_compat_properties()
 
     def test_negative_ordinals(self):
         Period(ordinal=-1000, freq='A')

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -14,7 +14,7 @@ from pandas.tseries.offsets import Day, Hour
 
 class TestTimedeltaIndexOps(Ops):
     def setup_method(self, method):
-        super(TestTimedeltaIndexOps, self).setup_method(method)
+        super().setup_method(method)
         mask = lambda x: isinstance(x, TimedeltaIndex)
         self.is_valid_objs = [o for o in self.objs if mask(o)]
         self.not_valid_objs = []

--- a/pandas/tests/io/formats/test_console.py
+++ b/pandas/tests/io/formats/test_console.py
@@ -10,7 +10,7 @@ class MockEncoding:  # TODO(py27): replace with mock
     side effect should be an exception that will be raised.
     """
     def __init__(self, encoding):
-        super(MockEncoding, self).__init__()
+        super().__init__()
         self.val = encoding
 
     @property

--- a/pandas/tests/io/msgpack/test_unpack.py
+++ b/pandas/tests/io/msgpack/test_unpack.py
@@ -49,8 +49,7 @@ class TestUnpack:
         class MyUnpacker(Unpacker):
 
             def __init__(self):
-                super(MyUnpacker, self).__init__(ext_hook=self._hook,
-                                                 encoding='utf-8')
+                super().__init__(ext_hook=self._hook, encoding='utf-8')
 
             def _hook(self, code, data):
                 if code == 1:

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -1138,7 +1138,7 @@ class TestReadHtml:
         class ErrorThread(threading.Thread):
             def run(self):
                 try:
-                    super(ErrorThread, self).run()
+                    super().run()
                 except Exception as e:
                     self.err = e
                 else:

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -329,7 +329,7 @@ class TestBasic(TestPackers):
 class TestIndex(TestPackers):
 
     def setup_method(self, method):
-        super(TestIndex, self).setup_method(method)
+        super().setup_method(method)
 
         self.d = {
             'string': tm.makeStringIndex(100),
@@ -394,7 +394,7 @@ class TestIndex(TestPackers):
 class TestSeries(TestPackers):
 
     def setup_method(self, method):
-        super(TestSeries, self).setup_method(method)
+        super().setup_method(method)
 
         self.d = {}
 
@@ -444,7 +444,7 @@ class TestSeries(TestPackers):
 class TestCategorical(TestPackers):
 
     def setup_method(self, method):
-        super(TestCategorical, self).setup_method(method)
+        super().setup_method(method)
 
         self.d = {}
 
@@ -468,7 +468,7 @@ class TestCategorical(TestPackers):
 class TestNDFrame(TestPackers):
 
     def setup_method(self, method):
-        super(TestNDFrame, self).setup_method(method)
+        super().setup_method(method)
 
         data = {
             'A': [0., 1., 2., 3., np.nan],
@@ -610,7 +610,7 @@ class TestCompression(TestPackers):
         else:
             self._SQLALCHEMY_INSTALLED = True
 
-        super(TestCompression, self).setup_method(method)
+        super().setup_method(method)
         data = {
             'A': np.arange(1000, dtype=np.float64),
             'B': np.arange(1000, dtype=np.int32),
@@ -799,7 +799,7 @@ class TestCompression(TestPackers):
 class TestEncoding(TestPackers):
 
     def setup_method(self, method):
-        super(TestEncoding, self).setup_method(method)
+        super().setup_method(method)
         data = {
             'A': ['\u2019'] * 1000,
             'B': np.arange(1000, dtype=np.int32),

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1041,7 +1041,7 @@ class _EngineToConnMixin:
 
     @pytest.fixture(autouse=True)
     def setup_method(self, load_iris_data):
-        super(_EngineToConnMixin, self).load_test_data_and_sql()
+        super().load_test_data_and_sql()
         engine = self.conn
         conn = engine.connect()
         self.__tx = conn.begin()
@@ -1056,7 +1056,7 @@ class _EngineToConnMixin:
         self.conn = self.__engine
         self.pandasSQL = sql.SQLDatabase(self.__engine)
         # XXX:
-        # super(_EngineToConnMixin, self).teardown_method(method)
+        # super().teardown_method(method)
 
 
 @pytest.mark.single

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -257,7 +257,7 @@ class Ops:
 class TestIndexOps(Ops):
 
     def setup_method(self, method):
-        super(TestIndexOps, self).setup_method(method)
+        super().setup_method(method)
         self.is_valid_objs = self.objs
         self.not_valid_objs = []
 

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -2162,7 +2162,7 @@ class TestMomentsConsistency(Base):
     ]
 
     def _create_data(self):
-        super(TestMomentsConsistency, self)._create_data()
+        super()._create_data()
         self.data = _consistency_data
 
     def setup_method(self, method):

--- a/pandas/tests/tseries/holiday/test_calendar.py
+++ b/pandas/tests/tseries/holiday/test_calendar.py
@@ -43,7 +43,7 @@ def test_calendar_caching():
 
     class TestCalendar(AbstractHolidayCalendar):
         def __init__(self, name=None, rules=None):
-            super(TestCalendar, self).__init__(name=name, rules=rules)
+            super().__init__(name=name, rules=rules)
 
     jan1 = TestCalendar(rules=[Holiday("jan1", year=2015, month=1, day=1)])
     jan2 = TestCalendar(rules=[Holiday("jan2", year=2015, month=1, day=2)])

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -344,7 +344,7 @@ class AbstractHolidayCalendar(metaclass=HolidayCalendarMetaClass):
         rules : array of Holiday objects
             A set of rules used to create the holidays.
         """
-        super(AbstractHolidayCalendar, self).__init__()
+        super().__init__()
         if name is None:
             name = self.__class__.__name__
         self.name = name

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -784,7 +784,7 @@ class BusinessHourMixin(BusinessMixin):
             return False
 
     def _repr_attrs(self):
-        out = super(BusinessHourMixin, self)._repr_attrs()
+        out = super()._repr_attrs()
         start = self.start.strftime('%H:%M')
         end = self.end.strftime('%H:%M')
         attrs = ['{prefix}={start}-{end}'.format(prefix=self._prefix,
@@ -806,7 +806,7 @@ class BusinessHour(BusinessHourMixin, SingleConstructorOffset):
     def __init__(self, n=1, normalize=False, start='09:00',
                  end='17:00', offset=timedelta(0)):
         BaseOffset.__init__(self, n, normalize)
-        super(BusinessHour, self).__init__(start=start, end=end, offset=offset)
+        super().__init__(start=start, end=end, offset=offset)
 
 
 class CustomBusinessDay(_CustomMixin, BusinessDay):


### PR DESCRIPTION
- [x] xref #25725

Simplifies the use of simple uses of ``super`` by converting to use python3 idioms. This is a quite big PR, but only deals with converting ``super(MyClass, self)`` to ``super()`` so it's very simple.

In addition to the uses of ``super`` dealt with in this PR, there are some more advanced uses of ``super`` in the code base, e.g. in classmethods and using ``super`` to jump to a specific point in the MRO-chain. I'd like to tackle those in a seperate PR in order to keep the the current large PR very simple.