### PR TITLE
DOC Fix inconsistencies

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1059,8 +1059,8 @@ class ExtensionScalarOpsMixin(ExtensionOpsMixin):
             `op` cannot be stored in the ExtensionArray. The dtype of the
             ndarray uses NumPy's normal inference rules.
 
-        Example
-        -------
+        Examples
+        --------
         Given an ExtensionArray subclass called MyExtensionArray, use
 
         >>> __add__ = cls._create_method(operator.add)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2127,8 +2127,8 @@ class Categorical(ExtensionArray, PandasObject):
         -------
         dict of categories -> indexers
 
-        Example
-        -------
+        Examples
+        --------
         In [1]: c = pd.Categorical(list('aabca'))
 
         In [2]: c

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2129,21 +2129,16 @@ class Categorical(ExtensionArray, PandasObject):
 
         Examples
         --------
-        In [1]: c = pd.Categorical(list('aabca'))
-
-        In [2]: c
-        Out[2]:
+        >>> c = pd.Categorical(list('aabca'))
+        >>> c
         [a, a, b, c, a]
         Categories (3, object): [a, b, c]
-
-        In [3]: c.categories
-        Out[3]: Index(['a', 'b', 'c'], dtype='object')
-
-        In [4]: c.codes
-        Out[4]: array([0, 0, 1, 2, 0], dtype=int8)
-
-        In [5]: c._reverse_indexer()
-        Out[5]: {'a': array([0, 1, 4]), 'b': array([2]), 'c': array([3])}
+        >>> c.categories
+        Index(['a', 'b', 'c'], dtype='object')
+        >>> c.codes
+        array([0, 0, 1, 2, 0], dtype=int8)
+        >>> c._reverse_indexer()
+        {'a': array([0, 1, 4]), 'b': array([2]), 'c': array([3])}
 
         """
         categories = self.categories

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -586,7 +586,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
         Return an iterator over the boxed values
 
         Yields
-        -------
+        ------
         tstamp : Timestamp
         """
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -93,7 +93,7 @@ cut : Bin values into discrete Intervals.
 qcut : Bin values into equal-sized Intervals based on rank or sample quantiles.
 
 Notes
-------
+-----
 See the `user guide
 <http://pandas.pydata.org/pandas-docs/stable/advanced.html#intervalindex>`_
 for more.

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1955,7 +1955,7 @@ class SparseAccessor(PandasDelegate):
         s : SparseSeries
 
         Examples
-        ---------
+        --------
         >>> from scipy import sparse
         >>> A = sparse.coo_matrix(([3.0, 1.0, 2.0], ([1, 0, 0], [0, 2, 3])),
                                shape=(3, 4))

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -763,7 +763,7 @@ def is_dtype_equal(source, target):
     target : The second dtype to compare
 
     Returns
-    ----------
+    -------
     boolean
         Whether or not the two dtypes are equal.
 
@@ -804,7 +804,7 @@ def is_dtype_union_equal(source, target):
     target : The second dtype to compare
 
     Returns
-    ----------
+    -------
     boolean
         Whether or not the two dtypes are equal.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -842,7 +842,7 @@ class DataFrame(NDFrame):
             tuples.
 
         Yields
-        -------
+        ------
         collections.namedtuple
             Yields a namedtuple for each row in the DataFrame with the first
             field possibly being the index and following fields being the
@@ -7252,7 +7252,7 @@ class DataFrame(NDFrame):
             Pairwise correlations.
 
         See Also
-        -------
+        --------
         DataFrame.corr
         """
         axis = self._get_axis_number(axis)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10291,11 +10291,11 @@ class NDFrame(PandasObject, SelectionMixin):
         Return index for %(position)s non-NA/null value.
 
         Returns
-        --------
+        -------
         scalar : type of index
 
         Notes
-        --------
+        -----
         If all elements are non-NA/null, returns None.
         Also returns None for empty %(klass)s.
         """

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -800,13 +800,13 @@ b  2""")
 
     def _transform_should_cast(self, func_nm):
         """
-        Parameters:
-        -----------
+        Parameters
+        ----------
         func_nm: str
             The name of the aggregation function being performed
 
