### PR TITLE
CLN: remove compat.lrange, part II

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -18,7 +18,7 @@ import pandas._libs.ops as libops
 import pandas._libs.parsers as parsers
 from pandas._libs.tslibs import parsing
 import pandas.compat as compat
-from pandas.compat import lrange, lzip
+from pandas.compat import lzip
 from pandas.errors import (
     AbstractMethodError, EmptyDataError, ParserError, ParserWarning)
 from pandas.util._decorators import Appender
@@ -1105,7 +1105,7 @@ class TextFileReader(BaseIterator):
         # c-engine, so only need for python parsers
         if engine != 'c':
             if is_integer(skiprows):
-                skiprows = lrange(skiprows)
+                skiprows = list(range(skiprows))
             if skiprows is None:
                 skiprows = set()
             elif not callable(skiprows):
@@ -1883,7 +1883,7 @@ class CParserWrapper(ParserBase):
                 self.names = ['{prefix}{i}'.format(prefix=self.prefix, i=i)
                               for i in range(self._reader.table_width)]
             else:
-                self.names = lrange(self._reader.table_width)
+                self.names = list(range(self._reader.table_width))
 
         # gh-9755
         #
@@ -1906,7 +1906,7 @@ class CParserWrapper(ParserBase):
             # GH 25623
             # validate that column indices in usecols are not out of bounds
             elif self.usecols_dtype == 'integer':
-                indices = lrange(self._reader.table_width)
+                indices = range(self._reader.table_width)
                 _validate_usecols_names(usecols, indices)
 
             if len(self.names) > len(usecols):
@@ -2607,7 +2607,7 @@ class PythonParser(ParserBase):
             # validate that column indices in usecols are not out of bounds
             if self.usecols_dtype == 'integer':
                 for col in columns:
-                    indices = lrange(len(col))
+                    indices = range(len(col))
                     _validate_usecols_names(self.usecols, indices)
 
             if names is not None:
@@ -2648,14 +2648,14 @@ class PythonParser(ParserBase):
             # GH 25623
             # validate that column indices in usecols are not out of bounds
             if self.usecols_dtype == 'integer':
-                _validate_usecols_names(self.usecols, lrange(ncols))
+                _validate_usecols_names(self.usecols, range(ncols))
 
             if not names:
                 if self.prefix:
                     columns = [['{prefix}{idx}'.format(
                         prefix=self.prefix, idx=i) for i in range(ncols)]]
                 else:
-                    columns = [lrange(ncols)]
+                    columns = [list(range(ncols))]
                 columns = self._handle_usecols(columns, columns[0])
             else:
                 if self.usecols is None or len(names) >= num_original_columns:
@@ -3007,7 +3007,7 @@ class PythonParser(ParserBase):
             if next_line is not None:
                 if len(next_line) == len(line) + self.num_original_columns:
                     # column and index names on diff rows
-                    self.index_col = lrange(len(line))
+                    self.index_col = list(range(len(line)))
                     self.buf = self.buf[1:]
 
                     for c in reversed(line):
@@ -3022,7 +3022,7 @@ class PythonParser(ParserBase):
             # Case 1
             self._implicit_index = True
             if self.index_col is None:
-                self.index_col = lrange(implicit_first_cols)
+                self.index_col = list(range(implicit_first_cols))
 
             index_name = None
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -4,7 +4,6 @@ import operator
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -460,8 +459,8 @@ class TestDataFrameQueryNumExprPandas:
 
     def test_query_syntax_error(self):
         engine, parser = self.engine, self.parser
-        df = DataFrame({"i": lrange(10), "+": lrange(3, 13),
-                        "r": lrange(4, 14)})
+        df = DataFrame({"i": range(10), "+": range(3, 13),
+                        "r": range(4, 14)})
         with pytest.raises(SyntaxError):
             df.query('i - +', engine=engine, parser=parser)
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import lmap, lrange
+from pandas.compat import lmap
 from pandas.errors import ParserError
 
 import pandas as pd
@@ -69,8 +69,8 @@ class TestDataFrameToCSV(TestData):
             assert_almost_equal(self.tsframe.values, recons.values)
 
             # corner case
