### PR TITLE
 TYPING: --disallow-any-expr for HTMLFormatter.__init__

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -550,7 +550,7 @@ class DataFrameFormatter(TableFormatter):
         table_id: Optional[str] = None,
         render_links: bool = False,
         bold_rows: bool = False,
-        escape: bool = True
+        escape: bool = True,
     ):
         self.frame = frame
         self.show_index_names = index_names

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -549,7 +549,8 @@ class DataFrameFormatter(TableFormatter):
         decimal: str = ".",
         table_id: Optional[str] = None,
         render_links: bool = False,
-        **kwds
+        bold_rows: bool = False,
+        escape: bool = True
     ):
         self.frame = frame
         self.show_index_names = index_names
@@ -580,7 +581,8 @@ class DataFrameFormatter(TableFormatter):
         else:
             self.justify = justify
 
-        self.kwds = kwds
+        self.bold_rows = bold_rows
+        self.escape = escape
 
         if columns is not None:
             self.columns = ensure_index(columns)

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -37,7 +37,7 @@ class HTMLFormatter(TableFormatter):
     def __init__(
         self,
         formatter: DataFrameFormatter,
-        classes: Optional[Union[str, List, Tuple]] = None,
+        classes: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
         border: Optional[int] = None,
     ) -> None:
         self.fmt = formatter
@@ -46,11 +46,11 @@ class HTMLFormatter(TableFormatter):
         self.frame = self.fmt.frame
         self.columns = self.fmt.tr_frame.columns
         self.elements = []  # type: List[str]
-        self.bold_rows = self.fmt.kwds.get("bold_rows", False)
-        self.escape = self.fmt.kwds.get("escape", True)
+        self.bold_rows = self.fmt.bold_rows
+        self.escape = self.fmt.escape
         self.show_dimensions = self.fmt.show_dimensions
         if border is None:
-            border = get_option("display.html.border")
+            border = cast(int, get_option("display.html.border"))
         self.border = border
         self.table_id = self.fmt.table_id
         self.render_links = self.fmt.render_links

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -39,12 +39,13 @@ class LatexFormatter(TableFormatter):
     ):
         self.fmt = formatter
         self.frame = self.fmt.frame
-        self.bold_rows = self.fmt.kwds.get("bold_rows", False)
+        self.bold_rows = self.fmt.bold_rows
         self.column_format = column_format
         self.longtable = longtable
         self.multicolumn = multicolumn
         self.multicolumn_format = multicolumn_format
         self.multirow = multirow
+        self.escape = self.fmt.escape
 
     def write_result(self, buf: IO[str]) -> None:
         """
@@ -142,7 +143,7 @@ class LatexFormatter(TableFormatter):
                     buf.write("\\endfoot\n\n")
                     buf.write("\\bottomrule\n")
                     buf.write("\\endlastfoot\n")
-            if self.fmt.kwds.get("escape", True):
+            if self.escape:
                 # escape backslashes first
                 crow = [
                     (


### PR DESCRIPTION
```
pandas\io\formats\html.py:44: error: Expression type contains "Any" (has type "Union[str, List[Any], Tuple[Any, ...], None]")
pandas\io\formats\html.py:49: error: Expression type contains "Any" (has type "Dict[str, Any]")
pandas\io\formats\html.py:49: error: Expression has type "Any"
pandas\io\formats\html.py:50: error: Expression type contains "Any" (has type "Dict[str, Any]")
pandas\io\formats\html.py:50: error: Expression has type "Any"
pandas\io\formats\html.py:54: error: Expression type contains "Any" (has type "Union[int, Any]")
```