### PR TITLE
CLN: simplify maybe_promote in float and complex cases

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -405,11 +405,8 @@ def maybe_promote(dtype, fill_value=np.nan):
                 dtype = np.min_scalar_type(fill_value)
 
         elif dtype.kind == "c":
-            if not np.can_cast(fill_value, dtype):
-                if np.can_cast(fill_value, np.dtype("c16")):
-                    dtype = np.dtype(np.complex128)
-                else:
-                    dtype = np.dtype(np.object_)
+            mst = np.min_scalar_type(fill_value)
+            dtype = np.promote_types(dtype, mst)
 
             if dtype.kind == "c" and not np.isnan(fill_value):
                 fill_value = dtype.type(fill_value)
@@ -490,16 +487,8 @@ def maybe_promote(dtype, fill_value=np.nan):
         if issubclass(dtype.type, np.bool_):
             dtype = np.dtype(np.object_)
         elif issubclass(dtype.type, (np.integer, np.floating)):
-            c8 = np.dtype(np.complex64)
-            info = np.finfo(dtype) if dtype.kind == "f" else np.iinfo(dtype)
-            if (
-                np.can_cast(fill_value, c8)
-                and np.can_cast(info.min, c8)
-                and np.can_cast(info.max, c8)
-            ):
-                dtype = np.dtype(np.complex64)
-            else:
-                dtype = np.dtype(np.complex128)
+            mst = np.min_scalar_type(fill_value)
+            dtype = np.promote_types(dtype, mst)
 
         elif dtype.kind == "c":
             mst = np.min_scalar_type(fill_value)


### PR DESCRIPTION
Analogous to #28899 (orthogonal) for complex and float dtypes.  I'm pretty sure that after the current crop of maybe_promote PRs goes through we can do another round of consolidating code.