### PR TITLE
CLN: Move base.StringMixin to computations.common

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -46,30 +46,6 @@ _indexops_doc_kwargs = dict(
 )
 
 
-class StringMixin:
-    """
-    Implements string methods so long as object defines a `__str__` method.
-    """
-
-    # side note - this could be made into a metaclass if more than one
-    #             object needs
-
-    # ----------------------------------------------------------------------
-    # Formatting
-
-    def __str__(self):
-        """
-        Return a string representation for a particular Object
-        """
-        raise AbstractMethodError(self)
-
-    def __repr__(self):
-        """
-        Return a string representation for a particular object.
-        """
-        return str(self)
-
-
 class PandasObject(DirNamesMixin):
 
     """baseclass for various pandas objects"""

--- a/pandas/core/computation/common.py
+++ b/pandas/core/computation/common.py
@@ -40,4 +40,4 @@ class NameResolutionError(NameError):
 
 class StringMixin:
     # TODO: delete this class. Removing this ATM caused a failure.
-    ...
+    pass

--- a/pandas/core/computation/common.py
+++ b/pandas/core/computation/common.py
@@ -36,3 +36,8 @@ def _remove_spaces_column_name(name):
 
 class NameResolutionError(NameError):
     pass
+
+
+class StringMixin:
+    # TODO: delete this class. Removing this ATM caused a failure.
+    ...

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -13,7 +13,6 @@ import numpy as np
 
 import pandas as pd
 from pandas.core import common as com
