### PR TITLE
DOC: Add regex example in str.split docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2255,7 +2255,7 @@ class StringMethods(NoNewAttributesMixin):
                             name=self._orig.name)
         return result
 
-    _shared_docs['str_split'] = ("""
+    _shared_docs['str_split'] = (r"""
     Split strings around given separator/delimiter.
 
     Splits the string in the Series/Index from the %(side)s,
@@ -2370,6 +2370,15 @@ class StringMethods(NoNewAttributesMixin):
     0          this is a regular sentence        None
     1  https://docs.python.org/3/tutorial  index.html
     2                                 NaN         NaN
+
+    Remember to escape special characters when explicitly using regular
+    expressions.
+
+    >>> s = pd.Series(["1+1=2"])
+
+    >>> s.str.split(r"\+|=", expand=True)
+         0    1    2
+    0    1    1    2
     """)
 
     @Appender(_shared_docs['str_split'] % {


### PR DESCRIPTION
- [x] closes #25296
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Adding the regex example in the `str.split()` documentation to make people aware of the need to escape special characters when using regular expressions as the pattern.

Error from docstring validation already exists in master's HEAD with no modifications. No additional error was introduced by the new docstring content.
Output of docstring validation:
```
$ python scripts/validate_docstrings.py pandas.Series.str.split

################################################################################
##################### Docstring (pandas.Series.str.split)  #####################
################################################################################

Split strings around given separator/delimiter.

Splits the string in the Series/Index from the beginning,
at the specified delimiter string. Equivalent to :meth:`str.split`.

Parameters
----------
pat : str, optional
    String or regular expression to split on.
    If not specified, split on whitespace.
n : int, default -1 (all)
    Limit number of splits in output.
    ``None``, 0 and -1 will be interpreted as return all splits.
expand : bool, default False
    Expand the splitted strings into separate columns.

    * If ``True``, return DataFrame/MultiIndex expanding dimensionality.
    * If ``False``, return Series/Index, containing lists of strings.

Returns
-------
Series, Index, DataFrame or MultiIndex
    Type matches caller unless ``expand=True`` (see Notes).

See Also
--------
 Series.str.split : Split strings around given separator/delimiter.
 Series.str.rsplit : Splits string around given separator/delimiter,
 starting from the right.
 Series.str.join : Join lists contained as elements in the Series/Index
 with passed delimiter.
 str.split : Standard library version for split.
 str.rsplit : Standard library version for rsplit.

Notes
-----
The handling of the `n` keyword depends on the number of found splits:

- If found splits > `n`,  make first `n` splits only
- If found splits <= `n`, make all splits
- If for a certain row the number of found splits < `n`,
  append `None` for padding up to `n` if ``expand=True``

If using ``expand=True``, Series and Index callers return DataFrame and
MultiIndex objects, respectively.

Examples
--------
>>> s = pd.Series(["this is a regular sentence",
"https://docs.python.org/3/tutorial/index.html", np.nan])

In the default setting, the string is split by whitespace.

>>> s.str.split()
0                   [this, is, a, regular, sentence]
1    [https://docs.python.org/3/tutorial/index.html]
2                                                NaN
dtype: object

Without the `n` parameter, the outputs of `rsplit` and `split`
are identical.

>>> s.str.rsplit()
0                   [this, is, a, regular, sentence]
1    [https://docs.python.org/3/tutorial/index.html]
2                                                NaN
dtype: object

The `n` parameter can be used to limit the number of splits on the
delimiter. The outputs of `split` and `rsplit` are different.

>>> s.str.split(n=2)
0                     [this, is, a regular sentence]
1    [https://docs.python.org/3/tutorial/index.html]
2                                                NaN
dtype: object

>>> s.str.rsplit(n=2)
0                     [this is a, regular, sentence]
1    [https://docs.python.org/3/tutorial/index.html]
2                                                NaN
dtype: object

The `pat` parameter can be used to split by other characters.

>>> s.str.split(pat = "/")
0                         [this is a regular sentence]
1    [https:, , docs.python.org, 3, tutorial, index...
2                                                  NaN
dtype: object

When using ``expand=True``, the split elements will expand out into
separate columns. If NaN is present, it is propagated throughout
the columns during the split.

>>> s.str.split(expand=True)
                                               0     1     2        3
0                                           this    is     a  regular
1  https://docs.python.org/3/tutorial/index.html  None  None     None
2                                            NaN   NaN   NaN      NaN 
             4
0     sentence
1         None
2          NaN

For slightly more complex use cases like splitting the html document name
from a url, a combination of parameter settings can be used.

>>> s.str.rsplit("/", n=1, expand=True)
                                    0           1
0          this is a regular sentence        None
1  https://docs.python.org/3/tutorial  index.html
2                                 NaN         NaN

Remember to escape special characters when explicitly using regular
expressions.

>>> s = pd.Series(["1+1=2", np.nan])

>>> s.str.split("\+|=", expand=True)
     0    1    2
0    1    1    2
1  NaN  NaN  NaN

################################################################################
################################## Validation ##################################
################################################################################

3 Errors found:
	Examples do not pass tests
	flake8 error: E902 TokenError: EOF in multi-line statement
	flake8 error: E999 SyntaxError: invalid syntax

################################################################################
################################### Doctests ###################################
################################################################################

**********************************************************************
Line 50, in pandas.Series.str.split
Failed example:
    s = pd.Series(["this is a regular sentence",
Exception raised:
    Traceback (most recent call last):
      File "/home/evan/anaconda3/envs/pandas/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.Series.str.split[0]>", line 1
        s = pd.Series(["this is a regular sentence",
                                                   ^
    SyntaxError: unexpected EOF while parsing
**********************************************************************
Line 55, in pandas.Series.str.split
Failed example:
    s.str.split()
Exception raised:
    Traceback (most recent call last):
      File "/home/evan/anaconda3/envs/pandas/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.Series.str.split[1]>", line 1, in <module>
        s.str.split()
    NameError: name 's' is not defined
**********************************************************************
Line 64, in pandas.Series.str.split
Failed example:
    s.str.rsplit()
Exception raised:
    Traceback (most recent call last):
      File "/home/evan/anaconda3/envs/pandas/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.Series.str.split[2]>", line 1, in <module>
        s.str.rsplit()
    NameError: name 's' is not defined
**********************************************************************
Line 73, in pandas.Series.str.split
Failed example:
    s.str.split(n=2)
Exception raised:
    Traceback (most recent call last):
      File "/home/evan/anaconda3/envs/pandas/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.Series.str.split[3]>", line 1, in <module>
        s.str.split(n=2)
    NameError: name 's' is not defined
**********************************************************************
Line 79, in pandas.Series.str.split
Failed example:
    s.str.rsplit(n=2)
Exception raised:
    Traceback (most recent call last):
      File "/home/evan/anaconda3/envs/pandas/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.Series.str.split[4]>", line 1, in <module>
        s.str.rsplit(n=2)
    NameError: name 's' is not defined
**********************************************************************
Line 87, in pandas.Series.str.split
Failed example:
    s.str.split(pat = "/")
Exception raised:
    Traceback (most recent call last):
      File "/home/evan/anaconda3/envs/pandas/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.Series.str.split[5]>", line 1, in <module>
        s.str.split(pat = "/")
    NameError: name 's' is not defined
**********************************************************************
Line 97, in pandas.Series.str.split
Failed example:
    s.str.split(expand=True)
Exception raised:
    Traceback (most recent call last):
      File "/home/evan/anaconda3/envs/pandas/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.Series.str.split[6]>", line 1, in <module>
        s.str.split(expand=True)
    NameError: name 's' is not defined
**********************************************************************
Line 110, in pandas.Series.str.split
Failed example:
    s.str.rsplit("/", n=1, expand=True)
Exception raised:
    Traceback (most recent call last):
      File "/home/evan/anaconda3/envs/pandas/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.Series.str.split[7]>", line 1, in <module>
        s.str.rsplit("/", n=1, expand=True)
    NameError: name 's' is not defined
```