### PR TITLE
Remove outdated docstring that no longer applies

### DIFF
--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -196,10 +196,6 @@ except (AttributeError, KeyError):
 def load(fh, encoding=None, is_verbose=False):
     """load a pickle, with a provided encoding
 
-    if compat is True:
-       fake the old class hierarchy
-       if it works, then return the new type objects
-
     Parameters
     ----------
     fh : a filelike object


### PR DESCRIPTION
- [X] closes #28136
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`


For a change this minor that affects only a comment, not sure if a `whatsnew entry` update is needed?