### PR TITLE
PERF: speed up IntervalIndex._intersection_non_unique by ~50x

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1250,15 +1250,9 @@ class IntervalIndex(IntervalMixin, Index):
             first_nan_loc = np.arange(len(self))[self.isna()][0]
             mask[first_nan_loc] = True
 
-        lmiss = other.left.get_indexer_non_unique(self.left)[1]
-        lmatch = np.setdiff1d(np.arange(len(self)), lmiss)
-
-        for i in lmatch:
-            potential = other.left.get_loc(self.left[i])
-            if is_scalar(potential):
-                if self.right[i] == other.right[potential]:
-                    mask[i] = True
-            elif self.right[i] in other.right[potential]:
+        other_tups = set(zip(other.left, other.right))
+        for i, tup in enumerate(zip(self.left, self.right)):
+            if tup in other_tups:
                 mask[i] = True
 
         return self[mask]


### PR DESCRIPTION
I've been backfilling `asv` data and noticed the following regression in `IntervalIndexMethod.time_intersection_both_duplicate` (see [here](https://qwhelan.github.io/pandas/#index_object.IntervalIndexMethod.time_intersection_both_duplicate?machine=T470-W10&os=Linux%204.4.0-17134-Microsoft&ram=20822880&p-param1=100000&commits=83eb2428-cdc07fde)):
![Screenshot from 2019-07-20 02-30-17](https://user-images.githubusercontent.com/440095/61577005-7407df00-aa96-11e9-9b13-7b323377babd.png)

This regression was missed as the benchmark was added in #26711, which was after introduction in #26225.

This PR both simplifies the `IntervalIndex._intersection_non_unique` logic (now equivalent to `MultiIndex._intersection_non_unique`) and provides a `~50x` speedup:
```
       before           after         ratio
     [9bab81e0]       [2848036e]
     <interval_non_unique_intersection~1>       <interval_non_unique_intersection>
-      12.6±0.1ms         725±30μs     0.06  index_object.IntervalIndexMethod.time_intersection_both_duplicate(1000)
-         4.96±0s         96.7±6ms     0.02  index_object.IntervalIndexMethod.time_intersection_both_duplicate(100000)
```
The new numbers are about `10x` faster than the old baseline.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
