### PR TITLE
Removed PyString refs from extension modules

### DIFF
--- a/pandas/_libs/src/parse_helper.h
+++ b/pandas/_libs/src/parse_helper.h
@@ -25,11 +25,6 @@ int to_double(char *item, double *p_value, char sci, char decimal,
     return (error == 0) && (!*p_end);
 }
 
-#if PY_VERSION_HEX < 0x02060000
-#define PyBytes_Check PyString_Check
-#define PyBytes_AS_STRING PyString_AS_STRING
-#endif  // PY_VERSION_HEX
-
 int floatify(PyObject *str, double *result, int *maybe_int) {
     int status;
     char *data;

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -435,7 +435,7 @@ static void *PyFloatToDOUBLE(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
     return NULL;
 }
 
-static void *PyStringToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
+static void *PyBytesToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                             size_t *_outLen) {
     PyObject *obj = (PyObject *)_obj;
     *_outLen = PyBytes_GET_SIZE(obj);
@@ -1869,7 +1869,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         return;
     } else if (PyBytes_Check(obj)) {
         PRINTMARK();
-        pc->PyTypeToJSON = PyStringToUTF8;
+        pc->PyTypeToJSON = PyBytesToUTF8;
         tc->type = JT_UTF8;
         return;
     } else if (PyUnicode_Check(obj)) {

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -2,6 +2,11 @@
 from cpython cimport PyTypeObject
 
 cdef extern from *:
+    """
+    PyObject* char_to_string(const char* data) {
+        return PyUnicode_FromString(data);
+    }
+    """
     object char_to_string(const char* data)
 
 

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -2,15 +2,6 @@
 from cpython cimport PyTypeObject
 
 cdef extern from *:
-    """
-    PyObject* char_to_string(const char* data) {
-    #if PY_VERSION_HEX >= 0x03000000
-        return PyUnicode_FromString(data);
-    #else
-        return PyString_FromString(data);
-    #endif
-    }
-    """
     object char_to_string(const char* data)
 
 
@@ -18,7 +9,6 @@ cdef extern from "Python.h":
     # Note: importing extern-style allows us to declare these as nogil
     # functions, whereas `from cpython cimport` does not.
     bint PyUnicode_Check(object obj) nogil
-    bint PyString_Check(object obj) nogil
     bint PyBool_Check(object obj) nogil
     bint PyFloat_Check(object obj) nogil
     bint PyComplex_Check(object obj) nogil

--- a/pandas/_libs/writers.pyx
+++ b/pandas/_libs/writers.pyx
@@ -3,11 +3,6 @@ from cython import Py_ssize_t
 
 from cpython cimport PyBytes_GET_SIZE, PyUnicode_GET_SIZE
 
-try:
-    from cpython cimport PyString_GET_SIZE
-except ImportError:
-    from cpython cimport PyUnicode_GET_SIZE as PyString_GET_SIZE
-
 import numpy as np
 from numpy cimport ndarray, uint8_t
 
@@ -126,11 +121,9 @@ def max_len_string_array(pandas_string[:] arr) -> Py_ssize_t:
     for i in range(length):
         val = arr[i]
         if isinstance(val, str):
-            l = PyString_GET_SIZE(val)
+            l = PyUnicode_GET_SIZE(val)
         elif isinstance(val, bytes):
             l = PyBytes_GET_SIZE(val)
-        elif isinstance(val, unicode):
-            l = PyUnicode_GET_SIZE(val)
 
         if l > m:
             m = l


### PR DESCRIPTION
We have some old PyString references hanging around in our extension modules. These are a relic of the old Py2 string handling and will be removed in Python 4 I think, so figured worth modernizing

https://docs.python.org/3/howto/cporting.html