### PR TITLE
remove last references to v0.18 in docs and code

### DIFF
--- a/doc/source/user_guide/advanced.rst
+++ b/doc/source/user_guide/advanced.rst
@@ -810,15 +810,10 @@ values **not** in the categories, similarly to how you can reindex **any** panda
 Int64Index and RangeIndex
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning::
+:class:`Int64Index` is a fundamental basic index in pandas. This is an immutable array
+implementing an ordered, sliceable set.
 
-   Indexing on an integer-based Index with floats has been clarified in 0.18.0, for a summary of the changes, see :ref:`here <whatsnew_0180.float_indexers>`.
-
-:class:`Int64Index` is a fundamental basic index in pandas.
-This is an immutable array implementing an ordered, sliceable set.
-Prior to 0.18.0, the ``Int64Index`` would provide the default index for all ``NDFrame`` objects.
-
-:class:`RangeIndex` is a sub-class of ``Int64Index`` added in version 0.18.0, now providing the default index for all ``NDFrame`` objects.
+:class:`RangeIndex` is a sub-class of ``Int64Index``  that provides the default index for all ``NDFrame`` objects.
 ``RangeIndex`` is an optimized version of ``Int64Index`` that can represent a monotonic ordered set. These are analogous to Python `range types <https://docs.python.org/3/library/stdtypes.html#typesseq-range>`__.
 
 .. _indexing.float64index:
@@ -879,16 +874,6 @@ In non-float indexes, slicing using floats will raise a ``TypeError``.
 
    In [1]: pd.Series(range(5))[3.5:4.5]
    TypeError: the slice start [3.5] is not a proper indexer for this index type (Int64Index)
-
-.. warning::
-
-   Using a scalar float indexer for ``.iloc`` has been removed in 0.18.0, so the following will raise a ``TypeError``:
-
-   .. code-block:: ipython
-
-      In [3]: pd.Series(range(5)).iloc[3.0]
-      TypeError: cannot do positional indexing on <class 'pandas.indexes.range.RangeIndex'> with these indexers [3.0] of <type 'float'>
-
 
 Here is a typical use-case for using this type of indexing. Imagine that you have a somewhat
 irregular timedelta-like indexing scheme, but the data is recorded as floats. This could, for

--- a/doc/source/user_guide/computation.rst
+++ b/doc/source/user_guide/computation.rst
@@ -893,10 +893,9 @@ Therefore, there is an assumption that :math:`x_0` is not an ordinary value
 but rather an exponentially weighted moment of the infinite series up to that
 point.
 
-One must have :math:`0 < \alpha \leq 1`, and while since version 0.18.0
-it has been possible to pass :math:`\alpha` directly, it's often easier
-to think about either the **span**, **center of mass (com)** or **half-life**
-of an EW moment:
+One must have :math:`0 < \alpha \leq 1`, and while it is possible to pass
+:math:`\alpha` directly, it's often easier to think about either the
+**span**, **center  of mass (com)** or **half-life** of an EW moment:
 
 .. math::
 

--- a/doc/source/user_guide/enhancingperf.rst
+++ b/doc/source/user_guide/enhancingperf.rst
@@ -628,8 +628,6 @@ new or modified columns is returned and the original frame is unchanged.
    df.eval('e = a - c', inplace=False)
    df
 
-.. versionadded:: 0.18.0
-
 As a convenience, multiple assignments can be performed by using a
 multi-line string.
 

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -36,10 +36,6 @@ this area.
    should be avoided. See :ref:`Returning a View versus Copy
    <indexing.view_versus_copy>`.
 
-.. warning::
-
-   Indexing on an integer-based Index with floats has been clarified in 0.18.0, for a summary of the changes, see :ref:`here <whatsnew_0180.float_indexers>`.
-
 See the :ref:`MultiIndex / Advanced Indexing <advanced>` for ``MultiIndex`` and more advanced indexing documentation.
 
 See the :ref:`cookbook<cookbook.selection>` for some advanced strategies.
@@ -82,8 +78,6 @@ of multi-axis indexing.
     * A boolean array.
     * A ``callable`` function with one argument (the calling Series or DataFrame) and
       that returns valid output for indexing (one of the above).
