### PR TITLE
Added cpp files to build clean

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -277,6 +277,7 @@ class CleanCommand(Command):
                     ".pyo",
                     ".pyd",
                     ".c",
+                    ".cpp",
                     ".orig",
                 ):
                     self._clean_me.append(filepath)


### PR DESCRIPTION
Looks like the Cython-compiled `window.cpp` hangs around after running `python setup.py clean --all` - this should take care of that
