### PR TITLE
DOC: Add pyjanitor to ecosystem.rst

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -23,6 +23,21 @@ or `search pypi for pandas <https://pypi.org/search/?q=pandas>`_.
 We'd like to make it easier for users to find these projects, if you know of other
 substantial projects that you feel should be on this list, please let us know.
 
+.. _ecosystem.data_cleaning_and_validation:
+
+Data cleaning and validation
+----------------------------
+
+`pyjanitor <https://github.com/ericmjl/pyjanitor/>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pyjanitor provides a clean API for cleaning data, using method chaining.
+
+`Engarde <https://engarde.readthedocs.io/en/latest/>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Engarde is a lightweight library used to explicitly state assumptions about your datasets
+and check that they're *actually* true.
 
 .. _ecosystem.stats:
 
@@ -328,18 +343,6 @@ Increasingly, packages are being built on top of pandas to address specific need
 
  * vaex.from_pandas
  * vaex.to_pandas_df
-
-
-.. _ecosystem.data_validation:
-
-Data validation
----------------
-
-`Engarde <https://engarde.readthedocs.io/en/latest/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Engarde is a lightweight library used to explicitly state your assumptions about your datasets
-and check that they're *actually* true.
 
 .. _ecosystem.extensions:
 


### PR DESCRIPTION
[pyjanitor](https://github.com/ericmjl/pyjanitor) is a quite nice pandas data cleaning library and gives its users some useful method on data frames. It's pipe oriented, so it can be helpful in data cleaning/transformation work.

Adding pyjanitor to the ecosystem page gives it visibility to our users and makes it easier for the users to discover if there is functionailty in pyjanitor, that will help their use cases.