### PR TITLE
BUG: make tz_localize operate on values rather than categories

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -293,6 +293,9 @@ Categorical
 - Using date accessors on a categorical dtyped :class:`Series` of datetimes was not returning an object of the
   same type as if one used the :meth:`.str.` / :meth:`.dt.` on a :class:`Series` of that type. E.g. when accessing :meth:`Series.dt.tz_localize` on a
   :class:`Categorical` with duplicate entries, the accessor was skipping duplicates (:issue: `27952`)
+- Using date accessors on a categorical dtyped :class:`Series` of datetimes was not returning the same object that would
+  be returned if one used the :meth:`.str.<method>` / :meth:`.dt.<method>` on a :class:`Series` of that type. E.g. when accessing :meth:`Series.dt.tz_localize` on a
+  :class:`Categorical` with duplicate entries, the accessor would skip duplicates (:issue: `27952`)
 -
 
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -288,6 +288,10 @@ Categorical
 - :meth:`Categorical.searchsorted` and :meth:`CategoricalIndex.searchsorted` now work on unordered categoricals also (:issue:`21667`)
 - Added test to assert roundtripping to parquet with :func:`DataFrame.to_parquet` or :func:`read_parquet` will preserve Categorical dtypes for string types (:issue:`27955`)
 - Changed the error message in :meth:`Categorical.remove_categories` to always show the invalid removals as a set (:issue:`28669`)
+- Using date accessors on a categorical dtyped series of datetimes was not returning a Series (or DataFrame) of the
+  same type as if one used the .str. / .dt. on a Series of that type, e.g. when accessing :meth:`Series.dt.tz_localize` on a
+  :class:`Categorical` with duplicate entries, the accessor was skipping duplicates (:issue: `27952`)
+-
 
 
 Datetimelike

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -288,15 +288,9 @@ Categorical
 - :meth:`Categorical.searchsorted` and :meth:`CategoricalIndex.searchsorted` now work on unordered categoricals also (:issue:`21667`)
 - Added test to assert roundtripping to parquet with :func:`DataFrame.to_parquet` or :func:`read_parquet` will preserve Categorical dtypes for string types (:issue:`27955`)
 - Changed the error message in :meth:`Categorical.remove_categories` to always show the invalid removals as a set (:issue:`28669`)
-- Using date accessors on a categorical dtyped series of datetimes was not returning a Series (or DataFrame) of the
-  same type as if one used the .str. / .dt. on a Series of that type, e.g. when accessing :meth:`Series.dt.tz_localize` on a
 - Using date accessors on a categorical dtyped :class:`Series` of datetimes was not returning an object of the
   same type as if one used the :meth:`.str.` / :meth:`.dt.` on a :class:`Series` of that type. E.g. when accessing :meth:`Series.dt.tz_localize` on a
   :class:`Categorical` with duplicate entries, the accessor was skipping duplicates (:issue: `27952`)
-- Using date accessors on a categorical dtyped :class:`Series` of datetimes was not returning the same object that would
-  be returned if one used the :meth:`.str.<method>` / :meth:`.dt.<method>` on a :class:`Series` of that type. E.g. when accessing :meth:`Series.dt.tz_localize` on a
-  :class:`Categorical` with duplicate entries, the accessor would skip duplicates (:issue: `27952`)
--
 
 
 Datetimelike

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -290,6 +290,8 @@ Categorical
 - Changed the error message in :meth:`Categorical.remove_categories` to always show the invalid removals as a set (:issue:`28669`)
 - Using date accessors on a categorical dtyped series of datetimes was not returning a Series (or DataFrame) of the
   same type as if one used the .str. / .dt. on a Series of that type, e.g. when accessing :meth:`Series.dt.tz_localize` on a
