### PR TITLE
DOC: Fix RangeIndex and other docstrings for missing period in summary

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -466,7 +466,7 @@ class Categorical(ExtensionArray, PandasObject):
     @property
     def dtype(self) -> CategoricalDtype:
         """
-        The :class:`~pandas.api.types.CategoricalDtype` for this instance
+        The :class:`~pandas.api.types.CategoricalDtype` for this instance.
         """
         return self._dtype
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -471,7 +471,7 @@ class Categorical(ExtensionArray, PandasObject):
     @property
     def dtype(self) -> CategoricalDtype:
         """
-        The :class:`~pandas.api.types.CategoricalDtype` for this instance
+        The :class:`~pandas.api.types.CategoricalDtype` for this instance.
         """
         return self._dtype
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1462,7 +1462,7 @@ class IndexOpsMixin:
 
     def memory_usage(self, deep=False):
         """
-        Memory usage of the values
+        Memory usage of the values.
 
         Parameters
         ----------

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -37,7 +37,7 @@ from pandas.io.formats.printing import pprint_thing
 class Grouper:
     """
     A Grouper allows the user to specify a groupby instruction for a target
-    object
+    object.
 
     This specification will select a column via the key parameter, or if the
     level and/or axis parameters are given, a level of the index of the target

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2020,7 +2020,7 @@ class Index(IndexOpsMixin, PandasObject):
     _index_shared_docs[
         "fillna"
     ] = """
-        Fill NA/NaN values with the specified value
+        Fill NA/NaN values with the specified value.
 
         Parameters
         ----------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2051,7 +2051,7 @@ class Index(IndexOpsMixin, PandasObject):
     _index_shared_docs[
         "dropna"
     ] = """
-        Return Index without NA/NaN values
+        Return Index without NA/NaN values.
 
         Parameters
         ----------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1593,7 +1593,7 @@ def bdate_range(
     **kwargs
 ):
     """
-    Return a fixed frequency DatetimeIndex, with business day as the default
+    Return a fixed frequency DatetimeIndex, with business day as the default.
     frequency
 
     Parameters

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1593,8 +1593,8 @@ def bdate_range(
     **kwargs
 ):
     """
-    Return a fixed frequency DatetimeIndex, with business day as the default.
-    frequency
+    Return a fixed frequency DatetimeIndex, with business day as the default
+    frequency.
 
     Parameters
     ----------

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1310,7 +1310,7 @@ def interval_range(
     start=None, end=None, periods=None, freq=None, name=None, closed="right"
 ):
     """
-    Return a fixed frequency IntervalIndex
+    Return a fixed frequency IntervalIndex.
 
     Parameters
     ----------

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -168,7 +168,7 @@ _num_index_shared_docs[
 ] = """
     Immutable ndarray implementing an ordered, sliceable set. The basic object
     storing axis labels for all pandas objects. %(klass)s is a special case
-    of `Index` with purely %(ltype)s labels. %(extra)s
+    of `Index` with purely %(ltype)s labels.
 
     Parameters
     ----------

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -168,7 +168,7 @@ _num_index_shared_docs[
 ] = """
     Immutable ndarray implementing an ordered, sliceable set. The basic object
     storing axis labels for all pandas objects. %(klass)s is a special case
-    of `Index` with purely %(ltype)s labels.
+    of `Index` with purely %(ltype)s labels. %(extra)s
 
     Parameters
     ----------

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -994,7 +994,7 @@ PeriodIndex._add_datetimelike_methods()
 def period_range(start=None, end=None, periods=None, freq=None, name=None):
     """
     Return a fixed frequency PeriodIndex, with day (calendar) as the default
-    frequency
+    frequency.
 
     Parameters
     ----------

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -282,7 +282,7 @@ class RangeIndex(Int64Index):
     @cache_readonly
     def step(self):
         """
-        The value of the `step` parameter(``1`` if this was not supplied).
+        The value of the `step` parameter (``1`` if this was not supplied).
         """
         # GH 25710
         return self._range.step
@@ -290,7 +290,7 @@ class RangeIndex(Int64Index):
     @property
     def _step(self):
         """
-        The value of the `step` parameter(``1`` if this was not supplied).
+        The value of the `step` parameter (``1`` if this was not supplied).
 
          .. deprecated:: 0.25.0
             Use ``step`` instead.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -236,7 +236,7 @@ class RangeIndex(Int64Index):
     @cache_readonly
     def start(self):
         """
-        The value of the `start` parameter (``0`` if this was not supplied)
+        The value of the `start` parameter.(``0`` if this was not supplied)
         """
         # GH 25710
         return self._range.start
@@ -244,7 +244,7 @@ class RangeIndex(Int64Index):
     @property
     def _start(self):
         """
