### PR TITLE
Fix docstrings

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -90,7 +90,7 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
     """
     A pandas ExtensionArray for NumPy data.
 
-    .. versionadded :: 0.24.0
+    .. versionadded:: 0.24.0
 
     This is mostly for internal compatibility, and is not especially
     useful on its own.

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -2102,7 +2102,7 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
     """
     DataFrame accessor for sparse data.
 
-    .. versionadded :: 0.25.0
+    .. versionadded:: 0.25.0
     """
 
     def _validate(self, data):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -727,7 +727,7 @@ class IndexOpsMixin:
         """
         Return the first element of the underlying data as a python scalar.
 
-        .. deprecated 0.25.0
+        .. deprecated:: 0.25.0
 
         Returns
         -------

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1559,7 +1559,7 @@ class IndexOpsMixin:
             A scalar or array of insertion points with the
             same shape as `value`.
 
-            .. versionchanged :: 0.24.0
+            .. versionchanged:: 0.24.0
                 If `value` is a scalar, an int is now always returned.
                 Previously, scalar inputs returned an 1-item array for
                 :class:`Series` and :class:`Categorical`.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -310,11 +310,11 @@ class DataFrame(NDFrame):
     data : ndarray (structured or homogeneous), Iterable, dict, or DataFrame
         Dict can contain Series, arrays, constants, or list-like objects
 
-        .. versionchanged :: 0.23.0
+        .. versionchanged:: 0.23.0
            If data is a dict, column order follows insertion-order for
            Python 3.6 and later.
 
-        .. versionchanged :: 0.25.0
+        .. versionchanged:: 0.25.0
            If data is a list of dicts, column order follows insertion-order
            Python 3.6 and later.
 
@@ -3560,7 +3560,7 @@ class DataFrame(NDFrame):
         or modified columns. All items are computed first, and then assigned
         in alphabetical order.
 
-        .. versionchanged :: 0.23.0
+        .. versionchanged:: 0.23.0
 
            Keyword argument order is maintained for Python 3.6 and later.
 
@@ -5628,7 +5628,7 @@ class DataFrame(NDFrame):
             If 'raise', will raise a ValueError if the DataFrame and `other`
             both contain non-NA data in the same place.
 
-            .. versionchanged :: 0.24.0
+            .. versionchanged:: 0.24.0
                Changed from `raise_conflict=False|True`
                to `errors='ignore'|'raise'`.
 
@@ -5774,7 +5774,7 @@ class DataFrame(NDFrame):
             specified, all remaining columns will be used and the result will
             have hierarchically indexed columns.
 
-            .. versionchanged :: 0.23.0
+            .. versionchanged:: 0.23.0
                Also accept list of column names.
 
         Returns
@@ -5903,7 +5903,7 @@ class DataFrame(NDFrame):
             If True: only show observed values for categorical groupers.
             If False: show all values for categorical groupers.
 
-            .. versionchanged :: 0.25.0
+            .. versionchanged:: 0.25.0
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11490,7 +11490,7 @@ min_count : int, default 0
     The required number of valid values to perform the operation. If fewer than
     ``min_count`` non-NA values are present the result will be NA.
 
-    .. versionadded :: 0.22.0
+    .. versionadded:: 0.22.0
 
        Added with the default being 0. This means the sum of an all-NA
        or empty Series is 0, and the product of an all-NA or empty

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -931,7 +931,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         return the first element of the underlying data as a python
         scalar
 
-        .. deprecated 0.25.0
+        .. deprecated:: 0.25.0
 
         """
         warnings.warn(

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -156,7 +156,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     data : array-like, Iterable, dict, or scalar value
         Contains data stored in Series.
 
-        .. versionchanged :: 0.23.0
+        .. versionchanged:: 0.23.0
            If data is a dict, argument order is maintained for Python 3.6
            and later.
 
@@ -370,7 +370,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Construct Series from array.
 
-        .. deprecated :: 0.23.0
+        .. deprecated:: 0.23.0
             Use pd.Series(..) constructor instead.
 
         Returns
@@ -597,7 +597,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Return object Series which contains boxed values.
 
-        .. deprecated :: 0.23.0
+        .. deprecated:: 0.23.0
 
            Use ``astype(object)`` instead.
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -952,7 +952,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Return the real value of vector.
 
-        .. deprecated 0.25.0
+        .. deprecated:: 0.25.0
         """
         warnings.warn(
             "`real` has be deprecated and will be removed in a future version",
@@ -970,7 +970,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Return imag value of vector.
 
-        .. deprecated 0.25.0
+        .. deprecated:: 0.25.0
         """
         warnings.warn(
             "`imag` has be deprecated and will be removed in a future version",

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -49,7 +49,7 @@ class SparseDataFrame(DataFrame):
     Parameters
     ----------
     data : same types as can be passed to DataFrame or scipy.sparse.spmatrix
-        .. versionchanged :: 0.23.0
+        .. versionchanged:: 0.23.0
            If data is a dict, argument order is maintained for Python 3.6
            and later.
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -55,7 +55,7 @@ class SparseSeries(Series):
     Parameters
     ----------
     data : {array-like, Series, SparseSeries, dict}
-        .. versionchanged :: 0.23.0
+        .. versionchanged:: 0.23.0
            If data is a dict, argument order is maintained for Python 3.6
            and later.
 

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -71,7 +71,7 @@ def read_feather(path, columns=None, use_threads=True):
     """
     Load a feather-format object from the file path.
 
-    .. versionadded 0.20.0
+    .. versionadded:: 0.20.0
 
     Parameters
     ----------
@@ -90,16 +90,16 @@ def read_feather(path, columns=None, use_threads=True):
     columns : sequence, default None
         If not provided, all columns are read.
 
-        .. versionadded 0.24.0
+        .. versionadded:: 0.24.0
     nthreads : int, default 1
         Number of CPU threads to use when reading to pandas.DataFrame.
 
-       .. versionadded 0.21.0
-       .. deprecated 0.24.0
+       .. versionadded:: 0.21.0
+       .. deprecated:: 0.24.0
     use_threads : bool, default True
         Whether to parallelize reading using multiple threads.
 
-       .. versionadded 0.24.0
+       .. versionadded:: 0.24.0
 
     Returns
     -------

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -231,7 +231,7 @@ def to_parquet(
         ``False``, they will not be written to the file. If ``None``, the
         engine's default behavior will be used.
 
-        .. versionadded 0.24.0
+        .. versionadded:: 0.24.0
 
     partition_cols : list, optional, default None
         Column names by which to partition the dataset
@@ -257,7 +257,7 @@ def read_parquet(path, engine="auto", columns=None, **kwargs):
     """
     Load a parquet object from the file path, returning a DataFrame.
 
-    .. versionadded 0.21.0
+    .. versionadded:: 0.21.0
 
     Parameters
     ----------
@@ -281,7 +281,7 @@ def read_parquet(path, engine="auto", columns=None, **kwargs):
     columns : list, default=None
         If not None, only these columns will be read from the file.
 
-        .. versionadded 0.21.1
+        .. versionadded:: 0.21.1
     **kwargs
         Any additional kwargs are passed to the engine.
 

--- a/pandas/io/spss.py
+++ b/pandas/io/spss.py
@@ -15,7 +15,7 @@ def read_spss(
     """
     Load an SPSS file from the file path, returning a DataFrame.
 
-    .. versionadded 0.25.0
+    .. versionadded:: 0.25.0
 
     Parameters
     ----------


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This fixes some docstring formatting issues: e.g. some deprecated directives do not appear in current docs because the two colons are missing `.. deprecated 0.25.0`.