### PR TITLE
BUG: preserve categorical & sparse types when grouping / pivot & preserve dtypes on ufuncs

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -316,6 +316,65 @@ of ``object`` dtype. :attr:`Series.str` will now infer the dtype data *within* t
     s
     s.str.startswith(b'a')
 
+<<<<<<< HEAD
+=======
+.. _whatsnew_0250.api_breaking.ufuncs:
+
+ufuncs on Extension Dtype
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Operations with ``numpy`` ufuncs on Extension Arrays, including Sparse Dtypes will now coerce the
+resulting dtypes to same as the input dtype; previously this would coerce to a dense dtype. (:issue:`23743`)
+
+.. ipython:: python
+
+   df = pd.DataFrame({'A': pd.Series([1, np.nan, 3], dtype=pd.SparseDtype('float64', np.nan))})
+   df
+   df.dtypes
+
+*Previous Behavior*:
+
+.. code-block:: python
+
+   In [3]: np.sqrt(df).dtypes
+   Out[3]:
+   A    float64
+   dtype: object
+
+*New Behavior*:
+
+.. ipython:: python
+
+   np.sqrt(df).dtypes
+
+.. _whatsnew_0250.api_breaking.groupby_categorical:
+
+Categorical dtypes are preserved during groupby
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, columns that were categorical, but not the groupby key(s) would be converted to ``object`` dtype during groupby operations. Pandas now will preserve these dtypes. (:issue:`18502`)
+
+.. ipython:: python
+
+   df = pd.DataFrame({'payload': [-1,-2,-1,-2],
+                      'col': pd.Categorical(["foo", "bar", "bar", "qux"], ordered=True)})
+   df
+   df.dtypes
+
+*Previous Behavior*:
+
+.. code-block:: python
+
+   In [5]: df.groupby('payload').first().col.dtype
+   Out[5]: dtype('O')
+
+*New Behavior*:
+
+.. ipython:: python
+
+   df.groupby('payload').first().col.dtype
+
+
 .. _whatsnew_0250.api_breaking.incompatible_index_unions:
 
 Incompatible Index Type Unions

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -323,7 +323,7 @@ of ``object`` dtype. :attr:`Series.str` will now infer the dtype data *within* t
 ufuncs on Extension Dtype
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Operations with ``numpy`` ufuncs on Extension Arrays, including Sparse Dtypes will now coerce the
+Operations with ``numpy`` ufuncs on Extension Arrays, including Sparse Dtypes will now preserve the
 resulting dtypes to same as the input dtype; previously this would coerce to a dense dtype. (:issue:`23743`)
 
 .. ipython:: python

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -328,7 +328,9 @@ resulting dtypes to same as the input dtype; previously this would coerce to a d
 
 .. ipython:: python
 
-   df = pd.DataFrame({'A': pd.Series([1, np.nan, 3], dtype=pd.SparseDtype('float64', np.nan))})
+   df = pd.DataFrame(
+       {'A': pd.Series([1, np.nan, 3],
+                       dtype=pd.SparseDtype('float64', np.nan))})
    df
    df.dtypes
 
@@ -356,8 +358,9 @@ Previously, columns that were categorical, but not the groupby key(s) would be c
 
 .. ipython:: python
 
-   df = pd.DataFrame({'payload': [-1,-2,-1,-2],
-                      'col': pd.Categorical(["foo", "bar", "bar", "qux"], ordered=True)})
+   df = pd.DataFrame(
+       {'payload': [-1, -2, -1, -2],
+        'col': pd.Categorical(["foo", "bar", "bar", "qux"], ordered=True)})
    df
    df.dtypes
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -323,7 +323,7 @@ of ``object`` dtype. :attr:`Series.str` will now infer the dtype data *within* t
 ufuncs on Extension Dtype
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Operations with ``numpy`` ufuncs on Extension Arrays, including Sparse Dtypes will now preserve the
+Operations with ``numpy`` ufuncs on DataFrames with Extension Arrays, including Sparse Dtypes will now preserve the
 resulting dtypes to same as the input dtype; previously this would coerce to a dense dtype. (:issue:`23743`)
 
 .. ipython:: python

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1926,8 +1926,20 @@ def make_sparse(arr, kind='block', fill_value=None, dtype=None, copy=False):
 
     index = _make_index(length, indices, kind)
     sparsified_values = arr[mask]
