### PR TITLE
get rid of the None engine tests and just have a separate test that ensures how that gets bound to a particular engine #26662 (comment)

### DIFF
--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -60,15 +60,12 @@ def engine(request):
     return request.param
 
 
-@pytest.mark.parametrize("kwargs", [dict(), dict(engine=None)])
-def test_default_engine(datapath, monkeypatch, kwargs):
-    """
-    A test for default ExcelFile engine value (which is None)
-    """
+@td.skip_if_no("xlrd")
+def test_default_engine(datapath, monkeypatch):
     monkeypatch.chdir(datapath("io", "data"))
     expected = "xlrd"
 
-    result = pd.ExcelFile("blank.xls", **kwargs)
+    result = pd.ExcelFile("blank.xls")
     assert result.engine == expected
 
 

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -63,7 +63,7 @@ def engine(request):
 @pytest.mark.parametrize("kwargs", [dict(), dict(engine=None)])
 def test_default_engine(datapath, monkeypatch, kwargs):
     """
-    A test for default ExcelFile engine value (which is None) and a bad engine value
+    A test for default ExcelFile engine value (which is None)
     """
     monkeypatch.chdir(datapath("io", "data"))
     expected = "xlrd"
@@ -502,7 +502,6 @@ class TestReaders:
         with open(pth, "rb") as f:
             actual = pd.read_excel(f, "Sheet1", index_col=0)
             tm.assert_frame_equal(expected, actual)
-
 
     @tm.network
     def test_read_from_http_url(self, read_ext):

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -60,6 +60,7 @@ def engine(request):
     return request.param
 
 
+@pytest.mark.filterwarnings("ignore:.*(tree\\.iter|html argument)")
 @td.skip_if_no("xlrd")
 def test_default_engine(datapath, monkeypatch):
     monkeypatch.chdir(datapath("io", "data"))


### PR DESCRIPTION
- [x] xref https://github.com/pandas-dev/pandas/pull/26662#discussion_r291258182, https://github.com/pandas-dev/pandas/pull/26543#issuecomment-497126487, #26784
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] I've replaced `None` engine tests with corresponding separate test for default engine value. I also excluded `test_bad_engine_raises` from `TestReaders` class.
