### PR TITLE
BUG: Ensure that fill_na in Categorical only replaces null values

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -21,7 +21,7 @@ Other enhancements
 Bug fixes
 ~~~~~~~~~
 
-- Bug in :func:`fill_na` in :class:`Categorical` would replace all values, not just those that are NaN (:issue:`26215`)
+- Bug in :func:`fill_na` in :meth:`Categorical.fillna` would replace all values, not just those that are NaN (:issue:`26215`)
 
 
 Categorical

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -21,13 +21,11 @@ Other enhancements
 Bug fixes
 ~~~~~~~~~
 
-- Bug in :func:`fill_na` in :meth:`Categorical.fillna` would replace all values, not just those that are NaN (:issue:`26215`)
-
 
 Categorical
 ^^^^^^^^^^^
 
--
+- Bug in :meth:`Categorical.fillna` would replace all values, not just those that are ``NaN`` (:issue:`26215`)
 -
 -
 

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -21,6 +21,8 @@ Other enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Bug in :func:`fill_na` in :class:`Categorical` would replace all values, not just those that are NaN (:issue:`26215`)
+
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1824,7 +1824,6 @@ class Categorical(ExtensionArray, PandasObject):
 
         # pad / bfill
         if method is not None:
-
             values = self.to_dense().reshape(-1, len(self))
             values = interpolate_2d(values, method, 0, None, value).astype(
                 self.categories.dtype
@@ -1838,10 +1837,9 @@ class Categorical(ExtensionArray, PandasObject):
             if isinstance(value, ABCSeries):
                 if not value[~value.isin(self.categories)].isna().all():
                     raise ValueError("fill value must be in categories")
-
                 values_codes = _get_codes_for_values(value, self.categories)
-                indexer = np.where(values_codes != -1)
-                codes[indexer] = values_codes[values_codes != -1]
+                indexer = np.where(codes == -1)
+                codes[indexer] = values_codes[codes == -1]
 
             # If value is not a dict or Series it should be a scalar
             elif is_hashable(value):

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1824,6 +1824,7 @@ class Categorical(ExtensionArray, PandasObject):
 
         # pad / bfill
         if method is not None:
+
             values = self.to_dense().reshape(-1, len(self))
             values = interpolate_2d(values, method, 0, None, value).astype(
                 self.categories.dtype
@@ -1837,9 +1838,10 @@ class Categorical(ExtensionArray, PandasObject):
             if isinstance(value, ABCSeries):
                 if not value[~value.isin(self.categories)].isna().all():
                     raise ValueError("fill value must be in categories")
+
                 values_codes = _get_codes_for_values(value, self.categories)
                 indexer = np.where(codes == -1)
-                codes[indexer] = values_codes[codes == -1]
+                codes[indexer] = values_codes[indexer]
 
             # If value is not a dict or Series it should be a scalar
             elif is_hashable(value):

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -579,25 +579,17 @@ class TestSeriesMissingData:
         tm.assert_series_equal(s.fillna(fill_value), exp)
 
     @pytest.mark.parametrize(
-        "new_categories, fill_value, expected_output",
+        "fill_value, expected_output",
         [
-            (
-                ["c", "d", "e"],
-                Series(["a", "b", "c", "d", "e"]),
-                ["a", "b", "b", "d", "e"],
-            )
+            (Series(["a", "b", "c", "d", "e"]), ["a", "b", "b", "d", "e"]),
+            (Series(["b", "d", "a", "d", "a"]), ["a", "d", "b", "d", "a"]),
         ],
     )
-    def test_fillna_categorical_with_new_categories(
-        self, new_categories, fill_value, expected_output
-    ):
+    def test_fillna_categorical_with_new_categories(self, fill_value, expected_output):
         # GH 26215
         data = ["a", np.nan, "b", np.nan, np.nan]
-        s = Series(Categorical(data, categories=["a", "b"]))
-        s.cat.add_categories(new_categories, inplace=True)
-        exp = Series(
-            Categorical(expected_output, categories=["a", "b"] + new_categories)
-        )
+        s = Series(Categorical(data, categories=["a", "b", "c", "d", "e"]))
+        exp = Series(Categorical(expected_output, categories=["a", "b", "c", "d", "e"]))
         tm.assert_series_equal(s.fillna(fill_value), exp)
 
     def test_fillna_categorical_raise(self):

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -578,6 +578,28 @@ class TestSeriesMissingData:
         exp = Series(Categorical(expected_output, categories=["a", "b"]))
         tm.assert_series_equal(s.fillna(fill_value), exp)
 
+    @pytest.mark.parametrize(
+        "new_categories, fill_value, expected_output",
+        [
+            (
+                ["c", "d", "e"],
+                Series(["a", "b", "c", "d", "e"]),
+                ["a", "b", "b", "d", "e"],
+            )
+        ],
+    )
+    def test_fillna_categorical_with_new_categories(
+        self, new_categories, fill_value, expected_output
+    ):
+        # GH 26215
+        data = ["a", np.nan, "b", np.nan, np.nan]
+        s = Series(Categorical(data, categories=["a", "b"]))
+        s.cat.add_categories(new_categories, inplace=True)
+        exp = Series(
+            Categorical(expected_output, categories=["a", "b"] + new_categories)
+        )
+        tm.assert_series_equal(s.fillna(fill_value), exp)
+
     def test_fillna_categorical_raise(self):
         data = ["a", np.nan, "b", np.nan, np.nan]
         s = Series(Categorical(data, categories=["a", "b"]))

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -583,6 +583,14 @@ class TestSeriesMissingData:
         [
             (Series(["a", "b", "c", "d", "e"]), ["a", "b", "b", "d", "e"]),
             (Series(["b", "d", "a", "d", "a"]), ["a", "d", "b", "d", "a"]),
+            (
+                Series(
+                    Categorical(
+                        ["b", "d", "a", "d", "a"], categories=["b", "c", "d", "e", "a"]
+                    )
+                ),
+                ["a", "d", "b", "d", "a"],
+            ),
         ],
     )
     def test_fillna_categorical_with_new_categories(self, fill_value, expected_output):


### PR DESCRIPTION
- [x] closes #26215
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
