### PR TITLE
BUG: fix inserting tz-aware datetime to Series, closes #12862

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1051,6 +1051,7 @@ Indexing
 - Bug in :class:`Categorical` and  :class:`CategoricalIndex` with :class:`Interval` values when using the ``in`` operator (``__contains``) with objects that are not comparable to the values in the ``Interval`` (:issue:`23705`)
 - Bug in :meth:`DataFrame.loc` and :meth:`DataFrame.iloc` on a :class:`DataFrame` with a single timezone-aware datetime64[ns] column incorrectly returning a scalar instead of a :class:`Series` (:issue:`27110`)
 - Bug in :class:`CategoricalIndex` and :class:`Categorical` incorrectly raising ``ValueError`` instead of ``TypeError`` when a list is passed using the ``in`` operator (``__contains__``) (:issue:`21729`)
+- Bug in :class:`Series` setting a new key (``__setitem__``) with a timezone-aware datetime incorrectly raising ``ValueError`` (:issue:`12862`)
 -
 
 Missing

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1232,7 +1232,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
                 if is_scalar(key) and not is_integer(key) and key not in self.index:
                     # GH#12862 adding an new key to the Series
-                    # Note: ave to exclude integers because that is ambiguously
+                    # Note: have to exclude integers because that is ambiguously
                     #  position-based
                     self.loc[key] = value
                     return

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1231,13 +1231,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 if _is_unorderable_exception(e):
                     raise IndexError(key)
 
-                if is_scalar(key) and not is_integer(key) and key not in self.index:
-                    # GH#12862 adding an new key to the Series
-                    # Note: have to exclude integers because that is ambiguously
-                    #  position-based
-                    self.loc[key] = value
-                    return
-
             if com.is_bool_indexer(key):
                 key = check_bool_indexer(self.index, key)
                 try:
@@ -1274,6 +1267,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                     self._set_values(key, value)
                 except Exception:
                     pass
+
+            if is_scalar(key) and not is_integer(key) and key not in self.index:
+                # GH#12862 adding an new key to the Series
+                # Note: have to exclude integers because that is ambiguously
+                #  position-based
+                self.loc[key] = value
+                return
 
             if is_scalar(key):
                 key = [key]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1230,6 +1230,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 if _is_unorderable_exception(e):
                     raise IndexError(key)
 
+                if is_scalar(key) and not is_integer(key) and key not in self.index:
+                    # GH#12862 adding an new key to the Series
+                    # Note: ave to exclude integers because that is ambiguously
+                    #  position-based
+                    self.loc[key] = value
+                    return
+
             if com.is_bool_indexer(key):
                 key = check_bool_indexer(self.index, key)
                 try:

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -802,7 +802,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         assert is_scalar(result) and result == "Z"
 
-    def test_loc_coerceion(self):
+    def test_loc_coercion(self):
 
         # 12411
         df = DataFrame({"date": [Timestamp("20130101").tz_localize("UTC"), pd.NaT]})
@@ -837,6 +837,26 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         result = df.iloc[3:]
         tm.assert_series_equal(result.dtypes, expected)
+
+    def test_setitem_new_key_tz(self):
+        # GH#12862 should not raise on assigning the second value
+        vals = [
+            pd.to_datetime(42).tz_localize("UTC"),
+            pd.to_datetime(666).tz_localize("UTC"),
+        ]
+        expected = pd.Series(vals, index=["foo", "bar"])
+
+        ser = pd.Series()
+        ser["foo"] = vals[0]
+        ser["bar"] = vals[1]
+
+        tm.assert_series_equal(ser, expected)
+
+        ser = pd.Series()
+        ser.loc["foo"] = vals[0]
+        ser.loc["bar"] = vals[1]
+
+        tm.assert_series_equal(ser, expected)
 
     def test_loc_non_unique(self):
         # GH3659

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -523,27 +523,6 @@ def test_setitem_with_tz_dst():
     tm.assert_series_equal(s, exp)
 
 
-def test_setitem_new_key_tz():
-    # GH#12862 should not raise on assigning the second value
-    vals = [
-        pd.to_datetime(42).tz_localize("UTC"),
-        pd.to_datetime(666).tz_localize("UTC"),
-    ]
-    expected = pd.Series(vals, index=["foo", "bar"])
-
-    ser = pd.Series()
-    ser["foo"] = vals[0]
-    ser["bar"] = vals[1]
-
-    tm.assert_series_equal(ser, expected)
-
-    ser = pd.Series()
-    ser.loc["foo"] = vals[0]
-    ser.loc["bar"] = vals[1]
-
-    tm.assert_series_equal(ser, expected)
-
-
 def test_categorical_assigning_ops():
     orig = Series(Categorical(["b", "b"], categories=["a", "b"]))
     s = orig.copy()

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -529,12 +529,18 @@ def test_setitem_new_key_tz():
         pd.to_datetime(42).tz_localize("UTC"),
         pd.to_datetime(666).tz_localize("UTC"),
     ]
+    expected = pd.Series(vals, index=["foo", "bar"])
 
     ser = pd.Series()
     ser["foo"] = vals[0]
     ser["bar"] = vals[1]
 
-    expected = pd.Series(vals, index=["foo", "bar"])
+    tm.assert_series_equal(ser, expected)
+
+    ser = pd.Series()
+    ser.loc["foo"] = vals[0]
+    ser.loc["bar"] = vals[1]
+
     tm.assert_series_equal(ser, expected)
 
 

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -523,7 +523,22 @@ def test_setitem_with_tz_dst():
     tm.assert_series_equal(s, exp)
 
 
-def test_categorial_assigning_ops():
+def test_setitem_new_key_tz():
+    # GH#12862 should not raise on assigning the second value
+    vals = [
+        pd.to_datetime(42).tz_localize("UTC"),
+        pd.to_datetime(666).tz_localize("UTC"),
+    ]
+
+    ser = pd.Series()
+    ser["foo"] = vals[0]
+    ser["bar"] = vals[1]
+
+    expected = pd.Series(vals, index=["foo", "bar"])
+    tm.assert_series_equal(ser, expected)
+
+
+def test_categorical_assigning_ops():
     orig = Series(Categorical(["b", "b"], categories=["a", "b"]))
     s = orig.copy()
     s[:] = "a"


### PR DESCRIPTION
- [x] closes #12862
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
