### PR TITLE
ENH: Explode multiple columns of DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6207,8 +6207,7 @@ class DataFrame(NDFrame):
 
     def explode(self, columns: Union[str, List[str]]) -> "DataFrame":
         """
-        Transform each element of a list-like to a row, replicating the
-        index values.
+        Transform each element of a list-like to a row, replicating the index values.
 
         .. versionadded:: 0.25.0
 
@@ -6230,8 +6229,8 @@ class DataFrame(NDFrame):
         See Also
         --------
         DataFrame.unstack : Pivot a level of the (necessarily hierarchical)
-            index labels
-        DataFrame.melt : Unpivot a DataFrame from wide format to long format
+            index labels.
+        DataFrame.melt : Unpivot a DataFrame from wide format to long format.
         Series.explode : Explode a DataFrame from list-like columns to long format.
 
         Notes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6269,7 +6269,7 @@ class DataFrame(NDFrame):
         0  [1, 2, 3]  1  [7, 8, 9]
         1        foo  1        bar
         2         []  1         []
-        3     [3, 4]  1     [8, 7]        
+        3     [3, 4]  1     [8, 7]
 
         >>> df.explode(['A','C'])
            B    A    C
@@ -6295,7 +6295,7 @@ class DataFrame(NDFrame):
         if not all([c in self.columns for c in columns]):
             raise ValueError("column name(s) not in index")
 
-        tmp = self.iloc[0:0, 0:0].copy() # creates empty temp df
+        tmp = self.iloc[0:0, 0:0].copy()  # creates empty temp df
         lengths_equal = []
 
         for row in self[columns].iterrows():
@@ -6311,7 +6311,7 @@ class DataFrame(NDFrame):
             for c in columns:
                 tmp[c] = self[c].explode()
         else:
-            e = "Elements from `columns` do not have equivalent length within in the same row"
+            e = "Elements in `columns` do not have equal length in the same row"
             raise ValueError(e)
 
         # join in exploded columns

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6261,7 +6261,7 @@ class DataFrame(NDFrame):
         3    3  1
         3    4  1
 
-        >>> df = pd.DataFrame({'A': [[1, 2, 3], 'foo', [], [3, 4]], 
+        >>> df = pd.DataFrame({'A': [[1, 2, 3], 'foo', [], [3, 4]],
                                'B': 1,
                                'C': [[7,8,9],'bar',[],[8,7]]})
         >>> df
@@ -6270,8 +6270,8 @@ class DataFrame(NDFrame):
         1        foo  1        bar
         2         []  1         []
         3     [3, 4]  1     [8, 7]        
-        
-        >>> df.explode(['A','C'])        
+
+        >>> df.explode(['A','C'])
            B    A    C
         0  1    1    7
         0  1    2    8
@@ -6279,7 +6279,7 @@ class DataFrame(NDFrame):
         1  1  foo  bar
         2  1  NaN  NaN
         3  1    3    8
-        3  1    4    7        
+        3  1    4    7
         """
 
         # Validate data
@@ -6295,23 +6295,24 @@ class DataFrame(NDFrame):
         if not all([c in self.columns for c in columns]):
             raise ValueError("column name(s) not in index")
 
-        tmp = self.iloc[0:0,0:0].copy() # creates empty temp df
+        tmp = self.iloc[0:0, 0:0].copy() # creates empty temp df
         lengths_equal = []
 
         for row in self[columns].iterrows():
             # converts non-lists into 1 element lists so len() is valid
-            r=row[1].apply(lambda x: x if type(x) in (list,tuple) else [x]) 
-            
+            r = row[1].apply(lambda x: x if type(x) in (list, tuple) else [x])
+
             # make sure all lists in the same record are the same length
             row_is_ok = len(set([len(r[c]) for c in columns])) == 1
-            lengths_equal.append(row_is_ok) 
+            lengths_equal.append(row_is_ok)
 
         # Explode all columns if lengths match
         if all(lengths_equal):
             for c in columns:
                 tmp[c] = self[c].explode()
         else:
-            raise ValueError("Exploded lists from `columns` do not have equivalent length within the same record")
+            e = "Elements from `columns` do not have equivalent length within in the same row"
+            raise ValueError(e)
 
         # join in exploded columns
         results = self.drop(columns, axis=1).join(tmp)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6298,7 +6298,7 @@ class DataFrame(NDFrame):
         lengths_equal = []
         
         for row in self[columns].iterrows():
-            # converts non-lists into 1 element lists
+            # converts non-lists into 1 element lists so len() is valid
             r=row[1].apply(lambda x: x if type(x) in (list,tuple) else [x]) 
             
             # make sure all lists in the same record are the same length

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6310,7 +6310,7 @@ class DataFrame(NDFrame):
             for c in columns:
                 tmp[c] = self[c].explode()
         else:
-            raise ValueError("lengths of lists in the same row not equal")
+            raise ValueError("Exploded lists from `columns` do not have equivalent length within the same record")
         
         # join in exploded columns
         results = self.drop(columns, axis=1).join(tmp)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6207,14 +6207,15 @@ class DataFrame(NDFrame):
 
     def explode(self, columns: Union[str, List[str]]) -> "DataFrame":
         """
-        Transform each element of a list-like to a row, replicating the index values.
+        Transform each element of a list-like to a row, replicating index values.
 
         .. versionadded:: 0.25.0
 
         Parameters
         ----------
-        column : str or tuple
-
+        columns : str or list
+            the column(s) to be exploded
+            
         Returns
         -------
         DataFrame

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6215,7 +6215,7 @@ class DataFrame(NDFrame):
         ----------
         columns : str or list
             the column(s) to be exploded
-            
+
         Returns
         -------
         DataFrame
@@ -6281,23 +6281,23 @@ class DataFrame(NDFrame):
         3  1    3    8
         3  1    4    7        
         """
-        
+
         # Validate data
         if not self.columns.is_unique:
             raise ValueError("columns must be unique")
-        
+
         if isinstance(columns, str):
             columns = [columns]
-        
+
         if not isinstance(columns, list):
             raise TypeError("columns value not list or sting")
-            
+
         if not all([c in self.columns for c in columns]):
             raise ValueError("column name(s) not in index")
-        
+
         tmp = self.iloc[0:0,0:0].copy() # creates empty temp df
         lengths_equal = []
-        
+
         for row in self[columns].iterrows():
             # converts non-lists into 1 element lists so len() is valid
             r=row[1].apply(lambda x: x if type(x) in (list,tuple) else [x]) 
@@ -6305,14 +6305,14 @@ class DataFrame(NDFrame):
             # make sure all lists in the same record are the same length
             row_is_ok = len(set([len(r[c]) for c in columns])) == 1
             lengths_equal.append(row_is_ok) 
-            
+
         # Explode all columns if lengths match
         if all(lengths_equal):
             for c in columns:
                 tmp[c] = self[c].explode()
         else:
             raise ValueError("Exploded lists from `columns` do not have equivalent length within the same record")
-        
+
         # join in exploded columns
         results = self.drop(columns, axis=1).join(tmp)
         return(results)


### PR DESCRIPTION
Now .explode() can take a list of column names and will explode multiple at the same time (given that each element across all the columns have the same length in every single row
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
