### PR TITLE
BLD: fix build error for PyPy on macOS (#26536)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -736,6 +736,11 @@ Sparse
 - Bug in :class:`SparseDataFrame` when adding a column in which the length of values does not match length of index, ``AssertionError`` is raised instead of raising ``ValueError`` (:issue:`25484`)
 - Introduce a better error message in :meth:`Series.sparse.from_coo` so it returns a ``TypeError`` for inputs that are not coo matrices (:issue:`26554`)
 
+Build Changes
+^^^^^^^^^^^^^
+
+- Fix install error with PyPy on macOS (:issue:`26536`)
+
 Other
 ^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -442,17 +442,17 @@ else:
     if debugging_symbols_requested:
         extra_compile_args.append('-g')
 
-# For mac, ensure extensions are built for at least macOS 10.9 when compiling
-# on a 10.9 system or above, overriding CPython distuitls behaviour which is
-# to target the version that python was built for. This may be overridden by
-# setting MACOSX_DEPLOYMENT_TARGET before calling setup.py
+# Build for at least macOS 10.9 when compiling on a 10.9 system or above,
+# overriding CPython distuitls behaviour which is to target the version that
+# python was built for. This may be overridden by setting
+# MACOSX_DEPLOYMENT_TARGET before calling setup.py
 if is_platform_mac():
     if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
         current_system = platform.mac_ver()[0]
-        python_target = \
-            get_config_vars().get('MACOSX_DEPLOYMENT_TARGET', current_system)
-        if LooseVersion(python_target) < '10.9' and \
-                LooseVersion(current_system) >= '10.9':
+        python_target = get_config_vars().get('MACOSX_DEPLOYMENT_TARGET',
+                                              current_system)
+        if (LooseVersion(python_target) < '10.9' and
+                LooseVersion(current_system) >= '10.9'):
             os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
 # enable coverage by building cython files by setting the environment variable

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from os.path import join as pjoin
 
 import pkg_resources
 import platform
-from distutils.sysconfig import get_config_var
+from distutils.sysconfig import get_config_vars
 import sys
 import shutil
 from distutils.version import LooseVersion
@@ -442,18 +442,18 @@ else:
     if debugging_symbols_requested:
         extra_compile_args.append('-g')
 
-# For mac, ensure extensions are built for macos 10.9 when compiling on a
-# 10.9 system or above, overriding distuitls behaviour which is to target
-# the version that python was built for. This may be overridden by setting
-# MACOSX_DEPLOYMENT_TARGET before calling setup.py
+# For mac, ensure extensions are built for at least macOS 10.9 when compiling
+# on a 10.9 system or above, overriding CPython distuitls behaviour which is
+# to target the version that python was built for. This may be overridden by
+# setting MACOSX_DEPLOYMENT_TARGET before calling setup.py
 if is_platform_mac():
     if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
-        current_system = LooseVersion(platform.mac_ver()[0])
-        python_target = LooseVersion(
-            get_config_var('MACOSX_DEPLOYMENT_TARGET'))
-        if python_target < '10.9' and current_system >= '10.9':
+        current_system = platform.mac_ver()[0]
+        python_target = \
+            get_config_vars().get('MACOSX_DEPLOYMENT_TARGET', current_system)
+        if LooseVersion(python_target) < '10.9' and \
+                LooseVersion(current_system) >= '10.9':
             os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
-
 
 # enable coverage by building cython files by setting the environment variable
 # "PANDAS_CYTHON_COVERAGE" (with a Truthy value) or by running build_ext


### PR DESCRIPTION
- [x] closes #26536
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This change should have no effect on CPython, and may fix a crash in when trying to install using PyPy (see #26536).

I've given this a very quick check by installing locally with `pip install -e` (cpython 3.6 on mac). I dont have an easy way to check it on PyPy, so Im hoping the OP from #26536 can do this (@bhy)