### PR TITLE
DOC: Fix section reference placement in whatsnew

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -21,26 +21,26 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
-.. _whatsnew_1000.enhancements.other:
+-
+-
 
--
--
+.. _whatsnew_1000.enhancements.other:
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 
-.. _whatsnew_1000.api_breaking:
+-
+-
 
--
--
+.. _whatsnew_1000.api_breaking:
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _whatsnew_1000.api.other:
-
 - :class:`pandas.core.groupby.GroupBy.transform` now raises on invalid operation names (:issue:`27489`).
 -
+
+.. _whatsnew_1000.api.other:
 
 Other API changes
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
A few of the section references are misaligned with the tick marks.  Moved the misaligned references as appropriate.