### PR TITLE
DEPR: Change current DeprecationWarnings to FutureWarnings

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -231,7 +231,7 @@ class RangeIndex(Int64Index):
             Use ``start`` instead.
         """
         warnings.warn(self._deprecation_message.format("_start", "start"),
-                      FutureWarning, stacklevel=2)
+                      DeprecationWarning, stacklevel=2)
         return self.start
 
     @cache_readonly
@@ -251,7 +251,7 @@ class RangeIndex(Int64Index):
         """
         # GH 25710
         warnings.warn(self._deprecation_message.format("_stop", "stop"),
-                      FutureWarning, stacklevel=2)
+                      DeprecationWarning, stacklevel=2)
         return self.stop
 
     @cache_readonly
@@ -272,7 +272,7 @@ class RangeIndex(Int64Index):
         """
         # GH 25710
         warnings.warn(self._deprecation_message.format("_step", "step"),
-                      FutureWarning, stacklevel=2)
+                      DeprecationWarning, stacklevel=2)
         return self.step
 
     @cache_readonly

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -231,7 +231,7 @@ class RangeIndex(Int64Index):
             Use ``start`` instead.
         """
         warnings.warn(self._deprecation_message.format("_start", "start"),
-                      DeprecationWarning, stacklevel=2)
+                      FutureWarning, stacklevel=2)
         return self.start
 
     @cache_readonly
@@ -251,7 +251,7 @@ class RangeIndex(Int64Index):
         """
         # GH 25710
         warnings.warn(self._deprecation_message.format("_stop", "stop"),
-                      DeprecationWarning, stacklevel=2)
+                      FutureWarning, stacklevel=2)
         return self.stop
 
     @cache_readonly
@@ -272,7 +272,7 @@ class RangeIndex(Int64Index):
         """
         # GH 25710
         warnings.warn(self._deprecation_message.format("_step", "step"),
-                      DeprecationWarning, stacklevel=2)
+                      FutureWarning, stacklevel=2)
         return self.step
 
     @cache_readonly

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -220,7 +220,7 @@ class Block(PandasObject):
         if dtype is not None:
             # issue 19431 fastparquet is passing this
             warnings.warn("dtype argument is deprecated, will be removed "
-                          "in a future release.", DeprecationWarning)
+                          "in a future release.", FutureWarning)
         if placement is None:
             placement = self.mgr_locs
         return make_block(values, placement=placement, ndim=ndim,
@@ -1794,7 +1794,7 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
                 "'ExtensionArray._formatting_values' is deprecated. "
                 "Specify 'ExtensionArray._formatter' instead."
             )
-            warnings.warn(msg, DeprecationWarning, stacklevel=10)
+            warnings.warn(msg, FutureWarning, stacklevel=10)
             return self.values._formatting_values()
 
         return self.values
@@ -3056,7 +3056,7 @@ def make_block(values, placement, klass=None, ndim=None, dtype=None,
     if fastpath is not None:
         # GH#19265 pyarrow is passing this
         warnings.warn("fastpath argument is deprecated, will be removed "
-                      "in a future release.", DeprecationWarning)
+                      "in a future release.", FutureWarning)
     if klass is None:
         dtype = dtype or values.dtype
         klass = get_block_type(values, dtype)

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -397,6 +397,6 @@ def test_formatting_values_deprecated():
 
     ser = pd.Series(DecimalArray2([decimal.Decimal('1.0')]))
 
-    with tm.assert_produces_warning(DeprecationWarning,
+    with tm.assert_produces_warning(FutureWarning,
                                     check_stacklevel=False):
         repr(ser)

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -171,12 +171,12 @@ class TestRangeIndex(Numeric):
         assert index.stop == stop
         assert index.step == step
 
-    def test_deprecated_start_stop_step_attrs(self):
+    @pytest.mark.parametrize('attr_name', ['_start', '_stop', '_step'])
+    def test_deprecated_start_stop_step_attrs(self, attr_name):
         # GH 26581
         idx = self.create_index()
-        for attr_name in ['_start', '_stop', '_step']:
-            with tm.assert_produces_warning(FutureWarning):
-                getattr(idx, attr_name)
+        with tm.assert_produces_warning(DeprecationWarning):
+            getattr(idx, attr_name)
 
     def test_copy(self):
         i = RangeIndex(5, name='Foo')

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -175,7 +175,7 @@ class TestRangeIndex(Numeric):
         # GH 26581
         idx = self.create_index()
         for attr_name in ['_start', '_stop', '_step']:
-            with tm.assert_produces_warning(DeprecationWarning):
+            with tm.assert_produces_warning(FutureWarning):
                 getattr(idx, attr_name)
 
     def test_copy(self):

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -287,7 +287,7 @@ class TestBlock:
     def test_make_block_same_class(self):
         # issue 19431
         block = create_block('M8[ns, US/Eastern]', [3])
-        with tm.assert_produces_warning(DeprecationWarning,
+        with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):
             block.make_block_same_class(block.values,
                                         dtype=block.values.dtype)
@@ -1254,7 +1254,7 @@ def test_holder(typestr, holder):
 def test_deprecated_fastpath():
     # GH#19265
     values = np.random.rand(3, 3)
-    with tm.assert_produces_warning(DeprecationWarning,
+    with tm.assert_produces_warning(FutureWarning,
                                     check_stacklevel=False):
         make_block(values, placement=np.arange(3), fastpath=True)
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

in prep for removal in 1.0 after 0.25.0 is released.