### PR TITLE
BUG: ignore errors for invalid dates in to_datetime() with errors=coerce (#25512)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -359,6 +359,7 @@ Datetimelike
 - Bug in :class:`Series` and :class:`DataFrame` repr where ``np.datetime64('NaT')`` and ``np.timedelta64('NaT')`` with ``dtype=object`` would be represented as ``NaN`` (:issue:`25445`)
 - Bug in :func:`to_datetime` which does not replace the invalid argument with ``NaT`` when error is set to coerce (:issue:`26122`)
 - Bug in adding :class:`DateOffset` with nonzero month to :class:`DatetimeIndex` would raise ``ValueError`` (:issue:`26258`)
+- Bug in :func:`to_datetime` which raises unhandled ``OverflowError`` when called with mix of invalid dates and ``NaN`` values with ``format='%Y%m%d'`` and ``error='coerce'`` (:issue:`25512`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -775,21 +775,21 @@ def _attempt_YYYYMMDD(arg, errors):
     # try intlike / strings that are ints
     try:
         return calc(arg.astype(np.int64))
-    except ValueError:
+    except (ValueError, OverflowError):
         pass
 
     # a float with actual np.nan
     try:
         carg = arg.astype(np.float64)
         return calc_with_mask(carg, notna(carg))
-    except ValueError:
+    except (ValueError, OverflowError):
         pass
 
     # string with NaN-like
     try:
         mask = ~algorithms.isin(arg, list(tslib.nat_strings))
         return calc_with_mask(arg, mask)
-    except ValueError:
+    except (ValueError, OverflowError):
         pass
 
     return None

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -83,35 +83,6 @@ class TestTimeConversionFormats:
         result = to_datetime(s, format='%Y%m%d', cache=cache)
         assert_series_equal(result, expected)
 
-        # GH 25512
-        # NaN before strings with invalid date values, errors=coerce
-        s = Series(['19801222', np.nan, '20010012', '10019999'])
-        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
-                                cache=cache)
-        expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
-        tm.assert_series_equal(result, expected)
-
-        # NaN after strings with invalid date values, errors=coerce
-        s = Series(['19801222', '20010012', '10019999', np.nan])
-        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
-                                cache=cache)
-        expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
-        tm.assert_series_equal(result, expected)
-
-        # NaN before integers with invalid date values, errors=coerce
-        s = Series([20190813, np.nan, 20010012, 20019999])
-        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
-                                cache=cache)
-        expected = Series([Timestamp('20190813'), np.nan, np.nan, np.nan])
-        tm.assert_series_equal(result, expected)
-
-        # NaN after integers with invalid date values, errors=coerce
-        s = Series([20190813, 20010012, np.nan, 20019999])
-        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
-                                cache=cache)
-        expected = Series([Timestamp('20190813'), np.nan, np.nan, np.nan])
-        tm.assert_series_equal(result, expected)
-
         # coercion
         # GH 7930
         s = Series([20121231, 20141231, 99991231])
@@ -125,6 +96,37 @@ class TestTimeConversionFormats:
         result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
                                 cache=cache)
         expected = Series(['20121231', '20141231', 'NaT'], dtype='M8[ns]')
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize('cache', [True, False])
+    def test_to_datetime_format_YYYYMMDD_overflow(self, cache):
+        # GH 25512
+        # NaN before strings with invalid date values, errors=coerce
+        s = Series(['19801222', np.nan, '20010012', '10019999'])
+        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
+                                cache=cache)
+        expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
+        assert_series_equal(result, expected)
+
+        # NaN after strings with invalid date values, errors=coerce
+        s = Series(['19801222', '20010012', '10019999', np.nan])
+        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
+                                cache=cache)
+        expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
+        assert_series_equal(result, expected)
+
+        # NaN before integers with invalid date values, errors=coerce
+        s = Series([20190813, np.nan, 20010012, 20019999])
+        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
+                                cache=cache)
+        expected = Series([Timestamp('20190813'), np.nan, np.nan, np.nan])
+        assert_series_equal(result, expected)
+
+        # NaN after integers with invalid date values, errors=coerce
+        s = Series([20190813, 20010012, np.nan, 20019999])
+        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
+                                cache=cache)
+        expected = Series([Timestamp('20190813'), np.nan, np.nan, np.nan])
         assert_series_equal(result, expected)
 
     @pytest.mark.parametrize('cache', [True, False])

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -84,18 +84,32 @@ class TestTimeConversionFormats:
         assert_series_equal(result, expected)
 
         # GH 25512
