### PR TITLE
BUG: fix+test fillna with non-nano datetime64; closes #27419

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2250,7 +2250,12 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
         if tipo is not None:
-            return is_dtype_equal(tipo, self.dtype)
+            if self.is_datetimetz:
+                # require exact match, since non-nano does not exist
+                return is_dtype_equal(tipo, self.dtype)
+
+            # GH#27419 if we get a non-nano datetime64 object
+            return is_datetime64_dtype(tipo)
         elif element is NaT:
             return True
         elif isinstance(element, datetime):

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -437,6 +437,17 @@ class TestSeriesMissingData:
         )
         assert_series_equal(df.fillna(method="bfill"), exp)
 
+    def test_datetime64_non_nano_fillna(self):
+        # GH#27419
+        ser = Series([Timestamp("2010-01-01"), pd.NaT, Timestamp("2000-01-01")])
+        val = np.datetime64("1975-04-05", "ms")
+
+        result = ser.fillna(val)
+        expected = Series(
+            [Timestamp("2010-01-01"), Timestamp("1975-04-05"), Timestamp("2000-01-01")]
+        )
+        tm.assert_series_equal(result, expected)
+
     def test_fillna_consistency(self):
         # GH 16402
         # fillna with a tz aware to a tz-naive, should result in object


### PR DESCRIPTION
- [x] closes #27419
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
