### PR TITLE
Don't cache metadata in GCS connections

### DIFF
--- a/pandas/io/gcs.py
+++ b/pandas/io/gcs.py
@@ -11,7 +11,7 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
     if mode is None:
         mode = 'rb'
 
-    fs = gcsfs.GCSFileSystem()
+    fs = gcsfs.GCSFileSystem(cache_timeout=0)
     filepath_or_buffer = fs.open(
         filepath_or_buffer, mode)  # type: gcsfs.GCSFile
     return filepath_or_buffer, None, compression, True


### PR DESCRIPTION
Currently if you access a bucket, change the contents, and try to read a new file w/ e.g. `read_parquet`, you see a `FileNotFoundError`; restarting Python fixes this. IMO since the `gcsfs` connection is hidden from the user, caching metadata doesn't really make sense (how would you even go about clearing this manually?).

@martindurant seem ok to you?