### PR TITLE
TST: Fix makeObjectSeries data as object type

### DIFF
--- a/pandas/tests/series/conftest.py
+++ b/pandas/tests/series/conftest.py
@@ -26,7 +26,7 @@ def string_series():
 @pytest.fixture
 def object_series():
     """
-    Fixture for Series of dtype datetime64[ns] with Index of unique strings
+    Fixture for Series of dtype object with Index of unique strings
     """
     s = tm.makeObjectSeries()
     s.name = "objects"

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1854,10 +1854,10 @@ def makeStringSeries(name=None):
 
 
 def makeObjectSeries(name=None):
-    dateIndex = makeDateIndex(N)
-    dateIndex = Index(dateIndex, dtype=object)
+    data = makeStringIndex(N)
+    data = Index(data, dtype=object)
     index = makeStringIndex(N)
-    return Series(dateIndex, index=index, name=name)
+    return Series(data, index=index, name=name)
 
 
 def getSeriesData():


### PR DESCRIPTION
- [x] closes #28378 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