-        The value of the `start` parameter (``0`` if this was not supplied)
+        The value of the `start` parameter.(``0`` if this was not supplied)
 
          .. deprecated:: 0.25.0
             Use ``start`` instead.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -259,14 +259,14 @@ class RangeIndex(Int64Index):
     @cache_readonly
     def stop(self):
         """
-        The value of the `stop` parameter
+        The value of the `stop` parameter.
         """
         return self._range.stop
 
     @property
     def _stop(self):
         """
-        The value of the `stop` parameter
+        The value of the `stop` parameter.
 
          .. deprecated:: 0.25.0
             Use ``stop`` instead.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -236,7 +236,7 @@ class RangeIndex(Int64Index):
     @cache_readonly
     def start(self):
         """
-        The value of the `start` parameter.(``0`` if this was not supplied)
+        The value of the `start` parameter(``0`` if this was not supplied).
         """
         # GH 25710
         return self._range.start
@@ -244,7 +244,7 @@ class RangeIndex(Int64Index):
     @property
     def _start(self):
         """
-        The value of the `start` parameter.(``0`` if this was not supplied)
+        The value of the `start` parameter(``0`` if this was not supplied).
 
          .. deprecated:: 0.25.0
             Use ``start`` instead.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -282,7 +282,7 @@ class RangeIndex(Int64Index):
     @cache_readonly
     def step(self):
         """
-        The value of the `step` parameter.(``1`` if this was not supplied)
+        The value of the `step` parameter(``1`` if this was not supplied).
         """
         # GH 25710
         return self._range.step
@@ -290,7 +290,7 @@ class RangeIndex(Int64Index):
     @property
     def _step(self):
         """
-        The value of the `step` parameter.(``1`` if this was not supplied)
+        The value of the `step` parameter(``1`` if this was not supplied).
 
          .. deprecated:: 0.25.0
             Use ``step`` instead.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -282,7 +282,7 @@ class RangeIndex(Int64Index):
     @cache_readonly
     def step(self):
         """
-        The value of the `step` parameter (``1`` if this was not supplied)
+        The value of the `step` parameter.(``1`` if this was not supplied)
         """
         # GH 25710
         return self._range.step
@@ -290,7 +290,7 @@ class RangeIndex(Int64Index):
     @property
     def _step(self):
         """
-        The value of the `step` parameter (``1`` if this was not supplied)
+        The value of the `step` parameter.(``1`` if this was not supplied)
 
          .. deprecated:: 0.25.0
             Use ``step`` instead.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -236,7 +236,7 @@ class RangeIndex(Int64Index):
     @cache_readonly
     def start(self):
         """
-        The value of the `start` parameter(``0`` if this was not supplied).
+        The value of the `start` parameter (``0`` if this was not supplied).
         """
         # GH 25710
         return self._range.start
@@ -244,7 +244,7 @@ class RangeIndex(Int64Index):
     @property
     def _start(self):
         """
-        The value of the `start` parameter(``0`` if this was not supplied).
+        The value of the `start` parameter (``0`` if this was not supplied).
 
          .. deprecated:: 0.25.0
             Use ``start`` instead.

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -713,7 +713,7 @@ def timedelta_range(
 ):
     """
     Return a fixed frequency TimedeltaIndex, with day as the default
-    frequency
+    frequency.
 
     Parameters
     ----------

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -177,8 +177,8 @@ def merge_ordered(
 ):
     """
     Perform merge with optional filling/interpolation designed for ordered
-    data like time series data. Optionally perform group-wise merge.(see
-    examples)
+    data like time series data. Optionally perform group-wise merge(see
+    examples).
 
     Parameters
     ----------

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -177,7 +177,7 @@ def merge_ordered(
 ):
     """
     Perform merge with optional filling/interpolation designed for ordered
-    data like time series data. Optionally perform group-wise merge(see
+    data like time series data. Optionally perform group-wise merge (see
     examples).
 
     Parameters

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -177,7 +177,7 @@ def merge_ordered(
 ):
     """
     Perform merge with optional filling/interpolation designed for ordered
-    data like time series data. Optionally perform group-wise merge (see
+    data like time series data. Optionally perform group-wise merge.(see
     examples)
 
     Parameters

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -58,7 +58,7 @@ def hash_pandas_object(
     obj, index=True, encoding="utf8", hash_key=None, categorize=True
 ):
     """
-    Return a data hash of the Index/Series/DataFrame
+    Return a data hash of the Index/Series/DataFrame.
 
     Parameters
     ----------


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

@datapythonista 

I added the period to the following cases:
pandas.Categorical.dtype: Summary does not end with a period
pandas.merge_ordered: Summary does not end with a period
pandas.bdate_range: Summary does not end with a period
pandas.period_range: Summary does not end with a period
pandas.timedelta_range: Summary does not end with a period
pandas.interval_range: Summary does not end with a period
pandas.util.hash_pandas_object: Summary does not end with a period
pandas.Grouper: Summary does not end with a period
pandas.Index.memory_usage: Summary does not end with a period
pandas.Index.fillna: Summary does not end with a period
pandas.Index.dropna: Summary does not end with a period
pandas.RangeIndex.start: Summary does not end with a period
pandas.RangeIndex.stop: Summary does not end with a period
pandas.RangeIndex.step: Summary does not end with a period