### PR TITLE
BUG: fix broken error message in ujson.encode() (GH18878)

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -301,6 +301,7 @@ Other
 - Using :meth:`DataFrame.replace` with overlapping keys in a nested dictionary will no longer raise, now matching the behavior of a flat dictionary (:issue:`27660`)
 - :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` now support dicts as ``compression`` argument with key ``'method'`` being the compression method and others as additional compression options when the compression method is ``'zip'``. (:issue:`26023`)
 - :meth:`Series.append` will no longer raise a ``TypeError`` when passed a tuple of ``Series`` (:issue:`28410`)
+- Fix corrupted error message when calling ``pandas.libs._json.encode()`` on a 0d array (:issue:`18878`)
 
 .. _whatsnew_1000.contributors:
 

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -1986,11 +1986,9 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         tc->type = JT_DOUBLE;
         return;
     } else if (PyArray_Check(obj) && PyArray_CheckScalar(obj)) {
-        tmpObj = PyObject_Repr(obj);
         PyErr_Format(PyExc_TypeError,
-                     "%s (0d array) is not JSON serializable at the moment",
-                     PyBytes_AS_STRING(tmpObj));
-        Py_DECREF(tmpObj);
+                     "%R (0d array) is not JSON serializable at the moment",
+                     obj);
         goto INVALID;
     }
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -780,8 +780,10 @@ class TestNumpyJSONTests:
         tm.assert_almost_equal(arr, arr_out)
 
     def test_0d_array(self):
-        with pytest.raises(TypeError):
+        msg = "array(1) (0d array) is not JSON serializable at the moment"
+        with pytest.raises(TypeError) as excinfo:
             ujson.encode(np.array(1))
+        assert str(excinfo.value) == msg
 
     @pytest.mark.parametrize(
         "bad_input,exc_type,kwargs",

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -780,10 +780,10 @@ class TestNumpyJSONTests:
         tm.assert_almost_equal(arr, arr_out)
 
     def test_0d_array(self):
-        msg = "array(1) (0d array) is not JSON serializable at the moment"
-        with pytest.raises(TypeError) as excinfo:
+        # gh-18878
+        msg = re.escape("array(1) (0d array) is not JSON serializable at the moment")
+        with pytest.raises(TypeError, match=msg):
             ujson.encode(np.array(1))
-        assert str(excinfo.value) == msg
 
     @pytest.mark.parametrize(
         "bad_input,exc_type,kwargs",


### PR DESCRIPTION
- [x] closes #18878
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
