### PR TITLE
TST: Move datetime specific test from common tests

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -96,14 +96,6 @@ class Base:
         df = idx.to_frame(index=False, name=idx_name)
         assert df.index is not idx
 
-    def test_to_frame_datetime_tz(self):
-        # GH 25809
-        idx = pd.date_range(start="2019-01-01", end="2019-01-30", freq="D")
-        idx = idx.tz_localize("UTC")
-        result = idx.to_frame()
-        expected = pd.DataFrame(idx, index=idx)
-        tm.assert_frame_equal(result, expected)
-
     def test_shift(self):
 
         # GH8083 test the base class for shift

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -450,3 +450,10 @@ class TestDatetimeIndex:
             result = np.asarray(idx, dtype=object)
 
         tm.assert_numpy_array_equal(result, expected)
+
+    def test_to_frame_datetime_tz(self):
+        # GH 25809
+        idx = date_range(start="2019-01-01", end="2019-01-30", freq="D", tz="UTC")
+        result = idx.to_frame()
+        expected = DataFrame(idx, index=idx)
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
This test gets rerun multiple times unnecessarily since it is included in the common tests but is actually datetime specific.  Moved it to the more appropriate `datetimes/test_datetime.py` file. Did a quick audit of the other common tests and the rest look fine.