### PR TITLE
WEB: Fix deployment of the website

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,7 @@ jobs:
           eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
   - script: |
-      cd doc/build/html
+      cd to_deploy
       git remote add origin git@github.com:pandas-dev/pandas-dev.github.io.git
       git push -f origin master
     displayName: 'Publish web and docs to GitHub pages'


### PR DESCRIPTION
The master build is broken [1], because one directory wasn't updated in #28497 (the step only runs in master builds and not PR builds, so couldn't be detected).

This updates the directory, the deployment should work again.

1. https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=17721