### PR TITLE
CLN: eval_kwargs

### DIFF
--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -62,10 +62,9 @@ def set_numexpr_threads(n=None):
         ne.set_num_threads(n)
 
 
-def _evaluate_standard(op, op_str, a, b, truediv=True, reversed=False):
+def _evaluate_standard(op, op_str, a, b, reversed=False):
     """ standard evaluation """
-    # truediv and reversed kwargs are included for compatibility
-    #  with _evaluate_numexpr signature
+    # `reversed` kwarg is included for compatibility with _evaluate_numexpr
     if _TEST_MODE:
         _store_test_result(False)
     with np.errstate(all="ignore"):
@@ -98,7 +97,7 @@ def _can_use_numexpr(op, op_str, a, b, dtype_check):
     return False
 
 
-def _evaluate_numexpr(op, op_str, a, b, truediv=True, reversed=False):
+def _evaluate_numexpr(op, op_str, a, b, reversed=False):
     result = None
 
     if _can_use_numexpr(op, op_str, a, b, "evaluate"):
@@ -113,7 +112,6 @@ def _evaluate_numexpr(op, op_str, a, b, truediv=True, reversed=False):
                 "a_value {op} b_value".format(op=op_str),
                 local_dict={"a_value": a_value, "b_value": b_value},
                 casting="safe",
-                truediv=truediv,
             )
         except ValueError as detail:
             if "unknown type object" in str(detail):
@@ -202,7 +200,7 @@ def _bool_arith_check(
     return True
 
 
-def evaluate(op, op_str, a, b, use_numexpr=True, truediv=True, reversed=False):
+def evaluate(op, op_str, a, b, use_numexpr=True, reversed=False):
     """
     Evaluate and return the expression of the op on a and b.
 
@@ -215,13 +213,12 @@ def evaluate(op, op_str, a, b, use_numexpr=True, truediv=True, reversed=False):
     b : right operand
     use_numexpr : bool, default True
         Whether to try to use numexpr.
-    truediv : bool, default True
     reversed : bool, default False
     """
 
     use_numexpr = use_numexpr and _bool_arith_check(op_str, a, b)
     if use_numexpr:
-        return _evaluate(op, op_str, a, b, truediv=truediv, reversed=reversed)
+        return _evaluate(op, op_str, a, b, reversed=reversed)
     return _evaluate_standard(op, op_str, a, b)
 
 

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -62,8 +62,10 @@ def set_numexpr_threads(n=None):
         ne.set_num_threads(n)
 
 
-def _evaluate_standard(op, op_str, a, b, **eval_kwargs):
+def _evaluate_standard(op, op_str, a, b, truediv=True, reversed=False):
     """ standard evaluation """
+    # truediv and reversed kwargs are included for compatibility
+    #  with _evaluate_numexpr signature
     if _TEST_MODE:
         _store_test_result(False)
     with np.errstate(all="ignore"):
@@ -96,7 +98,7 @@ def _can_use_numexpr(op, op_str, a, b, dtype_check):
     return False
 
 
-def _evaluate_numexpr(op, op_str, a, b, truediv=True, reversed=False, **eval_kwargs):
+def _evaluate_numexpr(op, op_str, a, b, truediv=True, reversed=False):
     result = None
 
     if _can_use_numexpr(op, op_str, a, b, "evaluate"):
@@ -112,7 +114,6 @@ def _evaluate_numexpr(op, op_str, a, b, truediv=True, reversed=False, **eval_kwa
                 local_dict={"a_value": a_value, "b_value": b_value},
                 casting="safe",
                 truediv=truediv,
-                **eval_kwargs
             )
         except ValueError as detail:
             if "unknown type object" in str(detail):
@@ -201,7 +202,7 @@ def _bool_arith_check(
     return True
 
 
-def evaluate(op, op_str, a, b, use_numexpr=True, **eval_kwargs):
+def evaluate(op, op_str, a, b, use_numexpr=True, truediv=True, reversed=False):
     """
     Evaluate and return the expression of the op on a and b.
 
@@ -214,11 +215,13 @@ def evaluate(op, op_str, a, b, use_numexpr=True, **eval_kwargs):
     b : right operand
     use_numexpr : bool, default True
         Whether to try to use numexpr.
+    truediv : bool, default True
+    reversed : bool, default False
     """
 
     use_numexpr = use_numexpr and _bool_arith_check(op_str, a, b)
     if use_numexpr:
-        return _evaluate(op, op_str, a, b, **eval_kwargs)
+        return _evaluate(op, op_str, a, b, truediv=truediv, reversed=reversed)
     return _evaluate_standard(op, op_str, a, b)
 
 

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -216,9 +216,6 @@ def _gen_eval_kwargs(name):
     if name in ["truediv", "rtruediv"]:
         kwargs["truediv"] = True
 
-    if name in ["ne"]:
-        kwargs["masker"] = True
-
     return kwargs
 
 
@@ -247,7 +244,7 @@ def _get_frame_op_default_axis(name):
         return "columns"
 
 
-def _get_opstr(op, cls):
+def _get_opstr(op):
     """
     Find the operation string, if any, to pass to numexpr for this
     operation.
@@ -255,19 +252,11 @@ def _get_opstr(op, cls):
     Parameters
     ----------
     op : binary operator
-    cls : class
 
     Returns
     -------
     op_str : string or None
     """
-    # numexpr is available for non-sparse classes
-    subtyp = getattr(cls, "_subtyp", "")
-    use_numexpr = "sparse" not in subtyp
-
-    if not use_numexpr:
-        # if we're not using numexpr, then don't pass a str_rep
-        return None
 
     return {
         operator.add: "+",
@@ -624,7 +613,7 @@ def _arith_method_SERIES(cls, op, special):
     Wrapper function for Series arithmetic operations, to avoid
     code duplication.
     """
-    str_rep = _get_opstr(op, cls)
+    str_rep = _get_opstr(op)
     op_name = _get_op_name(op, special)
     eval_kwargs = _gen_eval_kwargs(op_name)
     construct_result = (
@@ -999,7 +988,7 @@ def _align_method_FRAME(left, right, axis):
 
 
 def _arith_method_FRAME(cls, op, special):
-    str_rep = _get_opstr(op, cls)
+    str_rep = _get_opstr(op)
     op_name = _get_op_name(op, special)
     eval_kwargs = _gen_eval_kwargs(op_name)
     default_axis = _get_frame_op_default_axis(op_name)
@@ -1041,7 +1030,7 @@ def _arith_method_FRAME(cls, op, special):
 
 
 def _flex_comp_method_FRAME(cls, op, special):
-    str_rep = _get_opstr(op, cls)
+    str_rep = _get_opstr(op)
     op_name = _get_op_name(op, special)
     default_axis = _get_frame_op_default_axis(op_name)
 
@@ -1082,7 +1071,7 @@ def _flex_comp_method_FRAME(cls, op, special):
 
 
 def _comp_method_FRAME(cls, func, special):
-    str_rep = _get_opstr(func, cls)
+    str_rep = _get_opstr(func)
     op_name = _get_op_name(func, special)
 
     @Appender("Wrapper for comparison method {name}".format(name=op_name))

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -213,9 +213,6 @@ def _gen_eval_kwargs(name):
             # Exclude commutative operations
             kwargs["reversed"] = True
 
-    if name in ["truediv", "rtruediv"]:
-        kwargs["truediv"] = True
-
     return kwargs
 
 


### PR DESCRIPTION
A bunch of what we do in _gen_eval_kwargs is no longer necessary.