### PR TITLE
REF: Make CategoricalIndex comparison defer to Categorical comparison

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -89,6 +89,9 @@ def _cat_compare_op(op):
             return NotImplemented
 
         other = lib.item_from_zerodim(other)
+        if is_list_like(other) and len(other) != len(self):
+            # TODO: Could this fail if the categories are listlike objects?
+            raise ValueError("Lengths must match.")
 
         if not self.ordered:
             if op in ["__lt__", "__gt__", "__le__", "__ge__"]:

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -899,31 +899,11 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             opname = "__{op}__".format(op=op.__name__)
 
             def _evaluate_compare(self, other):
-
-                # if we have a Categorical type, then must have the same
-                # categories
-                if isinstance(other, CategoricalIndex):
-                    other = other._values
-                elif isinstance(other, Index):
-                    other = self._create_categorical(other._values, dtype=self.dtype)
-
-                if isinstance(other, (ABCCategorical, np.ndarray, ABCSeries)):
-                    if len(self.values) != len(other):
-                        raise ValueError("Lengths must match to compare")
-
-                if isinstance(other, ABCCategorical):
-                    if not self.values.is_dtype_equal(other):
-                        raise TypeError(
-                            "categorical index comparisons must "
-                            "have the same categories and ordered "
-                            "attributes"
-                        )
-
-                result = op(self.values, other)
+                result = op(self.array, other)
                 if isinstance(result, ABCSeries):
                     # Dispatch to pd.Categorical returned NotImplemented
                     # and we got a Series back; down-cast to ndarray
-                    result = result.values
+                    result = result._values
                 return result
 
             return compat.set_function_name(_evaluate_compare, opname, cls)

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -899,7 +899,8 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             opname = "__{op}__".format(op=op.__name__)
 
             def _evaluate_compare(self, other):
-                result = op(self.array, other)
+                with np.errstate(all="ignore"):
+                    result = op(self.array, other)
                 if isinstance(result, ABCSeries):
                     # Dispatch to pd.Categorical returned NotImplemented
                     # and we got a Series back; down-cast to ndarray

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -1040,7 +1040,11 @@ def _comp_method_SERIES(cls, op, special):
 
         if isinstance(other, ABCSeries) and not self._indexed_same(other):
             raise ValueError("Can only compare identically-labeled Series objects")
-        elif is_list_like(other) and len(other) != len(self):
+        elif (
+            is_list_like(other)
+            and len(other) != len(self)
+            and not isinstance(other, (set, frozenset))
+        ):
             raise ValueError("Lengths must match")
 
         elif is_categorical_dtype(self):

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -1038,11 +1038,10 @@ def _comp_method_SERIES(cls, op, special):
             # Defer to DataFrame implementation; fail early
             return NotImplemented
 
-        if is_list_like(other) and len(other) != len(self):
-            raise ValueError("Lengths must match")
-
         if isinstance(other, ABCSeries) and not self._indexed_same(other):
             raise ValueError("Can only compare identically-labeled Series objects")
+        elif is_list_like(other) and len(other) != len(self):
+            raise ValueError("Lengths must match")
 
         elif is_categorical_dtype(self):
             # Dispatch to Categorical implementation; CategoricalIndex

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -1038,7 +1038,10 @@ def _comp_method_SERIES(cls, op, special):
             # Defer to DataFrame implementation; fail early
             return NotImplemented
 
-        elif isinstance(other, ABCSeries) and not self._indexed_same(other):
+        if is_list_like(other) and len(other) != len(self):
+            raise ValueError("Lengths must match")
+
+        if isinstance(other, ABCSeries) and not self._indexed_same(other):
             raise ValueError("Can only compare identically-labeled Series objects")
 
         elif is_categorical_dtype(self):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -823,6 +823,11 @@ class TestCategoricalIndex(Base):
         msg = (
             "categorical index comparisons must have the same categories"
             " and ordered attributes"
+            "|"
+            "Categoricals can only be compared if 'categories' are the same. "
+            "Categories are different lengths"
+            "|"
+            "Categoricals can only be compared if 'ordered' is the same"
         )
         with pytest.raises(TypeError, match=msg):
             ci1 == ci2


### PR DESCRIPTION
Partially addresses #19513.

After this, CategoricalIndex will be defining comparison ops identically to DTA/TDA/PA, could share some code.