### PR TITLE
Fix a `np.random.np.random` typo in "computation.rst" in document.

### DIFF
--- a/doc/source/user_guide/computation.rst
+++ b/doc/source/user_guide/computation.rst
@@ -182,7 +182,7 @@ assigned the mean of the ranks (by default) for the group:
 
 .. ipython:: python
 
-   s = pd.Series(np.random.np.random.randn(5), index=list('abcde'))
+   s = pd.Series(np.random.randn(5), index=list('abcde'))
    s['d'] = s['b']  # so there's a tie
    s.rank()
 
@@ -192,7 +192,7 @@ ranking.
 
 .. ipython:: python
 
-   df = pd.DataFrame(np.random.np.random.randn(10, 6))
+   df = pd.DataFrame(np.random.randn(10, 6))
    df[4] = df[2][:5]  # some ties
    df
    df.rank(1)


### PR DESCRIPTION
There's `np.random.np.random` in /doc/source/user_guide/computation.rst, which I believe is a typo. But the weird thing is there's actually `np.random.np` in numpy (1.16.4), but not in numpy (1.17.2). That's maybe why the doc build passed before. While I'm trying to build the doc locally with numpy 1.17.2, it failed.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
