### PR TITLE
BUG:remove rollback from generate_range

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -972,7 +972,7 @@ Datetimelike
 - Bug where adding :class:`Timestamp` to a ``np.timedelta64`` object would raise instead of returning a :class:`Timestamp` (:issue:`24775`)
 - Bug where comparing a zero-dimensional numpy array containing a ``np.datetime64`` object to a :class:`Timestamp` would incorrect raise ``TypeError`` (:issue:`26916`)
 - Bug in :func:`to_datetime` which would raise ``ValueError: Tz-aware datetime.datetime cannot be converted to datetime64 unless utc=True`` when called with ``cache=True``, with ``arg`` including datetime strings with different offset (:issue:`26097`)
--
+- Bug in :func:`date_range` which omits the expected last date when offset.onOffset(start) and not offset.onOffset(end) and end.time() < start.time()
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -2253,6 +2253,20 @@ class TestBusinessHour(Base):
         for idx in [idx1, idx2, idx3]:
             tm.assert_index_equal(idx, expected)
 
+    def test_end_date_range(self):
+        start_date = Timestamp('2018-10-15-06')
+        end_date = Timestamp('2019-01-01-12')
+        twelve_hours = timedelta(hours=12)
+        month_end = MonthEnd()
+        # we expect (regardless of start_date) the last date in date_range to be
+        # offset.rollback(end)
+        expected_last_date = month_end.rollback(end_date).date()
+        # test over 31 days (12 hour periods)
+        for i in range(31 * 2):
+            start_date += twelve_hours
+            dates = date_range(start=start_date, end=end_date, freq=month_end)
+            assert dates[-1].date() == expected_last_date
+
 
 class TestCustomBusinessHour(Base):
     _offset = CustomBusinessHour

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -390,6 +390,31 @@ class DateOffset(BaseOffset):
     def name(self):
         return self.rule_code
 
+    def _roll(self, dt, direction=1):
+        """
+        Roll provided date backwards or forwards dependent on direction 
+        (only if not on offset)
+
+        negative offsets 'rollforward' onto a previous date, positive offsets
+        'rollforward' onto a future date
+        
+        Parameters
+        ----------
+        direction : int, default 1.
+            Either 1 or -1. Going forward in time if positive, 
+            going back backward in time if negative
+
+        Returns
+        -------
+        TimeStamp
+            Rolled timestamp if not on offset, otherwise unchanged timestamp.
+        """
+        dt = as_timestamp(dt)
+        if not self.onOffset(dt):
+            sign = np.sign(direction * self.n)
+            dt += sign * self.__class__(1, normalize=self.normalize, **self.kwds)
+        return dt
+
     def rollback(self, dt):
         """
         Roll provided date backward to next offset only if not on offset.
@@ -399,10 +424,7 @@ class DateOffset(BaseOffset):
         TimeStamp
             Rolled timestamp if not on offset, otherwise unchanged timestamp.
         """
-        dt = as_timestamp(dt)
-        if not self.onOffset(dt):
-            dt = dt - self.__class__(1, normalize=self.normalize, **self.kwds)
-        return dt
+        return self._roll(dt, direction=-1)
 
     def rollforward(self, dt):
         """
@@ -413,10 +435,7 @@ class DateOffset(BaseOffset):
         TimeStamp
             Rolled timestamp if not on offset, otherwise unchanged timestamp.
         """
-        dt = as_timestamp(dt)
-        if not self.onOffset(dt):
-            dt = dt + self.__class__(1, normalize=self.normalize, **self.kwds)
-        return dt
+        return self._roll(dt)
 
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -2730,9 +2730,6 @@ def generate_range(start=None, end=None, periods=None, offset=BDay()):
     if start and not offset.onOffset(start):
         start = offset.rollforward(start)
 
-    elif end and not offset.onOffset(end):
-        end = offset.rollback(end)
-
     if periods is None and end < start and offset.n >= 0:
         end = None
         periods = 0


### PR DESCRIPTION
'elif end and not offset.onOffset(end): end = offset.rollback(end)' gives
unwanted results for e.g. offset=MonthEnd when start.time() > end.time()


EXAMPLE:
In [1]: import pandas as pd

In [2]: from datetime import datetime

In [3]: pd.date_range(freq='M', start=datetime(2019, 4, 30, 0, 2), end=datetime(2019, 7, 1, 0, 1))
Out[3]: DatetimeIndex(['2019-04-30 00:02:00', '2019-05-31 00:02:00'], dtype='datetime64[ns]', freq='M')

In [4]: pd.date_range(freq='M', start=datetime(2019, 4, 30, 0, 1), end=datetime(2019, 7, 1, 0, 1))
Out[4]: DatetimeIndex(['2019-04-30 00:01:00', '2019-05-31 00:01:00', '2019-06-30 00:01:00'],
              dtype='datetime64[ns]', freq='M')

line 3 output expected to include 2019-06-30 as only 1 minute difference between start dates in lines 3 and 4




- [ ] closes #xxxx
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
