### PR TITLE
REF/TST: Corner cases for op(DataFrame, Series)

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -785,9 +785,9 @@ def _combine_series_frame(self, other, func, fill_value=None, axis=None, level=N
             return self._combine_match_index(other, func, level=level)
         else:
             return self._combine_match_columns(other, func, level=level)
-    else:
-        # default axis is columns
-        return self._combine_match_columns(other, func, level=level)
+
+    # default axis is columns
+    return self._combine_match_columns(other, func, level=level)
 
 
 def _align_method_FRAME(left, right, axis):

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -786,15 +786,6 @@ def _combine_series_frame(self, other, func, fill_value=None, axis=None, level=N
         else:
             return self._combine_match_columns(other, func, level=level)
     else:
-        if not len(other):
-            return self * np.nan
-
-        if not len(self):
-            # Ambiguous case, use _series so works with DataFrame
-            return self._constructor(
-                data=self._series, index=self.index, columns=self.columns
-            )
-
         # default axis is columns
         return self._combine_match_columns(other, func, level=level)
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -666,6 +666,7 @@ class TestFrameArithmetic:
 
 
 def test_frame_with_zero_len_series_corner_cases():
+    # GH#28600
     # easy all-float case
     df = pd.DataFrame(np.random.randn(6).reshape(3, 2), columns=["A", "B"])
     ser = pd.Series(dtype=np.float64)
@@ -686,7 +687,7 @@ def test_frame_with_zero_len_series_corner_cases():
 
 
 def test_zero_len_frame_with_series_corner_cases():
-
+    # GH#28600
     df = pd.DataFrame(columns=["A", "B"], dtype=np.float64)
     ser = pd.Series([1, 2], index=["A", "B"])
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -663,3 +663,33 @@ class TestFrameArithmetic:
         result = getattr(df, op)(num)
         expected = pd.DataFrame([[getattr(n, op)(num) for n in data]], columns=ind)
         tm.assert_frame_equal(result, expected)
+
+
+def test_frame_with_zero_len_series_corner_cases():
+    # easy all-float case
+    df = pd.DataFrame(np.random.randn(6).reshape(3, 2), columns=["A", "B"])
+    ser = pd.Series(dtype=np.float64)
+
+    result = df + ser
+    expected = pd.DataFrame(df.values * np.nan, columns=df.columns)
+    tm.assert_frame_equal(result, expected)
+
+    result = df == ser
+    expected = pd.DataFrame(False, index=df.index, columns=df.columns)
+    tm.assert_frame_equal(result, expected)
+
+    # non-float case should not raise on comparison
+    df2 = pd.DataFrame(df.values.view("M8[ns]"), columns=df.columns)
+    result = df2 == ser
+    expected = pd.DataFrame(False, index=df.index, columns=df.columns)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_zero_len_frame_with_series_corner_cases():
+
+    df = pd.DataFrame(columns=["A", "B"], dtype=np.float64)
+    ser = pd.Series([1, 2], index=["A", "B"])
+
+    result = df + ser
+    expected = df
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -782,7 +782,7 @@ def test_categorical_no_compress():
 
 def test_sort():
 
-    # http://stackoverflow.com/questions/23814368/sorting-pandas-categorical-labels-after-groupby  # noqa: flake8
+    # http://stackoverflow.com/questions/23814368/sorting-pandas-categorical-labels-after-groupby  # noqa: E501
     # This should result in a properly sorted Series so that the plot
     # has a sorted x axis
     # self.cat.groupby(['value_group'])['value_group'].count().plot(kind='bar')


### PR DESCRIPTION
We have two special cases in `_combine_series_frame` that are never tested ATM.  This adds tests for them, then notes that the special case handling code is unnecessary and this can now fall through to the general case code.  In a follow-up, we'll be able to simplify _combine_series_frame further, but for now I want to keep the changed logic obvious.

Also note that the removed
```
         if not len(other):
            return self * np.nan 
```

is actually wrong in the non-float test case in L681-685 in the test file.