### PR TITLE
Compat with numpy dev argsort (radix sort added)

### DIFF
--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -18,9 +18,10 @@ and methods that are spread throughout the codebase. This module will make it
 easier to adjust to future upstream changes in the analogous numpy signatures.
 """
 from collections import OrderedDict
+from distutils.version import LooseVersion
 from typing import Any, Dict, Optional, Union
 
-from numpy import ndarray
+from numpy import __version__ as _np_version, ndarray
 
 from pandas._libs.lib import is_bool, is_integer
 from pandas.errors import UnsupportedFunctionCall
@@ -107,6 +108,12 @@ ARGSORT_DEFAULTS = OrderedDict() \
 ARGSORT_DEFAULTS['axis'] = -1
 ARGSORT_DEFAULTS['kind'] = 'quicksort'
 ARGSORT_DEFAULTS['order'] = None
+
+if LooseVersion(_np_version) >= LooseVersion("1.17.0"):
+    # GH-26361. NumPy added radix sort and changed default to None.
+    ARGSORT_DEFAULTS['kind'] = None
+
+
 validate_argsort = CompatValidator(ARGSORT_DEFAULTS, fname='argsort',
                                    max_fname_arg_count=0, method='both')
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -10,8 +10,7 @@ from pandas.errors import PerformanceWarning
 
 import pandas as pd
 from pandas import (
-    DataFrame, Index, MultiIndex, Series, Timestamp, date_range,
-    read_csv)
+    DataFrame, Index, MultiIndex, Series, Timestamp, date_range, read_csv)
 import pandas.core.common as com
 import pandas.util.testing as tm
 from pandas.util.testing import (


### PR DESCRIPTION
https://github.com/numpy/numpy/commit/12fb1015511ac3804d0785bb0d1fe539385548ad
adds radix sort to np.argsort. For versions of NumPy with this change
(>=1.17), we need to adjust our validator.

Closes https://github.com/pandas-dev/pandas/issues/26361