### PR TITLE
DOC: Not running clipboard examples in the doc

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3249,11 +3249,12 @@ And then import the data directly to a ``DataFrame`` by calling:
 
 .. code-block:: python
 
-   clipdf = pd.read_clipboard()
-
-.. ipython:: python
-
-   clipdf
+    >>> clipdf = pd.read_clipboard()
+    >>> clipdf
+      A B C
+    x 1 4 p
+    y 2 5 q
+    z 3 6 r
 
 
 The ``to_clipboard`` method can be used to write the contents of a ``DataFrame`` to
@@ -3261,12 +3262,23 @@ the clipboard. Following which you can paste the clipboard contents into other
 applications (CTRL-V on many operating systems). Here we illustrate writing a
 ``DataFrame`` into clipboard and reading it back.
 
-.. ipython:: python
+.. code-block:: python
 
-    df = pd.DataFrame(np.random.randn(5, 3))
-    df
-    df.to_clipboard()
-    pd.read_clipboard()
+    >>> df = pd.DataFrame({'A': [1, 2, 3],
+    ...                    'B': [4, 5, 6],
+    ...                    'C': ['p', 'q', 'r']},
+    ...                   index=['x', 'y', 'z'])
+    >>> df
+      A B C
+    x 1 4 p
+    y 2 5 q
+    z 3 6 r
+    >>> df.to_clipboard()
+    >>> pd.read_clipboard()
+      A B C
+    x 1 4 p
+    y 2 5 q
+    z 3 6 r
 
 We can see that we got the same content back, which we had earlier written to the clipboard.
 


### PR DESCRIPTION
- [X] xref #26648, #26103
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The clipboard example in the docs is failing when building in azure (#26648), and had to be previously fixed in travis (#26103). I don't think there is any need to run those examples, and we can keep things simpler. This adds the same value to the doc reader, and doesn't require to set up a clipboard service in the doc builds. Also, we're thinking on having a doc build for windows (#26574) not sure if that could cause new problems.

CC: @jorisvandenbossche 

