### PR TITLE
Renaming asv setting build_cache_size

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -107,7 +107,7 @@
     // `asv` will cache wheels of the recent builds in each
     // environment, making them faster to install next time.  This is
     // number of builds to keep, per environment.
-    "wheel_cache_size": 8,
+    "build_cache_size": 8,
 
     // The commits after which the regression search in `asv publish`
     // should start looking for regressions. Dictionary whose keys are


### PR DESCRIPTION
The CI job that is checking that the benchmarks don't break is reporting that an `asv` setting has been renamed.

I think we've got a server where we run the benchmarks, not sure if we replicate the environment there at every run from `environment.yml`. Otherwise I guess we should do it manually before merging this.

@TomAugspurger I think you manage that server? does this make sense?
