### PR TITLE
TST/CLN: engine fixture for tests/io/excel/test_readers.py

### DIFF
--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -224,7 +224,7 @@ class TestRoundTrip:
 class _WriterBase:
 
     @pytest.fixture(autouse=True)
-    def set_engine_and_path(self, request, engine, ext):
+    def set_engine_and_path(self, engine, ext):
         """Fixture to set engine and open file for use in each test case
 
         Rather than requiring `engine=...` to be provided explicitly as an
@@ -252,14 +252,10 @@ class _WriterBase:
 
 @td.skip_if_no('xlrd')
 @pytest.mark.parametrize("engine,ext", [
-    pytest.param('openpyxl', '.xlsx', marks=pytest.mark.skipif(
-        not td.safe_import('openpyxl'), reason='No openpyxl')),
-    pytest.param('openpyxl', '.xlsm', marks=pytest.mark.skipif(
-        not td.safe_import('openpyxl'), reason='No openpyxl')),
-    pytest.param('xlwt', '.xls', marks=pytest.mark.skipif(
-        not td.safe_import('xlwt'), reason='No xlwt')),
-    pytest.param('xlsxwriter', '.xlsx', marks=pytest.mark.skipif(
-        not td.safe_import('xlsxwriter'), reason='No xlsxwriter'))
+    pytest.param('openpyxl', '.xlsx', marks=td.skip_if_no('openpyxl')),
+    pytest.param('openpyxl', '.xlsm', marks=td.skip_if_no('openpyxl')),
+    pytest.param('xlwt', '.xls', marks=td.skip_if_no('xlwt')),
+    pytest.param('xlsxwriter', '.xlsx', marks=td.skip_if_no('xlsxwriter'))
 ])
 class TestExcelWriter(_WriterBase):
     # Base class for test cases to run with different Excel writers.
@@ -1198,12 +1194,10 @@ class TestExcelWriter(_WriterBase):
 class TestExcelWriterEngineTests:
 
     @pytest.mark.parametrize('klass,ext', [
-        pytest.param(_XlsxWriter, '.xlsx', marks=pytest.mark.skipif(
-            not td.safe_import('xlsxwriter'), reason='No xlsxwriter')),
-        pytest.param(_OpenpyxlWriter, '.xlsx', marks=pytest.mark.skipif(
-            not td.safe_import('openpyxl'), reason='No openpyxl')),
-        pytest.param(_XlwtWriter, '.xls', marks=pytest.mark.skipif(
-            not td.safe_import('xlwt'), reason='No xlwt'))
+        pytest.param(_XlsxWriter, '.xlsx', marks=td.skip_if_no('xlsxwriter')),
+        pytest.param(
+            _OpenpyxlWriter, '.xlsx', marks=td.skip_if_no('openpyxl')),
+        pytest.param(_XlwtWriter, '.xls', marks=td.skip_if_no('xlwt'))
     ])
     def test_ExcelWriter_dispatch(self, klass, ext):
         with ensure_clean(ext) as path:


### PR DESCRIPTION
fixture for todos from #27114

use of safe_import in pytest.param #26735 (comment) #26784

cc @WillAyd 

