### PR TITLE
BENCH: fix noisy asv benchmarks that were running on exhausted generators

### DIFF
--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -55,7 +55,14 @@ class SeriesConstructors:
               [False, True],
               ['float', 'int']]
 
+    # Generators get exhausted on use, so run setup before every call
+    number = 1
+    repeat = (3, 250, 10)
+
     def setup(self, data_fmt, with_index, dtype):
+        if data_fmt in (gen_of_str, gen_of_tuples) and with_index:
+            raise NotImplementedError('Series constructors do not support '
+                                      'using generators with indexes')
         N = 10**4
         if dtype == 'float':
             arr = np.random.randn(N)

--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -72,6 +72,10 @@ class FromRecords:
     params = [None, 1000]
     param_names = ['nrows']
 
+    # Generators get exhausted on use, so run setup before every call
+    number = 1
+    repeat = (3, 250, 10)
+
     def setup(self, nrows):
         N = 100000
         self.gen = ((x, (x * 20), (x * 100)) for x in range(N))


### PR DESCRIPTION
Generators get consumed on first use, yielding abnormally fast benchmark times on the `n>1` iterations. Fortunately we can instruct `asv` to call `setup()` prior to every sample by setting `number = 1` and `repeat` appropriately. My local runs suggest the typical number of samples is `~150-250`, so an upper limit of `250` appears to be a good fit.

Here is current `master` with old benchmark version:
```
[ 75.00%] ··· Running (ctors.SeriesConstructors.time_series_constructor--).
[100.00%] ··· ctors.SeriesConstructors.time_series_constructor                                                                                                   4/40 failed
[100.00%] ··· ===================================== =============== ============= ============== =============
              --                                                        with_index / dtype
              ------------------------------------- ----------------------------------------------------------
                             data_fmt                False / float   False / int   True / float    True / int
              ===================================== =============== ============= ============== =============
                      <function gen_of_str>            130±0.9μs       116±6μs        failed         failed
                     <function gen_of_tuples>           113±3μs        112±20μs       failed         failed
              ===================================== =============== ============= ============== =============
```
And with the fixed benchmarks, we see the existing ones falsely report a `40x` speedup:
```
[ 50.00%] ··· ===================================== =============== ============= ============== ============
              --                                                        with_index / dtype
              ------------------------------------- ---------------------------------------------------------
                             data_fmt                False / float   False / int   True / float   True / int
              ===================================== =============== ============= ============== ============
                      <function gen_of_str>            4.61±0.1ms    4.21±0.07ms       n/a           n/a
                     <function gen_of_tuples>          3.39±0.1ms    3.43±0.07ms       n/a           n/a
              ===================================== =============== ============= ============== ============
```

Additionally, this PR resolves a few failing `asv` tests that I introduced in the first iteration.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
