### PR TITLE
PERF: Make matplotlib import lazy

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -204,7 +204,7 @@ import sys
 import pandas
 
 blacklist = {'bs4', 'gcsfs', 'html5lib', 'http', 'ipython', 'jinja2', 'hypothesis',
-             'lxml', 'numexpr', 'openpyxl', 'py', 'pytest', 's3fs', 'scipy',
+             'lxml', 'matplotlib', 'numexpr', 'openpyxl', 'py', 'pytest', 's3fs', 'scipy',
              'tables', 'urllib.request', 'xlrd', 'xlsxwriter', 'xlwt'}
 
 # GH#28227 for some of these check for top-level modules, while others are

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -108,7 +108,6 @@ from pandas.core.series import Series
 
 from pandas.io.formats import console, format as fmt
 from pandas.io.formats.printing import pprint_thing
-import pandas.plotting
 
 # ---------------------------------------------------------------------
 # Docstring templates
@@ -8362,10 +8361,24 @@ class DataFrame(NDFrame):
 
     # ----------------------------------------------------------------------
     # Add plotting methods to DataFrame
-    plot = CachedAccessor("plot", pandas.plotting.PlotAccessor)
-    hist = pandas.plotting.hist_frame
-    boxplot = pandas.plotting.boxplot_frame
     sparse = CachedAccessor("sparse", SparseFrameAccessor)
+
+    @property
+    def plot(self):
+        # property instead of CachedAccessor to allow for lazy matplotlib import
+        from pandas.plotting._core import PlotAccessor
+
+        return PlotAccessor(self)
+
+    def hist(self, *args, **kwargs):
+        from pandas.plotting._core import hist_frame
+
+        return hist_frame(self, *args, **kwargs)
+
+    def boxplot(self, *args, **kwargs):
+        from pandas.plotting._core import boxplot_frame
+
+        return boxplot_frame(self, *args, **kwargs)
 
 
 DataFrame._setup_axes(

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -59,8 +59,6 @@ import pandas.core.indexes.base as ibase
 from pandas.core.internals import BlockManager, make_block
 from pandas.core.series import Series
 
-from pandas.plotting import boxplot_frame_groupby
-
 NamedAgg = namedtuple("NamedAgg", ["column", "aggfunc"])
 # TODO(typing) the return value on this callable should be any *scalar*.
 AggScalar = Union[str, Callable[..., Any]]
@@ -1691,7 +1689,11 @@ class DataFrameGroupBy(NDFrameGroupBy):
             results.index = ibase.default_index(len(results))
         return results
 
-    boxplot = boxplot_frame_groupby
+    def boxplot(self, *args, **kwargs):
+        # wrap to allow for lazy import of matplotlib
+        from pandas.plotting import boxplot_frame_groupby
+
+        return boxplot_frame_groupby(self, *args, **kwargs)
 
 
 def _is_multi_agg_with_relabel(**kwargs):

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -611,8 +611,9 @@ b  2""",
         # need to setup the selection
         # as are not passed directly but in the grouper
         f = getattr(self._selected_obj, name)
+
         if not isinstance(f, types.MethodType):
-            return self.apply(lambda self: getattr(self, name))
+            return self.apply(lambda x: getattr(x, name))
 
         f = getattr(type(self._selected_obj), name)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -79,7 +79,6 @@ from pandas.core.strings import StringMethods
 from pandas.core.tools.datetimes import to_datetime
 
 import pandas.io.formats.format as fmt
-import pandas.plotting
 
 __all__ = ["Series"]
 
@@ -4758,12 +4757,23 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     str = CachedAccessor("str", StringMethods)
     dt = CachedAccessor("dt", CombinedDatetimelikeProperties)
     cat = CachedAccessor("cat", CategoricalAccessor)
-    plot = CachedAccessor("plot", pandas.plotting.PlotAccessor)
     sparse = CachedAccessor("sparse", SparseAccessor)
 
     # ----------------------------------------------------------------------
     # Add plotting methods to Series
-    hist = pandas.plotting.hist_series
+
+    @property
+    def plot(self):
+        # property instead of CachedAccessor to allow for lazy matplotlib import
+        from pandas.plotting._core import PlotAccessor
+
+        return PlotAccessor(self)
+
+    def hist(self, *args, **kwargs):
+        # pass-through to allow for lazy matplotlib import
+        from pandas.plotting._core import hist_series
+
+        return hist_series(self, *args, **kwargs)
 
 
 Series._setup_axes(

--- a/pandas/plotting/__init__.py
+++ b/pandas/plotting/__init__.py
@@ -56,6 +56,7 @@ https://github.com/pyviz/hvplot as a reference on how to write a backend.
 For the discussion about the API see
 https://github.com/pandas-dev/pandas/issues/26747.
 """
+
 from pandas.plotting._core import (
     PlotAccessor,
     boxplot,

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -186,7 +186,7 @@ def _grouped_plot(
         warnings.warn(
             "figsize='default' is deprecated. Specify figure " "size by tuple instead",
             FutureWarning,
-            stacklevel=5,
+            stacklevel=6,
         )
         figsize = None
 

--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -30,7 +30,8 @@ pytest.importorskip("matplotlib.pyplot")
 
 def test_initial_warning():
     code = (
-        "import pandas as pd; import matplotlib.pyplot as plt; "
+        "import pandas as pd; import pandas.plotting; "
+        "import matplotlib.pyplot as plt; "
         "s = pd.Series(1, pd.date_range('2000', periods=12)); "
         "fig, ax = plt.subplots(); "
         "ax.plot(s.index, s.values)"
@@ -47,6 +48,7 @@ def test_registry_mpl_resets():
         "import matplotlib.dates as mdates; "
         "n_conv = len(units.registry); "
         "import pandas as pd; "
+        "import pandas.plotting; "
         "pd.plotting.register_matplotlib_converters(); "
         "pd.plotting.deregister_matplotlib_converters(); "
         "assert len(units.registry) == n_conv"

--- a/pandas/tseries/plotting.py
+++ b/pandas/tseries/plotting.py
@@ -1,3 +1,2 @@
-# flake8: noqa
-
+__all__ = ["tsplot"]
 from pandas.plotting._matplotlib.timeseries import tsplot


### PR DESCRIPTION
Cuts import time by about 23%, from 393ms to 303ms (note these measurements are pretty noisy).  The percentage edges up to 26% if we ignore get_version, since that is negligible in a release.

Downside: we lose some docstrings on plotting methods.  Will need to decide if it is worth a refactor to keep them in place.