### PR TITLE
REF: separate out invalid ops

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -44,9 +44,10 @@ from pandas.core.dtypes.inference import is_array_like
 from pandas.core.dtypes.missing import is_valid_nat_for_dtype, isna
 
 from pandas._typing import DatetimeLikeScalar
-from pandas.core import missing, nanops, ops
+from pandas.core import missing, nanops
 from pandas.core.algorithms import checked_add_with_arr, take, unique1d, value_counts
 import pandas.core.common as com
+from pandas.core.ops.invalid import make_invalid_op
 
 from pandas.tseries import frequencies
 from pandas.tseries.offsets import DateOffset, Tick
@@ -930,18 +931,18 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
 
     # pow is invalid for all three subclasses; TimedeltaArray will override
     #  the multiplication and division ops
-    __pow__ = ops.make_invalid_op("__pow__")
-    __rpow__ = ops.make_invalid_op("__rpow__")
-    __mul__ = ops.make_invalid_op("__mul__")
-    __rmul__ = ops.make_invalid_op("__rmul__")
-    __truediv__ = ops.make_invalid_op("__truediv__")
-    __rtruediv__ = ops.make_invalid_op("__rtruediv__")
-    __floordiv__ = ops.make_invalid_op("__floordiv__")
-    __rfloordiv__ = ops.make_invalid_op("__rfloordiv__")
-    __mod__ = ops.make_invalid_op("__mod__")
-    __rmod__ = ops.make_invalid_op("__rmod__")
-    __divmod__ = ops.make_invalid_op("__divmod__")
-    __rdivmod__ = ops.make_invalid_op("__rdivmod__")
+    __pow__ = make_invalid_op("__pow__")
+    __rpow__ = make_invalid_op("__rpow__")
+    __mul__ = make_invalid_op("__mul__")
+    __rmul__ = make_invalid_op("__rmul__")
+    __truediv__ = make_invalid_op("__truediv__")
+    __rtruediv__ = make_invalid_op("__rtruediv__")
+    __floordiv__ = make_invalid_op("__floordiv__")
+    __rfloordiv__ = make_invalid_op("__rfloordiv__")
+    __mod__ = make_invalid_op("__mod__")
+    __rmod__ = make_invalid_op("__rmod__")
+    __divmod__ = make_invalid_op("__divmod__")
+    __rdivmod__ = make_invalid_op("__rdivmod__")
 
     def _add_datetimelike_scalar(self, other):
         # Overriden by TimedeltaArray

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -53,6 +53,7 @@ from pandas.core.algorithms import checked_add_with_arr
 from pandas.core.arrays import datetimelike as dtl
 from pandas.core.arrays._ranges import generate_regular_range
 import pandas.core.common as com
+from pandas.core.ops.invalid import invalid_comparison
 
 from pandas.tseries.frequencies import get_period_alias, to_offset
 from pandas.tseries.offsets import Day, Tick
@@ -171,13 +172,13 @@ def _dt_array_cmp(cls, op):
                 other = _to_M8(other, tz=self.tz)
             except ValueError:
                 # string that cannot be parsed to Timestamp
-                return ops.invalid_comparison(self, other, op)
+                return invalid_comparison(self, other, op)
 
             result = op(self.asi8, other.view("i8"))
             if isna(other):
                 result.fill(nat_result)
         elif lib.is_scalar(other) or np.ndim(other) == 0:
-            return ops.invalid_comparison(self, other, op)
+            return invalid_comparison(self, other, op)
         elif len(other) != len(self):
             raise ValueError("Lengths must match")
         else:
@@ -191,7 +192,7 @@ def _dt_array_cmp(cls, op):
             ):
                 # Following Timestamp convention, __eq__ is all-False
                 # and __ne__ is all True, others raise TypeError.
-                return ops.invalid_comparison(self, other, op)
+                return invalid_comparison(self, other, op)
 
             if is_object_dtype(other):
                 # We have to use _comp_method_OBJECT_ARRAY instead of numpy
@@ -204,7 +205,7 @@ def _dt_array_cmp(cls, op):
                 o_mask = isna(other)
             elif not (is_datetime64_dtype(other) or is_datetime64tz_dtype(other)):
                 # e.g. is_timedelta64_dtype(other)
