### PR TITLE
TST: fix flaky test

### DIFF
--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -425,7 +425,7 @@ test duplicates in time series
 """
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def dups():
     dates = [datetime(2000, 1, 2), datetime(2000, 1, 2),
              datetime(2000, 1, 2), datetime(2000, 1, 3),


### PR DESCRIPTION
One of the tests that uses this fixture modifies its value, so the `scope` kwarg is incorrect.  The failure depends on the order in which the test is run.  AFAICT only showing up on OSX.

Hits one of the checkboxes in #26823.