### PR TITLE
ENH: clearer error msg for unequal categoricals in merge_asof (GH#26136)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -37,7 +37,7 @@ Other Enhancements
 - :class:`RangeIndex` has gained :attr:`~RangeIndex.start`, :attr:`~RangeIndex.stop`, and :attr:`~RangeIndex.step` attributes (:issue:`25710`)
 - :class:`datetime.timezone` objects are now supported as arguments to timezone methods and constructors (:issue:`25065`)
 - :meth:`DataFrame.query` and :meth:`DataFrame.eval` now supports quoting column names with backticks to refer to names with spaces (:issue:`6508`)
-- :func:`merge_asof` now gives a clearer error message when merge keys are categoricals that are not equal (:issue:`26136`)
+- :func:`merge_asof` now gives a more clear error message when merge keys are categoricals that are not equal (:issue:`26136`)
 
 .. _whatsnew_0250.api_breaking:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -37,6 +37,7 @@ Other Enhancements
 - :class:`RangeIndex` has gained :attr:`~RangeIndex.start`, :attr:`~RangeIndex.stop`, and :attr:`~RangeIndex.step` attributes (:issue:`25710`)
 - :class:`datetime.timezone` objects are now supported as arguments to timezone methods and constructors (:issue:`25065`)
 - :meth:`DataFrame.query` and :meth:`DataFrame.eval` now supports quoting column names with backticks to refer to names with spaces (:issue:`6508`)
+- :func:`merge_asof` now gives a clearer error message when merge keys are categoricals that are not equal (:issue:`26136`)
 
 .. _whatsnew_0250.api_breaking:
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1449,6 +1449,13 @@ class _AsOfMerge(_OrderedMerge):
                 if (is_categorical_dtype(lk.dtype) and
                         is_categorical_dtype(rk.dtype)):
                     # The generic error message is confusing for categoricals.
+                    #
+                    # In this function, the join keys include both the original
+                    # ones of the merge_asof() call, and also the keys passed
+                    # to its by= argument. Unordered but equal categories
+                    # are not supported for the former, but will fail
+                    # later with a ValueError, so we don't *need* to check
+                    # for them here.
                     msg = ("incompatible merge keys [{i}] both sides "
                            "category, but not equal ones"
                            .format(i=i))

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1443,16 +1443,8 @@ class _AsOfMerge(_OrderedMerge):
          right_join_keys,
          join_names) = super()._get_merge_keys()
 
-        # validate index types are the same & are not unordered categoricals
+        # validate index types are the same
         for i, (lk, rk) in enumerate(zip(left_join_keys, right_join_keys)):
-            # TODO Wrong place to put this. By the time we get here, the "by"
-            # keys (which *can* be unordered) have been added to the join keys.
-            if any(is_categorical_dtype(dtype) and not dtype.ordered for
-                   dtype in [lk, rk]):
-                raise MergeError("incompatible merge keys [{i}] unordered "
-                                 "category, must be ordered".format(i=i))
-
-
             if not is_dtype_equal(lk.dtype, rk.dtype):
                 if (is_categorical_dtype(lk.dtype) and
                         is_categorical_dtype(rk.dtype)):

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1443,8 +1443,16 @@ class _AsOfMerge(_OrderedMerge):
          right_join_keys,
          join_names) = super()._get_merge_keys()
 
-        # validate index types are the same
+        # validate index types are the same & are not unordered categoricals
         for i, (lk, rk) in enumerate(zip(left_join_keys, right_join_keys)):
+            # TODO Wrong place to put this. By the time we get here, the "by"
+            # keys (which *can* be unordered) have been added to the join keys.
+            if any(is_categorical_dtype(dtype) and not dtype.ordered for
+                   dtype in [lk, rk]):
+                raise MergeError("incompatible merge keys [{i}] unordered "
+                                 "category, must be ordered".format(i=i))
+
+
             if not is_dtype_equal(lk.dtype, rk.dtype):
                 if (is_categorical_dtype(lk.dtype) and
                         is_categorical_dtype(rk.dtype)):

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1446,10 +1446,18 @@ class _AsOfMerge(_OrderedMerge):
         # validate index types are the same
         for i, (lk, rk) in enumerate(zip(left_join_keys, right_join_keys)):
             if not is_dtype_equal(lk.dtype, rk.dtype):
