### PR TITLE
TST: parametrize and de-duplicate arith tests

### DIFF
--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -190,7 +190,12 @@ def box(request):
 
 
 @pytest.fixture(
-    params=[pd.Index, pd.Series, pytest.param(pd.DataFrame, marks=pytest.mark.xfail)],
+    params=[
+        pd.Index,
+        pd.Series,
+        pytest.param(pd.DataFrame, marks=pytest.mark.xfail),
+        tm.to_array,
+    ],
     ids=id_func,
 )
 def box_df_fail(request):
@@ -206,6 +211,7 @@ def box_df_fail(request):
         (pd.Series, False),
         (pd.DataFrame, False),
         pytest.param((pd.DataFrame, True), marks=pytest.mark.xfail),
+        (tm.to_array, False),
     ],
     ids=id_func,
 )

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -825,6 +825,7 @@ class TestDatetime64Arithmetic:
         rng -= two_hours
         tm.assert_equal(rng, expected)
 
+    # TODO: redundant with test_dt64arr_add_timedeltalike_scalar
     def test_dt64arr_add_td64_scalar(self, box_with_array):
         # scalar timedeltas/np.timedelta64 objects
         # operate with np.timedelta64 correctly

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -348,28 +348,6 @@ class TestDatetime64SeriesComparison:
         expected = tm.box_expected([False, False], xbox)
         tm.assert_equal(result, expected)
 
-    @pytest.mark.parametrize(
-        "op",
-        [operator.eq, operator.ne, operator.gt, operator.ge, operator.lt, operator.le],
-    )
-    def test_comparison_tzawareness_compat(self, op):
-        # GH#18162
-        dr = pd.date_range("2016-01-01", periods=6)
-        dz = dr.tz_localize("US/Pacific")
-
-        # Check that there isn't a problem aware-aware and naive-naive do not
-        # raise
-        naive_series = Series(dr)
-        aware_series = Series(dz)
-        msg = "Cannot compare tz-naive and tz-aware"
-        with pytest.raises(TypeError, match=msg):
-            op(dz, naive_series)
-        with pytest.raises(TypeError, match=msg):
-            op(dr, aware_series)
-
-        # TODO: implement _assert_tzawareness_compat for the reverse
-        # comparison with the Series on the left-hand side
-
 
 class TestDatetimeIndexComparisons:
 
@@ -599,15 +577,18 @@ class TestDatetimeIndexComparisons:
         with pytest.raises(TypeError, match=msg):
             op(dz, np.array(list(dr), dtype=object))
 
-        # Check that there isn't a problem aware-aware and naive-naive do not
-        # raise
+        # Check that there isn't a problem aware-aware and naive-naive do not raise
         assert_all(dr == dr)
-        assert_all(dz == dz)
+        assert_all(dr == list(dr))
+        assert_all(list(dr) == dr)
+        assert_all(np.array(list(dr), dtype=object) == dr)
+        assert_all(dr == np.array(list(dr), dtype=object))
 
