### PR TITLE
CLN: Remove tupleize_cols keyword in io methods; from_csv method

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -337,7 +337,6 @@ Serialization / IO / conversion
 .. autosummary::
    :toctree: api/
 
-   DataFrame.from_csv
    DataFrame.from_dict
    DataFrame.from_items
    DataFrame.from_records

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -340,13 +340,6 @@ dialect : str or :class:`python:csv.Dialect` instance, default ``None``
   `skipinitialspace`, `quotechar`, and `quoting`. If it is necessary to
   override values, a ParserWarning will be issued. See :class:`python:csv.Dialect`
   documentation for more details.
-tupleize_cols : boolean, default ``False``
-    .. deprecated:: 0.21.0
-
-    This argument will be removed and will always convert to MultiIndex
-
-  Leave a list of tuples on columns as is (default is to convert to a MultiIndex
-  on the columns).
 
 Error handling
 ++++++++++++++

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1711,8 +1711,6 @@ function takes a number of arguments. Only the first is required.
 * ``escapechar``: Character used to escape ``sep`` and ``quotechar`` when
   appropriate (default None)
 * ``chunksize``: Number of rows to write at a time
-* ``tupleize_cols``: If False (default), write as a list of tuples, otherwise
-  write in an expanded line format suitable for ``read_csv``
 * ``date_format``: Format string for datetime objects
 
 Writing a formatted string

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -627,6 +627,7 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``pd.options.html.border`` (:issue:`16970`)
 - Removed the previously deprecated ``convert_objects`` (:issue:`11221`)
 - Removed the previously deprecated ``select`` method of ``DataFrame`` and ``Series`` (:issue:`17633`)
+- Removed the previously deprecated ``tupleize_cols`` keyword argument in :meth:`read_html`, :meth:`read_csv`, and :meth:`to_csv` (:issue:`17877`, :issue:`17820`)
 
 .. _whatsnew_0250.performance:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -628,6 +628,7 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``convert_objects`` (:issue:`11221`)
 - Removed the previously deprecated ``select`` method of ``DataFrame`` and ``Series`` (:issue:`17633`)
 - Removed the previously deprecated ``tupleize_cols`` keyword argument in :meth:`read_html`, :meth:`read_csv`, and :meth:`to_csv` (:issue:`17877`, :issue:`17820`)
+- Removed the previously deprecated ``DataFrame.from.csv`` and ``Series.from_csv`` (:issue:`17812`)
 
 .. _whatsnew_0250.performance:
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -297,7 +297,6 @@ cdef class TextReader:
         object encoding
         object compression
         object mangle_dupe_cols
-        object tupleize_cols
         object usecols
         list dtype_cast_order
         set unnamed_cols
@@ -351,7 +350,6 @@ cdef class TextReader:
                   skipfooter=0,
                   verbose=False,
                   mangle_dupe_cols=True,
-                  tupleize_cols=False,
                   float_precision=None,
                   skip_blank_lines=True):
 
@@ -370,7 +368,6 @@ cdef class TextReader:
         self.parser.chunksize = tokenize_chunksize
 
         self.mangle_dupe_cols = mangle_dupe_cols
-        self.tupleize_cols = tupleize_cols
 
         # For timekeeping
         self.clocks = []

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -331,7 +331,7 @@ class DataFrame(NDFrame):
 
     _constructor_sliced = Series  # type: Type[Series]
     _deprecations = NDFrame._deprecations | frozenset([
-        'get_value', 'set_value', 'from_csv', 'from_items'
+        'get_value', 'set_value', 'from_items'
     ])  # type: FrozenSet[str]
     _accessors = set()  # type: Set[str]
 
@@ -1785,73 +1785,6 @@ class DataFrame(NDFrame):
     def _from_arrays(cls, arrays, columns, index, dtype=None):
         mgr = arrays_to_mgr(arrays, columns, index, columns, dtype=dtype)
         return cls(mgr)
