### PR TITLE
CLN: Define UDFException for catching arbitrary Exception

### DIFF
--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -17,6 +17,10 @@ cnp.import_array()
 cimport pandas._libs.util as util
 from pandas._libs.lib import maybe_convert_objects
 
+# Alias for Exception to use specifically when catching exceptions raised
+#  by user-defined functions, since we cannot be any more specific for those
+UDFException = Exception
+
 
 cdef _get_result_array(object obj, Py_ssize_t size, Py_ssize_t cnt):
 
@@ -170,9 +174,9 @@ cdef class Reducer:
                 PyArray_SETITEM(result, PyArray_ITER_DATA(it), res)
                 chunk.data = chunk.data + self.increment
                 PyArray_ITER_NEXT(it)
-        except Exception, e:
-            if hasattr(e, 'args'):
-                e.args = e.args + (i,)
+        except Exception as err:
+            if hasattr(err, 'args'):
+                err.args = err.args + (i,)
             raise
         finally:
             # so we don't free the wrong memory
@@ -536,7 +540,7 @@ def apply_frame_axis0(object frame, object f, object names,
 
             try:
                 piece = f(chunk)
-            except Exception:
+            except UDFException:
                 # We can't be more specific without knowing something about `f`
                 raise InvalidApply('Let this error raise above us')
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -4,6 +4,7 @@ import warnings
 import numpy as np
 
 from pandas._libs import reduction as libreduction
+from pandas.errors import UDFException
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
@@ -206,7 +207,7 @@ class FrameApply:
         if not should_reduce:
             try:
                 r = self.f(Series([]))
-            except Exception:
+            except UDFException:
                 pass
             else:
                 should_reduce = not isinstance(r, Series)
@@ -326,7 +327,7 @@ class FrameApply:
             for i, v in enumerate(series_gen):
                 try:
                     results[i] = self.f(v)
-                except Exception:
+                except UDFException:
                     pass
                 else:
                     keys.append(v.name)
@@ -341,13 +342,15 @@ class FrameApply:
                 for i, v in enumerate(series_gen):
                     results[i] = self.f(v)
                     keys.append(v.name)
-            except Exception as e:
-                if hasattr(e, "args"):
+            except UDFException as err:
+                if hasattr(err, "args"):
 
                     # make sure i is defined
                     if i is not None:
                         k = res_index[i]
-                        e.args = e.args + ("occurred at index %s" % pprint_thing(k),)
+                        err.args = err.args + (
+                            "occurred at index %s" % pprint_thing(k),
+                        )
                 raise
 
         self.results = results

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from pandas.compat import set_function_name
 from pandas.compat.numpy import function as nv
-from pandas.errors import AbstractMethodError
+from pandas.errors import AbstractMethodError, UDFException
 from pandas.util._decorators import Appender, Substitution
 from pandas.util._validators import validate_fillna_kwargs
 
@@ -1155,7 +1155,7 @@ class ExtensionScalarOpsMixin(ExtensionOpsMixin):
                     # to an ndarray.
                     try:
                         res = self._from_sequence(arr)
-                    except Exception:
+                    except UDFException:
                         res = np.asarray(arr)
                 else:
                     res = np.asarray(arr)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -10,6 +10,7 @@ from pandas._config import get_option
 
 from pandas._libs import algos as libalgos, hashtable as htable, lib
 from pandas.compat.numpy import function as nv
+from pandas.errors import UDFException
 from pandas.util._decorators import (
     Appender,
     Substitution,
@@ -2613,7 +2614,7 @@ def _get_codes_for_values(values, categories):
         # Categorical(array[Period, Period], categories=PeriodIndex(...))
         try:
             values = categories.dtype.construct_array_type()._from_sequence(values)
-        except Exception:
+        except UDFException:
             # but that may fail for any reason, so fall back to object
             values = ensure_object(values)
             categories = ensure_object(categories)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -15,6 +15,7 @@ from pandas._config import get_option
 from pandas._libs import index as libindex, lib, reshape, tslibs
 from pandas.compat import PY36
 from pandas.compat.numpy import function as nv
+from pandas.errors import UDFException
 from pandas.util._decorators import Appender, Substitution, deprecate
 from pandas.util._validators import validate_bool_kwarg
 
@@ -2837,7 +2838,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             # if the type is compatible with the calling EA.
             try:
                 new_values = self._values._from_sequence(new_values)
-            except Exception:
+            except UDFException:
                 # https://github.com/pandas-dev/pandas/issues/22850
                 # pandas has no control over what 3rd-party ExtensionArrays
                 # do in _values_from_sequence. We still want ops to work

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -4,6 +4,7 @@
 Expose public exceptions & warnings
 """
 
+from pandas._libs.reduction import UDFException
 from pandas._libs.tslibs import NullFrequencyError, OutOfBoundsDatetime
 
 


### PR DESCRIPTION
Alias `UDFException = Exception` (User Defined Function) for cases where we can't be more specific than `except Exception`, but this way we can be explicit that we're doing this on purpose.

Maybe at the end of this process we can add a code check to disallow `except Exception` altogether.