### PR TITLE
BUG: Avoid undefined behaviour when converting from float to timedelta

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -360,7 +360,7 @@ def _wrap_results(result, dtype, fill_value=None):
 
             result = tslibs.Timedelta(result, unit="ns")
         else:
-            result = result.astype("i8").view(dtype)
+            result = result.astype("m8[ns]").view(dtype)
 
     return result
 


### PR DESCRIPTION
Summation of timedelta series with NaTs in them result in undefined
behaviour because the final wrapping step of the summation ends up
converting the NaNs in the sum through a direct cast to int64.  This
cast is undefined for NaN and just happens to work on x86_64 because
of the way `cvttd2si` works.  On Aarch64, the corresponding `fcvtzs` sets
the result to 0 on undefined input.

This fix trivially sets the conversion target to m8 instead of i8 so
that numpy correctly casts from NaN to NaT.  Note that the fix in
numpy for the same is pending in PR numpy/numpy#14669 .

There is an existing test (test_sum_nanops_timedelta in
frame/test_analytics.py) that exercises this bug and has been verified
to have been fixed with this and the numpy patch.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
