### PR TITLE
CLN: remove compat.lrange, part 3

### DIFF
--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -16,7 +16,6 @@ import pytest
 import pytz
 
 from pandas._libs import iNaT, lib, missing as libmissing
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes import inference
@@ -1302,8 +1301,7 @@ def test_datetimeindex_from_empty_datetime64_array():
 def test_nan_to_nat_conversions():
 
     df = DataFrame(dict({
-        'A': np.asarray(
-            lrange(10), dtype='float64'),
+        'A': np.asarray(range(10), dtype='float64'),
         'B': Timestamp('20010101')
     }))
     df.iloc[3:6, :] = np.nan

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -4,8 +4,6 @@ import inspect
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import (
     is_categorical_dtype, is_interval_dtype, is_object_dtype)
 
@@ -1091,13 +1089,13 @@ class TestDataFrameAlterAxes():
         tm.assert_frame_equal(rs, xp)
 
         rs = df.reset_index('a', col_fill=None)
-        xp = DataFrame(full, Index(lrange(3), name='d'),
+        xp = DataFrame(full, Index(range(3), name='d'),
                        columns=[['a', 'b', 'b', 'c'],
                                 ['a', 'mean', 'median', 'mean']])
         tm.assert_frame_equal(rs, xp)
 
         rs = df.reset_index('a', col_fill='blah', col_level=1)
-        xp = DataFrame(full, Index(lrange(3), name='d'),
+        xp = DataFrame(full, Index(range(3), name='d'),
                        columns=[['blah', 'b', 'b', 'c'],
                                 ['a', 'mean', 'median', 'mean']])
         tm.assert_frame_equal(rs, xp)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -6,7 +6,6 @@ import warnings
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -54,7 +53,7 @@ def assert_stat_op_calc(opname, alternative, frame, has_skipna=True,
         result = getattr(df, opname)()
         assert isinstance(result, Series)
 
-        df['a'] = lrange(len(df))
+        df['a'] = range(len(df))
         result = getattr(df, opname)()
         assert isinstance(result, Series)
         assert len(result)
@@ -1203,7 +1202,7 @@ class TestDataFrameAnalytics:
         float_string_frame.skew(1)
 
     def test_sum_bools(self):
-        df = DataFrame(index=lrange(1), columns=lrange(10))
+        df = DataFrame(index=range(1), columns=range(10))
         bools = isna(df)
         assert bools.sum(axis=1)[0] == 10
 
@@ -1212,7 +1211,7 @@ class TestDataFrameAnalytics:
 
     def test_cumsum_corner(self):
         dm = DataFrame(np.arange(20).reshape(4, 5),
-                       index=lrange(4), columns=lrange(5))
+                       index=range(4), columns=range(5))
         # ?(wesm)
         result = dm.cumsum()  # noqa
 
@@ -1327,12 +1326,12 @@ class TestDataFrameAnalytics:
         assert isinstance(ct2, Series)
 
         # GH#423
-        df = DataFrame(index=lrange(10))
+        df = DataFrame(index=range(10))
         result = df.count(1)
         expected = Series(0, index=df.index)
         tm.assert_series_equal(result, expected)
 
-        df = DataFrame(columns=lrange(10))
+        df = DataFrame(columns=range(10))
         result = df.count(0)
         expected = Series(0, index=df.columns)
         tm.assert_series_equal(result, expected)
@@ -2137,9 +2136,9 @@ class TestDataFrameAnalytics:
 
         # unaligned
         df = DataFrame(np.random.randn(3, 4),
-                       index=[1, 2, 3], columns=lrange(4))
+                       index=[1, 2, 3], columns=range(4))
         df2 = DataFrame(np.random.randn(5, 3),
-                        index=lrange(5), columns=[1, 2, 3])
+                        index=range(5), columns=[1, 2, 3])
 
         with pytest.raises(ValueError, match='aligned'):
             df.dot(df2)
@@ -2197,9 +2196,9 @@ class TestDataFrameAnalytics:
 
         # unaligned
         df = DataFrame(np.random.randn(3, 4),
-                       index=[1, 2, 3], columns=lrange(4))
+                       index=[1, 2, 3], columns=range(4))
         df2 = DataFrame(np.random.randn(5, 3),
-                        index=lrange(5), columns=[1, 2, 3])
+                        index=range(5), columns=[1, 2, 3])
 
         with pytest.raises(ValueError, match='aligned'):
             operator.matmul(df, df2)

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -4,8 +4,6 @@ import pydoc
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import (
     Categorical, DataFrame, Series, SparseDataFrame, compat, date_range,
@@ -234,7 +232,7 @@ class SharedWithSparse:
             self._assert_series_equal(s, expected)
 
         df = self.klass({'floats': np.random.randn(5),
-                         'ints': lrange(5)}, columns=['floats', 'ints'])
+                         'ints': range(5)}, columns=['floats', 'ints'])
 
         for tup in df.itertuples(index=False):
             assert isinstance(tup[1], int)

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 from pandas.errors import PerformanceWarning
 
 import pandas as pd
