### PR TITLE
Deprecate Series/Dataframe.to_dense/to_sparse

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1887,6 +1887,8 @@ class DataFrame(NDFrame):
 
     def to_sparse(self, fill_value=None, kind='block'):
         """
+        ..deprecated:: 0.25.0
+        
         Convert to SparseDataFrame.
 
         Implement the sparse version of the DataFrame meaning that any data
@@ -1939,6 +1941,9 @@ class DataFrame(NDFrame):
         >>> type(sdf)  # doctest: +SKIP
         <class 'pandas.core.sparse.frame.SparseDataFrame'>
         """
+        warning_message ="""to_sparse is deprecated and will be removed in a future version"""
+        warnings.warn(warning_message, FutureWarning, stacklevel=2)
+        
         from pandas.core.sparse.api import SparseDataFrame
         return SparseDataFrame(self._series, index=self.index,
                                columns=self.columns, default_kind=kind,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1941,8 +1941,9 @@ class DataFrame(NDFrame):
         >>> type(sdf)  # doctest: +SKIP
         <class 'pandas.core.sparse.frame.SparseDataFrame'>
         """
-        warning_message = """to_sparse is deprecated and will be
-            removed in a future version"""
+        warning_message = """\
+            to_sparse is deprecated and will be removed in a future version
+        """
         warnings.warn(warning_message, FutureWarning, stacklevel=2)
 
         from pandas.core.sparse.api import SparseDataFrame

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1888,7 +1888,7 @@ class DataFrame(NDFrame):
     def to_sparse(self, fill_value=None, kind='block'):
         """
         ..deprecated:: 0.25.0
-        
+
         Convert to SparseDataFrame.
 
         Implement the sparse version of the DataFrame meaning that any data
@@ -1941,9 +1941,10 @@ class DataFrame(NDFrame):
         >>> type(sdf)  # doctest: +SKIP
         <class 'pandas.core.sparse.frame.SparseDataFrame'>
         """
-        warning_message ="""to_sparse is deprecated and will be removed in a future version"""
+        warning_message = """to_sparse is deprecated and will be
+            removed in a future version"""
         warnings.warn(warning_message, FutureWarning, stacklevel=2)
-        
+
         from pandas.core.sparse.api import SparseDataFrame
         return SparseDataFrame(self._series, index=self.index,
                                columns=self.columns, default_kind=kind,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1573,6 +1573,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def to_sparse(self, kind='block', fill_value=None):
         """
+        ..deprecated:: 0.25.0
         Convert Series to SparseSeries.
 
         Parameters
@@ -1586,6 +1587,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         SparseSeries
             Sparse representation of the Series.
         """
+        warning_message ="""to_sparse is deprecated and will be removed in a future version"""
+        warnings.warn(warning_message, FutureWarning, stacklevel=2)
         from pandas.core.sparse.series import SparseSeries
 
         values = SparseArray(self, kind=kind, fill_value=fill_value)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1587,9 +1587,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         SparseSeries
             Sparse representation of the Series.
         """
-        warning_message = """to_sparse is deprecated and
-            will be removed in a future version"""
-        warnings.warn(warning_message, FutureWarning, stacklevel=2)
+
+        warnings.warn("to_sparse is deprecated and will be removed"
+                      "in a future version", FutureWarning, stacklevel=2)
         from pandas.core.sparse.series import SparseSeries
 
         values = SparseArray(self, kind=kind, fill_value=fill_value)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1587,7 +1587,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         SparseSeries
             Sparse representation of the Series.
         """
-        warning_message ="""to_sparse is deprecated and will be removed in a future version"""
+        warning_message = """to_sparse is deprecated and
+            will be removed in a future version"""
         warnings.warn(warning_message, FutureWarning, stacklevel=2)
         from pandas.core.sparse.series import SparseSeries
 

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -281,17 +281,16 @@ class SparseDataFrame(DataFrame):
         ..deprecated:: 0.25.0
         Use Dataframe.sparse.to_dense() instead
         """
-        
-        
-        warning_message ="""to_dense is deprecated and will be removed in a future version
-            
+
+        warning_message = """to_dense is deprecated and will be removed in a future version
+
             Use Dataframe.sparse.to_dense() instead
-            
+
             >>> df = pd.DataFrame({"A": pd.SparseArray([0, 1, 0])})
             >>> df.sparse.to_dense()
             """
         warnings.warn(warning_message, FutureWarning, stacklevel=2)
-        
+
         return SparseFrameAccessor(self).to_dense()
 
     def _apply_columns(self, func):

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -277,6 +277,21 @@ class SparseDataFrame(DataFrame):
 
     @Appender(SparseFrameAccessor.to_dense.__doc__)
     def to_dense(self):
+        """
+        ..deprecated:: 0.25.0
+        Use Dataframe.sparse.to_dense() instead
+        """
+        
+        
+        warning_message ="""to_dense is deprecated and will be removed in a future version
+            
+            Use Dataframe.sparse.to_dense() instead
+            
+            >>> df = pd.DataFrame({"A": pd.SparseArray([0, 1, 0])})
+            >>> df.sparse.to_dense()
+            """
+        warnings.warn(warning_message, FutureWarning, stacklevel=2)
+        
         return SparseFrameAccessor(self).to_dense()
 
     def _apply_columns(self, func):

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -282,7 +282,8 @@ class SparseDataFrame(DataFrame):
         Use Dataframe.sparse.to_dense() instead
         """
 
-        warning_message = """to_dense is deprecated and will be removed in a future version
+        warning_message = """\
+            to_dense is deprecated and will be removed in a future version
 
             Use Dataframe.sparse.to_dense() instead
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -428,6 +428,7 @@ class SparseSeries(Series):
 
     def to_dense(self):
         """
+            
         ..deprecated:: 0.25.0
         Convert SparseSeries to a Series.
         Returns

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -428,12 +428,15 @@ class SparseSeries(Series):
 
     def to_dense(self):
         """
+        ..deprecated:: 0.25.0
         Convert SparseSeries to a Series.
-
         Returns
         -------
         s : Series
         """
+        warning_message ="""to_dense is deprecated and will be removed in a future version"""
+        warnings.warn(warning_message, FutureWarning, stacklevel=2)
+                
         return Series(self.values.to_dense(), index=self.index,
                       name=self.name)
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -428,16 +428,17 @@ class SparseSeries(Series):
 
     def to_dense(self):
         """
-            
+
         ..deprecated:: 0.25.0
         Convert SparseSeries to a Series.
         Returns
         -------
         s : Series
         """
-        warning_message ="""to_dense is deprecated and will be removed in a future version"""
+        warning_message = """to_dense is deprecated and will be
+            removed in a future version"""
         warnings.warn(warning_message, FutureWarning, stacklevel=2)
-                
+
         return Series(self.values.to_dense(), index=self.index,
                       name=self.name)
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -435,9 +435,8 @@ class SparseSeries(Series):
         -------
         s : Series
         """
-        warning_message = """to_dense is deprecated and will be
-            removed in a future version"""
-        warnings.warn(warning_message, FutureWarning, stacklevel=2)
+        warnings.warn("to_dense is deprecated and will be removed"
+                      "in a future version", FutureWarning, stacklevel=2)
 
         return Series(self.values.to_dense(), index=self.index,
                       name=self.name)


### PR DESCRIPTION
- [x] closes #26557 
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Marks the methods mentioned in #26557 as deprecated, with proper messages. 