### PR TITLE
[ENH] nargsort handles EA with its _values_for_argsort

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -133,6 +133,7 @@ Other Enhancements
 - :meth:`DataFrame.describe` now formats integer percentiles without decimal point (:issue:`26660`)
 - Added support for reading SPSS .sav files using :func:`read_spss` (:issue:`26537`)
 - Added new option ``plotting.backend`` to be able to select a plotting backend different than the existing ``matplotlib`` one. Use ``pandas.set_option('plotting.backend', '<backend-module>')`` where ``<backend-module`` is a library implementing the pandas plotting API (:issue:`14130`)
+- :meth:`nargsort` handles ``ExtensionArray`` with its ``_values_for_argsort`` method (:issue:`25439`)
 
 .. _whatsnew_0250.api_breaking:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -133,7 +133,6 @@ Other Enhancements
 - :meth:`DataFrame.describe` now formats integer percentiles without decimal point (:issue:`26660`)
 - Added support for reading SPSS .sav files using :func:`read_spss` (:issue:`26537`)
 - Added new option ``plotting.backend`` to be able to select a plotting backend different than the existing ``matplotlib`` one. Use ``pandas.set_option('plotting.backend', '<backend-module>')`` where ``<backend-module`` is a library implementing the pandas plotting API (:issue:`14130`)
-- :meth:`nargsort` handles ``ExtensionArray`` without calling ``np.asanyarray`` (:issue:`25439`)
 
 .. _whatsnew_0250.api_breaking:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -133,7 +133,7 @@ Other Enhancements
 - :meth:`DataFrame.describe` now formats integer percentiles without decimal point (:issue:`26660`)
 - Added support for reading SPSS .sav files using :func:`read_spss` (:issue:`26537`)
 - Added new option ``plotting.backend`` to be able to select a plotting backend different than the existing ``matplotlib`` one. Use ``pandas.set_option('plotting.backend', '<backend-module>')`` where ``<backend-module`` is a library implementing the pandas plotting API (:issue:`14130`)
-- :meth:`nargsort` handles ``ExtensionArray`` with its ``_values_for_argsort`` method (:issue:`25439`)
+- :meth:`nargsort` handles ``ExtensionArray`` without calling ``np.asanyarray`` (:issue:`25439`)
 
 .. _whatsnew_0250.api_breaking:
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -9,8 +9,10 @@ from pandas._libs.hashtable import unique_label_indices
 from pandas.core.dtypes.cast import infer_dtype_from_array
 from pandas.core.dtypes.common import (
     ensure_int64, ensure_platform_int, is_categorical_dtype,
-    is_extension_array_dtype, is_list_like)
+    is_extension_array_dtype, is_list_like, is_sparse)
 from pandas.core.dtypes.missing import isna
+from pandas.core.dtypes.generic import ABCIndexClass
+
 
 import pandas.core.algorithms as algorithms
 
@@ -239,12 +241,12 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
     GH #6399, #5231
     """
 
+    mask = isna(items)
     # specially handle Categorical
     if is_categorical_dtype(items):
         if na_position not in {'first', 'last'}:
             raise ValueError('invalid na_position: {!r}'.format(na_position))
 
-        mask = isna(items)
         cnt_null = mask.sum()
         sorted_idx = items.argsort(ascending=ascending, kind=kind)
         if ascending and na_position == 'last':
@@ -255,15 +257,19 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
             sorted_idx = np.roll(sorted_idx, cnt_null)
         return sorted_idx
 
-    with warnings.catch_warnings():
-        # https://github.com/pandas-dev/pandas/issues/25439
-        # can be removed once ExtensionArrays are properly handled by nargsort
-        warnings.filterwarnings(
-            "ignore", category=FutureWarning,
-            message="Converting timezone-aware DatetimeArray to")
+    if (not isinstance(items, ABCIndexClass)
+            and is_extension_array_dtype(items)):
+
+        if is_sparse(items):
+            # The conversion to np.ndarray is the fact that
+            # SparseArray.isna() is also a SparseArray
+            mask = np.array(isna(items))
+
+        items = items._values_for_argsort()
+    else:
         items = np.asanyarray(items)
+
     idx = np.arange(len(items))
-    mask = isna(items)
     non_nans = items[~mask]
     non_nan_idx = idx[~mask]
     nan_idx = np.nonzero(mask)[0]

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -8,7 +8,6 @@ from pandas.core.dtypes.cast import infer_dtype_from_array
 from pandas.core.dtypes.common import (
     ensure_int64, ensure_platform_int, is_categorical_dtype,
     is_extension_array_dtype, is_list_like)
-from pandas.core.dtypes.generic import ABCIndexClass
 from pandas.core.dtypes.missing import isna
 
 import pandas.core.algorithms as algorithms
@@ -237,7 +236,9 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
     handles NaNs. It adds ascending and na_position parameters.
     GH #6399, #5231
     """
+    from pandas.core.internals.arrays import extract_array
 
+    items = extract_array(items)
     mask = np.asarray(isna(items))
     # specially handle Categorical
     if is_categorical_dtype(items):
@@ -254,9 +255,7 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
             sorted_idx = np.roll(sorted_idx, cnt_null)
         return sorted_idx
 
