### PR TITLE
BUG: fix+test assigning invalid NAT-like to DTA/TDA/PA

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -36,7 +36,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import is_array_like
-from pandas.core.dtypes.missing import isna
+from pandas.core.dtypes.missing import is_valid_nat_for_dtype, isna
 
 from pandas._typing import DatetimeLikeScalar
 from pandas.core import missing, nanops
@@ -492,7 +492,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
         elif isinstance(value, self._scalar_type):
             self._check_compatible_with(value)
             value = self._unbox_scalar(value)
-        elif is_valid_na(value, self.dtype):
+        elif is_valid_nat_for_dtype(value, self.dtype):
             value = iNaT
         elif not isna(value) and lib.is_integer(value) and value == iNaT:
             # exclude misc e.g. object() and any NAs not allowed above
@@ -1682,27 +1682,3 @@ def _ensure_datetimelike_to_i8(other, to_utc=False):
             # period array cannot be coerced to int
             other = Index(other)
     return other.asi8
-
-
-def is_valid_na(obj, dtype):
-    """
-    isna check that excludes incompatible dtypes
-
-    Parameters
-    ----------
-    obj : object
-    dtype : np.datetime64, np.timedelta64, DatetimeTZDtype, or PeriodDtype
-
-    Returns
-    -------
-    bool
-    """
-    if not isna(obj):
-        return False
-    if dtype.kind == "M":
-        return not isinstance(obj, np.timedelta64)
-    if dtype.kind == "m":
-        return not isinstance(obj, np.datetime64)
-
-    # must be PeriodDType
-    return not isinstance(obj, (np.datetime64, np.timedelta64))

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -492,7 +492,10 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
         elif isinstance(value, self._scalar_type):
             self._check_compatible_with(value)
             value = self._unbox_scalar(value)
-        elif is_valid_na(value, self.dtype) or value == iNaT:
+        elif is_valid_na(value, self.dtype):
+            value = iNaT
+        elif not isna(value) and lib.is_integer(value) and value == iNaT:
+            # exclude misc e.g. object() and any NAs not allowed above
             value = iNaT
         else:
             msg = (

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -559,3 +559,27 @@ def remove_na_arraylike(arr):
         return arr[notna(arr)]
     else:
         return arr[notna(lib.values_from_object(arr))]
+
+
+def is_valid_nat_for_dtype(obj, dtype):
+    """
+    isna check that excludes incompatible dtypes
+
+    Parameters
+    ----------
+    obj : object
+    dtype : np.datetime64, np.timedelta64, DatetimeTZDtype, or PeriodDtype
+
+    Returns
+    -------
+    bool
+    """
+    if not isna(obj):
+        return False
+    if dtype.kind == "M":
+        return not isinstance(obj, np.timedelta64)
+    if dtype.kind == "m":
+        return not isinstance(obj, np.datetime64)
+
+    # must be PeriodDType
+    return not isinstance(obj, (np.datetime64, np.timedelta64))

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -665,7 +665,6 @@ class TestPeriodArray(SharedTests):
 def test_nat_assignment_array(array):
     expected = type(array)._from_sequence([pd.NaT, array[1], array[2]])
 
-    all_nats = [pd.NaT, np.timedelta64("NaT", "ns"), np.datetime64("NaT", "ns")]
     casting_nats = {
         TimedeltaArray: [pd.NaT, np.timedelta64("NaT", "ns")],
         DatetimeArray: [pd.NaT, np.datetime64("NaT", "ns")],

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -665,16 +665,10 @@ class TestPeriodArray(SharedTests):
 def test_nat_assignment_array(array):
     expected = type(array)._from_sequence([pd.NaT, array[1], array[2]])
 
-    casting_nats = {
-        TimedeltaArray: [pd.NaT, np.timedelta64("NaT", "ns")],
-        DatetimeArray: [pd.NaT, np.datetime64("NaT", "ns")],
-        PeriodArray: [pd.NaT],
-    }[type(array)]
-    non_casting_nats = {
-        TimedeltaArray: [np.datetime64("NaT", "ns")],
-        DatetimeArray: [np.timedelta64("NaT", "ns")],
-        PeriodArray: [np.timedelta64("NaT", "ns"), np.datetime64("NaT", "ns")],
-    }[type(array)]
+    all_np_nats = [np.datetime64("NaT", "ns"), np.timedelta64("NaT", "ns")]
+    casting_nats = [x for x in all_np_nats if x.dtype.kind == array.dtype.kind]
+    casting_nats.append(pd.NaT)
+    non_casting_nats = [x for x in all_np_nats if x.dtype.kind != array.dtype.kind]
 
     for nat in casting_nats:
         arr = array.copy()


### PR DESCRIPTION
Broken off from #27311 for cleaner scope and to troubleshoot platform-specific failures.  Related but orthogonal to #27323.