### PR TITLE
BUG: Fix FastParquetImpl.write for non-existent file

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -218,6 +218,7 @@ I/O
 - Bug in :meth:`DataFrame.to_csv` where values were truncated when the length of ``na_rep`` was shorter than the text input data. (:issue:`25099`)
 - Bug in :func:`DataFrame.to_string` where values were truncated using display options instead of outputting the full content (:issue:`9784`)
 - Bug in :meth:`DataFrame.to_json` where a datetime column label would not be written out in ISO format with ``orient="table"`` (:issue:`28130`)
+- Bug in :func:`DataFrame.to_parquet` where writing to GCS would fail with `engine='fastparquet'` if the file did not already exist (:issue:`28326`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -160,11 +160,11 @@ class FastParquetImpl(BaseImpl):
             kwargs["file_scheme"] = "hive"
 
         if is_s3_url(path) or is_gcs_url(path):
-            # path is s3:// so we need to open the s3file in 'wb' mode.
+            # if path is s3:// or gs:// we need to open the file in 'wb' mode.
             # TODO: Support 'ab'
 
             path, _, _, _ = get_filepath_or_buffer(path, mode="wb")
-            # And pass the opened s3file to the fastparquet internal impl.
+            # And pass the opened file to the fastparquet internal impl.
             kwargs["open_with"] = lambda path, _: path
         else:
             path, _, _, _ = get_filepath_or_buffer(path)

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -7,7 +7,7 @@ from pandas.errors import AbstractMethodError
 
 from pandas import DataFrame, get_option
 
-from pandas.io.common import get_filepath_or_buffer, is_s3_url
+from pandas.io.common import get_filepath_or_buffer, is_gcs_url, is_s3_url
 
 
 def get_engine(engine):
@@ -159,7 +159,7 @@ class FastParquetImpl(BaseImpl):
         if partition_cols is not None:
             kwargs["file_scheme"] = "hive"
 
-        if is_s3_url(path):
+        if is_s3_url(path) or is_gcs_url(path):
             # path is s3:// so we need to open the s3file in 'wb' mode.
             # TODO: Support 'ab'
 

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -1,5 +1,5 @@
-import os
 from io import StringIO
+import os
 
 import numpy as np
 import pytest

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -75,14 +75,15 @@ def test_to_parquet_gcs_new_file(monkeypatch, tmpdir):
     )
 
     class MockGCSFileSystem:
-        def open(self, path, mode='r', *args):
-            if 'w' not in mode:
+        def open(self, path, mode="r", *args):
+            if "w" not in mode:
                 raise FileNotFoundError
-            return open(os.path.join(tmpdir, 'test.parquet'), mode)
+            return open(os.path.join(tmpdir, "test.parquet"), mode)
 
     monkeypatch.setattr("gcsfs.GCSFileSystem", MockGCSFileSystem)
-    df1.to_parquet("gs://test/test.csv", index=True, engine='fastparquet',
-                   compression=None)
+    df1.to_parquet(
+        "gs://test/test.csv", index=True, engine="fastparquet", compression=None
+    )
 
 
 @td.skip_if_no("gcsfs")

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -1,3 +1,4 @@
+import os
 from io import StringIO
 
 import numpy as np
@@ -58,6 +59,30 @@ def test_to_csv_gcs(monkeypatch):
     df2 = read_csv(StringIO(s.getvalue()), parse_dates=["dt"], index_col=0)
 
     assert_frame_equal(df1, df2)
+
+
+@td.skip_if_no("fastparquet")
+@td.skip_if_no("gcsfs")
+def test_to_parquet_gcs_new_file(monkeypatch, tmpdir):
+    """Regression test for writing to a not-yet-existent GCS Parquet file."""
+    df1 = DataFrame(
+        {
+            "int": [1, 3],
+            "float": [2.0, np.nan],
+            "str": ["t", "s"],
+            "dt": date_range("2018-06-18", periods=2),
+        }
+    )
+
+    class MockGCSFileSystem:
+        def open(self, path, mode='r', *args):
+            if 'w' not in mode:
+                raise FileNotFoundError
+            return open(os.path.join(tmpdir, 'test.parquet'), mode)
+
+    monkeypatch.setattr("gcsfs.GCSFileSystem", MockGCSFileSystem)
+    df1.to_parquet("gs://test/test.csv", index=True, engine='fastparquet',
+                   compression=None)
 
 
 @td.skip_if_no("gcsfs")


