### PR TITLE
BUG: close hdf store on any error

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -727,6 +727,7 @@ I/O
 - Bug in :meth:`DataFrame.to_clipboard` which did not work reliably in ipython (:issue:`22707`)
 - Bug in :func:`read_json` where default encoding was not set to ``utf-8`` (:issue:`29565`)
 - Bug in :class:`PythonParser` where str and bytes were being mixed when dealing with the decimal field (:issue:`29650`)
+- :meth:`read_hdf` now closes the store on any error thrown (:issue:`28430`)
 -
 
 Plotting

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -426,15 +426,12 @@ def read_hdf(
             chunksize=chunksize,
             auto_close=auto_close,
         )
-    except (ValueError, TypeError, KeyError):
-        if not isinstance(path_or_buf, HDFStore):
-            # if there is an error, close the store if we opened it.
-            try:
-                store.close()
-            except AttributeError:
-                pass
-
-        raise
+    finally:
+        # if there is an error, close the store if we opened it.
+        try:
+            store.close()
+        except AttributeError:
+            pass
 
 
 def _is_metadata_of(group: "Node", parent_group: "Node") -> bool:


### PR DESCRIPTION
NOTE: I'm opening the PR mainly to open a discussion about the current behaviour. If this is intended, please tell me. If not and you need me to write some tests, I'll do it :)

In `read_hdf`, if the `store.select()` call throws either a
`ValueError`, a `TypeError` or a `KeyError` then the store is closed.

However, if any other exception is thrown (e.g. an `AssertionError` if
there are gaps in blocks ref_loc) , the store is not closed and some
client code could end up trying to reopen the store and hit an
error like: `the file XXX is already opened. Please close it before
reopening in write mode`. Furthermore, the exception is re-raised in all
cases.

This commit just catches any exception.

Closes #28430 

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
