### PR TITLE
BUG: Allow ensure_index to coerce nan to NaT with numpy object array and tz Timestamp

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -50,7 +50,7 @@ Timedelta
 Timezones
 ^^^^^^^^^
 
--
+- Bug in :class:`Index` where a numpy object array with a timezone aware :class:`Timestamp` and ``np.nan`` would not return a :class:`DatetimeIndex` (:issue:`27011`)
 -
 -
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -469,19 +469,15 @@ class Index(IndexOpsMixin, PandasObject):
                     pass
                 elif inferred != "string":
                     if inferred.startswith("datetime"):
-                        if (
-                            lib.is_datetime_with_singletz_array(subarr)
-                            or "tz" in kwargs
-                        ):
-                            # only when subarr has the same tz
-                            from pandas import DatetimeIndex
+                        from pandas import DatetimeIndex
 
-                            try:
-                                return DatetimeIndex(
-                                    subarr, copy=copy, name=name, **kwargs
-                                )
-                            except OutOfBoundsDatetime:
-                                pass
+                        try:
+                            return DatetimeIndex(subarr, copy=copy, name=name, **kwargs)
+                        except (ValueError, OutOfBoundsDatetime):
+                            # GH 27011
+                            # If we have mixed timezones, just send it
+                            # down the base constructor
+                            pass
 
                     elif inferred.startswith("timedelta"):
                         from pandas import TimedeltaIndex

--- a/pandas/tests/arrays/interval/test_interval.py
+++ b/pandas/tests/arrays/interval/test_interval.py
@@ -42,10 +42,9 @@ class TestAttributes:
             (0, 1),
             (Timedelta("0 days"), Timedelta("1 day")),
             (Timestamp("2018-01-01"), Timestamp("2018-01-02")),
-            pytest.param(
+            (
                 Timestamp("2018-01-01", tz="US/Eastern"),
                 Timestamp("2018-01-02", tz="US/Eastern"),
-                marks=pytest.mark.xfail(strict=True, reason="GH 27011"),
             ),
         ],
     )

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -822,6 +822,12 @@ class TestDatetimeIndex:
         with pytest.raises(ValueError):
             pd.DatetimeIndex(["2000"], dtype="datetime64[us]")
 
+    def test_index_constructor_with_numpy_object_array_and_timestamp_tz_with_nan(self):
+        # GH 27011
+        result = Index(np.array([Timestamp("2019", tz="UTC"), np.nan], dtype=object))
+        expected = DatetimeIndex([Timestamp("2019", tz="UTC"), pd.NaT])
+        tm.assert_index_equal(result, expected)
+
 
 class TestTimeSeries:
     def test_dti_constructor_preserve_dti_freq(self):


### PR DESCRIPTION
- [x] closes #27011
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
