### PR TITLE
TST: add test for #9107

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -118,7 +118,6 @@ Datetimelike
 - Bug in :meth:`pandas.core.groupby.SeriesGroupBy.nunique` where ``NaT`` values were interfering with the count of unique values (:issue:`27951`)
 - Bug in :class:`Timestamp` subtraction when subtracting a :class:`Timestamp` from a ``np.datetime64`` object incorrectly raising ``TypeError`` (:issue:`28286`)
 - Addition and subtraction of integer or integer-dtype arrays with :class:`Timestamp` will now raise ``NullFrequencyError`` instead of ``ValueError`` (:issue:`28268`)
-- New test to ensure OutOfBoundsDatetime exception is raised when calling :func:``pd.to_datetime`` with out-of-bounds date strings
 
 
 Timedelta

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -118,7 +118,7 @@ Datetimelike
 - Bug in :meth:`pandas.core.groupby.SeriesGroupBy.nunique` where ``NaT`` values were interfering with the count of unique values (:issue:`27951`)
 - Bug in :class:`Timestamp` subtraction when subtracting a :class:`Timestamp` from a ``np.datetime64`` object incorrectly raising ``TypeError`` (:issue:`28286`)
 - Addition and subtraction of integer or integer-dtype arrays with :class:`Timestamp` will now raise ``NullFrequencyError`` instead of ``ValueError`` (:issue:`28268`)
--
+- New test to ensure OutOfBoundsDatetime exception is raised when calling :func:``pd.to_datetime`` with out-of-bounds date strings
 
 
 Timedelta

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1028,6 +1028,12 @@ class TestToDatetime:
         result = pd.to_datetime(expected).to_datetime64()
         assert result == expected
 
+    @pytest.mark.parametrize("dt_str", ["00010101", "13000101", "30000101", "99990101"])
+    def test_old_date_out_of_bounds_exception(self, dt_str):
+        # GH 9107
+        with pytest.raises(OutOfBoundsDatetime):
+            pd.to_datetime(dt_str, format="%Y%m%d")
+
 
 class TestToDatetimeUnit:
     @pytest.mark.parametrize("cache", [True, False])

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1029,7 +1029,7 @@ class TestToDatetime:
         assert result == expected
 
     @pytest.mark.parametrize("dt_str", ["00010101", "13000101", "30000101", "99990101"])
-    def test_old_date_out_of_bounds_exception(self, dt_str):
+    def test_to_datetime_with_format_out_of_bounds(self, dt_str):
         # GH 9107
         with pytest.raises(OutOfBoundsDatetime):
             pd.to_datetime(dt_str, format="%Y%m%d")


### PR DESCRIPTION
test to ensure OutOfBoundsDatetime exception is raised when calling
pd.to_datetime with out-of-bounds date strings

As discussed briefly in #28367 

- [x] closes #9107 ? the issue is no longer truly reproducible, this PR adds a test around the new behaviour 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
