### PR TITLE
BUG: Retain tz transformation in groupby.transform

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -120,7 +120,7 @@ Plotting
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
--
+- Bug in :meth:`pandas.core.groupby.DataFrameGroupBy.transform` where applying a timezone conversion lambda function would drop timezone information (:issue:`27496`)
 -
 -
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1025,8 +1025,8 @@ class SeriesGroupBy(GroupBy):
             object.__setattr__(group, "name", name)
             res = wrapper(group)
 
-            if hasattr(res, "values"):
-                res = res.values
+            if hasattr(res, "_values"):
+                res = res._values
 
             indexer = self._get_index(name)
             s = klass(res, indexer)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -42,7 +42,7 @@ import pandas.core.algorithms as algorithms
 from pandas.core.base import DataError, SpecificationError
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
-from pandas.core.generic import NDFrame, _shared_docs
+from pandas.core.generic import ABCDataFrame, ABCSeries, NDFrame, _shared_docs
 from pandas.core.groupby import base
 from pandas.core.groupby.groupby import GroupBy, _apply_docs, _transform_template
 from pandas.core.index import Index, MultiIndex
@@ -1025,7 +1025,7 @@ class SeriesGroupBy(GroupBy):
             object.__setattr__(group, "name", name)
             res = wrapper(group)
 
-            if hasattr(res, "_values"):
+            if isinstance(res, (ABCDataFrame, ABCSeries)):
                 res = res._values
 
             indexer = self._get_index(name)

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -1001,3 +1001,27 @@ def test_ffill_not_in_axis(func, key, val):
     expected = df
 
     assert_frame_equal(result, expected)
+
+
+def test_transform_lambda_with_datetimetz():
+    # GH 27496
+    df = DataFrame(
+        {
+            "time": [
+                Timestamp("2010-07-15 03:14:45"),
+                Timestamp("2010-11-19 18:47:06"),
+            ],
+            "timezone": ["Etc/GMT+4", "US/Eastern"],
+        }
+    )
+    result = df.groupby(["timezone"])["time"].transform(
+        lambda x: x.dt.tz_localize(x.name)
+    )
+    expected = Series(
+        [
+            Timestamp("2010-07-15 03:14:45", tz="Etc/GMT+4"),
+            Timestamp("2010-11-19 18:47:06", tz="US/Eastern"),
+        ],
+        name="time",
+    )
+    assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #27496
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
