### PR TITLE
PERF: added no exception versions of '_string_to_dts' and 'parse_iso_8601_datetime' functions

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -20,9 +20,8 @@ from pandas._libs.util cimport (
 from pandas._libs.tslibs.c_timestamp cimport _Timestamp
 
 from pandas._libs.tslibs.np_datetime cimport (
-    check_dts_bounds, npy_datetimestruct, _string_to_dts,
-    dt64_to_dtstruct, dtstruct_to_dt64, pydatetime_to_dt64, pydate_to_dt64,
-    get_datetime64_value)
+    check_dts_bounds, npy_datetimestruct, _string_to_dts, dt64_to_dtstruct,
+    dtstruct_to_dt64, pydatetime_to_dt64, pydate_to_dt64, get_datetime64_value)
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 
 from pandas._libs.tslibs.parsing import parse_datetime_string
@@ -597,8 +596,8 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                                 continue
                             elif is_raise:
                                 raise ValueError("time data {val} doesn't "
-                                                    "match format specified"
-                                                    .format(val=val))
+                                                 "match format specified"
+                                                 .format(val=val))
                             return values, tz_out
 
                         try:
@@ -614,18 +613,16 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                             raise TypeError("invalid string coercion to "
                                             "datetime")
 
-                        # If the dateutil parser returned tzinfo,
-                        # capture it to check if all arguments
-                        # have the same tzinfo
+                        # If the dateutil parser returned tzinfo, capture it
+                        # to check if all arguments have the same tzinfo
                         tz = py_dt.utcoffset()
                         if tz is not None:
                             seen_datetime_offset = 1
-                            # dateutil timezone objects cannot be hashed,
-                            # so store the UTC offsets in seconds instead
+                            # dateutil timezone objects cannot be hashed, so
+                            # store the UTC offsets in seconds instead
                             out_tzoffset_vals.add(tz.total_seconds())
                         else:
