### PR TITLE
DEPS: Adding missing doc dependencies to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,10 +17,17 @@ dependencies:
   - flake8-rst>=0.6.0,<=0.7.0
   - gitpython
   - hypothesis>=3.82
+  - ipywidgets
   - isort
   - moto
   - mypy
+  - nbconvert>=5.4.1
+  - nbformat
+  - notebook>=5.7.5
+  - pandoc
   - pycodestyle
+  - pyqt
+  - python-snappy
   - pytest>=4.0.2
   - pytest-mock
   - sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,10 +8,17 @@ flake8-comprehensions
 flake8-rst>=0.6.0,<=0.7.0
 gitpython
 hypothesis>=3.82
+ipywidgets
 isort
 moto
 mypy
+nbconvert>=5.4.1
+nbformat
+notebook>=5.7.5
+pandoc
 pycodestyle
+pyqt
+python-snappy
 pytest>=4.0.2
 pytest-mock
 sphinx


### PR DESCRIPTION
In #26648 we detected that `environment.yml` didn't contain some of the dependencies required to build the documentation. `environment.yml` is what we use to build the documentation locally. Adding them here.

CC: @jorisvandenbossche 
