### PR TITLE
TST: Allow for multiple variables on the same line in docstring validation

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2076,12 +2076,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Parameters
         ----------
-        skipna : bool, default True
-            Exclude NA/null values. If the entire Series is NA, the result
-            will be NA.
         axis : int, default 0
             For compatibility with DataFrame.idxmin. Redundant for application
             on Series.
+        skipna : bool, default True
+            Exclude NA/null values. If the entire Series is NA, the result
+            will be NA.
         *args, **kwargs
             Additional keywords have no effect but might be accepted
             for compatibility with NumPy.
@@ -2146,12 +2146,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Parameters
         ----------
-        skipna : bool, default True
-            Exclude NA/null values. If the entire Series is NA, the result
-            will be NA.
         axis : int, default 0
             For compatibility with DataFrame.idxmax. Redundant for application
             on Series.
+        skipna : bool, default True
+            Exclude NA/null values. If the entire Series is NA, the result
+            will be NA.
         *args, **kwargs
             Additional keywords have no effect but might be accepted
             for compatibility with NumPy.

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -39,6 +39,23 @@ class GoodDocStrings:
         """
         pass
 
+    def swap(self, arr, i, j, *args, **kwargs):
+        """
+        Swap two indecies on an array.
+
+        Parameters
+        ----------
+        arr : List
+            The list having indexes swapped.
+        i, j : int
+            The indexes being swapped.
+        *args, **kwargs
+            Extraneous parameters are being permitted.
+        """
+        temp = arr[i]
+        arr[i] = arr[j]
+        arr[j] = temp
+
     def sample(self):
         """
         Generate and return a random number.
@@ -634,6 +651,17 @@ class BadParameters:
         """
         pass
 
+    def bad_parameter_spacing(self, a, b):
+        """
+        The parameters on the same line have an extra space between them.
+
+        Parameters
+        ----------
+        a,  b : int
+            Foo bar baz.
+        """
+        pass
+
 
 class BadReturns:
     def return_not_documented(self):
@@ -827,6 +855,7 @@ class TestValidator:
         "func",
         [
             "plot",
+            "swap",
             "sample",
             "random_letters",
             "sample_values",
@@ -1001,6 +1030,11 @@ class TestValidator:
                 "BadParameters",
                 "list_incorrect_parameter_type",
                 ('Parameter "kind" type should use "str" instead of "string"',),
+            ),
+            (
+                "BadParameters",
+                "bad_parameter_spacing",
+                ("Parameters {b} not documented", "Unknown parameters { b}"),
             ),
             pytest.param(
                 "BadParameters",

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -41,20 +41,18 @@ class GoodDocStrings:
 
     def swap(self, arr, i, j, *args, **kwargs):
         """
-        Swap two indecies on an array.
+        Swap two indicies on an array.
 
         Parameters
         ----------
-        arr : List
+        arr : list
             The list having indexes swapped.
         i, j : int
             The indexes being swapped.
         *args, **kwargs
             Extraneous parameters are being permitted.
         """
-        temp = arr[i]
-        arr[i] = arr[j]
-        arr[j] = temp
+        pass
 
     def sample(self):
         """
@@ -286,9 +284,7 @@ class GoodDocStrings:
         i, j : int
             The indicies of the second value.
         """
-        temp = matrix[a][b]
-        matrix[a][b] = matrix[i][j]
-        matrix[i][j] = temp
+        pass
 
 
 class BadGenericDocStrings:

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -273,6 +273,23 @@ class GoodDocStrings:
         else:
             return None
 
+    def multiple_variables_on_one_line(self, matrix, a, b, i, j):
+        """
+        Swap two values in a matrix.
+
+        Parameters
+        ----------
+        matrix : list of list
+            A double list that represents a matrix.
+        a, b : int
+            The indicies of the first value.
+        i, j : int
+            The indicies of the second value.
+        """
+        temp = matrix[a][b]
+        matrix[a][b] = matrix[i][j]
+        matrix[i][j] = temp
+
 
 class BadGenericDocStrings:
     """Everything here has a bad docstring
@@ -866,6 +883,7 @@ class TestValidator:
             "good_imports",
             "no_returns",
             "empty_returns",
+            "multiple_variables_on_one_line",
         ],
     )
     def test_good_functions(self, capsys, func):

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -422,10 +422,11 @@ class Docstring:
 
     @property
     def doc_parameters(self):
-        return collections.OrderedDict(
-            (name, (type_, "".join(desc)))
-            for name, type_, desc in self.doc["Parameters"]
-        )
+        parameters = collections.OrderedDict()
+        for names, type_, desc in self.doc["Parameters"]:
+            for name in names.split(", "):
+                parameters[name] = (type_, "".join(desc))
+        return parameters
 
     @property
     def signature_parameters(self):


### PR DESCRIPTION
Allow for multiple variables to share the same type and description in documentation. For example, `i, j, k : int` Would be three variables, i, j, and k, which are all ints.

- [ ] tests added / passed 
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry - I'm not sure how to add this, if it needs done could I get a pointer?
