### PR TITLE
DOC: clarify see also for DataFrame.iterrows()

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -845,8 +845,8 @@ class DataFrame(NDFrame):
 
         See Also
         --------
-        itertuples : Iterate over DataFrame rows as namedtuples of the values.
-        items : Iterate over (column name, Series) pairs.
+        DataFrame.itertuples : Iterate over DataFrame rows as namedtuples of the values.
+        DataFrame.items : Iterate over (column name, Series) pairs.
 
         Notes
         -----


### PR DESCRIPTION
changed ` .x()` to `Dataframe.x()` in See Also for DataFrame.iterrows.