### PR TITLE
PERF: don't call RangeIndex._data unnecessarily

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -94,6 +94,12 @@ class Range:
     def time_min_trivial(self):
         self.idx_inc.min()
 
+    def time_get_loc_inc(self):
+        self.idx_inc.get_loc(900000)
+
+    def time_get_loc_dec(self):
+        self.idx_dec.get_loc(900000)
+
 
 class IndexAppend:
 

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -98,7 +98,7 @@ class Range:
         self.idx_inc.get_loc(900000)
 
     def time_get_loc_dec(self):
-        self.idx_dec.get_loc(900000)
+        self.idx_dec.get_loc(100000)
 
 
 class IndexAppend:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -393,6 +393,7 @@ Performance Improvements
 - Improved performance of :meth:`Series.searchsorted`. The speedup is especially large when the dtype is
   int8/int16/int32 and the searched key is within the integer bounds for the dtype (:issue:`22034`)
 - Improved performance of :meth:`pandas.core.groupby.GroupBy.quantile` (:issue:`20405`)
+- Improved performance when slicing :class:`RangeIndex` (:issue:`26565`)
 - Improved performance of :meth:`read_csv` by faster tokenizing and faster parsing of small float numbers (:issue:`25784`)
 - Improved performance of :meth:`read_csv` by faster parsing of N/A and boolean values (:issue:`25804`)
 - Improved performance of :meth:`IntervalIndex.is_monotonic`, :meth:`IntervalIndex.is_monotonic_increasing` and :meth:`IntervalIndex.is_monotonic_decreasing` by removing conversion to :class:`MultiIndex` (:issue:`24813`)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -67,7 +67,7 @@ class RangeIndex(Int64Index):
     _engine_type = libindex.Int64Engine
 
     # check whether self._data has benn called
-    _has_called_data = False  # type: bool
+    _cached_data = None  # type: np.ndarray
     # --------------------------------------------------------------------
     # Constructors
 
@@ -186,10 +186,12 @@ class RangeIndex(Int64Index):
         """ return the class to use for construction """
         return Int64Index
 
-    @cache_readonly
+    @property
     def _data(self):
-        self._has_called_data = True
-        return np.arange(self._start, self._stop, self._step, dtype=np.int64)
+        if self._cached_data is None:
+            self._cached_data = np.arange(self._start, self._stop, self._step,
+                                          dtype=np.int64)
+        return self._cached_data
 
     @cache_readonly
     def _int64index(self):
@@ -223,7 +225,7 @@ class RangeIndex(Int64Index):
         return None
 
     def _format_with_header(self, header, na_rep='NaN', **kwargs):
-        return header + [pprint_thing(x) for x in self._range]
+        return header + list(map(pprint_thing, self._range))
 
     # --------------------------------------------------------------------
     @property

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -188,6 +188,13 @@ class RangeIndex(Int64Index):
 
     @property
     def _data(self):
+        """
+        An int array that for performance reasons is created only when needed.
+
+        The constructed array is saved in ``_cached_data``. This allows us to
+        check if the array has been created without accessing ``_data`` and
+        triggering the construction.
+        """
         if self._cached_data is None:
             self._cached_data = np.arange(self._start, self._stop, self._step,
                                           dtype=np.int64)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -308,12 +308,12 @@ class RangeIndex(Int64Index):
 
     @Appender(_index_shared_docs['get_loc'])
     def get_loc(self, key, method=None, tolerance=None):
-        if method is None and tolerance is None:
+        if is_integer(key) and method is None and tolerance is None:
             try:
                 return self._range.index(key)
             except ValueError:
                 raise KeyError(key)
-        return super().__get_loc(key, method=method, tolerance=tolerance)
+        return super().get_loc(key, method=method, tolerance=tolerance)
 
     def tolist(self):
         return list(range(self._start, self._stop, self._step))

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -241,35 +241,40 @@ class TestRangeIndex(Numeric):
     def test_dtype(self):
         assert self.index.dtype == np.int64
 
