### PR TITLE
Revert CI changes from 27542

### DIFF
--- a/ci/deps/azure-36-locale.yaml
+++ b/ci/deps/azure-36-locale.yaml
@@ -7,6 +7,7 @@ dependencies:
   - bottleneck=1.2.*
   - cython=0.28.2
   - lxml
+  - matplotlib=2.2.2
   - numpy=1.14.*
   - openpyxl=2.4.8
   - python-dateutil

--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -11,6 +11,7 @@ dependencies:
   - gcsfs
   - geopandas
   - html5lib
+  - matplotlib
   - moto
   - nomkl
   - numexpr
@@ -38,8 +39,8 @@ dependencies:
   - xlsxwriter
   - xlwt
   # universal
-  - pytest>=4.0.2,<5.0.0
-  - pytest-xdist==1.28.0
+  - pytest
+  - pytest-xdist
   - pytest-cov
   - pytest-mock
   - hypothesis>=3.58.0

--- a/ci/deps/travis-36-locale.yaml
+++ b/ci/deps/travis-36-locale.yaml
@@ -35,7 +35,7 @@ dependencies:
   - xlwt
   # universal
   - pytest>=4.0.2
-  - pytest-xdist>=1.29.0
+  - pytest-xdist
   - pytest-mock
   - pip
   - pip:


### PR DESCRIPTION
- [X] closes #27546
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Think this was all a perfect storm of temporary issues, so let's see what reverting yields. 

Note: didn't revert the sudo tag removal on purpose