### PR TITLE
0.24.x | MyPy for Python2 Compatability - Patch "misplaced type annotation"

### DIFF
--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -397,6 +397,7 @@ def _get_fill(arr):
 
 
 def _sparse_array_op(left, right, op, name):
+    # type: (SparseArray, SparseArray, Callable, str) -> Any
     """
     Perform a binary operation between two arrays.
 
@@ -413,7 +414,6 @@ def _sparse_array_op(left, right, op, name):
     -------
     SparseArray
     """
-    # type: (SparseArray, SparseArray, Callable, str) -> Any
     if name.startswith('__'):
         # For lookups in _libs.sparse we need non-dunder op name
         name = name[2:-2]

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1846,13 +1846,13 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
             placement=self.mgr_locs)
 
     def shift(self, periods, axis=0, fill_value=None):
+        # type: (int, Optional[BlockPlacement]) -> List[ExtensionBlock]
         """
         Shift the block by `periods`.
 
         Dispatches to underlying ExtensionArray and re-boxes in an
         ExtensionBlock.
         """
-        # type: (int, Optional[BlockPlacement]) -> List[ExtensionBlock]
         return [
             self.make_block_same_class(
                 self.values.shift(periods=periods, fill_value=fill_value),


### PR DESCRIPTION
This PR fixes misplaced annotations error, after checking with **MyPy**.

**What was fixed?**

For Python 2 you need place mypy annotations `# type: ...` before docstrings.