### PR TITLE
Avoid calling S3File.s3

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -103,7 +103,7 @@ MultiIndex
 I/O
 ^^^
 
-- Avoid calling ``S3File.s3`` when reading parquet as this was removed in s3fs version 0.3.0 (:issue:`27756`)
+- Avoid calling ``S3File.s3`` when reading parquet, as this was removed in s3fs version 0.3.0 (:issue:`27756`)
 -
 -
 

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -103,7 +103,7 @@ MultiIndex
 I/O
 ^^^
 
--
+- Avoid calling ``S3File.s3`` when reading parquet as this was removed in s3fs version 0.3.0 (:issue:`27756`)
 -
 -
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -8,7 +8,6 @@ from pandas.errors import AbstractMethodError
 from pandas import DataFrame, get_option
 
 from pandas.io.common import get_filepath_or_buffer, is_s3_url
-from pandas.io.s3 import get_file_and_filesystem
 
 
 def get_engine(engine):
@@ -185,6 +184,7 @@ class FastParquetImpl(BaseImpl):
 
     def read(self, path, columns=None, **kwargs):
         if is_s3_url(path):
+            from pandas.io.s3 import get_file_and_filesystem
             # When path is s3:// an S3File is returned.
             # We need to retain the original path(str) while also
             # pass the S3File().open function to fsatparquet impl.

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -185,6 +185,7 @@ class FastParquetImpl(BaseImpl):
     def read(self, path, columns=None, **kwargs):
         if is_s3_url(path):
             from pandas.io.s3 import get_file_and_filesystem
+
             # When path is s3:// an S3File is returned.
             # We need to retain the original path(str) while also
             # pass the S3File().open function to fsatparquet impl.

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -8,6 +8,7 @@ from pandas.errors import AbstractMethodError
 from pandas import DataFrame, get_option
 
 from pandas.io.common import get_filepath_or_buffer, is_s3_url
+from pandas.io.s3 import get_file_and_filesystem
 
 
 def get_engine(engine):
@@ -187,9 +188,9 @@ class FastParquetImpl(BaseImpl):
             # When path is s3:// an S3File is returned.
             # We need to retain the original path(str) while also
             # pass the S3File().open function to fsatparquet impl.
-            s3, _, _, should_close = get_filepath_or_buffer(path)
+            s3, filesystem = get_file_and_filesystem(path)
             try:
-                parquet_file = self.api.ParquetFile(path, open_with=s3.s3.open)
+                parquet_file = self.api.ParquetFile(path, open_with=filesystem.open)
             finally:
                 s3.close()
         else:

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import IO, Any, Optional, Tuple
 from urllib.parse import urlparse as parse_url
 
 from pandas.compat._optional import import_optional_dependency
@@ -7,13 +7,9 @@ from pandas._typing import FilePathOrBuffer
 
 """ s3 support for remote file interactivity """
 
-
-if TYPE_CHECKING:
-    import s3fs
-else:
-    s3fs = import_optional_dependency(
-        "s3fs", extra="The s3fs package is required to handle s3 files."
-    )
+s3fs = import_optional_dependency(
+    "s3fs", extra="The s3fs package is required to handle s3 files."
+)
 
 
 def _strip_schema(url):
@@ -24,7 +20,7 @@ def _strip_schema(url):
 
 def get_file_and_filesystem(
     filepath_or_buffer: FilePathOrBuffer, mode: Optional[str] = None
-) -> Tuple[s3fs.S3File, s3fs.S3FileSystem]:
+) -> Tuple[IO, Any]:
     from botocore.exceptions import NoCredentialsError
 
     if mode is None:
@@ -50,6 +46,6 @@ def get_filepath_or_buffer(
     encoding: Optional[str] = None,
     compression: Optional[str] = None,
     mode: Optional[str] = None,
-) -> Tuple[s3fs.S3File, Optional[str], Optional[str], bool]:
+) -> Tuple[IO, Optional[str], Optional[str], bool]:
     file, _fs = get_file_and_filesystem(filepath_or_buffer, mode=mode)
     return file, None, compression, True

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -1,11 +1,10 @@
+""" s3 support for remote file interactivity """
 from typing import IO, Any, Optional, Tuple
 from urllib.parse import urlparse as parse_url
 
 from pandas.compat._optional import import_optional_dependency
 
 from pandas._typing import FilePathOrBuffer
-
-""" s3 support for remote file interactivity """
 
 s3fs = import_optional_dependency(
     "s3fs", extra="The s3fs package is required to handle s3 files."

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -1,11 +1,17 @@
+from typing import Optional, Tuple, TYPE_CHECKING
+from pandas._typing import FilePathOrBuffer
+
 """ s3 support for remote file interactivity """
 from urllib.parse import urlparse as parse_url
 
 from pandas.compat._optional import import_optional_dependency
 
-s3fs = import_optional_dependency(
-    "s3fs", extra="The s3fs package is required to handle s3 files."
-)
+if TYPE_CHECKING:
+    import s3fs
+else:
+    s3fs = import_optional_dependency(
+        "s3fs", extra="The s3fs package is required to handle s3 files."
+    )
 
 
 def _strip_schema(url):
@@ -14,7 +20,9 @@ def _strip_schema(url):
     return result.netloc + result.path
 
 
-def get_file_and_filesystem(filepath_or_buffer, encoding=None, mode=None):
+def get_file_and_filesystem(
+    filepath_or_buffer: FilePathOrBuffer, mode: Optional[str] = None
+) -> Tuple[s3fs.S3File, s3fs.S3FileSystem]:
     from botocore.exceptions import NoCredentialsError
 
     if mode is None:
@@ -36,9 +44,10 @@ def get_file_and_filesystem(filepath_or_buffer, encoding=None, mode=None):
 
 
 def get_filepath_or_buffer(
-    filepath_or_buffer, encoding=None, compression=None, mode=None
-):
-    file, _fs = get_file_and_filesystem(
-        filepath_or_buffer, encoding=encoding, mode=mode
-    )
+    filepath_or_buffer: FilePathOrBuffer,
+    encoding: Optional[str] = None,
+    compression: Optional[str] = None,
+    mode: Optional[str] = None,
+) -> Tuple[s3fs.S3File, Optional[str], Optional[str], bool]:
+    file, _fs = get_file_and_filesystem(filepath_or_buffer, mode=mode)
     return file, None, compression, True

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -1,10 +1,12 @@
-from typing import Optional, Tuple, TYPE_CHECKING
-from pandas._typing import FilePathOrBuffer
-
-""" s3 support for remote file interactivity """
+from typing import TYPE_CHECKING, Optional, Tuple
 from urllib.parse import urlparse as parse_url
 
 from pandas.compat._optional import import_optional_dependency
+
+from pandas._typing import FilePathOrBuffer
+
+""" s3 support for remote file interactivity """
+
 
 if TYPE_CHECKING:
     import s3fs


### PR DESCRIPTION
When reading from S3 using fastparquet. This attribute was removed in
s3fs 0.3.0. This change avoids accessing it by using a new method
`get_file_and_filesystem` which returns the filesystem in addition to the
file.

- [x] closes #27756
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
