### PR TITLE
REF: Parametrize test

### DIFF
--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -528,32 +528,33 @@ class TestBlockManager:
         assert mgr.get("g").dtype == "datetime64[ns, CET]"
         assert mgr.as_array().dtype == "object"
 
-    def test_astype(self):
+    @pytest.mark.parametrize("t", ["float16", "float32", "float64", "int32", "int64"])
+    def test_astype(self, t):
         # coerce all
         mgr = create_mgr("c: f4; d: f2; e: f8")
-        for t in ["float16", "float32", "float64", "int32", "int64"]:
-            t = np.dtype(t)
-            tmgr = mgr.astype(t)
-            assert tmgr.get("c").dtype.type == t
-            assert tmgr.get("d").dtype.type == t
-            assert tmgr.get("e").dtype.type == t
+
+        t = np.dtype(t)
+        tmgr = mgr.astype(t)
+        assert tmgr.get("c").dtype.type == t
+        assert tmgr.get("d").dtype.type == t
+        assert tmgr.get("e").dtype.type == t
 
         # mixed
         mgr = create_mgr("a,b: object; c: bool; d: datetime; e: f4; f: f2; g: f8")
-        for t in ["float16", "float32", "float64", "int32", "int64"]:
-            t = np.dtype(t)
-            tmgr = mgr.astype(t, errors="ignore")
-            assert tmgr.get("c").dtype.type == t
-            assert tmgr.get("e").dtype.type == t
-            assert tmgr.get("f").dtype.type == t
-            assert tmgr.get("g").dtype.type == t
 
-            assert tmgr.get("a").dtype.type == np.object_
-            assert tmgr.get("b").dtype.type == np.object_
-            if t != np.int64:
-                assert tmgr.get("d").dtype.type == np.datetime64
-            else:
-                assert tmgr.get("d").dtype.type == t
+        t = np.dtype(t)
+        tmgr = mgr.astype(t, errors="ignore")
+        assert tmgr.get("c").dtype.type == t
+        assert tmgr.get("e").dtype.type == t
+        assert tmgr.get("f").dtype.type == t
+        assert tmgr.get("g").dtype.type == t
+
+        assert tmgr.get("a").dtype.type == np.object_
+        assert tmgr.get("b").dtype.type == np.object_
+        if t != np.int64:
+            assert tmgr.get("d").dtype.type == np.datetime64
+        else:
+            assert tmgr.get("d").dtype.type == t
 
     def test_convert(self):
         def _compare(old_mgr, new_mgr):


### PR DESCRIPTION
Let me know if I'm mistaken here, but I think we would prefer parametrization over for loops inside tests (e.g., so `pytest` flags which case is failing), and this should be equivalent.