### PR TITLE
Fix type annotations in pandas.core.resample

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -29,9 +29,6 @@ ignore_errors=True
 [mypy-pandas.core.panel]
 ignore_errors=True
 
-[mypy-pandas.core.resample]
-ignore_errors=True
-
 [mypy-pandas.core.reshape.merge]
 ignore_errors=True
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -3,6 +3,7 @@ Provide user facing operators for doing the split part of the
 split-apply-combine paradigm.
 """
 
+from Typing import Tuple
 import warnings
 
 import numpy as np
@@ -84,7 +85,8 @@ class Grouper:
 
     >>> df.groupby(Grouper(level='date', freq='60s', axis=1))
     """
-    _attributes = ('key', 'level', 'freq', 'axis', 'sort')
+    _attributes = ('key', 'level', 'freq', 'axis',
+                   'sort')  # type: Tuple[str, ...]
 
     def __new__(cls, *args, **kwargs):
         if kwargs.get('freq') is not None:

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -3,7 +3,7 @@ Provide user facing operators for doing the split part of the
 split-apply-combine paradigm.
 """
 
-from Typing import Tuple
+from typing import Tuple
 import warnings
 
 import numpy as np

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,7 +1,7 @@
 import copy
 from datetime import timedelta
 from textwrap import dedent
-from typing import Dict
+from typing import Dict, no_type_check
 import warnings
 
 import numpy as np
@@ -965,6 +965,7 @@ class _GroupByMixin(GroupByMixin):
         self._groupby.grouper.mutated = True
         self.groupby = copy.copy(parent.groupby)
 
+    @no_type_check
     def _apply(self, f, grouper=None, *args, **kwargs):
         """
         Dispatch to _upsample; we are stripping all of the _upsample kwargs and

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,6 +1,7 @@
 import copy
 from datetime import timedelta
 from textwrap import dedent
+from typing import Dict
 import warnings
 
 import numpy as np
@@ -31,7 +32,7 @@ from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
 from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import DateOffset, Day, Nano, Tick
 
-_shared_docs_kwargs = dict()
+_shared_docs_kwargs = dict()  # type: Dict[str, str]
 
 
 class Resampler(_GroupBy):
@@ -873,25 +874,25 @@ for method in ['sum', 'prod']:
 for method in ['min', 'max', 'first', 'last', 'mean', 'sem',
                'median', 'ohlc']:
 
-    def f(self, _method=method, *args, **kwargs):
+    def g(self, _method=method, *args, **kwargs):
         nv.validate_resampler_func(_method, args, kwargs)
         return self._downsample(_method)
-    f.__doc__ = getattr(GroupBy, method).__doc__
-    setattr(Resampler, method, f)
+    g.__doc__ = getattr(GroupBy, method).__doc__
+    setattr(Resampler, method, g)
 
 # groupby & aggregate methods
 for method in ['count']:
-    def f(self, _method=method):
+    def h(self, _method=method):
         return self._downsample(_method)
-    f.__doc__ = getattr(GroupBy, method).__doc__
-    setattr(Resampler, method, f)
+    h.__doc__ = getattr(GroupBy, method).__doc__
+    setattr(Resampler, method, h)
 
 # series only methods
 for method in ['nunique']:
-    def f(self, _method=method):
+    def h(self, _method=method):
         return self._downsample(_method)
-    f.__doc__ = getattr(SeriesGroupBy, method).__doc__
-    setattr(Resampler, method, f)
+    h.__doc__ = getattr(SeriesGroupBy, method).__doc__
+    setattr(Resampler, method, h)
 
 
 def _maybe_process_deprecations(r, how=None, fill_method=None, limit=None):


### PR DESCRIPTION
Part of #25882
- [X] tests passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This PR addresses the following mypy errors in **pandas.core.resample**:
```
pandas/core/resample.py:34: error: Need type annotation for '_shared_docs_kwargs'
pandas/core/resample.py:876: error: All conditional function variants must have identical signatures
pandas/core/resample.py:884: error: All conditional function variants must have identical signatures
pandas/core/resample.py:891: error: All conditional function variants must have identical signatures
pandas/core/resample.py:1101: error: Definition of "_upsample" in base class "_GroupByMixin" is incompatible with definition in base class "DatetimeIndexResampler"
pandas/core/resample.py:1101: error: Definition of "_upsample" in base class "_GroupByMixin" is incompatible with definition in base class "Resampler"
pandas/core/resample.py:1101: error: Definition of "_downsample" in base class "_GroupByMixin" is incompatible with definition in base class "DatetimeIndexResampler"
pandas/core/resample.py:1101: error: Definition of "_groupby_and_aggregate" in base class "_GroupByMixin" is incompatible with definition in base class "Resampler"
pandas/core/resample.py:1217: error: Definition of "_upsample" in base class "_GroupByMixin" is incompatible with definition in base class "PeriodIndexResampler"
pandas/core/resample.py:1217: error: Definition of "_upsample" in base class "_GroupByMixin" is incompatible with definition in base class "DatetimeIndexResampler"
pandas/core/resample.py:1217: error: Definition of "_upsample" in base class "_GroupByMixin" is incompatible with definition in base class "Resampler"
pandas/core/resample.py:1217: error: Definition of "_downsample" in base class "_GroupByMixin" is incompatible with definition in base class "PeriodIndexResampler"
pandas/core/resample.py:1217: error: Definition of "_downsample" in base class "_GroupByMixin" is incompatible with definition in base class "DatetimeIndexResampler"
pandas/core/resample.py:1217: error: Definition of "_groupby_and_aggregate" in base class "_GroupByMixin" is incompatible with definition in base class "Resampler"
pandas/core/resample.py:1247: error: Definition of "_upsample" in base class "_GroupByMixin" is incompatible with definition in base class "DatetimeIndexResampler"
pandas/core/resample.py:1247: error: Definition of "_upsample" in base class "_GroupByMixin" is incompatible with definition in base class "Resampler"
pandas/core/resample.py:1247: error: Definition of "_downsample" in base class "_GroupByMixin" is incompatible with definition in base class "DatetimeIndexResampler"
pandas/core/resample.py:1247: error: Definition of "_groupby_and_aggregate" in base class "_GroupByMixin" is incompatible with definition in base class "Resampler"
pandas/core/resample.py:1299: error: Incompatible types in assignment (expression has type "Tuple[str, ...]", base class "Grouper" defined the type as "Tuple[str, str, str, str, str]")
```