### PR TITLE
ENH: MultiIndex.from_product infers names from inputs if not explicitly provided

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -28,7 +28,7 @@ Enhancements
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 
--
+- :meth:`MultiIndex.from_product` infers level names from inputs if not explicitly provided (:issue:`27292`)
 -
 
 .. _whatsnew_1000.api_breaking:

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -63,7 +63,7 @@ Other API changes
 ^^^^^^^^^^^^^^^^^
 
 - :meth:`pandas.api.types.infer_dtype` will now return "integer-na" for integer and ``np.nan`` mix (:issue:`27283`)
--
+- :meth:`MultiIndex.from_arrays` will no longer infer names from arrays if ``names=None`` is explicitly provided (:issue:`27292`)
 -
 
 .. _whatsnew_1000.deprecations:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -514,7 +514,7 @@ class MultiIndex(Index):
 
             ..versionchanged 1.0
 
-            If not explicitly provided, names will be inferred from the
+               If not explicitly provided, names will be inferred from the
                elements of iterables if an element has a name attribute
 
         Returns

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -512,6 +512,7 @@ class MultiIndex(Index):
         names : list / sequence of str, optional
             Names for the levels in the index. If not provided, these
             will be inferred from iterables if the iterable has a
+            name attribute.
 
         Returns
         -------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -511,8 +511,8 @@ class MultiIndex(Index):
             level).
         names : list / sequence of str, optional
             Names for the levels in the index. If not provided, these
-            will be inferred from iterables if the iterable has a
-            name attribute.
+            will be inferred from the elements of iterables if an element
+            has a name attribute
 
         Returns
         -------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -515,7 +515,7 @@ class MultiIndex(Index):
             ..versionchanged 1.0
 
             If not explicitly provided, names will be inferred from the
-            elements of iterables if an element has a name attribute
+               elements of iterables if an element has a name attribute
 
         Returns
         -------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -373,7 +373,7 @@ class MultiIndex(Index):
         return new_codes
 
     @classmethod
-    def from_arrays(cls, arrays, sortorder=None, names=None):
+    def from_arrays(cls, arrays, sortorder=None, names=_no_default_names):
         """
         Convert arrays to MultiIndex.
 
@@ -427,7 +427,7 @@ class MultiIndex(Index):
                 raise ValueError("all arrays must be same length")
 
         codes, levels = _factorize_from_iterables(arrays)
-        if names is None:
+        if names is _no_default_names:
             names = [getattr(arr, "name", None) for arr in arrays]
 
         return MultiIndex(
@@ -544,13 +544,10 @@ class MultiIndex(Index):
         elif is_iterator(iterables):
             iterables = list(iterables)
 
+        codes, levels = _factorize_from_iterables(iterables)
         if names is _no_default_names:
             names = [getattr(it, "name", None) for it in iterables]
 
-            if all(name is None for name in names):
-                names = None
-
-        codes, levels = _factorize_from_iterables(iterables)
         codes = cartesian_product(codes)
         return MultiIndex(levels, codes, sortorder=sortorder, names=names)
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -60,6 +60,8 @@ _index_doc_kwargs.update(
     dict(klass="MultiIndex", target_klass="MultiIndex or list of tuples")
 )
 
+_no_default_names = object()
+
 
 class MultiIndexUIntEngine(libindex.BaseMultiIndexCodesEngine, libindex.UInt64Engine):
     """
@@ -496,7 +498,7 @@ class MultiIndex(Index):
         return MultiIndex.from_arrays(arrays, sortorder=sortorder, names=names)
 
     @classmethod
