### PR TITLE
BUG: assignment to multiple columns when some column do not exist

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -40,6 +40,37 @@ Backwards incompatible API changes
 - :class:`pandas.core.groupby.GroupBy.transform` now raises on invalid operation names (:issue:`27489`).
 -
 
+.. _whatsnew_1000.api_breaking.multicolumn_assignment:
+
+Assignment to multiple columns of a DataFrame when some columns do not exist
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Assignment to multiple columns of a :class:`DataFrame` when some of the columns do not exist would previously assign the values to the last column. Now, new columns would be constructed withe the right values. (:issue:`13658`)
+
+.. ipython:: python
+
+   df = pd.DataFrame({'a': [0, 1, 2], 'b': [3, 4, 5]})
+   df
+
+*Previous behavior*:
+
+.. code-block:: ipython
+
+   In [3]: df[['a', 'c']] = 1
+   In [4]: df
+   Out[4]:
+      a  b
+   0  1  1
+   1  1  1
+   2  1  1
+
+*New behavior*:
+
+.. ipython:: python
+
+   df[['a', 'c']] = 1
+   df
+
 .. _whatsnew_1000.api.other:
 
 Other API changes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3007,6 +3007,12 @@ class DataFrame(NDFrame):
                 for k1, k2 in zip(key, value.columns):
                     self[k1] = value[k2]
             else:
+                if all(is_hashable(k) for k in key):
+                    for k in key:
+                        try:
+                            self[k]
+                        except KeyError:
+                            self[k] = np.nan
                 indexer = self.loc._get_listlike_indexer(
                     key, axis=1, raise_missing=False
                 )[1]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -808,6 +808,46 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         assert is_scalar(result) and result == "Z"
 
+    def test_loc_setitem_missing_columns_scalar_index_list_value(self):
+        # GH 26534
+        df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "B"])
+        df.loc[1, ["C", "D"]] = [7, 8]
+        expected = pd.DataFrame(
+            [[1, 2, np.nan, np.nan], [3, 4, 7, 8], [5, 6, np.nan, np.nan]],
+            columns=["A", "B", "C", "D"],
+        )
+        tm.assert_frame_equal(df, expected)
+
+    def test_loc_setitem_missing_columns_full_index_dataframe_value(self):
+        # GH 26534
+        df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "B"])
+        df2 = pd.DataFrame([[7, 8], [9, 10], [11, 12]], columns=["A", "C"])
+        df.loc[:, ["A", "C"]] = df2
+        expected = pd.DataFrame(
+            [[7, 2, 8], [9, 4, 10], [11, 6, 12]], columns=["A", "B", "C"]
+        )
+        tm.assert_frame_equal(df, expected)
+
+    def test_loc_setitem_missing_columns_list_index_scalar_value(self):
+        # GH 26534
+        df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "B"])
+        df.loc[[0, 2], ["B", "C", "D"]] = 9
+        expected = pd.DataFrame(
+            [[1, 9, 9, 9], [3, 4, np.nan, np.nan], [5, 9, 9, 9]],
+            columns=["A", "B", "C", "D"],
+        )
+        tm.assert_frame_equal(df, expected)
+
+    def test_loc_setitem_missing_columns_range_index_2dlist_value(self):
+        # GH 26534
+        df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "B"])
+        df.loc[1:3, ["B", "C", "D"]] = [[7, 8, 9], [10, 11, 12]]
+        expected = pd.DataFrame(
+            [[1, 2, np.nan, np.nan], [3, 7, 8, 9], [5, 10, 11, 12]],
+            columns=["A", "B", "C", "D"],
+        )
+        tm.assert_frame_equal(df, expected)
+
     def test_loc_coercion(self):
 
         # 12411

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -808,45 +808,29 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         assert is_scalar(result) and result == "Z"
 
-    def test_loc_setitem_missing_columns_scalar_index_list_value(self):
+    @pytest.mark.parametrize(
+        "index,box",
+        [
+            ((1, ["C", "D"]), [7, 8]),
+            (
+                (slice(None, None, None), ["A", "C"]),
+                pd.DataFrame([[7, 8], [9, 10], [11, 12]], columns=["A", "C"]),
+            ),
+            (([0, 2], ["B", "C", "D"]), 9),
+            ((slice(1, 3, None), ["B", "C", "D"]), [[7, 8, 9], [10, 11, 12]]),
+        ],
+    )
+    def test_loc_setitem_missing_columns(self, index, box):
         # GH 26534
         df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "B"])
-        df.loc[1, ["C", "D"]] = [7, 8]
-        expected = pd.DataFrame(
-            [[1, 2, np.nan, np.nan], [3, 4, 7, 8], [5, 6, np.nan, np.nan]],
-            columns=["A", "B", "C", "D"],
-        )
-        tm.assert_frame_equal(df, expected)
-
-    def test_loc_setitem_missing_columns_full_index_dataframe_value(self):
-        # GH 26534
-        df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "B"])
-        df2 = pd.DataFrame([[7, 8], [9, 10], [11, 12]], columns=["A", "C"])
-        df.loc[:, ["A", "C"]] = df2
-        expected = pd.DataFrame(
-            [[7, 2, 8], [9, 4, 10], [11, 6, 12]], columns=["A", "B", "C"]
-        )
-        tm.assert_frame_equal(df, expected)
-
-    def test_loc_setitem_missing_columns_list_index_scalar_value(self):
-        # GH 26534
-        df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "B"])
-        df.loc[[0, 2], ["B", "C", "D"]] = 9
-        expected = pd.DataFrame(
-            [[1, 9, 9, 9], [3, 4, np.nan, np.nan], [5, 9, 9, 9]],
-            columns=["A", "B", "C", "D"],
-        )
-        tm.assert_frame_equal(df, expected)
-
-    def test_loc_setitem_missing_columns_range_index_2dlist_value(self):
-        # GH 26534
-        df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=["A", "B"])
-        df.loc[1:3, ["B", "C", "D"]] = [[7, 8, 9], [10, 11, 12]]
-        expected = pd.DataFrame(
-            [[1, 2, np.nan, np.nan], [3, 7, 8, 9], [5, 10, 11, 12]],
-            columns=["A", "B", "C", "D"],
-        )
-        tm.assert_frame_equal(df, expected)
+        result = df.copy()
+        result.loc[index] = box
+        expected = df.copy()
+        for col in index[1]:
+            if col not in expected.columns:
+                expected[col] = np.nan
+        expected.loc[index] = box
+        tm.assert_frame_equal(result, expected)
 
     def test_loc_coercion(self):
 


### PR DESCRIPTION
- [x] closes #13658
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

In particular, the following code now behaves correctly.

```python
import pandas as pd
df = pd.DataFrame({'a': [0, 1, 2], 'b': [3, 4, 5]})
df[['a', 'c']] = 1
print(df)
```
v0.22: error

master: column `'c'` is converted to index `-1`, which causes last column to be overwritten.
```
   a  b
0  1  1
1  1  1
2  1  1
```

After this PR:
```
   a  b  c
0  1  3  1
1  1  4  1
2  1  5  1
```