-                raise MergeError("incompatible merge keys [{i}] {lkdtype} and "
-                                 "{rkdtype}, must be the same type"
-                                 .format(i=i, lkdtype=lk.dtype,
-                                         rkdtype=rk.dtype))
+                if (is_categorical_dtype(lk.dtype) and
+                        is_categorical_dtype(rk.dtype)):
+                    # The generic error message is confusing for categoricals.
+                    msg = ("incompatible merge keys [{i}] both sides "
+                           "category, but not equal ones"
+                           .format(i=i))
+                else:
+                    msg = ("incompatible merge keys [{i}] {lkdtype} and "
+                           "{rkdtype}, must be the same type"
+                           .format(i=i, lkdtype=lk.dtype,
+                                   rkdtype=rk.dtype))
+                raise MergeError(msg)
 
         # validate tolerance; must be a Timedelta if we have a DTI
         if self.tolerance is not None:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1456,14 +1456,15 @@ class _AsOfMerge(_OrderedMerge):
                     # are not supported for the former, but will fail
                     # later with a ValueError, so we don't *need* to check
                     # for them here.
-                    msg = ("incompatible merge keys [{i}] both sides "
-                           "category, but not equal ones"
-                           .format(i=i))
+                    msg = ("incompatible merge keys [{i}] {lkdtype} and "
+                           "{rkdtype}, both sides category, but not equal ones"
+                           .format(i=i, lkdtype=repr(lk.dtype),
+                                   rkdtype=repr(rk.dtype)))
                 else:
                     msg = ("incompatible merge keys [{i}] {lkdtype} and "
                            "{rkdtype}, must be the same type"
-                           .format(i=i, lkdtype=lk.dtype,
-                                   rkdtype=rk.dtype))
+                           .format(i=i, lkdtype=repr(lk.dtype),
+                                   rkdtype=repr(rk.dtype)))
                 raise MergeError(msg)
 
         # validate tolerance; must be a Timedelta if we have a DTI
@@ -1477,7 +1478,7 @@ class _AsOfMerge(_OrderedMerge):
             msg = ("incompatible tolerance {tolerance}, must be compat "
                    "with type {lkdtype}".format(
                        tolerance=type(self.tolerance),
-                       lkdtype=lt.dtype))
+                       lkdtype=repr(lt.dtype)))
 
             if is_datetime64_dtype(lt) or is_datetime64tz_dtype(lt):
                 if not isinstance(self.tolerance, Timedelta):

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -1009,22 +1009,9 @@ class TestAsOfMerge:
         msg = r'merge keys \[0\] both sides category, but not equal ones'
 
         left = pd.DataFrame({'left_val': [1, 5, 10],
-                             'a': pd.Categorical(['a', 'b', 'c'],
-                                                 ordered=True)})
-        right = pd.DataFrame({'right_val': [1, 2, 3, 6, 7],
-                              'a': pd.Categorical(['a', 'X', 'c', 'X', 'b'],
-                                                  ordered=True)})
-
-        with pytest.raises(MergeError, match=msg):
-            merge_asof(left, right, on='a')
-
-    def test_merge_datatype_unordered_categorical_raises(self):
-        msg = r'merge keys \[0\] unordered category, must be ordered'
-
-        left = pd.DataFrame({'left_val': [1, 5, 10],
                              'a': pd.Categorical(['a', 'b', 'c'])})
         right = pd.DataFrame({'right_val': [1, 2, 3, 6, 7],
-                              'a': pd.Categorical(['a', 'c', 'b', 'a', 'b'])})
+                              'a': pd.Categorical(['a', 'X', 'c', 'X', 'b'])})
 
         with pytest.raises(MergeError, match=msg):
             merge_asof(left, right, on='a')

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -1006,6 +1006,18 @@ class TestAsOfMerge:
         with pytest.raises(MergeError, match=msg):
             merge_asof(left, right, on='a')
 
