### PR TITLE
TST: Remove maybe_promote tests for iNaT as an NA value

### DIFF
--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -19,7 +19,6 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_object_dtype,
     is_scalar,
-    is_string_dtype,
     is_timedelta64_dtype,
 )
 from pandas.core.dtypes.dtypes import DatetimeTZDtype


### PR DESCRIPTION
These are left over from a time when maybe_promote treated iNaT as an NA value, which we stopped doing because it is ambiguous.

Removes 22 xfails (leaving 317 in this file)