### PR TITLE
CLN: de-kludge quantile, make interpolate_with_fill understand datetime64

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2456,15 +2456,7 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
                 result = self._holder._from_sequence(
                     result.astype(np.int64), freq=None, dtype=self.values.dtype
                 )
-            elif result.dtype == "M8[ns]":
-                # otherwise we get here via quantile and already have M8[ns]
-                result = self._holder._simple_new(
-                    result, freq=None, dtype=self.values.dtype
-                )
 
-        elif isinstance(result, np.datetime64):
-            # also for post-quantile
-            result = self._box_func(result)
         return result
 
     @property

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -908,7 +908,7 @@ class BlockManager(PandasObject):
             # Such assignment may incorrectly coerce NaT to None
             # result[blk.mgr_locs] = blk._slice((slice(None), loc))
             for i, rl in enumerate(blk.mgr_locs):
-                result[rl] = blk._try_coerce_result(blk.iget((i, loc)))
+                result[rl] = blk.iget((i, loc))
 
         if is_extension_array_dtype(dtype):
             result = dtype.construct_array_type()._from_sequence(result, dtype=dtype)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -466,8 +466,12 @@ def interpolate_2d(
     if is_datetime64tz_dtype(values):
         naive = values.view("M8[ns]")
         result = interpolate_2d(
-            naive, method=method, axis=axis, limit=limit,
-            fill_value=fill_value, dtype=dtype
+            naive,
+            method=method,
+            axis=axis,
+            limit=limit,
+            fill_value=fill_value,
+            dtype=dtype,
         )
         return type(values)._from_sequence(result, dtype=values.dtype)
 
@@ -499,7 +503,7 @@ def interpolate_2d(
     if ndim == 1:
         values = values[0]
 
-    if orig_values.dtype.kind == 'M':
+    if orig_values.dtype.kind == "M":
         # convert float back to datetime64
         values = values.astype(orig_values.dtype)
 


### PR DESCRIPTION
2 related-but-separate things here

-quantile: de-kludging the base class method and putting the datetimetz-specific stuff in a subclass method.  This will allow us to implement the refactor suggested in #14562.  If/when DTA supports 2D, we'll be able to get rid of the subclass override kludge altogether.

- interpolate_2d: have the core.missing function understand datetime64 dtypes so the blocks don't have to implement special handling.  There are only a couple other places where this is needed before we can get rid of the datetimetz-specific try_coerce_result altogether.