### PR TITLE
BUG: lzma is a required part of python, make it optional

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -103,7 +103,7 @@ MultiIndex
 
 I/O
 ^^^
-
+- Bug: importing `lzma` can fail when Python is not properly installed. For example, on MacOS, installing Python with `pyenv` when `xz` is not available does not raise any issues during installation. However, trying to `import pandas` afterwards will fail, since the module `lzma` will not be available. Usually, this can be solved by installing the appropriate Python dependencies, and then resintalling Python. This fix warns the user that Python was not properly installed during a `import pandas`. In this case, Pandas can still be used (not possible before this fix), but any call to the `lzma` module will raise a `RuntimeError`. (:issue: `27575`)
 -
 -
 -

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -103,8 +103,6 @@ MultiIndex
 
 I/O
 ^^^
-- Bug: importing `lzma` can fail when Python is not properly installed. For example, on MacOS, installing Python with `pyenv` when `xz` is not available does not raise any issues during installation. However, trying to `import pandas` afterwards will fail, since the module `lzma` will not be available. Usually, this can be solved by installing the appropriate Python dependencies, and then resintalling Python. This fix warns the user that Python was not properly installed during a `import pandas`. In this case, Pandas can still be used (not possible before this fix), but any call to the `lzma` module will raise a `RuntimeError`. The solution was to check for an `ImportError` when importing `lzma`. If we get an `ImportError`, then we set `lzma` to `None`. When we actually need to call some method of `lzma`, we first check `lzma is None` and raise a `RuntimeError` if true, otherwise `lzma` was imported and the code can run. (:issue: `27575`)
--
 - Avoid calling ``S3File.s3`` when reading parquet, as this was removed in s3fs version 0.3.0 (:issue:`27756`)
 -
 -
@@ -160,6 +158,15 @@ Other
 -
 -
 -
+
+I/O and LZMA
+~~~~~~~~~~~~
+
+- Issue: Some users may unknowingly have an incomplete Python installation, which lacks the `lzma` module from the standard library. In this case, `import pandas` fails due to an `ImportError`; (:issue: `27575`)
+- Change: Pandas will now warn, rather than raising an `ImportError` if the `lzma` module is not present. Any subsequent attempt to use `lzma` methods will raise a `RuntimeError`;
+- Possible Fix: Ensure you have the necessary libraries and reinstall Python;
+- Example: On MacOS, installing Python with `pyenv` may lead to an incomplete Python installation due to unmet system dependencies at compilation time (like `xz`). Compilation will succeed, but Python might fail at run time.
+
 
 .. _whatsnew_0.251.contributors:
 

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -162,11 +162,10 @@ Other
 I/O and LZMA
 ~~~~~~~~~~~~
 
-- Issue: Some users may unknowingly have an incomplete Python installation, which lacks the `lzma` module from the standard library. In this case, `import pandas` fails due to an `ImportError`; (:issue: `27575`)
-- Change: Pandas will now warn, rather than raising an `ImportError` if the `lzma` module is not present. Any subsequent attempt to use `lzma` methods will raise a `RuntimeError`;
-- Possible Fix: Ensure you have the necessary libraries and reinstall Python;
-- Example: On MacOS, installing Python with `pyenv` may lead to an incomplete Python installation due to unmet system dependencies at compilation time (like `xz`). Compilation will succeed, but Python might fail at run time.
-
+Some users may unknowingly have an incomplete Python installation, which lacks the `lzma` module from the standard library. In this case, `import pandas` failed due to an `ImportError` (:issue: `27575`).
+Pandas will now warn, rather than raising an `ImportError` if the `lzma` module is not present. Any subsequent attempt to use `lzma` methods will raise a `RuntimeError`.
+A possible fix for the lack of the `lzma` module is to ensure you have the necessary libraries and then re-install Python.
+For example, on MacOS installing Python with `pyenv` may lead to an incomplete Python installation due to unmet system dependencies at compilation time (like `xz`). Compilation will succeed, but Python might fail at run time. The issue can be solved by installing the necessary dependencies and then re-installing Python.
 
 .. _whatsnew_0.251.contributors:
 

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -103,7 +103,7 @@ MultiIndex
 
 I/O
 ^^^
