### PR TITLE
DEV: skip pandas/__init__.py in isort's pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
     hooks:
     -   id: isort
         language: python_venv
-        exclude: ^pandas/__init__\.py$
+        exclude: ^pandas/__init__\.py$|^pandas/core/api\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,4 @@ repos:
     hooks:
     -   id: isort
         language: python_venv
+        exclude: ^pandas/__init__\.py$


### PR DESCRIPTION
I noticed that when you modified `pandas/__init__.py`, isort actually completely reordered it when using pre-commit hook. Apparantly, isort ignores the skip config when you explicitly pass a path to isort (pre-commit basically does `isort pandas/__init__.py` when that file changed).

See https://github.com/pre-commit/mirrors-isort/issues/9, which suggested to add this exclude to the pre-commit config (although that duplicates the "skip" information from setup.cfg)