### PR TITLE
BUG: Fix windowing over read-only arrays

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -118,6 +118,7 @@ Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Bug in :meth:`pandas.core.groupby.DataFrameGroupBy.transform` where applying a timezone conversion lambda function would drop timezone information (:issue:`27496`)
+- Bug in windowing over read-only arrays (:issue:`27766`)
 -
 -
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -249,8 +249,8 @@ class _Window(PandasObject, SelectionMixin):
         # Convert inf to nan for C funcs
         inf = np.isinf(values)
         if inf.any():
-            values = values.copy()  # GH-27766, Don't write into user's data
-            values[inf] = np.nan
+            # GH-27766, Don't write into user's data
+            values = np.where(inf, np.nan, values)
 
         return values
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -249,7 +249,6 @@ class _Window(PandasObject, SelectionMixin):
         # Convert inf to nan for C funcs
         inf = np.isinf(values)
         if inf.any():
-            # GH-27766, Don't write into user's data
             values = np.where(inf, np.nan, values)
 
         return values

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -246,8 +246,11 @@ class _Window(PandasObject, SelectionMixin):
             except (ValueError, TypeError):
                 raise TypeError("cannot handle this type -> {0}".format(values.dtype))
 
-        # Always convert inf to nan
-        values[np.isinf(values)] = np.NaN
+        # Convert inf to nan for C funcs
+        inf = np.isinf(values)
+        if inf.any():
+            values = values.copy()  # GH-27766, Don't write into user's data
+            values[inf] = np.nan
 
         return values
 

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -326,3 +326,10 @@ class TestRolling(Base):
 
         result = df.rolling(2, axis=axis_frame).count()
         tm.assert_frame_equal(result, expected)
+
+    def test_readonly_array(self):
+        arr = np.array([1, 3, np.nan, 3, 5])
+        arr.setflags(write=False)
+        tm.assert_series_equal(
+            pd.Series(arr).rolling(2).mean(), pd.Series([np.nan, 2, np.nan, np.nan, 4])
+        )

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -328,8 +328,9 @@ class TestRolling(Base):
         tm.assert_frame_equal(result, expected)
 
     def test_readonly_array(self):
+        # GH-27766
         arr = np.array([1, 3, np.nan, 3, 5])
         arr.setflags(write=False)
-        tm.assert_series_equal(
-            pd.Series(arr).rolling(2).mean(), pd.Series([np.nan, 2, np.nan, np.nan, 4])
-        )
+        result = pd.Series(arr).rolling(2).mean()
+        expected = pd.Series([np.nan, 2, np.nan, np.nan, 4])
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #27766
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
