### PR TITLE
Use mypy default follow import strategy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,5 @@
 [mypy]
 ignore_missing_imports=True
-follow_imports=silent
 
 [mypy-pandas.conftest,pandas.tests.*]
 ignore_errors=True


### PR DESCRIPTION
This was put in place as we were fixing up old annotations but isn't required at this point, so can safely remove and stick with mypy defaults (which is more strict)
