### PR TITLE
BUG: Fix RecursionError when using a scalar point to select IntervalIndex columns

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -482,7 +482,7 @@ Interval
 
 - Construction of :class:`Interval` is restricted to numeric, :class:`Timestamp` and :class:`Timedelta` endpoints (:issue:`23013`)
 - Fixed bug in :class:`Series`/:class:`DataFrame` not displaying ``NaN`` in :class:`IntervalIndex` with missing values (:issue:`25984`)
--
+- Bug in :class:`DataFrame` with :class:`IntervalIndex` columns where selecting columns using a scalar point caused a ``RecursionError`` (:issue:`26490`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2887,7 +2887,7 @@ class DataFrame(NDFrame):
             # - the key itself is repeated (test on data.shape, #9519), or
             # - we have a MultiIndex on columns (test on self.columns, #21309)
             if data.shape[1] == 1 and not isinstance(self.columns, MultiIndex):
-                data = data[key]
+                data = data.squeeze()
 
         return data
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -70,7 +70,7 @@ from pandas.core.dtypes.common import (
     is_sequence,
     is_named_tuple)
 from pandas.core.dtypes.generic import (
-    ABCSeries, ABCDataFrame, ABCIndexClass, ABCMultiIndex)
+    ABCSeries, ABCDataFrame, ABCIndexClass, ABCIntervalIndex, ABCMultiIndex)
 from pandas.core.dtypes.missing import isna, notna
 
 from pandas.core import algorithms
@@ -2866,7 +2866,12 @@ class DataFrame(NDFrame):
         if is_single_key:
             if self.columns.nlevels > 1:
                 return self._getitem_multilevel(key)
+
             indexer = self.columns.get_loc(key)
+            if isinstance(self.columns, ABCIntervalIndex):
+                # GH 26490: convert points to Intervals
+                key = self.columns[indexer]
+
             if is_integer(indexer):
                 indexer = [indexer]
         else:
@@ -2887,7 +2892,7 @@ class DataFrame(NDFrame):
             # - the key itself is repeated (test on data.shape, #9519), or
             # - we have a MultiIndex on columns (test on self.columns, #21309)
             if data.shape[1] == 1 and not isinstance(self.columns, MultiIndex):
-                data = data.squeeze()
+                data = data[key]
 
         return data
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3240,6 +3240,31 @@ class TestDataFrameIndexing(TestData):
         result = df.loc[1, 'A']
         assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize('key', [1.5, pd.Interval(1, 2)])
+    def test_interval_index_columns(self, key):
+        # GH 26490
+        columns = pd.interval_range(0, 3)
+        df = pd.DataFrame([[0, 1, 2], [3, 4, 5], [6, 7, 8]], columns=columns)
+        expected = pd.Series([1, 4, 7], name=pd.Interval(1, 2))
+
+        result = df[key]
+        assert_series_equal(result, expected)
+
+        result = df.loc[:, key]
+        assert_series_equal(result, expected)
+
+    def test_interval_index_columns_overlapping(self):
+        # GH 26490
+        columns = pd.IntervalIndex.from_arrays([0, 1, 2], [2, 3, 4])
+        df = pd.DataFrame([[0, 1, 2], [3, 4, 5], [6, 7, 8]], columns=columns)
+        expected = pd.DataFrame([[1, 2], [4, 5], [7, 8]], columns=columns[1:])
+
+        result = df[2.5]
+        assert_frame_equal(result, expected)
+
+        result = df.loc[:, 2.5]
+        assert_frame_equal(result, expected)
+
 
 class TestDataFrameIndexingDatetimeWithTZ(TestData):
 


### PR DESCRIPTION
- [X] closes #26490
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
