### PR TITLE
DOC removed unnecessary use of parameter in example rename function call

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4005,7 +4005,7 @@ class DataFrame(NDFrame):
 
         Rename rows using a mapping:
         >>> df = pd.DataFrame(data={"A": [1, 2, 3], "B": [4, 5, 6]},
-                              index=["X", "Y", "Z"])
+        ...                   index=["X", "Y", "Z"])
         >>> df.rename(index={"X": "x", "Y": "y", "Z": "z"})
            A  B
         x  1  4

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4004,16 +4004,13 @@ class DataFrame(NDFrame):
         2  3  6
 
         Rename rows using a mapping:
-        >>> df = pd.DataFrame(data={"A": [1, 2, 3], "B": [4, 5, 6]},
-        ...                   index=["X", "Y", "Z"])
-        >>> df.rename(index={"X": "x", "Y": "y", "Z": "z"})
+        >>> df.rename(index={0: "x", 1: "y", 2: "z"})
            A  B
         x  1  4
         y  2  5
         z  3  6
 
         Cast index labels to a different type:
-        >>> df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         >>> df.index
         RangeIndex(start=0, stop=3, step=1)
         >>> df.rename(index=str).index

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4004,7 +4004,8 @@ class DataFrame(NDFrame):
         2  3  6
 
         Rename rows using a mapping:
-        >>> df = pd.DataFrame(data={"A": [1, 2, 3], "B": [4, 5, 6]}, index=["X", "Y", "Z"])
+        >>> df = pd.DataFrame(data={"A": [1, 2, 3], "B": [4, 5, 6]},
+                              index=["X", "Y", "Z"])
         >>> df.rename(index={"X": "x", "Y": "y", "Z": "z"})
            A  B
         x  1  4

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4003,7 +4003,7 @@ class DataFrame(NDFrame):
         1  2  5
         2  3  6
 
-        Rename rows using a mapping:
+        Rename index using a mapping:
         >>> df.rename(index={0: "x", 1: "y", 2: "z"})
            A  B
         x  1  4

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3995,12 +3995,28 @@ class DataFrame(NDFrame):
         We *highly* recommend using keyword arguments to clarify your
         intent.
 
+        Rename columns using a mapping:
         >>> df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         >>> df.rename(columns={"A": "a", "B": "c"})
            a  c
         0  1  4
         1  2  5
         2  3  6
+
+        Rename rows using a mapping:
+        >>> df = pd.DataFrame(data={"A": [1, 2, 3], "B": [4, 5, 6]}, index=["X", "Y", "Z"])
+        >>> df.rename(index={"X": "x", "Y": "y", "Z": "z"})
+           A  B
+        x  1  4
+        y  2  5
+        z  3  6
+
+        Cast index labels to a different type:
+        >>> df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        >>> df.index
+        RangeIndex(start=0, stop=3, step=1)
+        >>> df.rename(index=str).index
+        Index(['0', '1', '2'], dtype='object')
 
         >>> df.rename(columns={"A": "a", "C": "c"})
            a  B

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4016,13 +4016,7 @@ class DataFrame(NDFrame):
         >>> df.rename(index=str).index
         Index(['0', '1', '2'], dtype='object')
 
-        >>> df.rename(columns={"A": "a", "C": "c"})
-           a  B
-        0  1  4
-        1  2  5
-        2  3  6
-
-        >>> df.rename(columns={"A": "a", "C": "c"}, errors="raise")
+        >>> df.rename(columns={"A": "a", "B": "b", "C": "c"}, errors="raise")
         Traceback (most recent call last):
         KeyError: ['C'] not found in axis
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3996,19 +3996,19 @@ class DataFrame(NDFrame):
         intent.
 
         >>> df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        >>> df.rename(index=str, columns={"A": "a", "B": "c"})
+        >>> df.rename(columns={"A": "a", "B": "c"})
            a  c
         0  1  4
         1  2  5
         2  3  6
 
-        >>> df.rename(index=str, columns={"A": "a", "C": "c"})
+        >>> df.rename(columns={"A": "a", "C": "c"})
            a  B
         0  1  4
         1  2  5
         2  3  6
 
-        >>> df.rename(index=str, columns={"A": "a", "C": "c"}, errors="raise")
+        >>> df.rename(columns={"A": "a", "C": "c"}, errors="raise")
         Traceback (most recent call last):
         KeyError: ['C'] not found in axis
 


### PR DESCRIPTION
removed unnecessary (and misleading) use of index parameter in docstring example function call of rename function

xref #26248 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
