### PR TITLE
Removed ABCs from pandas._typing

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -1,33 +1,35 @@
 from pathlib import Path
-from typing import IO, AnyStr, TypeVar, Union
+from typing import IO, TYPE_CHECKING, AnyStr, TypeVar, Union
 
 import numpy as np
 
-from pandas._libs import Timestamp
-from pandas._libs.tslibs.period import Period
-from pandas._libs.tslibs.timedeltas import Timedelta
+if TYPE_CHECKING:  # Use for any internal imports
+    from pandas._libs import Timestamp
+    from pandas._libs.tslibs.period import Period
+    from pandas._libs.tslibs.timedeltas import Timedelta
 
-from pandas.core.dtypes.dtypes import ExtensionDtype
-from pandas.core.dtypes.generic import (
-    ABCDataFrame,
-    ABCExtensionArray,
-    ABCIndexClass,
-    ABCSeries,
-    ABCSparseSeries,
-)
+    from pandas.core.arrays.base import ExtensionArray
+    from pandas.core.dtypes.dtypes import ExtensionDtype
+    from pandas.core.dtypes.generic import (
+        ABCDataFrame,
+        ABCExtensionArray,
+        ABCIndexClass,
+        ABCSeries,
+        ABCSparseSeries,
+    )
+    from pandas.core.indexes.base import Index
+    from pandas.core.frame import DataFrame
+    from pandas.core.series import Series
+    from pandas.core.sparse.series import SparseSeries
+
 
 AnyArrayLike = TypeVar(
-    "AnyArrayLike",
-    ABCExtensionArray,
-    ABCIndexClass,
-    ABCSeries,
-    ABCSparseSeries,
-    np.ndarray,
+    "AnyArrayLike", "ExtensionArray", "Index", "Series", "SparseSeries", np.ndarray
 )
-ArrayLike = TypeVar("ArrayLike", ABCExtensionArray, np.ndarray)
-DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", Period, Timestamp, Timedelta)
-Dtype = Union[str, np.dtype, ExtensionDtype]
+ArrayLike = TypeVar("ArrayLike", "ExtensionArray", np.ndarray)
+DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", "Period", "Timestamp", "Timedelta")
+Dtype = Union[str, np.dtype, "ExtensionDtype"]
 FilePathOrBuffer = Union[str, Path, IO[AnyStr]]
 
-FrameOrSeries = TypeVar("FrameOrSeries", ABCSeries, ABCDataFrame)
+FrameOrSeries = TypeVar("FrameOrSeries", "Series", "DataFrame")
 Scalar = Union[str, int, float]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -7,21 +7,13 @@ import numpy as np
 # and use a string literal forward reference to it in subsequent types
 # https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
 if TYPE_CHECKING:
-    from pandas._libs import Period, Timedelta, Timestamp
-
-    from pandas.core.arrays.base import ExtensionArray
-    from pandas.core.dtypes.dtypes import ExtensionDtype
-    from pandas.core.dtypes.generic import (
-        ABCDataFrame,
-        ABCExtensionArray,
-        ABCIndexClass,
-        ABCSeries,
-        ABCSparseSeries,
-    )
-    from pandas.core.indexes.base import Index
-    from pandas.core.frame import DataFrame
-    from pandas.core.series import Series
-    from pandas.core.sparse.series import SparseSeries
+    from pandas._libs import Period, Timedelta, Timestamp  # noqa: F401
+    from pandas.core.arrays.base import ExtensionArray  # noqa: F401
+    from pandas.core.dtypes.dtypes import ExtensionDtype  # noqa: F401
+    from pandas.core.indexes.base import Index  # noqa: F401
+    from pandas.core.frame import DataFrame  # noqa: F401
+    from pandas.core.series import Series  # noqa: F401
+    from pandas.core.sparse.series import SparseSeries  # noqa: F401
 
 
 AnyArrayLike = TypeVar(

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -3,7 +3,10 @@ from typing import IO, TYPE_CHECKING, AnyStr, TypeVar, Union
 
 import numpy as np
 
-if TYPE_CHECKING:  # Use for any internal imports
+# To prevent import cycles place any internal imports in the branch below
+# and use a string literal forward reference to it in subsequent types
+# https://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
+if TYPE_CHECKING:
     from pandas._libs import Period, Timedelta, Timestamp
 
     from pandas.core.arrays.base import ExtensionArray

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -4,9 +4,7 @@ from typing import IO, TYPE_CHECKING, AnyStr, TypeVar, Union
 import numpy as np
 
 if TYPE_CHECKING:  # Use for any internal imports
-    from pandas._libs import Timestamp
-    from pandas._libs.tslibs.period import Period
-    from pandas._libs.tslibs.timedeltas import Timedelta
+    from pandas._libs import Period, Timedelta, Timestamp
 
     from pandas.core.arrays.base import ExtensionArray
     from pandas.core.dtypes.dtypes import ExtensionDtype

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -168,11 +168,11 @@ def ensure_int_or_float(arr: ArrayLike, copy=False) -> np.array:
     will remain unchanged.
     """
     try:
-        return arr.astype("int64", copy=copy, casting="safe")
+        return arr.astype("int64", copy=copy, casting="safe")  # type: ignore
     except TypeError:
         pass
     try:
-        return arr.astype("uint64", copy=copy, casting="safe")
+        return arr.astype("uint64", copy=copy, casting="safe")  # type: ignore
     except TypeError:
         return arr.astype("float64", copy=copy)
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -167,6 +167,7 @@ def ensure_int_or_float(arr: ArrayLike, copy=False) -> np.array:
     If the array is explicitly of type uint64 the type
     will remain unchanged.
     """
+    # TODO: GH27506 potential bug with ExtensionArrays
     try:
         return arr.astype("int64", copy=copy, casting="safe")  # type: ignore
     except TypeError:

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -980,8 +980,8 @@ class IntervalIndex(IntervalMixin, Index):
         else:
             target = self._maybe_convert_i8(target)
             indexer, missing = self._engine.get_indexer_non_unique(
-                target.values
-            )  # type: ignore
+                target.values  # type: ignore
+            )
 
         return ensure_platform_int(indexer), ensure_platform_int(missing)
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -956,9 +956,14 @@ class IntervalIndex(IntervalMixin, Index):
             )
             if self.closed != target_as_index.closed or is_object_dtype(common_subtype):
                 # different closed or incompatible subtype -> no matches
