### PR TITLE
CLN: Clean DirNameMixin._deprecated

### DIFF
--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -4,7 +4,7 @@ accessor.py contains base classes for implementing accessor properties
 that can be mixed into or pinned onto other pandas classes.
 
 """
-from typing import Set
+from typing import FrozenSet, Set
 import warnings
 
 from pandas.util._decorators import Appender
@@ -12,9 +12,7 @@ from pandas.util._decorators import Appender
 
 class DirNamesMixin:
     _accessors = set()  # type: Set[str]
-    _deprecations = frozenset(
-        ["asobject", "base", "data", "flags", "itemsize", "strides"]
-    )
+    _deprecations = frozenset()  # type: FrozenSet[str]
 
     def _dir_deletions(self):
         """

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -331,7 +331,9 @@ class Categorical(ExtensionArray, PandasObject):
     __array_priority__ = 1000
     _dtype = CategoricalDtype(ordered=False)
     # tolist is not actually deprecated, just suppressed in the __dir__
-    _deprecations = PandasObject._deprecations | frozenset(["tolist", "get_values"])
+    _deprecations = PandasObject._deprecations | frozenset(
+        ["tolist", "itemsize", "get_values"]
+    )
     _typ = "categorical"
 
     def __init__(

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -4,7 +4,7 @@ Base and utility classes for pandas objects.
 import builtins
 from collections import OrderedDict
 import textwrap
-from typing import Dict, Optional
+from typing import Dict, FrozenSet, Optional
 import warnings
 
 import numpy as np
@@ -653,7 +653,17 @@ class IndexOpsMixin:
 
     # ndarray compatibility
     __array_priority__ = 1000
-    _deprecations = frozenset(["item"])
+    _deprecations = frozenset(
+        [
+            "tolist",  # tolist is not deprecated, just suppressed in the __dir__
+            "base",
+            "data",
+            "item",
+            "itemsize",
+            "flags",
+            "strides",
+        ]
+    )  # type: FrozenSet[str]
 
     def transpose(self, *args, **kwargs):
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import operator
 from textwrap import dedent
-from typing import Union
+from typing import FrozenSet, Union
 import warnings
 
 import numpy as np
@@ -63,7 +63,7 @@ from pandas.core.dtypes.generic import (
 from pandas.core.dtypes.missing import array_equivalent, isna
 
 from pandas.core import ops
-from pandas.core.accessor import CachedAccessor, DirNamesMixin
+from pandas.core.accessor import CachedAccessor
 import pandas.core.algorithms as algos
 from pandas.core.arrays import ExtensionArray
 from pandas.core.base import IndexOpsMixin, PandasObject
@@ -206,10 +206,10 @@ class Index(IndexOpsMixin, PandasObject):
 
     # tolist is not actually deprecated, just suppressed in the __dir__
     _deprecations = (
-        IndexOpsMixin._deprecations
-        | DirNamesMixin._deprecations
-        | frozenset(["tolist", "contains", "dtype_str", "get_values", "set_value"])
-    )
+        PandasObject._deprecations
+        | IndexOpsMixin._deprecations
+        | frozenset(["asobject", "contains", "dtype_str", "get_values", "set_value"])
+    )  # type: FrozenSet[str]
 
     # To hand over control to subclasses
     _join_precedence = 1

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -54,7 +54,7 @@ from pandas.core.dtypes.missing import (
 
 import pandas as pd
 from pandas.core import algorithms, base, generic, nanops, ops
-from pandas.core.accessor import CachedAccessor, DirNamesMixin
+from pandas.core.accessor import CachedAccessor
 from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays.categorical import Categorical, CategoricalAccessor
 from pandas.core.arrays.sparse import SparseAccessor
@@ -178,10 +178,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     _deprecations = (
         base.IndexOpsMixin._deprecations
         | generic.NDFrame._deprecations
-        | DirNamesMixin._deprecations
         | frozenset(
             [
-                "tolist",  # tolist is not deprecated, just suppressed in the __dir__
                 "asobject",
                 "compress",
                 "valid",


### PR DESCRIPTION
This moves the content of ``DirNameMixin._deprecations`` to more appropriate locations, typically ``IndexOpsMixIn._deprecations``, as that is a common subclass of ``Index`` and ``Series``. The names in ``DirNameMixin._deprecations`` belonged to those two classes, so having the deprecated names located all the way up in ``DirNameMixin`` made them be available in all classes that subclass ``DirNameMixin``, which was unfortunate.

By having ``DirNameMixin._deprecations`` start with an empty set, it will be easier to use
``DirNameMixin`` and ``PandasObject`` where/when needed, without inheriting undesired names in ``_deprecated``.

This PR also moves ``"tolist"`` to ``IndexOpsMixIn._deprecations``, because ``tolist`` is defined in that class.
