### PR TITLE
CLN: dont catch on groupby.mean

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -971,6 +971,18 @@ class DataFrameGroupBy(GroupBy):
                 if result is not no_result:
                     # see if we can cast the block back to the original dtype
                     result = maybe_downcast_numeric(result, block.dtype)
+
+                    if result.ndim == 1 and isinstance(result, np.ndarray):
+                        # e.g. block.values was an IntegerArray
+                        try:
+                            # Cast back if feasible
+                            result = type(block.values)._from_sequence(
+                                result, dtype=block.values.dtype
+                            )
+                        except ValueError:
+                            # reshape to be valid for non-Extension Block
+                            result = result.reshape(1, -1)
+
                     newb = block.make_block(result)
 
             new_items.append(locs)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1212,16 +1212,9 @@ class GroupBy(_GroupBy):
         Name: B, dtype: float64
         """
         nv.validate_groupby_func("mean", args, kwargs, ["numeric_only"])
-        try:
-            return self._cython_agg_general(
-                "mean", alt=lambda x, axis: Series(x).mean(**kwargs), **kwargs
-            )
-        except GroupByError:
-            raise
-        except Exception:
-            with _group_selection_context(self):
-                f = lambda x: x.mean(axis=self.axis, **kwargs)
-                return self._python_agg_general(f)
+        return self._cython_agg_general(
+            "mean", alt=lambda x, axis: Series(x).mean(**kwargs), **kwargs
+        )
 
     @Substitution(name="groupby")
     @Appender(_common_see_also)


### PR DESCRIPTION
The new casting in cython_agg_blocks is specific to a single IntegerArray test case.  We could pretty reasonably move that into maybe_downcast_numeric.  For the moment id rather hold off since I expect other EA cases to show up here.

cc @WillAyd