### PR TITLE
read_excel and Excel File Engine conflict

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -665,6 +665,7 @@ I/O
 - Bug in :func:`read_json` where date strings with ``Z`` were not converted to a UTC timezone (:issue:`26168`)
 - Added ``cache_dates=True`` parameter to :meth:`read_csv`, which allows to cache unique dates when they are parsed (:issue:`25990`)
 - :meth:`DataFrame.to_excel` now raises a ``ValueError`` when the caller's dimensions exceed the limitations of Excel (:issue:`26051`)
+- :func:`read_excel` now raises a ``ValueError`` when its ``engine`` param and :class:`ExcelFile` passed since an :class:`ExcelFile` has an engine defined (:issue:`26566`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -665,7 +665,7 @@ I/O
 - Bug in :func:`read_json` where date strings with ``Z`` were not converted to a UTC timezone (:issue:`26168`)
 - Added ``cache_dates=True`` parameter to :meth:`read_csv`, which allows to cache unique dates when they are parsed (:issue:`25990`)
 - :meth:`DataFrame.to_excel` now raises a ``ValueError`` when the caller's dimensions exceed the limitations of Excel (:issue:`26051`)
-- :func:`read_excel` now raises a ``ValueError`` when its ``engine`` param and :class:`ExcelFile` passed since an :class:`ExcelFile` has an engine defined (:issue:`26566`)
+- :func:`read_excel` now raises a ``ValueError`` when input is of type :class:`pandas.io.excel.ExcelFile` and ``engine`` param is passed since :class:`pandas.io.excel.ExcelFile` has an engine defined (:issue:`26566`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -289,6 +289,9 @@ def read_excel(io,
 
     if not isinstance(io, ExcelFile):
         io = ExcelFile(io, engine=engine)
+    elif engine and engine != io.engine:
+        raise ValueError("Engine should not be specified when passing "
+                         "an ExcelFile - ExcelFile already has the engine set")
 
     return io.parse(
         sheet_name=sheet_name,
@@ -777,6 +780,7 @@ class ExcelFile:
         if engine not in self._engines:
             raise ValueError("Unknown engine: {engine}".format(engine=engine))
 
+        self.engine = engine
         # could be a str, ExcelFile, Book, etc.
         self.io = io
         # Always a string

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -839,9 +839,9 @@ class TestExcelFileRead:
         'xlrd',
         None
     ])
-    def test_read_excel_engine_value(self, ext, excel_engine):
+    def test_read_excel_engine_value(self, read_ext, excel_engine):
         # GH 26566
-        xl = ExcelFile("test1" + ext, engine=excel_engine)
+        xl = ExcelFile("test1" + read_ext, engine=excel_engine)
         msg = "Engine should not be specified when passing an ExcelFile"
         with pytest.raises(ValueError, match=msg):
             pd.read_excel(xl, engine='openpyxl')

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -834,3 +834,14 @@ class TestExcelFileRead:
             pd.read_excel(xlsx, 'Sheet1', index_col=0)
 
         assert f.closed
+
+    @pytest.mark.parametrize('excel_engine', [
+        'xlrd',
+        None
+    ])
+    def test_read_excel_engine_value(self, ext, excel_engine):
+        # GH 26566
+        xl = ExcelFile("test1" + ext, engine=excel_engine)
+        msg = "Engine should not be specified when passing an ExcelFile"
+        with pytest.raises(ValueError, match=msg):
+            pd.read_excel(xl, engine='openpyxl')


### PR DESCRIPTION
- [x] closes #26566
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry 

cc. @WillAyd 

Note I only decided to raise an error when the engine specified to `read_excel` was different to that of the ExcelFile - otherwise around 15 test cases would need to be changed - let me know what you think
