### PR TITLE
 CLN: pd.TimeGrouper

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -270,7 +270,7 @@ Removal of prior version deprecations/changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - Removed ``Panel`` (:issue:`25047`, :issue:`25191`, :issue:`25231`)
 -
--
+- Removed previously deprecated ``TimeGrouper`` (:issue:`16942`)
 -
 
 .. _whatsnew_0250.performance:

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -65,7 +65,7 @@ from pandas.core.api import (
     to_numeric, to_datetime, to_timedelta,
 
     # misc
-    np, TimeGrouper, Grouper, factorize, unique, value_counts,
+    np, Grouper, factorize, unique, value_counts,
     array, Categorical, set_eng_float_format, Series, DataFrame,
     Panel)
 

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -45,15 +45,3 @@ from pandas.core.tools.numeric import to_numeric
 from pandas.tseries.offsets import DateOffset
 from pandas.core.tools.datetimes import to_datetime
 from pandas.core.tools.timedeltas import to_timedelta
-
-
-# Deprecation: xref gh-16747
-class TimeGrouper:
-
-    def __new__(cls, *args, **kwargs):
-        from pandas.core.resample import TimeGrouper
-        import warnings
-        warnings.warn("pd.TimeGrouper is deprecated and will be removed; "
-                      "Please use pd.Grouper(freq=...)",
-                      FutureWarning, stacklevel=2)
-        return TimeGrouper(*args, **kwargs)

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -50,7 +50,7 @@ class TestPDApi(Base):
                ]
 
     # these are already deprecated; awaiting removal
-    deprecated_classes = ['TimeGrouper', 'Panel']
+    deprecated_classes = ['Panel']
 
     # these should be deprecated in the future
     deprecated_classes_in_future = []
@@ -130,17 +130,6 @@ class TestTesting(Base):
 
         from pandas import testing
         self.check(testing, self.funcs)
-
-
-class TestTopLevelDeprecations:
-
-    # top-level API deprecations
-    # GH 13790
-
-    def test_TimeGrouper(self):
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            pd.TimeGrouper(freq='D')
 
 
 class TestCDateRange:

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -10,8 +10,8 @@ import pytz
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, Timestamp, date_range
+from pandas.core.groupby.grouper import Grouper
 from pandas.core.groupby.ops import BinGrouper
-from pandas.core.resample import TimeGrouper
 from pandas.util import testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
@@ -366,7 +366,7 @@ class TestGroupBy:
             return x.value.sum()
 
         expected = df.groupby(pd.Grouper(key='date')).apply(sumfunc_value)
-        result = (df_dt.groupby(TimeGrouper(freq='M', key='date'))
+        result = (df_dt.groupby(Grouper(freq='M', key='date'))
                   .apply(sumfunc_value))
         assert_series_equal(result.reset_index(drop=True),
                             expected.reset_index(drop=True))

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -11,6 +11,7 @@ import pytz
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, Timestamp, date_range
 from pandas.core.groupby.ops import BinGrouper
+from pandas.core.resample import TimeGrouper
 from pandas.util import testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
@@ -365,10 +366,8 @@ class TestGroupBy:
             return x.value.sum()
 
         expected = df.groupby(pd.Grouper(key='date')).apply(sumfunc_value)
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            result = (df_dt.groupby(pd.TimeGrouper(freq='M', key='date'))
-                      .apply(sumfunc_value))
+        result = (df_dt.groupby(TimeGrouper(freq='M', key='date'))
+                  .apply(sumfunc_value))
         assert_series_equal(result.reset_index(drop=True),
                             expected.reset_index(drop=True))
 

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -6,10 +6,10 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Series
 from pandas.core.groupby.groupby import DataError
+from pandas.core.groupby.grouper import Grouper
 from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.period import PeriodIndex, period_range
 from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
-from pandas.core.resample import TimeGrouper
 import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_almost_equal, assert_frame_equal, assert_index_equal,
@@ -214,7 +214,7 @@ def test_apply_to_empty_series(empty_series):
 def test_resampler_is_iterable(series):
     # GH 15314
     freq = 'H'
-    tg = TimeGrouper(freq, convention='start')
+    tg = Grouper(freq=freq, convention='start')
     grouped = series.groupby(tg)
     resampled = series.resample(freq)
     for (rk, rv), (gk, gv) in zip(resampled, grouped):

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -10,10 +10,10 @@ from pandas.errors import UnsupportedFunctionCall
 
 import pandas as pd
 from pandas import DataFrame, Series, Timedelta, Timestamp, isna, notna
+from pandas.core.groupby.grouper import Grouper
 from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.period import Period, period_range
-from pandas.core.resample import (
-    DatetimeIndex, TimeGrouper, _get_timestamp_range_edges)
+from pandas.core.resample import DatetimeIndex, _get_timestamp_range_edges
 import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_almost_equal, assert_frame_equal, assert_series_equal)