-        # strings with invalid date values, errors=coerce
+        # NaN before strings with invalid date values, errors=coerce
+        s = Series(['19801222', np.nan, '20010012', '10019999'])
+        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
+                                cache=cache)
+        expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
+        tm.assert_series_equal(result, expected)
+
+        # NaN after strings with invalid date values, errors=coerce
         s = Series(['19801222', '20010012', '10019999', np.nan])
         result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
                                 cache=cache)
         expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
         tm.assert_series_equal(result, expected)
 
-        # integers with invalid date values, errors=coerce
-        s = Series([20010012, 20190813, 20019999, np.nan])
+        # NaN before integers with invalid date values, errors=coerce
+        s = Series([20190813, np.nan, 20010012, 20019999])
         result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
                                 cache=cache)
-        expected = Series([np.nan, Timestamp('20190813'), np.nan, np.nan])
+        expected = Series([Timestamp('20190813'), np.nan, np.nan, np.nan])
+        tm.assert_series_equal(result, expected)
+
+        # NaN after integers with invalid date values, errors=coerce
+        s = Series([20190813, 20010012, np.nan, 20019999])
+        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
+                                cache=cache)
+        expected = Series([Timestamp('20190813'), np.nan, np.nan, np.nan])
         tm.assert_series_equal(result, expected)
 
         # coercion

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -83,6 +83,21 @@ class TestTimeConversionFormats:
         result = to_datetime(s, format='%Y%m%d', cache=cache)
         assert_series_equal(result, expected)
 
+        # GH 25512
+        # strings with invalid date values, errors=coerce
+        s = Series(['19801222', '20010012', '10019999', np.nan])
+        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
+                                cache=cache)
+        expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
+        tm.assert_series_equal(result, expected)
+
+        # integers with invalid date values, errors=coerce
+        s = Series([20010012, 20190813, 20019999, np.nan])
+        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
+                                cache=cache)
+        expected = Series([np.nan, Timestamp('20190813'), np.nan, np.nan])
+        tm.assert_series_equal(result, expected)
+
         # coercion
         # GH 7930
         s = Series([20121231, 20141231, 99991231])

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -98,35 +98,23 @@ class TestTimeConversionFormats:
         expected = Series(['20121231', '20141231', 'NaT'], dtype='M8[ns]')
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize('cache', [True, False])
-    def test_to_datetime_format_YYYYMMDD_overflow(self, cache):
+    @pytest.mark.parametrize("input_s, expected", [
+        # NaN before strings with invalid date values
+        [Series(['19801222', np.nan, '20010012', '10019999']),
+         Series([Timestamp('19801222'), np.nan, np.nan, np.nan])],
+        # NaN after strings with invalid date values
+        [Series(['19801222', '20010012', '10019999', np.nan]),
+         Series([Timestamp('19801222'), np.nan, np.nan, np.nan])],
+        # NaN before integers with invalid date values
+        [Series([20190813, np.nan, 20010012, 20019999]),
+         Series([Timestamp('20190813'), np.nan, np.nan, np.nan])],
+        # NaN after integers with invalid date values
+        [Series([20190813, 20010012, np.nan, 20019999]),
+         Series([Timestamp('20190813'), np.nan, np.nan, np.nan])]])
+    def test_to_datetime_format_YYYYMMDD_overflow(self, input_s, expected):
         # GH 25512
-        # NaN before strings with invalid date values, errors=coerce
-        s = Series(['19801222', np.nan, '20010012', '10019999'])
-        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
-                                cache=cache)
-        expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
-        assert_series_equal(result, expected)
-
-        # NaN after strings with invalid date values, errors=coerce
-        s = Series(['19801222', '20010012', '10019999', np.nan])
-        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
-                                cache=cache)
-        expected = Series([Timestamp('19801222'), np.nan, np.nan, np.nan])
-        assert_series_equal(result, expected)
-
-        # NaN before integers with invalid date values, errors=coerce
-        s = Series([20190813, np.nan, 20010012, 20019999])
-        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
-                                cache=cache)
-        expected = Series([Timestamp('20190813'), np.nan, np.nan, np.nan])
-        assert_series_equal(result, expected)
-
-        # NaN after integers with invalid date values, errors=coerce
-        s = Series([20190813, 20010012, np.nan, 20019999])
-        result = pd.to_datetime(s, format='%Y%m%d', errors='coerce',
-                                cache=cache)
-        expected = Series([Timestamp('20190813'), np.nan, np.nan, np.nan])
+        # format='%Y%m%d', errors='coerce'
+        result = pd.to_datetime(input_s, format='%Y%m%d', errors='coerce')
         assert_series_equal(result, expected)
 
     @pytest.mark.parametrize('cache', [True, False])


### PR DESCRIPTION
- [x] closes #25512
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

parsing.try_parse_year_month_day() in _attempt_YYYYMMDD() throws not only ValueError but also OverFlowError for incorrect dates. So handling of this error was added.