-
-    @classmethod
-    def from_csv(cls, path, header=0, sep=',', index_col=0, parse_dates=True,
-                 encoding=None, tupleize_cols=None,
-                 infer_datetime_format=False):
-        """
-        Read CSV file.
-
-        .. deprecated:: 0.21.0
-            Use :func:`read_csv` instead.
-
-        It is preferable to use the more powerful :func:`read_csv`
-        for most general purposes, but ``from_csv`` makes for an easy
-        roundtrip to and from a file (the exact counterpart of
-        ``to_csv``), especially with a DataFrame of time series data.
-
-        This method only differs from the preferred :func:`read_csv`
-        in some defaults:
-
-        - `index_col` is ``0`` instead of ``None`` (take first column as index
-          by default)
-        - `parse_dates` is ``True`` instead of ``False`` (try parsing the index
-          as datetime by default)
-
-        So a ``pd.DataFrame.from_csv(path)`` can be replaced by
-        ``pd.read_csv(path, index_col=0, parse_dates=True)``.
-
-        Parameters
-        ----------
-        path : string file path or file handle / StringIO
-        header : int, default 0
-            Row to use as header (skip prior rows)
-        sep : string, default ','
-            Field delimiter
-        index_col : int or sequence, default 0
-            Column to use for index. If a sequence is given, a MultiIndex
-            is used. Different default from read_table
-        parse_dates : boolean, default True
-            Parse dates. Different default from read_table
-        tupleize_cols : boolean, default False
-            write multi_index columns as a list of tuples (if True)
-            or new (expanded format) if False)
-        infer_datetime_format : boolean, default False
-            If True and `parse_dates` is True for a column, try to infer the
-            datetime format based on the first datetime string. If the format
-            can be inferred, there often will be a large parsing speed-up.
-
-        Returns
-        -------
-        DataFrame
-
-        See Also
-        --------
-        read_csv
-        """
-
-        warnings.warn("from_csv is deprecated. Please use read_csv(...) "
-                      "instead. Note that some of the default arguments are "
-                      "different, so please refer to the documentation "
-                      "for from_csv when changing your function calls",
-                      FutureWarning, stacklevel=2)
-
-        from pandas.io.parsers import read_csv
-        return read_csv(path, header=header, sep=sep,
-                        parse_dates=parse_dates, index_col=index_col,
-                        encoding=encoding, tupleize_cols=tupleize_cols,
-                        infer_datetime_format=infer_datetime_format)
 
     def to_sparse(self, fill_value=None, kind='block'):
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2915,7 +2915,7 @@ class NDFrame(PandasObject, SelectionMixin):
                columns=None, header=True, index=True, index_label=None,
                mode='w', encoding=None, compression='infer', quoting=None,
                quotechar='"', line_terminator=None, chunksize=None,
-               tupleize_cols=None, date_format=None, doublequote=True,
+               date_format=None, doublequote=True,
                escapechar=None, decimal='.'):
         r"""
         Write object to a comma-separated values (csv) file.
@@ -2988,14 +2988,6 @@ class NDFrame(PandasObject, SelectionMixin):
             .. versionchanged:: 0.24.0
         chunksize : int or None
             Rows to write at a time.
-        tupleize_cols : bool, default False
-            Write MultiIndex columns as a list of tuples (if True) or in
-            the new, expanded format, where each MultiIndex column is a row
-            in the CSV (if False).
-
-            .. deprecated:: 0.21.0
-               This argument will be removed and will always write each row
-               of the multi-index as a separate row in the CSV file.
         date_format : str, default None
             Format string for datetime objects.
         doublequote : bool, default True
@@ -3029,13 +3021,6 @@ class NDFrame(PandasObject, SelectionMixin):
 
         df = self if isinstance(self, ABCDataFrame) else self.to_frame()
 
-        if tupleize_cols is not None:
-            warnings.warn("The 'tupleize_cols' parameter is deprecated and "
-                          "will be removed in a future version",
-                          FutureWarning, stacklevel=2)
-        else:
-            tupleize_cols = False
-
         from pandas.io.formats.csvs import CSVFormatter
         formatter = CSVFormatter(df, path_or_buf,
                                  line_terminator=line_terminator, sep=sep,
@@ -3045,7 +3030,6 @@ class NDFrame(PandasObject, SelectionMixin):
                                  cols=columns, header=header, index=index,
                                  index_label=index_label, mode=mode,
                                  chunksize=chunksize, quotechar=quotechar,
-                                 tupleize_cols=tupleize_cols,
                                  date_format=date_format,
                                  doublequote=doublequote,
                                  escapechar=escapechar, decimal=decimal)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -137,7 +137,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # tolist is not actually deprecated, just suppressed in the __dir__
     _deprecations = generic.NDFrame._deprecations | frozenset(
         ['asobject', 'reshape', 'get_value', 'set_value',
-         'from_csv', 'valid', 'tolist'])
+         'valid', 'tolist'])
 
     # Override cache_readonly bc Series is mutable
     hasnans = property(base.IndexOpsMixin.hasnans.func,
@@ -4232,74 +4232,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             rmask = self < right
 
         return lmask & rmask
-
-    @classmethod
-    def from_csv(cls, path, sep=',', parse_dates=True, header=None,
-                 index_col=0, encoding=None, infer_datetime_format=False):
-        """
-        Read CSV file.
-
-        .. deprecated:: 0.21.0
-            Use :func:`pandas.read_csv` instead.
-
-        It is preferable to use the more powerful :func:`pandas.read_csv`
-        for most general purposes, but ``from_csv`` makes for an easy
-        roundtrip to and from a file (the exact counterpart of
-        ``to_csv``), especially with a time Series.
-
-        This method only differs from :func:`pandas.read_csv` in some defaults:
-
-        - `index_col` is ``0`` instead of ``None`` (take first column as index
-          by default)
-        - `header` is ``None`` instead of ``0`` (the first row is not used as
-          the column names)
-        - `parse_dates` is ``True`` instead of ``False`` (try parsing the index
-          as datetime by default)
-
-        With :func:`pandas.read_csv`, the option ``squeeze=True`` can be used
-        to return a Series like ``from_csv``.
-
-        Parameters
-        ----------
-        path : str, file path, or file handle / StringIO
-        sep : str, default ','
-            Field delimiter.
-        parse_dates : bool, default True
-            Parse dates. Different default from read_table.
-        header : int, default None
-            Row to use as header (skip prior rows).
-        index_col : int or sequence, default 0
-            Column to use for index. If a sequence is given, a MultiIndex
-            is used. Different default from read_table.
-        encoding : str, optional
-            A string representing the encoding to use if the contents are
-            non-ascii, for python versions prior to 3.
-        infer_datetime_format : bool, default False
-            If True and `parse_dates` is True for a column, try to infer the
-            datetime format based on the first datetime string. If the format
-            can be inferred, there often will be a large parsing speed-up.
-
-        Returns
-        -------
-        Series
-
-        See Also
-        --------
-        read_csv
-        """
-
-        # We're calling `DataFrame.from_csv` in the implementation,
-        # which will propagate a warning regarding `from_csv` deprecation.
-        from pandas.core.frame import DataFrame
-        df = DataFrame.from_csv(path, header=header, index_col=index_col,
-                                sep=sep, parse_dates=parse_dates,
-                                encoding=encoding,
-                                infer_datetime_format=infer_datetime_format)
-        result = df.iloc[:, 0]
-        if header is None:
-            result.index.name = result.name = None
-
-        return result
 
     @Appender(generic.NDFrame.to_csv.__doc__)
     def to_csv(self, *args, **kwargs):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4307,7 +4307,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         names = ["path_or_buf", "sep", "na_rep", "float_format", "columns",
                  "header", "index", "index_label", "mode", "encoding",
                  "compression", "quoting", "quotechar", "line_terminator",
-                 "chunksize", "tupleize_cols", "date_format", "doublequote",
+                 "chunksize", "date_format", "doublequote",
                  "escapechar", "decimal"]
 
         old_names = ["path_or_buf", "index", "sep", "na_rep", "float_format",

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -24,9 +24,9 @@ class CSVFormatter:
 
     def __init__(self, obj, path_or_buf=None, sep=",", na_rep='',
                  float_format=None, cols=None, header=True, index=True,
-                 index_label=None, mode='w', nanRep=None, encoding=None,
+                 index_label=None, mode='w', encoding=None,
                  compression='infer', quoting=None, line_terminator='\n',
-                 chunksize=None, tupleize_cols=False, quotechar='"',
+                 chunksize=None, quotechar='"',
                  date_format=None, doublequote=True, escapechar=None,
                  decimal='.'):
 
@@ -68,9 +68,7 @@ class CSVFormatter:
 
         self.date_format = date_format
 
-        self.tupleize_cols = tupleize_cols
-        self.has_mi_columns = (isinstance(obj.columns, ABCMultiIndex) and
-                               not self.tupleize_cols)
+        self.has_mi_columns = isinstance(obj.columns, ABCMultiIndex)
 
         # validate mi options
         if self.has_mi_columns:

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -912,7 +912,7 @@ def _parse(flavor, io, match, attrs, encoding, displayed_only, **kwargs):
 
 def read_html(io, match='.+', flavor=None, header=None, index_col=None,
               skiprows=None, attrs=None, parse_dates=False,
-              tupleize_cols=None, thousands=',', encoding=None,
+              thousands=',', encoding=None,
               decimal='.', converters=None, na_values=None,
               keep_default_na=True, displayed_only=True):
     r"""Read HTML tables into a ``list`` of ``DataFrame`` objects.
@@ -975,14 +975,6 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
 
     parse_dates : bool, optional
         See :func:`~read_csv` for more details.
