### PR TITLE
PERF: Add if branch for empty sep in str.cat

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -60,6 +60,7 @@ def cat_core(list_of_columns: List, sep: str):
         The concatenation of list_of_columns with sep
     """
     if sep == "":
+        # no need to interleave sep if it is empty
         return np.sum(list_of_columns, axis=0)
     list_with_sep = [sep] * (2 * len(list_of_columns) - 1)
     list_with_sep[::2] = list_of_columns

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -59,7 +59,7 @@ def cat_core(list_of_columns: List, sep: str):
     nd.array
         The concatenation of list_of_columns with sep
     """
-    if sep == '':
+    if sep == "":
         return np.sum(list_of_columns, axis=0)
     list_with_sep = [sep] * (2 * len(list_of_columns) - 1)
     list_with_sep[::2] = list_of_columns

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -59,6 +59,8 @@ def cat_core(list_of_columns: List, sep: str):
     nd.array
         The concatenation of list_of_columns with sep
     """
+    if sep == '':
+        return np.sum(list_of_columns, axis=0)
     list_with_sep = [sep] * (2 * len(list_of_columns) - 1)
     list_with_sep[::2] = list_of_columns
     return np.sum(list_with_sep, axis=0)


### PR DESCRIPTION
Follow-up to #23167, resp dropping py2. The branch I'm readding here had to be deleted originally to pass some python2 bytes-tests. In case there is no separator, we can avoid all the list-ops and speed up cat_core by a fair bit.