### PR TITLE
REF: Refactor sparse HDF5 read / write

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -69,7 +69,7 @@ Other API changes
 ^^^^^^^^^^^^^^^^^
 
 - :meth:`pandas.api.types.infer_dtype` will now return "integer-na" for integer and ``np.nan`` mix (:issue:`27283`)
-- :func:`read_hdf` now reads sparse values into a :class:`Series` or :class:`DataFrame` with sparse values rather than a ``SparseDataFrame`` or ``SparseSeries`` (:issue:``)
+- :func:`read_hdf` now reads sparse values into a :class:`Series` or :class:`DataFrame` with sparse values rather than a ``SparseDataFrame`` or ``SparseSeries`` (:issue:`28456`)
 -
 
 .. _whatsnew_1000.deprecations:

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -69,7 +69,7 @@ Other API changes
 ^^^^^^^^^^^^^^^^^
 
 - :meth:`pandas.api.types.infer_dtype` will now return "integer-na" for integer and ``np.nan`` mix (:issue:`27283`)
--
+- :func:`read_hdf` now reads sparse values into a :class:`Series` or :class:`DataFrame` with sparse values rather than a ``SparseDataFrame`` or ``SparseSeries`` (:issue:``)
 -
 
 .. _whatsnew_1000.deprecations:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -183,7 +183,7 @@ _STORER_MAP = {
     "series": "SeriesFixed",
     "sparse_series": "SeriesFixed",
     "frame": "FrameFixed",
-    "sparse_frame": "FrameFixed",
+    "sparse_frame": "SparseFrameFixed",
 }
 
 # table class map
@@ -2722,6 +2722,18 @@ class GenericFixed(Fixed):
 
     def read_array(self, key, start=None, stop=None):
         """ read an array for the specified node (off of group """
+        if (
+            self.pandas_type == "sparse_series" or "sp_index_length" in self.attrs
+        ) and key not in self.group:
+            # Compatibility for files written with pandas 0.25.1 and earlier.
+            if "sp_values" in self.group:
+                key = "sp_values"
+            dtype = "Sparse"
+            sp_index = self.read_index("sp_index".format(key))
+        else:
+            dtype = None
+            sp_index = None
+
         import tables
 
         node = getattr(self.group, key)
@@ -2732,7 +2744,7 @@ class GenericFixed(Fixed):
         if isinstance(node, tables.VLArray):
             ret = node[0][start:stop]
         else:
-            dtype = getattr(attrs, "value_type", None)
+            dtype = getattr(attrs, "value_type", dtype)
             shape = getattr(attrs, "shape", None)
 
             if shape is not None:
@@ -2754,7 +2766,8 @@ class GenericFixed(Fixed):
                     raise NotImplementedError(
                         "start and/or stop are not supported in fixed Sparse reading"
                     )
-                sp_index = self.read_index("{}_sp_index".format(key))
+                if sp_index is None:
+                    sp_index = self.read_index("{}_sp_index".format(key))
                 ret = SparseArray(
                     ret, sparse_index=sp_index, fill_value=self.attrs.fill_value
                 )
@@ -3079,10 +3092,10 @@ class SeriesFixed(GenericFixed):
         except (TypeError, AttributeError):
             return None
 
-    def read(self, **kwargs):
+    def read(self, key="values", **kwargs):
         kwargs = self.validate_read(kwargs)
         index = self.read_index("index", **kwargs)
-        values = self.read_array("values", **kwargs)
+        values = self.read_array(key, **kwargs)
         return Series(values, index=index, name=self.name)
 
     def write(self, obj, **kwargs):
@@ -3182,6 +3195,22 @@ class BlockManagerFixed(GenericFixed):
 class FrameFixed(BlockManagerFixed):
     pandas_kind = "frame"
     obj_type = DataFrame
+
+
+class SparseFrameFixed(GenericFixed):
+    pandas_kind = "sparse_frame"
+    attributes = ["default_kind", "default_fill_value"]
+
+    def read(self, **kwargs):
+        kwargs = self.validate_read(kwargs)
+        columns = self.read_index("columns")
+        sdict = {}
+        for c in columns:
+            key = "sparse_series_{columns}".format(columns=c)
+            s = SeriesFixed(self.parent, getattr(self.group, key))
+            s.infer_axes()
+            sdict[c] = s.read(key=key)
+        return DataFrame(sdict)
 
 
 class Table(Fixed):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2756,7 +2756,10 @@ class GenericFixed(Fixed):
                     )
                 sp_index = self.read_index("{}_sp_index".format(key))
                 ret = SparseArray(
-                    ret, sparse_index=sp_index, fill_value=self.attrs.fill_value
+                    ret,
+                    sparse_index=sp_index,
+                    fill_value=self.attrs["{}_fill_value".format(key)],
+                    kind=self.attrs["{}_kind".format(key)],
                 )
 
         if transposed:
@@ -3032,9 +3035,11 @@ class GenericFixed(Fixed):
                     self.write_index("{}_sp_index".format(key), value.sp_index)
                     self._handle.create_array(self.group, key, value.sp_values)
                     getattr(self.group, key)._v_attrs.value_type = "Sparse"
