### PR TITLE
New benchmarks for parsing dates with dayfirst=True and format='%d-%m-%Y'

### DIFF
--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -272,22 +272,22 @@ class ReadCSVMemoryGrowth(BaseIO):
 
 
 class ReadCSVParseSpecialDate(StringIORewind):
-    params = (['mY', 'mdY', 'hm'], [False, True])
-    param_names = ['value', 'dayfirst']
+    params = (['mY', 'mdY', 'hm'],)
+    param_names = ['value']
     objects = {
         'mY': '01-2019\n10-2019\n02/2000\n',
         'mdY': '12/02/2010\n',
         'hm': '21:34\n'
     }
 
-    def setup(self, value, dayfirst):
+    def setup(self, value):
         count_elem = 10000
         data = self.objects[value] * count_elem
         self.StringIO_input = StringIO(data)
 
-    def time_read_special_date(self, value, dayfirst):
+    def time_read_special_date(self, value):
         read_csv(self.data(self.StringIO_input), sep=',', header=None,
-                 names=['Date'], parse_dates=['Date'], dayfirst=dayfirst)
+                 names=['Date'], parse_dates=['Date'])
 
 
 class ParseDateComparison(StringIORewind):

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -272,22 +272,22 @@ class ReadCSVMemoryGrowth(BaseIO):
 
 
 class ReadCSVParseSpecialDate(StringIORewind):
-    params = (['mY', 'mdY', 'hm'],)
-    params_name = ['value']
+    params = (['mY', 'mdY', 'hm'], [False, True])
+    params_name = ['value', 'dayfirst']
     objects = {
         'mY': '01-2019\n10-2019\n02/2000\n',
         'mdY': '12/02/2010\n',
         'hm': '21:34\n'
     }
 
-    def setup(self, value):
+    def setup(self, value, dayfirst):
         count_elem = 10000
         data = self.objects[value] * count_elem
         self.StringIO_input = StringIO(data)
 
-    def time_read_special_date(self, value):
+    def time_read_special_date(self, value, dayfirst):
         read_csv(self.data(self.StringIO_input), sep=',', header=None,
-                 names=['Date'], parse_dates=['Date'])
+                 names=['Date'], parse_dates=['Date'], dayfirst=dayfirst)
 
 
 from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -3,7 +3,7 @@ import string
 
 import numpy as np
 import pandas.util.testing as tm
-from pandas import DataFrame, Categorical, date_range, read_csv
+from pandas import DataFrame, Categorical, date_range, read_csv, to_datetime
 from pandas.io.parsers import _parser_defaults
 from io import StringIO
 
@@ -273,7 +273,7 @@ class ReadCSVMemoryGrowth(BaseIO):
 
 class ReadCSVParseSpecialDate(StringIORewind):
     params = (['mY', 'mdY', 'hm'], [False, True])
-    params_name = ['value', 'dayfirst']
+    param_names = ['value', 'dayfirst']
     objects = {
         'mY': '01-2019\n10-2019\n02/2000\n',
         'mdY': '12/02/2010\n',
@@ -288,6 +288,31 @@ class ReadCSVParseSpecialDate(StringIORewind):
     def time_read_special_date(self, value, dayfirst):
         read_csv(self.data(self.StringIO_input), sep=',', header=None,
                  names=['Date'], parse_dates=['Date'], dayfirst=dayfirst)
+
+
+class ParseDateComparison(StringIORewind):
+    params = ([False, True],)
+    param_names = ['cache_dates']
+
+    def setup(self, cache_dates):
+        count_elem = 10000
+        data = '12-02-2010\n' * count_elem
+        self.StringIO_input = StringIO(data)
+
+    def time_read_csv_dayfirst(self, cache_dates):
+        read_csv(self.data(self.StringIO_input), sep=',', header=None,
+                 names=['Date'], parse_dates=['Date'], cache_dates=cache_dates,
+                 dayfirst=True)
+
+    def time_to_datetime_dayfirst(self, cache_dates):
+        df = read_csv(self.data(self.StringIO_input),
+                      dtype={'date': str}, names=['date'])
+        to_datetime(df['date'], cache=cache_dates, dayfirst=True)
+
+    def time_to_datetime_format_DD_MM_YYYY(self, cache_dates):
+        df = read_csv(self.data(self.StringIO_input),
+                      dtype={'date': str}, names=['date'])
+        to_datetime(df['date'], cache=cache_dates, format='%d-%m-%Y')
 
 
 from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -354,8 +354,10 @@ class ToDatetimeFormatQuarters:
 class ToDatetimeFormat:
 
     def setup(self):
-        self.s = Series(['19MAY11', '19MAY11:00:00:00'] * 100000)
+        self.count = 100000
+        self.s = Series(['19MAY11', '19MAY11:00:00:00'] * self.count)
         self.s2 = self.s.str.replace(':\\S+$', '')
+        self.s3 = Series(['02-11-2000'] * self.count)
 
     def time_exact(self):
         to_datetime(self.s2, format='%d%b%y')
@@ -363,6 +365,8 @@ class ToDatetimeFormat:
     def time_no_exact(self):
         to_datetime(self.s, format='%d%b%y', exact=False)
 
+    def time_DDMMYYYY(self):
+        to_datetime(self.s3, format='%d-%m-%Y')
 
 class ToDatetimeCache:
 

--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -354,10 +354,8 @@ class ToDatetimeFormatQuarters:
 class ToDatetimeFormat:
 
     def setup(self):
-        self.count = 100000
-        self.s = Series(['19MAY11', '19MAY11:00:00:00'] * self.count)
+        self.s = Series(['19MAY11', '19MAY11:00:00:00'] * 100000)
         self.s2 = self.s.str.replace(':\\S+$', '')
-        self.s3 = Series(['02-11-2000'] * self.count)
 
     def time_exact(self):
         to_datetime(self.s2, format='%d%b%y')
@@ -365,8 +363,6 @@ class ToDatetimeFormat:
     def time_no_exact(self):
         to_datetime(self.s, format='%d%b%y', exact=False)
 
-    def time_DDMMYYYY(self):
-        to_datetime(self.s3, format='%d-%m-%Y')
 
 class ToDatetimeCache:
 


### PR DESCRIPTION
- [x] closes #25848
- [x] tests added
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Gap in performance between use dayfirst or format is acceptable now.

`asv run -E existing -b ParseDateComparison -a warmup_time=2 -a sample_time=2`:

| io.csv.ParseDateComparison.time_read_csv_dayfirst | parameter| time
:-:|:-:|:-:
-|cache_dates| -
-|False|      16.3±0.4ms
-|True|      7.22±0.2ms
| **io.csv.ParseDateComparison.time_to_datetime_dayfirst** | **parameter**| **time**
-|cache_dates| -
-|False|      15.0±0.3ms
-|True|      5.67±0.2ms
| **io.csv.ParseDateComparison.time_to_datetime_format_DD_MM_YYYY** | **parameter**| **time**
-| cache_dates|-
-|False|      25.0±0.4ms
-|True|      5.47±0.4ms