### PR TITLE
BUG: MultiIndex not dropping nan level and invalid code value

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -77,6 +77,40 @@ is respected in indexing. (:issue:`24076`, :issue:`16785`)
 
     df['2019-01-01 12:00:00+04:00':'2019-01-01 13:00:00+04:00']
 
+
+.. _whatsnew_0250.api_breaking.multi_indexing:
+
+
+MultiIndexing contracted from levels and codes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Constructing a :class:`MultiIndex` with NaN levels or codes value < -1 was allowed previously.
+Now, construction with codes value < -1 is not allowed and NaN levels' corresponding codes
+would be reassigned as -1. (:issue:`19387`)
+
+.. ipython:: python
+
+    pd.MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]], codes=[[0, -1, 1, 2, 3, 4]])
+    pd.MultiIndex(levels=[[1, 2]], codes=[[0, -2]])
+
+*Previous Behavior*:
+
+.. code-block:: ipython
+
+    MultiIndex(levels=[[nan, None, NaT, 128, 2]],
+               codes=[[0, -1, 1, 2, 3, 4]])
+    MultiIndex(levels=[[1, 2]],
+               codes=[[0, -2]])
+
+*New Behavior*:
+
+.. ipython:: python
+
+    MultiIndex(levels=[[nan, None, NaT, 128, 2]],
+               codes=[[-1, -1, -1, -1, 3, 4]])
+    ValueError: On level 0, code value (-2) < -1
+
+
 .. _whatsnew_0250.api_breaking.groupby_apply_first_group_once:
 
 GroupBy.apply on ``DataFrame`` evaluates first group only once
@@ -387,7 +421,7 @@ MultiIndex
 ^^^^^^^^^^
 
 - Bug in which incorrect exception raised by :class:`Timedelta` when testing the membership of :class:`MultiIndex` (:issue:`24570`)
-- Bug in :class:`Multindex` construction from levels and codes that would incorrectly allows code values < -1 or NaN levels (:issue:`19387`)
+-
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -90,25 +90,26 @@ would be reassigned as -1. (:issue:`19387`)
 
 .. ipython:: python
 
-    pd.MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]], codes=[[0, -1, 1, 2, 3, 4]])
-    pd.MultiIndex(levels=[[1, 2]], codes=[[0, -2]])
+    mi1 = pd.MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]], codes=[[0, -1, 1, 2, 3, 4]])
+    mi2 = pd.MultiIndex(levels=[[1, 2]], codes=[[0, -2]])
 
 *Previous Behavior*:
 
 .. code-block:: ipython
 
+    In [1]: mi1
     Out[1]: MultiIndex(levels=[[nan, None, NaT, 128, 2]],
                        codes=[[0, -1, 1, 2, 3, 4]])
+    In [2]: mi2
     Out[2]: MultiIndex(levels=[[1, 2]],
                        codes=[[0, -2]])
 
 *New Behavior*:
 
-.. ipython:: ipython
+.. ipython:: python
 
-    Out[1]: MultiIndex(levels=[[nan, None, NaT, 128, 2]],
-               codes=[[-1, -1, -1, -1, 3, 4]])
-    Out[2]: ValueError: On level 0, code value (-2) < -1
+    mi1
+    mi2
 
 
 .. _whatsnew_0250.api_breaking.groupby_apply_first_group_once:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -387,8 +387,7 @@ MultiIndex
 ^^^^^^^^^^
 
 - Bug in which incorrect exception raised by :class:`Timedelta` when testing the membership of :class:`MultiIndex` (:issue:`24570`)
-- Bug in :class:`Multindex` construction from levels and codes that would incorrectly allows code values < -1
-- Bug in :class:`Multindex` construction from levels and codes that would incorrectly allows NaN levels (:issue:`19387`)
+- Bug in :class:`Multindex` construction from levels and codes that would incorrectly allows code values < -1 or NaN levels (:issue:`19387`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -81,8 +81,8 @@ is respected in indexing. (:issue:`24076`, :issue:`16785`)
 .. _whatsnew_0250.api_breaking.multi_indexing:
 
 
-MultiIndexing contracted from levels and codes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+MultiIndex constructed from levels and codes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Constructing a :class:`MultiIndex` with NaN levels or codes value < -1 was allowed previously.
 Now, construction with codes value < -1 is not allowed and NaN levels' corresponding codes

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -387,8 +387,8 @@ MultiIndex
 ^^^^^^^^^^
 
 - Bug in which incorrect exception raised by :class:`Timedelta` when testing the membership of :class:`MultiIndex` (:issue:`24570`)
-- Bug in having code value < -1
-- Bug in not dropping nan level (:issue:`19387`)
+- Bug in :class:`Multindex` construction from levels and codes that would incorrectly allows code values < -1
+- Bug in :class:`Multindex` construction from levels and codes that would incorrectly allows NaN levels (:issue:`19387`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -387,8 +387,8 @@ MultiIndex
 ^^^^^^^^^^
 
 - Bug in which incorrect exception raised by :class:`Timedelta` when testing the membership of :class:`MultiIndex` (:issue:`24570`)
--
--
+- Bug in having code value < -1
+- Bug in not dropping nan level (:issue:`19387`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -97,18 +97,18 @@ would be reassigned as -1. (:issue:`19387`)
 
 .. code-block:: ipython
 
-    MultiIndex(levels=[[nan, None, NaT, 128, 2]],
-               codes=[[0, -1, 1, 2, 3, 4]])
-    MultiIndex(levels=[[1, 2]],
-               codes=[[0, -2]])
+    Out[1]: MultiIndex(levels=[[nan, None, NaT, 128, 2]],
+                       codes=[[0, -1, 1, 2, 3, 4]])
+    Out[2]: MultiIndex(levels=[[1, 2]],
+                       codes=[[0, -2]])
 
 *New Behavior*:
 
-.. ipython:: python
+.. ipython:: ipython
 
-    MultiIndex(levels=[[nan, None, NaT, 128, 2]],
+    Out[1]: MultiIndex(levels=[[nan, None, NaT, 128, 2]],
                codes=[[-1, -1, -1, -1, 3, 4]])
-    ValueError: On level 0, code value (-2) < -1
+    Out[2]: ValueError: On level 0, code value (-2) < -1
 
 
 .. _whatsnew_0250.api_breaking.groupby_apply_first_group_once:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -90,7 +90,8 @@ would be reassigned as -1. (:issue:`19387`)
 
 .. ipython:: python
 
-    mi1 = pd.MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]], codes=[[0, -1, 1, 2, 3, 4]])
+    mi1 = pd.MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
+                        codes=[[0, -1, 1, 2, 3, 4]])
     mi2 = pd.MultiIndex(levels=[[1, 2]], codes=[[0, -2]])
 
 *Previous Behavior*:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -244,7 +244,8 @@ class MultiIndex(Index):
         if verify_integrity:
             result._verify_integrity()
 
-        codes = [cls._reassign_na_codes(*it) for it in zip(levels, codes)]
+        codes = [cls._reassign_na_codes(level, code)
+                 for level, code in zip(levels, codes)]
         result._set_codes(codes, validate=False)
 
         if _set_identity:
@@ -254,7 +255,10 @@ class MultiIndex(Index):
 
     @classmethod
     def _reassign_na_codes(cls, level, code):
-        return [-1 if x == -1 or isna(level[x]) else x for x in code]
+        null_mask = isna(level)
+        if np.any(null_mask):
+            code = np.where((code == -1) | null_mask[code], -1, code)
+        return code
 
     def _verify_integrity(self, codes=None, levels=None):
         """

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -256,9 +256,9 @@ class MultiIndex(Index):
 
         Parameters
         ----------
-        code : list,  optional
+        code : list
             Code to reassign.
-        level : list, optional
+        level : list
             Level to check for missing values (NaN, NaT, None).
 
         Returns
@@ -734,7 +734,9 @@ class MultiIndex(Index):
                     level_codes, lev, copy=copy)._shallow_copy()
             new_codes = FrozenList(new_codes)
 
-        new_codes = self._verify_integrity(codes=new_codes)
+        if verify_integrity:
+            new_codes = self._verify_integrity(codes=new_codes)
+
         self._codes = new_codes
 
         self._tuples = None

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -256,10 +256,10 @@ class MultiIndex(Index):
 
         Parameters
         ----------
-        code : optional list
+        code : list,  optional
             Code to reassign.
-        level : optional list
-            Level to check for Nan.
+        level : list, optional
+            Level to check for missing values (NaN, NaT, None).
 
         Returns
         -------
@@ -324,9 +324,7 @@ class MultiIndex(Index):
 
         codes = [self._validate_codes(level, code)
                  for level, code in zip(levels, codes)]
-        new_codes = FrozenList(
-            _ensure_frozen(level_codes, lev, copy=False)._shallow_copy()
-            for lev, level_codes in zip(levels, codes))
+        new_codes = FrozenList(codes)
         return new_codes
 
     @classmethod

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -257,7 +257,7 @@ class MultiIndex(Index):
     def _reassign_na_codes(cls, level, code):
         null_mask = isna(level)
         if np.any(null_mask):
-            code = np.where((code == -1) | null_mask[code], -1, code)
+            code = np.where(null_mask[code], -1, code)
         return code
 
     def _verify_integrity(self, codes=None, levels=None):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -322,9 +322,12 @@ class MultiIndex(Index):
                                      values=[value for value in level],
                                      level=i))
 
-        codes = FrozenList([self._validate_codes(level, code)
-                           for level, code in zip(levels, codes)])
-        return codes
+        codes = [self._validate_codes(level, code)
+                 for level, code in zip(levels, codes)]
+        new_codes = FrozenList(
+            _ensure_frozen(level_codes, lev, copy=False)._shallow_copy()
+            for lev, level_codes in zip(levels, codes))
+        return new_codes
 
     @classmethod
     def from_arrays(cls, arrays, sortorder=None, names=None):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -250,7 +250,7 @@ class MultiIndex(Index):
 
         return result
 
-    def _validate_codes(self, level, code):
+    def _validate_codes(self, level: list, code: list):
         """
         Reassign code values as -1 if their corresponding levels are NaN.
 
@@ -264,7 +264,7 @@ class MultiIndex(Index):
         Returns
         -------
         code : new code where code value = -1 if it corresponds
-        to a NaN level.
+        to a level with missing values (NaN, NaT, None).
         """
         null_mask = isna(level)
         if np.any(null_mask):

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -91,7 +91,8 @@ def test_constructor_mismatched_codes_levels(idx):
 
 def test_na_levels():
     # GH26408
-    # test if codes are re-assigned value -1 for levels with na values
+    # test if codes are re-assigned value -1 for levels
+    # with mising values (NaN, NaT, None)
     result = MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
                         codes=[[0, -1, 1, 2, 3, 4]])
     expected = MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -84,6 +84,11 @@ def test_constructor_mismatched_codes_levels(idx):
     with pytest.raises(ValueError, match=label_error):
         idx.copy().set_codes([[0, 0, 0, 0], [0, 0]])
 
+    # test set_codes with verify_integrity=False
+    # the setting should not raise any value error
+    idx.copy().set_codes(codes=[[0, 0, 0, 0], [0, 0]],
+                         verify_integrity=False)
+
     # code value smaller than -1
     with pytest.raises(ValueError, match=code_value_error):
         MultiIndex(levels=[['a'], ['b']], codes=[[0, -2], [0, 0]])

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -64,10 +64,10 @@ def test_constructor_mismatched_codes_levels(idx):
     with pytest.raises(ValueError, match=msg):
         MultiIndex(levels=levels, codes=codes)
 
-    length_error = (r"On level 0, code max \(3\) >= length of level  \(1\)\."
+    length_error = (r"On level 0, code max \(3\) >= length of level \(1\)\."
                     " NOTE: this index is in an inconsistent state")
     label_error = r"Unequal code lengths: \[4, 2\]"
-    code_value_error = (r"On level 0, code value \(-2\) < -1")
+    code_value_error = r"On level 0, code value \(-2\) < -1"
 
     # important to check that it's looking at the right thing.
     with pytest.raises(ValueError, match=length_error):

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -91,6 +91,7 @@ def test_constructor_mismatched_codes_levels(idx):
 
 def test_na_levels():
     # GH26408
+    # test if codes are re-assigned value -1 for levels with na values
     result = MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
                         codes=[[0, -1, 1, 2, 3, 4]])
     expected = MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -67,6 +67,7 @@ def test_constructor_mismatched_codes_levels(idx):
     length_error = (r"On level 0, code max \(3\) >= length of level  \(1\)\."
                     " NOTE: this index is in an inconsistent state")
     label_error = r"Unequal code lengths: \[4, 2\]"
+    code_value_error = (r"On level 0, code value \(-2\) < -1")
 
     # important to check that it's looking at the right thing.
     with pytest.raises(ValueError, match=length_error):
@@ -82,6 +83,23 @@ def test_constructor_mismatched_codes_levels(idx):
 
     with pytest.raises(ValueError, match=label_error):
         idx.copy().set_codes([[0, 0, 0, 0], [0, 0]])
+
+    # code value smaller than -1
+    with pytest.raises(ValueError, match=code_value_error):
+        MultiIndex(levels=[['a'], ['b']], codes=[[0, -2], [0, 0]])
+
+
+def test_na_levels():
+    tm.assert_index_equal(
+        MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
+                   codes=[[0, -1, 1, 2, 3, 4]]),
+        MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
+                   codes=[[-1, -1, -1, -1, 3, 4]]))
+    tm.assert_index_equal(
+        MultiIndex(levels=[[np.nan, 's', pd.NaT, 128, None]],
+                   codes=[[0, -1, 1, 2, 3, 4]]),
+        MultiIndex(levels=[[np.nan, 's', pd.NaT, 128, None]],
+                   codes=[[-1, -1, 1, -1, 3, -1]]))
 
 
 def test_labels_deprecated(idx):

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -90,16 +90,30 @@ def test_constructor_mismatched_codes_levels(idx):
 
 
 def test_na_levels():
-    tm.assert_index_equal(
-        MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
-                   codes=[[0, -1, 1, 2, 3, 4]]),
-        MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
-                   codes=[[-1, -1, -1, -1, 3, 4]]))
-    tm.assert_index_equal(
-        MultiIndex(levels=[[np.nan, 's', pd.NaT, 128, None]],
-                   codes=[[0, -1, 1, 2, 3, 4]]),
-        MultiIndex(levels=[[np.nan, 's', pd.NaT, 128, None]],
-                   codes=[[-1, -1, 1, -1, 3, -1]]))
+    # GH26408
+    result = MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
+                        codes=[[0, -1, 1, 2, 3, 4]])
+    expected = MultiIndex(levels=[[np.nan, None, pd.NaT, 128, 2]],
+                          codes=[[-1, -1, -1, -1, 3, 4]])
+    tm.assert_index_equal(result, expected)
+
+    result = MultiIndex(levels=[[np.nan, 's', pd.NaT, 128, None]],
+                        codes=[[0, -1, 1, 2, 3, 4]])
+    expected = MultiIndex(levels=[[np.nan, 's', pd.NaT, 128, None]],
+                          codes=[[-1, -1, 1, -1, 3, -1]])
+    tm.assert_index_equal(result, expected)
+
+    # verify set_levels and set_codes
+    result = MultiIndex(
+        levels=[[1, 2, 3, 4, 5]], codes=[[0, -1, 1, 2, 3, 4]]).set_levels(
+            [[np.nan, 's', pd.NaT, 128, None]])
+    tm.assert_index_equal(result, expected)
+
+    result = MultiIndex(
+        levels=[[np.nan, 's', pd.NaT, 128, None]],
+        codes=[[1, 2, 2, 2, 2, 2]]).set_codes(
+            [[0, -1, 1, 2, 3, 4]])
+    tm.assert_index_equal(result, expected)
 
 
 def test_labels_deprecated(idx):

--- a/pandas/tests/indexes/multi/test_missing.py
+++ b/pandas/tests/indexes/multi/test_missing.py
@@ -73,6 +73,21 @@ def test_dropna():
     with pytest.raises(ValueError, match=msg):
         idx.dropna(how='xxx')
 
+    # GH26408
+    # test if missing values are dropped for mutiindex constructed
+    # from codes and values
+    idx = MultiIndex(levels=[[np.nan, None, pd.NaT, "128", 2],
+                             [np.nan, None, pd.NaT, "128", 2]],
+                     codes=[[0, -1, 1, 2, 3, 4],
+                            [0, -1, 3, 3, 3, 4]])
+    expected = MultiIndex.from_arrays([["128", 2], ["128", 2]])
+    tm.assert_index_equal(idx.dropna(), expected)
+    tm.assert_index_equal(idx.dropna(how='any'), expected)
+
+    expected = MultiIndex.from_arrays([[np.nan, np.nan, "128", 2],
+                                       ["128", "128", "128", 2]])
+    tm.assert_index_equal(idx.dropna(how='all'), expected)
+
 
 def test_nulls(idx):
     # this is really a smoke test for the methods


### PR DESCRIPTION
- [x] closes #19387
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Please take note that another bug is also fixed in this PR:

When the MultiIndex is constructed with code value < -1, a segmentation fault would be resulted in subsequent operations e.g. putting the MultiIndex in a DataFrame
Input:
```python
x = pd.MultiIndex(levels=[['a'], ['x', np.nan]], labels=[[0,-2], [0,1]])
pd.DataFrame(index=x)
```
A segmentation fault can be resulted by these commands