-
-      .. versionadded:: 0.18.1
 
   See more at :ref:`Selection by Position <indexing.integer>`,
   :ref:`Advanced Indexing <advanced>` and :ref:`Advanced
@@ -1101,9 +1095,7 @@ This is equivalent to (but faster than) the following.
    df2 = df.copy()
    df.apply(lambda x, y: x.where(x > 0, y), y=df['A'])
 
-.. versionadded:: 0.18.1
-
-Where can accept a callable as condition and ``other`` arguments. The function must
+``where`` can accept a callable as condition and ``other`` arguments. The function must
 be with one argument (the calling Series or DataFrame) and that returns valid output
 as condition and ``other`` argument.
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -296,7 +296,6 @@ compression : {``'infer'``, ``'gzip'``, ``'bz2'``, ``'zip'``, ``'xz'``, ``None``
   the ZIP file must contain only one data file to be read in.
   Set to ``None`` for no decompression.
 
-  .. versionadded:: 0.18.1 support for 'zip' and 'xz' compression.
   .. versionchanged:: 0.24.0 'infer' option added and set to default.
 thousands : str, default ``None``
   Thousands separator.

--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -484,8 +484,6 @@ not contain any instances of a particular category.
 Normalization
 ~~~~~~~~~~~~~
 
-.. versionadded:: 0.18.1
-
 Frequency tables can also be normalized to show percentages rather than counts
 using the ``normalize`` argument:
 

--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -6,10 +6,6 @@
    "source": [
     "# Styling\n",
     "\n",
-    "*New in version 0.17.1*\n",
-    "\n",
-    "<span style=\"color: red\">*Provisional: This is a new feature and still under development. We'll be adding features and possibly making breaking changes in future releases. We'd love to hear your feedback.*</span>\n",
-    "\n",
     "This document is written as a Jupyter Notebook, and can be viewed or downloaded [here](http://nbviewer.ipython.org/github/pandas-dev/pandas/blob/master/doc/source/style.ipynb).\n",
     "\n",
     "You can apply **conditional formatting**, the visual styling of a DataFrame\n",

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -364,16 +364,6 @@ Extracting substrings
 Extract first match in each subject (extract)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning::
-
-   In version 0.18.0, ``extract`` gained the ``expand`` argument. When
-   ``expand=False`` it returns a ``Series``, ``Index``, or
-   ``DataFrame``, depending on the subject and regular expression
-   pattern (same behavior as pre-0.18.0). When ``expand=True`` it
-   always returns a ``DataFrame``, which is more consistent and less
-   confusing from the perspective of a user. ``expand=True`` is the
-   default since version 0.23.0.
-
 The ``extract`` method accepts a `regular expression
 <https://docs.python.org/3/library/re.html>`__ with at least one
 capture group.
@@ -467,8 +457,6 @@ Extract all matches in each subject (extractall)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. _text.extractall:
-
-.. versionadded:: 0.18.0
 
 Unlike ``extract`` (which returns only the first match),
 

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -364,6 +364,15 @@ Extracting substrings
 Extract first match in each subject (extract)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. warning::
+
+   Before version 0.23, argument ``expand`` of the ``extract`` method defaulted to
+   ``False``. When ``expand=False``, ``expand`` returns a ``Series``, ``Index``, or
+   ``DataFrame``, depending on the subject and regular expression
+   pattern. When ``expand=True``, it always returns a ``DataFrame``,
+   which is more consistent and less confusing from the perspective of a user.
+   ``expand=True`` has been the default since version 0.23.0.
+
 The ``extract`` method accepts a `regular expression
 <https://docs.python.org/3/library/re.html>`__ with at least one
 capture group.

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -607,8 +607,6 @@ We are stopping on the included end-point as it is part of the index:
 
    dft['2013-1-15':'2013-1-15 12:30:00']
 
-.. versionadded:: 0.18.0
-
 ``DatetimeIndex`` partial string indexing also works on a ``DataFrame`` with a ``MultiIndex``:
 
 .. ipython:: python
