### PR TITLE
Allow operator overloading for custom classes to return custom objects

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -2249,7 +2249,7 @@ def _comp_method_FRAME(cls, func, special):
     @Appender('Wrapper for comparison method {name}'.format(name=op_name))
     def f(self, other):
         if hasattr(other, '__pandas_ufunc__'):
-            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            result = other.__pandas_ufunc__(func, '__call__', self, other)
             if result is not NotImplemented:
                 return result
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1667,6 +1667,11 @@ def _arith_method_SERIES(cls, op, special):
             raise
 
     def wrapper(left, right):
+        if hasattr(right, '__pandas_ufunc__'):
+            result = right.__pandas_ufunc__(op, '__call__', left, right)
+            if result is not NotImplemented:
+                return result
+
         if isinstance(right, ABCDataFrame):
             return NotImplemented
 
@@ -1791,6 +1796,11 @@ def _comp_method_SERIES(cls, op, special):
         return result
 
     def wrapper(self, other, axis=None):
+        if hasattr(other, '__pandas_ufunc__'):
+            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            if result is not NotImplemented:
+                return result
+
         # Validate the axis parameter
         if axis is not None:
             self._get_axis_number(axis)
@@ -1948,6 +1958,11 @@ def _bool_method_SERIES(cls, op, special):
     fill_bool = lambda x: x.fillna(False).astype(bool)
 
     def wrapper(self, other):
+        if hasattr(other, '__pandas_ufunc__'):
+            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            if result is not NotImplemented:
+                return result
+
         is_self_int_dtype = is_integer_dtype(self.dtype)
 
         self, other = _align_method_SERIES(self, other, align_asobject=True)
@@ -1996,6 +2011,11 @@ def _flex_method_SERIES(cls, op, special):
 
     @Appender(doc)
     def flex_wrapper(self, other, level=None, fill_value=None, axis=0):
+        if hasattr(other, '__pandas_ufunc__'):
+            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            if result is not NotImplemented:
+                return result
+
         # validate axis
         if axis is not None:
             self._get_axis_number(axis)
@@ -2147,6 +2167,10 @@ def _arith_method_FRAME(cls, op, special):
 
     @Appender(doc)
     def f(self, other, axis=default_axis, level=None, fill_value=None):
+        if hasattr(other, '__pandas_ufunc__'):
+            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            if result is not NotImplemented:
+                return result
 
         other = _align_method_FRAME(self, other, axis)
 
@@ -2191,6 +2215,10 @@ def _flex_comp_method_FRAME(cls, op, special):
 
     @Appender(doc)
     def f(self, other, axis=default_axis, level=None):
+        if hasattr(other, '__pandas_ufunc__'):
+            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            if result is not NotImplemented:
+                return result
 
         other = _align_method_FRAME(self, other, axis)
 
@@ -2220,6 +2248,10 @@ def _comp_method_FRAME(cls, func, special):
 
     @Appender('Wrapper for comparison method {name}'.format(name=op_name))
     def f(self, other):
+        if hasattr(other, '__pandas_ufunc__'):
+            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            if result is not NotImplemented:
+                return result
 
         other = _align_method_FRAME(self, other, axis=None)
 
@@ -2290,6 +2322,11 @@ def _arith_method_SPARSE_SERIES(cls, op, special):
     op_name = _get_op_name(op, special)
 
     def wrapper(self, other):
+        if hasattr(other, '__pandas_ufunc__'):
+            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            if result is not NotImplemented:
+                return result
+
         if isinstance(other, ABCDataFrame):
             return NotImplemented
         elif isinstance(other, ABCSeries):
@@ -2331,6 +2368,11 @@ def _arith_method_SPARSE_ARRAY(cls, op, special):
     def wrapper(self, other):
         from pandas.core.arrays.sparse.array import (
             SparseArray, _sparse_array_op, _wrap_result, _get_fill)
