### PR TITLE
Fix incorrect doc for to_datetime

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -627,7 +627,7 @@ def to_datetime(
         - If True, require an exact format match.
         - If False, allow the format to match anywhere in the target string.
 
-    unit : str, default 'ns'
+    unit : str, default None
         unit of the arg (D,s,ms,us,ns) denote the unit, which is an
         integer or float number. This will be based off the origin.
         Example, with unit='ms' and origin='unix' (the default), this
@@ -637,7 +637,7 @@ def to_datetime(
         datetime strings, and if it can be inferred, switch to a faster
         method of parsing them. In some cases this can increase the parsing
         speed by ~5-10x.
-    origin : scalar, default is 'unix'
+    origin : scalar, default 'unix'
         Define the reference date. The numeric values would be parsed as number
         of units (defined by `unit`) since this reference date.
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -627,7 +627,7 @@ def to_datetime(
         - If True, require an exact format match.
         - If False, allow the format to match anywhere in the target string.
 
-    unit : str, default None
+    unit : str, default 'ns'
         unit of the arg (D,s,ms,us,ns) denote the unit, which is an
         integer or float number. This will be based off the origin.
         Example, with unit='ms' and origin='unix' (the default), this


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This PR fixes incorrect doc for `pandas.to_datetime`.