### PR TITLE
[BLD] Add script that fails build if git tags do not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
   - pwd
   - uname -a
   - git --version
-  - git tag
+  - ./ci/check_git_tags.sh
   # Because travis runs on Google Cloud and has a /etc/boto.cfg,
   # it breaks moto import, see:
   # https://github.com/spulec/moto/issues/1771

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 
 git:
     # for cloning
-    depth: 2000
+    depth: false
 
 matrix:
     fast_finish: true

--- a/ci/check_git_tags.sh
+++ b/ci/check_git_tags.sh
@@ -1,0 +1,28 @@
+set -e
+
+if [[ ! $(git tag) ]]; then
+    echo "No git tags in clone, please sync your git tags with upstream using:"
+    echo "    git fetch --tags upstream"
+    echo "    git push --tags origin"
+    echo ""
+    echo "If the issue persists, the clone depth needs to be increased in .travis.yml"
+    exit 1
+fi
+
+# This will error if there are no tags and we omit --always
+DESCRIPTION=$(git describe --long --tags)
+echo "$DESCRIPTION"
+
+if [[ "$DESCRIPTION" == *"untagged"* ]]; then
+    echo "Unable to determine most recent tag, aborting build"
+    exit 1
+else
+    if [[ "$DESCRIPTION" != *"g"* ]]; then
+	# A good description will have the hash prefixed by g, a bad one will be
+	# just the hash
+	echo "Unable to determine most recent tag, aborting build"
+	exit 1
+    else
+	echo "$(git tag)"
+    fi
+fi

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -1,4 +1,5 @@
 import collections
+from distutils.version import LooseVersion
 from functools import partial
 import string
 
@@ -117,3 +118,13 @@ def test_git_version():
     git_version = pd.__git_version__
     assert len(git_version) == 40
     assert all(c in string.hexdigits for c in git_version)
+
+
+def test_version_tag():
+    version = pd.__version__
+    try:
+        version > LooseVersion("0.0.1")
+    except TypeError:
+        raise ValueError(
+            "No git tags exist, please sync tags between upstream and your repo"
+        )


### PR DESCRIPTION
The Travis build process can fail in hard to decipher ways if git tags are not synced between `upstream` and a developer's repo. This failure mode would occur in the main repo if we go 2000 commits (current clone depth, ~9 months) without tagging a release. This PR explicitly fails the build with instructions of how to resolve if this situation is encountered.

The underlying issue is that `versioneer` and the underlying `git describe` rely on tags to exist in the local repo for the purposes of creating a version description like:
```
v0.25.0-116-gee54d95952
```
As Travis makes a shallow clone, these tags are will not exist if:
 - A developer has not explicitly synced tags between repos (the default git behavior)
 - `pandas` goes 2000 commits without tagging a commit

If tags do not exist, we get something like:
```
0+untagged.2000.g66ada8c
```
Which causes causes tests involving downstream libraries like `pyarrow`, `statsmodels`, etc to fail their internal version checks in sometimes indecipherable ways like this:
```
=================================== FAILURES ===================================

____________________________ TestFeather.test_error ____________________________
[gw0] linux -- Python 3.7.3 /home/travis/miniconda3/envs/pandas-dev/bin/python
self = <pandas.tests.io.test_feather.TestFeather object at 0x7f353ab95c18>
    def test_error(self):
        for obj in [
            pd.Series([1, 2, 3]),
            1,
            "foo",
            pd.Timestamp("20130101"),
            np.array([1, 2, 3]),
        ]:
>           self.check_error_on_write(obj, ValueError)
pandas/tests/io/test_feather.py:49: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pandas/tests/io/test_feather.py:27: in check_error_on_write
    to_feather(df, path)
pandas/io/feather_format.py:24: in to_feather
    from pyarrow import feather
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
    from distutils.version import LooseVersion
    import os
    
    import six
    import pandas as pd
    import warnings
    
>   from pyarrow.compat import pdapi
E   ImportError: cannot import name 'pdapi' from 'pyarrow.compat' (/home/travis/miniconda3/envs/pandas-dev/lib/python3.7/site-packages/pyarrow/compat.py)
```

With some digging, you can eventually find that the root cause is:
```
self = LooseVersion ('0+untagged.2000.g66ada8c'), other = LooseVersion ('0.21')
    def _cmp (self, other):
        if isinstance(other, str):
            other = LooseVersion(other)
    
        if self.version == other.version:
            return 0
>       if self.version < other.version:
E       TypeError: '<' not supported between instances of 'str' and 'int'
```

Syncing tags between repos resolves the issue.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