-
-    tupleize_cols : bool, optional
-        If ``False`` try to parse multiple header rows into a
-        :class:`~pandas.MultiIndex`, otherwise return raw tuples. Defaults to
-        ``False``.
-
-        .. deprecated:: 0.21.0
-           This argument will be removed and will always convert to MultiIndex
 
     thousands : str, optional
         Separator to use to parse thousands. Defaults to ``','``.
@@ -1073,7 +1065,7 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
     _validate_header_arg(header)
     return _parse(flavor=flavor, io=io, match=match, header=header,
                   index_col=index_col, skiprows=skiprows,
-                  parse_dates=parse_dates, tupleize_cols=tupleize_cols,
+                  parse_dates=parse_dates,
                   thousands=thousands, attrs=attrs, encoding=encoding,
                   decimal=decimal, converters=converters, na_values=na_values,
                   keep_default_na=keep_default_na,

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -9,6 +9,7 @@ from io import StringIO
 import re
 import sys
 from textwrap import fill
+from typing import Any, Dict, Set
 import warnings
 
 import numpy as np
@@ -521,8 +522,8 @@ _python_unsupported = {
     'float_precision',
 }
 
-_deprecated_defaults = {}
-_deprecated_args = set()
+_deprecated_defaults = {}  # type: Dict[str, Any]
+_deprecated_args = set()  # type: Set[str]
 
 
 def _make_parser_function(name, default_sep=','):

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -293,13 +293,6 @@ dialect : str or csv.Dialect, optional
     `skipinitialspace`, `quotechar`, and `quoting`. If it is necessary to
     override values, a ParserWarning will be issued. See csv.Dialect
     documentation for more details.
-tupleize_cols : bool, default False
-    Leave a list of tuples on columns as is (default is to convert to
-    a MultiIndex on the columns).
-
-    .. deprecated:: 0.21.0
-       This argument will be removed and will always convert to MultiIndex
-
 error_bad_lines : bool, default True
     Lines with too many fields (e.g. a csv line with too many commas) will by
     default cause an exception to be raised, and no DataFrame will be returned.
@@ -501,7 +494,6 @@ _parser_defaults = {
     'squeeze': False,
     'compression': None,
     'mangle_dupe_cols': True,
-    'tupleize_cols': False,
     'infer_datetime_format': False,
     'skip_blank_lines': True
 }
@@ -514,7 +506,6 @@ _c_parser_defaults = {
     'memory_map': False,
     'error_bad_lines': True,
     'warn_bad_lines': True,
-    'tupleize_cols': False,
     'float_precision': None
 }
 
@@ -530,12 +521,8 @@ _python_unsupported = {
     'float_precision',
 }
 
-_deprecated_defaults = {
-    'tupleize_cols': None
-}
-_deprecated_args = {
-    'tupleize_cols',
-}
+_deprecated_defaults = {}
+_deprecated_args = set()
 
 
 def _make_parser_function(name, default_sep=','):
@@ -595,7 +582,6 @@ def _make_parser_function(name, default_sep=','):
                  comment=None,
                  encoding=None,
                  dialect=None,
-                 tupleize_cols=None,
 
                  # Error Handling
                  error_bad_lines=True,
@@ -691,7 +677,6 @@ def _make_parser_function(name, default_sep=','):
                     error_bad_lines=error_bad_lines,
                     low_memory=low_memory,
                     mangle_dupe_cols=mangle_dupe_cols,
-                    tupleize_cols=tupleize_cols,
                     infer_datetime_format=infer_datetime_format,
                     skip_blank_lines=skip_blank_lines)
 
@@ -1052,10 +1037,6 @@ class TextFileReader(BaseIterator):
                    "and will be removed in a future version."
                    .format(arg=arg))
 
-            if arg == 'tupleize_cols':
-                msg += (' Column tuples will then '
-                        'always be converted to MultiIndex.')
-
             if result.get(arg, depr_default) != depr_default:
                 # raise Exception(result.get(arg, depr_default), depr_default)
                 depr_warning += msg + '\n\n'
@@ -1362,7 +1343,6 @@ class ParserBase:
 
         self.true_values = kwds.get('true_values')
         self.false_values = kwds.get('false_values')
-        self.tupleize_cols = kwds.get('tupleize_cols', False)
         self.mangle_dupe_cols = kwds.get('mangle_dupe_cols', True)
         self.infer_datetime_format = kwds.pop('infer_datetime_format', False)
         self.cache_dates = kwds.pop('cache_dates', True)

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -582,19 +582,6 @@ class TestDataFrameToCSV(TestData):
             result.columns.names = df.columns.names
             assert_frame_equal(df, result)
 
