### PR TITLE
TST: update pandas_datareader dep, fix xfail

### DIFF
--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -48,5 +48,5 @@ dependencies:
   - pip:
     - brotlipy
     - coverage
-    - pandas-datareader
+    - pandas-datareader>=0.7.4
     - python-dateutil

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -103,7 +103,6 @@ def test_pandas_gbq(df):
     pandas_gbq = import_module("pandas_gbq")  # noqa
 
 
-@pytest.mark.xfail(reason="0.7.0 pending")
 @tm.network
 def test_pandas_datareader():
 


### PR DESCRIPTION
Locally the test fails because Quandl wants an API key, so fixing this test may be a multi-step process