### PR TITLE
Build table schema version fix

### DIFF
--- a/doc/source/whatsnew/v0.25.2.rst
+++ b/doc/source/whatsnew/v0.25.2.rst
@@ -100,7 +100,7 @@ Other
 ^^^^^
 
 - Compatibility with Python 3.8 in :meth:`DataFrame.query` (:issue:`27261`)
--
+- Bug in `io.json.build_table_schema` always returned version 0.20.0 regardless of Pandas version (:issue: `28455`)
 
 .. _whatsnew_0.252.contributors:
 

--- a/pandas/io/json/_table_schema.py
+++ b/pandas/io/json/_table_schema.py
@@ -19,6 +19,7 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype,
 )
 
+import pandas
 from pandas import DataFrame
 from pandas.api.types import CategoricalDtype
 import pandas.core.common as com
@@ -264,7 +265,7 @@ def build_table_schema(data, index=True, primary_key=None, version=True):
         schema["primaryKey"] = primary_key
 
     if version:
-        schema["pandas_version"] = "0.20.0"
+        schema["pandas_version"] = pandas.__version__
     return schema
 
 


### PR DESCRIPTION
- [x] Issue #28455 
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
