### PR TITLE
BLD: Correct gcsfs install on Azure

### DIFF
--- a/ci/incremental/setup_conda_environment.cmd
+++ b/ci/incremental/setup_conda_environment.cmd
@@ -14,9 +14,10 @@ conda list
 conda remove --all -q -y -n pandas-dev
 @rem Scipy, CFFI, jinja2 and IPython are optional dependencies, but exercised in the test suite
 conda env create --file=ci\deps\azure-windows-%CONDA_PY%.yaml
-conda install -c conda-forge gcsfs
 
 call activate pandas-dev
+@rem gh-26345: we need to separate this out so that Azure doesn't complain
+conda install -c conda-forge gcsfs
 conda list
 
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
Follow-up #26352

Also realized that the `gcsfs` install was placed in the wrong place (needs to be placed after the `activate` command).  However, you will notice then that the install is the culprit for the earlier 3.7 build failures (something is not right on `conda-forge` and / with `gcsfs` and `3.7`).  Note though that the install of `gcsfs` works just fine on `3.6`.