-        Returns:
-        --------
+        Returns
+        -------
         bool
             Whether transform should attempt to cast the result of aggregation
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -183,7 +183,7 @@ class Index(IndexOpsMixin, PandasObject):
         When True, attempt to create a MultiIndex if possible
 
     See Also
-    ---------
+    --------
     RangeIndex : Index implementing a monotonic integer range.
     CategoricalIndex : Index of :class:`Categorical` s.
     MultiIndex : A multi-level, or hierarchical, Index.
@@ -2629,7 +2629,7 @@ class Index(IndexOpsMixin, PandasObject):
         loc : int if unique index, slice if monotonic index, else mask
 
         Examples
-        ---------
+        --------
         >>> unique_index = pd.Index(list('abc'))
         >>> unique_index.get_loc('b')
         1
@@ -4650,7 +4650,7 @@ class Index(IndexOpsMixin, PandasObject):
         This function assumes that the data is sorted, so use at your own peril
 
         Examples
-        ---------
+        --------
         This is a method on all index types. For example you can do:
 
         >>> idx = pd.Index(list('abcd'))
@@ -4848,7 +4848,7 @@ class Index(IndexOpsMixin, PandasObject):
         This method only works if the index is monotonic or unique.
 
         Examples
-        ---------
+        --------
         >>> idx = pd.Index(list('abcd'))
         >>> idx.slice_locs(start='b', end='c')
         (1, 3)

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -468,7 +468,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         KeyError : if the key is not in the index
 
         Examples
-        ---------
+        --------
         >>> unique_index = pd.CategoricalIndex(list('abc'))
         >>> unique_index.get_loc('b')
         1

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -204,14 +204,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     month_name
     day_name
 
-    Notes
-    -----
-    To learn more about the frequency strings, please see `this link
-    <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
-
-    Creating a DatetimeIndex based on `start`, `periods`, and `end` has
-    been deprecated in favor of :func:`date_range`.
-
     See Also
     --------
     Index : The base pandas Index type.
@@ -219,6 +211,14 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     PeriodIndex : Index of Period data.
     to_datetime : Convert argument to datetime.
     date_range : Create a fixed-frequency DatetimeIndex.
+
+    Notes
+    -----
+    To learn more about the frequency strings, please see `this link
+    <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
+
+    Creating a DatetimeIndex based on `start`, `periods`, and `end` has
+    been deprecated in favor of :func:`date_range`.
     """
     _typ = 'datetimeindex'
     _join_precedence = 10

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -213,7 +213,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     been deprecated in favor of :func:`date_range`.
 
     See Also
-    ---------
+    --------
     Index : The base pandas Index type.
     TimedeltaIndex : Index of timedelta64 data.
     PeriodIndex : Index of Period data.

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -729,7 +729,7 @@ class IntervalIndex(IntervalMixin, Index):
         loc : int if unique index, slice if monotonic index, else mask
 
         Examples
-        ---------
+        --------
         >>> i1, i2 = pd.Interval(0, 1), pd.Interval(1, 2)
         >>> index = pd.IntervalIndex([i1, i2])
         >>> index.get_loc(1)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -58,7 +58,7 @@ class MultiIndexUIntEngine(libindex.BaseMultiIndexCodesEngine,
             Combinations of integers (one per row)
 
         Returns
-        ------
+        -------
         int_keys : scalar or 1-dimensional array, of dtype uint64
             Integer(s) representing one combination (each).
         """
