### PR TITLE
Issue/26506 Provides correct desciption in docstring that get_indexer methods are not yet supported

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -52,6 +52,9 @@ _unsortable_types = frozenset(('mixed', 'mixed-integer'))
 
 _index_doc_kwargs = dict(klass='Index', inplace='',
                          target_klass='Index',
+                         method_param_pad_notes='',
+                         method_param_backfill_notes='',
+                         method_param_nearest_notes='',
                          unique='Index', duplicated='np.ndarray')
 _index_shared_docs = dict()
 
@@ -2801,8 +2804,6 @@ class Index(IndexOpsMixin, PandasObject):
         and ``x`` is marked by -1, as it is not in ``index``.
         """
 
-    @Substitution(method_param_pad_notes='', method_param_backfill_notes='',
-                  method_param_nearest_notes='')
     @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
         method = missing.clean_reindex_fill_method(method)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2761,10 +2761,13 @@ class Index(IndexOpsMixin, PandasObject):
         target : %(target_klass)s
         method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}, optional
             * default: exact matches only.
-            * pad / ffill: find the PREVIOUS index value if no exact match.
-            * backfill / bfill: use NEXT index value if no exact match
+            * pad / ffill: find the PREVIOUS index value if no exact
+              match%(method_param_pad_notes)s.
+            * backfill / bfill: use NEXT index value if no exact
+              match%(method_param_backfill_notes)s.
             * nearest: use the NEAREST index value if no exact match. Tied
-              distances are broken by preferring the larger index value.
+              distances are broken by preferring the larger index
+              value%(method_param_nearest_notes)s.
         limit : int, optional
             Maximum number of consecutive labels in ``target`` to match for
             inexact matches.
@@ -2798,6 +2801,8 @@ class Index(IndexOpsMixin, PandasObject):
         and ``x`` is marked by -1, as it is not in ``index``.
         """
 
+    @Substitution(method_param_pad_notes='', method_param_backfill_notes='',
+                  method_param_nearest_notes='')
     @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
         method = missing.clean_reindex_fill_method(method)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -52,6 +52,7 @@ _unsortable_types = frozenset(('mixed', 'mixed-integer'))
 
 _index_doc_kwargs = dict(klass='Index', inplace='',
                          target_klass='Index',
+                         raises_section='',
                          unique='Index', duplicated='np.ndarray')
 _index_shared_docs = dict()
 
@@ -2788,7 +2789,7 @@ class Index(IndexOpsMixin, PandasObject):
             positions matches the corresponding target values. Missing values
             in the target are marked by -1.
 
-        Examples
+        %(raises_section)sExamples
         --------
         >>> index = pd.Index(['c', 'a', 'b'])
         >>> index.get_indexer(['a', 'b', 'x'])

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2689,7 +2689,7 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Indexing Methods
 
-    _get_loc_template = """
+    _index_shared_docs['get_loc'] = """
         Get integer location, slice or boolean mask for requested label.
 
         Parameters
@@ -2697,13 +2697,10 @@ class Index(IndexOpsMixin, PandasObject):
         key : label
         method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}, optional
             * default: exact matches only.
-            * pad / ffill: find the PREVIOUS index value if no exact
-              match%(notes)s.
-            * backfill / bfill: use NEXT index value if no exact
-              match%(notes)s.
+            * pad / ffill: find the PREVIOUS index value if no exact match.
+            * backfill / bfill: use NEXT index value if no exact match
             * nearest: use the NEAREST index value if no exact match. Tied
-              distances are broken by preferring the larger index
-              value%(notes)s.
+              distances are broken by preferring the larger index value.
         tolerance : optional
             Maximum distance from index value for inexact matches. The value of
             the index at the matching location most satisfy the equation
