### PR TITLE
BUG: Concatenation warning still appears with sort=False

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -125,7 +125,7 @@ Reshaping
 ^^^^^^^^^
 
 - A ``KeyError`` is now raised if ``.unstack()`` is called on a :class:`Series` or :class:`DataFrame` with a flat :class:`Index` passing a name which is not the correct one (:issue:`18303`)
-- :meth:`DataFrame.join` now suppresses the ``FutureWarning`` when the sort parameter is specified (:issue:`21952`) 
+- :meth:`DataFrame.join` now suppresses the ``FutureWarning`` when the sort parameter is specified (:issue:`21952`)
 -
 
 Sparse

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -125,7 +125,7 @@ Reshaping
 ^^^^^^^^^
 
 - A ``KeyError`` is now raised if ``.unstack()`` is called on a :class:`Series` or :class:`DataFrame` with a flat :class:`Index` passing a name which is not the correct one (:issue:`18303`)
--
+- :meth:`DataFrame.join` now suppresses the ``FutureWarning`` when the sort parameter is specified (:issue:`21952`) 
 -
 
 Sparse

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7217,10 +7217,10 @@ class DataFrame(NDFrame):
             # join indexes only using concat
             if can_concat:
                 if how == "left":
-                    res = concat(frames, axis=1, join="outer", verify_integrity=True)
+                    res = concat(frames, axis=1, join="outer", verify_integrity=True, sort=sort)
                     return res.reindex(self.index, copy=False)
                 else:
-                    return concat(frames, axis=1, join=how, verify_integrity=True)
+                    return concat(frames, axis=1, join=how, verify_integrity=True, sort=sort)
 
             joined = frames[0]
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7217,10 +7217,14 @@ class DataFrame(NDFrame):
             # join indexes only using concat
             if can_concat:
                 if how == "left":
-                    res = concat(frames, axis=1, join="outer", verify_integrity=True, sort=sort)
+                    res = concat(
+                        frames, axis=1, join="outer", verify_integrity=True, sort=sort
+                    )
                     return res.reindex(self.index, copy=False)
                 else:
-                    return concat(frames, axis=1, join=how, verify_integrity=True, sort=sort)
+                    return concat(
+                        frames, axis=1, join=how, verify_integrity=True, sort=sort
+                    )
 
             joined = frames[0]
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7218,12 +7218,12 @@ class DataFrame(NDFrame):
             if can_concat:
                 if how == "left":
                     res = concat(
-                        frames, axis=1, join="outer", verify_integrity=True, sort=sort
+                        frames, axis=1, join="outer", verify_integrity=True, #sort=sort
                     )
                     return res.reindex(self.index, copy=False)
                 else:
                     return concat(
-                        frames, axis=1, join=how, verify_integrity=True, sort=sort
+                        frames, axis=1, join=how, verify_integrity=True,# sort=sort
                     )
 
             joined = frames[0]

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7218,12 +7218,12 @@ class DataFrame(NDFrame):
             if can_concat:
                 if how == "left":
                     res = concat(
-                        frames, axis=1, join="outer", verify_integrity=True, #sort=sort
+                        frames, axis=1, join="outer", verify_integrity=True, sort=sort
                     )
                     return res.reindex(self.index, copy=False)
                 else:
                     return concat(
-                        frames, axis=1, join=how, verify_integrity=True,# sort=sort
+                        frames, axis=1, join=how, verify_integrity=True, sort=sort
                     )
 
             joined = frames[0]

--- a/pandas/tests/frame/test_join.py
+++ b/pandas/tests/frame/test_join.py
@@ -205,18 +205,16 @@ def test_join_left_sequence_non_unique_index():
 
 def test_suppress_future_warning_with_sort_kw(sort_kw):
     a = DataFrame(
-        {'col1': [1, 2, 3, 4, 5],
-        'col2': [6, 7, 8, 9, 10]},
-        index=['a', 'c', 'e', 'f', 'i'])
+        {"col1": [1, 2, 3, 4, 5], "col2": [6, 7, 8, 9, 10]},
+        index=["a", "c", "e", "f", "i"],
+    )
 
     b = DataFrame(
-        {'col4': [1, 2, 3, 4, 5],
-        'col3': [1, 2, 3, 4, 5]},
-        index=['a', 'b', 'c', 'd', 'e'])
+        {"col4": [1, 2, 3, 4, 5], "col3": [1, 2, 3, 4, 5]},
+        index=["a", "b", "c", "d", "e"],
+    )
 
-    c = DataFrame(
-        {'col5': [1, 2, 3, 4, 5]},
-        index=['f', 'g', 'h', 'i', 'j'])
+    c = DataFrame({"col5": [1, 2, 3, 4, 5]}, index=["f", "g", "h", "i", "j"])
 
     if sort_kw is None:
         # only warn if not explicitly specified

--- a/pandas/tests/frame/test_join.py
+++ b/pandas/tests/frame/test_join.py
@@ -204,26 +204,21 @@ def test_join_left_sequence_non_unique_index():
 
 
 def test_suppress_future_warning_with_sort_kw(sort_kw):
