### PR TITLE
pandas.read_parquet now has info that it accepts path_to_directory that contains multiple parquet files

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -269,6 +269,10 @@ def read_parquet(path, engine="auto", columns=None, **kwargs):
         expected. A local file could be:
         ``file://localhost/path/to/table.parquet``.
 
+        A file path can also be a directory name that contains multiple(partitioned)
+        parquet files (in addition to single file path). A directory path could be:
+        ``directory://usr/path/to/folder``.
+
         If you want to pass in a path object, pandas accepts any
         ``os.PathLike``.
 


### PR DESCRIPTION
- [x] closes #27820 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
