### PR TITLE
DOC:Remove DataFrame.append from the 10min intro

### DIFF
--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -491,21 +491,6 @@ Another example that can be given is:
    right
    pd.merge(left, right, on='key')
 
-
-Append
-~~~~~~
-
-Append rows to a dataframe. See the :ref:`Appending <merging.concatenation>`
-section.
-
-.. ipython:: python
-
-   df = pd.DataFrame(np.random.randn(8, 4), columns=['A', 'B', 'C', 'D'])
-   df
-   s = df.iloc[3]
-   df.append(s, ignore_index=True)
-
-
 Grouping
 --------
 

--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -469,12 +469,12 @@ Concatenating pandas objects together with :func:`concat`:
    pd.concat(pieces)
 
 .. note::
-   Adding a column to a ``DataFrame`` is relatively fast. However, adding 
-   a row requires a copy, and may be expensive. It is recommended to 
-   pass a pre-built list of records to the ``Dataframe`` constructor instead 
-   of building a ``Dataframe`` by iteratively appending records to it. 
+   Adding a column to a ``DataFrame`` is relatively fast. However, adding
+   a row requires a copy, and may be expensive. It is recommended to
+   pass a pre-built list of records to the ``Dataframe`` constructor instead
+   of building a ``Dataframe`` by iteratively appending records to it.
    See :ref:`Appending to dataframe <merging.concatenation>` for more.
-   
+
 Join
 ~~~~
 

--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -83,6 +83,14 @@ As you can see, the columns ``A``, ``B``, ``C``, and ``D`` are automatically
 tab completed. ``E`` is there as well; the rest of the attributes have been
 truncated for brevity.
 
+.. note::
+
+Adding a column to a DataFrame is relatively fast. Adding a row, however,
+requires a full copy of the data and a construction of a new Index, which
+may be expensive. Rather than iteratively building a DataFrame by
+appending records, we recommend passing the pre-built list of records
+to the DataFrame constructor. See :ref:`Appending to dataframe <merging.concatenation>` for more.
+
 Viewing data
 ------------
 

--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -469,12 +469,12 @@ Concatenating pandas objects together with :func:`concat`:
    pd.concat(pieces)
 
 .. note::
-   Adding a column to a DataFrame is relatively fast. Adding a row, however,
-   requires a full copy of the data and a construction of a new Index, which
-   may be expensive. Rather than iteratively building a DataFrame by
-   appending records, we recommend passing the pre-built list of records
-   to the DataFrame constructor. See :ref:`Appending to dataframe <merging.concatenation>` for more.
-
+   Adding a column to a ``DataFrame`` is relatively fast. However, adding 
+   a row requires a copy, and may be expensive. It is recommended to 
+   pass a pre-built list of records to the ``Dataframe`` constructor instead 
+   of building a ``Dataframe`` by iteratively appending records to it. 
+   See :ref:`Appending to dataframe <merging.concatenation>` for more.
+   
 Join
 ~~~~
 

--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -84,12 +84,11 @@ tab completed. ``E`` is there as well; the rest of the attributes have been
 truncated for brevity.
 
 .. note::
-
-Adding a column to a DataFrame is relatively fast. Adding a row, however,
-requires a full copy of the data and a construction of a new Index, which
-may be expensive. Rather than iteratively building a DataFrame by
-appending records, we recommend passing the pre-built list of records
-to the DataFrame constructor. See :ref:`Appending to dataframe <merging.concatenation>` for more.
+   Adding a column to a DataFrame is relatively fast. Adding a row, however,
+   requires a full copy of the data and a construction of a new Index, which
+   may be expensive. Rather than iteratively building a DataFrame by
+   appending records, we recommend passing the pre-built list of records
+   to the DataFrame constructor. See :ref:`Appending to dataframe <merging.concatenation>` for more.
 
 Viewing data
 ------------

--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -470,9 +470,9 @@ Concatenating pandas objects together with :func:`concat`:
 
 .. note::
    Adding a column to a ``DataFrame`` is relatively fast. However, adding
-   a row requires a copy, and may be expensive. It is recommended to
-   pass a pre-built list of records to the ``Dataframe`` constructor instead
-   of building a ``Dataframe`` by iteratively appending records to it.
+   a row requires a copy, and may be expensive. We recommend passing a
+   pre-built list of records to the ``DataFrame`` constructor instead
+   of building a ``DataFrame`` by iteratively appending records to it.
    See :ref:`Appending to dataframe <merging.concatenation>` for more.
 
 Join

--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -83,13 +83,6 @@ As you can see, the columns ``A``, ``B``, ``C``, and ``D`` are automatically
 tab completed. ``E`` is there as well; the rest of the attributes have been
 truncated for brevity.
 
-.. note::
-   Adding a column to a DataFrame is relatively fast. Adding a row, however,
-   requires a full copy of the data and a construction of a new Index, which
-   may be expensive. Rather than iteratively building a DataFrame by
-   appending records, we recommend passing the pre-built list of records
-   to the DataFrame constructor. See :ref:`Appending to dataframe <merging.concatenation>` for more.
-
 Viewing data
 ------------
 
@@ -474,6 +467,13 @@ Concatenating pandas objects together with :func:`concat`:
    pieces = [df[:3], df[3:7], df[7:]]
 
    pd.concat(pieces)
+
+.. note::
+   Adding a column to a DataFrame is relatively fast. Adding a row, however,
+   requires a full copy of the data and a construction of a new Index, which
+   may be expensive. Rather than iteratively building a DataFrame by
+   appending records, we recommend passing the pre-built list of records
+   to the DataFrame constructor. See :ref:`Appending to dataframe <merging.concatenation>` for more.
 
 Join
 ~~~~


### PR DESCRIPTION
Remove the `append` section from 10 min intro doc as complexity of that is very different than `list.append`

- [x] closes #27518

