### PR TITLE
DOC: Explicitly include "private" ExtensionArray methods in API docs

### DIFF
--- a/doc/source/reference/extensions.rst
+++ b/doc/source/reference/extensions.rst
@@ -32,6 +32,15 @@ objects.
    .. autosummary::
       :toctree: api/
 
+      api.extensions.ExtensionArray._concat_same_type
+      api.extensions.ExtensionArray._formatter
+      api.extensions.ExtensionArray._formatting_values
+      api.extensions.ExtensionArray._from_factorized
+      api.extensions.ExtensionArray._from_sequence
+      api.extensions.ExtensionArray._from_sequence_of_strings
+      api.extensions.ExtensionArray._ndarray_values
+      api.extensions.ExtensionArray._reduce
+      api.extensions.ExtensionArray._values_for_argsort
       api.extensions.ExtensionArray._values_for_factorize
       api.extensions.ExtensionArray.argsort
       api.extensions.ExtensionArray.astype

--- a/doc/source/reference/extensions.rst
+++ b/doc/source/reference/extensions.rst
@@ -18,10 +18,35 @@ objects.
    api.extensions.register_series_accessor
    api.extensions.register_index_accessor
    api.extensions.ExtensionDtype
-   api.extensions.ExtensionArray
 
 .. autosummary::
    :toctree: api/
    :template: autosummary/class_without_autosummary.rst
 
+   api.extensions.ExtensionArray
    arrays.PandasArray
+
+.. We need this autosummary so that methods and attributes are generated.
+.. Separate block, since they aren't classes.
+
+   .. autosummary::
+      :toctree: api/
+
+      api.extensions.ExtensionArray._values_for_factorize
+      api.extensions.ExtensionArray.argsort
+      api.extensions.ExtensionArray.astype
+      api.extensions.ExtensionArray.copy
+      api.extensions.ExtensionArray.dropna
+      api.extensions.ExtensionArray.factorize
+      api.extensions.ExtensionArray.fillna
+      api.extensions.ExtensionArray.isna
+      api.extensions.ExtensionArray.ravel
+      api.extensions.ExtensionArray.repeat
+      api.extensions.ExtensionArray.searchsorted
+      api.extensions.ExtensionArray.shift
+      api.extensions.ExtensionArray.take
+      api.extensions.ExtensionArray.unique
+      api.extensions.ExtensionArray.dtype
+      api.extensions.ExtensionArray.nbytes
+      api.extensions.ExtensionArray.ndim
+      api.extensions.ExtensionArray.shape

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -39,6 +39,30 @@ class ExtensionArray:
 
     .. versionadded:: 0.23.0
 
+    Attributes
+    ----------
+    dtype
+    nbytes
+    ndim
+    shape
+
+    Methods
+    -------
+    argsort
+    astype
+    copy
+    dropna
+    factorize
+    fillna
+    isna
+    ravel
+    repeat
+    searchsorted
+    shift
+    take
+    unique
+    _values_for_factorize
+
     Notes
     -----
     The interface includes the following abstract methods that must be

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -61,6 +61,15 @@ class ExtensionArray:
     shift
     take
     unique
+    _concat_same_type
+    _formatter
+    _formatting_values
+    _from_factorized
+    _from_sequence
+    _from_sequence_of_strings
+    _ndarray_values
+    _reduce
+    _values_for_argsort
     _values_for_factorize
 
     Notes
@@ -805,7 +814,7 @@ class ExtensionArray:
         See Also
         --------
         numpy.take
-        api.extensions.take
+        pandas.api.extensions.take
 
         Notes
         -----
@@ -972,6 +981,14 @@ class ExtensionArray:
 
         The expectation is that this is cheap to compute, and is primarily
         used for interacting with our indexers.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        array : ndarray
         """
         return np.array(self)
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -678,7 +678,7 @@ class ExtensionArray:
 
         See Also
         --------
-        pandas.factorize : Top-level factorize method that dispatches here.
+        factorize : Top-level factorize method that dispatches here.
 
         Notes
         -----
@@ -802,17 +802,17 @@ class ExtensionArray:
             When `indices` contains negative values other than ``-1``
             and `allow_fill` is True.
 
+        See Also
+        --------
+        numpy.take
+        api.extensions.take
+
         Notes
         -----
         ExtensionArray.take is called by ``Series.__getitem__``, ``.loc``,
         ``iloc``, when `indices` is a sequence of values. Additionally,
         it's called by :meth:`Series.reindex`, or any other method
         that causes realignment, with a `fill_value`.
-
-        See Also
-        --------
-        numpy.take
-        pandas.api.extensions.take
 
         Examples
         --------
@@ -927,6 +927,10 @@ class ExtensionArray:
         Parameters
         ----------
         order : {None, 'C', 'F', 'A', 'K'}, default 'C'
+
+        Returns
+        -------
+        ExtensionArray
 
         Notes
         -----

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -203,7 +203,6 @@ class ExtensionArray:
         Returns
         -------
         ExtensionArray
-
         """
         raise AbstractMethodError(cls)
 
@@ -221,7 +220,7 @@ class ExtensionArray:
 
         See Also
         --------
-        pandas.factorize
+        factorize
         ExtensionArray.factorize
         """
         raise AbstractMethodError(cls)
@@ -814,7 +813,7 @@ class ExtensionArray:
         See Also
         --------
         numpy.take
-        pandas.api.extensions.take
+        api.extensions.take
 
         Notes
         -----
@@ -895,7 +894,7 @@ class ExtensionArray:
 
         Parameters
         ----------
-        boxed: bool, default False
+        boxed : bool, default False
             An indicated for whether or not your array is being printed
             within a Series, DataFrame, or Index (True), or just by
             itself (False). This may be useful if you want scalar values
@@ -922,6 +921,10 @@ class ExtensionArray:
         .. deprecated:: 0.24.0
 
            Use :meth:`ExtensionArray._formatter` instead.
+
+        Returns
+        -------
+        array : ndarray
         """
         return np.array(self)
 
@@ -981,10 +984,6 @@ class ExtensionArray:
 
         The expectation is that this is cheap to compute, and is primarily
         used for interacting with our indexers.
-
-        Parameters
-        ----------
-        None
 
         Returns
         -------

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -306,12 +306,12 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
     def equals(self, other):
         """
-        Determine if two CategorialIndex objects contain the same elements.
+        Determine if two CategoricalIndex objects contain the same elements.
 
         Returns
         -------
         bool
-            If two CategorialIndex objects have equal elements True,
+            If two CategoricalIndex objects have equal elements True,
             otherwise False.
         """
         if self.is_(other):


### PR DESCRIPTION
- [x] closes #24067
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
