### PR TITLE
ENH: Add optional argument keep_index to dataframe melt method (merged master onto old PR)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6312,6 +6312,10 @@ class DataFrame(NDFrame):
         Name to use for the 'value' column.
     col_level : int or str, optional
         If columns are a MultiIndex then use this level to melt.
+    keep_index : boolean, optional, default False
+        If True, the original index is reused.
+        In the resulting MulitIndex the names of the unpivoted columns
+        are added as an additional level to ensure uniqueness.
 
     Returns
     -------
@@ -6396,6 +6400,7 @@ class DataFrame(NDFrame):
         var_name=None,
         value_name="value",
         col_level=None,
+        keep_index=False,
     ):
         from pandas.core.reshape.melt import melt
 
@@ -6406,6 +6411,7 @@ class DataFrame(NDFrame):
             var_name=var_name,
             value_name=value_name,
             col_level=col_level,
+            keep_index=keep_index,
         )
 
     # ----------------------------------------------------------------------

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -125,8 +125,9 @@ def melt(
         if len(frame.index.names) == len(set(frame.index.names)):
             orig_index_names = frame.index.names
         else:
-            orig_index_names = ["original_index_{i}".format(i=i)
-                                for i in range(len(frame.index.names))]
+            orig_index_names = [
+                "original_index_{i}".format(i=i) for i in range(len(frame.index.names))
+            ]
 
         result[orig_index_names] = frame._constructor(orig_index_values)
 


### PR DESCRIPTION
This PR merges master onto @NiklasKeck's PR branch (#17440) to add an optional argument to keep_index to `pd.melt`. There is quite a bit of discussion between the following 2 PRs and issues:

Index gets lost when DataFrame melt method is used #17440
ENH: Add optional argument keep_index to dataframe melt method #17459
Melt enhance #17677

Please let me know if additional things need to be done to complete this PR

----

Setting keep_index to True will reuse the original DataFrame index +
names of melted columns as additional level. closes issue #17440

(cherry picked from commit 0c64bf0e5f145781c0f74fb93ffcd63a6d964bd9)

- [x] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