-                return ops.invalid_comparison(self, other, op)
+                return invalid_comparison(self, other, op)
             else:
                 self._assert_tzawareness_compat(other)
                 if isinstance(other, (ABCIndexClass, ABCSeries)):

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -41,9 +41,9 @@ from pandas.core.dtypes.generic import (
 )
 from pandas.core.dtypes.missing import isna
 
-from pandas.core import ops
 from pandas.core.algorithms import checked_add_with_arr
 import pandas.core.common as com
+from pandas.core.ops.invalid import invalid_comparison
 
 from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import Tick
@@ -90,14 +90,14 @@ def _td_array_cmp(cls, op):
                 other = Timedelta(other)
             except ValueError:
                 # failed to parse as timedelta
-                return ops.invalid_comparison(self, other, op)
+                return invalid_comparison(self, other, op)
 
             result = op(self.view("i8"), other.value)
             if isna(other):
                 result.fill(nat_result)
 
         elif not is_list_like(other):
-            return ops.invalid_comparison(self, other, op)
+            return invalid_comparison(self, other, op)
 
         elif len(other) != len(self):
             raise ValueError("Lengths must match")
@@ -106,7 +106,7 @@ def _td_array_cmp(cls, op):
             try:
                 other = type(self)._from_sequence(other)._data
             except (ValueError, TypeError):
-                return ops.invalid_comparison(self, other, op)
+                return invalid_comparison(self, other, op)
 
             result = op(self.view("i8"), other.view("i8"))
             result = com.values_from_object(result)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -69,7 +69,8 @@ import pandas.core.common as com
 from pandas.core.indexers import maybe_convert_indices
 from pandas.core.indexes.frozen import FrozenList
 import pandas.core.missing as missing
-from pandas.core.ops import get_op_result_name, make_invalid_op
+from pandas.core.ops import get_op_result_name
+from pandas.core.ops.invalid import make_invalid_op
 import pandas.core.sorting as sorting
 from pandas.core.strings import StringMethods
 

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -49,16 +49,15 @@ from pandas.core.dtypes.missing import isna, notna
 import pandas as pd
 from pandas._typing import ArrayLike
 import pandas.core.common as com
