### PR TITLE
CLN: Use ABC classes for isinstance checks, remove unnecessary imports

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -88,7 +88,6 @@ from pandas.core.arrays.sparse import SparseFrameAccessor
 from pandas.core.generic import NDFrame, _shared_docs
 from pandas.core.index import (
     Index,
-    MultiIndex,
     ensure_index,
     ensure_index_from_sequences,
 )
@@ -1734,7 +1733,7 @@ class DataFrame(NDFrame):
             if is_datetime64_any_dtype(self.index) and convert_datetime64:
                 ix_vals = [self.index.to_pydatetime()]
             else:
-                if isinstance(self.index, MultiIndex):
+                if isinstance(self.index, ABCMultiIndex):
                     # array of tuples to numpy cols. copy copy copy
                     ix_vals = list(map(np.array, zip(*self.index.values)))
                 else:
@@ -1745,7 +1744,7 @@ class DataFrame(NDFrame):
             count = 0
             index_names = list(self.index.names)
 
-            if isinstance(self.index, MultiIndex):
+            if isinstance(self.index, ABCMultiIndex):
                 for i, n in enumerate(index_names):
                     if n is None:
                         index_names[i] = "level_%d" % count
@@ -2868,7 +2867,7 @@ class DataFrame(NDFrame):
             # The behavior is inconsistent. It returns a Series, except when
             # - the key itself is repeated (test on data.shape, #9519), or
             # - we have a MultiIndex on columns (test on self.columns, #21309)
-            if data.shape[1] == 1 and not isinstance(self.columns, MultiIndex):
+            if data.shape[1] == 1 and not isinstance(self.columns, ABCMultiIndex):
                 data = data[key]
 
         return data
@@ -3657,7 +3656,7 @@ class DataFrame(NDFrame):
         elif isinstance(value, DataFrame):
             # align right-hand-side columns if self.columns
             # is multi-index and self[key] is a sub-frame
-            if isinstance(self.columns, MultiIndex) and key in self.columns:
+            if isinstance(self.columns, ABCMultiIndex) and key in self.columns:
                 loc = self.columns.get_loc(key)
                 if isinstance(loc, (slice, Series, np.ndarray, Index)):
                     cols = maybe_droplevels(self.columns[loc], key)
@@ -3706,7 +3705,8 @@ class DataFrame(NDFrame):
 
         # broadcast across multiple columns if necessary
         if broadcast and key in self.columns and value.ndim == 1:
-            if not self.columns.is_unique or isinstance(self.columns, MultiIndex):
+            if not self.columns.is_unique or isinstance(self.columns,
+                                                        ABCMultiIndex):
                 existing_piece = self[key]
                 if isinstance(existing_piece, DataFrame):
                     value = np.tile(value, (len(existing_piece.columns), 1))
@@ -4601,7 +4601,7 @@ class DataFrame(NDFrame):
                 new_index = self.index.droplevel(level)
 
         if not drop:
-            if isinstance(self.index, MultiIndex):
+            if isinstance(self.index, ABCMultiIndex):
                 names = [
                     n if n is not None else ("level_%d" % i)
                     for (i, n) in enumerate(self.index.names)
@@ -4612,7 +4612,7 @@ class DataFrame(NDFrame):
                 names = [default] if self.index.name is None else [self.index.name]
                 to_insert = ((self.index, None),)
 
-            multi_col = isinstance(self.columns, MultiIndex)
+            multi_col = isinstance(self.columns, ABCMultiIndex)
             for i, (lev, lab) in reversed(list(enumerate(to_insert))):
                 if not (level is None or i in level):
                     continue
@@ -4994,7 +4994,7 @@ class DataFrame(NDFrame):
                 level, ascending=ascending, sort_remaining=sort_remaining
             )
 
