### PR TITLE
TST: add test_series_any_timedelta for GH17667

### DIFF
--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1065,6 +1065,22 @@ Thur,Lunch,Yes,51.51,17"""
         ex = DataFrame({"data": [False, False]}, index=["one", "two"])
         tm.assert_frame_equal(result, ex)
 
+    def test_series_any_timedelta(self):
+        df = DataFrame(
+            {
+                "a": Series([0, 0]),
+                "t": Series([pd.to_timedelta(0, "s"), pd.to_timedelta(1, "ms")]),
+            }
+        )
+
+        result = df.any(axis=0)
+        ex = Series(data=[False, True], index=["a", "t"])
+        tm.assert_series_equal(result, ex)
+
+        result = df.any(axis=1)
+        ex = Series(data=[False, True])
+        tm.assert_series_equal(result, ex)
+
     def test_std_var_pass_ddof(self):
         index = MultiIndex.from_arrays(
             [np.arange(5).repeat(10), np.tile(np.arange(10), 5)]

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1066,6 +1066,7 @@ Thur,Lunch,Yes,51.51,17"""
         tm.assert_frame_equal(result, ex)
 
     def test_series_any_timedelta(self):
+        # GH 17667
         df = DataFrame(
             {
                 "a": Series([0, 0]),
@@ -1074,12 +1075,12 @@ Thur,Lunch,Yes,51.51,17"""
         )
 
         result = df.any(axis=0)
-        ex = Series(data=[False, True], index=["a", "t"])
-        tm.assert_series_equal(result, ex)
+        expected = Series(data=[False, True], index=["a", "t"])
+        tm.assert_series_equal(result, expected)
 
         result = df.any(axis=1)
-        ex = Series(data=[False, True])
-        tm.assert_series_equal(result, ex)
+        expected = Series(data=[False, True])
+        tm.assert_series_equal(result, expected)
 
     def test_std_var_pass_ddof(self):
         index = MultiIndex.from_arrays(


### PR DESCRIPTION
Test case example is the same as the one given in the issue #17667 

- [x] closes #17667 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