@@ -1514,11 +1512,6 @@ Converting to Python datetimes
 Resampling
 ----------
 
-.. warning::
-
-   The interface to ``.resample`` has changed in 0.18.0 to be more groupby-like and hence more flexible.
-   See the :ref:`whatsnew docs <whatsnew_0180.breaking.resample>` for a comparison with prior versions.
-
 Pandas has a simple, powerful, and efficient functionality for performing
 resampling operations during frequency conversion (e.g., converting secondly
 data into 5-minutely data). This is extremely common in, but not limited to,
@@ -1528,8 +1521,8 @@ financial applications.
 on each of its groups. See some :ref:`cookbook examples <cookbook.resample>` for
 some advanced strategies.
 
-Starting in version 0.18.1, the ``resample()`` function can be used directly from
-``DataFrameGroupBy`` objects, see the :ref:`groupby docs <groupby.transform.window_resample>`.
+The ``resample()`` method can be used directly from ``DataFrameGroupBy`` objects,
+see the :ref:`groupby docs <groupby.transform.window_resample>`.
 
 .. note::
 

--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -1632,18 +1632,3 @@ when plotting a large number of points.
    :suppress:
 
     plt.close('all')
-
-
-.. _rplot:
-
-
-Trellis plotting interface
---------------------------
-
-.. warning::
-
-    The ``rplot`` trellis plotting interface has been **removed**. Please use
-    external packages like `seaborn <https://github.com/mwaskom/seaborn>`_ for
-    similar but more refined functionality and refer to our 0.18.1 documentation
-    `here <http://pandas.pydata.org/pandas-docs/version/0.18.1/visualization.html>`__
-    for how to convert to using it.

--- a/doc/source/whatsnew/v0.16.0.rst
+++ b/doc/source/whatsnew/v0.16.0.rst
@@ -530,7 +530,7 @@ Deprecations
   `seaborn <http://stanford.edu/~mwaskom/software/seaborn/>`_ for similar
   but more refined functionality (:issue:`3445`).
   The documentation includes some examples how to convert your existing code
