### PR TITLE
BUG: fix to_datetime(dti, utc=True)

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -31,7 +31,7 @@ Categorical
 
 Datetimelike
 ^^^^^^^^^^^^
-- Bug in :func:`to_datetime` where passing a timezone-naive :class:`DatetimeArray` or :class:`DatetimeIndex` and utc=True would incorrectly return a timezone-naive result (:issue:`27733`)
+- Bug in :func:`to_datetime` where passing a timezone-naive :class:`DatetimeArray` or :class:`DatetimeIndex` and ``utc=True`` would incorrectly return a timezone-naive result (:issue:`27733`)
 -
 -
 -

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -31,7 +31,7 @@ Categorical
 
 Datetimelike
 ^^^^^^^^^^^^
-
+- Bug in :func:`to_datetime` where passing a timezone-naive :class:`DatetimeArray` or :class:`DatetimeIndex` and utc=True would incorrectly return a timezone-naive result (:issue:`27733`)
 -
 -
 -

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -334,6 +334,9 @@ def _convert_listlike_datetimes(
                 return DatetimeIndex(arg, tz=tz, name=name)
             except ValueError:
                 pass
+        elif box and tz:
+            # DatetimeArray, DatetimeIndex
+            return arg.tz_localize(tz)
 
         return arg
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -334,7 +334,7 @@ def _convert_listlike_datetimes(
                 return DatetimeIndex(arg, tz=tz, name=name)
             except ValueError:
                 pass
-        elif box and tz:
+        elif tz:
             # DatetimeArray, DatetimeIndex
             return arg.tz_localize(tz)
 

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1623,15 +1623,17 @@ class TestToDatetimeMisc:
         tm.assert_index_equal(expected, idx5)
         tm.assert_index_equal(expected, idx6)
 
-    def test_to_datetime_dta_tz(self):
+    @pytest.mark.parametrize("klass", [DatetimeIndex, DatetimeArray])
+    def test_to_datetime_dta_tz(self, klass):
+        # GH#27733
         dti = date_range("2015-04-05", periods=3).rename("foo")
         expected = dti.tz_localize("UTC")
-        result = to_datetime(dti, utc=True)
-        tm.assert_index_equal(result, expected)
 
-        dta = dti.array
-        result = to_datetime(dta, utc=True)
-        tm.assert_equal(result, expected._data)
+        obj = klass(dti)
+        expected = klass(expected)
+
+        result = to_datetime(obj, utc=True)
+        tm.assert_equal(result, expected)
 
 
 class TestGuessDatetimeFormat:

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1623,6 +1623,16 @@ class TestToDatetimeMisc:
         tm.assert_index_equal(expected, idx5)
         tm.assert_index_equal(expected, idx6)
 
+    def test_to_datetime_dta_tz(self):
+        dti = date_range("2015-04-05", periods=3).rename("foo")
+        expected = dti.tz_localize("UTC")
+        result = to_datetime(dti, utc=True)
+        tm.assert_index_equal(result, expected)
+
+        dta = dti._data
+        result = to_datetime(dta, utc=True)
+        tm.assert_equal(result, expected._data)
+
 
 class TestGuessDatetimeFormat:
     @td.skip_if_not_us_locale

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1629,7 +1629,7 @@ class TestToDatetimeMisc:
         result = to_datetime(dti, utc=True)
         tm.assert_index_equal(result, expected)
 
-        dta = dti._data
+        dta = dti.array
         result = to_datetime(dta, utc=True)
         tm.assert_equal(result, expected._data)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


ATM `to_datetime(naive_dti, utc=True)` returns naive incorrect, same for naive `DatetimeArray`