### PR TITLE
Backport PR #28524: COMPAT: ensure no warnings on tab completion with Jedi 0.15

### DIFF
--- a/doc/source/whatsnew/v0.25.2.rst
+++ b/doc/source/whatsnew/v0.25.2.rst
@@ -100,7 +100,8 @@ Other
 ^^^^^
 
 - Compatibility with Python 3.8 in :meth:`DataFrame.query` (:issue:`27261`)
--
+- Fix to ensure that tab-completion in an IPython console does not raise
+  warnings for deprecated attributes (:issue:`27900`).
 
 .. _whatsnew_0.252.contributors:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -150,7 +150,7 @@ class NDFrame(PandasObject, SelectionMixin):
     _internal_names_set = set(_internal_names)  # type: Set[str]
     _accessors = set()  # type: Set[str]
     _deprecations = frozenset(
-        ["as_blocks", "blocks", "is_copy"]
+        ["as_blocks", "blocks", "is_copy", "ftypes", "ix"]
     )  # type: FrozenSet[str]
     _metadata = []  # type: List[str]
     _is_copy = None

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -225,7 +225,7 @@ class Index(IndexOpsMixin, PandasObject):
     """
 
     # tolist is not actually deprecated, just suppressed in the __dir__
-    _deprecations = DirNamesMixin._deprecations | frozenset(["tolist"])
+    _deprecations = DirNamesMixin._deprecations | frozenset(["tolist", "dtype_str"])
 
     # To hand over control to subclasses
     _join_precedence = 1

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -56,7 +56,7 @@ from pandas.core.dtypes.missing import (
 
 import pandas as pd
 from pandas.core import algorithms, base, generic, nanops, ops
-from pandas.core.accessor import CachedAccessor
+from pandas.core.accessor import CachedAccessor, DirNamesMixin
 from pandas.core.arrays import ExtensionArray, SparseArray
 from pandas.core.arrays.categorical import Categorical, CategoricalAccessor
 from pandas.core.arrays.sparse import SparseAccessor
@@ -178,8 +178,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     _metadata = ["name"]
     _accessors = {"dt", "cat", "str", "sparse"}
     # tolist is not actually deprecated, just suppressed in the __dir__
-    _deprecations = generic.NDFrame._deprecations | frozenset(
-        ["asobject", "reshape", "get_value", "set_value", "valid", "tolist"]
+    _deprecations = (
+        generic.NDFrame._deprecations
+        | DirNamesMixin._deprecations
+        | frozenset(["asobject", "reshape", "get_value", "set_value", "valid"])
+        | frozenset(["ftype", "real", "imag", "tolist"])
     )
 
     # Override cache_readonly bc Series is mutable


### PR DESCRIPTION
Backport for #28524

