### PR TITLE
improve test for timestamp addition/subtraction

### DIFF
--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -99,7 +99,7 @@ class TestTimestampArithmetic:
     @pytest.mark.parametrize('freq, td, td64', [
         ('D', timedelta(days=1), np.timedelta64(1, 'D')),
         ('W', timedelta(weeks=1), np.timedelta64(1, 'W')),
-        ('M', timedelta(months=1), np.timedelta64(1, 'M'))
+        ('M', None, np.timedelta64(1, 'M'))
     ])
     def test_addition_subtraction_preserve_frequency(self, freq, td, td64):
         ts = Timestamp('2014-03-05', freq=freq)

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -97,12 +97,15 @@ class TestTimestampArithmetic:
         assert type(ts - td64) == Timestamp
 
     @pytest.mark.parametrize('freq, td, td64', [
+        ('S', timedelta(seconds=1), np.timedelta64(1, 's')),
+        ('min', timedelta(minutes=1), np.timedelta64(1, 'm')),
+        ('H', timedelta(hours=1), np.timedelta64(1, 'h')),
         ('D', timedelta(days=1), np.timedelta64(1, 'D')),
         ('W', timedelta(weeks=1), np.timedelta64(1, 'W')),
         ('M', None, np.timedelta64(1, 'M'))
     ])
     def test_addition_subtraction_preserve_frequency(self, freq, td, td64):
-        ts = Timestamp('2014-03-05', freq=freq)
+        ts = Timestamp('2014-03-05 00:00:00', freq=freq)
         original_freq = ts.freq
 
         with tm.assert_produces_warning(FutureWarning):


### PR DESCRIPTION
This PR adds regression test cases for the addition/subtraction of time deltas to timestamps. In fact, this is causing issues in 0.24.2 when `freq="M"` and `freq="W"`, and the problem is solved in `master`.

- [ ] closes #27182 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
