### PR TITLE
CLN: remove StringMixin from code base, except in core.computation

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -32,7 +32,6 @@ from pandas import (
     to_datetime)
 from pandas.core.arrays.categorical import Categorical
 from pandas.core.arrays.sparse import BlockIndex, IntIndex
-from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.core.computation.pytables import Expr, maybe_expression
 from pandas.core.index import ensure_index
@@ -398,7 +397,7 @@ def _is_metadata_of(group, parent_group):
     return False
 
 
-class HDFStore(StringMixin):
+class HDFStore:
 
     """
     Dict-like IO interface for storing pandas objects in PyTables
@@ -520,7 +519,7 @@ class HDFStore(StringMixin):
     def __len__(self):
         return len(self.groups())
 
-    def __str__(self):
+    def __repr__(self):
         return '{type}\nFile path: {path}\n'.format(
             type=type(self), path=pprint_thing(self._path))
 
@@ -1519,7 +1518,7 @@ class TableIterator:
         return results
 
 
-class IndexCol(StringMixin):
+class IndexCol:
 
     """ an index column description class
 
@@ -1587,7 +1586,7 @@ class IndexCol(StringMixin):
         self.table = table
         return self
 
-    def __str__(self):
+    def __repr__(self):
         temp = tuple(
             map(pprint_thing,
                     (self.name,
@@ -1881,7 +1880,7 @@ class DataCol(IndexCol):
         self.set_data(data)
         self.set_metadata(metadata)
 
-    def __str__(self):
+    def __repr__(self):
         temp = tuple(
             map(pprint_thing,
                     (self.name,
@@ -2286,7 +2285,7 @@ class GenericDataIndexableCol(DataIndexableCol):
         pass
 
 
-class Fixed(StringMixin):
+class Fixed:
 
     """ represent an object in my store
         facilitate read/write of various types of objects
@@ -2336,7 +2335,7 @@ class Fixed(StringMixin):
     def format_type(self):
         return 'fixed'
 
-    def __str__(self):
+    def __repr__(self):
         """ return a pretty representation of myself """
         self.infer_axes()
         s = self.shape
@@ -3077,8 +3076,8 @@ class Table(Fixed):
     def format_type(self):
         return 'table'
 
-    def __str__(self):
-        """ return a pretty representatgion of myself """
+    def __repr__(self):
+        """ return a pretty representation of myself """
         self.infer_axes()
         dc = ",dc->[{columns}]".format(columns=(','.join(
             self.data_columns) if len(self.data_columns) else ''))

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -31,7 +31,6 @@ from pandas.core.dtypes.common import (
 from pandas import (
     Categorical, DatetimeIndex, NaT, Timestamp, concat, isna, to_datetime,
     to_timedelta)
-from pandas.core.base import StringMixin
 from pandas.core.frame import DataFrame
 from pandas.core.series import Series
 
@@ -712,7 +711,7 @@ class StataValueLabel:
         return bio.read()
 
 
-class StataMissingValue(StringMixin):
+class StataMissingValue:
     """
     An observation's missing value.
 


### PR DESCRIPTION
- [x] xref #25725 & #26495
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Removes use of ``StringMixin`` from pandas.io StringMixin is now only used in pandas.core.computation.

I haven't been able to remove this class from core.computation. If I do, I get an error about setting an attribute:

```python
        # assumes that resolvers are going from outermost scope to inner
        if isinstance(local_dict, Scope):
            resolvers += tuple(local_dict.resolvers.maps)
        self.resolvers = DeepChainMap(*resolvers)
E       AttributeError: 'Scope' object has no attribute 'resolvers'

pandas\core\computation\scope.py:134: AttributeError
```

I've looked into this and can't understand why this happens. From the looks of it, I should be able to set that atribute here, but it jusr doesn't work. I'd appreciate any hint.

I'll keep loking into removing it completely, but don't know if I'll crack that part.