+        if hasattr(other, '__pandas_ufunc__'):
+            result = other.__pandas_ufunc__(op, '__call__', self, other)
+            if result is not NotImplemented:
+                return result
+
         if isinstance(other, np.ndarray):
             if len(self) != len(other):
                 raise AssertionError("length mismatch: {self} vs. {other}"

--- a/pandas/tests/extension/test_ufunc.py
+++ b/pandas/tests/extension/test_ufunc.py
@@ -16,4 +16,4 @@ def test_ufunc_implemented():
 
 def test_ufunc_not_implemented():
     with pytest.raises(AssertionError):
-        pd.DataFrame() + CustomOperatorOverload()
+        pd.DataFrame() * CustomOperatorOverload()

--- a/pandas/tests/extension/test_ufunc.py
+++ b/pandas/tests/extension/test_ufunc.py
@@ -22,4 +22,4 @@ def test_ufunc_implemented():
 def test_ufunc_not_implemented():
     df = pd.DataFrame({'x': [1, 2]})
     with pytest.raises(AssertionError):
-        result = df * Pipe(lambda x: x + 1)
+        df * Pipe(lambda x: x + 1)

--- a/pandas/tests/extension/test_ufunc.py
+++ b/pandas/tests/extension/test_ufunc.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+import operator
+
+
+class CustomOperatorOverload(object):
+    def __pandas_ufunc__(self, func, method, *args, **kwargs):
+        if func == operator.add:
+            return 5
+        return NotImplemented
+
+
+def test_ufunc_implemented():
+    assert pd.DataFrame() + CustomOperatorOverload() == 5
+
+
+def test_ufunc_not_implemented():
+    with pytest.raises(AssertionError):
+        pd.DataFrame() + CustomOperatorOverload()

--- a/pandas/tests/extension/test_ufunc.py
+++ b/pandas/tests/extension/test_ufunc.py
@@ -11,9 +11,9 @@ class CustomOperatorOverload(object):
 
 
 def test_ufunc_implemented():
-    assert pd.DataFrame() + CustomOperatorOverload() == 5
+    assert pd.DataFrame({'x': [1]}) + CustomOperatorOverload() == 5
 
 
 def test_ufunc_not_implemented():
     with pytest.raises(AssertionError):
-        pd.DataFrame() * CustomOperatorOverload()
+        pd.DataFrame({'x': [1]}) * CustomOperatorOverload()

--- a/pandas/tests/extension/test_ufunc.py
+++ b/pandas/tests/extension/test_ufunc.py
@@ -3,17 +3,23 @@ import pytest
 import operator
 
 
-class CustomOperatorOverload(object):
+class Pipe:
+    def __init__(self, function):
+        self.function = function
+
     def __pandas_ufunc__(self, func, method, *args, **kwargs):
-        if func == operator.add:
-            return 5
+        if func == operator.__or__:
+            return self.function(args[0])
         return NotImplemented
 
 
 def test_ufunc_implemented():
-    assert pd.DataFrame({'x': [1]}) + CustomOperatorOverload() == 5
+    df = pd.DataFrame({'x': [1, 2]})
+    result = df | Pipe(lambda x: x + 1)
+    assert result.equals(df + 1)
 
 
 def test_ufunc_not_implemented():
+    df = pd.DataFrame({'x': [1, 2]})
     with pytest.raises(AssertionError):
-        pd.DataFrame({'x': [1]}) * CustomOperatorOverload()
+        result = df * Pipe(lambda x: x + 1)

--- a/pandas/tests/extension/test_ufunc.py
+++ b/pandas/tests/extension/test_ufunc.py
@@ -1,6 +1,8 @@
-import pandas as pd
-import pytest
 import operator
+
+import pytest
+
+import pandas as pd
 
 
 class Pipe:


### PR DESCRIPTION
Uses a similar convention as numpy's ufunc overriding mechanism (https://docs.scipy.org/doc/numpy-1.13.0/neps/ufunc-overrides.html) to fix #22255

- [x] closes #22255
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
