### PR TITLE
CLN: remove unnecessary dtype checks

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1,3 +1,4 @@
+import operator
 from shutil import get_terminal_size
 import textwrap
 from typing import Type, Union, cast
@@ -77,7 +78,9 @@ _take_msg = textwrap.dedent(
 )
 
 
-def _cat_compare_op(opname):
+def _cat_compare_op(op):
+    opname = "__{op}__".format(op=op.__name__)
+
     def f(self, other):
         # On python2, you can usually compare any type to any type, and
         # Categoricals can be seen as a custom type, but having different
@@ -1240,12 +1243,12 @@ class Categorical(ExtensionArray, PandasObject):
                 new_categories = new_categories.insert(len(new_categories), np.nan)
             return np.take(new_categories, self._codes)
 
-    __eq__ = _cat_compare_op("__eq__")
-    __ne__ = _cat_compare_op("__ne__")
-    __lt__ = _cat_compare_op("__lt__")
-    __gt__ = _cat_compare_op("__gt__")
-    __le__ = _cat_compare_op("__le__")
-    __ge__ = _cat_compare_op("__ge__")
+    __eq__ = _cat_compare_op(operator.eq)
+    __ne__ = _cat_compare_op(operator.ne)
+    __lt__ = _cat_compare_op(operator.lt)
+    __gt__ = _cat_compare_op(operator.gt)
+    __le__ = _cat_compare_op(operator.le)
+    __ge__ = _cat_compare_op(operator.ge)
 
     # for Series/ndarray like compat
     @property

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -223,8 +223,6 @@ def _dt_array_cmp(cls, op):
                 result = op(self.view("i8"), other.view("i8"))
                 o_mask = other._isnan
 
-            result = com.values_from_object(result)
-
             if o_mask.any():
                 result[o_mask] = nat_result
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1101,7 +1101,7 @@ class TestDatetime64Arithmetic:
             [
                 "unsupported operand type",
                 "cannot (add|subtract)",
-                "ufunc '(add|subtract)' cannot use operands with types",
+                "ufunc '?(add|subtract)'? cannot use operands with types",
             ]
         )
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1097,7 +1097,13 @@ class TestDatetime64Arithmetic:
     def test_dt64arr_add_sub_float(self, other, box_with_array):
         dti = DatetimeIndex(["2011-01-01", "2011-01-02"], freq="D")
         dtarr = tm.box_expected(dti, box_with_array)
-        msg = "|".join(["unsupported operand type", "cannot (add|subtract)"])
+        msg = "|".join(
+            [
+                "unsupported operand type",
+                "cannot (add|subtract)",
+                "ufunc '(add|subtract)' cannot use operands with types",
+            ]
+        )
         with pytest.raises(TypeError, match=msg):
             dtarr + other
         with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
these aren't accomplishing anything and are very non-performant.

Also, remove an unnecessary values_from_object call and use operator.foo instead of `"__foo__"` in categorical ops.