### PR TITLE
TST: Update test in #28798 to use a Categorical

### DIFF
--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1195,9 +1195,12 @@ def test_groupby_categorical_axis_1(code):
     assert_frame_equal(result, expected)
 
 
-def test_groupby_cat_preserves_structure(observed):
+def test_groupby_cat_preserves_structure(observed, ordered_fixture):
     # GH 28787
-    df = DataFrame([("Bob", 1), ("Greg", 2)], columns=["Name", "Item"])
+    df = DataFrame(
+        {"Name": Categorical(["Bob", "Greg"], ordered=ordered_fixture), "Item": [1, 2]},
+        columns=["Name", "Item"],
+    )
     expected = df.copy()
 
     result = (


### PR DESCRIPTION
- [x] xref #28798
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I merged #28798 too fast, as the column "Name" wasn't a Categorical, which was to be tested. I've made it a Categorical and for good measure I've added ``ordered_fixture`` to the test.