### PR TITLE
TST: Add astype_nansafe datetime tests

### DIFF
--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -3,6 +3,7 @@ import pytest
 
 import pandas.util._test_decorators as td
 
+from pandas.core.dtypes.cast import astype_nansafe
 import pandas.core.dtypes.common as com
 from pandas.core.dtypes.dtypes import (
     CategoricalDtype,
@@ -706,3 +707,14 @@ def test__get_dtype_fails(input_param, expected_error_message):
 )
 def test__is_dtype_type(input_param, result):
     assert com._is_dtype_type(input_param, lambda tipo: tipo == result)
+
+
+@pytest.mark.parametrize("from_type", [np.datetime64, np.timedelta64])
+@pytest.mark.parametrize(
+    "to_type", [np.int8, np.int16, np.int32, np.float16, np.float32]
+)
+def test_astype_datetime64_bad_dtype(from_type, to_type):
+    arr = np.array([from_type("2018")])
+
+    with pytest.raises(TypeError, match="cannot astype"):
+        astype_nansafe(arr, dtype=to_type)

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -723,7 +723,7 @@ def test__is_dtype_type(input_param, result):
         np.float32,
     ],
 )
-def test_astype_datetime64_bad_dtype(from_type, to_type):
+def test_astype_datetime64_bad_dtype_raises(from_type, to_type):
     arr = np.array([from_type("2018")])
 
     with pytest.raises(TypeError, match="cannot astype"):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -711,7 +711,17 @@ def test__is_dtype_type(input_param, result):
 
 @pytest.mark.parametrize("from_type", [np.datetime64, np.timedelta64])
 @pytest.mark.parametrize(
-    "to_type", [np.int8, np.int16, np.int32, np.float16, np.float32]
+    "to_type",
+    [
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.float16,
+        np.float32,
+    ],
 )
 def test_astype_datetime64_bad_dtype(from_type, to_type):
     arr = np.array([from_type("2018")])


### PR DESCRIPTION
Adds tests for `astype_nansafe` in situations where we can't perform a datetime casting because of a precision mismatch:

```
arr                                                                             
# array(['2018-01-01'], dtype='datetime64[D]')

arr.view(np.int32)                                                              
# array([17532,     0], dtype=int32)

arr.view(np.float32)                                                            
# array([2.4568e-41, 0.0000e+00], dtype=float32)
```

Related to https://github.com/pandas-dev/pandas/pull/28492