### PR TITLE
BUG: fix renaming in requirements generation script

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ numpydoc>=0.9.0
 nbconvert>=5.4.1
 nbsphinx
 pandoc
-dask-core
+dask
 toolz>=0.7.3
 fsspec>=0.5.1
 partd>=0.3.10

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -48,6 +48,9 @@ def conda_package_to_pip(package):
 
         break
 
+    if package in RENAME:
+        return RENAME[package]
+
     return package
 
 


### PR DESCRIPTION
- [x] closes #28714
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

