### PR TITLE
BUG: fix empty Series repr for subclasses

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -780,6 +780,7 @@ Other
 - Removed unused C functions from vendored UltraJSON implementation (:issue:`26198`)
 - Bug in :func:`factorize` when passing an ``ExtensionArray`` with a custom ``na_sentinel`` (:issue:`25696`).
 - Allow :class:`Index` and :class:`RangeIndex` to be passed to numpy ``min`` and ``max`` functions (:issue:`26125`)
+- Use actual class name in repr of empty objects of a ``Series`` subclass (:issue:`27001`).
 
 .. _whatsnew_0.250.contributors:
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -257,7 +257,8 @@ class SeriesFormatter:
         footer = self._get_footer()
 
         if len(series) == 0:
-            return 'Series([], ' + footer + ')'
+            return "{name}([], {footer})".format(
+                name=self.series.__class__.__name__, footer=footer)
 
         fmt_index, have_header = self._get_formatted_index()
         fmt_values = self._get_formatted_values()

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -39,6 +39,9 @@ class TestSeriesSubclassing:
 
         tm.assert_frame_equal(res, exp)
 
+    def test_subclass_empty_repr(self):
+        assert 'SubclassedSeries' in repr(tm.SubclassedSeries())
+
 
 @pytest.mark.filterwarnings("ignore:Sparse:FutureWarning")
 class TestSparseSeriesSubclassing:


### PR DESCRIPTION
Currently, the 'Series' name is hardcoded in the empty repr. This small patch ensures it uses the name of the class.