### PR TITLE
TYPING: _pytest.mark.structures.MarkDecorator -> Callable

### DIFF
--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -25,9 +25,8 @@ For more information, refer to the ``pytest`` documentation on ``skipif``.
 """
 from distutils.version import LooseVersion
 import locale
-from typing import Optional
+from typing import Callable, Optional
 
-from _pytest.mark.structures import MarkDecorator
 import pytest
 
 from pandas.compat import is_platform_32bit, is_platform_windows
@@ -103,7 +102,7 @@ def _skip_if_no_scipy():
     )
 
 
-def skip_if_installed(package: str,) -> MarkDecorator:
+def skip_if_installed(package: str,) -> Callable:
     """
     Skip a test if a package is installed.
 
@@ -117,7 +116,7 @@ def skip_if_installed(package: str,) -> MarkDecorator:
     )
 
 
-def skip_if_no(package: str, min_version: Optional[str] = None) -> MarkDecorator:
+def skip_if_no(package: str, min_version: Optional[str] = None) -> Callable:
     """
     Generic function to help skip tests when required packages are not
     present on the testing system.


### PR DESCRIPTION
xref #28133

```
pandas\util\_test_decorators.py:106: error: Return type becomes "Any" due to an unfollowed import
pandas\util\_test_decorators.py:120: error: Return type becomes "Any" due to an unfollowed import
```