### PR TITLE
PERF: data = np.nan to speed up empty dataframe creation 

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -387,7 +387,7 @@ class DataFrame(NDFrame):
     # Constructors
 
     def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False):
-        if data is None and index is not None and columns is not None:
+        if data is None and index is not None and columns is not None and dtype is None:
             data = np.nan
 
         if data is None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -387,8 +387,12 @@ class DataFrame(NDFrame):
     # Constructors
 
     def __init__(self, data=None, index=None, columns=None, dtype=None, copy=False):
+        if data is None and index is not None and columns is not None:
+            data = np.nan
+
         if data is None:
             data = {}
+
         if dtype is not None:
             dtype = self._validate_dtype(dtype)
 


### PR DESCRIPTION
- [x] closes #28188 

- Short summary
If we have enough information to know the shape of the final
dataframe, we set the value of data to np.nan if not set.

- Longer explanation
If I understand correctly the `__init__` of DataFrame, with this change 
when the first if evaluates True then all following ifs evaluate False 
until we enter the else in [frame.py:459](https://github.com/pandas-dev/pandas/blob/03b3c8fc82b3a18a3ddcad1b3b26d601467fc74c/pandas/core/frame.py#L459), and we are done because now the dataframe is initialized with a ndarray.
With the former behavior `data` defaults always to None,
hence the output dataframe has all dtypes object and its creation
is slow.
With the proposed code the output dataframe has all dtypes float and is
faster to create than before, but only when columns and index are given.

I don't know how to loose the current restriction of `dtype=None`. It would be nice to have a function that verifies that a type is compatible with nan.
