### PR TITLE
TST: added a test case for special character in file name

### DIFF
--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2167,7 +2167,7 @@ def test_suppress_error_output(all_parsers, capsys):
     compat.is_platform_windows() and not compat.PY36,
     reason="On Python < 3.6 won't pass on Windows",
 )
-@pytest.mark.parametrize("filename", ["sé-es-vé.csv", "ru-sй.csv"])
+@pytest.mark.parametrize("filename", ["sé-es-vé.csv", "ru-sй.csv", "中文文件名.csv"])
 def test_filename_with_special_chars(all_parsers, filename):
     # see gh-15086.
     parser = all_parsers


### PR DESCRIPTION
Added special character use case in the existing function "test_filename_with_special_chars"

- [x] closes #26074 
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
