### PR TITLE
CLN: match standardized dispatch logic in IntegerArray

### DIFF
--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -21,7 +21,7 @@ from pandas.core.dtypes.common import (
     is_scalar,
 )
 from pandas.core.dtypes.dtypes import register_extension_dtype
-from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
+from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.missing import isna, notna
 
 from pandas.core import nanops, ops
@@ -592,24 +592,28 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
 
     @classmethod
     def _create_comparison_method(cls, op):
+        op_name = op.__name__
+
         def cmp_method(self, other):
 
-            op_name = op.__name__
-            mask = None
-
-            if isinstance(other, (ABCSeries, ABCIndexClass)):
+            if isinstance(other, (ABCDataFrame, ABCSeries, ABCIndexClass)):
                 # Rely on pandas to unbox and dispatch to us.
                 return NotImplemented
+
+            other = lib.item_from_zerodim(other)
+            mask = None
 
             if isinstance(other, IntegerArray):
                 other, mask = other._data, other._mask
 
             elif is_list_like(other):
                 other = np.asarray(other)
-                if other.ndim > 0 and len(self) != len(other):
+                if other.ndim > 1:
+                    raise NotImplementedError(
+                        "can only perform ops with 1-d structures"
+                    )
+                if len(self) != len(other):
                     raise ValueError("Lengths must match to compare")
-
-            other = lib.item_from_zerodim(other)
 
             # numpy will show a DeprecationWarning on invalid elementwise
             # comparisons, this will raise in the future
@@ -683,31 +687,31 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
 
     @classmethod
     def _create_arithmetic_method(cls, op):
+        op_name = op.__name__
+
         def integer_arithmetic_method(self, other):
 
-            op_name = op.__name__
-            mask = None
-
-            if isinstance(other, (ABCSeries, ABCIndexClass)):
+            if isinstance(other, (ABCDataFrame, ABCSeries, ABCIndexClass)):
                 # Rely on pandas to unbox and dispatch to us.
                 return NotImplemented
 
-            if getattr(other, "ndim", 0) > 1:
-                raise NotImplementedError("can only perform ops with 1-d structures")
+            other = lib.item_from_zerodim(other)
+            mask = None
 
             if isinstance(other, IntegerArray):
                 other, mask = other._data, other._mask
 
-            elif getattr(other, "ndim", None) == 0:
-                other = other.item()
-
             elif is_list_like(other):
                 other = np.asarray(other)
-                if not other.ndim:
-                    other = other.item()
-                elif other.ndim == 1:
-                    if not (is_float_dtype(other) or is_integer_dtype(other)):
-                        raise TypeError("can only perform ops with numeric values")
+                if other.ndim > 1:
+                    raise NotImplementedError(
+                        "can only perform ops with 1-d structures"
+                    )
+                if len(self) != len(other):
+                    raise ValueError("Lengths must match")
+                if not (is_float_dtype(other) or is_integer_dtype(other)):
+                    raise TypeError("can only perform ops with numeric values")
+
             else:
                 if not (is_float(other) or is_integer(other)):
                     raise TypeError("can only perform ops with numeric values")

--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -280,7 +280,7 @@ class TestArithmeticOps(BaseOpsUtil):
         other = 0.01
         self._check_op(s, op, other)
 
-    @pytest.mark.parametrize("other", [1.0, 1.0, np.array(1.0), np.array([1.0])])
+    @pytest.mark.parametrize("other", [1.0, np.array(1.0)])
     def test_arithmetic_conversion(self, all_arithmetic_operators, other):
         # if we have a float operand we should have a float result
         # if that is equal to an integer
@@ -289,6 +289,15 @@ class TestArithmeticOps(BaseOpsUtil):
         s = pd.Series([1, 2, 3], dtype="Int64")
         result = op(s, other)
         assert result.dtype is np.dtype("float")
+
+    def test_arith_len_mismatch(self, all_arithmetic_operators):
+        # operating with a list-like with non-matching length raises
+        op = self.get_op_from_name(all_arithmetic_operators)
+        other = np.array([1.0])
+
+        s = pd.Series([1, 2, 3], dtype="Int64")
+        with pytest.raises(ValueError, match="Lengths must match"):
+            op(s, other)
 
     @pytest.mark.parametrize("other", [0, 0.5])
     def test_arith_zero_dim_ndarray(self, other):
@@ -322,8 +331,9 @@ class TestArithmeticOps(BaseOpsUtil):
                 ops(pd.Series(pd.date_range("20180101", periods=len(s))))
 
         # 2d
-        with pytest.raises(NotImplementedError):
-            opa(pd.DataFrame({"A": s}))
+        result = opa(pd.DataFrame({"A": s}))
+        assert result is NotImplemented
+
         with pytest.raises(NotImplementedError):
             opa(np.arange(len(s)).reshape(-1, len(s)))
 


### PR DESCRIPTION
Actual logic changes:
- return NotImplemented when operating with DataFrame (instead of raising NotImplementError)
- raise ValueError when operating with mismatched-length listlike

Everything else is just rearranging to use patterns that are more standard around the codebase, leading up to #23853