### PR TITLE
CLN: remove __metaclass__ from code base

### DIFF
--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -35,11 +35,8 @@ def _check_ne_builtin_clash(expr):
                                      .format(expr=expr, s=s))
 
 
-class AbstractEngine:
-
+class AbstractEngine(metaclass=abc.ABCMeta):
     """Object serving as a base class for all engines."""
-
-    __metaclass__ = abc.ABCMeta
 
     has_neg_frac = False
 


### PR DESCRIPTION
- [x] xref #25725 & #26165

Removes uses of ``__metaclass__`` from the code base. After #26165 there was actually only one left.
