### PR TITLE
CLN: remove util._decorators.make_signature and make related changes

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -9,7 +9,7 @@ from pandas._libs.tslibs.timedeltas import Timedelta
 
 from pandas.core.dtypes.dtypes import ExtensionDtype
 from pandas.core.dtypes.generic import (
-    ABCExtensionArray, ABCIndexClass, ABCSeries, ABCSparseSeries)
+    ABCDataFrame, ABCExtensionArray, ABCIndexClass, ABCSeries, ABCSparseSeries)
 
 AnyArrayLike = TypeVar('AnyArrayLike',
                        ABCExtensionArray,
@@ -22,3 +22,5 @@ DatetimeLikeScalar = TypeVar('DatetimeLikeScalar', Period, Timestamp,
                              Timedelta)
 Dtype = Union[str, np.dtype, ExtensionDtype]
 FilePathOrBuffer = Union[str, Path, IO[AnyStr]]
+
+FrameOrSeries = TypeVar('FrameOrSeries', ABCSeries, ABCDataFrame)

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -3,11 +3,6 @@ Provide basic components for groupby. These defintiions
 hold the whitelist of methods that are exposed on the
 SeriesGroupBy and the DataFrameGroupBy objects.
 """
-
-import types
-
-from pandas.util._decorators import make_signature
-
 from pandas.core.dtypes.common import is_list_like, is_scalar
 
 
@@ -116,14 +111,6 @@ def whitelist_method_generator(base, klass, whitelist):
     Since we don't want to override methods explicitly defined in the
     base class, any such name is skipped.
     """
-
-    method_wrapper_template = \
-        """def %(name)s(%(sig)s) :
-    \"""
-    %(doc)s
-    \"""
-    f = %(self)s.__getattr__('%(name)s')
-    return f(%(args)s)"""
     property_wrapper_template = \
         """@property
 def %(name)s(self) :
@@ -139,19 +126,6 @@ def %(name)s(self) :
         f = getattr(klass, name)
         doc = f.__doc__
         doc = doc if type(doc) == str else ''
-        if isinstance(f, types.MethodType):
-            wrapper_template = method_wrapper_template
-            decl, args = make_signature(f)
-            # pass args by name to f because otherwise
-            # GroupBy._make_wrapper won't know whether
-            # we passed in an axis parameter.
-            args_by_name = ['{0}={0}'.format(arg) for arg in args[1:]]
-            params = {'name': name,
-                      'doc': doc,
-                      'sig': ','.join(decl),
-                      'self': args[0],
-                      'args': ','.join(args_by_name)}
-        else:
-            wrapper_template = property_wrapper_template
-            params = {'name': name, 'doc': doc}
+        wrapper_template = property_wrapper_template
+        params = {'name': name, 'doc': doc}
         yield wrapper_template % params

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -3,7 +3,13 @@ Provide basic components for groupby. These defintiions
 hold the whitelist of methods that are exposed on the
 SeriesGroupBy and the DataFrameGroupBy objects.
 """
+from typing import TYPE_CHECKING, FrozenSet, Iterator, Type, Union
+
 from pandas.core.dtypes.common import is_list_like, is_scalar
+
+if TYPE_CHECKING:
+    from pandas import DataFrame, Series
+    from .groupby import GroupBy
 
 
 class GroupByMixin:
@@ -88,19 +94,21 @@ cython_cast_blacklist = frozenset(['rank', 'count', 'size', 'idxmin',
                                    'idxmax'])
 
 
-def whitelist_method_generator(base, klass, whitelist):
+def whitelist_method_generator(base: 'Type[GroupBy]',
+                               klass: 'Union[Type[DataFrame], Type[Series]]',
+                               whitelist: FrozenSet[str],
+                               ) -> Iterator[str]:
     """
     Yields all GroupBy member defs for DataFrame/Series names in whitelist.
 
     Parameters
     ----------
-    base : class
+    base : Groupby class
         base class
-    klass : class
+    klass : DataFrame or Series class
         class where members are defined.
-        Should be Series or DataFrame
-    whitelist : list
-        list of names of klass methods to be constructed
+    whitelist : frozenset
+        Set of names of klass methods to be constructed
 
     Returns
     -------

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -5,8 +5,6 @@ import pytest
 
 import pandas.compat as compat
 from pandas.compat import raise_with_traceback
-from pandas.util._decorators import deprecate_kwarg, make_signature
-from pandas.util._validators import validate_kwargs
 
 import pandas.util.testing as tm
 
@@ -35,22 +33,6 @@ def test_numpy_err_state_is_default():
 
     # The error state should be unchanged after that import.
     assert np.geterr() == expected
-
-
-@pytest.mark.parametrize("func,expected", [
-    # Case where the func does not have default kwargs.
-    (validate_kwargs, (["fname", "kwargs", "compat_args"],
-                       ["fname", "kwargs", "compat_args"])),
-
-    # Case where the func does have default kwargs.
-    (deprecate_kwarg, (["old_arg_name", "new_arg_name",
-                        "mapping=None", "stacklevel=2"],
-                       ["old_arg_name", "new_arg_name",
-                        "mapping", "stacklevel"]))
-])
-def test_make_signature(func, expected):
-    # see gh-17608
-    assert make_signature(func) == expected
 
 
 def test_raise_with_traceback():

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -319,33 +319,3 @@ def indent(text, indents=1):
         return ''
     jointext = ''.join(['\n'] + ['    '] * indents)
     return jointext.join(text.split('\n'))
-
-
-def make_signature(func):
-    """
-    Returns a tuple containing the paramenter list with defaults
-    and parameter list.
-
-    Examples
-    --------
-    >>> def f(a, b, c=2):
-    >>>     return a * b * c
-    >>> print(make_signature(f))
-    (['a', 'b', 'c=2'], ['a', 'b', 'c'])
-    """
-
-    spec = inspect.getfullargspec(func)
-    if spec.defaults is None:
-        n_wo_defaults = len(spec.args)
-        defaults = ('',) * n_wo_defaults
-    else:
-        n_wo_defaults = len(spec.args) - len(spec.defaults)
-        defaults = ('',) * n_wo_defaults + tuple(spec.defaults)
-    args = []
-    for var, default in zip(spec.args, defaults):
-        args.append(var if default == '' else var + '=' + repr(default))
-    if spec.varargs:
-        args.append('*' + spec.varargs)
-    if spec.varkw:
-        args.append('**' + spec.varkw)
-    return args, spec.args


### PR DESCRIPTION
``util._decorators.make_signature`` is only used in ``core.groupby.base.whitelist_method_generator``.

However, in that function it is only used inside an if statement, that is conditional upon an attribute being a method. That however can not happen, as the function parameter only takes classes as an input, so that if-statement is never true and its content never executed. The net effect is that a nice chunk of code can just be removed, which is nice.

In the future, we should just use jus use ``inspect.signature`` or ``inspect.getfullargspecs`` for signature inspection.