### PR TITLE
BUG: fix construction of NonConsolidatableBlock with inconsistent ndim (#27786)

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -274,6 +274,8 @@ class Block(PandasObject):
             )
         if placement is None:
             placement = self.mgr_locs
+        if ndim is None:
+            ndim = self.ndim
         return make_block(
             values, placement=placement, ndim=ndim, klass=self.__class__, dtype=dtype
         )

--- a/pandas/tests/extension/base/getitem.py
+++ b/pandas/tests/extension/base/getitem.py
@@ -260,3 +260,9 @@ class BaseGetitemTests(BaseExtensionTests):
         expected = pd.Series(data_missing._from_sequence([na, valid, valid]))
 
         self.assert_series_equal(result, expected)
+
+    def test_loc_len1(self, data):
+        # see GH-27785 take_nd with indexer of len 1 resulting in wrong ndim
+        df = pd.DataFrame({"A": data})
+        res = df.loc[[0], "A"]
+        assert res._data._block.ndim == 1


### PR DESCRIPTION
Manual backport of https://github.com/pandas-dev/pandas/pull/27786, meeseeksdev seemed to be inactive for a moment (PR was properly milestoned).