### PR TITLE
TST: Improve compatibility with pypy error messages

### DIFF
--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -887,7 +887,7 @@ class TestDatetime64Arithmetic:
 
         result = dtarr - tdarr
         tm.assert_equal(result, expected)
-        msg = "cannot subtract|bad operand type for unary -"
+        msg = "cannot subtract|(bad|unsupported) operand type for unary"
         with pytest.raises(TypeError, match=msg):
             tdarr - dtarr
 
@@ -1126,7 +1126,7 @@ class TestDatetime64DateOffsetArithmetic:
 
         result2 = -pd.offsets.Second(5) + ser
         tm.assert_equal(result2, expected)
-        msg = "bad operand type for unary"
+        msg = "(bad|unsupported) operand type for unary"
         with pytest.raises(TypeError, match=msg):
             pd.offsets.Second(5) - ser
 
@@ -1220,7 +1220,7 @@ class TestDatetime64DateOffsetArithmetic:
             expected = DatetimeIndex([x - off for x in vec_items])
             expected = tm.box_expected(expected, box_with_array)
             tm.assert_equal(expected, vec - off)
-            msg = "bad operand type for unary"
+            msg = "(bad|unsupported) operand type for unary"
             with pytest.raises(TypeError, match=msg):
                 off - vec
 
@@ -1336,7 +1336,7 @@ class TestDatetime64DateOffsetArithmetic:
             expected = DatetimeIndex([offset + x for x in vec_items])
             expected = tm.box_expected(expected, box_with_array)
             tm.assert_equal(expected, offset + vec)
-            msg = "bad operand type for unary"
+            msg = "(bad|unsupported) operand type for unary"
             with pytest.raises(TypeError, match=msg):
                 offset - vec
 
@@ -1920,7 +1920,7 @@ class TestTimestampSeriesArithmetic:
         result = dt1 - td1[0]
         exp = (dt1.dt.tz_localize(None) - td1[0]).dt.tz_localize(tz)
         tm.assert_series_equal(result, exp)
-        msg = "bad operand type for unary"
+        msg = "(bad|unsupported) operand type for unary"
         with pytest.raises(TypeError, match=msg):
             td1[0] - dt1
 

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -245,7 +245,7 @@ class TestTimedelta64ArithmeticUnsorted:
         with pytest.raises(TypeError, match=msg):
             td - dt
 
-        msg = "bad operand type for unary -: 'DatetimeArray'"
+        msg = "(bad|unsupported) operand type for unary"
         with pytest.raises(TypeError, match=msg):
             td - dti
 


### PR DESCRIPTION
This fixes a bunch of spurious errors when running the test suite on pypy3.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
