### PR TITLE
Support str param type for partition_cols in to_parquet function

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -105,7 +105,7 @@ I/O
 
 - Avoid calling ``S3File.s3`` when reading parquet, as this was removed in s3fs version 0.3.0 (:issue:`27756`)
 - Better error message when a negative header is passed in :func:`pandas.read_csv` (:issue:`27779`)
-- 
+-
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -105,6 +105,7 @@ I/O
 
 - Avoid calling ``S3File.s3`` when reading parquet, as this was removed in s3fs version 0.3.0 (:issue:`27756`)
 - Better error message when a negative header is passed in :func:`pandas.read_csv` (:issue:`27779`)
+- String support for paramater partition_cols in the :func:`pandas.to_parquet` (:issue:`27117`)
 -
 
 Plotting

--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -105,8 +105,7 @@ I/O
 
 - Avoid calling ``S3File.s3`` when reading parquet, as this was removed in s3fs version 0.3.0 (:issue:`27756`)
 - Better error message when a negative header is passed in :func:`pandas.read_csv` (:issue:`27779`)
-- String support for paramater partition_cols in the :func:`pandas.to_parquet` (:issue:`27117`)
--
+- 
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -29,7 +29,7 @@ Enhancements
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 
--
+- String support for paramater partition_cols in the :func:`pandas.to_parquet` (:issue:`27117`)
 -
 
 .. _whatsnew_1000.api_breaking:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2156,9 +2156,10 @@ class DataFrame(NDFrame):
 
             .. versionadded:: 0.24.0
 
-        partition_cols : list, optional, default None
-            Column names by which to partition the dataset
-            Columns are partitioned in the order they are given
+        partition_cols : list or string, optional, default None
+            Column names by which to partition the dataset.
+            Columns are partitioned in the order they are given.
+            String identifies a single column to be partitioned.
 
             .. versionadded:: 0.24.0
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2167,6 +2167,11 @@ class DataFrame(NDFrame):
             Additional arguments passed to the parquet library. See
             :ref:`pandas io <io.parquet>` for more details.
 
+            .. versionchanged:: 1.0.0
+
+        partition_cols
+            Added ability to pass in a string for a single column name
+
         See Also
         --------
         read_parquet : Read a parquet file.

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -244,6 +244,8 @@ def to_parquet(
     kwargs
         Additional keyword arguments passed to the engine
     """
+    if isinstance(partition_cols, str):
+        partition_cols = [partition_cols]
     impl = get_engine(engine)
     return impl.write(
         df,

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -244,6 +244,11 @@ def to_parquet(
 
     kwargs
         Additional keyword arguments passed to the engine
+
+        .. versionchanged:: 1.0.0
+
+    partition_cols
+        Added ability to pass in a string for a single column name
     """
     if isinstance(partition_cols, str):
         partition_cols = [partition_cols]

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -235,9 +235,10 @@ def to_parquet(
 
         .. versionadded:: 0.24.0
 
-    partition_cols : list, optional, default None
-        Column names by which to partition the dataset
-        Columns are partitioned in the order they are given
+    partition_cols : list or string, optional, default None
+        Column names by which to partition the dataset.
+        Columns are partitioned in the order they are given.
+        String identifies a single column to be partitioned.
 
         .. versionadded:: 0.24.0
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -483,7 +483,7 @@ class TestParquetPyArrow(Base):
 
             dataset = pq.ParquetDataset(path, validate_schema=False)
             assert len(dataset.partitions.partition_names) == 1
-            assert dataset.partitions.partition_names == set((partition_cols))
+            assert dataset.partitions.partition_names == [partition_cols]
 
     def test_empty_dataframe(self, pa):
         # GH #27339

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -476,6 +476,7 @@ class TestParquetPyArrow(Base):
     def test_partition_cols_string(self, pa, df_full):
         # GH #23283
         partition_cols = "bool"
+        partition_cols_list = [partition_cols]
         df = df_full
         with tm.ensure_clean_dir() as path:
             df.to_parquet(path, partition_cols=partition_cols, compression=None)
@@ -483,7 +484,7 @@ class TestParquetPyArrow(Base):
 
             dataset = pq.ParquetDataset(path, validate_schema=False)
             assert len(dataset.partitions.partition_names) == 1
-            assert dataset.partitions.partition_names == [partition_cols]
+            assert dataset.partitions.partition_names == set(partition_cols_list)
 
     def test_empty_dataframe(self, pa):
         # GH #27339

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -475,7 +475,7 @@ class TestParquetPyArrow(Base):
 
     def test_partition_cols_string(self, pa, df_full):
         # GH #23283
-        partition_cols = 'bool'
+        partition_cols = "bool"
         df = df_full
         with tm.ensure_clean_dir() as path:
             df.to_parquet(path, partition_cols=partition_cols, compression=None)
@@ -557,7 +557,7 @@ class TestParquetFastParquet(Base):
 
     def test_partition_cols_string(self, fp, df_full):
         # GH #23283
-        partition_cols = 'bool'
+        partition_cols = "bool"
         df = df_full
         with tm.ensure_clean_dir() as path:
             df.to_parquet(

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -483,7 +483,7 @@ class TestParquetPyArrow(Base):
 
             dataset = pq.ParquetDataset(path, validate_schema=False)
             assert len(dataset.partitions.partition_names) == 1
-            assert dataset.partitions.partition_names == set([partition_cols])
+            assert dataset.partitions.partition_names == set((partition_cols))
 
     def test_empty_dataframe(self, pa):
         # GH #27339

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -330,7 +330,7 @@ class TestBasic(Base):
         # non-default index
         for index in indexes:
             df.index = index
-            check_round_trip(df, engine, check_names=chetest_partition_cols_supportedck_names)
+            check_round_trip(df, engine, check_names=check_names)
 
         # index with meta-data
         df.index = [0, 1, 2]
@@ -416,7 +416,7 @@ class TestParquetPyArrow(Base):
         # GH18628
 
         df = df_full
-        # additional supported types for pyarrowtest_partition_cols_supported
+        # additional supported types for pyarrow
         df["datetime_tz"] = pd.date_range("20130101", periods=3, tz="Europe/Brussels")
 
         check_round_trip(


### PR DESCRIPTION
- [x] closes #27117 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Not sure where to add whatsnew entry #PandasHack2019
