### PR TITLE
Fix _table_mod is 'NoneType' issue

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1229,6 +1229,7 @@ class HDFStore:
     def get_node(self, key):
         """ return the node with the key or None if it does not exist """
         self._check_if_open()
+        _tables()
         try:
             if not key.startswith("/"):
                 key = "/" + key


### PR DESCRIPTION
- [x] closes #27253 
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Currently in get_node() it is not guaranteed that _table_mod is not none, and this breaks some packages that depend on Pandas, forcing use of older versions of Pandas. I added `_tables()` to fix this issue
see #27253 for more details