### PR TITLE
add some type annotations io/formats/format.py

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -6,7 +6,7 @@ and latex files. This module also applies to display formatting.
 from functools import partial
 from io import StringIO
 from shutil import get_terminal_size
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, TextIO, Tuple, Union
 from unicodedata import east_asian_width
 
 import numpy as np
@@ -135,7 +135,7 @@ class CategoricalFormatter:
     def __init__(
         self,
         categorical: ABCCategorical,
-        buf: Optional[StringIO] = None,
+        buf: Optional[TextIO] = None,
         length: bool = True,
         na_rep: str = "NaN",
         footer: bool = True,
@@ -194,7 +194,7 @@ class SeriesFormatter:
     def __init__(
         self,
         series: ABCSeries,
-        buf: Optional[StringIO] = None,
+        buf: Optional[TextIO] = None,
         length: bool = True,
         header: bool = True,
         index: bool = True,

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -181,14 +181,18 @@ class CategoricalFormatter:
             else:
                 return ""
 
-        values = [i.strip() for i in self._get_formatted_values()]
-        lines = ["[" + ", ".join(values) + "]"]
+        fmt_values = self._get_formatted_values()
+
+        fmt_values = ["{i}".format(i=i) for i in fmt_values]
+        fmt_values = [i.strip() for i in fmt_values]
+        values = ", ".join(fmt_values)
+        result = ["[" + values + "]"]
         if self.footer:
             footer = self._get_footer()
             if footer:
-                lines.append(footer)
+                result.append(footer)
 
-        return str("\n".join(lines))
+        return str("\n".join(result))
 
 
 class SeriesFormatter:
@@ -956,11 +960,13 @@ class DataFrameFormatter(TableFormatter):
             return adjoined
 
     def _get_column_name_list(self) -> List[str]:
+        names = []  # type: List[str]
         columns = self.frame.columns
         if isinstance(columns, ABCMultiIndex):
-            return ["" if name is None else name for name in columns.names]
+            names.extend("" if name is None else name for name in columns.names)
         else:
-            return ["" if columns.name is None else columns.name]
+            names.append("" if columns.name is None else columns.name)
+        return names
 
 
 # ----------------------------------------------------------------------

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -225,7 +225,7 @@ class SeriesFormatter:
 
     @property
     def truncate_v(self) -> bool:
-        return hasattr(self, 'tr_row_num')
+        return hasattr(self, "tr_row_num")
 
     def _chk_truncate(self) -> None:
         from pandas.core.reshape.concat import concat
@@ -510,11 +510,11 @@ class DataFrameFormatter(TableFormatter):
 
     @property
     def truncate_v(self) -> bool:
-        return hasattr(self, 'tr_row_num')
+        return hasattr(self, "tr_row_num")
 
     @property
     def truncate_h(self) -> bool:
-        return hasattr(self, 'tr_col_num')
+        return hasattr(self, "tr_col_num")
 
     @property
     def is_truncated(self) -> bool:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -180,7 +180,7 @@ class CategoricalFormatter:
             else:
                 return ""
 
-        values = ["{i}".format(i=i.strip()) for i in self._get_formatted_values()]
+        values = [i.strip() for i in self._get_formatted_values()]
         lines = ["[" + ", ".join(values) + "]"]
         if self.footer:
             footer = self._get_footer()

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -6,7 +6,7 @@ and latex files. This module also applies to display formatting.
 from functools import partial
 from io import StringIO
 from shutil import get_terminal_size
-from typing import List, Optional, TextIO, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, TextIO, Tuple, Union
 from unicodedata import east_asian_width
 
 import numpy as np
@@ -33,8 +33,6 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype,
 )
 from pandas.core.dtypes.generic import (
-    ABCCategorical,
-    ABCDataFrame,
     ABCIndexClass,
     ABCMultiIndex,
     ABCSeries,
@@ -49,6 +47,9 @@ from pandas.core.indexes.datetimes import DatetimeIndex
 
 from pandas.io.common import _expand_user, _stringify_path
 from pandas.io.formats.printing import adjoin, justify, pprint_thing
+
+if TYPE_CHECKING:
+    from pandas import Series, DataFrame, Categorical
 
 common_docstring = """
         Parameters
@@ -134,7 +135,7 @@ return_docstring = """
 class CategoricalFormatter:
     def __init__(
         self,
-        categorical: ABCCategorical,
+        categorical: "Categorical",
         buf: Optional[TextIO] = None,
         length: bool = True,
         na_rep: str = "NaN",
@@ -193,7 +194,7 @@ class CategoricalFormatter:
 class SeriesFormatter:
     def __init__(
         self,
-        series: ABCSeries,
+        series: "Series",
         buf: Optional[TextIO] = None,
         length: bool = True,
         header: bool = True,
@@ -851,7 +852,7 @@ class DataFrameFormatter(TableFormatter):
         else:
             raise TypeError("buf is not a file name and it has no write " " method")
 
-    def _get_formatted_column_labels(self, frame: ABCDataFrame) -> List[List[str]]:
+    def _get_formatted_column_labels(self, frame: "DataFrame") -> List[List[str]]:
         from pandas.core.index import _sparsify
 
         columns = frame.columns
@@ -908,7 +909,7 @@ class DataFrameFormatter(TableFormatter):
     def show_col_idx_names(self) -> bool:
         return all((self.has_column_names, self.show_index_names, self.header))
 
-    def _get_formatted_index(self, frame: ABCDataFrame) -> List[str]:
+    def _get_formatted_index(self, frame: "DataFrame") -> List[str]:
         # Note: this is only used by to_string() and to_latex(), not by
         # to_html().
         index = frame.index

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -180,18 +180,14 @@ class CategoricalFormatter:
             else:
                 return ""
 
-        fmt_values = self._get_formatted_values()
-
-        result = ["{i}".format(i=i) for i in fmt_values]  # type: Union[str, List[str]]
-        result = [i.strip() for i in result]
-        result = ", ".join(result)
-        result = ["[" + result + "]"]
+        values = ["{i}".format(i=i.strip()) for i in self._get_formatted_values()]
+        lines = ["[" + ", ".join(values) + "]"]
         if self.footer:
             footer = self._get_footer()
             if footer:
-                result.append(footer)
+                lines.append(footer)
 
-        return str("\n".join(result))
+        return str("\n".join(lines))
 
 
 class SeriesFormatter:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -948,13 +948,11 @@ class DataFrameFormatter(TableFormatter):
             return adjoined
 
     def _get_column_name_list(self) -> List[str]:
-        names = []  # type: List[str]
         columns = self.frame.columns
         if isinstance(columns, ABCMultiIndex):
-            names.extend("" if name is None else name for name in columns.names)
+            return ["" if name is None else name for name in columns.names]
         else:
-            names.append("" if columns.name is None else columns.name)
-        return names
+            return ["" if columns.name is None else columns.name]
 
 
 # ----------------------------------------------------------------------

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -204,7 +204,7 @@ class SeriesFormatter:
         dtype: bool = True,
         max_rows: Optional[int] = None,
         min_rows: Optional[int] = None,
-    ) -> None:
+    ):
         self.series = series
         self.buf = buf if buf is not None else StringIO()
         self.name = name

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -519,9 +519,7 @@ class HTMLFormatter(TableFormatter):
 
                 row.extend(fmt_values[j][i] for j in range(self.ncols))
                 if truncate_h:
-                    row.insert(
-                        self.row_levels - sparse_offset + truncate_h, "..."
-                    )
+                    row.insert(self.row_levels - sparse_offset + truncate_h, "...")
                 self.write_tr(
                     row,
                     indent,

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -37,7 +37,7 @@ class HTMLFormatter(TableFormatter):
         self,
         formatter: DataFrameFormatter,
         classes: Optional[Union[str, List, Tuple]] = None,
-        border: Optional[bool] = None,
+        border: Optional[int] = None,
     ) -> None:
         self.fmt = formatter
         self.classes = classes
@@ -252,7 +252,7 @@ class HTMLFormatter(TableFormatter):
             for lnum, (records, values) in enumerate(zip(level_lengths, levels)):
                 if truncate_h:
                     # modify the header lines
-                    ins_col = self.fmt.tr_col_num
+                    ins_col = truncate_h
                     if self.fmt.sparsify:
                         recs_new = {}
                         # Increment tags after ... col.
@@ -348,7 +348,7 @@ class HTMLFormatter(TableFormatter):
             align = self.fmt.justify
 
             if truncate_h:
-                ins_col = self.row_levels + self.fmt.tr_col_num
+                ins_col = self.row_levels + truncate_h
                 row.insert(ins_col, "...")
 
             self.write_tr(row, indent, self.indent_delta, header=True, align=align)
@@ -406,7 +406,7 @@ class HTMLFormatter(TableFormatter):
         row = []  # type: List[str]
         for i in range(nrows):
 
-            if truncate_v and i == (self.fmt.tr_row_num):
+            if truncate_v and i == truncate_v:
                 str_sep_row = ["..."] * len(row)
                 self.write_tr(
                     str_sep_row,
@@ -428,7 +428,7 @@ class HTMLFormatter(TableFormatter):
             row.extend(fmt_values[j][i] for j in range(self.ncols))
 
             if truncate_h:
-                dot_col_ix = self.fmt.tr_col_num + self.row_levels
+                dot_col_ix = truncate_h + self.row_levels
                 row.insert(dot_col_ix, "...")
             self.write_tr(
                 row, indent, self.indent_delta, tags=None, nindex_levels=self.row_levels
@@ -457,7 +457,7 @@ class HTMLFormatter(TableFormatter):
             if truncate_v:
                 # Insert ... row and adjust idx_values and
                 # level_lengths to take this into account.
-                ins_row = self.fmt.tr_row_num
+                ins_row = truncate_v
                 inserted = False
                 for lnum, records in enumerate(level_lengths):
                     rec_new = {}
@@ -520,7 +520,7 @@ class HTMLFormatter(TableFormatter):
                 row.extend(fmt_values[j][i] for j in range(self.ncols))
                 if truncate_h:
                     row.insert(
-                        self.row_levels - sparse_offset + self.fmt.tr_col_num, "..."
+                        self.row_levels - sparse_offset + truncate_h, "..."
                     )
                 self.write_tr(
                     row,
@@ -532,7 +532,7 @@ class HTMLFormatter(TableFormatter):
         else:
             row = []
             for i in range(len(frame)):
-                if truncate_v and i == (self.fmt.tr_row_num):
+                if truncate_v and i == truncate_v:
                     str_sep_row = ["..."] * len(row)
                     self.write_tr(
                         str_sep_row,
@@ -549,7 +549,7 @@ class HTMLFormatter(TableFormatter):
                 row.extend(idx_values[i])
                 row.extend(fmt_values[j][i] for j in range(self.ncols))
                 if truncate_h:
-                    row.insert(self.row_levels + self.fmt.tr_col_num, "...")
+                    row.insert(self.row_levels + truncate_h, "...")
                 self.write_tr(
                     row,
                     indent,

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -252,7 +252,7 @@ class HTMLFormatter(TableFormatter):
             for lnum, (records, values) in enumerate(zip(level_lengths, levels)):
                 if truncate_h:
                     # modify the header lines
-                    ins_col = truncate_h
+                    ins_col = self.fmt.tr_col_num
                     if self.fmt.sparsify:
                         recs_new = {}
                         # Increment tags after ... col.
@@ -348,7 +348,7 @@ class HTMLFormatter(TableFormatter):
             align = self.fmt.justify
 
             if truncate_h:
-                ins_col = self.row_levels + truncate_h
+                ins_col = self.row_levels + self.fmt.tr_col_num
                 row.insert(ins_col, "...")
 
             self.write_tr(row, indent, self.indent_delta, header=True, align=align)
@@ -406,7 +406,7 @@ class HTMLFormatter(TableFormatter):
         row = []  # type: List[str]
         for i in range(nrows):
 
-            if truncate_v and i == truncate_v:
+            if truncate_v and i == (self.fmt.tr_row_num):
                 str_sep_row = ["..."] * len(row)
                 self.write_tr(
                     str_sep_row,
@@ -428,7 +428,7 @@ class HTMLFormatter(TableFormatter):
             row.extend(fmt_values[j][i] for j in range(self.ncols))
 
             if truncate_h:
-                dot_col_ix = truncate_h + self.row_levels
+                dot_col_ix = self.fmt.tr_col_num + self.row_levels
                 row.insert(dot_col_ix, "...")
             self.write_tr(
                 row, indent, self.indent_delta, tags=None, nindex_levels=self.row_levels
@@ -457,7 +457,7 @@ class HTMLFormatter(TableFormatter):
             if truncate_v:
                 # Insert ... row and adjust idx_values and
                 # level_lengths to take this into account.
-                ins_row = truncate_v
+                ins_row = self.fmt.tr_row_num
                 inserted = False
                 for lnum, records in enumerate(level_lengths):
                     rec_new = {}
@@ -519,7 +519,9 @@ class HTMLFormatter(TableFormatter):
 
                 row.extend(fmt_values[j][i] for j in range(self.ncols))
                 if truncate_h:
-                    row.insert(self.row_levels - sparse_offset + truncate_h, "...")
+                    row.insert(
+                        self.row_levels - sparse_offset + self.fmt.tr_col_num, "..."
+                    )
                 self.write_tr(
                     row,
                     indent,
@@ -530,7 +532,7 @@ class HTMLFormatter(TableFormatter):
         else:
             row = []
             for i in range(len(frame)):
-                if truncate_v and i == truncate_v:
+                if truncate_v and i == (self.fmt.tr_row_num):
                     str_sep_row = ["..."] * len(row)
                     self.write_tr(
                         str_sep_row,
@@ -547,7 +549,7 @@ class HTMLFormatter(TableFormatter):
                 row.extend(idx_values[i])
                 row.extend(fmt_values[j][i] for j in range(self.ncols))
                 if truncate_h:
-                    row.insert(self.row_levels + truncate_h, "...")
+                    row.insert(self.row_levels + self.fmt.tr_col_num, "...")
                 self.write_tr(
                     row,
                     indent,

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -79,7 +79,7 @@ class HTMLFormatter(TableFormatter):
         # not showing (row) index
         return 0
 
-    def _get_columns_formatted_values(self) -> Iterable[Any]:
+    def _get_columns_formatted_values(self) -> Iterable:
         return self.columns
 
     @property
@@ -162,7 +162,7 @@ class HTMLFormatter(TableFormatter):
 
     def write_tr(
         self,
-        line: Iterable[Any],
+        line: Iterable,
         indent: int = 0,
         indent_delta: int = 0,
         header: bool = False,

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from pandas._config import get_option
 
-from pandas.core.dtypes.generic import ABCIndex, ABCMultiIndex
+from pandas.core.dtypes.generic import ABCMultiIndex
 
 from pandas import option_context
 
@@ -79,7 +79,7 @@ class HTMLFormatter(TableFormatter):
         # not showing (row) index
         return 0
 
-    def _get_columns_formatted_values(self) -> ABCIndex:
+    def _get_columns_formatted_values(self):
         return self.columns
 
     @property

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -4,7 +4,7 @@ Module for formatting output data in HTML.
 
 from collections import OrderedDict
 from textwrap import dedent
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from pandas._config import get_option
 
@@ -79,7 +79,7 @@ class HTMLFormatter(TableFormatter):
         # not showing (row) index
         return 0
 
-    def _get_columns_formatted_values(self):
+    def _get_columns_formatted_values(self) -> Iterable[Any]:
         return self.columns
 
     @property
@@ -90,12 +90,12 @@ class HTMLFormatter(TableFormatter):
     def ncols(self) -> int:
         return len(self.fmt.tr_frame.columns)
 
-    def write(self, s: str, indent: int = 0) -> None:
+    def write(self, s: Any, indent: int = 0) -> None:
         rs = pprint_thing(s)
         self.elements.append(" " * indent + rs)
 
     def write_th(
-        self, s: str, header: bool = False, indent: int = 0, tags: Optional[str] = None
+        self, s: Any, header: bool = False, indent: int = 0, tags: Optional[str] = None
     ) -> None:
         """
         Method for writting a formatted <th> cell.
@@ -125,11 +125,11 @@ class HTMLFormatter(TableFormatter):
 
         self._write_cell(s, kind="th", indent=indent, tags=tags)
 
-    def write_td(self, s: str, indent: int = 0, tags: Optional[str] = None) -> None:
+    def write_td(self, s: Any, indent: int = 0, tags: Optional[str] = None) -> None:
         self._write_cell(s, kind="td", indent=indent, tags=tags)
 
     def _write_cell(
-        self, s: str, kind: str = "td", indent: int = 0, tags: Optional[str] = None
+        self, s: Any, kind: str = "td", indent: int = 0, tags: Optional[str] = None
     ) -> None:
         if tags is not None:
             start_tag = "<{kind} {tags}>".format(kind=kind, tags=tags)
@@ -162,7 +162,7 @@ class HTMLFormatter(TableFormatter):
 
     def write_tr(
         self,
-        line: List[str],
+        line: Iterable[Any],
         indent: int = 0,
         indent_delta: int = 0,
         header: bool = False,


### PR DESCRIPTION
typing not added to all function signatures in io/formats/format.py in this pass to reduce the diff

~~this PR also contains a refactor to simplify the addition of type annotations; `truncate_h` and `tr_col_num` are dependant variables. `truncate_h` can be `True` or `False`. if `True`, `tr_col_num` is an `int` else if `truncate_h` is `False`, `tr_col_num` is `None`~~

~~same applies for `truncate_v` and `tr_row_num`~~
