### PR TITLE
BUG: Fix Series.sort_values descending & mergesort

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -445,6 +445,8 @@ Other
 - Fix corrupted error message when calling ``pandas.libs._json.encode()`` on a 0d array (:issue:`18878`)
 - Fix :class:`AbstractHolidayCalendar` to return correct results for
   years after 2030 (now goes up to 2200) (:issue:`27790`)
+- Bug in :meth:`Series.sort_values` when ``ascending`` is set to ``False`` and
+  ``kind`` is set to ``mergesort`` (:issue:`28697`)
 
 
 .. _whatsnew_1000.contributors:

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -86,6 +86,17 @@ class TestSeriesSorting:
         with pytest.raises(ValueError, match=msg):
             s.sort_values(inplace=True)
 
+    def test_sort_values_mergesort(self):
+        ser = Series([1, 2, 1, 3], ["first", "b", "second", "c"])
+        expected = Series([1, 1, 2, 3], ["first", "second", "b", "c"])
+        result = ser.sort_values(kind="mergesort")
+        tm.assert_series_equal(expected, result)
+
+        # ascending=False is not just a reverse of ascending=True
+        expected = Series([3, 2, 1, 1], ["c", "b", "first", "second"])
+        result = ser.sort_values(ascending=False, kind="mergesort")
+        tm.assert_series_equal(expected, result)
+
     def test_sort_index(self, datetime_series):
         rindex = list(datetime_series.index)
         random.shuffle(rindex)


### PR DESCRIPTION
The solution uses the `nargsort` function, which was created to handle
in one place the intricacies of sorting. Not adapting Series.sort_values
to use may have been an oversight.

- [ ] closes #28697
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
