### PR TITLE
DOC: fix docstring of core.comon.pipe (PR02)

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -445,7 +445,7 @@ def pipe(obj, func, *args, **kwargs):
 
     Parameters
     ----------
-    func : callable or tuple of (callable, string)
+    func : callable or tuple of (callable, str)
         Function to apply to this object or, alternatively, a
         ``(callable, data_keyword)`` tuple where ``data_keyword`` is a
         string indicating the keyword of `callable`` that expects the

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -451,9 +451,9 @@ def pipe(obj, func, *args, **kwargs):
         string indicating the keyword of `callable`` that expects the
         object.
     *args : iterable, optional
-        positional arguments passed into ``func``.
+        Positional arguments passed into ``func``.
     **kwargs : dict, optional
-        a dictionary of keyword arguments passed into ``func``.
+        A dictionary of keyword arguments passed into ``func``.
 
     Returns
     -------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -450,9 +450,9 @@ def pipe(obj, func, *args, **kwargs):
         ``(callable, data_keyword)`` tuple where ``data_keyword`` is a
         string indicating the keyword of `callable`` that expects the
         object.
-    args : iterable, optional
+    *args : iterable, optional
         positional arguments passed into ``func``.
-    kwargs : dict, optional
+    **kwargs : dict, optional
         a dictionary of keyword arguments passed into ``func``.
 
     Returns


### PR DESCRIPTION
Solves:
- Unknown parameters {kwargs, args}
- Parameter "func" type should use "str" instead of "string"
- Parameter "*args" description should start with a capital letter
- Parameter "**kwargs" description should start with a capital letter
- pandas.core.common.pipe : Unknown parameters {kwargs, args} in #27976 
