### PR TITLE
re-implement #27959

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -829,6 +829,13 @@ def _bool_method_SERIES(cls, op, special):
             # Defer to DataFrame implementation; fail early
             return NotImplemented
 
+        elif should_extension_dispatch(self, other):
+            lvalues = extract_array(self, extract_numpy=True)
+            rvalues = extract_array(other, extract_numpy=True)
+            res_values = dispatch_to_extension_op(op, lvalues, rvalues)
+            result = self._constructor(res_values, index=self.index, name=res_name)
+            return finalizer(result)
+
         elif isinstance(other, (ABCSeries, ABCIndexClass)):
             is_other_int_dtype = is_integer_dtype(other.dtype)
             other = other if is_other_int_dtype else fill_bool(other)


### PR DESCRIPTION
Previous version broke because a different branch changed the behavior of when extract_array is called.