### PR TITLE
Revert "DOC: temporary remove pyarrow example of reading subset columns (#18661)

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -4704,7 +4704,8 @@ Read only certain columns of a parquet file.
 
    result = pd.read_parquet('example_fp.parquet',
                             engine='fastparquet', columns=['a', 'b'])
-
+   result = pd.read_parquet('example_pa.parquet',
+                            engine='pyarrow', columns=['a', 'b'])
    result.dtypes
 
 


### PR DESCRIPTION
This reverts commit 695e89345a46c0cab06c479c83007f5adbb70ad5.

Closes https://github.com/pandas-dev/pandas/issues/18628 (reverts https://github.com/pandas-dev/pandas/pull/18661)
