### PR TITLE
DOC: fix example with Timestamp/integer addition

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -868,7 +868,7 @@ You can also set using these same indexers.
 
 .. ipython:: python
 
-   df.at[dates[-1] + 1, 0] = 7
+   df.at[dates[-1] + pd.Timedelta('1 day'), 0] = 7
    df
 
 Boolean indexing


### PR DESCRIPTION
Remaining warning that is being raised in the examples in the docs (the others are related to pyarrow).