### PR TITLE
[TEST] Add two more parameters to the test_dti_add_sub_nonzero_mth_offset

### DIFF
--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1435,37 +1435,38 @@ class TestDatetime64DateOffsetArithmetic:
         expected = tm.box_expected(expected, box_with_array)
         tm.assert_equal(res, expected)
 
-    @pytest.mark.parametrize("box", [pd.Index, pd.Series, pd.DataFrame])
-    @pytest.mark.parametrize("op, offset, exp", [
+    @pytest.mark.parametrize("op, offset, exp, exp_freq", [
         ('__add__', pd.DateOffset(months=3, days=10),
          [Timestamp('2014-04-11'), Timestamp('2015-04-11'),
-          Timestamp('2016-04-11'), Timestamp('2017-04-11')]),
+          Timestamp('2016-04-11'), Timestamp('2017-04-11')],
+         None),
         ('__add__', pd.DateOffset(months=3),
          [Timestamp('2014-04-01'), Timestamp('2015-04-01'),
-          Timestamp('2016-04-01'), Timestamp('2017-04-01')]),
+          Timestamp('2016-04-01'), Timestamp('2017-04-01')],
+         "AS-APR"),
         ('__sub__', pd.DateOffset(months=3, days=10),
          [Timestamp('2013-09-21'), Timestamp('2014-09-21'),
-          Timestamp('2015-09-21'), Timestamp('2016-09-21')]),
+          Timestamp('2015-09-21'), Timestamp('2016-09-21')],
+         None),
         ('__sub__', pd.DateOffset(months=3),
          [Timestamp('2013-10-01'), Timestamp('2014-10-01'),
-          Timestamp('2015-10-01'), Timestamp('2016-10-01')])
-
+          Timestamp('2015-10-01'), Timestamp('2016-10-01')],
+         "AS-OCT")
     ])
-    def test_dti_add_sub_nonzero_mth_offset(self, op, offset, exp,
+    def test_dti_add_sub_nonzero_mth_offset(self, op, offset,
+                                            exp, exp_freq,
                                             tz_aware_fixture,
-                                            box):
+                                            box_with_array):
         # GH 26258
         tz = tz_aware_fixture
         date = date_range(start='01 Jan 2014', end='01 Jan 2017', freq='AS',
                           tz=tz)
-        date = (tm.box_expected(date, box) if box is not pd.DataFrame
-                else tm.box_expected(date, box, False))
+        date = tm.box_expected(date, box_with_array, False)
         mth = getattr(date, op)
         result = mth(offset)
 
-        expected = pd.Index(exp, tz=tz)
-        expected = (tm.box_expected(expected, box) if box is not pd.DataFrame
-                    else tm.box_expected(expected, box, False))
+        expected = pd.DatetimeIndex(exp, tz=tz, freq=exp_freq)
+        expected = tm.box_expected(expected, box_with_array, False)
         tm.assert_equal(result, expected)
 
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1435,27 +1435,38 @@ class TestDatetime64DateOffsetArithmetic:
         expected = tm.box_expected(expected, box_with_array)
         tm.assert_equal(res, expected)
 
+    @pytest.mark.parametrize("box", [pd.Index, pd.Series, pd.DataFrame])
     @pytest.mark.parametrize("op, offset, exp", [
         ('__add__', pd.DateOffset(months=3, days=10),
-         DatetimeIndex([Timestamp('2014-04-11'), Timestamp('2015-04-11'),
-                        Timestamp('2016-04-11'), Timestamp('2017-04-11')])),
+         [Timestamp('2014-04-11'), Timestamp('2015-04-11'),
+          Timestamp('2016-04-11'), Timestamp('2017-04-11')]),
         ('__add__', pd.DateOffset(months=3),
-         DatetimeIndex([Timestamp('2014-04-01'), Timestamp('2015-04-01'),
-                        Timestamp('2016-04-01'), Timestamp('2017-04-01')])),
+         [Timestamp('2014-04-01'), Timestamp('2015-04-01'),
+          Timestamp('2016-04-01'), Timestamp('2017-04-01')]),
         ('__sub__', pd.DateOffset(months=3, days=10),
-         DatetimeIndex([Timestamp('2013-09-21'), Timestamp('2014-09-21'),
-                        Timestamp('2015-09-21'), Timestamp('2016-09-21')])),
+         [Timestamp('2013-09-21'), Timestamp('2014-09-21'),
+          Timestamp('2015-09-21'), Timestamp('2016-09-21')]),
         ('__sub__', pd.DateOffset(months=3),
-         DatetimeIndex([Timestamp('2013-10-01'), Timestamp('2014-10-01'),
-                        Timestamp('2015-10-01'), Timestamp('2016-10-01')]))
+         [Timestamp('2013-10-01'), Timestamp('2014-10-01'),
+          Timestamp('2015-10-01'), Timestamp('2016-10-01')])
 
     ])
-    def test_dti_add_sub_nonzero_mth_offset(self, op, offset, exp):
+    def test_dti_add_sub_nonzero_mth_offset(self, op, offset, exp,
+                                            tz_aware_fixture,
+                                            box):
         # GH 26258
-        date = date_range(start='01 Jan 2014', end='01 Jan 2017', freq='AS')
+        tz = tz_aware_fixture
+        date = date_range(start='01 Jan 2014', end='01 Jan 2017', freq='AS',
+                          tz=tz)
+        date = (tm.box_expected(date, box) if box is not pd.DataFrame
+                else tm.box_expected(date, box, False))
         mth = getattr(date, op)
         result = mth(offset)
-        tm.assert_equal(result, exp)
+
+        expected = pd.Index(exp, tz=tz)
+        expected = (tm.box_expected(expected, box) if box is not pd.DataFrame
+                    else tm.box_expected(expected, box, False))
+        tm.assert_equal(result, expected)
 
 
 class TestDatetime64OverflowHandling:


### PR DESCRIPTION
- follow up the comment in  #26292
- passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