+
+    # careful about casting here
+    # as we could easily specify a type that cannot hold the resulting values
+    # e.g. integer when we have floats
     if dtype is not None:
-        sparsified_values = astype_nansafe(sparsified_values, dtype=dtype)
+        try:
+            sparsified_values = astype_nansafe(
+                sparsified_values, dtype=dtype, casting='same_kind')
+        except TypeError:
+            dtype = 'float64'
+            sparsified_values = astype_nansafe(
+                sparsified_values, dtype=dtype, casting='unsafe')
+
+
     # TODO: copy
     return sparsified_values, index, fill_value
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -605,7 +605,7 @@ def coerce_to_dtypes(result, dtypes):
     return [conv(r, dtype) for r, dtype in zip(result, dtypes)]
 
 
-def astype_nansafe(arr, dtype, copy=True, skipna=False):
+def astype_nansafe(arr, dtype, copy=True, skipna=False, casting='unsafe'):
     """
     Cast the elements of an array to a given dtype a nan-safe manner.
 
@@ -616,8 +616,10 @@ def astype_nansafe(arr, dtype, copy=True, skipna=False):
     copy : bool, default True
         If False, a view will be attempted but may fail, if
         e.g. the item sizes don't align.
-    skipna: bool, default False
+    skipna : bool, default False
         Whether or not we should skip NaN when casting as a string-type.
+    casting : {‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}
+        optional, default 'unsafe'
 
     Raises
     ------
@@ -703,7 +705,7 @@ def astype_nansafe(arr, dtype, copy=True, skipna=False):
 
     if copy or is_object_dtype(arr) or is_object_dtype(dtype):
         # Explicit copy, or required since NumPy can't view from / to object.
-        return arr.astype(dtype, copy=True)
+        return arr.astype(dtype, copy=True, casting=casting)
 
     return arr.view(dtype)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -16,7 +16,7 @@ import itertools
 import sys
 import warnings
 from textwrap import dedent
-from typing import FrozenSet, List, Optional, Set, Type, Union
+from typing import FrozenSet, List, Optional, Tuple, Set, Type, Union
 
 import numpy as np
 import numpy.ma as ma
@@ -2651,14 +2651,15 @@ class DataFrame(NDFrame):
     def __array__(self, dtype=None):
         return com.values_from_object(self)
 
-    def __array_wrap__(self, result: np.ndarray, context=None) -> 'DataFrame':
+    def __array_wrap__(self, result: np.ndarray,
+                       context: Optional[Tuple] = None) -> 'DataFrame':
         """
         We are called post ufunc; reconstruct the original object and dtypes.
 
         Parameters
         ----------
         result : np.ndarray
-        context
+        context : tuple, optional
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1919,25 +1919,6 @@ class NDFrame(PandasObject, SelectionMixin):
     # ----------------------------------------------------------------------
     # Array Interface
 