+    def test_merge_datatype_categorical_error(self):
+        """ Tests merge datatype mismatch error """
+        msg = r'merge keys \[0\] both sides category, but not equal ones'
+
+        left = pd.DataFrame({'left_val': [1, 5, 10],
+                             'a': pd.Categorical(['a', 'b', 'c'])})
+        right = pd.DataFrame({'right_val': [1, 2, 3, 6, 7],
+                              'a': pd.Categorical(['a', 'X', 'c', 'X', 'b'])})
+
+        with pytest.raises(MergeError, match=msg):
+            merge_asof(left, right, on='a')
+
     @pytest.mark.parametrize('func', [lambda x: x, lambda x: to_datetime(x)],
                              ids=['numeric', 'datetime'])
     @pytest.mark.parametrize('side', ['left', 'right'])

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -994,8 +994,7 @@ class TestAsOfMerge:
 
         assert_frame_equal(result, expected)
 
-    def test_merge_datatype_error(self):
-        """ Tests merge datatype mismatch error """
+    def test_merge_datatype_error_raises(self):
         msg = r'merge keys \[0\] object and int64, must be the same type'
 
         left = pd.DataFrame({'left_val': [1, 5, 10],
@@ -1006,8 +1005,7 @@ class TestAsOfMerge:
         with pytest.raises(MergeError, match=msg):
             merge_asof(left, right, on='a')
 
-    def test_merge_datatype_categorical_error(self):
-        """ Tests merge datatype mismatch error """
+    def test_merge_datatype_categorical_error_raises(self):
         msg = r'merge keys \[0\] both sides category, but not equal ones'
 
         left = pd.DataFrame({'left_val': [1, 5, 10],

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -995,7 +995,7 @@ class TestAsOfMerge:
         assert_frame_equal(result, expected)
 
     def test_merge_datatype_error_raises(self):
-        msg = r'merge keys \[0\] object and int64, must be the same type'
+        msg = r'incompatible merge keys \[0\] .*, must be the same type'
 
         left = pd.DataFrame({'left_val': [1, 5, 10],
                              'a': ['a', 'b', 'c']})
@@ -1006,7 +1006,8 @@ class TestAsOfMerge:
             merge_asof(left, right, on='a')
 
     def test_merge_datatype_categorical_error_raises(self):
-        msg = r'merge keys \[0\] both sides category, but not equal ones'
+        msg = (r'incompatible merge keys \[0\] .* both sides category, '
+               'but not equal ones')
 
         left = pd.DataFrame({'left_val': [1, 5, 10],
                              'a': pd.Categorical(['a', 'b', 'c'])})

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -1009,9 +1009,22 @@ class TestAsOfMerge:
         msg = r'merge keys \[0\] both sides category, but not equal ones'
 
         left = pd.DataFrame({'left_val': [1, 5, 10],
+                             'a': pd.Categorical(['a', 'b', 'c'],
+                                                 ordered=True)})
+        right = pd.DataFrame({'right_val': [1, 2, 3, 6, 7],
+                              'a': pd.Categorical(['a', 'X', 'c', 'X', 'b'],
+                                                  ordered=True)})
+
+        with pytest.raises(MergeError, match=msg):
+            merge_asof(left, right, on='a')
+
+    def test_merge_datatype_unordered_categorical_raises(self):
+        msg = r'merge keys \[0\] unordered category, must be ordered'
+
+        left = pd.DataFrame({'left_val': [1, 5, 10],
                              'a': pd.Categorical(['a', 'b', 'c'])})
         right = pd.DataFrame({'right_val': [1, 2, 3, 6, 7],
-                              'a': pd.Categorical(['a', 'X', 'c', 'X', 'b'])})
+                              'a': pd.Categorical(['a', 'c', 'b', 'a', 'b'])})
 
         with pytest.raises(MergeError, match=msg):
             merge_asof(left, right, on='a')


### PR DESCRIPTION
- [x] closes #26136 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
