### PR TITLE
CLN: remove empty parenteses on class creation

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -148,8 +148,8 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -R --include="*.py" --include="*.pyx" -E "(DEPRECATED|DEPRECATE|Deprecated)(:|,|\.)" pandas
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
-    MSG='Check for python2 new-style classes' ; echo $MSG
-    invgrep -R --include="*.py" --include="*.pyx" -E "class\s\S*\(object\):" pandas scripts
+    MSG='Check for python2 new-style classes and for for empty parenteses' ; echo $MSG
+    invgrep -R --include="*.py" --include="*.pyx" -E "class\s\S*\((object)?\):" pandas scripts
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Check for backticks incorrectly rendering because of missing spaces' ; echo $MSG

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -497,7 +497,7 @@ class TestInference:
 class TestTypeInference:
 
     # Dummy class used for testing with Python objects
-    class Dummy():
+    class Dummy:
         pass
 
     def test_inferred_dtype_fixture(self, any_skipna_inferred_dtype):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -13,7 +13,7 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-class TestDataFrameAlterAxes():
+class TestDataFrameAlterAxes:
 
     def test_set_index_directly(self, float_string_frame):
         df = float_string_frame

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -29,7 +29,7 @@ def int_frame_const_col():
     return df
 
 
-class TestDataFrameApply():
+class TestDataFrameApply:
 
     def test_apply(self, float_frame):
         with np.errstate(all='ignore'):
@@ -829,7 +829,7 @@ def zip_frames(frames, axis=1):
         return pd.DataFrame(zipped)
 
 
-class TestDataFrameAggregate():
+class TestDataFrameAggregate:
 
     def test_agg_transform(self, axis, float_frame):
         other_axis = 1 if axis in {0, 'index'} else 0

--- a/pandas/tests/frame/test_asof.py
+++ b/pandas/tests/frame/test_asof.py
@@ -17,7 +17,7 @@ def date_range_frame():
     return DataFrame({'A': np.arange(N), 'B': np.arange(N)}, index=rng)
 
 
