### PR TITLE
DEPR: Remove previously deprecated IntervalIndex.from_intervals

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -65,7 +65,7 @@ Removal of prior version deprecations/changes
 - Changed the the default value of `inplace` in :meth:`DataFrame.set_index` and :meth:`Series.set_axis`. It now defaults to False (:issue:`27600`)
 - :meth:`pandas.Series.str.cat` now defaults to aligning ``others``, using ``join='left'`` (:issue:`27611`)
 - :meth:`pandas.Series.str.cat` does not accept list-likes *within* list-likes anymore (:issue:`27611`)
--
+- Removed the previously deprecated ``IntervalIndex.from_intervals`` in favor of the :class:`IntervalIndex` constructor (:issue:`19263`)
 
 .. _whatsnew_1000.performance:
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -359,50 +359,6 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         )
 
     _interval_shared_docs[
-        "from_intervals"
-    ] = """
-    Construct an %(klass)s from a 1d array of Interval objects
-
-    .. deprecated:: 0.23.0
-
-    Parameters
-    ----------
-    data : array-like (1-dimensional)
-        Array of Interval objects. All intervals must be closed on the same
-        sides.
-    copy : boolean, default False
-        by-default copy the data, this is compat only and ignored
-    dtype : dtype or None, default None
-        If None, dtype will be inferred
-
-        ..versionadded:: 0.23.0
-
-    See Also
-    --------
-    interval_range : Function to create a fixed frequency IntervalIndex.
-    %(klass)s.from_arrays : Construct an %(klass)s from a left and
-                                right array.
-    %(klass)s.from_breaks : Construct an %(klass)s from an array of
-                                splits.
-    %(klass)s.from_tuples : Construct an %(klass)s from an
-                                array-like of tuples.
-
-    Examples
-    --------
-    >>> pd.%(qualname)s.from_intervals([pd.Interval(0, 1),
-    ...                                  pd.Interval(1, 2)])
-    %(klass)s([(0, 1], (1, 2]],
-                  closed='right', dtype='interval[int64]')
-
-    The generic Index constructor work identically when it infers an array
-    of all intervals:
-
-    >>> pd.Index([pd.Interval(0, 1), pd.Interval(1, 2)])
-    %(klass)s([(0, 1], (1, 2]],
-                  closed='right', dtype='interval[int64]')
-    """
-
-    _interval_shared_docs[
         "from_tuples"
     ] = """
     Construct an %(klass)s from an array-like of tuples

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -270,22 +270,6 @@ class IntervalIndex(IntervalMixin, Index):
         return cls._simple_new(array, name=name)
 
     @classmethod
-    @Appender(_interval_shared_docs["from_intervals"] % _index_doc_kwargs)
-    def from_intervals(cls, data, closed=None, name=None, copy=False, dtype=None):
-        msg = (
-            "IntervalIndex.from_intervals is deprecated and will be "
-            "removed in a future version; Use IntervalIndex(...) instead"
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-        with rewrite_exception("IntervalArray", cls.__name__):
-            array = IntervalArray(data, closed=closed, copy=copy, dtype=dtype)
-
-        if name is None and isinstance(data, cls):
-            name = data.name
-
-        return cls._simple_new(array, name=name)
-
-    @classmethod
     @Appender(_interval_shared_docs["from_tuples"] % _index_doc_kwargs)
     def from_tuples(cls, data, closed="right", name=None, copy=False, dtype=None):
         with rewrite_exception("IntervalArray", cls.__name__):

--- a/pandas/tests/indexes/interval/test_construction.py
+++ b/pandas/tests/indexes/interval/test_construction.py
@@ -421,32 +421,3 @@ class TestClassConstructors(Base):
         result = Index(intervals)
         expected = Index(intervals, dtype=object)
         tm.assert_index_equal(result, expected)
-
-
-class TestFromIntervals(TestClassConstructors):
-    """
-    Tests for IntervalIndex.from_intervals, which is deprecated in favor of the
-    IntervalIndex constructor.  Same tests as the IntervalIndex constructor,
-    plus deprecation test.  Should only need to delete this class when removed.
-    """
-
-    @pytest.fixture
-    def constructor(self):
-        def from_intervals_ignore_warnings(*args, **kwargs):
-            with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-                return IntervalIndex.from_intervals(*args, **kwargs)
-
-        return from_intervals_ignore_warnings
-
-    def test_deprecated(self):
-        ivs = [Interval(0, 1), Interval(1, 2)]
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            IntervalIndex.from_intervals(ivs)
-
-    @pytest.mark.skip(reason="parent class test that is not applicable")
-    def test_index_object_dtype(self):
-        pass
-
-    @pytest.mark.skip(reason="parent class test that is not applicable")
-    def test_index_mixed_closed(self):
-        pass


### PR DESCRIPTION
Didn't see any references to `IntervalIndex.from_intervals` in the docs. 

We deprecated this before `IntervalArray` was implemented, so no `from_intervals` to worry about there; `IntervalArray` file just has a "shared" docstring for `from_intervals` that isn't actually shared.