### PR TITLE
CLN: standardize string repr to use __repr__

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -34,30 +34,27 @@ _indexops_doc_kwargs = dict(klass='IndexOpsMixin', inplace='',
 
 class StringMixin:
     """
-    Implements string methods so long as object defines a `__str__` method.
+    Require that an object defines a `__repr__` method.
     """
-    # side note - this could be made into a metaclass if more than one
-    #             object needs
+    # TODO: Remove this class from the code base. It's not needed after
+    #  dropping python2.
 
-    # ----------------------------------------------------------------------
-    # Formatting
-
-    def __str__(self):
+    def __repr__(self):
         """
         Return a string representation for a particular Object
         """
         raise AbstractMethodError(self)
 
-    def __repr__(self):
-        """
-        Return a string representation for a particular object.
-        """
-        return str(self)
-
 
 class PandasObject(DirNamesMixin):
 
     """baseclass for various pandas objects"""
+
+    subclasses = []
+
+    def __init_subclass__(cls, **kwargs):
+        if hasattr(cls, '_cache'):
+            PandasObject.subclasses.append(cls)
 
     @property
     def _constructor(self):

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -67,7 +67,7 @@ class Term(StringMixin):
     def local_name(self):
         return self.name.replace(_LOCAL_TAG, '')
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing(self.name)
 
     def __call__(self, *args, **kwargs):
@@ -166,9 +166,7 @@ class Constant(Term):
     def name(self):
         return self.value
 
-    def __str__(self):
-        # in python 2 str() of float
-        # can truncate shorter than repr()
+    def __repr__(self):
         return repr(self.name)
 
 
@@ -188,7 +186,7 @@ class Op(StringMixin):
     def __iter__(self):
         return iter(self.operands)
 
-    def __str__(self):
+    def __repr__(self):
         """Print a generic n-ary operator and its operands using infix
         notation"""
         # recurse over the operands
@@ -506,7 +504,7 @@ class UnaryOp(Op):
         operand = self.operand(env)
         return self.func(operand)
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing('{0}({1})'.format(self.op, self.operand))
 
     @property
@@ -531,7 +529,7 @@ class MathCall(Op):
         with np.errstate(all='ignore'):
             return self.func.func(*operands)
 
-    def __str__(self):
+    def __repr__(self):
         operands = map(str, self.operands)
         return pprint_thing('{0}({1})'.format(self.op, ','.join(operands)))
 

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -11,7 +11,6 @@ from pandas.compat.chainmap import DeepChainMap
 from pandas.core.dtypes.common import is_list_like
 
 import pandas as pd
-from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.core.computation import expr, ops
 from pandas.core.computation.common import _ensure_decoded
@@ -36,8 +35,7 @@ class Term(ops.Term):
 
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, str) else cls
-        supr_new = StringMixin.__new__
-        return supr_new(klass)
+        return object.__new__(klass)
 
     def __init__(self, name, env, side=None, encoding=None):
         super().__init__(name, env, side=side, encoding=encoding)
@@ -230,7 +228,7 @@ class BinOp(ops.BinOp):
 
 class FilterBinOp(BinOp):
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing("[Filter : [{lhs}] -> [{op}]"
                             .format(lhs=self.filter[0], op=self.filter[1]))
 
@@ -302,7 +300,7 @@ class JointFilterBinOp(FilterBinOp):
 
 class ConditionBinOp(BinOp):
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing("[Condition : [{cond}]]"
                             .format(cond=self.condition))
 
@@ -549,7 +547,7 @@ class Expr(expr.Expr):
                                         encoding=encoding)
             self.terms = self.parse()
 
-    def __str__(self):
+    def __repr__(self):
         if self.terms is not None:
             return pprint_thing(self.terms)
         return pprint_thing(self.expr)

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -78,8 +78,7 @@ def _get_pretty_string(obj):
     return sio.getvalue()
 
 
