### PR TITLE
Fix regression in .ix fallback with IntervalIndex

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -85,6 +85,7 @@ Indexing
 - Bug in partial-string indexing returning a NumPy array rather than a ``Series`` when indexing with a scalar like ``.loc['2015']`` (:issue:`27516`)
 - Break reference cycle involving :class:`Index` to allow garbage collection of :class:`Index` objects without running the GC. (:issue:`27585`)
 - Fix regression in assigning values to a single column of a DataFrame with a ``MultiIndex`` columns (:issue:`27841`).
+- Fix regression in ``.ix`` fallback with an ``IntervalIndex`` (:issue:`27865`).
 -
 
 Missing

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -124,7 +124,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             key = tuple(com.apply_if_callable(x, self.obj) for x in key)
             try:
                 values = self.obj._get_value(*key)
-            except (KeyError, TypeError, InvalidIndexError):
+            except (KeyError, TypeError, InvalidIndexError, AttributeError):
                 # TypeError occurs here if the key has non-hashable entries,
                 #  generally slice or list.
                 # TODO(ix): most/all of the TypeError cases here are for ix,
@@ -132,6 +132,9 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 # The InvalidIndexError is only catched for compatibility
                 #  with geopandas, see
                 #  https://github.com/pandas-dev/pandas/issues/27258
+                # TODO: The AttributeError is for IntervalIndex which
+                #  incorrectly implements get_value, see
+                #  https://github.com/pandas-dev/pandas/issues/27865
                 pass
             else:
                 if is_scalar(values):

--- a/pandas/tests/indexing/test_ix.py
+++ b/pandas/tests/indexing/test_ix.py
@@ -343,3 +343,13 @@ class TestIX:
             r = df.ix[0.2, "a"]
         e = df.loc[0.2, "a"]
         tm.assert_series_equal(r, e)
+
+    def test_ix_intervalindex(self):
+        # https://github.com/pandas-dev/pandas/issues/27865
+        df = DataFrame(
+            np.random.randn(5, 2),
+            index=pd.IntervalIndex.from_breaks([-np.inf, 0, 1, 2, 3, np.inf]),
+        )
+        result = df.ix[0:2, 0]
+        expected = df.iloc[0:2, 0]
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
closes #27865

cc @jbrockmendel this is another one from limiting the catched exceptions in https://github.com/pandas-dev/pandas/pull/27223/files#diff-7489e290a23303c4db4f803011ecaf8eR121. But also this time it's again rather a bug in the code that raises this error.

For some reason, `DataFrame._get_value` for a DataFrame with an IntervalIndex raises an AttributeError. That's a bug in itself which should be solved (and probably is the cause of more bugs in other places where `_get_value` is used, eg in `.at`). But will open a separate issue for that. 