### PR TITLE
BUG: Preserve sparse dtype when reindexing

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4502,7 +4502,7 @@ class NDFrame(PandasObject, SelectionMixin):
                                            fill_value=fill_value, copy=copy)
 
     def _reindex_with_indexers(self, reindexers, fill_value=None, copy=False,
-                               allow_dups=False):
+                               allow_dups=False, preserve_dtype=False):
         """allow_dups indicates an internal call here """
 
         # reindex doing multiple operations on different axes if indicated
@@ -4527,7 +4527,8 @@ class NDFrame(PandasObject, SelectionMixin):
         if copy and new_data is self._data:
             new_data = new_data.copy()
 
-        return self._constructor(new_data).__finalize__(self)
+        kwargs = {'dtype': self._data.dtype} if preserve_dtype else {}
+        return self._constructor(new_data, **kwargs).__finalize__(self)
 
     def filter(self, items=None, like=None, regex=None, axis=None):
         """

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -464,9 +464,19 @@ class SparseSeries(Series):
     def reindex(self, index=None, method=None, copy=True, limit=None,
                 **kwargs):
         # TODO: remove?
+        fill_value = kwargs.pop('fill_value', None)
+        if fill_value is None:
+            fill_value = self.fill_value
         return super(SparseSeries, self).reindex(index=index, method=method,
+                                                 fill_value=fill_value,
                                                  copy=copy, limit=limit,
                                                  **kwargs)
+
+    def _reindex_with_indexers(self, *args, **kwargs):
+        return super(SparseSeries, self)._reindex_with_indexers(
+            *args,
+            preserve_dtype=True,
+            **kwargs)
 
     def sparse_reindex(self, new_index):
         """

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -12,7 +12,7 @@ import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import (
-    DataFrame, Series, SparseDtype, SparseSeries, bdate_range, isna)
+    DataFrame, Series, SparseDtype, SparseSeries, bdate_range)
 from pandas.core.reshape.util import cartesian_product
 import pandas.core.sparse.frame as spf
 from pandas.tests.series.test_api import SharedWithSparse
@@ -309,7 +309,7 @@ class TestSparseSeries(SharedWithSparse):
         sp = SparseSeries(data, np.arange(100))
         sp = sp.reindex(np.arange(200))
         assert (sp.loc[:99] == data).all()
-        assert isna(sp.loc[100:]).all()
+        assert sp.loc[100:].isin((0,)).all()
 
         data = np.nan
         sp = SparseSeries(data, np.arange(100))
@@ -1030,6 +1030,11 @@ class TestSparseSeries(SharedWithSparse):
         dense_usage = dense_series.memory_usage(deep=deep)
 
         assert sparse_usage < dense_usage
+
+    @pytest.mark.parametrize('dtype', (np.float32, np.int32, np.bool))
+    def test_resize_preserves_dtype(self, dtype):
+        s = pd.SparseSeries([1, 0], dtype=dtype)
+        assert s.dtype == s.reindex([0, 1, 2]).dtype
 
 
 class TestSparseHandlingMultiIndexes:


### PR DESCRIPTION
- [ ] closes #26123.
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Hi, I've been taking a look at this but I need to verify some of the surrounding functionality so that I prevent introducing more breakages.

In this test, https://github.com/alex-hutton/pandas/blob/preserve-sparse-dtype-26123/pandas/tests/sparse/test_combine_concat.py#L99-L110 , my interpretation is that its purpose is to verify that if two `SparseSeries` are concatenated, a `fill_value` set on either of those `SparseSeries` should be ignored in favour of the default `fill_value` of `NaN`.

Is my interpretation correct, and is this test correct? It seems odd that the the `fill_value` of the `SparseSeries` should be disregarded, but I am probably missing something.