### PR TITLE
DOC: redirect from_csv search

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -1579,3 +1579,6 @@ generated/pandas.unique,../reference/api/pandas.unique
 generated/pandas.util.hash_array,../reference/api/pandas.util.hash_array
 generated/pandas.util.hash_pandas_object,../reference/api/pandas.util.hash_pandas_object
 generated/pandas.wide_to_long,../reference/api/pandas.wide_to_long
+
+# Cached searches
+reference/api/pandas.DataFrame.from_csv.html,../reference/api/pandas.read_csv

--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -1581,4 +1581,4 @@ generated/pandas.util.hash_pandas_object,../reference/api/pandas.util.hash_panda
 generated/pandas.wide_to_long,../reference/api/pandas.wide_to_long
 
 # Cached searches
-reference/api/pandas.DataFrame.from_csv.html,../reference/api/pandas.read_csv
+reference/api/pandas.DataFrame.from_csv,pandas.read_csv


### PR DESCRIPTION
A web search for "DataFrame from CSV" leads to
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.from_csv.html

which is currently a 404, since DataFrame.from_csv was removed. Redirect
it to read_csv.

Normally we shouldn't worry about this, but I suspect this is a common search term.