### PR TITLE
BUG: Incorrect Message in KeyError with MultiIndex

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1040,6 +1040,7 @@ Indexing
 
 - Improved exception message when calling :meth:`DataFrame.iloc` with a list of non-numeric objects (:issue:`25753`).
 - Improved exception message when calling ``.iloc`` or ``.loc`` with a boolean indexer with different length (:issue:`26658`).
+- Bug in ``KeyError`` exception message when indexing a :class:`MultiIndex` with a non-existant key not displaying the original key (:issue:`27250`).
 - Bug in ``.iloc`` and ``.loc`` with a boolean indexer not raising an ``IndexError`` when too few items are passed (:issue:`26658`).
 - Bug in :meth:`DataFrame.loc` and :meth:`Series.loc` where ``KeyError`` was not raised for a ``MultiIndex`` when the key was less than or equal to the number of levels in the :class:`MultiIndex` (:issue:`14885`).
 - Bug in which :meth:`DataFrame.append` produced an erroneous warning indicating that a ``KeyError`` will be thrown in the future when the data to be appended contains new columns (:issue:`22252`).

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2810,7 +2810,10 @@ class MultiIndex(Index):
 
                 if len(key) == self.nlevels and self.is_unique:
                     # Complete key in unique index -> standard get_loc
-                    return (self._engine.get_loc(key), None)
+                    try:
+                        return (self._engine.get_loc(key), None)
+                    except KeyError as e:
+                        raise KeyError(key) from e
                 else:
                     return partial_selection(key)
             else:

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -83,9 +83,9 @@ def test_series_getitem_returns_scalar(
 @pytest.mark.parametrize(
     "indexer,expected_error,expected_error_msg",
     [
-        (lambda s: s.__getitem__((2000, 3, 4)), KeyError, r"^356$"),
-        (lambda s: s[(2000, 3, 4)], KeyError, r"^356$"),
-        (lambda s: s.loc[(2000, 3, 4)], KeyError, r"^356$"),
+        (lambda s: s.__getitem__((2000, 3, 4)), KeyError, r"^\(2000, 3, 4\)$"),
+        (lambda s: s[(2000, 3, 4)], KeyError, r"^\(2000, 3, 4\)$"),
+        (lambda s: s.loc[(2000, 3, 4)], KeyError, r"^\(2000, 3, 4\)$"),
         (lambda s: s.loc[(2000, 3, 4, 5)], IndexingError, "Too many indexers"),
         (lambda s: s.__getitem__(len(s)), IndexError, "index out of bounds"),
         (lambda s: s[len(s)], IndexError, "index out of bounds"),

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -389,7 +389,7 @@ def test_loc_getitem_lowerdim_corner(multiindex_dataframe_random_data):
     df = multiindex_dataframe_random_data
 
     # test setup - check key not in dataframe
-    with pytest.raises(KeyError, match=r"^11$"):
+    with pytest.raises(KeyError, match=r"^\('bar', 'three'\)$"):
         df.loc[("bar", "three"), "B"]
 
     # in theory should be inserting in a sorted space????


### PR DESCRIPTION
- [x] closes #27250
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
