### PR TITLE
hide Index.get_values in docs and IPython tab completion

### DIFF
--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -165,6 +165,7 @@ Selecting
    Index.get_loc
    Index.get_slice_bound
    Index.get_value
+   Index.get_values
    Index.isin
    Index.slice_indexer
    Index.slice_locs

--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -165,7 +165,6 @@ Selecting
    Index.get_loc
    Index.get_slice_bound
    Index.get_value
-   Index.get_values
    Index.isin
    Index.slice_indexer
    Index.slice_locs

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -206,7 +206,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     # tolist is not actually deprecated, just suppressed in the __dir__
     _deprecations = DirNamesMixin._deprecations | frozenset(
-        ["tolist", "dtype_str", "set_value"]
+        ["tolist", "dtype_str", "get_values", "set_value"]
     )
 
     # To hand over control to subclasses


### PR DESCRIPTION
In #28621 I hid the deprecated method ``Index.set_value`` in the docs (in ``indexing.rst``) and in the REPL/Ipython (by adding it to ``Index._deprecations``). I like that as it hides not-recommended parts of the pandas API and guides users away from deprecated methods.

I've given the already deprecated method ``Indexc.get_values`` the same treatment in this PR. If there's consensus about it, I could go through various deprecations (at least the more obscure ones, like ``get_ftype_counts`` and ``get_ftype_counts`` etc.).