@@ -393,44 +392,44 @@ class TestDataFrameSelectReindex(TestData):
         df = DataFrame(np.random.randn(10, 4))
 
         # axis=0
-        result = df.reindex(lrange(15))
+        result = df.reindex(list(range(15)))
         assert np.isnan(result.values[-5:]).all()
 
-        result = df.reindex(lrange(15), fill_value=0)
-        expected = df.reindex(lrange(15)).fillna(0)
+        result = df.reindex(range(15), fill_value=0)
+        expected = df.reindex(range(15)).fillna(0)
         assert_frame_equal(result, expected)
 
         # axis=1
-        result = df.reindex(columns=lrange(5), fill_value=0.)
+        result = df.reindex(columns=range(5), fill_value=0.)
         expected = df.copy()
         expected[4] = 0.
         assert_frame_equal(result, expected)
 
-        result = df.reindex(columns=lrange(5), fill_value=0)
+        result = df.reindex(columns=range(5), fill_value=0)
         expected = df.copy()
         expected[4] = 0
         assert_frame_equal(result, expected)
 
-        result = df.reindex(columns=lrange(5), fill_value='foo')
+        result = df.reindex(columns=range(5), fill_value='foo')
         expected = df.copy()
         expected[4] = 'foo'
         assert_frame_equal(result, expected)
 
         # reindex_axis
         with tm.assert_produces_warning(FutureWarning):
-            result = df.reindex_axis(lrange(15), fill_value=0., axis=0)
-        expected = df.reindex(lrange(15)).fillna(0)
+            result = df.reindex_axis(range(15), fill_value=0., axis=0)
+        expected = df.reindex(range(15)).fillna(0)
         assert_frame_equal(result, expected)
 
         with tm.assert_produces_warning(FutureWarning):
-            result = df.reindex_axis(lrange(5), fill_value=0., axis=1)
-        expected = df.reindex(columns=lrange(5)).fillna(0)
+            result = df.reindex_axis(range(5), fill_value=0., axis=1)
+        expected = df.reindex(columns=range(5)).fillna(0)
         assert_frame_equal(result, expected)
 
         # other dtypes
         df['foo'] = 'foo'
-        result = df.reindex(lrange(15), fill_value=0)
-        expected = df.reindex(lrange(15)).fillna(0)
+        result = df.reindex(range(15), fill_value=0)
+        expected = df.reindex(range(15)).fillna(0)
         assert_frame_equal(result, expected)
 
     def test_reindex_dups(self):
@@ -1025,7 +1024,7 @@ class TestDataFrameSelectReindex(TestData):
         assert reindexed.values.dtype == np.object_
         assert isna(reindexed[0][1])
 
-        reindexed = frame.reindex(columns=lrange(3))
+        reindexed = frame.reindex(columns=range(3))
         assert reindexed.values.dtype == np.object_
         assert isna(reindexed[1]).all()
 
@@ -1093,22 +1092,22 @@ class TestDataFrameSelectReindex(TestData):
     def test_reindex_multi(self):
         df = DataFrame(np.random.randn(3, 3))
 
-        result = df.reindex(index=lrange(4), columns=lrange(4))
-        expected = df.reindex(lrange(4)).reindex(columns=lrange(4))
+        result = df.reindex(index=range(4), columns=range(4))
+        expected = df.reindex(list(range(4))).reindex(columns=range(4))
 
         assert_frame_equal(result, expected)
 
         df = DataFrame(np.random.randint(0, 10, (3, 3)))
 
-        result = df.reindex(index=lrange(4), columns=lrange(4))
-        expected = df.reindex(lrange(4)).reindex(columns=lrange(4))
+        result = df.reindex(index=range(4), columns=range(4))
+        expected = df.reindex(list(range(4))).reindex(columns=range(4))
 
         assert_frame_equal(result, expected)
 
         df = DataFrame(np.random.randint(0, 10, (3, 3)))
 
-        result = df.reindex(index=lrange(2), columns=lrange(2))
-        expected = df.reindex(lrange(2)).reindex(columns=lrange(2))
+        result = df.reindex(index=range(2), columns=range(2))
+        expected = df.reindex(range(2)).reindex(columns=range(2))
 
         assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -3,8 +3,6 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range
 import pandas.util.testing as tm
@@ -216,41 +214,41 @@ class TestDataFrameConcatCommon():
         # row appends of different dtypes (so need to do by-item)
         # can sometimes infer the correct type
 
-        df1 = DataFrame({'bar': Timestamp('20130101')}, index=lrange(5))
+        df1 = DataFrame({'bar': Timestamp('20130101')}, index=range(5))
         df2 = DataFrame()
         result = df1.append(df2)
         expected = df1.copy()
         assert_frame_equal(result, expected)
 
-        df1 = DataFrame({'bar': Timestamp('20130101')}, index=lrange(1))
-        df2 = DataFrame({'bar': 'foo'}, index=lrange(1, 2))
+        df1 = DataFrame({'bar': Timestamp('20130101')}, index=range(1))
+        df2 = DataFrame({'bar': 'foo'}, index=range(1, 2))
         result = df1.append(df2)
         expected = DataFrame({'bar': [Timestamp('20130101'), 'foo']})
         assert_frame_equal(result, expected)
 
