### PR TITLE
Fix inconsistent casting to bool

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -806,7 +806,13 @@ def _bool_method_SERIES(cls, op, special):
         return result
 
     fill_int = lambda x: x.fillna(0)
-    fill_bool = lambda x: x.fillna(False).astype(bool)
+
+    def fill_bool(x, left=None):
+        # if `left` is specifically not-boolean, we do not cast to bool
+        x = x.fillna(False)
+        if left is None or is_bool_dtype(left.dtype):
+            x = x.astype(bool)
+        return x
 
     def wrapper(self, other):
         is_self_int_dtype = is_integer_dtype(self.dtype)
@@ -835,7 +841,7 @@ def _bool_method_SERIES(cls, op, special):
 
         elif isinstance(other, (ABCSeries, ABCIndexClass)):
             is_other_int_dtype = is_integer_dtype(other.dtype)
-            other = other if is_other_int_dtype else fill_bool(other)
+            other = other if is_other_int_dtype else fill_bool(other, self)
 
         else:
             # scalars, list, tuple, np.array

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -103,11 +103,8 @@ class TestSeriesLogicalOps:
             s_0123 & [0.1, 4, 3.14, 2]
         with pytest.raises(TypeError):
             s_0123 & np.array([0.1, 4, 3.14, 2])
-
-        # FIXME: this should be consistent with the list case above
-        expected = Series([False, True, False, True])
-        result = s_0123 & Series([0.1, 4, -3.14, 2])
-        assert_series_equal(result, expected)
+        with pytest.raises(TypeError):
+            s_0123 & Series([0.1, 4, -3.14, 2])
 
     def test_logical_operators_int_dtype_with_str(self):
         s_1111 = Series([1] * 4, dtype="int8")
@@ -145,9 +142,8 @@ class TestSeriesLogicalOps:
         assert_series_equal(result, expected)
 
         s_abNd = Series(["a", "b", np.NaN, "d"])
-        result = s_0123 & s_abNd
-        expected = Series([False, True, False, True])
-        assert_series_equal(result, expected)
+        with pytest.raises(TypeError, match="unsupported.* 'int' and 'str'"):
+            s_0123 & s_abNd
 
     def test_logical_operators_bool_dtype_with_int(self):
         index = list("bca")


### PR DESCRIPTION
Series logical ops (`|`, `&`, `^`) have a bunch of inconsistencies.  This partially addresses one of them, and does so in a way that makes the diff for the next one much more manageable than it would be without this.