-        # FIXME: DataFrame case fails to raise for == and !=, wrong
-        #  message for inequalities
-        assert (dr == list(dr)).all()
-        assert (dz == list(dz)).all()
+        assert_all(dz == dz)
+        assert_all(dz == list(dz))
+        assert_all(list(dz) == dz)
+        assert_all(np.array(list(dz), dtype=object) == dz)
+        assert_all(dz == np.array(list(dz), dtype=object))
 
     @pytest.mark.parametrize(
         "op",

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1690,14 +1690,12 @@ class TestTimestampSeriesArithmetic:
         dt1 - dt2
         dt2 - dt1
 
-        # ## datetime64 with timetimedelta ###
+        # datetime64 with timetimedelta
         dt1 + td1
         td1 + dt1
         dt1 - td1
-        # TODO: Decide if this ought to work.
-        # td1 - dt1
 
-        # ## timetimedelta with datetime64 ###
+        # timetimedelta with datetime64
         td1 + dt1
         dt1 + td1
 
@@ -1895,7 +1893,7 @@ class TestTimestampSeriesArithmetic:
         with pytest.raises(TypeError, match=msg):
             method(other)
         with pytest.raises(TypeError, match=msg):
-            method(other.values)
+            method(np.array(other))
         with pytest.raises(TypeError, match=msg):
             method(pd.Index(other))
 
@@ -2361,34 +2359,34 @@ class TestDatetimeIndexArithmetic:
         idx = date_range("2011-01-01", periods=3, freq="2D", name="x")
 
         delta = np.timedelta64(1, "D")
+        exp = date_range("2011-01-02", periods=3, freq="2D", name="x")
         for result in [idx + delta, np.add(idx, delta)]:
             assert isinstance(result, DatetimeIndex)
-            exp = date_range("2011-01-02", periods=3, freq="2D", name="x")
             tm.assert_index_equal(result, exp)
             assert result.freq == "2D"
 
+        exp = date_range("2010-12-31", periods=3, freq="2D", name="x")
         for result in [idx - delta, np.subtract(idx, delta)]:
             assert isinstance(result, DatetimeIndex)
-            exp = date_range("2010-12-31", periods=3, freq="2D", name="x")
             tm.assert_index_equal(result, exp)
             assert result.freq == "2D"
 
         delta = np.array(
             [np.timedelta64(1, "D"), np.timedelta64(2, "D"), np.timedelta64(3, "D")]
         )
+        exp = DatetimeIndex(
+            ["2011-01-02", "2011-01-05", "2011-01-08"], freq="3D", name="x"
+        )
         for result in [idx + delta, np.add(idx, delta)]:
             assert isinstance(result, DatetimeIndex)
-            exp = DatetimeIndex(
-                ["2011-01-02", "2011-01-05", "2011-01-08"], freq="3D", name="x"
-            )
             tm.assert_index_equal(result, exp)
             assert result.freq == "3D"
 
+        exp = DatetimeIndex(
+            ["2010-12-31", "2011-01-01", "2011-01-02"], freq="D", name="x"
+        )
         for result in [idx - delta, np.subtract(idx, delta)]:
             assert isinstance(result, DatetimeIndex)
-            exp = DatetimeIndex(
-                ["2010-12-31", "2011-01-01", "2011-01-02"], freq="D", name="x"
-            )
             tm.assert_index_equal(result, exp)
             assert result.freq == "D"
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -577,7 +577,7 @@ class TestDatetimeIndexComparisons:
         with pytest.raises(TypeError, match=msg):
             op(dz, np.array(list(dr), dtype=object))
 
-        # Check that there isn't a problem aware-aware and naive-naive do not raise
+        # The aware==aware and naive==naive comparisons should *not* raise
         assert_all(dr == dr)
         assert_all(dr == list(dr))
         assert_all(list(dr) == dr)

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -561,9 +561,9 @@ class TestMultiplicationDivision:
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("op", [operator.mul, ops.rmul, operator.floordiv])
-    def test_mul_int_identity(self, op, numeric_idx, box):
+    def test_mul_int_identity(self, op, numeric_idx, box_with_array):
         idx = numeric_idx
-        idx = tm.box_expected(idx, box)
+        idx = tm.box_expected(idx, box_with_array)
 
         result = op(idx, 1)
         tm.assert_equal(result, idx)
@@ -615,8 +615,9 @@ class TestMultiplicationDivision:
             idx * np.array([1, 2])
 
     @pytest.mark.parametrize("op", [operator.pow, ops.rpow])
-    def test_pow_float(self, op, numeric_idx, box):
+    def test_pow_float(self, op, numeric_idx, box_with_array):
         # test power calculations both ways, GH#14973
+        box = box_with_array
         idx = numeric_idx
         expected = pd.Float64Index(op(idx.values, 2.0))
 
@@ -626,8 +627,9 @@ class TestMultiplicationDivision:
         result = op(idx, 2.0)
         tm.assert_equal(result, expected)
 
-    def test_modulo(self, numeric_idx, box):
+    def test_modulo(self, numeric_idx, box_with_array):
         # GH#9244
+        box = box_with_array
         idx = numeric_idx
         expected = Index(idx.values % 2)
 
@@ -1041,7 +1043,8 @@ class TestObjectDtypeEquivalence:
     # Tests that arithmetic operations match operations executed elementwise
 
     @pytest.mark.parametrize("dtype", [None, object])
-    def test_numarr_with_dtype_add_nan(self, dtype, box):
+    def test_numarr_with_dtype_add_nan(self, dtype, box_with_array):
+        box = box_with_array
         ser = pd.Series([1, 2, 3], dtype=dtype)
         expected = pd.Series([np.nan, np.nan, np.nan], dtype=dtype)
 
@@ -1055,7 +1058,8 @@ class TestObjectDtypeEquivalence:
         tm.assert_equal(result, expected)
 
     @pytest.mark.parametrize("dtype", [None, object])
-    def test_numarr_with_dtype_add_int(self, dtype, box):
+    def test_numarr_with_dtype_add_int(self, dtype, box_with_array):
+        box = box_with_array
         ser = pd.Series([1, 2, 3], dtype=dtype)
         expected = pd.Series([2, 3, 4], dtype=dtype)
 

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -89,7 +89,7 @@ class TestArithmetic:
 
     @pytest.mark.parametrize("op", [operator.add, ops.radd])
     @pytest.mark.parametrize("other", ["category", "Int64"])
-    def test_add_extension_scalar(self, other, box, op):
+    def test_add_extension_scalar(self, other, box_with_array, op):
         # GH#22378
         # Check that scalars satisfying is_extension_array_dtype(obj)
         # do not incorrectly try to dispatch to an ExtensionArray operation
@@ -97,8 +97,8 @@ class TestArithmetic:
         arr = pd.Series(["a", "b", "c"])
         expected = pd.Series([op(x, other) for x in arr])
 
-        arr = tm.box_expected(arr, box)
-        expected = tm.box_expected(expected, box)
+        arr = tm.box_expected(arr, box_with_array)
+        expected = tm.box_expected(expected, box_with_array)
 
         result = op(arr, other)
         tm.assert_equal(result, expected)
@@ -133,16 +133,17 @@ class TestArithmetic:
         ],
     )
     @pytest.mark.parametrize("dtype", [None, object])
-    def test_objarr_radd_str_invalid(self, dtype, data, box):
+    def test_objarr_radd_str_invalid(self, dtype, data, box_with_array):
         ser = Series(data, dtype=dtype)
 
-        ser = tm.box_expected(ser, box)
+        ser = tm.box_expected(ser, box_with_array)
         with pytest.raises(TypeError):
             "foo_" + ser
 
     @pytest.mark.parametrize("op", [operator.add, ops.radd, operator.sub, ops.rsub])
-    def test_objarr_add_invalid(self, op, box):
+    def test_objarr_add_invalid(self, op, box_with_array):
         # invalid ops
+        box = box_with_array
 
         obj_ser = tm.makeObjectSeries()
         obj_ser.name = "objects"

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1391,15 +1391,14 @@ class TestTimedeltaArraylikeAddSubOps:
     def test_td64arr_with_offset_series(self, names, box_df_fail):
         # GH#18849
         box = box_df_fail
-        if box is tm.to_array:
-            return
         box2 = Series if box in [pd.Index, tm.to_array] else box
+        exname = names[2] if box is not tm.to_array else names[1]
 
         tdi = TimedeltaIndex(["1 days 00:00:00", "3 days 04:00:00"], name=names[0])
         other = Series([pd.offsets.Hour(n=1), pd.offsets.Minute(n=-2)], name=names[1])
 
         expected_add = Series(
-            [tdi[n] + other[n] for n in range(len(tdi))], name=names[2]
+            [tdi[n] + other[n] for n in range(len(tdi))], name=exname
         )
         tdi = tm.box_expected(tdi, box)
         expected_add = tm.box_expected(expected_add, box2)
@@ -1414,7 +1413,7 @@ class TestTimedeltaArraylikeAddSubOps:
 
         # TODO: separate/parametrize add/sub test?
         expected_sub = Series(
-            [tdi[n] - other[n] for n in range(len(tdi))], name=names[2]
+            [tdi[n] - other[n] for n in range(len(tdi))], name=exname
         )
         expected_sub = tm.box_expected(expected_sub, box2)
 
@@ -2016,8 +2015,8 @@ class TestTimedeltaArraylikeMulDivOps:
     def test_td64arr_mul_int_series(self, box_df_fail, names):
         # GH#19042 test for correct name attachment
         box = box_df_fail  # broadcasts along wrong axis, but doesn't raise
-        if box is tm.to_array:
-            return
+        exname = names[2] if box is not tm.to_array else names[1]
+
         tdi = TimedeltaIndex(
             ["0days", "1day", "2days", "3days", "4days"], name=names[0]
         )
