### PR TITLE
PERF: restore performance for unsorted CategoricalDtype comparison

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -406,6 +406,12 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
             # but same order is not necessary.  There is no distinction between
             # ordered=False and ordered=None: CDT(., False) and CDT(., None)
             # will be equal if they have the same categories.
+            if (
+                self.categories.dtype == other.categories.dtype
+                and self.categories.equals(other.categories)
+            ):
+                # Check and see if they happen to be identical categories
+                return True
             return hash(self) == hash(other)
 
     def __repr__(self):


### PR DESCRIPTION
Fixes a performance regression introduced in #26403 very shortly before `0.25.0rc0` was cut, which can be seen [here](https://qwhelan.github.io/pandas/#indexing.CategoricalIndexIndexing.time_getitem_slice?machine=T470&num_cpu=4&os=Linux%205.0.0-20-generic&ram=20305904)
![Screenshot from 2019-07-17 23-29-08](https://user-images.githubusercontent.com/440095/61434418-c0aeb700-a8ea-11e9-8f02-8b7bb6dee96f.png)

When comparing `CategoricalDtype`s with `ordered=False` (the default), a hash is currently done that is relatively slow even for a small number of categories. If we check if the categories happen to be the same and in the same order, we see a significant speedup in the equal case. The `.equals()` function pre-exits, so overhead in the non-equal case should be minimal.

`asv` results:
```
       before           after         ratio
     [a4c19e7a]       [6810ff2f]
     <unsorted_cats~1>       <unsorted_cats>
-       179±0.4μs       25.6±0.4μs     0.14  indexing.CategoricalIndexIndexing.time_getitem_slice('monotonic_decr')
-         179±2μs         25.2±1μs     0.14  indexing.CategoricalIndexIndexing.time_getitem_slice('monotonic_incr')
-       180±0.4μs       25.1±0.3μs     0.14  indexing.CategoricalIndexIndexing.time_getitem_slice('non_monotonic')
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
