### PR TITLE
DOC: Pandas.Series.drop docstring PR02 (#27976)

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4154,9 +4154,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             Index labels to drop.
         axis : 0, default 0
             Redundant for application on Series.
-        index, columns : None
-            Redundant for application on Series, but index can be used instead
-            of labels.
+        index : single label or list-like
+            Redundant for application on Series, but 'index' can be used instead
+            of 'labels'.
+
+            .. versionadded:: 0.21.0
+        columns : single label or list-like
+            No change is made to the Series; use 'index' or 'labels' instead.
 
             .. versionadded:: 0.21.0
         level : int or level name, optional


### PR DESCRIPTION
- [x] addresses, but **does not fully close**, #27976 
- [x] tests added / passed - I didn't run the full `pytest` suite on the actual code, but rather re-ran:
```
./scripts/validate_docstrings.py pandas.Series.drop --errors=PR02
```
to confirm that the docstring formatting passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] ~whatsnew entry~ - not needed

First PR to pandas, which has been my go-to tool for many years now! Thanks, maintainers! 🎉 
