### PR TITLE
API: Add various deprecated attributes to ._deprecated

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -151,6 +151,8 @@ Other API changes
 
 - :meth:`pandas.api.types.infer_dtype` will now return "integer-na" for integer and ``np.nan`` mix (:issue:`27283`)
 - :meth:`MultiIndex.from_arrays` will no longer infer names from arrays if ``names=None`` is explicitly provided (:issue:`27292`)
+- In order to improve tab-completion, Pandas does not include most deprecated attributes when introspecting a pandas object using ``dir`` (e.g. ``dir(df)``).
+  To see which attributes are excluded, see an object's ``_deprecations`` attribute, for example ``pd.DataFrame._deprecations`` (:issue:`28805`).
 - The returned dtype of ::func:`pd.unique` now matches the input dtype. (:issue:`27874`)
 -
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -331,7 +331,7 @@ class Categorical(ExtensionArray, PandasObject):
     __array_priority__ = 1000
     _dtype = CategoricalDtype(ordered=False)
     # tolist is not actually deprecated, just suppressed in the __dir__
-    _deprecations = frozenset(["labels", "tolist"])
+    _deprecations = PandasObject._deprecations | frozenset(["get_values", "tolist"])
     _typ = "categorical"
 
     def __init__(
@@ -2521,6 +2521,10 @@ class CategoricalAccessor(PandasDelegate, PandasObject, NoNewAttributesMixin):
     >>> s.cat.as_ordered()
     >>> s.cat.as_unordered()
     """
+
+    _deprecations = PandasObject._deprecations | frozenset(
+        ["categorical", "index", "name"]
+    )
 
     def __init__(self, data):
         self._validate(data)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -331,7 +331,7 @@ class Categorical(ExtensionArray, PandasObject):
     __array_priority__ = 1000
     _dtype = CategoricalDtype(ordered=False)
     # tolist is not actually deprecated, just suppressed in the __dir__
-    _deprecations = PandasObject._deprecations | frozenset(["get_values", "tolist"])
+    _deprecations = PandasObject._deprecations | frozenset(["tolist", "get_values"])
     _typ = "categorical"
 
     def __init__(

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -263,6 +263,7 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
 
     _pandas_ftype = "sparse"
     _subtyp = "sparse_array"  # register ABCSparseArray
+    _deprecations = PandasObject._deprecations | frozenset(["get_values"])
 
     def __init__(
         self,

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -648,6 +648,7 @@ class IndexOpsMixin:
 
     # ndarray compatibility
     __array_priority__ = 1000
+    _deprecations = frozenset(["item"])
 
     def transpose(self, *args, **kwargs):
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -170,7 +170,19 @@ class NDFrame(PandasObject, SelectionMixin):
     _internal_names_set = set(_internal_names)  # type: Set[str]
     _accessors = set()  # type: Set[str]
     _deprecations = frozenset(
-        ["as_blocks", "blocks", "is_copy", "ftypes", "ix"]
+        [
+            "as_blocks",
+            "as_matrix",
+            "blocks",
+            "clip_lower",
+            "clip_upper",
+            "get_dtype_counts",
+            "get_ftype_counts",
+            "get_values",
+            "is_copy",
+            "ftypes",
+            "ix",
+        ]
     )  # type: FrozenSet[str]
     _metadata = []  # type: List[str]
     _is_copy = None

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -208,7 +208,7 @@ class Index(IndexOpsMixin, PandasObject):
     _deprecations = (
         IndexOpsMixin._deprecations
         | DirNamesMixin._deprecations
-        | frozenset(["contains", "tolist", "dtype_str", "get_values", "set_value"])
+        | frozenset(["tolist", "contains", "dtype_str", "get_values", "set_value"])
     )
 
     # To hand over control to subclasses

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -205,8 +205,10 @@ class Index(IndexOpsMixin, PandasObject):
     """
 
     # tolist is not actually deprecated, just suppressed in the __dir__
-    _deprecations = DirNamesMixin._deprecations | frozenset(
-        ["tolist", "dtype_str", "get_values", "set_value"]
+    _deprecations = (
+        IndexOpsMixin._deprecations
+        | DirNamesMixin._deprecations
+        | frozenset(["contains", "tolist", "dtype_str", "get_values", "set_value"])
     )
 
     # To hand over control to subclasses

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -229,6 +229,10 @@ class MultiIndex(Index):
     of the mentioned helper methods.
     """
 
+    _deprecations = Index._deprecations | frozenset(
+        ["labels", "set_labels", "to_hierarchical"]
+    )
+
     # initialize to zero-length tuples to make everything work
     _typ = "multiindex"
     _names = FrozenList()

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -175,11 +175,25 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     _metadata = ["name"]
     _accessors = {"dt", "cat", "str", "sparse"}
-    # tolist is not actually deprecated, just suppressed in the __dir__
     _deprecations = (
-        generic.NDFrame._deprecations
+        base.IndexOpsMixin._deprecations
+        | generic.NDFrame._deprecations
         | DirNamesMixin._deprecations
-        | frozenset(["asobject", "reshape", "valid", "tolist", "ftype", "real", "imag"])
+        | frozenset(
+            [
+                "asobject",
+                "compress",
+                "reshape",
+                "valid",
+                "tolist",  # tolist is not deprecated, just suppressed in the __dir__
+                "ftype",
+                "real",
+                "imag",
+                "put",
+                "ptp",
+                "nonzero",
+            ]
+        )
     )
 
     # Override cache_readonly bc Series is mutable

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -181,11 +181,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         | DirNamesMixin._deprecations
         | frozenset(
             [
+                "tolist",  # tolist is not deprecated, just suppressed in the __dir__
                 "asobject",
                 "compress",
-                "reshape",
                 "valid",
-                "tolist",  # tolist is not deprecated, just suppressed in the __dir__
                 "ftype",
                 "real",
                 "imag",

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -247,9 +247,6 @@ class TestSeriesMisc(TestData, SharedWithSparse):
     def test_tab_completion_with_categorical(self):
         # test the tab completion display
         ok_for_cat = [
-            "name",
-            "index",
-            "categorical",
             "categories",
             "codes",
             "ordered",


### PR DESCRIPTION
- [x] xref #28772
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This add various deprecated attributes to their respective types' ``_deprecated``. The effect is that these are now also hidden when tab-completing, making navigating the pandas attributes easier.

