### PR TITLE
Fix Memory Leak in to_json with Numeric Values

### DIFF
--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -128,10 +128,20 @@ class ToJSONMem:
 
     def setup_cache(self):
         df = DataFrame([[1]])
+        frames = {
+            'int': df,
+            'float': df.astype(float),
+        }
 
-        return df
+        return frames
 
-    def peakmem_numeric(self, df):
+    def peakmem_int(self, frames):
+        df = frames['int']
+        for _ in range(100_000):
+            df.to_json()
+
+    def peakmem_float(self, frames):
+        df = frames['float']
         for _ in range(100_000):
             df.to_json()
 

--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -124,4 +124,16 @@ class ToJSON(BaseIO):
         self.df_int_float_str.to_json(self.fname, orient='records', lines=True)
 
 
+class ToJSONMem:
+
+    def setup_cache(self):
+        df = DataFrame([[1]])
+
+        return df
+
+    def peakmem_numeric(self, df):
+        for _ in range(100_000):
+            df.to_json()
+
+
 from ..pandas_vb_common import setup  # noqa: F401

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -368,6 +368,7 @@ I/O
 - Improved the ``col_space`` parameter in :meth:`DataFrame.to_html` to accept a string so CSS length values can be set correctly (:issue:`25941`)
 - Fixed bug in loading objects from S3 that contain ``#`` characters in the URL (:issue:`25945`)
 - Adds ``use_bqstorage_api`` parameter to :func:`read_gbq` to speed up downloads of large data frames. This feature requires version 0.10.0 of the ``pandas-gbq`` library as well as the ``google-cloud-bigquery-storage`` and ``fastavro`` libraries. (:issue:`26104`)
+- Fixed memory leak in :meth:`DataFrame.to_json` when dealing with numeric data (:issue:`24889`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -709,7 +709,7 @@ int NpyArr_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
 
     NpyArr_freeItemValue(obj, tc);
 
-    if (PyArray_ISNUMBER(npyarr->array) || PyArray_ISDATETIME(npyarr->array))
+    if (PyArray_ISDATETIME(npyarr->array))
     {
         PRINTMARK();
         GET_TC(tc)->itemValue = obj;


### PR DESCRIPTION
- [X] closes #24889
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

It looks like the extension module is unnecessarily incrementing the reference count for numeric objects and never releasing it, which causes a leak in to_json.

Still trying to grok exactly what the purpose of npyCtxtPassthru (comment in same file mentions it is required when encoding multi-dimensional arrays).

Removing the check for PyArray_ISDATETIME caused segfaults but that doesn't appear to leak memory anyway so most likely intentional to increment that ref count.

ASV results:

```sh
       before           after         ratio
     [9feb3ad9]       [9bfd45d3]
     <master>         <json-mem-fix~1>
-           69.1M            57.7M     0.84  io.json.ToJSONMem.peakmem_float
-           69.1M            57.7M     0.83  io.json.ToJSONMem.peakmem_int

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```