-                return np.repeat(-1, len(target_as_index)), np.arange(len(target_as_index))
+                return (
+                    np.repeat(-1, len(target_as_index)),
+                    np.arange(len(target_as_index)),
+                )
 
-        if is_object_dtype(target_as_index) or isinstance(target_as_index, IntervalIndex):
+        if is_object_dtype(target_as_index) or isinstance(
+            target_as_index, IntervalIndex
+        ):
             # target_as_index might contain intervals: defer elementwise to get_loc
             indexer, missing = [], []
             for i, key in enumerate(target_as_index):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -934,7 +934,7 @@ class IntervalIndex(IntervalMixin, Index):
         elif not is_object_dtype(target):
             # homogeneous scalar index: use IntervalTree
             target = self._maybe_convert_i8(target)
-            indexer = self._engine.get_indexer(target.values)
+            indexer = self._engine.get_indexer(target.values)  # type: ignore
         else:
             # heterogeneous scalar index: defer elementwise to get_loc
             # (non-overlapping so get_loc guarantees scalar of KeyError)
@@ -979,7 +979,9 @@ class IntervalIndex(IntervalMixin, Index):
             indexer = np.concatenate(indexer)
         else:
             target = self._maybe_convert_i8(target)
-            indexer, missing = self._engine.get_indexer_non_unique(target.values)
+            indexer, missing = self._engine.get_indexer_non_unique(
+                target.values
+            )  # type: ignore
 
         return ensure_platform_int(indexer), ensure_platform_int(missing)
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -906,35 +906,35 @@ class IntervalIndex(IntervalMixin, Index):
             )
             raise InvalidIndexError(msg)
 
-        target = ensure_index(target)
+        target_as_index = ensure_index(target)
 
-        if isinstance(target, IntervalIndex):
+        if isinstance(target_as_index, IntervalIndex):
             # equal indexes -> 1:1 positional match
-            if self.equals(target):
+            if self.equals(target_as_index):
                 return np.arange(len(self), dtype="intp")
 
             # different closed or incompatible subtype -> no matches
             common_subtype = find_common_type(
-                [self.dtype.subtype, target.dtype.subtype]
+                [self.dtype.subtype, target_as_index.dtype.subtype]
             )
-            if self.closed != target.closed or is_object_dtype(common_subtype):
-                return np.repeat(np.intp(-1), len(target))
+            if self.closed != target_as_index.closed or is_object_dtype(common_subtype):
+                return np.repeat(np.intp(-1), len(target_as_index))
 
-            # non-overlapping -> at most one match per interval in target
+            # non-overlapping -> at most one match per interval in target_as_index
             # want exact matches -> need both left/right to match, so defer to
             # left/right get_indexer, compare elementwise, equality -> match
-            left_indexer = self.left.get_indexer(target.left)
-            right_indexer = self.right.get_indexer(target.right)
+            left_indexer = self.left.get_indexer(target_as_index.left)
+            right_indexer = self.right.get_indexer(target_as_index.right)
             indexer = np.where(left_indexer == right_indexer, left_indexer, -1)
