### PR TITLE
ENH: Json fill_value for missing fields

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -133,6 +133,7 @@ Other Enhancements
 - :meth:`DataFrame.describe` now formats integer percentiles without decimal point (:issue:`26660`)
 - Added support for reading SPSS .sav files using :func:`read_spss` (:issue:`26537`)
 - Added new option ``plotting.backend`` to be able to select a plotting backend different than the existing ``matplotlib`` one. Use ``pandas.set_option('plotting.backend', '<backend-module>')`` where ``<backend-module`` is a library implementing the pandas plotting API (:issue:`14130`)
+- :meth:`io.json.json_normalize` now accepts a `fill_value` argument to fill NaN fields in given columns (:issue:`16918`)
 
 .. _whatsnew_0250.api_breaking:
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -321,7 +321,8 @@ def dicts_to_array(dicts: list, columns: list, fill_value=None):
 
     result = np.empty((n, k), dtype='O')
     if fill_value:
-        onan = [fill_value[col] if col in fill_value else np.nan for col in columns]
+        onan = ([fill_value[col] if col in fill_value
+                else np.nan for col in columns])
     else:
         onan = list(np.full(k, np.nan))
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -308,17 +308,22 @@ def fast_unique_multiple_list_gen(object gen, bint sort=True):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def dicts_to_array(dicts: list, columns: list):
+def dicts_to_array(dicts: list, columns: list, fill_value=None):
     cdef:
         Py_ssize_t i, j, k, n
         ndarray[object, ndim=2] result
         dict row
-        object col, onan = np.nan
+        object col
+        list onan
 
     k = len(columns)
     n = len(dicts)
 
     result = np.empty((n, k), dtype='O')
+    if fill_value:
+        onan = [fill_value[col] if col in fill_value else np.nan for col in columns]
+    else:
+        onan = list(np.full(k, np.nan))
 
     for i in range(n):
         row = dicts[i]
@@ -327,7 +332,7 @@ def dicts_to_array(dicts: list, columns: list):
             if col in row:
                 result[i, j] = row[col]
             else:
-                result[i, j] = onan
+                result[i, j] = onan[j]
 
     return result
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -375,7 +375,7 @@ class DataFrame(NDFrame):
     # Constructors
 
     def __init__(self, data=None, index=None, columns=None, dtype=None,
-                 copy=False):
+                 copy=False, fill_value=None):
         if data is None:
             data = {}
         if dtype is not None:
@@ -431,7 +431,8 @@ class DataFrame(NDFrame):
                 if is_list_like(data[0]) and getattr(data[0], 'ndim', 1) == 1:
                     if is_named_tuple(data[0]) and columns is None:
                         columns = data[0]._fields
-                    arrays, columns = to_arrays(data, columns, dtype=dtype)
+                    arrays, columns = to_arrays(data, columns, dtype=dtype,
+                                                fill_value=fill_value)
                     columns = ensure_index(columns)
 
                     # set the index

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -371,7 +371,7 @@ def _get_axes(N, K, index, columns):
 # ---------------------------------------------------------------------
 # Conversion of Inputs to Arrays
 
-def to_arrays(data, columns, coerce_float=False, dtype=None):
+def to_arrays(data, columns, coerce_float=False, dtype=None, fill_value=None):
     """
     Return list of arrays, columns.
     """
@@ -396,7 +396,8 @@ def to_arrays(data, columns, coerce_float=False, dtype=None):
                                dtype=dtype)
     elif isinstance(data[0], abc.Mapping):
         return _list_of_dict_to_arrays(data, columns,
-                                       coerce_float=coerce_float, dtype=dtype)
+                                       coerce_float=coerce_float, dtype=dtype,
+                                       fill_value=fill_value)
     elif isinstance(data[0], ABCSeries):
         return _list_of_series_to_arrays(data, columns,
                                          coerce_float=coerce_float,
@@ -463,7 +464,8 @@ def _list_of_series_to_arrays(data, columns, coerce_float=False, dtype=None):
         return values.T, columns
 
 
-def _list_of_dict_to_arrays(data, columns, coerce_float=False, dtype=None):
+def _list_of_dict_to_arrays(data, columns, coerce_float=False, dtype=None,
+                            fill_value=None):
     if columns is None:
         gen = (list(x.keys()) for x in data)
         sort = not any(isinstance(d, OrderedDict) for d in data)
@@ -473,7 +475,8 @@ def _list_of_dict_to_arrays(data, columns, coerce_float=False, dtype=None):
     # classes
     data = [(type(d) is dict) and d or dict(d) for d in data]
 
-    content = list(lib.dicts_to_array(data, list(columns)).T)
+    content = list(lib.dicts_to_array(data, list(columns),
+                                      fill_value=fill_value).T)
     return _convert_object_array(content, columns, dtype=dtype,
                                  coerce_float=coerce_float)
 

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -96,11 +96,12 @@ def nested_to_record(ds, prefix="", sep=".", level=0):
     return new_ds
 
 
-def json_normalize(data, fill_value=None, record_path=None, meta=None,
+def json_normalize(data, record_path=None, meta=None,
                    meta_prefix=None,
                    record_prefix=None,
                    errors='raise',
-                   sep='.'):
+                   sep='.',
+                   fill_value=None):
     """
     Normalize semi-structured JSON data into a flat table.
 
@@ -151,7 +152,7 @@ def json_normalize(data, fill_value=None, record_path=None, meta=None,
     1  NaN         NaN      Regner        NaN       Mose       NaN
     2  2.0  Faye Raker         NaN        NaN        NaN       NaN
 
-    >>> json_normalize(data, fill_value={'id' : -1})
+    >>> json_normalize(data, fill_value={'id': -1})
        id        name name.family name.first name.given name.last
     0   1         NaN         NaN     Coleen        NaN      Volk
     1  -1         NaN      Regner        NaN       Mose       NaN

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -109,8 +109,6 @@ def json_normalize(data, record_path=None, meta=None,
     ----------
     data : dict or list of dicts
         Unserialized JSON objects
-    fill_value: dict, default None
-        default na values for specified columns
     record_path : string or list of strings, default None
         Path in each object to list of records. If not passed, data will be
         assumed to be an array of records
@@ -134,6 +132,11 @@ def json_normalize(data, record_path=None, meta=None,
         e.g., for sep='.', { 'foo' : { 'bar' : 0 } } -> foo.bar
 
         .. versionadded:: 0.20.0
+
+    fill_value : dict, default None
+        default na values for specified columns
+
+        .. versionadded:: 0.25.0
 
     Returns
     -------

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -38,6 +38,7 @@ def deep_nested():
              }
             ]
 
+
 @pytest.fixture
 def deep_nested_missing():
     # deeply nested data with some missing values
@@ -64,6 +65,7 @@ def deep_nested_missing():
                         ]
              }
             ]
+
 
 @pytest.fixture
 def state_data():


### PR DESCRIPTION
- [x] closes #16918
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

A new argument `fill_value` is added to allow users to supply default values for missing fields for each column. This enhancement also addresses the undesirable type conversion from `int` to `float` due to missing fields as raised in #16918