### PR TITLE
DOC: Fix rolling doc with win_type triang (#22268)

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -530,8 +530,8 @@ class Window(_Window):
     >>> df.rolling(2, win_type='triang').sum()
          B
     0  NaN
-    1  1.0
-    2  2.5
+    1  0.5
+    2  1.5
     3  NaN
     4  NaN
 


### PR DESCRIPTION
- [x] closes #22268 
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
