### PR TITLE
TST: suppress 1485 warnings issued by xml parser

### DIFF
--- a/pandas/tests/io/excel/__init__.py
+++ b/pandas/tests/io/excel/__init__.py
@@ -1,0 +1,6 @@
+import pytest
+
+pytestmark = pytest.mark.filterwarnings(
+    # Looks like tree.getiterator is deprecated in favor of tree.iter
+    "ignore:This method will be removed in future versions:PendingDeprecationWarning"
+)


### PR DESCRIPTION
So we don't have to scroll through tons of 

```
pandas/tests/io/excel/test_xlrd.py::test_excel_table_sheet_by_index[.xlsm]
  /usr/local/lib/python3.7/site-packages/xlrd/xlsx.py:312: PendingDeprecationWarning: This method will be removed in future versions.  Use 'tree.iter()' or 'list(tree.iter())' instead.
    for elem in self.tree.iter() if Element_has_iter else self.tree.getiterator():
```