### PR TITLE
CI: Check for whitespaces before class

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -190,9 +190,8 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -R --include="*.rst" ".. ipython ::" doc/source
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
-    # Check for blank lines after the class definition
     MSG='Check for extra blank lines after the class definition' ; echo $MSG
-    invgrep -R --include="*.py" --include="*.pyx" -E 'class.*:\n\n( )+"""' doc/source/
+    invgrep -R --include="*.py" --include="*.pyx" -E 'class.*:\n\n( )+"""' .
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Check that no file in the repo contains trailing whitespaces' ; echo $MSG

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -190,6 +190,11 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -R --include="*.rst" ".. ipython ::" doc/source
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
+    # Check for blank lines after the class definition
+    MSG='Check for extra blank lines after the class definition' ; echo $MSG
+    invgrep -R --include="*.py" --include="*.pyx" -E 'class.*:\n\n( )+"""' doc/source/
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
+
     MSG='Check that no file in the repo contains trailing whitespaces' ; echo $MSG
     set -o pipefail
     if [[ "$AZURE" == "true" ]]; then


### PR DESCRIPTION
xref #28209, https://github.com/python-sprints/pandas-mentoring/issues/161

Validate that we use
```python
class Foo:
    """
    Doc.
    """
    pass
```
instead of:
```python
class Bar:

    """
    Doc.
    """
    pass
```
(note the blank line between `class  Bar:` and the docstring.