-                            # Add a marker for naive string,
-                            # to track if we are
+                            # Add a marker for naive string, to track if we are
                             # parsing mixed naive and aware strings
                             out_tzoffset_vals.add('naive')
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -19,9 +19,10 @@ from pandas._libs.util cimport (
 
 from pandas._libs.tslibs.c_timestamp cimport _Timestamp
 
-from pandas._libs.tslibs.np_datetime cimport (_string_to_dts_noexc,
-    check_dts_bounds, npy_datetimestruct, _string_to_dts, dt64_to_dtstruct,
-    dtstruct_to_dt64, pydatetime_to_dt64, pydate_to_dt64, get_datetime64_value)
+from pandas._libs.tslibs.np_datetime cimport (
+    _string_to_dts_noexc, check_dts_bounds, npy_datetimestruct, _string_to_dts,
+    dt64_to_dtstruct, dtstruct_to_dt64, pydatetime_to_dt64, pydate_to_dt64,
+    get_datetime64_value)
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 
 from pandas._libs.tslibs.parsing import parse_datetime_string

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -20,7 +20,7 @@ from pandas._libs.util cimport (
 from pandas._libs.tslibs.c_timestamp cimport _Timestamp
 
 from pandas._libs.tslibs.np_datetime cimport (
-    _string_to_dts_noexc, check_dts_bounds, npy_datetimestruct, _string_to_dts,
+    check_dts_bounds, npy_datetimestruct, _string_to_dts,
     dt64_to_dtstruct, dtstruct_to_dt64, pydatetime_to_dt64, pydate_to_dt64,
     get_datetime64_value)
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
@@ -205,7 +205,8 @@ def _test_parse_iso8601(object ts):
     elif ts == 'today':
         return Timestamp.now().normalize()
 
-    _string_to_dts(ts, &obj.dts, &out_local, &out_tzoffset)
+    if _string_to_dts(ts, &obj.dts, &out_local, &out_tzoffset) == -1:
+        raise ValueError
     obj.value = dtstruct_to_dt64(&obj.dts)
     check_dts_bounds(&obj.dts)
     if out_local == 1:
@@ -580,7 +581,7 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                         iresult[i] = NPY_NAT
                         continue
 
-                    string_to_dts_failed = _string_to_dts_noexc(
+                    string_to_dts_failed = _string_to_dts(
                         val, &dts, &out_local,
                         &out_tzoffset
                     )

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -601,11 +601,9 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                             return values, tz_out
 
                         try:
-                            py_dt = parse_datetime_string(
-                                val,
-                                dayfirst=dayfirst,
-                                yearfirst=yearfirst
-                            )
+                            py_dt = parse_datetime_string(val,
+                                                          dayfirst=dayfirst,
+                                                          yearfirst=yearfirst)
                         except Exception:
                             if is_coerce:
                                 iresult[i] = NPY_NAT

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -580,11 +580,11 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                         iresult[i] = NPY_NAT
                         continue
 
+                    string_to_dts_failed = _string_to_dts_noexc(
+                        val, &dts, &out_local,
+                        &out_tzoffset
+                    )
                     try:
-                        string_to_dts_failed = _string_to_dts_noexc(
-                            val, &dts, &out_local,
-                            &out_tzoffset
-                        )
                         if string_to_dts_failed:
                             # An error at this point is a _parsing_ error
                             # specifically _not_ OutOfBoundsDatetime

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -584,7 +584,7 @@ cpdef array_to_datetime(ndarray[object] values, str errors='raise',
                         string_to_dts_failed = _string_to_dts_noexc(
                             val, &dts, &out_local,
                             &out_tzoffset
-                        ) != 0
+                        )
                         if string_to_dts_failed:
                             # An error at this point is a _parsing_ error
                             # specifically _not_ OutOfBoundsDatetime

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -393,9 +393,10 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
 
 
 cdef _TSObject create_tsobject_tz_using_offset(int64_t value,
-                                               object tz, int tzoffset):
+                                               int tzoffset, object tz=None):
     """
-    Create tsobject from numpy datetime64 using initial timezone offset
+    Convert a numpy datetime64 `value`, along with initial timezone offset
+    `tzoffset` to a _TSObject (with timezone object `tz` - optional).
 
     Parameters
     ----------
@@ -406,9 +407,8 @@ cdef _TSObject create_tsobject_tz_using_offset(int64_t value,
     tzoffset: int
 
     Returns
-    obj : _TSObject
     -------
-
+    obj : _TSObject
     """
     cdef:
         _TSObject obj
@@ -489,8 +489,8 @@ cdef _TSObject convert_str_to_tsobject(object ts, object tz, object unit,
                 check_dts_bounds(&dts)
                 value = dtstruct_to_dt64(&dts)
                 if out_local == 1:
-                    return create_tsobject_tz_using_offset(value, tz,
-                                                           out_tzoffset)
+                    return create_tsobject_tz_using_offset(value,
+                                                           out_tzoffset, tz)
                 else:
                     ts = value
                     if tz is not None:

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -445,7 +445,7 @@ cdef _TSObject convert_str_to_tsobject(object ts, object tz, object unit,
     else:
         string_to_dts_failed = _string_to_dts(
             ts, &obj.dts, &out_local,
-            &out_tzoffset
+            &out_tzoffset, False
         )
         if string_to_dts_failed:
             try:

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -402,9 +402,9 @@ cdef _TSObject create_tsobject_tz_using_offset(int64_t value,
     ----------
     value: int64_t
         numpy dt64
+    tzoffset: int
     tz : tzinfo or None
         timezone for the timezone-aware output.
-    tzoffset: int
 
     Returns
     -------

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -392,23 +392,42 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
     return obj
 
 
-cdef _TSObject setup_tsobject_tz_using_offset(_TSObject obj,
-                                              object tz, int tzoffset):
-    obj.tzinfo = pytz.FixedOffset(tzoffset)
-    obj.value = tz_convert_single(obj.value, obj.tzinfo, UTC)
+cdef _TSObject create_tsobject_tz_using_offset(int64_t value,
+                                               object tz, int tzoffset):
+    """
+    Create tsobject from numpy datetime64 using initial timezone offset
+
+    Parameters
+    ----------
+    value: int64_t
+        numpy dt64
+    tz : tzinfo or None
+        timezone for the timezone-aware output.
+    tzoffset: int
+
+    Returns
+    obj : _TSObject
+    -------
+
+    """
+    cdef:
+        _TSObject obj
+        datetime dt
+
+    tzinfo = pytz.FixedOffset(tzoffset)
+    value = tz_convert_single(value, tzinfo, UTC)
+    obj = convert_to_tsobject(value, tzinfo, None, 0, 0)
     if tz is None:
         check_overflows(obj)
         return obj
-    else:
-        # Keep the converter same as PyDateTime's
-        obj = convert_to_tsobject(obj.value, obj.tzinfo,
-                                  None, 0, 0)
-        dt = datetime(obj.dts.year, obj.dts.month, obj.dts.day,
-                      obj.dts.hour, obj.dts.min, obj.dts.sec,
-                      obj.dts.us, obj.tzinfo)
-        obj = convert_datetime_to_tsobject(
-            dt, tz, nanos=obj.dts.ps // 1000)
-        return obj
+
+    # Keep the converter same as PyDateTime's
+    dt = datetime(obj.dts.year, obj.dts.month, obj.dts.day,
+                  obj.dts.hour, obj.dts.min, obj.dts.sec,
+                  obj.dts.us, obj.tzinfo)
+    obj = convert_datetime_to_tsobject(
+        dt, tz, nanos=obj.dts.ps // 1000)
+    return obj
 
 
 cdef _TSObject convert_str_to_tsobject(object ts, object tz, object unit,
@@ -439,15 +458,13 @@ cdef _TSObject convert_str_to_tsobject(object ts, object tz, object unit,
     obj : _TSObject
     """
     cdef:
-        _TSObject obj
+        npy_datetimestruct dts
+        int64_t value  # numpy dt64
         int out_local = 0, out_tzoffset = 0
-        datetime dt
         bint do_parse_datetime_string = False
 
     if tz is not None:
         tz = maybe_get_tz(tz)
-
-    obj = _TSObject()
 
     assert isinstance(ts, str)
 
@@ -464,18 +481,18 @@ cdef _TSObject convert_str_to_tsobject(object ts, object tz, object unit,
         # equiv: datetime.today().replace(tzinfo=tz)
     else:
         string_to_dts_failed = _string_to_dts(
-            ts, &obj.dts, &out_local,
+            ts, &dts, &out_local,
             &out_tzoffset, False
         )
         try:
             if not string_to_dts_failed:
-                check_dts_bounds(&obj.dts)
-                obj.value = dtstruct_to_dt64(&obj.dts)
+                check_dts_bounds(&dts)
+                value = dtstruct_to_dt64(&dts)
                 if out_local == 1:
-                    return setup_tsobject_tz_using_offset(obj, tz,
-                                                          out_tzoffset)
+                    return create_tsobject_tz_using_offset(value, tz,
+                                                           out_tzoffset)
                 else:
-                    ts = obj.value
+                    ts = value
                     if tz is not None:
                         # shift for localize_tso
                         ts = tz_localize_to_utc(np.array([ts], dtype='i8'), tz,

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -467,10 +467,10 @@ cdef _TSObject convert_str_to_tsobject(object ts, object tz, object unit,
                     else:
                         # Keep the converter same as PyDateTime's
                         obj = convert_to_tsobject(obj.value, obj.tzinfo,
-                                                None, 0, 0)
+                                                  None, 0, 0)
                         dt = datetime(obj.dts.year, obj.dts.month, obj.dts.day,
-                                    obj.dts.hour, obj.dts.min, obj.dts.sec,
-                                    obj.dts.us, obj.tzinfo)
+                                      obj.dts.hour, obj.dts.min, obj.dts.sec,
+                                      obj.dts.us, obj.tzinfo)
                         obj = convert_datetime_to_tsobject(
                             dt, tz, nanos=obj.dts.ps // 1000)
                         return obj

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -74,3 +74,6 @@ cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil
 
 cdef int _string_to_dts(object val, npy_datetimestruct* dts,
                         int* out_local, int* out_tzoffset) except? -1
+# see np_datetime.pyx for reasons of second _noexc version
+cdef int _string_to_dts_noexc(object val, pandas_datetimestruct* dts,
+                              int* out_local, int* out_tzoffset) except? -2

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -75,5 +75,5 @@ cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil
 cdef int _string_to_dts(object val, npy_datetimestruct* dts,
                         int* out_local, int* out_tzoffset) except? -1
 # see np_datetime.pyx for reasons of second _noexc version
-cdef int _string_to_dts_noexc(object val, pandas_datetimestruct* dts,
-                              int* out_local, int* out_tzoffset) except? -2
+cdef int _string_to_dts_noexc(object val, npy_datetimestruct* dts,
+                              int* out_local, int* out_tzoffset)

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -73,4 +73,5 @@ cdef npy_timedelta get_timedelta64_value(object obj) nogil
 cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil
 
 cdef int _string_to_dts(object val, npy_datetimestruct* dts,
-                        int* out_local, int* out_tzoffset)
+                        int* out_local, int* out_tzoffset,
+                        bint want_exc) except? -1

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -73,7 +73,4 @@ cdef npy_timedelta get_timedelta64_value(object obj) nogil
 cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil
 
 cdef int _string_to_dts(object val, npy_datetimestruct* dts,
-                        int* out_local, int* out_tzoffset) except? -1
-# see np_datetime.pyx for reasons of second _noexc version
-cdef int _string_to_dts_noexc(object val, npy_datetimestruct* dts,
-                              int* out_local, int* out_tzoffset)
+                        int* out_local, int* out_tzoffset)

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -1,4 +1,4 @@
-from cpython cimport Py_EQ, Py_NE, Py_GE, Py_GT, Py_LT, Py_LE
+from cpython cimport Py_EQ, Py_NE, Py_GE, Py_GT, Py_LT, Py_LE, PyErr_Clear
 
 from cpython.datetime cimport (datetime, date,
                                PyDateTime_IMPORT,
@@ -34,8 +34,8 @@ cdef extern from "src/datetime/np_datetime_strings.h":
     int parse_iso_8601_datetime(const char *str, int len,
                                 npy_datetimestruct *out,
                                 int *out_local, int *out_tzoffset)
-    int parse_iso_8601_datetime_noexc(char *str, int len,
-                                      pandas_datetimestruct *out,
+    int parse_iso_8601_datetime_noexc(const char *str, int len,
+                                      npy_datetimestruct *out,
                                       int *out_local, int *out_tzoffset)
 
 
@@ -178,57 +178,25 @@ cdef inline int _string_to_dts(object val, npy_datetimestruct* dts,
         Py_ssize_t length
         const char* buf
 
-    if isinstance(val, unicode):
-        val = PyUnicode_AsASCIIString(val)
+    buf = get_c_string_buf_and_size(val, &length)
+    return parse_iso_8601_datetime(buf, length,
+                                   dts, out_local, out_tzoffset)
 
-    tmp = val
-    result = _cstring_to_dts(tmp, len(val), dts, out_local, out_tzoffset)
-
-    if result == -1:
-        raise ValueError('Unable to parse %s' % str(val))
-    return result
-
-
-cdef inline int _cstring_to_dts(char *val, int length,
-                                npy_datetimestruct* dts,
-                                int* out_local, int* out_tzoffset) except? -1:
-    # Note: without this "extra layer" between _string_to_dts
-    # and parse_iso_8601_datetime, calling _string_to_dts raises
-    # `SystemError: <class 'str'> returned a result with an error set`
-    # in Python3
-    cdef:
-        int result
-
-    result = parse_iso_8601_datetime(val, length,
-                                     dts, out_local, out_tzoffset)
-    return result
 
 # Slightly faster version that doesn't raise a ValueError
-# if a date cannot be parsed, but it does raise ValueError if 
-# "val" supplied is not a valid ASCII string.
+# if a date cannot be parsed, it reports various errors via return result.
 # Caller must check that return value == 0 to determine if parsing succeeded.
-# NOTE: to stop exception propagation when date parsing failed
-# this function is marked to cause an exception on a return value
-# that can never happen in a real life.
-cdef inline int _string_to_dts_noexc(object val, pandas_datetimestruct* dts,
-                               int* out_local, int* out_tzoffset) except -2:
+cdef inline int _string_to_dts_noexc(object val, npy_datetimestruct* dts,
+                                     int* out_local, int* out_tzoffset):
     cdef:
-        int result
-        char *tmp
+        Py_ssize_t length
+        const char* buf
 
-    if PyUnicode_Check(val):
-        val = PyUnicode_AsASCIIString(val)
+    buf = get_c_string_buf_and_size(val, &length)
+    if buf == NULL:
+        PyErr_Clear()
+        return -1
 
-    tmp = val
-    result = _cstring_to_dts_noexc(tmp, len(val), dts, out_local, out_tzoffset)
-    return result
-
-cdef inline int _cstring_to_dts_noexc(char *val, int length,
-                                pandas_datetimestruct* dts,
-                                int* out_local, int* out_tzoffset):
-    cdef:
-        int result
-
-    result = parse_iso_8601_datetime_noexc(val, length,
-                                           dts, out_local, out_tzoffset)
+    result = parse_iso_8601_datetime_noexc(buf, length,
+                                           dts, out_local, out_tzoffset);
     return result

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -170,11 +170,12 @@ cdef inline int64_t pydate_to_dt64(date val, npy_datetimestruct *dts):
 
 
 cdef inline int _string_to_dts(object val, npy_datetimestruct* dts,
-                               int* out_local, int* out_tzoffset):
+                               int* out_local, int* out_tzoffset,
+                               bint want_exc) except? -1:
     cdef:
         Py_ssize_t length
         const char* buf
 
     buf = get_c_string_buf_and_size(val, &length)
-    return parse_iso_8601_datetime(buf, length, 0,
+    return parse_iso_8601_datetime(buf, length, want_exc,
                                    dts, out_local, out_tzoffset)

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
@@ -66,25 +66,7 @@ This file implements string parsing and creation for NumPy datetime.
  *
  * Returns 0 on success, -1 on failure.
  */
-static int __parse_iso_8601_datetime(const char *str, int len, int want_exc,
-                            npy_datetimestruct *out,
-                            int *out_local, int *out_tzoffset);
-
-int parse_iso_8601_datetime(const char *str, int len,
-                            npy_datetimestruct *out,
-                            int *out_local, int *out_tzoffset) {
-    return __parse_iso_8601_datetime(str, len, 1, out, out_local, out_tzoffset);
-}
-
-// slightly faster version of parse_iso_8601_datetime which
-// doesn't set Python exceptions but still returns -1 on error
-int parse_iso_8601_datetime_noexc(const char *str, int len,
-                            npy_datetimestruct *out,
-                            int *out_local, int *out_tzoffset) {
-    return __parse_iso_8601_datetime(str, len, 0, out, out_local, out_tzoffset);
-}
-
-static int __parse_iso_8601_datetime(const char *str, int len, int want_exc,
+int parse_iso_8601_datetime(const char *str, int len, int want_exc,
                             npy_datetimestruct *out,
                             int *out_local, int *out_tzoffset) {
     int year_leap = 0;

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
@@ -66,11 +66,11 @@ This file implements string parsing and creation for NumPy datetime.
  *
  * Returns 0 on success, -1 on failure.
  */
-static int __parse_iso_8601_datetime(char *str, int len, int want_exc,
-                            pandas_datetimestruct *out,
+static int __parse_iso_8601_datetime(const char *str, int len, int want_exc,
+                            npy_datetimestruct *out,
                             int *out_local, int *out_tzoffset);
 
-int parse_iso_8601_datetime(char *str, int len,
+int parse_iso_8601_datetime(const char *str, int len,
                             npy_datetimestruct *out,
                             int *out_local, int *out_tzoffset) {
     return __parse_iso_8601_datetime(str, len, 1, out, out_local, out_tzoffset);
@@ -78,14 +78,14 @@ int parse_iso_8601_datetime(char *str, int len,
 
 // slightly faster version of parse_iso_8601_datetime which
 // doesn't set Python exceptions but still returns -1 on error
-int parse_iso_8601_datetime_noexc(char *str, int len,
-                            pandas_datetimestruct *out,
+int parse_iso_8601_datetime_noexc(const char *str, int len,
+                            npy_datetimestruct *out,
                             int *out_local, int *out_tzoffset) {
     return __parse_iso_8601_datetime(str, len, 0, out, out_local, out_tzoffset);
 }
 
-static int __parse_iso_8601_datetime(char *str, int len, int want_exc,
-                            pandas_datetimestruct *out,
+static int __parse_iso_8601_datetime(const char *str, int len, int want_exc,
+                            npy_datetimestruct *out,
                             int *out_local, int *out_tzoffset) {
     int year_leap = 0;
     int i, numdigits;

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.c
@@ -275,7 +275,8 @@ static int __parse_iso_8601_datetime(const char *str, int len, int want_exc,
         if (out->hour >= 24) {
             if (want_exc) {
                 PyErr_Format(PyExc_ValueError,
-                            "Hours out of range in datetime string \"%s\"", str);
+                             "Hours out of range in datetime string \"%s\"",
+                             str);
             }
             goto error;
         }
@@ -317,7 +318,8 @@ static int __parse_iso_8601_datetime(const char *str, int len, int want_exc,
         if (out->min >= 60) {
             if (want_exc) {
                 PyErr_Format(PyExc_ValueError,
-                            "Minutes out of range in datetime string \"%s\"", str);
+                             "Minutes out of range in datetime string \"%s\"",
+                             str);
             }
             goto error;
         }
@@ -356,7 +358,8 @@ static int __parse_iso_8601_datetime(const char *str, int len, int want_exc,
         if (out->sec >= 60) {
             if (want_exc) {
                 PyErr_Format(PyExc_ValueError,
-                            "Seconds out of range in datetime string \"%s\"", str);
+                             "Seconds out of range in datetime string \"%s\"",
+                             str);
             }
             goto error;
         }

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
@@ -54,17 +54,10 @@ This file implements string parsing and creation for NumPy datetime.
  * Returns 0 on success, -1 on failure.
  */
 int
-parse_iso_8601_datetime(const char *str, int len,
+parse_iso_8601_datetime(const char *str, int len, int want_exc,
                         npy_datetimestruct *out,
                         int *out_local,
                         int *out_tzoffset);
-// slightly faster version of parse_iso_8601_datetime which
-// doesn't set Python exceptions but still returns -1 on error
-int
-parse_iso_8601_datetime_noexc(const char *str, int len,
-                              npy_datetimestruct *out,
-                              int *out_local,
-                              int *out_tzoffset);
 
 /*
  * Provides a string length to use for converting datetime

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
@@ -58,6 +58,13 @@ parse_iso_8601_datetime(const char *str, int len,
                         npy_datetimestruct *out,
                         int *out_local,
                         int *out_tzoffset);
+// slightly faster version of parse_iso_8601_datetime which
+// doesn't set Python exceptions but still returns -1 on error
+int
+parse_iso_8601_datetime_noexc(char *str, int len,
+                    pandas_datetimestruct *out,
+                    int *out_local,
+                    int *out_tzoffset);
 
 /*
  * Provides a string length to use for converting datetime
@@ -79,5 +86,4 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
 int
 make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
                        NPY_DATETIMEUNIT base);
-
 #endif  // PANDAS__LIBS_TSLIBS_SRC_DATETIME_NP_DATETIME_STRINGS_H_

--- a/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/tslibs/src/datetime/np_datetime_strings.h
@@ -61,10 +61,10 @@ parse_iso_8601_datetime(const char *str, int len,
 // slightly faster version of parse_iso_8601_datetime which
 // doesn't set Python exceptions but still returns -1 on error
 int
-parse_iso_8601_datetime_noexc(char *str, int len,
-                    pandas_datetimestruct *out,
-                    int *out_local,
-                    int *out_tzoffset);
+parse_iso_8601_datetime_noexc(const char *str, int len,
+                              npy_datetimestruct *out,
+                              int *out_local,
+                              int *out_tzoffset);
 
 /*
  * Provides a string length to use for converting datetime

--- a/pandas/tests/tslibs/test_parse_iso8601.py
+++ b/pandas/tests/tslibs/test_parse_iso8601.py
@@ -46,13 +46,18 @@ def test_parsers_iso8601(date_str, exp):
     "20010101 12345Z",
 ])
 def test_parsers_iso8601_invalid(date_str):
-    with pytest.raises(ValueError):
+    msg = "Error parsing datetime string \"{s}\"".format(s=date_str)
+
+    with pytest.raises(ValueError, match=msg):
         tslib._test_parse_iso8601(date_str)
 
 
 def test_parsers_iso8601_invalid_offset_invalid():
     date_str = "2001-01-01 12-34-56"
-    with pytest.raises(ValueError):
+    msg = ("Timezone hours offset out of range "
+           "in datetime string \"{s}\"".format(s=date_str))
+
+    with pytest.raises(ValueError, match=msg):
         tslib._test_parse_iso8601(date_str)
 
 

--- a/pandas/tests/tslibs/test_parse_iso8601.py
+++ b/pandas/tests/tslibs/test_parse_iso8601.py
@@ -46,18 +46,13 @@ def test_parsers_iso8601(date_str, exp):
     "20010101 12345Z",
 ])
 def test_parsers_iso8601_invalid(date_str):
-    msg = "Error parsing datetime string \"{s}\"".format(s=date_str)
-
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ValueError):
         tslib._test_parse_iso8601(date_str)
 
 
 def test_parsers_iso8601_invalid_offset_invalid():
     date_str = "2001-01-01 12-34-56"
-    msg = ("Timezone hours offset out of range "
-           "in datetime string \"{s}\"".format(s=date_str))
-
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ValueError):
         tslib._test_parse_iso8601(date_str)
 
 


### PR DESCRIPTION
- [x] closes #N/A
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

`asv continuous -f 1.05 origin/master HEAD -b ^io.csv -b ^timeseries -a warmup_time=1 -a sample_time=1`:

master| patch| ratio| test name
-|-|-|-
98.4±3ms|         76.2±2ms|     0.77|  timeseries.ToDatetimeFormatQuarters.time_infer_quarter
15.2±0.6ms|      9.75±0.04ms|     0.64|  io.csv.ReadCSVParseSpecialDate.time_read_special_date('mdY')
37.1±2ms|       22.4±0.1ms|     0.60|  io.csv.ReadCSVParseSpecialDate.time_read_special_date('mY')