### PR TITLE
Make interpolate_2d handle datetime64 correctly

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1223,7 +1223,6 @@ class Block(PandasObject):
             fill_value=fill_value,
             dtype=self.dtype,
         )
-        values = self._try_coerce_result(values)
 
         blocks = [self.make_block_same_class(values, ndim=self.ndim)]
         return self._maybe_downcast(blocks, downcast)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2293,13 +2293,6 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
 
         return other
 
-    def _try_coerce_result(self, result):
-        """ reverse of try_coerce_args """
-        if isinstance(result, np.ndarray) and result.dtype.kind == "i":
-            # needed for _interpolate_with_ffill
-            result = result.view("M8[ns]")
-        return result
-
     def to_native_types(
         self, slicer=None, na_rep=None, date_format=None, quoting=None, **kwargs
     ):

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -463,18 +463,6 @@ def interpolate_2d(
     Perform an actual interpolation of values, values will be make 2-d if
     needed fills inplace, returns the result.
     """
-    if is_datetime64tz_dtype(values):
-        naive = values.view("M8[ns]")
-        result = interpolate_2d(
-            naive,
-            method=method,
-            axis=axis,
-            limit=limit,
-            fill_value=fill_value,
-            dtype=dtype,
-        )
-        return type(values)._from_sequence(result, dtype=values.dtype)
-
     orig_values = values
 
     transf = (lambda x: x) if axis == 0 else (lambda x: x.T)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -463,6 +463,19 @@ def interpolate_2d(
     Perform an actual interpolation of values, values will be make 2-d if
     needed fills inplace, returns the result.
     """
+    if is_datetime64tz_dtype(values):
+        naive = values.view("M8[ns]")
+        result = interpolate_2d(
+            naive,
+            method=method,
+            axis=axis,
+            limit=limit,
+            fill_value=fill_value,
+            dtype=dtype,
+        )
+        return type(values)._from_sequence(result, dtype=values.dtype)
+
+    orig_values = values
 
     transf = (lambda x: x) if axis == 0 else (lambda x: x.T)
 
@@ -470,7 +483,7 @@ def interpolate_2d(
     ndim = values.ndim
     if values.ndim == 1:
         if axis != 0:  # pragma: no cover
-            raise AssertionError("cannot interpolate on a ndim == 1 with " "axis != 0")
+            raise AssertionError("cannot interpolate on a ndim == 1 with axis != 0")
         values = values.reshape(tuple((1,) + values.shape))
 
     if fill_value is None:
@@ -489,6 +502,10 @@ def interpolate_2d(
     # reshape back
     if ndim == 1:
         values = values[0]
+
+    if orig_values.dtype.kind == "M":
+        # convert float back to datetime64
+        values = values.astype(orig_values.dtype)
 
     return values
 

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -885,7 +885,7 @@ def test_resample_dtype_preservation():
     assert result.val.dtype == np.int32
 
 
-def test_resample_dtype_coerceion():
+def test_resample_dtype_coercion():
 
     pytest.importorskip("scipy.interpolate")
 

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1535,7 +1535,7 @@ class TestSeriesInterpolateData:
 
     def test_interp_pad_datetime64tz_values(self):
         # GH#27628 missing.interpolate_2d should handle datetimetz values
-        dti = pd.date_range('2015-04-05', periods=3, tz="US/Central")
+        dti = pd.date_range("2015-04-05", periods=3, tz="US/Central")
         ser = pd.Series(dti)
         ser[1] = pd.NaT
         result = ser.interpolate(method="pad")

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1533,6 +1533,17 @@ class TestSeriesInterpolateData:
         )
         assert_series_equal(result, expected)
 
+    def test_interp_pad_datetime64tz_values(self):
+        # GH#27628 missing.interpolate_2d should handle datetimetz values
+        dti = pd.date_range('2015-04-05', periods=3, tz="US/Central")
+        ser = pd.Series(dti)
+        ser[1] = pd.NaT
+        result = ser.interpolate(method="pad")
+
+        expected = pd.Series(dti)
+        expected[1] = expected[0]
+        tm.assert_series_equal(result, expected)
+
     def test_interp_limit_no_nans(self):
         # GH 7173
         s = pd.Series([1.0, 2.0, 3.0])


### PR DESCRIPTION
Broken off from #27626 because I decided that is poorly scoped.