### PR TITLE
DOC: Fix docstrings lack of punctuation

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -957,7 +957,7 @@ class ExtensionArray:
         cls, to_concat: Sequence[ABCExtensionArray]
     ) -> ABCExtensionArray:
         """
-        Concatenate multiple array
+        Concatenate multiple array.
 
         Parameters
         ----------

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -514,7 +514,7 @@ class ExtensionArray:
 
     def dropna(self):
         """
-        Return ExtensionArray without NA values
+        Return ExtensionArray without NA values.
 
         Returns
         -------

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1283,7 +1283,7 @@ default 'raise'
         """
         Calculate TimedeltaArray of difference between index
         values and index converted to PeriodArray at specified
-        freq. Used for vectorized offsets
+        freq. Used for vectorized offsets.
 
         Parameters
         ----------

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1158,7 +1158,7 @@ default 'raise'
     def to_pydatetime(self):
         """
         Return Datetime Array/Index as object ndarray of datetime.datetime
-        objects
+        objects.
 
         Returns
         -------

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -426,7 +426,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
     @property
     def is_leap_year(self):
         """
-        Logical indicating if the date belongs to a leap year
+        Logical indicating if the date belongs to a leap year.
         """
         return isleapyear_arr(np.asarray(self.year))
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -735,7 +735,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
 
     def snap(self, freq="S"):
         """
-        Snap time stamps to nearest occurring frequency
+        Snap time stamps to nearest occurring frequency.
 
         Returns
         -------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -687,10 +687,10 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
                 behaviour and silence the warning.
 
         index : Index, optional
-            index of resulting Series. If None, defaults to original index
-        name : string, optional
-            name of resulting Series. If None, defaults to name of original
-            index
+            Index of resulting Series. If None, defaults to original index.
+        name : str, optional
+            Name of resulting Series. If None, defaults to name of original
+            index.
 
         Returns
         -------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -661,7 +661,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
     def to_series(self, keep_tz=None, index=None, name=None):
         """
         Create a Series with both index and values equal to the index keys
-        useful with map for returning an indexer based on an index
+        useful with map for returning an indexer based on an index.
 
         Parameters
         ----------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1762,7 +1762,7 @@ class MultiIndex(Index):
 
     def is_lexsorted(self):
         """
-        Return True if the codes are lexicographically sorted
+        Return True if the codes are lexicographically sorted.
 
         Returns
         -------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1250,7 +1250,7 @@ class MultiIndex(Index):
             self.levels[l].rename(name, inplace=True)
 
     names = property(
-        fset=_set_names, fget=_get_names, doc="""\nNames of levels in MultiIndex\n"""
+        fset=_set_names, fget=_get_names, doc="""\nNames of levels in MultiIndex.\n"""
     )
 
     @Appender(_index_shared_docs["_get_grouper_for_level"])

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2246,7 +2246,7 @@ class MultiIndex(Index):
 
     def reorder_levels(self, order):
         """
-        Rearrange levels using input order. May not drop or duplicate levels
+        Rearrange levels using input order. May not drop or duplicate levels.
 
         Parameters
         ----------

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -68,7 +68,7 @@ class TimedeltaIndex(
 ):
     """
     Immutable ndarray of timedelta64 data, represented internally as int64, and
-    which can be boxed to timedelta objects
+    which can be boxed to timedelta objects.
 
     Parameters
     ----------

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -73,15 +73,15 @@ class TimedeltaIndex(
     Parameters
     ----------
     data  : array-like (1-dimensional), optional
-        Optional timedelta-like data to construct index with
+        Optional timedelta-like data to construct index with.
     unit : unit of the arg (D,h,m,s,ms,us,ns) denote the unit, optional
-        which is an integer/float number
-    freq : string or pandas offset object, optional
+        Which is an integer/float number.
+    freq : str or pandas offset object, optional
         One of pandas date offset strings or corresponding objects. The string
         'infer' can be passed in order to set the frequency of the index as the
-        inferred frequency upon creation
+        inferred frequency upon creation.
     copy  : bool
-        Make a copy of input ndarray
+        Make a copy of input ndarray.
     start : starting value, timedelta-like, optional
         If data is None, start is used as the start point in generating regular
         timedelta data.
@@ -90,24 +90,24 @@ class TimedeltaIndex(
 
     periods  : int, optional, > 0
         Number of periods to generate, if generating index. Takes precedence
-        over end argument
+        over end argument.
 
         .. deprecated:: 0.24.0
 
     end : end time, timedelta-like, optional
         If periods is none, generated index will extend to first conforming
-        time on or just past end argument
+        time on or just past end argument.
 
         .. deprecated:: 0.24. 0
 
-    closed : string or None, default None
+    closed : str or None, default None
         Make the interval closed with respect to the given frequency to
-        the 'left', 'right', or both sides (None)
+        the 'left', 'right', or both sides (None).
 
         .. deprecated:: 0.24. 0
 
     name : object
-        Name to be stored in the index
+        Name to be stored in the index.
 
     Attributes
     ----------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -49,7 +49,7 @@ _NS = slice(None, None)
 # the public IndexSlicerMaker
 class _IndexSlice:
     """
