### PR TITLE
BUG: Fix take with read-only indexer, closes #17192

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1054,6 +1054,7 @@ Indexing
 - Bug in :class:`CategoricalIndex` and :class:`Categorical` incorrectly raising ``ValueError`` instead of ``TypeError`` when a list is passed using the ``in`` operator (``__contains__``) (:issue:`21729`)
 - Bug in setting a new value in a :class:`Series` with a :class:`Timedelta` object incorrectly casting the value to an integer (:issue:`22717`)
 - Bug in :class:`Series` setting a new key (``__setitem__``) with a timezone-aware datetime incorrectly raising ``ValueError`` (:issue:`12862`)
+- Bug in :meth:`DataFrame.iloc` when indexing with a read-only indexer (:issue:`17192`)
 -
 
 Missing

--- a/pandas/_libs/algos_take_helper.pxi.in
+++ b/pandas/_libs/algos_take_helper.pxi.in
@@ -148,7 +148,7 @@ def get_dispatch(dtypes):
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef inline take_1d_{{name}}_{{dest}}_memview({{c_type_in}}[:] values,
-                                              int64_t[:] indexer,
+                                              const int64_t[:] indexer,
                                               {{c_type_out}}[:] out,
                                               fill_value=np.nan):
 
@@ -159,7 +159,7 @@ cdef inline take_1d_{{name}}_{{dest}}_memview({{c_type_in}}[:] values,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def take_1d_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=1] values,
-                              int64_t[:] indexer,
+                              const int64_t[:] indexer,
                               {{c_type_out}}[:] out,
                               fill_value=np.nan):
 
@@ -178,7 +178,7 @@ def take_1d_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=1] values,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef inline take_2d_axis0_{{name}}_{{dest}}_memview({{c_type_in}}[:, :] values,
-                                                    int64_t[:] indexer,
+                                                    const int64_t[:] indexer,
                                                     {{c_type_out}}[:, :] out,
                                                     fill_value=np.nan):
 {{inner_take_2d_axis0}}
@@ -205,7 +205,7 @@ def take_2d_axis0_{{name}}_{{dest}}(ndarray[{{c_type_in}}, ndim=2] values,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef inline take_2d_axis1_{{name}}_{{dest}}_memview({{c_type_in}}[:, :] values,
-                                                    int64_t[:] indexer,
+                                                    const int64_t[:] indexer,
                                                     {{c_type_out}}[:, :] out,
                                                     fill_value=np.nan):
 {{inner_take_2d_axis1}}

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1248,7 +1248,7 @@ def test_ndframe_indexing_raises(idxr, error, error_message):
 
 def test_readonly_indices():
     # GH#17192 iloc with read-only array raising TypeError
-    df = pd.DataFrame({'data': np.ones(100, dtype='float64')})
+    df = pd.DataFrame({"data": np.ones(100, dtype="float64")})
     indices = np.array([1, 3, 6])
     indices.flags.writeable = False
 
@@ -1256,6 +1256,6 @@ def test_readonly_indices():
     expected = df.loc[[1, 3, 6]]
     tm.assert_frame_equal(result, expected)
 
-    result = df['data'].iloc[indices]
-    expected = df['data'].loc[[1, 3, 6]]
+    result = df["data"].iloc[indices]
+    expected = df["data"].loc[[1, 3, 6]]
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1244,3 +1244,18 @@ def test_ndframe_indexing_raises(idxr, error, error_message):
     frame = NDFrame(np.random.randint(5, size=(2, 2, 2)))
     with pytest.raises(error, match=error_message):
         idxr(frame)[0]
+
+
+def test_readonly_indices():
+    # GH#17192 iloc with read-only array raising TypeError
+    df = pd.DataFrame({'data': np.ones(100, dtype='float64')})
+    indices = np.array([1, 3, 6])
+    indices.flags.writeable = False
+
+    result = df.iloc[indices]
+    expected = df.loc[[1, 3, 6]]
+    tm.assert_frame_equal(result, expected)
+
+    result = df['data'].iloc[indices]
+    expected = df['data'].loc[[1, 3, 6]]
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #17192
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
