### PR TITLE
CLN: Remove unnecessary io function returns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1394,13 +1394,12 @@ class DataFrame(NDFrame):
         read_gbq : Read a DataFrame from Google BigQuery.
         """
         from pandas.io import gbq
-        return gbq.to_gbq(
-            self, destination_table, project_id=project_id,
-            chunksize=chunksize, reauth=reauth, if_exists=if_exists,
-            auth_local_webserver=auth_local_webserver,
-            table_schema=table_schema, location=location,
-            progress_bar=progress_bar, credentials=credentials,
-            verbose=verbose, private_key=private_key)
+        gbq.to_gbq(self, destination_table, project_id=project_id,
+                   chunksize=chunksize, reauth=reauth, if_exists=if_exists,
+                   auth_local_webserver=auth_local_webserver,
+                   table_schema=table_schema, location=location,
+                   progress_bar=progress_bar, credentials=credentials,
+                   verbose=verbose, private_key=private_key)
 
     @classmethod
     def from_records(cls, data, index=None, exclude=None, columns=None,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2403,7 +2403,7 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> os.remove('data.h5')
         """
         from pandas.io import pytables
-        return pytables.to_hdf(path_or_buf, key, self, **kwargs)
+        pytables.to_hdf(path_or_buf, key, self, **kwargs)
 
     def to_msgpack(self, path_or_buf=None, encoding='utf-8', **kwargs):
         """
@@ -2615,8 +2615,7 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> os.remove("./dummy.pkl")
         """
         from pandas.io.pickle import to_pickle
-        return to_pickle(self, path, compression=compression,
-                         protocol=protocol)
+        to_pickle(self, path, compression=compression, protocol=protocol)
 
     def to_clipboard(self, excel=True, sep=None, **kwargs):
         r"""

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -172,9 +172,9 @@ def to_gbq(dataframe, destination_table, project_id=None, chunksize=None,
            table_schema=None, location=None, progress_bar=True,
            credentials=None, verbose=None, private_key=None):
     pandas_gbq = _try_import()
-    return pandas_gbq.to_gbq(
-        dataframe, destination_table, project_id=project_id,
-        chunksize=chunksize, reauth=reauth, if_exists=if_exists,
-        auth_local_webserver=auth_local_webserver, table_schema=table_schema,
-        location=location, progress_bar=progress_bar,
-        credentials=credentials, verbose=verbose, private_key=private_key)
+    pandas_gbq.to_gbq(dataframe, destination_table, project_id=project_id,
+                      chunksize=chunksize, reauth=reauth, if_exists=if_exists,
+                      auth_local_webserver=auth_local_webserver,
+                      table_schema=table_schema, location=location,
+                      progress_bar=progress_bar, credentials=credentials,
+                      verbose=verbose, private_key=private_key)


### PR DESCRIPTION
These functions return a function either with empty return statement or doesn’t return. It causes docstring validation error with type RT01 (See #26234).

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
