### PR TITLE
REF: Consolidate alignment calls in DataFrame ops

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5281,12 +5281,7 @@ class DataFrame(NDFrame):
             # fastpath --> operate directly on values
             with np.errstate(all="ignore"):
                 new_data = func(self.values.T, other.values).T
-        return self._construct_result(new_data)
-
-    def _combine_match_columns(self, other: Series, func):
-        # at this point we have `self.columns.equals(other.index)`
-        new_data = ops.dispatch_to_series(self, other, func, axis="columns")
-        return self._construct_result(new_data)
+        return new_data
 
     def _construct_result(self, result) -> "DataFrame":
         """

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -457,7 +457,7 @@ def dispatch_to_series(left, right, func, str_rep=None, axis=None):
             return {i: func(a.iloc[:, i], b.iloc[:, i]) for i in range(len(a.columns))}
 
     elif isinstance(right, ABCSeries) and axis == "columns":
-        # We only get here if called via left._combine_match_columns,
+        # We only get here if called via _combine_frame_series,
         # in which case we specifically want to operate row-by-row
         assert right.index.equals(left.columns)
 
@@ -734,9 +734,11 @@ def _combine_series_frame(self, other, func, fill_value=None, axis=None, level=N
     axis = self._get_axis_number(axis)
     left, right = self.align(other, join="outer", axis=axis, level=level, copy=False)
     if axis == 0:
-        return left._combine_match_index(right, func)
+        new_data = left._combine_match_index(right, func)
     else:
-        return left._combine_match_columns(right, func)
+        new_data = dispatch_to_series(left, right, func, axis="columns")
+
+    return left._construct_result(new_data)
 
 
 def _align_method_FRAME(left, right, axis):

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -727,15 +727,16 @@ def _combine_series_frame(self, other, func, fill_value=None, axis=None, level=N
             "fill_value {fill} not supported.".format(fill=fill_value)
         )
 
-    if axis is not None:
-        axis = self._get_axis_number(axis)
-        if axis == 0:
-            return self._combine_match_index(other, func, level=level)
-        else:
-            return self._combine_match_columns(other, func, level=level)
+    if axis is None:
+        # default axis is columns
+        axis = 1
 
-    # default axis is columns
-    return self._combine_match_columns(other, func, level=level)
+    axis = self._get_axis_number(axis)
+    left, right = self.align(other, join="outer", axis=axis, level=level, copy=False)
+    if axis == 0:
+        return left._combine_match_index(right, func)
+    else:
+        return left._combine_match_columns(right, func)
 
 
 def _align_method_FRAME(left, right, axis):


### PR DESCRIPTION
Next step after this will be to consolidate _construct_result calls.  That hinges on some not-obvious alignment behaviors.