### PR TITLE
CLN/PERF: remove gc.collect from the setting_with_copy checks as not needed

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -5,7 +5,7 @@ import pandas.util.testing as tm
 from pandas import (Series, DataFrame, MultiIndex,
                     Int64Index, UInt64Index, Float64Index,
                     IntervalIndex, CategoricalIndex,
-                    IndexSlice, concat, date_range)
+                    IndexSlice, concat, date_range, option_context)
 
 
 class NumericSeriesIndexing:
@@ -333,6 +333,22 @@ class InsertColumns:
         np.random.seed(1234)
         for i in range(100):
             self.df[i] = np.random.randn(self.N)
+
+
+class ChainIndexing:
+
+    params = [None, 'warn']
+    param_names = ['mode']
+
+    def setup(self, mode):
+        self.N = 1000000
+
+    def time_chained_indexing(self, mode):
+        with warnings.catch_warnings(record=True):
+            with option_context('mode.chained_assignment', mode):
+                df = DataFrame({'A': np.arange(self.N), 'B': 'foo'})
+                df2 = df[df.A > self.N // 2]
+                df2['C'] = 1.0
 
 
 from .pandas_vb_common import setup  # noqa: F401

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -579,6 +579,7 @@ Performance Improvements
 - Improved performance of :attr:`IntervalIndex.is_unique` by removing conversion to ``MultiIndex`` (:issue:`24813`)
 - Restored performance of :meth:`DatetimeIndex.__iter__` by re-enabling specialized code path (:issue:`26702`)
 - Improved performance when building :class:`MultiIndex` with at least one :class:`CategoricalIndex` level (:issue:`22044`)
+- Improved performance by removing the need for a garbage collect when checking for ``SettingWithCopyWarning`` (:issue:``)
 
 .. _whatsnew_0250.bug_fixes:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -579,7 +579,7 @@ Performance Improvements
 - Improved performance of :attr:`IntervalIndex.is_unique` by removing conversion to ``MultiIndex`` (:issue:`24813`)
 - Restored performance of :meth:`DatetimeIndex.__iter__` by re-enabling specialized code path (:issue:`26702`)
 - Improved performance when building :class:`MultiIndex` with at least one :class:`CategoricalIndex` level (:issue:`22044`)
-- Improved performance by removing the need for a garbage collect when checking for ``SettingWithCopyWarning`` (:issue:``)
+- Improved performance by removing the need for a garbage collect when checking for ``SettingWithCopyWarning`` (:issue:`27031`)
 
 .. _whatsnew_0250.bug_fixes:
 


### PR DESCRIPTION
This doesn't look might much of a perf gain, but in practice the gc collect can happen at odd times, so this change removes this uncertainty (and is much simpler code)

```
(pandas) bash-3.2$ asv continuous --bench chained_indexing master gc --config asv_bench/asv.conf.json 
· Creating environments
· Discovering benchmarks
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For pandas commit d94146cf <master> (round 1/2):
[  0.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...........
[  0.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 25.00%] ··· Running (indexing.ChainIndexing.time_chained_indexing--).
[ 25.00%] · For pandas commit ab6cb31d <gc> (round 1/2):
[ 25.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...
[ 25.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 50.00%] ··· Running (indexing.ChainIndexing.time_chained_indexing--).
[ 50.00%] · For pandas commit ab6cb31d <gc> (round 2/2):
[ 50.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 75.00%] ··· indexing.ChainIndexing.time_chained_indexing                                                                                                                                                                                      ok
[ 75.00%] ··· ====== ==========
               mode            
              ------ ----------
               None   72.6±5ms 
               warn   67.2±4ms 
              ====== ==========

[ 75.00%] · For pandas commit d94146cf <master> (round 2/2):
[ 75.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...
[ 75.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[100.00%] ··· indexing.ChainIndexing.time_chained_indexing                                                                                                                                                                                      ok
[100.00%] ··· ====== ==========
               mode            
              ------ ----------
               None   69.4±4ms 
               warn   79.5±4ms 
              ====== ==========


BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```