### PR TITLE
BUG: Series.combine_first with mixed timezones

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -423,7 +423,7 @@ Reshaping
 - Bug in :func:`pandas.cut` where large bins could incorrectly raise an error due to an integer overflow (:issue:`26045`)
 - Bug in :func:`DataFrame.sort_index` where an error is thrown when a multi-indexed DataFrame is sorted on all levels with the initial level sorted last (:issue:`26053`)
 - Bug in :meth:`Series.nlargest` treats ``True`` as smaller than ``False`` (:issue:`26154`)
-- Bug in :meth:`Series.combine_first` where and combining a :class:`Series` with an :class:`Index` with mixed timezones would raise a ``ValueError`` (:issue:`26283`)
+- Bug in :meth:`Series.combine_first` where combining a :class:`Series` with an :class:`Index` with mixed timezones would raise a ``ValueError`` (:issue:`26283`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -423,6 +423,7 @@ Reshaping
 - Bug in :func:`pandas.cut` where large bins could incorrectly raise an error due to an integer overflow (:issue:`26045`)
 - Bug in :func:`DataFrame.sort_index` where an error is thrown when a multi-indexed DataFrame is sorted on all levels with the initial level sorted last (:issue:`26053`)
 - Bug in :meth:`Series.nlargest` treats ``True`` as smaller than ``False`` (:issue:`26154`)
+- Bug in :meth:`Series.combine_first` where and combining a :class:`Series` with an :class:`Index` with mixed timezones would raise a ``ValueError`` (:issue:`26283`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -489,6 +489,9 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
                 other = DatetimeIndex(other)
             except TypeError:
                 pass
+            except ValueError:
+                # GH 26283: Convert indexes with mixed tz to UTC
+                other = tools.to_datetime(other, utc=True)
 
         this, other = self._maybe_utc_convert(other)
 

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -5,7 +5,7 @@ from numpy import nan
 import pytest
 
 import pandas as pd
-from pandas import DataFrame, DatetimeIndex, Series, date_range
+from pandas import DataFrame, DatetimeIndex, Series, Timestamp, date_range
 import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
@@ -368,3 +368,23 @@ class TestTimeseries:
 
         appended = rng.append(rng2)
         tm.assert_index_equal(appended, rng3)
+
+    def test_combine_first_with_mixed_tz(self):
+        # GH 26283
+        uniform_tz = Series({Timestamp("2019-05-01", tz='UTC'): 1.0})
+
+        multi_tz = Series(
+            {
+                Timestamp("2019-05-01 01:00:00+0100", tz='Europe/London'): 2.0,
+                Timestamp("2019-05-02", tz='UTC'): 3.0
+            }
+        )
+
+        result = uniform_tz.combine_first(multi_tz)
+        expected = Series(
+            {
+                Timestamp("2019-05-01", tz='UTC'): 1.0,
+                Timestamp("2019-05-02", tz='UTC'): 3.0
+            }
+        )
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #26283
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
