### PR TITLE
CLN: Remove older deprecations

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -198,7 +198,6 @@ Reindexing / selection / label manipulation
    DataFrame.idxmin
    DataFrame.last
    DataFrame.reindex
-   DataFrame.reindex_axis
    DataFrame.reindex_like
    DataFrame.rename
    DataFrame.rename_axis

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -628,7 +628,7 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``convert_objects`` (:issue:`11221`)
 - Removed the previously deprecated ``select`` method of ``DataFrame`` and ``Series`` (:issue:`17633`)
 - Removed the previously deprecated behavior of :class:`Series` treated as list-like in :meth:`~Series.cat.rename_categories` (:issue:`17982`)
-- Removed the previously deprecated :meth:`~DataFrame.reindex_axis` and :meth:`~Series.reindex_axis`` (:issue:`17842`)
+- Removed the previously deprecated ``DataFrame.reindex_axis`` and ``Series.reindex_axis``` (:issue:`17842`)
 - Removed the previously deprecated behavior of altering column or index labels with :meth:`Series.rename_axis` or :meth:`DataFrame.rename_axis` (:issue:`17842`)
 
 .. _whatsnew_0250.performance:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -628,7 +628,7 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``convert_objects`` (:issue:`11221`)
 - Removed the previously deprecated ``select`` method of ``DataFrame`` and ``Series`` (:issue:`17633`)
 - Removed the previously deprecated behavior of :class:`Series` treated as list-like in :meth:`~Series.cat.rename_categories` (:issue:`17982`)
-- Removed the previously deprecated :meth:`~DataFrame.reindex_axis`` (:issue:`17842`)
+- Removed the previously deprecated :meth:`~DataFrame.reindex_axis` and :meth:`~Series.reindex_axis`` (:issue:`17842`)
 - Removed the previously deprecated behavior of altering column or index labels with :meth:`Series.rename_axis` or :meth:`DataFrame.rename_axis` (:issue:`17842`)
 
 .. _whatsnew_0250.performance:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -628,7 +628,8 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``convert_objects`` (:issue:`11221`)
 - Removed the previously deprecated ``select`` method of ``DataFrame`` and ``Series`` (:issue:`17633`)
 - Removed the previously deprecated behavior of :class:`Series` treated as list-like in :meth:`~Series.cat.rename_categories` (:issue:`17982`)