-                    self.attrs.fill_value = value.fill_value
-                    self.attrs.kind = value.kind
-                    self.attributes.extend(["fill_value", "kind"])
+                    setattr(self.attrs, "{}_fill_value".format(key), value.fill_value)
+                    setattr(self.attrs, "{}_kind".format(key), value.kind)
+                    self.attributes.extend(
+                        ["{}_fill_value".format(key), "{}_kind".format(key)]
+                    )
                 else:
                     self._handle.create_array(self.group, key, value)
 

--- a/pandas/tests/io/pytables/test_pytables.py
+++ b/pandas/tests/io/pytables/test_pytables.py
@@ -4883,6 +4883,29 @@ class TestHDFStore(Base):
             result = store["p"]
             assert_frame_equal(result, expected)
 
+    def test_read_legacy_sparse(self, datapath):
+        """
+        Generated with pandas 0.25.1 and
+
+        >>> s = pd.Series([1, None, 2, 3]).to_sparse()
+        >>> df = pd.DataFrame({"A": [1, None, 2, 3], "B": [1, 0, 0, 0]}).to_sparse()
+        >>> s.to_hdf("pandas/tests/io/data/legacy_hdf/legacy_sparse.h5", "series")
+        >>> df.to_hdf("pandas/tests/io/data/legacy_hdf/legacy_sparse.h5", "frame")
+        """
+        result = pd.read_hdf(
+            datapath("io", "data", "legacy_hdf", "legacy_sparse.h5"), "series"
+        )
+        expected = pd.Series(pd.SparseArray([1, None, 2, 3]))
+        tm.assert_series_equal(result, expected)
+
+        result = pd.read_hdf(
+            datapath("io", "data", "legacy_hdf", "legacy_sparse.h5"), "frame"
+        )
+        expected = pd.DataFrame(
+            {"A": pd.SparseArray([1, None, 2, 3]), "B": pd.SparseArray([1, 0, 0, 0])}
+        )
+        tm.assert_frame_equal(result, expected)
+
     @pytest.mark.parametrize("where", ["", (), (None,), [], [None]])
     def test_select_empty_where(self, where):
         # GH26610

--- a/pandas/tests/io/pytables/test_pytables.py
+++ b/pandas/tests/io/pytables/test_pytables.py
@@ -4883,29 +4883,6 @@ class TestHDFStore(Base):
             result = store["p"]
             assert_frame_equal(result, expected)
 
-    def test_read_legacy_sparse(self, datapath):
-        """
-        Generated with pandas 0.25.1 and
-
-        >>> s = pd.Series([1, None, 2, 3]).to_sparse()
-        >>> df = pd.DataFrame({"A": [1, None, 2, 3], "B": [1, 0, 0, 0]}).to_sparse()
-        >>> s.to_hdf("pandas/tests/io/data/legacy_hdf/legacy_sparse.h5", "series")
-        >>> df.to_hdf("pandas/tests/io/data/legacy_hdf/legacy_sparse.h5", "frame")
-        """
-        result = pd.read_hdf(
-            datapath("io", "data", "legacy_hdf", "legacy_sparse.h5"), "series"
-        )
-        expected = pd.Series(pd.SparseArray([1, None, 2, 3]))
-        tm.assert_series_equal(result, expected)
-
-        result = pd.read_hdf(
-            datapath("io", "data", "legacy_hdf", "legacy_sparse.h5"), "frame"
-        )
-        expected = pd.DataFrame(
-            {"A": pd.SparseArray([1, None, 2, 3]), "B": pd.SparseArray([1, 0, 0, 0])}
-        )
-        tm.assert_frame_equal(result, expected)
-
     @pytest.mark.parametrize("where", ["", (), (None,), [], [None]])
     def test_select_empty_where(self, where):
         # GH26610

--- a/pandas/tests/io/pytables/test_pytables.py
+++ b/pandas/tests/io/pytables/test_pytables.py
@@ -2373,6 +2373,17 @@ class TestHDFStore(Base):
         ss3 = s.apply(lambda x: pd.SparseArray(x, fill_value=0))
         self._check_double_roundtrip(ss3, tm.assert_frame_equal, check_frame_type=True)
 
+    def test_mixed_sparse_dense_frame(self):
+        df = pd.DataFrame(
+            {
+                "A": [0, 1, 2, 3],
+                "B": pd.SparseArray([0, 1, 2, 3], kind="block"),
+                "C": [0.0, 1.0, 2.0, 3.0],
+                "D": pd.SparseArray([0.0, 1.0, 2.0, 3.0], kind="integer"),
+            }
+        )
+        self._check_roundtrip(df, tm.assert_frame_equal)
+
     def test_float_index(self):
 
         # GH #454


### PR DESCRIPTION
In preparation for the removal of SparseSeries and SparseDataFrame, we
read into a Series[sparse] / DataFrame[sparse]. https://github.com/pandas-dev/pandas/pull/28425

cc @jreback @jorisvandenbossche.

I've just done the minimal amount to get this working. It may shed some light on how we can design an API for dispatching writing for 3rd party EAs (I think we should ask the EA for the values (arrays) to write, and the bits of extra metadata. Pandas should take care of the actual writing though. But that's for another day).