### PR TITLE
BUG: fix Sparse reduction

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -133,7 +133,7 @@ Reshaping
 
 Sparse
 ^^^^^^
-
+- Bug in reductions for :class:`Series` with Sparse dtypes (:issue:`27080`)
 -
 -
 -

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1693,6 +1693,9 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
                     for sp_value, fv in zip(sp_values, fill_value)
                 )
                 return arrays
+            elif is_scalar(sp_values):
+                # e.g. reductions
+                return sp_values
 
             return self._simple_new(
                 sp_values, self.sp_index, SparseDtype(sp_values.dtype, fill_value)

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -252,10 +252,7 @@ def test_object_series_ok():
     "values",
     [
         pd.array([1, 3, 2]),
-        pytest.param(
-            pd.array([1, 10, 0], dtype="Sparse[int]"),
-            marks=pytest.mark.xfail(resason="GH-27080. Bug in SparseArray"),
-        ),
+        pd.array([1, 10, 0], dtype="Sparse[int]"),
         pd.to_datetime(["2000", "2010", "2001"]),
         pd.to_datetime(["2000", "2010", "2001"]).tz_localize("CET"),
         pd.to_datetime(["2000", "2010", "2001"]).to_period(freq="D"),


### PR DESCRIPTION
- [x] closes #27080
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
