### PR TITLE
TST: Fix flaky import test

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -133,7 +133,7 @@ def test_pyarrow(df):
     tm.assert_frame_equal(result, df)
 
 
-def test_missing_required_dependency(capsys):
+def test_missing_required_dependency():
     # GH 23868
     # use the -S flag to disable site-packages
     call = ['python', '-S', '-c', 'import pandas']

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -1,7 +1,6 @@
 """
 Testing that we work in the downstream packages
 """
-import builtins
 import importlib
 import subprocess
 import sys
@@ -134,30 +133,13 @@ def test_pyarrow(df):
     tm.assert_frame_equal(result, df)
 
 
-def test_missing_required_dependency(monkeypatch):
+def test_missing_required_dependency(capsys):
     # GH 23868
-    original_import = __import__
+    # use the -S flag to disable site-packages
+    call = ['python', '-S', '-c', 'import pandas']
 
-    def mock_import_fail(name, *args, **kwargs):
-        if name == "numpy":
-            raise ImportError("cannot import name numpy")
-        elif name == "pytz":
-            raise ImportError("cannot import name some_dependency")
-        elif name == "dateutil":
-            raise ImportError("cannot import name some_other_dependency")
-        else:
-            return original_import(name, *args, **kwargs)
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        subprocess.check_output(call, stderr=subprocess.STDOUT)
 
-    expected_msg = (
-        "Unable to import required dependencies:"
-        "\nnumpy: cannot import name numpy"
-        "\npytz: cannot import name some_dependency"
-        "\ndateutil: cannot import name some_other_dependency"
-    )
-
-    import pandas as pd
-
-    with monkeypatch.context() as m:
-        m.setattr(builtins, "__import__", mock_import_fail)
-        with pytest.raises(ImportError, match=expected_msg):
-            importlib.reload(pd)
+    output = exc.value.stdout.decode()
+    assert all(x in output for x in ['numpy', 'pytz', 'dateutil'])


### PR DESCRIPTION
I'm not sure why, but the missing dependency test is
causing issues. Now we check that things work by running
it in a subprocess with site-packages disabled.

Closes https://github.com/pandas-dev/pandas/issues/26952