-  using ``rplot`` to seaborn: :ref:`rplot docs <rplot>`.
+  from ``rplot`` to seaborn `here <http://pandas.pydata.org/pandas-docs/version/0.18.1/visualization.html#trellis-plotting-interface>`__.
 
 - The ``pandas.sandbox.qtpandas`` interface is deprecated and will be removed in a future version.
   We refer users to the external package `pandas-qt <https://github.com/datalyze-solutions/pandas-qt>`_. (:issue:`9615`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3204,8 +3204,6 @@ class DataFrame(NDFrame):
             If the expression contains an assignment, whether to perform the
             operation inplace and mutate the existing DataFrame. Otherwise,
             a new DataFrame is returned.
-
-            .. versionadded:: 0.18.0.
         kwargs : dict
             See the documentation for :func:`eval` for complete details
             on the keyword arguments accepted by
@@ -6316,8 +6314,6 @@ class DataFrame(NDFrame):
             Level(s) of index to unstack, can pass level name
         fill_value : replace NaN with this value if the unstack produces
             missing values
-
-            .. versionadded:: 0.18.0
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2986,8 +2986,6 @@ class NDFrame(PandasObject, SelectionMixin):
             defaults to 'utf-8'.
         decimal : str, default '.'
             Character recognized as decimal separator, e.g. ',' in Europe.
-
-            .. versionadded:: 0.18.0
         multicolumn : bool, default True
             Use \multicolumn to enhance MultiIndex columns.
             The default will be read from the config module.
@@ -6819,14 +6817,6 @@ class NDFrame(PandasObject, SelectionMixin):
               `scipy.interpolate.BPoly.from_derivatives` which
               replaces 'piecewise_polynomial' interpolation method in
               scipy 0.18.
-
-            .. versionadded:: 0.18.1
-
-               Added support for the 'akima' method.
-               Added interpolate method 'from_derivatives' which replaces
-               'piecewise_polynomial' in SciPy 0.18; backwards-compatible with
-               SciPy < 0.18
-
         axis : {0 or 'index', 1 or 'columns', None}, default None
             Axis to interpolate along.
         limit : int, optional
@@ -9146,10 +9136,6 @@ class NDFrame(PandasObject, SelectionMixin):
             If other is callable, it is computed on the %(klass)s and
             should return scalar or %(klass)s. The callable must not
             change input %(klass)s (though pandas doesn't check it).
-
-            .. versionadded:: 0.18.1
-                A callable can be used as other.
-
         inplace : bool, default False
             Whether to perform the operation in place on the data.
         axis : int, default None

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1139,8 +1139,6 @@ class DatetimeIndexResampler(Resampler):
 class DatetimeIndexResamplerGroupby(_GroupByMixin, DatetimeIndexResampler):
     """
     Provides a resample of a groupby implementation
-
-    .. versionadded:: 0.18.1
     """
 
     @property
@@ -1285,8 +1283,6 @@ class TimedeltaIndexResampler(DatetimeIndexResampler):
 class TimedeltaIndexResamplerGroupby(_GroupByMixin, TimedeltaIndexResampler):
     """
     Provides a resample of a groupby implementation.
-
-    .. versionadded:: 0.18.1
     """
 
     @property

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3593,12 +3593,16 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def swaplevel(self, i=-2, j=-1, copy=True):
         """
-        Swap levels i and j in a MultiIndex.
+        Swap levels i and j in a :class:`MultiIndex`.
+
+        Default is to swap the two innermost levels of the index.
 
         Parameters
         ----------
         i, j : int, str (can be mixed)
             Level of index to be swapped. Can pass level name as string.
+        copy : bool, default True
+            Whether to copy underlying data.
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3604,11 +3604,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         -------
         Series
             Series with levels swapped in MultiIndex.
-
-        .. versionchanged:: 0.18.1
-
-           The indexes ``i`` and ``j`` are now optional, and default to
-           the two innermost levels of the index.
         """
         new_index = self.index.swaplevel(i, j)
         return self._constructor(self._values, index=new_index, copy=copy).__finalize__(
@@ -4458,10 +4453,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             The sequence of values to test. Passing in a single string will
             raise a ``TypeError``. Instead, turn a single string into a
             list of one element.
-
-            .. versionadded:: 0.18.1
-
-              Support for values as a set.
 
         Returns
         -------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -914,8 +914,6 @@ def str_extractall(arr, pat, flags=0):
     Series has exactly one match, extractall(pat).xs(0, level='match')
     is the same as extract(pat).
 
-    .. versionadded:: 0.18.0
-
     Parameters
     ----------
     pat : str

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1949,9 +1949,6 @@ class Rolling(_Rolling_and_Expanding):
 class RollingGroupby(_GroupByMixin, Rolling):
     """
     Provide a rolling groupby implementation.
-
-    .. versionadded:: 0.18.1
-
     """
 
     @property
@@ -2224,9 +2221,6 @@ class Expanding(_Rolling_and_Expanding):
 class ExpandingGroupby(_GroupByMixin, Expanding):
     """
     Provide a expanding groupby implementation.
-
-    .. versionadded:: 0.18.1
-
     """
 
     @property
@@ -2281,9 +2275,6 @@ class EWM(_Rolling):
     alpha : float, optional
         Specify smoothing factor :math:`\alpha` directly,
         :math:`0 < \alpha \leq 1`.
-
-        .. versionadded:: 0.18.0
-
     min_periods : int, default 0
         Minimum number of observations in window required to have a value
         (otherwise result is NA).

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -326,9 +326,6 @@ delim_whitespace : bool, default False
     used as the sep. Equivalent to setting ``sep='\\s+'``. If this option
     is set to True, nothing should be passed in for the ``delimiter``
     parameter.
-
-    .. versionadded:: 0.18.1 support for the Python parser.
-
 low_memory : bool, default True
     Internally process the file in chunks, resulting in lower memory use
     while parsing, but possibly mixed type inference.  To ensure no mixed


### PR DESCRIPTION
- [x] xref #27463

Somehow all the changes didn't get added to #27463, so here's a follow-up.

I've also removed a reference to 0.17 in style.ipynb which also makes the styler api non-provisional.