### PR TITLE
Handle construction of string ExtensionArray from lists

### DIFF
--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -470,7 +470,9 @@ def sanitize_array(data, index, dtype=None, copy=False, raise_cast_failure=False
 
     # This is to prevent mixed-type Series getting all casted to
     # NumPy string type, e.g. NaN --> '-1#IND'.
-    if issubclass(subarr.dtype.type, str):
+    if not (
+        is_extension_array_dtype(subarr.dtype) or is_extension_array_dtype(dtype)
+    ) and issubclass(subarr.dtype.type, str):
         # GH#16605
         # If not empty convert the data to dtype
         # GH#19853: If data is a scalar, subarr has already the result

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -468,32 +468,27 @@ def sanitize_array(data, index, dtype=None, copy=False, raise_cast_failure=False
         else:
             subarr = com.asarray_tuplesafe(data, dtype=dtype)
 
-    # This is to prevent mixed-type Series getting all casted to
-    # NumPy string type, e.g. NaN --> '-1#IND'.
-    if not (
-        is_extension_array_dtype(subarr.dtype) or is_extension_array_dtype(dtype)
-    ) and issubclass(subarr.dtype.type, str):
-        # GH#16605
-        # If not empty convert the data to dtype
-        # GH#19853: If data is a scalar, subarr has already the result
-        if not lib.is_scalar(data):
-            if not np.all(isna(data)):
-                data = np.array(data, dtype=dtype, copy=False)
-            subarr = np.array(data, dtype=object, copy=copy)
+    if not (is_extension_array_dtype(subarr.dtype) or is_extension_array_dtype(dtype)):
+        # This is to prevent mixed-type Series getting all casted to
+        # NumPy string type, e.g. NaN --> '-1#IND'.
+        if issubclass(subarr.dtype.type, str):
+            # GH#16605
+            # If not empty convert the data to dtype
+            # GH#19853: If data is a scalar, subarr has already the result
+            if not lib.is_scalar(data):
+                if not np.all(isna(data)):
+                    data = np.array(data, dtype=dtype, copy=False)
+                subarr = np.array(data, dtype=object, copy=copy)
 
-    if (
-        not (is_extension_array_dtype(subarr.dtype) or is_extension_array_dtype(dtype))
-        and is_object_dtype(subarr.dtype)
-        and not is_object_dtype(dtype)
-    ):
-        inferred = lib.infer_dtype(subarr, skipna=False)
-        if inferred == "period":
-            from pandas.core.arrays import period_array
+        if is_object_dtype(subarr.dtype) and not is_object_dtype(dtype):
+            inferred = lib.infer_dtype(subarr, skipna=False)
+            if inferred == "period":
+                from pandas.core.arrays import period_array
 
-            try:
-                subarr = period_array(subarr)
-            except IncompatibleFrequency:
-                pass
+                try:
+                    subarr = period_array(subarr)
+                except IncompatibleFrequency:
+                    pass
 
     return subarr
 

--- a/pandas/tests/extension/arrow/arrays.py
+++ b/pandas/tests/extension/arrow/arrays.py
@@ -78,6 +78,9 @@ class ArrowExtensionArray(ExtensionArray):
     def _from_sequence(cls, scalars, dtype=None, copy=False):
         return cls.from_scalars(scalars)
 
+    def __repr__(self):
+        return "{cls}({data})".format(cls=type(self).__name__, data=repr(self._data))
+
     def __getitem__(self, item):
         if pd.api.types.is_scalar(item):
             return self._data.to_pandas()[item]
@@ -162,9 +165,6 @@ class ArrowBoolArray(ArrowExtensionArray):
         self._data = values
         self._dtype = ArrowBoolDtype()
 
-    def __repr__(self):
-        return "ArrowBoolArray({})".format(repr(self._data))
-
 
 class ArrowStringArray(ArrowExtensionArray):
     def __init__(self, values):
@@ -174,6 +174,3 @@ class ArrowStringArray(ArrowExtensionArray):
         assert values.type == pa.string()
         self._data = values
         self._dtype = ArrowStringDtype()
-
-    def __repr__(self):
-        return "ArrowStringArray({})".format(repr(self._data))

--- a/pandas/tests/extension/arrow/arrays.py
+++ b/pandas/tests/extension/arrow/arrays.py
@@ -43,18 +43,27 @@ class ArrowBoolDtype(ExtensionDtype):
         return True
 
 
-class ArrowBoolArray(ExtensionArray):
-    def __init__(self, values):
-        if not isinstance(values, pa.ChunkedArray):
-            raise ValueError
+@register_extension_dtype
+class ArrowStringDtype(ExtensionDtype):
 
-        assert values.type == pa.bool_()
-        self._data = values
-        self._dtype = ArrowBoolDtype()
+    type = str
+    kind = "U"
+    name = "arrow_string"
+    na_value = pa.NULL
 
-    def __repr__(self):
-        return "ArrowBoolArray({})".format(repr(self._data))
+    @classmethod
+    def construct_from_string(cls, string):
+        if string == cls.name:
+            return cls()
+        else:
+            raise TypeError("Cannot construct a '{}' from '{}'".format(cls, string))
 
+    @classmethod
+    def construct_array_type(cls):
+        return ArrowStringArray
+
+
+class ArrowExtensionArray(ExtensionArray):
     @classmethod
     def from_scalars(cls, values):
         arr = pa.chunked_array([pa.array(np.asarray(values))])
@@ -142,3 +151,29 @@ class ArrowBoolArray(ExtensionArray):
 
     def all(self, axis=0, out=None):
         return self._data.to_pandas().all()
+
+
+class ArrowBoolArray(ArrowExtensionArray):
+    def __init__(self, values):
+        if not isinstance(values, pa.ChunkedArray):
+            raise ValueError
+
+        assert values.type == pa.bool_()
+        self._data = values
+        self._dtype = ArrowBoolDtype()
+
+    def __repr__(self):
+        return "ArrowBoolArray({})".format(repr(self._data))
+
+
+class ArrowStringArray(ArrowExtensionArray):
+    def __init__(self, values):
+        if not isinstance(values, pa.ChunkedArray):
+            raise ValueError
+
+        assert values.type == pa.string()
+        self._data = values
+        self._dtype = ArrowStringDtype()
+
+    def __repr__(self):
+        return "ArrowStringArray({})".format(repr(self._data))

--- a/pandas/tests/extension/arrow/test_bool.py
+++ b/pandas/tests/extension/arrow/test_bool.py
@@ -7,7 +7,7 @@ import pandas.util.testing as tm
 
 pytest.importorskip("pyarrow", minversion="0.10.0")
 
-from .bool import ArrowBoolArray, ArrowBoolDtype  # isort:skip
+from .arrays import ArrowBoolArray, ArrowBoolDtype  # isort:skip
 
 
 @pytest.fixture

--- a/pandas/tests/extension/arrow/test_string.py
+++ b/pandas/tests/extension/arrow/test_string.py
@@ -1,0 +1,13 @@
+import pytest
+
+import pandas as pd
+
+pytest.importorskip("pyarrow", minversion="0.10.0")
+
+from .arrays import ArrowStringDtype  # isort:skip
+
+
+def test_constructor_from_list():
+    # GH 27673
+    result = pd.Series(["E"], dtype=ArrowStringDtype())
+    assert isinstance(result.dtype, ArrowStringDtype)


### PR DESCRIPTION
I had to add a string-based Arrow Extension array to trigger the bug but did not run the same test suite as we do on the boolean array as I don't see it adding value but just runtime at the moment.

- [x] closes #27673
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
