### PR TITLE
CLN/API: clean-up of level argument of isin for indexes

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4649,7 +4649,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return Index(new_values, **attributes)
 
-    def isin(self, values, level=None):
+    def isin(self, values):
         """
         Return a boolean array where the index values are in `values`.
 
@@ -4674,6 +4674,11 @@ class Index(IndexOpsMixin, PandasObject):
         -------
         is_contained : ndarray
             NumPy array of boolean values.
+
+        Raises
+        ------
+        TypeError
+            If `level` is passed and the index is not a `MultiIndex`.
 
         See Also
         --------
@@ -4733,8 +4738,6 @@ class Index(IndexOpsMixin, PandasObject):
         >>> dti.isin(['2000-03-11'])
         array([ True, False, False])
         """
-        if level is not None:
-            self._validate_index_level(level)
         return algos.isin(self, values)
 
     def _get_string_slice(self, key, use_lhs=True, use_rhs=True):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -509,19 +509,8 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
 
         cls.__rsub__ = __rsub__
 
-    def isin(self, values, level=None):
-        """
-        Compute boolean array of whether each index value is found in the
-        passed set of values.
-
-        Parameters
-        ----------
-        values : set or sequence of values
-
-        Returns
-        -------
-        is_contained : ndarray (boolean dtype)
-        """
+    @Appender(Index.isin.__doc__)
+    def isin(self, values):
         if not isinstance(values, type(self)):
             try:
                 values = type(self)(values)

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -442,9 +442,7 @@ class Float64Index(NumericIndex):
         return super().is_unique and self._nan_idxs.size < 2
 
     @Appender(Index.isin.__doc__)
-    def isin(self, values, level=None):
-        if level is not None:
-            self._validate_index_level(level)
+    def isin(self, values):
         return algorithms.isin(np.array(self), values)
 
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1776,36 +1776,25 @@ class TestIndex(Base):
         tm.assert_numpy_array_equal(Float64Index([1.0, nulls_fixture]).isin(
             [pd.NaT]), np.array([False, False]))
 
-    @pytest.mark.parametrize("level", [0, -1])
     @pytest.mark.parametrize("index", [
         Index(['qux', 'baz', 'foo', 'bar']),
         # Float64Index overrides isin, so must be checked separately
         Float64Index([1.0, 2.0, 3.0, 4.0])])
-    def test_isin_level_kwarg(self, level, index):
+    def test_isin_nonexisting(self, index):
         values = index.tolist()[-2:] + ['nonexisting']
 
         expected = np.array([False, False, True, True])
-        tm.assert_numpy_array_equal(expected, index.isin(values, level=level))
+        tm.assert_numpy_array_equal(expected, index.isin(values))
 
-        index.name = 'foobar'
-        tm.assert_numpy_array_equal(expected,
-                                    index.isin(values, level='foobar'))
-
-    @pytest.mark.parametrize("level", [1, 10, -2])
+    @pytest.mark.parametrize("level", [
+        1, 10, -2, 1.0, 'foobar', 'xyzzy', np.nan])
     @pytest.mark.parametrize("index", [
         Index(['qux', 'baz', 'foo', 'bar']),
         # Float64Index overrides isin, so must be checked separately
         Float64Index([1.0, 2.0, 3.0, 4.0])])
-    def test_isin_level_kwarg_raises_bad_index(self, level, index):
-        with pytest.raises(IndexError, match='Too many levels'):
-            index.isin([], level=level)
-
-    @pytest.mark.parametrize("level", [1.0, 'foobar', 'xyzzy', np.nan])
-    @pytest.mark.parametrize("index", [
-        Index(['qux', 'baz', 'foo', 'bar']),
-        Float64Index([1.0, 2.0, 3.0, 4.0])])
-    def test_isin_level_kwarg_raises_key(self, level, index):
-        with pytest.raises(KeyError, match='must be same as name'):
+    def test_isin_level_kwarg_raises(self, level, index):
+        msg = r"isin\(\) got an unexpected keyword argument 'level'"
+        with pytest.raises(TypeError, match=msg):
             index.isin([], level=level)
 
     @pytest.mark.parametrize("empty", [[], Series(), np.array([])])


### PR DESCRIPTION
The docstring for Index.isin() states:

```
        level : str or int, optional
            Name or position of the index level to use (if the index is a
            `MultiIndex`).
```

But the keyword is accepted by the other indexes, validated and raises if the level parameter does not match the only level in the index.

This PR removes the levels argument from the indexes (except MultiIndex)

Series.isin() and DataFrame.isin() do not have a level parameter, so isin for indexes will be consistent.

The implementation for MultiIndex.isin is independent from Index.isin, so i think that a separate docstring for MultiIndex would be much clearer. (but out of scope for this PR)

The docstring for datetimelike indexes does not include the level parameter but is not part of the published api, so has been removed to avoid confusion.

NOTE: This is not a change to the api, but a clean-up to match the api to the published api.