### PR TITLE
TYPING: check-untyped-defs for util._decorators

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -833,45 +833,45 @@ class SeriesGroupBy(GroupBy):
         axis="",
     )
     @Appender(_shared_docs["aggregate"])
-    def aggregate(self, func_or_funcs=None, *args, **kwargs):
+    def aggregate(self, func=None, *args, **kwargs):
         _level = kwargs.pop("_level", None)
 
-        relabeling = func_or_funcs is None
+        relabeling = func is None
         columns = None
-        no_arg_message = "Must provide 'func_or_funcs' or named aggregation **kwargs."
+        no_arg_message = "Must provide 'func' or named aggregation **kwargs."
         if relabeling:
             columns = list(kwargs)
             if not PY36:
                 # sort for 3.5 and earlier
                 columns = list(sorted(columns))
 
-            func_or_funcs = [kwargs[col] for col in columns]
+            func = [kwargs[col] for col in columns]
             kwargs = {}
             if not columns:
                 raise TypeError(no_arg_message)
 
-        if isinstance(func_or_funcs, str):
-            return getattr(self, func_or_funcs)(*args, **kwargs)
+        if isinstance(func, str):
+            return getattr(self, func)(*args, **kwargs)
 
-        if isinstance(func_or_funcs, abc.Iterable):
+        if isinstance(func, abc.Iterable):
             # Catch instances of lists / tuples
             # but not the class list / tuple itself.
-            func_or_funcs = _maybe_mangle_lambdas(func_or_funcs)
-            ret = self._aggregate_multiple_funcs(func_or_funcs, (_level or 0) + 1)
+            func = _maybe_mangle_lambdas(func)
+            ret = self._aggregate_multiple_funcs(func, (_level or 0) + 1)
             if relabeling:
                 ret.columns = columns
         else:
-            cyfunc = self._get_cython_func(func_or_funcs)
+            cyfunc = self._get_cython_func(func)
             if cyfunc and not args and not kwargs:
                 return getattr(self, cyfunc)()
 
             if self.grouper.nkeys > 1:
-                return self._python_agg_general(func_or_funcs, *args, **kwargs)
+                return self._python_agg_general(func, *args, **kwargs)
 
             try:
-                return self._python_agg_general(func_or_funcs, *args, **kwargs)
+                return self._python_agg_general(func, *args, **kwargs)
             except Exception:
-                result = self._aggregate_named(func_or_funcs, *args, **kwargs)
+                result = self._aggregate_named(func, *args, **kwargs)
 
             index = Index(sorted(result), name=self.grouper.names[0])
             ret = Series(result, index=index)
@@ -1464,8 +1464,8 @@ class DataFrameGroupBy(NDFrameGroupBy):
         axis="",
     )
     @Appender(_shared_docs["aggregate"])
-    def aggregate(self, arg=None, *args, **kwargs):
-        return super().aggregate(arg, *args, **kwargs)
+    def aggregate(self, func=None, *args, **kwargs):
+        return super().aggregate(func, *args, **kwargs)
 
     agg = aggregate
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -788,7 +788,7 @@ class IntervalIndex(IntervalMixin, Index):
         return start, stop
 
     def get_loc(
-        self, key: Any, method: Optional[str] = None
+        self, key: Any, method: Optional[str] = None, tolerance=None
     ) -> Union[int, slice, np.ndarray]:
         """
         Get integer location, slice or boolean mask for requested label.
@@ -982,7 +982,7 @@ class IntervalIndex(IntervalMixin, Index):
             List of indices.
         """
         if self.is_overlapping:
-            return self.get_indexer_non_unique(target, **kwargs)[0]
+            return self.get_indexer_non_unique(target)[0]
         return self.get_indexer(target, **kwargs)
 
     @Appender(_index_shared_docs["get_value"] % _index_doc_kwargs)

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -206,8 +206,8 @@ class EWM(_Rolling):
         axis="",
     )
     @Appender(_shared_docs["aggregate"])
-    def aggregate(self, arg, *args, **kwargs):
-        return super().aggregate(arg, *args, **kwargs)
+    def aggregate(self, func, *args, **kwargs):
+        return super().aggregate(func, *args, **kwargs)
 
     agg = aggregate
 

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -136,8 +136,8 @@ class Expanding(_Rolling_and_Expanding):
         axis="",
     )
     @Appender(_shared_docs["aggregate"])
-    def aggregate(self, arg, *args, **kwargs):
-        return super().aggregate(arg, *args, **kwargs)
+    def aggregate(self, func, *args, **kwargs):
+        return super().aggregate(func, *args, **kwargs)
 
     agg = aggregate
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -901,12 +901,12 @@ class Window(_Window):
         axis="",
     )
     @Appender(_shared_docs["aggregate"])
