### PR TITLE
When a DataFrame is merged with an empty dataframe, it was creating an incorrect index for the resulting dataframe. Fix for it 

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -10,6 +10,8 @@ labeling information
 """
 import collections
 from collections import OrderedDict, abc
+import pandas
+from pandas import Series
 import functools
 from io import StringIO
 import itertools
@@ -7187,21 +7189,30 @@ class DataFrame(NDFrame):
             other = DataFrame({other.name: other})
 
         if isinstance(other, DataFrame):
-            return merge(
-                self,
-                other,
-                left_on=on,
-                how=how,
-                left_index=on is None,
-                right_index=True,
-                suffixes=(lsuffix, rsuffix),
-                sort=sort,
-            )
-        else:
-            if on is not None:
-                raise ValueError(
-                    "Joining multiple DataFrames only supported for joining on index"
+            if on is None:
+                return merge(
+                    self,
+                    other,
+                    left_on=on,
+                    how=how,
+                    left_index=True,
+                    right_index=True,
+                    suffixes=(lsuffix, rsuffix),
+                    sort=sort
                 )
+        else:
+            result = merge(
+                    self,
+                    other,
+                    left_on=on,
+                    how=how,
+                    left_index=False,
+                    right_index=True,
+                    suffixes=(lsuffix, rsuffix),
+                    sort=sort
+                    )
+            result.set_index([pandas.Series([i for i in range(len(result))])], inplace=True)
+            return result
 
             frames = [self] + list(other)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


In the current fix, if any dataframe is empty, a index is set explicitly using the set_index function