### PR TITLE
Remove redundant check arr_or_dtype is None

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1902,8 +1902,6 @@ def _is_dtype_type(arr_or_dtype, condition):
         if issubclass(arr_or_dtype, ExtensionDtype):
             arr_or_dtype = arr_or_dtype.type
         return condition(np.dtype(arr_or_dtype).type)
-    elif arr_or_dtype is None:
-        return condition(type(None))
 
     # if we have an array-like
     if hasattr(arr_or_dtype, 'dtype'):

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1892,6 +1892,9 @@ def _is_dtype_type(arr_or_dtype, condition):
     bool : if the condition is satisifed for the arr_or_dtype
     """
 
+    if arr_or_dtype is None:
+        return condition(type(None))
+
     # fastpath
     if isinstance(arr_or_dtype, np.dtype):
         return condition(arr_or_dtype.type)
@@ -1899,8 +1902,6 @@ def _is_dtype_type(arr_or_dtype, condition):
         if issubclass(arr_or_dtype, ExtensionDtype):
             arr_or_dtype = arr_or_dtype.type
         return condition(np.dtype(arr_or_dtype).type)
-    elif arr_or_dtype is None:
-        return condition(type(None))
 
     # if we have an array-like
     if hasattr(arr_or_dtype, 'dtype'):

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1901,7 +1901,7 @@ def _is_dtype_type(arr_or_dtype, condition):
         return condition(np.dtype(arr_or_dtype).type)
     elif arr_or_dtype is None:
         return condition(type(None))
-    
+
     # if we have an array-like
     if hasattr(arr_or_dtype, 'dtype'):
         arr_or_dtype = arr_or_dtype.dtype

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1892,9 +1892,6 @@ def _is_dtype_type(arr_or_dtype, condition):
     bool : if the condition is satisifed for the arr_or_dtype
     """
 
-    if arr_or_dtype is None:
-        return condition(type(None))
-
     # fastpath
     if isinstance(arr_or_dtype, np.dtype):
         return condition(arr_or_dtype.type)
@@ -1902,7 +1899,9 @@ def _is_dtype_type(arr_or_dtype, condition):
         if issubclass(arr_or_dtype, ExtensionDtype):
             arr_or_dtype = arr_or_dtype.type
         return condition(np.dtype(arr_or_dtype).type)
-
+    elif arr_or_dtype is None:
+        return condition(type(None))
+    
     # if we have an array-like
     if hasattr(arr_or_dtype, 'dtype'):
         arr_or_dtype = arr_or_dtype.dtype


### PR DESCRIPTION
- [ X ] tests passed
- [ X ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Checking whether `if arr_or_dtype is None` is done in the beginning of the function so the following check is redundant and can be safely removed.

This issue (among a few others) were flagged up by LGTM.com website: https://lgtm.com/projects/g/pandas-dev/pandas/alerts/?mode=tree. Some of the other numerical computing repositories have been analyzed there as well such as [numpy](https://lgtm.com/projects/g/numpy/numpy/alerts/?mode=tree) and [scipy](https://lgtm.com/projects/g/scipy/scipy/alerts/?mode=tree).

If you like, you can use LGTM for automatically reviewing code in pull requests. Here's an example of how Google's AMPHTML use that to flag up security vulnerabilities in their code base: ampproject/amphtml#13060.

(full disclosure: I'm a huge fan of `pandas` and also part of the team that runs LGTM.com)

