### PR TITLE
ENH: Reset MultiIndex at specific column levels

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4501,19 +4501,19 @@ class DataFrame(NDFrame):
             if multi_col:
                 col_level = _convert_to_listlike(col_level, 0)
                 col_fill = _convert_to_listlike(col_fill, [None])
-                if len(col_fill) == 1:
-                    col_fill = col_fill * len(col_level)
-                elif len(col_level) != len(col_fill):
-                    # ValueError is not raised if col_fill has only 1 value
-                    raise ValueError("Length of col_level={} should be "
-                                     "equal to length of col_fill={}."
-                                     .format(len(col_level), len(col_fill)))
-                if len(col_level) < len(level):
-                    # the last column level gets repeated
-                    # for the remaining index levels.
-                    multiply = self.index.nlevels - len(col_level)
-                    col_level += [col_level[-1]] * multiply
-                    col_fill += [col_fill[-1]] * multiply
+                within_limits = [col_level, col_fill]
+                display_param = ['col_level', 'col_fill']
+                for i, var in enumerate(within_limits):
+                    if len(var) <= len(level):
+                        # the last column level / fill value gets repeated
+                        # for the remaining index levels.
+                        multiply = len(level) - len(var)
+                        var += [var[-1]] * multiply
+                    else:
+                        raise ValueError("Length of {}={} exceeds the "
+                                         "length of level={}."
+                                         .format(display_param[i],
+                                                 len(var), len(level)))
                 col_level = list(reversed(col_level))
                 col_fill = list(reversed(col_fill))
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1689,9 +1689,10 @@ Thur,Lunch,Yes,51.51,17"""
         df = DataFrame(data, columns=mc, index=mi)
 
         with pytest.raises(ValueError,
-                           match=("Length of col_level=2 should be "
-                                  "equal to length of col_fill=3.")):
-            df.reset_index(col_level=[1, 0], col_fill=['p', 'q', 'r'])
+                           match=("Length of col_fill=3 exceeds the "
+                                  "length of level=2.")):
+            df.reset_index(level=[0, 1], col_level=[1, 0],
+                           col_fill=['p', 'q', 'r'])
 
         df_actual = df.reset_index(level=[0, 1], col_level=[1, 0],
                                    col_fill='o').T

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1680,6 +1680,31 @@ Thur,Lunch,Yes,51.51,17"""
                                                             col_fill='C')
         tm.assert_frame_equal(result, expected)
 
+    def test_reset_index_multiindex_index_and_columns(self):
+        mc = MultiIndex.from_product([['a'], ['b', 'c']],
+                                     names=['clev0', 'clev1'])
+        mi = MultiIndex.from_product([['x'], ['y', 'z']],
+                                     names=['ilev0', 'ilev1'])
+        data = np.array(range(4)).reshape(2, 2)
+        df = DataFrame(data, columns=mc, index=mi)
+
+        with pytest.raises(ValueError,
+                           match=("Length of col_level=2 should be "
+                                  "equal to length of col_fill=3.")):
+            df.reset_index(col_level=[1, 0], col_fill=['p', 'q', 'r'])
+
+        df_actual = df.reset_index(level=[0, 1], col_level=[1, 0],
+                                   col_fill='o').T
+        df_expected = DataFrame([['o', 'ilev0', 'x', 'x'],
+                                 ['ilev1', 'o', 'y', 'z'],
+                                 ['a', 'b', 0, 2],
+                                 ['a', 'c', 1, 3]])
+        df_expected = df_expected.set_index([0, 1])
+        df_expected = df_expected.rename_axis(('clev0', 'clev1'), axis=0)
+        df_expected.columns = [0, 1]
+
+        tm.assert_frame_equal(df_actual, df_expected)
+
     def test_set_index_period(self):
         # GH 6631
         df = DataFrame(np.random.random(6))


### PR DESCRIPTION
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

**Code Sample**
```python
>>> index = pd.MultiIndex.from_tuples([('bird', 'falcon'), ('bird', 'parrot'), ('mammal', 'lion'), ('mammal', 'monkey')], names=['class', 'name'])
>>> columns = pd.MultiIndex.from_tuples([('speed', 'max'), ('species', 'type')])
>>> df = pd.DataFrame([(389.0, 'fly'), ( 24.0, 'fly'), ( 80.5, 'run'), (np.nan, 'jump')], index=index, columns=columns)
>>> df
```
```console
               speed species
                 max    type
class  name
bird   falcon  389.0     fly
       parrot   24.0     fly
mammal lion     80.5     run
       monkey    NaN    jump
```
```python
>>> df.reset_index(level=['class', 'name'], col_level=[1, 0], col_fill=['genus', 'pet'])
```
```console
    genus    name  speed species
    class     pet    max    type
0    bird  falcon  389.0     fly
1    bird  parrot   24.0     fly
2  mammal    lion   80.5     run
3  mammal  monkey    NaN    jump
```
**Explanation**

For DataFrames having MultiIndex Index and MultiIndex columns,
the `col_level` parameter can also accept a list / tuple so that each
index level's name can be mapped to a specific column level.

if not enough `col_level` / `col_fill` values are given, then the last 
given value maps to the remaining levels.