### PR TITLE
REF: Parametrize value_counts tests

### DIFF
--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -52,9 +52,11 @@ for seed_nans in [True, False]:
 
 @pytest.mark.slow
 @pytest.mark.parametrize("df, keys, bins, n, m", binned, ids=ids)
-@pytest.mark.parametrize(
-    "isort, normalize, sort, ascending, dropna", list(product((False, True), repeat=5))
-)
+@pytest.mark.parametrize("isort", [True, False])
+@pytest.mark.parametrize("normalize", [True, False])
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("ascending", [True, False])
+@pytest.mark.parametrize("dropna", [True, False])
 def test_series_groupby_value_counts(
     df, keys, bins, n, m, isort, normalize, sort, ascending, dropna
 ):

--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -52,29 +52,28 @@ for seed_nans in [True, False]:
 
 @pytest.mark.slow
 @pytest.mark.parametrize("df, keys, bins, n, m", binned, ids=ids)
-def test_series_groupby_value_counts(df, keys, bins, n, m):
+@pytest.mark.parametrize(
+    "isort, normalize, sort, ascending, dropna", list(product((False, True), repeat=5))
+)
+def test_series_groupby_value_counts(
+    df, keys, bins, n, m, isort, normalize, sort, ascending, dropna
+):
     def rebuild_index(df):
         arr = list(map(df.index.get_level_values, range(df.index.nlevels)))
         df.index = MultiIndex.from_arrays(arr, names=df.index.names)
         return df
 
-    for isort, normalize, sort, ascending, dropna in product((False, True), repeat=5):
+    kwargs = dict(
+        normalize=normalize, sort=sort, ascending=ascending, dropna=dropna, bins=bins
+    )
 
-        kwargs = dict(
-            normalize=normalize,
-            sort=sort,
-            ascending=ascending,
-            dropna=dropna,
-            bins=bins,
-        )
+    gr = df.groupby(keys, sort=isort)
+    left = gr["3rd"].value_counts(**kwargs)
 
-        gr = df.groupby(keys, sort=isort)
-        left = gr["3rd"].value_counts(**kwargs)
+    gr = df.groupby(keys, sort=isort)
+    right = gr["3rd"].apply(Series.value_counts, **kwargs)
+    right.index.names = right.index.names[:-1] + ["3rd"]
 
-        gr = df.groupby(keys, sort=isort)
-        right = gr["3rd"].apply(Series.value_counts, **kwargs)
-        right.index.names = right.index.names[:-1] + ["3rd"]
-
-        # have to sort on index because of unstable sort on values
-        left, right = map(rebuild_index, (left, right))  # xref GH9212
-        tm.assert_series_equal(left.sort_index(), right.sort_index())
+    # have to sort on index because of unstable sort on values
+    left, right = map(rebuild_index, (left, right))  # xref GH9212
+    tm.assert_series_equal(left.sort_index(), right.sort_index())


### PR DESCRIPTION
Parametrizes the for loop in `test_series_groupby_value_counts`.  As a side note, this test seems to run for a pretty long time (a minute and a half); should it operate on less data perhaps?