-    def test_has_called_data(self):
-        # Calling RangeIndex._data caches a array of the same length.
-        # This tests whether RangeIndex._data has been called by doing methods
+    def test_cached_data(self):
+        # Calling RangeIndex._data caches an int64 array of the same length at
+        # self._cached_data. This tests whether _cached_data has been set.
         idx = RangeIndex(0, 100, 10)
-        assert idx._has_called_data is False
+
+        assert idx._cached_data is None
 
         repr(idx)
-        assert idx._has_called_data is False
+        assert idx._cached_data is None
 
         str(idx)
-        assert idx._has_called_data is False
+        assert idx._cached_data is None
 
         idx.get_loc(20)
-        assert idx._has_called_data is False
+        assert idx._cached_data is None
 
         df = pd.DataFrame({'a': range(10)}, index=idx)
 
         df.loc[50]
-        assert idx._has_called_data is False
+        assert idx._cached_data is None
 
         with pytest.raises(KeyError):
             df.loc[51]
-        assert idx._has_called_data is False
+        assert idx._cached_data is None
 
         df.loc[10:50]
-        assert idx._has_called_data is False
+        assert idx._cached_data is None
 
         df.iloc[5:10]
-        assert idx._has_called_data is False
+        assert idx._cached_data is None
+
+        # actually calling data._data
+        assert isinstance(idx._data, np.ndarray)
+        assert isinstance(idx._cached_data, np.ndarray)
 
     def test_is_monotonic(self):
         assert self.index.is_monotonic is True

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -242,6 +242,7 @@ class TestRangeIndex(Numeric):
         assert self.index.dtype == np.int64
 
     def test_cached_data(self):
+        # GH 26565
         # Calling RangeIndex._data caches an int64 array of the same length at
         # self._cached_data. This tests whether _cached_data has been set.
         idx = RangeIndex(0, 100, 10)

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -241,6 +241,36 @@ class TestRangeIndex(Numeric):
     def test_dtype(self):
         assert self.index.dtype == np.int64
 
+    def test_has_called_data(self):
+        # Calling RangeIndex._data caches a array of the same length.
+        # This tests whether RangeIndex._data has been called by doing methods
+        idx = RangeIndex(0, 100, 10)
+        assert idx._has_called_data is False
+
+        repr(idx)
+        assert idx._has_called_data is False
+
+        str(idx)
+        assert idx._has_called_data is False
+
+        idx.get_loc(20)
+        assert idx._has_called_data is False
+
+        df = pd.DataFrame({'a': range(10)}, index=idx)
+
+        df.loc[50]
+        assert idx._has_called_data is False
+
+        with pytest.raises(KeyError):
+            df.loc[51]
+        assert idx._has_called_data is False
+
+        df.loc[10:50]
+        assert idx._has_called_data is False
+
+        df.iloc[5:10]
+        assert idx._has_called_data is False
+
     def test_is_monotonic(self):
         assert self.index.is_monotonic is True
         assert self.index.is_monotonic_increasing is True


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I've looked into ``RangeIndex`` and found that the index type creates and caches a int64 array if/when ``RangeIndex._data`` property is being called. This basically means that in many cases, a ``RangeIndex`` has the same memory consumption and the same speed as an ``Int64Index``.

This PR improves on that situation by giving ``RangeIndex`` custom ``.get_loc`` and ``._format_with_header`` methods. This avoids the calls to ``._data`` in some cases, which helps on the speed and memory consumption (see performance improvements below). There are probably other case where ``RangeIndex._data`` can be avoided, which I'll investigate over the coming days.

```python
>>> %timeit pd.RangeIndex(1_000_000).get_loc(900_000)
8.95 ms ± 485 µs per loop  # master
4.31 µs ± 303 ns per loop  # this PR
>>> rng =  pd.RangeIndex(1_000_000)
>>> %timeit rng.get_loc(900_000)
17.3 µs ± 392 ns per loop  # master
547 ns ± 8.26 ns per loop  # this PR. get_loc is now lightningly fast
>>> df = pd.DataFrame({'a': range(1_000_000)})
>>> %timeit df.loc[800_000: 900_000]
132 µs ± 5.79 µs per loop  # master
89 µs ± 2.95 µs per loop  # this PR
```