### PR TITLE
TST: fix compression tests when run without virtualenv/condaenv

### DIFF
--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -139,7 +139,7 @@ def test_with_missing_lzma():
         import pandas
         """
     )
-    subprocess.check_output(["python", "-c", code])
+    subprocess.check_output(["python3", "-c", code])
 
 
 def test_with_missing_lzma_runtime():
@@ -156,4 +156,4 @@ def test_with_missing_lzma_runtime():
             df.to_csv('foo.csv', compression='xz')
         """
     )
-    subprocess.check_output(["python", "-c", code])
+    subprocess.check_output(["python3", "-c", code])

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -139,7 +139,7 @@ def test_with_missing_lzma():
         import pandas
         """
     )
-    subprocess.check_output(["python3", "-c", code])
+    subprocess.check_output([sys.executable, "-c", code])
 
 
 def test_with_missing_lzma_runtime():
@@ -156,4 +156,4 @@ def test_with_missing_lzma_runtime():
             df.to_csv('foo.csv', compression='xz')
         """
     )
-    subprocess.check_output(["python3", "-c", code])
+    subprocess.check_output([sys.executable, "-c", code])

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import subprocess
+import sys
 import textwrap
 import warnings
 


### PR DESCRIPTION
sys.executable is the pattern we use elsewhere in subprocess tests.