### PR TITLE
PERF: speed up MultiIndex.is_monotonic by 50x

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -70,7 +70,8 @@ Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Performance improvement in indexing with a non-unique :class:`IntervalIndex` (:issue:`27489`)
--
+- Performance improvement in `MultiIndex.is_monotonic` (:issue:`27495`)
+
 
 .. _whatsnew_1000.bug_fixes:
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1359,6 +1359,12 @@ class MultiIndex(Index):
         increasing) values.
         """
 
+        if all(x.is_monotonic for x in self.levels):
+            # If each level is sorted, we can operate on the codes directly. GH27495
+            return libalgos.is_lexsorted(
+                [x.astype("int64", copy=False) for x in self.codes]
+            )
+
         # reversed() because lexsort() wants the most significant key last.
         values = [
             self._get_level_values(i).values for i in reversed(range(len(self.levels)))


### PR DESCRIPTION
The current logic for `MultiIndex.is_monotonic` relies on `np.lexsort()` on `MultiIndex._values`. While the result is cached, this is slow as it triggers the creation of `._values`, needs to perform an `O(n log(n))` sort, as well as populate the hashmap of a transient `Index`.

This PR significantly speeds up this check by directly operating on `.codes` when `.levels` are individually sorted. This means we can leverage `libalgos.is_lexsorted()` which is `O(n)` (but has the downside of needing `int64` when `MultiIndex` compacts levels).
```
       before           after         ratio
     [5bd57f90]       [3320dded]
-      31.9±0.9ms         627±50μs     0.02  index_cached_properties.IndexCache.time_is_monotonic_decreasing('MultiIndex')
-      29.6±0.7ms         528±80μs     0.02  index_cached_properties.IndexCache.time_is_monotonic('MultiIndex')
-        29.9±1ms         524±90μs     0.02  index_cached_properties.IndexCache.time_is_monotonic_increasing('MultiIndex')
```

- [ ] closes #27099
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
