### PR TITLE
DOC: array class docstring pages without autosummary tables

### DIFF
--- a/doc/source/reference/arrays.rst
+++ b/doc/source/reference/arrays.rst
@@ -144,6 +144,7 @@ If the data are tz-aware, then every value in the array must have the same timez
 
 .. autosummary::
    :toctree: api/
+   :template: autosummary/class_without_autosummary.rst
 
    arrays.DatetimeArray
 
@@ -204,6 +205,7 @@ A collection of timedeltas may be stored in a :class:`TimedeltaArray`.
 
 .. autosummary::
    :toctree: api/
+   :template: autosummary/class_without_autosummary.rst
 
    arrays.TimedeltaArray
 
@@ -263,6 +265,7 @@ Every period in a ``PeriodArray`` must have the same ``freq``.
 
 .. autosummary::
    :toctree: api/
+   :template: autosummary/class_without_autosummary.rst
 
    arrays.PeriodArray
 
@@ -304,6 +307,7 @@ A collection of intervals may be stored in an :class:`arrays.IntervalArray`.
 
 .. autosummary::
    :toctree: api/
+   :template: autosummary/class_without_autosummary.rst
 
    arrays.IntervalArray
 
@@ -312,6 +316,29 @@ A collection of intervals may be stored in an :class:`arrays.IntervalArray`.
    :template: autosummary/class_without_autosummary.rst
 
    IntervalDtype
+
+
+.. Those attributes and methods are included in the API because the docstrings
+.. of IntervalIndex and IntervalArray are shared. Including it here to make
+.. sure a docstring page is built for them to avoid warnings
+
+..
+    .. autosummary::
+      :toctree: api/
+
+      arrays.IntervalArray.left
+      arrays.IntervalArray.right
+      arrays.IntervalArray.closed
+      arrays.IntervalArray.mid
+      arrays.IntervalArray.length
+      arrays.IntervalArray.is_non_overlapping_monotonic
+      arrays.IntervalArray.from_arrays
+      arrays.IntervalArray.from_tuples
+      arrays.IntervalArray.from_breaks
+      arrays.IntervalArray.overlaps
+      arrays.IntervalArray.set_closed
+      arrays.IntervalArray.to_tuples
+
 
 .. _api.arrays.integer_na:
 
@@ -323,6 +350,7 @@ Pandas provides this through :class:`arrays.IntegerArray`.
 
 .. autosummary::
    :toctree: api/
+   :template: autosummary/class_without_autosummary.rst
 
    arrays.IntegerArray
 
@@ -414,6 +442,7 @@ be stored efficiently as a :class:`SparseArray`.
 
 .. autosummary::
    :toctree: api/
+   :template: autosummary/class_without_autosummary.rst
 
    SparseArray
 

--- a/doc/source/reference/extensions.rst
+++ b/doc/source/reference/extensions.rst
@@ -19,4 +19,9 @@ objects.
    api.extensions.register_index_accessor
    api.extensions.ExtensionDtype
    api.extensions.ExtensionArray
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class_without_autosummary.rst
+
    arrays.PandasArray

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -236,6 +236,14 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin,
     freq : str or Offset, optional
     copy : bool, default False
         Whether to copy the underlying array of values.
+
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
     """
     _typ = "datetimearray"
     _scalar_type = Timestamp

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -269,6 +269,14 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
     <IntegerArray>
     [1, NaN, 3]
     Length: 3, dtype: UInt16
+
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
     """
 
     @cache_readonly

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -244,6 +244,14 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
     copy : bool, default False
         Whether to copy the `values` and `mask`.
 
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
+
     Returns
     -------
     IntegerArray
@@ -269,14 +277,6 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
     <IntegerArray>
     [1, NaN, 3]
     Length: 3, dtype: UInt16
-
-    Attributes
-    ----------
-    None
-
-    Methods
-    -------
-    None
     """
 
     @cache_readonly

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -98,6 +98,14 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
         The NumPy ndarray to wrap. Must be 1-dimensional.
     copy : bool, default False
         Whether to copy `values`.
+
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
     """
     # If you're wondering why pd.Series(cls) doesn't put the array in an
     # ExtensionBlock, search for `ABCPandasArray`. We check for

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -112,6 +112,14 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
     copy : bool, default False
         Whether to copy the ordinals before storing.
 
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
+
     See Also
     --------
     period_array : Create a new PeriodArray.
@@ -129,14 +137,6 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
 
     The `freq` indicates the span covered by each element of the array.
     All elements in the PeriodArray have the same `freq`.
-
-    Attributes
-    ----------
-    None
-
-    Methods
-    -------
-    None
     """
     # array priority higher than numpy scalars
     __array_priority__ = 1000

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -129,6 +129,14 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
 
     The `freq` indicates the span covered by each element of the array.
     All elements in the PeriodArray have the same `freq`.
+
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
     """
     # array priority higher than numpy scalars
     __array_priority__ = 1000

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -572,6 +572,14 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
         this determines ``self.sp_values`` and ``self.fill_value``.
     copy : bool, default False
         Whether to explicitly copy the incoming `data` array.
+
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
     """
 
     _pandas_ftype = 'sparse'

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -127,6 +127,14 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
     freq : Offset, optional
     copy : bool, default False
         Whether to copy the underlying array of data.
+
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
     """
     _typ = "timedeltaarray"
     _scalar_type = Timedelta


### PR DESCRIPTION
See discussion in https://github.com/pandas-dev/pandas/pull/26810

This just adds the "class_without_autosummary". Longer term, we could choose to add certain methods of the Array API to the html api pages, but for now just wanted to do this to get rid of the warnings.