### PR TITLE
CLN: Remove StringMixin from pandas.core.computation

### DIFF
--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -13,7 +13,6 @@ import numpy as np
 
 import pandas as pd
 from pandas.core import common as com
-from pandas.core.base import StringMixin
 from pandas.core.computation.common import (
     _BACKTICK_QUOTED_STRING, _remove_spaces_column_name)
 from pandas.core.computation.ops import (
@@ -701,7 +700,7 @@ class PythonExprVisitor(BaseExprVisitor):
         super().__init__(env, engine, parser, preparser=preparser)
 
 
-class Expr(StringMixin):
+class Expr:
 
     """Object encapsulating an expression.
 
@@ -732,7 +731,7 @@ class Expr(StringMixin):
     def __call__(self):
         return self.terms(self.env)
 
-    def __str__(self):
+    def __repr__(self):
         return printing.pprint_thing(self.terms)
 
     def __len__(self):

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -12,7 +12,6 @@ from pandas._libs.tslibs import Timestamp
 
 from pandas.core.dtypes.common import is_list_like, is_scalar
 
-from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.core.computation.common import _ensure_decoded, _result_type_many
 from pandas.core.computation.scope import _DEFAULT_GLOBALS
@@ -46,7 +45,7 @@ class UndefinedVariableError(NameError):
         super().__init__(msg.format(name))
 
 
-class Term(StringMixin):
+class Term:
 
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, str) else cls
@@ -67,7 +66,7 @@ class Term(StringMixin):
     def local_name(self):
         return self.name.replace(_LOCAL_TAG, '')
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing(self.name)
 
     def __call__(self, *args, **kwargs):
@@ -166,16 +165,14 @@ class Constant(Term):
     def name(self):
         return self.value
 
-    def __str__(self):
-        # in python 2 str() of float
-        # can truncate shorter than repr()
+    def __repr__(self):
         return repr(self.name)
 
 
 _bool_op_map = {'not': '~', 'and': '&', 'or': '|'}
 
 
-class Op(StringMixin):
+class Op:
 
     """Hold an operator of arbitrary arity
     """
@@ -188,7 +185,7 @@ class Op(StringMixin):
     def __iter__(self):
         return iter(self.operands)
 
-    def __str__(self):
+    def __repr__(self):
         """Print a generic n-ary operator and its operands using infix
         notation"""
         # recurse over the operands
@@ -506,7 +503,7 @@ class UnaryOp(Op):
         operand = self.operand(env)
         return self.func(operand)
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing('{0}({1})'.format(self.op, self.operand))
 
     @property
@@ -531,7 +528,7 @@ class MathCall(Op):
         with np.errstate(all='ignore'):
             return self.func.func(*operands)
 
-    def __str__(self):
+    def __repr__(self):
         operands = map(str, self.operands)
         return pprint_thing('{0}({1})'.format(self.op, ','.join(operands)))
 

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -11,7 +11,6 @@ from pandas.compat.chainmap import DeepChainMap
 from pandas.core.dtypes.common import is_list_like
 
 import pandas as pd
-from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.core.computation import expr, ops
 from pandas.core.computation.common import _ensure_decoded
@@ -36,7 +35,7 @@ class Term(ops.Term):
 
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, str) else cls
-        supr_new = StringMixin.__new__
+        supr_new = object.__new__
         return supr_new(klass)
 
     def __init__(self, name, env, side=None, encoding=None):
@@ -230,7 +229,7 @@ class BinOp(ops.BinOp):
 
 class FilterBinOp(BinOp):
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing("[Filter : [{lhs}] -> [{op}]"
                             .format(lhs=self.filter[0], op=self.filter[1]))
 
@@ -302,7 +301,7 @@ class JointFilterBinOp(FilterBinOp):
 
 class ConditionBinOp(BinOp):
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing("[Condition : [{cond}]]"
                             .format(cond=self.condition))
 
@@ -549,7 +548,7 @@ class Expr(expr.Expr):
                                         encoding=encoding)
             self.terms = self.parse()
 
-    def __str__(self):
+    def __repr__(self):
         if self.terms is not None:
             return pprint_thing(self.terms)
         return pprint_thing(self.expr)

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -15,7 +15,6 @@ import numpy as np
 from pandas._libs.tslibs import Timestamp
 from pandas.compat.chainmap import DeepChainMap
 
-from pandas.core.base import StringMixin
 import pandas.core.computation as compu
 
 
@@ -78,7 +77,7 @@ def _get_pretty_string(obj):
     return sio.getvalue()
 
 
-class Scope(StringMixin):
+class Scope:
 
     """Object to hold scope, with a few bells to deal with some custom syntax
     and contexts added by pandas.
@@ -135,13 +134,13 @@ class Scope(StringMixin):
         self.resolvers = DeepChainMap(*resolvers)
         self.temps = {}
 
-    def __str__(self):
+    def __repr__(self):
         scope_keys = _get_pretty_string(list(self.scope.keys()))
         res_keys = _get_pretty_string(list(self.resolvers.keys()))
-        unicode_str = '{name}(scope={scope_keys}, resolvers={res_keys})'
-        return unicode_str.format(name=type(self).__name__,
-                                  scope_keys=scope_keys,
-                                  res_keys=res_keys)
+        template = '{name}(scope={scope_keys}, resolvers={res_keys})'
+        return template.format(name=type(self).__name__,
+                               scope_keys=scope_keys,
+                               res_keys=res_keys)
 
     @property
     def has_resolvers(self):


### PR DESCRIPTION
- [x] xref #25725
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

StringMixin is not really useful anymore and only functions to reverse the calling order of ``__str__`` and ``__repr__``, which is now not-standard in Python3.

This removes the usage of StringMixin in pandas.core.computation. Followups will remove the class from other modules.
