### PR TITLE
BUG/TST:  fillna limit checks and tests

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -685,7 +685,8 @@ Missing
 
 - Fixed misleading exception message in :meth:`Series.interpolate` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 - Fixed class type displayed in exception message in :meth:`DataFrame.dropna` if invalid ``axis`` parameter passed (:issue:`25555`)
--
+- Fixed not throwing ValueError in :meth:`DataFrame.fillna` when called with a negative ``limit`` parameter value (:issue:`27042`)
+- 
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -685,7 +685,7 @@ Missing
 
 - Fixed misleading exception message in :meth:`Series.interpolate` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 - Fixed class type displayed in exception message in :meth:`DataFrame.dropna` if invalid ``axis`` parameter passed (:issue:`25555`)
-- Fixed not throwing `ValueError` in :meth:`DataFrame.fillna` when called with a negative ``limit`` parameter value (:issue:`27042`)
+- Fixed not throwing ``ValueError`` in :meth:`DataFrame.fillna` when called with a negative ``limit`` parameter value (:issue:`27042`)
 - 
 
 MultiIndex

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -686,7 +686,7 @@ Missing
 - Fixed misleading exception message in :meth:`Series.interpolate` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 - Fixed class type displayed in exception message in :meth:`DataFrame.dropna` if invalid ``axis`` parameter passed (:issue:`25555`)
 - Fixed not throwing ``ValueError`` in :meth:`DataFrame.fillna` when called with a negative ``limit`` parameter value (:issue:`27042`)
-- 
+-
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -685,7 +685,7 @@ Missing
 
 - Fixed misleading exception message in :meth:`Series.interpolate` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 - Fixed class type displayed in exception message in :meth:`DataFrame.dropna` if invalid ``axis`` parameter passed (:issue:`25555`)
-- Fixed not throwing ``ValueError`` in :meth:`DataFrame.fillna` when called with a negative ``limit`` parameter value (:issue:`27042`)
+- A ``ValueError`` will now be thrown by :meth:`DataFrame.fillna` when ``limit`` is not a positive integer (:issue:`27042`)
 -
 
 MultiIndex

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -685,7 +685,7 @@ Missing
 
 - Fixed misleading exception message in :meth:`Series.interpolate` if argument ``order`` is required, but omitted (:issue:`10633`, :issue:`24014`).
 - Fixed class type displayed in exception message in :meth:`DataFrame.dropna` if invalid ``axis`` parameter passed (:issue:`25555`)
-- Fixed not throwing ValueError in :meth:`DataFrame.fillna` when called with a negative ``limit`` parameter value (:issue:`27042`)
+- Fixed not throwing `ValueError` in :meth:`DataFrame.fillna` when called with a negative ``limit`` parameter value (:issue:`27042`)
 - 
 
 MultiIndex

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -344,12 +344,6 @@ class Block(PandasObject):
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
 
-        if not self._can_hold_na:
-            if inplace:
-                return self
-            else:
-                return self.copy()
-
         mask = isna(self.values)
         if limit is not None:
             if not is_integer(limit):
@@ -360,6 +354,12 @@ class Block(PandasObject):
                 raise NotImplementedError("number of dimensions for 'fillna' "
                                           "is currently limited to 2")
             mask[mask.cumsum(self.ndim - 1) > limit] = False
+
+        if not self._can_hold_na:
+            if inplace:
+                return self
+            else:
+                return self.copy()
 
         # fillna, but if we cannot coerce, then try again as an ObjectBlock
         try:

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -516,6 +516,22 @@ class TestDataFrameMissingData:
         # it works!
         df.fillna(np.nan)
 
+    @pytest.mark.parametrize("type", [int, float])
+    def test_fillna_positive_limit(self, type):
+        df = DataFrame(np.random.randn(10, 4)).astype(type)
+
+        msg = "Limit must be greater than 0"
+        with pytest.raises(ValueError, match=msg):
+            df.fillna(0, limit=-5)
+
+    @pytest.mark.parametrize("type", [int, float])
+    def test_fillna_integer_limit(self, type):
+        df = DataFrame(np.random.randn(10, 4)).astype(type)
+
+        msg = "Limit must be an integer"
+        with pytest.raises(ValueError, match=msg):
+            df.fillna(0, limit=0.5)
+
     def test_fillna_inplace(self):
         df = DataFrame(np.random.randn(10, 4))
         df[1][:4] = np.nan


### PR DESCRIPTION
Reversed the order of returning and performing checks on `limit`
in fillna method in blocks.py so that an ValueError is raised
before returning.

Alternative to PR #27074


- [tick ] closes #27042 
- [ ] tests added / passed
- [tick ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ tick] whatsnew entry
