### PR TITLE
CLN: remove unused args from _construct_result

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5269,7 +5269,7 @@ class DataFrame(NDFrame):
             with np.errstate(all="ignore"):
                 res_values = _arith_op(this.values, other.values)
             new_data = dispatch_fill_zeros(func, this.values, other.values, res_values)
-        return this._construct_result(other, new_data, _arith_op)
+        return this._construct_result(new_data)
 
     def _combine_match_index(self, other, func, level=None):
         left, right = self.align(other, join="outer", axis=0, level=level, copy=False)
@@ -5282,44 +5282,31 @@ class DataFrame(NDFrame):
             # fastpath --> operate directly on values
             with np.errstate(all="ignore"):
                 new_data = func(left.values.T, right.values).T
-        return left._construct_result(other, new_data, func)
+        return left._construct_result(new_data)
 
     def _combine_match_columns(self, other: Series, func, level=None):
         left, right = self.align(other, join="outer", axis=1, level=level, copy=False)
         # at this point we have `left.columns.equals(right.index)`
         new_data = ops.dispatch_to_series(left, right, func, axis="columns")
-        return left._construct_result(right, new_data, func)
+        return left._construct_result(new_data)
 
-    def _combine_const(self, other, func):
-        # scalar other or np.ndim(other) == 0
-        new_data = ops.dispatch_to_series(self, other, func)
-        return self._construct_result(other, new_data, func)
-
-    def _construct_result(self, other, result, func):
+    def _construct_result(self, result) -> "DataFrame":
         """
         Wrap the result of an arithmetic, comparison, or logical operation.
 
         Parameters
         ----------
-        other : object
         result : DataFrame
-        func : binary operator
 
         Returns
         -------
         DataFrame
-
-        Notes
-        -----
-        `func` is included for compat with SparseDataFrame signature, is not
-        needed here.
         """
         out = self._constructor(result, index=self.index, copy=False)
         # Pin columns instead of passing to constructor for compat with
         #  non-unique columns case
         out.columns = self.columns
         return out
-        # TODO: finalize?  we do for SparseDataFrame
 
     def combine(self, other, func, fill_value=None, overwrite=True):
         """

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -892,7 +892,8 @@ def _arith_method_FRAME(cls, op, special):
             if fill_value is not None:
                 self = self.fillna(fill_value)
 
-            return self._combine_const(other, op)
+            new_data = dispatch_to_series(self, other, op)
+            return self._construct_result(new_data)
 
     f.__name__ = op_name
 
@@ -926,7 +927,7 @@ def _flex_comp_method_FRAME(cls, op, special):
             if not self._indexed_same(other):
                 self, other = self.align(other, "outer", level=level, copy=False)
             new_data = dispatch_to_series(self, other, na_op, str_rep)
-            return self._construct_result(other, new_data, na_op)
+            return self._construct_result(new_data)
 
         elif isinstance(other, ABCSeries):
             return _combine_series_frame(
@@ -934,7 +935,8 @@ def _flex_comp_method_FRAME(cls, op, special):
             )
         else:
             # in this case we always have `np.ndim(other) == 0`
-            return self._combine_const(other, na_op)
+            new_data = dispatch_to_series(self, other, na_op)
+            return self._construct_result(new_data)
 
     f.__name__ = op_name
 
@@ -957,7 +959,7 @@ def _comp_method_FRAME(cls, func, special):
                     "Can only compare identically-labeled DataFrame objects"
                 )
             new_data = dispatch_to_series(self, other, func, str_rep)
-            return self._construct_result(other, new_data, func)
+            return self._construct_result(new_data)
 
         elif isinstance(other, ABCSeries):
             return _combine_series_frame(
@@ -967,8 +969,8 @@ def _comp_method_FRAME(cls, func, special):
 
             # straight boolean comparisons we want to allow all columns
             # (regardless of dtype to pass thru) See #4537 for discussion.
-            res = self._combine_const(other, func)
-            return res
+            new_data = dispatch_to_series(self, other, func)
+            return self._construct_result(new_data)
 
     f.__name__ = op_name
 


### PR DESCRIPTION
These were there for compat with the SparseDataFrame._construct_result signature, which is no longer relevant.

Also got rid of _combine_const; that was also just waiting for the SparseDataFrame version to be gone.