### PR TITLE
[BUG] Fixed behavior of DataFrameGroupBy.apply to respect _group_selection_context

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -271,6 +271,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.rolling` not allowing for rolling over datetimes when ``axis=1`` (:issue: `28192`)
 - Bug in :meth:`DataFrame.groupby` not offering selection by column name when ``axis=1`` (:issue:`27614`)
 - Bug in :meth:`DataFrameGroupby.agg` not able to use lambda function with named aggregation (:issue:`27519`)
+- Bug in :meth:`DataFrameGroupby.apply` causing grouped column to remain in ``DataFrame`` even when ``as_index=True`` was specified (:issue:`28549`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -724,7 +724,9 @@ b  2""",
             f = func
 
         # ignore SettingWithCopy here in case the user mutates
-        with option_context("mode.chained_assignment", None), _group_selection_context(self):
+        with option_context("mode.chained_assignment", None), _group_selection_context(
+            self
+        ):
             try:
                 result = self._python_apply_general(f)
             except TypeError:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -724,7 +724,7 @@ b  2""",
             f = func
 
         # ignore SettingWithCopy here in case the user mutates
-        with option_context("mode.chained_assignment", None):
+        with option_context("mode.chained_assignment", None), _group_selection_context(self):
             try:
                 result = self._python_apply_general(f)
             except TypeError:
@@ -736,8 +736,7 @@ b  2""",
                 # fails on *some* columns, e.g. a numeric operation
                 # on a string grouper column
 
-                with _group_selection_context(self):
-                    return self._python_apply_general(f)
+                return self._python_apply_general(f)
 
         return result
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -702,7 +702,6 @@ b  2""",
         )
     )
     def apply(self, func, *args, **kwargs):
-
         func = self._is_builtin_func(func)
 
         # this is needed so we don't try and wrap strings. If we could
@@ -737,6 +736,13 @@ b  2""",
                 # except if the udf is trying an operation that
                 # fails on *some* columns, e.g. a numeric operation
                 # on a string grouper column
+
+                # GH 28549
+                # This block should only be hit
+                # because of an operation failing on a
+                # grouper column if is_index=False.
+                # Otherwise it will only be hit by an operation
+                # failing on another column, and will fail both attempts
 
                 return self._python_apply_general(f)
 

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -368,6 +368,10 @@ def test_apply_chunk_view():
     df = DataFrame({"key": [1, 1, 1, 2, 2, 2, 3, 3, 3], "value": range(9)})
 
     result = df.groupby("key", group_keys=False).apply(lambda x: x[:2])
+    # GH 28549
+    # key no longer included in reduction output
+    df.pop("key")
+
     expected = df.take([0, 1, 3, 4, 6, 7])
     tm.assert_frame_equal(result, expected)
 
@@ -402,6 +406,10 @@ def test_apply_typecast_fail():
 
     result = df.groupby("d").apply(f)
 
+    # GH 28549
+    # key no longer included in reduction output
+    df.pop("d")
+
     expected = df.copy()
     expected["v2"] = np.tile([0.0, 0.5, 1], 2)
 
@@ -425,6 +433,10 @@ def test_apply_multiindex_fail():
         return group
 
     result = df.groupby("d").apply(f)
+
+    # GH 28549
+    # key no longer included in reduction output
+    df.pop("d")
 
     expected = df.copy()
     expected["v2"] = np.tile([0.0, 0.5, 1], 2)
@@ -611,24 +623,25 @@ def test_groupby_apply_all_none():
     tm.assert_frame_equal(result, expected)
 
 
-def test_groupby_apply_none_first():
+@pytest.mark.parametrize("groups, vars_, index, expected_vars", [
+    ([1, 1, 1, 2], [0, 1, 2, 3], [[1, 1], [0, 2]], [0, 2]),
+    ([1, 2, 2, 2], [0, 1, 2, 3], [[2, 2], [1, 3]], [1, 3])
+])
+def test_groupby_apply_none_first(groups, vars_, index, expected_vars):
     # GH 12824. Tests if apply returns None first.
-    test_df1 = DataFrame({"groups": [1, 1, 1, 2], "vars": [0, 1, 2, 3]})
-    test_df2 = DataFrame({"groups": [1, 2, 2, 2], "vars": [0, 1, 2, 3]})
+    test_df = DataFrame({"groups": groups, "vars": vars_})
 
     def test_func(x):
         if x.shape[0] < 2:
             return None
         return x.iloc[[0, -1]]
 
-    result1 = test_df1.groupby("groups").apply(test_func)
-    result2 = test_df2.groupby("groups").apply(test_func)
-    index1 = MultiIndex.from_arrays([[1, 1], [0, 2]], names=["groups", None])
-    index2 = MultiIndex.from_arrays([[2, 2], [1, 3]], names=["groups", None])
-    expected1 = DataFrame({"groups": [1, 1], "vars": [0, 2]}, index=index1)
-    expected2 = DataFrame({"groups": [2, 2], "vars": [1, 3]}, index=index2)
-    tm.assert_frame_equal(result1, expected1)
-    tm.assert_frame_equal(result2, expected2)
+    result = test_df.groupby("groups").apply(test_func)
+    index = MultiIndex.from_arrays(index, names=["groups", None])
+
+    # GH 28549 "groups" should not be in output of apply
+    expected = DataFrame({"vars": expected_vars}, index=index)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_groupby_apply_return_empty_chunk():

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -623,10 +623,13 @@ def test_groupby_apply_all_none():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("groups, vars_, index, expected_vars", [
-    ([1, 1, 1, 2], [0, 1, 2, 3], [[1, 1], [0, 2]], [0, 2]),
-    ([1, 2, 2, 2], [0, 1, 2, 3], [[2, 2], [1, 3]], [1, 3])
-])
+@pytest.mark.parametrize(
+    "groups, vars_, index, expected_vars",
+    [
+        ([1, 1, 1, 2], [0, 1, 2, 3], [[1, 1], [0, 2]], [0, 2]),
+        ([1, 2, 2, 2], [0, 1, 2, 3], [[2, 2], [1, 3]], [1, 3]),
+    ],
+)
 def test_groupby_apply_none_first(groups, vars_, index, expected_vars):
     # GH 12824. Tests if apply returns None first.
     test_df = DataFrame({"groups": groups, "vars": vars_})

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -95,9 +95,15 @@ def test_basic():
         return x.drop_duplicates("person_name").iloc[0]
 
     result = g.apply(f)
-    expected = x.iloc[[0, 1]].copy()
+
+    # GH 28549
+    # grouper key should not be present after apply
+    # with as_index=True
+    dropped = x.drop("person_id", 1)
+
+    expected = dropped.iloc[[0, 1]].copy()
     expected.index = Index([1, 2], name="person_id")
-    expected["person_name"] = expected["person_name"].astype("object")
+    expected["person_name"] = expected["person_name"]
     tm.assert_frame_equal(result, expected)
 
     # GH 9921

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -98,7 +98,8 @@ def test_basic():
 
     # GH 28549
     # grouper key should not be present after apply
-    # with as_index=True
+    # with as_index=True.
+    # TODO split this into multiple tests
     dropped = x.drop("person_id", 1)
 
     expected = dropped.iloc[[0, 1]].copy()

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -104,7 +104,6 @@ def test_builtins_apply(keys, f):
 
     # GH 28549
     # grouping keys should not be included in output
-    # without set_index=True
     if isinstance(keys, list):
         result_shape = len(df.columns) - len(keys)
     else:
@@ -128,9 +127,9 @@ def test_builtins_apply(keys, f):
 
     # GH 28549
     # grouping keys should not be in output
-    dropped = df.drop(keys, 1)
+    df = df.drop(keys, 1)
 
-    tm.assert_series_equal(getattr(result, fname)(), getattr(dropped, fname)())
+    tm.assert_series_equal(getattr(result, fname)(), getattr(df, fname)())
 
 
 def test_arg_passthru():

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -960,8 +960,12 @@ def test_no_mutate_but_looks_like(as_index):
     df = DataFrame({"key": [1, 1, 1, 2, 2, 2, 3, 3, 3], "value": range(9)})
 
     def run_test(df, as_index):
-        result1 = df.groupby("key", group_keys=True, as_index=as_index).apply(lambda x: x[:].key)
-        result2 = df.groupby("key", group_keys=True, as_index=as_index).apply(lambda x: x.key)
+        result1 = df.groupby("key", group_keys=True, as_index=as_index).apply(
+            lambda x: x[:].key
+        )
+        result2 = df.groupby("key", group_keys=True, as_index=as_index).apply(
+            lambda x: x.key
+        )
         return result1, result2
 
     if as_index:


### PR DESCRIPTION
- [x] closes #28549 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

There were lots of inconsistencies among tests about whether or not `apply` should return the grouper column(s), and almost no testing on the impact of `as_index` on `apply` operations.  This hopefully should provide better coverage, and also normalize the behavior everywhere. 