### PR TITLE
PERF: asv for import

### DIFF
--- a/asv_bench/benchmarks/package.py
+++ b/asv_bench/benchmarks/package.py
@@ -10,6 +10,9 @@ from pandas.compat import PY37
 class TimeImport:
     def time_import(self):
         if PY37:
+            # on py37+ we the "-X importtime" usage gives us a more precise
+            #  measurement of the import time we actually care about,
+            #  without the subprocess or interpreter overhead
             cmd = [sys.executable, "-X", "importtime", "-c", "import pandas as pd"]
             p = subprocess.run(cmd, stderr=subprocess.PIPE)
 
@@ -19,4 +22,4 @@ class TimeImport:
             return total
 
         cmd = [sys.executable, "-c", "import pandas as pd"]
-        p = subprocess.run(cmd, stderr=subprocess.PIPE)
+        subprocess.run(cmd, stderr=subprocess.PIPE)

--- a/asv_bench/benchmarks/package.py
+++ b/asv_bench/benchmarks/package.py
@@ -11,14 +11,12 @@ class TimeImport:
     def time_import(self):
         if PY37:
             cmd = [sys.executable, "-X", "importtime", "-c", "import pandas as pd"]
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            _, stderr = p.communicate()
+            p = subprocess.run(cmd, stderr=subprocess.PIPE)
 
-            line = stderr.splitlines()[-1]
+            line = p.stderr.splitlines()[-1]
             field = line.split(b"|")[-2].strip()
             total = int(field)  # microseconds
             return total
 
         cmd = [sys.executable, "-c", "import pandas as pd"]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        p.communicate()
+        p = subprocess.run(cmd, stderr=subprocess.PIPE)

--- a/asv_bench/benchmarks/package.py
+++ b/asv_bench/benchmarks/package.py
@@ -6,6 +6,7 @@ import sys
 
 from pandas.compat import PY37
 
+
 class TimeImport:
     def time_import(self):
         if PY37:

--- a/asv_bench/benchmarks/package.py
+++ b/asv_bench/benchmarks/package.py
@@ -1,0 +1,23 @@
+"""
+Benchmarks for pandas at the package-level.
+"""
+import subprocess
+import sys
+
+from pandas.compat import PY37
+
+class TimeImport:
+    def time_import(self):
+        if PY37:
+            cmd = [sys.executable, "-X", "importtime", "-c", 'import pandas as pd']
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            _, stderr = p.communicate()
+
+            line = stderr.splitlines()[-1]
+            field = line.split(b'|')[-2].strip()
+            total = int(field)  # microseconds
+            return total
+
+        cmd = [sys.executable, "-c", 'import pandas as pd']
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p.communicate()

--- a/asv_bench/benchmarks/package.py
+++ b/asv_bench/benchmarks/package.py
@@ -9,15 +9,15 @@ from pandas.compat import PY37
 class TimeImport:
     def time_import(self):
         if PY37:
-            cmd = [sys.executable, "-X", "importtime", "-c", 'import pandas as pd']
+            cmd = [sys.executable, "-X", "importtime", "-c", "import pandas as pd"]
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             _, stderr = p.communicate()
 
             line = stderr.splitlines()[-1]
-            field = line.split(b'|')[-2].strip()
+            field = line.split(b"|")[-2].strip()
             total = int(field)  # microseconds
             return total
 
-        cmd = [sys.executable, "-c", 'import pandas as pd']
+        cmd = [sys.executable, "-c", "import pandas as pd"]
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p.communicate()

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -23,7 +23,7 @@ str_type = str
 ordered_sentinel = object()  # type: object
 
 
-def register_extension_dtype(cls: Type[ExtensionDtype],) -> Type[ExtensionDtype]:
+def register_extension_dtype(cls: Type[ExtensionDtype]) -> Type[ExtensionDtype]:
     """
     Register an ExtensionType with pandas as class decorator.
 

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -102,7 +102,7 @@ def _skip_if_no_scipy():
     )
 
 
-def skip_if_installed(package: str,) -> Callable:
+def skip_if_installed(package: str) -> Callable:
     """
     Skip a test if a package is installed.
 


### PR DESCRIPTION
- [x] closes #26663

for py37 this uses `-X importtime` to get a more precise number without subprocess overhead.  Doesn't actually do anything with it, but what the heck.

Couple of unrelated cleanups.