-class Scope(StringMixin):
-
+class Scope:
     """Object to hold scope, with a few bells to deal with some custom syntax
     and contexts added by pandas.
 
@@ -135,13 +134,13 @@ class Scope(StringMixin):
         self.resolvers = DeepChainMap(*resolvers)
         self.temps = {}
 
-    def __str__(self):
+    def __repr__(self):
         scope_keys = _get_pretty_string(list(self.scope.keys()))
         res_keys = _get_pretty_string(list(self.resolvers.keys()))
-        unicode_str = '{name}(scope={scope_keys}, resolvers={res_keys})'
-        return unicode_str.format(name=type(self).__name__,
-                                  scope_keys=scope_keys,
-                                  res_keys=res_keys)
+        template = '{name}(scope={scope_keys}, resolvers={res_keys})'
+        return template.format(name=type(self).__name__,
+                               scope_keys=scope_keys,
+                               res_keys=res_keys)
 
     @property
     def has_resolvers(self):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -399,7 +399,6 @@ def _is_metadata_of(group, parent_group):
 
 
 class HDFStore(StringMixin):
-
     """
     Dict-like IO interface for storing pandas objects in PyTables
     either Fixed or Table format.
@@ -520,7 +519,7 @@ class HDFStore(StringMixin):
     def __len__(self):
         return len(self.groups())
 
-    def __str__(self):
+    def __repr__(self):
         return '{type}\nFile path: {path}\n'.format(
             type=type(self), path=pprint_thing(self._path))
 
@@ -1519,8 +1518,7 @@ class TableIterator:
         return results
 
 
-class IndexCol(StringMixin):
-
+class IndexCol:
     """ an index column description class
 
         Parameters
@@ -1587,7 +1585,7 @@ class IndexCol(StringMixin):
         self.table = table
         return self
 
-    def __str__(self):
+    def __repr__(self):
         temp = tuple(
             map(pprint_thing,
                     (self.name,
@@ -1881,7 +1879,7 @@ class DataCol(IndexCol):
         self.set_data(data)
         self.set_metadata(metadata)
 
-    def __str__(self):
+    def __repr__(self):
         temp = tuple(
             map(pprint_thing,
                     (self.name,
@@ -2286,8 +2284,7 @@ class GenericDataIndexableCol(DataIndexableCol):
         pass
 
 
-class Fixed(StringMixin):
-
+class Fixed:
     """ represent an object in my store
         facilitate read/write of various types of objects
         this is an abstract base class
@@ -2336,7 +2333,7 @@ class Fixed(StringMixin):
     def format_type(self):
         return 'fixed'
 
-    def __str__(self):
+    def __repr__(self):
         """ return a pretty representation of myself """
         self.infer_axes()
         s = self.shape
@@ -3077,7 +3074,7 @@ class Table(Fixed):
     def format_type(self):
         return 'table'
 
-    def __str__(self):
+    def __repr__(self):
         """ return a pretty representatgion of myself """
         self.infer_axes()
         dc = ",dc->[{columns}]".format(columns=(','.join(

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -712,7 +712,7 @@ class StataValueLabel:
         return bio.read()
 
 
-class StataMissingValue(StringMixin):
+class StataMissingValue:
     """
     An observation's missing value.
 


### PR DESCRIPTION
- [x] xref #25725 & #26495
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Removes use of ``StringMixin`` from io.pytables and from io.stata. It's now only used in core.computation.

I haven't been able to remove this class from core.computation. If I do, I get an error about setting an attribute:

```python
        # assumes that resolvers are going from outermost scope to inner
        if isinstance(local_dict, Scope):
            resolvers += tuple(local_dict.resolvers.maps)
        self.resolvers = DeepChainMap(*resolvers)
E       AttributeError: 'Scope' object has no attribute 'resolvers'

pandas\core\computation\scope.py:134: AttributeError
```

I've looked into this and can't understand why this happens. From the looks of it, I should be able to set that atribute. I'd appreciate any hint.

Because of the above problem, I've changed ``StringMixin`` to only define a ``__repr__`` and making related changes. This means that all string reps in pandas are now defined through ``__repr__``, which is better than defining them through ``__str__``.