### PR TITLE
Remove read_table deprecation

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1298,7 +1298,7 @@ Deprecations
 - :meth:`Series.compress` is deprecated. Use ``Series[condition]`` instead (:issue:`18262`)
 - The signature of :meth:`Series.to_csv` has been uniformed to that of :meth:`DataFrame.to_csv`: the name of the first argument is now ``path_or_buf``, the order of subsequent arguments has changed, the ``header`` argument now defaults to ``True``. (:issue:`19715`)
 - :meth:`Categorical.from_codes` has deprecated providing float values for the ``codes`` argument. (:issue:`21767`)
-- :func:`pandas.read_table` is deprecated. Instead, use :func:`read_csv` passing ``sep='\t'`` if necessary (:issue:`21948`)
+- :func:`pandas.read_table` is deprecated. Instead, use :func:`read_csv` passing ``sep='\t'`` if necessary. This deprecation has been removed in 0.25.0. (:issue:`21948`)
 - :meth:`Series.str.cat` has deprecated using arbitrary list-likes *within* list-likes. A list-like container may still contain
   many ``Series``, ``Index`` or 1-dimensional ``np.ndarray``, or alternatively, only scalar values. (:issue:`21950`)
 - :meth:`FrozenNDArray.searchsorted` has deprecated the ``v`` parameter in favor of ``value`` (:issue:`14645`)

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -604,6 +604,7 @@ Other deprecations
 - The :meth:`Series.ftype`, :meth:`Series.ftypes` and :meth:`DataFrame.ftypes` methods are deprecated and will be removed in a future version.
   Instead, use :meth:`Series.dtype` and :meth:`DataFrame.dtypes` (:issue:`26705`).
 - :meth:`Timedelta.resolution` is deprecated and replaced with :meth:`Timedelta.resolution_string`.  In a future version, :meth:`Timedelta.resolution` will be changed to behave like the standard library :attr:`timedelta.resolution` (:issue:`21344`)
+- func:`read_table` has been undeprecated. (:issue:`25220`)
 
 .. _whatsnew_0250.prior_deprecations:
 
@@ -872,7 +873,6 @@ Other
 - Allow :class:`Index` and :class:`RangeIndex` to be passed to numpy ``min`` and ``max`` functions (:issue:`26125`)
 - Use actual class name in repr of empty objects of a ``Series`` subclass (:issue:`27001`).
 - Bug in :class:`DataFrame` where passing an object array of timezone-aware `datetime` objects would incorrectly raise ``ValueError`` (:issue:`13287`)
-- func:`read_table` has been undeprecated (:issue:`25220`)
 
 .. _whatsnew_0.250.contributors:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -872,6 +872,7 @@ Other
 - Allow :class:`Index` and :class:`RangeIndex` to be passed to numpy ``min`` and ``max`` functions (:issue:`26125`)
 - Use actual class name in repr of empty objects of a ``Series`` subclass (:issue:`27001`).
 - Bug in :class:`DataFrame` where passing an object array of timezone-aware `datetime` objects would incorrectly raise ``ValueError`` (:issue:`13287`)
