### PR TITLE
DO NOT MERGE: Pinned hypothesis

### DIFF
--- a/ci/deps/azure-windows-37.yaml
+++ b/ci/deps/azure-windows-37.yaml
@@ -29,5 +29,5 @@ dependencies:
   - pytest-xdist
   - pytest-mock
   - moto
-  - hypothesis>=3.58.0
+  - hypothesis=4.17.2
   - isort


### PR DESCRIPTION
I noticed our CI failures started around the time a new hypothesis version was posted to conda-forge so seeing if pinning that fixes the issue