-        df1 = DataFrame({'bar': Timestamp('20130101')}, index=lrange(1))
-        df2 = DataFrame({'bar': np.nan}, index=lrange(1, 2))
+        df1 = DataFrame({'bar': Timestamp('20130101')}, index=range(1))
+        df2 = DataFrame({'bar': np.nan}, index=range(1, 2))
         result = df1.append(df2)
         expected = DataFrame(
             {'bar': Series([Timestamp('20130101'), np.nan], dtype='M8[ns]')})
         assert_frame_equal(result, expected)
 
-        df1 = DataFrame({'bar': Timestamp('20130101')}, index=lrange(1))
-        df2 = DataFrame({'bar': np.nan}, index=lrange(1, 2), dtype=object)
+        df1 = DataFrame({'bar': Timestamp('20130101')}, index=range(1))
+        df2 = DataFrame({'bar': np.nan}, index=range(1, 2), dtype=object)
         result = df1.append(df2)
         expected = DataFrame(
             {'bar': Series([Timestamp('20130101'), np.nan], dtype='M8[ns]')})
         assert_frame_equal(result, expected)
 
-        df1 = DataFrame({'bar': np.nan}, index=lrange(1))
-        df2 = DataFrame({'bar': Timestamp('20130101')}, index=lrange(1, 2))
+        df1 = DataFrame({'bar': np.nan}, index=range(1))
+        df2 = DataFrame({'bar': Timestamp('20130101')}, index=range(1, 2))
         result = df1.append(df2)
         expected = DataFrame(
             {'bar': Series([np.nan, Timestamp('20130101')], dtype='M8[ns]')})
         assert_frame_equal(result, expected)
 
-        df1 = DataFrame({'bar': Timestamp('20130101')}, index=lrange(1))
-        df2 = DataFrame({'bar': 1}, index=lrange(1, 2), dtype=object)
+        df1 = DataFrame({'bar': Timestamp('20130101')}, index=range(1))
+        df2 = DataFrame({'bar': 1}, index=range(1, 2), dtype=object)
         result = df1.append(df2)
         expected = DataFrame({'bar': Series([Timestamp('20130101'), 1])})
         assert_frame_equal(result, expected)
@@ -379,7 +377,7 @@ class TestDataFrameConcatCommon():
         str_dates = ['20120209', '20120222']
         dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]
 
-        A = DataFrame(str_dates, index=lrange(2), columns=['aa'])
+        A = DataFrame(str_dates, index=range(2), columns=['aa'])
         C = DataFrame([[1, 2], [3, 4]], index=str_dates, columns=dt_dates)
 
         tst = A.join(C, on='aa')
@@ -535,12 +533,12 @@ class TestDataFrameConcatCommon():
 class TestDataFrameCombineFirst():
 
     def test_combine_first_mixed(self):
-        a = Series(['a', 'b'], index=lrange(2))
-        b = Series(lrange(2), index=lrange(2))
+        a = Series(['a', 'b'], index=range(2))
+        b = Series(range(2), index=range(2))
         f = DataFrame({'A': a, 'B': b})
 
