### PR TITLE
BUG: _can_use_numexpr fails when passed large Series

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -54,7 +54,7 @@ Numeric
 ^^^^^^^
 - Bug in :meth:`Series.interpolate` when using a timezone aware :class:`DatetimeIndex` (:issue:`27548`)
 - Bug when printing negative floating point complex numbers would raise an ``IndexError`` (:issue:`27484`)
--
+- Bug where :class:`DataFrame` arithmetic operators such as :meth:`DataFrame.mul` with a :class:`Series` with axis=1 would raise an ``AttributeError`` on :class:`DataFrame` larger than the minimum threshold to invoke numexpr (:issue:`27636`)
 -
 
 Conversion

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -80,7 +80,7 @@ def _can_use_numexpr(op, op_str, a, b, dtype_check):
             # check for dtype compatibility
             dtypes = set()
             for o in [a, b]:
-                if hasattr(o, "dtypes"):
+                if hasattr(o, "dtypes") and o.ndim > 1:
                     s = o.dtypes.value_counts()
                     if len(s) > 1:
                         return False

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -80,16 +80,14 @@ def _can_use_numexpr(op, op_str, a, b, dtype_check):
             # check for dtype compatibility
             dtypes = set()
             for o in [a, b]:
-                if hasattr(o, "dtypes"):
-                    # Series implements dtypes, check for dimension count
-                    if o.ndim > 1:
-                        s = o.dtypes.value_counts()
-                        if len(s) > 1:
-                            return False
-                        dtypes |= set(s.index.astype(str))
-                    else:
-                        dtypes |= {o.dtypes.name}
-                elif isinstance(o, np.ndarray):
+                # Series implements dtypes, check for dimension count as well
+                if hasattr(o, "dtypes") and o.ndim > 1:
+                    s = o.dtypes.value_counts()
+                    if len(s) > 1:
+                        return False
+                    dtypes |= set(s.index.astype(str))
+                # ndarray and Series Case
+                elif hasattr(o, "dtype"):
                     dtypes |= {o.dtype.name}
 
             # allowed are a superset
@@ -183,7 +181,7 @@ def _has_bool_dtype(x):
 
 
 def _bool_arith_check(
-    op_str, a, b, not_allowed=frozenset(("/", "//", "**")), unsupported=None
+        op_str, a, b, not_allowed=frozenset(("/", "//", "**")), unsupported=None
 ):
     if unsupported is None:
         unsupported = {"+": "|", "*": "&", "-": "^"}

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -76,7 +76,6 @@ def _can_use_numexpr(op, op_str, a, b, dtype_check):
 
         # required min elements (otherwise we are adding overhead)
         if np.prod(a.shape) > _MIN_ELEMENTS:
-
             # check for dtype compatibility
             dtypes = set()
             for o in [a, b]:
@@ -181,7 +180,7 @@ def _has_bool_dtype(x):
 
 
 def _bool_arith_check(
-        op_str, a, b, not_allowed=frozenset(("/", "//", "**")), unsupported=None
+    op_str, a, b, not_allowed=frozenset(("/", "//", "**")), unsupported=None
 ):
     if unsupported is None:
         unsupported = {"+": "|", "*": "&", "-": "^"}

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -80,11 +80,15 @@ def _can_use_numexpr(op, op_str, a, b, dtype_check):
             # check for dtype compatibility
             dtypes = set()
             for o in [a, b]:
-                if hasattr(o, "dtypes") and o.ndim > 1:
-                    s = o.dtypes.value_counts()
-                    if len(s) > 1:
-                        return False
-                    dtypes |= set(s.index.astype(str))
+                if hasattr(o, "dtypes"):
+                    # Series implements dtypes, check for dimension count
+                    if o.ndim > 1:
+                        s = o.dtypes.value_counts()
+                        if len(s) > 1:
+                            return False
+                        dtypes |= set(s.index.astype(str))
+                    else:
+                        dtypes |= {o.dtypes.name}
                 elif isinstance(o, np.ndarray):
                     dtypes |= {o.dtype.name}
 


### PR DESCRIPTION
This fixes a regression introduced in #27145 where _can_use_numexpr would fail if passed a Series and not a DataFrame. I decided not to use run_arithmetic in the test_suite because there is a separate issue when running floordiv that is out of the scope of the fix. I will open a separate issue in improving the test coverage of "test_expressions.py" as it currently does not check any of the arguments you can pass to the operators, such as 'axis', 'level' and 'fill_value'.

- [x] closes #27636 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
