### PR TITLE
BUG: Raise when casting infinity to int

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -174,7 +174,7 @@ Indexing
 - Bug in assignment using a reverse slicer (:issue:`26939`)
 - Bug in reindexing a :meth:`PeriodIndex` with another type of index that contained a `Period` (:issue:`28323`) (:issue:`28337`)
 - Fix assignment of column via `.loc` with numpy non-ns datetime type (:issue:`27395`)
-- Bug in :meth:`Float64Index.astype` where ``np.inf`` was not handled properly when casting to an integer dtype
+- Bug in :meth:`Float64Index.astype` where ``np.inf`` was not handled properly when casting to an integer dtype (:issue:`28475`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -174,6 +174,7 @@ Indexing
 - Bug in assignment using a reverse slicer (:issue:`26939`)
 - Bug in reindexing a :meth:`PeriodIndex` with another type of index that contained a `Period` (:issue:`28323`) (:issue:`28337`)
 - Fix assignment of column via `.loc` with numpy non-ns datetime type (:issue:`27395`)
+- Bug in :meth:`Float64Index.astype` where ``np.inf`` was not handled properly when casting to an integer dtype
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -367,12 +367,13 @@ class Float64Index(NumericIndex):
                 "values are required for conversion"
             ).format(dtype=dtype)
             raise TypeError(msg)
-        elif (
-            is_integer_dtype(dtype) and not is_extension_array_dtype(dtype)
-        ) and self.hasnans:
+        elif is_integer_dtype(dtype) and not is_extension_array_dtype(dtype):
             # TODO(jreback); this can change once we have an EA Index type
             # GH 13149
-            raise ValueError("Cannot convert NA to integer")
+            if self.hasnans:
+                raise ValueError("Cannot convert NA to integer")
+            elif not np.isfinite(self).all():
+                raise ValueError("Cannot convert infinity to integer")
         return super().astype(dtype, copy=copy)
 
     @Appender(_index_shared_docs["_convert_scalar_indexer"])

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -5,6 +5,7 @@ import numpy as np
 from pandas._libs import index as libindex
 from pandas.util._decorators import Appender, cache_readonly
 
+from pandas.core.dtypes.cast import astype_nansafe
 from pandas.core.dtypes.common import (
     is_bool,
     is_bool_dtype,
@@ -370,10 +371,8 @@ class Float64Index(NumericIndex):
         elif is_integer_dtype(dtype) and not is_extension_array_dtype(dtype):
             # TODO(jreback); this can change once we have an EA Index type
             # GH 13149
-            if self.hasnans:
-                raise ValueError("Cannot convert NA to integer")
-            elif not np.isfinite(self).all():
-                raise ValueError("Cannot convert infinity to integer")
+            arr = astype_nansafe(self.values, dtype=dtype)
+            return Int64Index(arr)
         return super().astype(dtype, copy=copy)
 
     @Appender(_index_shared_docs["_convert_scalar_indexer"])

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -143,7 +143,7 @@ class TestFloatSubtype(Base):
         tm.assert_index_equal(result, expected)
 
         # raises with NA
-        msg = "Cannot convert NA to integer"
+        msg = r"Cannot convert non-finite values \(NA or inf\) to integer"
         with pytest.raises(ValueError, match=msg):
             index.insert(0, np.nan).astype(dtype)
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -242,14 +242,15 @@ class TestFloat64Index(Numeric):
         # GH 13149
         for dtype in ["int16", "int32", "int64"]:
             i = Float64Index([0, 1.1, np.NAN])
-            msg = "Cannot convert NA to integer"
+            msg = r"Cannot convert non-finite values \(NA or inf\) to integer"
             with pytest.raises(ValueError, match=msg):
                 i.astype(dtype)
 
     def test_cannot_cast_inf_to_int(self):
         idx = pd.Float64Index([1, 2, np.inf])
 
-        with pytest.raises(ValueError, match="Cannot convert infinity to integer"):
+        msg = r"Cannot convert non-finite values \(NA or inf\) to integer"
+        with pytest.raises(ValueError, match=msg):
             idx.astype(int)
 
     def test_type_coercion_fail(self, any_int_dtype):

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -246,6 +246,12 @@ class TestFloat64Index(Numeric):
             with pytest.raises(ValueError, match=msg):
                 i.astype(dtype)
 
+    def test_cannot_cast_inf_to_int(self):
+        idx = pd.Float64Index([1, 2, np.inf])
+
+        with pytest.raises(ValueError, match="Cannot convert infinity to integer"):
+            idx.astype(int)
+
     def test_type_coercion_fail(self, any_int_dtype):
         # see gh-15832
         msg = "Trying to coerce float values to integers"


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] whatsnew entry

Raises a `ValueError` when attempting to cast a `Float64Index` with infinite values to a (non-`ExtensionArray`) integer dtype.  Currently this returns a garbage value:

```
idx                                                               
# Float64Index([1.0, 2.0, inf], dtype='float64')
idx.astype(int)                                                   
# Int64Index([1, 2, -9223372036854775808], dtype='int64')
```

Related PR: https://github.com/pandas-dev/pandas/pull/28438