### PR TITLE
BUG: pd.MultiIndex.get_loc(np.nan)

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -229,6 +229,7 @@ Indexing
 - Bug in reindexing a :meth:`PeriodIndex` with another type of index that contained a `Period` (:issue:`28323`) (:issue:`28337`)
 - Fix assignment of column via `.loc` with numpy non-ns datetime type (:issue:`27395`)
 - Bug in :meth:`Float64Index.astype` where ``np.inf`` was not handled properly when casting to an integer dtype (:issue:`28475`)
+- When index is ``MultiIndex``, Using ``.get_loc`` can't find ``nan`` with a null value as input (:issue:`19132`)
 
 Missing
 ^^^^^^^

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -439,3 +439,26 @@ def test_timestamp_multiindex_indexer():
     )
     should_be = pd.Series(data=np.arange(24, len(qidx) + 24), index=qidx, name="foo")
     tm.assert_series_equal(result, should_be)
+
+
+def test_get_loc_with_a_missing_value():
+    # issue 19132
+    idx = MultiIndex.from_product([[np.nan, 1]] * 2)
+    expected = slice(0, 2, None)
+    assert idx.get_loc(np.nan) == expected
+
+    idx = MultiIndex.from_arrays([[np.nan, 1, 2, np.nan], [3, np.nan, np.nan, 4]])
+    expected = np.array([True, False, False, True])
+    tm.assert_numpy_array_equal(idx.get_loc(np.nan), expected)
+
+
+def test_get_indexer_with_nan():
+    # issue 19132
+    idx = MultiIndex.from_arrays([[1, np.nan, 2], [3, 4, 5]])
+    result = idx.get_indexer([1, np.nan, 2])
+    expected = np.array([-1, -1, -1], dtype="int32")
+    tm.assert_numpy_array_equal(result.astype("int32"), expected)
+
+    result = idx.get_indexer([(np.nan, 4)])
+    expected = np.array([1], dtype="int32")
+    tm.assert_numpy_array_equal(result.astype("int32"), expected)


### PR DESCRIPTION
MultiIndex.get_loc can find nan when input is NA value(e.g. nan, None)

- [ ] closes #19132
- [x] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
