### PR TITLE
BUG: fix IntervalIndex for pivot table raise type error 

### DIFF
--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -59,6 +59,7 @@ Bug Fixes
 
 - Bug in :meth:`~pandas.core.groupby.GroupBy.transform` where applying a function to a timezone aware column would return a timezone naive result (:issue:`24198`)
 - Bug in :func:`DataFrame.join` when joining on a timezone aware :class:`DatetimeIndex` (:issue:`23931`)
+- Bug in :func:`DataFrame.pivot_table` where use :class:`IntervalIndex` as pivot index would raise TypeError (:issue:`25814`)
 
 **Visualization**
 

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -59,7 +59,6 @@ Bug Fixes
 
 - Bug in :meth:`~pandas.core.groupby.GroupBy.transform` where applying a function to a timezone aware column would return a timezone naive result (:issue:`24198`)
 - Bug in :func:`DataFrame.join` when joining on a timezone aware :class:`DatetimeIndex` (:issue:`23931`)
-- Bug in :func:`DataFrame.pivot_table` where use :class:`IntervalIndex` as pivot index would raise ``TypeError`` (:issue:`25814`)
 
 **Visualization**
 

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -59,7 +59,7 @@ Bug Fixes
 
 - Bug in :meth:`~pandas.core.groupby.GroupBy.transform` where applying a function to a timezone aware column would return a timezone naive result (:issue:`24198`)
 - Bug in :func:`DataFrame.join` when joining on a timezone aware :class:`DatetimeIndex` (:issue:`23931`)
-- Bug in :func:`DataFrame.pivot_table` where use :class:`IntervalIndex` as pivot index would raise `TypeError` (:issue:`25814`)
+- Bug in :func:`DataFrame.pivot_table` where use :class:`IntervalIndex` as pivot index would raise ``TypeError`` (:issue:`25814`)
 
 **Visualization**
 

--- a/doc/source/whatsnew/v0.24.2.rst
+++ b/doc/source/whatsnew/v0.24.2.rst
@@ -59,7 +59,7 @@ Bug Fixes
 
 - Bug in :meth:`~pandas.core.groupby.GroupBy.transform` where applying a function to a timezone aware column would return a timezone naive result (:issue:`24198`)
 - Bug in :func:`DataFrame.join` when joining on a timezone aware :class:`DatetimeIndex` (:issue:`23931`)
-- Bug in :func:`DataFrame.pivot_table` where use :class:`IntervalIndex` as pivot index would raise TypeError (:issue:`25814`)
+- Bug in :func:`DataFrame.pivot_table` where use :class:`IntervalIndex` as pivot index would raise `TypeError` (:issue:`25814`)
 
 **Visualization**
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -700,6 +700,7 @@ Reshaping
 - Bug in :func:`pandas.cut` where large bins could incorrectly raise an error due to an integer overflow (:issue:`26045`)
 - Bug in :func:`DataFrame.sort_index` where an error is thrown when a multi-indexed ``DataFrame`` is sorted on all levels with the initial level sorted last (:issue:`26053`)
 - Bug in :meth:`Series.nlargest` treats ``True`` as smaller than ``False`` (:issue:`26154`)
