### PR TITLE
CLN: remove unused row_bool_subset

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -690,50 +690,6 @@ def generate_bins_dt64(ndarray[int64_t] values, const int64_t[:] binner,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def row_bool_subset(const float64_t[:, :] values,
-                    ndarray[uint8_t, cast=True] mask):
-    cdef:
-        Py_ssize_t i, j, n, k, pos = 0
-        ndarray[float64_t, ndim=2] out
-
-    n, k = (<object>values).shape
-    assert (n == len(mask))
-
-    out = np.empty((mask.sum(), k), dtype=np.float64)
-
-    for i in range(n):
-        if mask[i]:
-            for j in range(k):
-                out[pos, j] = values[i, j]
-            pos += 1
-
-    return out
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def row_bool_subset_object(ndarray[object, ndim=2] values,
-                           ndarray[uint8_t, cast=True] mask):
-    cdef:
-        Py_ssize_t i, j, n, k, pos = 0
-        ndarray[object, ndim=2] out
-
-    n, k = (<object>values).shape
-    assert (n == len(mask))
-
-    out = np.empty((mask.sum(), k), dtype=object)
-
-    for i in range(n):
-        if mask[i]:
-            for j in range(k):
-                out[pos, j] = values[i, j]
-            pos += 1
-
-    return out
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
 def get_level_sorter(const int64_t[:] label,
                      const int64_t[:] starts):
     """

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -20,7 +20,6 @@ from pandas.core.dtypes.common import (
     ensure_float64,
     ensure_int64,
     ensure_int_or_float,
-    ensure_object,
     ensure_platform_int,
     is_bool_dtype,
     is_categorical_dtype,
@@ -567,15 +566,8 @@ class BaseGrouper:
                 result[mask] = np.nan
 
         if kind == "aggregate" and self._filter_empty_groups and not counts.all():
-            if result.ndim == 2:
-                try:
-                    result = lib.row_bool_subset(result, (counts > 0).view(np.uint8))
-                except ValueError:
-                    result = lib.row_bool_subset_object(
-                        ensure_object(result), (counts > 0).view(np.uint8)
-                    )
-            else:
-                result = result[counts > 0]
+            assert result.ndim != 2
+            result = result[counts > 0]
 
         if vdim == 1 and arity == 1:
             result = result[:, 0]


### PR DESCRIPTION
@jreback can you confirm my hunch that the `result.ndim == 2` block in groupby.ops was for Panel?

Tracing back the blame, row_bool_subset was introduced [here](https://github.com/pandas-dev/pandas/commit/b15ae85e1f647821755d35bedd6143ad1e9c3678) in 2012 to close #152 and it started being called only for result.ndim == 2 [here](https://github.com/pandas-dev/pandas/commit/9bfdc3c037e926143e708463d76fcdae3fb709f2)