### PR TITLE
CLN: remove uses of compat.lrange, part I

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -15,7 +15,7 @@ import numpy as np
 from pandas._config import config
 
 from pandas._libs import Timestamp, iNaT, properties
-from pandas.compat import lrange, lzip, set_function_name, to_str
+from pandas.compat import lzip, set_function_name, to_str
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import (
@@ -1101,7 +1101,7 @@ class NDFrame(PandasObject, SelectionMixin):
         result = self if inplace else self.copy(deep=copy)
 
         # start in the axis order to eliminate too many copies
-        for axis in lrange(self._AXIS_LEN):
+        for axis in range(self._AXIS_LEN):
             v = axes.get(self._AXIS_NAMES[axis])
             if v is None:
                 continue
@@ -1294,7 +1294,7 @@ class NDFrame(PandasObject, SelectionMixin):
             # is specified
             result = self if inplace else self.copy(deep=copy)
 
-            for axis in lrange(self._AXIS_LEN):
+            for axis in range(self._AXIS_LEN):
                 v = axes.get(self._AXIS_NAMES[axis])
                 if v is sentinel:
                     continue

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -9,7 +9,7 @@ from pandas._config import get_option
 
 from pandas._libs import (
     Timestamp, algos as libalgos, index as libindex, lib, tslibs)
-from pandas.compat import lrange, lzip
+from pandas.compat import lzip
 from pandas.compat.numpy import function as nv
 from pandas.errors import PerformanceWarning, UnsortedIndexError
 from pandas.util._decorators import Appender, cache_readonly, deprecate_kwarg
@@ -1913,7 +1913,7 @@ class MultiIndex(Index):
                 if isinstance(loc, int):
                     inds.append(loc)
                 elif isinstance(loc, slice):
-                    inds.extend(lrange(loc.start, loc.stop))
+                    inds.extend(range(loc.start, loc.stop))
                 elif com.is_bool_indexer(loc):
                     if self.lexsort_depth == 0:
                         warnings.warn('dropping on a non-lexsorted multi-index'

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from pandas._libs import index as libindex, lib
 import pandas.compat as compat
-from pandas.compat import lrange
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, cache_readonly
 
@@ -292,7 +291,7 @@ class RangeIndex(Int64Index):
         return False
 
     def tolist(self):
-        return lrange(self._start, self._stop, self._step)
+        return list(range(self._start, self._stop, self._step))
 
     @Appender(_index_shared_docs['_shallow_copy'])
     def _shallow_copy(self, values=None, **kwargs):

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -9,7 +9,7 @@ import numpy.ma as ma
 
 from pandas._libs import lib
 from pandas._libs.tslibs import IncompatibleFrequency
-from pandas.compat import lmap, lrange, raise_with_traceback
+from pandas.compat import lmap, raise_with_traceback
 
 from pandas.core.dtypes.cast import (
     construct_1d_arraylike_from_scalar, construct_1d_ndarray_preserving_na,
@@ -339,7 +339,7 @@ def get_names_from_index(data):
     if not has_some_name:
         return ibase.default_index(len(data))
 
-    index = lrange(len(data))
+    index = list(range(len(data)))
     count = 0
     for i, s in enumerate(data):
         n = getattr(s, 'name', None)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -452,7 +452,7 @@ class _Concatenator:
                                      "to {length}".format(length=ndim - 1))
 
             # ufff...
-            indices = compat.lrange(ndim)
+            indices = list(range(ndim))
             indices.remove(self.axis)
 
             for i, ax in zip(indices, self.join_axes):

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from pandas.compat import lrange
 from pandas.util._decorators import Appender, Substitution
 
 from pandas.core.dtypes.cast import maybe_downcast_to_dtype
@@ -303,7 +302,7 @@ def _generate_marginal_results(table, data, values, rows, cols, aggfunc,
         row_margin = row_margin.stack()
 
         # slight hack
-        new_order = [len(cols)] + lrange(len(cols))
+        new_order = [len(cols)] + list(range(len(cols)))
         row_margin.index = row_margin.index.reorder_levels(new_order)
     else:
         row_margin = Series(np.nan, index=result.columns)

--- a/pandas/io/excel/_util.py
+++ b/pandas/io/excel/_util.py
@@ -1,7 +1,5 @@
 import warnings
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import is_integer, is_list_like
 
 _writers = {}
@@ -112,7 +110,7 @@ def _range2cols(areas):
     for rng in areas.split(","):
         if ":" in rng:
             rng = rng.split(":")
-            cols.extend(lrange(_excel2num(rng[0]), _excel2num(rng[1]) + 1))
+            cols.extend(range(_excel2num(rng[0]), _excel2num(rng[1]) + 1))
         else:
             cols.append(_excel2num(rng))
 
@@ -141,7 +139,7 @@ def _maybe_convert_usecols(usecols):
                        "deprecated. Please pass in a list of int from "
                        "0 to `usecols` inclusive instead."),
                       FutureWarning, stacklevel=2)
-        return lrange(usecols + 1)
+        return list(range(usecols + 1))
 
     if isinstance(usecols, str):
         return _range2cols(usecols)

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -9,7 +9,7 @@ import numbers
 import os
 import re
 
-from pandas.compat import lmap, lrange, raise_with_traceback
+from pandas.compat import lmap, raise_with_traceback
 from pandas.errors import AbstractMethodError, EmptyDataError
 
 from pandas.core.dtypes.common import is_list_like
@@ -101,7 +101,8 @@ def _get_skiprows(skiprows):
         A proper iterator to use to skip rows of a DataFrame.
     """
     if isinstance(skiprows, slice):
-        return lrange(skiprows.start or 0, skiprows.stop, skiprows.step or 1)
+        start, step = skiprows.start or 0, skiprows.step or 1
+        return list(range(start, skiprows.stop, step))
     elif isinstance(skiprows, numbers.Integral) or is_list_like(skiprows):
         return skiprows
     elif skiprows is None:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -18,7 +18,6 @@ from pandas._config import config, get_option
 
 from pandas._libs import lib, writers as libwriters
 from pandas._libs.tslibs import timezones
-from pandas.compat import lrange
 from pandas.errors import PerformanceWarning
 
 from pandas.core.dtypes.common import (
@@ -4101,7 +4100,7 @@ class AppendableTable(LegacyTable):
             # we must remove in reverse order!
             pg = groups.pop()
             for g in reversed(groups):
-                rows = sorted_series.take(lrange(g, pg))
+                rows = sorted_series.take(range(g, pg))
                 table.remove_rows(start=rows[rows.index[0]
                                              ], stop=rows[rows.index[-1]] + 1)
                 pg = g

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from pandas._libs.lib import infer_dtype
 from pandas._libs.writers import max_len_string_array
-from pandas.compat import lmap, lrange, lzip
+from pandas.compat import lmap, lzip
 from pandas.util._decorators import Appender, deprecate_kwarg
 
 from pandas.core.dtypes.common import (
@@ -874,7 +874,7 @@ class StataParser:
                     (65530, np.int8)
                 ]
             )
-        self.TYPE_MAP = lrange(251) + list('bhlfd')
+        self.TYPE_MAP = list(range(251)) + list('bhlfd')
         self.TYPE_MAP_XML = \
             dict(
                 [

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import DataFrame, Index, MultiIndex, Series, bdate_range, compat
+from pandas import DataFrame, Index, MultiIndex, Series, bdate_range
 from pandas.util import testing as tm
 
 
@@ -340,7 +340,7 @@ def test_apply_multikey_corner(tsframe):
 def test_apply_chunk_view():
     # Low level tinkering could be unsafe, make sure not
     df = DataFrame({'key': [1, 1, 1, 2, 2, 2, 3, 3, 3],
-                    'value': compat.lrange(9)})
+                    'value': range(9)})
 
     result = df.groupby('key', group_keys=False).apply(lambda x: x[:2])
     expected = df.take([0, 1, 3, 4, 6, 7])
@@ -350,7 +350,7 @@ def test_apply_chunk_view():
 def test_apply_no_name_column_conflict():
     df = DataFrame({'name': [1, 1, 1, 1, 1, 1, 2, 2, 2, 2],
                     'name2': [0, 0, 0, 1, 1, 1, 0, 0, 1, 1],
-                    'value': compat.lrange(10)[::-1]})
+                    'value': list(range(10))[::-1]})
 
     # it works! #2605
     grouped = df.groupby(['name', 'name2'])

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -350,7 +350,7 @@ def test_apply_chunk_view():
 def test_apply_no_name_column_conflict():
     df = DataFrame({'name': [1, 1, 1, 1, 1, 1, 2, 2, 2, 2],
                     'name2': [0, 0, 0, 1, 1, 1, 0, 0, 1, 1],
-                    'value': list(range(10))[::-1]})
+                    'value': range(9, -1, -1)})
 
     # it works! #2605
     grouped = df.groupby(['name', 'name2'])

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -6,7 +6,7 @@ from io import StringIO
 import numpy as np
 import pytest
 
-from pandas.compat import lmap, lrange, lzip
+from pandas.compat import lmap, lzip
 from pandas.errors import PerformanceWarning
 
 import pandas as pd
@@ -84,7 +84,7 @@ def test_groupby_nonobject_dtype(mframe, df_mixed_floats):
 
     # GH 3911, mixed frame non-conversion
     df = df_mixed_floats.copy()
-    df['value'] = lrange(len(df))
+    df['value'] = range(len(df))
 
     def max_value(group):
         return group.loc[group['value'].idxmax()]
@@ -249,11 +249,11 @@ def test_len():
 
 def test_basic_regression():
     # regression
-    T = [1.0 * x for x in lrange(1, 10) * 10][:1095]
-    result = Series(T, lrange(0, len(T)))
+    T = [1.0 * x for x in list(range(1, 10)) * 10][:1095]
+    result = Series(T)
 
     groupings = np.random.random((1100, ))
-    groupings = Series(groupings, lrange(0, len(groupings))) * 10.
+    groupings = Series(groupings) * 10.
 
     grouped = result.groupby(groupings)
     grouped.mean()
@@ -320,9 +320,9 @@ def test_indices_concatenation_order():
         else:
             return y
 
-    df = DataFrame({'a': [1, 2, 2, 2], 'b': lrange(4), 'c': lrange(5, 9)})
+    df = DataFrame({'a': [1, 2, 2, 2], 'b': range(4), 'c': range(5, 9)})
 
-    df2 = DataFrame({'a': [3, 2, 2, 2], 'b': lrange(4), 'c': lrange(5, 9)})
+    df2 = DataFrame({'a': [3, 2, 2, 2], 'b': range(4), 'c': range(5, 9)})
 
     # correct result
     result1 = df.groupby('a').apply(f1)
@@ -875,7 +875,7 @@ def test_mutate_groups():
         'cat1': ['a'] * 8 + ['b'] * 6,
         'cat2': ['c'] * 2 + ['d'] * 2 + ['e'] * 2 + ['f'] * 2 + ['c'] * 2 +
         ['d'] * 2 + ['e'] * 2,
-        'cat3': lmap(lambda x: 'g%s' % x, lrange(1, 15)),
+        'cat3': lmap(lambda x: 'g%s' % x, range(1, 15)),
         'val': np.random.randint(100, size=14),
     })
 
@@ -1063,8 +1063,8 @@ def test_groupby_mixed_type_columns():
 def test_cython_grouper_series_bug_noncontig():
     arr = np.empty((100, 100))
     arr.fill(np.nan)
-    obj = Series(arr[:, 0], index=lrange(100))
-    inds = np.tile(lrange(10), 10)
+    obj = Series(arr[:, 0])
+    inds = np.tile(range(10), 10)
 
     result = obj.groupby(inds).agg(Series.median)
     assert result.isna().all()
@@ -1086,7 +1086,7 @@ def test_series_grouper_noncontig_index():
 
 def test_convert_objects_leave_decimal_alone():
 
-    s = Series(lrange(5))
+    s = Series(range(5))
     labels = np.array(['a', 'b', 'c', 'd', 'e'], dtype='O')
 
     def convert_fast(x):
@@ -1217,7 +1217,7 @@ def test_groupby_nat_exclude():
 
 
 def test_groupby_2d_malformed():
-    d = DataFrame(index=lrange(2))
+    d = DataFrame(index=range(2))
     d['group'] = ['g1', 'g2']
     d['zeros'] = [0, 0]
     d['ones'] = [1, 1]

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -249,11 +249,10 @@ def test_len():
 
 def test_basic_regression():
     # regression
-    T = [1.0 * x for x in list(range(1, 10)) * 10][:1095]
-    result = Series(T)
+    result = Series([1.0 * x for x in list(range(1, 10)) * 10])
 
-    groupings = np.random.random((1100, ))
-    groupings = Series(groupings) * 10.
+    data = np.random.random(1100) * 10.
+    groupings = Series(data)
 
     grouped = result.groupby(groupings)
     grouped.mean()

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -3,8 +3,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import (
     CategoricalIndex, DataFrame, Index, MultiIndex, Series, Timestamp,
@@ -481,7 +479,7 @@ class TestGrouping():
     def test_groupby_level_index_names(self):
         # GH4014 this used to raise ValueError since 'exp'>1 (in py2)
         df = DataFrame({'exp': ['A'] * 3 + ['B'] * 3,
-                        'var1': lrange(6), }).set_index('exp')
+                        'var1': range(6), }).set_index('exp')
         df.groupby(level='exp')
         msg = "level name foo is not the name of the index"
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, Timestamp, isna
 from pandas.util.testing import (
@@ -84,9 +82,9 @@ def test_first_last_nth_dtypes(df_mixed_floats):
     assert_frame_equal(nth, expected)
 
     # GH 2763, first/last shifting dtypes
-    idx = lrange(10)
+    idx = list(range(10))
     idx.append(9)
-    s = Series(data=lrange(11), index=idx, name='IntCol')
+    s = Series(data=range(11), index=idx, name='IntCol')
     assert s.dtype == 'int64'
     f = s.groupby(level=0).first()
     assert f.dtype == 'int64'

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 from pandas.errors import PerformanceWarning, UnsortedIndexError
 
 import pandas as pd
@@ -97,7 +96,7 @@ def test_unsortedindex():
     mi = pd.MultiIndex.from_tuples([('z', 'a'), ('x', 'a'), ('y', 'b'),
                                     ('x', 'b'), ('y', 'a'), ('z', 'b')],
                                    names=['one', 'two'])
-    df = pd.DataFrame([[i, 10 * i] for i in lrange(6)], index=mi,
+    df = pd.DataFrame([[i, 10 * i] for i in range(6)], index=mi,
                       columns=['one', 'two'])
 
     # GH 16734: not sorted, but no real slicing

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -9,7 +9,7 @@ from numpy.random import randn
 import pytest
 import pytz
 
-from pandas.compat import lrange, lzip
+from pandas.compat import lzip
 
 from pandas.core.dtypes.common import is_float_dtype, is_integer_dtype
 
@@ -127,8 +127,8 @@ class TestMultiLevel(Base):
         multi = Series(1., index=[['a', 'a', 'b', 'b'], ['x', 'y', 'x', 'y']])
         assert isinstance(multi.index, MultiIndex)
 
-        multi = Series(lrange(4), index=[['a', 'a', 'b', 'b'],
-                                         ['x', 'y', 'x', 'y']])
+        multi = Series(range(4), index=[['a', 'a', 'b', 'b'],
+                                        ['x', 'y', 'x', 'y']])
         assert isinstance(multi.index, MultiIndex)
 
     def test_reindex_level(self):
@@ -1317,7 +1317,7 @@ Thur,Lunch,Yes,51.51,17"""
         index = MultiIndex.from_tuples([(0, 0), (1, 1)],
                                        names=['\u0394', 'i1'])
 
-        s = Series(lrange(2), index=index)
+        s = Series(range(2), index=index)
         df = DataFrame(np.random.randn(2, 4), index=index)
         repr(s)
         repr(df)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -22,7 +22,7 @@ from pandas._config.localization import (  # noqa:F401
     can_set_locale, get_locales, set_locale)
 
 from pandas._libs import testing as _testing
-from pandas.compat import lmap, lrange, lzip, raise_with_traceback
+from pandas.compat import lmap, lzip, raise_with_traceback
 
 from pandas.core.dtypes.common import (
     is_bool, is_categorical_dtype, is_datetime64_dtype, is_datetime64tz_dtype,
@@ -364,7 +364,7 @@ def randbool(size=(), p=0.5):
 
 RANDS_CHARS = np.array(list(string.ascii_letters + string.digits),
                        dtype=(np.str_, 1))
-RANDU_CHARS = np.array(list("".join(map(chr, lrange(1488, 1488 + 26))) +
+RANDU_CHARS = np.array(list("".join(map(chr, range(1488, 1488 + 26))) +
                             string.digits), dtype=(np.unicode_, 1))
 
 
@@ -1592,11 +1592,11 @@ def makeBoolIndex(k=10, name=None):
 
 
 def makeIntIndex(k=10, name=None):
-    return Index(lrange(k), name=name)
+    return Index(list(range(k)), name=name)
 
 
 def makeUIntIndex(k=10, name=None):
-    return Index([2**63 + i for i in lrange(k)], name=name)
+    return Index([2**63 + i for i in range(k)], name=name)
 
 
 def makeRangeIndex(k=10, name=None, **kwargs):


### PR DESCRIPTION
- [ ] xref #25725

This PR starts the removal of ``compat.lrange`` from the code base. This removal requires some attention, as in most cases a plain ``range(...)`` should be used, but in some cases a ``list(range(...))`` needs to be used.

``lrange`` is used quite a lot, so there will be 1 or 2 more PRs, before this is removal is completed.