@@ -42,7 +42,7 @@ def test_custom_grouper(index):
     dti = index
     s = Series(np.array([1] * len(dti)), index=dti, dtype='int64')
 
-    b = TimeGrouper(Minute(5))
+    b = Grouper(freq=Minute(5))
     g = s.groupby(b)
 
     # check all cython functions work
@@ -50,7 +50,7 @@ def test_custom_grouper(index):
     for f in funcs:
         g._cython_agg_general(f)
 
-    b = TimeGrouper(Minute(5), closed='right', label='right')
+    b = Grouper(freq=Minute(5), closed='right', label='right')
     g = s.groupby(b)
     # check all cython functions work
     funcs = ['add', 'mean', 'prod', 'ohlc', 'min', 'max', 'var']
@@ -116,7 +116,7 @@ def test_resample_integerarray():
 def test_resample_basic_grouper(series):
     s = series
     result = s.resample('5Min').last()
-    grouper = TimeGrouper(Minute(5), closed='left', label='left')
+    grouper = Grouper(freq=Minute(5), closed='left', label='left')
     expected = s.groupby(grouper).agg(lambda x: x[-1])
     assert_series_equal(result, expected)
 
@@ -373,7 +373,7 @@ def test_resample_upsampling_picked_but_not_correct():
 def test_resample_frame_basic():
     df = tm.makeTimeDataFrame()
 
-    b = TimeGrouper('M')
+    b = Grouper(freq='M')
     g = df.groupby(b)
 
     # check all cython functions work
@@ -521,7 +521,7 @@ def test_nearest_upsample_with_limit():
 def test_resample_ohlc(series):
     s = series
 
-    grouper = TimeGrouper(Minute(5))
+    grouper = Grouper(freq=Minute(5))
     expect = s.groupby(grouper).agg(lambda x: x[-1])
     result = s.resample('5Min').ohlc()
 

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -6,8 +6,8 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Series
+from pandas.core.groupby.grouper import Grouper
 from pandas.core.indexes.datetimes import date_range
-from pandas.core.resample import TimeGrouper
 import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
