### PR TITLE
fixes #26622: pd.MultiIndex.isin should fail when input args are too short

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -82,7 +82,6 @@ Other Enhancements
 - :meth:`DataFrame.query` and :meth:`DataFrame.eval` now supports quoting column names with backticks to refer to names with spaces (:issue:`6508`)
 - :func:`merge_asof` now gives a more clear error message when merge keys are categoricals that are not equal (:issue:`26136`)
 - :meth:`pandas.core.window.Rolling` supports exponential (or Poisson) window type (:issue:`21303`)
-- :meth:`MultiIndex.isin` now fails when args are too short (:issue:`26622`)
 -
 
 .. _whatsnew_0250.api_breaking:
@@ -609,6 +608,7 @@ MultiIndex
 ^^^^^^^^^^
 
 - Bug in which incorrect exception raised by :class:`Timedelta` when testing the membership of :class:`MultiIndex` (:issue:`24570`)
+- :meth:`MultiIndex.isin` now raises ``ValueError`` when args are too short (:issue:`26622`)
 -
 
 I/O

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -82,6 +82,7 @@ Other Enhancements
 - :meth:`DataFrame.query` and :meth:`DataFrame.eval` now supports quoting column names with backticks to refer to names with spaces (:issue:`6508`)
 - :func:`merge_asof` now gives a more clear error message when merge keys are categoricals that are not equal (:issue:`26136`)
 - :meth:`pandas.core.window.Rolling` supports exponential (or Poisson) window type (:issue:`21303`)
+- :meth:`MultiIndex.isin` now fails when args are too short (:issue:`26622`)
 -
 
 .. _whatsnew_0250.api_breaking:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -608,7 +608,7 @@ MultiIndex
 ^^^^^^^^^^
 
 - Bug in which incorrect exception raised by :class:`Timedelta` when testing the membership of :class:`MultiIndex` (:issue:`24570`)
-- :meth:`MultiIndex.isin` now raises ``ValueError`` when args are too short (:issue:`26622`)
+- :meth:`MultiIndex.isin` now raises ``ValueError`` when items in values are not the same length as the number of levels in the MultiIndex (:issue:`26622`)
 -
 
 I/O

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3176,11 +3176,11 @@ class MultiIndex(Index):
     def isin(self, values, level=None):
         if level is None:
             # validate value length
-            levcount = len(self.levels)
+            levcnt = len(self.levels)
             for val in values:
-                if len(val) != levcount:
+                if len(val) != levcnt:
                     raise ValueError('Value length must be equal to count of '
-                                     'levels. len(%s) != %d' % (val, levcount))
+                                     'levels. len(%s) != %d' % (val, levcnt))
 
             values = MultiIndex.from_tuples(values,
                                             names=self.names).values

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3176,11 +3176,11 @@ class MultiIndex(Index):
     def isin(self, values, level=None):
         if level is None:
             # validate value length
-            levcnt = len(self.levels)
+            nlvl = len(self.levels)
             for val in values:
-                if len(val) != levcnt:
+                if len(val) != nlvl:
                     raise ValueError('Value length must be equal to count of '
-                                     'levels. len(%s) != %d' % (val, levcnt))
+                                     'levels. len({}) != {}'.format(val, nlvl))
 
             values = MultiIndex.from_tuples(values,
                                             names=self.names).values

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3179,8 +3179,9 @@ class MultiIndex(Index):
             nlvl = len(self.levels)
             for val in values:
                 if len(val) != nlvl:
-                    raise ValueError('Value length must be equal to count of '
-                                     'levels. len({}) != {}'.format(val, nlvl))
+                    raise ValueError('Length of each element in values must '
+                                     'match number of levels in MultiIndex. '
+                                     'len({}) != {}'.format(val, nlvl))
 
             values = MultiIndex.from_tuples(values,
                                             names=self.names).values

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3175,6 +3175,13 @@ class MultiIndex(Index):
     @Appender(Index.isin.__doc__)
     def isin(self, values, level=None):
         if level is None:
+            # validate value length
+            levcount = len(self.levels)
+            for val in values:
+                if len(val) != levcount:
+                    raise ValueError('Value length must be equal to count of '
+                                     'levels. len(%s) != %d' % (val, levcount))
+
             values = MultiIndex.from_tuples(values,
                                             names=self.names).values
             return algos.isin(self.values, values)