-    def aggregate(self, arg, *args, **kwargs):
-        result, how = self._aggregate(arg, *args, **kwargs)
+    def aggregate(self, func, *args, **kwargs):
+        result, how = self._aggregate(func, *args, **kwargs)
         if result is None:
 
             # these must apply directly
-            result = arg(self)
+            result = func(self)
 
         return result
 
@@ -1788,8 +1788,8 @@ class Rolling(_Rolling_and_Expanding):
         axis="",
     )
     @Appender(_shared_docs["aggregate"])
-    def aggregate(self, arg, *args, **kwargs):
-        return super().aggregate(arg, *args, **kwargs)
+    def aggregate(self, func, *args, **kwargs):
+        return super().aggregate(func, *args, **kwargs)
 
     agg = aggregate
 


### PR DESCRIPTION
- [X] closes #27404 
xref #27568

```
$ mypy pandas/util/_decorators.py --check-untyped-defs --follow-imports skip
pandas\util\_decorators.py:181: error: Item "function" of "Union[Dict[Any, Any], Callable[[Any], Any]]" has no attribute "get"
pandas\util\_decorators.py:183: error: "Dict[Any, Any]" not callable
pandas\util\_decorators.py:201: error: Argument 1 to "get" of "Mapping" has incompatible type "Optional[str]"; expected "str"
pandas\util\_decorators.py:207: error: Invalid index type "Optional[str]" for "Dict[str, Any]"; expected type "str"
pandas\util\_decorators.py:293: error: Item "Tuple[Any, ...]" of "Union[Tuple[Any, ...], Dict[str, Any]]" has no attribute "update"
```

```
$ mypy pandas/util/_decorators.py --disallow-any-generics --follow-imports skip
pandas\util\_decorators.py:12: error: Missing type parameters for generic type
pandas\util\_decorators.py:18: error: Missing type parameters for generic type
pandas\util\_decorators.py:93: error: Missing type parameters for generic type
pandas\util\_decorators.py:95: error: Missing type parameters for generic type
pandas\util\_decorators.py:217: error: Missing type parameters for generic type
pandas\util\_decorators.py:282: error: Missing type parameters for generic type
pandas\util\_decorators.py:323: error: Missing type parameters for generic type
```

also fixes following errors arising from more precise typing...

```
pandas\core\indexes\interval.py:790: error: Signature of "get_loc" incompatible with supertype "Index"
pandas\core\indexes\interval.py:985: error: Too many arguments for "get_indexer_non_unique" of "IntervalIndex"
pandas\core\groupby\generic.py:889: error: Incompatible types in assignment (expression has type "Callable[[DefaultArg(Any, 'func_or_funcs'), VarArg(Any), KwArg(Any)], Any]", base class "SelectionMixin" defined the type as "Callable[[Arg(Any, 'func'), VarArg(Any), KwArg(Any)], Any]")
pandas\core\groupby\generic.py:1470: error: Incompatible types in assignment (expression has type "Callable[[DefaultArg(Any, 'arg'), VarArg(Any), KwArg(Any)], Any]", base class "NDFrameGroupBy" defined the type as "Callable[[Arg(Any, 'func'), VarArg(Any), KwArg(Any)], Any]")
pandas\core\window\rolling.py:913: error: Incompatible types in assignment (expression has type "Callable[[Arg(Any, 'arg'), VarArg(Any), KwArg(Any)], Any]", base class "_Window" defined the type as "Callable[[Arg(Any, 'func'), VarArg(Any), KwArg(Any)], Any]")
pandas\core\window\rolling.py:1794: error: Incompatible types in assignment (expression has type "Callable[[Arg(Any, 'arg'), VarArg(Any), KwArg(Any)], Any]", base class "_Window" defined the type as "Callable[[Arg(Any, 
'func'), VarArg(Any), KwArg(Any)], Any]")
pandas\core\window\expanding.py:142: error: Incompatible types in assignment (expression has type "Callable[[Arg(Any, 'arg'), VarArg(Any), KwArg(Any)], Any]", base class "_Window" defined the type as "Callable[[Arg(Any, 'func'), VarArg(Any), KwArg(Any)], Any]")
pandas\core\window\ewm.py:212: error: Incompatible types in assignment (expression has type "Callable[[Arg(Any, 'arg'), VarArg(Any), KwArg(Any)], Any]", base class "_Window" defined the type as "Callable[[Arg(Any, 'func'), VarArg(Any), KwArg(Any)], Any]")
```