-- Bug: importing `lzma` can fail when Python is not properly installed. For example, on MacOS, installing Python with `pyenv` when `xz` is not available does not raise any issues during installation. However, trying to `import pandas` afterwards will fail, since the module `lzma` will not be available. Usually, this can be solved by installing the appropriate Python dependencies, and then resintalling Python. This fix warns the user that Python was not properly installed during a `import pandas`. In this case, Pandas can still be used (not possible before this fix), but any call to the `lzma` module will raise a `RuntimeError`. (:issue: `27575`)
+- Bug: importing `lzma` can fail when Python is not properly installed. For example, on MacOS, installing Python with `pyenv` when `xz` is not available does not raise any issues during installation. However, trying to `import pandas` afterwards will fail, since the module `lzma` will not be available. Usually, this can be solved by installing the appropriate Python dependencies, and then resintalling Python. This fix warns the user that Python was not properly installed during a `import pandas`. In this case, Pandas can still be used (not possible before this fix), but any call to the `lzma` module will raise a `RuntimeError`. The solution was to check for an `ImportError` when importing `lzma`. If we get an `ImportError`, then we set `lzma` to `None`. When we actually need to call some method of `lzma`, we first check `lzma is None` and raise a `RuntimeError` if true, otherwise `lzma` was imported and the code can run. (:issue: `27575`)
 -
 -
 -

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -106,7 +106,6 @@ I/O
 - Bug: importing `lzma` can fail when Python is not properly installed. For example, on MacOS, installing Python with `pyenv` when `xz` is not available does not raise any issues during installation. However, trying to `import pandas` afterwards will fail, since the module `lzma` will not be available. Usually, this can be solved by installing the appropriate Python dependencies, and then resintalling Python. This fix warns the user that Python was not properly installed during a `import pandas`. In this case, Pandas can still be used (not possible before this fix), but any call to the `lzma` module will raise a `RuntimeError`. The solution was to check for an `ImportError` when importing `lzma`. If we get an `ImportError`, then we set `lzma` to `None`. When we actually need to call some method of `lzma`, we first check `lzma is None` and raise a `RuntimeError` if true, otherwise `lzma` was imported and the code can run. (:issue: `27575`)
 -
 - Avoid calling ``S3File.s3`` when reading parquet, as this was removed in s3fs version 0.3.0 (:issue:`27756`)
->>>>>>> 35821a5794e434117b14797f010602c8e412b36c
 -
 -
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -2,7 +2,6 @@
 # See LICENSE for the license
 import bz2
 import gzip
-import lzma
 import os
 import sys
 import time
@@ -59,8 +58,11 @@ from pandas.core.arrays import Categorical
 from pandas.core.dtypes.concat import union_categoricals
 import pandas.io.common as icom
 
+from pandas.compat import import_lzma
 from pandas.errors import (ParserError, DtypeWarning,
                            EmptyDataError, ParserWarning)
+
+lzma = import_lzma()
 
 # Import CParserError as alias of ParserError for backwards compatibility.
 # Ultimately, we want to remove this import. See gh-12665 and gh-14479.

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -646,7 +646,11 @@ cdef class TextReader:
                     raise ValueError('Multiple files found in compressed '
                                      'zip file %s', str(zip_names))
             elif self.compression == 'xz':
-                if lzma is None: raise RuntimeError("lzma module not available.")
+                if lzma is None:
+                    raise RuntimeError("lzma module not available. "
+                                       "A Python re-install with the proper "
+                                       "dependencies might be required to "
+                                       "solve this issue.")
                 if isinstance(source, str):
                     source = lzma.LZMAFile(source, 'rb')
                 else:

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -646,6 +646,7 @@ cdef class TextReader:
                     raise ValueError('Multiple files found in compressed '
                                      'zip file %s', str(zip_names))
             elif self.compression == 'xz':
+                if lzma is None: raise RuntimeError("lzma module not available.")
                 if isinstance(source, str):
                     source = lzma.LZMAFile(source, 'rb')
                 else:

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -58,11 +58,11 @@ from pandas.core.arrays import Categorical
 from pandas.core.dtypes.concat import union_categoricals
 import pandas.io.common as icom
 
-from pandas.compat import import_lzma
+from pandas.compat import _import_lzma, _get_lzma_file
 from pandas.errors import (ParserError, DtypeWarning,
                            EmptyDataError, ParserWarning)
 
-lzma = import_lzma()
+lzma = _import_lzma()
 
 # Import CParserError as alias of ParserError for backwards compatibility.
 # Ultimately, we want to remove this import. See gh-12665 and gh-14479.
