### PR TITLE
BUG/TST: Fillna limit Error Reporting

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -685,7 +685,7 @@ Missing
 
 - Fixed misleading exception message in :meth:`Series.interpolate` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 - Fixed class type displayed in exception message in :meth:`DataFrame.dropna` if invalid ``axis`` parameter passed (:issue:`25555`)
-- Fixed not throwing ValueError when a DataFrame of full integers has fillna called with a negative limit value
+- Fixed not throwing ValueError in :meth:`DataFrame.fillna` when called with a negative ``limit`` parameter value (:issue:`27042`)
 -
 
 MultiIndex

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -685,6 +685,7 @@ Missing
 
 - Fixed misleading exception message in :meth:`Series.interpolate` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 - Fixed class type displayed in exception message in :meth:`DataFrame.dropna` if invalid ``axis`` parameter passed (:issue:`25555`)
+- Fixed not throwing ValueError when a DataFrame of full integers has fillna called with a negative limit value
 -
 
 MultiIndex

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -445,7 +445,7 @@ class ExtensionArray:
         from pandas.util._validators import validate_fillna_kwargs
         from pandas.core.missing import pad_1d, backfill_1d
 
-        value, method = validate_fillna_kwargs(value, method)
+        value, method, limit = validate_fillna_kwargs(value, method, limit)
 
         mask = self.isna()
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1756,8 +1756,8 @@ class Categorical(ExtensionArray, PandasObject):
         -------
         filled : Categorical with NA/NaN filled
         """
-        value, method = validate_fillna_kwargs(
-            value, method, validate_scalar_dict_value=False
+        value, method, limit = validate_fillna_kwargs(
+            value, method, limit, validate_scalar_dict_value=False
         )
 
         if value is None:

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -767,7 +767,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin,
         if isinstance(value, ABCSeries):
             value = value.array
 
-        value, method = validate_fillna_kwargs(value, method)
+        value, method, limit = validate_fillna_kwargs(value, method, limit)
 
         mask = self.isna()
 

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -254,7 +254,7 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
 
     def fillna(self, value=None, method=None, limit=None):
         # TODO(_values_for_fillna): remove this
-        value, method = validate_fillna_kwargs(value, method)
+        value, method, limit = validate_fillna_kwargs(value, method, limit)
 
         mask = self.isna()
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6025,7 +6025,7 @@ class NDFrame(PandasObject, SelectionMixin):
         3   NaN 3.0 NaN 4
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
-        value, method = validate_fillna_kwargs(value, method)
+        value, method, limit = validate_fillna_kwargs(value, method, limit)
 
         self._consolidate_inplace()
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -352,10 +352,6 @@ class Block(PandasObject):
 
         mask = isna(self.values)
         if limit is not None:
-            if not is_integer(limit):
-                raise ValueError('Limit must be an integer')
-            if limit < 1:
-                raise ValueError('Limit must be greater than 0')
             if self.ndim > 2:
                 raise NotImplementedError("number of dimensions for 'fillna' "
                                           "is currently limited to 2")

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -516,6 +516,22 @@ class TestDataFrameMissingData:
         # it works!
         df.fillna(np.nan)
 
+    @pytest.mark.parametrize("type", [int, float])
+    def test_fillna_positive_limit(self, type):
+        df = DataFrame(np.random.randn(10, 4)).astype(type)
+
+        msg = "Limit must be greater than 0"
+        with pytest.raises(ValueError, match=msg):
+            df.fillna(0, limit=-5)
+
+    @pytest.mark.parametrize("type", [int, float])
+    def test_fillna_integer_limit(self, type):
+        df = DataFrame(np.random.randn(10, 4)).astype(type)
+
+        msg = "Limit must be an integer"
+        with pytest.raises(ValueError, match=msg):
+            df.fillna(0, limit=0.5)
+
     def test_fillna_inplace(self):
         df = DataFrame(np.random.randn(10, 4))
         df[1][:4] = np.nan

--- a/pandas/tests/util/test_validate_fillna_kwargs.py
+++ b/pandas/tests/util/test_validate_fillna_kwargs.py
@@ -25,22 +25,22 @@ def test_value_and_method(value, method):
 @pytest.mark.parametrize("value", [(1, 2, 3), [1, 2, 3]])
 def test_valid_value(value):
 
-        msg = ('"value" parameter must be a scalar or dict, but '
-               'you passed a "{0}"'.format(type(value).__name__))
+    msg = ('"value" parameter must be a scalar or dict, but '
+           'you passed a "{0}"'.format(type(value).__name__))
 
-        with pytest.raises(TypeError, match=msg):
-                validate_fillna_kwargs(value, None, None)
+    with pytest.raises(TypeError, match=msg):
+        validate_fillna_kwargs(value, None, None)
 
 
 def test_integer_limit():
 
-        msg = "Limit must be an integer"
-        with pytest.raises(ValueError, match=msg):
-                validate_fillna_kwargs(0, None, 0.5)
+    msg = "Limit must be an integer"
+    with pytest.raises(ValueError, match=msg):
+        validate_fillna_kwargs(0, None, 0.5)
 
 
 def test_positive_limit():
 
-        msg = "Limit must be greater than 0"
-        with pytest.raises(ValueError, match=msg):
-                validate_fillna_kwargs(5, None, -5)
+    msg = "Limit must be greater than 0"
+    with pytest.raises(ValueError, match=msg):
+        validate_fillna_kwargs(5, None, -5)

--- a/pandas/tests/util/test_validate_fillna_kwargs.py
+++ b/pandas/tests/util/test_validate_fillna_kwargs.py
@@ -2,22 +2,25 @@ import pytest
 
 from pandas.util._validators import validate_fillna_kwargs
 
+
 def test_no_value_or_method():
 
     msg = "Must specify a fill 'value' or 'method'."
 
     with pytest.raises(ValueError, match=msg):
-         validate_fillna_kwargs(None, None, None)
+        validate_fillna_kwargs(None, None, None)
 
 
-@pytest.mark.parametrize("value", [0, {'A': 0, 'B': 1, 'C': 2, 'D': 3, 'E': 4}])
+@pytest.mark.parametrize("value",
+                         [0, {'A': 0, 'B': 1, 'C': 2, 'D': 3, 'E': 4}])
 @pytest.mark.parametrize("method", ['backfill', 'bfill', 'pad', 'ffill'])
 def test_value_and_method(value, method):
 
     msg = "Cannot specify both 'value' and 'method'."
-    
+
     with pytest.raises(ValueError, match=msg):
         validate_fillna_kwargs(value, method, None)
+
 
 @pytest.mark.parametrize("value", [(1, 2, 3), [1, 2, 3]])
 def test_valid_value(value):
@@ -28,15 +31,16 @@ def test_valid_value(value):
         with pytest.raises(TypeError, match=msg):
                 validate_fillna_kwargs(value, None, None)
 
+
 def test_integer_limit():
 
         msg = "Limit must be an integer"
         with pytest.raises(ValueError, match=msg):
-                validate_fillna_kwargs(0,None, 0.5)
+                validate_fillna_kwargs(0, None, 0.5)
+
+
 def test_positive_limit():
 
         msg = "Limit must be greater than 0"
         with pytest.raises(ValueError, match=msg):
                 validate_fillna_kwargs(5, None, -5)
-
-

--- a/pandas/tests/util/test_validate_fillna_kwargs.py
+++ b/pandas/tests/util/test_validate_fillna_kwargs.py
@@ -11,15 +11,12 @@ def test_no_value_or_method():
         validate_fillna_kwargs(None, None, None)
 
 
-@pytest.mark.parametrize("value",
-                         [0, {'A': 0, 'B': 1, 'C': 2, 'D': 3, 'E': 4}])
-@pytest.mark.parametrize("method", ['backfill', 'bfill', 'pad', 'ffill'])
-def test_value_and_method(value, method):
+def test_value_and_method():
 
     msg = "Cannot specify both 'value' and 'method'."
 
     with pytest.raises(ValueError, match=msg):
-        validate_fillna_kwargs(value, method, None)
+        validate_fillna_kwargs(0, 'ffill', None)
 
 
 @pytest.mark.parametrize("value", [(1, 2, 3), [1, 2, 3]])

--- a/pandas/tests/util/test_validate_fillna_kwargs.py
+++ b/pandas/tests/util/test_validate_fillna_kwargs.py
@@ -1,0 +1,42 @@
+import pytest
+
+from pandas.util._validators import validate_fillna_kwargs
+
+def test_no_value_or_method():
+
+    msg = "Must specify a fill 'value' or 'method'."
+
+    with pytest.raises(ValueError, match=msg):
+         validate_fillna_kwargs(None, None, None)
+
+
+@pytest.mark.parametrize("value", [0, {'A': 0, 'B': 1, 'C': 2, 'D': 3, 'E': 4}])
+@pytest.mark.parametrize("method", ['backfill', 'bfill', 'pad', 'ffill'])
+def test_value_and_method(value, method):
+
+    msg = "Cannot specify both 'value' and 'method'."
+    
+    with pytest.raises(ValueError, match=msg):
+        validate_fillna_kwargs(value, method, None)
+
+@pytest.mark.parametrize("value", [(1, 2, 3), [1, 2, 3]])
+def test_valid_value(value):
+
+        msg = ('"value" parameter must be a scalar or dict, but '
+               'you passed a "{0}"'.format(type(value).__name__))
+
+        with pytest.raises(TypeError, match=msg):
+                validate_fillna_kwargs(value, None, None)
+
+def test_integer_limit():
+
+        msg = "Limit must be an integer"
+        with pytest.raises(ValueError, match=msg):
+                validate_fillna_kwargs(0,None, 0.5)
+def test_positive_limit():
+
+        msg = "Limit must be greater than 0"
+        with pytest.raises(ValueError, match=msg):
+                validate_fillna_kwargs(5, None, -5)
+
+

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -4,7 +4,7 @@ for validating data or function arguments
 """
 import warnings
 
