### PR TITLE
CLN: remove unnecessary validate_for_numeric_binop

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 import operator
 from textwrap import dedent
 from typing import Union
@@ -49,7 +49,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
-    ABCDateOffset,
     ABCDatetimeArray,
     ABCDatetimeIndex,
     ABCIndexClass,
@@ -5383,51 +5382,6 @@ class Index(IndexOpsMixin, PandasObject):
                 "cannot evaluate a numeric op "
                 "{opstr} for type: {typ}".format(opstr=opstr, typ=type(self).__name__)
             )
-
-    def _validate_for_numeric_binop(self, other, op):
-        """
-        Return valid other; evaluate or raise TypeError if we are not of
-        the appropriate type.
-
-        Notes
-        -----
-        This is an internal method called by ops.
-        """
-        opstr = "__{opname}__".format(opname=op.__name__)
-        # if we are an inheritor of numeric,
-        # but not actually numeric (e.g. DatetimeIndex/PeriodIndex)
-        if not self._is_numeric_dtype:
-            raise TypeError(
-                "cannot evaluate a numeric op {opstr} "
-                "for type: {typ}".format(opstr=opstr, typ=type(self).__name__)
-            )
-
-        if isinstance(other, Index):
-            if not other._is_numeric_dtype:
-                raise TypeError(
-                    "cannot evaluate a numeric op "
-                    "{opstr} with type: {typ}".format(opstr=opstr, typ=type(other))
-                )
-        elif isinstance(other, np.ndarray) and not other.ndim:
-            other = other.item()
-
-        if isinstance(other, (Index, ABCSeries, np.ndarray)):
-            if len(self) != len(other):
-                raise ValueError("cannot evaluate a numeric op with unequal lengths")
-            other = com.values_from_object(other)
-            if other.dtype.kind not in ["f", "i", "u"]:
-                raise TypeError("cannot evaluate a numeric op with a non-numeric dtype")
-        elif isinstance(other, (ABCDateOffset, np.timedelta64, timedelta)):
-            # higher up to handle
-            pass
-        elif isinstance(other, (datetime, np.datetime64)):
-            # higher up to handle
-            pass
-        else:
-            if not (is_float(other) or is_integer(other)):
-                raise TypeError("can only perform ops with scalar values")
-
-        return other
 
     @classmethod
     def _add_numeric_methods_binary(cls):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -25,6 +25,7 @@ from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries, ABCTimedeltaInde
 
 from pandas.core import ops
 import pandas.core.common as com
+from pandas.core.construction import extract_array
 import pandas.core.indexes.base as ibase
 from pandas.core.indexes.base import Index, _index_shared_docs
 from pandas.core.indexes.numeric import Int64Index
@@ -782,7 +783,7 @@ class RangeIndex(Int64Index):
                     # Must be an np.ndarray; GH#22390
                     return op(self._int64index, other)
 
-                other = self._validate_for_numeric_binop(other, op)
+                other = extract_array(other, extract_numpy=True)
                 attrs = self._get_attributes_dict()
                 attrs = self._maybe_update_attributes(attrs)
 


### PR DESCRIPTION
Lots of Index ops cleanup, breaking it up into small pieces.