### PR TITLE
CI: Disable codecov comments and re-enable results in the checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,13 @@
 codecov:
   branch: master
 
+comment: off
+
 coverage:
   status:
     project:
       default:
-        enabled: no
         target: '82'
     patch:
       default:
-        enabled: no
         target: '50'


### PR DESCRIPTION
- [x] closes #26896

Depending on how flaky the coverage calculations are, we could consider adding `threshold` to the yaml to specify how far the coverage can drop while posting success.

https://docs.codecov.io/docs/commit-status
