### PR TITLE
CLN: simplify maybe_convert_objects, soft_convert_objects

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -740,25 +740,18 @@ def astype_nansafe(arr, dtype, copy=True, skipna=False):
     return arr.view(dtype)
 
 
-def maybe_convert_objects(
-    values: np.ndarray,
-    convert_dates: bool = True,
-    convert_numeric: bool = True,
-    convert_timedeltas: bool = True,
-    copy: bool = True,
-):
+def maybe_convert_objects(values: np.ndarray, convert_numeric: bool = True):
     """ if we have an object dtype, try to coerce dates and/or numbers """
-    validate_bool_kwarg(convert_dates, "convert_dates")
     validate_bool_kwarg(convert_numeric, "convert_numeric")
-    validate_bool_kwarg(convert_timedeltas, "convert_timedeltas")
-    validate_bool_kwarg(copy, "copy")
+
+    orig_values = values
 
     # convert dates
-    if convert_dates and values.dtype == np.object_:
+    if values.dtype == np.object_:
         values = lib.maybe_convert_objects(values, convert_datetime=True)
 
     # convert timedeltas
-    if convert_timedeltas and values.dtype == np.object_:
+    if values.dtype == np.object_:
         values = lib.maybe_convert_objects(values, convert_timedelta=True)
 
     # convert to numeric