-    # This is also set in IndexOpsMixin
-    # GH#23114 Ensure ndarray.__op__(DataFrame) returns NotImplemented
-    __array_priority__ = 1000
-
-    def __array__(self, dtype=None):
-        return com.values_from_object(self)
-
-    def __array_wrap__(self, result, context=None):
-        d = self._construct_axes_dict(self._AXIS_ORDERS, copy=False)
-        return self._constructor(result, **d).__finalize__(self)
-
-    # ideally we would define this to avoid the getattr checks, but
-    # is slower
-    # @property
-    # def __array_interface__(self):
-    #    """ provide numpy array interface method """
-    #    values = self.values
-    #    return dict(typestr=values.dtype.str,shape=values.shape,data=values)
-
     def to_dense(self):
         """
         Return dense representation of NDFrame (as opposed to sparse).
@@ -5692,6 +5673,11 @@ class NDFrame(PandasObject, SelectionMixin):
             new_data = self._data.astype(dtype=dtype, copy=copy, errors=errors,
                                          **kwargs)
             return self._constructor(new_data).__finalize__(self)
+
+        if not results:
+            if copy:
+                self = self.copy()
+            return self
 
         # GH 19920: retain column metadata after concat
         result = pd.concat(results, axis=1, copy=False)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -156,12 +156,19 @@ class NDFrameGroupBy(GroupBy):
 
                 obj = self.obj[data.items[locs]]
                 s = groupby(obj, self.grouper)
-                result = s.aggregate(lambda x: alt(x, axis=self.axis))
+                try:
+                    result = s.aggregate(lambda x: alt(x, axis=self.axis))
+                except Exception:
+                    # we may have an exception in trying to aggregate
+                    # continue and exclude the block
+                    pass
 
             finally:
 
+                dtype = block.values.dtype
+
                 # see if we can cast the block back to the original dtype
-                result = block._try_coerce_and_cast_result(result)
+                result = block._try_coerce_and_cast_result(result, dtype=dtype)
                 newb = block.make_block(result)
 
             new_items.append(locs)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1185,7 +1185,7 @@ class GroupBy(_GroupBy):
             return self._cython_agg_general(
                 'median',
                 alt=lambda x,
-                axis: Series(x).median(**kwargs),
+                axis: Series(x).median(axis=axis, **kwargs),
                 **kwargs)
         except GroupByError:
             raise

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -19,7 +19,7 @@ from pandas.util._decorators import cache_readonly
 from pandas.core.dtypes.common import (
     ensure_float64, ensure_int64, ensure_int_or_float, ensure_object,
     ensure_platform_int, is_bool_dtype, is_categorical_dtype, is_complex_dtype,
-    is_datetime64_any_dtype, is_integer_dtype, is_numeric_dtype,
+    is_datetime64_any_dtype, is_integer_dtype, is_numeric_dtype, is_sparse,
     is_timedelta64_dtype, needs_i8_conversion)
 from pandas.core.dtypes.missing import _maybe_fill, isna
 
@@ -451,9 +451,9 @@ class BaseGrouper:
 
         # categoricals are only 1d, so we
         # are not setup for dim transforming
-        if is_categorical_dtype(values):
+        if is_categorical_dtype(values) or is_sparse(values):
             raise NotImplementedError(
-                "categoricals are not support in cython ops ATM")
+                "{} are not support in cython ops".format(values.dtype))
         elif is_datetime64_any_dtype(values):
             if how in ['add', 'prod', 'cumsum', 'cumprod']:
                 raise NotImplementedError(

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1772,8 +1772,16 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
         """
         if we have an operation that operates on for example floats
         we want to try to cast back to our EA here if possible
