### PR TITLE
STY: whitespace before class docstringsd

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -47,7 +47,6 @@ _indexops_doc_kwargs = dict(
 
 
 class PandasObject(DirNamesMixin):
-
     """baseclass for various pandas objects"""
 
     @property

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -367,8 +367,8 @@ def add_ops(op_classes):
 @disallow(_unsupported_nodes)
 @add_ops(_op_classes)
 class BaseExprVisitor(ast.NodeVisitor):
-
-    """Custom ast walker. Parsers of other engines should subclass this class
+    """
+    Custom ast walker. Parsers of other engines should subclass this class
     if necessary.
 
     Parameters
@@ -803,8 +803,8 @@ class PythonExprVisitor(BaseExprVisitor):
 
 
 class Expr:
-
-    """Object encapsulating an expression.
+    """
+    Object encapsulating an expression.
 
     Parameters
     ----------

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -478,7 +478,6 @@ def _validate_where(w):
 
 
 class Expr(expr.Expr):
-
     """ hold a pytables like expression, comprised of possibly multiple 'terms'
 
     Parameters
@@ -573,7 +572,6 @@ class Expr(expr.Expr):
 
 
 class TermValue:
-
     """ hold a term value the we use to construct a condition/filter """
 
     def __init__(self, value, converted, kind):

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1011,7 +1011,6 @@ b  2""",
 
 
 class GroupBy(_GroupBy):
-
     """
     Class for grouping and aggregating relational data.
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -217,7 +217,6 @@ class Grouper:
 
 
 class Grouping:
-
     """
     Holds the grouping information for a single key
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -706,7 +706,6 @@ class BaseGrouper:
 
 
 class BinGrouper(BaseGrouper):
-
     """
     This is an internal Grouper class
 

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -22,7 +22,6 @@ from pandas.io.formats.printing import pprint_thing
 
 
 class FrozenList(PandasObject, list):
-
     """
     Container that doesn't allow setting item *but*
     because it's technically non-hashable, will be used

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -271,7 +271,6 @@ def nargsort(items, kind="quicksort", ascending=True, na_position="last"):
 
 
 class _KeyMapper:
-
     """
     Ease my suffering. Map compressed group id -> key tuple
     """

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -576,7 +576,6 @@ class MMapWrapper(BaseIterator):
 
 
 class UTF8Recoder(BaseIterator):
-
     """
     Iterator that reads an encoded stream and re-encodes the input to UTF-8
     """

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -846,7 +846,6 @@ class Unpacker(_Unpacker):
 
 
 class Iterator:
-
     """ manage the unpacking iteration,
         close the file on completion """
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -429,7 +429,6 @@ def _is_metadata_of(group, parent_group):
 
 
 class HDFStore:
-
     """
     Dict-like IO interface for storing pandas objects in PyTables.
 
@@ -1546,7 +1545,6 @@ class HDFStore:
 
 
 class TableIterator:
-
     """ define the iteration interface on a table
 
         Parameters
@@ -1654,7 +1652,6 @@ class TableIterator:
 
 
 class IndexCol:
-
     """ an index column description class
 
         Parameters
@@ -1968,7 +1965,6 @@ class IndexCol:
 
 
 class GenericIndexCol(IndexCol):
-
     """ an index which is not represented in the data of the table """
 
     @property
@@ -2006,7 +2002,6 @@ class GenericIndexCol(IndexCol):
 
 
 class DataCol(IndexCol):
-
     """ a data holding column, by definition this is not indexable
 
         Parameters
@@ -2456,7 +2451,6 @@ class DataCol(IndexCol):
 
 
 class DataIndexableCol(DataCol):
-
     """ represent a data column that can be indexed """
 
     is_data_indexable = True
@@ -2479,7 +2473,6 @@ class DataIndexableCol(DataCol):
 
 
 class GenericDataIndexableCol(DataIndexableCol):
-
     """ represent a generic pytables data column """
 
     def get_attr(self):
@@ -2487,7 +2480,6 @@ class GenericDataIndexableCol(DataIndexableCol):
 
 
 class Fixed:
-
     """ represent an object in my store
         facilitate read/write of various types of objects
         this is an abstract base class
@@ -2655,7 +2647,6 @@ class Fixed:
 
 
 class GenericFixed(Fixed):
-
     """ a generified fixed version """
 
     _index_type_map = {DatetimeIndex: "datetime", PeriodIndex: "period"}
@@ -3252,7 +3243,6 @@ class FrameFixed(BlockManagerFixed):
 
 
 class Table(Fixed):
-
     """ represent a table:
           facilitate read/write of various types of tables
 
@@ -4127,7 +4117,6 @@ class Table(Fixed):
 
 
 class WORMTable(Table):
-
     """ a write-once read-many table: this format DOES NOT ALLOW appending to a
          table. writing is a one-time operation the data are stored in a format
          that allows for searching the data on disk
@@ -4149,7 +4138,6 @@ class WORMTable(Table):
 
 
 class LegacyTable(Table):
-
     """ an appendable table: allow append/query/delete operations to a
           (possibly) already existing appendable table this table ALLOWS
           append (but doesn't require them), and stores the data in a format
@@ -4603,7 +4591,6 @@ class GenericTable(AppendableFrameTable):
 
 
 class AppendableMultiFrameTable(AppendableFrameTable):
-
     """ a frame with a multi-index """
 
     table_type = "appendable_multiframe"
@@ -4962,7 +4949,6 @@ def _need_convert(kind):
 
 
 class Selection:
-
     """
     Carries out a selection operation on a tables.Table object.
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -565,7 +565,6 @@ class PandasSQLTest:
 
 
 class _TestSQLApi(PandasSQLTest):
-
     """
     Base class to test the public API.
 

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -50,7 +50,6 @@ def sort_with_none(request):
 
 
 class TestConcatAppendCommon:
-
     """
     Test common dtype coercion rules between concat and append.
     """


### PR DESCRIPTION
all occurrences of `'class.*:\n\n(    )+"""'`

@datapythonista would it make sense to add this to the checks or docstring validation?