### PR TITLE
DOC: Series.between() can take arguments that are not just scalars

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4410,9 +4410,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Parameters
         ----------
-        left : scalar
+        left : scalar or list-like
             Left boundary.
-        right : scalar
+        right : scalar or list-like
             Right boundary.
         inclusive : bool, default True
             Include boundaries.


### PR DESCRIPTION
modified the docs of Series.between() to reflect that it can take any
list like object like Series

closes #28435