### PR TITLE
Backport PR #28400 on branch 0.25.x (Fix a typo in "computation.rst" in document.)

### DIFF
--- a/doc/source/user_guide/computation.rst
+++ b/doc/source/user_guide/computation.rst
@@ -182,7 +182,7 @@ assigned the mean of the ranks (by default) for the group:
 
 .. ipython:: python
 
-   s = pd.Series(np.random.np.random.randn(5), index=list('abcde'))
+   s = pd.Series(np.random.randn(5), index=list('abcde'))
    s['d'] = s['b']  # so there's a tie
    s.rank()
 
@@ -192,7 +192,7 @@ ranking.
 
 .. ipython:: python
 
-   df = pd.DataFrame(np.random.np.random.randn(10, 6))
+   df = pd.DataFrame(np.random.randn(10, 6))
    df[4] = df[2][:5]  # some ties
    df
    df.rank(1)


### PR DESCRIPTION
Manually backporting #28400 since the bot isn't responding; did a cherry-pick of 6d47fabaf94d7427b48b30a3808545738cd778c6.  This should fix the failing doc builds on the 0.25.x branch.
