### PR TITLE
PERF: restore DatetimeIndex.__iter__ performance by using non-EA implementation

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -513,6 +513,7 @@ Performance Improvements
 - Improved performance of :meth:`IntervalIndex.intersection` (:issue:`24813`)
 - Improved performance of :meth:`read_csv` by faster concatenating date columns without extra conversion to string for integer/float zero and float ``NaN``; by faster checking the string for the possibility of being a date (:issue:`25754`)
 - Improved performance of :attr:`IntervalIndex.is_unique` by removing conversion to ``MultiIndex`` (:issue:`24813`)
+- Restored performance of :meth:`DatetimeIndex.__iter__` by re-enabling specialized code path (:issue:`26702`)
 
 .. _whatsnew_0250.bug_fixes:
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -243,6 +243,8 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     _is_numeric_dtype = False
     _infer_as_myclass = True
 
+    # Use faster implementation given we know we have DatetimeArrays
+    __iter__ = DatetimeArray.__iter__
     # some things like freq inference make use of these attributes.
     _bool_ops = DatetimeArray._bool_ops
     _object_ops = DatetimeArray._object_ops


### PR DESCRIPTION
The `timeseries.TimeIteration.time_iter` benchmark shows a `6.4x` regression here: https://qwhelan.github.io/pandas/#timeseries.Iteration.time_iter?p-time_index=%3Cfunction%20date_range%3E&commits=08395af4-fc24c2cd . An iteration of `asv find` blames https://github.com/pandas-dev/pandas/commit/1fc76b80#diff-26a6d2ca7adfca586aabbb1c9dd8bf36R74 . I believe what is happening is:
- `pandas.core.indexes.datetimelike.ea_passthrough` was modified from calling `getattr()` to being passed a classmethod directly
- The corresponding change in `DatetimeIndexOpsMixin.__init__` then implicitly changed `__iter__` from `DatetimeArray.__iter__` to `DatetimeLikeArrayMixin.__iter__`. The latter must assume an `ExtensionArray`, so is intrinsically slower.
- This regression was then hidden in `asv` due to inadvertent inclusion of memory addresses when using certain parameters. This is resolved in https://github.com/airspeed-velocity/asv/pull/771 and explains why my `asv` results shows this regression while http://pandas.pydata.org/speed/pandas/#timeseries.Iteration.time_iter? does not

Reverting back to old behavior yields a `7x` speedup:
```
$ asv compare HEAD^ HEAD --only-changed
       before           after         ratio
     [649ad5c9]       [4d0c13cc]
     <any_all_fix>       <datetime_iter>
-      3.30±0.02s          469±6ms     0.14  timeseries.Iteration.time_iter(<function date_range>)
-        34.7±1ms       11.2±0.2ms     0.32  timeseries.Iteration.time_iter_preexit(<function date_range>)
```
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