-        elif isinstance(labels, MultiIndex):
+        elif isinstance(labels, ABCMultiIndex):
             from pandas.core.sorting import lexsort_indexer
 
             indexer = lexsort_indexer(
@@ -5280,7 +5280,7 @@ class DataFrame(NDFrame):
         type of caller (new object)
         """
         axis = self._get_axis_number(axis)
-        if not isinstance(self._get_axis(axis), MultiIndex):  # pragma: no cover
+        if not isinstance(self._get_axis(axis), ABCMultiIndex):  # pragma: no cover
             raise TypeError("Can only reorder levels on a hierarchical axis.")
 
         result = self.copy()
@@ -7778,7 +7778,7 @@ class DataFrame(NDFrame):
         count_axis = frame._get_axis(axis)
         agg_axis = frame._get_agg_axis(axis)
 
-        if not isinstance(count_axis, MultiIndex):
+        if not isinstance(count_axis, ABCMultiIndex):
             raise TypeError(
                 "Can only count levels on hierarchical "
                 "{ax}.".format(ax=self._get_axis_name(axis))

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -86,11 +86,7 @@ from pandas.core.arrays import Categorical, ExtensionArray
 from pandas.core.arrays.datetimelike import DatetimeLikeArrayMixin as DatetimeLikeArray
 from pandas.core.arrays.sparse import SparseFrameAccessor
 from pandas.core.generic import NDFrame, _shared_docs
-from pandas.core.index import (
-    Index,
-    ensure_index,
-    ensure_index_from_sequences,
-)
+from pandas.core.index import Index, ensure_index, ensure_index_from_sequences
 from pandas.core.indexes import base as ibase
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.multi import maybe_droplevels
@@ -3705,8 +3701,7 @@ class DataFrame(NDFrame):
 
         # broadcast across multiple columns if necessary
         if broadcast and key in self.columns and value.ndim == 1:
-            if not self.columns.is_unique or isinstance(self.columns,
-                                                        ABCMultiIndex):
+            if not self.columns.is_unique or isinstance(self.columns, ABCMultiIndex):
                 existing_piece = self[key]
                 if isinstance(existing_piece, DataFrame):
                     value = np.tile(value, (len(existing_piece.columns), 1))

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -422,8 +422,9 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
             # if we have a partial multiindex, then need to adjust the plane
             # indexer here
-            if len(labels) == 1 and isinstance(self.obj[labels[0]].axes[0],
-                                               ABCMultiIndex):
+            if len(labels) == 1 and isinstance(
+                self.obj[labels[0]].axes[0], ABCMultiIndex
+            ):
                 item = labels[0]
                 obj = self.obj[item]
                 index = obj.index

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -22,11 +22,11 @@ from pandas.core.dtypes.common import (
     is_sparse,
 )
 from pandas.core.dtypes.concat import concat_compat
-from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
+from pandas.core.dtypes.generic import ABCDataFrame, ABCMultiIndex, ABCSeries
 from pandas.core.dtypes.missing import _infer_fill_value, isna
 
 import pandas.core.common as com
-from pandas.core.index import Index, InvalidIndexError, MultiIndex
+from pandas.core.index import Index, InvalidIndexError
 from pandas.core.indexers import is_list_like_indexer, length_of_indexer
 
 
@@ -172,7 +172,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
         ax = self.obj._get_axis(0)
 
-        if isinstance(ax, MultiIndex) and self.name != "iloc":
+        if isinstance(ax, ABCMultiIndex) and self.name != "iloc":
             try:
                 return ax.get_loc(key)
             except Exception:
@@ -241,7 +241,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 )
 
     def _is_nested_tuple_indexer(self, tup: Tuple):
-        if any(isinstance(ax, MultiIndex) for ax in self.obj.axes):
+        if any(isinstance(ax, ABCMultiIndex) for ax in self.obj.axes):
             return any(is_nested_tuple(tup, ax) for ax in self.obj.axes)
         return False
 
@@ -329,7 +329,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         # GH 10360, GH 27841
         if isinstance(indexer, tuple) and len(indexer) == len(self.obj.axes):
             for i, ax in zip(indexer, self.obj.axes):
-                if isinstance(ax, MultiIndex) and not (
+                if isinstance(ax, ABCMultiIndex) and not (
                     is_integer(i) or com.is_null_slice(i)
                 ):
                     take_split_path = True
@@ -422,7 +422,8 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
             # if we have a partial multiindex, then need to adjust the plane
             # indexer here
-            if len(labels) == 1 and isinstance(self.obj[labels[0]].axes[0], MultiIndex):
+            if len(labels) == 1 and isinstance(self.obj[labels[0]].axes[0],
+                                               ABCMultiIndex):
                 item = labels[0]
                 obj = self.obj[item]
                 index = obj.index
@@ -495,7 +496,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 # we have an equal len Frame
                 if isinstance(value, ABCDataFrame):
                     sub_indexer = list(indexer)
-                    multiindex_indexer = isinstance(labels, MultiIndex)
+                    multiindex_indexer = isinstance(labels, ABCMultiIndex)
 
                     for item in labels:
                         if item in value:
@@ -777,8 +778,8 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 # we have a multi-index and are trying to align
                 # with a particular, level GH3738
                 if (
-                    isinstance(ax, MultiIndex)
-                    and isinstance(df.index, MultiIndex)
+                    isinstance(ax, ABCMultiIndex)
+                    and isinstance(df.index, ABCMultiIndex)
                     and ax.nlevels != df.index.nlevels
                 ):
                     raise TypeError(
@@ -904,7 +905,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         ax0 = self.obj._get_axis(0)
         # ...but iloc should handle the tuple as simple integer-location
         # instead of checking it as multiindex representation (GH 13797)
-        if isinstance(ax0, MultiIndex) and self.name != "iloc":
+        if isinstance(ax0, ABCMultiIndex) and self.name != "iloc":
             result = self._handle_lowerdim_multi_index_axis0(tup)
             if result is not None:
                 return result
@@ -1004,7 +1005,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         if isinstance(key, slice):
             return self._get_slice_axis(key, axis=axis)
         elif is_list_like_indexer(key) and not (
-            isinstance(key, tuple) and isinstance(labels, MultiIndex)
+            isinstance(key, tuple) and isinstance(labels, ABCMultiIndex)
         ):
 
             if hasattr(key, "ndim") and key.ndim > 1:
@@ -1017,7 +1018,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             key = labels._maybe_cast_indexer(key)
 
             if is_integer(key):
-                if axis == 0 and isinstance(labels, MultiIndex):
+                if axis == 0 and isinstance(labels, ABCMultiIndex):
                     try:
                         return self._get_label(key, axis=axis)
                     except (KeyError, TypeError):
@@ -1228,7 +1229,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         try:
             return labels.get_loc(obj)
         except LookupError:
-            if isinstance(obj, tuple) and isinstance(labels, MultiIndex):
+            if isinstance(obj, tuple) and isinstance(labels, ABCMultiIndex):
                 if len(obj) == labels.nlevels:
                     return {"key": obj}
                 raise
@@ -1248,7 +1249,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 # always valid
                 return {"key": obj}
 
-            if obj >= self.obj.shape[axis] and not isinstance(labels, MultiIndex):
+            if obj >= self.obj.shape[axis] and not isinstance(labels, ABCMultiIndex):
                 # a positional
                 raise ValueError("cannot set by positional indexing with enlargement")
 
@@ -1715,7 +1716,7 @@ class _LocIndexer(_LocationIndexer):
                 return False
 
             ax = self.obj.axes[i]
-            if isinstance(ax, MultiIndex):
+            if isinstance(ax, ABCMultiIndex):
                 return False
 
             if isinstance(k, str) and ax._supports_partial_string_indexing:
@@ -1737,7 +1738,7 @@ class _LocIndexer(_LocationIndexer):
     def _get_partial_string_timestamp_match_key(self, key, labels):
         """Translate any partial string timestamp matches in key, returning the
         new key (GH 10331)"""
-        if isinstance(labels, MultiIndex):
+        if isinstance(labels, ABCMultiIndex):
             if (
                 isinstance(key, str)
                 and labels.levels[0]._supports_partial_string_indexing
@@ -1781,7 +1782,7 @@ class _LocIndexer(_LocationIndexer):
             # to a list of keys
             # we will use the *values* of the object
             # and NOT the index if its a PandasObject
-            if isinstance(labels, MultiIndex):
+            if isinstance(labels, ABCMultiIndex):
 
                 if isinstance(key, (ABCSeries, np.ndarray)) and key.ndim <= 1:
                     # Series, or 0,1 ndim ndarray
@@ -1809,7 +1810,7 @@ class _LocIndexer(_LocationIndexer):
                     key = tuple([key])
 
             # an iterable multi-selection
-            if not (isinstance(key, tuple) and isinstance(labels, MultiIndex)):
+            if not (isinstance(key, tuple) and isinstance(labels, ABCMultiIndex)):
 
                 if hasattr(key, "ndim") and key.ndim > 1:
                     raise ValueError("Cannot index with multidimensional key")
@@ -2474,7 +2475,7 @@ def is_nested_tuple(tup, labels):
     for i, k in enumerate(tup):
 
         if is_list_like(k) or isinstance(k, slice):
-            return isinstance(labels, MultiIndex)
+            return isinstance(labels, ABCMultiIndex)
 
     return False
 


### PR DESCRIPTION
Per #27353 changed ``isinstance`` checks listed in the @WillAyd script to use ABCs where it enabled removal of imports only. 

Note there may be additional files which can be cleaned as the script does not parse multi-line statements.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
