### PR TITLE
BUG: Fix Index constructor with mixed closed Intervals

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -762,7 +762,7 @@ Interval
 
 - Construction of :class:`Interval` is restricted to numeric, :class:`Timestamp` and :class:`Timedelta` endpoints (:issue:`23013`)
 - Fixed bug in :class:`Series`/:class:`DataFrame` not displaying ``NaN`` in :class:`IntervalIndex` with missing values (:issue:`25984`)
--
+- Bug in :class:`Index` constructor where passing mixed closed :class:`Interval` objects would result in a ``ValueError`` instead of an ``object`` dtype ``Index`` (:issue:`27172`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -421,7 +421,11 @@ class Index(IndexOpsMixin, PandasObject):
                     return Float64Index(subarr, copy=copy, name=name)
                 elif inferred == 'interval':
                     from .interval import IntervalIndex
-                    return IntervalIndex(subarr, name=name, copy=copy)
+                    try:
+                        return IntervalIndex(subarr, name=name, copy=copy)
+                    except ValueError:
+                        # GH27172: mixed closed Intervals --> object dtype
+                        pass
                 elif inferred == 'boolean':
                     # don't support boolean explicitly ATM
                     pass

--- a/pandas/tests/indexes/interval/test_construction.py
+++ b/pandas/tests/indexes/interval/test_construction.py
@@ -364,6 +364,16 @@ class TestClassConstructors(Base):
         assert type(result) is Index
         tm.assert_numpy_array_equal(result.values, np.array(values))
 
+    def test_index_mixed_closed(self):
+        # GH27172
+        intervals = [Interval(0, 1, closed='left'),
+                     Interval(1, 2, closed='right'),
+                     Interval(2, 3, closed='neither'),
+                     Interval(3, 4, closed='both')]
+        result = Index(intervals)
+        expected = Index(intervals, dtype=object)
+        tm.assert_index_equal(result, expected)
+
 
 class TestFromIntervals(TestClassConstructors):
     """
@@ -387,4 +397,8 @@ class TestFromIntervals(TestClassConstructors):
 
     @pytest.mark.skip(reason='parent class test that is not applicable')
     def test_index_object_dtype(self):
+        pass
+
+    @pytest.mark.skip(reason='parent class test that is not applicable')
+    def test_index_mixed_closed(self):
         pass

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -22,7 +22,8 @@ from pandas import (
     CategoricalIndex, DataFrame, DatetimeIndex, Float64Index, Int64Index,
     PeriodIndex, RangeIndex, Series, TimedeltaIndex, UInt64Index, date_range,
     isna, period_range)
-from pandas.core.index import _get_combined_index, ensure_index_from_sequences
+from pandas.core.index import (
+    _get_combined_index, ensure_index, ensure_index_from_sequences)
 from pandas.core.indexes.api import Index, MultiIndex
 from pandas.core.sorting import safe_sort
 from pandas.tests.indexes.common import Base
@@ -2430,6 +2431,16 @@ class TestIndexUtils:
     ])
     def test_ensure_index_from_sequences(self, data, names, expected):
         result = ensure_index_from_sequences(data, names)
+        tm.assert_index_equal(result, expected)
+
+    def test_ensure_index_mixed_closed_intervals(self):
+        # GH27172
+        intervals = [pd.Interval(0, 1, closed='left'),
+                     pd.Interval(1, 2, closed='right'),
+                     pd.Interval(2, 3, closed='neither'),
+                     pd.Interval(3, 4, closed='both')]
+        result = ensure_index(intervals)
+        expected = Index(intervals, dtype=object)
         tm.assert_index_equal(result, expected)
 
 


### PR DESCRIPTION
- [X] closes #27172
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Note that this solution uses the same pattern that's used to support a list of mixed frequency `Period` objects:
https://github.com/pandas-dev/pandas/blob/527e714647a16ad31f80ea535af5a63156515861/pandas/core/indexes/base.py#L444-L448