-    Create an object to more easily perform multi-index slicing
+    Create an object to more easily perform multi-index slicing.
 
     See Also
     --------


### PR DESCRIPTION
- [ ] xref #27977
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Similar to issue #27979, and as pointed out by @datapythonista, the summaries of some dosctrings don’t end with a period. 

I added the period to the following cases:
```
•       pandas.IndexSlice
•	pandas.MultiIndex.names
•	pandas.MultiIndex.is_lexsorted
•	pandas.MultiIndex.reorder_levels
•	pandas.DatetimeIndex.snap
•	pandas.DatetimeIndex.to_perioddelta
•	pandas.DatetimeIndex.to_pydatetime
•	pandas.DatetimeIndex.to_series
•	pandas.TimedeltaIndex
•	pandas.PeriodIndex.is_leap_year
•	pandas.api.extensions.ExtensionArray._concat_same_type
•	pandas.api.extensions.ExtensionArray.dropna
```

These are the outputs of validate_docstrings.py when evaluating each case:

**pandas.IndexSlice**
```
4 Errors found:
	Examples do not pass tests
	flake8 error: E231 missing whitespace after ',' (4 times)
	flake8 error: E902 TokenError: EOF in multi-line statement
	flake8 error: E999 SyntaxError: invalid syntax
1 Warnings found:
	No extended summary found
```
**pandas.MultiIndex.names**
```
3 Warnings found:
	No extended summary found
	See Also section not found
	No examples section found
```
**pandas.MultiIndex.is_lexsorted**
```
1 Errors found:
	Return value has no description
3 Warnings found:
	No extended summary found
	See Also section not found
	No examples section found
```
**pandas.MultiIndex.reorder_levels**
```
2 Errors found:
	Parameters {order} not documented
	Return value has no description
3 Warnings found:
	No extended summary found
	See Also section not found
	No examples section found
```
**pandas.DatetimeIndex.snap**
```
2 Errors found:
	Parameters {freq} not documented
	Return value has no description
3 Warnings found:
	No extended summary found
	See Also section not found
	No examples section found
```
**pandas.DatetimeIndex.to_perioddelta**
```
5 Errors found:
	Summary should fit in a single line
	Parameters {**kwargs, *args} not documented
	Unknown parameters {freq}
	Parameter "freq" has no description
	Return value has no description
2 Warnings found:
	See Also section not found
	No examples section found
```
**pandas.DatetimeIndex.to_pydatetime**
```
4 Errors found:
	Summary should fit in a single line
	Parameters {**kwargs, *args} not documented
	The first line of the Returns section should contain only the type, unless multiple values are being returned
	Return value has no description
2 Warnings found:
	See Also section not found
	No examples section found
```
**pandas.DatetimeIndex.to_series**
```
2 Errors found:
	Summary should fit in a single line
	Return value has no description
2 Warnings found:
	See Also section not found
	No examples section found
```
**pandas.TimedeltaIndex**
```
3 Errors found:
	Summary should fit in a single line
	Parameters {dtype, verify_integrity, periods, copy, data} not documented
	Unknown parameters {periods , copy , data }
1 Warnings found:
	No examples section found
```
**pandas.PeriodIndex.is_leap_year**
```
3 Warnings found:
	No extended summary found
	See Also section not found
	No examples section found
```
**pandas.api.extensions.ExtensionArray._concat_same_type**
```
2 Errors found:
	Parameter "to_concat" has no description
	Return value has no description
3 Warnings found:
	No extended summary found
	See Also section not found
	No examples section found
```
**pandas.api.extensions.ExtensionArray.dropna**
```
2 Errors found:
	The first line of the Returns section should contain only the type, unless multiple values are being returned
	Return value has no description
3 Warnings found:
	No extended summary found
	See Also section not found
	No examples section found
```
I would be happy to also work on the other errors/warnings in this PR on another.