### PR TITLE
TST: label-based indexing fails with certain list indexers in case of…

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1081,3 +1081,21 @@ def test_series_loc_getitem_label_list_missing_values():
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
         result = s.loc[key]
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "columns, column_key, expected_columns, check_column_type",
+    [
+        ([2011, 2012, 2013], [2011, 2012], [0, 1], True),
+        ([2011, 2012, "All"], [2011, 2012], [0, 1], False),
+        ([2011, 2012, "All"], [2011, "All"], [0, 2], True),
+    ],
+)
+def test_loc_getitem_label_list_integer_labels(
+    columns, column_key, expected_columns, check_column_type
+):
+    # gh-14836
+    df = DataFrame(np.random.rand(3, 3), columns=columns, index=list("ABC"))
+    expected = df.iloc[:, expected_columns]
+    result = df.loc[["A", "B", "C"], column_key]
+    tm.assert_frame_equal(result, expected, check_column_type=check_column_type)


### PR DESCRIPTION
… mixed integers/strings columns names

- [ ] closes #14836
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [n/a ] whatsnew entry
