### PR TITLE
DEP: Bump Cython to 0.29.13

### DIFF
--- a/ci/deps/azure-35-compat.yaml
+++ b/ci/deps/azure-35-compat.yaml
@@ -18,7 +18,7 @@ dependencies:
   - xlsxwriter=0.9.8
   - xlwt=1.2.0
   # universal
-  - cython=0.28.2
+  - cython=0.29.13
   - hypothesis>=3.58.0
   - pytest-xdist
   - pytest-mock

--- a/ci/deps/azure-35-compat.yaml
+++ b/ci/deps/azure-35-compat.yaml
@@ -18,13 +18,13 @@ dependencies:
   - xlsxwriter=0.9.8
   - xlwt=1.2.0
   # universal
-  - cython=0.29.13
   - hypothesis>=3.58.0
   - pytest-xdist
   - pytest-mock
   - pytest-azurepipelines
   - pip
   - pip:
-    # for python 3.5, pytest>=4.0.2 is not available in conda
+    # for python 3.5, pytest>=4.0.2, cython>=0.29.13 is not available in conda
+    - cython>=0.29.13
     - pytest==4.5.0
     - html5lib==1.0b2

--- a/ci/deps/azure-36-32bit.yaml
+++ b/ci/deps/azure-36-32bit.yaml
@@ -19,4 +19,4 @@ dependencies:
   - pip
   - pip:
     # Anaconda doesn't build a new enough Cython
-    - cython=0.29.13
+    - cython>=0.29.13

--- a/ci/deps/azure-36-32bit.yaml
+++ b/ci/deps/azure-36-32bit.yaml
@@ -6,7 +6,6 @@ dependencies:
   - gcc_linux-32
   - gcc_linux-32
   - gxx_linux-32
-  - cython=0.29.13
   - numpy=1.14.*
   - python-dateutil
   - python=3.6.*
@@ -18,3 +17,6 @@ dependencies:
   - pytest-azurepipelines
   - hypothesis>=3.58.0
   - pip
+  - pip:
+    # Anaconda doesn't build a new enough Cython
+    - cython=0.29.13

--- a/ci/deps/azure-36-32bit.yaml
+++ b/ci/deps/azure-36-32bit.yaml
@@ -6,7 +6,7 @@ dependencies:
   - gcc_linux-32
   - gcc_linux-32
   - gxx_linux-32
-  - cython=0.28.2
+  - cython=0.29.13
   - numpy=1.14.*
   - python-dateutil
   - python=3.6.*

--- a/ci/deps/azure-36-locale.yaml
+++ b/ci/deps/azure-36-locale.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - beautifulsoup4==4.6.0
   - bottleneck=1.2.*
-  - cython=0.28.2
+  - cython=0.29.13
   - lxml
   - matplotlib=2.2.2
   - numpy=1.14.*

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - beautifulsoup4
-  - cython>=0.28.2
+  - cython>=0.29.13
   - gcsfs
   - html5lib
   - ipython

--- a/ci/deps/azure-37-locale.yaml
+++ b/ci/deps/azure-37-locale.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - beautifulsoup4
-  - cython>=0.28.2
+  - cython>=0.29.13
   - html5lib
   - ipython
   - jinja2

--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.7.*
   - pytz
-  - Cython>=0.28.2
+  - Cython>=0.29.13
   # universal
   # pytest < 5 until defaults has pytest-xdist>=1.29.0
   - pytest>=4.0.2,<5.0

--- a/ci/deps/azure-macos-35.yaml
+++ b/ci/deps/azure-macos-35.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - beautifulsoup4
   - bottleneck
-  - cython>=0.28.2
+  - cython>=0.29.13
   - html5lib
   - jinja2
   - lxml

--- a/ci/deps/azure-macos-35.yaml
+++ b/ci/deps/azure-macos-35.yaml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - beautifulsoup4
   - bottleneck
-  - cython>=0.29.13
   - html5lib
   - jinja2
   - lxml
@@ -24,6 +23,8 @@ dependencies:
   - xlwt
   - pip
   - pip:
+    # Anaconda / conda-forge don't build for 3.5
+    - cython>=0.29.13
     - pyreadstat
     # universal
     - pytest>=5.0.1
@@ -32,4 +33,3 @@ dependencies:
     - hypothesis>=3.58.0
     # https://github.com/pandas-dev/pandas/issues/27421
     - pytest-azurepipelines<1.0.0
-

--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -20,7 +20,7 @@ dependencies:
   - xlsxwriter
   - xlwt
   # universal
-  - cython>=0.28.2
+  - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.29.0
   - pytest-mock

--- a/ci/deps/azure-windows-37.yaml
+++ b/ci/deps/azure-windows-37.yaml
@@ -25,7 +25,7 @@ dependencies:
   - xlsxwriter
   - xlwt
   # universal
-  - cython>=0.28.2
+  - cython>=0.29.13
   - pytest>=5.0.0
   - pytest-xdist>=1.29.0
   - pytest-mock

--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - beautifulsoup4
   - botocore>=1.11
-  - cython>=0.28.2
+  - cython>=0.29.13
   - dask
   - fastparquet>=0.2.1
   - gcsfs

--- a/ci/deps/travis-36-locale.yaml
+++ b/ci/deps/travis-36-locale.yaml
@@ -6,7 +6,7 @@ dependencies:
   - beautifulsoup4
   - blosc=1.14.3
   - python-blosc
-  - cython>=0.28.2
+  - cython>=0.29.13
   - fastparquet=0.2.1
   - gcsfs=0.2.2
   - html5lib

--- a/ci/deps/travis-36-slow.yaml
+++ b/ci/deps/travis-36-slow.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - beautifulsoup4
-  - cython>=0.28.2
+  - cython>=0.29.13
   - html5lib
   - lxml
   - matplotlib

--- a/ci/deps/travis-37.yaml
+++ b/ci/deps/travis-37.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3.7.*
   - botocore>=1.11
-  - cython>=0.28.2
+  - cython>=0.29.13
   - numpy
   - python-dateutil
   - nomkl

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - asv
 
   # building
-  - cython>=0.28.2
+  - cython>=0.29.13
 
   # code checks
   - black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ numpy>=1.15
 python-dateutil>=2.6.1
 pytz
 asv
-cython>=0.28.2
+cython>=0.29.13
 black
 cpplint
 flake8

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ def is_platform_mac():
 
 
 min_numpy_ver = "1.13.3"
+min_cython_ver = "0.29.13"
+
 setuptools_kwargs = {
     "install_requires": [
         "python-dateutil >= 2.6.1",
@@ -43,7 +45,6 @@ setuptools_kwargs = {
 }
 
 
-min_cython_ver = "0.28.2"
 try:
     import Cython
 


### PR DESCRIPTION
In preperation for Python 3.8, we need to ensure we compile the sdist
with new enough versions of Cython. This is the latest current release.

xref https://github.com/pandas-dev/pandas/issues/28341