### PR TITLE
DOC: update fixing unknown parameters errors (error code PR02)

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1404,7 +1404,7 @@ class PlotAccessor(PandasObject):
             - A column name or position whose values will be used to color the
               marker points according to a colormap.
 
-        **kwds
+        **kwargs
             Keyword arguments to pass on to :meth:`DataFrame.plot`.
 
         Returns

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -28,7 +28,7 @@ def hist_series(
     yrot=None,
     figsize=None,
     bins=10,
-    **kwds
+    **kwargs
 ):
     """
     Draw histogram of the input series using matplotlib.
@@ -56,7 +56,7 @@ def hist_series(
         bin edges are calculated and returned. If bins is a sequence, gives
         bin edges, including left edge of first bin and right edge of last
         bin. In this case, bins is returned unmodified.
-    `**kwds` : keywords
+    `**kwargs
         To be passed to the actual plotting function
 
     Returns
@@ -80,7 +80,7 @@ def hist_series(
         yrot=yrot,
         figsize=figsize,
         bins=bins,
-        **kwds
+        **kwargs
     )
 
 
@@ -99,7 +99,7 @@ def hist_frame(
     figsize=None,
     layout=None,
     bins=10,
-    **kwds
+    **kwargs
 ):
     """
     Make a histogram of the DataFrame's.
