### PR TITLE
REF: use dispatch_to_extension_op for bool ops

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -818,11 +818,10 @@ def _bool_method_SERIES(cls, op, special):
             # Defer to DataFrame implementation; fail early
             return NotImplemented
 
-        elif is_extension_array_dtype(self):
+        elif should_extension_dispatch(self, other):
             # e.g. SparseArray
-            res_values = op(self._values, other)
-            return self._constructor(res_values, index=self.index, name=res_name)
-            # TODO: finalize?
+            res_values = dispatch_to_extension_op(op, self, other)
+            return _construct_result(self, res_values, index=self.index, name=res_name)
 
         elif isinstance(other, (ABCSeries, ABCIndexClass)):
             is_other_int_dtype = is_integer_dtype(other.dtype)

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -818,6 +818,12 @@ def _bool_method_SERIES(cls, op, special):
             # Defer to DataFrame implementation; fail early
             return NotImplemented
 
+        elif is_extension_array_dtype(self):
+            # e.g. SparseArray
+            res_values = op(self._values, other)
+            return self._constructor(res_values, index=self.index, name=res_name)
+            # TODO: finalize?
+
         elif isinstance(other, (ABCSeries, ABCIndexClass)):
             is_other_int_dtype = is_integer_dtype(other.dtype)
             other = fill_int(other) if is_other_int_dtype else fill_bool(other)


### PR DESCRIPTION
Along with #27912 this completes the process of doing this for all Series ops.  From there we can move the array-specific components to array_ops and define the PandasArray ops appropriately.