### PR TITLE
CLN: remove __bytes__

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -250,6 +250,7 @@ Other API Changes
 - Bug in :meth:`DatetimeIndex.snap` which didn't preserving the ``name`` of the input :class:`Index` (:issue:`25575`)
 - The ``arg`` argument in :meth:`pandas.core.groupby.DataFrameGroupBy.agg` has been renamed to ``func`` (:issue:`26089`)
 - The ``arg`` argument in :meth:`pandas.core.window._Window.aggregate` has been renamed to ``func`` (:issue:`26372`)
+- Most Pandas classes had a ``__bytes__`` method, which was used for getting a python2-style bytestring representation of the object. This method has been removed as a part of dropping Python2 (:issue:`26447`)
 
 .. _whatsnew_0250.deprecations:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -48,15 +48,6 @@ class StringMixin:
         """
         raise AbstractMethodError(self)
 
-    def __bytes__(self):
-        """
-        Return a bytes representation for a particular object.
-        """
-        from pandas._config import get_option
-
-        encoding = get_option("display.encoding")
-        return str(self).encode(encoding, 'replace')
-
     def __repr__(self):
         """
         Return a string representation for a particular object.

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -132,15 +132,6 @@ class PandasExtensionDtype(ExtensionDtype):
         """
         return self.name
 
-    def __bytes__(self):
-        """
-        Return a string representation for a particular object.
-        """
-        from pandas._config import get_option
-
-        encoding = get_option("display.encoding")
-        return str(self).encode(encoding, 'replace')
-
     def __repr__(self):
         """
         Return a string representation for a particular object.

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -140,9 +140,12 @@ class TestDataFrameReprInfoEtc(TestData):
         df = DataFrame({'A': ["\u05d0"]})
         str(df)
 
-    def test_bytestring_with_unicode(self):
-        df = DataFrame({'A': ["\u05d0"]})
-        bytes(df)
+    def test_str_to_bytes_raises(self):
+        # GH 26447
+        df = DataFrame({'A': ["abc"]})
+        msg = "^'str' object cannot be interpreted as an integer$"
+        with pytest.raises(TypeError, match=msg):
+            bytes(df)
 
     def test_very_wide_info_repr(self):
         df = DataFrame(np.random.randn(10, 20),

--- a/pandas/tests/indexes/multi/test_format.py
+++ b/pandas/tests/indexes/multi/test_format.py
@@ -88,12 +88,6 @@ def test_unicode_string_with_unicode():
     str(idx)
 
 
-def test_bytestring_with_unicode():
-    d = {"a": ["\u05d0", 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}
-    idx = pd.DataFrame(d).set_index(["a", "b"]).index
-    bytes(idx)
-
-
 def test_repr_max_seq_item_setting(idx):
     # GH10182
     idx = idx.repeat(50)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2388,10 +2388,12 @@ class TestMixedIntIndex(Base):
                            "c": [7, 8, 9]})
         repr(df.columns)  # should not raise UnicodeDecodeError
 
-    @pytest.mark.parametrize("func", [str, bytes])
-    def test_with_unicode(self, func):
-        index = Index(list(range(1000)))
-        func(index)
+    def test_str_to_bytes_raises(self):
+        # GH 26447
+        index = Index([str(x) for x in range(10)])
+        msg = "^'str' object cannot be interpreted as an integer$"
+        with pytest.raises(TypeError, match=msg):
+            bytes(index)
 
     def test_intersect_str_dates(self):
         dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]

--- a/pandas/tests/indexes/test_frozen.py
+++ b/pandas/tests/indexes/test_frozen.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy as np
+import pytest
 
 from pandas.core.indexes.frozen import FrozenList, FrozenNDArray
 from pandas.tests.test_base import CheckImmutable, CheckStringMixin
@@ -49,6 +50,12 @@ class TestFrozenList(CheckImmutable, CheckStringMixin):
         expected = FrozenList([1, 3])
         self.check_result(result, expected)
 
+    def test_tricky_container_to_bytes_raises(self):
+        # GH 26447
+        msg = "^'str' object cannot be interpreted as an integer$"
+        with pytest.raises(TypeError, match=msg):
+            bytes(self.unicode_container)
+
 
 class TestFrozenNDArray(CheckImmutable, CheckStringMixin):
     mutable_methods = ('put', 'itemset', 'fill')
@@ -67,6 +74,9 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin):
         # see gh-9031
         with tm.assert_produces_warning(FutureWarning):
             FrozenNDArray([1, 2, 3])
+
+    def test_tricky_container_to_bytes(self):
+        bytes(self.unicode_container)
 
     def test_shallow_copying(self):
         original = self.container.copy()

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 import numpy as np
+import pytest
 
 import pandas as pd
 from pandas import (
@@ -152,9 +153,12 @@ class TestSeriesRepr(TestData):
         df = Series(["\u05d0"], name="\u05d1")
         str(df)
 
-    def test_bytestring_with_unicode(self):
-        df = Series(["\u05d0"], name="\u05d1")
-        bytes(df)
+    def test_str_to_bytes_raises(self):
+        # GH 26447
+        df = Series(["abc"], name="abc")
+        msg = "^'str' object cannot be interpreted as an integer$"
+        with pytest.raises(TypeError, match=msg):
+            bytes(df)
 
     def test_timeseries_repr_object_dtype(self):
         index = Index([datetime(2000, 1, 1) + timedelta(i)

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -38,7 +38,6 @@ class CheckStringMixin:
             pytest.skip('Need unicode_container to test with this')
         repr(self.unicode_container)
         str(self.unicode_container)
-        bytes(self.unicode_container)
 
 
 class CheckImmutable:


### PR DESCRIPTION
- [x] xref #25725

Remove ``__bytes__`` method from ``StringMixin`` and ``PandasExtensionDtype``. These are the only uses of ``__bytes__`` in the code base.
