### PR TITLE
DOC: fix punctuation in Timestamp/Timedelta docstrings

### DIFF
--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -545,7 +545,7 @@ class NaTType(_NaT):
         """)
     round = _make_nat_func('round',  # noqa:E128
         """
-        Round the Timestamp to the specified resolution
+        Round the Timestamp to the specified resolution.
 
         Parameters
         ----------

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -583,7 +583,7 @@ default 'raise'
         """)
     floor = _make_nat_func('floor',  # noqa:E128
         """
-        return a new Timestamp floored to this resolution
+        return a new Timestamp floored to this resolution.
 
         Parameters
         ----------
@@ -617,7 +617,7 @@ default 'raise'
         """)
     ceil = _make_nat_func('ceil',  # noqa:E128
         """
-        return a new Timestamp ceiled to this resolution
+        return a new Timestamp ceiled to this resolution.
 
         Parameters
         ----------
@@ -729,7 +729,7 @@ default 'raise'
         """)
     replace = _make_nat_func('replace',  # noqa:E128
         """
-        implements datetime.replace, handles nanoseconds
+        implements datetime.replace, handles nanoseconds.
 
         Parameters
         ----------

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1150,7 +1150,7 @@ cdef class _Timedelta(timedelta):
         """
         Format Timedelta as ISO 8601 Duration like
         ``P[n]Y[n]M[n]DT[n]H[n]M[n]S``, where the ``[n]`` s are replaced by the
-        values. See https://en.wikipedia.org/wiki/ISO_8601#Durations
+        values. See https://en.wikipedia.org/wiki/ISO_8601#Durations.
 
         .. versionadded:: 0.20.0
 
@@ -1314,7 +1314,7 @@ class Timedelta(_Timedelta):
 
     def round(self, freq):
         """
-        Round the Timedelta to the specified resolution
+        Round the Timedelta to the specified resolution.
 
         Parameters
         ----------
@@ -1332,7 +1332,7 @@ class Timedelta(_Timedelta):
 
     def floor(self, freq):
         """
-        return a new Timedelta floored to this resolution
+        Return a new Timedelta floored to this resolution.
 
         Parameters
         ----------
@@ -1342,7 +1342,7 @@ class Timedelta(_Timedelta):
 
     def ceil(self, freq):
         """
-        return a new Timedelta ceiled to this resolution
+        Return a new Timedelta ceiled to this resolution.
 
         Parameters
         ----------

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1332,7 +1332,7 @@ class Timedelta(_Timedelta):
 
     def floor(self, freq):
         """
-        Return a new Timedelta floored to this resolution.
+        return a new Timedelta floored to this resolution.
 
         Parameters
         ----------
@@ -1342,7 +1342,7 @@ class Timedelta(_Timedelta):
 
     def ceil(self, freq):
         """
-        Return a new Timedelta ceiled to this resolution.
+        return a new Timedelta ceiled to this resolution.
 
         Parameters
         ----------

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -483,7 +483,7 @@ default 'raise'
 
     def floor(self, freq, ambiguous='raise', nonexistent='raise'):
         """
-        Return a new Timestamp floored to this resolution.
+        return a new Timestamp floored to this resolution.
 
         Parameters
         ----------
@@ -519,7 +519,7 @@ default 'raise'
 
     def ceil(self, freq, ambiguous='raise', nonexistent='raise'):
         """
-        Return a new Timestamp ceiled to this resolution.
+        return a new Timestamp ceiled to this resolution.
 
         Parameters
         ----------
@@ -893,7 +893,7 @@ default 'raise'
                 hour=None, minute=None, second=None, microsecond=None,
                 nanosecond=None, tzinfo=object, fold=0):
         """
-        Implements datetime.replace, handles nanoseconds.
+        implements datetime.replace, handles nanoseconds.
 
         Parameters
         ----------

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -246,7 +246,7 @@ class Timestamp(_Timestamp):
         Timestamp.fromordinal(ordinal, freq=None, tz=None)
 
         passed an ordinal, translate and convert to a ts
-        note: by definition there cannot be any tz info on the ordinal itself.
+        note: by definition there cannot be any tz info on the ordinal itself
 
         Parameters
         ----------
@@ -336,7 +336,7 @@ class Timestamp(_Timestamp):
         """
         Timestamp.combine(date, time)
 
-        date, time -> datetime with same date and time fields.
+        date, time -> datetime with same date and time fields
         """
         return cls(datetime.combine(date, time))
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -910,7 +910,7 @@ default 'raise'
 
         Returns
         -------
-        Timestamp with fields replaced.
+        Timestamp with fields replaced
         """
 
         cdef:

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -246,7 +246,7 @@ class Timestamp(_Timestamp):
         Timestamp.fromordinal(ordinal, freq=None, tz=None)
 
         passed an ordinal, translate and convert to a ts
-        note: by definition there cannot be any tz info on the ordinal itself
+        note: by definition there cannot be any tz info on the ordinal itself.
 
         Parameters
         ----------
@@ -336,7 +336,7 @@ class Timestamp(_Timestamp):
         """
         Timestamp.combine(date, time)
 
-        date, time -> datetime with same date and time fields
+        date, time -> datetime with same date and time fields.
         """
         return cls(datetime.combine(date, time))
 
@@ -441,7 +441,7 @@ class Timestamp(_Timestamp):
 
     def round(self, freq, ambiguous='raise', nonexistent='raise'):
         """
-        Round the Timestamp to the specified resolution
+        Round the Timestamp to the specified resolution.
 
         Parameters
         ----------
@@ -483,7 +483,7 @@ default 'raise'
 
     def floor(self, freq, ambiguous='raise', nonexistent='raise'):
         """