@@ -2027,7 +2026,7 @@ class TestTimedeltaArraylikeMulDivOps:
         expected = Series(
             ["0days", "1day", "4days", "9days", "16days"],
             dtype="timedelta64[ns]",
-            name=names[2],
+            name=exname,
         )
 
         tdi = tm.box_expected(tdi, box)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -968,10 +968,11 @@ class TestTimedeltaArraylikeAddSubOps:
     # ------------------------------------------------------------------
     # Operations with int-like others
 
-    def test_td64arr_add_int_series_invalid(self, box):
+    def test_td64arr_add_int_series_invalid(self, box_with_array):
+        box = box_with_array
         tdser = pd.Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
         tdser = tm.box_expected(tdser, box)
-        err = TypeError if box is not pd.Index else NullFrequencyError
+        err = TypeError if box not in [pd.Index, tm.to_array] else NullFrequencyError
         int_ser = Series([2, 3, 4])
 
         with pytest.raises(err):
@@ -1059,11 +1060,12 @@ class TestTimedeltaArraylikeAddSubOps:
         ],
         ids=lambda x: type(x).__name__,
     )
-    def test_td64arr_add_sub_numeric_arr_invalid(self, box, vec, dtype):
+    def test_td64arr_add_sub_numeric_arr_invalid(self, box_with_array, vec, dtype):
+        box = box_with_array
         tdser = pd.Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
         tdser = tm.box_expected(tdser, box)
         err = TypeError
-        if box is pd.Index and not dtype.startswith("float"):
+        if box in [pd.Index, tm.to_array] and not dtype.startswith("float"):
             err = NullFrequencyError
 
         vector = vec.astype(dtype)
@@ -1141,7 +1143,8 @@ class TestTimedeltaArraylikeAddSubOps:
         # roundtrip
         tm.assert_series_equal(result + td2, td1)
 
-    def test_td64arr_add_td64_array(self, box):
+    def test_td64arr_add_td64_array(self, box_with_array):
+        box = box_with_array
         dti = pd.date_range("2016-01-01", periods=3)
         tdi = dti - dti.shift(1)
         tdarr = tdi.values
@@ -1155,7 +1158,8 @@ class TestTimedeltaArraylikeAddSubOps:
         result = tdarr + tdi
         tm.assert_equal(result, expected)
 
-    def test_td64arr_sub_td64_array(self, box):
+    def test_td64arr_sub_td64_array(self, box_with_array):
+        box = box_with_array
         dti = pd.date_range("2016-01-01", periods=3)
         tdi = dti - dti.shift(1)
         tdarr = tdi.values
@@ -1229,8 +1233,9 @@ class TestTimedeltaArraylikeAddSubOps:
         else:
             assert result.dtypes[0] == "timedelta64[ns]"
 
-    def test_td64arr_add_sub_td64_nat(self, box):
+    def test_td64arr_add_sub_td64_nat(self, box_with_array):
         # GH#23320 special handling for timedelta64("NaT")
+        box = box_with_array
         tdi = pd.TimedeltaIndex([NaT, Timedelta("1s")])
         other = np.timedelta64("NaT")
         expected = pd.TimedeltaIndex(["NaT"] * 2)
@@ -1247,8 +1252,9 @@ class TestTimedeltaArraylikeAddSubOps:
         result = other - obj
         tm.assert_equal(result, expected)
 
-    def test_td64arr_sub_NaT(self, box):
+    def test_td64arr_sub_NaT(self, box_with_array):
         # GH#18808
+        box = box_with_array
         ser = Series([NaT, Timedelta("1s")])
         expected = Series([NaT, NaT], dtype="timedelta64[ns]")
 
@@ -1258,8 +1264,9 @@ class TestTimedeltaArraylikeAddSubOps:
         res = ser - pd.NaT
         tm.assert_equal(res, expected)
 
-    def test_td64arr_add_timedeltalike(self, two_hours, box):
+    def test_td64arr_add_timedeltalike(self, two_hours, box_with_array):
         # only test adding/sub offsets as + is now numeric
+        box = box_with_array
         rng = timedelta_range("1 days", "10 days")
         expected = timedelta_range("1 days 02:00:00", "10 days 02:00:00", freq="D")
         rng = tm.box_expected(rng, box)
@@ -1268,8 +1275,9 @@ class TestTimedeltaArraylikeAddSubOps:
         result = rng + two_hours
         tm.assert_equal(result, expected)
 
-    def test_td64arr_sub_timedeltalike(self, two_hours, box):
+    def test_td64arr_sub_timedeltalike(self, two_hours, box_with_array):
         # only test adding/sub offsets as - is now numeric
+        box = box_with_array
         rng = timedelta_range("1 days", "10 days")
         expected = timedelta_range("0 days 22:00:00", "9 days 22:00:00")
 
@@ -1352,8 +1360,9 @@ class TestTimedeltaArraylikeAddSubOps:
 
     # TODO: combine with test_td64arr_add_offset_index by parametrizing
     # over second box?
-    def test_td64arr_add_offset_array(self, box):
+    def test_td64arr_add_offset_array(self, box_with_array):
         # GH#18849
+        box = box_with_array
         tdi = TimedeltaIndex(["1 days 00:00:00", "3 days 04:00:00"])
         other = np.array([pd.offsets.Hour(n=1), pd.offsets.Minute(n=-2)])
 
@@ -1428,6 +1437,8 @@ class TestTimedeltaArraylikeAddSubOps:
     def test_td64arr_with_offset_series(self, names, box_df_fail):
         # GH#18849
         box = box_df_fail
+        if box is tm.to_array:
+            return
         box2 = Series if box in [pd.Index, tm.to_array] else box
 
         tdi = TimedeltaIndex(["1 days 00:00:00", "3 days 04:00:00"], name=names[0])
@@ -2051,6 +2062,8 @@ class TestTimedeltaArraylikeMulDivOps:
     def test_td64arr_mul_int_series(self, box_df_fail, names):
         # GH#19042 test for correct name attachment
         box = box_df_fail  # broadcasts along wrong axis, but doesn't raise
+        if box is tm.to_array:
+            return
         tdi = TimedeltaIndex(
             ["0days", "1day", "2days", "3days", "4days"], name=names[0]
         )
@@ -2064,7 +2077,7 @@ class TestTimedeltaArraylikeMulDivOps:
         )
 
         tdi = tm.box_expected(tdi, box)
-        box = Series if (box is pd.Index and type(ser) is Series) else box
+        box = Series if (box is pd.Index or box is tm.to_array) else box
         expected = tm.box_expected(expected, box)
 
         result = ser * tdi
@@ -2115,7 +2128,11 @@ class TestTimedeltaArraylikeMulDivOps:
             tm.assert_equal(result, expected)
 
 
-class TestTimedeltaArraylikeInvalidArithmeticOps:
+class TestTimedelta64ArrayLikeArithmetic:
+    # Arithmetic tests for timedelta64[ns] vectors fully parametrized over
+    #  DataFrame/Series/TimedeltaIndex/TimedeltaArray.  Ideally all arithmetic
+    #  tests will eventually end up here.
+
     def test_td64arr_pow_invalid(self, scalar_td, box_with_array):
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
         td1.iloc[2] = np.nan

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -968,17 +968,20 @@ class TestTimedeltaArraylikeAddSubOps:
     # ------------------------------------------------------------------
     # Operations with int-like others
 
-    @pytest.mark.parametrize("other", [
-        # GH#19123
-        1,
-        Series([20, 30, 40], dtype="uint8"),
-        np.array([20, 30, 40], dtype="uint8"),
-        pd.UInt64Index([20, 30, 40]),
-        pd.Int64Index([20, 30, 40]),
-        Series([2, 3, 4]),
-        1.5,
-        np.array(2),
-    ])
+    @pytest.mark.parametrize(
+        "other",
+        [
+            # GH#19123
+            1,
+            Series([20, 30, 40], dtype="uint8"),
+            np.array([20, 30, 40], dtype="uint8"),
+            pd.UInt64Index([20, 30, 40]),
+            pd.Int64Index([20, 30, 40]),
+            Series([2, 3, 4]),
+            1.5,
+            np.array(2),
+        ],
+    )
     def test_td64arr_addsub_numeric_invalid(self, box_with_array, other):
         box = box_with_array
         tdser = pd.Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
@@ -1397,9 +1400,7 @@ class TestTimedeltaArraylikeAddSubOps:
         tdi = TimedeltaIndex(["1 days 00:00:00", "3 days 04:00:00"], name=names[0])
         other = Series([pd.offsets.Hour(n=1), pd.offsets.Minute(n=-2)], name=names[1])
 
-        expected_add = Series(
-            [tdi[n] + other[n] for n in range(len(tdi))], name=exname
-        )
+        expected_add = Series([tdi[n] + other[n] for n in range(len(tdi))], name=exname)
         tdi = tm.box_expected(tdi, box)
         expected_add = tm.box_expected(expected_add, box2)
 
