### PR TITLE
Fix to_json Memory Tests

### DIFF
--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -118,18 +118,18 @@ class ToJSON(BaseIO):
     def time_to_json(self, orient, frame):
         getattr(self, frame).to_json(self.fname, orient=orient)
 
-    def mem_to_json(self, orient, frame):
-        return getattr(self, frame).to_json(self.fname, orient=orient)
+    def peakmem_to_json(self, orient, frame):
+        getattr(self, frame).to_json(self.fname, orient=orient)
 
     def time_to_json_wide(self, orient, frame):
         base_df = getattr(self, frame).copy()
         df = concat([base_df.iloc[:100]] * 1000, ignore_index=True, axis=1)
         df.to_json(self.fname, orient=orient)
 
-    def mem_to_json_wide(self, orient, frame):
+    def peakmem_to_json_wide(self, orient, frame):
         base_df = getattr(self, frame).copy()
         df = concat([base_df.iloc[:100]] * 1000, ignore_index=True, axis=1)
-        return df.to_json(self.fname, orient=orient)
+        df.to_json(self.fname, orient=orient)
 
 
 class ToJSONLines(BaseIO):

--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -119,7 +119,7 @@ class ToJSON(BaseIO):
         getattr(self, frame).to_json(self.fname, orient=orient)
 
     def mem_to_json(self, orient, frame):
-        getattr(self, frame).to_json(self.fname, orient=orient)
+        return getattr(self, frame).to_json(self.fname, orient=orient)
 
     def time_to_json_wide(self, orient, frame):
         base_df = getattr(self, frame).copy()
@@ -129,7 +129,7 @@ class ToJSON(BaseIO):
     def mem_to_json_wide(self, orient, frame):
         base_df = getattr(self, frame).copy()
         df = concat([base_df.iloc[:100]] * 1000, ignore_index=True, axis=1)
-        df.to_json(self.fname, orient=orient)
+        return df.to_json(self.fname, orient=orient)
 
 
 class ToJSONLines(BaseIO):


### PR DESCRIPTION
Inspired by @mroeschke I noticed the JSON tests weren't actually measuring anything because you need to return something for the `mem_` tests which these weren't. In any case probably better served as `peakmem_`