+
+        result could be a 2-D numpy array, e.g. the result of
+        a numeric operation; but it must be shape (1, X) because
+        we by-definition operate on the ExtensionBlocks one-by-one
+
+        result could also be an EA Array itself, in which case it
+        is already a 1-D array
         """
         try:
+
             result = self._holder._from_sequence(
                 np.asarray(result).ravel(), dtype=dtype)
         except Exception:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -600,7 +600,8 @@ class Block(PandasObject):
                         values = self.get_values(dtype=dtype)
 
                     # _astype_nansafe works fine with 1-d only
-                    values = astype_nansafe(values.ravel(), dtype, copy=True)
+                    values = astype_nansafe(
+                        values.ravel(), dtype, copy=True, **kwargs)
 
                 # TODO(extension)
                 # should we make this attribute?
@@ -1766,6 +1767,19 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
             slicer = slicer[1]
 
         return self.values[slicer]
+
+    def _try_cast_result(self, result, dtype=None):
+        """
+        if we have an operation that operates on for example floats
+        we want to try to cast back to our EA here if possible
+        """
+        try:
+            result = self._holder._from_sequence(
+                np.asarray(result).ravel(), dtype=dtype)
+        except Exception:
+            pass
+
+        return result
 
     def formatting_values(self):
         # Deprecating the ability to override _formatting_values.

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -666,7 +666,10 @@ def sanitize_array(data, index, dtype=None, copy=False,
                 data = np.array(data, dtype=dtype, copy=False)
             subarr = np.array(data, dtype=object, copy=copy)
 
-    if is_object_dtype(subarr.dtype) and dtype != 'object':
+    if (not (is_extension_array_dtype(subarr.dtype) or
+             is_extension_array_dtype(dtype)) and
+            is_object_dtype(subarr.dtype) and
+            not is_object_dtype(dtype)):
         inferred = lib.infer_dtype(subarr, skipna=False)
         if inferred == 'period':
             try:

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -72,11 +72,12 @@ class disallow:
 
 class bottleneck_switch:
 
-    def __init__(self, **kwargs):
+    def __init__(self, name=None, **kwargs):
+        self.name = name
         self.kwargs = kwargs
 
     def __call__(self, alt):
-        bn_name = alt.__name__
+        bn_name = self.name or alt.__name__
 
         try:
             bn_func = getattr(bn, bn_name)
@@ -804,7 +805,8 @@ def nansem(values, axis=None, skipna=True, ddof=1, mask=None):
 
 
 def _nanminmax(meth, fill_value_typ):
-    @bottleneck_switch()
+
+    @bottleneck_switch(name='nan' + meth)
     def reduction(values, axis=None, skipna=True, mask=None):
 
         values, mask, dtype, dtype_max, fill_value = _get_values(
@@ -824,7 +826,6 @@ def _nanminmax(meth, fill_value_typ):
         result = _wrap_results(result, dtype, fill_value)
         return _maybe_null_out(result, axis, mask, values.shape)
 
-    reduction.__name__ = 'nan' + meth
     return reduction
 
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -782,10 +782,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         # we try to cast extension array types back to the original
         if is_extension_array_dtype(self):
-            result = result.astype(self.dtype,
-                                   copy=False,
-                                   errors='ignore',
-                                   casting='same_kind')
+            result = result.astype(self.dtype, copy=False)
 
         return result.__finalize__(self)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5,8 +5,8 @@ from collections import OrderedDict
 from io import StringIO
 from shutil import get_terminal_size
 from textwrap import dedent
-import warnings
 from typing import Optional, Tuple
+import warnings
 
 import numpy as np
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6,6 +6,7 @@ from io import StringIO
 from shutil import get_terminal_size
 from textwrap import dedent
 import warnings
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -762,20 +763,20 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             dtype = 'M8[ns]'
         return np.asarray(self.array, dtype)
 
-    def __array_wrap__(self, result: np.ndarray, context=None) -> 'Series':
+    def __array_wrap__(self, result: np.ndarray,
+                       context: Optional[Tuple] = None) -> 'Series':
         """
         We are called post ufunc; reconstruct the original object and dtypes.
 
         Parameters
         ----------
         result : np.ndarray
