### PR TITLE
DEPS: Using cpplint from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,8 +22,7 @@ dependencies:
   - isort  # check that imports are in the right order
   - mypy
   - pycodestyle  # used by flake8
-  - pip:
-    - cpplint
+  - cpplint
 
   # documentation
   - gitpython  # obtain contributors from git for whatsnew

--- a/environment.yml
+++ b/environment.yml
@@ -16,13 +16,13 @@ dependencies:
   - cython>=0.28.2
 
   # code checks
+  - cpplint
   - flake8
   - flake8-comprehensions  # used by flake8, linting of unnecessary comprehensions
   - flake8-rst>=0.6.0,<=0.7.0  # linting of code blocks in rst files
   - isort  # check that imports are in the right order
   - mypy
   - pycodestyle  # used by flake8
-  - cpplint
 
   # documentation
   - gitpython  # obtain contributors from git for whatsnew

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,13 +3,13 @@ python-dateutil>=2.5.0
 pytz
 asv
 cython>=0.28.2
+cpplint
 flake8
 flake8-comprehensions
 flake8-rst>=0.6.0,<=0.7.0
 isort
 mypy
 pycodestyle
-cpplint
 gitpython
 sphinx
 numpydoc>=0.9.0


### PR DESCRIPTION
Follow up of #26691. `cpplint` was installed from pip, but it's now available in conda-forge.

CC: @TomAugspurger 