### PR TITLE
ENH: add NDFrame.select_str

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -32,6 +32,7 @@ Attributes and underlying data
    DataFrame.get_dtype_counts
    DataFrame.get_ftype_counts
    DataFrame.select_dtypes
+   DataFrame.select_str
    DataFrame.values
    DataFrame.get_values
    DataFrame.axes

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -211,6 +211,7 @@ Reindexing / selection / label manipulation
    Series.rename_axis
    Series.reset_index
    Series.sample
+   Series.select_str
    Series.set_axis
    Series.take
    Series.tail

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3347,6 +3347,11 @@ class DataFrame(NDFrame):
         * To select Pandas datetimetz dtypes, use ``'datetimetz'`` (new in
           0.20.0) or ``'datetime64[ns, tz]'``
 
+        See Also
+        --------
+        DataFrame.select_str
+        DataFrame.loc
+
         Examples
         --------
         >>> df = pd.DataFrame({'a': [1, 2] * 3,

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -806,6 +806,24 @@ class TestDataFrameSelectReindex:
         tm.assert_series_equal(res1, exp2)
         tm.assert_frame_equal(res2, exp1)
 
+    def test_select_str(self, float_frame):
+        fcopy = float_frame.copy()
+        fcopy["AA"] = 1
+
+        # regex
+        selected = fcopy.select_str(regex="[A]+")
+        assert len(selected.columns) == 2
+        assert "AA" in selected
+
+        # doesn't have to be at beginning
+        df = DataFrame(
+            {"aBBa": [1, 2], "BBaBB": [1, 2], "aCCa": [1, 2], "aCCaBB": [1, 2]}
+        )
+
+        result = df.select_str(regex="BB")
+        exp = df[[x for x in df.columns if "BB" in x]]
+        assert_frame_equal(result, exp)
+
     def test_filter(self, float_frame, float_string_frame):
         # Items
         filtered = float_frame.filter(["A", "B", "E"])


### PR DESCRIPTION
- [x] closes #26642
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Adds a method ``select_str`` to supplement ``select_dtypes``. This PR is intended to be followed by a PR that deprecate ``NDFrame.filter``.

I miss the most having a string focused axis-filtering method, and is ``NDFrame.filter`` a bit unfocused  and badly named IMO. I think usage of parameter ``items`` in ``NDFrame.filter`` can just be replaced by recommending ``NDFrame.__getitem__`` and parameter ``like`` is less useful than ``startswith`` and ``endswith`` (is less precise). So this is not a 100 % replacement for ``NDFrame.filter``, but intends to make something that is more useful (IMO, of course).

This is not fully tested and need a whatsnew etc. but I would like to get some response before I go further.
