### PR TITLE
CLN: Clean uses of super, part II

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -144,6 +144,10 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -R --include="*.py" --include="*.pyx" -E "class\s\S*\(object\):" pandas scripts
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
+    MSG='Check for python2-style super usage' ; echo $MSG
+    invgrep -R --include="*.py" --include="*.pyx" -E "super\(\w*, (self|cls)\)" pandas
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
+
     MSG='Check for backticks incorrectly rendering because of missing spaces' ; echo $MSG
     invgrep -R --include="*.rst" -E "[a-zA-Z0-9]\`\`?[a-zA-Z0-9]" doc/source/
     RET=$(($RET + $?)) ; echo $MSG "DONE"

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -483,44 +483,43 @@ cdef class TimedeltaEngine(DatetimeEngine):
 cdef class PeriodEngine(Int64Engine):
 
     cdef _get_index_values(self):
-        return super(PeriodEngine, self).vgetter()
+        return super().vgetter()
 
     cpdef _call_map_locations(self, values):
-        super(PeriodEngine, self)._call_map_locations(values.view('i8'))
+        super()._call_map_locations(values.view('i8'))
 
     def _call_monotonic(self, values):
-        return super(PeriodEngine, self)._call_monotonic(values.view('i8'))
+        return super()._call_monotonic(values.view('i8'))
 
     def get_indexer(self, values):
         cdef ndarray[int64_t, ndim=1] ordinals
 
-        super(PeriodEngine, self)._ensure_mapping_populated()
+        super()._ensure_mapping_populated()
 
-        freq = super(PeriodEngine, self).vgetter().freq
+        freq = super().vgetter().freq
         ordinals = periodlib.extract_ordinals(values, freq)
 
         return self.mapping.lookup(ordinals)
 
     def get_pad_indexer(self, other, limit=None):
-        freq = super(PeriodEngine, self).vgetter().freq
+        freq = super().vgetter().freq
         ordinal = periodlib.extract_ordinals(other, freq)
 
         return algos.pad(self._get_index_values(),
                          np.asarray(ordinal), limit=limit)
 
     def get_backfill_indexer(self, other, limit=None):
-        freq = super(PeriodEngine, self).vgetter().freq
+        freq = super().vgetter().freq
         ordinal = periodlib.extract_ordinals(other, freq)
 
         return algos.backfill(self._get_index_values(),
                               np.asarray(ordinal), limit=limit)
 
     def get_indexer_non_unique(self, targets):
-        freq = super(PeriodEngine, self).vgetter().freq
+        freq = super().vgetter().freq
         ordinal = periodlib.extract_ordinals(targets, freq)
         ordinal_array = np.asarray(ordinal)
-
-        return super(PeriodEngine, self).get_indexer_non_unique(ordinal_array)
+        return super().get_indexer_non_unique(ordinal_array)
 
 
 cpdef convert_scalar(ndarray arr, object value):

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -983,7 +983,7 @@ default 'raise'
         return create_timestamp_from_ts(value, dts, _tzinfo, self.freq)
 
     def isoformat(self, sep='T'):
-        base = super(_Timestamp, self).isoformat(sep=sep)
+        base = super().isoformat(sep=sep)
         if self.nanosecond == 0:
             return base
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2025,8 +2025,8 @@ class Categorical(ExtensionArray, PandasObject):
         return result
 
     def __repr__(self):
