### PR TITLE
STYLE: run pre-commit filters on the repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,21 @@
 repos:
-    - repo: https://github.com/python/black
-      rev: stable
-      hooks:
-          - id: black
-            language_version: python3.7
-    - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.7.7
-      hooks:
-          - id: flake8
-            language: python_venv
-            additional_dependencies: [flake8-comprehensions]
-    - repo: https://github.com/pre-commit/mirrors-isort
-      rev: v4.3.20
-      hooks:
-          - id: isort
-            language: python_venv
+-   repo: https://github.com/python/black
+    rev: stable
+    hooks:
+    -   id: black
+        language_version: python3.7
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.7
+    hooks:
+    -   id: flake8
+        language: python_venv
+        additional_dependencies: [flake8-comprehensions]
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.20
+    hooks:
+    -   id: isort
+        language: python_venv
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.2
+    hooks:
+    -   id: seed-isort-config

--- a/asv_bench/benchmarks/attrs_caching.py
+++ b/asv_bench/benchmarks/attrs_caching.py
@@ -32,4 +32,4 @@ class CacheReadonly:
         self.obj.prop
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/attrs_caching.py
+++ b/asv_bench/benchmarks/attrs_caching.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from pandas import DataFrame
 
 try:

--- a/asv_bench/benchmarks/binary_ops.py
+++ b/asv_bench/benchmarks/binary_ops.py
@@ -155,4 +155,4 @@ class AddOverflowArray:
         )
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/binary_ops.py
+++ b/asv_bench/benchmarks/binary_ops.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from pandas import DataFrame, Series, date_range
 from pandas.core.algorithms import checked_add_with_arr
 

--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -280,4 +280,4 @@ class Indexing:
         self.index.sort_values(ascending=False)
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -1,7 +1,9 @@
+import warnings
+
 import numpy as np
+
 import pandas as pd
 import pandas.util.testing as tm
-import warnings
 
 try:
     from pandas.api.types import union_categoricals

--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -113,4 +113,4 @@ class MultiIndexConstructor:
         MultiIndex.from_product(self.iterables)
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -1,6 +1,7 @@
 import numpy as np
+
+from pandas import DatetimeIndex, Index, MultiIndex, Series, Timestamp
 import pandas.util.testing as tm
-from pandas import Series, Index, DatetimeIndex, Timestamp, MultiIndex
 
 
 def no_change(arr):

--- a/asv_bench/benchmarks/dtypes.py
+++ b/asv_bench/benchmarks/dtypes.py
@@ -1,13 +1,13 @@
+import numpy as np
+
 from pandas.api.types import pandas_dtype
 
-import numpy as np
 from .pandas_vb_common import (
-    numeric_dtypes,
     datetime_dtypes,
-    string_dtypes,
     extension_dtypes,
+    numeric_dtypes,
+    string_dtypes,
 )
