### PR TITLE
TST: add test to confirm adding 'm' to a Series of strings does not error

### DIFF
--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -74,7 +74,7 @@ class TestSeriesArithmetic:
         ],
     )
     def test_string_addition(self, target_add, input_value, expected_value):
-        # GH28658
+        # GH28658 - ensure adding 'm' does not raise an error
         a = Series(input_value)
 
         result = a + target_add

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -66,6 +66,21 @@ class TestSeriesArithmetic:
         with pytest.raises(IncompatibleFrequency, match=msg):
             ts + ts.asfreq("D", how="end")
 
+    @pytest.mark.parametrize(
+        "target_add,input_value,expected_value",
+        [
+            ("!", ["hello", "world"], ["hello!", "world!"]),
+            ("m", ["hello", "world"], ["hellom", "worldm"]),
+        ],
+    )
+    def test_string_addition(self, target_add, input_value, expected_value):
+        # GH28658
+        a = Series(input_value)
+
+        result = a + target_add
+        expected = Series(expected_value)
+        tm.assert_series_equal(result, expected)
+
 
 # ------------------------------------------------------------------
 # Comparisons


### PR DESCRIPTION
adds a test to check for regressions later.   Replacement PR for #28732

- [ X ] closes #28658 
- [ X ] tests added / passed
- [ X ] passes `black pandas`
- [ X ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ -  ] whatsnew entry
