### PR TITLE
Removed continued parametrization of FilePathOrBuffer

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, AnyStr, Optional, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Optional, TypeVar, Union
 
 import numpy as np
 
@@ -22,7 +22,7 @@ AnyArrayLike = TypeVar(
 ArrayLike = TypeVar("ArrayLike", "ExtensionArray", np.ndarray)
 DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", "Period", "Timestamp", "Timedelta")
 Dtype = Union[str, np.dtype, "ExtensionDtype"]
-FilePathOrBuffer = Union[str, Path, IO[AnyStr]]
+FilePathOrBuffer = Union[str, Path, IO]
 
 FrameOrSeries = TypeVar("FrameOrSeries", "Series", "DataFrame")
 Scalar = Union[str, int, float]

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -10,7 +10,7 @@ import lzma
 import mmap
 import os
 import pathlib
-from typing import IO, AnyStr, BinaryIO, Optional, TextIO, Type
+from typing import IO, BinaryIO, Optional, TextIO, Type
 from urllib.error import URLError  # noqa
 from urllib.parse import (  # noqa
     urlencode,
@@ -96,9 +96,7 @@ def _is_url(url) -> bool:
         return False
 
 
-def _expand_user(
-    filepath_or_buffer: FilePathOrBuffer[AnyStr]
-) -> FilePathOrBuffer[AnyStr]:
+def _expand_user(filepath_or_buffer: FilePathOrBuffer) -> FilePathOrBuffer:
     """Return the argument with an initial component of ~ or ~user
        replaced by that user's home directory.
 
@@ -126,9 +124,7 @@ def _validate_header_arg(header) -> None:
         )
 
 
-def _stringify_path(
-    filepath_or_buffer: FilePathOrBuffer[AnyStr]
-) -> FilePathOrBuffer[AnyStr]:
+def _stringify_path(filepath_or_buffer: FilePathOrBuffer) -> FilePathOrBuffer:
     """Attempt to convert a path-like object to a string.
 
     Parameters

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -491,9 +491,7 @@ class TableFormatter:
         raise AbstractMethodError(self)
 
     def get_result(
-        self,
-        buf: Optional[FilePathOrBuffer] = None,
-        encoding: Optional[str] = None,
+        self, buf: Optional[FilePathOrBuffer] = None, encoding: Optional[str] = None
     ) -> Optional[str]:
         with self.get_buffer(buf, encoding=encoding) as f:
             self.write_result(buf=f)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -469,7 +469,7 @@ class TableFormatter:
 
     @contextmanager
     def get_buffer(
-        self, buf: Optional[FilePathOrBuffer[str]], encoding: Optional[str] = None
+        self, buf: Optional[FilePathOrBuffer], encoding: Optional[str] = None
     ):
         if buf is not None:
             buf = _stringify_path(buf)
@@ -492,7 +492,7 @@ class TableFormatter:
 
     def get_result(
         self,
-        buf: Optional[FilePathOrBuffer[str]] = None,
+        buf: Optional[FilePathOrBuffer] = None,
         encoding: Optional[str] = None,
     ) -> Optional[str]:
         with self.get_buffer(buf, encoding=encoding) as f:
@@ -861,12 +861,12 @@ class DataFrameFormatter(TableFormatter):
             st = ed
         return "\n\n".join(str_lst)
 
-    def to_string(self, buf: Optional[FilePathOrBuffer[str]] = None) -> Optional[str]:
+    def to_string(self, buf: Optional[FilePathOrBuffer] = None) -> Optional[str]:
         return self.get_result(buf=buf)
 
     def to_latex(
         self,
-        buf: Optional[FilePathOrBuffer[str]] = None,
+        buf: Optional[FilePathOrBuffer] = None,
         column_format: Optional[str] = None,
         longtable: bool = False,
         encoding: Optional[str] = None,
@@ -904,7 +904,7 @@ class DataFrameFormatter(TableFormatter):
 
     def to_html(
         self,
-        buf: Optional[FilePathOrBuffer[str]] = None,
+        buf: Optional[FilePathOrBuffer] = None,
         classes: Optional[Union[str, List, Tuple]] = None,
         notebook: bool = False,
         border: Optional[int] = None,


### PR DESCRIPTION
follow up to #27598 to simplify things a bit. I think it was a mistake to add `IO[AnyStr]` as `AnyStr` is a TypeVar and not something to actually parametrize with. The source for `IO` already does this:

https://github.com/python/cpython/blob/8990ac0ab0398bfb9c62031288030fe7c630c2c7/Lib/typing.py#L1452

 I'm not sure why mypy doesn't error on this. 

@simonjayhawkins 