### PR TITLE
Bug: merge_asof() cannot use datetime.timedelta as tolerance kwarg 

### DIFF
--- a/doc/source/whatsnew/v0.25.1.rst
+++ b/doc/source/whatsnew/v0.25.1.rst
@@ -99,6 +99,7 @@ Reshaping
 - Bug in :meth:`DataFrame.crosstab` when ``margins`` set to ``True`` and ``normalize`` is not ``False``, an error is raised. (:issue:`27500`)
 - :meth:`DataFrame.join` now suppresses the ``FutureWarning`` when the sort parameter is specified (:issue:`21952`)
 - Bug in :meth:`DataFrame.join` raising with readonly arrays (:issue:`27943`)
+- Bug :meth:`merge_asof` could not use datetime.timedelta for `tolerance` kwarg (:issue:`28098`)
 
 Sparse
 ^^^^^^


### PR DESCRIPTION
- [x] Fixes issue #28098
- [x] tests added / passed [1/0]
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