-from pandas.core.base import StringMixin
 from pandas.core.computation.common import (
     _BACKTICK_QUOTED_STRING,
     _remove_spaces_column_name,
@@ -799,7 +798,7 @@ class PythonExprVisitor(BaseExprVisitor):
         super().__init__(env, engine, parser, preparser=preparser)
 
 
-class Expr(StringMixin):
+class Expr:
 
     """Object encapsulating an expression.
 
@@ -831,7 +830,7 @@ class Expr(StringMixin):
     def __call__(self):
         return self.terms(self.env)
 
-    def __str__(self):
+    def __repr__(self):
         return printing.pprint_thing(self.terms)
 
     def __len__(self):

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -12,7 +12,6 @@ from pandas._libs.tslibs import Timestamp
 
 from pandas.core.dtypes.common import is_list_like, is_scalar
 
-from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.core.computation.common import _ensure_decoded, _result_type_many
 from pandas.core.computation.scope import _DEFAULT_GLOBALS
@@ -63,7 +62,7 @@ class UndefinedVariableError(NameError):
         super().__init__(msg.format(name))
 
 
-class Term(StringMixin):
+class Term:
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, str) else cls
         supr_new = super(Term, klass).__new__
@@ -82,7 +81,7 @@ class Term(StringMixin):
     def local_name(self):
         return self.name.replace(_LOCAL_TAG, "")
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing(self.name)
 
     def __call__(self, *args, **kwargs):
@@ -182,7 +181,7 @@ class Constant(Term):
     def name(self):
         return self.value
 
-    def __str__(self):
+    def __repr__(self):
         # in python 2 str() of float
         # can truncate shorter than repr()
         return repr(self.name)
@@ -191,7 +190,7 @@ class Constant(Term):
 _bool_op_map = {"not": "~", "and": "&", "or": "|"}
 
 
-class Op(StringMixin):
+class Op:
 
     """Hold an operator of arbitrary arity
     """
@@ -204,7 +203,7 @@ class Op(StringMixin):
     def __iter__(self):
         return iter(self.operands)
 
-    def __str__(self):
+    def __repr__(self):
         """Print a generic n-ary operator and its operands using infix
         notation"""
         # recurse over the operands
@@ -537,7 +536,7 @@ class UnaryOp(Op):
         operand = self.operand(env)
         return self.func(operand)
 
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing("{0}({1})".format(self.op, self.operand))
 
     @property
@@ -562,7 +561,7 @@ class MathCall(Op):
         with np.errstate(all="ignore"):
             return self.func.func(*operands)
 
-    def __str__(self):
+    def __repr__(self):
         operands = map(str, self.operands)
         return pprint_thing("{0}({1})".format(self.op, ",".join(operands)))
 

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -13,7 +13,7 @@ from pandas.core.dtypes.common import is_list_like
 import pandas as pd
 import pandas.core.common as com
 from pandas.core.computation import expr, ops
-from pandas.core.computation.common import StringMixin, _ensure_decoded
+from pandas.core.computation.common import _ensure_decoded
 from pandas.core.computation.expr import BaseExprVisitor
 from pandas.core.computation.ops import UndefinedVariableError, is_term
 
@@ -31,8 +31,7 @@ class Scope(expr.Scope):
 class Term(ops.Term):
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, str) else cls
-        supr_new = StringMixin.__new__
-        return supr_new(klass)
+        return object.__new__(klass)
 
     def __init__(self, name, env, side=None, encoding=None):
         super().__init__(name, env, side=side, encoding=encoding)

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -11,10 +11,9 @@ from pandas.compat.chainmap import DeepChainMap
 from pandas.core.dtypes.common import is_list_like
 
 import pandas as pd
-from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.core.computation import expr, ops
-from pandas.core.computation.common import _ensure_decoded
+from pandas.core.computation.common import StringMixin, _ensure_decoded
 from pandas.core.computation.expr import BaseExprVisitor
 from pandas.core.computation.ops import UndefinedVariableError, is_term
 
@@ -231,7 +230,7 @@ class BinOp(ops.BinOp):
 
 
 class FilterBinOp(BinOp):
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing(
             "[Filter : [{lhs}] -> [{op}]".format(lhs=self.filter[0], op=self.filter[1])
         )
@@ -297,7 +296,7 @@ class JointFilterBinOp(FilterBinOp):
 
 
 class ConditionBinOp(BinOp):
-    def __str__(self):
+    def __repr__(self):
         return pprint_thing("[Condition : [{cond}]]".format(cond=self.condition))
 
     def invert(self):
@@ -548,7 +547,7 @@ class Expr(expr.Expr):
             )
             self.terms = self.parse()
 
-    def __str__(self):
+    def __repr__(self):
         if self.terms is not None:
             return pprint_thing(self.terms)
         return pprint_thing(self.expr)

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -15,8 +15,8 @@ import numpy as np
 from pandas._libs.tslibs import Timestamp
 from pandas.compat.chainmap import DeepChainMap
 
-from pandas.core.base import StringMixin
 import pandas.core.computation as compu
+from pandas.core.computation.common import StringMixin
 
 
 def _ensure_scope(
@@ -141,7 +141,7 @@ class Scope(StringMixin):
         self.resolvers = DeepChainMap(*resolvers)
         self.temps = {}
 
-    def __str__(self):
+    def __repr__(self):
         scope_keys = _get_pretty_string(list(self.scope.keys()))
         res_keys = _get_pretty_string(list(self.resolvers.keys()))
         unicode_str = "{name}(scope={scope_keys}, resolvers={res_keys})"

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -14,7 +14,6 @@ from pandas import (
     period_range,
     timedelta_range,
 )
-from pandas.core.base import StringMixin
 from pandas.core.index import MultiIndex
 import pandas.util.testing as tm
 
@@ -226,11 +225,11 @@ class TestCategoricalRepr:
     def test_categorical_repr_unicode(self):
         # see gh-21002
 
-        class County(StringMixin):
+        class County:
             name = "San Sebastián"
             state = "PR"
 
-            def __str__(self):
+            def __repr__(self):
                 return self.name + ", " + self.state
 
         cat = pd.Categorical([County() for _ in range(61)])


### PR DESCRIPTION
``StringMixin`` should be removed, but I can't figure out how to remove it without breaking tests, so this moves ``StringMixin`` to core.computation, which is the only module, where it is currently used.

This makes ``core.base.py`` a bit cleaner.