### PR TITLE
BUG: Fix CategoricalIndex.__contains__ with non-hashable, closes #21729

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1049,6 +1049,7 @@ Indexing
 - Bug which produced ``AttributeError`` on partial matching :class:`Timestamp` in a :class:`MultiIndex`  (:issue:`26944`)
 - Bug in :class:`Categorical` and  :class:`CategoricalIndex` with :class:`Interval` values when using the ``in`` operator (``__contains``) with objects that are not comparable to the values in the ``Interval`` (:issue:`23705`)
 - Bug in :meth:`DataFrame.loc` and :meth:`DataFrame.iloc` on a :class:`DataFrame` with a single timezone-aware datetime64[ns] column incorrectly returning a scalar instead of a :class:`Series` (:issue:`27110`)
+- Bug in :class:`CategoricalIndex` and :class:`Categorical` incorrectly raising ``ValueError`` instead of ``TypeError`` when a list is passed using the ``in`` operator (``__contains__``) (:issue:`21729`)
 -
 
 Missing

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2020,7 +2020,7 @@ class Categorical(ExtensionArray, PandasObject):
         Returns True if `key` is in this Categorical.
         """
         # if key is a NaN, check if any NaN is in self.
-        if isna(key):
+        if is_scalar(key) and isna(key):
             return self.isna().any()
 
         return contains(self, key, container=self._codes)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -77,6 +77,7 @@ from pandas.core.dtypes.generic import (
     ABCMultiIndex,
     ABCSeries,
 )
+from pandas.core.dtypes.inference import is_hashable
 from pandas.core.dtypes.missing import isna, notna
 
 from pandas.core import algorithms, common as com, nanops, ops
@@ -2954,16 +2955,12 @@ class DataFrame(NDFrame):
         key = lib.item_from_zerodim(key)
         key = com.apply_if_callable(key, self)
 
-        # shortcut if the key is in columns
-        try:
+        if is_hashable(key):
+            # shortcut if the key is in columns
             if self.columns.is_unique and key in self.columns:
                 if self.columns.nlevels > 1:
                     return self._getitem_multilevel(key)
                 return self._get_item_cache(key)
-        except (TypeError, ValueError):
-            # The TypeError correctly catches non hashable "key" (e.g. list)
-            # The ValueError can be removed once GH #21729 is fixed
-            pass
 
         # Do we have a slicer (on rows)?
         indexer = convert_to_index_sliceable(self, key)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -60,6 +60,7 @@ from pandas.core.dtypes.common import (
     is_extension_array_dtype,
     is_extension_type,
     is_float_dtype,
+    is_hashable,
     is_integer,
     is_integer_dtype,
     is_iterator,
@@ -77,7 +78,6 @@ from pandas.core.dtypes.generic import (
     ABCMultiIndex,
     ABCSeries,
 )
-from pandas.core.dtypes.inference import is_hashable
 from pandas.core.dtypes.missing import isna, notna
 
 from pandas.core import algorithms, common as com, nanops, ops

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -407,7 +407,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     @Appender(_index_shared_docs["contains"] % _index_doc_kwargs)
     def __contains__(self, key):
         # if key is a NaN, check if any NaN is in self.
-        if isna(key):
+        if is_scalar(key) and isna(key):
             return self.hasnans
 
         return contains(self, key, container=self._engine)

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -417,3 +417,15 @@ class TestCategoricalOps:
         cat = Categorical(pd.IntervalIndex.from_breaks(range(3)))
         result = item in cat
         assert result is expected
+
+    def test_contains_list(self):
+        # GH#21729
+        cat = Categorical([1, 2, 3])
+
+        assert "a" not in cat
+
+        with pytest.raises(TypeError, match="unhashable type"):
+            ["a"] in cat
+
+        with pytest.raises(TypeError, match="unhashable type"):
+            ["a", "b"] in cat

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -276,6 +276,18 @@ class TestCategoricalIndex(Base):
         result = item in ci
         assert result is expected
 
+    def test_contains_list(self):
+        # GH#21729
+        idx = pd.CategoricalIndex([1, 2, 3])
+
+        assert "a" not in idx
+
+        with pytest.raises(TypeError, match="unhashable type"):
+            ["a"] in idx
+
+        with pytest.raises(TypeError, match="unhashable type"):
+            ["a", "b"] in idx
+
     def test_map(self):
         ci = pd.CategoricalIndex(list("ABABC"), categories=list("CBA"), ordered=True)
         result = ci.map(lambda x: x.lower())


### PR DESCRIPTION
- [x] closes #21729
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
