### PR TITLE
Make package PEP 561 compatible

### DIFF
--- a/pandas/py.typed
+++ b/pandas/py.typed
@@ -1,0 +1,2 @@
+partial
+

--- a/setup.py
+++ b/setup.py
@@ -808,7 +808,7 @@ setup(
     maintainer=AUTHOR,
     version=versioneer.get_version(),
     packages=find_packages(include=["pandas", "pandas.*"]),
-    package_data={"": ["templates/*", "_libs/*.dll"]},
+    package_data={"": ["templates/*", "_libs/*.dll", "py.typed"]},
     ext_modules=maybe_cythonize(extensions, compiler_directives=directives),
     maintainer_email=EMAIL,
     description=DESCRIPTION,


### PR DESCRIPTION
Pandas has growing number of type annotations but these are not properly advertised to type checking tools. According to [PEP 561](https://www.python.org/dev/peps/pep-0561/) packages providing annotations should contain `py.typed` files in corresponding packages.

`py.typed` is applied recursively, if placed in the root, and can accept missing annotations, if contains `partial\n`.

This PR adds such file and includes it in `package_data`.

- [x] closes #28142
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
