### PR TITLE
Change conda channel order for Windows builds

### DIFF
--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -1,17 +1,15 @@
 name: pandas-dev
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   - blosc
   - bottleneck
-  - boost-cpp<1.67
   - fastparquet>=0.2.1
   - matplotlib=3.0.2
   - numexpr
   - numpy=1.15.*
   - openpyxl
-  - parquet-cpp
   - pyarrow
   - pytables
   - python-dateutil

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -238,6 +238,12 @@ def test_cross_engine_pa_fp(df_cross_compat, pa, fp):
 def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
     # cross-compat with differing reading/writing engines
 
+    if pyarrow.__version__.startswith("0.14"):
+        pytest.xfail(
+            "Reading fastparquet with pyarrow in 0.14 fails: "
+            "https://issues.apache.org/jira/browse/ARROW-6492"
+        )
+
     df = df_cross_compat
     with tm.ensure_clean() as path:
         df.to_parquet(path, engine=fp, compression=None)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -1,5 +1,6 @@
 """ test parquet compat """
 import datetime
+from distutils.version import LooseVersion
 import os
 from warnings import catch_warnings
 
@@ -238,7 +239,10 @@ def test_cross_engine_pa_fp(df_cross_compat, pa, fp):
 def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
     # cross-compat with differing reading/writing engines
 
-    if pyarrow.__version__.startswith("0.14"):
+    if (
+        LooseVersion(pyarrow.__version__) < "0.15"
+        and LooseVersion(pyarrow.__version__) >= "0.13"
+    ):
         pytest.xfail(
             "Reading fastparquet with pyarrow in 0.14 fails: "
             "https://issues.apache.org/jira/browse/ARROW-6492"


### PR DESCRIPTION
- [x] closes #28356
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
