### PR TITLE
DOC: fix SyntaxError in doc build on Windows

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -319,7 +319,7 @@ header = """\
    pd.options.display.max_rows = 15
 
    import os
-   os.chdir('{}')
+   os.chdir(r'{}')
 """.format(os.path.dirname(os.path.dirname(__file__)))
 
 


### PR DESCRIPTION
i'm getting this error for most files during doc build on Windows...

```
>>>-------------------------------------------------------------------------
Exception in C:\Users\simon\OneDrive\code\pandas-simonjayhawkins\doc\source\development\contributing.rst at block ending on line None
Specify :okexcept: as an option in the ipython:: block to suppress this message
  File "<ipython-input-1-9cb881b1c9b0>", line 1
    os.chdir('C:\Users\simon\OneDrive\code\pandas-simonjayhawkins\doc')
            ^
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape

<<<-------------------------------------------------------------------------
```