### PR TITLE
CLN/REF: stop allowing iNaT in DatetimeBlock

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2633,8 +2633,8 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
 
     def _try_coerce_args(self, other):
         """
-        Coerce values and other to int64, with null values converted to
-        iNaT. values is always ndarray-like, other may not be
+        Coerce values and other to datetime64[ns], with null values
+        converted to datetime64("NaT", "ns").
 
         Parameters
         ----------

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1360,14 +1360,6 @@ def _nanpercentile_1d(values, mask, q, na_value, interpolation):
     quantiles : scalar or array
     """
     # mask is Union[ExtensionArray, ndarray]
-    if values.dtype.kind == "m":
-        # need to cast to integer to avoid rounding errors in numpy
-        result = _nanpercentile_1d(values.view("i8"), mask, q, na_value, interpolation)
-
-        # Note: we have to do do `astype` and not view because in general we
-        #  have float result at this point, not i8
-        return result.astype(values.dtype)
-
     values = values[~mask]
 
     if len(values) == 0:

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1362,14 +1362,6 @@ def _nanpercentile_1d(values, mask, q, na_value, interpolation):
     quantiles : scalar or array
     """
     # mask is Union[ExtensionArray, ndarray]
-    if values.dtype.kind == "m":
-        # need to cast to integer to avoid rounding errors in numpy
-        result = _nanpercentile_1d(values.view("i8"), mask, q, na_value, interpolation)
-
-        # Note: we have to do do `astype` and not view because in general we
-        #  have float result at this point, not i8
-        return result.astype(values.dtype)
-
     values = values[~mask]
 
     if len(values) == 0:
@@ -1401,6 +1393,16 @@ def nanpercentile(values, q, axis, na_value, mask, ndim, interpolation):
     -------
     quantiles : scalar or array
     """
+    if values.dtype.kind in ["m", "M"]:
+        # need to cast to integer to avoid rounding errors in numpy
+        result = nanpercentile(
+            values.view("i8"), q, axis, na_value.view("i8"), mask, ndim, interpolation
+        )
+
+        # Note: we have to do do `astype` and not view because in general we
+        #  have float result at this point, not i8
+        return result.astype(values.dtype)
+
     if not lib.is_scalar(mask) and mask.any():
         if ndim == 1:
             return _nanpercentile_1d(

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1362,6 +1362,14 @@ def _nanpercentile_1d(values, mask, q, na_value, interpolation):
     quantiles : scalar or array
     """
     # mask is Union[ExtensionArray, ndarray]
+    if values.dtype.kind == "m":
+        # need to cast to integer to avoid rounding errors in numpy
+        result = _nanpercentile_1d(values.view("i8"), mask, q, na_value, interpolation)
+
+        # Note: we have to do do `astype` and not view because in general we
+        #  have float result at this point, not i8
+        return result.astype(values.dtype)
+
     values = values[~mask]
 
     if len(values) == 0:

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1150,6 +1150,7 @@ class TestDataFrameIndexing(TestData):
             with pytest.raises(KeyError, match=msg):
                 float_frame.ix[:, ["E"]] = 1
 
+            # FIXME: don't leave commented-out
             # partial setting now allows this GH2578
             # pytest.raises(KeyError, float_frame.ix.__setitem__,
             #               (slice(None, None), 'E'), 1)
@@ -1676,9 +1677,11 @@ class TestDataFrameIndexing(TestData):
         )
         assert_series_equal(result, expected)
 
-        # set an allowable datetime64 type
+        # GH#16674 iNaT is treated as an integer when given by the user
         df.loc["b", "timestamp"] = iNaT
-        assert isna(df.loc["b", "timestamp"])
+        assert not isna(df.loc["b", "timestamp"])
+        assert df["timestamp"].dtype == np.object_
+        assert df.loc["b", "timestamp"] == iNaT
 
         # allow this syntax
         df.loc["c", "timestamp"] = np.nan

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -338,7 +338,7 @@ class TestDatetimeBlock:
         vals = (np.datetime64("2010-10-10"), datetime(2010, 10, 10), date(2010, 10, 10))
         for val in vals:
             coerced = block._try_coerce_args(val)
-            assert np.int64 == type(coerced)
+            assert np.datetime64 == type(coerced)
             assert pd.Timestamp("2010-10-10") == pd.Timestamp(coerced)
 
 

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -780,9 +780,11 @@ class TestSeriesMissingData:
         td1[0] = td[0]
         assert not isna(td1[0])
 
+        # GH#16674 iNaT is treated as an integer when given by the user
         td1[1] = iNaT
-        assert isna(td1[1])
-        assert td1[1].value == iNaT
+        assert not isna(td1[1])
+        assert td1.dtype == np.object_
+        assert td1[1] == iNaT
         td1[1] = td[1]
         assert not isna(td1[1])
 
@@ -792,6 +794,7 @@ class TestSeriesMissingData:
         td1[2] = td[2]
         assert not isna(td1[2])
 
+        # FIXME: don't leave commented-out
         # boolean setting
         # this doesn't work, not sure numpy even supports it
         # result = td[(td>np.timedelta64(timedelta(days=3))) &


### PR DESCRIPTION
Sits on top of #27411 

xref #16674.  The broader goal is de-special-casing code in internals.
