### PR TITLE
Make a fastpath conditional on `data is None`

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -341,9 +341,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             keys, values = zip(*data.items())
             values = list(values)
         elif index is not None:
-            # fastpath for Series(data=None). Just use broadcasting a scalar
-            # instead of reindexing.
-            values = na_value_for_dtype(dtype)
+            if data is None:
+                # fastpath for Series(data=None). Just use broadcasting a scalar
+                # instead of reindexing.
+                values = na_value_for_dtype(dtype)
+            else:
+                values = []
             keys = index
         else:
             keys, values = [], []


### PR DESCRIPTION
As per the pre-existing comment in the code: this is a fastpath for the
case `data is None`. Better include an if-statement to make sure this
condition actually holds.

When this if-statement is not present, failure occurs at a later point
in the code when an empty index is used, because that later code expects data
to be array-like, but we convert to a scalar here.

====

NOTE: this is a "shoot from the hip" (completely untested) PR as it stands.
I hope it can contribute towards a solution nonetheless, but it needs at least
tests

- [x] closes #26469
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