@@ -2735,14 +2732,8 @@ class Index(IndexOpsMixin, PandasObject):
         >>> non_monotonic_index.get_loc('b')
         array([False,  True, False,  True], dtype=bool)
         """
-    _index_shared_docs['get_loc_base'] = _get_loc_template % {
-        'notes': '',
-    }
-    _index_shared_docs['get_loc_interval'] = _get_loc_template % {
-        'notes': ' (not yet implemented for IntervalIndex)',
-    }
 
-    @Appender(_index_shared_docs['get_loc_base'])
+    @Appender(_index_shared_docs['get_loc'])
     def get_loc(self, key, method=None, tolerance=None):
         if method is None:
             if tolerance is not None:
@@ -2760,7 +2751,7 @@ class Index(IndexOpsMixin, PandasObject):
             raise KeyError(key)
         return loc
 
-    _get_indexer_template = """
+    _index_shared_docs['get_indexer'] = """
         Compute indexer and mask for new index given the current index. The
         indexer should be then used as an input to ndarray.take to align the
         current data to the new index.
@@ -2770,13 +2761,10 @@ class Index(IndexOpsMixin, PandasObject):
         target : %(target_klass)s
         method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}, optional
             * default: exact matches only.
-            * pad / ffill: find the PREVIOUS index value if no exact
-              match%(notes)s.
-            * backfill / bfill: use NEXT index value if no exact
-              match%(notes)s.
-            * nearest: use the NEAREST index value if no exact match.
-              Tied distances are broken by preferring the larger index
-              value%(notes)s.
+            * pad / ffill: find the PREVIOUS index value if no exact match.
+            * backfill / bfill: use NEXT index value if no exact match
+            * nearest: use the NEAREST index value if no exact match. Tied
+              distances are broken by preferring the larger index value.
         limit : int, optional
             Maximum number of consecutive labels in ``target`` to match for
             inexact matches.
@@ -2809,14 +2797,8 @@ class Index(IndexOpsMixin, PandasObject):
         Notice that the return value is an array of locations in ``index``
         and ``x`` is marked by -1, as it is not in ``index``.
         """
-    _index_shared_docs['get_indexer_base'] = _get_indexer_template % {
-        'notes': '',
-    }
-    _index_shared_docs['get_indexer_interval'] = _get_indexer_template % {
-        'notes': ' (not yet implemented for IntervalIndex)',
-    }
 
-    @Appender(_index_shared_docs['get_indexer_base'] % _index_doc_kwargs)
+    @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
         method = missing.clean_reindex_fill_method(method)
         target = ensure_index(target)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2788,8 +2788,8 @@ class Index(IndexOpsMixin, PandasObject):
             Integers from 0 to n - 1 indicating that the index at these
             positions matches the corresponding target values. Missing values
             in the target are marked by -1.
-
-        %(raises_section)sExamples
+        %(raises_section)s
+        Examples
         --------
         >>> index = pd.Index(['c', 'a', 'b'])
         >>> index.get_indexer(['a', 'b', 'x'])

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -52,9 +52,6 @@ _unsortable_types = frozenset(('mixed', 'mixed-integer'))
 
 _index_doc_kwargs = dict(klass='Index', inplace='',
                          target_klass='Index',
-                         method_param_pad_notes='',
-                         method_param_backfill_notes='',
-                         method_param_nearest_notes='',
                          unique='Index', duplicated='np.ndarray')
 _index_shared_docs = dict()
 
@@ -2764,13 +2761,10 @@ class Index(IndexOpsMixin, PandasObject):
         target : %(target_klass)s
         method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}, optional
             * default: exact matches only.
-            * pad / ffill: find the PREVIOUS index value if no exact
-              match%(method_param_pad_notes)s.
-            * backfill / bfill: use NEXT index value if no exact
-              match%(method_param_backfill_notes)s.
+            * pad / ffill: find the PREVIOUS index value if no exact match.
+            * backfill / bfill: use NEXT index value if no exact match
             * nearest: use the NEAREST index value if no exact match. Tied
-              distances are broken by preferring the larger index
-              value%(method_param_nearest_notes)s.
+              distances are broken by preferring the larger index value.
         limit : int, optional
             Maximum number of consecutive labels in ``target`` to match for
             inexact matches.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2689,7 +2689,7 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Indexing Methods
 
