### PR TITLE
CLN: remove unnecessary fastpath, transpose kwargs in internals

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9175,7 +9175,6 @@ class NDFrame(PandasObject, SelectionMixin):
                 errors=errors,
                 try_cast=try_cast,
                 axis=block_axis,
-                transpose=self._AXIS_REVERSED,
             )
 
             return self._constructor(new_data).__finalize__(self)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2300,9 +2300,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
         elif isinstance(other, (datetime, np.datetime64, date)):
             other = self._box_func(other)
             if getattr(other, "tz") is not None:
-                raise TypeError(
-                    "cannot coerce a Timestamp with a tz on a naive Block"
-                )
+                raise TypeError("cannot coerce a Timestamp with a tz on a naive Block")
             other = other.asm8.view("i8")
         elif hasattr(other, "dtype") and is_datetime64_dtype(other):
             other = other.astype("i8", copy=False).view("i8")

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -143,7 +143,7 @@ class Block(PandasObject):
             ndim = values.ndim
 
         if self._validate_ndim and values.ndim != ndim:
-            msg = "Wrong number of dimensions. values.ndim != ndim " "[{} != {}]"
+            msg = "Wrong number of dimensions. values.ndim != ndim [{} != {}]"
             raise ValueError(msg.format(values.ndim, ndim))
 
         return ndim
@@ -259,7 +259,7 @@ class Block(PandasObject):
         if dtype is not None:
             # issue 19431 fastparquet is passing this
             warnings.warn(
-                "dtype argument is deprecated, will be removed " "in a future release.",
+                "dtype argument is deprecated, will be removed in a future release.",
                 FutureWarning,
             )
         if placement is None:
@@ -399,7 +399,7 @@ class Block(PandasObject):
                 raise ValueError("Limit must be greater than 0")
             if self.ndim > 2:
                 raise NotImplementedError(
-                    "number of dimensions for 'fillna' " "is currently limited to 2"
+                    "number of dimensions for 'fillna' is currently limited to 2"
                 )
             mask[mask.cumsum(self.ndim - 1) > limit] = False
 
@@ -533,7 +533,7 @@ class Block(PandasObject):
 
         if not (dtypes == "infer" or isinstance(dtypes, dict)):
             raise ValueError(
-                "downcast must have a dictionary or 'infer' as " "its argument"
+                "downcast must have a dictionary or 'infer' as its argument"
             )
 
         # operate column-by-column
@@ -1025,7 +1025,7 @@ class Block(PandasObject):
                     or mask[mask].shape[-1] == len(new)
                     or len(new) == 1
                 ):
-                    raise ValueError("cannot assign mismatch " "length to masked array")
+                    raise ValueError("cannot assign mismatch length to masked array")
 
             np.putmask(new_values, mask, new)
 
@@ -1421,7 +1421,7 @@ class Block(PandasObject):
                 cond = cond.T
 
         if not hasattr(cond, "shape"):
-            raise ValueError("where must have a condition that is ndarray " "like")
+            raise ValueError("where must have a condition that is ndarray like")
 
         # our where function
         def func(cond, values, other):
@@ -2301,7 +2301,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
             other = self._box_func(other)
             if getattr(other, "tz") is not None:
                 raise TypeError(
-                    "cannot coerce a Timestamp with a tz on a " "naive Block"
+                    "cannot coerce a Timestamp with a tz on a naive Block"
                 )
             other = other.asm8.view("i8")
         elif hasattr(other, "dtype") and is_datetime64_dtype(other):
@@ -2976,7 +2976,7 @@ class ObjectBlock(Block):
         # only one will survive
         if to_rep_re and regex_re:
             raise AssertionError(
-                "only one of to_replace and regex can be " "regex compilable"
+                "only one of to_replace and regex can be regex compilable"
             )
 
         # if regex was passed as something that can be a regex (rather than a
