### PR TITLE
CLN: Remove deprecated parse_cols from read_excel

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -313,8 +313,8 @@ Removal of prior version deprecations/changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - Removed ``Panel`` (:issue:`25047`, :issue:`25191`, :issue:`25231`)
 - Removed the previously deprecated ``sheetname`` keyword in :func:`read_excel` (:issue:`16442`, :issue:`20938`)
-- Removed previously deprecated ``TimeGrouper`` (:issue:`16942`)
--
+- Removed the previously deprecated ``TimeGrouper`` (:issue:`16942`)
+- Removed the previously deprecated ``parse_cols`` keyword in :func:`read_excel` (:issue:`16488`)
 
 .. _whatsnew_0250.performance:
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -64,12 +64,6 @@ index_col : int, list of int, default None
     those columns will be combined into a ``MultiIndex``.  If a
     subset of data is selected with ``usecols``, index_col
     is based on the subset.
-parse_cols : int or list, default None
-    Alias of `usecols`.
-
-    .. deprecated:: 0.21.0
-       Use `usecols` instead.
-
 usecols : int, str, list-like, or callable default None
     Return a subset of the columns.
 
@@ -260,14 +254,12 @@ Comment lines in the excel input file can be skipped using the `comment` kwarg
 
 
 @Appender(_read_excel_doc)
-@deprecate_kwarg("parse_cols", "usecols")
 @deprecate_kwarg("skip_footer", "skipfooter")
 def read_excel(io,
                sheet_name=0,
                header=0,
                names=None,
                index_col=None,
-               parse_cols=None,
                usecols=None,
                squeeze=False,
                dtype=None,
@@ -290,7 +282,7 @@ def read_excel(io,
                mangle_dupe_cols=True,
                **kwds):
 
-    for arg in ('sheet', 'sheetname'):
+    for arg in ('sheet', 'sheetname', 'parse_cols'):
         if arg in kwds:
             raise TypeError("read_excel() got an unexpected keyword argument "
                             "`{}`".format(arg))

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -147,17 +147,9 @@ class ReadingTestsBase(SharedItems):
                 df2 = self.get_exceldf("test1", ext, "Sheet2", skiprows=[1],
                                        index_col=0, usecols=3)
 
-        # parse_cols instead of usecols, usecols as int
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            with ignore_xlrd_time_clock_warning():
-                df3 = self.get_exceldf("test1", ext, "Sheet2", skiprows=[1],
-                                       index_col=0, parse_cols=3)
-
         # TODO add index to xls file)
         tm.assert_frame_equal(df1, df_ref, check_names=False)
         tm.assert_frame_equal(df2, df_ref, check_names=False)
-        tm.assert_frame_equal(df3, df_ref, check_names=False)
 
     @td.skip_if_no('xlrd', '1.0.1')  # GH-22682
     def test_usecols_list(self, ext):
@@ -169,15 +161,9 @@ class ReadingTestsBase(SharedItems):
         df2 = self.get_exceldf('test1', ext, 'Sheet2', skiprows=[1],
                                index_col=0, usecols=[0, 2, 3])
 
-        with tm.assert_produces_warning(FutureWarning):
-            with ignore_xlrd_time_clock_warning():
-                df3 = self.get_exceldf('test1', ext, 'Sheet2', skiprows=[1],
-                                       index_col=0, parse_cols=[0, 2, 3])
-
         # TODO add index to xls file)
         tm.assert_frame_equal(df1, dfref, check_names=False)
         tm.assert_frame_equal(df2, dfref, check_names=False)
-        tm.assert_frame_equal(df3, dfref, check_names=False)
 
     @td.skip_if_no('xlrd', '1.0.1')  # GH-22682
     def test_usecols_str(self, ext):
@@ -190,15 +176,9 @@ class ReadingTestsBase(SharedItems):
         df3 = self.get_exceldf('test1', ext, 'Sheet2', skiprows=[1],
                                index_col=0, usecols='A:D')
 
-        with tm.assert_produces_warning(FutureWarning):
-            with ignore_xlrd_time_clock_warning():
-                df4 = self.get_exceldf('test1', ext, 'Sheet2', skiprows=[1],
-                                       index_col=0, parse_cols='A:D')
-
         # TODO add index to xls, read xls ignores index name ?
         tm.assert_frame_equal(df2, df1, check_names=False)
         tm.assert_frame_equal(df3, df1, check_names=False)
-        tm.assert_frame_equal(df4, df1, check_names=False)
 
         df1 = dfref.reindex(columns=['B', 'C'])
         df2 = self.get_exceldf('test1', ext, 'Sheet1', index_col=0,
@@ -342,7 +322,7 @@ class ReadingTestsBase(SharedItems):
         tm.assert_frame_equal(parsed, expected)
 
     @td.skip_if_no('xlrd', '1.0.1')  # GH-22682
-    @pytest.mark.parametrize('arg', ['sheet', 'sheetname'])
+    @pytest.mark.parametrize('arg', ['sheet', 'sheetname', 'parse_cols'])
     def test_unexpected_kwargs_raises(self, ext, arg):
         # gh-17964
         excel = self.get_excelfile('test1', ext)


### PR DESCRIPTION
- [x] xref #6581
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
