### PR TITLE
DOC: Update index parameter in pandas to_parquet

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2148,10 +2148,14 @@ class DataFrame(NDFrame):
             'pyarrow' is unavailable.
         compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
-        index : bool, default True
+        index : bool, default None
             If ``True``, include the dataframe's index(es) in the file output.
             If ``False``, they will not be written to the file.
-            If ``None``, RangeIndex will be stored as metadata-only.
+            If ``None``, similar to ``True`` the dataframe's index(es)
+            will be saved. However, instead of being saved as values,
+            the RangeIndex will be stored as a range in the metadata so it
+            doesn't require much space and is faster. Other indexes will
+            be included as columns in the file output.
 
             .. versionadded:: 0.24.0
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2151,6 +2151,7 @@ class DataFrame(NDFrame):
         index : bool, default True
             If ``True``, include the dataframe's index(es) in the file output.
             If ``False``, they will not be written to the file.
+            If ``None``, RangeIndex will be stored as metadata-only.
 
             .. versionadded:: 0.24.0
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2119,7 +2119,7 @@ class DataFrame(NDFrame):
         fname,
         engine="auto",
         compression="snappy",
-        index=None,
+        index=True,
         partition_cols=None,
         **kwargs
     ):
@@ -2148,10 +2148,9 @@ class DataFrame(NDFrame):
             'pyarrow' is unavailable.
         compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
-        index : bool, default None
+        index : bool, default True
             If ``True``, include the dataframe's index(es) in the file output.
-            If ``False``, they will not be written to the file. If ``None``,
-            the behavior depends on the chosen engine.
+            If ``False``, they will not be written to the file.
 
             .. versionadded:: 0.24.0
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2119,7 +2119,7 @@ class DataFrame(NDFrame):
         fname,
         engine="auto",
         compression="snappy",
-        index=True,
+        index=None,
         partition_cols=None,
         **kwargs
     ):

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -206,7 +206,7 @@ def to_parquet(
     path,
     engine="auto",
     compression="snappy",
-    index=None,
+    index=True,
     partition_cols=None,
     **kwargs
 ):
@@ -228,10 +228,9 @@ def to_parquet(
         'pyarrow' is unavailable.
     compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
         Name of the compression to use. Use ``None`` for no compression.
-    index : bool, default None
+    index : bool, default True
         If ``True``, include the dataframe's index(es) in the file output. If
-        ``False``, they will not be written to the file. If ``None``, the
-        engine's default behavior will be used.
+        ``False``, they will not be written to the file.
 
         .. versionadded:: 0.24.0
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -228,10 +228,14 @@ def to_parquet(
         'pyarrow' is unavailable.
     compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
         Name of the compression to use. Use ``None`` for no compression.
-    index : bool, default True
+    index : bool, default None
         If ``True``, include the dataframe's index(es) in the file output. If
         ``False``, they will not be written to the file.
-        If ``None``, RangeIndex will be stored as metadata-only.
+        If ``None``, similar to ``True`` the dataframe's index(es)
+        will be saved. However, instead of being saved as values,
+        the RangeIndex will be stored as a range in the metadata so it
+        doesn't require much space and is faster. Other indexes will
+        be included as columns in the file output.
 
         .. versionadded:: 0.24.0
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -206,7 +206,7 @@ def to_parquet(
     path,
     engine="auto",
     compression="snappy",
-    index=True,
+    index=None,
     partition_cols=None,
     **kwargs
 ):

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -230,7 +230,7 @@ def to_parquet(
         Name of the compression to use. Use ``None`` for no compression.
     index : bool, default True
         If ``True``, include the dataframe's index(es) in the file output. If
-        ``False``, they will not be written to the file. 
+        ``False``, they will not be written to the file.
         If ``None``, RangeIndex will be stored as metadata-only.
 
         .. versionadded:: 0.24.0

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -230,7 +230,8 @@ def to_parquet(
         Name of the compression to use. Use ``None`` for no compression.
     index : bool, default True
         If ``True``, include the dataframe's index(es) in the file output. If
-        ``False``, they will not be written to the file.
+        ``False``, they will not be written to the file. 
+        If ``None``, RangeIndex will be stored as metadata-only.
 
         .. versionadded:: 0.24.0
 


### PR DESCRIPTION
- [ ] closes #xxxx (reference: https://github.com/python-sprints/pandas-mentoring/issues/156)
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The documentation ([https://dev.pandas.io/reference/api/pandas.DataFrame.to_parquet.html#pandas.DataFrame.to_parquet](https://dev.pandas.io/reference/api/pandas.DataFrame.to_parquet.html#pandas.DataFrame.to_parquet)) says that for `DataFrame.to_parquet` when the value for the index parameter is `None`, the behavior will depend on the engine. However if we try this both engines, `pyarrow` and `fastparquet`, will keep the index. This PR proposes to set the default value of the index parameter as `index=True` instead of `index=None` since both engines keep the index anyway. Would appreciate any discussion/feedback :)

Sample code to demonstrate how both engines treat the index:
```
import pandas as pd 
  
data = {'name':['a', 'b', 'c', 'd']} 
df = pd.DataFrame(data, index =['rank_1', 'rank_2', 'rank_3', 'rank_4'])

df.info()
```
Output:
```
<class 'pandas.core.frame.DataFrame'>
Index: 4 entries, rank_1 to rank_4
Data columns (total 1 columns):
name    4 non-null object
dtypes: object(1)
memory usage: 64.0+ bytes
```
```
# pyarrow
df.to_parquet("test_pyarrow.parquet", engine="pyarrow")
df_read_pyarrow = pd.read_parquet("test_pyarrow.parquet", engine="pyarrow")
df_read_pyarrow.info()
```
Output:
```
<class 'pandas.core.frame.DataFrame'>
Index: 4 entries, rank_1 to rank_4
Data columns (total 1 columns):
name    4 non-null object
dtypes: object(1)
memory usage: 64.0+ bytes
```

```
# fastparquet
df.to_parquet("test_fastparquet.parquet", engine="fastparquet")
df_read_fastparquet = pd.read_parquet("test_fastparquet.parquet", engine="fastparquet")
df_read_fastparquet.info()
```
Output:
```
<class 'pandas.core.frame.DataFrame'>
Index: 4 entries, rank_1 to rank_4
Data columns (total 1 columns):
name    4 non-null object
dtypes: object(1)
memory usage: 64.0+ bytes
```