### PR TITLE
TST: return pytest MarkDecorator from td.skip_if_no #26735

### DIFF
--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -108,9 +108,7 @@ def test_gcs_get_filepath_or_buffer(monkeypatch):
     assert_frame_equal(df1, df2)
 
 
-@pytest.mark.skipif(
-    td.safe_import("gcsfs"), reason="Only check when gcsfs not installed"
-)
+@td.skip_if_installed("gcsfs")
 def test_gcs_not_present_exception():
     with pytest.raises(ImportError) as e:
         read_csv("gs://test/test.csv")


### PR DESCRIPTION
- [x] xref https://github.com/pandas-dev/pandas/pull/26735#issuecomment-500156276
- [x] tests added / passed
- [ ] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] I've replaced `safe_import` function with a corresponding test decorator. I've also investigated whether `safe_import` could be replaced with `_safe_import` and the answer is negative (see `pandas/tests/io/excel/test_writers.py`).