@@ -1412,9 +1413,7 @@ class TestTimedeltaArraylikeAddSubOps:
         tm.assert_equal(res2, expected_add)
 
         # TODO: separate/parametrize add/sub test?
-        expected_sub = Series(
-            [tdi[n] - other[n] for n in range(len(tdi))], name=exname
-        )
+        expected_sub = Series([tdi[n] - other[n] for n in range(len(tdi))], name=exname)
         expected_sub = tm.box_expected(expected_sub, box2)
 
         with tm.assert_produces_warning(PerformanceWarning):

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -968,72 +968,34 @@ class TestTimedeltaArraylikeAddSubOps:
     # ------------------------------------------------------------------
     # Operations with int-like others
 
-    def test_td64arr_add_int_series_invalid(self, box_with_array):
-        box = box_with_array
-        tdser = pd.Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
-        tdser = tm.box_expected(tdser, box)
-        err = TypeError if box not in [pd.Index, tm.to_array] else NullFrequencyError
-        int_ser = Series([2, 3, 4])
-
-        with pytest.raises(err):
-            tdser + int_ser
-        with pytest.raises(err):
-            int_ser + tdser
-        with pytest.raises(err):
-            tdser - int_ser
-        with pytest.raises(err):
-            int_ser - tdser
-
-    def test_td64arr_add_intlike(self, box_with_array):
+    @pytest.mark.parametrize("other", [
         # GH#19123
-        tdi = TimedeltaIndex(["59 days", "59 days", "NaT"])
-        ser = tm.box_expected(tdi, box_with_array)
-
-        err = TypeError
-        if box_with_array in [pd.Index, tm.to_array]:
-            err = NullFrequencyError
-
-        other = Series([20, 30, 40], dtype="uint8")
-
-        # TODO: separate/parametrize
-        with pytest.raises(err):
-            ser + 1
-        with pytest.raises(err):
-            ser - 1
-
-        with pytest.raises(err):
-            ser + other
-        with pytest.raises(err):
-            ser - other
-
-        with pytest.raises(err):
-            ser + np.array(other)
-        with pytest.raises(err):
-            ser - np.array(other)
-
-        with pytest.raises(err):
-            ser + pd.Index(other)
-        with pytest.raises(err):
-            ser - pd.Index(other)
-
-    @pytest.mark.parametrize("scalar", [1, 1.5, np.array(2)])
-    def test_td64arr_add_sub_numeric_scalar_invalid(self, box_with_array, scalar):
+        1,
+        Series([20, 30, 40], dtype="uint8"),
+        np.array([20, 30, 40], dtype="uint8"),
+        pd.UInt64Index([20, 30, 40]),
+        pd.Int64Index([20, 30, 40]),
+        Series([2, 3, 4]),
+        1.5,
+        np.array(2),
+    ])
+    def test_td64arr_addsub_numeric_invalid(self, box_with_array, other):
         box = box_with_array
-
         tdser = pd.Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
         tdser = tm.box_expected(tdser, box)
+
         err = TypeError
-        if box in [pd.Index, tm.to_array] and not isinstance(scalar, float):
+        if box in [pd.Index, tm.to_array] and not isinstance(other, float):
             err = NullFrequencyError
 
         with pytest.raises(err):
-            tdser + scalar
+            tdser + other
         with pytest.raises(err):
-            scalar + tdser
+            other + tdser
         with pytest.raises(err):
-            tdser - scalar
+            tdser - other
         with pytest.raises(err):
-            scalar - tdser
+            other - tdser
 
     @pytest.mark.parametrize(
         "dtype",

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1044,14 +1044,6 @@ class TestTimedeltaArraylikeAddSubOps:
     # Operations with timedelta-like others
 
     # TODO: this was taken from tests.series.test_ops; de-duplicate
-    @pytest.mark.parametrize(
-        "scalar_td",
-        [
-            timedelta(minutes=5, seconds=4),
-            Timedelta(minutes=5, seconds=4),
-            Timedelta("5m4s").to_timedelta64(),
-        ],
-    )
     def test_operators_timedelta64_with_timedelta(self, scalar_td):
         # smoke tests
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)


### PR DESCRIPTION
Hopefully before long we can get rid of `box` fixture altogether, then rename `box_with_array` to `box`