### PR TITLE
 DEPR: Removed the previously deprecated ExtensionArray._formatting_values

### DIFF
--- a/doc/source/reference/extensions.rst
+++ b/doc/source/reference/extensions.rst
@@ -34,7 +34,6 @@ objects.
 
       api.extensions.ExtensionArray._concat_same_type
       api.extensions.ExtensionArray._formatter
-      api.extensions.ExtensionArray._formatting_values
       api.extensions.ExtensionArray._from_factorized
       api.extensions.ExtensionArray._from_sequence
       api.extensions.ExtensionArray._from_sequence_of_strings

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -65,7 +65,7 @@ Removal of prior version deprecations/changes
 - Changed the the default value of `inplace` in :meth:`DataFrame.set_index` and :meth:`Series.set_axis`. It now defaults to False (:issue:`27600`)
 - :meth:`pandas.Series.str.cat` now defaults to aligning ``others``, using ``join='left'`` (:issue:`27611`)
 - :meth:`pandas.Series.str.cat` does not accept list-likes *within* list-likes anymore (:issue:`27611`)
--
+- Removed the previously deprecated :meth:`ExtensionArray._formatting_values`. Use :attr:`ExtensionArray._formatter` instead. (:issue:`23601`)
 
 .. _whatsnew_1000.performance:
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -66,7 +66,6 @@ class ExtensionArray:
     unique
     _concat_same_type
     _formatter
-    _formatting_values
     _from_factorized
     _from_sequence
     _from_sequence_of_strings
@@ -907,21 +906,6 @@ class ExtensionArray:
         if boxed:
             return str
         return repr
-
-    def _formatting_values(self) -> np.ndarray:
-        # At the moment, this has to be an array since we use result.dtype
-        """
-        An array of values to be printed in, e.g. the Series repr
-
-        .. deprecated:: 0.24.0
-
-           Use :meth:`ExtensionArray._formatter` instead.
-
-        Returns
-        -------
-        array : ndarray
-        """
-        return np.array(self)
 
     # ------------------------------------------------------------------------
     # Reshaping

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -68,13 +68,7 @@ from pandas.core.dtypes.missing import (
 )
 
 import pandas.core.algorithms as algos
-from pandas.core.arrays import (
-    Categorical,
-    DatetimeArray,
-    ExtensionArray,
-    PandasDtype,
-    TimedeltaArray,
-)
+from pandas.core.arrays import Categorical, DatetimeArray, PandasDtype, TimedeltaArray
 from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.construction import extract_array
@@ -208,10 +202,6 @@ class Block(PandasObject):
         this should be the pure internal API format
         """
         return self.values
-
-    def formatting_values(self):
-        """Return the internal values used by the DataFrame/SeriesFormatter"""
-        return self.internal_values()
 
     def get_values(self, dtype=None):
         """
@@ -1883,21 +1873,6 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
         is already a 1-D array
         """
         return result
-
-    def formatting_values(self):
-        # Deprecating the ability to override _formatting_values.
-        # Do the warning here, it's only user in pandas, since we
-        # have to check if the subclass overrode it.
-        fv = getattr(type(self.values), "_formatting_values", None)
-        if fv and fv != ExtensionArray._formatting_values:
-            msg = (
-                "'ExtensionArray._formatting_values' is deprecated. "
-                "Specify 'ExtensionArray._formatter' instead."
-            )
-            warnings.warn(msg, FutureWarning, stacklevel=10)
-            return self.values._formatting_values()
-
-        return self.values
 
     def concat_same_type(self, to_concat, placement=None):
         """

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1581,10 +1581,6 @@ class SingleBlockManager(BlockManager):
     def internal_values(self):
         return self._block.internal_values()
 
-    def formatting_values(self):
-        """Return the internal values used by the DataFrame/SeriesFormatter"""
-        return self._block.formatting_values()
-
     def get_values(self):
         """ return a dense type view """
         return np.array(self._block.to_dense(), copy=False)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -562,13 +562,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         return self._data.internal_values()
 
-    def _formatting_values(self):
-        """
-        Return the values that can be formatted (used by SeriesFormatter
-        and DataFrameFormatter).
-        """
-        return self._data.formatting_values()
-
     def get_values(self):
         """
         Same as values (but handles sparseness conversions); is a view.

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -336,9 +336,11 @@ class SeriesFormatter:
         return fmt_index, have_header
 
     def _get_formatted_values(self) -> List[str]:
-        values_to_format = self.tr_series._formatting_values()
         return format_array(
-            values_to_format, None, float_format=self.float_format, na_rep=self.na_rep
+            self.tr_series._values,
+            None,
+            float_format=self.float_format,
+            na_rep=self.na_rep,
         )
 
     def to_string(self) -> str:
@@ -903,9 +905,8 @@ class DataFrameFormatter(TableFormatter):
     def _format_col(self, i: int) -> List[str]:
         frame = self.tr_frame
         formatter = self._get_formatter(i)
-        values_to_format = frame.iloc[:, i]._formatting_values()
         return format_array(
-            values_to_format,
+            frame.iloc[:, i]._values,
             formatter,
             float_format=self.float_format,
             na_rep=self.na_rep,

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -392,17 +392,6 @@ def test_ufunc_fallback(data):
     tm.assert_series_equal(result, expected)
 
 
-def test_formatting_values_deprecated():
-    class DecimalArray2(DecimalArray):
-        def _formatting_values(self):
-            return np.array(self)
-
-    ser = pd.Series(DecimalArray2([decimal.Decimal("1.0")]))
-
-    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        repr(ser)
-
-
 def test_array_ufunc():
     a = to_decimal([1, 2, 3])
     result = np.exp(a)

--- a/pandas/tests/extension/test_external_block.py
+++ b/pandas/tests/extension/test_external_block.py
@@ -2,16 +2,13 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas.core.internals import BlockManager, SingleBlockManager
+from pandas.core.internals import BlockManager
 from pandas.core.internals.blocks import Block, NonConsolidatableMixIn
 
 
 class CustomBlock(NonConsolidatableMixIn, Block):
 
     _holder = np.ndarray
-
-    def formatting_values(self):
-        return np.array(["Val: {}".format(i) for i in self.values])
 
     def concat_same_type(self, to_concat, placement=None):
         """
@@ -33,22 +30,6 @@ def df():
     blocks = blocks + (custom_block,)
     block_manager = BlockManager(blocks, [pd.Index(["a", "b"]), df1.index])
     return pd.DataFrame(block_manager)
-
-
-def test_custom_repr():
-    values = np.arange(3, dtype="int64")
-
-    # series
-    block = CustomBlock(values, placement=slice(0, 3))
-
-    s = pd.Series(SingleBlockManager(block, pd.RangeIndex(3)))
-    assert repr(s) == "0    Val: 0\n1    Val: 1\n2    Val: 2\ndtype: int64"
-
-    # dataframe
-    block = CustomBlock(values, placement=slice(0, 1))
-    blk_mgr = BlockManager([block], [["col"], range(3)])
-    df = pd.DataFrame(blk_mgr)
-    assert repr(df) == "      col\n0  Val: 0\n1  Val: 1\n2  Val: 2"
 
 
 def test_concat_series():


### PR DESCRIPTION
and revert #17143, see https://github.com/pandas-dev/pandas/pull/17143#issuecomment-505080265