### PR TITLE
DOC/BLD: remove old sphinx pin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,8 +27,7 @@ dependencies:
 
   # documentation
   - gitpython  # obtain contributors from git for whatsnew
-  # some styling is broken with sphinx >= 2 (https://github.com/pandas-dev/pandas/issues/26058)
-  - sphinx=1.8.5
+  - sphinx
   - numpydoc>=0.9.0
 
   # documentation (jupyter notebooks)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ isort
 mypy
 pycodestyle
 gitpython
-sphinx==1.8.5
+sphinx
 numpydoc>=0.9.0
 nbconvert>=5.4.1
 nbsphinx


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/26058 and https://github.com/pandas-dev/pandas-sphinx-theme/issues/25

We need a newer sphinx version for the new theme. There were some styling issues with the parameter listings on the docstring API pages, but those probably need to redesigned anyway with the new theme.