### PR TITLE
DOC: #25723 passing kwargs to excel document engine

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -2871,6 +2871,7 @@ with ``on_demand=True``.
 
 .. code-block:: python
     
+    import xlrd
     xlrd_book = xlrd.open_workbook('path_to_file.xls', on_demand=True)
     with pd.ExcelFile(xlrd_book) as xls:
         df1 = pd.read_excel(xls, 'Sheet1')

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -2341,10 +2341,10 @@ round-trippable manner.
   .. ipython:: python
 
    df = pd.DataFrame({'foo': [1, 2, 3, 4],
-		      'bar': ['a', 'b', 'c', 'd'],
-		      'baz': pd.date_range('2018-01-01', freq='d', periods=4),
-		      'qux': pd.Categorical(['a', 'b', 'c', 'c'])
-		      }, index=pd.Index(range(4), name='idx'))
+          'bar': ['a', 'b', 'c', 'd'],
+          'baz': pd.date_range('2018-01-01', freq='d', periods=4),
+          'qux': pd.Categorical(['a', 'b', 'c', 'c'])
+          }, index=pd.Index(range(4), name='idx'))
    df
    df.dtypes
 
@@ -2870,7 +2870,7 @@ For example, sheets can be loaded on demand by calling ``xlrd.open_workbook()``
 with ``on_demand=True``.
 
 .. code-block:: python
-    
+
     import xlrd
     xlrd_book = xlrd.open_workbook('path_to_file.xls', on_demand=True)
     with pd.ExcelFile(xlrd_book) as xls:

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -2864,11 +2864,13 @@ of sheet names can simply be passed to ``read_excel`` with no loss in performanc
     data = pd.read_excel('path_to_file.xls', ['Sheet1', 'Sheet2'],
                          index_col=None, na_values=['NA'])
 
-If control is needed over how a file is read, an ``xlrd`` workbook 
-created with the desired keyword arguments can be passed to ``ExcelFile``.
+``ExcelFile`` can also be called with a ``xlrd.book.Book`` object
+as a parameter. This allows the user to control how the excel file is read.
+For example, sheets can be loaded on demand by calling ``xlrd.open_workbook()``
+with ``on_demand=True``.
 
 .. code-block:: python
-
+    
     xlrd_book = xlrd.open_workbook('path_to_file.xls', on_demand=True)
     with pd.ExcelFile(xlrd_book) as xls:
         df1 = pd.read_excel(xls, 'Sheet1')

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -2864,6 +2864,16 @@ of sheet names can simply be passed to ``read_excel`` with no loss in performanc
     data = pd.read_excel('path_to_file.xls', ['Sheet1', 'Sheet2'],
                          index_col=None, na_values=['NA'])
 
+If control is needed over how a file is read, an ``xlrd`` workbook 
+created with the desired keyword arguments can be passed to ``ExcelFile``.
+
+.. code-block:: python
+
+    xlrd_book = xlrd.open_workbook('path_to_file.xls', on_demand=True)
+    with pd.ExcelFile(xlrd_book) as xls:
+        df1 = pd.read_excel(xls, 'Sheet1')
+        df2 = pd.read_excel(xls, 'Sheet2')
+
 .. _io.excel.specifying_sheets:
 
 Specifying Sheets


### PR DESCRIPTION
- [x] closes #25723
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This pr tries to address #25723.

Made a small addition to the ExcelFile section of user_guide/io.rst regarding the discussion in #25723.
