### PR TITLE
CLN: streamline Series _construct_result calls

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -566,11 +566,26 @@ def _align_method_SERIES(left, right, align_asobject=False):
     return left, right
 
 
-def _construct_result(left, result, index, name):
+def _construct_result(
+    left: ABCSeries,
+    result: Union[np.ndarray, ABCExtensionArray],
+    index: ABCIndexClass,
+    name,
+):
     """
-    If the raw op result has a non-None name (e.g. it is an Index object) and
-    the name argument is None, then passing name to the constructor will
-    not be enough; we still need to override the name attribute.
+    Construct an appropriately-labelled Series from the result of an op.
+
+    Parameters
+    ----------
+    left : Series
+    result : ndarray or ExtensionArray
+    index : Index
+    name : object
+
+    Returns
+    -------
+    Series
+        In the case of __divmod__ or __rdivmod__, a 2-tuple of Series.
     """
     if isinstance(result, tuple):
         # produced by divmod or rdivmod

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -5,7 +5,7 @@ This is not a public API.
 """
 import datetime
 import operator
-from typing import Tuple
+from typing import Tuple, Union
 
 import numpy as np
 
@@ -13,7 +13,12 @@ from pandas._libs import Timedelta, Timestamp, lib
 from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.common import is_list_like, is_timedelta64_dtype
-from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
+from pandas.core.dtypes.generic import (
+    ABCDataFrame,
+    ABCExtensionArray,
+    ABCIndexClass,
+    ABCSeries,
+)
 from pandas.core.dtypes.missing import isna
 
 from pandas.core.construction import extract_array

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2738,10 +2738,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             result = func(this_vals, other_vals)
 
         name = ops.get_op_result_name(self, other)
-        if func.__name__ in ["divmod", "rdivmod"]:
-            ret = ops._construct_divmod_result(self, result, new_index, name)
-        else:
-            ret = ops._construct_result(self, result, new_index, name)
+        ret = ops._construct_result(self, result, new_index, name)
         return ret
 
     def combine(self, other, func, fill_value=None):


### PR DESCRIPTION
After this, the three Series methods in `ops.__init__` are just about in sync, the last holdout being alignment behavior in the comparison method.