-        return a new Timestamp floored to this resolution
+        Return a new Timestamp floored to this resolution.
 
         Parameters
         ----------
@@ -519,7 +519,7 @@ default 'raise'
 
     def ceil(self, freq, ambiguous='raise', nonexistent='raise'):
         """
-        return a new Timestamp ceiled to this resolution
+        Return a new Timestamp ceiled to this resolution.
 
         Parameters
         ----------
@@ -556,7 +556,7 @@ default 'raise'
     @property
     def tz(self):
         """
-        Alias for tzinfo
+        Alias for tzinfo.
         """
         return self.tzinfo
 
@@ -754,7 +754,7 @@ default 'raise'
     def resolution(self):
         """
         Return resolution describing the smallest difference between two
-        times that can be represented by Timestamp object_state
+        times that can be represented by Timestamp object_state.
         """
         # GH#21336, GH#21365
         return Timedelta(nanoseconds=1)
@@ -893,7 +893,7 @@ default 'raise'
                 hour=None, minute=None, second=None, microsecond=None,
                 nanosecond=None, tzinfo=object, fold=0):
         """
-        implements datetime.replace, handles nanoseconds
+        Implements datetime.replace, handles nanoseconds.
 
         Parameters
         ----------
@@ -910,7 +910,7 @@ default 'raise'
 
         Returns
         -------
-        Timestamp with fields replaced
+        Timestamp with fields replaced.
         """
 
         cdef:

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -361,7 +361,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     _interval_shared_docs[
         "from_tuples"
     ] = """
-    Construct an %(klass)s from an array-like of tuples
+    Construct an %(klass)s from an array-like of tuples.
 
     Parameters
     ----------
@@ -854,7 +854,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def left(self):
         """
         Return the left endpoints of each Interval in the IntervalArray as
-        an Index
+        an Index.
         """
         return self._left
 
@@ -862,7 +862,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def right(self):
         """
         Return the right endpoints of each Interval in the IntervalArray as
-        an Index
+        an Index.
         """
         return self._right
 
@@ -870,7 +870,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def closed(self):
         """
         Whether the intervals are closed on the left-side, right-side, both or
-        neither
+        neither.
         """
         return self._closed
 
@@ -878,7 +878,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         "set_closed"
     ] = """
         Return an %(klass)s identical to the current one, but closed on the
-        specified side
+        specified side.
 
         .. versionadded:: 0.24.0
 
@@ -917,7 +917,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def length(self):
         """
         Return an Index with entries denoting the length of each Interval in
-        the IntervalArray
+        the IntervalArray.
         """
         try:
             return self.right - self.left
@@ -945,7 +945,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     ] = """
         Return True if the %(klass)s is non-overlapping (no Intervals share
         points) and is either monotonic increasing or monotonic decreasing,
-        else False
+        else False.
         """
     # https://github.com/python/mypy/issues/1362
     # Mypy does not support decorated properties
@@ -995,7 +995,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     _interval_shared_docs[
         "to_tuples"
     ] = """
-        Return an %(return_type)s of tuples of the form (left, right)
+        Return an %(return_type)s of tuples of the form (left, right).
 
         Parameters
         ----------

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -361,7 +361,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     _interval_shared_docs[
         "from_tuples"
     ] = """
-    Construct an %(klass)s from an array-like of tuples.
+    Construct an %(klass)s from an array-like of tuples
 
     Parameters
     ----------
@@ -854,7 +854,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def left(self):
         """
         Return the left endpoints of each Interval in the IntervalArray as
-        an Index.
+        an Index
         """
         return self._left
 
@@ -862,7 +862,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def right(self):
         """
         Return the right endpoints of each Interval in the IntervalArray as
-        an Index.
+        an Index
         """
         return self._right
 
@@ -870,7 +870,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def closed(self):
         """
         Whether the intervals are closed on the left-side, right-side, both or
-        neither.
+        neither
         """
         return self._closed
 
@@ -878,7 +878,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         "set_closed"
     ] = """
         Return an %(klass)s identical to the current one, but closed on the
-        specified side.
+        specified side
 
         .. versionadded:: 0.24.0
 
@@ -917,7 +917,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def length(self):
         """
         Return an Index with entries denoting the length of each Interval in
-        the IntervalArray.
+        the IntervalArray
         """
         try:
             return self.right - self.left
@@ -945,7 +945,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     ] = """
         Return True if the %(klass)s is non-overlapping (no Intervals share
         points) and is either monotonic increasing or monotonic decreasing,
-        else False.
+        else False
         """
     # https://github.com/python/mypy/issues/1362
     # Mypy does not support decorated properties
@@ -995,7 +995,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     _interval_shared_docs[
         "to_tuples"
     ] = """
-        Return an %(return_type)s of tuples of the form (left, right).
+        Return an %(return_type)s of tuples of the form (left, right)
 
         Parameters
         ----------


### PR DESCRIPTION
- [ ] xref #27977
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Add periods to Timestamp and Timedelta doctrings for the following attributes and methods:
```
pandas.Timestamp.resolution
pandas.Timestamp.tz
pandas.Timestamp.ceil
pandas.Timestamp.combine
pandas.Timestamp.floor
pandas.Timestamp.fromordinal
pandas.Timestamp.replace
pandas.Timestamp.round
pandas.Timestamp.weekday
pandas.Timedelta.ceil
pandas.Timedelta.floor
pandas.Timedelta.isoformat
pandas.Timedelta.round
```

I did not find the method for `pandas.Timestamp.isoweekday` this in the Timestamp source code. Was this deprecated ? @datapythonista 