-        # We want PandasObject.__repr__, which dispatches to __unicode__
-        return super(ExtensionArray, self).__repr__()
+        # We want to bypass ExtensionArray.__repr__.
+        return str(self)
 
     def _maybe_coerce_indexer(self, indexer):
         """

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1769,7 +1769,7 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
     def _add_comparison_ops(cls):
         cls.__and__ = cls._create_comparison_method(operator.and_)
         cls.__or__ = cls._create_comparison_method(operator.or_)
-        super(SparseArray, cls)._add_comparison_ops()
+        super()._add_comparison_ops()
 
     # ----------
     # Formatting

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -879,7 +879,7 @@ class PeriodDtype(ExtensionDtype, PandasExtensionDtype):
                     return False
             else:
                 return False
-        return super(PeriodDtype, cls).is_dtype(dtype)
+        return super().is_dtype(dtype)
 
     @classmethod
     def construct_array_type(cls):
@@ -1047,4 +1047,4 @@ class IntervalDtype(PandasExtensionDtype, ExtensionDtype):
                     return False
             else:
                 return False
-        return super(IntervalDtype, cls).is_dtype(dtype)
+        return super().is_dtype(dtype)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6328,10 +6328,9 @@ class DataFrame(NDFrame):
 
     def _aggregate(self, arg, axis=0, *args, **kwargs):
         if axis == 1:
-            # NDFrame.aggregate returns a tuple, and we need to transpose
+            # NDFrame._aggregate returns a tuple, and we need to transpose
             # only result
-            result, how = (super(DataFrame, self.T)
-                           ._aggregate(arg, *args, **kwargs))
+            result, how = self.T._aggregate(arg, *args, axis=0, **kwargs)
             result = result.T if result is not None else result
             return result, how
         return super()._aggregate(arg, *args, **kwargs)
@@ -6342,7 +6341,7 @@ class DataFrame(NDFrame):
     def transform(self, func, axis=0, *args, **kwargs):
         axis = self._get_axis_number(axis)
         if axis == 1:
-            return super(DataFrame, self.T).transform(func, *args, **kwargs).T
+            return self.T.transform(func, *args, axis=0, **kwargs).T
         return super().transform(func, *args, **kwargs)
 
     def apply(self, func, axis=0, broadcast=None, raw=False, reduce=None,

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -90,7 +90,7 @@ class Grouper:
         if kwargs.get('freq') is not None:
             from pandas.core.resample import TimeGrouper
             cls = TimeGrouper
-        return super(Grouper, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, key=None, level=None, freq=None, axis=0, sort=False):
         self.key = key

--- a/pandas/io/msgpack/__init__.py
+++ b/pandas/io/msgpack/__init__.py
@@ -15,7 +15,7 @@ class ExtType(namedtuple('ExtType', 'code data')):
             raise TypeError("data must be bytes")
         if not 0 <= code <= 127:
             raise ValueError("code must be 0~127")
-        return super(ExtType, cls).__new__(cls, code, data)
+        return super().__new__(cls, code, data)
 
 import os  # noqa
 

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -222,9 +222,7 @@ class DecimalArray2(DecimalArray):
         if isinstance(scalars, (pd.Series, pd.Index)):
             raise TypeError
 
-        return super(DecimalArray2, cls)._from_sequence(
-            scalars, dtype=dtype, copy=copy
-        )
+        return super()._from_sequence(scalars, dtype=dtype, copy=copy)
 
 
 @pytest.mark.parametrize("box", [pd.Series, pd.Index])

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -712,7 +712,7 @@ class TestEvalNumexprPython(TestEvalNumexprPandas):
 
     @classmethod
     def setup_class(cls):
-        super(TestEvalNumexprPython, cls).setup_class()
+        super().setup_class()
         import numexpr as ne
         cls.ne = ne
         cls.engine = 'numexpr'
@@ -738,7 +738,7 @@ class TestEvalPythonPython(TestEvalNumexprPython):
 
     @classmethod
     def setup_class(cls):
-        super(TestEvalPythonPython, cls).setup_class()
+        super().setup_class()
         cls.engine = 'python'
         cls.parser = 'python'
 
@@ -768,7 +768,7 @@ class TestEvalPythonPandas(TestEvalPythonPython):
 
     @classmethod
     def setup_class(cls):
-        super(TestEvalPythonPandas, cls).setup_class()
+        super().setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
 
@@ -1494,7 +1494,7 @@ class TestOperationsNumExprPython(TestOperationsNumExprPandas):
 
     @classmethod
     def setup_class(cls):
-        super(TestOperationsNumExprPython, cls).setup_class()
+        super().setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'python'
         cls.arith_ops = expr._arith_ops_syms + expr._cmp_ops_syms
@@ -1570,7 +1570,7 @@ class TestOperationsPythonPython(TestOperationsNumExprPython):
 
     @classmethod
     def setup_class(cls):
-        super(TestOperationsPythonPython, cls).setup_class()
+        super().setup_class()
         cls.engine = cls.parser = 'python'
         cls.arith_ops = expr._arith_ops_syms + expr._cmp_ops_syms
         cls.arith_ops = filter(lambda x: x not in ('in', 'not in'),
@@ -1581,7 +1581,7 @@ class TestOperationsPythonPandas(TestOperationsNumExprPandas):
 
     @classmethod
     def setup_class(cls):
-        super(TestOperationsPythonPandas, cls).setup_class()
+        super().setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
         cls.arith_ops = expr._arith_ops_syms + expr._cmp_ops_syms
@@ -1708,7 +1708,7 @@ class TestMathPythonPandas(TestMathPythonPython):
 
     @classmethod
     def setup_class(cls):
-        super(TestMathPythonPandas, cls).setup_class()
+        super().setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
 
@@ -1717,7 +1717,7 @@ class TestMathNumExprPandas(TestMathPythonPython):
 
     @classmethod
     def setup_class(cls):
-        super(TestMathNumExprPandas, cls).setup_class()
+        super().setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'pandas'
 
@@ -1726,7 +1726,7 @@ class TestMathNumExprPython(TestMathPythonPython):
 
     @classmethod
     def setup_class(cls):
-        super(TestMathNumExprPython, cls).setup_class()
+        super().setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'python'
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -694,7 +694,7 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
 
     @classmethod
     def setup_class(cls):
-        super(TestDataFrameQueryNumExprPython, cls).setup_class()
+        super().setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'python'
         cls.frame = TestData().frame
@@ -794,7 +794,7 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
 
     @classmethod
     def setup_class(cls):
-        super(TestDataFrameQueryPythonPandas, cls).setup_class()
+        super().setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
         cls.frame = TestData().frame
@@ -815,7 +815,7 @@ class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
 
     @classmethod
     def setup_class(cls):
-        super(TestDataFrameQueryPythonPython, cls).setup_class()
+        super().setup_class()
         cls.engine = cls.parser = 'python'
         cls.frame = TestData().frame
 

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -317,8 +317,7 @@ def get_calendar(name):
 class HolidayCalendarMetaClass(type):
 
     def __new__(cls, clsname, bases, attrs):
-        calendar_class = super(HolidayCalendarMetaClass, cls).__new__(
-            cls, clsname, bases, attrs)
+        calendar_class = super().__new__(cls, clsname, bases, attrs)
         register(calendar_class)
         return calendar_class
 


### PR DESCRIPTION
- [x] xref #25725 & #26177

Continuation from #26177. In addition to the uses of ``super`` dealt with in #26177, there were some more advanced uses of ``super`` in the code base, e.g. in classmethods and using ``super`` to jump to a specific point in the MRO-chain.

This PR specifically deals with:
* ``super(..., self)`` in pyx-files
* ``super(..., cls)`` in the whole code base
* Changes some specific uses of ``super``, se comments .