-        a = Series(['a', 'b'], index=lrange(5, 7))
-        b = Series(lrange(2), index=lrange(5, 7))
+        a = Series(['a', 'b'], index=range(5, 7))
+        b = Series(range(2), index=range(5, 7))
         g = DataFrame({'A': a, 'B': b})
 
         exp = pd.DataFrame({'A': list('abab'), 'B': [0., 1., 0., 1.]},
@@ -861,7 +859,7 @@ class TestDataFrameCombineFirst():
         df2_obj = DataFrame.from_records(rows, columns=['date', 'test'])
 
         ind = date_range(start="2000/1/1", freq="D", periods=10)
-        df1 = DataFrame({'date': ind, 'test': lrange(10)})
+        df1 = DataFrame({'date': ind, 'test': range(10)})
 
         # it works!
         pd.concat([df1, df2_obj])

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy.ma as ma
 import pytest
 
-from pandas.compat import PY36, is_platform_little_endian, lmap, lrange
+from pandas.compat import PY36, is_platform_little_endian, lmap
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import is_integer_dtype
@@ -116,7 +116,7 @@ class TestDataFrameConstructors(TestData):
         result = DataFrame([DataFrame()])
         assert result.shape == (1, 0)
 
-        result = DataFrame([DataFrame(dict(A=lrange(5)))])
+        result = DataFrame([DataFrame(dict(A=np.arange(5)))])
         assert isinstance(result.iloc[0, 0], DataFrame)
 
     def test_constructor_mixed_dtypes(self):
@@ -234,7 +234,7 @@ class TestDataFrameConstructors(TestData):
     def test_constructor_ordereddict(self):
         import random
         nitems = 100
-        nums = lrange(nitems)
+        nums = list(range(nitems))
         random.shuffle(nums)
         expected = ['A%d' % i for i in nums]
         df = DataFrame(OrderedDict(zip(expected, [[0]] * nitems)))
@@ -676,14 +676,14 @@ class TestDataFrameConstructors(TestData):
 
         # automatic labeling
         frame = DataFrame(mat)
-        tm.assert_index_equal(frame.index, pd.Index(lrange(2)))
-        tm.assert_index_equal(frame.columns, pd.Index(lrange(3)))
+        tm.assert_index_equal(frame.index, pd.Int64Index(range(2)))
+        tm.assert_index_equal(frame.columns, pd.Int64Index(range(3)))
 
         frame = DataFrame(mat, index=[1, 2])
-        tm.assert_index_equal(frame.columns, pd.Index(lrange(3)))
+        tm.assert_index_equal(frame.columns, pd.Int64Index(range(3)))
 
         frame = DataFrame(mat, columns=['A', 'B', 'C'])
-        tm.assert_index_equal(frame.index, pd.Index(lrange(2)))
+        tm.assert_index_equal(frame.index, pd.Int64Index(range(2)))
 
         # 0-length axis
         frame = DataFrame(empty((0, 3)))
@@ -862,11 +862,11 @@ class TestDataFrameConstructors(TestData):
         assert df.values.shape == (0, 0)
 
     @pytest.mark.parametrize("data, index, columns, dtype, expected", [
-        (None, lrange(10), ['a', 'b'], object, np.object_),
+        (None, list(range(10)), ['a', 'b'], object, np.object_),
         (None, None, ['a', 'b'], 'int64', np.dtype('int64')),
-        (None, lrange(10), ['a', 'b'], int, np.dtype('float64')),
+        (None, list(range(10)), ['a', 'b'], int, np.dtype('float64')),
         ({}, None, ['foo', 'bar'], None, np.object_),
-        ({'b': 1}, lrange(10), list('abc'), int, np.dtype('float64'))
+        ({'b': 1}, list(range(10)), list('abc'), int, np.dtype('float64'))
     ])
     def test_constructor_dtype(self, data, index, columns, dtype, expected):
         df = DataFrame(data, index, columns, dtype)
@@ -1171,7 +1171,7 @@ class TestDataFrameConstructors(TestData):
             DataFrame(data)
 
     def test_constructor_scalar(self):
-        idx = Index(lrange(3))
+        idx = Index(range(3))
         df = DataFrame({"a": 0}, index=idx)
         expected = DataFrame({"a": [0, 0, 0]}, index=idx)
         tm.assert_frame_equal(df, expected, check_dtype=False)
@@ -1683,12 +1683,12 @@ class TestDataFrameConstructors(TestData):
         expected = Series({'float64': 1})
         tm.assert_series_equal(result, expected)
 
-        df = DataFrame({'a': 1}, index=lrange(3))
+        df = DataFrame({'a': 1}, index=range(3))
         result = df.get_dtype_counts()
         expected = Series({'int64': 1})
         tm.assert_series_equal(result, expected)
 
-        df = DataFrame({'a': 1.}, index=lrange(3))
+        df = DataFrame({'a': 1.}, index=range(3))
         result = df.get_dtype_counts()
         expected = Series({'float64': 1})
         tm.assert_series_equal(result, expected)
@@ -2131,7 +2131,7 @@ class TestDataFrameConstructors(TestData):
 
         # tuples is in the order of the columns
         result = DataFrame.from_records(tuples)
-        tm.assert_index_equal(result.columns, pd.Index(lrange(8)))
+        tm.assert_index_equal(result.columns, pd.RangeIndex(8))
 
         # test exclude parameter & we are casting the results here (as we don't
         # have dtype info to recover)

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import iNaT
-from pandas.compat import lrange
 
 from pandas.core.dtypes.common import is_float_dtype, is_integer, is_scalar
 from pandas.core.dtypes.dtypes import CategoricalDtype
@@ -159,7 +158,8 @@ class TestDataFrameIndexing(TestData):
         with pytest.raises(ValueError, match=msg):
             data['A'] = range(len(data.index) - 1)
 
-        df = DataFrame(0, lrange(3), ['tt1', 'tt2'], dtype=np.int_)
+        df = DataFrame(0, index=range(3), columns=['tt1', 'tt2'],
+                       dtype=np.int_)
         df.loc[1, ['tt1', 'tt2']] = [1, 2]
 
         result = df.loc[df.index[1], ['tt1', 'tt2']]
@@ -432,7 +432,7 @@ class TestDataFrameIndexing(TestData):
             self.frame.NONEXISTENT_NAME
 
     def test_setattr_column(self):
-        df = DataFrame({'foobar': 1}, index=lrange(10))
+        df = DataFrame({'foobar': 1}, index=range(10))
 
         df.foobar = 5
         assert (df.foobar == 5).all()
@@ -636,8 +636,7 @@ class TestDataFrameIndexing(TestData):
     def test_frame_setitem_timestamp(self):
         # GH#2155
         columns = date_range(start='1/1/2012', end='2/1/2012', freq=BDay())
-        index = lrange(10)
-        data = DataFrame(columns=columns, index=index)
+        data = DataFrame(columns=columns, index=range(10))
         t = datetime(2012, 11, 1)
         ts = Timestamp(t)
         data[ts] = np.nan  # works, mostly a smoke-test
@@ -705,11 +704,11 @@ class TestDataFrameIndexing(TestData):
         from decimal import Decimal
 
         # Created as float type
-        dm = DataFrame(index=lrange(3), columns=lrange(3))
+        dm = DataFrame(index=range(3), columns=range(3))
 
         coercable_series = Series([Decimal(1) for _ in range(3)],
-                                  index=lrange(3))
-        uncoercable_series = Series(['foo', 'bzr', 'baz'], index=lrange(3))
+                                  index=range(3))
+        uncoercable_series = Series(['foo', 'bzr', 'baz'], index=range(3))
 
         dm[0] = np.ones(3)
         assert len(dm.columns) == 3
