### PR TITLE
REF: rename _data-->_mgr

### DIFF
--- a/pandas/_libs/properties.pyx
+++ b/pandas/_libs/properties.pyx
@@ -57,10 +57,10 @@ cdef class AxisProperty:
             list axes
 
         if obj is None:
-            # Only instances have _data, not classes
+            # Only instances have _mgr, not classes
             return self
         else:
-            axes = obj._data.axes
+            axes = obj._mgr.axes
         return axes[self.axis]
 
     def __set__(self, obj, value):

--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -148,7 +148,7 @@ cdef class Reducer:
                         object.__setattr__(cached_typ, 'index', self.index)
 
                     object.__setattr__(
-                        cached_typ._data._block, 'values', chunk)
+                        cached_typ._mgr._block, 'values', chunk)
                     object.__setattr__(cached_typ, 'name', name)
                     res = self.f(cached_typ)
                 else:
@@ -279,7 +279,7 @@ cdef class SeriesBinGrouper:
                     object.__setattr__(cached_ityp, '_index_data', islider.buf)
                     cached_ityp._engine.clear_mapping()
                     object.__setattr__(
-                        cached_typ._data._block, 'values', vslider.buf)
+                        cached_typ._mgr._block, 'values', vslider.buf)
                     object.__setattr__(cached_typ, '_index', cached_ityp)
                     object.__setattr__(cached_typ, 'name', name)
 
@@ -405,7 +405,7 @@ cdef class SeriesGrouper:
                         object.__setattr__(cached_ityp, '_data', islider.buf)
                         cached_ityp._engine.clear_mapping()
                         object.__setattr__(
-                            cached_typ._data._block, 'values', vslider.buf)
+                            cached_typ._mgr._block, 'values', vslider.buf)
                         object.__setattr__(cached_typ, '_index', cached_ityp)
                         object.__setattr__(cached_typ, 'name', name)
 
@@ -577,7 +577,7 @@ cdef class BlockSlider:
         self.dummy = frame[:0]
         self.index = self.dummy.index
 
