### PR TITLE
DEPR: deprecate __bytes__ methods

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -258,7 +258,7 @@ Deprecations
 - Deprecated the ``units=M`` (months) and ``units=Y`` (year) parameters for ``units`` of :func:`pandas.to_timedelta`, :func:`pandas.Timedelta` and :func:`pandas.TimedeltaIndex` (:issue:`16344`)
 - The functions :func:`pandas.to_datetime` and :func:`pandas.to_timedelta` have deprecated the ``box`` keyword. Instead, use :meth:`to_numpy` or :meth:`Timestamp.to_datetime64` or :meth:`Timedelta.to_timedelta64`. (:issue:`24416`)
 - The :meth:`DataFrame.compound` and :meth:`Series.compound` methods are deprecated and will be removed in a future version.
-
+- Deprecated the ``__bytes__`` method of :class:`pandas.core.base.StringMixin` and :class:`pandas.core.dtypes.PandasExtensionDtype` and their subclasses. The method was needed for Python2 compatibility (:issue:`26444`).
 
 .. _whatsnew_0250.prior_deprecations:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -51,7 +51,12 @@ class StringMixin:
     def __bytes__(self):
         """
         Return a bytes representation for a particular object.
+
+        .. deprecated:: 0.25.0
         """
+        warnings.warn("{obj}.__bytes__ is deprecated and will be removed "
+                      "in a future version".format(obj=type(self).__name__),
+                      FutureWarning, stacklevel=2)
         from pandas._config import get_option
 
         encoding = get_option("display.encoding")

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -134,8 +134,13 @@ class PandasExtensionDtype(ExtensionDtype):
 
     def __bytes__(self):
         """
-        Return a string representation for a particular object.
+        Return a bytes representation for a particular object.
+
+        .. deprecated:: 0.25.0
         """
+        warnings.warn("{obj}.__bytes__ is deprecated and will be removed "
+                      "in a future version".format(obj=type(self).__name__),
+                      FutureWarning, stacklevel=2)
         from pandas._config import get_option
 
         encoding = get_option("display.encoding")

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -50,6 +50,10 @@ class Base:
         assert not len(self.dtype._cache)
         assert result == self.dtype
 
+    def test_bytes_deprecated(self):
+        with tm.assert_produces_warning(FutureWarning):
+            bytes(self.dtype)
+
 
 class TestCategoricalDtype(Base):
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -31,14 +31,16 @@ class CheckStringMixin:
     def test_string_methods_dont_fail(self):
         repr(self.container)
         str(self.container)
-        bytes(self.container)
 
     def test_tricky_container(self):
         if not hasattr(self, 'unicode_container'):
             pytest.skip('Need unicode_container to test with this')
         repr(self.unicode_container)
         str(self.unicode_container)
-        bytes(self.unicode_container)
+
+    def test_bytes_deprecated(self):
+        with tm.assert_produces_warning(FutureWarning):
+            bytes(self.container)
 
 
 class CheckImmutable:


### PR DESCRIPTION
- [x] xref #25725

Deprecate the use of ``__bytes__`` method from ``StringMixin`` and ``PandasExtensionDtype``. These are the only uses of ``__bytes__`` in the code base.