-
+- Removed the previously deprecated :meth:`~DataFrame.reindex_axis`` (:issue:`17842`)
+- Removed the previously deprecated behavior of altering column or index labels with :meth:`Series.rename_axis` or :meth:`DataFrame.rename_axis` (:issue:`17842`)
 
 .. _whatsnew_0250.performance:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -627,6 +627,8 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``pd.options.html.border`` (:issue:`16970`)
 - Removed the previously deprecated ``convert_objects`` (:issue:`11221`)
 - Removed the previously deprecated ``select`` method of ``DataFrame`` and ``Series`` (:issue:`17633`)
+- Removed the previously deprecated behavior of :class:`Series` treated as list-like in :meth:`~Series.cat.rename_categories` (:issue:`17982`)
+
 
 .. _whatsnew_0250.performance:
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -887,11 +887,6 @@ class Categorical(ExtensionArray, PandasObject):
 
              .. versionadded:: 0.23.0
 
-           .. warning::
-
-              Currently, Series are considered list like. In a future version
-              of pandas they'll be considered dict-like.
-
         inplace : bool, default False
            Whether or not to rename the categories inplace or return a copy of
            this categorical with renamed categories.
@@ -938,15 +933,6 @@ class Categorical(ExtensionArray, PandasObject):
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
         cat = self if inplace else self.copy()
-
-        if isinstance(new_categories, ABCSeries):
-            msg = ("Treating Series 'new_categories' as a list-like and using "
-                   "the values. In a future version, 'rename_categories' will "
-                   "treat Series like a dictionary.\n"
-                   "For dict-like, use 'new_categories.to_dict()'\n"
-                   "For list-like, use 'new_categories.values'.")
-            warn(msg, FutureWarning, stacklevel=2)
-            new_categories = list(new_categories)
 
         if is_dict_like(new_categories):
             cat.categories = [new_categories.get(item, item)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3768,13 +3768,6 @@ class DataFrame(NDFrame):
         kwargs.pop('labels', None)
         return super().reindex(**kwargs)
 
-    @Appender(_shared_docs['reindex_axis'] % _shared_doc_kwargs)
-    def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
-                     limit=None, fill_value=np.nan):
-        return super().reindex_axis(labels=labels, axis=axis, method=method,
-                                    level=level, copy=copy, limit=limit,
-                                    fill_value=fill_value)
-
     def drop(self, labels=None, axis=0, index=None, columns=None,
              level=None, inplace=False, errors='raise'):
         """

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1244,13 +1244,6 @@ class Panel(NDFrame):
         return super().rename(items=items, major_axis=major_axis,
                               minor_axis=minor_axis, **kwargs)
 
-    @Appender(_shared_docs['reindex_axis'] % _shared_doc_kwargs)
-    def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
-                     limit=None, fill_value=np.nan):
-        return super().reindex_axis(labels=labels, axis=axis, method=method,
-                                    level=level, copy=copy, limit=limit,
-                                    fill_value=fill_value)
-
     @Substitution(**_shared_doc_kwargs)
     @Appender(NDFrame.transpose.__doc__)
     def transpose(self, *args, **kwargs):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -18,7 +18,7 @@ from pandas.core.dtypes.missing import notna
 
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
-from pandas.core.generic import NDFrame, _shared_docs
+from pandas.core.generic import NDFrame
 from pandas.core.index import (
     Index, MultiIndex, _get_objs_combined_axis, ensure_index)
 import pandas.core.indexes.base as ibase

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3998,27 +3998,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return super().shift(periods=periods, freq=freq, axis=axis,
                              fill_value=fill_value)
 
-    def reindex_axis(self, labels, axis=0, **kwargs):
-        """
-        Conform Series to new index with optional filling logic.
-
-        .. deprecated:: 0.21.0
-            Use ``Series.reindex`` instead.
-
-        Returns
-        -------
-        Series
-            Reindexed Series.
-        """
-        # for compatibility with higher dims
-        if axis != 0:
-            raise ValueError("cannot reindex series on non-zero axis!")
-        msg = ("'.reindex_axis' is deprecated and will be removed in a future "
-               "version. Use '.reindex' instead.")
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-
-        return self.reindex(index=labels, **kwargs)
-
     def memory_usage(self, index=True, deep=False):
         """
         Return the memory usage of the Series.

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -91,12 +91,7 @@ class TestCategoricalAPI:
     def test_rename_categories_series(self):
         # https://github.com/pandas-dev/pandas/issues/17981
         c = Categorical(['a', 'b'])
-        xpr = "Treating Series 'new_categories' as a list-like "
-        with tm.assert_produces_warning(FutureWarning) as rec:
-            result = c.rename_categories(Series([0, 1]))
-
-        assert len(rec) == 1
-        assert xpr in str(rec[0].message)
+        result = c.rename_categories(Series([0, 1], index=['a', 'b']))
         expected = Categorical([0, 1])
         tm.assert_categorical_equal(result, expected)
 

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -668,24 +668,20 @@ class TestDataFrameAlterAxes:
         assert no_return is None
         tm.assert_frame_equal(result, expected)
 
-    def test_rename_axis_warns(self):
+    def test_rename_axis_raises(self):
         # https://github.com/pandas-dev/pandas/issues/17833
         df = DataFrame({"A": [1, 2], "B": [1, 2]})
-        with tm.assert_produces_warning(FutureWarning) as w:
+        with pytest.raises(ValueError, match="Use `.rename`"):
             df.rename_axis(id, axis=0)
-            assert 'rename' in str(w[0].message)
 
-        with tm.assert_produces_warning(FutureWarning) as w:
+        with pytest.raises(ValueError, match="Use `.rename`"):
             df.rename_axis({0: 10, 1: 20}, axis=0)
-            assert 'rename' in str(w[0].message)
 
-        with tm.assert_produces_warning(FutureWarning) as w:
+        with pytest.raises(ValueError, match="Use `.rename`"):
             df.rename_axis(id, axis=1)
-            assert 'rename' in str(w[0].message)
 
-        with tm.assert_produces_warning(FutureWarning) as w:
+        with pytest.raises(ValueError, match="Use `.rename`"):
             df['A'].rename_axis(id)
-            assert 'rename' in str(w[0].message)
 
     def test_rename_axis_mapper(self):
         # GH 19978

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -416,17 +416,6 @@ class TestDataFrameSelectReindex:
         expected[4] = 'foo'
         assert_frame_equal(result, expected)
 
-        # reindex_axis
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.reindex_axis(range(15), fill_value=0., axis=0)
-        expected = df.reindex(range(15)).fillna(0)
-        assert_frame_equal(result, expected)
-
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.reindex_axis(range(5), fill_value=0., axis=1)
-        expected = df.reindex(columns=range(5)).fillna(0)
-        assert_frame_equal(result, expected)
-
         # other dtypes
         df['foo'] = 'foo'
         result = df.reindex(range(15), fill_value=0)
@@ -1025,33 +1014,6 @@ class TestDataFrameSelectReindex:
         # ints are weird
         smaller = int_frame.reindex(columns=['A', 'B', 'E'])
         assert smaller['E'].dtype == np.float64
-
-    def test_reindex_axis(self, float_frame, int_frame):
-        cols = ['A', 'B', 'E']
-        with tm.assert_produces_warning(FutureWarning) as m:
-            reindexed1 = int_frame.reindex_axis(cols, axis=1)
-            assert 'reindex' in str(m[0].message)
-        reindexed2 = int_frame.reindex(columns=cols)
-        assert_frame_equal(reindexed1, reindexed2)
-
-        rows = int_frame.index[0:5]
-        with tm.assert_produces_warning(FutureWarning) as m:
-            reindexed1 = int_frame.reindex_axis(rows, axis=0)
-            assert 'reindex' in str(m[0].message)
-        reindexed2 = int_frame.reindex(index=rows)
-        assert_frame_equal(reindexed1, reindexed2)
-
-        msg = ("No axis named 2 for object type"
-               " <class 'pandas.core.frame.DataFrame'>")
-        with pytest.raises(ValueError, match=msg):
-            int_frame.reindex_axis(rows, axis=2)
-
-        # no-op case
-        cols = float_frame.columns.copy()
-        with tm.assert_produces_warning(FutureWarning) as m:
-            newFrame = float_frame.reindex_axis(cols, axis=1)
-            assert 'reindex' in str(m[0].message)
-        assert_frame_equal(newFrame, float_frame)
 
     def test_reindex_with_nans(self):
         df = DataFrame([[1, 2], [3, 4], [np.nan, np.nan], [7, 8], [9, 10]],

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -1516,14 +1516,6 @@ class TestSparseSeriesAnalytics:
                                                 raise_on_extra_warnings=False):
                     getattr(getattr(self, series), func)()
 
-    def test_deprecated_reindex_axis(self):
-        # https://github.com/pandas-dev/pandas/issues/17833
-        # Multiple FutureWarnings, can't check stacklevel
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False) as m:
-            self.bseries.reindex_axis([0, 1, 2])
-        assert 'reindex' in str(m[0].message)
-
 
 @pytest.mark.parametrize(
     'datetime_type', (np.datetime64,


### PR DESCRIPTION
- [x] xref #6581
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Removed:

- Using `Series` as list-like in `rename_categories`
- `DataFrame/Series.reindex_axis`
- Renaming labels using `rename_axis`