-    if (not isinstance(items, ABCIndexClass)
-            and is_extension_array_dtype(items)):
-
+    if is_extension_array_dtype(items):
         items = items._values_for_argsort()
     else:
         items = np.asanyarray(items)

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -238,7 +238,7 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
     GH #6399, #5231
     """
 
-    mask = isna(items)
+    mask = np.asarray(isna(items))
     # specially handle Categorical
     if is_categorical_dtype(items):
         if na_position not in {'first', 'last'}:
@@ -256,11 +256,6 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
 
     if (not isinstance(items, ABCIndexClass)
             and is_extension_array_dtype(items)):
-
-        if is_sparse(items):
-            # The conversion to np.ndarray is due to the fact that
-            # SparseArray.isna() is also a SparseArray
-            mask = np.array(isna(items))
 
         items = items._values_for_argsort()
     else:

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -1,6 +1,4 @@
 """ miscellaneous sorting / groupby utilities """
-import warnings
-
 import numpy as np
 
 from pandas._libs import algos, hashtable, lib
@@ -10,9 +8,8 @@ from pandas.core.dtypes.cast import infer_dtype_from_array
 from pandas.core.dtypes.common import (
     ensure_int64, ensure_platform_int, is_categorical_dtype,
     is_extension_array_dtype, is_list_like, is_sparse)
-from pandas.core.dtypes.missing import isna
 from pandas.core.dtypes.generic import ABCIndexClass
-
+from pandas.core.dtypes.missing import isna
 
 import pandas.core.algorithms as algorithms
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -7,7 +7,7 @@ from pandas._libs.hashtable import unique_label_indices
 from pandas.core.dtypes.cast import infer_dtype_from_array
 from pandas.core.dtypes.common import (
     ensure_int64, ensure_platform_int, is_categorical_dtype,
-    is_extension_array_dtype, is_list_like, is_sparse)
+    is_extension_array_dtype, is_list_like)
 from pandas.core.dtypes.generic import ABCIndexClass
 from pandas.core.dtypes.missing import isna
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -258,7 +258,7 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
             and is_extension_array_dtype(items)):
 
         if is_sparse(items):
-            # The conversion to np.ndarray is the fact that
+            # The conversion to np.ndarray is due to the fact that
             # SparseArray.isna() is also a SparseArray
             mask = np.array(isna(items))
 

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -44,6 +44,15 @@ class BaseMethodsTests(BaseExtensionTests):
         expected = pd.Series(np.array([1, -1, 0], dtype=np.int64))
         self.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize('na_position, expected', [
+        ('last', np.array([2, 0, 1])),
+        ('first', np.array([1, 2, 0]))
+    ])
+    def test_nargsort(self, data_missing_for_sorting, na_position, expected):
+        from pandas.core.sorting import nargsort
+        result = nargsort(data_missing_for_sorting, na_position=na_position)
+        tm.assert_numpy_array_equal(result, expected)
+
     @pytest.mark.parametrize('ascending', [True, False])
     def test_sort_values(self, data_for_sorting, ascending):
         ser = pd.Series(data_for_sorting)

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
+from pandas.core.sorting import nargsort
 import pandas.util.testing as tm
 
 from .base import BaseExtensionTests
@@ -49,9 +50,9 @@ class BaseMethodsTests(BaseExtensionTests):
         ('first', np.array([1, 2, 0]))
     ])
     def test_nargsort(self, data_missing_for_sorting, na_position, expected):
-        from pandas.core.sorting import nargsort
+        # GH 25439
         result = nargsort(data_missing_for_sorting, na_position=na_position)
-        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected, check_dtype=False)
 
     @pytest.mark.parametrize('ascending', [True, False])
     def test_sort_values(self, data_for_sorting, ascending):

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -46,13 +46,13 @@ class BaseMethodsTests(BaseExtensionTests):
         self.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize('na_position, expected', [
-        ('last', np.array([2, 0, 1])),
-        ('first', np.array([1, 2, 0]))
+        ('last', np.array([2, 0, 1], dtype='int64')),
+        ('first', np.array([1, 2, 0], dtype='int64'))
     ])
     def test_nargsort(self, data_missing_for_sorting, na_position, expected):
         # GH 25439
         result = nargsort(data_missing_for_sorting, na_position=na_position)
-        tm.assert_numpy_array_equal(result, expected, check_dtype=False)
+        tm.assert_numpy_array_equal(result, expected)
 
     @pytest.mark.parametrize('ascending', [True, False])
     def test_sort_values(self, data_for_sorting, ascending):

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -181,13 +181,6 @@ class TestSorting:
         exp = list(range(5)) + list(range(105, 110)) + list(range(104, 4, -1))
         tm.assert_numpy_array_equal(result, np.array(exp), check_dtype=False)
 
-    def test_nargsort_datetimearray_warning(self):
-        # https://github.com/pandas-dev/pandas/issues/25439
-        # can be removed once the FutureWarning for np.array(DTA) is removed
-        data = to_datetime([0, 2, 0, 1]).tz_localize('Europe/Brussels')
-        with tm.assert_produces_warning(None):
-            nargsort(data)
-
 
 class TestMerge:
 

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -6,8 +6,7 @@ import numpy as np
 from numpy import nan
 import pytest
 
-from pandas import (
-    DataFrame, MultiIndex, Series, array, concat, merge, to_datetime)
+from pandas import DataFrame, MultiIndex, Series, array, concat, merge
 from pandas.core import common as com
 from pandas.core.sorting import (
     decons_group_index, get_group_index, is_int64_overflow_possible,


### PR DESCRIPTION
-  closes #25439
-  1 test added and 1 test deleted
-  passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
-  whatsnew entry

Presently, `nargsort` can handle EA too. Because `np.asanyarray` turns EA into `np.ndarray`.
https://github.com/pandas-dev/pandas/blob/430f0fd04646a0ab44ccbfbad706dfe22e9fabfe/pandas/core/sorting.py#L264
In this PR, `nargsort` use `EA._values_for_argsort` instead to avoid the `np.ndarray` conversion.