### PR TITLE
DOC/CI: restore travis CI doc build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,14 @@ matrix:
     # In allow_failures
     - dist: trusty
       env:
-        - JOB="3.6, doc" ENV_FILE="environment.yml" DOC=true
+        - JOB="3.6, doc" ENV_FILE="ci/deps/travis-36-doc.yaml" DOC=true
     allow_failures:
       - dist: trusty
         env:
           - JOB="3.6, slow" ENV_FILE="ci/deps/travis-36-slow.yaml" PATTERN="slow"
       - dist: trusty
         env:
-          - JOB="3.6, doc" ENV_FILE="environment.yml" DOC=true
+          - JOB="3.6, doc" ENV_FILE="ci/deps/travis-36-doc.yaml" DOC=true
 
 before_install:
   - echo "before_install"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
     name: Windows
     vmImage: vs2017-win2016
 
-- job: 'Checks_and_doc'
+- job: 'Checks'
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 90

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
     name: Windows
     vmImage: vs2017-win2016
 
-- job: 'Checks'
+- job: 'Checks_and_doc'
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 90

--- a/ci/deps/travis-36-doc.yaml
+++ b/ci/deps/travis-36-doc.yaml
@@ -1,0 +1,46 @@
+name: pandas-dev
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - beautifulsoup4
+  - bottleneck
+  - cython>=0.28.2
+  - fastparquet>=0.2.1
+  - gitpython
+  - html5lib
+  - hypothesis>=3.58.0
+  - ipykernel
+  - ipython
+  - ipywidgets
+  - lxml
+  - matplotlib
+  - nbconvert>=5.4.1
+  - nbformat
+  - nbsphinx
+  - notebook>=5.7.5
+  - numexpr
+  - numpy
+  - numpydoc
+  - openpyxl
+  - pandoc
+  - pyarrow
+  - pyqt
+  - pytables
+  - python-dateutil
+  - python-snappy
+  - python=3.6.*
+  - pytz
+  - scipy
+  - seaborn
+  - sphinx
+  - sqlalchemy
+  - statsmodels
+  - xarray
+  - xlrd
+  - xlsxwriter
+  - xlwt
+  # universal
+  - pytest>=4.0.2
+  - pytest-xdist
+  - isort


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/26591#issuecomment-498040997

This is one option (adding back the specific doc build environment yml file), another option would be to actually update the main `environment.yaml` file to be suitable for the doc build. 
At the moment, my preference is to add back the separate yml file because 1) those additional dependencies are not necessarily needed for a dev env setup, and just makes that env even more heavy and 2) we might want to pin to certain versions from time to time for the doc build (eg we should consider pinning sphinx to < 2.0, which is not necessarily needed for all contributors to do as well).

Another thing is that this env could actually use an update (eg python 3.6 -> 3.7)

cc @datapythonista 
