### PR TITLE
DOC: Fix typo in min_rows / max_rows option example

### DIFF
--- a/doc/source/user_guide/options.rst
+++ b/doc/source/user_guide/options.rst
@@ -163,7 +163,7 @@ determines how many rows are shown in the truncated repr.
 .. ipython:: python
 
    pd.set_option('max_rows', 8)
-   pd.set_option('max_rows', 4)
+   pd.set_option('min_rows', 4)
    # below max_rows -> all rows shown
    df = pd.DataFrame(np.random.randn(7, 2))
    df


### PR DESCRIPTION
 - Fix typo in example
 - Regenerated output also seems to fix a bad output in the next line (out 32 in current online documentation) where df is truncated, when it shouldn't by according to the code 
