### PR TITLE
WIP: Add indent support in to_json

### DIFF
--- a/pandas/_libs/src/ujson/lib/ultrajson.h
+++ b/pandas/_libs/src/ujson/lib/ultrajson.h
@@ -245,6 +245,10 @@ typedef struct __JSONObjectEncoder {
   int encodeHTMLChars;
 
   /*
+  Configuration for spaces of indent */
+  int indent;  
+
+  /*
   Set to an error message if error occurred */
   const char *errorMsg;
   JSOBJ errorObj;

--- a/pandas/_libs/src/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/ujson/lib/ultrajsonenc.c
@@ -968,7 +968,6 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
             enc->iterBegin(obj, &tc);
 
             Buffer_AppendCharUnchecked(enc, '[');
-	    Buffer_AppendIndentNewlineUnchecked (enc);
 
             while (enc->iterNext(obj, &tc)) {
                 if (count > 0) {
@@ -976,7 +975,6 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
 #ifndef JSON_NO_EXTRA_WHITESPACE
                     Buffer_AppendCharUnchecked(buffer, ' ');
 #endif
-		    Buffer_AppendIndentNewlineUnchecked (enc);
                 }
 
                 iterObj = enc->iterGetValue(obj, &tc);
@@ -988,8 +986,6 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
             }
 
             enc->iterEnd(obj, &tc);
-	    Buffer_AppendIndentNewlineUnchecked (enc);
-	    Buffer_AppendIndentUnchecked (enc, enc->level);
             Buffer_Reserve(enc, 2);
             Buffer_AppendCharUnchecked(enc, ']');
             break;
@@ -1001,6 +997,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
 
             Buffer_AppendCharUnchecked(enc, '{');
 	    Buffer_AppendIndentNewlineUnchecked (enc);
+	    Buffer_AppendIndentUnchecked (enc, enc->level + 2);
 
             while (enc->iterNext(obj, &tc)) {
                 if (count > 0) {
@@ -1009,21 +1006,20 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
                     Buffer_AppendCharUnchecked(enc, ' ');
 #endif
 		    Buffer_AppendIndentNewlineUnchecked (enc);
+		    Buffer_AppendIndentUnchecked (enc, enc->level + 2);
                 }
 
                 iterObj = enc->iterGetValue(obj, &tc);
                 objName = enc->iterGetName(obj, &tc, &szlen);
 
                 enc->level++;
-		Buffer_AppendIndentUnchecked (enc, enc->level);
                 encode(iterObj, enc, objName, szlen);
                 count++;
             }
 
             enc->iterEnd(obj, &tc);
 	    Buffer_AppendIndentNewlineUnchecked (enc);
-	    Buffer_AppendIndentUnchecked (enc, enc->level);
-            Buffer_Reserve(enc, 2);
+	    Buffer_AppendIndentUnchecked (enc, enc->level + 1);
             Buffer_AppendCharUnchecked(enc, '}');
             break;
         }

--- a/pandas/_libs/src/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/ujson/lib/ultrajsonenc.c
@@ -722,6 +722,20 @@ FASTCALL_ATTR INLINE_PREFIX void FASTCALL_MSVC strreverse(char *begin,
     while (end > begin) aux = *end, *end-- = *begin, *begin++ = aux;
 }
 
+void Buffer_AppendIndentNewlineUnchecked(JSONObjectEncoder *enc)
+{
+  if (enc->indent > 0) Buffer_AppendCharUnchecked(enc, '\n');
+}
+
+void Buffer_AppendIndentUnchecked(JSONObjectEncoder *enc, JSINT32 value)
+{
+  int i;
+  if (enc->indent > 0)
+    while (value-- > 0)
+      for (i = 0; i < enc->indent; i++)
+        Buffer_AppendCharUnchecked(enc, ' ');
+}
+
 void Buffer_AppendIntUnchecked(JSONObjectEncoder *enc, JSINT32 value) {
     char *wstr;
     JSUINT32 uvalue = (value < 0) ? -value : value;
@@ -954,6 +968,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
             enc->iterBegin(obj, &tc);
 
             Buffer_AppendCharUnchecked(enc, '[');
+	    Buffer_AppendIndentNewlineUnchecked (enc);
 
             while (enc->iterNext(obj, &tc)) {
                 if (count > 0) {
@@ -961,16 +976,20 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
 #ifndef JSON_NO_EXTRA_WHITESPACE
                     Buffer_AppendCharUnchecked(buffer, ' ');
 #endif
+		    Buffer_AppendIndentNewlineUnchecked (enc);
                 }
 
                 iterObj = enc->iterGetValue(obj, &tc);
 
                 enc->level++;
+		Buffer_AppendIndentUnchecked (enc, enc->level);
                 encode(iterObj, enc, NULL, 0);
                 count++;
             }
 
             enc->iterEnd(obj, &tc);
+	    Buffer_AppendIndentNewlineUnchecked (enc);
+	    Buffer_AppendIndentUnchecked (enc, enc->level);
             Buffer_Reserve(enc, 2);
             Buffer_AppendCharUnchecked(enc, ']');
             break;
@@ -981,6 +1000,7 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
             enc->iterBegin(obj, &tc);
 
             Buffer_AppendCharUnchecked(enc, '{');
+	    Buffer_AppendIndentNewlineUnchecked (enc);
 
             while (enc->iterNext(obj, &tc)) {
                 if (count > 0) {
@@ -988,17 +1008,21 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name,
 #ifndef JSON_NO_EXTRA_WHITESPACE
                     Buffer_AppendCharUnchecked(enc, ' ');
 #endif
+		    Buffer_AppendIndentNewlineUnchecked (enc);
                 }
 
                 iterObj = enc->iterGetValue(obj, &tc);
                 objName = enc->iterGetName(obj, &tc, &szlen);
 
                 enc->level++;
+		Buffer_AppendIndentUnchecked (enc, enc->level);
                 encode(iterObj, enc, objName, szlen);
                 count++;
             }
 
             enc->iterEnd(obj, &tc);
+	    Buffer_AppendIndentNewlineUnchecked (enc);
+	    Buffer_AppendIndentUnchecked (enc, enc->level);
             Buffer_Reserve(enc, 2);
             Buffer_AppendCharUnchecked(enc, '}');
             break;

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -2397,6 +2397,8 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
         pyEncoder.defaultHandler = odefHandler;
     }
 
