### PR TITLE
COMPAT: unique() should preserve the dtype of the input

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -151,6 +151,7 @@ Other API changes
 
 - :meth:`pandas.api.types.infer_dtype` will now return "integer-na" for integer and ``np.nan`` mix (:issue:`27283`)
 - :meth:`MultiIndex.from_arrays` will no longer infer names from arrays if ``names=None`` is explicitly provided (:issue:`27292`)
+- The returned dtype of ::func:`pd.unique` now matches the input dtype. (:issue:`27874`)
 -
 
 .. _whatsnew_1000.api.documentation:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -396,7 +396,7 @@ def unique(values):
 
     table = htable(len(values))
     uniques = table.unique(values)
-    uniques = _reconstruct_data(uniques, dtype, original)
+    uniques = _reconstruct_data(uniques, original.dtype, original)
     return uniques
 
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -180,13 +180,13 @@ def _reconstruct_data(values, dtype, original):
     if is_extension_array_dtype(dtype):
         values = dtype.construct_array_type()._from_sequence(values)
     elif is_bool_dtype(dtype):
-        values = values.astype(dtype)
+        values = values.astype(dtype, copy=False)
 
         # we only support object dtypes bool Index
         if isinstance(original, ABCIndexClass):
-            values = values.astype(object)
+            values = values.astype(object, copy=False)
     elif dtype is not None:
-        values = values.astype(dtype)
+        values = values.astype(dtype, copy=False)
 
     return values
 


### PR DESCRIPTION
The behavior of `pd.unique()` is surprising, because -- unlike `np.unique()` -- the result does not have the same `dtype` as the input:

```python
In [1]: pd.Series([1,2,3], dtype=np.uint8).unique()
Out[1]: array([1, 2, 3], dtype=uint64)
```

This PR just casts the output array to match the input dtype.  Supercedes #27869.

**Update:** Augmented the tests to cover narrow dtypes.

~I added a new assertion in `test_value_counts_unique_nunique()`, but it may not be sufficient.  From what I can see, there isn't good coverage of `Series` whose *data* is not `int`/`float`/ etc.  There is only good coverage of various *index* types. Any advice concerning test coverage?~

- [x] closes #27869
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
