### PR TITLE
WEB/CI: Fixing target path of the web build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,7 +121,7 @@ jobs:
 
   - script: |
       source activate pandas-dev
-      python web/pandas_web.py web/pandas
+      python web/pandas_web.py web/pandas --target-path=web/build
     displayName: 'Build website'
 
   - script: |


### PR DESCRIPTION
http://dev,pandas.io is currently not serving the website (http://dev,pandas.io/docs)

In the deployment of the new website, when building the web, the target default path `build` is not working as expected. The path is later expected to be `web/build`, but since the script is called from the root and not from inside web, the target path is `build/`, and the website is not copied.

This PR fixes the target path to be the correct one, and should fix http://dev,pandas.io

@TomAugspurger if you don't mind having a quick look.