@@ -646,15 +646,10 @@ cdef class TextReader:
                     raise ValueError('Multiple files found in compressed '
                                      'zip file %s', str(zip_names))
             elif self.compression == 'xz':
-                if lzma is None:
-                    raise RuntimeError("lzma module not available. "
-                                       "A Python re-install with the proper "
-                                       "dependencies might be required to "
-                                       "solve this issue.")
                 if isinstance(source, str):
-                    source = lzma.LZMAFile(source, 'rb')
+                    source = _get_lzma_file(lzma)(source, 'rb')
                 else:
-                    source = lzma.LZMAFile(filename=source)
+                    source = _get_lzma_file(lzma)(filename=source)
             else:
                 raise ValueError('Unrecognized compression type: %s' %
                                  self.compression)

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -69,6 +69,8 @@ def is_platform_32bit():
 
 
 def _import_lzma():
+    """Attempts to import lzma, warning the user when lzma is not available.
+    """
     try:
         import lzma
 
@@ -83,6 +85,9 @@ def _import_lzma():
 
 
 def _get_lzma_file(lzma):
+    """Returns the lzma method LZMAFile when the module was correctly imported.
+    Otherwise, raises a RuntimeError.
+    """
     if lzma is None:
         raise RuntimeError(
             "lzma module not available. "

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -10,6 +10,8 @@ Other items:
 import platform
 import struct
 import sys
+import warnings
+
 
 PY35 = sys.version_info[:2] == (3, 5)
 PY36 = sys.version_info >= (3, 6)
@@ -68,8 +70,6 @@ def is_platform_32bit():
 
 
 def import_lzma():
-    import warnings
-
     try:
         import lzma
 

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -65,3 +65,16 @@ def is_platform_mac():
 
 def is_platform_32bit():
     return struct.calcsize("P") * 8 < 64
+
+
+def import_lzma():
+    import warnings
+    try:
+        import lzma
+        return lzma
+    except ImportError:
+        msg = (
+            "Could not import the lzma module. Your installed Python is incomplete. "
+            "Attempting to use `lzma` compression will result in a RuntimeError."
+        )
+        warnings.warn(msg)

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -68,14 +68,25 @@ def is_platform_32bit():
     return struct.calcsize("P") * 8 < 64
 
 
-def import_lzma():
+def _import_lzma():
     try:
         import lzma
 
         return lzma
     except ImportError:
         msg = (
-            "Could not import the lzma module. Your installed Python is incomplete. "
-            "Attempting to use `lzma` compression will result in a RuntimeError."
+            "Could not import the lzma module. "
+            "Your installed Python is incomplete. "
+            "Attempting to use lzma compression will result in a RuntimeError."
         )
         warnings.warn(msg)
+
+
+def _get_lzma_file(lzma):
+    if lzma is None:
+        raise RuntimeError(
+            "lzma module not available. "
+            "A Python re-install with the proper "
+            "dependencies might be required to solve this issue."
+        )
+    return lzma.LZMAFile

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -12,7 +12,6 @@ import struct
 import sys
 import warnings
 
-
 PY35 = sys.version_info[:2] == (3, 5)
 PY36 = sys.version_info >= (3, 6)
 PY37 = sys.version_info >= (3, 7)

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -69,8 +69,10 @@ def is_platform_32bit():
 
 def import_lzma():
     import warnings
+
     try:
         import lzma
+
         return lzma
     except ImportError:
         msg = (

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -22,7 +22,7 @@ from urllib.parse import (  # noqa
 from urllib.request import pathname2url, urlopen
 import zipfile
 
-from pandas.compat import import_lzma
+from pandas.compat import _get_lzma_file, _import_lzma
 from pandas.errors import (  # noqa
     AbstractMethodError,
     DtypeWarning,
@@ -35,7 +35,7 @@ from pandas.core.dtypes.common import is_file_like
 
 from pandas._typing import FilePathOrBuffer
 
-lzma = import_lzma()
+lzma = _import_lzma()
 
 # gh-12665: Alias for now and remove later.
 CParserError = ParserError
@@ -397,15 +397,7 @@ def _get_handle(
 
         # XZ Compression
         elif compression == "xz":
-            if lzma is None:
-                raise RuntimeError(
-                    "lzma module not available. "
-                    "A Python re-install with the proper "
-                    "dependencies might be required to "
-                    "solve this issue."
-                )
-            else:
-                f = lzma.LZMAFile(path_or_buf, mode)
+            f = _get_lzma_file(lzma)(path_or_buf, mode)
 
         # Unrecognized Compression
         else:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -397,7 +397,10 @@ def _get_handle(
 
         # XZ Compression
         elif compression == "xz":
-            f = lzma.LZMAFile(path_or_buf, mode)
+            if lzma is None:
+                raise RuntimeError("lzma module not available.")
+            else:
+                f = lzma.LZMAFile(path_or_buf, mode)
 
         # Unrecognized Compression
         else:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -22,6 +22,7 @@ from urllib.parse import (  # noqa
 from urllib.request import pathname2url, urlopen
 import zipfile
 
+from pandas.compat import import_lzma
 from pandas.errors import (  # noqa
     AbstractMethodError,
     DtypeWarning,
@@ -30,7 +31,6 @@ from pandas.errors import (  # noqa
     ParserWarning,
 )
 
-from pandas.compat import import_lzma
 from pandas.core.dtypes.common import is_file_like
 
 from pandas._typing import FilePathOrBuffer

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -398,7 +398,12 @@ def _get_handle(
         # XZ Compression
         elif compression == "xz":
             if lzma is None:
-                raise RuntimeError("lzma module not available.")
+                raise RuntimeError(
+                    "lzma module not available. "
+                    "A Python re-install with the proper "
+                    "dependencies might be required to "
+                    "solve this issue."
+                )
             else:
                 f = lzma.LZMAFile(path_or_buf, mode)
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -6,7 +6,6 @@ import csv
 import gzip
 from http.client import HTTPException  # noqa
 from io import BytesIO
-import lzma
 import mmap
 import os
 import pathlib
@@ -31,9 +30,12 @@ from pandas.errors import (  # noqa
     ParserWarning,
 )
 
+from pandas.compat import import_lzma
 from pandas.core.dtypes.common import is_file_like
 
 from pandas._typing import FilePathOrBuffer
+
+lzma = import_lzma()
 
 # gh-12665: Alias for now and remove later.
 CParserError = ParserError

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -130,6 +130,7 @@ def test_compression_warning(compression_only):
 
 
 def test_with_missing_lzma():
+    """Tests if import pandas fails when lzma is not present."""
     # https://github.com/pandas-dev/pandas/issues/27575
     code = textwrap.dedent(
         """\
@@ -137,5 +138,18 @@ def test_with_missing_lzma():
         sys.modules['lzma'] = None
         import pandas
         """
+    )
+    subprocess.check_output(["python", "-c", code])
+
+
+def test_with_missing_lzma_runtime():
+    """Tests if RuntimeError is hit when calling lzma without
+    having the module available."""
+    code = textwrap.dedent(
+        """
+        import sys
+        from pandas.compat import _import_lzma, _get_lzma_file
+        lzma = _import_lzma()
+        _get_lzma_file(lzma)"""
     )
     subprocess.check_output(["python", "-c", code])

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -130,7 +130,7 @@ def test_compression_warning(compression_only):
 
 
 def test_with_missing_lzma():
-    """Tests if import pandas fails when lzma is not present."""
+    """Tests if import pandas works when lzma is not present."""
     # https://github.com/pandas-dev/pandas/issues/27575
     code = textwrap.dedent(
         """\
@@ -148,8 +148,12 @@ def test_with_missing_lzma_runtime():
     code = textwrap.dedent(
         """
         import sys
-        from pandas.compat import _import_lzma, _get_lzma_file
-        lzma = _import_lzma()
-        _get_lzma_file(lzma)"""
+        import pytest
+        sys.modules['lzma'] = None
+        import pandas
+        df = pandas.DataFrame()
+        with pytest.raises(RuntimeError, match='lzma module'):
+            df.to_csv('foo.csv', compression='xz')
+        """
     )
     subprocess.check_output(["python", "-c", code])

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -1,5 +1,7 @@
 import contextlib
 import os
+import subprocess
+import textwrap
 import warnings
 
 import pytest
@@ -125,3 +127,15 @@ def test_compression_warning(compression_only):
         with tm.assert_produces_warning(RuntimeWarning, check_stacklevel=False):
             with f:
                 df.to_csv(f, compression=compression_only)
+
+
+def test_with_missing_lzma():
+    # https://github.com/pandas-dev/pandas/issues/27575
+    code = textwrap.dedent(
+        """\
+        import sys
+        sys.modules['lzma'] = None
+        import pandas
+        """
+    )
+    subprocess.check_output(["python", "-c", code])

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -271,7 +271,10 @@ class TestCompression:
             with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as f:
                 f.write(src_path, os.path.basename(src_path))
         elif compression == "xz":
-            f = lzma.LZMAFile(dest_path, "w")
+            if lzma is None:
+                raise RuntimeError("lzma module not available.")
+            else:
+                f = lzma.LZMAFile(dest_path, "w")
         else:
             msg = "Unrecognized compression type: {}".format(compression)
             raise ValueError(msg)

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -21,7 +21,7 @@ import zipfile
 
 import pytest
 
-from pandas.compat import import_lzma, is_platform_little_endian
+from pandas.compat import _get_lzma_file, _import_lzma, is_platform_little_endian
 
 import pandas as pd
 from pandas import Index
@@ -29,7 +29,7 @@ import pandas.util.testing as tm
 
 from pandas.tseries.offsets import Day, MonthEnd
 
-lzma = import_lzma()
+lzma = _import_lzma()
 
 
 @pytest.fixture(scope="module")
@@ -271,15 +271,7 @@ class TestCompression:
             with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as f:
                 f.write(src_path, os.path.basename(src_path))
         elif compression == "xz":
-            if lzma is None:
-                raise RuntimeError(
-                    "lzma module not available. "
-                    "A Python re-install with the proper "
-                    "dependencies might be required to "
-                    "solve this issue."
-                )
-            else:
-                f = lzma.LZMAFile(dest_path, "w")
+            f = _get_lzma_file(lzma)(dest_path, "w")
         else:
             msg = "Unrecognized compression type: {}".format(compression)
             raise ValueError(msg)

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -272,7 +272,12 @@ class TestCompression:
                 f.write(src_path, os.path.basename(src_path))
         elif compression == "xz":
             if lzma is None:
-                raise RuntimeError("lzma module not available.")
+                raise RuntimeError(
+                    "lzma module not available. "
+                    "A Python re-install with the proper "
+                    "dependencies might be required to "
+                    "solve this issue."
+                )
             else:
                 f = lzma.LZMAFile(dest_path, "w")
         else:

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -21,7 +21,7 @@ import zipfile
 
 import pytest
 
-from pandas.compat import is_platform_little_endian, import_lzma
+from pandas.compat import import_lzma, is_platform_little_endian
 
 import pandas as pd
 from pandas import Index

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -13,7 +13,6 @@ $ python generate_legacy_storage_files.py <output_dir> pickle
 import bz2
 import glob
 import gzip
-import lzma
 import os
 import pickle
 import shutil
@@ -22,13 +21,15 @@ import zipfile
 
 import pytest
 
-from pandas.compat import is_platform_little_endian
+from pandas.compat import is_platform_little_endian, import_lzma
 
 import pandas as pd
 from pandas import Index
 import pandas.util.testing as tm
 
 from pandas.tseries.offsets import Day, MonthEnd
+
+lzma = import_lzma()
 
 
 @pytest.fixture(scope="module")

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -268,7 +268,6 @@ def write_to_compressed(compression, path, data, dest="test"):
 
         compress_method = bz2.BZ2File
     elif compression == "xz":
-        lzma = import_lzma()
         if lzma is None:
             raise RuntimeError("lmza module not available.")
         else:

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -25,7 +25,7 @@ from pandas._config.localization import (  # noqa:F401
 )
 
 import pandas._libs.testing as _testing
-from pandas.compat import raise_with_traceback, import_lzma
+from pandas.compat import import_lzma, raise_with_traceback
 
 from pandas.core.dtypes.common import (
     is_bool,

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -213,7 +213,12 @@ def decompress_file(path, compression):
         f = bz2.BZ2File(path, "rb")
     elif compression == "xz":
         if lzma is None:
-            raise RuntimeError("lzma module not available.")
+            raise RuntimeError(
+                "lzma module not available. "
+                "A Python re-install with the proper "
+                "dependencies might be required to "
+                "solve this issue."
+            )
         else:
             f = lzma.LZMAFile(path, "rb")
     elif compression == "zip":
@@ -269,7 +274,12 @@ def write_to_compressed(compression, path, data, dest="test"):
         compress_method = bz2.BZ2File
     elif compression == "xz":
         if lzma is None:
-            raise RuntimeError("lmza module not available.")
+            raise RuntimeError(
+                "lzma module not available. "
+                "A Python re-install with the proper "
+                "dependencies might be required to "
+                "solve this issue."
+            )
         else:
             compress_method = lzma.LZMAFile
     else:

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -25,7 +25,7 @@ from pandas._config.localization import (  # noqa:F401
 )
 
 import pandas._libs.testing as _testing
-from pandas.compat import import_lzma, raise_with_traceback
+from pandas.compat import _get_lzma_file, _import_lzma, raise_with_traceback
 
 from pandas.core.dtypes.common import (
     is_bool,
@@ -69,7 +69,7 @@ from pandas.core.arrays import (
 from pandas.io.common import urlopen
 from pandas.io.formats.printing import pprint_thing
 
-lzma = import_lzma()
+lzma = _import_lzma()
 
 N = 30
 K = 4
@@ -212,15 +212,7 @@ def decompress_file(path, compression):
     elif compression == "bz2":
         f = bz2.BZ2File(path, "rb")
     elif compression == "xz":
-        if lzma is None:
-            raise RuntimeError(
-                "lzma module not available. "
-                "A Python re-install with the proper "
-                "dependencies might be required to "
-                "solve this issue."
-            )
-        else:
-            f = lzma.LZMAFile(path, "rb")
+        f = _get_lzma_file(lzma)(path, "rb")
     elif compression == "zip":
         zip_file = zipfile.ZipFile(path)
         zip_names = zip_file.namelist()
@@ -273,15 +265,7 @@ def write_to_compressed(compression, path, data, dest="test"):
 
         compress_method = bz2.BZ2File
     elif compression == "xz":
-        if lzma is None:
-            raise RuntimeError(
-                "lzma module not available. "
-                "A Python re-install with the proper "
-                "dependencies might be required to "
-                "solve this issue."
-            )
-        else:
-            compress_method = lzma.LZMAFile
+        compress_method = _get_lzma_file(lzma)
     else:
         msg = "Unrecognized compression type: {}".format(compression)
         raise ValueError(msg)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -212,7 +212,10 @@ def decompress_file(path, compression):
     elif compression == "bz2":
         f = bz2.BZ2File(path, "rb")
     elif compression == "xz":
-        f = lzma.LZMAFile(path, "rb")
+        if lzma is None:
+            raise RuntimeError("lzma module not available.")
+        else:
+            f = lzma.LZMAFile(path, "rb")
     elif compression == "zip":
         zip_file = zipfile.ZipFile(path)
         zip_names = zip_file.namelist()
@@ -266,8 +269,10 @@ def write_to_compressed(compression, path, data, dest="test"):
         compress_method = bz2.BZ2File
     elif compression == "xz":
         lzma = import_lzma()
-
-        compress_method = lzma.LZMAFile
+        if lzma is None:
+            raise RuntimeError("lmza module not available.")
+        else:
+            compress_method = lzma.LZMAFile
     else:
         msg = "Unrecognized compression type: {}".format(compression)
         raise ValueError(msg)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from functools import wraps
 import gzip
 import http.client
-import lzma
 import os
 import re
 from shutil import rmtree
@@ -26,7 +25,7 @@ from pandas._config.localization import (  # noqa:F401
 )
 
 import pandas._libs.testing as _testing
-from pandas.compat import raise_with_traceback
+from pandas.compat import raise_with_traceback, import_lzma
 
 from pandas.core.dtypes.common import (
     is_bool,
@@ -69,6 +68,8 @@ from pandas.core.arrays import (
 
 from pandas.io.common import urlopen
 from pandas.io.formats.printing import pprint_thing
+
+lzma = import_lzma()
 
 N = 30
 K = 4
@@ -264,7 +265,7 @@ def write_to_compressed(compression, path, data, dest="test"):
 
         compress_method = bz2.BZ2File
     elif compression == "xz":
-        import lzma
+        lzma = import_lzma()
 
         compress_method = lzma.LZMAFile
     else:


### PR DESCRIPTION
Importing `lzma` when Python has been compiled without its support (usually due to a lack of `xz` in the system) will raise a warning. Substituted `import lzma` for helper function.

- [x] closes #27575
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry