### PR TITLE
Remove NDFrame.select

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -204,7 +204,6 @@ Reindexing / Selection / Label manipulation
    DataFrame.rename_axis
    DataFrame.reset_index
    DataFrame.sample
-   DataFrame.select
    DataFrame.set_axis
    DataFrame.set_index
    DataFrame.tail

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -211,7 +211,6 @@ Reindexing / Selection / Label manipulation
    Series.rename_axis
    Series.reset_index
    Series.sample
-   Series.select
    Series.set_axis
    Series.take
    Series.tail

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -485,6 +485,7 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``parse_cols`` keyword in :func:`read_excel` (:issue:`16488`)
 - Removed the previously deprecated ``pd.options.html.border`` (:issue:`16970`)
 - Removed the previously deprecated ``convert_objects`` (:issue:`11221`)
+- Removed the previously deprecated ``select`` method of ``DataFrame`` and ``Series`` (:issue:`17633`)
 
 .. _whatsnew_0250.performance:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3682,40 +3682,6 @@ class NDFrame(PandasObject, SelectionMixin):
 
     _xs = xs  # type: Callable
 
-    def select(self, crit, axis=0):
-        """
-        Return data corresponding to axis labels matching criteria.
-
-        .. deprecated:: 0.21.0
-            Use df.loc[df.index.map(crit)] to select via labels
-
-        Parameters
-        ----------
-        crit : function
-            To be called on each index (label). Should return True or False
-        axis : int
-
-        Returns
-        -------
-        selection : same type as caller
-        """
-        warnings.warn("'select' is deprecated and will be removed in a "
-                      "future release. You can use "
-                      ".loc[labels.map(crit)] as a replacement",
-                      FutureWarning, stacklevel=2)
-
-        axis = self._get_axis_number(axis)
-        axis_name = self._get_axis_name(axis)
-        axis_values = self._get_axis(axis)
-
-        if len(axis_values) > 0:
-            new_axis = axis_values[
-                np.asarray([bool(crit(label)) for label in axis_values])]
-        else:
-            new_axis = axis_values
-
-        return self.reindex(**{axis_name: new_axis})
-
     def reindex_like(self, other, method=None, copy=True, limit=None,
                      tolerance=None):
         """

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -895,41 +895,6 @@ class TestDataFrameSelectReindex(TestData):
         result = empty.filter(like='foo')
         assert_frame_equal(result, empty)
 
-    def test_select(self):
-
-        # deprecated: gh-12410
-        f = lambda x: x.weekday() == 2
-        index = self.tsframe.index[[f(x) for x in self.tsframe.index]]
-        expected_weekdays = self.tsframe.reindex(index=index)
-
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            result = self.tsframe.select(f, axis=0)
-            assert_frame_equal(result, expected_weekdays)
-
-            result = self.frame.select(lambda x: x in ('B', 'D'), axis=1)
-            expected = self.frame.reindex(columns=['B', 'D'])
-            assert_frame_equal(result, expected, check_names=False)
-
-        # replacement
-        f = lambda x: x.weekday == 2
-        result = self.tsframe.loc(axis=0)[f(self.tsframe.index)]
-        assert_frame_equal(result, expected_weekdays)
-
-        crit = lambda x: x in ['B', 'D']
-        result = self.frame.loc(axis=1)[(self.frame.columns.map(crit))]
-        expected = self.frame.reindex(columns=['B', 'D'])
-        assert_frame_equal(result, expected, check_names=False)
-
-        # doc example
-        df = DataFrame({'A': [1, 2, 3]}, index=['foo', 'bar', 'baz'])
-
-        crit = lambda x: x in ['bar', 'baz']
-        with tm.assert_produces_warning(FutureWarning):
-            expected = df.select(crit)
-        result = df.loc[df.index.map(crit)]
-        assert_frame_equal(result, expected, check_names=False)
-
     def test_take(self):
         # homogeneous
         order = [3, 1, 2, 0]

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -772,20 +772,6 @@ miscellaneous methods
 """
 
 
-def test_select(test_data):
-    # deprecated: gh-12410
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        n = len(test_data.ts)
-        result = test_data.ts.select(lambda x: x >= test_data.ts.index[n // 2])
-        expected = test_data.ts.reindex(test_data.ts.index[n // 2:])
-        assert_series_equal(result, expected)
-
-        result = test_data.ts.select(lambda x: x.weekday() == 2)
-        expected = test_data.ts[test_data.ts.index.weekday == 2]
-        assert_series_equal(result, expected)
-
-
 def test_pop():
     # GH 6600
     df = DataFrame({'A': 0, 'B': np.arange(5, dtype='int64'), 'C': 0, })


### PR DESCRIPTION
- [x] xref #17633
- [x] whatsnew entry

Removes ``NDFrame.select``, that was deprecated in 0.21.