+- Bug in :func:`DataFrame.pivot_table` where use :class:`IntervalIndex` as pivot index would raise ``TypeError`` (:issue:`25814`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -700,7 +700,7 @@ Reshaping
 - Bug in :func:`pandas.cut` where large bins could incorrectly raise an error due to an integer overflow (:issue:`26045`)
 - Bug in :func:`DataFrame.sort_index` where an error is thrown when a multi-indexed ``DataFrame`` is sorted on all levels with the initial level sorted last (:issue:`26053`)
 - Bug in :meth:`Series.nlargest` treats ``True`` as smaller than ``False`` (:issue:`26154`)
-- Bug in :func:`DataFrame.pivot_table` where use :class:`IntervalIndex` as pivot index would raise ``TypeError`` (:issue:`25814`)
+- Bug in :func:`DataFrame.pivot_table` with a :class:`IntervalIndex` as pivot index would raise ``TypeError`` (:issue:`25814`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -181,7 +181,7 @@ def contains(cat, key, container):
     #  can't be in container either.
     try:
         loc = cat.categories.get_loc(key)
-    except KeyError:
+    except (KeyError, TypeError):
         return False
 
     # loc is the location of key in categories, but also the *value*

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -198,6 +198,17 @@ class TestPivotTable:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_pivot_with_interval_index(self, dropna):
+        df = pd.DataFrame(
+            {'A': pd.Categorical([pd.Interval(0, 1)] * 4),
+             'B': [1] * 4})
+        result = df.pivot_table(index='A', values='B', dropna=dropna)
+        expected = pd.DataFrame(
+            {'B': [1]},
+            index=pd.Index(pd.Categorical([pd.Interval(0, 1)]),
+                           name='A'))
+        tm.assert_frame_equal(result, expected)
+
     def test_pass_array(self):
         result = self.data.pivot_table(
             'D', index=self.data.A, columns=self.data.C)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -19,11 +19,6 @@ def dropna(request):
     return request.param
 
 
-@pytest.fixture(params=['right', 'left'])
-def closed(request):
-    return request.param
-
-
 @pytest.fixture(params=[([0] * 4, [1] * 4), (range(0, 3), range(1, 4))])
 def interval_values(request, closed):
     left, right = request.param

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -211,6 +211,7 @@ class TestPivotTable:
         tm.assert_frame_equal(result, expected)
 
     def test_pivot_with_interval_index(self, interval_values, dropna):
+        # GH 25814
         df = pd.DataFrame(
             {'A': interval_values,
              'B': [1] * interval_values.size})

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -19,6 +19,18 @@ def dropna(request):
     return request.param
 
 
+@pytest.fixture(
+    params=[
+        pd.Categorical([pd.Interval(0, 1, 'right')] * 4),
+        pd.Categorical([pd.Interval(0, 1, 'left')] * 4),
+        pd.Categorical([pd.Interval(low, high, 'right')
+                        for low, high in zip(range(0, 3), range(1, 4))]),
+        pd.Categorical([pd.Interval(low, high, 'left')
+                        for low, high in zip(range(0, 3), range(1, 4))])])
+def interval_values(request):
+    return request.param
+
+
 class TestPivotTable:
 
     def setup_method(self, method):
@@ -198,14 +210,14 @@ class TestPivotTable:
 
         tm.assert_frame_equal(result, expected)
 
-    def test_pivot_with_interval_index(self, dropna):
+    def test_pivot_with_interval_index(self, interval_values, dropna):
         df = pd.DataFrame(
-            {'A': pd.Categorical([pd.Interval(0, 1)] * 4),
-             'B': [1] * 4})
+            {'A': interval_values,
+             'B': [1] * interval_values.size})
         result = df.pivot_table(index='A', values='B', dropna=dropna)
         expected = pd.DataFrame(
             {'B': [1]},
-            index=pd.Index(pd.Categorical([pd.Interval(0, 1)]),
+            index=pd.Index(interval_values.unique(),
                            name='A'))
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -19,16 +19,15 @@ def dropna(request):
     return request.param
 
 
-@pytest.fixture(
-    params=[
-        pd.Categorical([pd.Interval(0, 1, 'right')] * 4),
-        pd.Categorical([pd.Interval(0, 1, 'left')] * 4),
-        pd.Categorical([pd.Interval(low, high, 'right')
-                        for low, high in zip(range(0, 3), range(1, 4))]),
-        pd.Categorical([pd.Interval(low, high, 'left')
-                        for low, high in zip(range(0, 3), range(1, 4))])])
-def interval_values(request):
+@pytest.fixture(params=['right', 'left'])
+def closed(request):
     return request.param
+
+
+@pytest.fixture(params=[([0] * 4, [1] * 4), (range(0, 3), range(1, 4))])
+def interval_values(request, closed):
+    left, right = request.param
+    return Categorical(pd.IntervalIndex.from_arrays(left, right, closed))
 
 
 class TestPivotTable:
@@ -212,14 +211,14 @@ class TestPivotTable:
 
     def test_pivot_with_interval_index(self, interval_values, dropna):
         # GH 25814
-        df = pd.DataFrame(
+        df = DataFrame(
             {'A': interval_values,
              'B': [1] * interval_values.size})
         result = df.pivot_table(index='A', values='B', dropna=dropna)
-        expected = pd.DataFrame(
+        expected = DataFrame(
             {'B': [1]},
-            index=pd.Index(interval_values.unique(),
-                           name='A'))
+            index=Index(interval_values.unique(),
+                        name='A'))
         tm.assert_frame_equal(result, expected)
 
     def test_pass_array(self):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -213,10 +213,10 @@ class TestPivotTable:
         # GH 25814
         df = DataFrame(
             {'A': interval_values,
-             'B': [1] * interval_values.size})
+             'B': 1})
         result = df.pivot_table(index='A', values='B', dropna=dropna)
         expected = DataFrame(
-            {'B': [1]},
+            {'B': 1},
             index=Index(interval_values.unique(),
                         name='A'))
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Close (#25814). When use IntervalIndex for pivot table, raise
TypeError: cannot determine next label for type <class 'str'> 
- [x] closes #25814
- [x] tets added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
