### PR TITLE
DOC: Updated Series.items 'See also' section for clarity

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1681,7 +1681,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        DataFrame.items : Equivalent to Series.items for DataFrame.
+        DataFrame.items : Iterate over (column name, Series) pairs.
+        DataFrame.iterrows : Iterate over DataFrame rows as (index, Series) pairs.
 
         Examples
         --------


### PR DESCRIPTION
I changed the See also to:

DataFrame.items : Iterate over (column name, Series) pairs.
DataFrame.iterrows : Iterate over DataFrame rows as (index, Series) pairs.

No assertions about the equivalence of DataFrame.items and Series.items

closes #27859