+    encoder->indent = indent;
+
     pyEncoder.originalOutputFormat = pyEncoder.outputFormat;
     PRINTMARK();
     ret = JSON_EncodeObject(oinput, encoder, buffer, sizeof(buffer));

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -2268,7 +2268,7 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
     static char *kwlist[] = {
         "obj",    "ensure_ascii", "double_precision", "encode_html_chars",
         "orient", "date_unit",    "iso_dates",        "default_handler",
-        NULL};
+	"indent", NULL};
 
     char buffer[65536];
     char *ret;
@@ -2281,6 +2281,7 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
     char *sdateFormat = NULL;
     PyObject *oisoDates = 0;
     PyObject *odefHandler = 0;
+    int indent = 0;
 
     PyObjectEncoder pyEncoder = {{
         Object_beginTypeContext,
@@ -2302,6 +2303,7 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
         idoublePrecision,
         1,  // forceAscii
         0,  // encodeHTMLChars
+	0,  // indent
     }};
     JSONObjectEncoder *encoder = (JSONObjectEncoder *)&pyEncoder;
 
@@ -2326,10 +2328,10 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
 
     PRINTMARK();
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiOssOO", kwlist, &oinput,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiOssOOi", kwlist, &oinput,
                                      &oensureAscii, &idoublePrecision,
                                      &oencodeHTMLChars, &sOrient, &sdateFormat,
-                                     &oisoDates, &odefHandler)) {
+                                     &oisoDates, &odefHandler, &indent)) {
         return NULL;
     }
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2178,7 +2178,7 @@ class NDFrame(PandasObject, SelectionMixin):
     def to_json(self, path_or_buf=None, orient=None, date_format=None,
                 double_precision=10, force_ascii=True, date_unit='ms',
                 default_handler=None, lines=False, compression='infer',
-                index=True):
+                index=True, indent=0):
         """
         Convert the object to a JSON string.
 
@@ -2260,6 +2260,11 @@ class NDFrame(PandasObject, SelectionMixin):
 
             .. versionadded:: 0.23.0
 
+        indent : integer, default 0
+           Length of whitespace used to indent each record.
+
+           .. versionadded:: 0.25.0
+
         Returns
         -------
         None or str
@@ -2325,7 +2330,7 @@ class NDFrame(PandasObject, SelectionMixin):
                             force_ascii=force_ascii, date_unit=date_unit,
                             default_handler=default_handler,
                             lines=lines, compression=compression,
-                            index=index)
+                            index=index, indent=indent)
 
     def to_hdf(self, path_or_buf, key, **kwargs):
         """

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1326,13 +1326,13 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         result = df.to_json(indent=4)
         expected = """{
-    "a": {
-        "0": "foo",
-        "1": "baz"
+    "a":{
+        "0":"foo",
+        "1":"baz"
     },
-    "b": {
-        "0": "bar",
-        "1": "qux"
+    "b":{
+        "0":"bar",
+        "1":"qux"
     }
 }"""
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1317,3 +1317,23 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
                           index=DatetimeIndex(['2019-01-01 11:00:00'],
                                               tz='UTC'))
         assert_series_equal(result, expected)
+
+    def test_to_json_indent(self):
+        # GH 12004
+        df = pd.DataFrame([
+            ['foo', 'bar'], ['baz', 'qux']
+        ], columns=['a', 'b'])
+
+        result = df.to_json(indent=4)
+        expected = """{
+    "a": {
+        "0": "foo",
+        "1": "baz"
+    },
+    "b": {
+        "0": "bar",
+        "1": "qux"
+    }
+}"""
+
+        assert result == expected


### PR DESCRIPTION
- [X] closes #12004
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is a WIP and requires a little more refinement (namely around how `level` is incremented in the extension module, testing arrays) but is more or less the direction I think we could head in

This is mostly inspired by changes done in https://github.com/esnme/ultrajson/commit/930dfa5525219d52c8422cf416ca308bc7382870#diff-edae06c872e58ad6edf574f4414aac9f
