### PR TITLE
BUG: Fix #26210: MultiIndex Sorting with NaNs

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -564,6 +564,9 @@ def invalidate_string_dtypes(dtype_set):
 
 def coerce_indexer_dtype(indexer, categories):
     """ coerce the indexer input array to the smallest dtype possible """
+    indexer = np.array(indexer)
+    if not is_integer_dtype(indexer) and len(indexer):
+        raise TypeError("Categorical indexer must be of integer type")
     length = len(categories)
     if length < _int8_max:
         return ensure_int8(indexer)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -563,8 +563,11 @@ def invalidate_string_dtypes(dtype_set):
 
 
 def coerce_indexer_dtype(indexer, categories):
-    """ coerce the indexer input array to the smallest dtype possible """
-    indexer = np.array(indexer)
+    """Coerce the indexer input array to the smallest dtype possible.
+       If `indexer` is not equal to an array of integers
+       then a TypeError is raised.
+    """
+    indexer = np.asarray(indexer)
     if not is_integer_dtype(indexer) and len(indexer):
         raise TypeError("Categorical indexer must be of integer type")
     length = len(categories)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1707,7 +1707,7 @@ class MultiIndex(Index):
                 # ... and reassigned value -1:
                 code_mapping[uniques] = np.arange(len(uniques)) - has_na
 
-                level_codes = code_mapping[level_codes]
+                level_codes = code_mapping[level_codes].astype(int)
 
                 # new levels are simple
                 lev = lev.take(uniques[has_na:])

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1633,7 +1633,7 @@ class MultiIndex(Index):
                     # indexer to reorder the level codes
                     indexer = ensure_int64(indexer)
                     ri = lib.get_reverse_indexer(indexer, len(indexer))
-                    level_codes = algos.take_1d(ri, level_codes)
+                    level_codes = algos.take_1d(ri, level_codes, fill_value=-1)
 
             new_levels.append(lev)
             new_codes.append(level_codes)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1705,9 +1705,10 @@ class MultiIndex(Index):
                 # -1 (if present) is mapped to last position
                 code_mapping = np.zeros(len(lev) + has_na)
                 # ... and reassigned value -1:
-                code_mapping[uniques] = np.arange(len(uniques)) - has_na
+                code_mapping[uniques] = np.arange(len(uniques),
+                                                  dtype=int) - has_na
 
-                level_codes = code_mapping[level_codes].astype(int)
+                level_codes = code_mapping[level_codes]
 
                 # new levels are simple
                 lev = lev.take(uniques[has_na:])

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -107,6 +107,13 @@ def test_copy_in_constructor():
     assert mi.levels[0][0] == val
 
 
+def test_constructor_bad_codes():
+    levels = [['a', 'b'], [1, 2]]
+    codes = [[0, 0.5, 1], np.array([0, np.nan, -1])]
+    with pytest.raises(TypeError):
+        MultiIndex(levels=levels, codes=codes)
+
+
 # ----------------------------------------------------------------------------
 # from_arrays
 # ----------------------------------------------------------------------------

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -107,7 +107,8 @@ def test_copy_in_constructor():
     assert mi.levels[0][0] == val
 
 
-def test_constructor_bad_codes():
+def test_constructor_invalid_codes():
+    """GH # 26210"""
     levels = [['a', 'b'], [1, 2]]
     codes = [[0, 0.5, 1], np.array([0, np.nan, -1])]
     with pytest.raises(TypeError):

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -263,3 +263,27 @@ def test_argsort(idx):
     result = idx.argsort()
     expected = idx.values.argsort()
     tm.assert_numpy_array_equal(result, expected)
