### PR TITLE
accept a dictionary in plot colors

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -502,6 +502,7 @@ Plotting
 - :func:`set_option` now validates that the plot backend provided to ``'plotting.backend'`` implements the backend when the option is set, rather than when a plot is created (:issue:`28163`)
 - :meth:`DataFrame.plot` now allow a ``backend`` keyword arugment to allow changing between backends in one session (:issue:`28619`).
 - Bug in color validation incorrectly raising for non-color styles (:issue:`29122`).
+- :func:`.plot` for line/bar now accepts color by dictonary (:issue:`8193`).
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -741,7 +741,10 @@ class MPLPlot:
         has_color = "color" in kwds or self.colormap is not None
         nocolor_style = style is None or re.match("[a-z]+", style) is None
         if (has_color or self.subplots) and nocolor_style:
-            kwds["color"] = colors[col_num % len(colors)]
+            if isinstance(colors, dict):
+                kwds["color"] = colors[label]
+            else:
+                kwds["color"] = colors[col_num % len(colors)]
         return style, kwds
 
     def _get_colors(self, num_colors=None, color_kwds="color"):
@@ -1354,12 +1357,13 @@ class BarPlot(MPLPlot):
 
         pos_prior = neg_prior = np.zeros(len(self.data))
         K = self.nseries
-
         for i, (label, y) in enumerate(self._iter_data(fillna=0)):
             ax = self._get_ax(i)
             kwds = self.kwds.copy()
             if self._is_series:
                 kwds["color"] = colors
+            elif isinstance(colors, dict):
+                kwds["color"] = colors[label]
             else:
                 kwds["color"] = colors[i % ncolors]
 

--- a/pandas/plotting/_matplotlib/style.py
+++ b/pandas/plotting/_matplotlib/style.py
@@ -27,7 +27,11 @@ def _get_standard_colors(
             warnings.warn(
                 "'color' and 'colormap' cannot be used simultaneously. Using 'color'"
             )
-        colors = list(color) if is_list_like(color) else color
+        colors = (
+            list(color)
+            if is_list_like(color) and not isinstance(color, dict)
+            else color
+        )
     else:
         if color_type == "default":
             # need to call list() on the result to copy so we don't

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -416,3 +416,24 @@ class TestDataFramePlots(TestPlotBase):
         color_list = cm.gnuplot(np.linspace(0, 1, 16))
         p = df.A.plot.bar(figsize=(16, 7), color=color_list)
         assert p.patches[1].get_facecolor() == p.patches[17].get_facecolor()
+
+    @pytest.mark.slow
+    def test_dictionary_color(self):
+        # issue-8193
+        # Test plot color dictionary format
+        data_files = ["a", "b"]
+
+        expected = [(0.5, 0.24, 0.6), (0.3, 0.7, 0.7)]
+
+        df1 = DataFrame(np.random.rand(2, 2), columns=data_files)
+        dic_color = {"b": (0.3, 0.7, 0.7), "a": (0.5, 0.24, 0.6)}
+
+        # Bar color test
+        ax = df1.plot(kind="bar", color=dic_color)
+        colors = [rect.get_facecolor()[0:-1] for rect in ax.get_children()[0:3:2]]
+        assert all(color == expected[index] for index, color in enumerate(colors))
+
+        # Line color test
+        ax = df1.plot(kind="line", color=dic_color)
+        colors = [rect.get_color() for rect in ax.get_lines()[0:2]]
+        assert all(color == expected[index] for index, color in enumerate(colors))


### PR DESCRIPTION
- [ ] closes #8193
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Line/bar plot accepts color by dictonary.
@elisamalzoni