### PR DESCRIPTION
`PyArrowImpl` already correctly opens a non-existent file for writing (https://github.com/pandas-dev/pandas/blob/master/pandas/io/parquet.py#L95), with `engine='fastparquet'` this fails for e.g. a GCS URL (though it looks like S3 is already correct):
```
[nav] In [1]: pd.DataFrame().to_parquet('gs://city_data/test/blah.parquet')
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-1-dde78378baaa> in <module>
----> 1 pd.DataFrame().to_parquet('gs://city_data/test/blah.parquet')

~/venvs/model/lib/python3.7/site-packages/pandas/core/frame.py in to_parquet(self, fname, engine, compression, index, partition_cols, **kwargs)
   2215             index=index,
   2216             partition_cols=partition_cols,
-> 2217             **kwargs
   2218         )
   2219

~/venvs/model/lib/python3.7/site-packages/pandas/io/parquet.py in to_parquet(df, path, engine, compression, index, partition_cols, **kwargs)
    250         index=index,
    251         partition_cols=partition_cols,
--> 252         **kwargs
    253     )
    254

~/venvs/model/lib/python3.7/site-packages/pandas/io/parquet.py in write(self, df, path, compression, index, partition_cols, **kwargs)
    171             kwargs["open_with"] = lambda path, _: path
    172         else:
--> 173             path, _, _, _ = get_filepath_or_buffer(path)
    174
    175         with catch_warnings(record=True):

~/venvs/model/lib/python3.7/site-packages/pandas/io/common.py in get_filepath_or_buffer(filepath_or_buffer, encoding, compression, mode)
    212
    213         return gcs.get_filepath_or_buffer(
--> 214             filepath_or_buffer, encoding=encoding, compression=compression, mode=mode
    215         )
    216

~/venvs/model/lib/python3.7/site-packages/pandas/io/gcs.py in get_filepath_or_buffer(filepath_or_buffer, encoding, compression, mode)
     15
     16     fs = gcsfs.GCSFileSystem()
---> 17     filepath_or_buffer = fs.open(filepath_or_buffer, mode)
     18     return filepath_or_buffer, None, compression, True

<decorator-gen-147> in open(self, path, mode, block_size, acl, consistency, metadata)

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in _tracemethod(f, self, *args, **kwargs)
     51         logger.log(logging.DEBUG - 1, tb_io.getvalue())
     52
---> 53     return f(self, *args, **kwargs)
     54
     55

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in open(self, path, mode, block_size, acl, consistency, metadata)
   1148         if 'b' in mode:
   1149             return GCSFile(self, path, mode, block_size, consistency=const,
-> 1150                            metadata=metadata)
   1151         else:
   1152             mode = mode.replace('t', '') + 'b'

<decorator-gen-150> in __init__(self, gcsfs, path, mode, block_size, acl, consistency, metadata)

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in _tracemethod(f, self, *args, **kwargs)
     51         logger.log(logging.DEBUG - 1, tb_io.getvalue())
     52
---> 53     return f(self, *args, **kwargs)
     54
     55

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in __init__(self, gcsfs, path, mode, block_size, acl, consistency, metadata)
   1276             raise NotImplementedError('File mode not supported')
   1277         if mode == 'rb':
-> 1278             self.details = gcsfs.info(path)
   1279             self.size = self.details['size']
   1280         else:

<decorator-gen-136> in info(self, path)

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in _tracemethod(f, self, *args, **kwargs)
     51         logger.log(logging.DEBUG - 1, tb_io.getvalue())
     52
---> 53     return f(self, *args, **kwargs)
     54
     55

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in info(self, path)
    863
    864         try:
--> 865             return self._get_object(path)
    866         except FileNotFoundError:
    867             logger.debug("info FileNotFound at path: %s", path)

<decorator-gen-122> in _get_object(self, path)

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in _tracemethod(f, self, *args, **kwargs)
     51         logger.log(logging.DEBUG - 1, tb_io.getvalue())
     52
---> 53     return f(self, *args, **kwargs)
     54
     55

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in _get_object(self, path)
    539             raise FileNotFoundError(path)
    540
--> 541         result = self._process_object(bucket, self._call('GET', 'b/{}/o/{}', bucket, key).json())
    542
    543         return result

<decorator-gen-121> in _call(self, method, path, *args, **kwargs)

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in _tracemethod(f, self, *args, **kwargs)
     51         logger.log(logging.DEBUG - 1, tb_io.getvalue())
     52
---> 53     return f(self, *args, **kwargs)
     54
     55

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in _call(self, method, path, *args, **kwargs)
    482                 r = self.session.request(method, path,
    483                                          params=kwargs, json=json, headers=headers, data=data, timeout=self.requests_timeout)
--> 484                 validate_response(r, path)
    485                 break
    486             except (HttpError, RequestException, RateLimitException, GoogleAuthError) as e:

~/venvs/model/lib/python3.7/site-packages/gcsfs/core.py in validate_response(r, path)
    156
    157         if r.status_code == 404:
--> 158             raise FileNotFoundError(path)
    159         elif r.status_code == 403:
    160             raise IOError("Forbidden: %s\n%s" % (path, msg))

FileNotFoundError: https://www.googleapis.com/storage/v1/b/city_data/o/test%2Fblah.parquet
```
