### PR TITLE
CI: Disabling dev docs push from azure-pipelines while we fix it

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,9 @@ jobs:
   - script: |
       cd doc/build/html
       git remote add origin git@github.com:pandas-dev/pandas-dev.github.io.git
-      git push origin master -f
+      # There is a problem with the key and master is failing. Disabling the push while we fix the problem.
+      # See: https://github.com/pandas-dev/pandas/pull/26591
+      # git push origin master -f
     displayName: 'Publish docs to GitHub pages'
     condition : |
       and(not(eq(variables['Build.Reason'], 'PullRequest')),


### PR DESCRIPTION
master builds are failing, this temporary fixes them while we figure out why the ssh key is not working.

See: #26591

CC: @jreback 