@@ -866,7 +865,7 @@ class TestDataFrameIndexing(TestData):
         assert isna(df.iloc[:8:2]).values.all()
 
     def test_getitem_setitem_integer_slice_keyerrors(self):
-        df = DataFrame(np.random.randn(10, 5), index=lrange(0, 20, 2))
+        df = DataFrame(np.random.randn(10, 5), index=range(0, 20, 2))
 
         # this is OK
         cp = df.copy()
@@ -886,7 +885,7 @@ class TestDataFrameIndexing(TestData):
         assert_frame_equal(result2, expected)
 
         # non-monotonic, raise KeyError
-        df2 = df.iloc[lrange(5) + lrange(5, 10)[::-1]]
+        df2 = df.iloc[list(range(5)) + list(range(5, 10))[::-1]]
         with pytest.raises(KeyError, match=r"^3$"):
             df2.loc[3:11]
         with pytest.raises(KeyError, match=r"^3$"):
@@ -1870,7 +1869,7 @@ class TestDataFrameIndexing(TestData):
 
     def test_set_value_with_index_dtype_change(self):
         df_orig = DataFrame(np.random.randn(3, 3),
-                            index=lrange(3), columns=list('ABC'))
+                            index=range(3), columns=list('ABC'))
 
         # this is actually ambiguous as the 2 is interpreted as a positional
         # so column is not created
@@ -1902,7 +1901,7 @@ class TestDataFrameIndexing(TestData):
     def test_get_set_value_no_partial_indexing(self):
         # partial w/ MultiIndex raise exception
         index = MultiIndex.from_tuples([(0, 1), (0, 2), (1, 1), (1, 2)])
-        df = DataFrame(index=index, columns=lrange(4))
+        df = DataFrame(index=index, columns=range(4))
         with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):
             with pytest.raises(KeyError, match=r"^0$"):
@@ -1940,7 +1939,7 @@ class TestDataFrameIndexing(TestData):
         assert_series_equal(result, expected)
 
     def test_iloc_row(self):
-        df = DataFrame(np.random.randn(10, 4), index=lrange(0, 20, 2))
+        df = DataFrame(np.random.randn(10, 4), index=range(0, 20, 2))
 
         result = df.iloc[1]
         exp = df.loc[2]
@@ -1971,7 +1970,7 @@ class TestDataFrameIndexing(TestData):
 
     def test_iloc_col(self):
 
-        df = DataFrame(np.random.randn(4, 10), columns=lrange(0, 20, 2))
+        df = DataFrame(np.random.randn(4, 10), columns=range(0, 20, 2))
 
         result = df.iloc[:, 1]
         exp = df.loc[:, 2]
@@ -2158,7 +2157,7 @@ class TestDataFrameIndexing(TestData):
         rng = date_range('1/1/2000 00:00:00', periods=10, freq='10s')
         df = DataFrame({'A': np.random.randn(len(rng)), 'B': rng})
 
-        result = df.reindex(lrange(15))
+        result = df.reindex(range(15))
         assert np.issubdtype(result['B'].dtype, np.dtype('M8[ns]'))
 
         mask = com.isna(result)['B']
@@ -2511,7 +2510,7 @@ class TestDataFrameIndexing(TestData):
         # this is numpy dependent
 
         dm = DataFrame(np.arange(20.).reshape(4, 5),
-                       index=lrange(4), columns=lrange(5))
+                       index=range(4), columns=range(5))
 
         dm.xs(2)[:] = 10
         assert (dm.xs(2) == 10).all()
@@ -2534,7 +2533,7 @@ class TestDataFrameIndexing(TestData):
         assert result == 1
 
     def test_boolean_indexing(self):
