### PR TITLE
Unpin pytest

### DIFF
--- a/ci/deps/azure-35-compat.yaml
+++ b/ci/deps/azure-35-compat.yaml
@@ -26,5 +26,5 @@ dependencies:
   - pip
   - pip:
     # for python 3.5, pytest>=4.0.2 is not available in conda
-    - pytest>=4.6.1
+    - pytest>=4.6.2
     - html5lib==1.0b2

--- a/ci/deps/azure-35-compat.yaml
+++ b/ci/deps/azure-35-compat.yaml
@@ -26,5 +26,5 @@ dependencies:
   - pip
   - pip:
     # for python 3.5, pytest>=4.0.2 is not available in conda
-    - pytest==4.5.0
+    - pytest>=4.6.1
     - html5lib==1.0b2

--- a/ci/deps/azure-macos-35.yaml
+++ b/ci/deps/azure-macos-35.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pip:
     - python-dateutil==2.5.3
     # universal
-    - pytest>=4.6.1
+    - pytest>=4.6.2
     - pytest-xdist
     - pytest-mock
     - hypothesis>=3.58.0

--- a/ci/deps/azure-macos-35.yaml
+++ b/ci/deps/azure-macos-35.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pip:
     - python-dateutil==2.5.3
     # universal
-    - pytest==4.5.0
+    - pytest>=4.6.1
     - pytest-xdist
     - pytest-mock
     - hypothesis>=3.58.0


### PR DESCRIPTION
Follow up from #26619. Since pytest have just done a point release for 4.6.1 we should be good to remove the pin.

https://github.com/pytest-dev/pytest/issues/5358

cc @simonjayhawkins 