### PR TITLE
Set index with prepend

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4169,8 +4169,9 @@ class DataFrame(NDFrame):
                    'one-dimensional arrays.')
 
         if append and prepend:
-            raise ValueError('Appending and prepending to an index are mutually '
-                             'exclusive, so they can not both be True.')
+            raise ValueError('Appending and prepending to an index are '
+                             'mutually exclusive, so they can not both '
+                             'be True.')
 
         missing = []
         for col in keys:

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -121,7 +121,7 @@ class TestDataFrameAlterAxes:
                                       ('tuple', 'as', 'label')])
     @pytest.mark.parametrize('drop', [True, False])
     def test_set_index_prepend_to_multiindex(self, frame_of_index_cols,
-                                            drop, keys):
+                                             drop, keys):
         # prepend to existing multiindex
         df = frame_of_index_cols.set_index(['D'], drop=drop, prepend=True)
 


### PR DESCRIPTION
Associated issue: https://github.com/pandas-dev/pandas/issues/26742

This PR adds the ability to _prepend_ indices to existing ones using `.set_index()`, in the same vein as the `append` argument.

This avoid having to do the awkward alternatives:
- `.reset_index().set_index(...)`
- `.set_index(append=True).swaplevel(...)` or `.set_index(append=True).reorder_levels(...)`

`prepend` is mutually exclusive with `append`. The code will test for this and raise ValueError if not.

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
