### PR TITLE
Add support to names keyword in Index

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -504,9 +504,7 @@ class Index(IndexOpsMixin, PandasObject):
                     # 10697
                     from .multi import MultiIndex
 
-                    return MultiIndex.from_tuples(
-                        data, names=names or name
-                    )
+                    return MultiIndex.from_tuples(data, names=names or name)
             # other iterable of some kind
             subarr = com.asarray_tuplesafe(data, dtype=object)
             return Index(subarr, dtype=dtype, copy=copy, name=name, **kwargs)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -178,7 +178,7 @@ class Index(IndexOpsMixin, PandasObject):
         Make a copy of input ndarray
     name : object, optional
         Name to be stored in the index
-    names: tuple of objects, optional
+    names : tuple of objects, optional
         Names to be stored in the index (only accepts tuple of length 1)
     tupleize_cols : bool (default: True)
         When True, attempt to create a MultiIndex if possible

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -178,10 +178,10 @@ class Index(IndexOpsMixin, PandasObject):
         Make a copy of input ndarray
     name : object, optional
         Name to be stored in the index
-    names : tuple of objects, optional
-        Names to be stored in the index (only accepts tuple of length 1)
     tupleize_cols : bool (default: True)
         When True, attempt to create a MultiIndex if possible
+    names : tuple of objects, optional
+        Names to be stored in the index (only accepts tuple of length 1)
 
     See Also
     --------
@@ -261,17 +261,15 @@ class Index(IndexOpsMixin, PandasObject):
         dtype=None,
         copy=False,
         name=None,
-        names=None,
         fastpath=None,
         tupleize_cols=True,
+        names=None,
         **kwargs
     ):
 
         if names is not None:
             if name is not None:
                 raise TypeError("Using name and names is unsupported")
-            elif names is not None and not is_list_like(names):
-                raise TypeError("names must be list-like")
             elif len(names) > 1:
                 raise TypeError("names must be list-like of size 1")
             # infer name from names when MultiIndex cannot be created

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -374,25 +374,25 @@ class TestIndex(Base):
     def test_constructor_names(self):
         # test both `name` and `names`
         with pytest.raises(TypeError):
-            idx = Index([1, 2, 3], name='a', names=('a',))
+            idx = Index([1, 2, 3], name="a", names=("a",))
 
         # test non-list-like `names`
         with pytest.raises(TypeError):
-            idx = Index([1, 2, 3], names='a')
+            idx = Index([1, 2, 3], names="a")
 
         # test list-like with length > 1
         with pytest.raises(TypeError):
-            idx = Index([1, 2, 3], names=('a', 'b'))
+            idx = Index([1, 2, 3], names=("a", "b"))
 
         # test using `name` for a flat `Index`
-        idx = Index([1, 2, 3], name='a')
-        assert idx.name == 'a'
-        assert idx.names == ('a',)
+        idx = Index([1, 2, 3], name="a")
+        assert idx.name == "a"
+        assert idx.names == ("a",)
 
         # test using `names` for a flat `Index`
-        idx = Index([1, 2, 3], names=('a',))
-        assert idx.name == 'a'
-        assert idx.names == ('a',)
+        idx = Index([1, 2, 3], names=("a",))
+        assert idx.name == "a"
+        assert idx.names == ("a",)
 
     @pytest.mark.parametrize(
         "vals",

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -376,10 +376,6 @@ class TestIndex(Base):
         with pytest.raises(TypeError):
             idx = Index([1, 2, 3], name="a", names=("a",))
 
-        # test non-list-like `names`
-        with pytest.raises(TypeError):
-            idx = Index([1, 2, 3], names="a")
-
         # test list-like with length > 1
         with pytest.raises(TypeError):
             idx = Index([1, 2, 3], names=("a", "b"))

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -371,6 +371,29 @@ class TestIndex(Base):
         result = index._simple_new(index.values, dtype)
         tm.assert_index_equal(result, index)
 
+    def test_constructor_names(self):
+        # test both `name` and `names`
+        with pytest.raises(TypeError):
+            idx = Index([1, 2, 3], name='a', names=('a',))
+
+        # test non-list-like `names`
+        with pytest.raises(TypeError):
+            idx = Index([1, 2, 3], names='a')
+
+        # test list-like with length > 1
+        with pytest.raises(TypeError):
+            idx = Index([1, 2, 3], names=('a', 'b'))
+
+        # test using `name` for a flat `Index`
+        idx = Index([1, 2, 3], name='a')
+        assert idx.name == 'a'
+        assert idx.names == ('a',)
+
+        # test using `names` for a flat `Index`
+        idx = Index([1, 2, 3], names=('a',))
+        assert idx.name == 'a'
+        assert idx.names == ('a',)
+
     @pytest.mark.parametrize(
         "vals",
         [


### PR DESCRIPTION
- [x] closes #19082
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
