### PR TITLE
TST/CLN: use float_frame fixture to remove use of tm.getSeriesData()

### DIFF
--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -712,10 +712,9 @@ class TestAdditionSubtraction:
         tm.assert_series_equal(df['result'], df['expected'], check_names=False)
 
     # TODO: taken from tests.frame.test_operators, needs cleanup
-    def test_frame_operators(self):
-        seriesd = tm.getSeriesData()
-        frame = pd.DataFrame(seriesd)
-        frame2 = pd.DataFrame(seriesd, columns=['D', 'C', 'B', 'A'])
+    def test_frame_operators(self, float_frame):
+        frame = float_frame
+        frame2 = pd.DataFrame(float_frame, columns=['D', 'C', 'B', 'A'])
 
         garbage = np.random.random(4)
         colSeries = pd.Series(garbage, index=np.array(frame.columns))

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -48,9 +48,8 @@ class TestDataFrameUnaryOperators:
         with pytest.raises(TypeError):
             (- df['a'])
 
-    def test_invert(self):
-        _seriesd = tm.getSeriesData()
-        df = pd.DataFrame(_seriesd)
+    def test_invert(self, float_frame):
+        df = float_frame
 
         assert_frame_equal(-(df < 0), ~(df < 0))
 

--- a/pandas/tests/groupby/conftest.py
+++ b/pandas/tests/groupby/conftest.py
@@ -31,18 +31,8 @@ def ts():
 
 
 @pytest.fixture
-def seriesd():
-    return tm.getSeriesData()
-
-
-@pytest.fixture
 def tsd():
     return tm.getTimeSeriesData()
-
-
-@pytest.fixture
-def frame(seriesd):
-    return DataFrame(seriesd)
 
 
 @pytest.fixture

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1306,12 +1306,12 @@ def test_skip_group_keys():
     assert_series_equal(result, expected)
 
 
-def test_no_nonsense_name(frame):
+def test_no_nonsense_name(float_frame):
     # GH #995
-    s = frame['C'].copy()
+    s = float_frame['C'].copy()
     s.name = None
 
-    result = s.groupby(frame['A']).agg(np.sum)
+    result = s.groupby(float_frame['A']).agg(np.sum)
     assert result.name is None
 
 

--- a/pandas/tests/indexing/test_ix.py
+++ b/pandas/tests/indexing/test_ix.py
@@ -182,9 +182,9 @@ class TestIX:
                                       4: 5}})
         tm.assert_frame_equal(df, expected)
 
-    def test_ix_assign_column_mixed(self):
+    def test_ix_assign_column_mixed(self, float_frame):
         # GH #1142
-        df = DataFrame(tm.getSeriesData())
+        df = float_frame
         df['foo'] = 'bar'
 
         orig = df.loc[:, 'B'].copy()

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -287,9 +287,8 @@ def test_to_html_with_no_bold():
     assert '<strong' not in result
 
 
-def test_to_html_columns_arg():
-    df = DataFrame(tm.getSeriesData())
-    result = df.to_html(columns=['A'])
+def test_to_html_columns_arg(float_frame):
+    result = float_frame.to_html(columns=['A'])
     assert '<th>B</th>' not in result
 
 


### PR DESCRIPTION
this PR removes 2 unnecessary fixtures from `pandas\tests\groupby\conftest.py`
 
and a few small changes to remove use of `tm.getSeriesData()` with a couple of exceptions:

- conftest files: `pandas\conftest.py` and `pandas\tests\frame\conftest.py` (needed for fixtures)
- `pandas\tests\frame\common.py` (this module will be removed on completion of #22471)
- `pandas\tests\io\json\test_pandas.py` (would benefit from fixturisation and access to other frame fixtures, separate PR and then maybe have a code-checks rule for `getSeriesData` in `test_*.py` files)
