### PR TITLE
REF: implement should_extension_dispatch

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -460,7 +460,7 @@ def masked_arith_op(x, y, op):
 # Dispatch logic
 
 
-def should_extension_dispatch(left, right) -> bool:
+def should_extension_dispatch(left: ABCSeries, right: Any) -> bool:
     """
     Identify cases where Series operation should use dispatch_to_extension_op.
 

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -349,7 +349,9 @@ class TestCategoricalOps:
             ("__mul__", r"\*"),
             ("__truediv__", "/"),
         ]:
-            msg = r"Series cannot perform the operation {}".format(str_rep)
+            msg = r"Series cannot perform the operation {}|unsupported operand".format(
+                str_rep
+            )
             with pytest.raises(TypeError, match=msg):
                 getattr(df, op)(df)
 
@@ -375,7 +377,9 @@ class TestCategoricalOps:
             ("__mul__", r"\*"),
             ("__truediv__", "/"),
         ]:
-            msg = r"Series cannot perform the operation {}".format(str_rep)
+            msg = r"Series cannot perform the operation {}|unsupported operand".format(
+                str_rep
+            )
             with pytest.raises(TypeError, match=msg):
                 getattr(s, op)(2)
 

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -211,7 +211,7 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
 
     def test_add_series_with_extension_array(self, data):
         ser = pd.Series(data)
-        with pytest.raises(TypeError, match="cannot perform"):
+        with pytest.raises(TypeError, match="cannot perform|unsupported operand"):
             ser + data
 
     def test_divmod_series_array(self):


### PR DESCRIPTION
This uses should_extension_dispatch in _arith_method_SERIES.  We'll be able to use it in _comp_method_SERIES after #27803. (this is orthogonal to 27803 so doesn't matter what order they go in)