### PR TITLE
Remove annotations to make CI happy

### DIFF
--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -53,7 +53,7 @@ def import_optional_dependency(
     extra: str = "",
     raise_on_missing: bool = True,
     on_version: str = "raise",
-) -> Optional[types.ModuleType]:
+):
     """
     Import an optional dependency.
 

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -1,7 +1,6 @@
 import distutils.version
 import importlib
 import types
-from typing import Optional
 import warnings
 
 # Update install.rst when updating versions!

--- a/pandas/io/gcs.py
+++ b/pandas/io/gcs.py
@@ -15,5 +15,5 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
 
     fs = gcsfs.GCSFileSystem()
     filepath_or_buffer = fs.open(
-        filepath_or_buffer, mode)  # type: gcsfs.GCSFile
+        filepath_or_buffer, mode)
     return filepath_or_buffer, None, compression, True

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -34,5 +34,5 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
         # for that bucket.
         fs = s3fs.S3FileSystem(anon=True)
         filepath_or_buffer = fs.open(
-            _strip_schema(filepath_or_buffer), mode)  # type: s3fs.S3File
+            _strip_schema(filepath_or_buffer), mode)
     return filepath_or_buffer, None, compression, True


### PR DESCRIPTION
I must have been a little quick in merging #26802 as it looks like this is causing mypy failures in CI.

Most of these are pretty niche and I think a result of import machinery. Will try to dive deeper later but this should get things green for now