### PR TITLE
[MINOR] Fix formatting string in _ODFReader.get_sheet_by_name

### DIFF
--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -60,7 +60,7 @@ class _ODFReader(_BaseExcelReader):
             if table.getAttribute("name") == name:
                 return table
 
-        raise ValueError("sheet {name} not found".format(name))
+        raise ValueError("sheet {name} not found".format(name=name))
 
     def get_sheet_data(self, sheet, convert_float: bool) -> List[List[Scalar]]:
         """Parse an ODF Table into a list of lists


### PR DESCRIPTION
This PR fixes minor problem with `_ODFReader.get_sheet_by_name` method.  

If `name` is not found, it attempts to raise a `ValueError` with formatted string that expects keyword argument `name`, however `names` is passed as a positional argument. In effect it will throw unexpected `KeyError`.

Steps to reproduce the problem:

```python
from odf.opendocument import OpenDocumentSpreadsheet
import tempfile

path = tempfile.mktemp()
OpenDocumentSpreadsheet().save(path)
pd.read_excel(path, engine="odf", sheet_name="foo")

# Traceback (most recent call last):
...
# KeyError: 'name'

```

Expected behavior

```python
# Traceback (most recent call last):
# ...
# ValueError: sheet foo not found

```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
