### PR TITLE
DOC: remove usage of lrange in docs

### DIFF
--- a/doc/source/whatsnew/v0.11.0.rst
+++ b/doc/source/whatsnew/v0.11.0.rst
@@ -239,13 +239,8 @@ Enhancements
     - support ``read_hdf/to_hdf`` API similar to ``read_csv/to_csv``
 
       .. ipython:: python
-          :suppress:
 
-          from pandas.compat import lrange
-
-      .. ipython:: python
-
-          df = pd.DataFrame({'A': lrange(5), 'B': lrange(5)})
+          df = pd.DataFrame({'A': range(5), 'B': range(5)})
           df.to_hdf('store.h5', 'table', append=True)
           pd.read_hdf('store.h5', 'table', where=['index > 2'])
 

--- a/doc/source/whatsnew/v0.12.0.rst
+++ b/doc/source/whatsnew/v0.12.0.rst
@@ -83,13 +83,8 @@ API changes
     ``iloc`` API to be *purely* positional based.
 
     .. ipython:: python
-       :suppress:
 
-       from pandas.compat import lrange
-
-    .. ipython:: python
-
-       df = pd.DataFrame(lrange(5), list('ABCDE'), columns=['a'])
+       df = pd.DataFrame(range(5), index=list('ABCDE'), columns=['a'])
        mask = (df.a % 2 == 0)
        mask
 


### PR DESCRIPTION
Due to the recent removals (eg https://github.com/pandas-dev/pandas/pull/26396 and others)