-from pandas.core.dtypes.common import is_bool
+from pandas.core.dtypes.common import is_bool, is_integer
 
 
 def _check_arg_length(fname, args, max_fname_arg_count, compat_args):
@@ -322,7 +322,8 @@ def validate_axis_style_args(data, args, kwargs, arg_name, method_name):
     return out
 
 
-def validate_fillna_kwargs(value, method, validate_scalar_dict_value=True):
+def validate_fillna_kwargs(value, method, limit,
+                           validate_scalar_dict_value=True):
     """Validate the keyword arguments to 'fillna'.
 
     This checks that exactly one of 'value' and 'method' is specified.
@@ -355,4 +356,10 @@ def validate_fillna_kwargs(value, method, validate_scalar_dict_value=True):
     elif value is not None and method is not None:
         raise ValueError("Cannot specify both 'value' and 'method'.")
 
-    return value, method
+    if limit is not None:
+        if not is_integer(limit):
+            raise ValueError('Limit must be an integer')
+        if limit < 1:
+            raise ValueError('Limit must be greater than 0')
+
+    return value, method, limit


### PR DESCRIPTION
fillna method was not throwing an ValueError with a dataframe full of
integers (no NAs) and limit keyword set to a negative number. Issue can
be seen in GH27042.

Begun with writing tests for checking the behaviour of fillna
and values of limit in test/frame/test_missing.py for both negative and
non-integer values of limit.

Then wrote new test file tests/util/test_validate_fillna_kwargs.py,
where the function would now also take limit as an argument and
perform necassary checks in there.

Made changes to util/_validators.py to correctly check values of limit
as was already done in core/internal/blocks.py

Updated calls to validate_fillna_kwargs in various files
to include the limit argument.

- [x ] closes #27042 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x ] whatsnew entry