@@ -779,7 +772,8 @@ def maybe_convert_objects(
             # soft-conversion
             values = lib.maybe_convert_objects(values)
 
-    values = values.copy() if copy else values
+    if values is orig_values:
+        values = values.copy()
 
     return values
 
@@ -799,7 +793,6 @@ def soft_convert_objects(
     validate_bool_kwarg(timedelta, "timedelta")
     validate_bool_kwarg(coerce, "coerce")
     validate_bool_kwarg(copy, "copy")
-    assert not coerce  # we're only called from one place in internals.blocks
 
     conversion_count = sum((datetime, numeric, timedelta))
     if conversion_count == 0:

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -729,21 +729,32 @@ def astype_nansafe(arr, dtype, copy=True, skipna=False):
 
 
 def maybe_convert_objects(values: np.ndarray, convert_numeric: bool = True):
-    """ if we have an object dtype, try to coerce dates and/or numbers """
+    """
+    If we have an object dtype array, try to coerce dates and/or numbers.
+
+    Parameters
+    ----------
+    values : ndarray
+    convert_numeric : bool, default True
+
+    Returns
+    -------
+    ndarray or DatetimeIndex
+    """
     validate_bool_kwarg(convert_numeric, "convert_numeric")
 
     orig_values = values
 
     # convert dates
-    if values.dtype == np.object_:
+    if is_object_dtype(values.dtype):
         values = lib.maybe_convert_objects(values, convert_datetime=True)
 
     # convert timedeltas
-    if values.dtype == np.object_:
+    if is_object_dtype(values.dtype):
         values = lib.maybe_convert_objects(values, convert_timedelta=True)
 
     # convert to numeric
-    if values.dtype == np.object_:
+    if is_object_dtype(values.dtype):
         if convert_numeric:
             try:
                 new_values = lib.maybe_convert_numeric(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6038,6 +6038,11 @@ class NDFrame(PandasObject, SelectionMixin):
         -------
         converted : same as input object
         """
+        validate_bool_kwarg(datetime, "datetime")
+        validate_bool_kwarg(numeric, "numeric")
+        validate_bool_kwarg(timedelta, "timedelta")
+        validate_bool_kwarg(coerce, "coerce")
+        validate_bool_kwarg(copy, "copy")
         return self._constructor(
             self._data.convert(
                 datetime=datetime,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2783,7 +2783,6 @@ class ObjectBlock(Block):
         """
         return lib.is_bool_array(self.values.ravel())
 
-    # TODO: Refactor when convert_objects is removed since there will be 1 path
     def convert(
         self,
         copy: bool = True,

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -826,9 +826,7 @@ class Block(PandasObject):
                 convert=convert,
             )
         if convert:
-            blocks = [
-                b.convert(numeric=False, copy=not inplace) for b in blocks
-            ]
+            blocks = [b.convert(numeric=False, copy=not inplace) for b in blocks]
         return blocks
 
     def _replace_single(self, *args, **kwargs):
@@ -3074,9 +3072,7 @@ class ObjectBlock(Block):
                 mask=mask,
             )
             if convert:
-                block = [
-                    b.convert(numeric=False, copy=True) for b in block
-                ]
+                block = [b.convert(numeric=False, copy=True) for b in block]
             return block
         return self
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -827,7 +827,7 @@ class Block(PandasObject):
             )
         if convert:
             blocks = [
-                b.convert(by_item=True, numeric=False, copy=not inplace) for b in blocks
+                b.convert(numeric=False, copy=not inplace) for b in blocks
             ]
         return blocks
 
@@ -2781,7 +2781,6 @@ class ObjectBlock(Block):
     # TODO: Refactor when convert_objects is removed since there will be 1 path
     def convert(
         self,
-        by_item: bool = True,
         datetime: bool = True,
         numeric: bool = True,
         timedelta: bool = True,
@@ -2812,7 +2811,7 @@ class ObjectBlock(Block):
             values = _block_shape(values, ndim=self.ndim)
             return values
 
-        if by_item and self.ndim == 2:
+        if self.ndim == 2:
             blocks = self.split_and_operate(None, f, False)
         else:
             values = f(None, self.values.ravel(), None)
@@ -3036,7 +3035,7 @@ class ObjectBlock(Block):
         # convert
         block = self.make_block(new_values)
         if convert:
-            block = block.convert(by_item=True, numeric=False)
+            block = block.convert(numeric=False)
         return block
 
     def _replace_coerce(
@@ -3076,7 +3075,7 @@ class ObjectBlock(Block):
             )
             if convert:
                 block = [
-                    b.convert(by_item=True, numeric=False, copy=True) for b in block
+                    b.convert(numeric=False, copy=True) for b in block
                 ]
             return block
         return self

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -668,7 +668,14 @@ class Block(PandasObject):
                 )
         return newb
 
-    def convert(self, copy=True, **kwargs):
+    def convert(
+        self,
+        copy: bool = True,
+        datetime: bool = True,
+        numeric: bool = True,
+        timedelta: bool = True,
+        coerce: bool = False,
+    ):
         """ attempt to coerce any object types to better types return a copy
         of the block (if copy = True) by definition we are not an ObjectBlock
         here!
@@ -2779,11 +2786,11 @@ class ObjectBlock(Block):
     # TODO: Refactor when convert_objects is removed since there will be 1 path
     def convert(
         self,
+        copy: bool = True,
         datetime: bool = True,
         numeric: bool = True,
         timedelta: bool = True,
         coerce: bool = False,
-        copy: bool = True,
     ):
         """ attempt to coerce any object types to better types return a copy of
         the block (if copy = True) by definition we ARE an ObjectBlock!!!!!

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2779,21 +2779,15 @@ class ObjectBlock(Block):
         return lib.is_bool_array(self.values.ravel())
 
     # TODO: Refactor when convert_objects is removed since there will be 1 path
-    def convert(self, *args, **kwargs):
+    def convert(self, **kwargs):
         """ attempt to coerce any object types to better types return a copy of
         the block (if copy = True) by definition we ARE an ObjectBlock!!!!!
 
         can return multiple blocks!
         """
-
-        if args:
-            raise NotImplementedError
         by_item = kwargs.pop("by_item", True)
 
-        new_inputs = ["coerce", "datetime", "numeric", "timedelta"]
-
-        fn_inputs = new_inputs
-        fn_inputs += ["copy"]
+        fn_inputs = ["coerce", "datetime", "numeric", "timedelta", "copy"]
 
         fn_kwargs = {key: kwargs.pop(key) for key in fn_inputs if key in kwargs}
         if kwargs:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1551,7 +1551,6 @@ class SingleBlockManager(BlockManager):
 
     def convert(self, **kwargs):
         """ convert the whole block as one """
-        kwargs["by_item"] = False
         return self.apply("convert", **kwargs)
 
     @property

--- a/pandas/tests/dtypes/cast/test_convert_objects.py
+++ b/pandas/tests/dtypes/cast/test_convert_objects.py
@@ -5,9 +5,8 @@ from pandas.core.dtypes.cast import maybe_convert_objects
 
 
 @pytest.mark.parametrize("data", [[1, 2], ["apply", "banana"]])
-@pytest.mark.parametrize("copy", [True, False])
-def test_maybe_convert_objects_copy(data, copy):
+def test_maybe_convert_objects_copy(data):
     arr = np.array(data)
-    out = maybe_convert_objects(arr, copy=copy)
+    out = maybe_convert_objects(arr)
 
-    assert (arr is out) is (not copy)
+    assert arr is not out

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -584,10 +584,6 @@ class TestBlockManager:
         new_mgr = mgr.convert()
         _compare(mgr, new_mgr)
 
-        mgr = create_mgr("a, b: object; f: i8; g: f8")
-        new_mgr = mgr.convert()
-        _compare(mgr, new_mgr)
-
         # convert
         mgr = create_mgr("a,b,foo: object; f: i8; g: f8")
         mgr.set("a", np.array(["1"] * N, dtype=np.object_))


### PR DESCRIPTION
Block.replace has code for dispatching to either maybe_convert_objects or soft_convert_objects, but the former is only reached from the tests.  So rip that out and use soft_convert_objects.

Both of the functions have branches that are unreachable, so rip those out, along with adding types and validation.