### PR TITLE
BUG: Categorical.copy deep kwarg

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -457,10 +457,8 @@ class Categorical(ExtensionArray, PandasObject):
         # Defer to CategoricalFormatter's formatter.
         return None
 
+    @Appender(ExtensionArray.copy.__doc__)
     def copy(self, deep: bool = False):
-        """
-        Copy constructor.
-        """
         values = self._codes
         if deep:
             values = values.copy()
@@ -2298,7 +2296,9 @@ class Categorical(ExtensionArray, PandasObject):
 
         # unlike np.unique, unique1d does not sort
         unique_codes = unique1d(self.codes)
-        cat = self.copy()  # Don't need deep here
+
+        # We don't need a deep copy since we overwrite cat._codes immediately
+        cat = self.copy()
 
         # keep nan in codes
         cat._codes = unique_codes

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -720,7 +720,10 @@ class Block(PandasObject):
         """ copy constructor """
         values = self.values
         if deep:
-            values = values.copy()
+            if self.is_extension:
+                values = values.copy(deep=True)
+            else:
+                values = values.copy()
         return self.make_block_same_class(values, ndim=self.ndim)
 
     def replace(self, to_replace, value, inplace=False, filter=None,
@@ -1855,7 +1858,7 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
             dtype = self.dtype
 
         try:
-            result = self.values.copy()
+            result = self.values.copy(deep=True)
             icond = ~cond
             if lib.is_scalar(other):
                 result[icond] = other

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -594,7 +594,7 @@ def sanitize_array(data, index, dtype=None, copy=False,
             subarr = data.astype(dtype)
 
         if copy:
-            subarr = data.copy()
+            subarr = data.copy(deep=True)
         return subarr
 
     elif isinstance(data, (list, tuple)) and len(data) > 0:

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -18,7 +18,9 @@ class BaseSetitemTests(BaseExtensionTests):
     def test_setitem_sequence(self, data, box_in_series):
         if box_in_series:
             data = pd.Series(data)
-        original = data.copy()
+            original = data.copy()
+        else:
+            original = data.copy(deep=True)
 
         data[[0, 1]] = [data[1], data[0]]
         assert data[0] == original[1]

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -246,6 +246,7 @@ class TestParsing(base.BaseParsingTests):
 
 
 def test_copy_deep(data):
+    # GH#27024
     assert data[0] != data[1]
 
     orig = data.copy(deep=True)

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -243,3 +243,28 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
 
 class TestParsing(base.BaseParsingTests):
     pass
+
+
+def test_copy_deep(data):
+    assert data[0] != data[1]
+
+    orig = data.copy(deep=True)
+    other = data.copy(deep=True)
+
+    # Modifying other will _not_ modify `data`
+    other[0] = other[1]
+    assert other[0] == other[1]
+    assert data[0] != data[1]
+
+    # Modifying other _will_ modify `data`
+    other2 = data.copy(deep=False)
+    other2[0] = other2[1]
+    assert other2[0] == other2[1]
+    assert data[0] == data[1]
+
+    # Default behavior should be deep=False
+    data = orig.copy(deep=True)
+    other3 = data.copy()
+
+    other3[0] = other3[1]
+    assert data[0] == data[1]


### PR DESCRIPTION
Would close #26995 if I hadn't just updated that to reflect the fact that several other pandas-internal EAs don't handle the `deep` kwarg correctly.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
