### PR TITLE
CLN: simplify MultiIndex._shallow_copy

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -924,12 +924,12 @@ class MultiIndex(Index):
 
     @Appender(_index_shared_docs['_shallow_copy'])
     def _shallow_copy(self, values=None, **kwargs):
-        names = kwargs.pop('names', kwargs.pop('name', self.names))
         if values is not None:
+            names = kwargs.pop('names', kwargs.pop('name', self.names))
             # discards freq
             kwargs.pop('freq', None)
             return MultiIndex.from_tuples(values, names=names, **kwargs)
-        return self.copy(names=names, **kwargs)
+        return self.copy(**kwargs)
 
     @cache_readonly
     def dtype(self):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -924,12 +924,12 @@ class MultiIndex(Index):
 
     @Appender(_index_shared_docs['_shallow_copy'])
     def _shallow_copy(self, values=None, **kwargs):
+        names = kwargs.pop('names', kwargs.pop('name', self.names))
         if values is not None:
-            names = kwargs.pop('names', kwargs.pop('name', self.names))
             # discards freq
             kwargs.pop('freq', None)
             return MultiIndex.from_tuples(values, names=names, **kwargs)
-        return self.view()
+        return self.copy(names=names, **kwargs)
 
     @cache_readonly
     def dtype(self):
@@ -1810,7 +1810,7 @@ class MultiIndex(Index):
             new_levels.append(lev)
             new_codes.append(level_codes)
 
-        result = self._shallow_copy()
+        result = self.view()
 
         if changed:
             result._reset_identity()

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -175,7 +175,7 @@ def test_is_():
     assert mi2.is_(mi)
     assert mi.is_(mi2)
 
-    assert mi.is_(mi.set_names(["C", "D"]))
+    assert not mi.is_(mi.set_names(["C", "D"]))
     mi2 = mi.view()
     mi2.set_names(["E", "F"], inplace=True)
     assert mi.is_(mi2)


### PR DESCRIPTION
``MultiIndex._shallow_copy``  doesnt pass on kwargs, unless ``values`` is passed also, but just silently drops the kwargs. This makes ``_shallow_copy`` currently a bit unreliable.

This PR fixes that problem by calling ``.copy`` directly and passing kwargs to ``copy``and not passing the call through ``.view``. Also, ``_shallow_copy`` doesn't call ``.view`` on other index types, so this PR makes ``MultiIndex._shallow_copy`` conform with other index types.