### PR TITLE
TST/CLN: declass smaller test files in tests\io\excel

### DIFF
--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -1,124 +1,123 @@
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas import DataFrame
 from pandas.util.testing import ensure_clean
 
 from pandas.io.excel import ExcelWriter, _OpenpyxlWriter
 
+openpyxl = pytest.importorskip("openpyxl")
 
-@td.skip_if_no('openpyxl')
-@pytest.mark.parametrize("ext", ['.xlsx'])
-class TestOpenpyxlTests:
+pytestmark = pytest.mark.parametrize("ext", ['.xlsx'])
 
-    def test_to_excel_styleconverter(self, ext):
-        from openpyxl import styles
 
-        hstyle = {
-            "font": {
-                "color": '00FF0000',
-                "bold": True,
+def test_to_excel_styleconverter(ext):
+    from openpyxl import styles
+
+    hstyle = {
+        "font": {
+            "color": '00FF0000',
+            "bold": True,
+        },
+        "borders": {
+            "top": "thin",
+            "right": "thin",
+            "bottom": "thin",
+            "left": "thin",
+        },
+        "alignment": {
+            "horizontal": "center",
+            "vertical": "top",
+        },
+        "fill": {
+            "patternType": 'solid',
+            'fgColor': {
+                'rgb': '006666FF',
+                'tint': 0.3,
             },
-            "borders": {
-                "top": "thin",
-                "right": "thin",
-                "bottom": "thin",
-                "left": "thin",
-            },
-            "alignment": {
-                "horizontal": "center",
-                "vertical": "top",
-            },
-            "fill": {
-                "patternType": 'solid',
-                'fgColor': {
-                    'rgb': '006666FF',
-                    'tint': 0.3,
-                },
-            },
-            "number_format": {
-                "format_code": "0.00"
-            },
-            "protection": {
-                "locked": True,
-                "hidden": False,
-            },
-        }
+        },
+        "number_format": {
+            "format_code": "0.00"
+        },
+        "protection": {
+            "locked": True,
+            "hidden": False,
+        },
+    }
 
-        font_color = styles.Color('00FF0000')
-        font = styles.Font(bold=True, color=font_color)
-        side = styles.Side(style=styles.borders.BORDER_THIN)
-        border = styles.Border(top=side, right=side, bottom=side, left=side)
-        alignment = styles.Alignment(horizontal='center', vertical='top')
-        fill_color = styles.Color(rgb='006666FF', tint=0.3)
-        fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
+    font_color = styles.Color('00FF0000')
+    font = styles.Font(bold=True, color=font_color)
+    side = styles.Side(style=styles.borders.BORDER_THIN)
+    border = styles.Border(top=side, right=side, bottom=side, left=side)
+    alignment = styles.Alignment(horizontal='center', vertical='top')
+    fill_color = styles.Color(rgb='006666FF', tint=0.3)
+    fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
 
-        number_format = '0.00'
+    number_format = '0.00'
 
-        protection = styles.Protection(locked=True, hidden=False)
+    protection = styles.Protection(locked=True, hidden=False)
 
-        kw = _OpenpyxlWriter._convert_to_style_kwargs(hstyle)
-        assert kw['font'] == font
-        assert kw['border'] == border
-        assert kw['alignment'] == alignment
-        assert kw['fill'] == fill
-        assert kw['number_format'] == number_format
-        assert kw['protection'] == protection
+    kw = _OpenpyxlWriter._convert_to_style_kwargs(hstyle)
+    assert kw['font'] == font
+    assert kw['border'] == border
+    assert kw['alignment'] == alignment
+    assert kw['fill'] == fill
+    assert kw['number_format'] == number_format
+    assert kw['protection'] == protection
 
-    def test_write_cells_merge_styled(self, ext):
-        from pandas.io.formats.excel import ExcelCell
 
-        sheet_name = 'merge_styled'
+def test_write_cells_merge_styled(ext):
+    from pandas.io.formats.excel import ExcelCell
 
-        sty_b1 = {'font': {'color': '00FF0000'}}
-        sty_a2 = {'font': {'color': '0000FF00'}}
+    sheet_name = 'merge_styled'
 
-        initial_cells = [
-            ExcelCell(col=1, row=0, val=42, style=sty_b1),
-            ExcelCell(col=0, row=1, val=99, style=sty_a2),
-        ]
+    sty_b1 = {'font': {'color': '00FF0000'}}
+    sty_a2 = {'font': {'color': '0000FF00'}}
 
-        sty_merged = {'font': {'color': '000000FF', 'bold': True}}
-        sty_kwargs = _OpenpyxlWriter._convert_to_style_kwargs(sty_merged)
-        openpyxl_sty_merged = sty_kwargs['font']
-        merge_cells = [
-            ExcelCell(col=0, row=0, val='pandas',
-                      mergestart=1, mergeend=1, style=sty_merged),
-        ]
+    initial_cells = [
+        ExcelCell(col=1, row=0, val=42, style=sty_b1),
+        ExcelCell(col=0, row=1, val=99, style=sty_a2),
+    ]
 
-        with ensure_clean(ext) as path:
-            writer = _OpenpyxlWriter(path)
-            writer.write_cells(initial_cells, sheet_name=sheet_name)
-            writer.write_cells(merge_cells, sheet_name=sheet_name)
+    sty_merged = {'font': {'color': '000000FF', 'bold': True}}
+    sty_kwargs = _OpenpyxlWriter._convert_to_style_kwargs(sty_merged)
+    openpyxl_sty_merged = sty_kwargs['font']
+    merge_cells = [
+        ExcelCell(col=0, row=0, val='pandas',
+                  mergestart=1, mergeend=1, style=sty_merged),
+    ]
 
-            wks = writer.sheets[sheet_name]
-            xcell_b1 = wks['B1']
-            xcell_a2 = wks['A2']
-            assert xcell_b1.font == openpyxl_sty_merged
-            assert xcell_a2.font == openpyxl_sty_merged
+    with ensure_clean(ext) as path:
+        writer = _OpenpyxlWriter(path)
+        writer.write_cells(initial_cells, sheet_name=sheet_name)
+        writer.write_cells(merge_cells, sheet_name=sheet_name)
 
-    @pytest.mark.parametrize("mode,expected", [
-        ('w', ['baz']), ('a', ['foo', 'bar', 'baz'])])
-    def test_write_append_mode(self, ext, mode, expected):
-        import openpyxl
-        df = DataFrame([1], columns=['baz'])
+        wks = writer.sheets[sheet_name]
+        xcell_b1 = wks['B1']
+        xcell_a2 = wks['A2']
+        assert xcell_b1.font == openpyxl_sty_merged
+        assert xcell_a2.font == openpyxl_sty_merged
 
-        with ensure_clean(ext) as f:
-            wb = openpyxl.Workbook()
-            wb.worksheets[0].title = 'foo'
-            wb.worksheets[0]['A1'].value = 'foo'
-            wb.create_sheet('bar')
-            wb.worksheets[1]['A1'].value = 'bar'
-            wb.save(f)
 
-            writer = ExcelWriter(f, engine='openpyxl', mode=mode)
-            df.to_excel(writer, sheet_name='baz', index=False)
-            writer.save()
+@pytest.mark.parametrize("mode,expected", [
+    ('w', ['baz']), ('a', ['foo', 'bar', 'baz'])])
+def test_write_append_mode(ext, mode, expected):
+    df = DataFrame([1], columns=['baz'])
 
-            wb2 = openpyxl.load_workbook(f)
-            result = [sheet.title for sheet in wb2.worksheets]
-            assert result == expected
+    with ensure_clean(ext) as f:
+        wb = openpyxl.Workbook()
+        wb.worksheets[0].title = 'foo'
+        wb.worksheets[0]['A1'].value = 'foo'
+        wb.create_sheet('bar')
+        wb.worksheets[1]['A1'].value = 'bar'
+        wb.save(f)
 
-            for index, cell_value in enumerate(expected):
-                assert wb2.worksheets[index]['A1'].value == cell_value
+        writer = ExcelWriter(f, engine='openpyxl', mode=mode)
+        df.to_excel(writer, sheet_name='baz', index=False)
+        writer.save()
+
+        wb2 = openpyxl.load_workbook(f)
+        result = [sheet.title for sheet in wb2.worksheets]
+        assert result == expected
+
+        for index, cell_value in enumerate(expected):
+            assert wb2.worksheets[index]['A1'].value == cell_value

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -1,4 +1,4 @@
-import pandas.util._test_decorators as td
+import pytest
 
 import pandas as pd
 import pandas.util.testing as tm
@@ -6,30 +6,24 @@ from pandas.util.testing import ensure_clean
 
 from pandas.io.excel import ExcelFile
 
+xlrd = pytest.importorskip("xlrd")
+xlwt = pytest.importorskip("xlwt")
 
-@td.skip_if_no('xlrd')
-class TestXlrdReader:
-    """
-    This is the base class for the xlrd tests, and 3 different file formats
-    are supported: xls, xlsx, xlsm
-    """
 
-    @td.skip_if_no("xlwt")
-    def test_read_xlrd_book(self, read_ext, frame):
-        import xlrd
-        df = frame
+def test_read_xlrd_book(read_ext, frame):
+    df = frame
 
-        engine = "xlrd"
-        sheet_name = "SheetA"
+    engine = "xlrd"
+    sheet_name = "SheetA"
 
-        with ensure_clean(read_ext) as pth:
-            df.to_excel(pth, sheet_name)
-            book = xlrd.open_workbook(pth)
+    with ensure_clean(read_ext) as pth:
+        df.to_excel(pth, sheet_name)
+        book = xlrd.open_workbook(pth)
 
-            with ExcelFile(book, engine=engine) as xl:
-                result = pd.read_excel(xl, sheet_name, index_col=0)
-                tm.assert_frame_equal(df, result)
-
-            result = pd.read_excel(book, sheet_name=sheet_name,
-                                   engine=engine, index_col=0)
+        with ExcelFile(book, engine=engine) as xl:
+            result = pd.read_excel(xl, sheet_name, index_col=0)
             tm.assert_frame_equal(df, result)
+
+        result = pd.read_excel(book, sheet_name=sheet_name,
+                               engine=engine, index_col=0)
+        tm.assert_frame_equal(df, result)

--- a/pandas/tests/io/excel/test_xlsxwriter.py
+++ b/pandas/tests/io/excel/test_xlsxwriter.py
@@ -2,66 +2,64 @@ import warnings
 
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas import DataFrame
 from pandas.util.testing import ensure_clean
 
 from pandas.io.excel import ExcelWriter
 
+xlsxwriter = pytest.importorskip("xlsxwriter")
 
-@td.skip_if_no('xlsxwriter')
-@pytest.mark.parametrize("ext", ['.xlsx'])
-class TestXlsxWriterTests:
+pytestmark = pytest.mark.parametrize("ext", ['.xlsx'])
 
-    @td.skip_if_no('openpyxl')
-    def test_column_format(self, ext):
-        # Test that column formats are applied to cells. Test for issue #9167.
-        # Applicable to xlsxwriter only.
-        with warnings.catch_warnings():
-            # Ignore the openpyxl lxml warning.
-            warnings.simplefilter("ignore")
-            import openpyxl
 
-        with ensure_clean(ext) as path:
-            frame = DataFrame({'A': [123456, 123456],
-                               'B': [123456, 123456]})
+def test_column_format(ext):
+    # Test that column formats are applied to cells. Test for issue #9167.
+    # Applicable to xlsxwriter only.
+    with warnings.catch_warnings():
+        # Ignore the openpyxl lxml warning.
+        warnings.simplefilter("ignore")
+        openpyxl = pytest.importorskip("openpyxl")
 
-            writer = ExcelWriter(path)
-            frame.to_excel(writer)
+    with ensure_clean(ext) as path:
+        frame = DataFrame({'A': [123456, 123456],
+                           'B': [123456, 123456]})
 
-            # Add a number format to col B and ensure it is applied to cells.
-            num_format = '#,##0'
-            write_workbook = writer.book
-            write_worksheet = write_workbook.worksheets()[0]
-            col_format = write_workbook.add_format({'num_format': num_format})
-            write_worksheet.set_column('B:B', None, col_format)
-            writer.save()
+        writer = ExcelWriter(path)
+        frame.to_excel(writer)
 
-            read_workbook = openpyxl.load_workbook(path)
-            try:
-                read_worksheet = read_workbook['Sheet1']
-            except TypeError:
-                # compat
-                read_worksheet = read_workbook.get_sheet_by_name(name='Sheet1')
+        # Add a number format to col B and ensure it is applied to cells.
+        num_format = '#,##0'
+        write_workbook = writer.book
+        write_worksheet = write_workbook.worksheets()[0]
+        col_format = write_workbook.add_format({'num_format': num_format})
+        write_worksheet.set_column('B:B', None, col_format)
+        writer.save()
 
-            # Get the number format from the cell.
-            try:
-                cell = read_worksheet['B2']
-            except TypeError:
-                # compat
-                cell = read_worksheet.cell('B2')
+        read_workbook = openpyxl.load_workbook(path)
+        try:
+            read_worksheet = read_workbook['Sheet1']
+        except TypeError:
+            # compat
+            read_worksheet = read_workbook.get_sheet_by_name(name='Sheet1')
 
-            try:
-                read_num_format = cell.number_format
-            except Exception:
-                read_num_format = cell.style.number_format._format_code
+        # Get the number format from the cell.
+        try:
+            cell = read_worksheet['B2']
+        except TypeError:
+            # compat
+            cell = read_worksheet.cell('B2')
 
-            assert read_num_format == num_format
+        try:
+            read_num_format = cell.number_format
+        except Exception:
+            read_num_format = cell.style.number_format._format_code
 
-    def test_write_append_mode_raises(self, ext):
-        msg = "Append mode is not supported with xlsxwriter!"
+        assert read_num_format == num_format
 
-        with ensure_clean(ext) as f:
-            with pytest.raises(ValueError, match=msg):
-                ExcelWriter(f, engine='xlsxwriter', mode='a')
+
+def test_write_append_mode_raises(ext):
+    msg = "Append mode is not supported with xlsxwriter!"
+
+    with ensure_clean(ext) as f:
+        with pytest.raises(ValueError, match=msg):
+            ExcelWriter(f, engine='xlsxwriter', mode='a')

--- a/pandas/tests/io/excel/test_xlwt.py
+++ b/pandas/tests/io/excel/test_xlwt.py
@@ -1,69 +1,68 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 from pandas import DataFrame, MultiIndex
 from pandas.util.testing import ensure_clean
 
 from pandas.io.excel import ExcelWriter, _XlwtWriter
 
+xlwt = pytest.importorskip("xlwt")
 
-@td.skip_if_no('xlwt')
-@pytest.mark.parametrize("ext,", ['.xls'])
-class TestXlwtTests:
+pytestmark = pytest.mark.parametrize("ext,", ['.xls'])
 
-    def test_excel_raise_error_on_multiindex_columns_and_no_index(
-            self, ext):
-        # MultiIndex as columns is not yet implemented 9794
-        cols = MultiIndex.from_tuples([('site', ''),
-                                       ('2014', 'height'),
-                                       ('2014', 'weight')])
-        df = DataFrame(np.random.randn(10, 3), columns=cols)
-        with pytest.raises(NotImplementedError):
-            with ensure_clean(ext) as path:
-                df.to_excel(path, index=False)
 
-    def test_excel_multiindex_columns_and_index_true(self, ext):
-        cols = MultiIndex.from_tuples([('site', ''),
-                                       ('2014', 'height'),
-                                       ('2014', 'weight')])
-        df = pd.DataFrame(np.random.randn(10, 3), columns=cols)
-        with ensure_clean(ext) as path:
-            df.to_excel(path, index=True)
-
-    def test_excel_multiindex_index(self, ext):
-        # MultiIndex as index works so assert no error #9794
-        cols = MultiIndex.from_tuples([('site', ''),
-                                       ('2014', 'height'),
-                                       ('2014', 'weight')])
-        df = DataFrame(np.random.randn(3, 10), index=cols)
+def test_excel_raise_error_on_multiindex_columns_and_no_index(ext):
+    # MultiIndex as columns is not yet implemented 9794
+    cols = MultiIndex.from_tuples([('site', ''),
+                                   ('2014', 'height'),
+                                   ('2014', 'weight')])
+    df = DataFrame(np.random.randn(10, 3), columns=cols)
+    with pytest.raises(NotImplementedError):
         with ensure_clean(ext) as path:
             df.to_excel(path, index=False)
 
-    def test_to_excel_styleconverter(self, ext):
-        import xlwt
 
-        hstyle = {"font": {"bold": True},
-                  "borders": {"top": "thin",
-                              "right": "thin",
-                              "bottom": "thin",
-                              "left": "thin"},
-                  "alignment": {"horizontal": "center", "vertical": "top"}}
+def test_excel_multiindex_columns_and_index_true(ext):
+    cols = MultiIndex.from_tuples([('site', ''),
+                                   ('2014', 'height'),
+                                   ('2014', 'weight')])
+    df = pd.DataFrame(np.random.randn(10, 3), columns=cols)
+    with ensure_clean(ext) as path:
+        df.to_excel(path, index=True)
 
-        xls_style = _XlwtWriter._convert_to_style(hstyle)
-        assert xls_style.font.bold
-        assert xlwt.Borders.THIN == xls_style.borders.top
-        assert xlwt.Borders.THIN == xls_style.borders.right
-        assert xlwt.Borders.THIN == xls_style.borders.bottom
-        assert xlwt.Borders.THIN == xls_style.borders.left
-        assert xlwt.Alignment.HORZ_CENTER == xls_style.alignment.horz
-        assert xlwt.Alignment.VERT_TOP == xls_style.alignment.vert
 
-    def test_write_append_mode_raises(self, ext):
-        msg = "Append mode is not supported with xlwt!"
+def test_excel_multiindex_index(ext):
+    # MultiIndex as index works so assert no error #9794
+    cols = MultiIndex.from_tuples([('site', ''),
+                                   ('2014', 'height'),
+                                   ('2014', 'weight')])
+    df = DataFrame(np.random.randn(3, 10), index=cols)
+    with ensure_clean(ext) as path:
+        df.to_excel(path, index=False)
 
-        with ensure_clean(ext) as f:
-            with pytest.raises(ValueError, match=msg):
-                ExcelWriter(f, engine='xlwt', mode='a')
+
+def test_to_excel_styleconverter(ext):
+    hstyle = {"font": {"bold": True},
+              "borders": {"top": "thin",
+                          "right": "thin",
+                          "bottom": "thin",
+                          "left": "thin"},
+              "alignment": {"horizontal": "center", "vertical": "top"}}
+
+    xls_style = _XlwtWriter._convert_to_style(hstyle)
+    assert xls_style.font.bold
+    assert xlwt.Borders.THIN == xls_style.borders.top
+    assert xlwt.Borders.THIN == xls_style.borders.right
+    assert xlwt.Borders.THIN == xls_style.borders.bottom
+    assert xlwt.Borders.THIN == xls_style.borders.left
+    assert xlwt.Alignment.HORZ_CENTER == xls_style.alignment.horz
+    assert xlwt.Alignment.VERT_TOP == xls_style.alignment.vert
+
+
+def test_write_append_mode_raises(ext):
+    msg = "Append mode is not supported with xlwt!"
+
+    with ensure_clean(ext) as f:
+        with pytest.raises(ValueError, match=msg):
+            ExcelWriter(f, engine='xlwt', mode='a')


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/26755#pullrequestreview-247416090

the larger files `pandas/tests/io/excel/test_readers.py` and `pandas/tests/io/excel/test_writers.py` have been left for separate PRs

any idiom changes other than required to declass are also omitted to make the diff easier to check.