-        elif not is_object_dtype(target):
+        elif not is_object_dtype(target_as_index):
             # homogeneous scalar index: use IntervalTree
-            target = self._maybe_convert_i8(target)
-            indexer = self._engine.get_indexer(target.values)  # type: ignore
+            target_as_index = self._maybe_convert_i8(target_as_index)
+            indexer = self._engine.get_indexer(target_as_index.values)
         else:
             # heterogeneous scalar index: defer elementwise to get_loc
             # (non-overlapping so get_loc guarantees scalar of KeyError)
             indexer = []
-            for key in target:
+            for key in target_as_index:
                 try:
                     loc = self.get_loc(key)
                 except KeyError:
@@ -947,21 +947,21 @@ class IntervalIndex(IntervalMixin, Index):
     def get_indexer_non_unique(
         self, target: AnyArrayLike
     ) -> Tuple[np.ndarray, np.ndarray]:
-        target = ensure_index(target)
+        target_as_index = ensure_index(target)
 
-        # check that target IntervalIndex is compatible
-        if isinstance(target, IntervalIndex):
+        # check that target_as_index IntervalIndex is compatible
+        if isinstance(target_as_index, IntervalIndex):
             common_subtype = find_common_type(
-                [self.dtype.subtype, target.dtype.subtype]
+                [self.dtype.subtype, target_as_index.dtype.subtype]
             )
-            if self.closed != target.closed or is_object_dtype(common_subtype):
+            if self.closed != target_as_index.closed or is_object_dtype(common_subtype):
                 # different closed or incompatible subtype -> no matches
-                return np.repeat(-1, len(target)), np.arange(len(target))
+                return np.repeat(-1, len(target_as_index)), np.arange(len(target_as_index))
 
-        if is_object_dtype(target) or isinstance(target, IntervalIndex):
-            # target might contain intervals: defer elementwise to get_loc
+        if is_object_dtype(target_as_index) or isinstance(target_as_index, IntervalIndex):
+            # target_as_index might contain intervals: defer elementwise to get_loc
             indexer, missing = [], []
-            for i, key in enumerate(target):
+            for i, key in enumerate(target_as_index):
                 try:
                     locs = self.get_loc(key)
                     if isinstance(locs, slice):
@@ -973,9 +973,9 @@ class IntervalIndex(IntervalMixin, Index):
                 indexer.append(locs)
             indexer = np.concatenate(indexer)
         else:
-            target = self._maybe_convert_i8(target)
+            target_as_index = self._maybe_convert_i8(target_as_index)
             indexer, missing = self._engine.get_indexer_non_unique(
-                target.values  # type: ignore
+                target_as_index.values
             )
 
         return ensure_platform_int(indexer), ensure_platform_int(missing)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -240,7 +240,7 @@ class _Window(PandasObject, SelectionMixin):
 
         return values
 
-    def _wrap_result(self, result, block=None, obj=None) -> FrameOrSeries:
+    def _wrap_result(self, result, block=None, obj=None):
         """
         Wrap a single result.
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ exclude =
     .eggs/*.py,
     versioneer.py,
     env  # exclude asv benchmark environments from linting
+    pandas/_typing.py
 
 [flake8-rst]
 bootstrap =

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ exclude =
     .eggs/*.py,
     versioneer.py,
     env  # exclude asv benchmark environments from linting
-    pandas/_typing.py
 
 [flake8-rst]
 bootstrap =

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,9 @@ filterwarnings =
 
 [coverage:run]
 branch = False
-omit = */tests/*
+omit =
+     */tests/*
+     pandas/_typing.py
 plugins = Cython.Coverage
 
 [coverage:report]


### PR DESCRIPTION
- [X] closes #27146
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This reveals a few new typing issues so won't pass CI but submitting as draft

Here's one way I think that works to avoid import cycles. Basically any internal imports in pandas._typing need to be set in a TYPE_CHECKING block to prevent their runtime evaluation from causing import cycles.

To illustrate the effectiveness like this if you put something like this at the end of pandas._typing:

```python
def func(obj: FrameOrSeries) -> None:
    reveal_type(obj)
```

It would previously give you

```sh
pandas/_typing.py:43: note: Revealed type is 'Any'
```

Whereas now gives:

```sh
pandas/_typing.py:44: note: Revealed type is 'pandas.core.series.Series*'
pandas/_typing.py:44: note: Revealed type is 'pandas.core.frame.DataFrame*'
```

@topper-123 any way to check VSCode to see if this works with code completion?

In the long run this may not be needed with PEP 563:

https://www.python.org/dev/peps/pep-0563/

But I think this hack gets us there in the meantime