### PR TITLE
BUG: datetime64 - Timestamp incorrectly raising TypeError

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -97,7 +97,7 @@ Datetimelike
 - Bug in :meth:`Series.__setitem__` incorrectly casting ``np.timedelta64("NaT")`` to ``np.datetime64("NaT")`` when inserting into a :class:`Series` with datetime64 dtype (:issue:`27311`)
 - Bug in :meth:`Series.dt` property lookups when the underlying data is read-only (:issue:`27529`)
 - Bug in ``HDFStore.__getitem__`` incorrectly reading tz attribute created in Python 2 (:issue:`26443`)
--
+- Bug in :class:`Timestamp` subtraction when subtracting a :class:`Timestamp` from a ``np.datetime64`` object incorrectly raising ``TypeError`` (:issue:`????`)
 
 
 Timedelta

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -97,7 +97,7 @@ Datetimelike
 - Bug in :meth:`Series.__setitem__` incorrectly casting ``np.timedelta64("NaT")`` to ``np.datetime64("NaT")`` when inserting into a :class:`Series` with datetime64 dtype (:issue:`27311`)
 - Bug in :meth:`Series.dt` property lookups when the underlying data is read-only (:issue:`27529`)
 - Bug in ``HDFStore.__getitem__`` incorrectly reading tz attribute created in Python 2 (:issue:`26443`)
-- Bug in :class:`Timestamp` subtraction when subtracting a :class:`Timestamp` from a ``np.datetime64`` object incorrectly raising ``TypeError`` (:issue:`????`)
+- Bug in :class:`Timestamp` subtraction when subtracting a :class:`Timestamp` from a ``np.datetime64`` object incorrectly raising ``TypeError`` (:issue:`28286`)
 
 
 Timedelta

--- a/pandas/_libs/tslibs/c_timestamp.pyx
+++ b/pandas/_libs/tslibs/c_timestamp.pyx
@@ -313,7 +313,8 @@ cdef class _Timestamp(datetime):
                 pass
 
         elif is_datetime64_object(self):
-            # cython semantics for __rsub__, `other` is actually the Timestamp
+            # GH#28286 cython semantics for __rsub__, `other` is actually
+            #  the Timestamp
             return type(other)(self) - other
 
         # scalar Timestamp/datetime - Timedelta -> yields a Timestamp (with

--- a/pandas/_libs/tslibs/c_timestamp.pyx
+++ b/pandas/_libs/tslibs/c_timestamp.pyx
@@ -312,6 +312,10 @@ cdef class _Timestamp(datetime):
             except (OverflowError, OutOfBoundsDatetime):
                 pass
 
+        elif is_datetime64_object(self):
+            # cython semantics for __rsub__, `other` is actually the Timestamp
+            return type(other)(self) - other
+
         # scalar Timestamp/datetime - Timedelta -> yields a Timestamp (with
         # same timezone if specified)
         return datetime.__sub__(self, other)

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -76,6 +76,9 @@ class TestTimestampArithmetic:
         assert other.to_pydatetime() - ts == td
         if tz_naive_fixture is None:
             assert other.to_datetime64() - ts == td
+        else:
+            with pytest.raises(TypeError, match="subtraction must have"):
+                other.to_datetime64() - ts
 
     def test_timestamp_sub_datetime(self):
         dt = datetime(2013, 10, 12)

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -66,6 +66,17 @@ class TestTimestampArithmetic:
         result = val + timedelta(1)
         assert result.nanosecond == val.nanosecond
 
+    def test_rsub_dtscalars(self, tz_naive_fixture):
+        # In particular, check that datetime64 - Timestamp works
+        td = Timedelta(1235345642000)
+        ts = Timestamp.now(tz_naive_fixture)
+        other = ts + td
+
+        assert other - ts == td
+        assert other.to_pydatetime() - ts == td
+        if tz_naive_fixture is None:
+            assert other.to_datetime64() - ts == td
+
     def test_timestamp_sub_datetime(self):
         dt = datetime(2013, 10, 12)
         ts = Timestamp(datetime(2013, 10, 13))

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -67,7 +67,7 @@ class TestTimestampArithmetic:
         assert result.nanosecond == val.nanosecond
 
     def test_rsub_dtscalars(self, tz_naive_fixture):
-        # In particular, check that datetime64 - Timestamp works
+        # In particular, check that datetime64 - Timestamp works GH#28286
         td = Timedelta(1235345642000)
         ts = Timestamp.now(tz_naive_fixture)
         other = ts + td


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
