### PR TITLE
BUG: fix array_equivalent with mismatched tzawareness

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -445,8 +445,14 @@ def array_equivalent(left, right, strict_nan=False):
                 if not isinstance(right_value, float) or not np.isnan(right_value):
                     return False
             else:
-                if np.any(left_value != right_value):
-                    return False
+                try:
+                    if np.any(left_value != right_value):
+                        return False
+                except TypeError as err:
+                    if "Cannot compare tz-naive" in str(err):
+                        # tzawareness compat failure, see GH#28507
+                        return False
+                    raise
         return True
 
     # NaNs can occur in float and complex arrays.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4324,12 +4324,9 @@ class Index(IndexOpsMixin, PandasObject):
             # if other is not object, use other's logic for coercion
             return other.equals(self)
 
-        try:
-            return array_equivalent(
-                com.values_from_object(self), com.values_from_object(other)
-            )
-        except Exception:
-            return False
+        return array_equivalent(
+            com.values_from_object(self), com.values_from_object(other)
+        )
 
     def identical(self, other):
         """

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -332,10 +332,26 @@ def test_array_equivalent():
     assert not array_equivalent(DatetimeIndex([0, np.nan]), TimedeltaIndex([0, np.nan]))
 
 
-def test_array_equivalent_tzawareness():
+@pytest.mark.parametrize(
+    "lvalue",
+    [
+        pd.Timestamp.now(),
+        pd.Timestamp.now().to_datetime64(),
+        pd.Timestamp.now().to_pydatetime(),
+    ],
+)
+@pytest.mark.parametrize(
+    "rvalue",
+    [
+        pd.Timestamp.now("UTC"),
+        pd.Timestamp.now().to_datetime64(),
+        pd.Timestamp.now("UTC").to_pydatetime(),
+    ],
+)
+def test_array_equivalent_tzawareness(lvalue, rvalue):
     # we shouldn't raise if comparing tzaware and tznaive datetimes
-    left = np.array([pd.Timestamp.now()], dtype=object)
-    right = np.array([pd.Timestamp.now("UTC")], dtype=object)
+    left = np.array([lvalue], dtype=object)
+    right = np.array([rvalue], dtype=object)
 
     assert not array_equivalent(left, right, strict_nan=True)
     assert not array_equivalent(left, right, strict_nan=False)

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -332,6 +332,15 @@ def test_array_equivalent():
     assert not array_equivalent(DatetimeIndex([0, np.nan]), TimedeltaIndex([0, np.nan]))
 
 
+def test_array_equivalent_tzawareness():
+    # we shouldn't raise if comparing tzaware and tznaive datetimes
+    left = np.array([pd.Timestamp.now()], dtype=object)
+    right = np.array([pd.Timestamp.now("UTC")], dtype=object)
+
+    assert not array_equivalent(left, right, strict_nan=True)
+    assert not array_equivalent(left, right, strict_nan=False)
+
+
 def test_array_equivalent_compat():
     # see gh-13388
     m = np.array([(1, 2), (3, 4)], dtype=[("a", int), ("b", float)])

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -25,6 +25,9 @@ import pandas as pd
 from pandas import DatetimeIndex, Float64Index, NaT, Series, TimedeltaIndex, date_range
 from pandas.util import testing as tm
 
+now = pd.Timestamp.now()
+utcnow = pd.Timestamp.now("UTC")
+
 
 @pytest.mark.parametrize("notna_f", [notna, notnull])
 def test_notna_notnull(notna_f):
@@ -333,19 +336,17 @@ def test_array_equivalent():
 
 
 @pytest.mark.parametrize(
-    "lvalue",
+    "lvalue, rvalue",
     [
-        pd.Timestamp.now(),
-        pd.Timestamp.now().to_datetime64(),
-        pd.Timestamp.now().to_pydatetime(),
-    ],
-)
-@pytest.mark.parametrize(
-    "rvalue",
-    [
-        pd.Timestamp.now("UTC"),
-        pd.Timestamp.now().to_datetime64(),
-        pd.Timestamp.now("UTC").to_pydatetime(),
+        # There are 3 variants for each of lvalue and rvalue. We include all
+        #  three for the tz-naive `now` and exclude the datetim64 variant
+        #  for utcnow because it drops tzinfo.
+        (now, utcnow),
+        (now.to_datetime64(), utcnow),
+        (now.to_pydatetime(), utcnow),
+        (now, utcnow),
+        (now.to_datetime64(), utcnow.to_pydatetime()),
+        (now.to_pydatetime(), utcnow.to_pydatetime()),
     ],
 )
 def test_array_equivalent_tzawareness(lvalue, rvalue):


### PR DESCRIPTION
Some of this can be simplified if we change the behavior discussed in #28507.