### PR TITLE
TST: make test_astype_categorical_to_other deterministic

### DIFF
--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -268,7 +268,8 @@ class TestSeriesDtypes:
 
     def test_astype_categorical_to_other(self):
 
-        df = DataFrame({'value': np.random.randint(0, 10000, 100)})
+        value = np.random.RandomState(0).randint(0, 10000, 100)
+        df = DataFrame({'value': value})
         labels = ["{0} - {1}".format(i, i + 499) for i in range(0, 10000, 500)]
         cat_labels = Categorical(labels, labels)
 


### PR DESCRIPTION
The use of an unseeded random number generator means that this test can
occasionally fail for no particular reason.

In particular, I saw the following error:
```
=================================== FAILURES ===================================
______________ TestSeriesDtypes.test_astype_categorical_to_other _______________

self = <pandas.tests.series.test_dtypes.TestSeriesDtypes object at 0x7f223951b750>

    def test_astype_categorical_to_other(self):

        df = DataFrame({'value': np.random.randint(0, 10000, 100)})
        labels = ["{0} - {1}".format(i, i + 499) for i in range(0, 10000, 500)]
        cat_labels = Categorical(labels, labels)

        df = df.sort_values(by=['value'], ascending=True)
        df['value_group'] = pd.cut(df.value, range(0, 10500, 500),
                                   right=False, labels=cat_labels)

        s = df['value_group']
        expected = s
        tm.assert_series_equal(s.astype('category'), expected)
        tm.assert_series_equal(s.astype(CategoricalDtype()), expected)
        msg = (r"could not convert string to float: '(0 - 499|9500 - 9999)'|"
               r"invalid literal for float\(\): (0 - 499|9500 - 9999)")
        with pytest.raises(ValueError, match=msg):
>           s.astype('float64')
E           AssertionError: Pattern 'could not convert string to float: '(0 - 499|9500 - 9999)'|invalid literal for float\(\): (0 - 499|9500 - 9999)' not found in 'invalid literal for float(): 9000 - 9499'
```
By setting the random number seed, this should no longer be able to happen.

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