-        self.blocks = [b.values for b in self.dummy._data.blocks]
+        self.blocks = [b.values for b in self.dummy._mgr.blocks]
 
         for x in self.blocks:
             util.set_array_not_contiguous(x)

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -326,7 +326,7 @@ static PyObject *get_sub_attr(PyObject *obj, char *attr, char *subAttr) {
 }
 
 static int is_simple_frame(PyObject *obj) {
-    PyObject *check = get_sub_attr(obj, "_data", "is_mixed_type");
+    PyObject *check = get_sub_attr(obj, "_mgr", "is_mixed_type");
     int ret = (check == Py_False);
 
     if (!check) {
@@ -984,7 +984,7 @@ void PdBlock_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
         goto BLKRET;
     }
 
-    blocks = get_sub_attr(obj, "_data", "blocks");
+    blocks = get_sub_attr(obj, "_mgr", "blocks");
     if (!blocks) {
         GET_TC(tc)->iterNext = NpyArr_iterNextNone;
         goto BLKRET;

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1710,7 +1710,7 @@ def take_nd(
         if arr.flags.f_contiguous and axis == arr.ndim - 1:
             # minor tweak that can make an order-of-magnitude difference
             # for dataframes initialized directly from 2-d ndarrays
-            # (s.t. df.values is c-contiguous and df._data.blocks[0] is its
+            # (s.t. df.values is c-contiguous and df._mgr.blocks[0] is its
             # f-contiguous transpose)
             out = np.empty(out_shape, dtype=dtype, order="F")
         else:

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -166,7 +166,7 @@ class FrameApply:
         # ufunc
         elif isinstance(self.f, np.ufunc):
             with np.errstate(all="ignore"):
-                results = self.obj._data.apply("apply", func=self.f)
+                results = self.obj._mgr.apply("apply", func=self.f)
             return self.obj._constructor(
                 data=results, index=self.index, columns=self.columns, copy=False
             )

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -80,7 +80,7 @@ ABCPandasArray = create_pandas_abc_type("ABCPandasArray", "_typ", ("npy_extensio
 
 class _ABCGeneric(type):
     def __instancecheck__(cls, inst):
-        return hasattr(inst, "_data")
+        return hasattr(inst, "_mgr")
 
 
 ABCGeneric = _ABCGeneric("ABCGeneric", tuple(), {})

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -144,7 +144,7 @@ def _isna_new(obj):
     ):
         return _isna_ndarraylike(obj)
     elif isinstance(obj, ABCGeneric):
-        return obj._constructor(obj._data.isna(func=isna))
+        return obj._constructor(obj._mgr.isna(func=isna))
     elif isinstance(obj, list):
         return _isna_ndarraylike(np.asarray(obj, dtype=object))
     elif hasattr(obj, "__array__"):
@@ -172,7 +172,7 @@ def _isna_old(obj):
     elif isinstance(obj, (ABCSeries, np.ndarray, ABCIndexClass)):
         return _isna_ndarraylike_old(obj)
     elif isinstance(obj, ABCGeneric):
-        return obj._constructor(obj._data.isna(func=_isna_old))
+        return obj._constructor(obj._mgr.isna(func=_isna_old))
     elif isinstance(obj, list):
         return _isna_ndarraylike_old(np.asarray(obj, dtype=object))
     elif hasattr(obj, "__array__"):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1196,9 +1196,7 @@ class NDFrame(PandasObject, SelectionMixin):
                     ]
                     raise KeyError("{} not found in axis".format(missing_labels))
 
-            result._mgr = result._mgr.rename_axis(
-                f, axis=baxis, copy=copy, level=level
-            )
+            result._mgr = result._mgr.rename_axis(f, axis=baxis, copy=copy, level=level)
             result._clear_item_cache()
 
         if inplace:
@@ -5941,9 +5939,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         else:
             # else, only a single dtype is given
-            new_data = self._mgr.astype(
-                dtype=dtype, copy=copy, errors=errors, **kwargs
-            )
+            new_data = self._mgr.astype(dtype=dtype, copy=copy, errors=errors, **kwargs)
             return self._constructor(new_data).__finalize__(self)
 
         # GH 19920: retain column metadata after concat

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -252,7 +252,7 @@ class NDFrameGroupBy(GroupBy):
                         # Backwards compat for groupby.agg() with sparse
                         # values. concat no longer converts DataFrame[Sparse]
                         # to SparseDataFrame, so we do it here.
-                        result = SparseDataFrame(result._data)
+                        result = SparseDataFrame(result._mgr)
                 except Exception:
                     result = self._aggregate_generic(func, *args, **kwargs)
 
@@ -1502,9 +1502,9 @@ class DataFrameGroupBy(NDFrameGroupBy):
     def _get_data_to_aggregate(self):
         obj = self._obj_with_exclusions
         if self.axis == 1:
-            return obj.T._data, 1
+            return obj.T._mgr, 1
         else:
-            return obj._data, 1
+            return obj._mgr, 1
 
     def _insert_inaxis_grouper_inplace(self, result):
         # zip in reverse so we can always insert at loc 0

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -591,7 +591,7 @@ def _get_grouper(
     def is_in_axis(key):
         if not _is_label_like(key):
             try:
-                obj._data.items.get_loc(key)
+                obj._mgr.items.get_loc(key)
             except Exception:
                 return False
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -323,8 +323,8 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
         # if there is only one block/type, still have to take split path
         # unless the block is one-dimensional or it can hold the value
-        if not take_split_path and self.obj._data.blocks:
-            blk, = self.obj._data.blocks
+        if not take_split_path and self.obj._mgr.blocks:
+            blk, = self.obj._mgr.blocks
             if 1 < blk.ndim:  # in case of dict, keys are indices
                 val = list(value.values()) if isinstance(value, dict) else value
                 take_split_path = not blk._can_hold_element(val)
@@ -390,7 +390,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     # so the object is the same
                     index = self.obj._get_axis(i)
                     labels = index.insert(len(index), key)
-                    self.obj._data = self.obj.reindex(labels, axis=i)._data
+                    self.obj._mgr = self.obj.reindex(labels, axis=i)._mgr
                     self.obj._maybe_update_cacher(clear=True)
                     self.obj._is_copy = None
 
@@ -431,9 +431,9 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                         except TypeError:
                             as_obj = self.obj.astype(object)
                             new_values = np.concatenate([as_obj, new_values])
-                    self.obj._data = self.obj._constructor(
+                    self.obj._mgr = self.obj._constructor(
                         new_values, index=new_index, name=self.obj.name
-                    )._data
+                    )._mgr
                     self.obj._maybe_update_cacher(clear=True)
                     return self.obj
 
@@ -463,7 +463,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
                         value = Series(value, index=self.obj.columns, name=indexer)
 
-                    self.obj._data = self.obj.append(value)._data
+                    self.obj._mgr = self.obj.append(value)._mgr
                     self.obj._maybe_update_cacher(clear=True)
                     return self.obj
 
@@ -518,7 +518,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     idx = index._convert_slice_indexer(idx)
                     obj._consolidate_inplace()
                     obj = obj.copy()
-                    obj._data = obj._data.setitem(indexer=tuple([idx]), value=value)
+                    obj._mgr = obj._mgr.setitem(indexer=tuple([idx]), value=value)
                     self.obj[item] = obj
                     return
 
@@ -549,7 +549,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     # set the item, possibly having a dtype change
                     s._consolidate_inplace()
                     s = s.copy()
-                    s._data = s._data.setitem(indexer=pi, value=v)
+                    s._mgr = s._mgr.setitem(indexer=pi, value=v)
                     s._maybe_update_cacher(clear=True)
 
                 # reset the sliced object if unique
@@ -673,7 +673,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
             # actually do the set
             self.obj._consolidate_inplace()
-            self.obj._data = self.obj._data.setitem(indexer=indexer, value=value)
+            self.obj._mgr = self.obj._mgr.setitem(indexer=indexer, value=value)
             self.obj._maybe_update_cacher(clear=True)
 
     def _align_series(self, indexer, ser, multiindex_indexer=False):
@@ -2450,7 +2450,7 @@ def convert_to_index_sliceable(obj, key):
     elif isinstance(key, str):
 
         # we are an actual column
-        if key in obj._data.items:
+        if key in obj._mgr.items:
             return None
 
         # We might have a datetimelike string that we can translate to a

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -1525,7 +1525,7 @@ def add_special_arithmetic_methods(cls):
             # this makes sure that we are aligned like the input
             # we are updating inplace so we want to ignore is_copy
             self._update_inplace(
-                result.reindex_like(self, copy=False)._data, verify_is_copy=False
+                result.reindex_like(self, copy=False)._mgr, verify_is_copy=False
             )
 
             return self

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1648,7 +1648,7 @@ def _take_new_index(obj, indexer, new_index, axis=0):
         if axis == 1:
             raise NotImplementedError("axis 1 is not supported")
         return DataFrame(
-            obj._data.reindex_indexer(new_axis=new_index, indexer=indexer, axis=1)
+            obj._mgr.reindex_indexer(new_axis=new_index, indexer=indexer, axis=1)
         )
     else:
         raise ValueError("'obj' should be either a Series or a DataFrame")

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -436,8 +436,8 @@ class _Concatenator:
             if self.axis == 0:
                 name = com.consensus_name_attr(self.objs)
 
-                mgr = self.objs[0]._data.concat(
-                    [x._data for x in self.objs], self.new_axes
+                mgr = self.objs[0]._mgr.concat(
+                    [x._mgr for x in self.objs], self.new_axes
                 )
                 cons = _concat._get_series_result_type(mgr, self.objs)
                 return cons(mgr, name=name).__finalize__(self, method="concat")
@@ -456,7 +456,7 @@ class _Concatenator:
         else:
             mgrs_indexers = []
             for obj in self.objs:
-                mgr = obj._data
+                mgr = obj._mgr
                 indexers = {}
                 for ax, new_labels in enumerate(self.new_axes):
                     if ax == self.axis:
@@ -467,7 +467,7 @@ class _Concatenator:
                     if not new_labels.equals(obj_labels):
                         indexers[ax] = obj_labels.reindex(new_labels)[1]
 
-                mgrs_indexers.append((obj._data, indexers))
+                mgrs_indexers.append((obj._mgr, indexers))
 
             new_data = concatenate_block_managers(
                 mgrs_indexers, self.new_axes, concat_axis=self.axis, copy=self.copy
@@ -565,7 +565,7 @@ class _Concatenator:
             else:
                 return ensure_index(self.keys).set_names(self.names)
         else:
-            indexes = [x._data.axes[self.axis] for x in self.objs]
+            indexes = [x._mgr.axes[self.axis] for x in self.objs]
 
         if self.ignore_index:
             idx = ibase.default_index(sum(len(i) for i in indexes))

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -642,7 +642,7 @@ class _MergeOperation:
 
         join_index, left_indexer, right_indexer = self._get_join_info()
 
-        ldata, rdata = self.left._data, self.right._data
+        ldata, rdata = self.left._mgr, self.right._mgr
         lsuf, rsuf = self.suffixes
 
         llabels, rlabels = _items_overlap_with_suffix(
@@ -840,8 +840,8 @@ class _MergeOperation:
         )
 
     def _get_join_info(self):
-        left_ax = self.left._data.axes[self.axis]
-        right_ax = self.right._data.axes[self.axis]
+        left_ax = self.left._mgr.axes[self.axis]
+        right_ax = self.right._mgr.axes[self.axis]
 
         if self.left_index and self.right_index and self.how != "asof":
             join_index, left_indexer, right_indexer = left_ax.join(
@@ -1449,7 +1449,7 @@ class _OrderedMerge(_MergeOperation):
         join_index, left_indexer, right_indexer = self._get_join_info()
 
         # this is a bit kludgy
-        ldata, rdata = self.left._data, self.right._data
+        ldata, rdata = self.left._mgr, self.right._mgr
         lsuf, rsuf = self.suffixes
 
         llabels, rlabels = _items_overlap_with_suffix(

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -425,7 +425,7 @@ def _unstack_frame(obj, level, fill_value=None):
         unstacker = partial(
             _Unstacker, index=obj.index, level=level, fill_value=fill_value
         )
-        blocks = obj._data.unstack(unstacker, fill_value=fill_value)
+        blocks = obj._mgr.unstack(unstacker, fill_value=fill_value)
         return obj._constructor(blocks)
     else:
         unstacker = _Unstacker(

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -115,7 +115,7 @@ class SparseDataFrame(DataFrame):
             mgr = self._init_matrix(data, index, columns, dtype=dtype)
         elif isinstance(data, SparseDataFrame):
             mgr = self._init_mgr(
-                data._data, dict(index=index, columns=columns), dtype=dtype, copy=copy
+                data._mgr, dict(index=index, columns=columns), dtype=dtype, copy=copy
             )
         elif isinstance(data, DataFrame):
             mgr = self._init_dict(data, data.index, data.columns, dtype=dtype)
@@ -283,7 +283,7 @@ class SparseDataFrame(DataFrame):
         return dict(
             _typ=self._typ,
             _subtyp=self._subtyp,
-            _data=self._data,
+            _mgr=self._mgr,
             _default_fill_value=self._default_fill_value,
             _default_kind=self._default_kind,
         )
@@ -314,7 +314,7 @@ class SparseDataFrame(DataFrame):
                 sp_values, sparse_index=sp_index, fill_value=fv
             )
 
-        self._data = to_manager(series_dict, columns, index)
+        self._mgr = to_manager(series_dict, columns, index)
         self._default_fill_value = fv
         self._default_kind = kind
 

--- a/pandas/core/sparse/scipy_sparse.py
+++ b/pandas/core/sparse/scipy_sparse.py
@@ -26,7 +26,7 @@ def _to_ijv(ss, row_levels=(0,), column_levels=(1,), sort_labels=False):
     _check_is_partition([row_levels, column_levels], range(ss.index.nlevels))
 
     # from the SparseSeries: get the labels and data for non-null entries
-    values = ss._data.internal_values()._valid_sp_values
+    values = ss._mgr.internal_values()._valid_sp_values
 
     nonnull_labels = ss.dropna()
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -176,7 +176,7 @@ class SparseSeries(Series):
     @property
     def block(self):
         warnings.warn("SparseSeries.block is deprecated.", FutureWarning, stacklevel=2)
-        return self._data._block
+        return self._mgr._block
 
     @property
     def fill_value(self):
@@ -273,7 +273,7 @@ class SparseSeries(Series):
         return dict(
             _typ=self._typ,
             _subtyp=self._subtyp,
-            _data=self._data,
+            _mgr=self._mgr,
             fill_value=self.fill_value,
             name=self.name,
         )
@@ -343,7 +343,7 @@ class SparseSeries(Series):
     def _get_values(self, indexer):
         try:
             return self._constructor(
-                self._data.get_slice(indexer), fastpath=True
+                self._mgr.get_slice(indexer), fastpath=True
             ).__finalize__(self)
         except Exception:
             return self[indexer]
@@ -465,7 +465,7 @@ class SparseSeries(Series):
             values = new_values
         new_index = values.index
         values = SparseArray(values, fill_value=self.fill_value, kind=self.kind)
-        self._data = SingleBlockManager(values, new_index)
+        self._mgr = SingleBlockManager(values, new_index)
         self._index = new_index
 
     _set_value.__doc__ = set_value.__doc__
@@ -482,7 +482,7 @@ class SparseSeries(Series):
         values = self.values.to_dense()
         values[key] = libindex.convert_scalar(values, value)
         values = SparseArray(values, fill_value=self.fill_value, kind=self.kind)
-        self._data = SingleBlockManager(values, self.index)
+        self._mgr = SingleBlockManager(values, self.index)
 
     def to_dense(self):
         """

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -129,7 +129,7 @@ class CSVFormatter:
         self.cols = cols
 
         # preallocate data 2d list
-        self.blocks = self.obj._data.blocks
+        self.blocks = self.obj._mgr.blocks
         ncols = sum(b.shape[0] for b in self.blocks)
         self.data = [None] * ncols
 

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -492,7 +492,7 @@ def encode(obj):
             # return d
         else:
 
-            data = obj._data
+            data = obj._mgr
             if not data.is_consolidated():
                 data = data.consolidate()
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3204,7 +3204,7 @@ class BlockManagerFixed(GenericFixed):
 
     def write(self, obj, **kwargs):
         super().write(obj, **kwargs)
-        data = obj._data
+        data = obj._mgr
         if not data.is_consolidated():
             data = data.consolidate()
 
@@ -3842,20 +3842,20 @@ class Table(Fixed):
 
         # figure out data_columns and get out blocks
         block_obj = self.get_object(obj)._consolidate()
-        blocks = block_obj._data.blocks
-        blk_items = get_blk_items(block_obj._data, blocks)
+        blocks = block_obj._mgr.blocks
+        blk_items = get_blk_items(block_obj._mgr, blocks)
         if len(self.non_index_axes):
             axis, axis_labels = self.non_index_axes[0]
             data_columns = self.validate_data_columns(data_columns, min_itemsize)
             if len(data_columns):
                 mgr = block_obj.reindex(
                     Index(axis_labels).difference(Index(data_columns)), axis=axis
-                )._data
+                )._mgr
 
                 blocks = list(mgr.blocks)
                 blk_items = get_blk_items(mgr, blocks)
                 for c in data_columns:
-                    mgr = block_obj.reindex([c], axis=axis)._data
+                    mgr = block_obj.reindex([c], axis=axis)._mgr
                     blocks.extend(mgr.blocks)
                     blk_items.extend(get_blk_items(mgr, mgr.blocks))
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -693,7 +693,7 @@ class SQLTable(PandasObject):
         column_names = list(map(str, temp.columns))
         ncols = len(column_names)
         data_list = [None] * ncols
-        blocks = temp._data.blocks
+        blocks = temp._mgr.blocks
 
         for b in blocks:
             if b.is_datetime:

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1363,7 +1363,7 @@ def test_nan_to_nat_conversions():
     assert result == iNaT
 
     s = df["B"].copy()
-    s._data = s._data.setitem(indexer=tuple([slice(8, 9)]), value=np.nan)
+    s._mgr = s._mgr.setitem(indexer=tuple([slice(8, 9)]), value=np.nan)
     assert isna(s[8])
 
     assert s[8].value == np.datetime64("NaT").astype(np.int64)

--- a/pandas/tests/extension/base/casting.py
+++ b/pandas/tests/extension/base/casting.py
@@ -10,7 +10,7 @@ class BaseCastingTests(BaseExtensionTests):
     def test_astype_object_series(self, all_data):
         ser = pd.Series({"A": all_data})
         result = ser.astype(object)
-        assert isinstance(result._data.blocks[0], ObjectBlock)
+        assert isinstance(result._mgr.blocks[0], ObjectBlock)
 
     def test_tolist(self, data):
         result = pd.Series(data).tolist()

--- a/pandas/tests/extension/base/constructors.py
+++ b/pandas/tests/extension/base/constructors.py
@@ -25,13 +25,13 @@ class BaseConstructorsTests(BaseExtensionTests):
         result = pd.Series(data)
         assert result.dtype == data.dtype
         assert len(result) == len(data)
-        assert isinstance(result._data.blocks[0], ExtensionBlock)
-        assert result._data.blocks[0].values is data
+        assert isinstance(result._mgr.blocks[0], ExtensionBlock)
+        assert result._mgr.blocks[0].values is data
 
         # Series[EA] is unboxed / boxed correctly
         result2 = pd.Series(result)
         assert result2.dtype == data.dtype
-        assert isinstance(result2._data.blocks[0], ExtensionBlock)
+        assert isinstance(result2._mgr.blocks[0], ExtensionBlock)
 
     @pytest.mark.parametrize("from_series", [True, False])
     def test_dataframe_constructor_from_dict(self, data, from_series):
@@ -40,13 +40,13 @@ class BaseConstructorsTests(BaseExtensionTests):
         result = pd.DataFrame({"A": data})
         assert result.dtypes["A"] == data.dtype
         assert result.shape == (len(data), 1)
-        assert isinstance(result._data.blocks[0], ExtensionBlock)
+        assert isinstance(result._mgr.blocks[0], ExtensionBlock)
 
     def test_dataframe_from_series(self, data):
         result = pd.DataFrame(pd.Series(data))
         assert result.dtypes[0] == data.dtype
         assert result.shape == (len(data), 1)
-        assert isinstance(result._data.blocks[0], ExtensionBlock)
+        assert isinstance(result._mgr.blocks[0], ExtensionBlock)
 
     def test_series_given_mismatched_index_raises(self, data):
         msg = "Length of passed values is 3, index implies 5"

--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -53,7 +53,7 @@ class BaseInterfaceTests(BaseExtensionTests):
 
     def test_is_numeric_honored(self, data):
         result = pd.Series(data)
-        assert result._data.blocks[0].is_numeric is data.dtype._is_numeric
+        assert result._mgr.blocks[0].is_numeric is data.dtype._is_numeric
 
     def test_isna_extension_array(self, data_missing):
         # If your `isna` returns an ExtensionArray, you must also implement

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -27,7 +27,7 @@ class BaseReshapingTests(BaseExtensionTests):
             dtype = result.dtype
 
         assert dtype == data.dtype
-        assert isinstance(result._data.blocks[0], ExtensionBlock)
+        assert isinstance(result._mgr.blocks[0], ExtensionBlock)
 
     @pytest.mark.parametrize("in_frame", [True, False])
     def test_concat_all_na_block(self, data_missing, in_frame):

--- a/pandas/tests/extension/test_external_block.py
+++ b/pandas/tests/extension/test_external_block.py
@@ -27,7 +27,7 @@ class CustomBlock(NonConsolidatableMixIn, Block):
 @pytest.fixture
 def df():
     df1 = pd.DataFrame({"a": [1, 2, 3]})
-    blocks = df1._data.blocks
+    blocks = df1._mgr.blocks
     values = np.arange(3, dtype="int64")
     custom_block = CustomBlock(values, placement=slice(1, 2))
     blocks = blocks + (custom_block,)
@@ -58,17 +58,17 @@ def test_concat_series():
     s = pd.Series(block, pd.RangeIndex(3), fastpath=True)
 
     res = pd.concat([s, s])
-    assert isinstance(res._data.blocks[0], CustomBlock)
+    assert isinstance(res._mgr.blocks[0], CustomBlock)
 
 
 def test_concat_dataframe(df):
     # GH17728
     res = pd.concat([df, df])
-    assert isinstance(res._data.blocks[1], CustomBlock)
+    assert isinstance(res._mgr.blocks[1], CustomBlock)
 
 
 def test_concat_axis1(df):
     # GH17954
     df2 = pd.DataFrame({"c": [0.1, 0.2, 0.3]})
     res = pd.concat([df, df2], axis=1)
-    assert isinstance(res._data.blocks[1], CustomBlock)
+    assert isinstance(res._mgr.blocks[1], CustomBlock)

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -558,10 +558,10 @@ class TestDataFrameSelectReindex:
 
     def test_align_float(self, float_frame):
         af, bf = float_frame.align(float_frame)
-        assert af._data is not float_frame._data
+        assert af._mgr is not float_frame._mgr
 
         af, bf = float_frame.align(float_frame, copy=False)
-        assert af._data is float_frame._data
+        assert af._mgr is float_frame._mgr
 
         # axis = 0
         other = float_frame.iloc[:-5, :3]

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -48,18 +48,18 @@ class TestDataFrameBlockInternals:
         assert dti[1] == ts
 
     def test_cast_internals(self, float_frame):
-        casted = DataFrame(float_frame._data, dtype=int)
+        casted = DataFrame(float_frame._mgr, dtype=int)
         expected = DataFrame(float_frame._series, dtype=int)
         assert_frame_equal(casted, expected)
 
-        casted = DataFrame(float_frame._data, dtype=np.int32)
+        casted = DataFrame(float_frame._mgr, dtype=np.int32)
         expected = DataFrame(float_frame._series, dtype=np.int32)
         assert_frame_equal(casted, expected)
 
     def test_consolidate(self, float_frame):
         float_frame["E"] = 7.0
         consolidated = float_frame._consolidate()
-        assert len(consolidated._data.blocks) == 1
+        assert len(consolidated._mgr.blocks) == 1
 
         # Ensure copy, do I want this?
         recons = consolidated._consolidate()
@@ -67,10 +67,10 @@ class TestDataFrameBlockInternals:
         tm.assert_frame_equal(recons, consolidated)
 
         float_frame["F"] = 8.0
-        assert len(float_frame._data.blocks) == 3
+        assert len(float_frame._mgr.blocks) == 3
 
         float_frame._consolidate(inplace=True)
-        assert len(float_frame._data.blocks) == 1
+        assert len(float_frame._mgr.blocks) == 1
 
     def test_consolidate_inplace(self, float_frame):
         frame = float_frame.copy()  # noqa
@@ -81,9 +81,9 @@ class TestDataFrameBlockInternals:
 
     def test_values_consolidate(self, float_frame):
         float_frame["E"] = 7.0
-        assert not float_frame._data.is_consolidated()
+        assert not float_frame._mgr.is_consolidated()
         _ = float_frame.values  # noqa
-        assert float_frame._data.is_consolidated()
+        assert float_frame._mgr.is_consolidated()
 
     def test_modify_values(self, float_frame):
         float_frame.values[5] = 5
@@ -305,7 +305,7 @@ class TestDataFrameBlockInternals:
         df1 = df0.reset_index()[["A", "B", "C"]]
         # this assert verifies that the above operations have
         # induced a block rearrangement
-        assert df0._data.blocks[0].dtype != df1._data.blocks[0].dtype
+        assert df0._mgr.blocks[0].dtype != df1._mgr.blocks[0].dtype
 
         # do the real tests
         assert_frame_equal(df0, df1)
@@ -353,7 +353,7 @@ class TestDataFrameBlockInternals:
 
         # copy objects
         copy = float_string_frame.copy()
-        assert copy._data is not float_string_frame._data
+        assert copy._mgr is not float_string_frame._mgr
 
     def test_pickle(self, float_string_frame, timezone_frame):
         empty_frame = DataFrame()
@@ -362,7 +362,7 @@ class TestDataFrameBlockInternals:
         assert_frame_equal(float_string_frame, unpickled)
 
         # buglet
-        float_string_frame._data.ndim
+        float_string_frame._mgr.ndim
 
         # empty
         unpickled = tm.round_trip_pickle(empty_frame)
@@ -621,7 +621,7 @@ starting,ending,measure
         result = pd.DataFrame({"A": arr})
         expected = pd.DataFrame({"A": [1, 2, 3]})
         tm.assert_frame_equal(result, expected)
-        assert isinstance(result._data.blocks[0], IntBlock)
+        assert isinstance(result._mgr.blocks[0], IntBlock)
 
     def test_add_column_with_pandas_array(self):
         # GH 26390
@@ -634,6 +634,6 @@ starting,ending,measure
                 "c": pd.array([1, 2, None, 3]),
             }
         )
-        assert type(df["c"]._data.blocks[0]) == ObjectBlock
-        assert type(df2["c"]._data.blocks[0]) == ObjectBlock
+        assert type(df["c"]._mgr.blocks[0]) == ObjectBlock
+        assert type(df2["c"]._mgr.blocks[0]) == ObjectBlock
         assert_frame_equal(df, df2)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1451,7 +1451,7 @@ class TestDataFrameConstructors:
         index = list(float_frame.index[:5])
         columns = list(float_frame.columns[:3])
 
-        result = DataFrame(float_frame._data, index=index, columns=columns)
+        result = DataFrame(float_frame._mgr, index=index, columns=columns)
         tm.assert_index_equal(result.index, Index(index))
         tm.assert_index_equal(result.columns, Index(columns))
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3417,8 +3417,8 @@ class TestDataFrameIndexingDatetimeWithTZ(TestData):
 
         # assert that A & C are not sharing the same base (e.g. they
         # are copies)
-        b1 = df._data.blocks[1]
-        b2 = df._data.blocks[2]
+        b1 = df._mgr.blocks[1]
+        b2 = df._mgr.blocks[2]
         tm.assert_extension_array_equal(b1.values, b2.values)
         assert id(b1.values._data.base) != id(b2.values._data.base)
 
@@ -3548,7 +3548,7 @@ class TestDataFrameIndexingCategorical:
 
         result1 = df["D"]
         result2 = df["E"]
-        tm.assert_categorical_equal(result1._data._block.values, d)
+        tm.assert_categorical_equal(result1._mgr._block.values, d)
 
         # sorting
         s.name = "E"

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -476,8 +476,8 @@ class TestDataFrameNonuniqueIndexes(TestData):
         )
         df = pd.concat([df_float, df_int, df_bool, df_object, df_dt], axis=1)
 
-        assert len(df._data._blknos) == len(df.columns)
-        assert len(df._data._blklocs) == len(df.columns)
+        assert len(df._mgr._blknos) == len(df.columns)
+        assert len(df._mgr._blklocs) == len(df.columns)
 
         # testing iloc
         for i in range(len(df.columns)):

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -699,7 +699,7 @@ class TestDataFrameOperators:
         assert_series_equal(s, s2)
         assert_series_equal(s_orig + 1, s)
         assert s is s2
-        assert s._data is s2._data
+        assert s._mgr is s2._mgr
 
         df = df_orig.copy()
         df2 = df
@@ -707,7 +707,7 @@ class TestDataFrameOperators:
         assert_frame_equal(df, df2)
         assert_frame_equal(df_orig + 1, df)
         assert df is df2
-        assert df._data is df2._data
+        assert df._mgr is df2._mgr
 
         # dtype change
         s = s_orig.copy()
@@ -722,7 +722,7 @@ class TestDataFrameOperators:
         assert_frame_equal(df, df2)
         assert_frame_equal(df_orig + 1.5, df)
         assert df is df2
-        assert df._data is df2._data
+        assert df._mgr is df2._mgr
 
         # mixed dtype
         arr = np.random.randint(0, 10, size=5)
@@ -733,7 +733,7 @@ class TestDataFrameOperators:
         expected = DataFrame({"A": arr.copy() + 1, "B": "foo"})
         assert_frame_equal(df, expected)
         assert_frame_equal(df2, expected)
-        assert df._data is df2._data
+        assert df._mgr is df2._mgr
 
         df = df_orig.copy()
         df2 = df
@@ -741,7 +741,7 @@ class TestDataFrameOperators:
         expected = DataFrame({"A": arr.copy() + 1.5, "B": "foo"})
         assert_frame_equal(df, expected)
         assert_frame_equal(df2, expected)
-        assert df._data is df2._data
+        assert df._mgr is df2._mgr
 
     @pytest.mark.parametrize(
         "op",

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -175,24 +175,24 @@ class Generic:
 
         o = self._construct(shape=4, value=9, dtype=np.int64)
         result = o.copy()
-        result._data = o._data.downcast(dtypes="infer")
+        result._mgr = o._mgr.downcast(dtypes="infer")
         self._compare(result, o)
 
         o = self._construct(shape=4, value=9.0)
         expected = o.astype(np.int64)
         result = o.copy()
-        result._data = o._data.downcast(dtypes="infer")
+        result._mgr = o._mgr.downcast(dtypes="infer")
         self._compare(result, expected)
 
         o = self._construct(shape=4, value=9.5)
         result = o.copy()
-        result._data = o._data.downcast(dtypes="infer")
+        result._mgr = o._mgr.downcast(dtypes="infer")
         self._compare(result, o)
 
         # are close
         o = self._construct(shape=4, value=9.000000000005)
         result = o.copy()
-        result._data = o._data.downcast(dtypes="infer")
+        result._mgr = o._mgr.downcast(dtypes="infer")
         expected = o.astype(np.int64)
         self._compare(result, expected)
 

--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -407,7 +407,7 @@ class TestMultiIndexSetItem:
         s = dft["foo", "two"]
         dft["foo", "two"] = s > s.median()
         tm.assert_series_equal(dft["foo", "two"], s > s.median())
-        # assert isinstance(dft._data.blocks[1].items, MultiIndex)
+        # assert isinstance(dft._mgr.blocks[1].items, MultiIndex)
 
         reindexed = dft.reindex(columns=[("foo", "two")])
         tm.assert_series_equal(reindexed["foo", "two"], s > s.median())

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -595,7 +595,7 @@ class TestiLoc(Base):
         columns = list(range(0, 8, 2))
         df = DataFrame(arr, index=index, columns=columns)
 
-        df._data.blocks[0].mgr_locs
+        df._mgr.blocks[0].mgr_locs
         result = df.iloc[1:5, 2:4]
         str(result)
         result.dtypes

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1332,7 +1332,7 @@ def test_block_shape():
     a = pd.Series([1, 2, 3]).reindex(idx)
     b = pd.Series(pd.Categorical([1, 2, 3])).reindex(idx)
 
-    assert a._data.blocks[0].mgr_locs.indexer == b._data.blocks[0].mgr_locs.indexer
+    assert a._mgr.blocks[0].mgr_locs.indexer == b._mgr.blocks[0].mgr_locs.indexer
 
 
 def test_make_block_no_pandas_array():

--- a/pandas/tests/io/pytables/test_pytables.py
+++ b/pandas/tests/io/pytables/test_pytables.py
@@ -2486,7 +2486,7 @@ class TestHDFStore(Base):
             df["foo"] = np.random.randn(len(df))
             store["df"] = df
             recons = store["df"]
-            assert recons._data.is_consolidated()
+            assert recons._mgr.is_consolidated()
 
         # empty
         self._check_roundtrip(df[:0], tm.assert_frame_equal)

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -666,7 +666,7 @@ class TestCompression(TestPackers):
             expected = self.frame[k]
             assert_frame_equal(value, expected)
             # make sure that we can write to the new frames
-            for block in value._data.blocks:
+            for block in value._mgr.blocks:
                 assert block.values.flags.writeable
 
     def test_compression_zlib(self):
@@ -719,7 +719,7 @@ class TestCompression(TestPackers):
                     assert_frame_equal(value, expected)
                     # make sure that we can write to the new frames even though
                     # we needed to copy the data
-                    for block in value._data.blocks:
+                    for block in value._mgr.blocks:
                         assert block.values.flags.writeable
                         # mutate the data in some way
                         block.values[0] += rhs[block.dtype]

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1151,28 +1151,28 @@ class TestConcatenate:
         # These are actual copies.
         result = concat([df, df2, df3], axis=1, copy=True)
 
-        for b in result._data.blocks:
+        for b in result._mgr.blocks:
             assert b.values.base is None
 
         # These are the same.
         result = concat([df, df2, df3], axis=1, copy=False)
 
-        for b in result._data.blocks:
+        for b in result._mgr.blocks:
             if b.is_float:
-                assert b.values.base is df._data.blocks[0].values.base
+                assert b.values.base is df._mgr.blocks[0].values.base
             elif b.is_integer:
-                assert b.values.base is df2._data.blocks[0].values.base
+                assert b.values.base is df2._mgr.blocks[0].values.base
             elif b.is_object:
                 assert b.values.base is not None
 
         # Float block was consolidated.
         df4 = DataFrame(np.random.randn(4, 1))
         result = concat([df, df2, df3, df4], axis=1, copy=False)
-        for b in result._data.blocks:
+        for b in result._mgr.blocks:
             if b.is_float:
                 assert b.values.base is None
             elif b.is_integer:
-                assert b.values.base is df2._data.blocks[0].values.base
+                assert b.values.base is df2._mgr.blocks[0].values.base
             elif b.is_object:
                 assert b.values.base is not None
 

--- a/pandas/tests/series/test_block_internals.py
+++ b/pandas/tests/series/test_block_internals.py
@@ -31,8 +31,8 @@ class TestSeriesBlockInternals:
         ser = pd.Series(dti)
         assert ser._values is not dti
         assert ser._values._data.base is not dti._data._data.base
-        assert ser._data.blocks[0].values is not dti
-        assert ser._data.blocks[0].values._data.base is not dti._data._data.base
+        assert ser._mgr.blocks[0].values is not dti
+        assert ser._mgr.blocks[0].values._data.base is not dti._data._data.base
 
         ser[::3] = pd.NaT
         assert ser[0] is pd.NaT

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -631,7 +631,7 @@ class TestSeriesConstructors:
         s = pd.Series(index)
 
         # we make 1 copy; this is just a smoke test here
-        assert s._data.blocks[0].values is not index
+        assert s._mgr.blocks[0].values is not index
 
     def test_constructor_pass_none(self):
         s = Series(None, index=range(5))

--- a/pandas/tests/series/test_internals.py
+++ b/pandas/tests/series/test_internals.py
@@ -207,7 +207,7 @@ class TestSeriesInternals:
         ser = pd.Series([1, 2, 3])
         result = pd.Series(ser.array)
         tm.assert_series_equal(ser, result)
-        assert isinstance(result._data.blocks[0], IntBlock)
+        assert isinstance(result._mgr.blocks[0], IntBlock)
 
     def test_astype_no_pandas_dtype(self):
         # https://github.com/pandas-dev/pandas/pull/24866
@@ -219,17 +219,17 @@ class TestSeriesInternals:
 
     def test_from_array(self):
         result = pd.Series(pd.array(["1H", "2H"], dtype="timedelta64[ns]"))
-        assert result._data.blocks[0].is_extension is False
+        assert result._mgr.blocks[0].is_extension is False
 
         result = pd.Series(pd.array(["2015"], dtype="datetime64[ns]"))
-        assert result._data.blocks[0].is_extension is False
+        assert result._mgr.blocks[0].is_extension is False
 
     def test_from_list_dtype(self):
         result = pd.Series(["1H", "2H"], dtype="timedelta64[ns]")
-        assert result._data.blocks[0].is_extension is False
+        assert result._mgr.blocks[0].is_extension is False
 
         result = pd.Series(["2015"], dtype="datetime64[ns]")
-        assert result._data.blocks[0].is_extension is False
+        assert result._mgr.blocks[0].is_extension is False
 
 
 def test_hasnans_unchached_for_series():

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -681,7 +681,7 @@ class TestSparseDataFrame(SharedWithSparse):
         sdf = pd.SparseDataFrame([[np.nan, 1], [2, np.nan]])
         with pd.option_context("mode.chained_assignment", None):
             sdf[0][1] = 2
-        assert len(sdf._data.blocks) == 2
+        assert len(sdf._mgr.blocks) == 2
 
     def test_delitem(self, float_frame):
         A = float_frame["A"]


### PR DESCRIPTION
At the sprint there was discussion of trimming down the exposed surface of internals.  Among the things that makes this difficult is identifying exactly what that surface is.  This makes it feasiable to grep for all accesses by using the unambiguous `._mgr` instead of the overloaded `._data`.