### PR TITLE
Better error message for DataFrame.hist() without numerical columns (…

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2426,6 +2426,10 @@ def hist_frame(data, column=None, by=None, grid=True, xlabelsize=None,
     data = data._get_numeric_data()
     naxes = len(data.columns)
 
+    if naxes == 0:
+        raise ValueError("hist method requires numerical columns, "
+                         "nothing to plot.")
+
     fig, axes = _subplots(naxes=naxes, ax=ax, squeeze=False,
                           sharex=sharex, sharey=sharey, figsize=figsize,
                           layout=layout)

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -210,7 +210,7 @@ class TestDataFramePlots(TestPlotBase):
             ser.hist(foo='bar')
 
     @pytest.mark.slow
-    def test_hist_non_numerical(self):
+    def test_hist_non_numerical_raises(self):
         # check non-numerical df raises appropriate exception and error message
         df = DataFrame(np.random.rand(10, 2))
         df_o = df.astype(np.object)

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -210,6 +210,16 @@ class TestDataFramePlots(TestPlotBase):
             ser.hist(foo='bar')
 
     @pytest.mark.slow
+    def test_hist_non_numerical(self):
+        # check non-numerical df raises appropriate exception and error message
+        df = DataFrame(np.random.rand(10, 2))
+        df_o = df.astype(np.object)
+
+        msg = "hist method requires numerical columns, nothing to plot."
+        with pytest.raises(ValueError, match=msg):
+            df_o.hist()
+
+    @pytest.mark.slow
     def test_hist_layout(self):
         df = DataFrame(randn(100, 3))
 

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -211,7 +211,7 @@ class TestDataFramePlots(TestPlotBase):
 
     @pytest.mark.slow
     def test_hist_non_numerical_raises(self):
-        # check non-numerical df raises appropriate exception and error message
+        # gh-10444
         df = DataFrame(np.random.rand(10, 2))
         df_o = df.astype(np.object)
 


### PR DESCRIPTION
Closes #10444

Added simple check for non-zero number of numeric columns plus suggested error message in case the check fails. 

Happy to make any adjustments this if desired.
