### PR TITLE
GH28301 check for non-unique index in stack_multi_columns

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -184,7 +184,7 @@ Groupby/resample/rolling
 Reshaping
 ^^^^^^^^^
 
--
+- Bug in :meth:`DataFrame.stack` not handling non-unique indexes correctly when creating MultiIndex (:issue: `28301`)
 -
 
 Sparse

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -725,8 +725,9 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
         new_names = list(this.index.names)
         new_codes = [lab.repeat(levsize) for lab in this.index.codes]
     else:
-        new_levels = [this.index]
-        new_codes = [np.arange(N).repeat(levsize)]
+        old_codes, old_levels = _factorize_from_iterable(this.index)
+        new_levels = [old_levels]
+        new_codes = [old_codes.repeat(levsize)]
         new_names = [this.index.name]  # something better?
 
     new_levels.append(level_vals)

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -1015,7 +1015,9 @@ class TestDataFrameReshape(TestData):
         df = pd.DataFrame(index=index, columns=columns).fillna(1)
         stacked = df.stack()
         new_index = pd.MultiIndex.from_tuples(stacked.index.to_numpy())
-        expected = pd.DataFrame(stacked.to_numpy(), index=new_index, columns=stacked.columns)
+        expected = pd.DataFrame(
+            stacked.to_numpy(), index=new_index, columns=stacked.columns
+        )
         tm.assert_frame_equal(stacked, expected)
         stacked_codes = np.asarray(stacked.index.codes)
         expected_codes = np.asarray(new_index.codes)

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -1002,6 +1002,26 @@ class TestDataFrameReshape(TestData):
         )
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "index, columns",
+        [
+            ([0, 0, 1, 1], pd.MultiIndex.from_product([[1, 2], ["a", "b"]])),
+            ([0, 0, 2, 3], pd.MultiIndex.from_product([[1, 2], ["a", "b"]])),
+            ([0, 1, 2, 3], pd.MultiIndex.from_product([[1, 2], ["a", "b"]])),
+        ],
+    )
+    def test_stack_multi_columns_non_unique_index(self, index, columns):
+        # GH-28301
+        df = pd.DataFrame(index=index, columns=columns).fillna(1)
+        stacked = df.stack(-1)
+        new_index = pd.MultiIndex.from_tuples(stacked.index.values)
+
+        tm.assert_index_equal(stacked.index, new_index)
+
+        a = np.asarray(stacked.index.codes)
+        b = np.asarray(new_index.codes)
+        tm.assert_numpy_array_equal(a, b)
+
     @pytest.mark.parametrize("level", [0, 1])
     def test_unstack_mixed_extension_types(self, level):
         index = pd.MultiIndex.from_tuples(

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -1013,14 +1013,13 @@ class TestDataFrameReshape(TestData):
     def test_stack_multi_columns_non_unique_index(self, index, columns):
         # GH-28301
         df = pd.DataFrame(index=index, columns=columns).fillna(1)
-        stacked = df.stack(-1)
-        new_index = pd.MultiIndex.from_tuples(stacked.index.values)
-
-        tm.assert_index_equal(stacked.index, new_index)
-
-        a = np.asarray(stacked.index.codes)
-        b = np.asarray(new_index.codes)
-        tm.assert_numpy_array_equal(a, b)
+        stacked = df.stack()
+        new_index = pd.MultiIndex.from_tuples(stacked.index.to_numpy())
+        expected = pd.DataFrame(stacked.to_numpy(), index=new_index, columns=stacked.columns)
+        tm.assert_frame_equal(stacked, expected)
+        stacked_codes = np.asarray(stacked.index.codes)
+        expected_codes = np.asarray(new_index.codes)
+        tm.assert_numpy_array_equal(stacked_codes, expected_codes)
 
     @pytest.mark.parametrize("level", [0, 1])
     def test_unstack_mixed_extension_types(self, level):


### PR DESCRIPTION
- [x] closes #28301
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The old implementation used `arange` to generate codes for a non-multiindex, which ended up creating bad codes if the index was not unique.  The fix is just a straightforward factorize.