### PR TITLE
DataFrame html repr: also follow min_rows setting

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -105,6 +105,7 @@ I/O
 
 - Avoid calling ``S3File.s3`` when reading parquet, as this was removed in s3fs version 0.3.0 (:issue:`27756`)
 - Better error message when a negative header is passed in :func:`pandas.read_csv` (:issue:`27779`)
+- Follow the ``min_rows`` display option (introduced in v0.25.0) correctly in the html repr in the notebook (:issue:`27991`).
 -
 
 Plotting

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -669,15 +669,18 @@ class DataFrame(NDFrame):
 
         if get_option("display.notebook_repr_html"):
             max_rows = get_option("display.max_rows")
+            min_rows = get_option("display.min_rows")
             max_cols = get_option("display.max_columns")
             show_dimensions = get_option("display.show_dimensions")
 
-            return self.to_html(
+            formatter = fmt.DataFrameFormatter(
+                self,
                 max_rows=max_rows,
+                min_rows=min_rows,
                 max_cols=max_cols,
                 show_dimensions=show_dimensions,
-                notebook=True,
             )
+            return formatter.to_html(notebook=True)
         else:
             return None
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -471,28 +471,35 @@ class TestDataFrameFormatting:
 
         # default setting no truncation even if above min_rows
         assert ".." not in repr(df)
+        assert ".." not in df._repr_html_()
 
         df = pd.DataFrame({"a": range(61)})
 
         # default of max_rows 60 triggers truncation if above
         assert ".." in repr(df)
+        assert ".." in df._repr_html_()
 
         with option_context("display.max_rows", 10, "display.min_rows", 4):
             # truncated after first two rows
             assert ".." in repr(df)
             assert "2  " not in repr(df)
+            assert "..." in df._repr_html_()
+            assert "<td>2</td>" not in df._repr_html_()
 
         with option_context("display.max_rows", 12, "display.min_rows", None):
             # when set to None, follow value of max_rows
             assert "5    5" in repr(df)
+            assert "<td>5</td>" in df._repr_html_()
 
         with option_context("display.max_rows", 10, "display.min_rows", 12):
             # when set value higher as max_rows, use the minimum
             assert "5    5" not in repr(df)
+            assert "<td>5</td>" not in df._repr_html_()
 
         with option_context("display.max_rows", None, "display.min_rows", 12):
             # max_rows of None -> never truncate
             assert ".." not in repr(df)
+            assert ".." not in df._repr_html_()
 
     def test_str_max_colwidth(self):
         # GH 7856


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/27095, where I forgot to apply this setting in the html repr as well.

Thoughts on including this in 0.25.1 or not? It's kind of a oversight of the 0.25 feature, but also an actual change of course in the user experience in the notebook.