### PR TITLE
TYPING: add index and columns attributes to DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -15,7 +15,7 @@ from io import StringIO
 import itertools
 import sys
 from textwrap import dedent
-from typing import FrozenSet, List, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, FrozenSet, List, Optional, Set, Tuple, Type, Union
 import warnings
 
 import numpy as np
@@ -368,6 +368,10 @@ class DataFrame(NDFrame):
     1  4  5  6
     2  7  8  9
     """
+
+    if TYPE_CHECKING:  # attributes index and columns are created dynamically
+        index = None  # type: Index
+        columns = None  # type: Index
 
     @property
     def _constructor(self):


### PR DESCRIPTION
diff for `mypy pandas --disallow-any-expr`

```
2887,2888d2886
< pandas\io\formats\format.py:626: error: Expression has type "Any"
< pandas\io\formats\format.py:651: error: Expression has type "Any"
2907,2909d2904
< pandas\io\formats\format.py:786: error: Expression has type "Any"
< pandas\io\formats\format.py:789: error: Expression has type "Any"
< pandas\io\formats\format.py:790: error: Expression has type "Any"
2922d2916
< pandas\io\formats\format.py:838: error: Expression has type "Any"
2944d2937
< pandas\io\formats\format.py:948: error: Expression has type "Any"
2970a2964,2979
> pandas\io\formats\format.py:976: error: Expression has type "Any"
> pandas\io\formats\format.py:978: error: Expression type contains "Any" (has type "Iterator[Tuple[Any, Any]]")
> pandas\io\formats\format.py:978: error: Expression has type "Any"
> pandas\io\formats\format.py:978: error: Expression type contains "Any" (has type "Iterator[Any]")
> pandas\io\formats\format.py:978: error: Expression type contains "Any" (has type "Callable[[Any], Any]")
> pandas\io\formats\format.py:980: error: Expression type contains "Any" (has type "Tuple[int, Tuple[Any, Any]]")
> pandas\io\formats\format.py:980: error: Expression type contains "Any" (has type "List[Any]")
> pandas\io\formats\format.py:980: error: List comprehension has incompatible type List[List[Any]]; expected List[Tuple[Any, ...]]
> pandas\io\formats\format.py:980: error: Expression has type "Any"
> pandas\io\formats\format.py:980: error: Expression type contains "Any" (has type "Union[bool, Any]")
> pandas\io\formats\format.py:980: error: Expression type contains "Any" (has type "Optional[Callable[..., Any]]")
> pandas\io\formats\format.py:980: error: Expression type contains "Any" (has type "Dict[Any, Any]")
> pandas\io\formats\format.py:981: error: Expression type contains "Any" (has type "Tuple[Any, Any]")
> pandas\io\formats\format.py:981: error: Expression has type "Any"
> pandas\io\formats\format.py:981: error: Expression type contains "Any" (has type "enumerate[Tuple[Any, Any]]")
> pandas\io\formats\format.py:981: error: Expression type contains "Any" (has type "Iterator[Tuple[Any, Any]]")
2973,2976d2981
< pandas\io\formats\format.py:988: error: Expression has type "Any"
< pandas\io\formats\format.py:992: error: Expression has type "Any"
< pandas\io\formats\format.py:1006: error: Expression has type "Any"
< pandas\io\formats\format.py:1007: error: Expression has type "Any"
2981a2987,2989
> pandas\io\formats\format.py:1018: error: Expression type contains "Any" (has type "List[Any]")
> pandas\io\formats\format.py:1018: error: Expression has type "Any"
> pandas\io\formats\format.py:1018: error: Expression type contains "Any" (has type "Optional[Callable[..., Any]]")
2989d2996
< pandas\io\formats\format.py:1044: error: Expression has type "Any"
3875d3881
< pandas\core\frame.py:2792: error: Expression has type "Any"
3929d3934
< pandas\core\frame.py:6255: error: Expression has type "Any"
4655,4657d4659
< pandas\io\formats\latex.py:56: error: Expression has type "Any"
< pandas\io\formats\latex.py:59: error: Expression has type "Any"
< pandas\io\formats\latex.py:60: error: Expression has type "Any"
4719d4720
< pandas\io\formats\html.py:93: error: Expression has type "Any"
4732d4732
< pandas\io\formats\html.py:201: error: Expression has type "Any"
5059d5058
< pandas\util\_doctools.py:184: error: Expression has type "Any"
```