### PR TITLE
CLN: core.generic.NDFrame.astype

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5899,7 +5899,7 @@ class NDFrame(PandasObject, SelectionMixin):
                         col.astype(dtype=dtype[col_name], copy=copy, errors=errors)
                     )
                 else:
-                    results.append(results.append(col.copy() if copy else col))
+                    results.append(col.copy() if copy else col)
 
         elif is_extension_array_dtype(dtype) and self.ndim > 1:
             # GH 18099/22869: columnwise conversion to extension dtype


### PR DESCRIPTION
mypy error: `pandas\core\generic.py:5902: error: "append" of "list" does not return a value`

This does not actually manifest as a bug with the current implementation since `pd.concat` ignores `None`.

```python
>>> import pandas as pd
>>>
>>> pd.__version__
'0.26.0.dev0+498.gaf498fe8f'
>>>
>>> d = {'col1': [1, 2], 'col2': [3, 4]}
>>>
>>> df = pd.DataFrame(data=d)
>>>
>>> df
   col1  col2
0     1     3
1     2     4
>>>
>>> df.astype({'col1': 'int32'}).dtypes
col1    int32
col2    int64
dtype: object
>>>
>>> results = []
>>> results.append(df['col1'].astype('int32'))
>>> results.append(results.append(df['col2']))
>>> results
[0    1
1    2
Name: col1, dtype: int32, 0    3
1    4
Name: col2, dtype: int64, None]
>>>
>>> pd.concat(results, axis=1)
   col1  col2
0     1     3
1     2     4
>>>
```