@@ -16,7 +16,7 @@ test_series = Series(np.random.randn(1000),
 
 
 def test_apply():
-    grouper = TimeGrouper(freq='A', label='right', closed='right')
+    grouper = Grouper(freq='A', label='right', closed='right')
 
     grouped = test_series.groupby(grouper)
 
@@ -36,7 +36,7 @@ def test_count():
 
     expected = test_series.groupby(lambda x: x.year).count()
 
-    grouper = TimeGrouper(freq='A', label='right', closed='right')
+    grouper = Grouper(freq='A', label='right', closed='right')
     result = test_series.groupby(grouper).count()
     expected.index = result.index
     assert_series_equal(result, expected)
@@ -60,7 +60,7 @@ def test_apply_iteration():
     N = 1000
     ind = pd.date_range(start="2000-01-01", freq="D", periods=N)
     df = DataFrame({'open': 1, 'close': 2}, index=ind)
-    tg = TimeGrouper('M')
+    tg = Grouper(freq='M')
 
     _, grouper, _ = tg._get_grouper(df)
 
@@ -89,7 +89,7 @@ def test_fails_on_no_datetime_index(name, func):
     msg = ("Only valid with DatetimeIndex, TimedeltaIndex "
            "or PeriodIndex, but got an instance of '{}'".format(name))
     with pytest.raises(TypeError, match=msg):
-        df.groupby(TimeGrouper('D'))
+        df.groupby(Grouper(freq='D'))
 
 
 def test_aaa_group_order():
@@ -101,7 +101,7 @@ def test_aaa_group_order():
     df['key'] = [datetime(2013, 1, 1), datetime(2013, 1, 2),
                  datetime(2013, 1, 3), datetime(2013, 1, 4),
                  datetime(2013, 1, 5)] * 4
-    grouped = df.groupby(TimeGrouper(key='key', freq='D'))
+    grouped = df.groupby(Grouper(key='key', freq='D'))
 
     tm.assert_frame_equal(grouped.get_group(datetime(2013, 1, 1)),
                           df[::5])
@@ -131,7 +131,7 @@ def test_aggregate_normal(resample_method):
                     datetime(2013, 1, 5)] * 4
 
     normal_grouped = normal_df.groupby('key')
-    dt_grouped = dt_df.groupby(TimeGrouper(key='key', freq='D'))
+    dt_grouped = dt_df.groupby(Grouper(key='key', freq='D'))
 
     expected = getattr(normal_grouped, resample_method)()
     dt_result = getattr(dt_grouped, resample_method)()
@@ -191,7 +191,7 @@ def test_aggregate_with_nat(func, fill_value):
                     datetime(2013, 1, 4), datetime(2013, 1, 5)] * 4
 
     normal_grouped = normal_df.groupby('key')
-    dt_grouped = dt_df.groupby(TimeGrouper(key='key', freq='D'))
+    dt_grouped = dt_df.groupby(Grouper(key='key', freq='D'))
 
     normal_result = getattr(normal_grouped, func)()
     dt_result = getattr(dt_grouped, func)()
@@ -218,7 +218,7 @@ def test_aggregate_with_nat_size():
                     datetime(2013, 1, 4), datetime(2013, 1, 5)] * 4
 
     normal_grouped = normal_df.groupby('key')
-    dt_grouped = dt_df.groupby(TimeGrouper(key='key', freq='D'))
+    dt_grouped = dt_df.groupby(Grouper(key='key', freq='D'))
 
     normal_result = normal_grouped.size()
     dt_result = dt_grouped.size()
@@ -234,7 +234,7 @@ def test_aggregate_with_nat_size():
 
 def test_repr():
     # GH18203
-    result = repr(TimeGrouper(key='A', freq='H'))
+    result = repr(Grouper(key='A', freq='H'))
     expected = ("TimeGrouper(key='A', freq=<Hour>, axis=0, sort=True, "
                 "closed='left', label='left', how='mean', "
                 "convention='e', base=0)")

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -16,9 +16,7 @@ test_series = Series(np.random.randn(1000),
 
 
 def test_apply():
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        grouper = pd.TimeGrouper(freq='A', label='right', closed='right')
+    grouper = TimeGrouper(freq='A', label='right', closed='right')
 
     grouped = test_series.groupby(grouper)
 
@@ -38,9 +36,7 @@ def test_count():
 
     expected = test_series.groupby(lambda x: x.year).count()
 
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        grouper = pd.TimeGrouper(freq='A', label='right', closed='right')
+    grouper = TimeGrouper(freq='A', label='right', closed='right')
     result = test_series.groupby(grouper).count()
     expected.index = result.index
     assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] xref #6581
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
