### PR TITLE
BUG: Don't cast categorical nan to int

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -110,7 +110,7 @@ Categorical
 ^^^^^^^^^^^
 
 - Added test to assert the :func:`fillna` raises the correct ValueError message when the value isn't a value from categories (:issue:`13628`)
-- Bug in :meth:`astype` where ``nans`` were handled incorrectly when casting to int (:issue:`28406`)
+- Bug in :meth:`Categorical.astype` where ``NaN`` values were handled incorrectly when casting to int (:issue:`28406`)
 -
 -
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -110,6 +110,7 @@ Categorical
 ^^^^^^^^^^^
 
 - Added test to assert the :func:`fillna` raises the correct ValueError message when the value isn't a value from categories (:issue:`13628`)
+- Bug in :meth:`astype` where ``nans`` were handled incorrectly  when casting to int (:issue:`28406`)
 -
 -
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -110,7 +110,7 @@ Categorical
 ^^^^^^^^^^^
 
 - Added test to assert the :func:`fillna` raises the correct ValueError message when the value isn't a value from categories (:issue:`13628`)
-- Bug in :meth:`astype` where ``nans`` were handled incorrectly  when casting to int (:issue:`28406`)
+- Bug in :meth:`astype` where ``nans`` were handled incorrectly when casting to int (:issue:`28406`)
 -
 -
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -520,7 +520,7 @@ class Categorical(ExtensionArray, PandasObject):
             if dtype == self.dtype:
                 return self
             return self._set_dtype(dtype)
-        if is_integer_dtype(dtype) and self.isin([np.nan, -np.inf, np.inf]).any():
+        if is_integer_dtype(dtype) and self.isna().any():
             msg = "Cannot cast to int."
             raise ValueError(msg)
         return np.array(self, dtype=dtype, copy=copy)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -520,7 +520,7 @@ class Categorical(ExtensionArray, PandasObject):
             if dtype == self.dtype:
                 return self
             return self._set_dtype(dtype)
-        if is_integer_dtype(dtype) and not np.isfinite(self.__array__()).all():
+        if is_integer_dtype(dtype) and self.isin([np.nan, -np.inf, np.inf]).any():
             msg = "Cannot cast to int."
             raise ValueError(msg)
         return np.array(self, dtype=dtype, copy=copy)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -520,7 +520,7 @@ class Categorical(ExtensionArray, PandasObject):
             if dtype == self.dtype:
                 return self
             return self._set_dtype(dtype)
-        if is_integer_dtype(dtype) and self.isin([np.nan, -np.inf, np.inf]).any():
+        if is_integer_dtype(dtype) and np.isfinite(self.__array__()).all():
             msg = "Cannot cast to int."
             raise ValueError(msg)
         return np.array(self, dtype=dtype, copy=copy)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -520,6 +520,9 @@ class Categorical(ExtensionArray, PandasObject):
             if dtype == self.dtype:
                 return self
             return self._set_dtype(dtype)
+        if is_integer_dtype(dtype) and self.isin([np.nan, -np.inf, np.inf]).any():
+            msg = "Cannot cast to int."
+            raise ValueError(msg)
         return np.array(self, dtype=dtype, copy=copy)
 
     @cache_readonly

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -520,7 +520,7 @@ class Categorical(ExtensionArray, PandasObject):
             if dtype == self.dtype:
                 return self
             return self._set_dtype(dtype)
-        if is_integer_dtype(dtype) and np.isfinite(self.__array__()).all():
+        if is_integer_dtype(dtype) and not np.isfinite(self.__array__()).all():
             msg = "Cannot cast to int."
             raise ValueError(msg)
         return np.array(self, dtype=dtype, copy=copy)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -521,7 +521,7 @@ class Categorical(ExtensionArray, PandasObject):
                 return self
             return self._set_dtype(dtype)
         if is_integer_dtype(dtype) and self.isna().any():
-            msg = "Cannot cast to int."
+            msg = "Cannot convert float NaN to integer"
             raise ValueError(msg)
         return np.array(self, dtype=dtype, copy=copy)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4731,7 +4731,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Guaranteed return of an indexer even when non-unique.
 
-        This dispatches to get_indexer or get_indexer_nonunique
+        This dispatches to get_indexer or get_indexer_non_unique
         as appropriate.
 
         Returns

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4718,7 +4718,7 @@ class Index(IndexOpsMixin, PandasObject):
             return pself.get_indexer_non_unique(ptarget)
 
         if is_categorical(target):
-            tgt_values = target.__array__()
+            tgt_values = np.asarray(target)
         elif self.is_all_dates:
             tgt_values = target.asi8
         else:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4713,6 +4713,9 @@ class Index(IndexOpsMixin, PandasObject):
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)
     def get_indexer_non_unique(self, target):
         target = ensure_index(target)
+        pself, ptarget = self._maybe_promote(target)
+        if pself is not self or ptarget is not target:
+            return pself.get_indexer_non_unique(ptarget)
 
         if is_categorical(target):
             tgt_values = target.__array__()

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4713,13 +4713,10 @@ class Index(IndexOpsMixin, PandasObject):
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)
     def get_indexer_non_unique(self, target):
         target = ensure_index(target)
-        if is_categorical(target):
-            target = target.astype(target.dtype.categories.dtype)
-        pself, ptarget = self._maybe_promote(target)
-        if pself is not self or ptarget is not target:
-            return pself.get_indexer_non_unique(ptarget)
 
