### PR TITLE
COMPAT: restore shape for 'invalid' Index with nd array

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -111,7 +111,7 @@ Plotting
 ^^^^^^^^
 
 - Added a pandas_plotting_backends entrypoint group for registering plot backends. See :ref:`extending.plotting-backends` for more (:issue:`26747`).
--
+- Fix compatibility issue with matplotlib when passing a pandas ``Index`` to a plot call (:issue:`27775`).
 -
 
 Groupby/resample/rolling

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5600,7 +5600,10 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Return a tuple of the shape of the underlying data.
         """
-        return (len(self),)
+        # not using "(len(self), )" to return "correct" shape if the values
+        # consists of a >1 D array (see GH-27775)
+        # overridden in MultiIndex.shape to avoid materializing the values
+        return self._values.shape
 
 
 Index._add_numeric_methods_disabled()

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -623,6 +623,15 @@ class MultiIndex(Index):
         return self.values
 
     @property
+    def shape(self):
+        """
+        Return a tuple of the shape of the underlying data.
+        """
+        # overriding the base Index.shape definition to avoid materializing
+        # the values (GH-27384, GH-27775)
+        return (len(self),)
+
+    @property
     def array(self):
         """
         Raises a ValueError for `MultiIndex` because there's no single

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2805,3 +2805,17 @@ def test_deprecated_fastpath():
 
     expected = pd.CategoricalIndex(["a", "b", "c"], name="test")
     tm.assert_index_equal(idx, expected)
+
+
+def test_shape_of_invalid_index():
+    # Currently, it is possible to create "invalid" index objects backed by
+    # a multi-dimensional array (see https://github.com/pandas-dev/pandas/issues/27125
+    # about this). However, as long as this is not solved in general,this test ensures
+    # that the returned shape is consistent with this underlying array for
+    # compat with matplotlib (see https://github.com/pandas-dev/pandas/issues/27775)
+    a = np.arange(8).reshape(2, 2, 2)
+    idx = pd.Index(a)
+    assert idx.shape == a.shape
+
+    idx = pd.Index([0, 1, 2, 3])
+    assert idx[:, None].shape == (4, 1)


### PR DESCRIPTION
closes #27775
