### PR TITLE
BENCH: Add peakmem benchmarks for rolling

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -21,6 +21,9 @@ class Methods:
     def time_rolling(self, constructor, window, dtype, method):
         getattr(self.roll, method)()
 
+    def peakmem_rolling(self, constructor, window, dtype, method):
+        getattr(self.roll, method)()
+
 
 class ExpandingMethods:
 


### PR DESCRIPTION
```
$ asv dev -b rolling

[ 20.00%] ··· rolling.Methods.peakmem_rolling                                                                                                                                                             ok
[ 20.00%] ··· ============ ======== ======= ======== ======= ======= ======= ======= ======= ======= ======= =======
              --                                                             method
              ----------------------------- ------------------------------------------------------------------------
               contructor   window   dtype   median    mean    max     min     std    count    skew    kurt    sum
              ============ ======== ======= ======== ======= ======= ======= ======= ======= ======= ======= =======
               DataFrame      10      int    69.4M    67.7M   67.8M   67.7M   68.5M   68.6M   67.8M   67.7M   67.7M
               DataFrame      10     float   69.4M    67.8M   67.9M   67.7M   68.5M   68.6M   67.8M   67.8M   67.7M
               DataFrame     1000     int    69.6M    67.8M   67.9M   67.7M   68.6M   68.7M   67.8M   67.8M   67.7M
               DataFrame     1000    float   70.4M    67.7M   67.8M   67.8M   68.6M   68.5M   67.8M   67.8M   67.7M
                 Series       10      int    72.5M    70.1M    70M    70.1M   71.7M   73.4M    70M    70.1M    70M
                 Series       10     float   72.5M    70.1M   70.1M    70M    71.7M   73.4M    70M     70M    70.1M
                 Series      1000     int    72.6M     70M    70.2M   70.1M   71.7M   73.4M    70M    70.1M    70M
                 Series      1000    float   72.6M    70.1M    70M    70.1M   71.6M   73.3M    70M     70M    70.1M
              ============ ======== ======= ======== ======= ======= ======= ======= ======= ======= ======= =======

[ 45.00%] ··· rolling.VariableWindowMethods.peakmem_rolling                                                                                                                                               ok
[ 45.00%] ··· ============ ======== ======= ======== ======= ======= ======= ======= ======= ======= ======= =======
              --                                                             method
              ----------------------------- ------------------------------------------------------------------------
               contructor   window   dtype   median    mean    max     min     std    count    skew    kurt    sum
              ============ ======== ======= ======== ======= ======= ======= ======= ======= ======= ======= =======
               DataFrame     50s      int    69.5M    69.6M   69.6M   69.6M   70.3M   69.5M   69.6M   69.5M   69.6M
               DataFrame     50s     float   69.6M    69.6M   69.6M   69.6M   70.3M   69.5M   69.5M   69.6M   69.5M
               DataFrame      1h      int    69.7M    69.5M   69.6M   69.6M   70.4M   69.5M   69.6M   69.6M   69.6M
               DataFrame      1h     float   69.6M    69.5M   69.6M   69.5M   70.3M   69.6M   69.5M   69.6M   69.6M
               DataFrame      1d      int    74.4M    69.5M   69.7M   69.7M   70.4M   69.5M   69.6M   69.6M   69.6M
               DataFrame      1d     float   73.7M    69.6M   69.7M   69.8M   70.4M   69.5M   69.6M   69.5M   69.5M
                 Series      50s      int    71.1M    71.2M   71.1M   71.1M   71.9M    71M     71M    71.1M   71.1M
                 Series      50s     float   71.1M    71.1M   71.1M   71.1M   71.8M    71M    71.1M    71M    71.1M
                 Series       1h      int    71.1M    71.1M   71.1M   71.1M   71.9M   71.1M   71.1M   71.1M   71.1M
                 Series       1h     float   71.2M     71M    71.1M   71.1M   71.9M    71M    71.1M   71.1M   71.1M
                 Series       1d      int    73.9M    71.1M   71.2M   71.2M   71.8M   71.1M   71.2M    71M     71M
                 Series       1d     float    73M      71M    71.2M   71.2M   71.9M    71M     71M     71M    71.1M
              ============ ======== ======= ======== ======= ======= ======= ======= ======= ======= ======= =======
```
