### PR TITLE
Bump python_requires to 3.5.3

### DIFF
--- a/ci/deps/azure-35-compat.yaml
+++ b/ci/deps/azure-35-compat.yaml
@@ -11,7 +11,7 @@ dependencies:
   - openpyxl=2.4.8
   - pytables=3.4.2
   - python-dateutil=2.6.1
-  - python=3.5.*
+  - python=3.5.2
   - pytz=2017.2
   - scipy=0.19.0
   - xlrd=1.1.0

--- a/ci/deps/azure-35-compat.yaml
+++ b/ci/deps/azure-35-compat.yaml
@@ -11,7 +11,7 @@ dependencies:
   - openpyxl=2.4.8
   - pytables=3.4.2
   - python-dateutil=2.6.1
-  - python=3.5.2
+  - python=3.5.3
   - pytz=2017.2
   - scipy=0.19.0
   - xlrd=1.1.0

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -5,7 +5,7 @@ What's new in 0.25.0 (April XX, 2019)
 
 .. warning::
 
-   Starting with the 0.25.x series of releases, pandas only supports Python 3.5.2 and higher.
+   Starting with the 0.25.x series of releases, pandas only supports Python 3.5.3 and higher.
    See :ref:`install.dropping-27` for more details.
 
 .. warning::

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -5,8 +5,12 @@ What's new in 0.25.0 (April XX, 2019)
 
 .. warning::
 
-   Starting with the 0.25.x series of releases, pandas only supports Python 3.5 and higher.
+   Starting with the 0.25.x series of releases, pandas only supports Python 3.5.2 and higher.
    See :ref:`install.dropping-27` for more details.
+
+.. warning::
+
+   The minimum supported Python version will be bumped to 3.6 in a future release.
 
 .. warning::
 

--- a/setup.py
+++ b/setup.py
@@ -783,7 +783,7 @@ setup(name=DISTNAME,
       long_description=LONG_DESCRIPTION,
       classifiers=CLASSIFIERS,
       platforms='any',
-      python_requires='>=3.5',
+      python_requires='>=3.5.2',
       extras_require={
           'test': [
               # sync with setup.cfg minversion & install.rst

--- a/setup.py
+++ b/setup.py
@@ -783,7 +783,7 @@ setup(name=DISTNAME,
       long_description=LONG_DESCRIPTION,
       classifiers=CLASSIFIERS,
       platforms='any',
-      python_requires='>=3.5.2',
+      python_requires='>=3.5.3',
       extras_require={
           'test': [
               # sync with setup.cfg minversion & install.rst


### PR DESCRIPTION
Mentioned during sprint today some of the typing constructs we use were not added until Python 3.5.2, specifically typing.Type and typing.DefaultDict and maybe at some point typing.TYPE_CHECKING

https://docs.python.org/3/library/typing.html#typing.Type

This is a bump of the setup files and docs to 3.5.2. 