-class TestFrameAsof():
+class TestFrameAsof:
 
     def test_basic(self, date_range_frame):
         df = date_range_frame

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -19,7 +19,7 @@ from pandas.util.testing import (
 # structure
 
 
-class TestDataFrameBlockInternals():
+class TestDataFrameBlockInternals:
     def test_setitem_invalidates_datetime_index_freq(self):
         # GH#24096 altering a datetime64tz column inplace invalidates the
         #  `freq` attribute on the underlying DatetimeIndex

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -9,7 +9,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
-class TestDataFrameConcatCommon():
+class TestDataFrameConcatCommon:
 
     def test_concat_multiple_frames_dtypes(self):
 
@@ -530,7 +530,7 @@ class TestDataFrameConcatCommon():
         tm.assert_frame_equal(result, expected)
 
 
-class TestDataFrameCombineFirst():
+class TestDataFrameCombineFirst:
 
     def test_combine_first_mixed(self):
         a = Series(['a', 'b'], index=range(2))
@@ -865,7 +865,7 @@ class TestDataFrameCombineFirst():
         pd.concat([df1, df2_obj])
 
 
-class TestDataFrameUpdate():
+class TestDataFrameUpdate:
 
     def test_update_nan(self):
         # #15593 #15617

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1001,7 +1001,7 @@ class TestDataFrameConstructors(TestData):
 
     def test_constructor_iterable(self):
         # GH 21987
-        class Iter():
+        class Iter:
             def __iter__(self):
                 for i in range(10):
                     yield [1, 2, 3]

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -21,7 +21,7 @@ def _skip_if_no_pchip():
         pytest.skip('scipy.interpolate.pchip missing')
 
 
-class TestDataFrameMissingData():
+class TestDataFrameMissingData:
 
     def test_dropEmptyRows(self, float_frame):
         N = len(float_frame.index)
@@ -643,7 +643,7 @@ class TestDataFrameMissingData():
         assert_frame_equal(res, exp)
 
 
-class TestDataFrameInterpolate():
+class TestDataFrameInterpolate:
 
     def test_interp_basic(self):
         df = DataFrame({'A': [1, 2, np.nan, 4],

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -10,7 +10,7 @@ from pandas.util.testing import assert_frame_equal
 # Column add, remove, delete.
 
 
-class TestDataFrameMutateColumns():
+class TestDataFrameMutateColumns:
 
     def test_assign(self):
         df = DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -93,7 +93,7 @@ class TestSelection:
 # grouping
 # --------------------------------
 
-class TestGrouping():
+class TestGrouping:
 
     def test_grouper_index_types(self):
         # related GH5375
@@ -556,7 +556,7 @@ class TestGrouping():
 # get_group
 # --------------------------------
 
-class TestGetGroup():
+class TestGetGroup:
     def test_get_group(self):
         # GH 5267
         # be datelike friendly
@@ -660,7 +660,7 @@ class TestGetGroup():
 # groups & iteration
 # --------------------------------
 
-class TestIteration():
+class TestIteration:
 
     def test_groups(self, df):
         grouped = df.groupby(['A'])

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -1805,7 +1805,7 @@ def test_invalid_file_buffer_mock(all_parsers):
     parser = all_parsers
     msg = "Invalid file path or buffer object type"
 
-    class Foo():
+    class Foo:
         pass
 
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -21,7 +21,7 @@ def test_read_csv_gcs(monkeypatch):
     df1 = DataFrame({'int': [1, 3], 'float': [2.0, np.nan], 'str': ['t', 's'],
                      'dt': date_range('2018-06-18', periods=2)})
 
-    class MockGCSFileSystem():
+    class MockGCSFileSystem:
         def open(*args):
             return StringIO(df1.to_csv(index=False))
 
@@ -37,7 +37,7 @@ def test_to_csv_gcs(monkeypatch):
                      'dt': date_range('2018-06-18', periods=2)})
     s = StringIO()
 
-    class MockGCSFileSystem():
+    class MockGCSFileSystem:
         def open(*args):
             return s
 

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -11,7 +11,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
-class TestSeriesApply():
+class TestSeriesApply:
 
     def test_apply(self, datetime_series):
         with np.errstate(all='ignore'):
@@ -170,7 +170,7 @@ class TestSeriesApply():
         tm.assert_series_equal(result, expected)
 
 
-class TestSeriesAggregate():
+class TestSeriesAggregate:
 
     def test_transform(self, string_series):
         # transforming functions
@@ -416,7 +416,7 @@ class TestSeriesAggregate():
             series.agg(func)
 
 
-class TestSeriesMap():
+class TestSeriesMap:
 
     def test_map(self, datetime_series):
         index, data = tm.getMixedTypeDict()

--- a/pandas/tests/series/test_asof.py
+++ b/pandas/tests/series/test_asof.py
@@ -5,7 +5,7 @@ from pandas import Series, Timestamp, date_range, isna, notna, offsets
 import pandas.util.testing as tm
 
 
-class TestSeriesAsof():
+class TestSeriesAsof:
 
     def test_basic(self):
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -192,7 +192,7 @@ class TestSeriesConstructors:
 
     def test_constructor_iterable(self):
         # GH 21987
-        class Iter():
+        class Iter:
             def __iter__(self):
                 for i in range(10):
                     yield i

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -21,7 +21,7 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_series_equal
 
 
-class TestSeriesDatetimeValues():
+class TestSeriesDatetimeValues:
 
     def test_dt_namespace_accessor(self):
 

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -14,7 +14,7 @@ from pandas.util.testing import (
 from pandas.io.common import _get_handle
 
 
-class TestSeriesToCSV():
+class TestSeriesToCSV:
 
     def read_csv(self, path, **kwargs):
         params = dict(squeeze=True, index_col=0,
@@ -191,7 +191,7 @@ class TestSeriesToCSV():
                                                    encoding=encoding))
 
 
-class TestSeriesIO():
+class TestSeriesIO:
 
     def test_to_frame(self, datetime_series):
         datetime_series.name = None

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -39,7 +39,7 @@ def _simple_ts(start, end, freq='D'):
     return Series(np.random.randn(len(rng)), index=rng)
 
 
-class TestSeriesMissingData():
+class TestSeriesMissingData:
 
     def test_remove_na_deprecation(self):
         # see gh-16971
@@ -875,7 +875,7 @@ def interp_methods_ind(request):
     return method, kwargs
 
 
-class TestSeriesInterpolateData():
+class TestSeriesInterpolateData:
     def test_interpolate(self, datetime_series, string_series):
         ts = Series(np.arange(len(datetime_series), dtype=float),
                     datetime_series.index)

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -12,7 +12,7 @@ import pandas.util._test_decorators as td
 The decorators can be applied to classes:
 
 @td.skip_if_some_reason
-class Foo():
+class Foo:
     ...
 
 Or individual functions:


### PR DESCRIPTION
Minor clean-up: Some classes are created with a ``()`` which is not needed.