### PR TITLE
Accept empty dataframes in DataFrame.to_parquet

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1101,6 +1101,7 @@ I/O
 - Fixed bug in :func:`DataFrame.to_excel()` where custom objects (i.e. `PeriodIndex`) inside merged cells were not being converted into types safe for the Excel writer (:issue:`27006`)
 - Bug in :meth:`read_hdf` where reading a timezone aware :class:`DatetimeIndex` would raise a ``TypeError`` (:issue:`11926`)
 - Bug in :meth:`to_msgpack` and :meth:`read_msgpack` which would raise a ``ValueError`` rather than a ``FileNotFoundError`` for an invalid path (:issue:`27160`)
+- Fixed bug in :meth:`DataFrame.to_parquet` which would raise a ``ValueError`` when the dataframe had no columns (:issue:`27339`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -55,7 +55,7 @@ class BaseImpl:
             raise ValueError("to_parquet only supports IO with DataFrames")
 
         # must have value column names (strings only)
-        if df.columns.inferred_type not in {"string", "unicode"}:
+        if df.columns.inferred_type not in {"string", "unicode", "empty"}:
             raise ValueError("parquet must have string column names")
 
         # index level names must be strings

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -472,6 +472,7 @@ class TestParquetPyArrow(Base):
             assert dataset.partitions.partition_names == set(partition_cols)
 
     def test_empty_dataframe(self, pa):
+        # GH #27339
         df = pd.DataFrame()
         check_round_trip(df, pa)
 
@@ -572,6 +573,7 @@ class TestParquetFastParquet(Base):
                 )
 
     def test_empty_dataframe(self, fp):
+        # GH #27339
         df = pd.DataFrame()
         expected = df.copy()
         expected.index.name = "index"

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -471,6 +471,10 @@ class TestParquetPyArrow(Base):
             assert len(dataset.partitions.partition_names) == 2
             assert dataset.partitions.partition_names == set(partition_cols)
 
+    def test_empty_dataframe(self, pa):
+        df = pd.DataFrame()
+        check_round_trip(df, pa)
+
 
 class TestParquetFastParquet(Base):
     @td.skip_if_no("fastparquet", min_version="0.2.1")
@@ -566,3 +570,9 @@ class TestParquetFastParquet(Base):
                     partition_on=partition_cols,
                     partition_cols=partition_cols,
                 )
+
+    def test_empty_dataframe(self, fp):
+        df = pd.DataFrame()
+        expected = df.copy()
+        expected.index.name = "index"
+        check_round_trip(df, fp, expected=expected)


### PR DESCRIPTION
Fixes #27339

I wrote two tests because `fastparquet` adds a name to the index when it deserializes.

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