--- a/pandas/tests/indexes/multi/test_contains.py
+++ b/pandas/tests/indexes/multi/test_contains.py
@@ -1,10 +1,12 @@
+import re
+
 import numpy as np
 import pytest
-import re
+
+from pandas.compat import PYPY
 
 import pandas as pd
 from pandas import MultiIndex
-from pandas.compat import PYPY
 import pandas.util.testing as tm
 
 

--- a/pandas/tests/indexes/multi/test_contains.py
+++ b/pandas/tests/indexes/multi/test_contains.py
@@ -58,19 +58,19 @@ def test_isin():
     assert len(result) == 0
     assert result.dtype == np.bool_
 
-    msg_tmpl = 'Value length must be equal to count of levels. len(%s) != %d'
-    levcnt = len(idx.levels)
+    msg_tmpl = 'Value length must be equal to count of levels. len({}) != {}'
+    nlvl = len(idx.levels)
 
     # some values too short
     vals_short = [('foo',), ('bar', 3), ('quux',)]
-    msg = re.escape(msg_tmpl % (vals_short[0], levcnt))
+    msg = re.escape(msg_tmpl.format(vals_short[0], nlvl))
 
     with pytest.raises(ValueError, match=msg):
         idx.isin(vals_short)
 
     # some values too long
     vals_long = [('foo', 2), ('bar', 3, 2), ('quux', 4)]
-    msg = re.escape(msg_tmpl % (vals_long[1], levcnt))
+    msg = re.escape(msg_tmpl.format(vals_long[1], nlvl))
 
     with pytest.raises(ValueError, match=msg):
         idx.isin(vals_long)

--- a/pandas/tests/indexes/multi/test_contains.py
+++ b/pandas/tests/indexes/multi/test_contains.py
@@ -70,7 +70,8 @@ def test_isin_values_raises(values, expected_badix):
     ])
 
     nlvl = len(idx.levels)
-    msg = re.escape('Value length must be equal to count of levels. '
+    msg = re.escape('Length of each element in values must '
+                    'match number of levels in MultiIndex. '
                     'len({}) != {}'.format(values[expected_badix], nlvl))
 
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/indexes/multi/test_contains.py
+++ b/pandas/tests/indexes/multi/test_contains.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import re
 
 from pandas.compat import PYPY
 
@@ -57,6 +58,22 @@ def test_isin():
     assert len(result) == 0
     assert result.dtype == np.bool_
 
+    msg_tmpl = 'Value length must be equal to count of levels. len(%s) != %d'
+    levcnt = len(idx.levels)
+
+    # some values too short
+    vals_short = [('foo',), ('bar', 3), ('quux',)]
+    msg = re.escape(msg_tmpl % (vals_short[0], levcnt))
+
+    with pytest.raises(ValueError, match=msg):
+        idx.isin(vals_short)
+
+    # some values too long
+    vals_long = [('foo', 2), ('bar', 3, 2), ('quux', 4)]
+    msg = re.escape(msg_tmpl % (vals_long[1], levcnt))
+
+    with pytest.raises(ValueError, match=msg):
+        idx.isin(vals_long)
 
 @pytest.mark.skipif(PYPY, reason="tuples cmp recursively on PyPy")
 def test_isin_nan_not_pypy():

--- a/pandas/tests/indexes/multi/test_contains.py
+++ b/pandas/tests/indexes/multi/test_contains.py
@@ -75,6 +75,7 @@ def test_isin():
     with pytest.raises(ValueError, match=msg):
         idx.isin(vals_long)
 
+
 @pytest.mark.skipif(PYPY, reason="tuples cmp recursively on PyPy")
 def test_isin_nan_not_pypy():
     idx = MultiIndex.from_arrays([['foo', 'bar'], [1.0, np.nan]])

--- a/pandas/tests/indexes/multi/test_contains.py
+++ b/pandas/tests/indexes/multi/test_contains.py
@@ -60,19 +60,20 @@ def test_isin():
     assert result.dtype == np.bool_
 
 
-@pytest.mark.parametrize('values, expected_badix',
-                         [([('foo',), ('bar', 3), ('quux',)], 0),
-                          ([('foo', 2), ('bar', 3, 2), ('quux', 4)], 1)])
-def test_isin_values_raises(values, expected_badix):
+@pytest.mark.parametrize('values, expected_msg',
+                         [([('foo',), ('bar', 3), ('quux',)],
+                           "len(('foo',)) != 2"),
+                          ([('foo', 2), ('bar', 3, 2), ('quux', 4)],
+                           "len(('bar', 3, 2)) != 2")])
+def test_isin_bad_values_raises(values, expected_msg):
     idx = MultiIndex.from_arrays([
         ['qux', 'baz', 'foo', 'bar'],
         np.arange(4)
     ])
 
-    nlvl = len(idx.levels)
     msg = re.escape('Length of each element in values must '
                     'match number of levels in MultiIndex. '
-                    'len({}) != {}'.format(values[expected_badix], nlvl))
+                    + expected_msg)
 
     with pytest.raises(ValueError, match=msg):
         idx.isin(values)

