### PR TITLE
Remove Panel References from Tests

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -11,7 +11,7 @@ from pandas.errors import PerformanceWarning
 
 import pandas as pd
 from pandas import (
-    DataFrame, Index, MultiIndex, Panel, Series, Timestamp, date_range,
+    DataFrame, Index, MultiIndex, Series, Timestamp, date_range,
     read_csv)
 import pandas.core.common as com
 import pandas.util.testing as tm
@@ -510,30 +510,31 @@ def test_frame_multi_key_function_list():
 
 
 @pytest.mark.parametrize('op', [lambda x: x.sum(), lambda x: x.mean()])
-@pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
 def test_groupby_multiple_columns(df, op):
     data = df
+
     grouped = data.groupby(['A', 'B'])
 
     result1 = op(grouped)
 
-    expected = defaultdict(dict)
+    keys = []
+    values = []
     for n1, gp1 in data.groupby('A'):
         for n2, gp2 in gp1.groupby('B'):
-            expected[n1][n2] = op(gp2.loc[:, ['C', 'D']])
-    expected = {k: DataFrame(v)
-                for k, v in expected.items()}
-    expected = Panel.fromDict(expected).swapaxes(0, 1)
-    expected.major_axis.name, expected.minor_axis.name = 'A', 'B'
+            keys.append((n1, n2))
+            values.append(op(gp2.loc[:, ['C', 'D']]))
+
+    mi = MultiIndex.from_tuples(keys, names=['A', 'B'])
+    expected = pd.concat(values, axis=1).T
+    expected.index = mi
 
     # a little bit crude
     for col in ['C', 'D']:
         result_col = op(grouped[col])
+        pivoted = result1[col]
         exp = expected[col]
-        pivoted = result1[col].unstack()
-        pivoted2 = result_col.unstack()
-        assert_frame_equal(pivoted.reindex_like(exp), exp)
-        assert_frame_equal(pivoted2.reindex_like(exp), exp)
+        assert_series_equal(result_col, exp)
+        assert_series_equal(pivoted, exp)
 
     # test single series works the same
     result = data['C'].groupby([data['A'], data['B']]).mean()

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from datetime import datetime
 from decimal import Decimal
 from io import StringIO

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -512,7 +512,6 @@ def test_frame_multi_key_function_list():
 @pytest.mark.parametrize('op', [lambda x: x.sum(), lambda x: x.mean()])
 def test_groupby_multiple_columns(df, op):
     data = df
-
     grouped = data.groupby(['A', 'B'])
 
     result1 = op(grouped)

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -2350,7 +2350,6 @@ class TestExcelWriterEngineTests:
         with pytest.raises(ValueError, match='No engine'):
             ExcelWriter('nothing')
 
-    @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
     def test_register_writer(self):
         # some awkward mocking to test out dispatch and such actually works
         called_save = []

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -587,8 +587,6 @@ class TestCategoricalReshape:
 
     def test_reshaping_multi_index_categorical(self):
 
-        # construct a MultiIndexed DataFrame formerly created
-        #  via `tm.makePanel().to_frame()`
         cols = ['ItemA', 'ItemB', 'ItemC']
         data = {c: tm.makeTimeDataFrame() for c in cols}
         df = pd.concat({c: data[c].stack() for c in data}, axis='columns')

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -1061,6 +1061,7 @@ class TestSparseDataFrame(SharedWithSparse):
             from_dense_lp = frame.stack().to_frame()
 
             from_sparse_lp = spf.stack_sparse_frame(frame)
+
             tm.assert_numpy_array_equal(from_dense_lp.values,
                                         from_sparse_lp.values)
 

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -9,7 +9,7 @@ from pandas.compat import lrange
 from pandas.errors import PerformanceWarning
 
 import pandas as pd
-from pandas import DataFrame, Panel, Series, bdate_range, compat
+from pandas import DataFrame, Series, bdate_range, compat
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.sparse import frame as spf
 from pandas.core.sparse.api import (
@@ -1053,17 +1053,14 @@ class TestSparseDataFrame(SharedWithSparse):
         _check(float_frame_fill0, float_frame_fill0_dense)
         _check(float_frame_fill2, float_frame_fill2_dense)
 
-    @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
     def test_stack_sparse_frame(self, float_frame, float_frame_int_kind,
                                 float_frame_fill0, float_frame_fill2):
         def _check(frame):
             dense_frame = frame.to_dense()  # noqa
 
-            wp = Panel.from_dict({'foo': frame})
-            from_dense_lp = wp.to_frame()
+            from_dense_lp = frame.stack().to_frame()
 
             from_sparse_lp = spf.stack_sparse_frame(frame)
-
             tm.assert_numpy_array_equal(from_dense_lp.values,
                                         from_sparse_lp.values)
 


### PR DESCRIPTION
ref #25632 this removes a good deal of Panel references from tests though not all (excluding anything for msgpack). 

I think after this and #25567 get merged we can starting finalizing the Panel removal and get out of docs as well