### PR TITLE
CLN: unify __finalize__ treatment for Series ops

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -606,6 +606,9 @@ def _construct_result(left, result, index, name, dtype=None):
     """
     out = left._constructor(result, index=index, dtype=dtype)
     out = out.__finalize__(left)
+
+    # Set the result's name after __finalize__ is called because __finalize__
+    #  would set it back to self.name
     out.name = name
     return out
 


### PR DESCRIPTION
ATM we have three slightly different usages for the arithmetic, comparison and logical ops, with no clear reason for the differences.  This changes that to make the arithmetic the one true version, which has the added benefit of letting us share _construct_result code across these three functions.
