### PR TITLE
CLN: True option in Series.groupby.nth(dropna=)

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -640,6 +640,7 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``raise_on_error`` keyword argument in :meth:`DataFrame.where` and :meth:`DataFrame.mask` (:issue:`17744`)
 - Removed the previously deprecated ``ordered`` and ``categories`` keyword arguments in ``astype`` (:issue:`17742`)
 - Removed the previously deprecated ``cdate_range`` (:issue:`17691`)
+- Removed the previously deprecated ``True`` option for the ``dropan`` keyword argument in :func:`SeriesGroupBy.nth` (:issue:`17493`)
 
 .. _whatsnew_0250.performance:
 

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -644,7 +644,7 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``raise_on_error`` keyword argument in :meth:`DataFrame.where` and :meth:`DataFrame.mask` (:issue:`17744`)
 - Removed the previously deprecated ``ordered`` and ``categories`` keyword arguments in ``astype`` (:issue:`17742`)
 - Removed the previously deprecated ``cdate_range`` (:issue:`17691`)
-- Removed the previously deprecated ``True`` option for the ``dropan`` keyword argument in :func:`SeriesGroupBy.nth` (:issue:`17493`)
+- Removed the previously deprecated ``True`` option for the ``dropna`` keyword argument in :func:`SeriesGroupBy.nth` (:issue:`17493`)
 
 .. _whatsnew_0250.performance:
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -13,7 +13,6 @@ import datetime
 from functools import partial, wraps
 import types
 from typing import FrozenSet, List, Optional, Tuple, Type, Union
-import warnings
 
 import numpy as np
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1741,22 +1741,11 @@ class GroupBy(_GroupBy):
                 "dropna option with a list of nth values is not supported")
 
         if dropna not in ['any', 'all']:
-            if isinstance(self._selected_obj, Series) and dropna is True:
-                warnings.warn("the dropna={dropna} keyword is deprecated,"
-                              "use dropna='all' instead. "
-                              "For a Series groupby, dropna must be "
-                              "either None, 'any' or 'all'.".format(
-                                  dropna=dropna),
-                              FutureWarning,
-                              stacklevel=2)
-                dropna = 'all'
-            else:
-                # Note: when agg-ing picker doesn't raise this,
-                # just returns NaN
-                raise ValueError("For a DataFrame groupby, dropna must be "
-                                 "either None, 'any' or 'all', "
-                                 "(was passed {dropna}).".format(
-                                     dropna=dropna))
+            # Note: when agg-ing picker doesn't raise this, just returns NaN
+            raise ValueError("For a DataFrame groupby, dropna must be "
+                             "either None, 'any' or 'all', "
+                             "(was passed {dropna}).".format(
+                                 dropna=dropna))
 
         # old behaviour, but with all and any support for DataFrames.
         # modified in GH 7559 to have better perf

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -167,6 +167,9 @@ def test_nth():
     result = s.groupby(g, sort=False).nth(0, dropna='all')
     assert_series_equal(result, expected)
 
+    with pytest.raises(ValueError, match='For a DataFrame groupby'):
+        s.groupby(g, sort=False).nth(0, dropna=True)
+
     # doc example
     df = DataFrame([[1, np.nan], [1, 4], [5, 6]], columns=['A', 'B'])
     g = df.groupby('A')

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -3,8 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, Timestamp, isna
-from pandas.util.testing import (
-    assert_frame_equal, assert_produces_warning, assert_series_equal)
+from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 def test_first_last_nth(df):
@@ -171,10 +170,7 @@ def test_nth():
     # doc example
     df = DataFrame([[1, np.nan], [1, 4], [5, 6]], columns=['A', 'B'])
     g = df.groupby('A')
-    # PR 17493, related to issue 11038
-    # test Series.nth with True for dropna produces FutureWarning
-    with assert_produces_warning(FutureWarning):
-        result = g.B.nth(0, dropna=True)
+    result = g.B.nth(0, dropna='all')
     expected = g.B.first()
     assert_series_equal(result, expected)
 


### PR DESCRIPTION
- [x] xref #6581
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