+- Using date accessors on a categorical dtyped :class:`Series` of datetimes was not returning an object of the
+  same type as if one used the :meth:`.str.` / :meth:`.dt.` on a :class:`Series` of that type. E.g. when accessing :meth:`Series.dt.tz_localize` on a
   :class:`Categorical` with duplicate entries, the accessor was skipping duplicates (:issue: `27952`)
 -
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -322,7 +322,7 @@ class CombinedDatetimelikeProperties(
         orig = data if is_categorical_dtype(data) else None
         if orig is not None:
             data = Series(
-                orig.values,
+                orig.array,
                 name=orig.name,
                 copy=False,
                 dtype=orig.values.categories.dtype,

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -322,7 +322,7 @@ class CombinedDatetimelikeProperties(
         orig = data if is_categorical_dtype(data) else None
         if orig is not None:
             data = Series(
-                np.asarray(orig.values),
+                orig.values,
                 name=orig.name,
                 copy=False,
                 dtype=orig.values.categories.dtype,

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -16,7 +16,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.generic import ABCSeries
 
 from pandas.core.accessor import PandasDelegate, delegate_names
-from pandas.core.algorithms import take_1d
 from pandas.core.arrays import DatetimeArray, PeriodArray, TimedeltaArray
 from pandas.core.base import NoNewAttributesMixin, PandasObject
 from pandas.core.indexes.datetimes import DatetimeIndex
@@ -75,9 +74,7 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
 
         result = np.asarray(result)
 
-        # blow up if we operate on categories
         if self.orig is not None:
-            result = take_1d(result, self.orig.cat.codes)
             index = self.orig.index
         else:
             index = self._parent.index
@@ -324,7 +321,11 @@ class CombinedDatetimelikeProperties(
 
         orig = data if is_categorical_dtype(data) else None
         if orig is not None:
-            data = Series(orig.values.categories, name=orig.name, copy=False)
+            data = Series(
+                orig.values.astype(orig.values.categories.dtype),
+                name=orig.name,
+                copy=False,
+            )
 
         if is_datetime64_dtype(data.dtype):
             return DatetimeProperties(data, orig)

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -322,9 +322,10 @@ class CombinedDatetimelikeProperties(
         orig = data if is_categorical_dtype(data) else None
         if orig is not None:
             data = Series(
-                orig.values.astype(orig.values.categories.dtype),
+                orig.values.__array__(),
                 name=orig.name,
                 copy=False,
+                dtype=orig.values.categories.dtype,
             )
 
         if is_datetime64_dtype(data.dtype):

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -322,7 +322,7 @@ class CombinedDatetimelikeProperties(
         orig = data if is_categorical_dtype(data) else None
         if orig is not None:
             data = Series(
-                orig.values.__array__(),
+                np.asarray(orig.values),
                 name=orig.name,
                 copy=False,
                 dtype=orig.values.categories.dtype,

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -1137,7 +1137,18 @@ class TestCategoricalIndex(Base):
         expected = datetimes.dt.tz_localize(tz)
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("accessor", [("year"), ("month"), ("day")])
+    def test_dt_tz_convert(self, tz_aware_fixture):
+        # GH 27952
+        tz = tz_aware_fixture
+        datetimes = pd.Series(
+            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns, MET]"
+        )
+        categorical = datetimes.astype("category")
+        result = categorical.dt.tz_convert(tz)
+        expected = datetimes.dt.tz_convert(tz)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("accessor", ["year", "month", "day"])
     def test_dt_other_accessors(self, accessor):
         # GH 27952
         datetimes = pd.Series(

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -1125,3 +1125,26 @@ class TestCategoricalIndex(Base):
             ci.values._codes = ci.values._codes.astype("int64")
         assert np.issubdtype(ci.codes.dtype, dtype)
         assert isinstance(ci._engine, engine_type)
+
+    def test_dt_tz_localize(self, tz_aware_fixture):
+        # GH 27952
+        tz = tz_aware_fixture
+        datetimes = pd.Series(
+            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns]"
+        )
+        categorical = datetimes.astype("category")
+        result = categorical.dt.tz_localize(tz)
+        expected = datetimes.dt.tz_localize(tz)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("accessor", [("year"), ("month"), ("day")])
+    def test_dt_other_accessors(self, accessor):
+        # GH 27952
+        tz = None
+        datetimes = pd.Series(
+            ["2018-01-01", "2018-01-01", "2019-01-02"], dtype="datetime64[ns]"
+        )
+        categorical = datetimes.astype("category")
+        result = getattr(categorical.dt, accessor)
+        expected = getattr(datetimes.dt, accessor)
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -1125,36 +1125,3 @@ class TestCategoricalIndex(Base):
             ci.values._codes = ci.values._codes.astype("int64")
         assert np.issubdtype(ci.codes.dtype, dtype)
         assert isinstance(ci._engine, engine_type)
-
-    def test_dt_tz_localize(self, tz_aware_fixture):
-        # GH 27952
-        tz = tz_aware_fixture
-        datetimes = pd.Series(
-            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns]"
-        )
-        categorical = datetimes.astype("category")
-        result = categorical.dt.tz_localize(tz)
-        expected = datetimes.dt.tz_localize(tz)
-        tm.assert_series_equal(result, expected)
-
-    def test_dt_tz_convert(self, tz_aware_fixture):
-        # GH 27952
-        tz = tz_aware_fixture
-        datetimes = pd.Series(
-            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns, MET]"
-        )
-        categorical = datetimes.astype("category")
-        result = categorical.dt.tz_convert(tz)
-        expected = datetimes.dt.tz_convert(tz)
-        tm.assert_series_equal(result, expected)
-
-    @pytest.mark.parametrize("accessor", ["year", "month", "day"])
-    def test_dt_other_accessors(self, accessor):
-        # GH 27952
-        datetimes = pd.Series(
-            ["2018-01-01", "2018-01-01", "2019-01-02"], dtype="datetime64[ns]"
-        )
-        categorical = datetimes.astype("category")
-        result = getattr(categorical.dt, accessor)
-        expected = getattr(datetimes.dt, accessor)
-        tm.assert_series_equal(result, expected)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -1140,7 +1140,6 @@ class TestCategoricalIndex(Base):
     @pytest.mark.parametrize("accessor", [("year"), ("month"), ("day")])
     def test_dt_other_accessors(self, accessor):
         # GH 27952
-        tz = None
         datetimes = pd.Series(
             ["2018-01-01", "2018-01-01", "2019-01-02"], dtype="datetime64[ns]"
         )

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -344,6 +344,72 @@ class TestSeriesDatetimeValues:
         expected = Series([2017, 2017, 2018, 2018], name="foo")
         tm.assert_series_equal(result, expected)
 
+    def test_dt_tz_localize(self, tz_aware_fixture):
+        # GH 27952
+        tz = tz_aware_fixture
+        datetimes = pd.Series(
+            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns]"
+        )
+        categorical = datetimes.astype("category")
+        result = categorical.dt.tz_localize(tz)
+        expected = datetimes.dt.tz_localize(tz)
+        tm.assert_series_equal(result, expected)
+
+    def test_dt_tz_convert(self, tz_aware_fixture):
+        # GH 27952
+        tz = tz_aware_fixture
+        datetimes = pd.Series(
+            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns, MET]"
+        )
+        categorical = datetimes.astype("category")
+        result = categorical.dt.tz_convert(tz)
+        expected = datetimes.dt.tz_convert(tz)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("accessor", ["year", "month", "day"])
+    def test_dt_other_accessors(self, accessor):
+        # GH 27952
+        datetimes = pd.Series(
+            ["2018-01-01", "2018-01-01", "2019-01-02"], dtype="datetime64[ns]"
+        )
+        categorical = datetimes.astype("category")
+        result = getattr(categorical.dt, accessor)
+        expected = getattr(datetimes.dt, accessor)
+        tm.assert_series_equal(result, expected)
+
+    def test_dt_tz_localize(self, tz_aware_fixture):
+        # GH 27952
+        tz = tz_aware_fixture
+        datetimes = pd.Series(
+            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns]"
+        )
+        categorical = datetimes.astype("category")
+        result = categorical.dt.tz_localize(tz)
+        expected = datetimes.dt.tz_localize(tz)
+        tm.assert_series_equal(result, expected)
+
+    def test_dt_tz_convert(self, tz_aware_fixture):
+        # GH 27952
+        tz = tz_aware_fixture
+        datetimes = pd.Series(
+            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns, MET]"
+        )
+        categorical = datetimes.astype("category")
+        result = categorical.dt.tz_convert(tz)
+        expected = datetimes.dt.tz_convert(tz)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("accessor", ["year", "month", "day"])
+    def test_dt_other_accessors(self, accessor):
+        # GH 27952
+        datetimes = pd.Series(
+            ["2018-01-01", "2018-01-01", "2019-01-02"], dtype="datetime64[ns]"
+        )
+        categorical = datetimes.astype("category")
+        result = getattr(categorical.dt, accessor)
+        expected = getattr(datetimes.dt, accessor)
+        tm.assert_series_equal(result, expected)
+
     def test_dt_accessor_no_new_attributes(self):
         # https://github.com/pandas-dev/pandas/issues/10673
         s = Series(date_range("20130101", periods=5, freq="D"))

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -344,7 +344,7 @@ class TestSeriesDatetimeValues:
         expected = Series([2017, 2017, 2018, 2018], name="foo")
         tm.assert_series_equal(result, expected)
 
-    def test_dt_tz_localize(self, tz_aware_fixture):
+    def test_dt_tz_localize_categorical(self, tz_aware_fixture):
         # GH 27952
         tz = tz_aware_fixture
         datetimes = pd.Series(

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -355,7 +355,7 @@ class TestSeriesDatetimeValues:
         expected = datetimes.dt.tz_localize(tz)
         tm.assert_series_equal(result, expected)
 
-    def test_dt_tz_convert(self, tz_aware_fixture):
+    def test_dt_tz_convert_categorical(self, tz_aware_fixture):
         # GH 27952
         tz = tz_aware_fixture
         datetimes = pd.Series(
@@ -367,7 +367,7 @@ class TestSeriesDatetimeValues:
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("accessor", ["year", "month", "day"])
-    def test_dt_other_accessors(self, accessor):
+    def test_dt_other_accessors_categorical(self, accessor):
         # GH 27952
         datetimes = pd.Series(
             ["2018-01-01", "2018-01-01", "2019-01-02"], dtype="datetime64[ns]"

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -377,39 +377,6 @@ class TestSeriesDatetimeValues:
         expected = getattr(datetimes.dt, accessor)
         tm.assert_series_equal(result, expected)
 
-    def test_dt_tz_localize(self, tz_aware_fixture):
-        # GH 27952
-        tz = tz_aware_fixture
-        datetimes = pd.Series(
-            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns]"
-        )
-        categorical = datetimes.astype("category")
-        result = categorical.dt.tz_localize(tz)
-        expected = datetimes.dt.tz_localize(tz)
-        tm.assert_series_equal(result, expected)
-
-    def test_dt_tz_convert(self, tz_aware_fixture):
-        # GH 27952
-        tz = tz_aware_fixture
-        datetimes = pd.Series(
-            ["2019-01-01", "2019-01-01", "2019-01-02"], dtype="datetime64[ns, MET]"
-        )
-        categorical = datetimes.astype("category")
-        result = categorical.dt.tz_convert(tz)
-        expected = datetimes.dt.tz_convert(tz)
-        tm.assert_series_equal(result, expected)
-
-    @pytest.mark.parametrize("accessor", ["year", "month", "day"])
-    def test_dt_other_accessors(self, accessor):
-        # GH 27952
-        datetimes = pd.Series(
-            ["2018-01-01", "2018-01-01", "2019-01-02"], dtype="datetime64[ns]"
-        )
-        categorical = datetimes.astype("category")
-        result = getattr(categorical.dt, accessor)
-        expected = getattr(datetimes.dt, accessor)
-        tm.assert_series_equal(result, expected)
-
     def test_dt_accessor_no_new_attributes(self):
         # https://github.com/pandas-dev/pandas/issues/10673
         s = Series(date_range("20130101", periods=5, freq="D"))


### PR DESCRIPTION
- [x] closes #27952
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