-
 
 _numpy_dtypes = [
     np.dtype(dtype) for dtype in (numeric_dtypes + datetime_dtypes + string_dtypes)

--- a/asv_bench/benchmarks/dtypes.py
+++ b/asv_bench/benchmarks/dtypes.py
@@ -40,4 +40,4 @@ class DtypesInvalid:
             pass
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/eval.py
+++ b/asv_bench/benchmarks/eval.py
@@ -62,4 +62,4 @@ class Query:
         self.df.query("(a >= @self.min_val) & (a <= @self.max_val)")
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/eval.py
+++ b/asv_bench/benchmarks/eval.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import pandas as pd
 
 try:

--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -104,4 +104,4 @@ class FromLists:
         self.df = DataFrame(self.data)
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -1,6 +1,7 @@
 import numpy as np
+
+from pandas import DataFrame, MultiIndex, Series, Timestamp, date_range
 import pandas.util.testing as tm
-from pandas import DataFrame, Series, MultiIndex, Timestamp, date_range
 
 try:
     from pandas.tseries.offsets import Nano, Hour

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -609,4 +609,4 @@ class Describe:
         self.df.describe()
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -1,5 +1,5 @@
-import warnings
 import string
+import warnings
 
 import numpy as np
 

--- a/asv_bench/benchmarks/gil.py
+++ b/asv_bench/benchmarks/gil.py
@@ -1,7 +1,8 @@
 import numpy as np
-import pandas.util.testing as tm
-from pandas import DataFrame, Series, read_csv, factorize, date_range
+
+from pandas import DataFrame, Series, date_range, factorize, read_csv
 from pandas.core.algorithms import take_1d
+import pandas.util.testing as tm
 
 try:
     from pandas import (

--- a/asv_bench/benchmarks/gil.py
+++ b/asv_bench/benchmarks/gil.py
@@ -36,7 +36,7 @@ except ImportError:
         return wrapper
 
 
-from .pandas_vb_common import BaseIO
+from .pandas_vb_common import BaseIO  # noqa: E402 isort:skip
 
 
 class ParallelGroupbyMethods:

--- a/asv_bench/benchmarks/gil.py
+++ b/asv_bench/benchmarks/gil.py
@@ -301,4 +301,4 @@ class ParallelFactorize:
             self.loop()
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -15,7 +15,6 @@ from pandas import (
 )
 import pandas.util.testing as tm
 
-
 method_blacklist = {
     "object": {
         "median",

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -626,4 +626,4 @@ class TransformNaN:
         self.df_nans.groupby("key").transform("first")
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -1,15 +1,17 @@
 import gc
+
 import numpy as np
-import pandas.util.testing as tm
+
 from pandas import (
+    DatetimeIndex,
+    Float64Index,
+    Index,
+    IntervalIndex,
+    RangeIndex,
     Series,
     date_range,
-    DatetimeIndex,
-    Index,
-    RangeIndex,
-    Float64Index,
-    IntervalIndex,
 )
+import pandas.util.testing as tm
 
 
 class SetOperations:

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -243,4 +243,4 @@ class GC:
             gc.enable()
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -371,4 +371,4 @@ class ChainIndexing:
                 df2["C"] = 1.0
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -1,22 +1,23 @@
 import warnings
 
 import numpy as np
-import pandas.util.testing as tm
+
 from pandas import (
-    Series,
-    DataFrame,
-    MultiIndex,
-    Int64Index,
-    UInt64Index,
-    Float64Index,
-    IntervalIndex,
     CategoricalIndex,
+    DataFrame,
+    Float64Index,
     IndexSlice,
+    Int64Index,
+    IntervalIndex,
+    MultiIndex,
+    Series,
+    UInt64Index,
     concat,
     date_range,
     option_context,
     period_range,
 )
+import pandas.util.testing as tm
 
 
 class NumericSeriesIndexing:

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -1,8 +1,9 @@
 import numpy as np
-import pandas.util.testing as tm
-from pandas import DataFrame, Series, to_numeric
 
-from .pandas_vb_common import numeric_dtypes, lib
+from pandas import DataFrame, Series, to_numeric
+import pandas.util.testing as tm
+
+from .pandas_vb_common import lib, numeric_dtypes
 
 
 class NumericInferOps:

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -120,4 +120,4 @@ class MaybeConvertNumeric:
         lib.maybe_convert_numeric(data, set(), coerce_numeric=False)
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -1,10 +1,11 @@
+from io import StringIO
 import random
 import string
 
 import numpy as np
+
+from pandas import Categorical, DataFrame, date_range, read_csv, to_datetime
 import pandas.util.testing as tm
-from pandas import DataFrame, Categorical, date_range, read_csv, to_datetime
-from io import StringIO
 
 from ..pandas_vb_common import BaseIO
 

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -406,4 +406,4 @@ class ParseDateComparison(StringIORewind):
         to_datetime(df["date"], cache=cache_dates, format="%d-%m-%Y")
 
 
-from ..pandas_vb_common import setup  # noqa: F401
+from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/io/excel.py
+++ b/asv_bench/benchmarks/io/excel.py
@@ -1,6 +1,8 @@
 from io import BytesIO
+
 import numpy as np
-from pandas import DataFrame, date_range, ExcelWriter, read_excel
+
+from pandas import DataFrame, ExcelWriter, date_range, read_excel
 import pandas.util.testing as tm
 
 

--- a/asv_bench/benchmarks/io/excel.py
+++ b/asv_bench/benchmarks/io/excel.py
@@ -35,4 +35,4 @@ class Excel:
         writer_write.save()
 
 
-from ..pandas_vb_common import setup  # noqa: F401
+from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/io/hdf.py
+++ b/asv_bench/benchmarks/io/hdf.py
@@ -1,5 +1,6 @@
 import numpy as np
-from pandas import DataFrame, date_range, HDFStore, read_hdf
+
+from pandas import DataFrame, HDFStore, date_range, read_hdf
 import pandas.util.testing as tm
 
 from ..pandas_vb_common import BaseIO

--- a/asv_bench/benchmarks/io/hdf.py
+++ b/asv_bench/benchmarks/io/hdf.py
@@ -127,4 +127,4 @@ class HDF(BaseIO):
         self.df.to_hdf(self.fname, "df", format=format)
 
 
-from ..pandas_vb_common import setup  # noqa: F401
+from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -1,6 +1,7 @@
 import numpy as np
+
+from pandas import DataFrame, concat, date_range, read_json, timedelta_range
 import pandas.util.testing as tm
-from pandas import DataFrame, date_range, timedelta_range, concat, read_json
 
 from ..pandas_vb_common import BaseIO
 

--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -214,4 +214,4 @@ class ToJSONMem:
             df.to_json()
 
 
-from ..pandas_vb_common import setup  # noqa: F401
+from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/io/msgpack.py
+++ b/asv_bench/benchmarks/io/msgpack.py
@@ -27,4 +27,4 @@ class MSGPack(BaseIO):
         self.df.to_msgpack(self.fname)
 
 
-from ..pandas_vb_common import setup  # noqa: F401
+from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/io/msgpack.py
+++ b/asv_bench/benchmarks/io/msgpack.py
@@ -1,5 +1,7 @@
 import warnings
+
 import numpy as np
+
 from pandas import DataFrame, date_range, read_msgpack
 import pandas.util.testing as tm
 

--- a/asv_bench/benchmarks/io/pickle.py
+++ b/asv_bench/benchmarks/io/pickle.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from pandas import DataFrame, date_range, read_pickle
 import pandas.util.testing as tm
 

--- a/asv_bench/benchmarks/io/pickle.py
+++ b/asv_bench/benchmarks/io/pickle.py
@@ -25,4 +25,4 @@ class Pickle(BaseIO):
         self.df.to_pickle(self.fname)
 
 
-from ..pandas_vb_common import setup  # noqa: F401
+from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/io/sql.py
+++ b/asv_bench/benchmarks/io/sql.py
@@ -141,4 +141,4 @@ class ReadSQLTableDtypes:
         read_sql_table(self.table_name, self.con, columns=[dtype])
 
 
-from ..pandas_vb_common import setup  # noqa: F401
+from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/io/sql.py
+++ b/asv_bench/benchmarks/io/sql.py
@@ -1,9 +1,10 @@
 import sqlite3
 
 import numpy as np
-import pandas.util.testing as tm
-from pandas import DataFrame, date_range, read_sql_query, read_sql_table
 from sqlalchemy import create_engine
+
+from pandas import DataFrame, date_range, read_sql_query, read_sql_table
+import pandas.util.testing as tm
 
 
 class SQL:

--- a/asv_bench/benchmarks/io/stata.py
+++ b/asv_bench/benchmarks/io/stata.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from pandas import DataFrame, date_range, read_stata
 import pandas.util.testing as tm
 

--- a/asv_bench/benchmarks/io/stata.py
+++ b/asv_bench/benchmarks/io/stata.py
@@ -50,4 +50,4 @@ class StataMissing(Stata):
         self.df.to_stata(self.fname, self.convert_dates)
 
 
-from ..pandas_vb_common import setup  # noqa: F401
+from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -348,4 +348,4 @@ class Align:
         self.ts1.align(self.ts2, join="left")
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -1,8 +1,9 @@
 import string
 
 import numpy as np
+
+from pandas import DataFrame, MultiIndex, Series, concat, date_range, merge, merge_asof
 import pandas.util.testing as tm
-from pandas import DataFrame, Series, MultiIndex, date_range, concat, merge, merge_asof
 
 try:
     from pandas import merge_ordered

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -1,8 +1,9 @@
 import string
 
 import numpy as np
+
+from pandas import DataFrame, MultiIndex, date_range
 import pandas.util.testing as tm
-from pandas import date_range, MultiIndex, DataFrame
 
 
 class GetLoc:

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -146,4 +146,4 @@ class CategoricalLevel:
         self.df.set_index(["a", "b"])
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/offset.py
+++ b/asv_bench/benchmarks/offset.py
@@ -1,7 +1,8 @@
-import warnings
 from datetime import datetime
+import warnings
 
 import numpy as np
+
 import pandas as pd
 
 try:

--- a/asv_bench/benchmarks/pandas_vb_common.py
+++ b/asv_bench/benchmarks/pandas_vb_common.py
@@ -1,7 +1,8 @@
-import os
 from importlib import import_module
+import os
 
 import numpy as np
+
 import pandas as pd
 
 # Compatibility import for lib

--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -1,4 +1,5 @@
 from pandas import DataFrame, Period, PeriodIndex, Series, date_range, period_range
+
 from pandas.tseries.frequencies import to_offset
 
 

--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -1,11 +1,12 @@
+import matplotlib
 import numpy as np
-from pandas import DataFrame, Series, DatetimeIndex, date_range
+
+from pandas import DataFrame, DatetimeIndex, Series, date_range
 
 try:
     from pandas.plotting import andrews_curves
 except ImportError:
     from pandas.tools.plotting import andrews_curves
-import matplotlib
 
 matplotlib.use("Agg")
 

--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -93,4 +93,4 @@ class Misc:
         andrews_curves(self.df, "Name")
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/reindex.py
+++ b/asv_bench/benchmarks/reindex.py
@@ -1,6 +1,8 @@
 import numpy as np
+
+from pandas import DataFrame, Index, MultiIndex, Series, date_range, period_range
 import pandas.util.testing as tm
-from pandas import DataFrame, Series, MultiIndex, Index, date_range, period_range
+
 from .pandas_vb_common import lib
 
 

--- a/asv_bench/benchmarks/reindex.py
+++ b/asv_bench/benchmarks/reindex.py
@@ -159,4 +159,4 @@ class LibFastZip:
         lib.fast_zip(self.col_array_list)
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/replace.py
+++ b/asv_bench/benchmarks/replace.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import pandas as pd
 
 

--- a/asv_bench/benchmarks/replace.py
+++ b/asv_bench/benchmarks/replace.py
@@ -56,4 +56,4 @@ class Convert:
         self.data.replace(self.to_replace)
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/reshape.py
+++ b/asv_bench/benchmarks/reshape.py
@@ -1,9 +1,10 @@
-import string
 from itertools import product
+import string
 
 import numpy as np
-from pandas import DataFrame, MultiIndex, date_range, melt, wide_to_long
+
 import pandas as pd
+from pandas import DataFrame, MultiIndex, date_range, melt, wide_to_long
 
 
 class Melt:

--- a/asv_bench/benchmarks/reshape.py
+++ b/asv_bench/benchmarks/reshape.py
@@ -262,4 +262,4 @@ class Explode:
         self.series.explode()
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -121,4 +121,4 @@ class PeakMemFixed:
             self.roll.max()
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -1,5 +1,6 @@
-import pandas as pd
 import numpy as np
+
+import pandas as pd
 
 
 class Methods:

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -275,4 +275,4 @@ class NanOps:
         self.func()
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 
 import numpy as np
+
+from pandas import NaT, Series, date_range
 import pandas.util.testing as tm
-from pandas import Series, date_range, NaT
 
 
 class SeriesConstructor:

--- a/asv_bench/benchmarks/sparse.py
+++ b/asv_bench/benchmarks/sparse.py
@@ -136,4 +136,4 @@ class ArithmeticBlock:
         self.arr1 / self.arr2
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -148,4 +148,4 @@ class Covariance:
         self.s.cov(self.s2)
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -1,6 +1,6 @@
 import numpy as np
-import pandas as pd
 
+import pandas as pd
 
 ops = ["mean", "sum", "median", "std", "skew", "kurt", "mad", "prod", "sem", "var"]
 

--- a/asv_bench/benchmarks/strings.py
+++ b/asv_bench/benchmarks/strings.py
@@ -1,7 +1,8 @@
 import warnings
 
 import numpy as np
-from pandas import Series, DataFrame
+
+from pandas import DataFrame, Series
 import pandas.util.testing as tm
 
 

--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -2,7 +2,9 @@ from datetime import timedelta
 
 import dateutil
 import numpy as np
-from pandas import to_datetime, date_range, Series, DataFrame, period_range
+
+from pandas import DataFrame, Series, date_range, period_range, to_datetime
+
 from pandas.tseries.frequencies import infer_freq
 
 try:

--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -426,4 +426,4 @@ class DatetimeAccessor:
         self.series.dt.year
 
 
-from .pandas_vb_common import setup  # noqa: F401
+from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/ci/print_skipped.py
+++ b/ci/print_skipped.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
+import math
 import os
 import sys
-import math
 import xml.etree.ElementTree as et
 
 

--- a/doc/logo/pandas_logo.py
+++ b/doc/logo/pandas_logo.py
@@ -1,7 +1,6 @@
 # script to generate the pandas logo
 
-from matplotlib import pyplot as plt
-from matplotlib import rcParams
+from matplotlib import pyplot as plt, rcParams
 import numpy as np
 
 rcParams["mathtext.fontset"] = "cm"

--- a/doc/make.py
+++ b/doc/make.py
@@ -11,17 +11,17 @@ Usage
     $ python make.py html
     $ python make.py latex
 """
+import argparse
+import csv
 import importlib
-import sys
 import os
 import shutil
-import csv
 import subprocess
-import argparse
+import sys
 import webbrowser
+
 import docutils
 import docutils.parsers.rst
-
 
 DOC_PATH = os.path.dirname(os.path.abspath(__file__))
 SOURCE_PATH = os.path.join(DOC_PATH, "source")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,15 +10,15 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-import inspect
 import importlib
+import inspect
 import logging
-import jinja2
-from sphinx.ext.autosummary import _import_by_name
-from numpydoc.docscrape import NumpyDocString
+import os
+import sys
 
+import jinja2
+from numpydoc.docscrape import NumpyDocString
+from sphinx.ext.autosummary import _import_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -433,10 +433,14 @@ ipython_exec_lines = [
 # Add custom Documenter to handle attributes/methods of an AccessorProperty
 # eg pandas.Series.str and pandas.Series.dt (see GH9322)
 
-import sphinx
-from sphinx.util import rpartition
-from sphinx.ext.autodoc import Documenter, MethodDocumenter, AttributeDocumenter
-from sphinx.ext.autosummary import Autosummary
+import sphinx  # noqa: E402 isort:skip
+from sphinx.util import rpartition  # noqa: E402 isort:skip
+from sphinx.ext.autodoc import (  # noqa: E402 isort:skip
+    AttributeDocumenter,
+    Documenter,
+    MethodDocumenter,
+)
+from sphinx.ext.autosummary import Autosummary  # noqa: E402 isort:skip
 
 
 class AccessorDocumenter(MethodDocumenter):

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -141,7 +141,7 @@ copyright = "2008-2014, the pandas development team"
 # built documents.
 #
 # The short X.Y version.
-import pandas
+import pandas  # noqa: E402 isort:skip
 
 # version = '%s r%s' % (pandas.__version__, svn_version())
 version = str(pandas.__version__)

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3206,7 +3206,7 @@ argument to ``to_excel`` and to ``ExcelWriter``. The built-in engines are:
    writer = pd.ExcelWriter('path_to_file.xlsx', engine='xlsxwriter')
 
    # Or via pandas configuration.
-   from pandas import options. # noqa: E402
+   from pandas import options  # noqa: E402
    options.io.excel.xlsx.writer = 'xlsxwriter'
 
    df.to_excel('path_to_file.xlsx', sheet_name='Sheet1')

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3206,7 +3206,7 @@ argument to ``to_excel`` and to ``ExcelWriter``. The built-in engines are:
    writer = pd.ExcelWriter('path_to_file.xlsx', engine='xlsxwriter')
 
    # Or via pandas configuration.
-   from pandas import options                                     # noqa: E402
+   from pandas import options. # noqa: E402
    options.io.excel.xlsx.writer = 'xlsxwriter'
 
    df.to_excel('path_to_file.xlsx', sheet_name='Sheet1')

--- a/doc/sphinxext/contributors.py
+++ b/doc/sphinxext/contributors.py
@@ -8,11 +8,10 @@ This will be replaced with a message indicating the number of
 code contributors and commits, and then list each contributor
 individually.
 """
+from announce import build_components
 from docutils import nodes
 from docutils.parsers.rst import Directive
 import git
-
-from announce import build_components
 
 
 class ContributorsDirective(Directive):

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -23,8 +23,11 @@ from pandas.core.arrays.integer import (
     UInt64Dtype,
 )
 from pandas.core.construction import array
-from pandas.core.frame import DataFrame
+
 from pandas.core.groupby import Grouper, NamedAgg
+
+# DataFrame needs to be imported after NamedAgg to avoid a circular import
+from pandas.core.frame import DataFrame  # isort:skip
 from pandas.core.index import (
     CategoricalIndex,
     DatetimeIndex,

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -2,6 +2,16 @@
 
 import numpy as np
 
+from pandas.core.dtypes.dtypes import (
+    CategoricalDtype,
+    DatetimeTZDtype,
+    IntervalDtype,
+    PeriodDtype,
+)
+from pandas.core.dtypes.missing import isna, isnull, notna, notnull
+
+from pandas.core.algorithms import factorize, unique, value_counts
+from pandas.core.arrays import Categorical
 from pandas.core.arrays.integer import (
     Int8Dtype,
     Int16Dtype,
@@ -12,45 +22,35 @@ from pandas.core.arrays.integer import (
     UInt32Dtype,
     UInt64Dtype,
 )
-from pandas.core.algorithms import factorize, unique, value_counts
-from pandas.core.dtypes.missing import isna, isnull, notna, notnull
-from pandas.core.dtypes.dtypes import (
-    CategoricalDtype,
-    PeriodDtype,
-    IntervalDtype,
-    DatetimeTZDtype,
-)
-from pandas.core.arrays import Categorical
 from pandas.core.construction import array
+from pandas.core.frame import DataFrame
 from pandas.core.groupby import Grouper, NamedAgg
-from pandas.io.formats.format import set_eng_float_format
 from pandas.core.index import (
-    Index,
     CategoricalIndex,
-    Int64Index,
-    UInt64Index,
-    RangeIndex,
-    Float64Index,
-    MultiIndex,
-    IntervalIndex,
-    TimedeltaIndex,
     DatetimeIndex,
-    PeriodIndex,
+    Float64Index,
+    Index,
+    Int64Index,
+    IntervalIndex,
+    MultiIndex,
     NaT,
+    PeriodIndex,
+    RangeIndex,
+    TimedeltaIndex,
+    UInt64Index,
 )
+from pandas.core.indexes.datetimes import Timestamp, bdate_range, date_range
+from pandas.core.indexes.interval import Interval, interval_range
 from pandas.core.indexes.period import Period, period_range
 from pandas.core.indexes.timedeltas import Timedelta, timedelta_range
-from pandas.core.indexes.datetimes import Timestamp, date_range, bdate_range
-from pandas.core.indexes.interval import Interval, interval_range
-
-from pandas.core.series import Series
-from pandas.core.frame import DataFrame
-
-# TODO: Remove import when statsmodels updates #18264
-from pandas.core.reshape.reshape import get_dummies
-
 from pandas.core.indexing import IndexSlice
-from pandas.core.tools.numeric import to_numeric
-from pandas.tseries.offsets import DateOffset
+from pandas.core.reshape.reshape import (
+    get_dummies,
+)  # TODO: Remove get_dummies import when statsmodels updates #18264
+from pandas.core.series import Series
 from pandas.core.tools.datetimes import to_datetime
+from pandas.core.tools.numeric import to_numeric
 from pandas.core.tools.timedeltas import to_timedelta
+
+from pandas.io.formats.format import set_eng_float_format
+from pandas.tseries.offsets import DateOffset

--- a/pandas/io/msgpack/__init__.py
+++ b/pandas/io/msgpack/__init__.py
@@ -2,8 +2,8 @@
 
 from collections import namedtuple
 
-from pandas.io.msgpack.exceptions import *  # noqa
-from pandas.io.msgpack._version import version  # noqa
+from pandas.io.msgpack.exceptions import *  # noqa: F401,F403 isort:skip
+from pandas.io.msgpack._version import version  # noqa: F401 isort:skip
 
 
 class ExtType(namedtuple("ExtType", "code data")):
@@ -19,10 +19,14 @@ class ExtType(namedtuple("ExtType", "code data")):
         return super().__new__(cls, code, data)
 
 
-import os  # noqa
+import os  # noqa: F401,E402 isort:skip
 
-from pandas.io.msgpack._packer import Packer  # noqa
-from pandas.io.msgpack._unpacker import unpack, unpackb, Unpacker  # noqa
+from pandas.io.msgpack._unpacker import (  # noqa: F401,E402 isort:skip
+    Unpacker,
+    unpack,
+    unpackb,
+)
+from pandas.io.msgpack._packer import Packer  # noqa: E402 isort:skip
 
 
 def pack(o, stream, **kwargs):

--- a/pandas/tests/io/pytables/test_pytables.py
+++ b/pandas/tests/io/pytables/test_pytables.py
@@ -37,7 +37,6 @@ from pandas import (
 import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal, set_timezone
 
-from pandas.io import pytables as pytables  # noqa: E402 isort:skip
 from pandas.io.formats.printing import pprint_thing
 from pandas.io.pytables import (
     ClosedFileError,
@@ -46,6 +45,8 @@ from pandas.io.pytables import (
     Term,
     read_hdf,
 )
+
+from pandas.io import pytables as pytables  # noqa: E402 isort:skip
 from pandas.io.pytables import TableIterator  # noqa: E402 isort:skip
 
 tables = pytest.importorskip("tables")

--- a/pandas/tests/io/pytables/test_pytables.py
+++ b/pandas/tests/io/pytables/test_pytables.py
@@ -37,7 +37,7 @@ from pandas import (
 import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal, set_timezone
 
-from pandas.io import pytables as pytables  # noqa:E402
+from pandas.io import pytables as pytables  # noqa: E402 isort:skip
 from pandas.io.formats.printing import pprint_thing
 from pandas.io.pytables import (
     ClosedFileError,
@@ -46,7 +46,7 @@ from pandas.io.pytables import (
     Term,
     read_hdf,
 )
-from pandas.io.pytables import TableIterator  # noqa:E402
+from pandas.io.pytables import TableIterator  # noqa: E402 isort:skip
 
 tables = pytest.importorskip("tables")
 

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, ensure_clean
 
-from pandas.io.feather_format import read_feather, to_feather  # noqa:E402
+from pandas.io.feather_format import read_feather, to_feather  # noqa: E402 isort:skip
 
 pyarrow = pytest.importorskip("pyarrow")
 

--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -10,11 +10,11 @@ files will probably erase them.
 Usage::
     $ ./find_commits_touching_func.py  (see arguments below)
 """
-import logging
-import re
-import os
 import argparse
 from collections import namedtuple
+import logging
+import os
+import re
 
 from dateutil.parser import parse
 

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -16,8 +16,8 @@ import argparse
 import os
 import re
 import sys
-import yaml
 
+import yaml
 
 EXCLUDE = {"python=3"}
 RENAME = {"pytables": "tables", "pyqt": "pyqt5"}

--- a/scripts/merge-pr.py
+++ b/scripts/merge-pr.py
@@ -22,13 +22,14 @@
 #   usage: ./apache-pr-merge.py    (see config env vars below)
 #
 # Lightly modified from version of this script in incubator-parquet-format
-from subprocess import check_output
-from requests.auth import HTTPBasicAuth
-import requests
 
 import os
+from subprocess import check_output
 import sys
 import textwrap
+
+import requests
+from requests.auth import HTTPBasicAuth
 
 PANDAS_HOME = "."
 PROJECT_NAME = "pandas"

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -2,11 +2,12 @@ import io
 import random
 import string
 import textwrap
-import pytest
-import numpy as np
-import pandas as pd
 
+import numpy as np
+import pytest
 import validate_docstrings
+
+import pandas as pd
 
 validate_one = validate_docstrings.validate_one
 

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -41,20 +41,20 @@ except ImportError:
 # script. Setting here before matplotlib is loaded.
 # We don't warn for the number of open plots, as none is actually being opened
 os.environ["MPLBACKEND"] = "Template"
-import matplotlib
+import matplotlib  # noqa: E402 isort:skip
 
 matplotlib.rc("figure", max_open_warning=10000)
 
-import numpy
+import numpy  # noqa: E402 isort:skip
 
 BASE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 sys.path.insert(0, os.path.join(BASE_PATH))
-import pandas
+import pandas  # noqa: E402 isort:skip
 
 sys.path.insert(1, os.path.join(BASE_PATH, "doc", "sphinxext"))
-from numpydoc.docscrape import NumpyDocString
-from pandas.io.formats.printing import pprint_thing
+from numpydoc.docscrape import NumpyDocString  # noqa: E402 isort:skip
+from pandas.io.formats.printing import pprint_thing  # noqa: E402 isort:skip
 
 
 PRIVATE_CLASSES = ["NDFrame", "IndexOpsMixin"]

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -13,20 +13,20 @@ Usage::
     $ ./validate_docstrings.py
     $ ./validate_docstrings.py pandas.DataFrame.head
 """
-import os
-import sys
-import json
-import re
-import glob
-import functools
-import collections
 import argparse
-import pydoc
-import inspect
-import importlib
-import doctest
-import tempfile
 import ast
+import collections
+import doctest
+import functools
+import glob
+import importlib
+import inspect
+import json
+import os
+import pydoc
+import re
+import sys
+import tempfile
 import textwrap
 
 import flake8.main.application

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,64 +110,21 @@ directory = coverage_html_report
 
 # To be kept consistent with "Import Formatting" section in contributing.rst
 [isort]
-known_pre_libs=pandas._config
-known_pre_core=pandas._libs,pandas.util._*,pandas.compat,pandas.errors
-known_dtypes=pandas.core.dtypes
-known_post_core=pandas.tseries,pandas.io,pandas.plotting
-sections=FUTURE,STDLIB,THIRDPARTY,PRE_LIBS,PRE_CORE,DTYPES,FIRSTPARTY,POST_CORE,LOCALFOLDER
-
-known_first_party=pandas
-known_third_party=_pytest,announce,dateutil,docutils,flake8,git,hypothesis,jinja2,lxml,matplotlib,numpy,numpydoc,pkg_resources,pyarrow,pytest,pytz,requests,scipy,setuptools,sphinx,sqlalchemy,validate_docstrings,yaml
-
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-combine_as_imports=True
-line_length=88
-force_sort_within_sections=True
-skip_glob=env,
-skip=
-    pandas/__init__.py
-    pandas/core/api.py,
-    pandas/io/msgpack/__init__.py
-    asv_bench/benchmarks/attrs_caching.py,
-    asv_bench/benchmarks/binary_ops.py,
-    asv_bench/benchmarks/categoricals.py,
-    asv_bench/benchmarks/ctors.py,
-    asv_bench/benchmarks/eval.py,
-    asv_bench/benchmarks/frame_ctor.py,
-    asv_bench/benchmarks/frame_methods.py,
-    asv_bench/benchmarks/gil.py,
-    asv_bench/benchmarks/groupby.py,
-    asv_bench/benchmarks/index_object.py,
-    asv_bench/benchmarks/indexing.py,
-    asv_bench/benchmarks/inference.py,
-    asv_bench/benchmarks/io/csv.py,
-    asv_bench/benchmarks/io/excel.py,
-    asv_bench/benchmarks/io/hdf.py,
-    asv_bench/benchmarks/io/json.py,
-    asv_bench/benchmarks/io/msgpack.py,
-    asv_bench/benchmarks/io/pickle.py,
-    asv_bench/benchmarks/io/sql.py,
-    asv_bench/benchmarks/io/stata.py,
-    asv_bench/benchmarks/join_merge.py,
-    asv_bench/benchmarks/multiindex_object.py,
-    asv_bench/benchmarks/panel_ctor.py,
-    asv_bench/benchmarks/panel_methods.py,
-    asv_bench/benchmarks/plotting.py,
-    asv_bench/benchmarks/reindex.py,
-    asv_bench/benchmarks/replace.py,
-    asv_bench/benchmarks/reshape.py,
-    asv_bench/benchmarks/rolling.py,
-    asv_bench/benchmarks/series_methods.py,
-    asv_bench/benchmarks/sparse.py,
-    asv_bench/benchmarks/stat_ops.py,
-    asv_bench/benchmarks/timeseries.py
-    asv_bench/benchmarks/pandas_vb_common.py
-    asv_bench/benchmarks/offset.py
-    asv_bench/benchmarks/dtypes.py
-    asv_bench/benchmarks/strings.py
-    asv_bench/benchmarks/period.py
+known_pre_libs = pandas._config
+known_pre_core = pandas._libs,pandas.util._*,pandas.compat,pandas.errors
+known_dtypes = pandas.core.dtypes
+known_post_core = pandas.tseries,pandas.io,pandas.plotting
+sections = FUTURE,STDLIB,THIRDPARTY,PRE_LIBS,PRE_CORE,DTYPES,FIRSTPARTY,POST_CORE,LOCALFOLDER
+known_first_party = pandas
+known_third_party = _pytest,announce,dateutil,docutils,flake8,git,hypothesis,jinja2,lxml,matplotlib,numpy,numpydoc,pkg_resources,pyarrow,pytest,pytz,requests,scipy,setuptools,sphinx,sqlalchemy,validate_docstrings,yaml
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+combine_as_imports = True
+line_length = 88
+force_sort_within_sections = True
+skip_glob = env,
+skip = pandas/__init__.py,pandas/core/api.py
 
 [mypy]
 ignore_missing_imports=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ known_post_core=pandas.tseries,pandas.io,pandas.plotting
 sections=FUTURE,STDLIB,THIRDPARTY,PRE_LIBS,PRE_CORE,DTYPES,FIRSTPARTY,POST_CORE,LOCALFOLDER
 
 known_first_party=pandas
-known_third_party=Cython,numpy,dateutil,matplotlib,python-dateutil,pytz,pyarrow,pytest
+known_third_party=_pytest,announce,dateutil,docutils,flake8,git,hypothesis,jinja2,lxml,matplotlib,numpy,numpydoc,pkg_resources,pyarrow,pytest,pytz,requests,scipy,setuptools,sphinx,sqlalchemy,validate_docstrings,yaml
 
 multi_line_output=3
 include_trailing_comma=True

--- a/setup.py
+++ b/setup.py
@@ -831,9 +831,7 @@ setup(
         ]
     },
     entry_points={
-        "pandas_plotting_backends": [
-            "matplotlib = pandas:plotting._matplotlib",
-        ],
+        "pandas_plotting_backends": ["matplotlib = pandas:plotting._matplotlib"]
     },
     **setuptools_kwargs
 )

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ except ImportError:
 # The import of Extension must be after the import of Cython, otherwise
 # we do not get the appropriately patched class.
 # See https://cython.readthedocs.io/en/latest/src/reference/compilation.html
-from distutils.extension import Extension  # noqa:E402
-from distutils.command.build import build  # noqa:E402
+from distutils.extension import Extension  # noqa: E402 isort:skip
+from distutils.command.build import build  # noqa: E402 isort:skip
 
 try:
     if not _CYTHON_INSTALLED:

--- a/setup.py
+++ b/setup.py
@@ -6,16 +6,16 @@ Parts of this file were taken from the pyzmq project
 BSD license. Parts are from lxml (https://github.com/lxml/lxml)
 """
 
+from distutils.sysconfig import get_config_vars
+from distutils.version import LooseVersion
 import os
 from os.path import join as pjoin
+import platform
+import shutil
+import sys
 
 import pkg_resources
-import platform
-from distutils.sysconfig import get_config_vars
-import sys
-import shutil
-from distutils.version import LooseVersion
-from setuptools import setup, Command, find_packages
+from setuptools import Command, find_packages, setup
 
 # versioning
 import versioneer


### PR DESCRIPTION
I noticed that `pre-commit` is used and ran `pre-commit run --all-files` which results in massive diffs, mostly because of `isort`.

I have added the correct `noqa` and `isort:skip` flags to the lines which needed it to function correctly with the current `.pre-commit-config.yaml`, such that the imports are correctly sorted now.

I also added `seed-isort-config` such that `setup.cfg` is parsed for `pre-commit` and fixed the formatting of `.pre-commit-config.yaml`.

~~Finally, there is `pandas/__init__.py` that is touched by `pre-commit run --all-files`, however, this has less trivial changes and might result in something breaking, so I don't dare to touch it.~~
It was because the `skip` entry in `[isort]` in `setup.cfg` is somehow ignored when running pre-commit and I can't figure out why (I will open an issue in the `isort` repo when it's clear that this will be merged). I have also deleted the other ignored files because I fixed the problems there. `pandas/core/api.py` needs to stay in `skip` because `isort` and `black` make conflicting edits.