### PR TITLE
CLN: remove _maybe_update_attributes

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -776,11 +776,13 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         res2 = other - res1 * self
         return res1, res2
 
-    # Note: TimedeltaIndex overrides this in call to cls._add_numeric_methods
     def __neg__(self):
         if self.freq is not None:
             return type(self)(-self._data, freq=-self.freq)
         return type(self)(-self._data)
+
+    def __pos__(self):
+        return type(self)(self._data, freq=self.freq)
 
     def __abs__(self):
         # Note: freq is not preserved

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -722,7 +722,6 @@ class Index(IndexOpsMixin, PandasObject):
             return result
 
         attrs = self._get_attributes_dict()
-        attrs = self._maybe_update_attributes(attrs)
         return Index(result, **attrs)
 
     @cache_readonly
@@ -5368,12 +5367,6 @@ class Index(IndexOpsMixin, PandasObject):
         cls.__abs__ = make_invalid_op("__abs__")
         cls.__inv__ = make_invalid_op("__inv__")
 
-    def _maybe_update_attributes(self, attrs):
-        """
-        Update Index attributes (e.g. freq) depending on op.
-        """
-        return attrs
-
     def _validate_for_numeric_unaryop(self, op, opstr):
         """
         Validate if we can perform a numeric unary operation.
@@ -5463,7 +5456,6 @@ class Index(IndexOpsMixin, PandasObject):
 
                 self._validate_for_numeric_unaryop(op, opstr)
                 attrs = self._get_attributes_dict()
-                attrs = self._maybe_update_attributes(attrs)
                 return Index(op(self.values), **attrs)
 
             _evaluate_numeric_unary.__name__ = opstr

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -15,6 +15,7 @@ from pandas.util._decorators import Appender, cache_readonly, deprecate_kwarg
 
 from pandas.core.dtypes.common import (
     ensure_int64,
+    is_bool_dtype,
     is_dtype_equal,
     is_float,
     is_integer,
@@ -162,6 +163,20 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
     @Appender(DatetimeLikeArrayMixin.asi8.__doc__)
     def asi8(self):
         return self._data.asi8
+
+    def __array_wrap__(self, result, context=None):
+        """
+        Gets called after a ufunc.
+        """
+        result = lib.item_from_zerodim(result)
+        if is_bool_dtype(result) or lib.is_scalar(result):
+            return result
+
+        attrs = self._get_attributes_dict()
+        if not is_period_dtype(self) and attrs["freq"]:
+            # no need to infer if freq is None
+            attrs["freq"] = "infer"
+        return Index(result, **attrs)
 
     # ------------------------------------------------------------------------
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -465,14 +465,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
             return _to_M8(value)
         raise ValueError("Passed item and index have different timezone")
 
-    def _maybe_update_attributes(self, attrs):
-        """ Update Index attributes (e.g. freq) depending on op """
-        freq = attrs.get("freq", None)
-        if freq is not None:
-            # no need to infer if freq is None
-            attrs["freq"] = "infer"
-        return attrs
-
     # --------------------------------------------------------------------
     # Rendering Methods
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -74,7 +74,7 @@ class RangeIndex(Int64Index):
     _engine_type = libindex.Int64Engine
     _range = None  # type: range
 
-    # check whether self._data has benn called
+    # check whether self._data has been called
     _cached_data = None  # type: np.ndarray
     # --------------------------------------------------------------------
     # Constructors
@@ -784,7 +784,6 @@ class RangeIndex(Int64Index):
 
                 other = self._validate_for_numeric_binop(other, op)
                 attrs = self._get_attributes_dict()
-                attrs = self._maybe_update_attributes(attrs)
 
                 left, right = self, other
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -47,6 +47,7 @@ class TimedeltaDelegateMixin(DatetimelikeDelegateMixin):
     _delegated_methods = TimedeltaArray._datetimelike_methods + [
         "_box_values",
         "__neg__",
+        "__pos__",
         "__abs__",
     ]
     _raw_properties = {"components"}

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -44,7 +44,11 @@ class TimedeltaDelegateMixin(DatetimelikeDelegateMixin):
     # which we we dont' want to expose in the .dt accessor.
     _delegate_class = TimedeltaArray
     _delegated_properties = TimedeltaArray._datetimelike_ops + ["components"]
-    _delegated_methods = TimedeltaArray._datetimelike_methods + ["_box_values"]
+    _delegated_methods = TimedeltaArray._datetimelike_methods + [
+        "_box_values",
+        "__neg__",
+        "__abs__",
+    ]
     _raw_properties = {"components"}
     _raw_methods = {"to_pytimedelta"}
 
@@ -56,7 +60,7 @@ class TimedeltaDelegateMixin(DatetimelikeDelegateMixin):
     TimedeltaArray,
     TimedeltaDelegateMixin._delegated_methods,
     typ="method",
-    overwrite=False,
+    overwrite=True,
 )
 class TimedeltaIndex(
     DatetimeIndexOpsMixin, dtl.TimelikeOps, Int64Index, TimedeltaDelegateMixin
@@ -278,14 +282,6 @@ class TimedeltaIndex(
             raise Exception("invalid pickle state")
 
     _unpickle_compat = __setstate__
-
-    def _maybe_update_attributes(self, attrs):
-        """ Update Index attributes (e.g. freq) depending on op """
-        freq = attrs.get("freq", None)
-        if freq is not None:
-            # no need to infer if freq is None
-            attrs["freq"] = "infer"
-        return attrs
 
     # -------------------------------------------------------------------
     # Rendering Methods
@@ -689,7 +685,6 @@ class TimedeltaIndex(
 
 
 TimedeltaIndex._add_comparison_ops()
-TimedeltaIndex._add_numeric_methods_unary()
 TimedeltaIndex._add_logical_methods_disabled()
 TimedeltaIndex._add_datetimelike_methods()
 


### PR DESCRIPTION
It is only non-trivial for DTI and TDI, and only actually needed in `__array_wrap__`.  It is cleaner to implement the relevant patch in `DatetimeIndexOpsMixin.__array_wrap__` and avoid the need for maybe_update_attributes altogether.

