### PR TITLE
Slicing an index with DateTime throws AttributeError: 'int' object has no attribute 'stop'

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -672,7 +672,7 @@ Indexing
 - Bug in which :meth:`DataFrame.to_csv` caused a segfault for a reindexed data frame, when the indices were single-level :class:`MultiIndex` (:issue:`26303`).
 - Fixed bug where assigning a :class:`arrays.PandasArray` to a :class:`pandas.core.frame.DataFrame` would raise error (:issue:`26390`)
 - Allow keyword arguments for callable local reference used in the :meth:`DataFrame.query` string (:issue:`26426`)
-- Bug which produced ``AttributeError`` on partial matching on a TimeStamp multiindex  (:issue:`26944`)
+- Bug which produced ``AttributeError`` on partial matching :class:`Timestamp`s in a :class:`MultiIndex`  (:issue:`26944`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -672,7 +672,7 @@ Indexing
 - Bug in which :meth:`DataFrame.to_csv` caused a segfault for a reindexed data frame, when the indices were single-level :class:`MultiIndex` (:issue:`26303`).
 - Fixed bug where assigning a :class:`arrays.PandasArray` to a :class:`pandas.core.frame.DataFrame` would raise error (:issue:`26390`)
 - Allow keyword arguments for callable local reference used in the :meth:`DataFrame.query` string (:issue:`26426`)
-
+- Bug which produced ``AttributeError`` on partial matching on a TimeStamp multiindex  (:issue:`26944`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -672,7 +672,7 @@ Indexing
 - Bug in which :meth:`DataFrame.to_csv` caused a segfault for a reindexed data frame, when the indices were single-level :class:`MultiIndex` (:issue:`26303`).
 - Fixed bug where assigning a :class:`arrays.PandasArray` to a :class:`pandas.core.frame.DataFrame` would raise error (:issue:`26390`)
 - Allow keyword arguments for callable local reference used in the :meth:`DataFrame.query` string (:issue:`26426`)
-- Bug which produced ``AttributeError`` on partial matching :class:`Timestamp`s in a :class:`MultiIndex`  (:issue:`26944`)
+- Bug which produced ``AttributeError`` on partial matching :class:`Timestamp` in a :class:`MultiIndex`  (:issue:`26944`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2755,7 +2755,9 @@ class MultiIndex(Index):
                 # a partial date slicer on a DatetimeIndex generates a slice
                 # note that the stop ALREADY includes the stopped point (if
                 # it was a string sliced)
-                return convert_indexer(start.start, stop.stop, step)
+                start = getattr(start, 'start', start)
+                stop = getattr(stop, 'stop', stop)
+                return convert_indexer(start, stop, step)
 
             elif level > 0 or self.lexsort_depth == 0 or step is not None:
                 # need to have like semantics here to right

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -407,3 +407,4 @@ def test_timestamp_multiindex_indexer():
                       data={'foo': range(len(dt_index)), 'bar': 'x', 'zaa': 3})
     df = df.reset_index().set_index(["date", "bar", "zaa"])
     assert df.loc[pd.IndexSlice['2019-1-2':, "x", :], 'foo'][-1] == 98
+    

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -404,8 +404,17 @@ def test_timestamp_multiindex_indexer():
     idx = pd.MultiIndex.from_product([
         pd.date_range("2019-01-01T00:15:33", periods=100, freq="H",
                       name="date"),
-        ['x'],
-        [3]
-    ])
+            ['x'],
+            [3]
+        ])
     df = pd.DataFrame({'foo': np.arange(len(idx))}, idx)
-    assert df.loc[pd.IndexSlice['2019-1-2':, "x", :], 'foo'][-1] == 98
+    result = df.loc[pd.IndexSlice['2019-1-2':, "x", :], 'foo']
+    qidx = pd.MultiIndex.from_product([
+        pd.date_range(start="2019-01-02T00:15:33", end='2019-01-05T02:15:33',
+                  freq="H", name="date"),
+            ['x'],
+            [3]
+        ])
+    should_be = pd.Series(data=np.arange(24,len(qidx)+24), index=qidx,
+                          name="foo")
+    tm.assert_series_equal(result, should_be)

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -404,17 +404,17 @@ def test_timestamp_multiindex_indexer():
     idx = pd.MultiIndex.from_product([
         pd.date_range("2019-01-01T00:15:33", periods=100, freq="H",
                       name="date"),
-            ['x'],
-            [3]
-        ])
+        ['x'],
+        [3]
+    ])
     df = pd.DataFrame({'foo': np.arange(len(idx))}, idx)
     result = df.loc[pd.IndexSlice['2019-1-2':, "x", :], 'foo']
     qidx = pd.MultiIndex.from_product([
         pd.date_range(start="2019-01-02T00:15:33", end='2019-01-05T02:15:33',
-                  freq="H", name="date"),
-            ['x'],
-            [3]
-        ])
-    should_be = pd.Series(data=np.arange(24,len(qidx)+24), index=qidx,
+                      freq="H", name="date"),
+        ['x'],
+        [3]
+    ])
+    should_be = pd.Series(data=np.arange(24, len(qidx) + 24), index=qidx,
                           name="foo")
     tm.assert_series_equal(result, should_be)

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -401,9 +401,10 @@ def test_get_indexer_categorical_time():
 
 def test_timestamp_multiindex_indexer():
     # https://github.com/pandas-dev/pandas/issues/26944
-    dt_index = pd.date_range(start="1jan2019 00:15:33", periods=100,
-                             freq="h", name="date")
-    df = pd.DataFrame(index=dt_index,
-                      data={'foo': range(len(dt_index)), 'bar': 'x', 'zaa': 3})
-    df = df.reset_index().set_index(["date", "bar", "zaa"])
+    idx = pd.MultiIndex.from_product([
+        pd.date_range("2019-01-01T00:15:33", periods=100, freq="H", name="date"),
+        ['x'],
+        [3]
+    ])
+    df = pd.DataFrame({'foo': np.arange(len(idx))}, idx)
     assert df.loc[pd.IndexSlice['2019-1-2':, "x", :], 'foo'][-1] == 98

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -402,7 +402,8 @@ def test_get_indexer_categorical_time():
 def test_timestamp_multiindex_indexer():
     # https://github.com/pandas-dev/pandas/issues/26944
     idx = pd.MultiIndex.from_product([
-        pd.date_range("2019-01-01T00:15:33", periods=100, freq="H", name="date"),
+        pd.date_range("2019-01-01T00:15:33", periods=100, freq="H",
+                      name="date"),
         ['x'],
         [3]
     ])

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -407,4 +407,3 @@ def test_timestamp_multiindex_indexer():
                       data={'foo': range(len(dt_index)), 'bar': 'x', 'zaa': 3})
     df = df.reset_index().set_index(["date", "bar", "zaa"])
     assert df.loc[pd.IndexSlice['2019-1-2':, "x", :], 'foo'][-1] == 98
-    

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -401,8 +401,9 @@ def test_get_indexer_categorical_time():
 
 def test_timestamp_multiindex_indexer():
     # https://github.com/pandas-dev/pandas/issues/26944
-    dt_index = pd.date_range(start="1jan2019 00:15:33", periods=100, freq="h", name="date")
-    df = pd.DataFrame(index=dt_index, data={'foo': range(len(dt_index)), 'bar': 'x', 'zaa': 3})
+    dt_index = pd.date_range(start="1jan2019 00:15:33", periods=100,
+                             freq="h", name="date")
+    df = pd.DataFrame(index=dt_index,
+                      data={'foo': range(len(dt_index)), 'bar': 'x', 'zaa': 3})
     df = df.reset_index().set_index(["date", "bar", "zaa"])
     assert df.loc[pd.IndexSlice['2019-1-2':, "x", :], 'foo'][-1] == 98
-

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -397,3 +397,12 @@ def test_get_indexer_categorical_time():
          Categorical(date_range("2012-01-01", periods=3, freq='H'))])
     result = midx.get_indexer(midx)
     tm.assert_numpy_array_equal(result, np.arange(9, dtype=np.intp))
+
+
+def test_timestamp_multiindex_indexer():
+    # https://github.com/pandas-dev/pandas/issues/26944
+    dt_index = pd.date_range(start="1jan2019 00:15:33", periods=100, freq="h", name="date")
+    df = pd.DataFrame(index=dt_index, data={'foo': range(len(dt_index)), 'bar': 'x', 'zaa': 3})
+    df = df.reset_index().set_index(["date", "bar", "zaa"])
+    assert df.loc[pd.IndexSlice['2019-1-2':, "x", :], 'foo'][-1] == 98
+


### PR DESCRIPTION
Fixes GH26944 AttributeError on partial multiindex timestamp slice

- [x] closes #26944
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
