### PR TITLE
Linebreak is bleeding into the documentation page

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -687,8 +687,7 @@ class IndexOpsMixin:
 
     T = property(
         transpose,
-        doc="""\nReturn the transpose, which is by
-                                definition self.\n""",
+        doc="""\nReturn the transpose, which is by definition self.\n""",
     )
 
     @property

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -687,7 +687,9 @@ class IndexOpsMixin:
 
     T = property(
         transpose,
-        doc="""\nReturn the transpose, which is by definition self.\n""",
+        doc="""
+        Return the transpose, which is by definition self.
+        """,
     )
 
     @property


### PR DESCRIPTION
https://pandas.pydata.org/pandas-docs/stable/reference/series.html

```html
<table><td>
...
<tr class="row-even"><td><a class="reference internal" href="api/pandas.Series.T.html#pandas.Series.T" title="pandas.Series.T"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Series.T</span></code></a></td>
<td>Return the transpose, which is by</td>
</tr>
...
</td>
</table>
```
And looks weird on https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.T.html#pandas.Series.T

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
