### PR TITLE
BUG: Fix merging non-indexes causes Index dtype promotion in when keys are missing

### DIFF
--- a/doc/source/whatsnew/v0.25.4.rst
+++ b/doc/source/whatsnew/v0.25.4.rst
@@ -1,0 +1,6 @@
+
+Reshaping
+^^^^^^^^^
+
+- Added new option to allow user to specify NA value for certain joins when missing keys when not using left_index when how='right', or right_index when how='left' causing dtype promotion (:issue:`28220`).
+

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -230,6 +230,12 @@ validate : str, optional
 
     .. versionadded:: 0.21.0
 
+index_na_value : value, optional
+    If a join requires NA values to be placed in the index use this value or
+    accept the default NA for the dtype which may involve a type promotion
+
+    .. versionadded:: 0.25.2
+
 Returns
 -------
 DataFrame


### PR DESCRIPTION
... from left or right side. (GH28220)
Also closes GH24897, GH24212, and GH17257

- [x] closes #28220, #24897, #24212, and #17257
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Probably requires a bit more cleanup and reduction of spaghetti... Not in love with the the solution (as it's quite similar to using both indexes) and requires extension test case changes, but hoping to get some comments and feedback on making it better.