+
+
+def test_sort_levels_monotonic_with_negatives():
+    """GH # 26210"""
+    ix = MultiIndex(levels=[['B', 'A'], ['x']],
+                    codes=[[-1, 0, 1], [0, 0, 0]])
+    res = ix._sort_levels_monotonic()
+    expected = MultiIndex(levels=[['A', 'B'], ['x']],
+                          codes=[[-1, 1, 0], [0, 0, 0]])
+    tm.assert_index_equal(res, expected)
+
+
+@pytest.mark.parametrize('na_position', ['first', 'last'])
+def test_sort_index_with_nans(na_position):
+    """GH # 26210"""
+    ix = MultiIndex(levels=[['B', 'A'], ['x']],
+                    codes=[[-1, 0, 1], [0, 0, 0]])
+    s = pd.Series([1, 2, 3], ix)
+    sorted = s.sort_index(na_position=na_position)
+    if na_position == 'first':
+        expected = pd.Series([1, 3, 2], [[np.nan, 'A', 'B'], ['x', 'x', 'x']])
+    else:
+        expected = pd.Series([3, 2, 1], [['A', 'B', np.nan], ['x', 'x', 'x']])
+    tm.assert_series_equal(sorted, expected)

--- a/pandas/tests/indexing/multiindex/test_sorted.py
+++ b/pandas/tests/indexing/multiindex/test_sorted.py
@@ -91,23 +91,3 @@ class TestMultiIndexSorted:
         expected.index = expected.index.droplevel(0)
         tm.assert_series_equal(result, expected)
         tm.assert_series_equal(result2, expected)
-
-    def test_sort_levels_monotonic_with_negatives(self):
-        ix = MultiIndex(levels=[['B', 'A'], ['x']],
-                        codes=[[-1, 0, 1], [0, 0, 0]])
-        res = ix._sort_levels_monotonic()
-        expected = MultiIndex(levels=[['A', 'B'], ['x']],
-                              codes=[[-1, 1, 0], [0, 0, 0]])
-        tm.assert_index_equal(res, expected)
-
-    @pytest.mark.parametrize('na_position', ['first', 'last'])
-    def test_sort_index_with_nans(self, na_position):
-        ix = MultiIndex(levels=[['B', 'A'], ['x']],
-                        codes=[[-1, 0, 1], [0, 0, 0]])
-        s = Series([1, 2, 3], ix)
-        sorted = s.sort_index(na_position=na_position)
-        if na_position == 'first':
-            expected = Series([1, 3, 2], [[np.nan, 'A', 'B'], ['x', 'x', 'x']])
-        else:
-            expected = Series([3, 2, 1], [['A', 'B', np.nan], ['x', 'x', 'x']])
-        tm.assert_series_equal(sorted, expected)

--- a/pandas/tests/indexing/multiindex/test_sorted.py
+++ b/pandas/tests/indexing/multiindex/test_sorted.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from numpy.random import randn
 

--- a/pandas/tests/indexing/multiindex/test_sorted.py
+++ b/pandas/tests/indexing/multiindex/test_sorted.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from numpy.random import randn
 
@@ -90,3 +91,23 @@ class TestMultiIndexSorted:
         expected.index = expected.index.droplevel(0)
         tm.assert_series_equal(result, expected)
         tm.assert_series_equal(result2, expected)
+
+    def test_sort_levels_monotonic_with_negatives(self):
+        ix = MultiIndex(levels=[['B', 'A'], ['x']],
+                        codes=[[-1, 0, 1], [0, 0, 0]])
+        res = ix._sort_levels_monotonic()
+        expected = MultiIndex(levels=[['A', 'B'], ['x']],
+                              codes=[[-1, 1, 0], [0, 0, 0]])
+        tm.assert_index_equal(res, expected)
+
+    @pytest.mark.parametrize('na_position', ['first', 'last'])
+    def test_sort_index_with_nans(self, na_position):
+        ix = MultiIndex(levels=[['B', 'A'], ['x']],
+                        codes=[[-1, 0, 1], [0, 0, 0]])
+        s = Series([1, 2, 3], ix)
+        sorted = s.sort_index(na_position=na_position)
+        if na_position == 'first':
+            expected = Series([1, 3, 2], [[np.nan, 'A', 'B'], ['x', 'x', 'x']])
+        else:
+            expected = Series([3, 2, 1], [['A', 'B', np.nan], ['x', 'x', 'x']])
+        tm.assert_series_equal(sorted, expected)


### PR DESCRIPTION
- [x] closes #xxxx
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
