### PR TITLE
Clean up Abstract and Naming Definitions for GroupBy

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -132,6 +132,9 @@ def pin_whitelisted_properties(klass: Type[FrameOrSeries], whitelist: FrozenSet[
 class SeriesGroupBy(GroupBy):
     _apply_whitelist = base.series_apply_whitelist
 
+    def _iterate_slices(self):
+        yield self._selection_name, self._selected_obj
+
     @property
     def _selection_name(self):
         """

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -345,7 +345,9 @@ class SeriesGroupBy(GroupBy):
         return self._reindex_output(result)._convert(datetime=True)
 
     def _wrap_transformed_output(self, output, names=None):
-        return self._wrap_series_output(output=output, index=self.obj.index, names=names)
+        return self._wrap_series_output(
+            output=output, index=self.obj.index, names=names
+        )
 
     def _wrap_applied_output(self, keys, values, not_indexed_same=False):
         if len(keys) == 0:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -928,9 +928,6 @@ b  2""",
 
         return self._wrap_aggregated_output(output)
 
-    def _wrap_applied_output(self, *args, **kwargs):
-        raise AbstractMethodError(self)
-
     def _concat_objects(self, keys, values, not_indexed_same=False):
         from pandas.core.reshape.concat import concat
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -739,9 +739,6 @@ b  2""",
 
         return result
 
-    def aggregate(self, func=None, *args, **kwargs):
-        raise AbstractMethodError
-
     def _python_apply_general(self, f):
         keys, values, mutated = self.grouper.apply(f, self._selected_obj, self.axis)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -747,7 +747,7 @@ b  2""",
         )
 
     def _iterate_slices(self):
-        yield self._selection_name, self._selected_obj
+        raise AbstractMethodError(self)
 
     def transform(self, func, *args, **kwargs):
         raise AbstractMethodError(self)
@@ -870,6 +870,12 @@ b  2""",
         return self._wrap_transformed_output(output, names)
 
     def _wrap_aggregated_output(self, output, names=None):
+        raise AbstractMethodError(self)
+
+    def _wrap_transformed_output(self, output, names=None):
+        raise AbstractMethodError(self)
+
+    def _wrap_applied_output(self, keys, values, not_indexed_same=False):
         raise AbstractMethodError(self)
 
     def _cython_agg_general(self, how, alt=None, numeric_only=True, min_count=-1):

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -739,6 +739,9 @@ b  2""",
 
         return result
 
+    def aggregate(self, func=None, *args, **kwargs):
+        raise AbstractMethodError
+
     def _python_apply_general(self, f):
         keys, values, mutated = self.grouper.apply(f, self._selected_obj, self.axis)
 


### PR DESCRIPTION
Summary of changes:

  - Made `_iterate_slices` abstract in base class, moved pre-existing definition from Base -> Series where it was actually being called (DataFrame already overrides)
  - Made `_wrap_transformed_output` Abstract in base class, as both Series and DataFrame override this
  - Redefined `_wrap_applied_output`; this was Abstract in base class before but its definition was not in sync with how the subclasses actually defined
  - Renamed `_wrap_output` to `_wrap_series_output` as it is only valid for SeriesGroupBy
  - Renamed `_wrap_generic_output` to `_wrap_frame_output` as it is only valid for DataFrameGroupBy
  - Renamed `_aggregate_generic` to `_aggregate_frame` as it is only valid for DataFrameGroupBy

More to come in separate PRs
