### PR TITLE
CLN: use invalid_comparison for incorrect case in Index comparison

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -112,17 +112,11 @@ def _make_comparison_op(op, cls):
             with np.errstate(all="ignore"):
                 result = op(self.values, np.asarray(other))
 
-        # technically we could support bool dtyped Index
-        # for now just return the indexing array directly
         if is_bool_dtype(result):
             return result
-        try:
-            return Index(result)
-        except TypeError:
-            return result
+        return ops.invalid_comparison(self, other, op)
 
     name = "__{name}__".format(name=op.__name__)
-    # TODO: docstring?
     return set_function_name(cmp_method, name, cls)
 
 

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -118,4 +118,7 @@ def test_elementwise_comparison_warning():
     # this test.
     idx = Index([1, 2])
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        idx == "a"
+        result = idx == "a"
+
+    expected = np.array([False, False])
+    tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
Only one test reaches this point, and we aren't currently checking for the output, just that a warning is emitted.  This fixes the currently-incorrect output and updates the test to check for it.