### PR TITLE
ENH: add regex parameter to .loc

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -569,7 +569,7 @@ without using a temporary variable.
 Selection by regular expression
 -------------------------------
 
-.. versionadded:: 0.25.0
+.. versionadded:: 1.0
 
 it is possible to call :attr:`~DataFrame.loc` with parameter ``regex=True`` to select by
 row/columns axis labels that match a regular expression pattern.

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -563,6 +563,38 @@ without using a temporary variable.
    (bb.groupby(['year', 'team']).sum()
       .loc[lambda df: df.r > 100])
 
+
+.. _indexing.selecting_with_regex:
+
+Selection by regular expression
+-------------------------------
+
+.. versionadded:: 0.25.0
+
+it is possible to call :attr:`~DataFrame.loc` with parameter ``regex=True`` to select by
+row/columns axis labels that match a regular expression pattern.
+
+.. ipython:: python
+
+    df = pd.DataFrame(1, index=["A", "AB", "BC"], columns=["BC", "AB", "A"])
+    df
+
+    df.loc(regex=True)["B", "B"]
+    df.loc(axis=1, regex=True)["B"]
+
+The regex matching will only work when looking up single strings, not list of strings etc.
+
+.. ipython:: python
+
+    df.loc(regex=True)[["A"], "A"]
+
+*Notice*: Is is currently not possible to set values for a given regular expression.
+
+.. ipython:: python
+
+    df.loc(regex=True)["B", "B"] = [[1, 2], [3, 4]]
+
+
 .. _indexing.deprecate_ix:
 
 IX indexer is deprecated

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -576,23 +576,24 @@ row/columns axis labels that match a regular expression pattern.
 
 .. ipython:: python
 
-    df = pd.DataFrame(1, index=["A", "AB", "BC"], columns=["BC", "AB", "A"])
-    df
+    df_re = pd.DataFrame(1, index=["A", "AB", "BC"], columns=["BC", "AB", "A"])
+    df_re
 
-    df.loc(regex=True)["B", "B"]
-    df.loc(axis=1, regex=True)["B"]
+    df_re.loc(regex=True)["B", "B"]
+    df_re.loc(axis=1, regex=True)["B"]
 
 The regex matching will only work when looking up single strings, not list of strings etc.
 
 .. ipython:: python
 
-    df.loc(regex=True)[["A"], "A"]
+    df_re.loc(regex=True)[["A"], "A"]
 
 *Notice*: Is is currently not possible to set values for a given regular expression.
 
 .. ipython:: python
+    :okexcept:
 
-    df.loc(regex=True)["B", "B"] = [[1, 2], [3, 4]]
+    df_re.loc(regex=True)["B", "B"] = [[1, 2], [3, 4]]
 
 
 .. _indexing.deprecate_ix:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -182,36 +182,6 @@ The repr now looks like this:
     json_normalize(data, max_level=1)
 
 
-.. _whatsnew_0250.enhancements.loc_regex:
-
-Selection using regular expressions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-It is now possible to call :attr:`~DataFrame.loc` with parameter ``regex=True`` to select by
-row/columns axis labels that match a regular expression pattern.
-
-.. ipython:: python
-
-    df = pd.DataFrame(1, index=["A", "AB", "BC"], columns=["BC", "AB", "A"])
-    df
-
-    df.loc(regex=True)["B", "B"]
-    df.loc(axis=1, regex=True)["B"]
-
-The regex matching will only work when looking up single strings, not list of strings etc.
-
-.. ipython:: python
-
-    df.loc(regex=True)[["A"], "A"]
-
-Is is currently not possible to set values for a given regular expression.
-
-.. ipython:: python
-    :okexcept:
-
-    df.loc(regex=True)["B", "B"] = [[1, 2], [3, 4]]
-
-
 .. _whatsnew_0250.enhancements.explode:
 
 Series.explode to split list-like values to rows

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -182,6 +182,35 @@ The repr now looks like this:
     json_normalize(data, max_level=1)
 
 
+.. _whatsnew_0250.enhancements.loc_regex:
+
+Selection using regular expressions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is now possible to call :attr:`~DataFrame.loc` with parameter ``regex=True`` to select by
+row/columns axis labels that match a regular expression pattern.
+
+.. ipython:: python
+
+    df = pd.DataFrame(1, index=["A", "AB", "BC"], columns=["BC", "AB", "A"])
+    df
+
+    df.loc(regex=True)["B", "B"]
+    df.loc(axis=1, regex=True)["B"]
+
+The regex matching will only work when looking up single strings, not list of strings etc.
+
+.. ipython:: python
+
+    df.loc(regex=True)[["A"], "A"]
+
+Is is currently not possible to set values for a given regular expression.
+
+.. ipython:: python
+
+    df.loc(regex=True)["B", "B"] = [[1, 2], [3, 4]]
+
+
 .. _whatsnew_0250.enhancements.explode:
 
 Series.explode to split list-like values to rows

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -207,6 +207,7 @@ The regex matching will only work when looking up single strings, not list of st
 Is is currently not possible to set values for a given regular expression.
 
 .. ipython:: python
+    :okexcept:
 
     df.loc(regex=True)["B", "B"] = [[1, 2], [3, 4]]
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -21,7 +21,7 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
-.. _whatsnew_0250.enhancements.loc_regex:
+.. _whatsnew_1000.enhancements.loc_regex:
 
 Selection using regular expressions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -21,6 +21,36 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
+.. _whatsnew_0250.enhancements.loc_regex:
+
+Selection using regular expressions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is now possible to call :attr:`~DataFrame.loc` with parameter ``regex=True`` to select by
+row/columns axis labels that match a regular expression pattern.
+
+.. ipython:: python
+
+    df = pd.DataFrame(1, index=["A", "AB", "BC"], columns=["BC", "AB", "A"])
+    df
+
+    df.loc(regex=True)["B", "B"]
+    df.loc(axis=1, regex=True)["B"]
+
+The regex matching will only work when looking up single strings, not list of strings etc.
+
+.. ipython:: python
+
+    df.loc(regex=True)[["A"], "A"]
+
+Is is currently not possible to set values for a given regular expression.
+
+.. ipython:: python
+    :okexcept:
+
+    df.loc(regex=True)["B", "B"] = [[1, 2], [3, 4]]
+
+
 .. _whatsnew_1000.enhancements.other:
 
 -

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -941,11 +941,11 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 if com.is_null_slice(new_key):
                     return section
 
-                return self._getitem_lower_dim(section, new_key)
+                return self._getitem_lower_section(section, new_key)
 
         raise IndexingError("not applicable")
 
-    def _getitem_lower_dim(self, section, key):
+    def _getitem_lower_section(self, section, key):
         # This is an elided recursive call to iloc/loc/etc'
         return getattr(section, self.name)[key]
 
@@ -1871,14 +1871,13 @@ class _LocIndexer(_LocationIndexer):
                 return self.obj.iloc[tuple(indexer)]
 
         elif self.regex and isinstance(key, (str, bytes)):
-            print(key, axis)
             return self._getitem_regex(key, axis=axis)
 
         # fall thru to straight lookup
         self._validate_key(key, axis)
         return self._get_label(key, axis=axis)
 
-    def _getitem_lower_dim(self, section, key):
+    def _getitem_lower_section(self, section, key):
         return getattr(section, self.name)(regex=self.regex)[key]
 
     def __setitem__(self, key, value):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -13,6 +13,66 @@ from pandas.tests.indexing.common import Base
 from pandas.util import testing as tm
 
 
+class TestLocRegex:
+    # test calls to df.loc, with a regex parameter set to True,
+    # ie. df.loc(..., regex=True)[...]
+
+    idx = ["AB", "BC", "CD", "DE"]
+    cols = idx[::-1]
+
+    def test_regex_frame(self):
+        idx, cols = self.idx, self.cols
+
+        df = pd.DataFrame(1, index=idx, columns=cols)
+        ser = df["AB"]
+
+        result = df.loc(regex=True)["B"]
+        expected = pd.DataFrame(1, index=["AB", "BC"], columns=cols)
+        tm.assert_frame_equal(result, expected)
+
+        result = ser.loc(regex=True)["B"]
+        expected = pd.Series(1, index=["AB", "BC"], name="AB")
+        tm.assert_series_equal(result, expected)
+
+        result = df.loc(regex=True)[:, "B"]
+        expected = pd.DataFrame(1, index=idx, columns=["BC", "AB"])
+        tm.assert_frame_equal(result, expected)
+
+        result = df.loc(regex=True)["B", "B"]
+        expected = pd.DataFrame(1, index=["AB", "BC"], columns=["BC", "AB"])
+        tm.assert_frame_equal(result, expected)
+
+    def test_regex_empty(self):
+        idx, cols = self.idx, self.cols
+
+        df = pd.DataFrame(1, index=idx, columns=cols)
+        ser = df["AB"]
+
+        result = df.loc(regex=True)["X"]
+        expected = pd.DataFrame(columns=cols, dtype="int64")
+        tm.assert_frame_equal(result, expected)
+
+        result = ser.loc(regex=True)["X"]
+        expected = pd.Series(name="AB", dtype="int64")
+        tm.assert_series_equal(result, expected)
+
+        result = df.loc(regex=True)[:, "X"]
+        expected = pd.DataFrame(index=idx, dtype="int64")
+        tm.assert_frame_equal(result, expected)
+
+        result = df.loc(regex=True)["X", "X"]
+        expected = pd.DataFrame(dtype="int64")
+        tm.assert_frame_equal(result, expected)
+
+    def test_regex_inserting(self):
+        idx, cols = self.idx, self.cols
+
+        df = pd.DataFrame(1, index=idx, columns=cols)
+
+        with pytest.raises(TypeError, match="Inserting with regex not supported"):
+            df.loc(regex=True)["B", "B"] = [[2, 2], [2, 2]]
+
+
 class TestLoc(Base):
     def test_loc_getitem_dups(self):
         # GH 5678

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -69,7 +69,8 @@ class TestLocRegex:
 
         df = pd.DataFrame(1, index=idx, columns=cols)
 
-        with pytest.raises(TypeError, match="Inserting with regex not supported"):
+        msg = "Inserting with regex has not been implemented"
+        with pytest.raises(NotImplementedError, match=msg):
             df.loc(regex=True)["B", "B"] = [[2, 2], [2, 2]]
 
 


### PR DESCRIPTION
- [x] closes #26642
- [x] xref #27340
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Adds a ``regex`` parameter to ``NDFrame.loc.__call__``, so we can now do:

```python
>>> df = pd.DataFrame(1, index=["A", "AB", "BC", "CD"], columns=["CD", "BC", "AB", "A"])
>>> df.loc(regex=True)["B", "B"]
    BC  AB
AB   1   1
BC   1   1
```

This is intended to be followed up by deprecating ``NDFrame.filter``.

This implementation does not allow setting values using ``regex=True``, as the most urgent motivation is to get a replacement for ``NDFrame.filter``. Setting values can come later, even after version 1.0.
