### PR TITLE
CLN: remove compat.lrange

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -4,9 +4,6 @@ compat
 
 Cross-compatible functions for different versions of Python.
 
-Key items to import for compatible code:
-* lists: lrange()
-
 Other items:
 * platform checker
 """
@@ -17,11 +14,6 @@ import sys
 PY36 = sys.version_info >= (3, 6)
 PY37 = sys.version_info >= (3, 7)
 PYPY = platform.python_implementation() == 'PyPy'
-
-
-# list-producing versions of the major Python iterating functions
-def lrange(*args, **kwargs):
-    return list(range(*args, **kwargs))
 
 
 # ----------------------------------------------------------------------------

--- a/pandas/plotting/_converter.py
+++ b/pandas/plotting/_converter.py
@@ -12,7 +12,6 @@ import numpy as np
 from pandas._libs import lib, tslibs
 from pandas._libs.tslibs import resolution
 from pandas._libs.tslibs.frequencies import FreqGroup, get_freq
-from pandas.compat import lrange
 
 from pandas.core.dtypes.common import (
     is_datetime64_ns_dtype, is_float, is_float_dtype, is_integer,
@@ -1029,7 +1028,7 @@ class TimeSeries_DateLocator(Locator):
             base = self.base
             (d, m) = divmod(vmin, base)
             vmin = (d + 1) * base
-            locs = lrange(vmin, vmax + 1, base)
+            locs = list(range(vmin, vmax + 1, base))
         return locs
 
     def autoscale(self):

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from pandas._config import get_option
 
-from pandas.compat import lrange
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, cache_readonly
 
@@ -583,9 +582,9 @@ class MPLPlot:
                 x = self.data.index._mpl_repr()
             else:
                 self._need_to_set_index = True
-                x = lrange(len(index))
+                x = list(range(len(index)))
         else:
-            x = lrange(len(index))
+            x = list(range(len(index)))
 
         return x
 

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -1,7 +1,6 @@
 # being a bit too dynamic
 import numpy as np
 
-from pandas.compat import lrange
 from pandas.util._decorators import deprecate_kwarg
 
 from pandas.core.dtypes.missing import notna
@@ -81,8 +80,8 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
         rdelta_ext = (rmax_ - rmin_) * range_padding / 2.
         boundaries_list.append((rmin_ - rdelta_ext, rmax_ + rdelta_ext))
 
-    for i, a in zip(lrange(n), df.columns):
-        for j, b in zip(lrange(n), df.columns):
+    for i, a in enumerate(df.columns):
+        for j, b in enumerate(df.columns):
             ax = axes[i, j]
 
             if i == j:
@@ -420,7 +419,7 @@ def bootstrap_plot(series, fig=None, size=50, samples=500, **kwds):
                           for sampling in samplings])
     if fig is None:
         fig = plt.figure()
-    x = lrange(samples)
+    x = list(range(samples))
     axes = []
     ax1 = fig.add_subplot(2, 3, 1)
     ax1.set_xlabel("Sample")
@@ -532,7 +531,7 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
             raise ValueError('Length of xticks must match number of columns')
         x = xticks
     else:
-        x = lrange(ncols)
+        x = list(range(ncols))
 
     if ax is None:
         ax = plt.gca()

--- a/pandas/plotting/_style.py
+++ b/pandas/plotting/_style.py
@@ -4,8 +4,6 @@ import warnings
 
 import numpy as np
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import is_list_like
 
 
@@ -49,7 +47,7 @@ def _get_standard_colors(num_colors=None, colormap=None, color_type='default',
                 rs = com.random_state(column)
                 return rs.rand(3).tolist()
 
-            colors = [random_color(num) for num in lrange(num_colors)]
+            colors = [random_color(num) for num in range(num_colors)]
         else:
             raise ValueError("color_type must be either 'default' or 'random'")
 

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -3,8 +3,6 @@ import collections
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 from pandas import Categorical, Index, isna
@@ -16,7 +14,7 @@ class TestCategoricalMissing:
     def test_na_flags_int_categories(self):
         # #1457
 
-        categories = lrange(10)
+        categories = list(range(10))
         labels = np.random.randint(0, 10, 20)
         labels[::5] = -1
 

--- a/pandas/tests/frame/test_duplicates.py
+++ b/pandas/tests/frame/test_duplicates.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas import DataFrame, Series
 import pandas.util.testing as tm
 
@@ -88,8 +86,8 @@ def test_drop_duplicates():
                     'B': ['one', 'one', 'two', 'two',
                           'two', 'two', 'one', 'two'],
                     'C': [1, 1, 2, 2, 2, 2, 1, 2],
-                    'D': lrange(8)})
-
+                    'D': range(8),
+                    })
     # single column
     result = df.drop_duplicates('AAA')
     expected = df[:2]
@@ -211,8 +209,8 @@ def test_drop_duplicates_for_take_all():
                     'B': ['one', 'one', 'two', 'two',
                           'two', 'two', 'one', 'two'],
                     'C': [1, 1, 2, 2, 2, 2, 1, 2],
-                    'D': lrange(8)})
-
+                    'D': range(8),
+                    })
     # single column
     result = df.drop_duplicates('AAA')
     expected = df.iloc[[0, 1, 2, 6]]
@@ -246,8 +244,8 @@ def test_drop_duplicates_tuple():
                     'B': ['one', 'one', 'two', 'two',
                           'two', 'two', 'one', 'two'],
                     'C': [1, 1, 2, 2, 2, 2, 1, 2],
-                    'D': lrange(8)})
-
+                    'D': range(8),
+                    })
     # single column
     result = df.drop_duplicates(('AA', 'AB'))
     expected = df[:2]
@@ -292,8 +290,8 @@ def test_drop_duplicates_NA():
                     'B': ['one', 'one', 'two', 'two',
                           'two', 'two', 'one', 'two'],
                     'C': [1.0, np.nan, np.nan, np.nan, 1., 1., 1, 1.],
-                    'D': lrange(8)})
-
+                    'D': range(8),
+                    })
     # single column
     result = df.drop_duplicates('A')
     expected = df.loc[[0, 2, 3]]
@@ -327,8 +325,8 @@ def test_drop_duplicates_NA():
                     'B': ['one', 'one', 'two', 'two',
                           'two', 'two', 'one', 'two'],
                     'C': [1.0, np.nan, np.nan, np.nan, 1., 1., 1, 1.],
-                    'D': lrange(8)})
-
+                    'D': range(8),
+                    })
     # single column
     result = df.drop_duplicates('C')
     expected = df[:2]
@@ -398,8 +396,8 @@ def test_drop_duplicates_inplace():
                       'B': ['one', 'one', 'two', 'two',
                             'two', 'two', 'one', 'two'],
                       'C': [1, 1, 2, 2, 2, 2, 1, 2],
-                      'D': lrange(8)})
-
+                      'D': range(8),
+                      })
     # single column
     df = orig.copy()
     df.drop_duplicates('A', inplace=True)

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -11,7 +11,6 @@ import pytest
 import pytz
 
 from pandas._libs.tslibs import conversion, timezones
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -958,7 +957,7 @@ class TestDatetimeIndexTimezones:
     def test_dti_take_dont_lose_meta(self, tzstr):
         rng = date_range('1/1/2000', periods=20, tz=tzstr)
 
-        result = rng.take(lrange(5))
+        result = rng.take(range(5))
         assert result.tz == rng.tz
         assert result.freq == rng.freq
 

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 from pandas.compat.numpy import _np_version_under1p17
 
 import pandas as pd
@@ -32,8 +31,8 @@ def test_groupby(idx):
 
 
 def test_truncate():
-    major_axis = Index(lrange(4))
-    minor_axis = Index(lrange(2))
+    major_axis = Index(list(range(4)))
+    minor_axis = Index(list(range(2)))
 
     major_codes = np.array([0, 0, 1, 2, 3, 3])
     minor_codes = np.array([0, 1, 0, 1, 0, 1])

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import Timestamp
-from pandas.compat import lrange
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 
@@ -383,7 +382,7 @@ def test_from_product_empty_two_levels(first, second):
 def test_from_product_empty_three_levels(N):
     # GH12258
     names = ['A', 'B', 'C']
-    lvl2 = lrange(N)
+    lvl2 = list(range(N))
     result = MultiIndex.from_product([[], lvl2, []], names=names)
     expected = MultiIndex(levels=[[], lvl2, []],
                           codes=[[], [], []], names=names)

--- a/pandas/tests/indexes/multi/test_drop.py
+++ b/pandas/tests/indexes/multi/test_drop.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 from pandas.errors import PerformanceWarning
 
 import pandas as pd
@@ -73,9 +72,10 @@ def test_droplevel_with_names(idx):
     assert dropped.name == 'second'
 
     index = MultiIndex(
-        levels=[Index(lrange(4)), Index(lrange(4)), Index(lrange(4))],
-        codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
-            [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])],
+        levels=[Index(range(4)), Index(range(4)), Index(range(4))],
+        codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]),
+               np.array([0, 1, 0, 0, 0, 1, 0, 1]),
+               np.array([1, 0, 1, 1, 0, 0, 1, 0])],
         names=['one', 'two', 'three'])
     dropped = index.droplevel(0)
     assert dropped.names == ('two', 'three')
@@ -87,9 +87,10 @@ def test_droplevel_with_names(idx):
 
 def test_droplevel_list():
     index = MultiIndex(
-        levels=[Index(lrange(4)), Index(lrange(4)), Index(lrange(4))],
-        codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
-            [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])],
+        levels=[Index(range(4)), Index(range(4)), Index(range(4))],
+        codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]),
+               np.array([0, 1, 0, 0, 0, 1, 0, 1]),
+               np.array([1, 0, 1, 1, 0, 0, 1, 0])],
         names=['one', 'two', 'three'])
 
     dropped = index[:2].droplevel(['three', 'one'])

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import Index, MultiIndex, Series
 import pandas.util.testing as tm
@@ -96,17 +94,21 @@ def test_equals_multi(idx):
     assert not idx.equals(idx[-1])
 
     # different number of levels
-    index = MultiIndex(levels=[Index(lrange(4)), Index(lrange(4)), Index(
-        lrange(4))], codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
-            [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])])
+    index = MultiIndex(levels=[Index(list(range(4))),
+                               Index(list(range(4))),
+                               Index(list(range(4)))],
+                       codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]),
+                              np.array([0, 1, 0, 0, 0, 1, 0, 1]),
+                              np.array([1, 0, 1, 1, 0, 0, 1, 0])],
+                       )
 
     index2 = MultiIndex(levels=index.levels[:-1], codes=index.codes[:-1])
     assert not index.equals(index2)
     assert not index.equal_levels(index2)
 
     # levels are different
-    major_axis = Index(lrange(4))
-    minor_axis = Index(lrange(2))
+    major_axis = Index(list(range(4)))
+    minor_axis = Index(list(range(2)))
 
     major_codes = np.array([0, 0, 1, 2, 2, 3])
     minor_codes = np.array([0, 1, 0, 0, 1, 0])
@@ -178,14 +180,14 @@ def test_is_():
     mi2.set_names(["E", "F"], inplace=True)
     assert mi.is_(mi2)
     # levels are inherent properties, they change identity
-    mi3 = mi2.set_levels([lrange(10), lrange(10)])
+    mi3 = mi2.set_levels([list(range(10)), list(range(10))])
     assert not mi3.is_(mi2)
     # shouldn't change
     assert mi2.is_(mi)
     mi4 = mi3.view()
 
     # GH 17464 - Remove duplicate MultiIndex levels
-    mi4.set_levels([lrange(10), lrange(10)], inplace=True)
+    mi4.set_levels([list(range(10)), list(range(10))], inplace=True)
     assert not mi4.is_(mi3)
     mi5 = mi.view()
     mi5.set_levels(mi5.levels, inplace=True)

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -3,8 +3,6 @@ from datetime import timedelta
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import (
     Categorical, CategoricalIndex, Index, IntervalIndex, MultiIndex,
@@ -66,10 +64,13 @@ def test_slice_locs_with_type_mismatch():
 
 
 def test_slice_locs_not_sorted():
-    index = MultiIndex(levels=[Index(lrange(4)), Index(lrange(4)), Index(
-        lrange(4))], codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
-            [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])])
-
+    index = MultiIndex(levels=[Index(np.arange(4)),
+                               Index(np.arange(4)),
+                               Index(np.arange(4))],
+                       codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]),
+                              np.array([0, 1, 0, 0, 0, 1, 0, 1]),
+                              np.array([1, 0, 1, 1, 0, 0, 1, 0])],
+                       )
     msg = "[Kk]ey length.*greater than MultiIndex lexsort depth"
     with pytest.raises(KeyError, match=msg):
         index.slice_locs((1, 0, 1), (2, 1, 0))
@@ -121,8 +122,8 @@ def test_putmask_with_wrong_mask(idx):
 
 
 def test_get_indexer():
-    major_axis = Index(lrange(4))
-    minor_axis = Index(lrange(2))
+    major_axis = Index(np.arange(4))
+    minor_axis = Index(np.arange(2))
 
     major_codes = np.array([0, 0, 1, 2, 2, 3, 3], dtype=np.intp)
     minor_codes = np.array([0, 1, 0, 0, 1, 0, 1], dtype=np.intp)
@@ -164,8 +165,8 @@ def test_get_indexer():
     assert (r1 == [-1, -1, -1]).all()
 
     # create index with duplicates
-    idx1 = Index(lrange(10) + lrange(10))
-    idx2 = Index(lrange(20))
+    idx1 = Index(list(range(10)) + list(range(10)))
+    idx2 = Index(list(range(20)))
 
     msg = "Reindexing only valid with uniquely valued Index objects"
     with pytest.raises(InvalidIndexError, match=msg):
@@ -266,9 +267,13 @@ def test_get_loc(idx):
         idx.get_loc('foo', method='nearest')
 
     # 3 levels
-    index = MultiIndex(levels=[Index(lrange(4)), Index(lrange(4)), Index(
-        lrange(4))], codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
-            [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])])
+    index = MultiIndex(levels=[Index(np.arange(4)),
+                               Index(np.arange(4)),
+                               Index(np.arange(4))],
+                       codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]),
+                              np.array([0, 1, 0, 0, 0, 1, 0, 1]),
+                              np.array([1, 0, 1, 1, 0, 0, 1, 0])],
+                       )
     with pytest.raises(KeyError, match=r"^\(1, 1\)$"):
         index.get_loc((1, 1))
     assert index.get_loc((2, 0)) == slice(3, 5)
@@ -288,10 +293,13 @@ def test_get_loc_duplicates():
 
 
 def test_get_loc_level():
-    index = MultiIndex(levels=[Index(lrange(4)), Index(lrange(4)), Index(
-        lrange(4))], codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
-            [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])])
-
+    index = MultiIndex(levels=[Index(np.arange(4)),
+                               Index(np.arange(4)),
+                               Index(np.arange(4))],
+                       codes=[np.array([0, 0, 1, 2, 2, 2, 3, 3]),
+                              np.array([0, 1, 0, 0, 0, 1, 0, 1]),
+                              np.array([1, 0, 1, 1, 0, 0, 1, 0])],
+                       )
     loc, new_index = index.get_loc_level((0, 1))
     expected = slice(1, 2)
     exp_index = index[expected].droplevel(0).droplevel(0)
@@ -312,8 +320,10 @@ def test_get_loc_level():
     with pytest.raises(KeyError, match=r"^2$"):
         index.drop(1, level=2).get_loc_level(2, level=2)
 
-    index = MultiIndex(levels=[[2000], lrange(4)], codes=[np.array(
-        [0, 0, 0, 0]), np.array([0, 1, 2, 3])])
+    index = MultiIndex(levels=[[2000], list(range(4))],
+                       codes=[np.array([0, 0, 0, 0]),
+                              np.array([0, 1, 2, 3])],
+                       )
     result, new_index = index.get_loc_level((2000, slice(None, None)))
     expected = slice(None, None)
     assert result == expected

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -3,8 +3,6 @@ import re
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 
 import pandas as pd
@@ -97,11 +95,11 @@ def test_values_multiindex_periodindex():
 
 def test_consistency():
     # need to construct an overflow
-    major_axis = lrange(70000)
-    minor_axis = lrange(10)
+    major_axis = list(range(70000))
+    minor_axis = list(range(10))
 
     major_codes = np.arange(70000)
-    minor_codes = np.repeat(lrange(10), 7000)
+    minor_codes = np.repeat(range(10), 7000)
 
     # the fact that is works means it's consistent
     index = MultiIndex(levels=[major_axis, minor_axis],

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs.period import IncompatibleFrequency
-from pandas.compat import lrange
 
 from pandas.core.dtypes.dtypes import PeriodDtype
 
@@ -111,7 +110,7 @@ class TestPeriodIndex:
     def test_constructor_invalid_quarters(self):
         msg = "Quarter must be 1 <= q <= 4"
         with pytest.raises(ValueError, match=msg):
-            PeriodIndex(year=lrange(2000, 2004), quarter=lrange(4),
+            PeriodIndex(year=range(2000, 2004), quarter=list(range(4)),
                         freq='Q-DEC')
 
     def test_constructor_corner(self):

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs import period as libperiod
-from pandas.compat import lrange
 
 import pandas as pd
 from pandas import (
@@ -116,7 +115,7 @@ class TestGetItem:
 
     def test_getitem_datetime(self):
         rng = period_range(start='2012-01-01', periods=10, freq='W-MON')
-        ts = Series(lrange(len(rng)), index=rng)
+        ts = Series(range(len(rng)), index=rng)
 
         dt1 = datetime(2011, 10, 2)
         dt4 = datetime(2012, 4, 20)
@@ -140,7 +139,7 @@ class TestGetItem:
     def test_getitem_list_periods(self):
         # GH 7710
         rng = period_range(start='2012-01-01', periods=10, freq='D')
-        ts = Series(lrange(len(rng)), index=rng)
+        ts = Series(range(len(rng)), index=rng)
         exp = ts.iloc[[1]]
         tm.assert_series_equal(ts[[Period('2012-01-02', freq='D')]], exp)
 

--- a/pandas/tests/indexes/period/test_tools.py
+++ b/pandas/tests/indexes/period/test_tools.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslibs.ccalendar import MONTHS
-from pandas.compat import lrange
 
 import pandas as pd
 from pandas import (
@@ -273,7 +272,7 @@ class TestPeriodIndexConversion:
 
     def test_to_timestamp_quarterly_bug(self):
         years = np.arange(1960, 2000).repeat(4)
-        quarters = np.tile(lrange(1, 5), 40)
+        quarters = np.tile(list(range(1, 5)), 40)
 
         pindex = PeriodIndex(year=years, quarter=quarters)
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -11,7 +11,7 @@ import pytest
 import pandas._config.config as cf
 
 from pandas._libs.tslib import Timestamp
-from pandas.compat import PY36, lrange
+from pandas.compat import PY36
 from pandas.compat.numpy import np_datetime64_compat
 
 from pandas.core.dtypes.common import is_unsigned_integer_dtype
@@ -1611,10 +1611,10 @@ class TestIndex(Base):
     def test_drop_by_str_label(self):
         # TODO: Parametrize these after replacing self.strIndex with fixture
         n = len(self.strIndex)
-        drop = self.strIndex[lrange(5, 10)]
+        drop = self.strIndex[list(range(5, 10))]
         dropped = self.strIndex.drop(drop)
 
-        expected = self.strIndex[lrange(5) + lrange(10, n)]
+        expected = self.strIndex[list(range(5)) + list(range(10, n))]
         tm.assert_index_equal(dropped, expected)
 
         dropped = self.strIndex.drop(self.strIndex[0])
@@ -1631,15 +1631,15 @@ class TestIndex(Base):
 
         # errors='ignore'
         n = len(self.strIndex)
-        drop = self.strIndex[lrange(5, 10)]
+        drop = self.strIndex[list(range(5, 10))]
         mixed = drop.tolist() + ['foo']
         dropped = self.strIndex.drop(mixed, errors='ignore')
 
-        expected = self.strIndex[lrange(5) + lrange(10, n)]
+        expected = self.strIndex[list(range(5)) + list(range(10, n))]
         tm.assert_index_equal(dropped, expected)
 
         dropped = self.strIndex.drop(['foo', 'bar'], errors='ignore')
-        expected = self.strIndex[lrange(n)]
+        expected = self.strIndex[list(range(n))]
         tm.assert_index_equal(dropped, expected)
 
     def test_drop_by_numeric_label_loc(self):
@@ -2379,7 +2379,7 @@ class TestMixedIntIndex(Base):
     @pytest.mark.parametrize("klass", [Series, DataFrame])
     def test_int_name_format(self, klass):
         index = Index(['a', 'b', 'c'], name=0)
-        result = klass(lrange(3), index=index)
+        result = klass(list(range(3)), index=index)
         assert '0' in repr(result)
 
     def test_print_unicode_columns(self):
@@ -2390,7 +2390,7 @@ class TestMixedIntIndex(Base):
 
     @pytest.mark.parametrize("func", [str, bytes])
     def test_with_unicode(self, func):
-        index = Index(lrange(1000))
+        index = Index(list(range(1000)))
         func(index)
 
     def test_intersect_str_dates(self):

--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -5,8 +5,6 @@ from warnings import catch_warnings, filterwarnings
 
 import numpy as np
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import is_scalar
 
 from pandas import (
@@ -38,16 +36,16 @@ class Base:
 
     def setup_method(self, method):
 
-        self.series_ints = Series(np.random.rand(4), index=lrange(0, 8, 2))
+        self.series_ints = Series(np.random.rand(4), index=np.arange(0, 8, 2))
         self.frame_ints = DataFrame(np.random.randn(4, 4),
-                                    index=lrange(0, 8, 2),
-                                    columns=lrange(0, 12, 3))
+                                    index=np.arange(0, 8, 2),
+                                    columns=np.arange(0, 12, 3))
 
         self.series_uints = Series(np.random.rand(4),
-                                   index=UInt64Index(lrange(0, 8, 2)))
+                                   index=UInt64Index(np.arange(0, 8, 2)))
         self.frame_uints = DataFrame(np.random.randn(4, 4),
-                                     index=UInt64Index(lrange(0, 8, 2)),
-                                     columns=UInt64Index(lrange(0, 12, 3)))
+                                     index=UInt64Index(range(0, 8, 2)),
+                                     columns=UInt64Index(range(0, 12, 3)))
 
         self.series_floats = Series(np.random.rand(4),
                                     index=Float64Index(range(0, 8, 2)))
@@ -105,7 +103,7 @@ class Base:
 
         axes = f.axes
         if values:
-            axes = [lrange(len(a)) for a in axes]
+            axes = (list(range(len(a))) for a in axes)
 
         return itertools.product(*axes)
 

--- a/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/multiindex/test_chaining_and_caching.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas import DataFrame, MultiIndex, Series
 from pandas.core import common as com
 import pandas.util.testing as tm
@@ -53,7 +51,7 @@ def test_indexer_caching():
     # GH5727
     # make sure that indexers are in the _internal_names_set
     n = 1000001
-    arrays = [lrange(n), lrange(n)]
+    arrays = (range(n), range(n))
     index = MultiIndex.from_tuples(zip(*arrays))
     s = Series(np.zeros(n), index=index)
     str(s)

--- a/pandas/tests/indexing/multiindex/test_ix.py
+++ b/pandas/tests/indexing/multiindex/test_ix.py
@@ -2,7 +2,6 @@ from warnings import catch_warnings, simplefilter
 
 import pytest
 
-from pandas.compat import lrange
 from pandas.errors import PerformanceWarning
 
 from pandas import DataFrame, MultiIndex
@@ -19,14 +18,14 @@ class TestMultiIndexIx:
 
         # with integer labels
         df = frame.copy()
-        df.columns = lrange(3)
+        df.columns = list(range(3))
         df.loc[('bar', 'two'), 1] = 7
         assert df.loc[('bar', 'two'), 1] == 7
 
         with catch_warnings(record=True):
             simplefilter("ignore", DeprecationWarning)
             df = frame.copy()
-            df.columns = lrange(3)
+            df.columns = list(range(3))
             df.ix[('bar', 'two'), 1] = 7
         assert df.loc[('bar', 'two'), 1] == 7
 

--- a/pandas/tests/indexing/multiindex/test_xs.py
+++ b/pandas/tests/indexing/multiindex/test_xs.py
@@ -3,8 +3,6 @@ from itertools import product
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas import DataFrame, Index, MultiIndex, Series, concat, date_range
 import pandas.core.common as com
 from pandas.util import testing as tm
@@ -150,7 +148,7 @@ def test_xs_setting_with_copy_error_multiple(four_level_index_dataframe):
 
 def test_xs_integer_key():
     # see gh-2107
-    dates = lrange(20111201, 20111205)
+    dates = range(20111201, 20111205)
     ids = 'abcde'
     index = MultiIndex.from_tuples(
         [x for x in product(dates, ids)],

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -2,8 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import (
-    DataFrame, Series, Timestamp, compat, date_range, option_context)
+from pandas import DataFrame, Series, Timestamp, date_range, option_context
 from pandas.core import common as com
 from pandas.util import testing as tm
 
@@ -16,7 +15,7 @@ class TestCaching:
         with option_context('chained_assignment', None):
 
             # #3970
-            df = DataFrame({"aa": compat.lrange(5), "bb": [2.2] * 5})
+            df = DataFrame({"aa": np.arange(5), "bb": [2.2] * 5})
 
             # Creates a second float block
             df["cc"] = 0.0

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -5,8 +5,6 @@ from warnings import catch_warnings, filterwarnings, simplefilter
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import DataFrame, Series, concat, date_range, isna
 from pandas.api.types import is_scalar
@@ -253,7 +251,7 @@ class TestiLoc(Base):
     def test_iloc_getitem_array(self):
 
         # array like
-        s = Series(index=lrange(1, 4))
+        s = Series(index=range(1, 4))
         self.check_result('array like', 'iloc', s.index, 'ix',
                           {0: [2, 4, 6], 1: [3, 6, 9], 2: [4, 8, 12]},
                           typs=['ints', 'uints'])
@@ -380,8 +378,8 @@ class TestiLoc(Base):
         tm.assert_frame_equal(df, expected)
 
     def test_iloc_getitem_frame(self):
-        df = DataFrame(np.random.randn(10, 4), index=lrange(0, 20, 2),
-                       columns=lrange(0, 8, 2))
+        df = DataFrame(np.random.randn(10, 4), index=range(0, 20, 2),
+                       columns=range(0, 8, 2))
 
         result = df.iloc[2]
         with catch_warnings(record=True):
@@ -436,7 +434,7 @@ class TestiLoc(Base):
         tm.assert_frame_equal(result, expected)
 
         # with index-like
-        s = Series(index=lrange(1, 5))
+        s = Series(index=range(1, 5))
         result = df.iloc[s.index]
         with catch_warnings(record=True):
             filterwarnings("ignore", "\\n.ix", DeprecationWarning)
@@ -531,7 +529,7 @@ class TestiLoc(Base):
         result = df.iloc[:, 2:3]
         tm.assert_frame_equal(result, expected)
 
-        s = Series(np.random.randn(10), index=lrange(0, 20, 2))
+        s = Series(np.random.randn(10), index=range(0, 20, 2))
 
         s.iloc[1] = 1
         result = s.iloc[1]
@@ -584,13 +582,13 @@ class TestiLoc(Base):
     def test_iloc_mask(self):
 
         # GH 3631, iloc with a mask (of a series) should raise
-        df = DataFrame(lrange(5), list('ABCDE'), columns=['a'])
+        df = DataFrame(list(range(5)), index=list('ABCDE'), columns=['a'])
         mask = (df.a % 2 == 0)
         msg = ("iLocation based boolean indexing cannot use an indexable as"
                " a mask")
         with pytest.raises(ValueError, match=msg):
             df.iloc[mask]
-        mask.index = lrange(len(mask))
+        mask.index = range(len(mask))
         msg = ("iLocation based boolean indexing on an integer type is not"
                " available")
         with pytest.raises(NotImplementedError, match=msg):
@@ -653,7 +651,7 @@ class TestiLoc(Base):
 
         # GH 4017, non-unique indexing (on the axis)
         df = DataFrame({'A': [0.1] * 3000, 'B': [1] * 3000})
-        idx = np.array(lrange(30)) * 99
+        idx = np.arange(30) * 99
         expected = df.iloc[idx]
 
         df3 = concat([df, 2 * df, 3 * df])

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -7,8 +7,6 @@ import weakref
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import is_float_dtype, is_integer_dtype
 
 import pandas as pd
@@ -29,7 +27,7 @@ class TestFancy(Base):
         # GH5508
 
         # len of indexer vs length of the 1d ndarray
-        df = DataFrame(index=Index(lrange(1, 11)))
+        df = DataFrame(index=Index(np.arange(1, 11)))
         df['foo'] = np.zeros(10, dtype=np.float64)
         df['bar'] = np.zeros(10, dtype=np.complex)
 
@@ -48,7 +46,7 @@ class TestFancy(Base):
         tm.assert_series_equal(result, expected)
 
         # dtype getting changed?
-        df = DataFrame(index=Index(lrange(1, 11)))
+        df = DataFrame(index=Index(np.arange(1, 11)))
         df['foo'] = np.zeros(10, dtype=np.float64)
         df['bar'] = np.zeros(10, dtype=np.complex)
 
@@ -345,8 +343,9 @@ class TestFancy(Base):
         # GH 3626, an assignment of a sub-df to a df
         df = DataFrame({'FC': ['a', 'b', 'a', 'b', 'a', 'b'],
                         'PF': [0, 0, 0, 0, 1, 1],
-                        'col1': lrange(6),
-                        'col2': lrange(6, 12)})
+                        'col1': list(range(6)),
+                        'col2': list(range(6, 12)),
+                        })
         df.iloc[1, 0] = np.nan
         df2 = df.copy()
 

--- a/pandas/tests/indexing/test_ix.py
+++ b/pandas/tests/indexing/test_ix.py
@@ -5,8 +5,6 @@ from warnings import catch_warnings
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import is_scalar
 
 import pandas as pd
@@ -194,7 +192,9 @@ class TestIX:
         tm.assert_series_equal(df.B, orig + 1)
 
         # GH 3668, mixed frame with series value
-        df = DataFrame({'x': lrange(10), 'y': lrange(10, 20), 'z': 'bar'})
+        df = DataFrame({'x': np.arange(10),
+                        'y': np.arange(10, 20),
+                        'z': 'bar'})
         expected = df.copy()
 
         for i in range(5):
@@ -212,7 +212,7 @@ class TestIX:
         expected = DataFrame({'a': [1, 2, 3], 'b': [100, 1, -100]})
         tm.assert_frame_equal(df, expected)
 
-        df = DataFrame({'a': lrange(4)})
+        df = DataFrame({'a': list(range(4))})
         df['b'] = np.nan
         df.loc[[1, 3], 'b'] = [100, -100]
         expected = DataFrame({'a': [0, 1, 2, 3],
@@ -222,7 +222,7 @@ class TestIX:
         # ok, but chained assignments are dangerous
         # if we turn off chained assignment it will work
         with option_context('chained_assignment', None):
-            df = DataFrame({'a': lrange(4)})
+            df = DataFrame({'a': list(range(4))})
             df['b'] = np.nan
             df['b'].loc[[1, 3]] = [100, -100]
             tm.assert_frame_equal(df, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -5,8 +5,6 @@ from warnings import catch_warnings, filterwarnings
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import DataFrame, Series, Timestamp, date_range
 from pandas.api.types import is_scalar
@@ -620,7 +618,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         def gen_test(l, l2):
             return pd.concat([
                 DataFrame(np.random.randn(l, len(columns)),
-                          index=lrange(l), columns=columns),
+                          index=np.arange(l), columns=columns),
                 DataFrame(np.ones((l2, len(columns))),
                           index=[0] * l2, columns=columns)])
 

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.internals import BlockPlacement
-from pandas.compat import lrange
 
 import pandas as pd
 from pandas import (
@@ -907,7 +906,7 @@ class TestIndexing:
 
                 # fancy indexer
                 assert_slice_ok(mgr, ax, [])
-                assert_slice_ok(mgr, ax, lrange(mgr.shape[ax]))
+                assert_slice_ok(mgr, ax, list(range(mgr.shape[ax])))
 
                 if mgr.shape[ax] >= 3:
                     assert_slice_ok(mgr, ax, [0, 1, 2])
@@ -925,13 +924,13 @@ class TestIndexing:
         for mgr in self.MANAGERS:
             for ax in range(mgr.ndim):
                 # take/fancy indexer
-                assert_take_ok(mgr, ax, [])
-                assert_take_ok(mgr, ax, [0, 0, 0])
-                assert_take_ok(mgr, ax, lrange(mgr.shape[ax]))
+                assert_take_ok(mgr, ax, indexer=[])
+                assert_take_ok(mgr, ax, indexer=[0, 0, 0])
+                assert_take_ok(mgr, ax, indexer=list(range(mgr.shape[ax])))
 
                 if mgr.shape[ax] >= 3:
-                    assert_take_ok(mgr, ax, [0, 1, 2])
-                    assert_take_ok(mgr, ax, [-1, -2, -3])
+                    assert_take_ok(mgr, ax, indexer=[0, 1, 2])
+                    assert_take_ok(mgr, ax, indexer=[-1, -2, -3])
 
     def test_reindex_axis(self):
         def assert_reindex_axis_is_ok(mgr, axis, new_labels, fill_value):

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -13,7 +13,6 @@ import tarfile
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 from pandas.errors import ParserError
 import pandas.util._test_decorators as td
 
@@ -245,10 +244,9 @@ def test_parse_ragged_csv(c_parser_only):
     # too many columns, cause segfault if not careful
     data = "1,2\n3,4,5"
 
-    result = parser.read_csv(StringIO(data), header=None,
-                             names=lrange(50))
+    result = parser.read_csv(StringIO(data), header=None, names=range(50))
     expected = parser.read_csv(StringIO(data), header=None,
-                               names=lrange(3)).reindex(columns=lrange(50))
+                               names=range(3)).reindex(columns=range(50))
 
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -16,7 +16,6 @@ import numpy as np
 import pytest
 
 from pandas._libs.tslib import Timestamp
-from pandas.compat import lrange
 from pandas.errors import DtypeWarning, EmptyDataError, ParserError
 
 from pandas import DataFrame, Index, MultiIndex, Series, compat, concat
@@ -923,8 +922,9 @@ def test_skip_initial_space(all_parsers):
             '-9999.0,   -9999.0,   -9999.0,  -9999.0, 000, 012, 128')
     parser = all_parsers
 
-    result = parser.read_csv(StringIO(data), names=lrange(33), header=None,
-                             na_values=["-9999.0"], skipinitialspace=True)
+    result = parser.read_csv(StringIO(data), names=list(range(33)),
+                             header=None, na_values=["-9999.0"],
+                             skipinitialspace=True)
     expected = DataFrame([["09-Apr-2012", "01:10:18.300", 2456026.548822908,
                            12849, 1.00361, 1.12551, 330.65659,
                            355626618.16711, 73.48821, 314.11625, 1917.09447,

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -15,7 +15,7 @@ import pytz
 from pandas._libs.tslib import Timestamp
 from pandas._libs.tslibs import parsing
 from pandas._libs.tslibs.parsing import parse_datetime_string
-from pandas.compat import is_platform_windows, lrange
+from pandas.compat import is_platform_windows
 from pandas.compat.numpy import np_array_datetime64_compat
 
 import pandas as pd
@@ -321,7 +321,7 @@ def test_date_parser_int_bug(all_parsers):
 def test_nat_parse(all_parsers):
     # see gh-3062
     parser = all_parsers
-    df = DataFrame(dict({"A": np.asarray(lrange(10), dtype="float64"),
+    df = DataFrame(dict({"A": np.arange(10, dtype="float64"),
                          "B": pd.Timestamp("20010101")}))
     df.iloc[3:6, :] = np.nan
 

--- a/pandas/tests/io/parser/test_skiprows.py
+++ b/pandas/tests/io/parser/test_skiprows.py
@@ -9,14 +9,13 @@ from io import StringIO
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 from pandas.errors import EmptyDataError
 
 from pandas import DataFrame, Index
 import pandas.util.testing as tm
 
 
-@pytest.mark.parametrize("skiprows", [lrange(6), 6])
+@pytest.mark.parametrize("skiprows", [list(range(6)), 6])
 def test_skip_rows_bug(all_parsers, skiprows):
     # see gh-505
     parser = all_parsers

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -6,7 +6,6 @@ import sys
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 from pandas import DataFrame, Index, NaT, Series, isna
@@ -238,7 +237,7 @@ class TestTSPlot(TestPlotBase):
     def test_fake_inferred_business(self):
         _, ax = self.plt.subplots()
         rng = date_range('2001-1-1', '2001-1-10')
-        ts = Series(lrange(len(rng)), rng)
+        ts = Series(range(len(rng)), index=rng)
         ts = ts[:3].append(ts[5:])
         ts.plot(ax=ax)
         assert not hasattr(ax, 'freq')
@@ -249,21 +248,22 @@ class TestTSPlot(TestPlotBase):
         _check_plot_works(ser.plot)
 
         dr = date_range(ser.index[0], freq='BQS', periods=10)
-        ser = Series(np.random.randn(len(dr)), dr)
+        ser = Series(np.random.randn(len(dr)), index=dr)
         _check_plot_works(ser.plot)
 
     @pytest.mark.slow
     def test_plot_multiple_inferred_freq(self):
-        dr = Index([datetime(2000, 1, 1), datetime(2000, 1, 6), datetime(
-            2000, 1, 11)])
-        ser = Series(np.random.randn(len(dr)), dr)
+        dr = Index([datetime(2000, 1, 1),
+                    datetime(2000, 1, 6),
+                    datetime(2000, 1, 11)])
+        ser = Series(np.random.randn(len(dr)), index=dr)
         _check_plot_works(ser.plot)
 
     @pytest.mark.slow
     def test_uhf(self):
         import pandas.plotting._converter as conv
         idx = date_range('2012-6-22 21:59:51.960928', freq='L', periods=500)
-        df = DataFrame(np.random.randn(len(idx), 2), idx)
+        df = DataFrame(np.random.randn(len(idx), 2), index=idx)
 
         _, ax = self.plt.subplots()
         df.plot(ax=ax)
@@ -280,7 +280,7 @@ class TestTSPlot(TestPlotBase):
     @pytest.mark.slow
     def test_irreg_hf(self):
         idx = date_range('2012-6-22 21:59:51', freq='S', periods=100)
-        df = DataFrame(np.random.randn(len(idx), 2), idx)
+        df = DataFrame(np.random.randn(len(idx), 2), index=idx)
 
         irreg = df.iloc[[0, 1, 3, 4]]
         _, ax = self.plt.subplots()
@@ -1283,7 +1283,7 @@ class TestTSPlot(TestPlotBase):
     @pytest.mark.slow
     def test_ax_plot(self):
         x = date_range(start='2012-01-02', periods=10, freq='D')
-        y = lrange(len(x))
+        y = list(range(len(x)))
         _, ax = self.plt.subplots()
         lines = ax.plot(x, y, label='Y')
         tm.assert_index_equal(DatetimeIndex(lines[0].get_xdata()), x)

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -10,7 +10,6 @@ import numpy as np
 from numpy.random import rand, randn
 import pytest
 
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.api import is_list_like
@@ -230,7 +229,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_data(df.plot(y='B'), df.B.plot())
 
         # columns.inferred_type == 'integer'
-        df.columns = lrange(1, len(df.columns) + 1)
+        df.columns = np.arange(1, len(df.columns) + 1)
         self._check_data(df.plot(x=1, y=2), df.set_index(1)[2].plot())
         self._check_data(df.plot(x=1), df.set_index(1).plot())
         self._check_data(df.plot(y=1), df[1].plot())
@@ -1279,7 +1278,7 @@ class TestDataFramePlots(TestPlotBase):
 
         df = DataFrame(randn(10, 15),
                        index=list(string.ascii_letters[:10]),
-                       columns=lrange(15))
+                       columns=range(15))
         _check_plot_works(df.plot.bar)
 
         df = DataFrame({'a': [0, 1], 'b': [1, 0]})
@@ -1357,7 +1356,7 @@ class TestDataFramePlots(TestPlotBase):
     @pytest.mark.slow
     def test_bar_stacked_center(self):
         # GH2157
-        df = DataFrame({'A': [3] * 5, 'B': lrange(5)}, index=lrange(5))
+        df = DataFrame({'A': [3] * 5, 'B': list(range(5))}, index=range(5))
         self._check_bar_alignment(df, kind='bar', stacked=True)
         self._check_bar_alignment(df, kind='bar', stacked=True, width=0.9)
         self._check_bar_alignment(df, kind='barh', stacked=True)
@@ -1365,7 +1364,7 @@ class TestDataFramePlots(TestPlotBase):
 
     @pytest.mark.slow
     def test_bar_center(self):
-        df = DataFrame({'A': [3] * 5, 'B': lrange(5)}, index=lrange(5))
+        df = DataFrame({'A': [3] * 5, 'B': list(range(5))}, index=range(5))
         self._check_bar_alignment(df, kind='bar', stacked=False)
         self._check_bar_alignment(df, kind='bar', stacked=False, width=0.9)
         self._check_bar_alignment(df, kind='barh', stacked=False)
@@ -1373,7 +1372,7 @@ class TestDataFramePlots(TestPlotBase):
 
     @pytest.mark.slow
     def test_bar_subplots_center(self):
-        df = DataFrame({'A': [3] * 5, 'B': lrange(5)}, index=lrange(5))
+        df = DataFrame({'A': [3] * 5, 'B': list(range(5))}, index=range(5))
         self._check_bar_alignment(df, kind='bar', subplots=True)
         self._check_bar_alignment(df, kind='bar', subplots=True, width=0.9)
         self._check_bar_alignment(df, kind='barh', subplots=True)
@@ -1391,7 +1390,7 @@ class TestDataFramePlots(TestPlotBase):
 
     @pytest.mark.slow
     def test_bar_edge(self):
-        df = DataFrame({'A': [3] * 5, 'B': lrange(5)}, index=lrange(5))
+        df = DataFrame({'A': [3] * 5, 'B': list(range(5))}, index=range(5))
 
         self._check_bar_alignment(df, kind='bar', stacked=True, align='edge')
         self._check_bar_alignment(df, kind='bar', stacked=True, width=0.9,
@@ -1421,7 +1420,7 @@ class TestDataFramePlots(TestPlotBase):
         expected = np.array([.1, 1., 10., 100])
 
         # no subplots
-        df = DataFrame({'A': [3] * 5, 'B': lrange(1, 6)}, index=lrange(5))
+        df = DataFrame({'A': [3] * 5, 'B': list(range(1, 6))}, index=range(5))
         ax = df.plot.bar(grid=True, log=True)
         tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), expected)
 

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -10,7 +10,6 @@ import numpy as np
 from numpy.random import randn
 import pytest
 
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -705,7 +704,7 @@ class TestSeriesPlots(TestPlotBase):
 
     @pytest.mark.slow
     def test_valid_object_plot(self):
-        s = Series(lrange(10), dtype=object)
+        s = Series(range(10), dtype=object)
         for kind in plotting._core._common_kinds:
             _check_plot_works(s.plot, kind=kind)
 

--- a/pandas/tests/reductions/test_stat_reductions.py
+++ b/pandas/tests/reductions/test_stat_reductions.py
@@ -6,7 +6,6 @@ import inspect
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -54,7 +53,7 @@ class TestSeriesStatReductions:
 
             # GH#2888
             items = [0]
-            items.extend(lrange(2 ** 40, 2 ** 40 + 1000))
+            items.extend(range(2 ** 40, 2 ** 40 + 1000))
             s = Series(items, dtype='int64')
             tm.assert_almost_equal(float(f(s)), float(alternate(s.values)))
 
@@ -92,7 +91,7 @@ class TestSeriesStatReductions:
         self._check_stat_op('median', np.median, string_series)
 
         # test with integers, test failure
-        int_ts = Series(np.ones(10, dtype=int), index=lrange(10))
+        int_ts = Series(np.ones(10, dtype=int), index=range(10))
         tm.assert_almost_equal(np.median(int_ts), int_ts.median())
 
     def test_prod(self):

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -7,7 +7,6 @@ import pytz
 
 from pandas._libs.tslibs.ccalendar import DAYS, MONTHS
 from pandas._libs.tslibs.period import IncompatibleFrequency
-from pandas.compat import lrange
 
 import pandas as pd
 from pandas import DataFrame, Series, Timestamp
@@ -436,7 +435,7 @@ class TestPeriodIndex:
 
     def test_resample_tz_localized(self):
         dr = date_range(start='2012-4-13', end='2012-5-1')
-        ts = Series(lrange(len(dr)), dr)
+        ts = Series(range(len(dr)), index=dr)
 
         ts_utc = ts.tz_localize('UTC')
         ts_local = ts_utc.tz_convert('America/Los_Angeles')

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -3,7 +3,6 @@ from numpy.random import randn
 import pytest
 
 from pandas._libs import join as libjoin
-from pandas.compat import lrange
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, concat, merge
@@ -538,7 +537,7 @@ class TestJoin:
 
         # smoke test
         joined = left.join(right, on='key', sort=False)
-        tm.assert_index_equal(joined.index, pd.Index(lrange(4)))
+        tm.assert_index_equal(joined.index, pd.Index(list(range(4))))
 
     def test_join_mixed_non_unique_index(self):
         # GH 12814, unorderable types in py3 with a non-unique index

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -7,8 +7,6 @@ import numpy as np
 from numpy import nan
 import pytest
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import is_categorical_dtype, is_object_dtype
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
@@ -28,7 +26,7 @@ NGROUPS = 8
 
 
 def get_test_data(ngroups=NGROUPS, n=N):
-    unique_groups = lrange(ngroups)
+    unique_groups = list(range(ngroups))
     arr = np.asarray(np.tile(unique_groups, n // ngroups))
 
     if len(arr) < n:
@@ -229,8 +227,8 @@ class TestMerge:
         tm.assert_series_equal(merged['value_y'], exp)
 
     def test_merge_copy(self):
-        left = DataFrame({'a': 0, 'b': 1}, index=lrange(10))
-        right = DataFrame({'c': 'foo', 'd': 'bar'}, index=lrange(10))
+        left = DataFrame({'a': 0, 'b': 1}, index=range(10))
+        right = DataFrame({'c': 'foo', 'd': 'bar'}, index=range(10))
 
         merged = merge(left, right, left_index=True,
                        right_index=True, copy=True)
@@ -242,8 +240,8 @@ class TestMerge:
         assert (right['d'] == 'bar').all()
 
     def test_merge_nocopy(self):
-        left = DataFrame({'a': 0, 'b': 1}, index=lrange(10))
-        right = DataFrame({'c': 'foo', 'd': 'bar'}, index=lrange(10))
+        left = DataFrame({'a': 0, 'b': 1}, index=range(10))
+        right = DataFrame({'c': 'foo', 'd': 'bar'}, index=range(10))
 
         merged = merge(left, right, left_index=True,
                        right_index=True, copy=False)
@@ -258,9 +256,10 @@ class TestMerge:
         # #733, be a bit more 1337 about not returning unconsolidated DataFrame
 
         left = DataFrame({'key': [1, 1, 2, 2, 3],
-                          'value': lrange(5)}, columns=['value', 'key'])
+                          'value': list(range(5))},
+                         columns=['value', 'key'])
         right = DataFrame({'key': [1, 1, 2, 3, 4, 5],
-                           'rvalue': lrange(6)})
+                           'rvalue': list(range(6))})
 
         joined = merge(left, right, on='key', how='outer')
         expected = DataFrame({'key': [1, 1, 1, 1, 2, 2, 3, 4, 5],
@@ -295,8 +294,9 @@ class TestMerge:
 
     def test_handle_join_key_pass_array(self):
         left = DataFrame({'key': [1, 1, 2, 2, 3],
-                          'value': lrange(5)}, columns=['value', 'key'])
-        right = DataFrame({'rvalue': lrange(6)})
+                          'value': np.arange(5)},
+                         columns=['value', 'key'])
+        right = DataFrame({'rvalue': np.arange(6)})
         key = np.array([1, 1, 2, 3, 4, 5])
 
         merged = merge(left, right, left_on='key', right_on=key, how='outer')
@@ -306,8 +306,8 @@ class TestMerge:
         assert merged['key'].notna().all()
         assert merged2['key'].notna().all()
 
-        left = DataFrame({'value': lrange(5)}, columns=['value'])
-        right = DataFrame({'rvalue': lrange(6)})
+        left = DataFrame({'value': np.arange(5)}, columns=['value'])
+        right = DataFrame({'rvalue': np.arange(6)})
         lkey = np.array([1, 1, 2, 2, 3])
         rkey = np.array([1, 1, 2, 3, 4, 5])
 
@@ -316,8 +316,8 @@ class TestMerge:
                                                         2, 3, 4, 5],
                                                        name='key_0'))
 
-        left = DataFrame({'value': lrange(3)})
-        right = DataFrame({'rvalue': lrange(6)})
+        left = DataFrame({'value': np.arange(3)})
+        right = DataFrame({'rvalue': np.arange(6)})
 
         key = np.array([0, 1, 1, 2, 2, 3], dtype=np.int64)
         merged = merge(left, right, left_index=True, right_on=key, how='outer')

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -4,8 +4,6 @@ import numpy as np
 from numpy import nan
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import Categorical, Series, date_range, isna
 import pandas.util.testing as tm
@@ -206,7 +204,7 @@ def test_reindex_series_add_nat():
     rng = date_range('1/1/2000 00:00:00', periods=10, freq='10s')
     series = Series(rng)
 
-    result = series.reindex(lrange(15))
+    result = series.reindex(range(15))
     assert np.issubdtype(result.dtype, np.dtype('M8[ns]'))
 
     mask = result.isna()
@@ -280,9 +278,9 @@ def test_reindex_pad():
     assert_series_equal(result, expected)
 
     # GH4618 shifted series downcasting
-    s = Series(False, index=lrange(0, 5))
+    s = Series(False, index=range(0, 5))
     result = s.shift(1).fillna(method='bfill')
-    expected = Series(False, index=lrange(0, 5))
+    expected = Series(False, index=range(0, 5))
     assert_series_equal(result, expected)
 
 

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import is_integer
 
 import pandas as pd
@@ -141,8 +139,8 @@ def test_where_unsafe_int(sint_dtype):
     s = Series(np.arange(10), dtype=sint_dtype)
     mask = s < 5
 
-    s[mask] = lrange(2, 7)
-    expected = Series(lrange(2, 7) + lrange(5, 10), dtype=sint_dtype)
+    s[mask] = range(2, 7)
+    expected = Series(list(range(2, 7)) + list(range(5, 10)), dtype=sint_dtype)
 
     assert_series_equal(s, expected)
 
@@ -151,8 +149,9 @@ def test_where_unsafe_float(float_dtype):
     s = Series(np.arange(10), dtype=float_dtype)
     mask = s < 5
 
-    s[mask] = lrange(2, 7)
-    expected = Series(lrange(2, 7) + lrange(5, 10), dtype=float_dtype)
+    s[mask] = range(2, 7)
+    data = list(range(2, 7)) + list(range(5, 10))
+    expected = Series(data, dtype=float_dtype)
 
     assert_series_equal(s, expected)
 
@@ -170,7 +169,7 @@ def test_where_unsafe_upcast(dtype, expected_dtype):
     s = Series(np.arange(10), dtype=dtype)
     values = [2.5, 3.5, 4.5, 5.5, 6.5]
     mask = s < 5
-    expected = Series(values + lrange(5, 10), dtype=expected_dtype)
+    expected = Series(values + list(range(5, 10)), dtype=expected_dtype)
     s[mask] = values
     assert_series_equal(s, expected)
 
@@ -181,7 +180,7 @@ def test_where_unsafe():
     values = [2.5, 3.5, 4.5, 5.5]
 
     mask = s > 5
-    expected = Series(lrange(6) + values, dtype="float64")
+    expected = Series(list(range(6)) + values, dtype="float64")
 
     s[mask] = values
     assert_series_equal(s, expected)
@@ -189,8 +188,8 @@ def test_where_unsafe():
     # see gh-3235
     s = Series(np.arange(10), dtype='int64')
     mask = s < 5
-    s[mask] = lrange(2, 7)
-    expected = Series(lrange(2, 7) + lrange(5, 10), dtype='int64')
+    s[mask] = range(2, 7)
+    expected = Series(list(range(2, 7)) + list(range(5, 10)), dtype='int64')
     assert_series_equal(s, expected)
     assert s.dtype == expected.dtype
 

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -5,7 +5,6 @@ import pytest
 
 from pandas._libs import iNaT
 import pandas._libs.index as _index
-from pandas.compat import lrange
 
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex, NaT, Series, Timestamp, date_range
@@ -116,7 +115,7 @@ def test_series_set_value():
 def test_slice_locs_indexerror():
     times = [datetime(2000, 1, 1) + timedelta(minutes=i * 10)
              for i in range(100000)]
-    s = Series(lrange(100000), times)
+    s = Series(range(100000), times)
     s.loc[datetime(1900, 1, 1):datetime(2100, 1, 1)]
 
 
@@ -649,19 +648,19 @@ def test_indexing():
     # GH3546 (not including times on the last day)
     idx = date_range(start='2013-05-31 00:00', end='2013-05-31 23:00',
                      freq='H')
-    ts = Series(lrange(len(idx)), index=idx)
+    ts = Series(range(len(idx)), index=idx)
     expected = ts['2013-05']
     assert_series_equal(expected, ts)
 
     idx = date_range(start='2013-05-31 00:00', end='2013-05-31 23:59',
                      freq='S')
-    ts = Series(lrange(len(idx)), index=idx)
+    ts = Series(range(len(idx)), index=idx)
     expected = ts['2013-05']
     assert_series_equal(expected, ts)
 
     idx = [Timestamp('2013-05-31 00:00'),
            Timestamp(datetime(2013, 5, 31, 23, 59, 59, 999999))]
-    ts = Series(lrange(len(idx)), index=idx)
+    ts = Series(range(len(idx)), index=idx)
     expected = ts['2013']
     assert_series_equal(expected, ts)
 

--- a/pandas/tests/series/indexing/test_iloc.py
+++ b/pandas/tests/series/indexing/test_iloc.py
@@ -1,13 +1,11 @@
 import numpy as np
 
-from pandas.compat import lrange
-
 from pandas import Series
 from pandas.util.testing import assert_almost_equal, assert_series_equal
 
 
 def test_iloc():
-    s = Series(np.random.randn(10), index=lrange(0, 20, 2))
+    s = Series(np.random.randn(10), index=list(range(0, 20, 2)))
 
     for i in range(len(s)):
         result = s.iloc[i]

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -5,8 +5,6 @@ from datetime import timedelta
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas.core.dtypes.common import is_scalar
 
 import pandas as pd
@@ -53,7 +51,7 @@ def test_basic_getitem_with_labels(test_data):
     assert_series_equal(result, expected)
 
     # integer indexes, be careful
-    s = Series(np.random.randn(10), index=lrange(0, 20, 2))
+    s = Series(np.random.randn(10), index=list(range(0, 20, 2)))
     inds = [0, 2, 5, 7, 8]
     arr_inds = np.array([0, 2, 5, 7, 8])
     with tm.assert_produces_warning(FutureWarning,
@@ -255,7 +253,7 @@ def test_series_box_timestamp():
 
 
 def test_getitem_ambiguous_keyerror():
-    s = Series(lrange(10), index=lrange(0, 20, 2))
+    s = Series(range(10), index=list(range(0, 20, 2)))
     with pytest.raises(KeyError, match=r"^1$"):
         s[1]
     with pytest.raises(KeyError, match=r"^1$"):
@@ -263,7 +261,7 @@ def test_getitem_ambiguous_keyerror():
 
 
 def test_getitem_unordered_dup():
-    obj = Series(lrange(5), index=['c', 'a', 'a', 'b', 'b'])
+    obj = Series(range(5), index=['c', 'a', 'a', 'b', 'b'])
     assert is_scalar(obj['c'])
     assert obj['c'] == 0
 
@@ -290,7 +288,7 @@ def test_getitem_dups():
 
 
 def test_setitem_ambiguous_keyerror():
-    s = Series(lrange(10), index=lrange(0, 20, 2))
+    s = Series(range(10), index=list(range(0, 20, 2)))
 
     # equivalent of an append
     s2 = s.copy()

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import Series, Timestamp
 from pandas.util.testing import assert_series_equal
@@ -53,7 +51,7 @@ def test_loc_getitem_not_monotonic(test_data):
 
 
 def test_loc_getitem_setitem_integer_slice_keyerrors():
-    s = Series(np.random.randn(10), index=lrange(0, 20, 2))
+    s = Series(np.random.randn(10), index=list(range(0, 20, 2)))
 
     # this is OK
     cp = s.copy()
@@ -73,7 +71,7 @@ def test_loc_getitem_setitem_integer_slice_keyerrors():
     assert_series_equal(result2, expected)
 
     # non-monotonic, raise KeyError
-    s2 = s.iloc[lrange(5) + lrange(5, 10)[::-1]]
+    s2 = s.iloc[list(range(5)) + list(range(9, 4, -1))]
     with pytest.raises(KeyError, match=r"^3$"):
         s2.loc[3:11]
     with pytest.raises(KeyError, match=r"^3$"):
@@ -120,7 +118,7 @@ def test_basic_setitem_with_labels(test_data):
     assert_series_equal(cp, exp)
 
     # integer indexes, be careful
-    s = Series(np.random.randn(10), index=lrange(0, 20, 2))
+    s = Series(np.random.randn(10), index=list(range(0, 20, 2)))
     inds = [0, 4, 6]
     arr_inds = np.array([0, 4, 6])
 

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 import pandas as pd
 from pandas import DataFrame, Index, Series
 import pandas.util.testing as tm
@@ -80,14 +78,14 @@ def test_get_nan_multiple():
 def test_delitem():
     # GH 5542
     # should delete the item inplace
-    s = Series(lrange(5))
+    s = Series(range(5))
     del s[0]
 
-    expected = Series(lrange(1, 5), index=lrange(1, 5))
+    expected = Series(range(1, 5), index=range(1, 5))
     assert_series_equal(s, expected)
 
     del s[1]
-    expected = Series(lrange(2, 5), index=lrange(2, 5))
+    expected = Series(range(2, 5), index=range(2, 5))
     assert_series_equal(s, expected)
 
     # empty
@@ -156,13 +154,13 @@ def test_getitem_negative_out_of_bounds():
 
 
 def test_getitem_regression():
-    s = Series(lrange(5), index=lrange(5))
-    result = s[lrange(5)]
+    s = Series(range(5), index=list(range(5)))
+    result = s[list(range(5))]
     assert_series_equal(result, s)
 
 
 def test_getitem_setitem_slice_bug():
-    s = Series(lrange(10), lrange(10))
+    s = Series(range(10), index=list(range(10)))
     result = s[-12:]
     assert_series_equal(result, s)
 
@@ -172,7 +170,7 @@ def test_getitem_setitem_slice_bug():
     result = s[:-12]
     assert_series_equal(result, s[:0])
 
-    s = Series(lrange(10), lrange(10))
+    s = Series(range(10), index=list(range(10)))
     s[-12:] = 0
     assert (s == 0).all()
 

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -3,8 +3,6 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from pandas.compat import lrange
-
 from pandas import DataFrame, Index, MultiIndex, RangeIndex, Series
 import pandas.util.testing as tm
 
@@ -111,7 +109,7 @@ class TestSeriesAlterAxes:
     def test_set_index_makes_timeseries(self):
         idx = tm.makeDateIndex(10)
 
-        s = Series(lrange(10))
+        s = Series(range(10))
         s.index = idx
         assert s.index.is_all_dates
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy import nan
 import pytest
 
-from pandas.compat import lrange
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -73,11 +72,11 @@ class TestSeriesAnalytics:
         assert isna(shifted[4])
 
         result = s.argsort()
-        expected = Series(lrange(5), dtype='int64')
+        expected = Series(range(5), dtype='int64')
         assert_series_equal(result, expected)
 
         result = shifted.argsort()
-        expected = Series(lrange(4) + [-1], dtype='int64')
+        expected = Series(list(range(4)) + [-1], dtype='int64')
         assert_series_equal(result, expected)
 
     def test_argsort_stable(self):
@@ -289,18 +288,18 @@ class TestSeriesAnalytics:
         assert_series_equal(result, expected)
 
     def test_built_in_round(self):
-        s = Series([1.123, 2.123, 3.123], index=lrange(3))
+        s = Series([1.123, 2.123, 3.123], index=range(3))
         result = round(s)
-        expected_rounded0 = Series([1., 2., 3.], index=lrange(3))
+        expected_rounded0 = Series([1., 2., 3.], index=range(3))
         tm.assert_series_equal(result, expected_rounded0)
 
         decimals = 2
-        expected_rounded = Series([1.12, 2.12, 3.12], index=lrange(3))
+        expected_rounded = Series([1.12, 2.12, 3.12], index=range(3))
         result = round(s, decimals)
         tm.assert_series_equal(result, expected_rounded)
 
     def test_prod_numpy16_bug(self):
-        s = Series([1., 1., 1.], index=lrange(3))
+        s = Series([1., 1., 1.], index=range(3))
         result = s.prod()
 
         assert not isinstance(result, Series)
@@ -738,7 +737,7 @@ class TestSeriesAnalytics:
         assert_series_equal(result, expected)
 
         # timedelta64[ns]
-        s = Series(pd.to_timedelta(lrange(5), unit='d'))
+        s = Series(pd.to_timedelta(range(5), unit='d'))
         result = s.isin(s[0:2])
         assert_series_equal(result, expected)
 

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -5,7 +5,6 @@ from numpy import nan
 import pytest
 
 from pandas._libs.sparse import BlockIndex, IntIndex
-from pandas.compat import lrange
 from pandas.errors import PerformanceWarning
 
 import pandas as pd
@@ -168,7 +167,7 @@ class TestSparseDataFrame(SharedWithSparse):
 
     def test_constructor_convert_index_once(self):
         arr = np.array([1.5, 2.5, 3.5])
-        sdf = SparseDataFrame(columns=lrange(4), index=arr)
+        sdf = SparseDataFrame(columns=range(4), index=arr)
         assert sdf[0].index is sdf[1].index
 
     def test_constructor_from_series(self):
@@ -766,8 +765,8 @@ class TestSparseDataFrame(SharedWithSparse):
         tm.assert_frame_equal(result, expected)
 
     def test_fillna(self, float_frame_fill0, float_frame_fill0_dense):
-        df = float_frame_fill0.reindex(lrange(5))
-        dense = float_frame_fill0_dense.reindex(lrange(5))
+        df = float_frame_fill0.reindex(list(range(5)))
+        dense = float_frame_fill0_dense.reindex(list(range(5)))
 
         result = df.fillna(0)
         expected = dense.fillna(0)

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -1,26 +1,3 @@
 """
 Testing that functions from compat work as expected
 """
-import builtins
-
-from pandas.compat import lrange
-
-
-class TestBuiltinIterators:
-
-    @classmethod
-    def check_results(cls, results, expecteds, lengths):
-        for result, expected, length in zip(results, expecteds, lengths):
-            assert isinstance(result, list)
-            assert len(result) == length
-            assert result == expected
-
-    def test_lrange(self):
-        results = lrange(10),
-        expecteds = list(builtins.range(10)),
-        lengths = 10,
-
-        results += lrange(1, 10, 2),
-        lengths += 5,
-        expecteds += list(builtins.range(1, 10, 2)),
-        self.check_results(results, expecteds, lengths)

--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -18,8 +18,6 @@ from collections import namedtuple
 
 from dateutil.parser import parse
 
-from pandas.compat import lrange
-
 try:
     import sh
 except ImportError:
@@ -176,7 +174,7 @@ def pprint_hits(hits):
 
     print(('\nThese commits touched the %s method in these files '
            'on these dates:\n') % args.funcname)
-    for i in sorted(lrange(len(hits)), key=sorter):
+    for i in sorted(range(len(hits)), key=sorter):
         hit = hits[i]
         h, s, d = get_commit_vitals(hit.commit)
         p = hit.path.split(os.path.realpath(os.curdir) + os.path.sep)[-1]


### PR DESCRIPTION
- [x] xref #25725,
- [x] xref #26281, #26289 & #26319

Fourth and final part of the removal of ``compat.lrange`` from the code base.