### PR TITLE
adds non regression test for GH27358

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2397,6 +2397,13 @@ class TestDataFrameConstructors:
         assert result.index.name == "foo"
         tm.assert_index_equal(result.columns, expected)
 
+    def test_from_records_series_list_dict(self):
+        # GH27358
+        expected = DataFrame([[{"a": 1, "b": 2}, {"a": 3, "b": 4}]]).T
+        data = Series([[{"a": 1, "b": 2}], [{"a": 3, "b": 4}]])
+        result = DataFrame.from_records(data)
+        tm.assert_frame_equal(result, expected)
+
     def test_to_frame_with_falsey_names(self):
         # GH 16114
         result = Series(name=0).to_frame().dtypes
@@ -2425,13 +2432,6 @@ class TestDataFrameConstructors:
 
         expected = DataFrame([[1, 2, 3], [4, 5, 6]])
         result = DataFrame(List([List([1, 2, 3]), List([4, 5, 6])]))
-        tm.assert_frame_equal(result, expected)
-
-    def test_from_records_series_list_dict(self):
-        # GH27358
-        expected = pd.DataFrame([[{"a": 1, "b": 2}, {"a": 3, "b": 4}]]).T
-        data = Series([[{"a": 1, "b": 2}], [{"a": 3, "b": 4}]])
-        result = pd.DataFrame.from_records(data)
         tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2427,6 +2427,13 @@ class TestDataFrameConstructors:
         result = DataFrame(List([List([1, 2, 3]), List([4, 5, 6])]))
         tm.assert_frame_equal(result, expected)
 
+    def test_from_records_series_list_dict(self):
+        # GH27358
+        expected = pd.DataFrame([[{"a": 1, "b": 2}, {"a": 3, "b": 4}]]).T
+        data = Series([[{"a": 1, "b": 2}], [{"a": 3, "b": 4}]])
+        result = pd.DataFrame.from_records(data)
+        tm.assert_frame_equal(result, expected)
+
 
 class TestDataFrameConstructorWithDatetimeTZ:
     def test_from_dict(self):


### PR DESCRIPTION
- [X] closes #27358
- [X] tests added / passed
- [ ] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
