### PR TITLE
Add type hints for (BlockManager|SingleBlockManager).blocks

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -3,7 +3,7 @@ from functools import partial
 import itertools
 import operator
 import re
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Sequence, Tuple
 
 import numpy as np
 
@@ -95,9 +95,12 @@ class BlockManager(PandasObject):
     __slots__ = ['axes', 'blocks', '_ndim', '_shape', '_known_consolidated',
                  '_is_consolidated', '_blknos', '_blklocs']
 
-    def __init__(self, blocks, axes, do_integrity_check=True):
+    def __init__(self,
+                 blocks: Sequence[Block],
+                 axes: Sequence[Index],
+                 do_integrity_check: bool = True):
         self.axes = [ensure_index(ax) for ax in axes]
-        self.blocks = tuple(blocks)
+        self.blocks = tuple(blocks)  # type: Tuple[Block, ...]
 
         for block in blocks:
             if block.is_sparse:
@@ -1415,8 +1418,11 @@ class SingleBlockManager(BlockManager):
     _known_consolidated = True
     __slots__ = ()
 
-    def __init__(self, block, axis, do_integrity_check=False, fastpath=False):
-
+    def __init__(self,
+                 block: Block,
+                 axis: Union[Index, List[Index]],
+                 do_integrity_check: bool = False,
+                 fastpath: bool = False):
         if isinstance(axis, list):
             if len(axis) != 1:
                 raise ValueError("cannot create SingleBlockManager with more "
@@ -1455,7 +1461,7 @@ class SingleBlockManager(BlockManager):
         if not isinstance(block, Block):
             block = make_block(block, placement=slice(0, len(axis)), ndim=1)
 
-        self.blocks = [block]
+        self.blocks = [block]  # type: List[Block]
 
     def _post_setstate(self):
         pass

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -3,7 +3,7 @@ from functools import partial
 import itertools
 import operator
 import re
-from typing import List, Optional, Union, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -1461,7 +1461,7 @@ class SingleBlockManager(BlockManager):
         if not isinstance(block, Block):
             block = make_block(block, placement=slice(0, len(axis)), ndim=1)
 
-        self.blocks = [block]  # type: List[Block]
+        self.blocks = tuple([block])
 
     def _post_setstate(self):
         pass


### PR DESCRIPTION
- [x] xref #26792  & #26871

This PR add a type hint for ``(BlockManager|SingleBlockManager).blocks`` and ``(BlockManager|SingleBlockManager).__init__``.

This follows up to the type hints added in #26871 and makes it easier to work with the ``BlockManager`` and blocks in Pandas.