### PR TITLE
REF: stop allowing iNaT in TimedeltaBlock methods

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1362,6 +1362,14 @@ def _nanpercentile_1d(values, mask, q, na_value, interpolation):
     quantiles : scalar or array
     """
     # mask is Union[ExtensionArray, ndarray]
+    if values.dtype.kind == "m":
+        # need to cast to integer to avoid rounding errors in numpy
+        result = _nanpercentile_1d(values.view("i8"), mask, q, na_value, interpolation)
+
+        # Note: we have to do do `astype` and not view because in general we
+        #  have float result at this point, not i8
+        return result.astype(values.dtype)
+
     values = values[~mask]
 
     if len(values) == 0:

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -780,9 +780,11 @@ class TestSeriesMissingData:
         td1[0] = td[0]
         assert not isna(td1[0])
 
+        # GH#16674 iNaT is treated as an integer when given by the user
         td1[1] = iNaT
-        assert isna(td1[1])
-        assert td1[1].value == iNaT
+        assert not isna(td1[1])
+        assert td1.dtype == np.object_
+        assert td1[1] == iNaT
         td1[1] = td[1]
         assert not isna(td1[1])
 
@@ -792,6 +794,7 @@ class TestSeriesMissingData:
         td1[2] = td[2]
         assert not isna(td1[2])
 
+        # FIXME: don't leave commented-out
         # boolean setting
         # this doesn't work, not sure numpy even supports it
         # result = td[(td>np.timedelta64(timedelta(days=3))) &


### PR DESCRIPTION
Working towards minimizing the amount of special-casing we do within internals