-    _index_shared_docs['get_loc'] = """
+    _get_loc_template = """
         Get integer location, slice or boolean mask for requested label.
 
         Parameters
@@ -2697,10 +2697,13 @@ class Index(IndexOpsMixin, PandasObject):
         key : label
         method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}, optional
             * default: exact matches only.
-            * pad / ffill: find the PREVIOUS index value if no exact match.
-            * backfill / bfill: use NEXT index value if no exact match
+            * pad / ffill: find the PREVIOUS index value if no exact
+              match%(notes)s.
+            * backfill / bfill: use NEXT index value if no exact
+              match%(notes)s.
             * nearest: use the NEAREST index value if no exact match. Tied
-              distances are broken by preferring the larger index value.
+              distances are broken by preferring the larger index
+              value%(notes)s.
         tolerance : optional
             Maximum distance from index value for inexact matches. The value of
             the index at the matching location most satisfy the equation
@@ -2732,8 +2735,14 @@ class Index(IndexOpsMixin, PandasObject):
         >>> non_monotonic_index.get_loc('b')
         array([False,  True, False,  True], dtype=bool)
         """
+    _index_shared_docs['get_loc_base'] = _get_loc_template % {
+        'notes': '',
+    }
+    _index_shared_docs['get_loc_interval'] = _get_loc_template % {
+        'notes': ' (not yet implemented for IntervalIndex)',
+    }
 
-    @Appender(_index_shared_docs['get_loc'])
+    @Appender(_index_shared_docs['get_loc_base'])
     def get_loc(self, key, method=None, tolerance=None):
         if method is None:
             if tolerance is not None:
@@ -2751,7 +2760,7 @@ class Index(IndexOpsMixin, PandasObject):
             raise KeyError(key)
         return loc
 
-    _index_shared_docs['get_indexer'] = """
+    _get_indexer_template = """
         Compute indexer and mask for new index given the current index. The
         indexer should be then used as an input to ndarray.take to align the
         current data to the new index.
@@ -2761,10 +2770,13 @@ class Index(IndexOpsMixin, PandasObject):
         target : %(target_klass)s
         method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}, optional
             * default: exact matches only.
-            * pad / ffill: find the PREVIOUS index value if no exact match.
-            * backfill / bfill: use NEXT index value if no exact match
-            * nearest: use the NEAREST index value if no exact match. Tied
-              distances are broken by preferring the larger index value.
+            * pad / ffill: find the PREVIOUS index value if no exact
+              match%(notes)s.
+            * backfill / bfill: use NEXT index value if no exact
+              match%(notes)s.
+            * nearest: use the NEAREST index value if no exact match.
+              Tied distances are broken by preferring the larger index
+              value%(notes)s.
         limit : int, optional
             Maximum number of consecutive labels in ``target`` to match for
             inexact matches.
@@ -2797,8 +2809,14 @@ class Index(IndexOpsMixin, PandasObject):
         Notice that the return value is an array of locations in ``index``
         and ``x`` is marked by -1, as it is not in ``index``.
         """
+    _index_shared_docs['get_indexer_base'] = _get_indexer_template % {
+        'notes': '',
+    }
+    _index_shared_docs['get_indexer_interval'] = _get_indexer_template % {
+        'notes': ' (not yet implemented for IntervalIndex)',
+    }
 