-    a = DataFrame(
-        {'col1': [1, 2]},
-        index=['c', 'a']
+    a = DataFrame({"col1": [1, 2]}, index=["c", "a"])
+
+    b = DataFrame({"col2": [4, 5]}, index=["b", "a"])
+
+    c = DataFrame({"col3": [7, 8]}, index=["a", "b"])
+
+    expected = DataFrame(
+        {
+            "col1": {"a": 2.0, "b": float("nan"), "c": 1.0},
+            "col2": {"a": 5.0, "b": 4.0, "c": float("nan")},
+            "col3": {"a": 7.0, "b": 8.0, "c": float("nan")},
+        }
     )
-
-    b = DataFrame(
-        {'col2': [4, 5]},
-        index=['b', 'a']
-    )
-
-    c = DataFrame(
-        {'col3': [7, 8]},
-        index=['a', 'b']
-    )
-
-
-    expected = DataFrame( {'col1': {'a': 2.0, 'b': float('nan'), 'c': 1.0}, 'col2': {'a': 5.0, 'b': 4.0, 'c': float('nan')}, 'col3': {'a': 7.0, 'b': 8.0, 'c': float('nan')}} )
     if sort_kw is False:
-        expected = expected.reindex(index=['c', 'a', 'b'])
-
+        expected = expected.reindex(index=["c", "a", "b"])
 
     if sort_kw is None:
         # only warn if not explicitly specified
@@ -232,5 +227,5 @@ def test_suppress_future_warning_with_sort_kw(sort_kw):
         ctx = tm.assert_produces_warning(None, check_stacklevel=False)
 
     with ctx:
-        result = a.join([b, c], how='outer', sort=sort_kw)
+        result = a.join([b, c], how="outer", sort=sort_kw)
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_join.py
+++ b/pandas/tests/frame/test_join.py
@@ -24,6 +24,14 @@ def right():
     return DataFrame({"b": [300, 100, 200]}, index=[3, 1, 2])
 
 
+@pytest.fixture(params=[True, False, None])
+def sort_kw(request):
+    """Boolean sort keyword for join.
+    Includes the default of None.
+    """
+    return request.param
+
+
 @pytest.mark.parametrize(
     "how, sort, expected",
     [
@@ -193,3 +201,28 @@ def test_join_left_sequence_non_unique_index():
     )
 
     tm.assert_frame_equal(joined, expected)
+
+
+def test_suppress_future_warning_with_sort_kw(sort_kw):
+    a = DataFrame(
+        {'col1': [1, 2, 3, 4, 5],
+        'col2': [6, 7, 8, 9, 10]},
+        index=['a', 'c', 'e', 'f', 'i'])
+
+    b = DataFrame(
+        {'col4': [1, 2, 3, 4, 5],
+        'col3': [1, 2, 3, 4, 5]},
+        index=['a', 'b', 'c', 'd', 'e'])
+
+    c = DataFrame(
+        {'col5': [1, 2, 3, 4, 5]},
+        index=['f', 'g', 'h', 'i', 'j'])
+
+    if sort_kw is None:
+        # only warn if not explicitly specified
+        ctx = tm.assert_produces_warning(FutureWarning, check_stacklevel=False)
+    else:
+        ctx = tm.assert_produces_warning(None, check_stacklevel=False)
+
+    with ctx:
+        a.join([b, c], sort=sort_kw)

--- a/pandas/tests/frame/test_join.py
+++ b/pandas/tests/frame/test_join.py
@@ -24,14 +24,6 @@ def right():
     return DataFrame({"b": [300, 100, 200]}, index=[3, 1, 2])
 
 
-@pytest.fixture(params=[True, False, None])
-def sort_kw(request):
-    """Boolean sort keyword for join.
-    Includes the default of None.
-    """
-    return request.param
-
-
 @pytest.mark.parametrize(
     "how, sort, expected",
     [
@@ -203,6 +195,7 @@ def test_join_left_sequence_non_unique_index():
     tm.assert_frame_equal(joined, expected)
 
 
+@pytest.mark.parametrize("sort_kw", [True, False, None])
 def test_suppress_future_warning_with_sort_kw(sort_kw):
     a = DataFrame({"col1": [1, 2]}, index=["c", "a"])
 

--- a/pandas/tests/frame/test_join.py
+++ b/pandas/tests/frame/test_join.py
@@ -205,16 +205,25 @@ def test_join_left_sequence_non_unique_index():
 
 def test_suppress_future_warning_with_sort_kw(sort_kw):
     a = DataFrame(
-        {"col1": [1, 2, 3, 4, 5], "col2": [6, 7, 8, 9, 10]},
-        index=["a", "c", "e", "f", "i"],
+        {'col1': [1, 2]},
+        index=['c', 'a']
     )
 
     b = DataFrame(
-        {"col4": [1, 2, 3, 4, 5], "col3": [1, 2, 3, 4, 5]},
-        index=["a", "b", "c", "d", "e"],
+        {'col2': [4, 5]},
+        index=['b', 'a']
     )
 
-    c = DataFrame({"col5": [1, 2, 3, 4, 5]}, index=["f", "g", "h", "i", "j"])
+    c = DataFrame(
+        {'col3': [7, 8]},
+        index=['a', 'b']
+    )
+
+
+    expected = DataFrame( {'col1': {'a': 2.0, 'b': float('nan'), 'c': 1.0}, 'col2': {'a': 5.0, 'b': 4.0, 'c': float('nan')}, 'col3': {'a': 7.0, 'b': 8.0, 'c': float('nan')}} )
+    if sort_kw is False:
+        expected = expected.reindex(index=['c', 'a', 'b'])
+
 
     if sort_kw is None:
         # only warn if not explicitly specified
@@ -223,4 +232,5 @@ def test_suppress_future_warning_with_sort_kw(sort_kw):
         ctx = tm.assert_produces_warning(None, check_stacklevel=False)
 
     with ctx:
-        a.join([b, c], sort=sort_kw)
+        result = a.join([b, c], how='outer', sort=sort_kw)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #21952 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
