### PR TITLE
Raise exception in read_csv when prefix is set, but not used because a header exists

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1930,9 +1930,8 @@ class CParserWrapper(ParserBase):
                 ]
             else:
                 self.names = list(range(self._reader.table_width))
-        else:
-            if self.prefix:
-                raise ValueError("argument prefix must be None if header not None")
+        elif self.prefix:
+            raise ValueError("argument prefix must be None if no headers provided")
 
         # gh-9755
         #

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1930,6 +1930,9 @@ class CParserWrapper(ParserBase):
                 ]
             else:
                 self.names = list(range(self._reader.table_width))
+        else:
+            if self.prefix:
+                raise ValueError("argument prefix must be None if header not None")
 
         # gh-9755
         #


### PR DESCRIPTION
Raised an error if argument prefix is set when there are headers present during pandas read_csv.

- [x] closes #27394
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
