### PR TITLE
BUG: inconsistency when passing dict to Series with index

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -348,6 +348,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         else:
             keys, values = [], []
 
+        # Check that keys and index are the same length so reindex does not drop rows
+        if index is not None and len(index) != len(keys):
+            raise ValueError(
+                "Length of passed values is {val}, "
+                "index implies {ind}".format(val=len(data), ind=len(index))
+            )
+
         # Input is now list-like, so rely on "standard" construction:
         s = Series(values, index=keys, dtype=dtype)
 


### PR DESCRIPTION
* Adds ValueError if passing a dict into pd.Series with a different size than the passed index parameter.  Closes #28418 



- [x] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

(Will add whatsnew / test if this solution is acceptable.)
