### PR TITLE
BLD: fix build warnings

### DIFF
--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -1,5 +1,5 @@
 import cython
-from cython import Py_ssize_t, size_t
+from cython import Py_ssize_t
 
 import numpy as np
 cimport numpy as cnp
@@ -119,8 +119,8 @@ def left_outer_join(const int64_t[:] left, const int64_t[:] right,
     right_indexer = _get_result_indexer(right_sorter, right_indexer)
 
     if not sort:  # if not asked to sort, revert to original order
-        # cast to avoid build warning
-        if len(left) == <size_t>len(left_indexer):
+        # cast to avoid build warning GH#26757
+        if <Py_ssize_t>len(left) == len(left_indexer):
             # no multiple matches for any row on the left
             # this is a short-cut to avoid groupsort_indexer
             # otherwise, the `else` path also works in this case

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -1,5 +1,5 @@
 import cython
-from cython import Py_ssize_t
+from cython import Py_ssize_t, size_t
 
 import numpy as np
 cimport numpy as cnp
@@ -119,7 +119,8 @@ def left_outer_join(const int64_t[:] left, const int64_t[:] right,
     right_indexer = _get_result_indexer(right_sorter, right_indexer)
 
     if not sort:  # if not asked to sort, revert to original order
-        if len(left) == len(left_indexer):
+        # cast to avoid build warning
+        if len(left) == <size_t>len(left_indexer):
             # no multiple matches for any row on the left
             # this is a short-cut to avoid groupsort_indexer
             # otherwise, the `else` path also works in this case

--- a/pandas/_libs/ops.pyx
+++ b/pandas/_libs/ops.pyx
@@ -4,7 +4,7 @@ from cpython cimport (PyObject_RichCompareBool,
                       Py_EQ, Py_NE, Py_LT, Py_LE, Py_GT, Py_GE)
 
 import cython
-from cython import Py_ssize_t, size_t
+from cython import Py_ssize_t
 
 import numpy as np
 from numpy cimport ndarray, uint8_t, import_array
@@ -118,11 +118,11 @@ def vec_compare(object[:] left, object[:] right, object op):
     result : ndarray[bool]
     """
     cdef:
-        size_t i, n = len(left)
+        Py_ssize_t i, n = len(left)
         ndarray[uint8_t, cast=True] result
         int flag
 
-    if n != len(right):
+    if n != <Py_ssize_t>len(right):
         raise ValueError('Arrays were different lengths: {n} vs {nright}'
                          .format(n=n, nright=len(right)))
 

--- a/pandas/_libs/ops.pyx
+++ b/pandas/_libs/ops.pyx
@@ -4,7 +4,7 @@ from cpython cimport (PyObject_RichCompareBool,
                       Py_EQ, Py_NE, Py_LT, Py_LE, Py_GT, Py_GE)
 
 import cython
-from cython import Py_ssize_t
+from cython import Py_ssize_t, size_t
 
 import numpy as np
 from numpy cimport ndarray, uint8_t, import_array
@@ -118,7 +118,7 @@ def vec_compare(object[:] left, object[:] right, object op):
     result : ndarray[bool]
     """
     cdef:
-        Py_ssize_t i, n = len(left)
+        size_t i, n = len(left)
         ndarray[uint8_t, cast=True] result
         int flag
 
@@ -220,7 +220,7 @@ def vec_binop(object[:] left, object[:] right, object op):
     result : ndarray[object]
     """
     cdef:
-        Py_ssize_t i, n = len(left)
+        size_t i, n = len(left)
         object[:] result
 
     if n != len(right):

--- a/pandas/_libs/ops.pyx
+++ b/pandas/_libs/ops.pyx
@@ -220,10 +220,10 @@ def vec_binop(object[:] left, object[:] right, object op):
     result : ndarray[object]
     """
     cdef:
-        size_t i, n = len(left)
+        Py_ssize_t i, n = len(left)
         object[:] result
 
-    if n != len(right):
+    if n != <Py_ssize_t>len(right):
         raise ValueError('Arrays were different lengths: {n} vs {nright}'
                          .format(n=n, nright=len(right)))
 

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -8,6 +8,7 @@ from io import StringIO
 from libc.string cimport strchr
 
 import cython
+from cython import size_t, Py_ssize_t
 
 from cpython cimport PyObject_Str, PyUnicode_Join
 
@@ -603,7 +604,7 @@ def try_parse_date_and_time(object[:] dates, object[:] times,
                             date_parser=None, time_parser=None,
                             dayfirst=False, default=None):
     cdef:
-        Py_ssize_t i, n
+        size_t i, n
         object[:] result
 
     n = len(dates)
@@ -639,7 +640,7 @@ def try_parse_date_and_time(object[:] dates, object[:] times,
 def try_parse_year_month_day(object[:] years, object[:] months,
                              object[:] days):
     cdef:
-        Py_ssize_t i, n
+        size_t i, n
         object[:] result
 
     n = len(years)
@@ -661,7 +662,7 @@ def try_parse_datetime_components(object[:] years,
                                   object[:] seconds):
 
     cdef:
-        Py_ssize_t i, n
+        size_t i, n
         object[:] result
         int secs
         double float_secs

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -604,11 +604,12 @@ def try_parse_date_and_time(object[:] dates, object[:] times,
                             date_parser=None, time_parser=None,
                             dayfirst=False, default=None):
     cdef:
-        size_t i, n
+        Py_ssize_t i, n
         object[:] result
 
     n = len(dates)
-    if len(times) != n:
+    # Cast to avoid build warning see GH#26757
+    if <Py_ssize_t>len(times) != n:
         raise ValueError('Length of dates and times must be equal')
     result = np.empty(n, dtype='O')
 
@@ -640,11 +641,12 @@ def try_parse_date_and_time(object[:] dates, object[:] times,
 def try_parse_year_month_day(object[:] years, object[:] months,
                              object[:] days):
     cdef:
-        size_t i, n
+        Py_ssize_t i, n
         object[:] result
 
     n = len(years)
-    if len(months) != n or len(days) != n:
+    # Cast to avoid build warning see GH#26757
+    if <Py_ssize_t>len(months) != n or <Py_ssize_t>len(days) != n:
         raise ValueError('Length of years/months/days must all be equal')
     result = np.empty(n, dtype='O')
 
@@ -662,15 +664,17 @@ def try_parse_datetime_components(object[:] years,
                                   object[:] seconds):
 
     cdef:
-        size_t i, n
+        Py_ssize_t i, n
         object[:] result
         int secs
         double float_secs
         double micros
 
     n = len(years)
-    if (len(months) != n or len(days) != n or len(hours) != n or
-            len(minutes) != n or len(seconds) != n):
+    # Cast to avoid build warning see GH#26757
+    if (<Py_ssize_t>len(months) != n or <Py_ssize_t>len(days) != n or
+            <Py_ssize_t>len(hours) != n or <Py_ssize_t>len(minutes) != n or
+            <Py_ssize_t>len(seconds) != n):
         raise ValueError('Length of all datetime components must be equal')
     result = np.empty(n, dtype='O')
 

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -8,7 +8,7 @@ from io import StringIO
 from libc.string cimport strchr
 
 import cython
-from cython import size_t, Py_ssize_t
+from cython import Py_ssize_t
 
 from cpython cimport PyObject_Str, PyUnicode_Join
 

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1,7 +1,7 @@
 # cython: boundscheck=False, wraparound=False, cdivision=True
 
 import cython
-from cython import Py_ssize_t, size_t
+from cython import Py_ssize_t
 from libcpp.deque cimport deque
 
 from libc.stdlib cimport malloc, free
@@ -1821,13 +1821,13 @@ def ewmcov(float64_t[:] input_x, float64_t[:] input_y,
     """
 
     cdef:
-        size_t N = len(input_x)
+        Py_ssize_t N = len(input_x)
         float64_t alpha, old_wt_factor, new_wt, mean_x, mean_y, cov
         float64_t sum_wt, sum_wt2, old_wt, cur_x, cur_y, old_mean_x, old_mean_y
         Py_ssize_t i, nobs
         ndarray[float64_t] output
 
-    if len(input_y) != N:
+    if <Py_ssize_t>len(input_y) != N:
         raise ValueError("arrays are of different lengths "
                          "({N} and {len_y})".format(N=N, len_y=len(input_y)))
 

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1,7 +1,7 @@
 # cython: boundscheck=False, wraparound=False, cdivision=True
 
 import cython
-from cython import Py_ssize_t
+from cython import Py_ssize_t, size_t
 from libcpp.deque cimport deque
 
 from libc.stdlib cimport malloc, free
@@ -1821,7 +1821,7 @@ def ewmcov(float64_t[:] input_x, float64_t[:] input_y,
     """
 
     cdef:
-        Py_ssize_t N = len(input_x)
+        size_t N = len(input_x)
         float64_t alpha, old_wt_factor, new_wt, mean_x, mean_y, cov
         float64_t sum_wt, sum_wt2, old_wt, cur_x, cur_y, old_mean_x, old_mean_y
         Py_ssize_t i, nobs

--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -1,5 +1,6 @@
 # cython: profile=False
 # cython: boundscheck=False, initializedcheck=False
+from cython import size_t
 
 import numpy as np
 import pandas.io.sas.sas_constants as const
@@ -18,8 +19,9 @@ cdef const uint8_t[:] rle_decompress(int result_length,
     cdef:
         uint8_t control_byte, x
         uint8_t[:] result = np.zeros(result_length, np.uint8)
-        int rpos = 0, ipos = 0, length = len(inbuff)
+        int rpos = 0
         int i, nbytes, end_of_first_byte
+        size_t ipos = 0, length = len(inbuff)
 
     while ipos < length:
         control_byte = inbuff[ipos] & 0xF0
@@ -123,8 +125,9 @@ cdef const uint8_t[:] rdc_decompress(int result_length,
     cdef:
         uint8_t cmd
         uint16_t ctrl_bits, ctrl_mask = 0, ofs, cnt
-        int ipos = 0, rpos = 0, k
+        int rpos = 0, k
         uint8_t[:] outbuff = np.zeros(result_length, dtype=np.uint8)
+        size_t ipos = 0
 
     ii = -1
 

--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -1,6 +1,6 @@
 # cython: profile=False
 # cython: boundscheck=False, initializedcheck=False
-from cython import size_t
+from cython import Py_ssize_t
 
 import numpy as np
 import pandas.io.sas.sas_constants as const
@@ -21,7 +21,7 @@ cdef const uint8_t[:] rle_decompress(int result_length,
         uint8_t[:] result = np.zeros(result_length, np.uint8)
         int rpos = 0
         int i, nbytes, end_of_first_byte
-        size_t ipos = 0, length = len(inbuff)
+        Py_ssize_t ipos = 0, length = len(inbuff)
 
     while ipos < length:
         control_byte = inbuff[ipos] & 0xF0
@@ -127,11 +127,11 @@ cdef const uint8_t[:] rdc_decompress(int result_length,
         uint16_t ctrl_bits, ctrl_mask = 0, ofs, cnt
         int rpos = 0, k
         uint8_t[:] outbuff = np.zeros(result_length, dtype=np.uint8)
-        size_t ipos = 0
+        Py_ssize_t ipos = 0, length = len(inbuff)
 
     ii = -1
 
-    while ipos < len(inbuff):
+    while ipos < length:
         ii += 1
         ctrl_mask = ctrl_mask >> 1
         if ctrl_mask == 0:


### PR DESCRIPTION
xref #25995, #17936

AFAICT these warnings are caused by cython casting `len(some_ndarray)` to `int` or `Py_ssize_t` but casting `len(some_memoryview)` to `size_t`.  Easiest fix is to declare the affected len variables as `size_t` since we know they'll never be negative.