--- a/pandas/tests/indexes/multi/test_contains.py
+++ b/pandas/tests/indexes/multi/test_contains.py
@@ -2,10 +2,9 @@ import numpy as np
 import pytest
 import re
 
-from pandas.compat import PYPY
-
 import pandas as pd
 from pandas import MultiIndex
+from pandas.compat import PYPY
 import pandas.util.testing as tm
 
 
@@ -58,22 +57,24 @@ def test_isin():
     assert len(result) == 0
     assert result.dtype == np.bool_
 
-    msg_tmpl = 'Value length must be equal to count of levels. len({}) != {}'
+
+@pytest.mark.parametrize(['values', 'badix'],
+                         [([('foo',), ('bar', 3), ('quux',)], 0),
+                          ([('foo', 2), ('bar', 3, 2), ('quux', 4)], 1)])
+def test_isin_values_raises(values, badix):
+    print(values)
+    print(badix)
+    idx = MultiIndex.from_arrays([
+        ['qux', 'baz', 'foo', 'bar'],
+        np.arange(4)
+    ])
+
     nlvl = len(idx.levels)
-
-    # some values too short
-    vals_short = [('foo',), ('bar', 3), ('quux',)]
-    msg = re.escape(msg_tmpl.format(vals_short[0], nlvl))
+    msg = re.escape('Value length must be equal to count of levels. '
+                    'len({}) != {}'.format(values[badix], nlvl))
 
     with pytest.raises(ValueError, match=msg):
-        idx.isin(vals_short)
-
-    # some values too long
-    vals_long = [('foo', 2), ('bar', 3, 2), ('quux', 4)]
-    msg = re.escape(msg_tmpl.format(vals_long[1], nlvl))
-
-    with pytest.raises(ValueError, match=msg):
-        idx.isin(vals_long)
+        idx.isin(values)
 
 
 @pytest.mark.skipif(PYPY, reason="tuples cmp recursively on PyPy")

--- a/pandas/tests/indexes/multi/test_contains.py
+++ b/pandas/tests/indexes/multi/test_contains.py
@@ -60,12 +60,10 @@ def test_isin():
     assert result.dtype == np.bool_
 
 
-@pytest.mark.parametrize(['values', 'badix'],
+@pytest.mark.parametrize('values, expected_badix',
                          [([('foo',), ('bar', 3), ('quux',)], 0),
                           ([('foo', 2), ('bar', 3, 2), ('quux', 4)], 1)])
-def test_isin_values_raises(values, badix):
-    print(values)
-    print(badix)
+def test_isin_values_raises(values, expected_badix):
     idx = MultiIndex.from_arrays([
         ['qux', 'baz', 'foo', 'bar'],
         np.arange(4)
@@ -73,7 +71,7 @@ def test_isin_values_raises(values, badix):
 
     nlvl = len(idx.levels)
     msg = re.escape('Value length must be equal to count of levels. '
-                    'len({}) != {}'.format(values[badix], nlvl))
+                    'len({}) != {}'.format(values[expected_badix], nlvl))
 
     with pytest.raises(ValueError, match=msg):
         idx.isin(values)


### PR DESCRIPTION
- [x] closes #26622
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This fixes #26622 by making `pd.MultiIndex.isin` fail when input args are too short, as well as when they are too long (the current behavior). It also replaces existing error message with something a little bit clearly and more directly related to `isin` and its parameters.

Currently, `isin` does some validation by [constructing a new `MultiIndex` and then taking its `values`](https://github.com/pandas-dev/pandas/blob/addc5fcd95064b765d4ee4260304d44822fdee3b/pandas/core/indexes/multi.py#L3178):

    values = MultiIndex.from_tuples(values, names=self.names).values

Though the code I wrote should handle all validation relating to the length of the elements of `values`, I left this line in since I was unsure if it was validating/fixing anything else. Does anyone know if that line is safe to remove now?