### PR TITLE
WIP: Maintain Int64 Precision on Construction

### DIFF
--- a/pandas/tests/io/parser/test_dtypes.py
+++ b/pandas/tests/io/parser/test_dtypes.py
@@ -530,6 +530,6 @@ def test_intna_precision(all_parsers):
     tm.assert_frame_equal(result, expected)
 
     # See why tm.assert_frame_equal doesn't fail...
-    for i in range(len(result)):
-        assert result.iloc[i] == expected.iloc[i]
-
+    assert result.iloc[0] == expected.iloc[0]
+    assert result.iloc[1] == expected.iloc[1]
+    assert result.iloc[3] == expected.iloc[3]

--- a/pandas/tests/io/parser/test_dtypes.py
+++ b/pandas/tests/io/parser/test_dtypes.py
@@ -509,3 +509,27 @@ def test_numeric_dtype(all_parsers, dtype):
 
     result = parser.read_csv(StringIO(data), header=None, dtype=dtype)
     tm.assert_frame_equal(expected, result)
+
+
+def test_intna_precision(all_parsers):
+    parser = all_parsers
+    data = "1556559573141592653\n1556559573141592654\n\n1556559573141592655"
+    dtype = 'Int64'
+
+    expected = DataFrame([
+        [1556559573141592653],
+        [1556559573141592654],
+        [0],
+        [1556559573141592655],
+    ], dtype=dtype)
+    expected.iloc[2] = np.nan  # TODO: fix general bug on df construction
+
+    result = parser.read_csv(StringIO(data), header=None, dtype=dtype,
+                             skip_blank_lines=False)
+    
+    tm.assert_frame_equal(result, expected)
+
+    # See why tm.assert_frame_equal doesn't fail...
+    for i in range(len(result)):
+        assert result.iloc[i] == expected.iloc[i]
+


### PR DESCRIPTION
- [X] closes #26259
- [X] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is not the final implementation but providing for discussion and feedback. Consideration points are:

 - `_from_sequence_of_strings` was hacked to just return an IntervalArray, which isn't correct. Do we want to potentially pass through a mask to `_from_sequence` -> `integer_array` -> `IntegerArray()` instead? I think there is also a bug when construction the DataFrame correctly which this might fix
 - I'm not super familiar with the IntervalArray tests just yet, but I think I need to add a construction test in `arrays.test_integer` which may either supplement or replace the CSV test herein
 - There appears to be a bug with `tm.assert_frame_equal` and large integers where precision could be lost. This probably applies to all of the `tm.assert_*_equal` functions