### PR TITLE
DOC: disable nbsphinx including requirejs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -120,6 +120,9 @@ plot_html_show_source_link = False
 plot_pre_code = """import numpy as np
 import pandas as pd"""
 
+# nbsphinx do not use requirejs (breaks bootstrap)
+nbsphinx_requirejs_path = ""
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["../_templates"]
 


### PR DESCRIPTION
To fix https://github.com/pandas-dev/pandas-sphinx-theme/issues/25. With their latest release, `nbsphinx` started including require.js by default, which doesn't play nice with the bootstrap.js (and as a result, no javascript at all works). 
This is using an option of `nbsphinx` to not include requirejs (which we don't need, nbsphinx added this for rendering notebooks with plotly, I think)