### PR TITLE
BUG: avoid incorrectly inheriting result

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -143,7 +143,11 @@ class NDFrameGroupBy(GroupBy):
         new_blocks = []
         new_items = []
         deleted_items = []
+        no_result = object()
         for block in data.blocks:
+
+            # avoid inheriting result from previous step in loop
+            result = no_result
 
             locs = block.mgr_locs.as_array
             try:
@@ -171,15 +175,16 @@ class NDFrameGroupBy(GroupBy):
                 except TypeError:
                     # we may have an exception in trying to aggregate
                     # continue and exclude the block
-                    pass
+                    deleted_items.append(locs)
+                    continue
 
             finally:
+                if result is not no_result:
+                    dtype = block.values.dtype
 
-                dtype = block.values.dtype
-
-                # see if we can cast the block back to the original dtype
-                result = block._try_coerce_and_cast_result(result, dtype=dtype)
-                newb = block.make_block(result)
+                    # see if we can cast the block back to the original dtype
+                    result = block._try_coerce_and_cast_result(result, dtype=dtype)
+                    newb = block.make_block(result)
 
             new_items.append(locs)
             new_blocks.append(newb)


### PR DESCRIPTION
This has caused problems in a number of local branches, but I don't have a good test case on master.  Suggestions welcome.  Still though, the failure mode is pretty clear, so this fixes it.