### PR TITLE
REF: Refactor signature of RangeIndex._simple_new

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -525,7 +525,7 @@ Performance Improvements
 - Improved performance of :meth:`Series.searchsorted`. The speedup is especially large when the dtype is
   int8/int16/int32 and the searched key is within the integer bounds for the dtype (:issue:`22034`)
 - Improved performance of :meth:`pandas.core.groupby.GroupBy.quantile` (:issue:`20405`)
-- Improved performance of slicing and other selected operation on a :class:`RangeIndex` (:issue:`26565`, :issue:`26617`)
+- Improved performance of slicing and other selected operation on a :class:`RangeIndex` (:issue:`26565`, :issue:`26617`, :issue:`26722`)
 - Improved performance of :meth:`read_csv` by faster tokenizing and faster parsing of small float numbers (:issue:`25784`)
 - Improved performance of :meth:`read_csv` by faster parsing of N/A and boolean values (:issue:`25804`)
 - Improved performance of :attr:`IntervalIndex.is_monotonic`, :attr:`IntervalIndex.is_monotonic_increasing` and :attr:`IntervalIndex.is_monotonic_decreasing` by removing conversion to :class:`MultiIndex` (:issue:`24813`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -270,8 +270,10 @@ class Index(IndexOpsMixin, PandasObject):
             data = data.to_numpy()
 
         # range
-        if isinstance(data, (RangeIndex, range)):
+        if isinstance(data, RangeIndex):
             return RangeIndex(start=data, copy=copy, dtype=dtype, name=name)
+        elif isinstance(data, range):
+            return RangeIndex.from_range(data, dtype=dtype, name=name)
 
         # categorical
         elif is_categorical_dtype(data) or is_categorical_dtype(dtype):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -270,11 +270,8 @@ class Index(IndexOpsMixin, PandasObject):
             data = data.to_numpy()
 
         # range
-        if isinstance(data, RangeIndex):
+        if isinstance(data, (RangeIndex, range)):
             return RangeIndex(start=data, copy=copy, dtype=dtype, name=name)
-        elif isinstance(data, range):
-            return RangeIndex.from_range(data, copy=copy, dtype=dtype,
-                                         name=name)
 
         # categorical
         elif is_categorical_dtype(data) or is_categorical_dtype(dtype):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -40,7 +40,7 @@ class RangeIndex(Int64Index):
 
     Parameters
     ----------
-    start : int (default: 0), range or RangeIndex instance
+    start : int (default: 0), or other RangeIndex instance
         If int and "stop" is not given, interpreted as "stop" instead.
     stop : int (default: 0)
     step : int (default: 1)
@@ -84,11 +84,12 @@ class RangeIndex(Int64Index):
             if fastpath:
                 return cls._simple_new(range(start, stop, step), name=name)
 
-        # RangeIndex, range
-        if isinstance(start, (RangeIndex, range)):
-            if isinstance(start, RangeIndex):
-                name = start.name if name is None else name
-                start = start._range
+        cls._validate_dtype(dtype)
+
+        # RangeIndex
+        if isinstance(start, RangeIndex):
+            name = start.name if name is None else name
+            start = start._range
             return cls._simple_new(start, dtype=dtype, name=name)
 
         # validate the arguments
@@ -122,13 +123,13 @@ class RangeIndex(Int64Index):
             raise TypeError(
                 '{0}(...) must be called with object coercible to a '
                 'range, {1} was passed'.format(cls.__name__, repr(data)))
+
+        cls._validate_dtype(dtype)
         return cls._simple_new(data, dtype=dtype, name=name)
 
     @classmethod
     def _simple_new(cls, values, name=None, dtype=None, **kwargs):
         result = object.__new__(cls)
-
-        cls._validate_dtype(dtype)
 
         # handle passed None, non-integers
         if values is None:

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -94,9 +94,9 @@ class TestRangeIndex(Numeric):
 
     def test_constructor_range(self):
 
-        result = RangeIndex(range(1, 5, 2))
-        expected = RangeIndex(1, 5, 2)
-        tm.assert_index_equal(result, expected, exact=True)
+        msg = "Value needs to be a scalar value, was type <class 'range'>"
+        with pytest.raises(TypeError, match=msg):
+            result = RangeIndex(range(1, 5, 2))
 
         result = RangeIndex.from_range(range(1, 5, 2))
         expected = RangeIndex(1, 5, 2)

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -94,8 +94,9 @@ class TestRangeIndex(Numeric):
 
     def test_constructor_range(self):
 
-        with pytest.raises(TypeError):
-            RangeIndex(range(1, 5, 2))
+        result = RangeIndex(range(1, 5, 2))
+        expected = RangeIndex(1, 5, 2)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = RangeIndex.from_range(range(1, 5, 2))
         expected = RangeIndex(1, 5, 2)
@@ -120,6 +121,9 @@ class TestRangeIndex(Numeric):
 
         with pytest.raises(TypeError):
             Index(range(1, 5, 2), dtype='float64')
+        msg = r'^from_range\(\) got an unexpected keyword argument'
+        with pytest.raises(TypeError, match=msg):
+            pd.RangeIndex.from_range(range(10), copy=True)
 
     def test_constructor_name(self):
         # GH12288


### PR DESCRIPTION
This PR refactors ``RangeIndex._simple_new``, so its signature is the same as ``Index._simple_new``. This will help typing later on, as currently mypy complains about the different signatures. In short a ``_simple_new`` now expects a ``range`` as its input. As a ``range`` is immutable, the code is easy to reason about.

Additionally, the signature of ``RangeIndex.from_range`` has dropped the ``**kwargs`` part of its signature. This makes the class method a bit easier to reason about. Other classes with a ``from_*`` class method don't have a ``**kwargs`` part.

After this PR, ``RangeIndex`` will be ready for adding type hints.

EDIT; Performance improvements:

```python
>>> rng = pd.RangeIndex(1_000_000)
>>> sl = slice(0, 900_000)
>>> %timeit rng[sl]  # slicing
7.65 µs ± 8.11 ns per loop  # master
1.85 µs ± 8.11 ns per loop  # this PR
```