@@ -3248,7 +3248,7 @@ def make_block(values, placement, klass=None, ndim=None, dtype=None, fastpath=No
     if fastpath is not None:
         # GH#19265 pyarrow is passing this
         warnings.warn(
-            "fastpath argument is deprecated, will be removed " "in a future release.",
+            "fastpath argument is deprecated, will be removed in a future release.",
             FutureWarning,
         )
     if klass is None:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -976,8 +976,6 @@ class BlockManager(PandasObject):
         if values.ndim != 1:
             return values
 
-        # Note: returning values here causes 6 test failures
-
         # shortcut for select a single-dim from a 2-dim BM
         return SingleBlockManager(
             [

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -936,7 +936,7 @@ class BlockManager(PandasObject):
             self._known_consolidated = True
             self._rebuild_blknos_and_blklocs()
 
-    def get(self, item, fastpath=True):
+    def get(self, item):
         """
         Return values for selected item (ndarray or BlockManager).
         """
@@ -954,7 +954,7 @@ class BlockManager(PandasObject):
                     else:
                         raise ValueError("cannot label index with a null key")
 
-            return self.iget(loc, fastpath=fastpath)
+            return self.iget(loc)
         else:
 
             if isna(item):
@@ -965,18 +965,20 @@ class BlockManager(PandasObject):
                 new_axis=self.items[indexer], indexer=indexer, axis=0, allow_dups=True
             )
 
-    def iget(self, i, fastpath=True):
+    def iget(self, i):
         """
-        Return the data as a SingleBlockManager if fastpath=True and possible
+        Return the data as a SingleBlockManager if possible
 
         Otherwise return as a ndarray
         """
         block = self.blocks[self._blknos[i]]
         values = block.iget(self._blklocs[i])
-        if not fastpath or values.ndim != 1:
+        if values.ndim != 1:
             return values
 
-        # fastpath shortcut for select a single-dim from a 2-dim BM
+        # Note: returning values here causes 6 test failures
+
+        # shortcut for select a single-dim from a 2-dim BM
         return SingleBlockManager(
             [
                 block.make_block_same_class(

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -418,9 +418,6 @@ class TestBlockManager:
         block = make_block(values=values.copy(), placement=np.arange(3))
         mgr = BlockManager(blocks=[block], axes=[cols, np.arange(3)])
 
-        assert_almost_equal(mgr.get("a", fastpath=False), values[0])
-        assert_almost_equal(mgr.get("b", fastpath=False), values[1])
-        assert_almost_equal(mgr.get("c", fastpath=False), values[2])
         assert_almost_equal(mgr.get("a").internal_values(), values[0])
         assert_almost_equal(mgr.get("b").internal_values(), values[1])
         assert_almost_equal(mgr.get("c").internal_values(), values[2])
@@ -701,6 +698,7 @@ class TestBlockManager:
         )
 
     def test_reindex_index(self):
+        # TODO: should this be pytest.skip?
         pass
 
     def test_reindex_items(self):
@@ -710,18 +708,6 @@ class TestBlockManager:
         reindexed = mgr.reindex_axis(["g", "c", "a", "d"], axis=0)
         assert reindexed.nblocks == 2
         tm.assert_index_equal(reindexed.items, pd.Index(["g", "c", "a", "d"]))
-        assert_almost_equal(
-            mgr.get("g", fastpath=False), reindexed.get("g", fastpath=False)
-        )
-        assert_almost_equal(
-            mgr.get("c", fastpath=False), reindexed.get("c", fastpath=False)
-        )
-        assert_almost_equal(
-            mgr.get("a", fastpath=False), reindexed.get("a", fastpath=False)
-        )
-        assert_almost_equal(
-            mgr.get("d", fastpath=False), reindexed.get("d", fastpath=False)
-        )
         assert_almost_equal(
             mgr.get("g").internal_values(), reindexed.get("g").internal_values()
         )
@@ -748,17 +734,11 @@ class TestBlockManager:
             numeric.items, pd.Index(["int", "float", "complex", "bool"])
         )
         assert_almost_equal(
-            mgr.get("float", fastpath=False), numeric.get("float", fastpath=False)
-        )
-        assert_almost_equal(
             mgr.get("float").internal_values(), numeric.get("float").internal_values()
         )
 
         # Check sharing
         numeric.set("float", np.array([100.0, 200.0, 300.0]))
-        assert_almost_equal(
-            mgr.get("float", fastpath=False), np.array([100.0, 200.0, 300.0])
-        )
         assert_almost_equal(
             mgr.get("float").internal_values(), np.array([100.0, 200.0, 300.0])
         )
@@ -768,9 +748,6 @@ class TestBlockManager:
             numeric.items, pd.Index(["int", "float", "complex", "bool"])
         )
         numeric2.set("float", np.array([1000.0, 2000.0, 3000.0]))
-        assert_almost_equal(
-            mgr.get("float", fastpath=False), np.array([100.0, 200.0, 300.0])
-        )
         assert_almost_equal(
             mgr.get("float").internal_values(), np.array([100.0, 200.0, 300.0])
         )
@@ -786,16 +763,10 @@ class TestBlockManager:
         bools = mgr.get_bool_data()
         tm.assert_index_equal(bools.items, pd.Index(["bool"]))
         assert_almost_equal(
-            mgr.get("bool", fastpath=False), bools.get("bool", fastpath=False)
-        )
-        assert_almost_equal(
             mgr.get("bool").internal_values(), bools.get("bool").internal_values()
         )
 
         bools.set("bool", np.array([True, False, True]))
-        tm.assert_numpy_array_equal(
-            mgr.get("bool", fastpath=False), np.array([True, False, True])
-        )
         tm.assert_numpy_array_equal(
             mgr.get("bool").internal_values(), np.array([True, False, True])
         )
@@ -803,9 +774,6 @@ class TestBlockManager:
         # Check sharing
         bools2 = mgr.get_bool_data(copy=True)
         bools2.set("bool", np.array([False, True, False]))
-        tm.assert_numpy_array_equal(
-            mgr.get("bool", fastpath=False), np.array([True, False, True])
-        )
         tm.assert_numpy_array_equal(
             mgr.get("bool").internal_values(), np.array([True, False, True])
         )


### PR DESCRIPTION
also clean up some unfortunate formatting left by black.

I _think_ we can also get rid of the transpose kwarg in putmask, separate pass.