-    @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
+    @Appender(_index_shared_docs['get_indexer_base'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
         method = missing.clean_reindex_fill_method(method)
         target = ensure_index(target)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -807,7 +807,8 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
-    @Substitution(dict(_index_doc_kwargs, **{'raises_section': textwrap.dedent("""\
+    @Substitution(dict(_index_doc_kwargs,
+                       **{'raises_section': textwrap.dedent("""\
         Raises
         ------
         raises NotImplementedError if any method other than than the default

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -807,8 +807,8 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
-    @Substitution(dict(_index_doc_kwargs,
-                       **{'raises_section': textwrap.dedent("""\
+    @Substitution(**dict(_index_doc_kwargs,
+                         **{'raises_section': textwrap.dedent("""\
         Raises
         ------
         NotImplementedError

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -806,13 +806,12 @@ class IntervalIndex(IntervalMixin, Index):
         return series.iloc[loc]
 
     @Substitution(**dict(_index_doc_kwargs,
-                         **{'raises_section': textwrap.dedent("""\
+                         **{'raises_section': textwrap.dedent("""
         Raises
         ------
         NotImplementedError
             If any method other than than the default method is specified as
             these are not yet implemented.
-
         """)}))
     @Appender(_index_shared_docs['get_indexer'])
     def get_indexer(self, target, method=None, limit=None, tolerance=None):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -39,9 +39,6 @@ _index_doc_kwargs.update(
     dict(klass='IntervalIndex',
          qualname="IntervalIndex",
          target_klass='IntervalIndex or list of Intervals',
-         method_param_pad_notes=' (not yet supported)',
-         method_param_backfill_notes=' (not yet supported)',
-         method_param_nearest_notes=' (not yet supported)',
          name=textwrap.dedent("""\
          name : object, optional
               Name to be stored in the index.
@@ -651,8 +648,6 @@ class IntervalIndex(IntervalMixin, Index):
             return
 
         if method in ['bfill', 'backfill', 'pad', 'ffill', 'nearest']:
-            # The documentation warns these methods are not implemented so if
-            # this is fixed please fix the doc string.
             msg = 'method {method} not yet implemented for IntervalIndex'
             raise NotImplementedError(msg.format(method=method))
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -809,7 +809,8 @@ class IntervalIndex(IntervalMixin, Index):
                          **{'raises_section': textwrap.dedent("""
         Raises
         ------
-        NotImplementedError: If any method argument other than the default of
+        NotImplementedError
+            If any method argument other than the default of
             None is specified as these are not yet implemented.
         """)}))
     @Appender(_index_shared_docs['get_indexer'])

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -807,9 +807,9 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
-    @Substitution(method_param_pad_notes=' (not yet supported).',
-                  method_param_backfill_notes=' (not yet supported).',
-                  method_param_nearest_notes=' (not yet supported).')
+    @Substitution(method_param_pad_notes=' (not yet supported)',
+                  method_param_backfill_notes=' (not yet supported)',
+                  method_param_nearest_notes=' (not yet supported)')
     @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -8,7 +8,7 @@ from pandas._config import get_option
 
 from pandas._libs import Timedelta, Timestamp
 from pandas._libs.interval import Interval, IntervalMixin, IntervalTree
-from pandas.util._decorators import Appender, cache_readonly
+from pandas.util._decorators import Appender, Substitution, cache_readonly
 from pandas.util._exceptions import rewrite_exception
 
 from pandas.core.dtypes.cast import (
@@ -807,13 +807,14 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
-    @Appender(textwrap.dedent("""
+    @Substitution(dict(_index_doc_kwargs, **{'raises_section': textwrap.dedent("""\
         Raises
         ------
         raises NotImplementedError if any method other than than the default
             method is specified as these are not yet implemented.
-        """))
-    @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
+
+        """)}))
+    @Appender(_index_shared_docs['get_indexer'])
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
 
         self._check_method(method)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -8,7 +8,7 @@ from pandas._config import get_option
 
 from pandas._libs import Timedelta, Timestamp
 from pandas._libs.interval import Interval, IntervalMixin, IntervalTree
-from pandas.util._decorators import Appender, cache_readonly
+from pandas.util._decorators import Appender, Substitution, cache_readonly
 from pandas.util._exceptions import rewrite_exception
 
 from pandas.core.dtypes.cast import (
@@ -807,49 +807,11 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
+    @Substitution(method_param_pad_notes=' (not yet supported).',
+                  method_param_backfill_notes=' (not yet supported).',
+                  method_param_nearest_notes=' (not yet supported).')
+    @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
-        """
-        Compute indexer and mask for new index given the current index. The
-        indexer should be then used as an input to ndarray.take to align the
-        current data to the new index.
-
-        Parameters
-        ----------
-        target : %(target_klass)s
-        method : {None}, optional
-            * default: exact matches only.
-        limit : int, optional
-            Maximum number of consecutive labels in ``target`` to match for
-            inexact matches.
-        tolerance : optional
-            Maximum distance between original and new labels for inexact
-            matches. The values of the index at the matching locations most
-            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
-            Tolerance may be a scalar value, which applies the same tolerance
-            to all values, or list-like, which applies variable tolerance per
-            element. List-like includes list, tuple, array, Series, and must be
-            the same size as the index and its dtype must exactly match the
-            index's type.
-
-            .. versionadded:: 0.21.0 (list-like tolerance)
-
-        Returns
-        -------
-        indexer : ndarray of int
-            Integers from 0 to n - 1 indicating that the index at these
-            positions matches the corresponding target values. Missing values
-            in the target are marked by -1.
-
-        Examples
-        --------
-        >>> index = pd.Index(['c', 'a', 'b'])
-        >>> index.get_indexer(['a', 'b', 'x'])
-        array([ 1,  2, -1])
-
-        Notice that the return value is an array of locations in ``index``
-        and ``x`` is marked by -1, as it is not in ``index``.
-        """
 
         self._check_method(method)
         target = ensure_index(target)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -811,8 +811,9 @@ class IntervalIndex(IntervalMixin, Index):
                        **{'raises_section': textwrap.dedent("""\
         Raises
         ------
-        raises NotImplementedError if any method other than than the default
-            method is specified as these are not yet implemented.
+        NotImplementedError
+            If any method other than than the default method is specified as
+            these are not yet implemented.
 
         """)}))
     @Appender(_index_shared_docs['get_indexer'])

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -39,6 +39,9 @@ _index_doc_kwargs.update(
     dict(klass='IntervalIndex',
          qualname="IntervalIndex",
          target_klass='IntervalIndex or list of Intervals',
+         method_param_pad_notes=' (not yet supported)',
+         method_param_backfill_notes=' (not yet supported)',
+         method_param_nearest_notes=' (not yet supported)',
          name=textwrap.dedent("""\
          name : object, optional
               Name to be stored in the index.
@@ -807,9 +810,6 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
-    @Substitution(method_param_pad_notes=' (not yet supported)',
-                  method_param_backfill_notes=' (not yet supported)',
-                  method_param_nearest_notes=' (not yet supported)')
     @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -8,7 +8,7 @@ from pandas._config import get_option
 
 from pandas._libs import Timedelta, Timestamp
 from pandas._libs.interval import Interval, IntervalMixin, IntervalTree
-from pandas.util._decorators import Appender, Substitution, cache_readonly
+from pandas.util._decorators import Appender, cache_readonly
 from pandas.util._exceptions import rewrite_exception
 
 from pandas.core.dtypes.cast import (

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -648,8 +648,6 @@ class IntervalIndex(IntervalMixin, Index):
             return
 
         if method in ['bfill', 'backfill', 'pad', 'ffill', 'nearest']:
-            # The documentation warns these methods are not implemented so if
-            # this is fixed please fix the doc string.
             msg = 'method {method} not yet implemented for IntervalIndex'
             raise NotImplementedError(msg.format(method=method))
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -648,6 +648,8 @@ class IntervalIndex(IntervalMixin, Index):
             return
 
         if method in ['bfill', 'backfill', 'pad', 'ffill', 'nearest']:
+            # The documentation warns these methods are not implemented so if
+            # this is fixed please fix the doc string.
             msg = 'method {method} not yet implemented for IntervalIndex'
             raise NotImplementedError(msg.format(method=method))
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -809,9 +809,8 @@ class IntervalIndex(IntervalMixin, Index):
                          **{'raises_section': textwrap.dedent("""
         Raises
         ------
-        NotImplementedError
-            If any method other than than the default method is specified as
-            these are not yet implemented.
+        NotImplementedError: If any method argument other than the default of
+            None is specified as these are not yet implemented.
         """)}))
     @Appender(_index_shared_docs['get_indexer'])
     def get_indexer(self, target, method=None, limit=None, tolerance=None):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -648,6 +648,8 @@ class IntervalIndex(IntervalMixin, Index):
             return
 
         if method in ['bfill', 'backfill', 'pad', 'ffill', 'nearest']:
+            # The documentation warns that these methods are not yet implemented
+            # so it would be worth updating the documentation when fixing.
             msg = 'method {method} not yet implemented for IntervalIndex'
             raise NotImplementedError(msg.format(method=method))
 
@@ -723,6 +725,7 @@ class IntervalIndex(IntervalMixin, Index):
         key : label
         method : {None}, optional
             * default: matches where the label is within an interval only.
+            * other methods not
 
         Returns
         -------
@@ -805,7 +808,7 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
-    @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
+    @Appender(_index_shared_docs['get_indexer_interval'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
 
         self._check_method(method)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -807,6 +807,12 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
+    @Appender(textwrap.dedent("""
+        Raises
+        ------
+        raises NotImplementedError if any method other than than the default
+            method is specified as these are not yet implemented.
+        """))
     @Appender(_index_shared_docs['get_indexer'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -648,8 +648,6 @@ class IntervalIndex(IntervalMixin, Index):
             return
 
         if method in ['bfill', 'backfill', 'pad', 'ffill', 'nearest']:
-            # The documentation warns that these methods are not yet implemented
-            # so it would be worth updating the documentation when fixing.
             msg = 'method {method} not yet implemented for IntervalIndex'
             raise NotImplementedError(msg.format(method=method))
 
@@ -725,7 +723,6 @@ class IntervalIndex(IntervalMixin, Index):
         key : label
         method : {None}, optional
             * default: matches where the label is within an interval only.
-            * other methods not
 
         Returns
         -------
@@ -808,8 +805,49 @@ class IntervalIndex(IntervalMixin, Index):
             loc = self.get_loc(key)
         return series.iloc[loc]
 
-    @Appender(_index_shared_docs['get_indexer_interval'] % _index_doc_kwargs)
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
+        """
+        Compute indexer and mask for new index given the current index. The
+        indexer should be then used as an input to ndarray.take to align the
+        current data to the new index.
+
+        Parameters
+        ----------
+        target : %(target_klass)s
+        method : {None}, optional
+            * default: exact matches only.
+        limit : int, optional
+            Maximum number of consecutive labels in ``target`` to match for
+            inexact matches.
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations most
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+
+            Tolerance may be a scalar value, which applies the same tolerance
+            to all values, or list-like, which applies variable tolerance per
+            element. List-like includes list, tuple, array, Series, and must be
+            the same size as the index and its dtype must exactly match the
+            index's type.
+
+            .. versionadded:: 0.21.0 (list-like tolerance)
+
+        Returns
+        -------
+        indexer : ndarray of int
+            Integers from 0 to n - 1 indicating that the index at these
+            positions matches the corresponding target values. Missing values
+            in the target are marked by -1.
+
+        Examples
+        --------
+        >>> index = pd.Index(['c', 'a', 'b'])
+        >>> index.get_indexer(['a', 'b', 'x'])
+        array([ 1,  2, -1])
+
+        Notice that the return value is an array of locations in ``index``
+        and ``x`` is marked by -1, as it is not in ``index``.
+        """
 
         self._check_method(method)
         target = ensure_index(target)


### PR DESCRIPTION
- [x] fixes docstring for #26506 until implementation is ready
- [x] 46585 tests passed - none added as documentation change only
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
```
$ git diff upstream/master -u -- "*.py" | flake8 --diff && echo yes
yes
```
- [x] whatsnew entry
Provides correct desciption in docstring that Interval.get_indexer using any method other than default are not yet supported
