### PR TITLE
CLN: Remove StringMixin from PandasObject

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -213,6 +213,20 @@ are returned. (:issue:`21521`)
     df.groupby("a").ffill()
 
 
+``__str__`` methods now call ``__repr__`` rather than vica-versa
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pandas has until now mostly defined string representations in a Pandas objects's
+``__str__``/``__unicode__``/``__bytes__`` methods, and called ``__str__`` from the ``__repr__``
+method, if a specific ``__repr__`` method is not found. This is not needed for Python3.
+In Pandas 0.25, the string representations of Pandas objects are now generally
+defined in ``__repr__``, and calls to ``__str__`` in general now pass the call on to
+the ``__repr__``, if a specific ``__str__`` method doesn't exist, as is standard for Python.
+This change is backward compatible for direct usage of Pandas, but if you subclass
+Pandas objects *and* give your subclasses specific ``__str__``/``__repr__`` methods,
+you may have to adjust your ``__str__``/``__repr__`` methods (:issue:`26495`).
+
+
 .. _whatsnew_0250.api_breaking.deps:
 
 Increased minimum versions for dependencies

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2022,7 +2022,7 @@ class Categorical(ExtensionArray, PandasObject):
         result = formatter.to_string()
         return str(result)
 
-    def __str__(self):
+    def __repr__(self):
         """
         String representation.
         """
@@ -2036,10 +2036,6 @@ class Categorical(ExtensionArray, PandasObject):
             result = ('[], {repr_msg}'.format(repr_msg=msg))
 
         return result
-
-    def __repr__(self):
-        # We want to bypass the ExtensionArray.__repr__
-        return str(self)
 
     def _maybe_coerce_indexer(self, indexer):
         """

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1831,7 +1831,7 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
     # ----------
     # Formatting
     # -----------
-    def __str__(self):
+    def __repr__(self):
         return '{self}\nFill: {fill}\n{index}'.format(
             self=printing.pprint_thing(self),
             fill=printing.pprint_thing(self.fill_value),

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -55,7 +55,7 @@ class StringMixin:
         return str(self)
 
 
-class PandasObject(StringMixin, DirNamesMixin):
+class PandasObject(DirNamesMixin):
 
     """baseclass for various pandas objects"""
 
@@ -64,7 +64,7 @@ class PandasObject(StringMixin, DirNamesMixin):
         """class constructor (for this class it's just `__class__`"""
         return self.__class__
 
-    def __str__(self):
+    def __repr__(self):
         """
         Return a string representation for a particular object.
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -610,7 +610,7 @@ class DataFrame(NDFrame):
         return info_repr_option and not (self._repr_fits_horizontal_() and
                                          self._repr_fits_vertical_())
 
-    def __str__(self):
+    def __repr__(self):
         """
         Return a string representation for a particular DataFrame.
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2022,7 +2022,7 @@ class NDFrame(PandasObject, SelectionMixin):
     # ----------------------------------------------------------------------
     # Rendering Methods
 
-    def __str__(self):
+    def __repr__(self):
         # string representation based upon iterating over self
         # (since, by definition, `PandasContainers` are iterable)
         prepr = '[%s]' % ','.join(map(pprint_thing, self))

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -373,8 +373,8 @@ class _GroupBy(PandasObject, SelectionMixin):
     def __len__(self):
         return len(self.groups)
 
-    def __str__(self):
-        # TODO: Better str/repr for GroupBy object
+    def __repr__(self):
+        # TODO: Better repr for GroupBy object
         return object.__repr__(self)
 
     def _assure_grouper(self):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -932,7 +932,7 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Rendering Methods
 
-    def __str__(self):
+    def __repr__(self):
         """
         Return a string representation for this object.
         """

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -149,7 +149,7 @@ class FrozenNDArray(PandasObject, np.ndarray):
         arr = self.view(np.ndarray).copy()
         return arr
 
-    def __str__(self):
+    def __repr__(self):
         """
         Return a string representation for this object.
         """

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -233,8 +233,7 @@ class Block(PandasObject):
         return make_block(values, placement=placement, ndim=ndim,
                           klass=self.__class__, dtype=dtype)
 
-    def __str__(self):
-
+    def __repr__(self):
         # don't want to print out all of the items here
         name = pprint_thing(self.__class__.__name__)
         if self._is_single_block:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -291,7 +291,7 @@ class BlockManager(PandasObject):
     def __len__(self):
         return len(self.items)
 
-    def __str__(self):
+    def __repr__(self):
         output = pprint_thing(self.__class__.__name__)
         for i, ax in enumerate(self.axes):
             if i == 0:

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -340,7 +340,7 @@ class Panel(NDFrame):
     # ----------------------------------------------------------------------
     # Magic methods
 
-    def __str__(self):
+    def __repr__(self):
         """
         Return a string representation for a particular Panel.
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1384,7 +1384,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # ----------------------------------------------------------------------
     # Rendering Methods
 
-    def __str__(self):
+    def __repr__(self):
         """
         Return a string representation for a particular Series.
         """

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -217,9 +217,8 @@ class SparseSeries(Series):
         return SparseArray(self.values, sparse_index=self.sp_index,
                            fill_value=fill_value, kind=kind, copy=copy)
 
-    def __str__(self):
-        # currently, unicode is same as repr...fixes infinite loop
-        series_rep = Series.__str__(self)
+    def __repr__(self):
+        series_rep = Series.__repr__(self)
         rep = '{series}\n{index!r}'.format(series=series_rep,
                                            index=self.sp_index)
         return rep

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -157,7 +157,7 @@ class _Window(PandasObject, SelectionMixin):
     def _window_type(self):
         return self.__class__.__name__
 
-    def __str__(self):
+    def __repr__(self):
         """
         Provide a nice str repr of our rolling object.
         """


### PR DESCRIPTION
- [x] closes #26495
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Addresses #26495. In addition to the use of StringMixin in PandasObject, StringMixin is also used in core.computation and the io.pytables. I'd like to tackle those in a different PR, as there is some funkyness there (calls that depend on frame depth etc.)
