### PR TITLE
BUG: Timedelta not formatted correctly in to_json

### DIFF
--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -66,7 +66,8 @@ class ToJSON(BaseIO):
     fname = "__test__.json"
     params = [
         ["split", "columns", "index", "values", "records"],
-        ["df", "df_date_idx", "df_td_int_ts", "df_int_floats", "df_int_float_str"],
+        ["df", "df_date_idx", "df_td", "df_td_int_ts", "df_int_floats",
+         "df_int_float_str"],
     ]
     param_names = ["orient", "frame"]
 
@@ -81,6 +82,13 @@ class ToJSON(BaseIO):
         strings = tm.makeStringIndex(N)
         self.df = DataFrame(np.random.randn(N, ncols), index=np.arange(N))
         self.df_date_idx = DataFrame(np.random.randn(N, ncols), index=index)
+        self.df_td = DataFrame(
+            {
+                "td_1": timedeltas,
+                "td_2": timedeltas
+            },
+            index=index,
+        )
         self.df_td_int_ts = DataFrame(
             {
                 "td_1": timedeltas,
@@ -117,6 +125,10 @@ class ToJSON(BaseIO):
 
     def time_to_json(self, orient, frame):
         getattr(self, frame).to_json(self.fname, orient=orient)
+
+    def time_to_json_iso(self, orient, frame):
+        getattr(self, frame).to_json(self.fname, orient=orient,
+                                     date_format="iso")
 
     def peakmem_to_json(self, orient, frame):
         getattr(self, frame).to_json(self.fname, orient=orient)

--- a/doc/source/whatsnew/v0.25.2.rst
+++ b/doc/source/whatsnew/v0.25.2.rst
@@ -63,8 +63,9 @@ I/O
 
 - Fix regression in notebook display where <th> tags not used for :attr:`DataFrame.index` (:issue:`28204`).
 - Regression in :meth:`~DataFrame.to_csv` where writing a :class:`Series` or :class:`DataFrame` indexed by an :class:`IntervalIndex` would incorrectly raise a ``TypeError`` (:issue:`28210`)
+- Bug in :meth:`DataFrame.to_json` and :meth:`Series.to_json` where :class:`Timedelta` was not correctly formatted when `date_format="iso"` (:issue:`28256`).
 -
--
+
 
 Plotting
 ^^^^^^^^

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -735,12 +735,20 @@ int NpyArr_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
     NpyArr_freeItemValue(obj, tc);
 
     if (PyArray_ISDATETIME(npyarr->array)) {
-        PRINTMARK();
-        GET_TC(tc)->itemValue = obj;
-        Py_INCREF(obj);
-        ((PyObjectEncoder *)tc->encoder)->npyType = PyArray_TYPE(npyarr->array);
-        ((PyObjectEncoder *)tc->encoder)->npyValue = npyarr->dataptr;
-        ((PyObjectEncoder *)tc->encoder)->npyCtxtPassthru = npyarr;
+        if (PyArray_TYPE(npyarr->array) == NPY_TIMEDELTA) {
+            PRINTMARK();
+            PyObject *item = npyarr->getitem(npyarr->dataptr, npyarr->array);
+            PyObject *td = PyObject_CallFunction(cls_timedelta, "(O)", item);
+            GET_TC(tc)->itemValue = td;
+            Py_DECREF(item);
+        } else {
+            PRINTMARK();
+            GET_TC(tc)->itemValue = obj;
+            Py_INCREF(obj);
+            ((PyObjectEncoder *)tc->encoder)->npyType = PyArray_TYPE(npyarr->array);
+            ((PyObjectEncoder *)tc->encoder)->npyValue = npyarr->dataptr;
+            ((PyObjectEncoder *)tc->encoder)->npyCtxtPassthru = npyarr;
+        }
     } else {
         PRINTMARK();
         GET_TC(tc)->itemValue = npyarr->getitem(npyarr->dataptr, npyarr->array);

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -170,34 +170,34 @@ class Writer:
 
 class SeriesWriter(Writer):
     _default_orient = "index"
-
-    def __init__(
-        self,
-        obj,
-        orient: Optional[str],
-        date_format: str,
-        double_precision: int,
-        ensure_ascii: bool,
-        date_unit: str,
-        index: bool,
-        default_handler: Optional[Callable[[Any], Serializable]] = None,
-        indent: int = 0,
-    ):
-        super().__init__(
-            obj,
-            orient,
-            date_format,
-            double_precision,
-            ensure_ascii,
-            date_unit,
-            index,
-            default_handler=default_handler,
-            indent=indent,
-        )
-
-        if is_timedelta64_dtype(obj.dtype) and self.date_format == "iso":
-            obj = obj.copy()
-            self.obj = obj.apply(lambda x: x.isoformat())
+    #
+    # def __init__(
+    #     self,
+    #     obj,
+    #     orient: Optional[str],
+    #     date_format: str,
+    #     double_precision: int,
+    #     ensure_ascii: bool,
+    #     date_unit: str,
+    #     index: bool,
+    #     default_handler: Optional[Callable[[Any], Serializable]] = None,
+    #     indent: int = 0,
+    # ):
+    #     super().__init__(
+    #         obj,
+    #         orient,
+    #         date_format,
+    #         double_precision,
+    #         ensure_ascii,
+    #         date_unit,
+    #         index,
+    #         default_handler=default_handler,
+    #         indent=indent,
+    #     )
+    #
+    #     if is_timedelta64_dtype(obj.dtype) and self.date_format == "iso":
+    #         obj = obj.copy()
+    #         self.obj = obj.apply(lambda x: x.isoformat())
 
     def _format_axes(self):
         if not self.obj.index.is_unique and self.orient == "index":
@@ -234,36 +234,36 @@ class SeriesWriter(Writer):
 class FrameWriter(Writer):
     _default_orient = "columns"
 
-    def __init__(
-        self,
-        obj,
-        orient: Optional[str],
-        date_format: str,
-        double_precision: int,
-        ensure_ascii: bool,
-        date_unit: str,
-        index: bool,
-        default_handler: Optional[Callable[[Any], Serializable]] = None,
-        indent: int = 0,
-    ):
-        super().__init__(
-            obj,
-            orient,
-            date_format,
-            double_precision,
-            ensure_ascii,
-            date_unit,
-            index,
-            default_handler=default_handler,
-            indent=indent,
-        )
-
-        obj = obj.copy()
-        timedeltas = obj.select_dtypes(include=["timedelta"]).columns
-
-        if len(timedeltas) and self.date_format == "iso":
-            obj[timedeltas] = obj[timedeltas].applymap(lambda x: x.isoformat())
-            self.obj = obj
+    # def __init__(
+    #     self,
+    #     obj,
+    #     orient: Optional[str],
+    #     date_format: str,
+    #     double_precision: int,
+    #     ensure_ascii: bool,
+    #     date_unit: str,
+    #     index: bool,
+    #     default_handler: Optional[Callable[[Any], Serializable]] = None,
+    #     indent: int = 0,
+    # ):
+    #     super().__init__(
+    #         obj,
+    #         orient,
+    #         date_format,
+    #         double_precision,
+    #         ensure_ascii,
+    #         date_unit,
+    #         index,
+    #         default_handler=default_handler,
+    #         indent=indent,
+    #     )
+    #
+    #     obj = obj.copy()
+    #     timedeltas = obj.select_dtypes(include=["timedelta"]).columns
+    #
+    #     if len(timedeltas) and self.date_format == "iso":
+    #         obj[timedeltas] = obj[timedeltas].applymap(lambda x: x.isoformat())
+    #         self.obj = obj
 
     def _format_axes(self):
         """

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -613,8 +613,7 @@ class TestTableOrient:
         result = df.to_json(orient="table")
         js = json.loads(result)
         assert js["schema"]["fields"][1]["name"] == "2016-01-01T00:00:00.000Z"
-        # TODO - below expectation is not correct; see GH 28256
-        assert js["schema"]["fields"][2]["name"] == 10000
+        assert js["schema"]["fields"][2]["name"] == "P0DT0H0M10S"
 
     @pytest.mark.parametrize(
         "case",

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -813,6 +813,40 @@ class TestPandasContainer:
         result = read_json(df.to_json())
         assert_frame_equal(result, df)
 
+    @pytest.mark.parametrize(
+        "date_format,expected",
+        [
+            ("iso", '{"0":"P1DT0H0M0S","1":"P2DT0H0M0S"}'),
+            ("epoch", '{"0":86400000,"1":172800000}'),
+        ],
+    )
+    def test_series_timedelta_to_json(self, date_format, expected):
+        # GH28156: to_json not correctly formatting Timedelta
+        s = Series(pd.timedelta_range(start="1D", periods=2))
+
+        result = s.to_json(date_format=date_format)
+        assert result == expected
+
+        result = s.astype(object).to_json(date_format=date_format)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "date_format,expected",
+        [
+            ("iso", '{"0":{"0":"P1DT0H0M0S","1":"P2DT0H0M0S"}}'),
+            ("epoch", '{"0":{"0":86400000,"1":172800000}}'),
+        ],
+    )
+    def test_dataframe_timedelta_to_json(self, date_format, expected):
+        # GH28156: to_json not correctly formatting Timedelta
+        df = DataFrame(pd.timedelta_range(start="1D", periods=2))
+
+        result = df.to_json(date_format=date_format)
+        assert result == expected
+
+        result = df.astype(object).to_json(date_format=date_format)
+        assert result == expected
+
     def test_path(self):
         with ensure_clean("test.json") as path:
             for df in [


### PR DESCRIPTION
- [x] closes #28256
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
