### PR TITLE
TST: Fix xfails for non-box maybe_promote on integer dtypes

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -449,11 +449,13 @@ def maybe_promote(dtype, fill_value=np.nan):
 
                 else:
                     # bump to signed integer dtype that holds all of `mst` range
+                    # Note: we have to use itemsize because some (windows)
+                    #  builds don't satisfiy e.g. np.uint32 == np.uint32
                     ndt = {
-                        np.uint32: np.int64,
-                        np.uint16: np.int32,
-                        np.uint8: np.int16,  # TODO: Test for this case
-                    }[mst.type]
+                        4: np.int64,
+                        2: np.int32,
+                        1: np.int16,  # TODO: Test for this case
+                    }[mst.itemsize]
                     dtype = np.dtype(ndt)
 
             fill_value = dtype.type(fill_value)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -453,6 +453,8 @@ def maybe_promote(dtype, fill_value=np.nan):
                     pass
                 elif mst == np.uint32:
                     dtype = np.dtype(np.int64)
+                elif mst == np.uint16:
+                    dtype = np.dtype(np.int32)
                 else:
                     raise NotImplementedError(dtype, mst)
 

--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -156,7 +156,8 @@ def _assert_match(result_fill_value, expected_fill_value):
         assert ex_type.__name__ == "uint64"
     elif res_type.__name__ == "ulonglong":
         # On some builds we get this instead of np.uint64
-        assert res_type.dtype.itemsize == 8
+        # Note: cant check res_type.dtype.itemsize directly on numpy 1.18
+        assert res_type(0).itemsize == 8
         assert ex_type == res_type or ex_type == np.uint64
     else:
         # On some builds, type comparison fails, e.g. np.int32 != np.int32

--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -151,7 +151,11 @@ def _assert_match(result_fill_value, expected_fill_value):
     # GH#23982/25425 require the same type in addition to equality/NA-ness
     res_type = type(result_fill_value)
     ex_type = type(expected_fill_value)
-    assert res_type == ex_type
+    if res_type.__name__ == "uint64":
+        # No idea why, but these do not compare as equal
+        assert ex_type.__name__ == "uint64"
+    else:
+        assert res_type == ex_type
 
     match_value = result_fill_value == expected_fill_value
 
@@ -276,25 +280,24 @@ def test_maybe_promote_int_with_int(dtype, fill_value, expected_dtype, box):
     boxed, box_dtype = box  # read from parametrized fixture
 
     if not boxed:
-        if expected_dtype == object:
-            pytest.xfail("overflow error")
         if expected_dtype == "int32":
             pytest.xfail("always upcasts to platform int")
-        if dtype == "int8" and expected_dtype == "int16":
+        elif dtype == "int8" and expected_dtype == "int16":
             pytest.xfail("casts to int32 instead of int16")
-        if (
+        elif (
             issubclass(dtype.type, np.unsignedinteger)
             and np.iinfo(dtype).max < fill_value <= np.iinfo("int64").max
         ):
             pytest.xfail("falsely casts to signed")
-        if (dtype, expected_dtype) in [
+        elif (dtype, expected_dtype) in [
             ("uint8", "int16"),
             ("uint32", "int64"),
         ] and fill_value != np.iinfo("int32").min - 1:
-            pytest.xfail("casts to int32 instead of int8/int16")
-        # this following xfail is "only" a consequence of the - now strictly
-        # enforced - principle that maybe_promote_with_scalar always casts
-        pytest.xfail("wrong return type of fill_value")
+            pass#pytest.xfail("casts to int32 instead of int8/int16")
+        elif expected_dtype != object:
+            # this following xfail is "only" a consequence of the - now strictly
+            # enforced - principle that maybe_promote_with_scalar always casts
+            pass#pytest.xfail("wrong return type of fill_value")
     if boxed:
         if expected_dtype != object:
             pytest.xfail("falsely casts to object")

--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -279,25 +279,6 @@ def test_maybe_promote_int_with_int(dtype, fill_value, expected_dtype, box):
     expected_dtype = np.dtype(expected_dtype)
     boxed, box_dtype = box  # read from parametrized fixture
 
-    if not boxed:
-        if expected_dtype == "int32":
-            pytest.xfail("always upcasts to platform int")
-        elif dtype == "int8" and expected_dtype == "int16":
-            pytest.xfail("casts to int32 instead of int16")
-        elif (
-            issubclass(dtype.type, np.unsignedinteger)
-            and np.iinfo(dtype).max < fill_value <= np.iinfo("int64").max
-        ):
-            pytest.xfail("falsely casts to signed")
-        elif (dtype, expected_dtype) in [
-            ("uint8", "int16"),
-            ("uint32", "int64"),
-        ] and fill_value != np.iinfo("int32").min - 1:
-            pass#pytest.xfail("casts to int32 instead of int8/int16")
-        elif expected_dtype != object:
-            # this following xfail is "only" a consequence of the - now strictly
-            # enforced - principle that maybe_promote_with_scalar always casts
-            pass#pytest.xfail("wrong return type of fill_value")
     if boxed:
         if expected_dtype != object:
             pytest.xfail("falsely casts to object")

--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -152,14 +152,15 @@ def _assert_match(result_fill_value, expected_fill_value):
     res_type = type(result_fill_value)
     ex_type = type(expected_fill_value)
     if res_type.__name__ == "uint64":
-        # No idea why, but these do not compare as equal
+        # No idea why, but these (sometimes) do not compare as equal
         assert ex_type.__name__ == "uint64"
     elif res_type.__name__ == "ulonglong":
         # On some builds we get this instead of np.uint64
         assert res_type.dtype.itemsize == 8
         assert ex_type == res_type or ex_type == np.uint64
     else:
-        assert res_type == ex_type
+        # On some builds, type comparison fails, e.g. np.int32 != np.int32
+        assert res_type == ex_type or res_type.__name__ == ex_type.__name__
 
     match_value = result_fill_value == expected_fill_value
 

--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -154,6 +154,10 @@ def _assert_match(result_fill_value, expected_fill_value):
     if res_type.__name__ == "uint64":
         # No idea why, but these do not compare as equal
         assert ex_type.__name__ == "uint64"
+    elif res_type.__name__ == "ulonglong":
+        # On some builds we get this instead of np.uint64
+        assert res_type.dtype.itemsize == 8
+        assert ex_type == res_type or ex_type == np.uint64
     else:
         assert res_type == ex_type
 


### PR DESCRIPTION
Orthogonal to other outstanding maybe_promote PRs.

This one required pretty significant changes to the code.  Using `np.min_scalar_type` and `np.can_cast` cleans this up a bit, but it is still pretty verbose.  AFAICT there is no clear way to make it shorter without significantly sacrificing clarity.

In a follow-up I think L410-459 can be refactored out to a helper function.  Waiting on that until I figure out the boxed=True cases, which are still troublesome.