### PR TITLE
xfail constructor test for numpydev

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -12,6 +12,7 @@ _np_version_under1p14 = _nlv < LooseVersion('1.14')
 _np_version_under1p15 = _nlv < LooseVersion('1.15')
 _np_version_under1p16 = _nlv < LooseVersion('1.16')
 _np_version_under1p17 = _nlv < LooseVersion('1.17')
+_is_numpy_dev = '.dev' in str(_nlv)
 
 
 if _nlv < '1.13.3':
@@ -64,5 +65,6 @@ __all__ = ['np',
            '_np_version_under1p14',
            '_np_version_under1p15',
            '_np_version_under1p16',
-           '_np_version_under1p17'
+           '_np_version_under1p17',
+           '_is_numpy_dev'
            ]

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -15,7 +15,7 @@ from pandas.core.dtypes.common import is_integer_dtype
 import pandas as pd
 from pandas import (
     Categorical, DataFrame, Index, MultiIndex, RangeIndex, Series, Timedelta,
-    Timestamp, date_range, isna)
+    Timestamp, compat, date_range, isna)
 from pandas.tests.frame.common import TestData
 import pandas.util.testing as tm
 
@@ -113,6 +113,7 @@ class TestDataFrameConstructors(TestData):
         assert df.loc[1, 0] is None
         assert df.loc[0, 1] == '2'
 
+    @pytest.mark.xfail(compat.numpy._is_numpy_dev, reason="GH-26546")
     def test_constructor_list_frames(self):
         # see gh-3243
         result = DataFrame([DataFrame()])


### PR DESCRIPTION
xref #26546. It seems like that will be fixed upstream, which will require new wheels. xfailing for now.

When fixed and new wheels are available, this will fail again, but we can merge PRs in the meantime.