+- func:`read_table` has been undeprecated (:issue:`25220`)
 
 .. _whatsnew_0.250.contributors:
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -713,7 +713,7 @@ read_csv = Appender(_doc_read_csv_and_table.format(
 read_table = _make_parser_function('read_table', default_sep='\t')
 read_table = Appender(_doc_read_csv_and_table.format(
                       func_name='read_table',
-                      summary="""Read general delimited file into DataFrame.""",
+                      summary='Read general delimited file into DataFrame.',
                       _default_sep=r"'\\t' (tab-stop)")
                       )(read_table)
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -540,14 +540,8 @@ _deprecated_args = {
 
 def _make_parser_function(name, default_sep=','):
 
-    # prepare read_table deprecation
-    if name == "read_table":
-        sep = False
-    else:
-        sep = default_sep
-
     def parser_f(filepath_or_buffer: FilePathOrBuffer,
-                 sep=sep,
+                 sep=default_sep,
                  delimiter=None,
 
                  # Column and Index Locations and Names
@@ -612,19 +606,6 @@ def _make_parser_function(name, default_sep=','):
                  low_memory=_c_parser_defaults['low_memory'],
                  memory_map=False,
                  float_precision=None):
-
-        # deprecate read_table GH21948
-        if name == "read_table":
-            if sep is False and delimiter is None:
-                warnings.warn("read_table is deprecated, use read_csv "
-                              "instead, passing sep='\\t'.",
-                              FutureWarning, stacklevel=2)
-            else:
-                warnings.warn("read_table is deprecated, use read_csv "
-                              "instead.",
-                              FutureWarning, stacklevel=2)
-            if sep is False:
-                sep = default_sep
 
         # gh-23761
         #
@@ -732,10 +713,7 @@ read_csv = Appender(_doc_read_csv_and_table.format(
 read_table = _make_parser_function('read_table', default_sep='\t')
 read_table = Appender(_doc_read_csv_and_table.format(
                       func_name='read_table',
-                      summary="""Read general delimited file into DataFrame.
-
-.. deprecated:: 0.24.0
-  Use :func:`pandas.read_csv` instead, passing ``sep='\\t'`` if necessary.""",
+                      summary="""Read general delimited file into DataFrame.""",
                       _default_sep=r"'\\t' (tab-stop)")
                       )(read_table)
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -1917,16 +1917,14 @@ def test_read_csv_memory_growth_chunksize(all_parsers):
             pass
 
 
-def test_read_table_deprecated(all_parsers):
+def test_read_table_equivalency_to_read_csv(all_parsers):
     # see gh-21948
+    # As of 0.25.0, read_table is undeprecated
     parser = all_parsers
     data = "a\tb\n1\t2\n3\t4"
     expected = parser.read_csv(StringIO(data), sep="\t")
-
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        result = parser.read_table(StringIO(data))
-        tm.assert_frame_equal(result, expected)
+    result = parser.read_table(StringIO(data))
+    tm.assert_frame_equal(result, expected)
 
 
 def test_first_row_bom(all_parsers):

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -160,6 +160,7 @@ bar2,12,13,14,15
 
     @pytest.mark.parametrize('reader, module, error_class, fn_ext', [
         (pd.read_csv, 'os', FileNotFoundError, 'csv'),
+        (pd.read_table, 'os', FileNotFoundError, 'csv'),
         (pd.read_fwf, 'os', FileNotFoundError, 'txt'),
         (pd.read_excel, 'xlrd', FileNotFoundError, 'xlsx'),
         (pd.read_feather, 'feather', Exception, 'feather'),
@@ -191,18 +192,9 @@ bar2,12,13,14,15
                 msg1, msg2, msg3, msg4, msg5)):
             reader(path)
 
-    def test_read_non_existant_read_table(self):
-        path = os.path.join(HERE, 'data', 'does_not_exist.' + 'csv')
-        msg1 = r"File b'.+does_not_exist\.csv' does not exist"
-        msg2 = (r"\[Errno 2\] File .+does_not_exist\.csv does not exist:"
-                r" '.+does_not_exist\.csv'")
-        with pytest.raises(FileNotFoundError, match=r"({}|{})".format(
-                msg1, msg2)):
-            with tm.assert_produces_warning(FutureWarning):
-                pd.read_table(path)
-
     @pytest.mark.parametrize('reader, module, path', [
         (pd.read_csv, 'os', ('io', 'data', 'iris.csv')),
+        (pd.read_table, 'os', ('io', 'data', 'iris.csv')),
         (pd.read_fwf, 'os', ('io', 'data', 'fixed_width_format.txt')),
         (pd.read_excel, 'xlrd', ('io', 'data', 'test1.xlsx')),
         (pd.read_feather, 'feather', ('io', 'data', 'feather-0_3_1.feather')),
@@ -221,21 +213,6 @@ bar2,12,13,14,15
         mypath = CustomFSPath(path)
         result = reader(mypath)
         expected = reader(path)
-
-        if path.endswith('.pickle'):
-            # categorical
-            tm.assert_categorical_equal(result, expected)
-        else:
-            tm.assert_frame_equal(result, expected)
-
-    def test_read_fspath_all_read_table(self, datapath):
-        path = datapath('io', 'data', 'iris.csv')
-
-        mypath = CustomFSPath(path)
-        with tm.assert_produces_warning(FutureWarning):
-            result = pd.read_table(mypath)
-        with tm.assert_produces_warning(FutureWarning):
-            expected = pd.read_table(path)
 
         if path.endswith('.pickle'):
             # categorical


### PR DESCRIPTION
- [x] closes #25220
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Let me know if the whatsnew note should be a special section in the `Deprecation` section.