### PR TITLE
Add type hints for (DataFrame|Series)._data

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6,7 +6,7 @@ import json
 import operator
 import pickle
 from textwrap import dedent
-from typing import Callable, FrozenSet, List, Set
+from typing import Callable, FrozenSet, List, Optional, Set
 import warnings
 import weakref
 
@@ -35,6 +35,7 @@ from pandas.core.dtypes.inference import is_hashable
 from pandas.core.dtypes.missing import isna, notna
 
 import pandas as pd
+from pandas._typing import Dtype
 from pandas.core import missing, nanops
 import pandas.core.algorithms as algos
 from pandas.core.base import PandasObject, SelectionMixin
@@ -118,12 +119,17 @@ class NDFrame(PandasObject, SelectionMixin):
     ])  # type: FrozenSet[str]
     _metadata = []  # type: List[str]
     _is_copy = None
+    _data = None  # type: BlockManager
 
     # ----------------------------------------------------------------------
     # Constructors
 
-    def __init__(self, data, axes=None, copy=False, dtype=None,
-                 fastpath=False):
+    def __init__(self,
+                 data: BlockManager,
+                 axes: Optional[List[Index]] = None,
+                 copy: bool = False,
+                 dtype: Optional[Dtype] = None,
+                 fastpath: bool = False):
 
         if not fastpath:
             if dtype is not None:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -142,6 +142,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # Override cache_readonly bc Series is mutable
     hasnans = property(base.IndexOpsMixin.hasnans.func,
                        doc=base.IndexOpsMixin.hasnans.__doc__)
+    _data = None  # type: SingleBlockManager
 
     # ----------------------------------------------------------------------
     # Constructors


### PR DESCRIPTION
- [x] xref #26792

This PR add a type hint for ``(DataFrame|Series)._data`` and ``NDFrame.__init__``. This makes it easier to work with the ``BlockManager`` in Pandas.