-            # tupleize_cols=True and index=False
-            df = _make_frame(True)
-            with tm.assert_produces_warning(FutureWarning):
-                df.to_csv(path, tupleize_cols=True, index=False)
-
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                result = read_csv(path, header=0,
-                                  tupleize_cols=True,
-                                  index_col=None)
-            result.columns = df.columns
-            assert_frame_equal(df, result)
-
             # whatsnew example
             df = _make_frame()
             df.to_csv(path)
@@ -606,18 +593,6 @@ class TestDataFrameToCSV(TestData):
             df.to_csv(path)
             result = read_csv(path, header=[0, 1],
                               index_col=[0])
-            assert_frame_equal(df, result)
-
-            # column & index are multi-index (compatibility)
-            df = mkdf(5, 3, r_idx_nlevels=2, c_idx_nlevels=4)
-            with tm.assert_produces_warning(FutureWarning):
-                df.to_csv(path, tupleize_cols=True)
-
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                result = read_csv(path, header=0, index_col=[0, 1],
-                                  tupleize_cols=True)
-            result.columns = df.columns
             assert_frame_equal(df, result)
 
             # invalid options

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -33,15 +33,6 @@ class TestDataFrameToCSV(TestData):
 
         return pd.read_csv(path, **params)
 
-    def test_from_csv_deprecation(self):
-        # see gh-17812
-        with ensure_clean('__tmp_from_csv_deprecation__') as path:
-            self.tsframe.to_csv(path)
-
-            with tm.assert_produces_warning(FutureWarning):
-                depr_recons = DataFrame.from_csv(path)
-                assert_frame_equal(self.tsframe, depr_recons)
-
     def test_to_csv_from_csv1(self):
 
         with ensure_clean('__tmp_to_csv_from_csv1__') as path:

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -122,17 +122,3 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         with pytest.raises(ValueError, match=msg):
             read_csv(NoNextBuffer(data), engine=python_engine)
-
-
-class TestDeprecatedFeatures:
-
-    @pytest.mark.parametrize("engine", ["c", "python"])
-    @pytest.mark.parametrize("kwargs", [{"tupleize_cols": True},
-                                        {"tupleize_cols": False}])
-    def test_deprecated_args(self, engine, kwargs):
-        data = "1,2,3"
-        arg, _ = list(kwargs.items())[0]
-
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            read_csv(StringIO(data), engine=engine, **kwargs)

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -310,9 +310,8 @@ class TestReadHtml:
 
     @pytest.mark.slow
     def test_multiindex_header_skiprows_tuples(self):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            df = self._bank_data(header=[0, 1], skiprows=1)[0]
-            assert isinstance(df.columns, MultiIndex)
+        df = self._bank_data(header=[0, 1], skiprows=1)[0]
+        assert isinstance(df.columns, MultiIndex)
 
     @pytest.mark.slow
     def test_multiindex_header_skiprows(self):

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -311,9 +311,8 @@ class TestReadHtml:
     @pytest.mark.slow
     def test_multiindex_header_skiprows_tuples(self):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            df = self._bank_data(header=[0, 1], skiprows=1,
-                                 tupleize_cols=True)[0]
-            assert isinstance(df.columns, Index)
+            df = self._bank_data(header=[0, 1], skiprows=1)[0]
+            assert isinstance(df.columns, MultiIndex)
 
     @pytest.mark.slow
     def test_multiindex_header_skiprows(self):

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -29,17 +29,6 @@ class TestSeriesToCSV:
 
         return out
 
-    def test_from_csv_deprecation(self, datetime_series):
-        # see gh-17812
-        with ensure_clean() as path:
-            datetime_series.to_csv(path, header=False)
-
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                ts = self.read_csv(path)
-                depr_ts = Series.from_csv(path)
-                assert_series_equal(depr_ts, ts)
-
     @pytest.mark.parametrize("arg", ["path", "header", "both"])
     def test_to_csv_deprecation(self, arg, datetime_series):
         # see gh-19715
@@ -67,11 +56,6 @@ class TestSeriesToCSV:
 
             assert ts.name is None
             assert ts.index.name is None
-
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                depr_ts = Series.from_csv(path)
-                assert_series_equal(depr_ts, ts)
 
             # see gh-10483
             datetime_series.to_csv(path, header=True)


### PR DESCRIPTION
- [x] xref #6581
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Removes:

- `tupleize_cols` keyword in `read_html`, `read_csv`, `to_csv`
- `DataFrame/Series.from_csv`