### PR TITLE
TYPING: errors reported by mypy 0.730

### DIFF
--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -71,7 +71,7 @@ class _LoadSparseSeries:
 
     # https://github.com/python/mypy/issues/1020
     # error: Incompatible return type for "__new__" (returns "Series", but must return
-    # a subtype of "_LoadSparseSeries")    def __new__(cls) -> "Series":
+    # a subtype of "_LoadSparseSeries")
     def __new__(cls) -> "Series":  # type: ignore
         from pandas import Series
 

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -68,7 +68,11 @@ Loading a saved '{cls}' as a {new} with sparse values.
 
 class _LoadSparseSeries:
     # To load a SparseSeries as a Series[Sparse]
-    def __new__(cls) -> "Series":
+
+    # https://github.com/python/mypy/issues/1020
+    # error: Incompatible return type for "__new__" (returns "Series", but must return
+    # a subtype of "_LoadSparseSeries")    def __new__(cls) -> "Series":
+    def __new__(cls) -> "Series":  # type: ignore
         from pandas import Series
 
         warnings.warn(
@@ -82,7 +86,11 @@ class _LoadSparseSeries:
 
 class _LoadSparseFrame:
     # To load a SparseDataFrame as a DataFrame[Sparse]
-    def __new__(cls) -> "DataFrame":
+
+    # https://github.com/python/mypy/issues/1020
+    # error: Incompatible return type for "__new__" (returns "DataFrame", but must
+    # return a subtype of "_LoadSparseFrame")
+    def __new__(cls) -> "DataFrame":  # type: ignore
         from pandas import DataFrame
 
         warnings.warn(


### PR DESCRIPTION
errors reported by mypy 0.730 on master.

```
pandas\compat\pickle_compat.py:71: error: Incompatible return type for "__new__" (returns "Series", but must return a subtype of "_LoadSparseSeries")
pandas\compat\pickle_compat.py:85: error: Incompatible return type for "__new__" (returns "DataFrame", but must return a subtype of "_LoadSparseFrame")
```

probably makes sense to apply these changes now to avoid ci breakage on mypy bump.
