### PR TITLE
REF: define concat classmethods in the appropriate places

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -51,6 +51,7 @@ from pandas.core.dtypes.generic import (
     ABCDataFrame,
     ABCDateOffset,
     ABCDatetimeArray,
+    ABCDatetimeIndex,
     ABCIndexClass,
     ABCMultiIndex,
     ABCPandasArray,
@@ -4309,14 +4310,26 @@ class Index(IndexOpsMixin, PandasObject):
 
         if len(typs) == 1:
             return self._concat_same_dtype(to_concat, name=name)
-        return _concat._concat_index_asobject(to_concat, name=name)
+        return Index._concat_same_dtype(self, to_concat, name=name)
 
-    def _concat_same_dtype(self, to_concat, name):
+    @classmethod
+    def _concat_same_dtype(cls, to_concat, name):
         """
         Concatenate to_concat which has the same class.
         """
         # must be overridden in specific classes
-        return _concat._concat_index_asobject(to_concat, name)
+        klasses = (ABCDatetimeIndex, ABCTimedeltaIndex, ABCPeriodIndex, ExtensionArray)
+        to_concat = [
+            x.astype(object) if isinstance(x, klasses) else x for x in to_concat
+        ]
+
+        self = to_concat[0]
+        attribs = self._get_attributes_dict()
+        attribs["name"] = name
+
+        to_concat = [x._values if isinstance(x, Index) else x for x in to_concat]
+
+        return self._shallow_copy_with_infer(np.concatenate(to_concat), **attribs)
 
     def putmask(self, mask, value):
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4312,8 +4312,7 @@ class Index(IndexOpsMixin, PandasObject):
             return self._concat_same_dtype(to_concat, name=name)
         return Index._concat_same_dtype(self, to_concat, name=name)
 
-    @classmethod
-    def _concat_same_dtype(cls, to_concat, name):
+    def _concat_same_dtype(self, to_concat, name):
         """
         Concatenate to_concat which has the same class.
         """

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -17,7 +17,6 @@ from pandas.core.dtypes.common import (
     needs_i8_conversion,
     pandas_dtype,
 )
-import pandas.core.dtypes.concat as _concat
 from pandas.core.dtypes.generic import (
     ABCFloat64Index,
     ABCInt64Index,
@@ -129,7 +128,8 @@ class NumericIndex(Index):
         pass
 
     def _concat_same_dtype(self, indexes, name):
-        return _concat._concat_index_same_dtype(indexes).rename(name)
+        result = type(indexes[0])(np.concatenate([x._values for x in indexes]))
+        return result.rename(name)
 
     @property
     def is_all_dates(self):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -645,8 +645,7 @@ class RangeIndex(Int64Index):
 
         return super().join(other, how, level, return_indexers, sort)
 
-    @classmethod
-    def _concat_same_dtype(cls, indexes, name):
+    def _concat_same_dtype(self, indexes, name):
         """
         Concatenates multiple RangeIndex instances. All members of "indexes" must
         be of type RangeIndex; result will be RangeIndex if possible, Int64Index
@@ -689,11 +688,11 @@ class RangeIndex(Int64Index):
             # Get the stop value from "next" or alternatively
             # from the last non-empty index
             stop = non_empty_indexes[-1].stop if next_ is None else next_
-            return cls(start, stop, step).rename(name)
+            return RangeIndex(start, stop, step).rename(name)
 
         # Here all "indexes" had 0 length, i.e. were empty.
         # In this case return an empty range index.
-        return cls(0, 0).rename(name)
+        return RangeIndex(0, 0).rename(name)
 
     def __len__(self):
         """

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -11,7 +11,6 @@ import pandas.compat as compat
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, cache_readonly
 
-from pandas.core.dtypes import concat as _concat
 from pandas.core.dtypes.common import (
     ensure_platform_int,
     ensure_python_int,
@@ -646,8 +645,55 @@ class RangeIndex(Int64Index):
 
         return super().join(other, how, level, return_indexers, sort)
 
-    def _concat_same_dtype(self, indexes, name):
-        return _concat._concat_rangeindex_same_dtype(indexes).rename(name)
+    @classmethod
+    def _concat_same_dtype(cls, indexes, name):
+        """
+        Concatenates multiple RangeIndex instances. All members of "indexes" must
+        be of type RangeIndex; result will be RangeIndex if possible, Int64Index
+        otherwise. E.g.:
+        indexes = [RangeIndex(3), RangeIndex(3, 6)] -> RangeIndex(6)
+        indexes = [RangeIndex(3), RangeIndex(4, 6)] -> Int64Index([0,1,2,4,5])
+        """
+        start = step = next_ = None
+
+        # Filter the empty indexes
+        non_empty_indexes = [obj for obj in indexes if len(obj)]
+
+        for obj in non_empty_indexes:
+            rng = obj._range  # type: range
+
+            if start is None:
+                # This is set by the first non-empty index
+                start = rng.start
+                if step is None and len(rng) > 1:
+                    step = rng.step
+            elif step is None:
+                # First non-empty index had only one element
+                if rng.start == start:
+                    result = Int64Index(np.concatenate([x._values for x in indexes]))
+                    return result.rename(name)
+
+                step = rng.start - start
+
+            non_consecutive = (step != rng.step and len(rng) > 1) or (
+                next_ is not None and rng.start != next_
+            )
+            if non_consecutive:
+                result = Int64Index(np.concatenate([x._values for x in indexes]))
+                return result.rename(name)
+
+            if step is not None:
+                next_ = rng[-1] + step
+
+        if non_empty_indexes:
+            # Get the stop value from "next" or alternatively
+            # from the last non-empty index
+            stop = non_empty_indexes[-1].stop if next_ is None else next_
+            return cls(start, stop, step).rename(name)
+
+        # Here all "indexes" had 0 length, i.e. were empty.
+        # In this case return an empty range index.
+        return cls(0, 0).rename(name)
 
     def __len__(self):
         """

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -411,7 +411,7 @@ class TestCategoricalIndex(Base):
         tm.assert_index_equal(result, expected, exact=True)
 
     def test_append_to_another(self):
-        # hits _concat_index_asobject
+        # hits Index._concat_same_dtype
         fst = Index(["a", "b"])
         snd = CategoricalIndex(["d", "e"])
         result = fst.append(snd)


### PR DESCRIPTION
cc @jorisvandenbossche we briefly discussed at the sprint the idea that `dtype.concat` is a weird place to define these functions.

This PR takes the subset of `dtypes.concat` methods that are a) private and b) equivalent to `klass._concat_same_dtype` for some `klass` and moves the implementation to the appropriate class.

The categorical one is left in place for now because a) it is public and b) it'd be a pretty big move in and of itself.