### PR TITLE
CLN: catch stricter in json

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -972,13 +972,8 @@ class Parser:
         for date_unit in date_units:
             try:
                 new_data = to_datetime(new_data, errors="raise", unit=date_unit)
-            except ValueError:
+            except (ValueError, OverflowError):
                 continue
-            except OverflowError:
-                # TODO: Why would this be treated different from ValueError?
-                #  In the one test where this is hit, continuing instead of
-                #  breaking doesn't make the test fail
-                break
             return new_data, True
         return data, False
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -974,7 +974,10 @@ class Parser:
                 new_data = to_datetime(new_data, errors="raise", unit=date_unit)
             except ValueError:
                 continue
-            except Exception:
+            except OverflowError:
+                # TODO: Why would this be treated different from ValueError?
+                #  In the one test where this is hit, continuing instead of
+                #  breaking doesn't make the test fail
                 break
             return new_data, True
         return data, False


### PR DESCRIPTION
@WillAyd think there is a compelling reason to keep this as `break` instead of lumping it into the `continue` clause above?

(obviously the TODO comment will be removed/resolved before merge)