### PR TITLE
ERR: FutureWarning difficult to identify source

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -332,7 +332,6 @@ Timezones
 - Bug in :func:`to_datetime` where an uninformative ``RuntimeError`` was raised when passing a naive :class:`Timestamp` with datetime strings with mixed UTC offsets (:issue:`25978`)
 - Bug in :func:`to_datetime` with ``unit='ns'`` would drop timezone information from the parsed argument (:issue:`26168`)
 - Bug in :func:`DataFrame.join` where joining a timezone aware index with a timezone aware column would result in a column of ``NaN`` (:issue:`26335`)
-- FutureWarning message raised by :func:`DatetimeIndex.to_series` updated to identify source of warning (:issue:`26329`)
 
 Numeric
 ^^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -332,6 +332,7 @@ Timezones
 - Bug in :func:`to_datetime` where an uninformative ``RuntimeError`` was raised when passing a naive :class:`Timestamp` with datetime strings with mixed UTC offsets (:issue:`25978`)
 - Bug in :func:`to_datetime` with ``unit='ns'`` would drop timezone information from the parsed argument (:issue:`26168`)
 - Bug in :func:`DataFrame.join` where joining a timezone aware index with a timezone aware column would result in a column of ``NaN`` (:issue:`26335`)
+- FutureWarning message raised by :func:`DatetimeIndex.to_series` updated to identify source of warning (:issue:`26329`)
 
 Numeric
 ^^^^^^^

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -689,7 +689,8 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
             name = self.name
 
         if keep_tz is None and self.tz is not None:
-            warnings.warn("The default of the 'keep_tz' keyword will change "
+            warnings.warn("The default of the 'keep_tz' keyword in "
+                          "DatetimeIndex.to_series will change "
                           "to True in a future release. You can set "
                           "'keep_tz=True' to obtain the future behaviour and "
                           "silence this warning.", FutureWarning, stacklevel=2)

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -460,9 +460,13 @@ class TestDataFrameAlterAxes:
                       name='B')
         tm.assert_series_equal(result, comp)
 
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(FutureWarning) as m:
             result = idx.to_series(index=[0, 1])
         tm.assert_series_equal(result, expected.dt.tz_convert(None))
+        msg = ("The default of the 'keep_tz' keyword in "
+               "DatetimeIndex.to_series will change to True in a future "
+               "release.")
+        assert msg in str(m[0].message)
 
         with tm.assert_produces_warning(FutureWarning):
             result = idx.to_series(keep_tz=False, index=[0, 1])


### PR DESCRIPTION
- [x] closes #26329
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [n/a ] whatsnew entry
