### PR TITLE
REGR: Fix to_csv with IntervalIndex

### DIFF
--- a/doc/source/whatsnew/v0.25.2.rst
+++ b/doc/source/whatsnew/v0.25.2.rst
@@ -62,7 +62,7 @@ Missing
 I/O
 ^^^
 
--
+- Regression in :meth:`~DataFrame.to_csv` where writing a :class:`Series` or :class:`DataFrame` indexed by an :class:`IntervalIndex` would incorrectly raise a ``TypeError`` (:issue:`28210`)
 -
 -
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1096,12 +1096,8 @@ class IntervalIndex(IntervalMixin, Index):
         return header + list(self._format_native_types(**kwargs))
 
     def _format_native_types(self, na_rep="NaN", quoting=None, **kwargs):
-        """ actually format my specific types """
-        from pandas.io.formats.format import ExtensionArrayFormatter
-
-        return ExtensionArrayFormatter(
-            values=self, na_rep=na_rep, justify="all", leading_space=False
-        ).get_result()
+        # GH 28210: use base method but with different default na_rep
+        return super()._format_native_types(na_rep=na_rep, quoting=quoting, **kwargs)
 
     def _format_data(self, name=None):
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -695,6 +695,15 @@ class TestDataFrameToCSV(TestData):
             tm.assert_index_equal(recons.columns, exp.columns)
             assert len(recons) == 0
 
+    def test_to_csv_interval_index(self):
+        # GH 28210
+        df = DataFrame({"A": list("abc"), "B": range(3)}, index=pd.interval_range(0, 3))
+
+        # can't roundtrip interval index via read_csv so check string output (GH 23595)
+        result = df.to_csv(path_or_buf=None)
+        expected = ',A,B\n"(0, 1]",a,0\n"(1, 2]",b,1\n"(2, 3]",c,2\n'
+        assert result == expected
+
     def test_to_csv_float32_nanrep(self):
         df = DataFrame(np.random.randn(1, 4).astype(np.float32))
         df[1] = np.nan

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -417,6 +417,46 @@ class TestIntervalIndex(Base):
         result = repr(obj)
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "tuples, closed, expected_data",
+        [
+            ([(0, 1), (1, 2), (2, 3)], "left", ["[0, 1)", "[1, 2)", "[2, 3)"]),
+            (
+                [(0.5, 1.0), np.nan, (2.0, 3.0)],
+                "right",
+                ["(0.5, 1.0]", "NaN", "(2.0, 3.0]"],
+            ),
+            (
+                [
+                    (Timestamp("20180101"), Timestamp("20180102")),
+                    np.nan,
+                    ((Timestamp("20180102"), Timestamp("20180103"))),
+                ],
+                "both",
+                ["[2018-01-01, 2018-01-02]", "NaN", "[2018-01-02, 2018-01-03]"],
+            ),
+            (
+                [
+                    (Timedelta("0 days"), Timedelta("1 days")),
+                    (Timedelta("1 days"), Timedelta("2 days")),
+                    np.nan,
+                ],
+                "neither",
+                [
+                    "(0 days 00:00:00, 1 days 00:00:00)",
+                    "(1 days 00:00:00, 2 days 00:00:00)",
+                    "NaN",
+                ],
+            ),
+        ],
+    )
+    def test_to_native_types(self, tuples, closed, expected_data):
+        # GH 28210
+        index = IntervalIndex.from_tuples(tuples, closed=closed)
+        result = index.to_native_types()
+        expected = np.array(expected_data)
+        tm.assert_numpy_array_equal(result, expected)
+
     def test_get_item(self, closed):
         i = IntervalIndex.from_arrays((0, 1, np.nan), (1, 2, np.nan), closed=closed)
         assert i[0] == Interval(0.0, 1.0, closed=closed)

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -195,10 +195,15 @@ class TestSeriesToCSV:
         # GH 28210
         s = Series(["foo", "bar", "baz"], index=pd.interval_range(0, 3))
 
-        # can't roundtrip interval index via read_csv so check string output (GH 23595)
-        result = s.to_csv(path_or_buf=None, header=False)
-        expected = '"(0, 1]",foo\n"(1, 2]",bar\n"(2, 3]",baz\n'
-        assert result == expected
+        with ensure_clean("__tmp_to_csv_interval_index__.csv") as path:
+            s.to_csv(path, header=False)
+            result = self.read_csv(path, index_col=0, squeeze=True)
+
+            # can't roundtrip intervalindex via read_csv so check string repr (GH 23595)
+            expected = s.copy()
+            expected.index = expected.index.astype(str)
+
+            assert_series_equal(result, expected)
 
 
 class TestSeriesIO:

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -191,6 +191,15 @@ class TestSeriesToCSV:
                     s, pd.read_csv(fh, index_col=0, squeeze=True, encoding=encoding)
                 )
 
+    def test_to_csv_interval_index(self):
+        # GH 28210
+        s = Series(["foo", "bar", "baz"], index=pd.interval_range(0, 3))
+
+        # can't roundtrip interval index via read_csv so check string output (GH 23595)
+        result = s.to_csv(path_or_buf=None, header=False)
+        expected = '"(0, 1]",foo\n"(1, 2]",bar\n"(2, 3]",baz\n'
+        assert result == expected
+
 
 class TestSeriesIO:
     def test_to_frame(self, datetime_series):


### PR DESCRIPTION
- [X] closes #28210
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