-    def from_product(cls, iterables, sortorder=None, names=None):
+    def from_product(cls, iterables, sortorder=None, names=_no_default_names):
         """
         Make a MultiIndex from the cartesian product of multiple iterables.
 
@@ -508,7 +510,8 @@ class MultiIndex(Index):
             Level of sortedness (must be lexicographically sorted by that
             level).
         names : list / sequence of str, optional
-            Names for the levels in the index.
+            Names for the levels in the index. If not provided, these
+            will be inferred from iterables if the iterable has a
 
         Returns
         -------
@@ -540,6 +543,12 @@ class MultiIndex(Index):
             raise TypeError("Input must be a list / sequence of iterables.")
         elif is_iterator(iterables):
             iterables = list(iterables)
+
+        if names is _no_default_names:
+            names = [getattr(it, "name", None) for it in iterables]
+
+            if all(name is None for name in names):
+                names = None
 
         codes, levels = _factorize_from_iterables(iterables)
         codes = cartesian_product(codes)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -510,9 +510,12 @@ class MultiIndex(Index):
             Level of sortedness (must be lexicographically sorted by that
             level).
         names : list / sequence of str, optional
-            Names for the levels in the index. If not provided, these
-            will be inferred from the elements of iterables if an element
-            has a name attribute
+            Names for the levels in the index.
+
+            ..versionchanged 1.0
+
+            If not explicitly provided, names will be inferred from the
+            elements of iterables if an element has a name attribute
 
         Returns
         -------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -512,7 +512,7 @@ class MultiIndex(Index):
         names : list / sequence of str, optional
             Names for the levels in the index.
 
-            ..versionchanged 1.0
+            .. versionchanged:: 1.0.0
 
                If not explicitly provided, names will be inferred from the
                elements of iterables if an element has a name attribute

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -539,6 +539,41 @@ def test_from_product_iterator():
         MultiIndex.from_product(0)
 
 
+@pytest.mark.parametrize(
+    "a, b, expected_names",
+    [
+        (
+            pd.Series([1, 2, 3], name="foo"),
+            pd.Series(["a", "b"], name="bar"),
+            ["foo", "bar"],
+        ),
+        (pd.Series([1, 2, 3], name="foo"), ["a", "b"], ["foo", None]),
+        ([1, 2, 3], ["a", "b"], None),
+    ],
+)
+def test_from_product_infer_names(a, b, expected_names):
+    result = MultiIndex.from_product([a, b])
+    expected = MultiIndex(
+        levels=[[1, 2, 3], ["a", "b"]],
+        codes=[[0, 0, 1, 1, 2, 2], [0, 1, 0, 1, 0, 1]],
+        names=expected_names,
+    )
+    tm.assert_index_equal(result, expected)
+
+
+def test_from_product_respects_none_names():
+    a = pd.Series([1, 2, 3], name="foo")
+    b = pd.Series(["a", "b"], name="bar")
+
+    result = MultiIndex.from_product([a, b], names=None)
+    expected = MultiIndex(
+        levels=[[1, 2, 3], ["a", "b"]],
+        codes=[[0, 0, 1, 1, 2, 2], [0, 1, 0, 1, 0, 1]],
+        names=None,
+    )
+    tm.assert_index_equal(result, expected)
+
+
 def test_create_index_existing_name(idx):
 
     # GH11193, when an existing index is passed, and a new name is not

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -349,6 +349,7 @@ def test_from_arrays_different_lengths(idx1, idx2):
 
 
 def test_from_arrays_respects_none_names():
+    # GH27292
     a = pd.Series([1, 2, 3], name="foo")
     b = pd.Series(["a", "b", "c"], name="bar")
 
@@ -564,6 +565,7 @@ def test_from_product_iterator():
     ],
 )
 def test_from_product_infer_names(a, b, expected_names):
+    # GH27292
     result = MultiIndex.from_product([a, b])
     expected = MultiIndex(
         levels=[[1, 2, 3], ["a", "b"]],
@@ -574,6 +576,7 @@ def test_from_product_infer_names(a, b, expected_names):
 
 
 def test_from_product_respects_none_names():
+    # GH27292
     a = pd.Series([1, 2, 3], name="foo")
     b = pd.Series(["a", "b"], name="bar")
 

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -348,6 +348,18 @@ def test_from_arrays_different_lengths(idx1, idx2):
         MultiIndex.from_arrays([idx1, idx2])
 
 
+def test_from_arrays_respects_none_names():
+    a = pd.Series([1, 2, 3], name="foo")
+    b = pd.Series(["a", "b", "c"], name="bar")
+
+    result = MultiIndex.from_arrays([a, b], names=None)
+    expected = MultiIndex(
+        levels=[[1, 2, 3], ["a", "b", "c"]], codes=[[0, 1, 2], [0, 1, 2]], names=None
+    )
+
+    tm.assert_index_equal(result, expected)
+
+
 # ----------------------------------------------------------------------------
 # from_tuples
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
- [x] closes #27292
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Infers names in `MultiIndex.from_product`  and normalizes handing of `names=None` between `from_arrays` and `from_product`