### PR TITLE
GH28337: Period index doesn't handle reindexing with a non-period index

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -145,7 +145,7 @@ Indexing
 ^^^^^^^^
 
 - Bug in assignment using a reverse slicer (:issue:`26939`)
--
+- Bug in reindexing a :meth:`PeriodIndex` with another type of index that contained a `Period` (:issue:`28323`) (:issue:`28337`)
 
 Missing
 ^^^^^^^
@@ -214,7 +214,7 @@ Other
 - Trying to set the ``display.precision``, ``display.max_rows`` or ``display.max_columns`` using :meth:`set_option` to anything but a ``None`` or a positive int will raise a ``ValueError`` (:issue:`23348`)
 - Using :meth:`DataFrame.replace` with overlapping keys in a nested dictionary will no longer raise, now matching the behavior of a flat dictionary (:issue:`27660`)
 - :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` now support dicts as ``compression`` argument with key ``'method'`` being the compression method and others as additional compression options when the compression method is ``'zip'``. (:issue:`26023`)
-- Reindexing a `PeriodIndex` with an index of dtype `Object` no longer uses the `PeriodIndex`'s `_int64index`
+-
 
 .. _whatsnew_1000.contributors:
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -214,7 +214,7 @@ Other
 - Trying to set the ``display.precision``, ``display.max_rows`` or ``display.max_columns`` using :meth:`set_option` to anything but a ``None`` or a positive int will raise a ``ValueError`` (:issue:`23348`)
 - Using :meth:`DataFrame.replace` with overlapping keys in a nested dictionary will no longer raise, now matching the behavior of a flat dictionary (:issue:`27660`)
 - :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` now support dicts as ``compression`` argument with key ``'method'`` being the compression method and others as additional compression options when the compression method is ``'zip'``. (:issue:`26023`)
-
+- Reindexing a `PeriodIndex` with an index of dtype `Object` no longer uses the `PeriodIndex`'s `_int64index`
 
 .. _whatsnew_1000.contributors:
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -651,10 +651,13 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
 
         if isinstance(target, PeriodIndex):
             target = target.asi8
+            self_index = self._int64index
+        else:
+            self_index = self
 
         if tolerance is not None:
             tolerance = self._convert_tolerance(tolerance, target)
-        return Index.get_indexer(self._int64index, target, method, limit, tolerance)
+        return Index.get_indexer(self_index, target, method, limit, tolerance)
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)
     def get_indexer_non_unique(self, target):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -354,6 +354,35 @@ class TestPeriodIndex(DatetimeLike):
         df = df.set_index(idx2)
         tm.assert_index_equal(df.index, idx2)
 
+    @pytest.mark.parametrize(
+        "p_values, o_values, values, expected_values",
+        [
+            (
+                [Period("2019Q1", "Q-DEC"), Period("2019Q2", "Q-DEC")],
+                [Period("2019Q1", "Q-DEC"), Period("2019Q2", "Q-DEC"), "All"],
+                [1.0, 1.0],
+                [1.0, 1.0, np.nan],
+            ),
+            (
+                [Period("2019Q1", "Q-DEC"), Period("2019Q2", "Q-DEC")],
+                [Period("2019Q1", "Q-DEC"), Period("2019Q2", "Q-DEC")],
+                [1.0, 1.0],
+                [1.0, 1.0],
+            ),
+        ],
+    )
+    def test_period_reindex_with_object(
+        self, p_values, o_values, values, expected_values
+    ):
+        # GH 28337
+        period_index = PeriodIndex(p_values)
+        object_index = Index(o_values)
+
+        s = pd.Series(values, index=period_index)
+        result = s.reindex(object_index)
+        expected = pd.Series(expected_values, index=object_index)
+        tm.assert_series_equal(result, expected)
+
     def test_factorize(self):
         idx1 = PeriodIndex(
             ["2014-01", "2014-01", "2014-02", "2014-02", "2014-03", "2014-03"], freq="M"

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -677,6 +677,31 @@ class TestPivotTable:
             pv = pd.pivot(df, index="p1", columns="p2", values="data1")
         tm.assert_frame_equal(pv, expected)
 
+    def test_pivot_periods_with_margins(self):
+        df = DataFrame(
+            {
+                "a": [1, 1, 2, 2],
+                "b": [
+                    pd.Period("2019Q1"),
+                    pd.Period("2019Q2"),
+                    pd.Period("2019Q1"),
+                    pd.Period("2019Q2"),
+                ],
+                "x": 1.0,
+            }
+        )
+
+        expected = DataFrame(
+            data=1.0,
+            index=pd.Index([1, 2, "All"], name="a"),
+            columns=pd.Index(
+                [pd.Period("2019Q1"), pd.Period("2019Q2"), "All"], name="b"
+            ),
+        )
+
+        result = df.pivot_table(index="a", columns="b", values="x", margins=True)
+        tm.assert_frame_equal(expected, result)
+
     @pytest.mark.parametrize(
         "values",
         [

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -678,6 +678,7 @@ class TestPivotTable:
         tm.assert_frame_equal(pv, expected)
 
     def test_pivot_periods_with_margins(self):
+        # GH 28323
         df = DataFrame(
             {
                 "a": [1, 1, 2, 2],


### PR DESCRIPTION
closes #28323
closes #28337 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Adds a workaround to allow period indexes to be reindexed with non-period indexes.