-        if self.is_all_dates:
+        if is_categorical(target):
+            tgt_values = target.__array__()
+        elif self.is_all_dates:
             tgt_values = target.asi8
         else:
             tgt_values = target._ndarray_values

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import Categorical, CategoricalIndex
+from pandas import Categorical, CategoricalIndex, Timestamp
 from pandas.api.types import CategoricalDtype
 from pandas.tests.extension import base
 import pandas.util.testing as tm
@@ -198,9 +198,10 @@ class TestMethods(base.BaseMethodsTests):
 
 class TestCasting(base.BaseCastingTests):
     @pytest.mark.parametrize("cls", [Categorical, CategoricalIndex])
-    def test_cast_nan_to_int(self, cls):
+    @pytest.mark.parametrize("values", [[1, np.nan], [Timestamp("2000"), pd.NaT]])
+    def test_cast_nan_to_int(self, cls, values):
         # GH 28406
-        s = cls([0, 1, np.nan])
+        s = cls(values)
 
         msg = "Cannot (cast|convert)"
         with pytest.raises((ValueError, TypeError), match=msg):

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -200,9 +200,10 @@ class TestCasting(base.BaseCastingTests):
     @pytest.mark.parametrize("cls", [Categorical, CategoricalIndex])
     @pytest.mark.parametrize("value", [np.nan, -np.inf, np.inf])
     def test_cast_nan_to_int(self, cls, value):
+        # GH 28406
         s = cls([0, 1, value])
 
-        with pytest.raises((ValueError, TypeError)):
+        with pytest.raises((ValueError, TypeError), match="Cannot cast"):
             s.astype(int)
 
 

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -202,7 +202,8 @@ class TestCasting(base.BaseCastingTests):
         # GH 28406
         s = cls([0, 1, np.nan])
 
-        with pytest.raises((ValueError, TypeError), match="Cannot cast"):
+        msg = "Cannot (cast|convert)"
+        with pytest.raises((ValueError, TypeError), match=msg):
             s.astype(int)
 
 

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -198,10 +198,9 @@ class TestMethods(base.BaseMethodsTests):
 
 class TestCasting(base.BaseCastingTests):
     @pytest.mark.parametrize("cls", [Categorical, CategoricalIndex])
-    @pytest.mark.parametrize("value", [np.nan, -np.inf, np.inf])
-    def test_cast_nan_to_int(self, cls, value):
+    def test_cast_nan_to_int(self, cls):
         # GH 28406
-        s = cls([0, 1, value])
+        s = cls([0, 1, np.nan])
 
         with pytest.raises((ValueError, TypeError), match="Cannot cast"):
             s.astype(int)

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -202,7 +202,7 @@ class TestCasting(base.BaseCastingTests):
     def test_cast_nan_to_int(self, cls, value):
         s = cls([0, 1, value])
 
-        with pytest.raises(ValueError):
+        with pytest.raises((ValueError, TypeError)):
             s.astype(int)
 
 

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -197,14 +197,12 @@ class TestMethods(base.BaseMethodsTests):
 
 
 class TestCasting(base.BaseCastingTests):
-    def test_cast_nan_to_int(self):
-        s1 = pd.Series([0, 1, np.nan], dtype="category")
-        s2 = pd.Series([0, 1, np.inf], dtype="category")
+    @pytest.mark.parametrize("value", [np.nan, -np.inf, np.inf])
+    def test_cast_nan_to_int(self, value):
+        s = pd.Series([0, 1, value], dtype="category")
 
         with pytest.raises(ValueError):
-            s1.astype(int)
-        with pytest.raises(ValueError):
-            s2.astype(int)
+            s.astype(int)
 
 
 class TestArithmeticOps(base.BaseArithmeticOpsTests):

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import Categorical
+from pandas import Categorical, CategoricalIndex
 from pandas.api.types import CategoricalDtype
 from pandas.tests.extension import base
 import pandas.util.testing as tm
@@ -197,9 +197,10 @@ class TestMethods(base.BaseMethodsTests):
 
 
 class TestCasting(base.BaseCastingTests):
+    @pytest.mark.parametrize("cls", [Categorical, CategoricalIndex])
     @pytest.mark.parametrize("value", [np.nan, -np.inf, np.inf])
-    def test_cast_nan_to_int(self, value):
-        s = pd.Series([0, 1, value], dtype="category")
+    def test_cast_nan_to_int(self, cls, value):
+        s = cls([0, 1, value])
 
         with pytest.raises(ValueError):
             s.astype(int)

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -197,7 +197,14 @@ class TestMethods(base.BaseMethodsTests):
 
 
 class TestCasting(base.BaseCastingTests):
-    pass
+    def test_cast_nan_to_int(self):
+        s1 = pd.Series([0, 1, np.nan], dtype="category")
+        s2 = pd.Series([0, 1, np.inf], dtype="category")
+
+        with pytest.raises(ValueError):
+            s1.astype(int)
+        with pytest.raises(ValueError):
+            s2.astype(int)
 
 
 class TestArithmeticOps(base.BaseArithmeticOpsTests):


### PR DESCRIPTION
- [x] closes #28406
- [x] passes `black pandas`
- [x] tests added / passed
- [x] whatsnew entry

This raises an error when attempting to cast a `Categorical` or `CategoricalIndex` containing `nans` to an integer dtype.  Also had to remove the casting within `get_indexer_non_unique` since this won't always be possible.