@@ -98,7 +98,7 @@ class MultiIndexPyIntEngine(libindex.BaseMultiIndexCodesEngine,
             Combinations of integers (one per row)
 
         Returns
-        ------
+        -------
         int_keys : int, or 1-dimensional array of dtype object
             Integer(s) representing one combination (each).
         """
@@ -181,7 +181,7 @@ class MultiIndex(Index):
     Index : The base pandas Index type.
 
     Examples
-    ---------
+    --------
     A new ``MultiIndex`` is typically constructed using one of the helper
     methods :meth:`MultiIndex.from_arrays`, :meth:`MultiIndex.from_product`
     and :meth:`MultiIndex.from_tuples`. For example (using ``.from_arrays``):
@@ -1399,7 +1399,7 @@ class MultiIndex(Index):
             a single :class:`Index` (or subclass thereof).
 
         Examples
-        ---------
+        --------
 
         Create a MultiIndex:
 
@@ -2361,7 +2361,7 @@ class MultiIndex(Index):
             boolean mask array, otherwise it is always a slice or int.
 
         Examples
-        ---------
+        --------
         >>> mi = pd.MultiIndex.from_arrays([list('abb'), list('def')])
 
         >>> mi.get_loc('b')
@@ -2371,7 +2371,7 @@ class MultiIndex(Index):
         1
 
         Notes
-        ------
+        -----
         The key cannot be a slice, list of same-level labels, a boolean mask,
         or a sequence of such. If you want to use those, use
         :meth:`MultiIndex.get_locs` instead.
@@ -2479,7 +2479,7 @@ class MultiIndex(Index):
         (1, None)
 
         See Also
-        ---------
+        --------
         MultiIndex.get_loc  : Get location for a label or a tuple of labels.
         MultiIndex.get_locs : Get location for a label/slice/list/mask or a
                               sequence of such.
@@ -2691,7 +2691,7 @@ class MultiIndex(Index):
         locs : array of integers suitable for passing to iloc
 
         Examples
-        ---------
+        --------
         >>> mi = pd.MultiIndex.from_arrays([list('abb'), list('def')])
 
         >>> mi.get_locs('b')

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -180,6 +180,11 @@ class MultiIndex(Index):
     MultiIndex.from_frame   : Make a MultiIndex from a DataFrame.
     Index : The base pandas Index type.
 
+    Notes
+    -----
+    See the `user guide
+    <http://pandas.pydata.org/pandas-docs/stable/advanced.html>`_ for more.
+
     Examples
     --------
     A new ``MultiIndex`` is typically constructed using one of the helper
@@ -194,11 +199,6 @@ class MultiIndex(Index):
 
     See further examples for how to construct a MultiIndex in the doc strings
     of the mentioned helper methods.
-
-    Notes
-    -----
-    See the `user guide
-    <http://pandas.pydata.org/pandas-docs/stable/advanced.html>`_ for more.
     """
 
     # initialize to zero-length tuples to make everything work
@@ -2360,6 +2360,20 @@ class MultiIndex(Index):
             If the key is past the lexsort depth, the return may be a
             boolean mask array, otherwise it is always a slice or int.
 
+        See Also
+        --------
+        Index.get_loc : The get_loc method for (single-level) index.
+        MultiIndex.slice_locs : Get slice location given start label(s) and
+                                end label(s).
+        MultiIndex.get_locs : Get location for a label/slice/list/mask or a
+                              sequence of such.
+
+        Notes
+        -----
+        The key cannot be a slice, list of same-level labels, a boolean mask,
+        or a sequence of such. If you want to use those, use
+        :meth:`MultiIndex.get_locs` instead.
+
         Examples
         --------
         >>> mi = pd.MultiIndex.from_arrays([list('abb'), list('def')])
@@ -2369,20 +2383,6 @@ class MultiIndex(Index):
 
         >>> mi.get_loc(('b', 'e'))
         1
-
-        Notes
-        -----
-        The key cannot be a slice, list of same-level labels, a boolean mask,
-        or a sequence of such. If you want to use those, use
-        :meth:`MultiIndex.get_locs` instead.
-
-        See Also
-        --------
-        Index.get_loc : The get_loc method for (single-level) index.
-        MultiIndex.slice_locs : Get slice location given start label(s) and
-                                end label(s).
-        MultiIndex.get_locs : Get location for a label/slice/list/mask or a
-                              sequence of such.
         """
         if method is not None:
             raise NotImplementedError('only the default get_loc method is '
@@ -2463,6 +2463,12 @@ class MultiIndex(Index):
               Element 1: The resulting sliced multiindex/index. If the key
               contains all levels, this will be ``None``.
 
+        See Also
+        --------
+        MultiIndex.get_loc  : Get location for a label or a tuple of labels.
+        MultiIndex.get_locs : Get location for a label/slice/list/mask or a
+                              sequence of such.
+
         Examples
         --------
         >>> mi = pd.MultiIndex.from_arrays([list('abb'), list('def')],
@@ -2477,12 +2483,6 @@ class MultiIndex(Index):
 
         >>> mi.get_loc_level(['b', 'e'])
         (1, None)
-
-        See Also
-        --------
-        MultiIndex.get_loc  : Get location for a label or a tuple of labels.
-        MultiIndex.get_locs : Get location for a label/slice/list/mask or a
-                              sequence of such.
         """
 
         def maybe_droplevels(indexer, levels, drop_level):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -144,6 +144,14 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
     strftime
     to_timestamp
 
+    See Also
+    --------
+    Index : The base pandas Index type.
+    Period : Represents a period of time.
+    DatetimeIndex : Index with datetime64 data.
+    TimedeltaIndex : Index of timedelta64 data.
+    period_range : Create a fixed-frequency PeriodIndex.
+
     Notes
     -----
     Creating a PeriodIndex based on `start`, `periods`, and `end` has
@@ -152,14 +160,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
     Examples
     --------
     >>> idx = pd.PeriodIndex(year=year_arr, quarter=q_arr)
-
-    See Also
-    --------
-    Index : The base pandas Index type.
-    Period : Represents a period of time.
-    DatetimeIndex : Index with datetime64 data.
-    TimedeltaIndex : Index of timedelta64 data.
-    period_range : Create a fixed-frequency PeriodIndex.
     """
     _typ = 'periodindex'
     _attributes = ['name', 'freq']

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -154,7 +154,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
     >>> idx = pd.PeriodIndex(year=year_arr, quarter=q_arr)
 
     See Also
-    ---------
+    --------
     Index : The base pandas Index type.
     Period : Represents a period of time.
     DatetimeIndex : Index with datetime64 data.

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -131,7 +131,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, dtl.TimelikeOps, Int64Index,
     to_frame
 
     See Also
-    ---------
+    --------
     Index : The base pandas Index type.
     Timedelta : Represents a duration between two dates or times.
     DatetimeIndex : Index of datetime64 data.

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -670,8 +670,8 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             a `pd.MultiIndex`, to avoid unnecessary broadcasting.
 
 
-        Returns:
-        --------
+        Returns
+        -------
         `np.array` of `ser` broadcast to the appropriate shape for assignment
         to the locations selected by `indexer`
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2367,12 +2367,12 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
         n : int, number of periods to diff
         axis : int, axis to diff upon. default 0
 
-        Return
-        ------
+        Returns
+        -------
         A list with a new TimeDeltaBlock.
 
-        Note
-        ----
+        Notes
+        -----
         The arguments here are mimicking shift so they are called correctly
         by apply.
         """

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2212,8 +2212,8 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
         """Input validation for values passed to __init__. Ensure that
         we have datetime64TZ, coercing if necessary.
 
-        Parametetrs
-        -----------
+        Parameters
+        ----------
         values : array-like
             Must be convertible to datetime64
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -861,7 +861,7 @@ def nanargmax(values, axis=None, skipna=True, mask=None):
         nan-mask if known
 
     Returns
-    --------
+    -------
     result : int
         The index of max value in specified axis or -1 in the NA case
 
@@ -891,7 +891,7 @@ def nanargmin(values, axis=None, skipna=True, mask=None):
         nan-mask if known
 
     Returns
-    --------
+    -------
     result : int
         The index of min value in specified axis or -1 in the NA case
 
@@ -1099,7 +1099,7 @@ def nanprod(values, axis=None, skipna=True, min_count=0, mask=None):
     6.0
 
     Returns
-    --------
+    -------
     The product of all elements on a given axis. ( NaNs are treated as 1)
     """
     mask = _maybe_get_mask(values, skipna, mask)

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -884,7 +884,7 @@ DataFrame.gt : Compare DataFrames for strictly greater than
     inequality elementwise.
 
 Notes
---------
+-----
 Mismatched indices will be unioned together.
 `NaN` values are considered different (i.e. `NaN` != `NaN`).
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1037,7 +1037,7 @@ def str_join(arr, sep):
         delimiter.
 
     Raises
-    -------
+    ------
     AttributeError
         If the supplied Series contains neither strings nor lists.
 

--- a/pandas/io/excel/_util.py
+++ b/pandas/io/excel/_util.py
@@ -185,7 +185,7 @@ def _fill_mi_header(row, control_row):
         different indexes.
 
     Returns
-    ----------
+    -------
     Returns changed row and control_row
     """
     last = row[0]

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1611,7 +1611,7 @@ def get_level_lengths(levels, sentinel=''):
         Value which states that no new index starts on there.
 
     Returns
-    ----------
+    -------
     Returns list of maps. For each level returns map of indexes (key is index
     in row and value is length of index).
     """

--- a/pandas/io/json/table_schema.py
+++ b/pandas/io/json/table_schema.py
@@ -131,7 +131,7 @@ def convert_json_field_to_pandas_type(field):
     dtype
 
     Raises
-    -----
+    ------
     ValueError
         If the type of the provided field is unknown or currently unsupported
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1727,8 +1727,8 @@ class ParserBase:
         try_num_bool : bool, default try
            try to cast values to numeric (first preference) or boolean
 
-        Returns:
-        --------
+        Returns
+        -------
         converted : ndarray
         na_count : int
         """

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3470,8 +3470,8 @@ class Table(Fixed):
         leagcy tables create an indexable column, indexable index,
         non-indexable fields
 
-            Parameters:
-            -----------
+            Parameters
+            ----------
             axes: a list of the axes in order to create (names or numbers of
                 the axes)
             obj : the object to create axes on

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -751,8 +751,8 @@ class HDFStore(StringMixin):
         key : object
         column: the column of interest
 
-        Exceptions
-        ----------
+        Raises
+        ------
         raises KeyError if the column is not found (or key is not a valid
             store)
         raises ValueError if the column can not be extracted individually (it
@@ -777,8 +777,8 @@ class HDFStore(StringMixin):
         iterator : boolean, return an iterator, default False
         chunksize : nrows to include in iteration, return an iterator
 
-        Exceptions
-        ----------
+        Raises
+        ------
         raises KeyError if keys or selector is not found or keys is empty
         raises TypeError if keys is not a list or tuple
         raises ValueError if the tables are not ALL THE SAME DIMENSIONS
@@ -890,8 +890,8 @@ class HDFStore(StringMixin):
         -------
         number of rows removed (or None if not a Table)
 
-        Exceptions
-        ----------
+        Raises
+        ------
         raises KeyError if key is not a valid store
 
         """
@@ -1059,8 +1059,8 @@ class HDFStore(StringMixin):
         ----------
         key : object (the node to index)
 
-        Exceptions
-        ----------
+        Raises
+        ------
         raises if the node is not a table
 
         """
@@ -3347,8 +3347,8 @@ class Table(Fixed):
         optlevel: optimization level (defaults to 6)
         kind    : kind of index (defaults to 'medium')
 
-        Exceptions
-        ----------
+        Raises
+        ------
         raises if the node is not a table
 
         """

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -597,7 +597,7 @@ class StataValueLabel:
     Parse a categorical column and prepare formatted output
 
     Parameters
-    -----------
+    ----------
     value : int8, int16, int32, float32 or float64
         The Stata missing value code
 
@@ -718,7 +718,7 @@ class StataMissingValue(StringMixin):
     An observation's missing value.
 
     Parameters
-    -----------
+    ----------
     value : int8, int16, int32, float32 or float64
         The Stata missing value code
 

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -597,15 +597,15 @@ def autocorrelation_plot(series, ax=None, **kwds):
     """
     Autocorrelation plot for time series.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     series: Time series
     ax: Matplotlib axis object, optional
     kwds : keywords
         Options to pass to matplotlib plotting method
 
-    Returns:
-    -----------
+    Returns
+    -------
     class:`matplotlib.axis.Axes`
     """
     import matplotlib.pyplot as plt


### PR DESCRIPTION
Fix a few inconsistencies in the docstrings.

Not sure how pandas community feels about these kinds of fixes (and this is my first PR to pandas). I just notice things that are different from how they occur most of the time and decided to fix them up. 

### Examples
#### Add 's' to headers
```
Example
```
to
```
Examples
```

#### Correct number of hyphens under headers
```
Yields
-------
```
to
```
Yields
------
```

#### Rewrite testcase in standard format
```
In [1]: c = pd.Categorical(list('aabca'))
```
to
```
>>> c = pd.Categorical(list('aabca'))
```


