### PR TITLE
arrays/period: allow parsing of PeriodDtype columns from read_csv

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1186,6 +1186,7 @@ ExtensionArray
 - :meth:`Series.count` miscounts NA values in ExtensionArrays (:issue:`26835`)
 - Added ``Series.__array_ufunc__`` to better handle NumPy ufuncs applied to Series backed by extension arrays (:issue:`23293`).
 - Keyword argument ``deep`` has been removed from :meth:`ExtensionArray.copy` (:issue:`27083`)
+- Allow parsing of `PeriodDType` columns when using `read_csv()` (:issue:`26934`)
 
 Other
 ^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1103,6 +1103,7 @@ I/O
 - Bug in :meth:`read_hdf` where reading a timezone aware :class:`DatetimeIndex` would raise a ``TypeError`` (:issue:`11926`)
 - Bug in :meth:`to_msgpack` and :meth:`read_msgpack` which would raise a ``ValueError`` rather than a ``FileNotFoundError`` for an invalid path (:issue:`27160`)
 - Fixed bug in :meth:`DataFrame.to_parquet` which would raise a ``ValueError`` when the dataframe had no columns (:issue:`27339`)
+- Allow parsing of :class:`PeriodDtype` columns when using :func:`read_csv` (:issue:`26934`)
 
 Plotting
 ^^^^^^^^
@@ -1186,7 +1187,6 @@ ExtensionArray
 - :meth:`Series.count` miscounts NA values in ExtensionArrays (:issue:`26835`)
 - Added ``Series.__array_ufunc__`` to better handle NumPy ufuncs applied to Series backed by extension arrays (:issue:`23293`).
 - Keyword argument ``deep`` has been removed from :meth:`ExtensionArray.copy` (:issue:`27083`)
-- Allow parsing of :class:`PeriodDtype` columns when using `read_csv()` (:issue:`26934`)
 
 Other
 ^^^^^

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -1186,7 +1186,7 @@ ExtensionArray
 - :meth:`Series.count` miscounts NA values in ExtensionArrays (:issue:`26835`)
 - Added ``Series.__array_ufunc__`` to better handle NumPy ufuncs applied to Series backed by extension arrays (:issue:`23293`).
 - Keyword argument ``deep`` has been removed from :meth:`ExtensionArray.copy` (:issue:`27083`)
-- Allow parsing of `PeriodDType` columns when using `read_csv()` (:issue:`26934`)
+- Allow parsing of :class:`PeriodDtype` columns when using `read_csv()` (:issue:`26934`)
 
 Other
 ^^^^^

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -254,6 +254,10 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         return cls(ordinals, freq=freq)
 
     @classmethod
+    def _from_sequence_of_strings(cls, strings, dtype=None, copy=False):
+        return cls._from_sequence(strings, dtype, copy)
+
+    @classmethod
     def _from_datetime64(cls, data, freq, tz=None):
         """
         Construct a PeriodArray from a datetime64 array

--- a/pandas/tests/extension/test_period.py
+++ b/pandas/tests/extension/test_period.py
@@ -158,6 +158,4 @@ class TestPrinting(BasePeriodTests, base.BasePrintingTests):
 class TestParsing(BasePeriodTests, base.BaseParsingTests):
     @pytest.mark.parametrize("engine", ["c", "python"])
     def test_EA_types(self, engine, data):
-        expected_msg = r".*must implement _from_sequence_of_strings.*"
-        with pytest.raises(NotImplementedError, match=expected_msg):
-            super().test_EA_types(engine, data)
+        super().test_EA_types(engine, data)


### PR DESCRIPTION
Fixes: https://github.com/pandas-dev/pandas/issues/26934

Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
