### PR TITLE
DOC: Skip creating redirects if docs build fails

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -220,10 +220,11 @@ class DocBuilder:
         if os.path.exists(zip_fname):
             os.remove(zip_fname)
 
-        if self.single_doc_html is not None:
-            self._open_browser(self.single_doc_html)
-        else:
-            self._add_redirects()
+        if ret_code == 0:
+            if self.single_doc_html is not None:
+                self._open_browser(self.single_doc_html)
+            else:
+                self._add_redirects()
         return ret_code
 
     def latex(self, force=False):


### PR DESCRIPTION
When the doc build fails, we still try to create the redirected pages, which fails, and adds to the log a misleading error (it looks in the logs like the problem is not the original error but that something is failing in the redirects).

See for example https://travis-ci.org/pandas-dev/pandas/jobs/542714631:
```
Recursion error:
maximum recursion depth exceeded while calling a Python object
This can happen with very large or deeply nested source files.  You can carefully increase the default Python recursion limit of 1000 in conf.py with e.g.:
    import sys; sys.setrecursionlimit(1500)
Traceback (most recent call last):
  File "./make.py", line 341, in <module>
    sys.exit(main())
  File "./make.py", line 337, in main
    return getattr(builder, args.command)()
  File "./make.py", line 226, in html
    self._add_redirects()
  File "./make.py", line 209, in _add_redirects
    with open(path, 'w') as moved_page_fd:
FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/build/pandas-dev/pandas/doc/build/html/generated/pandas.api.extensions.ExtensionArray.argsort.html'
```

Here I make the redirects be created only if the doc build succeeded. Also opening the browser if we're building a single page.