### PR TITLE
REF: Assert json roundtrip equal

### DIFF
--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -36,6 +36,12 @@ _cat_frame["sort"] = np.arange(len(_cat_frame), dtype="int64")
 
 _mixed_frame = _frame.copy()
 
+def assert_json_roundtrip_equal(result, expected, orient):
+    if orient == "records" or orient == "values":
+        expected = expected.reset_index(drop=True)
+    if orient == "values":
+        expected.columns = range(len(expected.columns))
+    assert_frame_equal(result, expected)
 
 class TestPandasContainer:
     @pytest.fixture(scope="function", autouse=True)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -96,25 +96,15 @@ class TestPandasContainer:
         result = read_json(df.to_json(orient=orient), orient=orient)
         expected = df.copy()
 
-        if orient == "records" or orient == "values":
-            expected = expected.reset_index(drop=True)
-        if orient == "values":
-            expected.columns = range(len(expected.columns))
-
-        assert_frame_equal(result, expected)
-
+        assert_json_roundtrip_equal(result, expected, orient)
+        
     @pytest.mark.parametrize("orient", ["split", "records", "values"])
     def test_frame_non_unique_index(self, orient):
         df = DataFrame([["a", "b"], ["c", "d"]], index=[1, 1], columns=["x", "y"])
         result = read_json(df.to_json(orient=orient), orient=orient)
         expected = df.copy()
 
-        if orient == "records" or orient == "values":
-            expected = expected.reset_index(drop=True)
-        if orient == "values":
-            expected.columns = range(len(expected.columns))
-
-        assert_frame_equal(result, expected)
+        assert_json_roundtrip_equal(result, expected, orient)
 
     @pytest.mark.parametrize("orient", ["index", "columns"])
     def test_frame_non_unique_index_raises(self, orient):
@@ -178,12 +168,7 @@ class TestPandasContainer:
             # TODO: debug why sort is required
             expected = expected.sort_index()
 
-        if orient == "records" or orient == "values":
-            expected = expected.reset_index(drop=True)
-        if orient == "values":
-            expected.columns = range(len(expected.columns))
-
-        tm.assert_frame_equal(result, expected)
+        assert_json_roundtrip_equal(result, expected, orient)
 
     @pytest.mark.parametrize("dtype", [False, np.int64])
     @pytest.mark.parametrize("convert_axes", [True, False])
@@ -252,12 +237,7 @@ class TestPandasContainer:
         elif orient == "records" and convert_axes:
             expected.columns = expected.columns.astype(np.int64)
 
-        if orient == "records" or orient == "values":
-            expected = expected.reset_index(drop=True)
-        if orient == "values":
-            expected.columns = range(len(expected.columns))
-
-        tm.assert_frame_equal(result, expected)
+        assert_json_roundtrip_equal(result, expected, orient)
 
     @pytest.mark.parametrize("convert_axes", [True, False])
     @pytest.mark.parametrize("numpy", [True, False])
@@ -283,12 +263,7 @@ class TestPandasContainer:
         if not numpy and (orient == "index" or (PY35 and orient == "columns")):
             expected = expected.sort_index()
 
-        if orient == "records" or orient == "values":
-            expected = expected.reset_index(drop=True)
-        if orient == "values":
-            expected.columns = range(len(expected.columns))
-
-        tm.assert_frame_equal(result, expected)
+        assert_json_roundtrip_equal(result, expected, orient)
 
     @pytest.mark.parametrize("convert_axes", [True, False])
     @pytest.mark.parametrize("numpy", [True, False])
@@ -326,12 +301,7 @@ class TestPandasContainer:
 
             expected.index = idx
 
-        if orient == "records" or orient == "values":
-            expected = expected.reset_index(drop=True)
-        if orient == "values":
-            expected.columns = range(len(expected.columns))
-
-        tm.assert_frame_equal(result, expected)
+        assert_json_roundtrip_equal(result, expected, orient)
 
     @pytest.mark.parametrize("convert_axes", [True, False])
     @pytest.mark.parametrize("numpy", [True, False])
@@ -360,12 +330,7 @@ class TestPandasContainer:
         if not numpy and (orient == "index" or (PY35 and orient == "columns")):
             expected = expected.sort_index()
 
-        if orient == "records" or orient == "values":
-            expected = expected.reset_index(drop=True)
-        if orient == "values":
-            expected.columns = range(len(expected.columns))
-
-        tm.assert_frame_equal(result, expected)
+        assert_json_roundtrip_equal(result, expected, orient)
 
     @pytest.mark.parametrize(
         "data,msg,orient",

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -36,6 +36,7 @@ _cat_frame["sort"] = np.arange(len(_cat_frame), dtype="int64")
 
 _mixed_frame = _frame.copy()
 
+
 def assert_json_roundtrip_equal(result, expected, orient):
     if orient == "records" or orient == "values":
         expected = expected.reset_index(drop=True)
@@ -97,7 +98,7 @@ class TestPandasContainer:
         expected = df.copy()
 
         assert_json_roundtrip_equal(result, expected, orient)
-        
+
     @pytest.mark.parametrize("orient", ["split", "records", "values"])
     def test_frame_non_unique_index(self, orient):
         df = DataFrame([["a", "b"], ["c", "d"]], index=[1, 1], columns=["x", "y"])

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -44,6 +44,7 @@ def assert_json_roundtrip_equal(result, expected, orient):
         expected.columns = range(len(expected.columns))
     assert_frame_equal(result, expected)
 
+
 class TestPandasContainer:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, datapath):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -44,7 +44,6 @@ def assert_json_roundtrip_equal(result, expected, orient):
         expected.columns = range(len(expected.columns))
     assert_frame_equal(result, expected)
 
-
 class TestPandasContainer:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, datapath):
@@ -184,11 +183,6 @@ class TestPandasContainer:
         if not numpy and (orient == "index" or (PY35 and orient == "columns")):
             expected = expected.sort_index()
 
-        if orient == "records" or orient == "values":
-            expected = expected.reset_index(drop=True)
-        if orient == "values":
-            expected.columns = range(len(expected.columns))
-
         if (
             numpy
             and (is_platform_32bit() or is_platform_windows())
@@ -198,7 +192,7 @@ class TestPandasContainer:
             # TODO: see what is causing roundtrip dtype loss
             expected = expected.astype(np.int32)
 
-        tm.assert_frame_equal(result, expected)
+        assert_json_roundtrip_equal(result, expected, orient)
 
     @pytest.mark.parametrize("dtype", [None, np.float64, np.int, "U3"])
     @pytest.mark.parametrize("convert_axes", [True, False])


### PR DESCRIPTION
Replaces a some frequently repeated lines with a function.

- [x] closes #28555
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry