### PR TITLE
TST: test custom _formatter for ExtensionArray + revert ExtensionArrayFormatter removal

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1061,9 +1061,11 @@ class IntervalIndex(IntervalMixin, Index):
 
     def _format_native_types(self, na_rep='NaN', quoting=None, **kwargs):
         """ actually format my specific types """
-        from pandas.io.formats.format import format_array
-        return format_array(values=self, na_rep=na_rep, justify='all',
-                            leading_space=False)
+        from pandas.io.formats.format import ExtensionArrayFormatter
+        return ExtensionArrayFormatter(values=self,
+                                       na_rep=na_rep,
+                                       justify='all',
+                                       leading_space=False).get_result()
 
     def _format_data(self, name=None):
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -849,7 +849,7 @@ class DataFrameFormatter(TableFormatter):
 # Array formatters
 
 
-def format_array(values, formatter=None, float_format=None, na_rep='NaN',
+def format_array(values, formatter, float_format=None, na_rep='NaN',
                  digits=None, space=None, justify='right', decimal='.',
                  leading_space=None):
     """
@@ -879,23 +879,14 @@ def format_array(values, formatter=None, float_format=None, na_rep='NaN',
     List[str]
     """
 
-    if is_extension_array_dtype(values.dtype):
-        if isinstance(values, (ABCIndexClass, ABCSeries)):
-            values = values._values
-
-        if is_categorical_dtype(values.dtype):
-            # Categorical is special for now, so that we can preserve tzinfo
-            values = values.get_values()
-
-        if not is_datetime64tz_dtype(values.dtype):
-            values = np.asarray(values)
-
     if is_datetime64_dtype(values.dtype):
         fmt_klass = Datetime64Formatter
     elif is_datetime64tz_dtype(values):
         fmt_klass = Datetime64TZFormatter
     elif is_timedelta64_dtype(values.dtype):
         fmt_klass = Timedelta64Formatter
+    elif is_extension_array_dtype(values.dtype):
+        fmt_klass = ExtensionArrayFormatter
     elif is_float_dtype(values.dtype) or is_complex_dtype(values.dtype):
         fmt_klass = FloatArrayFormatter
     elif is_integer_dtype(values.dtype):
@@ -1188,6 +1179,29 @@ class Datetime64Formatter(GenericArrayFormatter):
                                                       self.date_format),
             na_rep=self.nat_rep).reshape(values.shape)
         return fmt_values.tolist()
+
+
+class ExtensionArrayFormatter(GenericArrayFormatter):
+    def _format_strings(self):
+        values = self.values
+        if isinstance(values, (ABCIndexClass, ABCSeries)):
+            values = values._values
+
+        formatter = values._formatter(boxed=True)
+
+        if is_categorical_dtype(values.dtype):
+            # Categorical is special for now, so that we can preserve tzinfo
+            array = values.get_values()
+        else:
+            array = np.asarray(values)
+
+        fmt_values = format_array(array,
+                                  formatter,
+                                  float_format=self.float_format,
+                                  na_rep=self.na_rep, digits=self.digits,
+                                  space=self.space, justify=self.justify,
+                                  leading_space=self.leading_space)
+        return fmt_values
 
 
 def format_percentiles(percentiles):

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -137,6 +137,11 @@ class DecimalArray(ExtensionArray, ExtensionScalarOpsMixin):
     def _na_value(self):
         return decimal.Decimal('NaN')
 
+    def _formatter(self, boxed=False):
+        if boxed:
+            return "Decimal: {0}".format
+        return repr
+
     @classmethod
     def _concat_same_type(cls, to_concat):
         return cls(np.concatenate([x._data for x in to_concat]))

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -200,7 +200,13 @@ class TestSetitem(BaseDecimal, base.BaseSetitemTests):
 
 
 class TestPrinting(BaseDecimal, base.BasePrintingTests):
-    pass
+
+    def test_series_repr(self, data):
+        # Overriding this base test to explicitly test that
+        # the custom _formatter is used
+        ser = pd.Series(data)
+        assert data.dtype.name in repr(ser)
+        assert "Decimal: " in repr(ser)
 
 
 # TODO(extension)


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/26833#issuecomment-502012046

@simonjayhawkins this would be a test for the `_formatter` functionality (it is passing on master before the removal of ExtensionArrayFormatter

Adds an actual test for EA._formatter + reverts https://github.com/pandas-dev/pandas/pull/26833 until we have a more complete solution for simplifying the formatters that take the EA._formatter into account.