### PR TITLE
BUG: Avoid try/except in blocks, fix setitem bug in datetimelike EA

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -473,6 +473,8 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
         # to a period in from_sequence). For DatetimeArray, it's Timestamp...
         # I don't know if mypy can do that, possibly with Generics.
         # https://mypy.readthedocs.io/en/latest/generics.html
+        if lib.is_scalar(value) and not isna(value):
+            value = com.maybe_box_datetimelike(value)
 
         if is_list_like(value):
             is_slice = isinstance(key, slice)

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -179,6 +179,19 @@ class TestDatetimeArray:
         a[0] = pd.Timestamp("2000", tz="US/Central")
         assert a.freq is None
 
+    @pytest.mark.parametrize("obj", [
+        pd.Timestamp.now(),
+        pd.Timestamp.now().to_datetime64(),
+        pd.Timestamp.now().to_pydatetime(),
+    ])
+    def test_setitem_objects(self, obj):
+        # make sure we accept datetime64 and datetime in addition to Timestamp
+        dti = pd.date_range("2000", periods=2, freq="D")
+        arr = dti._data
+
+        arr[0] = obj
+        assert arr[0] == obj
+
     def test_repeat_preserves_tz(self):
         dti = pd.date_range("2000", periods=2, freq="D", tz="US/Central")
         arr = DatetimeArray(dti)

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -179,11 +179,14 @@ class TestDatetimeArray:
         a[0] = pd.Timestamp("2000", tz="US/Central")
         assert a.freq is None
 
-    @pytest.mark.parametrize("obj", [
-        pd.Timestamp.now(),
-        pd.Timestamp.now().to_datetime64(),
-        pd.Timestamp.now().to_pydatetime(),
-    ])
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            pd.Timestamp.now(),
+            pd.Timestamp.now().to_datetime64(),
+            pd.Timestamp.now().to_pydatetime(),
+        ],
+    )
     def test_setitem_objects(self, obj):
         # make sure we accept datetime64 and datetime in addition to Timestamp
         dti = pd.date_range("2000", periods=2, freq="D")

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -125,11 +125,14 @@ class TestTimedeltaArray:
         a[0] = pd.Timedelta("1H")
         assert a.freq is None
 
-    @pytest.mark.parametrize("obj", [
-        pd.Timedelta(seconds=1),
-        pd.Timedelta(seconds=1).to_timedelta64(),
-        pd.Timedelta(seconds=1).to_pytimedelta()
-    ])
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            pd.Timedelta(seconds=1),
+            pd.Timedelta(seconds=1).to_timedelta64(),
+            pd.Timedelta(seconds=1).to_pytimedelta(),
+        ],
+    )
     def test_setitem_objects(self, obj):
         # make sure we accept timedelta64 and timedelta in addition to Timedelta
         tdi = pd.timedelta_range("2 Days", periods=4, freq="H")

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -125,6 +125,19 @@ class TestTimedeltaArray:
         a[0] = pd.Timedelta("1H")
         assert a.freq is None
 
+    @pytest.mark.parametrize("obj", [
+        pd.Timedelta(seconds=1),
+        pd.Timedelta(seconds=1).to_timedelta64(),
+        pd.Timedelta(seconds=1).to_pytimedelta()
+    ])
+    def test_setitem_objects(self, obj):
+        # make sure we accept timedelta64 and timedelta in addition to Timedelta
+        tdi = pd.timedelta_range("2 Days", periods=4, freq="H")
+        arr = TimedeltaArray(tdi, freq=tdi.freq)
+
+        arr[0] = obj
+        assert arr[0] == pd.Timedelta(seconds=1)
+
 
 class TestReductions:
     def test_min_max(self):

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -418,7 +418,7 @@ class TestIndexOps(Ops):
                     values = o._shallow_copy(v)
                 else:
                     o = o.copy()
-                    o[0:2] = iNaT
+                    o[0:2] = pd.NaT
                     values = o._values
 
             elif needs_i8_conversion(o):


### PR DESCRIPTION
The initial impetus for this was avoiding two try/excepts in Block methods (i.e. the diff in internals.blocks).  This uncovered the bug in DTA/TDA, which accounts for the rest of the diff.