-        context
+        context : tuple, optional
 
         Returns
         -------
         Series
         """
-
         result = self._constructor(result, index=self.index,
                                    copy=False)
 

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -472,6 +472,7 @@ class TestSparseArray:
         # float -> float
         arr = SparseArray([None, None, 0, 2])
         result = arr.astype("Sparse[float32]")
+
         expected = SparseArray([None, None, 0, 2], dtype=np.dtype('float32'))
         tm.assert_sp_array_equal(result, expected)
 

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -154,32 +154,6 @@ class TestGetitem(BaseSparseTests, base.BaseGetitemTests):
         self._check_unsupported(data)
         super().test_reindex(data, na_value)
 
-    def test_getitem_mask(self, data):
-        # Empty mask, raw array
-        mask = np.zeros(len(data), dtype=bool)
-        result = data[mask]
-        assert len(result) == 0
-        assert isinstance(result, type(data))
-
-        # Empty mask, in series
-        mask = np.zeros(len(data), dtype=bool)
-        result = pd.Series(data)[mask]
-        assert len(result) == 0
-
-        # we change int -> float because of the masking
-        assert result.dtype == SparseDtype('float64', data.dtype.fill_value)
-
-        # non-empty mask, raw array
-        mask[0] = True
-        result = data[mask]
-        assert len(result) == 1
-        assert isinstance(result, type(data))
-
-        # non-empty mask, in series
-        result = pd.Series(data)[mask]
-        assert len(result) == 1
-        assert result.dtype == data.dtype
-
 
 # Skipping TestSetitem, since we don't implement it.
 

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -154,6 +154,32 @@ class TestGetitem(BaseSparseTests, base.BaseGetitemTests):
         self._check_unsupported(data)
         super().test_reindex(data, na_value)
 
+    def test_getitem_mask(self, data):
+        # Empty mask, raw array
+        mask = np.zeros(len(data), dtype=bool)
+        result = data[mask]
+        assert len(result) == 0
+        assert isinstance(result, type(data))
+
+        # Empty mask, in series
+        mask = np.zeros(len(data), dtype=bool)
+        result = pd.Series(data)[mask]
+        assert len(result) == 0
+
+        # we change int -> float because of the masking
+        assert result.dtype == SparseDtype('float64', data.dtype.fill_value)
+
+        # non-empty mask, raw array
+        mask[0] = True
+        result = data[mask]
+        assert len(result) == 1
+        assert isinstance(result, type(data))
+
+        # non-empty mask, in series
+        result = pd.Series(data)[mask]
+        assert len(result) == 1
+        assert result.dtype == data.dtype
+
 
 # Skipping TestSetitem, since we don't implement it.
 

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -12,7 +12,7 @@ import pandas as pd
 from pandas import (
     DataFrame, Index, MultiIndex, Series, Timestamp, date_range, isna)
 import pandas.core.nanops as nanops
-from pandas.util import testing as tm
+from pandas.util import _test_decorators as td, testing as tm
 
 
 @pytest.mark.parametrize("agg_func", ['any', 'all'])
@@ -461,11 +461,8 @@ def test_groupby_cumprod():
 
 
 def scipy_sem(*args, **kwargs):
-    try:
-        from scipy.stats import sem
-        return sem(*args, ddof=1, **kwargs)
-    except ImportError:
-        pytest.skip("No Scipy installed")
+    from scipy.stats import sem
+    return sem(*args, ddof=1, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -481,7 +478,7 @@ def scipy_sem(*args, **kwargs):
      ('first', lambda x: x.iloc[0]),
      ('last', lambda x: x.iloc[-1]),
      ('count', np.size),
-     ('sem', scipy_sem)])
+     pytest.param('sem', scipy_sem, mark=td._skip_if_no_scipy)])
 def test_ops_general(op, targop):
     df = DataFrame(np.random.randn(1000))
     labels = np.random.randint(0, 50, size=1000).astype(float)

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -479,8 +479,7 @@ def scipy_sem(*args, **kwargs):
      ('last', lambda x: x.iloc[-1]),
      ('count', np.size),
      pytest.param(
-         'sem', scipy_sem, marks=[pytest.mark.skipif(
-             td._skip_if_no_scipy(), reason='scipy not installed')])])
+         'sem', scipy_sem, marks=td.skip_if_no_scipy)])
 def test_ops_general(op, targop):
     df = DataFrame(np.random.randn(1000))
     labels = np.random.randint(0, 50, size=1000).astype(float)

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -478,7 +478,9 @@ def scipy_sem(*args, **kwargs):
      ('first', lambda x: x.iloc[0]),
      ('last', lambda x: x.iloc[-1]),
      ('count', np.size),
-     pytest.param('sem', scipy_sem, mark=td._skip_if_no_scipy)])
+     pytest.param(
+         'sem', scipy_sem, marks=[pytest.mark.skipif(
+             td._skip_if_no_scipy(), reason='scipy not installed')])])
 def test_ops_general(op, targop):
     df = DataFrame(np.random.randn(1000))
     labels = np.random.randint(0, 50, size=1000).astype(float)

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -282,18 +282,21 @@ def test_first_last_tz(data, expected_first, expected_last):
 ])
 def test_first_last_tz_multi_column(method, ts, alpha):
     # GH 21603
+    category_string = pd.Series(list('abc')).astype(
+        'category')
     df = pd.DataFrame({'group': [1, 1, 2],
-                       'category_string': pd.Series(list('abc')).astype(
-                           'category'),
+                       'category_string': category_string,
                        'datetimetz': pd.date_range('20130101', periods=3,
                                                    tz='US/Eastern')})
     result = getattr(df.groupby('group'), method)()
-    expepcted = pd.DataFrame({'category_string': [alpha, 'c'],
-                              'datetimetz': [ts,
-                                             Timestamp('2013-01-03',
-                                                       tz='US/Eastern')]},
-                             index=pd.Index([1, 2], name='group'))
-    assert_frame_equal(result, expepcted)
+    expected = pd.DataFrame(
+        {'category_string': pd.Categorical(
+            [alpha, 'c'], dtype=category_string.dtype),
+         'datetimetz': [ts,
+                        Timestamp('2013-01-03',
+                                  tz='US/Eastern')]},
+        index=pd.Index([1, 2], name='group'))
+    assert_frame_equal(result, expected)
 
 
 def test_nth_multi_index_as_expected():

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -112,6 +112,12 @@ def test_resample_integerarray():
                       dtype="Int64")
     assert_series_equal(result, expected)
 
+    result = ts.resample('3T').mean()
+    expected = Series([1, 4, 7],
+                      index=pd.date_range('1/1/2000', periods=3, freq='3T'),
+                      dtype='Int64')
+    assert_series_equal(result, expected)
+
 
 def test_resample_basic_grouper(series):
     s = series

--- a/pandas/tests/sparse/frame/test_analytics.py
+++ b/pandas/tests/sparse/frame/test_analytics.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from pandas import DataFrame, SparseDataFrame, SparseSeries
+from pandas import (
+    DataFrame, Series, SparseDataFrame, SparseDtype, SparseSeries)
 from pandas.util import testing as tm
 
 
@@ -39,3 +40,16 @@ def test_quantile_multi():
 
     tm.assert_frame_equal(result, dense_expected)
     tm.assert_sp_frame_equal(result, sparse_expected)
+
+
+@pytest.mark.parametrize('func', [np.exp, np.sqrt], ids=lambda x: x.__name__)
+def test_ufunc(func):
+    # GH 23743
+    # assert we preserve the incoming dtype on ufunc operation
+    df = DataFrame(
+        {'A': Series([1, np.nan, 3], dtype=SparseDtype('float64', np.nan))})
+    result = func(df)
+    expected = DataFrame(
+        {'A': Series(func([1, np.nan, 3]),
+                     dtype=SparseDtype('float64', np.nan))})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/sparse/frame/test_analytics.py
+++ b/pandas/tests/sparse/frame/test_analytics.py
@@ -42,7 +42,7 @@ def test_quantile_multi():
     tm.assert_sp_frame_equal(result, sparse_expected)
 
 
-@pytest.mark.parametrize('func', [np.exp, np.sqrt], ids=lambda x: x.__name__)
+@pytest.mark.parametrize('func', [np.exp, np.sqrt], ids=str)
 def test_ufunc(func):
     # GH 23743
     # assert we preserve the incoming dtype on ufunc operation

--- a/pandas/tests/sparse/frame/test_analytics.py
+++ b/pandas/tests/sparse/frame/test_analytics.py
@@ -55,5 +55,5 @@ def test_ufunc(data, dtype, func):
     result = func(df)
     expected = DataFrame(
         {'A': Series(func(data),
-                     dtype=dtype)})
+                     dtype=SparseDtype('float64', dtype.fill_value))})
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/sparse/frame/test_analytics.py
+++ b/pandas/tests/sparse/frame/test_analytics.py
@@ -42,14 +42,18 @@ def test_quantile_multi():
     tm.assert_sp_frame_equal(result, sparse_expected)
 
 
+@pytest.mark.parametrize(
+    'data, dtype',
+    [([1, np.nan, 3], SparseDtype('float64', np.nan)),
+     ([1, 2, 3], SparseDtype('int'))])
 @pytest.mark.parametrize('func', [np.exp, np.sqrt], ids=str)
-def test_ufunc(func):
+def test_ufunc(data, dtype, func):
     # GH 23743
     # assert we preserve the incoming dtype on ufunc operation
     df = DataFrame(
-        {'A': Series([1, np.nan, 3], dtype=SparseDtype('float64', np.nan))})
+        {'A': Series(data, dtype=dtype)})
     result = func(df)
     expected = DataFrame(
-        {'A': Series(func([1, np.nan, 3]),
-                     dtype=SparseDtype('float64', np.nan))})
+        {'A': Series(func(data),
+                     dtype=dtype)})
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/sparse/series/test_analytics.py
+++ b/pandas/tests/sparse/series/test_analytics.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+
+from pandas import Series, SparseDtype
+from pandas.util import testing as tm
+
+
+@pytest.mark.parametrize('func', [np.exp, np.sqrt], ids=lambda x: x.__name__)
+def test_ufunc(func):
+    # GH 23743
+    # assert we preserve the incoming dtype on ufunc operation
+    s = Series([1, np.nan, 3], dtype=SparseDtype('float64', np.nan))
+    result = func(s)
+    expected = Series(func([1, np.nan, 3]),
+                      dtype=SparseDtype('float64', np.nan))
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/sparse/series/test_analytics.py
+++ b/pandas/tests/sparse/series/test_analytics.py
@@ -5,12 +5,16 @@ from pandas import Series, SparseDtype
 from pandas.util import testing as tm
 
 
+@pytest.mark.parametrize(
+    'data, dtype',
+    [([1, np.nan, 3], SparseDtype('float64', np.nan)),
+     ([1, 2, 3], SparseDtype('int'))])
 @pytest.mark.parametrize('func', [np.exp, np.sqrt], ids=str)
-def test_ufunc(func):
+def test_ufunc(data, dtype, func):
     # GH 23743
     # assert we preserve the incoming dtype on ufunc operation
-    s = Series([1, np.nan, 3], dtype=SparseDtype('float64', np.nan))
+    s = Series(data, dtype=dtype)
     result = func(s)
-    expected = Series(func([1, np.nan, 3]),
-                      dtype=SparseDtype('float64', np.nan))
+    expected = Series(func(data),
+                      dtype=dtype)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/sparse/series/test_analytics.py
+++ b/pandas/tests/sparse/series/test_analytics.py
@@ -5,7 +5,7 @@ from pandas import Series, SparseDtype
 from pandas.util import testing as tm
 
 
-@pytest.mark.parametrize('func', [np.exp, np.sqrt], ids=lambda x: x.__name__)
+@pytest.mark.parametrize('func', [np.exp, np.sqrt], ids=str)
 def test_ufunc(func):
     # GH 23743
     # assert we preserve the incoming dtype on ufunc operation

--- a/pandas/tests/sparse/series/test_analytics.py
+++ b/pandas/tests/sparse/series/test_analytics.py
@@ -16,5 +16,5 @@ def test_ufunc(data, dtype, func):
     s = Series(data, dtype=dtype)
     result = func(s)
     expected = Series(func(data),
-                      dtype=dtype)
+                      dtype=SparseDtype('float64', dtype.fill_value))
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/sparse/test_groupby.py
+++ b/pandas/tests/sparse/test_groupby.py
@@ -29,11 +29,10 @@ class TestSparseGroupBy:
         sparse_grouped_last = sparse_grouped.last()
         sparse_grouped_nth = sparse_grouped.nth(1)
 
-        dense_grouped_first = dense_grouped.first().to_sparse()
-        dense_grouped_last = dense_grouped.last().to_sparse()
-        dense_grouped_nth = dense_grouped.nth(1).to_sparse()
+        dense_grouped_first = pd.DataFrame(dense_grouped.first().to_sparse())
+        dense_grouped_last = pd.DataFrame(dense_grouped.last().to_sparse())
+        dense_grouped_nth = pd.DataFrame(dense_grouped.nth(1).to_sparse())
 
-        # TODO: shouldn't these all be spares or not?
         tm.assert_frame_equal(sparse_grouped_first,
                               dense_grouped_first)
         tm.assert_frame_equal(sparse_grouped_last,
@@ -69,5 +68,6 @@ def test_groupby_includes_fill_value(fill_value):
                        'b': [fill_value, 1, fill_value, fill_value]})
     sdf = df.to_sparse(fill_value=fill_value)
     result = sdf.groupby('a').sum()
-    expected = df.groupby('a').sum().to_sparse(fill_value=fill_value)
+    expected = pd.DataFrame(df.groupby('a').sum().to_sparse(
+        fill_value=fill_value))
     tm.assert_frame_equal(result, expected, check_index_type=False)

--- a/pandas/tests/sparse/test_pivot.py
+++ b/pandas/tests/sparse/test_pivot.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
+from pandas import _np_version_under1p17
 import pandas.util.testing as tm
 
 
@@ -53,7 +54,8 @@ class TestPivotTable:
          'std',
          'var',
          'sem',
-         'median',
+         pytest.param('median', marks=pytest.mark.xfail(
+             not _np_version_under1p17, reason="fails on numpy > 1.16")),
          'first',
          'last'])
     @pytest.mark.parametrize('dropna', [True, False])

--- a/pandas/tests/sparse/test_pivot.py
+++ b/pandas/tests/sparse/test_pivot.py
@@ -47,10 +47,20 @@ class TestPivotTable:
         #                            values='E', aggfunc='sum')
         # tm.assert_frame_equal(res_sparse, res_dense)
 
-    def test_pivot_table_multi(self):
+    @pytest.mark.parametrize(
+        'func',
+        ['mean',
+         'std',
+         'var',
+         'sem',
+         'median',
+         'first',
+         'last'])
+    def test_pivot_table_multi(self, func):
+
         res_sparse = pd.pivot_table(self.sparse, index='A', columns='B',
-                                    values=['D', 'E'])
+                                    values=['D', 'E'], aggfunc=func)
         res_dense = pd.pivot_table(self.dense, index='A', columns='B',
-                                   values=['D', 'E'])
+                                   values=['D', 'E'], aggfunc=func)
         res_dense = res_dense.apply(lambda x: x.astype("Sparse[float64]"))
         tm.assert_frame_equal(res_sparse, res_dense)

--- a/pandas/tests/sparse/test_pivot.py
+++ b/pandas/tests/sparse/test_pivot.py
@@ -56,11 +56,14 @@ class TestPivotTable:
          'median',
          'first',
          'last'])
-    def test_pivot_table_multi(self, func):
+    @pytest.mark.parametrize('dropna', [True, False])
+    def test_pivot_table_multi(self, func, dropna):
 
-        res_sparse = pd.pivot_table(self.sparse, index='A', columns='B',
-                                    values=['D', 'E'], aggfunc=func)
-        res_dense = pd.pivot_table(self.dense, index='A', columns='B',
-                                   values=['D', 'E'], aggfunc=func)
+        res_sparse = pd.pivot_table(
+            self.sparse, index='A', columns='B',
+            values=['D', 'E'], aggfunc=func, dropna=dropna)
+        res_dense = pd.pivot_table(
+            self.dense, index='A', columns='B',
+            values=['D', 'E'], aggfunc=func, dropna=dropna)
         res_dense = res_dense.apply(lambda x: x.astype("Sparse[float64]"))
         tm.assert_frame_equal(res_sparse, res_dense)


### PR DESCRIPTION
closes #18502
closes #23743