### PR TITLE
Use Matplotlib built-in converters for python date(time)s

### DIFF
--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -44,14 +44,7 @@ _mpl_units = {}  # Cache for units overwritten by us
 
 
 def get_pairs():
-    pairs = [
-        (tslibs.Timestamp, DatetimeConverter),
-        (Period, PeriodConverter),
-        (pydt.datetime, DatetimeConverter),
-        (pydt.date, DatetimeConverter),
-        (pydt.time, TimeConverter),
-        (np.datetime64, DatetimeConverter),
-    ]
+    pairs = [(tslibs.Timestamp, DatetimeConverter), (Period, PeriodConverter)]
     return pairs
 
 


### PR DESCRIPTION
In Matplotlib we have and maintain unit converters for the python build in datetime objects and `np.datetime64`, so there is no need to provide another converter. This would fix https://github.com/pandas-dev/pandas/issues/27479