### PR TITLE
POC: 2D support for 1D ExtensionArray subclasses

### DIFF
--- a/pandas/tests/extension/arrow/bool.py
+++ b/pandas/tests/extension/arrow/bool.py
@@ -45,7 +45,9 @@ class _ArrowBoolArray(ExtensionArray):
     def __init__(self, values):
         if isinstance(values, _ArrowBoolArray):
             values = values._data
-        if not isinstance(values, pa.ChunkedArray):
+        elif isinstance(values, np.ndarray):
+            values = pa.chunked_array([pa.array(values)])
+        elif not isinstance(values, pa.ChunkedArray):
             raise ValueError
 
         assert values.type == pa.bool_()
@@ -117,6 +119,7 @@ class _ArrowBoolArray(ExtensionArray):
         else:
             return type(self)(copy.copy(self._data))
 
+    @classmethod
     def _concat_same_type(cls, to_concat):
         chunks = list(itertools.chain.from_iterable(x._data.chunks
                                                     for x in to_concat))

--- a/pandas/tests/extension/arrow/bool.py
+++ b/pandas/tests/extension/arrow/bool.py
@@ -14,6 +14,7 @@ import pyarrow as pa
 import pandas as pd
 from pandas.api.extensions import (
     ExtensionArray, ExtensionDtype, register_extension_dtype, take)
+from pandas.core.arrays.base import ReshapeWrapper
 
 
 @register_extension_dtype
@@ -40,8 +41,10 @@ class ArrowBoolDtype(ExtensionDtype):
         return True
 
 
-class ArrowBoolArray(ExtensionArray):
+class _ArrowBoolArray(ExtensionArray):
     def __init__(self, values):
+        if isinstance(values, _ArrowBoolArray):
+            values = values._data
         if not isinstance(values, pa.ChunkedArray):
             raise ValueError
 
@@ -142,3 +145,7 @@ class ArrowBoolArray(ExtensionArray):
 
     def all(self, axis=0, out=None):
         return self._data.to_pandas().all()
+
+
+class ArrowBoolArray(ReshapeWrapper, _ArrowBoolArray):
+    pass

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -131,3 +131,35 @@ class TestReshape:
             data.reshape(-1, -1)
         with pytest.raises(ValueError, match="Product of shape"):
             data.reshape(len(data), 2)
+
+
+class Test2D:
+    def test_getitem_collike(self, data):
+        collike = data.reshape(1, -1)
+
+        result = collike[:, :]
+        assert result.shape == (1, 100)
+
+        result = collike[:, ::2]
+        assert result.shape == (1, 50)
+
+        result = collike[0, :]
+        assert result.shape == (100,)
+
+        result = collike[0, ::2]
+        assert result.shape == (50,)
+
+    def test_getitem_rowlike(self, data):
+        rowlike = data.reshape(-1, 1)
+
+        result = rowlike[:, :]
+        assert result.shape == (100, 1)
+
+        result = rowlike[::2, :]
+        assert result.shape == (50, 1)
+
+        result = rowlike[:, 0]
+        assert result.shape == (100,)
+
+        result = rowlike[::2, 0]
+        assert result.shape == (50,)

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -66,3 +66,68 @@ def test_is_bool_dtype(data):
     result = s[data]
     expected = s[np.asarray(data)]
     tm.assert_series_equal(result, expected)
+
+
+class TestReshape:
+
+    @pytest.mark.parametrize('shape', [(1, -1), (-1, 1)])
+    def test_ravel(self, data, shape):
+        dim2 = data.reshape(shape)
+        assert dim2.ndim == 2
+
+        assert dim2.ravel().shape == data.shape
+
+    def test_transpose(self, data):
+        assert data.T.shape == data.shape
+
+        rowlike = data.reshape(-1, 1)
+        collike = data.reshape(1, -1)
+
+        rt1 = rowlike.T
+        rt2 = rowlike.transpose()
+
+        ct1 = collike.T
+        ct2 = collike.transpose()
+
+        assert ct1.shape == ct2.shape == rowlike.shape
+        assert rt1.shape == rt2.shape == collike.shape
+
+    def test_swapaxes(self, data):
+        rowlike = data.reshape(-1, 1)
+        collike = data.reshape(1, -1)
+
+        for arr in [data, rowlike, collike]:
+            assert arr.swapaxes(0, 0).shape == arr.shape
+
+        assert rowlike.swapaxes(0, 1).shape == collike.shape
+        assert rowlike.swapaxes(1, 0).shape == collike.shape
+        assert collike.swapaxes(0, 1).shape == rowlike.shape
+        assert collike.swapaxes(1, 0).shape == rowlike.shape
+
+    def test_reshape(self, data):
+        size = len(data)
+
+        collike1 = data.reshape(1, -1)
+        collike2 = data.reshape((1, -1))
+        collike3 = data.reshape(1, size)
+        collike4 = data.reshape((1, size))
+        collike5 = collike1.reshape(collike1.shape)
+        for collike in [collike1, collike2, collike3, collike4, collike5]:
+            assert collike.shape == (1, size)
+            assert collike.ndim == 2
+
+        rowlike1 = data.reshape(-1, 1)
+        rowlike2 = data.reshape((-1, 1))
+        rowlike3 = data.reshape(size, 1)
+        rowlike4 = data.reshape((size, 1))
+        rowlike5 = rowlike1.reshape(rowlike1.shape)
+        rowlike6 = collike1.reshape(-1, 1)
+        for collike in [rowlike1, rowlike2, rowlike3, rowlike4,
+                        rowlike5, rowlike6]:
+            assert collike.shape == (size, 1)
+            assert collike.ndim == 2
+
+        with pytest.raises(ValueError, match="Invalid shape"):
+            data.reshape(-1, -1)
+        with pytest.raises(ValueError, match="Product of shape"):
+            data.reshape(len(data), 2)

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -137,6 +137,8 @@ class Test2D:
     def test_getitem_collike(self, data):
         collike = data.reshape(1, -1)
 
+        assert collike[0, 0] is data[0]
+
         result = collike[:, :]
         assert result.shape == (1, 100)
 
@@ -152,6 +154,8 @@ class Test2D:
     def test_getitem_rowlike(self, data):
         rowlike = data.reshape(-1, 1)
 
+        assert rowlike[0, 0] is data[0]
+
         result = rowlike[:, :]
         assert result.shape == (100, 1)
 
@@ -163,3 +167,27 @@ class Test2D:
 
         result = rowlike[::2, 0]
         assert result.shape == (50,)
+
+    def test_take_rowlike(self, data):
+        rowlike = data.reshape(1, -1)
+
+        result = rowlike.take([0], axis=0)
+        assert result.shape == (100, 1)
+
+        result2 = rowlike.take([0, 5, 10], axis=1)
+        assert result2.shape == (1, 3)
+        assert result2[0, 0] == data[0]
+        assert result2[0, 1] == data[5]
+        assert result2[0, 2] == data[10]
+
+    def test_take_collike(self, data):
+        collike = data.reshape(-1, 1)
+
+        result = collike.take([0], axis=1)
+        assert result.shape == (1, 100)
+
+        result2 = collike.take([0, 5, 10], axis=0)
+        assert result2.shape == (3, 1)
+        assert result2[0, 0] == data[0]
+        assert result2[1, 0] == data[5]
+        assert result2[2, 0] == data[10]


### PR DESCRIPTION
[ci skip]

Companion to #26914 trying out a way to implement 2D methods for EA subclasses that don't do it natively.

Chose the arrow EA as the example to start with, then discovered that equality checks return a scalar instead of operating elementwise, so mostly just comparing the shapes.