### PR TITLE
catch iterator input in io.json.json_normalize

### DIFF
--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -189,6 +189,9 @@ def json_normalize(data, record_path=None, meta=None,
             result = result[spec]
 
         return result
+    
+    if data is iter(data):
+        raise ValueError("Argument data should be a dict or list of dicts, not an iterator")
 
     if isinstance(data, list) and not data:
         return DataFrame()

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -189,9 +189,10 @@ def json_normalize(data, record_path=None, meta=None,
             result = result[spec]
 
         return result
-    
+
     if data is iter(data):
-        raise ValueError("Argument data should be a dict or list of dicts, not an iterator")
+        raise ValueError("Argument data should be a dict or a list "
+                         "of dicts, not an iterator")
 
     if isinstance(data, list) and not data:
         return DataFrame()


### PR DESCRIPTION
The data argument in json_normalize should be an dictionary or list of dictionaries. If an iterator is passed, unexpected behavior can occur. In particular, this will result in the loss of the first row. See https://stackoverflow.com/questions/56362810/missing-first-document-when-loading-multi-document-yaml-file-in-pandas-dataframe.

In my proposal, an error is thrown. Alternatively, the iterator could be turned into a list:

```
if data is iter(data):
    data = [x for x in data]
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
