### PR TITLE
BUG: value_counts can handle the case even with empty groups (#28479)

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -299,6 +299,7 @@ Other
 - Using :meth:`DataFrame.replace` with overlapping keys in a nested dictionary will no longer raise, now matching the behavior of a flat dictionary (:issue:`27660`)
 - :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` now support dicts as ``compression`` argument with key ``'method'`` being the compression method and others as additional compression options when the compression method is ``'zip'``. (:issue:`26023`)
 - :meth:`Series.append` will no longer raise a ``TypeError`` when passed a tuple of ``Series`` (:issue:`28410`)
+- :meth:`SeriesGroupBy.value_counts` will be able to handle the case even when the :class:`Grouper` makes empty groups (:issue: 28479)
 
 .. _whatsnew_1000.contributors:
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1259,7 +1259,14 @@ class SeriesGroupBy(GroupBy):
         rep = partial(np.repeat, repeats=np.add.reduceat(inc, idx))
 
         # multi-index components
-        labels = list(map(rep, self.grouper.recons_labels)) + [llab(lab, inc)]
+        try:
+            labels = list(map(rep, self.grouper.recons_labels)) + [llab(lab, inc)]
+        except ValueError:
+            # If applying rep to recons_labels go fail, use ids which has no
+            # consecutive duplicates instead.
+            _ids_idx = np.ones(len(ids), dtype=bool)
+            _ids_idx[1:] = ids[1:] != ids[:-1]
+            labels = list(map(rep, [ids[_ids_idx]])) + [llab(lab, inc)]
         levels = [ping.group_index for ping in self.grouper.groupings] + [lev]
         names = self.grouper.names + [self._selection_name]
 


### PR DESCRIPTION
* If applying rep to recons_labels go fail, use ids which has no
  consecutive duplicates instead. 

- [x] closes #28479 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

xuancong84 found that value_counts() crashes if `groupby` object contains empty groups.
However, even though I made the construction of DataFrame don't skip empty rows, it still crashed.
Till then, I already tried in many ways though, in this time I tried to correct the callee `self.grouper.recons_labels`. After several tests, I found that If freq of `Grouper` is too long so that it has empty groups in some periods then it crashes. And also have found that this is solved by using `ids` which has no consecutive duplicates instead of `self.grouper.recons_labels`.