-            dm = DataFrame({'s1': Series(lrange(3), lrange(3)),
-                            's2': Series(lrange(2), lrange(2))})
+            dm = DataFrame({'s1': Series(range(3), index=np.arange(3)),
+                            's2': Series(range(2), index=np.arange(2))})
             dm.to_csv(path)
 
             recons = self.read_csv(path)
@@ -259,8 +259,8 @@ class TestDataFrameToCSV(TestData):
             kwargs = dict(parse_dates=False)
             if cnlvl:
                 if rnlvl is not None:
-                    kwargs['index_col'] = lrange(rnlvl)
-                kwargs['header'] = lrange(cnlvl)
+                    kwargs['index_col'] = list(range(rnlvl))
+                kwargs['header'] = list(range(cnlvl))
 
                 with ensure_clean('__tmp_to_csv_moar__') as path:
                     df.to_csv(path, encoding='utf8',
@@ -392,7 +392,7 @@ class TestDataFrameToCSV(TestData):
             df.columns = cols
             _do_test(df, dupe_col=True)
 
-        _do_test(DataFrame(index=lrange(10)))
+        _do_test(DataFrame(index=np.arange(10)))
         _do_test(mkdf(chunksize // 2 + 1, 2, r_idx_nlevels=2), rnlvl=2)
         for ncols in [2, 3, 4]:
             base = int(chunksize // ncols)
@@ -617,7 +617,7 @@ class TestDataFrameToCSV(TestData):
             for i in [6, 7]:
                 msg = 'len of {i}, but only 5 lines in file'.format(i=i)
                 with pytest.raises(ParserError, match=msg):
-                    read_csv(path, header=lrange(i), index_col=0)
+                    read_csv(path, header=list(range(i)), index_col=0)
 
             # write with cols
             msg = 'cannot specify cols with a MultiIndex'
@@ -695,8 +695,9 @@ class TestDataFrameToCSV(TestData):
 
     def test_to_csv_dups_cols(self):
 
-        df = DataFrame(np.random.randn(1000, 30), columns=lrange(
-            15) + lrange(15), dtype='float64')
+        df = DataFrame(np.random.randn(1000, 30),
+                       columns=list(range(15)) + list(range(15)),
+                       dtype='float64')
 
         with ensure_clean() as filename:
             df.to_csv(filename)  # single dtype, fine
@@ -706,10 +707,10 @@ class TestDataFrameToCSV(TestData):
 
         df_float = DataFrame(np.random.randn(1000, 3), dtype='float64')
         df_int = DataFrame(np.random.randn(1000, 3), dtype='int64')
-        df_bool = DataFrame(True, index=df_float.index, columns=lrange(3))
-        df_object = DataFrame('foo', index=df_float.index, columns=lrange(3))
+        df_bool = DataFrame(True, index=df_float.index, columns=range(3))
+        df_object = DataFrame('foo', index=df_float.index, columns=range(3))
         df_dt = DataFrame(Timestamp('20010101'),
-                          index=df_float.index, columns=lrange(3))
+                          index=df_float.index, columns=range(3))
         df = pd.concat([df_float, df_int, df_bool, df_object,
                         df_dt], axis=1, ignore_index=True)
 
@@ -746,7 +747,7 @@ class TestDataFrameToCSV(TestData):
 
     def test_to_csv_chunking(self):
 
-        aa = DataFrame({'A': lrange(100000)})
+        aa = DataFrame({'A': range(100000)})
         aa['B'] = aa.A + 1.0
         aa['C'] = aa.A + 2.0
         aa['D'] = aa.A + 3.0

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -4,8 +4,6 @@ import dateutil
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import (
     DataFrame, DatetimeIndex, Index, Timestamp, date_range, offsets)
@@ -102,7 +100,7 @@ class TestDatetimeIndex:
         # GH#2658
         start = '2013-01-07'
         idx = date_range(start=start, freq="1d", periods=10, tz='US/Eastern')
-        df = DataFrame(lrange(10), index=idx)
+        df = DataFrame(np.arange(10), index=idx)
         df["2013-01-14 23:44:34.437768-05:00":]  # no exception here
 
     def test_append_join_nondatetimeindex(self):

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -5,8 +5,6 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, option_context
 from pandas.util import testing as tm
@@ -51,7 +49,7 @@ def biggie_df_fixture(request):
     if request.param == 'mixed':
         df = DataFrame({'A': np.random.randn(200),
                         'B': tm.makeStringIndex(200)},
-                       index=lrange(200))
+                       index=np.arange(200))
         df.loc[:20, 'A'] = np.nan
         df.loc[:20, 'B'] = np.nan
         return df
@@ -177,7 +175,7 @@ def test_to_html_multiindex_odd_even_truncate(max_rows, expected, datapath):
 @pytest.mark.parametrize('df,formatters,expected', [
     (DataFrame(
         [[0, 1], [2, 3], [4, 5], [6, 7]],
-        columns=['foo', None], index=lrange(4)),
+        columns=['foo', None], index=np.arange(4)),
      {'__index__': lambda x: 'abcd' [x]},
      'index_formatter'),
 
@@ -303,13 +301,13 @@ def test_to_html_columns_arg():
 
 @pytest.mark.parametrize('columns,justify,expected', [
     (MultiIndex.from_tuples(
-        list(zip(np.arange(2).repeat(2), np.mod(lrange(4), 2))),
+        list(zip(np.arange(2).repeat(2), np.mod(range(4), 2))),
         names=['CL0', 'CL1']),
      'left',
      'multiindex_1'),
 
     (MultiIndex.from_tuples(
-        list(zip(range(4), np.mod(lrange(4), 2)))),
+        list(zip(range(4), np.mod(range(4), 2)))),
      'right',
      'multiindex_2')
 ])

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import is_platform_32bit, lrange
+from pandas.compat import is_platform_32bit
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -647,7 +647,7 @@ class TestPandasContainer:
         _check_all_orients(self.ts)
 
         # dtype
-        s = Series(lrange(6), index=['a', 'b', 'c', 'd', 'e', 'f'])
+        s = Series(range(6), index=['a', 'b', 'c', 'd', 'e', 'f'])
         _check_all_orients(Series(s, dtype=np.float64), dtype=np.float64)
         _check_all_orients(Series(s, dtype=np.int), dtype=np.int)
 
@@ -677,8 +677,8 @@ class TestPandasContainer:
 
     def test_typ(self):
 
-        s = Series(lrange(6), index=['a', 'b', 'c',
-                                     'd', 'e', 'f'], dtype='int64')
+        s = Series(range(6), index=['a', 'b', 'c',
+                                    'd', 'e', 'f'], dtype='int64')
         result = read_json(s.to_json(), typ=None)
         assert_series_equal(result, s)
 
@@ -841,7 +841,7 @@ class TestPandasContainer:
     def test_doc_example(self):
         dfj2 = DataFrame(np.random.randn(5, 2), columns=list('AB'))
         dfj2['date'] = Timestamp('20130101')
-        dfj2['ints'] = lrange(5)
+        dfj2['ints'] = range(5)
         dfj2['bools'] = True
         dfj2.index = pd.date_range('20130101', periods=5)
 

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -10,8 +10,7 @@ from warnings import catch_warnings, simplefilter
 import numpy as np
 import pytest
 
-from pandas.compat import (
-    PY36, is_platform_little_endian, is_platform_windows, lrange)
+from pandas.compat import PY36, is_platform_little_endian, is_platform_windows
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import is_categorical_dtype
@@ -196,7 +195,7 @@ class TestHDFStore(Base):
             assert_frame_equal(o, roundtrip('frame', o))
 
             # table
-            df = DataFrame(dict(A=lrange(5), B=lrange(5)))
+            df = DataFrame(dict(A=range(5), B=range(5)))
             df.to_hdf(path, 'table', append=True)
             result = read_hdf(path, 'table', where=['index>2'])
             assert_frame_equal(df[df.index > 2], result)
@@ -370,7 +369,7 @@ class TestHDFStore(Base):
 
         with ensure_clean_store(self.path) as store:
 
-            df = DataFrame(dict(A=lrange(5), B=lrange(5)))
+            df = DataFrame(dict(A=range(5), B=range(5)))
             store.put("df", df)
 
             assert store.keys() == ["/df"]
@@ -3092,7 +3091,7 @@ class TestHDFStore(Base):
 
         # GH 3499, losing frequency info on index recreation
         df = DataFrame(dict(
-            A=Series(lrange(3),
+            A=Series(range(3),
                      index=date_range('2000-1-1', periods=3, freq='H'))))
 
         with ensure_clean_store(self.path) as store:
@@ -3110,7 +3109,7 @@ class TestHDFStore(Base):
             # try to append a table with a different frequency
             with catch_warnings(record=True):
                 df2 = DataFrame(dict(
-                    A=Series(lrange(3),
+                    A=Series(range(3),
                              index=date_range('2002-1-1',
                                               periods=3, freq='D'))))
                 store.append('data', df2)
@@ -3120,12 +3119,12 @@ class TestHDFStore(Base):
             # this is ok
             _maybe_remove(store, 'df2')
             df2 = DataFrame(dict(
-                A=Series(lrange(3),
+                A=Series(range(3),
                          index=[Timestamp('20010101'), Timestamp('20010102'),
                                 Timestamp('20020101')])))
             store.append('df2', df2)
             df3 = DataFrame(dict(
-                A=Series(lrange(3),
+                A=Series(range(3),
                          index=date_range('2002-1-1', periods=3,
                                           freq='D'))))
             store.append('df2', df3)
@@ -3139,19 +3138,19 @@ class TestHDFStore(Base):
             with catch_warnings(record=True):
 
                 df = DataFrame(dict(
-                    A=Series(lrange(3),
+                    A=Series(range(3),
                              index=date_range('2000-1-1',
                                               periods=3, freq='H'))))
                 df.to_hdf(path, 'data', mode='w', append=True)
                 df2 = DataFrame(dict(
-                    A=Series(lrange(3),
+                    A=Series(range(3),
                              index=date_range('2002-1-1', periods=3,
                                               freq='D'))))
                 df2.to_hdf(path, 'data', append=True)
 
                 idx = date_range('2000-1-1', periods=3, freq='H')
                 idx.name = 'foo'
-                df = DataFrame(dict(A=Series(lrange(3), index=idx)))
+                df = DataFrame(dict(A=Series(range(3), index=idx)))
                 df.to_hdf(path, 'data', mode='w', append=True)
 
             assert read_hdf(path, 'data').index.name == 'foo'
@@ -3160,7 +3159,7 @@ class TestHDFStore(Base):
 
                 idx2 = date_range('2001-1-1', periods=3, freq='H')
                 idx2.name = 'bar'
-                df2 = DataFrame(dict(A=Series(lrange(3), index=idx2)))
+                df2 = DataFrame(dict(A=Series(range(3), index=idx2)))
                 df2.to_hdf(path, 'data', append=True)
 
             assert read_hdf(path, 'data').index.name is None
@@ -3464,7 +3463,7 @@ class TestHDFStore(Base):
             # get coordinates back & test vs frame
             _maybe_remove(store, 'df')
 
-            df = DataFrame(dict(A=lrange(5), B=lrange(5)))
+            df = DataFrame(dict(A=range(5), B=range(5)))
             store.append('df', df)
             c = store.select_as_coordinates('df', ['index<3'])
             assert((c.values == np.arange(3)).all())
@@ -4950,7 +4949,7 @@ class TestTimezones(Base):
         with ensure_clean_store(self.path) as store:
 
             # GH 4098 example
-            df = DataFrame(dict(A=Series(lrange(3), index=date_range(
+            df = DataFrame(dict(A=Series(range(3), index=date_range(
                 '2000-1-1', periods=3, freq='H', tz=gettz('US/Eastern')))))
 
             _maybe_remove(store, 'df')
@@ -5018,7 +5017,7 @@ class TestTimezones(Base):
         with ensure_clean_store(self.path) as store:
 
             # GH 4098 example
-            df = DataFrame(dict(A=Series(lrange(3), index=date_range(
+            df = DataFrame(dict(A=Series(range(3), index=date_range(
                 '2000-1-1', periods=3, freq='H', tz='US/Eastern'))))
 
             _maybe_remove(store, 'df')

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -26,7 +26,7 @@ import warnings
 import numpy as np
 import pytest
 
-from pandas.compat import PY36, lrange
+from pandas.compat import PY36
 
 from pandas.core.dtypes.common import (
     is_datetime64_dtype, is_datetime64tz_dtype)
@@ -2348,12 +2348,13 @@ class TestXSQLite(SQLiteMixIn):
 
         frame['txt'] = ['a'] * len(frame)
         frame2 = frame.copy()
-        frame2['Idx'] = Index(lrange(len(frame2))) + 10
+        new_idx = Index(np.arange(len(frame2))) + 10
+        frame2['Idx'] = new_idx.copy()
         sql.to_sql(frame2, name='test_table2', con=self.conn, index=False)
         result = sql.read_sql("select * from test_table2", self.conn,
                               index_col='Idx')
         expected = frame.copy()
-        expected.index = Index(lrange(len(frame2))) + 10
+        expected.index = new_idx
         expected.index.name = 'Idx'
         tm.assert_frame_equal(expected, result)
 
@@ -2611,7 +2612,7 @@ class TestXMySQL(MySQLMixIn):
 
         frame['txt'] = ['a'] * len(frame)
         frame2 = frame.copy()
-        index = Index(lrange(len(frame2))) + 10
+        index = Index(np.arange(len(frame2))) + 10
         frame2['Idx'] = index
         drop_sql = "DROP TABLE IF EXISTS test_table2"
         cur = self.conn.cursor()

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -2,8 +2,6 @@ from datetime import datetime, timedelta
 
 import numpy as np
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import (
     Categorical, DataFrame, Index, Series, date_range, option_context,
@@ -23,7 +21,7 @@ class TestSeriesRepr(TestData):
                            codes=[[0, 0, 0, 1, 1, 2, 2, 3, 3, 3],
                                   [0, 1, 2, 0, 1, 1, 2, 0, 1, 2]],
                            names=['first', 'second'])
-        s = Series(lrange(0, len(index)), index=index, name='sth')
+        s = Series(range(len(index)), index=index, name='sth')
         expected = ["first  second", "foo    one       0",
                     "       two       1", "       three     2",
                     "bar    one       3", "       two       4",
@@ -44,7 +42,7 @@ class TestSeriesRepr(TestData):
         assert "Name:" not in repr(s)
 
         # Test big Series (diff code path).
-        s = Series(lrange(0, 1000))
+        s = Series(range(1000))
 
         s.name = "test"
         assert "Name: test" in repr(s)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -9,7 +9,6 @@ import pytest
 
 from pandas._libs import (
     algos as libalgos, groupby as libgroupby, hashtable as ht)
-from pandas.compat import lrange
 from pandas.compat.numpy import np_array_datetime64_compat
 import pandas.util._test_decorators as td
 
@@ -1565,7 +1564,7 @@ class TestTseriesUtil:
 
     def test_backfill(self):
         old = Index([1, 5, 10])
-        new = Index(lrange(12))
+        new = Index(list(range(12)))
 
         filler = libalgos.backfill["int64_t"](old.values, new.values)
 
@@ -1575,7 +1574,7 @@ class TestTseriesUtil:
 
         # corner case
         old = Index([1, 4])
-        new = Index(lrange(5, 10))
+        new = Index(list(range(5, 10)))
         filler = libalgos.backfill["int64_t"](old.values, new.values)
 
         expect_filler = np.array([-1, -1, -1, -1, -1], dtype=np.int64)
@@ -1583,7 +1582,7 @@ class TestTseriesUtil:
 
     def test_pad(self):
         old = Index([1, 5, 10])
-        new = Index(lrange(12))
+        new = Index(list(range(12)))
 
         filler = libalgos.pad["int64_t"](old.values, new.values)
 
@@ -1593,7 +1592,7 @@ class TestTseriesUtil:
 
         # corner case
         old = Index([5, 10])
-        new = Index(lrange(5))
+        new = Index(np.arange(5))
         filler = libalgos.pad["int64_t"](old.values, new.values)
         expect_filler = np.array([-1, -1, -1, -1, -1], dtype=np.int64)
         tm.assert_numpy_array_equal(filler, expect_filler)


### PR DESCRIPTION
- [ ] xref #25725 & #26281

Second part of the removal of ``compat.lrange`` from the code base.