### PR TITLE
Allow `fillna(value=None, method="constant")`

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1813,8 +1813,6 @@ class Categorical(ExtensionArray, PandasObject):
             value, method, validate_scalar_dict_value=False
         )
 
-        if value is None:
-            value = np.nan
         if limit is not None:
             raise NotImplementedError(
                 "specifying a limit for fillna has not been implemented yet"

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -560,12 +560,15 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             )
             raise TypeError(msg)
 
-        value = getattr(value, "_values", value)
-        self._check_closed_matches(value, name="value")
+        if value is not None:
+            value = getattr(value, "_values", value)
+            self._check_closed_matches(value, name="value")
 
-        left = self.left.fillna(value=value.left)
-        right = self.right.fillna(value=value.right)
-        return self._shallow_copy(left, right)
+            left = self.left.fillna(value=value.left)
+            right = self.right.fillna(value=value.right)
+            return self._shallow_copy(left, right)
+        else:
+            return self
 
     @property
     def dtype(self):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6194,7 +6194,7 @@ class NDFrame(PandasObject, SelectionMixin):
             axis = 0
         axis = self._get_axis_number(axis)
 
-        if value is None:
+        if value is None and method is not None:
 
             if self._is_mixed_type and axis == 1:
                 if inplace:

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -439,7 +439,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     @Appender(ibase._index_shared_docs["fillna"])
     def fillna(self, value, downcast=None):
         self._assert_can_do_op(value)
-        return CategoricalIndex(self._data.fillna(value), name=self.name)
+        return CategoricalIndex(self._data.fillna(value, method="constant"), name=self.name)
 
     def argsort(self, *args, **kwargs):
         return self.values.argsort(*args, **kwargs)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -74,7 +74,7 @@ def mask_missing(arr, values_to_mask):
 
 def clean_fill_method(method, allow_nearest=False):
     # asfreq is compat for resampling
-    if method in [None, "asfreq"]:
+    if method in [None, "asfreq", "constant"]:
         return None
 
     if isinstance(method, str):
@@ -84,16 +84,17 @@ def clean_fill_method(method, allow_nearest=False):
         elif method == "bfill":
             method = "backfill"
 
-    valid_methods = ["pad", "backfill"]
-    expecting = "pad (ffill) or backfill (bfill)"
+    valid_methods = ["pad", "backfill", "constant"]
+    expecting = "pad (ffill), backfill (bfill), or constant"
     if allow_nearest:
         valid_methods.append("nearest")
-        expecting = "pad (ffill), backfill (bfill) or nearest"
+        expecting = "pad (ffill), backfill (bfill), constant, or nearest"
     if method not in valid_methods:
         msg = "Invalid fill method. Expecting {expecting}. Got {method}".format(
             expecting=expecting, method=method
         )
         raise ValueError(msg)
+
     return method
 
 

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -82,3 +82,9 @@ class TestCategoricalMissing:
         expected = Categorical([Point(0, 0), Point(0, 1), Point(0, 0)])
 
         tm.assert_categorical_equal(result, expected)
+
+    def test_fillna_None(self):
+        cat = Categorical([1, 2, 3, None, np.nan])
+        result = cat.fillna(None, method="constant")
+        expected = Categorical([1, 2, 3, None, None])
+        tm.assert_categorical_equal(result, expected)

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -808,6 +808,11 @@ class TestSparseArray:
         exp = SparseArray([-1, -1, -1, -1], fill_value=0, dtype=np.float64)
         tm.assert_sp_array_equal(res, exp)
 
+        s = SparseArray([1, np.nan, np.nan, np.nan], fill_value=0)
+        res = s.fillna(None, method="constant")
+        exp = s
+        tm.assert_sp_array_equal(res, exp)
+
         # float dtype's fill_value is np.nan, replaced by -1
         s = SparseArray([0.0, 0.0, 0.0, 0.0])
         res = s.fillna(-1)

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -721,6 +721,12 @@ class TestDataFrameMissingData:
         res = df.add(2, fill_value=0)
         assert_frame_equal(res, exp)
 
+    def test_fillna_None(self):
+        df = DataFrame({"a": [1, 2, np.nan], "b": ['a', None, 'c']})
+        exp = df.fillna(None, method="constant")
+        res = exp
+        assert_frame_equal(res, exp)
+
 
 class TestDataFrameInterpolate:
     def test_interp_basic(self):

--- a/pandas/tests/indexes/datetimes/test_missing.py
+++ b/pandas/tests/indexes/datetimes/test_missing.py
@@ -60,3 +60,21 @@ class TestDatetimeIndex:
             dtype=object,
         )
         tm.assert_index_equal(idx.fillna("x"), exp)
+
+        # fill None
+        idx = pd.DatetimeIndex(["2011-01-01 09:00", pd.NaT, "2011-01-01 11:00"])
+        exp = idx
+        tm.assert_index_equal(idx.fillna(None), exp)
+
+        # fill None on object
+        idx = pd.Index(
+            [
+                pd.Timestamp("2011-01-01 09:00", tz=tz),
+                None,
+                pd.Timestamp("2011-01-01 11:00", tz=tz),
+                "x",
+            ],
+            dtype=object,
+        )
+        exp = idx
+        tm.assert_index_equal(idx.fillna(None), exp)

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -93,6 +93,24 @@ class TestPeriodIndex(DatetimeLike):
         )
         tm.assert_index_equal(idx.fillna(pd.Period("2011-01-01", freq="D")), exp)
 
