### PR TITLE
BUG: Keep categorical name in groupby

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -284,6 +284,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.rolling` not allowing for rolling over datetimes when ``axis=1`` (:issue: `28192`)
 - Bug in :meth:`DataFrame.groupby` not offering selection by column name when ``axis=1`` (:issue:`27614`)
 - Bug in :meth:`DataFrameGroupby.agg` not able to use lambda function with named aggregation (:issue:`27519`)
+- Bug in :meth:`DataFrame.groupby` losing column name information when grouping by a categorical column (:issue:`28787`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -330,7 +330,8 @@ class Grouping:
                 self._group_index = CategoricalIndex(
                     Categorical.from_codes(
                         codes=codes, categories=categories, ordered=self.grouper.ordered
-                    )
+                    ),
+                    name=self.name,
                 )
 
             # we are done

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1195,19 +1195,13 @@ def test_groupby_categorical_axis_1(code):
     assert_frame_equal(result, expected)
 
 
-def test_groupby_cat_preserves_structure():
+def test_groupby_cat_preserves_structure(observed):
     # GH 28787
-    df = DataFrame({"Name": ["Bob", "Greg"], "Item": [1, 2]})
-    expected = (
-        df.groupby("Name", observed=True)
-        .agg(pd.DataFrame.sum, skipna=True)
-        .reset_index()
-    )
-    expected["Name"] = expected["Name"].astype("category")
+    df = DataFrame({"Name": Categorical(["Bob", "Greg"]), "Item": [1, 2]})
+    expected = df.copy()
 
-    df["Name"] = df["Name"].astype("category")
     result = (
-        df.groupby("Name", observed=True)
+        df.groupby("Name", observed=observed)
         .agg(pd.DataFrame.sum, skipna=True)
         .reset_index()
     )

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1206,4 +1206,4 @@ def test_groupby_cat_preserves_structure(observed):
         .reset_index()
     )
 
-    assert_frame_equal(result, expected)
+    assert_frame_equal(result, expected, check_like=True)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1197,7 +1197,7 @@ def test_groupby_categorical_axis_1(code):
 
 def test_groupby_cat_preserves_structure(observed):
     # GH 28787
-    df = DataFrame({"Name": Categorical(["Bob", "Greg"]), "Item": [1, 2]})
+    df = DataFrame([("Bob", 1), ("Greg", 2)], columns=["Name", "Item"])
     expected = df.copy()
 
     result = (
@@ -1206,4 +1206,4 @@ def test_groupby_cat_preserves_structure(observed):
         .reset_index()
     )
 
-    assert_frame_equal(result, expected, check_like=True)
+    assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1204,3 +1204,4 @@ def test_groupby_cat_preserves_group_name():
     result = df.groupby("a").grouper.levels[0].name
 
     assert result == expected
+    assert result == "a"

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1195,13 +1195,21 @@ def test_groupby_categorical_axis_1(code):
     assert_frame_equal(result, expected)
 
 
-def test_groupby_cat_preserves_group_name():
+def test_groupby_cat_preserves_structure():
     # GH 28787
-    df = DataFrame({"a": [1, 2, 3]})
-    expected = df.groupby("a").grouper.levels[0].name
+    df = DataFrame({"Name": ["Bob", "Greg"], "Item": [1, 2]})
+    expected = (
+        df.groupby("Name", observed=True)
+        .agg(pd.DataFrame.sum, skipna=True)
+        .reset_index()
+    )
+    expected["Name"] = expected["Name"].astype("category")
 
-    df["a"] = df["a"].astype("category")
-    result = df.groupby("a").grouper.levels[0].name
+    df["Name"] = df["Name"].astype("category")
+    result = (
+        df.groupby("Name", observed=True)
+        .agg(pd.DataFrame.sum, skipna=True)
+        .reset_index()
+    )
 
-    assert result == expected
-    assert result == "a"
+    assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -674,7 +674,7 @@ def test_preserve_categories():
 
     # ordered=True
     df = DataFrame({"A": Categorical(list("ba"), categories=categories, ordered=True)})
-    index = CategoricalIndex(categories, categories, ordered=True)
+    index = CategoricalIndex(categories, categories, ordered=True, name="A")
     tm.assert_index_equal(
         df.groupby("A", sort=True, observed=False).first().index, index
     )
@@ -684,8 +684,8 @@ def test_preserve_categories():
 
     # ordered=False
     df = DataFrame({"A": Categorical(list("ba"), categories=categories, ordered=False)})
-    sort_index = CategoricalIndex(categories, categories, ordered=False)
-    nosort_index = CategoricalIndex(list("bac"), list("bac"), ordered=False)
+    sort_index = CategoricalIndex(categories, categories, ordered=False, name="A")
+    nosort_index = CategoricalIndex(list("bac"), list("bac"), ordered=False, name="A")
     tm.assert_index_equal(
         df.groupby("A", sort=True, observed=False).first().index, sort_index
     )
@@ -1193,3 +1193,14 @@ def test_groupby_categorical_axis_1(code):
     result = df.groupby(cat, axis=1).mean()
     expected = df.T.groupby(cat, axis=0).mean().T
     assert_frame_equal(result, expected)
+
+
+def test_groupby_cat_preserves_group_name():
+    # GH 28787
+    df = DataFrame({"a": [1, 2, 3]})
+    expected = df.groupby("a").grouper.levels[0].name
+
+    df["a"] = df["a"].astype("category")
+    result = df.groupby("a").grouper.levels[0].name
+
+    assert result == expected


### PR DESCRIPTION
- [x] closes #28787
- [x] tests added / passed
- [x] passes `black pandas`
- [x] whatsnew entry

Fixes an issue where column name information was getting dropped when grouping by a categorical column.  I had to change a couple existing tests which I think were incorrect since they were implicitly assuming this behavior was expected.  Also confirmed that this fixes the problem from #28787:

```python
[ins] In [1]: import pandas as pd 
         ...:  
         ...: df = pd.DataFrame(data=(('Bob', 2),  ('Greg', None), ('Greg', 6)), columns=['Name', 'Items']) 
         ...:  
         ...: df_cat = df.copy() 
         ...: df_cat['Name'] = df_cat['Name'].astype('category') 
         ...: df_cat.groupby('Name', observed=True).agg(pd.DataFrame.sum, skipna=True).reset_index() 
         ...:                                                                                                                                                              
Out[1]: 
   Name  Items
0   Bob    2.0
1  Greg    6.0
```