### PR TITLE
DEPR: Deprecate NDFrame.swapaxes

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -478,6 +478,8 @@ Other Deprecations
 - The :meth:`DataFrame.compound` and :meth:`Series.compound` methods are deprecated and will be removed in a future version (:issue:`26405`).
 - The internal attributes ``_start``, ``_stop`` and ``_step`` attributes of :class:`RangeIndex` have been deprecated.
   Use the public attributes :attr:`~RangeIndex.start`, :attr:`~RangeIndex.stop` and :attr:`~RangeIndex.step` instead (:issue:`26581`).
+- The :meth:`DataFrame.swapaxes` and :meth:`Series.swapaxes` methods are deprecated and will be removed in a future version.
+  Use :meth:`DataFrame.transpose` and :meth:`Series.transpose` instead(:issue:`26654`).
 
 
 .. _whatsnew_0250.prior_deprecations:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -479,7 +479,7 @@ Other Deprecations
 - The internal attributes ``_start``, ``_stop`` and ``_step`` attributes of :class:`RangeIndex` have been deprecated.
   Use the public attributes :attr:`~RangeIndex.start`, :attr:`~RangeIndex.stop` and :attr:`~RangeIndex.step` instead (:issue:`26581`).
 - The :meth:`DataFrame.swapaxes` and :meth:`Series.swapaxes` methods are deprecated and will be removed in a future version.
-  Use :meth:`DataFrame.transpose` and :meth:`Series.transpose` instead(:issue:`26654`).
+  Use :meth:`DataFrame.transpose` and :meth:`Series.transpose` instead (:issue:`26654`).
 
 
 .. _whatsnew_0250.prior_deprecations:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -695,10 +695,17 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Interchange axes and swap values axes appropriately.
 
+        .. deprecated:: 0.25.0
+            Use ``.T`` or ``.transpose()`` instead.
+
         Returns
         -------
         y : same as input
         """
+        warnings.warn("{obj}.swapaxes is deprecated and will be removed "
+                      "in a future version. Use {obj}.T or {obj}.transpose() "
+                      "instead".format(obj=type(self).__name__),
+                      FutureWarning, stacklevel=2)
         i = self._get_axis_number(axis1)
         j = self._get_axis_number(axis2)
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -468,14 +468,14 @@ class BaseGrouper:
         arity = self._cython_arity.get(how, 1)
 
         vdim = values.ndim
-        swapped = False
+        transposed = False
         if vdim == 1:
             values = values[:, None]
             out_shape = (self.ngroups, arity)
         else:
             if axis > 0:
-                swapped = True
-                values = values.swapaxes(0, axis)
+                transposed = True
+                values = values.transpose()
             if arity > 1:
                 raise NotImplementedError("arity of more than 1 is not "
                                           "supported for the 'how' argument")
@@ -567,8 +567,8 @@ class BaseGrouper:
         else:
             names = None
 
-        if swapped:
-            result = result.swapaxes(0, axis)
+        if transposed:
+            result = result.transpose()
 
         return result, names
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1350,6 +1350,7 @@ class Block(PandasObject):
         # might need to separate out blocks
         axis = cond.ndim - 1
         cond = cond.swapaxes(axis, 0)
+
         mask = np.array([cond[i].all() for i in range(cond.shape[0])],
                         dtype=bool)
 

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -363,15 +363,13 @@ class SharedWithSparse:
         for col, s in mixed_T.items():
             assert s.dtype == np.object_
 
-    def test_swapaxes(self):
+    def test_swapaxes_deprecated(self):
         df = self.klass(np.random.randn(10, 5))
-        self._assert_frame_equal(df.T, df.swapaxes(0, 1))
-        self._assert_frame_equal(df.T, df.swapaxes(1, 0))
-        self._assert_frame_equal(df, df.swapaxes(0, 0))
-        msg = ("No axis named 2 for object type"
-               r" <class 'pandas.core(.sparse)?.frame.(Sparse)?DataFrame'>")
-        with pytest.raises(ValueError, match=msg):
-            df.swapaxes(2, 5)
+
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            swapped = df.swapaxes(0, 1)
+
+        tm.assert_frame_equal(swapped, df.T)
 
     def test_axis_aliases(self, float_frame):
         f = float_frame

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -431,7 +431,7 @@ class Generic:
 
     def test_split_compat(self):
         # xref GH8846
-        o = self._construct(shape=10)
+        o = self._construct(shape=10).values
         assert len(np.array_split(o, 5)) == 5
         assert len(np.array_split(o, 2)) == 2
 


### PR DESCRIPTION
- [x] xref #18262
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

``.swapaxes`` are not needed, now that ``Panel`` is being removed.