-        idx = lrange(3)
+        idx = list(range(3))
         cols = ['A', 'B', 'C']
         df1 = DataFrame(index=idx, columns=cols,
                         data=np.array([[0.0, 0.5, 1.0],

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -4,7 +4,6 @@ import dateutil
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -83,7 +82,7 @@ class TestDataFrameMissingData():
         assert_frame_equal(inp, expected)
 
         dropped = df.dropna(axis=0)
-        expected = df.loc[lrange(2, 6)]
+        expected = df.loc[list(range(2, 6))]
         inp = df.copy()
         inp.dropna(axis=0, inplace=True)
         assert_frame_equal(dropped, expected)
@@ -98,7 +97,7 @@ class TestDataFrameMissingData():
         assert_frame_equal(inp, expected)
 
         dropped = df.dropna(axis=0, thresh=4)
-        expected = df.loc[lrange(2, 6)]
+        expected = df.loc[range(2, 6)]
         inp = df.copy()
         inp.dropna(axis=0, thresh=4, inplace=True)
         assert_frame_equal(dropped, expected)
@@ -414,9 +413,9 @@ class TestDataFrameMissingData():
         assert_series_equal(result, expected)
 
         # empty block
-        df = DataFrame(index=lrange(3), columns=['A', 'B'], dtype='float64')
+        df = DataFrame(index=range(3), columns=['A', 'B'], dtype='float64')
         result = df.fillna('nan')
-        expected = DataFrame('nan', index=lrange(3), columns=['A', 'B'])
+        expected = DataFrame('nan', index=range(3), columns=['A', 'B'])
         assert_frame_equal(result, expected)
 
         # equiv of replace
@@ -616,7 +615,7 @@ class TestDataFrameMissingData():
     def test_fillna_col_reordering(self):
         cols = ["COL." + str(i) for i in range(5, 0, -1)]
         data = np.random.rand(20, 5)
-        df = DataFrame(index=lrange(20), columns=cols, data=data)
+        df = DataFrame(index=range(20), columns=cols, data=data)
         filled = df.fillna(method='ffill')
         assert df.columns.tolist() == filled.columns.tolist()
 

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas.compat import PY36, lrange
+from pandas.compat import PY36
 
 from pandas import DataFrame, Index, MultiIndex, Series
 import pandas.util.testing as tm
@@ -133,12 +133,12 @@ class TestDataFrameMutateColumns():
         # from the vb_suite/frame_methods/frame_insert_columns
         N = 10
         K = 5
-        df = DataFrame(index=lrange(N))
+        df = DataFrame(index=range(N))
         new_col = np.random.randn(N)
         for i in range(K):
             df[i] = new_col
         expected = DataFrame(np.repeat(new_col, K).reshape(N, K),
-                             index=lrange(N))
+                             index=range(N))
         assert_frame_equal(df, expected)
 
     def test_insert(self):

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, date_range
 from pandas.tests.frame.common import TestData
@@ -23,7 +21,7 @@ class TestDataFrameNonuniqueIndexes(TestData):
         # assignment
         # GH 3687
         arr = np.random.randn(3, 2)
-        idx = lrange(2)
+        idx = list(range(2))
         df = DataFrame(arr, columns=['A', 'A'])
         df.columns = idx
         expected = DataFrame(arr, columns=idx)

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -7,7 +7,7 @@ import textwrap
 import numpy as np
 import pytest
 
-from pandas.compat import PYPY, lrange
+from pandas.compat import PYPY
 
 import pandas as pd
 from pandas import (
@@ -43,7 +43,7 @@ class TestDataFrameReprInfoEtc(TestData):
         # big mixed
         biggie = DataFrame({'A': np.random.randn(200),
                             'B': tm.makeStringIndex(200)},
-                           index=lrange(200))
+                           index=range(200))
         biggie.loc[:20, 'A'] = np.nan
         biggie.loc[:20, 'B'] = np.nan
 
@@ -88,8 +88,8 @@ class TestDataFrameReprInfoEtc(TestData):
     @pytest.mark.slow
     def test_repr_big(self):
         # big one
-        biggie = DataFrame(np.zeros((200, 4)), columns=lrange(4),
-                           index=lrange(200))
+        biggie = DataFrame(np.zeros((200, 4)), columns=range(4),
+                           index=range(200))
         repr(biggie)
 
     def test_repr_unsortable(self):

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -3,8 +3,6 @@ import random
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import (
     Categorical, DataFrame, IntervalIndex, MultiIndex, NaT, Series, Timestamp,
@@ -442,7 +440,7 @@ class TestDataFrameSortIndexKinds(TestData):
 
         # with 9816, these are all translated to .sort_values
 
-        df = DataFrame([lrange(5, 9), lrange(4)],
+        df = DataFrame([range(5, 9), range(4)],
                        columns=['a', 'a', 'b', 'b'])
 
         with pytest.raises(ValueError, match='not unique'):

--- a/pandas/tests/frame/test_timezones.py
+++ b/pandas/tests/frame/test_timezones.py
@@ -7,8 +7,6 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 
 import pandas as pd
@@ -94,7 +92,7 @@ class TestDataFrameTimezones:
         test2 = DataFrame(np.zeros((3, 3)),
                           index=date_range("2012-11-15 00:00:00", periods=3,
                                            freq="250L", tz="US/Central"),
-                          columns=lrange(3, 6))
+                          columns=range(3, 6))
 
         result = test1.join(test2, how='outer')
         ex_index = test1.index.union(test2.index)

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas.compat import is_platform_32bit, is_platform_windows, lrange
+from pandas.compat import is_platform_32bit, is_platform_windows
 
 import pandas as pd
 from pandas import (
@@ -232,10 +232,10 @@ class TestDataFrameFormatting:
 
     def test_repr_obeys_max_seq_limit(self):
         with option_context("display.max_seq_items", 2000):
-            assert len(printing.pprint_thing(lrange(1000))) > 1000
+            assert len(printing.pprint_thing(list(range(1000)))) > 1000
 
         with option_context("display.max_seq_items", 5):
-            assert len(printing.pprint_thing(lrange(1000))) < 100
+            assert len(printing.pprint_thing(list(range(1000)))) < 100
 
     def test_repr_set(self):
         assert printing.pprint_thing({1}) == '{1}'
@@ -265,9 +265,9 @@ class TestDataFrameFormatting:
             assert '\\' not in repr(df)
 
     def test_expand_frame_repr(self):
-        df_small = DataFrame('hello', [0], [0])
-        df_wide = DataFrame('hello', [0], lrange(10))
-        df_tall = DataFrame('hello', lrange(30), lrange(5))
+        df_small = DataFrame('hello', index=[0], columns=[0])
+        df_wide = DataFrame('hello', index=[0], columns=range(10))
+        df_tall = DataFrame('hello', index=range(30), columns=range(5))
 
         with option_context('mode.sim_interactive', True):
             with option_context('display.max_columns', 10, 'display.width', 20,
@@ -292,7 +292,7 @@ class TestDataFrameFormatting:
     def test_repr_non_interactive(self):
         # in non interactive mode, there can be no dependency on the
         # result of terminal auto size detection
-        df = DataFrame('hello', lrange(1000), lrange(5))
+        df = DataFrame('hello', index=range(1000), columns=range(5))
 
         with option_context('mode.sim_interactive', False, 'display.width', 0,
                             'display.max_rows', 5000):
@@ -1175,7 +1175,7 @@ class TestDataFrameFormatting:
         # big mixed
         biggie = DataFrame({'A': np.random.randn(200),
                             'B': tm.makeStringIndex(200)},
-                           index=lrange(200))
+                           index=np.arange(200))
 
         biggie.loc[:20, 'A'] = np.nan
         biggie.loc[:20, 'B'] = np.nan
@@ -1357,7 +1357,7 @@ class TestDataFrameFormatting:
 
     def test_to_string_float_index(self):
         index = Index([1.5, 2, 3, 4, 5])
-        df = DataFrame(lrange(5), index=index)
+        df = DataFrame(np.arange(5), index=index)
 
         result = df.to_string()
         expected = ('     0\n'
@@ -1399,7 +1399,7 @@ class TestDataFrameFormatting:
         assert output == expected
 
     def test_to_string_index_formatter(self):
-        df = DataFrame([lrange(5), lrange(5, 10), lrange(10, 15)])
+        df = DataFrame([range(5), range(5, 10), range(10, 15)])
 
         rs = df.to_string(formatters={'__index__': lambda x: 'abc' [x]})
 
@@ -1485,12 +1485,12 @@ c  10  11  12  13  14\
         assert df.to_string(decimal=',') == expected
 
     def test_to_string_line_width(self):
-        df = DataFrame(123, lrange(10, 15), lrange(30))
+        df = DataFrame(123, index=range(10, 15), columns=range(30))
         s = df.to_string(line_width=80)
         assert max(len(l) for l in s.split('\n')) == 80
 
     def test_show_dimensions(self):
-        df = DataFrame(123, lrange(10, 15), lrange(30))
+        df = DataFrame(123, index=range(10, 15), columns=range(30))
 
         with option_context('display.max_rows', 10, 'display.max_columns', 40,
                             'display.width', 500, 'display.expand_frame_repr',

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -4,8 +4,6 @@ from itertools import chain
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import DataFrame, Index, Series, isna
 from pandas.conftest import _get_cython_table_params
@@ -500,7 +498,7 @@ class TestSeriesMap():
         assert not isna(merged['c'])
 
     def test_map_type_inference(self):
-        s = Series(lrange(3))
+        s = Series(range(3))
         s2 = s.map(lambda x: np.where(x == 0, 0, 1))
         assert issubclass(s2.dtype.type, np.integer)
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -8,7 +8,7 @@ import pytest
 
 from pandas._libs import lib
 from pandas._libs.tslib import iNaT
-from pandas.compat import PY36, lrange
+from pandas.compat import PY36
 
 from pandas.core.dtypes.common import (
     is_categorical_dtype, is_datetime64tz_dtype)
@@ -124,13 +124,13 @@ class TestSeriesConstructors:
 
         if input_class is not list:
             # With index:
-            empty = Series(index=lrange(10))
-            empty2 = Series(input_class(), index=lrange(10))
+            empty = Series(index=range(10))
+            empty2 = Series(input_class(), index=range(10))
             assert_series_equal(empty, empty2)
 
             # With index and dtype float64:
-            empty = Series(np.nan, index=lrange(10))
-            empty2 = Series(input_class(), index=lrange(10), dtype='float64')
+            empty = Series(np.nan, index=range(10))
+            empty2 = Series(input_class(), index=range(10), dtype='float64')
             assert_series_equal(empty, empty2)
 
             # GH 19853 : with empty string, index and dtype str
@@ -140,8 +140,8 @@ class TestSeriesConstructors:
 
     @pytest.mark.parametrize('input_arg', [np.nan, float('nan')])
     def test_constructor_nan(self, input_arg):
-        empty = Series(dtype='float64', index=lrange(10))
-        empty2 = Series(input_arg, index=lrange(10))
+        empty = Series(dtype='float64', index=range(10))
+        empty2 = Series(input_arg, index=range(10))
 
         assert_series_equal(empty, empty2, check_index_type=False)
 
@@ -250,12 +250,12 @@ class TestSeriesConstructors:
         gen = (i for i in range(10))
 
         result = Series(gen)
-        exp = Series(lrange(10))
+        exp = Series(range(10))
         assert_series_equal(result, exp)
 
         gen = (i for i in range(10))
-        result = Series(gen, index=lrange(10, 20))
-        exp.index = lrange(10, 20)
+        result = Series(gen, index=range(10, 20))
+        exp.index = range(10, 20)
         assert_series_equal(result, exp)
 
     def test_constructor_map(self):
@@ -263,12 +263,12 @@ class TestSeriesConstructors:
         m = map(lambda x: x, range(10))
 
         result = Series(m)
-        exp = Series(lrange(10))
+        exp = Series(range(10))
         assert_series_equal(result, exp)
 
         m = map(lambda x: x, range(10))
-        result = Series(m, index=lrange(10, 20))
-        exp.index = lrange(10, 20)
+        result = Series(m, index=range(10, 20))
+        exp.index = range(10, 20)
         assert_series_equal(result, exp)
 
     def test_constructor_categorical(self):
@@ -574,10 +574,10 @@ class TestSeriesConstructors:
         assert s._data.blocks[0].values is not index
 
     def test_constructor_pass_none(self):
-        s = Series(None, index=lrange(5))
+        s = Series(None, index=range(5))
         assert s.dtype == np.float64
 
-        s = Series(None, index=lrange(5), dtype=object)
+        s = Series(None, index=range(5), dtype=object)
         assert s.dtype == np.object_
 
         # GH 7431
@@ -670,15 +670,15 @@ class TestSeriesConstructors:
 
     def test_constructor_dtype_datetime64(self):
 
-        s = Series(iNaT, dtype='M8[ns]', index=lrange(5))
+        s = Series(iNaT, dtype='M8[ns]', index=range(5))
         assert isna(s).all()
 
         # in theory this should be all nulls, but since
         # we are not specifying a dtype is ambiguous
-        s = Series(iNaT, index=lrange(5))
+        s = Series(iNaT, index=range(5))
         assert not isna(s).all()
 
-        s = Series(nan, dtype='M8[ns]', index=lrange(5))
+        s = Series(nan, dtype='M8[ns]', index=range(5))
         assert isna(s).all()
 
         s = Series([datetime(2001, 1, 2, 0, 0), iNaT], dtype='M8[ns]')

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import iNaT
-from pandas.compat import lrange
 
 import pandas as pd
 from pandas import (
@@ -82,7 +81,7 @@ class TestSeriesDtypes:
         tm.assert_series_equal(result, Series(np.arange(1, 5)))
 
     def test_astype_datetime(self):
-        s = Series(iNaT, dtype='M8[ns]', index=lrange(5))
+        s = Series(iNaT, dtype='M8[ns]', index=range(5))
 
         s = s.astype('O')
         assert s.dtype == np.object_

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -7,7 +7,6 @@ import pytest
 
 from pandas._libs.tslib import iNaT
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
-from pandas.compat import lrange
 from pandas.errors import NullFrequencyError
 import pandas.util._test_decorators as td
 
@@ -919,11 +918,11 @@ class TestTimeSeries(TestData):
         dr = date_range(start='1/1/2012', freq='5min', periods=10)
 
         # BAD Example, datetimes first
-        s = Series(np.arange(10), index=[dr, lrange(10)])
+        s = Series(np.arange(10), index=[dr, np.arange(10)])
         grouped = s.groupby(lambda x: x[1] % 2 == 0)
         result = grouped.count()
 
-        s = Series(np.arange(10), index=[lrange(10), dr])
+        s = Series(np.arange(10), index=[np.arange(10), dr])
         grouped = s.groupby(lambda x: x[0] % 2 == 0)
         expected = grouped.count()
 

--- a/pandas/tests/series/test_timezones.py
+++ b/pandas/tests/series/test_timezones.py
@@ -9,7 +9,6 @@ import pytest
 import pytz
 
 from pandas._libs.tslibs import conversion, timezones
-from pandas.compat import lrange
 
 from pandas import DatetimeIndex, Index, NaT, Series, Timestamp
 from pandas.core.indexes.datetimes import date_range
@@ -194,7 +193,7 @@ class TestSeriesTimezones:
 
         # mixed
         rng1 = date_range('1/1/2011 01:00', periods=1, freq='H')
-        rng2 = lrange(100)
+        rng2 = range(100)
         ser1 = Series(np.random.randn(len(rng1)), index=rng1)
         ser2 = Series(np.random.randn(len(rng2)), index=rng2)
         ts_result = ser1.append(ser2)


### PR DESCRIPTION
- [x] xref #25725, #26281 & #26289

Third part of the removal of ``compat.lrange`` from the code base.