### PR TITLE
DEPR: Deprecate Index.set_value

### DIFF
--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -166,7 +166,6 @@ Selecting
    Index.get_slice_bound
    Index.get_value
    Index.get_values
-   Index.set_value
    Index.isin
    Index.slice_indexer
    Index.slice_locs

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -123,7 +123,7 @@ Documentation Improvements
 Deprecations
 ~~~~~~~~~~~~
 
-- `Index.set_value` has been deprecated. For a given index ``idx``, array ``arr``,
+- ``Index.set_value`` has been deprecated. For a given index ``idx``, array ``arr``,
   value in ``idx`` of ``idx_val`` and a new value of ``val``, ``idx.set_value(arr, idx_val, val)``
   is equivalent to ``arr[idx.get_loc(idx_val)] = val``, which should be used instead (:issue:`28621`).
 -

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -123,9 +123,9 @@ Documentation Improvements
 Deprecations
 ~~~~~~~~~~~~
 
-- :meth:`Index.set_values` has been deprecated. For a given index ``idx``, array ``arr``,
+- `Index.set_value` has been deprecated. For a given index ``idx``, array ``arr``,
   value in ``idx`` of ``idx_val`` and a new value of ``val``, ``idx.set_value(arr, idx_val, val)``
-  is equivalent to ``arr[idx.get_loc(idx_val) = val``, which should be used instead (:issue:`28621`).
+  is equivalent to ``arr[idx.get_loc(idx_val)] = val``, which should be used instead (:issue:`28621`).
 -
 
 .. _whatsnew_1000.prior_deprecations:

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -123,7 +123,9 @@ Documentation Improvements
 Deprecations
 ~~~~~~~~~~~~
 
--
+- :meth:`Index.set_values` has been deprecated. For a given index ``idx``, array ``arr``,
+  value in ``idx`` of ``idx_val`` and a new value of ``val``, ``idx.set_value(arr, idx_val, val)``
+  is equivalent to ``arr[idx.get_loc(idx_val) = val``, which should be used instead (:issue:`28621`).
 -
 
 .. _whatsnew_1000.prior_deprecations:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -205,7 +205,9 @@ class Index(IndexOpsMixin, PandasObject):
     """
 
     # tolist is not actually deprecated, just suppressed in the __dir__
-    _deprecations = DirNamesMixin._deprecations | frozenset(["tolist", "dtype_str"])
+    _deprecations = DirNamesMixin._deprecations | frozenset(
+        ["tolist", "dtype_str", "set_value"]
+    )
 
     # To hand over control to subclasses
     _join_precedence = 1

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4680,10 +4680,20 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Fast lookup of value from 1-dimensional ndarray.
 
+        .. deprecated:: 1.0
+
         Notes
         -----
         Only use this if you know what you're doing.
         """
+        warnings.warn(
+            (
+                "The 'set_value' method is deprecated, and "
+                "will be removed in a future version."
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
         self._engine.set_value(
             com.values_from_object(arr), com.values_from_object(key), value
         )

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1908,15 +1908,19 @@ class TestIndex(Base):
         index = Index([5, datetime.now(), 7])
         assert not getattr(index, attr)
 
-    def test_get_set_value(self):
+    def test_set_value_deprecated(self):
+        idx = self.create_index()
+        arr = np.array([1, 2, 3])
+        with tm.assert_produces_warning(FutureWarning):
+            idx.set_value(arr, idx[1], 80)
+        assert arr[1] == 80
+
+    def test_get_value(self):
         # TODO: Remove function? GH 19728
         values = np.random.randn(100)
         date = self.dateIndex[67]
 
         assert_almost_equal(self.dateIndex.get_value(values, date), values[67])
-
-        self.dateIndex.set_value(values, date, 10)
-        assert values[67] == 10
 
     @pytest.mark.parametrize("values", [["foo", "bar", "quux"], {"foo", "bar", "quux"}])
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1909,6 +1909,7 @@ class TestIndex(Base):
         assert not getattr(index, attr)
 
     def test_set_value_deprecated(self):
+        # GH 28621
         idx = self.create_index()
         arr = np.array([1, 2, 3])
         with tm.assert_produces_warning(FutureWarning):


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Deprecates ``Index.set_value``. This is a very little used and confusing method IMO.

For a given index ``idx``, array ``arr``,  value ``idx_val`` in ``idx`` and a new value of ``val``, ``idx.set_value(arr, idx_val, val)``  is equivalent to ``arr[idx.get_loc(idx_val) = val``, which is more standard and should be used instead.
