### PR TITLE
Add defensive check for argument errors keyword in to_numeric

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -41,6 +41,7 @@ Other Enhancements
 - :meth:`DataFrame.query` and :meth:`DataFrame.eval` now supports quoting column names with backticks to refer to names with spaces (:issue:`6508`)
 - :func:`merge_asof` now gives a more clear error message when merge keys are categoricals that are not equal (:issue:`26136`)
 - :meth:`pandas.core.window.Rolling` supports exponential (or Poisson) window type (:issue:`21303`)
+- :func:`to_numeric` now gives a error message when errors argument value is not in the tuple of accepted values. (:issue:`26466`)
 
 .. _whatsnew_0250.api_breaking:
 

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -105,6 +105,9 @@ def to_numeric(arg, errors='raise', downcast=None):
     if downcast not in (None, 'integer', 'signed', 'unsigned', 'float'):
         raise ValueError('invalid downcasting method provided')
 
+    if errors not in ('ignore', 'raise', 'coerce'):
+        raise ValueError('invalid error value specified')
+
     is_series = False
     is_index = False
     is_scalars = False

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -413,6 +413,16 @@ def test_downcast_invalid_cast():
         to_numeric(data, downcast=invalid_downcast)
 
 
+def test_errors_invalid_value():
+    # see gh-26466
+    data = ["1", 2, 3]
+    invalid_error_value = "invalid"
+    msg = "invalid error value specified"
+
+    with pytest.raises(ValueError, match=msg):
+        to_numeric(data, errors=invalid_error_value)
+
+
 @pytest.mark.parametrize("data", [
     ["1", 2, 3],
     [1, 2, 3],


### PR DESCRIPTION
- [x] closes #26394 
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] Added defensive check for argument `errors` in func `to_numeric`