+        # fill None
+        idx = pd.PeriodIndex(["2011-01-01 09:00", pd.NaT, "2011-01-01 11:00"], freq="H")
+        exp = idx
+        tm.assert_index_equal(idx.fillna(None), exp)
+
+        # fill None on object
+        idx = pd.Index(
+            [
+                pd.Period("2011-01-01 09:00", freq="H"),
+                None,
+                pd.Period("2011-01-01 11:00", freq="H"),
+                "x",
+            ],
+            dtype=object,
+        )
+        exp = idx
+        tm.assert_index_equal(idx.fillna(None), exp)
+
     def test_no_millisecond_field(self):
         msg = "type object 'DatetimeIndex' has no attribute 'millisecond'"
         with pytest.raises(AttributeError, match=msg):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -985,6 +985,11 @@ class TestCategoricalIndex(Base):
         with pytest.raises(ValueError, match=msg):
             idx.fillna(2.0)
 
+        # fill by None
+        idx = CategoricalIndex([1.0, np.nan, 3.0, 1.0], name="x")
+        exp = idx
+        tm.assert_index_equal(idx.fillna(None), exp)
+
     def test_take_fill_value(self):
         # GH 12631
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -401,6 +401,11 @@ class TestFloat64Index(Numeric):
         exp = Index([1.0, "obj", 3.0], name="x")
         tm.assert_index_equal(idx.fillna("obj"), exp)
 
+    def test_fillna_None(self):
+        idx = Index([1.0, np.nan, 3.0], dtype=float, name="x")
+        exp = idx
+        tm.assert_index_equal(idx.fillna(None), exp)
+
     def test_take_fill_value(self):
         # GH 12631
         idx = pd.Float64Index([1.0, 2.0, 3.0], name="xxx")

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -63,6 +63,18 @@ class TestTimedeltaIndex(DatetimeLike):
         )
         tm.assert_index_equal(idx.fillna("x"), exp)
 
+        # fill None
+        idx = pd.TimedeltaIndex(["1 day", pd.NaT, "3 day"])
+        exp = idx
+        tm.assert_index_equal(idx.fillna(None), exp)
+
+        # fill None on object
+        exp = pd.Index(
+            [pd.Timedelta("1 day"), None, pd.Timedelta("3 day")], dtype=object
+        )
+        exp = idx
+        tm.assert_index_equal(idx.fillna(None), exp)
+
     @pytest.mark.parametrize("sort", [None, False])
     def test_difference_freq(self, sort):
         # GH14323: Difference of TimedeltaIndex should not preserve frequency

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -219,7 +219,7 @@ def test_fillna():
 
     msg = (
         r"Invalid fill method\. Expecting pad \(ffill\), backfill"
-        r" \(bfill\) or nearest\. Got 0"
+        r" \(bfill\), constant, or nearest\. Got 0"
     )
     with pytest.raises(ValueError, match=msg):
         r.fillna(0)

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -245,7 +245,7 @@ def test_reindex_corner(test_data):
     ts = test_data.ts[::2]
     msg = (
         r"Invalid fill method\. Expecting pad \(ffill\), backfill"
-        r" \(bfill\) or nearest\. Got foo"
+        r" \(bfill\), constant, or nearest\. Got foo"
     )
     with pytest.raises(ValueError, match=msg):
         ts.reindex(test_data.ts.index, method="foo")

--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -122,8 +122,8 @@ class TestSeriesReplace(TestData):
         # make sure things don't get corrupted when fillna call fails
         s = ser.copy()
         msg = (
-            r"Invalid fill method\. Expecting pad \(ffill\) or backfill"
-            r" \(bfill\)\. Got crash_cymbal"
+            r"Invalid fill method\. Expecting pad \(ffill\), backfill"
+            r" \(bfill\), or constant\. Got crash_cymbal"
         )
         with pytest.raises(ValueError, match=msg):
             s.replace([1, 2, 3], inplace=True, method="crash_cymbal")

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -356,17 +356,18 @@ def validate_fillna_kwargs(value, method, validate_scalar_dict_value=True):
 
     if value is None and method is None:
         raise ValueError("Must specify a fill 'value' or 'method'.")
-    elif value is None and method is not None:
-        method = clean_fill_method(method)
+    elif value is None and method not in (None, "constant"):
+        pass
 
-    elif value is not None and method is None:
+    elif value is not None and method in (None, "constant"):
         if validate_scalar_dict_value and isinstance(value, (list, tuple)):
             raise TypeError(
                 '"value" parameter must be a scalar or dict, but '
                 'you passed a "{0}"'.format(type(value).__name__)
             )
 
-    elif value is not None and method is not None:
+    elif value is not None and method not in (None, "constant"):
         raise ValueError("Cannot specify both 'value' and 'method'.")
 
+    method = clean_fill_method(method)
     return value, method


### PR DESCRIPTION
Sometimes data has object columns that contain both `NaN`s and `None` and we want to standardize them to `None`. Currently `fillna` doesn't allow `value=None` because `None` is used to mean "no value", and `method=None` to mean "fill with the value", so when both are none it's considered invalid. (On columns with dtypes that have their own NAs, like floats, timestamps, etc., filling with `None` leaves them as-is.)

To get around this, I added `method="constant"` which should also be taken to mean "fill with the value". `method="constant"` is required if filling with `None` (so that `value=None, method=None` still throws), otherwise it works the same as before.

As far as I can tell, doing it this way shouldn't break any existing code. I updated/added some tests for the new behaviour. If it looks like this change might be accepted, I'll update the docs as well.

- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry