### PR TITLE
Fix type annotations in pandas.core.ops

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -26,9 +26,6 @@ ignore_errors=True
 [mypy-pandas.core.internals.blocks]
 ignore_errors=True
 
-[mypy-pandas.core.ops]
-ignore_errors=True
-
 [mypy-pandas.core.panel]
 ignore_errors=True
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -6,7 +6,7 @@ This is not a public API.
 import datetime
 import operator
 import textwrap
-from typing import Dict, Optional, Union, cast
+from typing import Dict, Optional
 import warnings
 
 import numpy as np
@@ -626,7 +626,7 @@ _op_descriptions = {
            'desc': 'Greater than or equal to',
            'reverse': None,
            'series_examples': None}
-}  # type: Dict[str, Dict[str, Optional[Union[bool, str]]]]
+}  # type: Dict[str, Dict[str, Optional[str]]]
 
 # When TypedDict becomes available, this annotation would be much better and
 # more readable if defined using that structure. The casts() below would not be
@@ -635,12 +635,10 @@ _op_descriptions = {
 
 _op_names = list(_op_descriptions.keys())
 for key in _op_names:
-    _op_descriptions[key]['reversed'] = False
     reverse_op = _op_descriptions[key]['reverse']
     if reverse_op is not None:
-        _op_descriptions[cast(str, reverse_op)] = _op_descriptions[key].copy()
-        _op_descriptions[cast(str, reverse_op)]['reversed'] = True
-        _op_descriptions[cast(str, reverse_op)]['reverse'] = key
+        _op_descriptions[reverse_op] = _op_descriptions[key].copy()
+        _op_descriptions[reverse_op]['reverse'] = key
 
 _flex_doc_SERIES = """
 Return {desc} of series and other, element-wise (binary operator `{op_name}`).
@@ -1016,7 +1014,7 @@ def _make_flex_doc(op_name, typ):
     op_name = op_name.replace('__', '')
     op_desc = _op_descriptions[op_name]
 
-    if op_desc['reversed']:
+    if op_name.startswith('r'):
         equiv = 'other ' + op_desc['op'] + ' ' + typ
     else:
         equiv = typ + ' ' + op_desc['op'] + ' other'

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -6,8 +6,10 @@ This is not a public API.
 import datetime
 import operator
 import textwrap
+from typing import Dict, Optional
 import warnings
 
+from mypy_extensions import TypedDict
 import numpy as np
 
 from pandas._libs import algos as libalgos, lib, ops as libops
@@ -560,6 +562,18 @@ e    NaN
 dtype: float64
 """
 
+Operator_description = TypedDict(
+    'Operator_description',
+    {
+        'op': str,
+        'desc': str,
+        'reverse': Optional[str],
+        'series_examples': Optional[str],
+        'df_examples': Optional[str],
+        'reversed': bool
+    },
+    total=False)
+
 _op_descriptions = {
     # Arithmetic Operators
     'add': {'op': '+',
@@ -625,7 +639,7 @@ _op_descriptions = {
            'desc': 'Greater than or equal to',
            'reverse': None,
            'series_examples': None}
-}
+}  # type: Dict[str, Operator_description]
 
 _op_names = list(_op_descriptions.keys())
 for key in _op_names:

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -628,11 +628,6 @@ _op_descriptions = {
            'series_examples': None}
 }  # type: Dict[str, Dict[str, Optional[str]]]
 
-# When TypedDict becomes available, this annotation would be much better and
-# more readable if defined using that structure. The casts() below would not be
-# necessary, because only the dictionary values keyed to 'reversed' would be
-# typed as bool. See GH#26377.
-
 _op_names = list(_op_descriptions.keys())
 for key in _op_names:
     reverse_op = _op_descriptions[key]['reverse']

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -6,10 +6,9 @@ This is not a public API.
 import datetime
 import operator
 import textwrap
-from typing import Dict, Optional
+from typing import Dict, Optional, Union, cast
 import warnings
 
-from mypy_extensions import TypedDict
 import numpy as np
 
 from pandas._libs import algos as libalgos, lib, ops as libops
@@ -562,18 +561,6 @@ e    NaN
 dtype: float64
 """
 
-Operator_description = TypedDict(
-    'Operator_description',
-    {
-        'op': str,
-        'desc': str,
-        'reverse': Optional[str],
-        'series_examples': Optional[str],
-        'df_examples': Optional[str],
-        'reversed': bool
-    },
-    total=False)
-
 _op_descriptions = {
     # Arithmetic Operators
     'add': {'op': '+',
@@ -639,16 +626,21 @@ _op_descriptions = {
            'desc': 'Greater than or equal to',
            'reverse': None,
            'series_examples': None}
-}  # type: Dict[str, Operator_description]
+}  # type: Dict[str, Dict[str, Optional[Union[bool, str]]]]
+
+# When TypedDict becomes available, this annotation would be much better and
+# more readable if defined using that structure. The casts() below would not be
+# necessary, because only the dictionary values keyed to 'reversed' would be
+# typed as bool. See GH#26377.
 
 _op_names = list(_op_descriptions.keys())
 for key in _op_names:
     _op_descriptions[key]['reversed'] = False
     reverse_op = _op_descriptions[key]['reverse']
     if reverse_op is not None:
-        _op_descriptions[reverse_op] = _op_descriptions[key].copy()
-        _op_descriptions[reverse_op]['reversed'] = True
-        _op_descriptions[reverse_op]['reverse'] = key
+        _op_descriptions[cast(str, reverse_op)] = _op_descriptions[key].copy()
+        _op_descriptions[cast(str, reverse_op)]['reversed'] = True
+        _op_descriptions[cast(str, reverse_op)]['reverse'] = key
 
 _flex_doc_SERIES = """
 Return {desc} of series and other, element-wise (binary operator `{op_name}`).


### PR DESCRIPTION
Part of #25882
- [X] tests passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Corrects these errors in `pandas.core.ops`:
```
pandas/core/ops.py:632: error: Unsupported target for indexed assignment
pandas/core/ops.py:633: error: Value of type "object" is not indexable
pandas/core/ops.py:635: error: "object" has no attribute "copy"
pandas/core/ops.py:636: error: Unsupported target for indexed assignment
pandas/core/ops.py:637: error: Unsupported target for indexed assignment
```
