### PR TITLE
BUG: Make sure correct values are passed to Rolling._on when axis=1

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -177,7 +177,7 @@ Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 -
--
+- Bug in :meth:`DataFrame.rolling` not allowing for rolling over datetimes when ``axis=1`` (:issue: `28192`)
 - Bug in :meth:`DataFrame.groupby` not offering selection by column name when ``axis=1`` (:issue:`27614`)
 - Bug in :meth:`DataFrameGroupby.agg` not able to use lambda function with named aggregation (:issue:`27519`)
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1653,7 +1653,10 @@ class Rolling(_Rolling_and_Expanding):
     def _on(self):
 
         if self.on is None:
-            return self.obj.index
+            if self.axis == 0:
+                return self.obj.index
+            elif self.axis == 1:
+                return self.obj.transpose().index
         elif isinstance(self.obj, ABCDataFrame) and self.on in self.obj.columns:
             return Index(self.obj[self.on])
         else:

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1656,7 +1656,7 @@ class Rolling(_Rolling_and_Expanding):
             if self.axis == 0:
                 return self.obj.index
             elif self.axis == 1:
-                return self.obj.transpose().index
+                return self.obj.columns
         elif isinstance(self.obj, ABCDataFrame) and self.on in self.obj.columns:
             return Index(self.obj[self.on])
         else:

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -335,10 +335,11 @@ class TestRolling(Base):
         expected = pd.Series([np.nan, 2, np.nan, np.nan, 4])
         tm.assert_series_equal(result, expected)
 
-    def test_rolling_datetime(self, axis_frame):
+    def test_rolling_datetime(self, axis_frame, tz_naive_fixture):
         # GH-28192
+        tz = tz_naive_fixture
         df = pd.DataFrame(
-            {i: [1] * 2 for i in pd.date_range("2019-8-01", "2019-08-03", freq="D")}
+            {i: [1] * 2 for i in pd.date_range("2019-8-01", "2019-08-03", freq="D", tz=tz)}
         )
         if axis_frame in [0, "index"]:
             result = df.T.rolling("2D", axis=axis_frame).sum().T
@@ -348,11 +349,11 @@ class TestRolling(Base):
             {
                 **{
                     i: [1.0] * 2
-                    for i in pd.date_range("2019-8-01", periods=1, freq="D")
+                    for i in pd.date_range("2019-8-01", periods=1, freq="D", tz=tz)
                 },
                 **{
                     i: [2.0] * 2
-                    for i in pd.date_range("2019-8-02", "2019-8-03", freq="D")
+                    for i in pd.date_range("2019-8-02", "2019-8-03", freq="D", tz=tz)
                 },
             }
         )

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -334,3 +334,26 @@ class TestRolling(Base):
         result = pd.Series(arr).rolling(2).mean()
         expected = pd.Series([np.nan, 2, np.nan, np.nan, 4])
         tm.assert_series_equal(result, expected)
+
+    def test_rolling_datetime(self, axis_frame):
+        # GH-28192
+        df = pd.DataFrame(
+            {i: [1] * 2 for i in pd.date_range("2019-8-01", "2019-08-03", freq="D")}
+        )
+        if axis_frame in [0, "index"]:
+            result = df.T.rolling("2d", axis=axis_frame).sum().T
+        else:
+            result = df.rolling("2d", axis=axis_frame).sum()
+        expected = pd.DataFrame(
+            {
+                **{
+                    i: [1.0] * 2
+                    for i in pd.date_range("2019-8-01", periods=1, freq="D")
+                },
+                **{
+                    i: [2.0] * 2
+                    for i in pd.date_range("2019-8-02", "2019-8-03", freq="D")
+                },
+            }
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -339,7 +339,10 @@ class TestRolling(Base):
         # GH-28192
         tz = tz_naive_fixture
         df = pd.DataFrame(
-            {i: [1] * 2 for i in pd.date_range("2019-8-01", "2019-08-03", freq="D", tz=tz)}
+            {
+                i: [1] * 2
+                for i in pd.date_range("2019-8-01", "2019-08-03", freq="D", tz=tz)
+            }
         )
         if axis_frame in [0, "index"]:
             result = df.T.rolling("2D", axis=axis_frame).sum().T

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -341,9 +341,9 @@ class TestRolling(Base):
             {i: [1] * 2 for i in pd.date_range("2019-8-01", "2019-08-03", freq="D")}
         )
         if axis_frame in [0, "index"]:
-            result = df.T.rolling("2d", axis=axis_frame).sum().T
+            result = df.T.rolling("2D", axis=axis_frame).sum().T
         else:
-            result = df.rolling("2d", axis=axis_frame).sum()
+            result = df.rolling("2D", axis=axis_frame).sum()
         expected = pd.DataFrame(
             {
                 **{


### PR DESCRIPTION
- [x] closes #28192
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
