### PR TITLE
[CI] Add pip dependence explicitly

### DIFF
--- a/ci/deps/azure-macos-35.yaml
+++ b/ci/deps/azure-macos-35.yaml
@@ -22,6 +22,7 @@ dependencies:
   - xlrd
   - xlsxwriter
   - xlwt
+  - pip
   - pip:
     - pyreadstat
     # universal


### PR DESCRIPTION
Close #27374. Get rid of the conda warning.