-
-from . import missing
-from .docstrings import (
+from pandas.core.ops import missing
+from pandas.core.ops.docstrings import (
     _arith_doc_FRAME,
     _flex_comp_doc_FRAME,
     _make_flex_doc,
     _op_descriptions,
 )
-from .invalid import invalid_comparison
-from .roperator import (  # noqa:F401
+from pandas.core.ops.invalid import invalid_comparison
+from pandas.core.ops.roperator import (  # noqa:F401
     radd,
     rand_,
     rdiv,

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -319,6 +319,7 @@ def _get_op_name(op, special):
 # -----------------------------------------------------------------------------
 # Masking NA values and fallbacks for operations numpy does not support
 
+
 def fill_binop(left, right, fill_value):
     """
     If a non-None fill_value is given, replace null entries in left and right
@@ -445,6 +446,7 @@ def masked_arith_op(x, y, op):
 
 # -----------------------------------------------------------------------------
 # Dispatch logic
+
 
 def should_series_dispatch(left, right, op):
     """
@@ -612,6 +614,7 @@ def dispatch_to_extension_op(op, left, right):
 # -----------------------------------------------------------------------------
 # Functions that add arithmetic methods to objects, given arithmetic factory
 # methods
+
 
 def _get_method_wrappers(cls):
     """

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -319,7 +319,6 @@ def _get_op_name(op, special):
 # -----------------------------------------------------------------------------
 # Masking NA values and fallbacks for operations numpy does not support
 
-
 def fill_binop(left, right, fill_value):
     """
     If a non-None fill_value is given, replace null entries in left and right
@@ -446,7 +445,6 @@ def masked_arith_op(x, y, op):
 
 # -----------------------------------------------------------------------------
 # Dispatch logic
-
 
 def should_series_dispatch(left, right, op):
     """
@@ -614,7 +612,6 @@ def dispatch_to_extension_op(op, left, right):
 # -----------------------------------------------------------------------------
 # Functions that add arithmetic methods to objects, given arithmetic factory
 # methods
-
 
 def _get_method_wrappers(cls):
     """

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -57,6 +57,7 @@ from .docstrings import (
     _make_flex_doc,
     _op_descriptions,
 )
+from .invalid import invalid_comparison
 from .roperator import (  # noqa:F401
     radd,
     rand_,
@@ -173,29 +174,6 @@ def maybe_upcast_for_op(obj):
 
 
 # -----------------------------------------------------------------------------
-
-
-def make_invalid_op(name):
-    """
-    Return a binary method that always raises a TypeError.
-
-    Parameters
-    ----------
-    name : str
-
-    Returns
-    -------
-    invalid_op : function
-    """
-
-    def invalid_op(self, other=None):
-        raise TypeError(
-            "cannot perform {name} with this index type: "
-            "{typ}".format(name=name, typ=type(self).__name__)
-        )
-
-    invalid_op.__name__ = name
-    return invalid_op
 
 
 def _gen_eval_kwargs(name):
@@ -464,38 +442,6 @@ def masked_arith_op(x, y, op):
     result, changed = maybe_upcast_putmask(result, ~mask, np.nan)
     result = result.reshape(x.shape)  # 2D compat
     return result
-
-
-def invalid_comparison(left, right, op):
-    """
-    If a comparison has mismatched types and is not necessarily meaningful,
-    follow python3 conventions by:
-
-        - returning all-False for equality
-        - returning all-True for inequality
-        - raising TypeError otherwise
-
-    Parameters
-    ----------
-    left : array-like
-    right : scalar, array-like
-    op : operator.{eq, ne, lt, le, gt}
-
-    Raises
-    ------
-    TypeError : on inequality comparisons
-    """
-    if op is operator.eq:
-        res_values = np.zeros(left.shape, dtype=bool)
-    elif op is operator.ne:
-        res_values = np.ones(left.shape, dtype=bool)
-    else:
-        raise TypeError(
-            "Invalid comparison between dtype={dtype} and {typ}".format(
-                dtype=left.dtype, typ=type(right).__name__
-            )
-        )
-    return res_values
 
 
 # -----------------------------------------------------------------------------

--- a/pandas/core/ops/invalid.py
+++ b/pandas/core/ops/invalid.py
@@ -1,0 +1,61 @@
+"""
+Templates for invalid operations.
+"""
+import operator
+
+import numpy as np
+
+
+def invalid_comparison(left, right, op):
+    """
+    If a comparison has mismatched types and is not necessarily meaningful,
+    follow python3 conventions by:
+
+        - returning all-False for equality
+        - returning all-True for inequality
+        - raising TypeError otherwise
+
+    Parameters
+    ----------
+    left : array-like
+    right : scalar, array-like
+    op : operator.{eq, ne, lt, le, gt}
+
+    Raises
+    ------
+    TypeError : on inequality comparisons
+    """
+    if op is operator.eq:
+        res_values = np.zeros(left.shape, dtype=bool)
+    elif op is operator.ne:
+        res_values = np.ones(left.shape, dtype=bool)
+    else:
+        raise TypeError(
+            "Invalid comparison between dtype={dtype} and {typ}".format(
+                dtype=left.dtype, typ=type(right).__name__
+            )
+        )
+    return res_values
+
+
+def make_invalid_op(name: str):
+    """
+    Return a binary method that always raises a TypeError.
+
+    Parameters
+    ----------
+    name : str
+
+    Returns
+    -------
+    invalid_op : function
+    """
+
+    def invalid_op(self, other=None):
+        raise TypeError(
+            "cannot perform {name} with this index type: "
+            "{typ}".format(name=name, typ=type(self).__name__)
+        )
+
+    invalid_op.__name__ = name
+    return invalid_op


### PR DESCRIPTION
We moved ops.py to `ops.__init__` a while back, still need to get the bulk of it out of `__init__`.  This separates out templated invalid operations, which are the main things that outside modules import  (this helps us move towards getting rid of the `import pandas as pd` in the main file)