### PR TITLE
PERF, BENCH: Fix performance issue when indexing into non-unique DatetimeIndex/PeriodIndex.

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
+import warnings
 
 try:
     from pandas.api.types import union_categoricals
@@ -122,11 +123,16 @@ class Rank:
         ncats = 100
 
         self.s_str = pd.Series(tm.makeCategoricalIndex(N, ncats)).astype(str)
-        self.s_str_cat = self.s_str.astype("category")
-        self.s_str_cat_ordered = self.s_str_cat.cat.as_ordered()
+        self.s_str_cat = pd.Series(self.s_str, dtype="category")
+        with warnings.catch_warnings(record=True):
+            str_cat_type = pd.CategoricalDtype(set(self.s_str), ordered=True)
+            self.s_str_cat_ordered = self.s_str.astype(str_cat_type)
+
         self.s_int = pd.Series(np.random.randint(0, ncats, size=N))
-        self.s_int_cat = self.s_int.astype("category")
-        self.s_int_cat_ordered = self.s_int_cat.cat.as_ordered()
+        self.s_int_cat = pd.Series(self.s_int, dtype="category")
+        with warnings.catch_warnings(record=True):
+            int_cat_type = pd.CategoricalDtype(set(self.s_int), ordered=True)
+            self.s_int_cat_ordered = self.s_int.astype(int_cat_type)
 
     def time_rank_string(self):
         self.s_str.rank()

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -938,6 +938,8 @@ Performance improvements
 - Improved performance when building :class:`MultiIndex` with at least one :class:`CategoricalIndex` level (:issue:`22044`)
 - Improved performance by removing the need for a garbage collect when checking for ``SettingWithCopyWarning`` (:issue:`27031`)
 - For :meth:`to_datetime` changed default value of cache parameter to ``True`` (:issue:`26043`)
+- Improved performance of :class:`DatetimeIndex` and :class:`PeriodIndex` slicing given non-unique, monotonic data (:issue:`27136`).
+
 
 .. _whatsnew_0250.bug_fixes:
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4792,7 +4792,6 @@ class Index(IndexOpsMixin, PandasObject):
             return pself.get_indexer_non_unique(ptarget)
 
         if self.is_all_dates:
-            self = Index(self.asi8)
             tgt_values = target.asi8
         else:
             tgt_values = target._ndarray_values

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -604,6 +604,30 @@ def test_indexing_over_size_cutoff():
         _index._SIZE_CUTOFF = old_cutoff
 
 
+def test_indexing_over_size_cutoff_period_index():
+    # GH 27136
+
+    old_cutoff = _index._SIZE_CUTOFF
+    try:
+        _index._SIZE_CUTOFF = 1000
+
+        n = 1100
+        idx = pd.period_range("1/1/2000", freq="T", periods=n)
+        assert idx._engine.over_size_threshold
+
+        s = pd.Series(np.random.randn(len(idx)), index=idx)
+
+        pos = n - 1
+        timestamp = idx[pos]
+        assert timestamp in s.index
+
+        # it works!
+        s[timestamp]
+        assert len(s.loc[[timestamp]]) > 0
+    finally:
+        _index._SIZE_CUTOFF = old_cutoff
+
+
 def test_indexing_unordered():
     # GH 2437
     rng = date_range(start="2011-01-01", end="2011-01-15")


### PR DESCRIPTION
This PR fixes a number of issues involving non-unique non-numeric indexing:
- The `NonNumericSeriesIndexing` benchmark incorrectly assumes `tm.makeStringIndex()` returns a monotonic `Index`. It does not and unfortunately invalidates the existing results here.
  - While modifying this, figured should add `PeriodIndex` and `non_monotonic` cases
- The `setup()` function creates an index but does not trigger the engine mapping to be populated. This leads to noisy and erroneous results.
  - See here for examples and compare with below: https://pandas.pydata.org/speed/pandas/#indexing.NonNumericSeriesIndexing.time_getitem_scalar
- A `PeriodIndex` or `DatetimeIndex` with non-unique, monotonic data creates an entirely new `Index` when being sliced. This means the engine mapping gets recomputed on every list-like query.
- A `PeriodIndex` is actually a `PeriodEngine` plus a separate `Int64Index` (with associated `Int64Engine`). The former contains a mapping of `{Period: value}` while being a subclass of `Int64Engine`. This means calls to `_bin_search()` fail as the underlying array consists of `Period` objects. This only occurs when the index is non-unique, monotonic, *and* `>= 1M` elements long.
  - We add an explicit test for this failure mode
- A number of index calls pass `value.ordinal` to the `PeriodEngine`; as that is a `{Period: value}` mapping, all such calls fail.
  - We instead pass `value.ordinal` queries to the `Int64Engine`, where they succeed.
- Finally, `PeriodIndex.get_memory()` does not account for the memory of its associated `Int64Index`. This is fixed by simply adding it to the total.

```
       before           after         ratio
     [2811464a]       [a68caa2a]
     <import_bench~1>       <period_fix>
           failed         62.4±2μs      n/a  indexing.NonNumericSeriesIndexing.time_get_value('period', 'unique_monotonic_inc')
           failed         216±20μs      n/a  indexing.NonNumericSeriesIndexing.time_getitem_label_slice('period', 'unique_monotonic_inc')
           failed      2.74±0.05ms      n/a  indexing.NonNumericSeriesIndexing.time_getitem_list_like('period', 'unique_monotonic_inc')
           failed        160±0.5μs      n/a  indexing.NonNumericSeriesIndexing.time_getitem_pos_slice('period', 'unique_monotonic_inc')
           failed       43.0±0.2μs      n/a  indexing.NonNumericSeriesIndexing.time_getitem_scalar('period', 'unique_monotonic_inc')
-        718±10μs         207±10μs     0.29  indexing.NonNumericSeriesIndexing.time_getitem_label_slice('period', 'non_monotonic')
-     2.53±0.05ms         701±10μs     0.28  indexing.NonNumericSeriesIndexing.time_getitem_list_like('period', 'non_monotonic')
-      33.8±0.9ms      2.32±0.04ms     0.07  indexing.NonNumericSeriesIndexing.time_getitem_list_like('period', 'nonunique_monotonic_inc')
-      62.7±0.5ms          532±3μs     0.01  indexing.NonNumericSeriesIndexing.time_getitem_list_like('datetime', 'nonunique_monotonic_inc')

       before           after         ratio
     [2811464a]       [a68caa2a]
     <import_bench~1>       <period_fix>
+      40.7±0.7μs       46.8±0.8μs     1.15  indexing.NonNumericSeriesIndexing.time_get_value('period', 'non_monotonic')
+        27.0±2μs       30.4±0.6μs     1.12  indexing.NonNumericSeriesIndexing.time_getitem_scalar('period', 'non_monotonic')
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
