### PR TITLE
OPS: Remove mask_cmp_op fallback behavior

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -199,7 +199,7 @@ Timezones
 Numeric
 ^^^^^^^
 - Bug in :meth:`DataFrame.quantile` with zero-column :class:`DataFrame` incorrectly raising (:issue:`23925`)
--
+- :class:`DataFrame` inequality comparisons with object-dtype and ``complex`` entries failing to raise ``TypeError`` like their :class:`Series` counterparts (:issue:`28079`)
 -
 
 Conversion

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -28,7 +28,7 @@ from pandas.core.dtypes.generic import (
     ABCIndexClass,
     ABCSeries,
 )
-from pandas.core.dtypes.missing import isna, notna
+from pandas.core.dtypes.missing import isna
 
 from pandas._typing import ArrayLike
 from pandas.core.construction import array, extract_array

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -242,7 +242,12 @@ class TestFrameFlexComparisons:
         df = pd.DataFrame({"a": arr})
         df2 = pd.DataFrame({"a": arr2})
 
-        msg = "'>' not supported between instances of '.*' and 'complex'"
+        msg = "|".join(
+            [
+                "'>' not supported between instances of '.*' and 'complex'",
+                r"unorderable types: .*complex\(\)",  # PY35
+            ]
+        )
         with pytest.raises(TypeError, match=msg):
             # inequalities are not well-defined for complex numbers
             df.gt(df2)

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -235,21 +235,41 @@ class TestFrameFlexComparisons:
         rs = df.le(df)
         assert not rs.loc[0, 0]
 
+    def test_bool_flex_frame_complex_dtype(self):
         # complex
         arr = np.array([np.nan, 1, 6, np.nan])
         arr2 = np.array([2j, np.nan, 7, None])
         df = pd.DataFrame({"a": arr})
         df2 = pd.DataFrame({"a": arr2})
-        rs = df.gt(df2)
-        assert not rs.values.any()
+
+        msg = "'>' not supported between instances of '.*' and 'complex'"
+        with pytest.raises(TypeError, match=msg):
+            # inequalities are not well-defined for complex numbers
+            df.gt(df2)
+        with pytest.raises(TypeError, match=msg):
+            # regression test that we get the same behavior for Series
+            df["a"].gt(df2["a"])
+        with pytest.raises(TypeError, match=msg):
+            # Check that we match numpy behavior here
+            df.values > df2.values
+
         rs = df.ne(df2)
         assert rs.values.all()
 
         arr3 = np.array([2j, np.nan, None])
         df3 = pd.DataFrame({"a": arr3})
-        rs = df3.gt(2j)
-        assert not rs.values.any()
 
+        with pytest.raises(TypeError, match=msg):
+            # inequalities are not well-defined for complex numbers
+            df3.gt(2j)
+        with pytest.raises(TypeError, match=msg):
+            # regression test that we get the same behavior for Series
+            df3["a"].gt(2j)
+        with pytest.raises(TypeError, match=msg):
+            # Check that we match numpy behavior here
+            df3.values > 2j
+
+    def test_bool_flex_frame_object_dtype(self):
         # corner, dtype=object
         df1 = pd.DataFrame({"col": ["foo", np.nan, "bar"]})
         df2 = pd.DataFrame({"col": ["foo", datetime.now(), "bar"]})

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -782,7 +782,7 @@ def test_categorical_no_compress():
 
 def test_sort():
 
-    # http://stackoverflow.com/questions/23814368/sorting-pandas-categorical-labels-after-groupby  # noqa: flake8
+    # http://stackoverflow.com/questions/23814368/sorting-pandas-categorical-labels-after-groupby  # noqa: E501
     # This should result in a properly sorted Series so that the plot
     # has a sorted x axis
     # self.cat.groupby(['value_group'])['value_group'].count().plot(kind='bar')


### PR DESCRIPTION
- [x] closes #28079 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

xref #28050. 

To make the Series vs DataFrame behavior consistent, the two main options are a) change the DataFrame behavior (this PR) or b) change the Series behavior.  The latter is complicated by the fact that for object dtypes the Series comparisons go through comp_method_OBJECT_ARRAY instead of the numpy op, so we would still have to change the complex-case test changed here.