### PR TITLE
in groupby sorting index when length of groupings is one

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2408,7 +2408,10 @@ class GroupBy(_GroupBy):
         if groupings is None:
             return output
         elif len(groupings) == 1:
-            return output
+            if self.sort:
+                return output.sort_index()
+            else:
+                return output
 
         # if we only care about the observed values
         # we are done


### PR DESCRIPTION
#### Reference Issues/PRs
Example: Fixes #27369  "Bug: groupby(..., observed=True) doesn't respect sort keys"


#### What does this implement/fix? Explain your changes.
Sorts the index when the length of groupings is one (if `sefl.sorted` equals `True`)


