### PR TITLE
Remove extraneous brackets

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -536,7 +536,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     datetime_format : string, default None
         Format string for datetime objects written into Excel files
         (e.g. 'YYYY-MM-DD HH:MM:SS')
-    mode : 'w' or 'a', default 'w'
+    mode : {'w', 'a'}, default 'w'
         File mode to use (write or append).
 
         .. versionadded:: 0.24.0

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -146,7 +146,7 @@ parse_dates : bool, list-like, or dict, default False
       each as a separate date column.
     * list of lists. e.g.  If [[1, 3]] -> combine columns 1 and 3 and parse as
       a single date column.
-    * dict, e.g. {{'foo' : [1, 3]}} -> parse columns 1, 3 as date and call
+    * dict, e.g. {'foo' : [1, 3]} -> parse columns 1, 3 as date and call
       result 'foo'
 
     If a column or index contains an unparseable date, the entire column or
@@ -536,7 +536,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     datetime_format : string, default None
         Format string for datetime objects written into Excel files
         (e.g. 'YYYY-MM-DD HH:MM:SS')
-    mode : {'w' or 'a'}, default 'w'
+    mode : 'w' or 'a', default 'w'
         File mode to use (write or append).
 
         .. versionadded:: 0.24.0


### PR DESCRIPTION
Trivial documentation changes

Dictionary should have one set of brackets (as seen below in documentation example `{'a': np.float64, 'b': np.int32}`).

Brackets don't make sense around `'w' or 'a'`.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
