### PR TITLE
DOC: Clarify that unique() promotes dtype to 64-bit

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -320,6 +320,7 @@ def unique(values):
     of appearance. This does NOT sort.
 
     Significantly faster than numpy.unique. Includes NA values.
+    For numeric input, the dtype of the result will be promoted to 64-bit.
 
     Parameters
     ----------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2122,6 +2122,7 @@ class Index(IndexOpsMixin, PandasObject):
         Returns
         -------
         Index without duplicates
+        For numeric input, the dtype of the result will be promoted to 64-bit.
 
         See Also
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1910,8 +1910,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Notes
         -----
-        Returns the unique values as a NumPy array. In case of an
-        extension-array backed Series, a new
+        Returns the unique values as a NumPy array.
+        For numeric input, the dtype of the result will be promoted to 64-bit.
+        In case of an extension-array backed Series, a new
         :class:`~api.extensions.ExtensionArray` of that type with just
         the unique values is returned. This includes
 


### PR DESCRIPTION
I found this behavior surprising:

```python
In [1]: pd.Series([1,2,3], dtype=np.uint8).unique()
Out[1]: array([1, 2, 3], dtype=uint64)
```
... because I did not expect a different dtype in the result.  This PR adds a sentence to the docs to clarify this.

- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- (n/a) closes #xxxx
- (n/a) tests added / passed
- (n/a) whatsnew entry