@@ -151,7 +151,7 @@ def hist_frame(
         bin edges are calculated and returned. If bins is a sequence, gives
         bin edges, including left edge of first bin and right edge of last
         bin. In this case, bins is returned unmodified.
-    **kwds
+    **kwargs
         All other plotting keyword arguments to be passed to
         :meth:`matplotlib.pyplot.hist`.
 
@@ -194,7 +194,7 @@ def hist_frame(
         figsize=figsize,
         layout=layout,
         bins=bins,
-        **kwds
+        **kwargs
     )
 
 
@@ -209,7 +209,7 @@ def boxplot(
     figsize=None,
     layout=None,
     return_type=None,
-    **kwds
+    **kwargs
 ):
     """
     Make a box plot from DataFrame columns.
@@ -260,7 +260,7 @@ def boxplot(
 
           If ``return_type`` is `None`, a NumPy array
           of axes with the same shape as ``layout`` is returned.
-    **kwds
+    **kwargs
         All other plotting keyword arguments to be passed to
         :func:`matplotlib.pyplot.boxplot`.
 
@@ -385,7 +385,7 @@ def boxplot(
         figsize=figsize,
         layout=layout,
         return_type=return_type,
-        **kwds
+        **kwargs
     )
 
 
@@ -401,7 +401,7 @@ def boxplot_frame(
     figsize=None,
     layout=None,
     return_type=None,
-    **kwds
+    **kwargs
 ):
     plot_backend = _get_plot_backend()
     return plot_backend.boxplot_frame(
@@ -415,7 +415,7 @@ def boxplot_frame(
         figsize=figsize,
         layout=layout,
         return_type=return_type,
-        **kwds
+        **kwargs
     )
 
 
@@ -431,7 +431,7 @@ def boxplot_frame_groupby(
     layout=None,
     sharex=False,
     sharey=True,
-    **kwds
+    **kwargs
 ):
     """
     Make box plots from DataFrameGroupBy data.
@@ -459,7 +459,7 @@ def boxplot_frame_groupby(
         Whether y-axes will be shared among subplots
 
         .. versionadded:: 0.23.1
-    `**kwds` : Keyword Arguments
+    `**kwargs
         All other plotting keyword arguments to be passed to
         matplotlib's boxplot function
 
@@ -495,7 +495,7 @@ def boxplot_frame_groupby(
         layout=layout,
         sharex=sharex,
         sharey=sharey,
-        **kwds
+        **kwargs
     )
 
 
@@ -586,7 +586,7 @@ class PlotAccessor(PandasObject):
         labels with "(right)" in the legend
     include_bool : bool, default is False
         If True, boolean values can be plotted.
-    `**kwds` : keywords
+    `**kwargs
         Options to pass to matplotlib plotting method.
 
     Returns

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -56,7 +56,7 @@ def hist_series(
         bin edges are calculated and returned. If bins is a sequence, gives
         bin edges, including left edge of first bin and right edge of last
         bin. In this case, bins is returned unmodified.
-    `**kwargs
+    **kwargs
         To be passed to the actual plotting function
 
     Returns
@@ -459,7 +459,7 @@ def boxplot_frame_groupby(
         Whether y-axes will be shared among subplots
 
         .. versionadded:: 0.23.1
-    `**kwargs
+    **kwargs
         All other plotting keyword arguments to be passed to
         matplotlib's boxplot function
 
@@ -586,7 +586,7 @@ class PlotAccessor(PandasObject):
         labels with "(right)" in the legend
     include_bool : bool, default is False
         If True, boolean values can be plotted.
-    `**kwargs
+    **kwargs
         Options to pass to matplotlib plotting method.
 
     Returns

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -810,7 +810,7 @@ class PlotAccessor(PandasObject):
             The values to be plotted.
             Either the location or the label of the columns to be used.
             By default, it will use the remaining DataFrame numeric columns.
-        **kwds
+        **kwargs
             Keyword arguments to pass on to :meth:`DataFrame.plot`.
 
         Returns
@@ -880,7 +880,7 @@ class PlotAccessor(PandasObject):
         y : label or position, optional
             Allows plotting of one column versus another. If not specified,
             all numerical columns are used.
-        **kwds
+        **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
 
@@ -963,7 +963,7 @@ class PlotAccessor(PandasObject):
             Column to be used for categories.
         y : label or position, default All numeric columns in dataframe
             Columns to be plotted from the DataFrame.
-        **kwds
+        **kwargs
             Keyword arguments to pass on to :meth:`DataFrame.plot`.
 
         Returns
@@ -1049,7 +1049,7 @@ class PlotAccessor(PandasObject):
         ----------
         by : str or sequence
             Column in the DataFrame to group by.
-        **kwds : optional
+        **kwargs : optional
             Additional keywords are documented in
             :meth:`DataFrame.plot`.
 
@@ -1092,7 +1092,7 @@ class PlotAccessor(PandasObject):
             Column in the DataFrame to group by.
         bins : int, default 10
             Number of histogram bins to be used.
-        **kwds
+        **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
 
@@ -1148,7 +1148,7 @@ class PlotAccessor(PandasObject):
             1000 equally spaced points are used. If `ind` is a NumPy array, the
             KDE is evaluated at the points passed. If `ind` is an integer,
             `ind` number of equally spaced points are used.
-        **kwds : optional
+        **kwargs : optional
             Additional keyword arguments are documented in
             :meth:`pandas.%(this-datatype)s.plot`.
 
@@ -1322,7 +1322,7 @@ class PlotAccessor(PandasObject):
         y : int or label, optional
             Label or position of the column to plot.
             If not provided, ``subplots=True`` argument must be passed.
-        **kwds
+        **kwargs
             Keyword arguments to pass on to :meth:`DataFrame.plot`.
 
         Returns
@@ -1476,7 +1476,7 @@ class PlotAccessor(PandasObject):
             Alternatively, gridsize can be a tuple with two elements
             specifying the number of hexagons in the x-direction and the
             y-direction.
-        **kwds
+        **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1049,7 +1049,7 @@ class PlotAccessor(PandasObject):
         ----------
         by : str or sequence
             Column in the DataFrame to group by.
-        **kwargs : optional
+        **kwargs
             Additional keywords are documented in
             :meth:`DataFrame.plot`.
 
@@ -1148,7 +1148,7 @@ class PlotAccessor(PandasObject):
             1000 equally spaced points are used. If `ind` is a NumPy array, the
             KDE is evaluated at the points passed. If `ind` is an integer,
             `ind` number of equally spaced points are used.
-        **kwargs : optional
+        **kwargs
             Additional keyword arguments are documented in
             :meth:`pandas.%(this-datatype)s.plot`.
 
@@ -1250,7 +1250,7 @@ class PlotAccessor(PandasObject):
         stacked : bool, default True
             Area plots are stacked by default. Set to False to create a
             unstacked plot.
-        **kwds : optional
+        **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -782,7 +782,9 @@ def test_categorical_no_compress():
 
 def test_sort():
 
-    # http://stackoverflow.com/questions/23814368/sorting-pandas-categorical-labels-after-groupby  # noqa: flake8
+    # http://stackoverflow.com/questions/23814368/
+    # sorting-pandas-categorical-labels-after-groupby
+    # noqa: flake8
     # This should result in a properly sorted Series so that the plot
     # has a sorted x axis
     # self.cat.groupby(['value_group'])['value_group'].count().plot(kind='bar')


### PR DESCRIPTION
- Documentation update fixing some of the methods with a PR-2 error code which involved updating **kwds to **kwargs

- No tests required

- The data frame.plot methods now have the docstring arguments updated from **kwds to **kwargs to match the method signature and exclude them from the PR02 errors:

