### PR TITLE
ASV: remove large IntervalIndex benchmark

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -188,7 +188,7 @@ class Float64IndexMethod:
 
 class IntervalIndexMethod:
     # GH 24813
-    params = [10**3, 10**5, 10**7]
+    params = [10**3, 10**5]
 
     def setup(self, N):
         left = np.append(np.arange(N), np.array(0))


### PR DESCRIPTION
Closes #26709

The `setup` for that `N` took 30s+ on my machine. I doubt that was intended.