### PR TITLE
Install pyreadstat using conda instead

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -79,5 +79,4 @@ dependencies:
   - xlrd  # pandas.read_excel, DataFrame.to_excel, pandas.ExcelWriter, pandas.ExcelFile
   - xlsxwriter  # pandas.read_excel, DataFrame.to_excel, pandas.ExcelWriter, pandas.ExcelFile
   - xlwt  # pandas.read_excel, DataFrame.to_excel, pandas.ExcelWriter, pandas.ExcelFile
-  - pip:
-    - pyreadstat  # pandas.read_spss
+  - pyreadstat  # pandas.read_spss


### PR DESCRIPTION
```
> conda search pyreadstat -c conda-forge
Loading channels: done
# Name                       Version           Build  Channel
pyreadstat                     0.2.1  py36h301d43c_0  conda-forge
pyreadstat                     0.2.1  py37h301d43c_0  conda-forge
pyreadstat                     0.2.5  py36h301d43c_0  conda-forge
pyreadstat                     0.2.5  py37h301d43c_0  conda-forge
pyreadstat                     0.2.6  py36h301d43c_0  conda-forge
pyreadstat                     0.2.6  py37h301d43c_0  conda-forge
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
