### PR TITLE
Pandas.io.formats.style.Styler docstring PR02

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1357,7 +1357,6 @@ class Styler:
         **kwargs : optional
             A dictionary of keyword arguments passed into ``func``.
 
-
         Returns
         -------
         object :

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -645,7 +645,7 @@ class Styler:
         subset : IndexSlice
             a valid indexer to limit ``data`` to *before* applying the
             function. Consider using a pandas.IndexSlice
-        kwargs : dict
+        **kwargs : dict
             pass along to ``func``
 
         Returns
@@ -697,7 +697,7 @@ class Styler:
         subset : IndexSlice
             a valid indexer to limit ``data`` to *before* applying the
             function. Consider using a pandas.IndexSlice
-        kwargs : dict
+        **kwargs : dict
             pass along to ``func``
 
         Returns
@@ -732,7 +732,7 @@ class Styler:
         subset : IndexSlice
             a valid indexer to limit ``data`` to *before* applying the
             function. Consider using a pandas.IndexSlice
-        kwargs : dict
+        **kwargs : dict
             pass along to ``cond``
 
         Returns
@@ -965,8 +965,10 @@ class Styler:
         ----------
         cmap : str or colormap
             matplotlib colormap
-        low, high : float
-            compress the range by these values.
+        low : float
+            compress the range by the low.
+        high : float
+            compress the range by the high.
         axis : {0 or 'index', 1 or 'columns', None}, default 0
             apply to each column (``axis=0`` or ``'index'``), to each row
             (``axis=1`` or ``'columns'``), or to the entire DataFrame at once
@@ -1078,7 +1080,7 @@ class Styler:
         ----------
         subset : IndexSlice
             a valid slice for ``data`` to limit the style application to
-        kwargs : dict
+        **kwargs : dict
             property: value pairs to be set for each cell
 
         Returns
@@ -1350,8 +1352,11 @@ class Styler:
             Function to apply to the Styler.  Alternatively, a
             ``(callable, keyword)`` tuple where ``keyword`` is a string
             indicating the keyword of ``callable`` that expects the Styler.
-        *args, **kwargs :
+        *args : optional
             Arguments passed to `func`.
+        **kwargs : optional
+            A dictionary of keyword arguments passed into ``func``.
+
 
         Returns
         -------


### PR DESCRIPTION
Solves:

- Unknown parameters {kwargs} in apply method in Styler class
- Unknown parameters {kwargs} in applymap method in Styler class
- Unknown parameters {kwargs} in where method in Styler class
- Unknown parameters {low, high}  in background_gradient method in Styler class
- Unknown parameters {kwargs} in set_properties method in Styler class
- Unknown parameters {*args, **kwargs :} in pipe method in Styler class

for issues:

pandas.io.formats.style.Styler.apply: Unknown parameters {kwargs}
pandas.io.formats.style.Styler.applymap: Unknown parameters {kwargs}
pandas.io.formats.style.Styler.where: Unknown parameters {kwargs}
pandas.io.formats.style.Styler.set_properties: Unknown parameters {kwargs}
pandas.io.formats.style.Styler.pipe: Unknown parameters {*args, **kwargs :}
pandas.io.formats.style.Styler.background_gradient: Unknown parameters {low, high}

all in #27976

