### PR TITLE
CLN: Remove python2-style longs in regexes

### DIFF
--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -83,9 +83,9 @@ def test_series_getitem_returns_scalar(
 
 
 @pytest.mark.parametrize('indexer,expected_error,expected_error_msg', [
-    (lambda s: s.__getitem__((2000, 3, 4)), KeyError, r"^356L?$"),
-    (lambda s: s[(2000, 3, 4)], KeyError, r"^356L?$"),
-    (lambda s: s.loc[(2000, 3, 4)], KeyError, r"^356L?$"),
+    (lambda s: s.__getitem__((2000, 3, 4)), KeyError, r"^356$"),
+    (lambda s: s[(2000, 3, 4)], KeyError, r"^356$"),
+    (lambda s: s.loc[(2000, 3, 4)], KeyError, r"^356$"),
     (lambda s: s.loc[(2000, 3, 4, 5)], IndexingError, 'Too many indexers'),
     (lambda s: s.__getitem__(len(s)), IndexError, 'index out of bounds'),
     (lambda s: s[len(s)], IndexError, 'index out of bounds'),

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -124,11 +124,11 @@ class TestMultiIndexLoc:
         tm.assert_frame_equal(rs, xp)
 
         # missing label
-        with pytest.raises(KeyError, match=r"^2L?$"):
+        with pytest.raises(KeyError, match=r"^2$"):
             mi_int.loc[2]
         with catch_warnings(record=True):
             # GH 21593
-            with pytest.raises(KeyError, match=r"^2L?$"):
+            with pytest.raises(KeyError, match=r"^2$"):
                 mi_int.ix[2]
 
     def test_loc_multiindex_too_many_dims(self):
@@ -375,7 +375,7 @@ def test_loc_getitem_int(frame_random_data_integer_multi_index):
 def test_loc_getitem_int_raises_exception(
         frame_random_data_integer_multi_index):
     df = frame_random_data_integer_multi_index
-    with pytest.raises(KeyError, match=r"^3L?$"):
+    with pytest.raises(KeyError, match=r"^3$"):
         df.loc[3]
 
 
@@ -383,7 +383,7 @@ def test_loc_getitem_lowerdim_corner(multiindex_dataframe_random_data):
     df = multiindex_dataframe_random_data
 
     # test setup - check key not in dataframe
-    with pytest.raises(KeyError, match=r"^11L?$"):
+    with pytest.raises(KeyError, match=r"^11$"):
         df.loc[('bar', 'three'), 'B']
 
     # in theory should be inserting in a sorted space????

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -406,7 +406,7 @@ def test_datetime_indexing():
     s = Series(len(index), index=index)
     stamp = Timestamp('1/8/2000')
 
-    with pytest.raises(KeyError, match=r"^947289600000000000L?$"):
+    with pytest.raises(KeyError, match=r"^947289600000000000$"):
         s[stamp]
     s[stamp] = 0
     assert s[stamp] == 0
@@ -415,7 +415,7 @@ def test_datetime_indexing():
     s = Series(len(index), index=index)
     s = s[::-1]
 
-    with pytest.raises(KeyError, match=r"^947289600000000000L?$"):
+    with pytest.raises(KeyError, match=r"^947289600000000000$"):
         s[stamp]
     s[stamp] = 0
     assert s[stamp] == 0
@@ -507,7 +507,7 @@ def test_duplicate_dates_indexing(dups):
         expected = Series(np.where(mask, 0, ts), index=ts.index)
         assert_series_equal(cp, expected)
 
-    with pytest.raises(KeyError, match=r"^947116800000000000L?$"):
+    with pytest.raises(KeyError, match=r"^947116800000000000$"):
         ts[datetime(2000, 1, 6)]
 
     # new index

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -256,9 +256,9 @@ def test_series_box_timestamp():
 
 def test_getitem_ambiguous_keyerror():
     s = Series(lrange(10), index=lrange(0, 20, 2))
-    with pytest.raises(KeyError, match=r"^1L?$"):
+    with pytest.raises(KeyError, match=r"^1$"):
         s[1]
-    with pytest.raises(KeyError, match=r"^1L?$"):
+    with pytest.raises(KeyError, match=r"^1$"):
         s.loc[1]
 
 

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -74,9 +74,9 @@ def test_loc_getitem_setitem_integer_slice_keyerrors():
 
     # non-monotonic, raise KeyError
     s2 = s.iloc[lrange(5) + lrange(5, 10)[::-1]]
-    with pytest.raises(KeyError, match=r"^3L?$"):
+    with pytest.raises(KeyError, match=r"^3$"):
         s2.loc[3:11]
-    with pytest.raises(KeyError, match=r"^3L?$"):
+    with pytest.raises(KeyError, match=r"^3$"):
         s2.loc[3:11] = 0
 
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -471,7 +471,7 @@ class TestSeriesAnalytics:
         assert_almost_equal(a.dot(b['1']), expected['1'])
         assert_almost_equal(a.dot(b2['1']), expected['1'])
 
-        msg = r"Dot product shape mismatch, \(4L?,\) vs \(3L?,\)"
+        msg = r"Dot product shape mismatch, \(4,\) vs \(3,\)"
         # exception raised is of type Exception
         with pytest.raises(Exception, match=msg):
             a.dot(a.values[:3])


### PR DESCRIPTION
- [x] xref #25725

Minor cleanup: Cleanup some regexes that guard against python2 style longs in their error messages.