### PR TITLE
Repeat headings every n-th row in Jupyter-lab notebook

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -343,6 +343,8 @@ with cf.config_prefix("display"):
     )
     cf.register_option("max_categories", 8, pc_max_categories_doc, validator=is_int)
     cf.register_option("max_colwidth", 50, max_colwidth_doc, validator=is_int)
+    cf.register_option("repeating_row_index", 0, validator=is_int)
+
     if is_terminal():
         max_cols = 0  # automatically determine optimal number of columns
     else:

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -421,8 +421,7 @@ class HTMLFormatter(TableFormatter):
                     nindex_levels=self.row_levels,
                 )
             j = get_option("display.repeating_row_index")
-            
-            if j > 0 and i % j == 0 and i > 0 :
+            if j > 0 and i % j == 0 and i > 0:
                 row.append(self._write_col_header(indent))
 
             row = []

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -420,6 +420,10 @@ class HTMLFormatter(TableFormatter):
                     tags=None,
                     nindex_levels=self.row_levels,
                 )
+            j = get_option("display.repeating_row_index")
+            
+            if j > 0 and i % j == 0 and i > 0 :
+                row.append(self._write_col_header(indent))
 
             row = []
             if self.fmt.index:


### PR DESCRIPTION
- [ ] closes #27563
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Adds a new option in `pd.set_option()` method.

Usage:
```python
# n is an int that represents the interval of rows which the headers are repeated (default = 0, no repetition)
pd.set_option("display.repeating_row_index", n)   
```
Before | After (n = 3)
----------- | -------------
![Imgur](https://i.imgur.com/jPjDAu0.png) | ![Imgur](https://i.imgur.com/uodLczI.png)


@leostayner 