### PR TITLE
CLN: Consistent and Annotated Return Type of _iterate_slices

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -17,7 +17,7 @@ from textwrap import dedent
 from typing import (
     FrozenSet,
     Hashable,
-    Iterator,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -872,7 +872,7 @@ class DataFrame(NDFrame):
         """
 
     @Appender(_shared_docs["items"])
-    def items(self) -> Iterator[Tuple[Hashable, Series]]:
+    def items(self) -> Iterable[Tuple[Hashable, Series]]:
         if self.columns.is_unique and hasattr(self, "_item_cache"):
             for k in self.columns:
                 yield k, self._get_item_cache(k)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -14,7 +14,18 @@ from io import StringIO
 import itertools
 import sys
 from textwrap import dedent
-from typing import FrozenSet, List, Optional, Sequence, Set, Tuple, Type, Union
+from typing import (
+    FrozenSet,
+    Hashable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 import warnings
 
 import numpy as np
@@ -861,7 +872,7 @@ class DataFrame(NDFrame):
         """
 
     @Appender(_shared_docs["items"])
-    def items(self):
+    def items(self) -> Iterator[Tuple[Hashable, Series]]:
         if self.columns.is_unique and hasattr(self, "_item_cache"):
             for k in self.columns:
                 yield k, self._get_item_cache(k)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -909,7 +909,7 @@ class DataFrameGroupBy(GroupBy):
     agg = aggregate
 
     def _iterate_slices(self) -> Iterator[Tuple[Hashable, Series]]:
-        obj = self._selected_obj.copy()
+        obj = self._selected_obj
         if self.axis == 1:
             obj = obj.T
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -16,7 +16,7 @@ from typing import (
     Callable,
     FrozenSet,
     Hashable,
-    Iterator,
+    Iterable,
     Sequence,
     Tuple,
     Type,
@@ -142,7 +142,7 @@ def pin_whitelisted_properties(klass: Type[FrameOrSeries], whitelist: FrozenSet[
 class SeriesGroupBy(GroupBy):
     _apply_whitelist = base.series_apply_whitelist
 
-    def _iterate_slices(self) -> Iterator[Tuple[Hashable, Series]]:
+    def _iterate_slices(self) -> Iterable[Tuple[Hashable, Series]]:
         yield self._selection_name, self._selected_obj
 
     @property
@@ -908,7 +908,7 @@ class DataFrameGroupBy(GroupBy):
 
     agg = aggregate
 
-    def _iterate_slices(self) -> Iterator[Tuple[Hashable, Series]]:
+    def _iterate_slices(self) -> Iterable[Tuple[Hashable, Series]]:
         obj = self._selected_obj
         if self.axis == 1:
             obj = obj.T

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -14,7 +14,7 @@ from functools import partial, wraps
 import inspect
 import re
 import types
-from typing import FrozenSet, Hashable, Iterator, List, Optional, Tuple, Type, Union
+from typing import FrozenSet, Hashable, Iterable, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
@@ -758,7 +758,7 @@ b  2""",
             keys, values, not_indexed_same=mutated or self.mutated
         )
 
-    def _iterate_slices(self) -> Iterator[Tuple[Hashable, Series]]:
+    def _iterate_slices(self) -> Iterable[Tuple[Hashable, Series]]:
         raise AbstractMethodError(self)
 
     def transform(self, func, *args, **kwargs):

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -14,7 +14,7 @@ from functools import partial, wraps
 import inspect
 import re
 import types
-from typing import FrozenSet, List, Optional, Tuple, Type, Union
+from typing import FrozenSet, Hashable, Iterator, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
@@ -758,7 +758,7 @@ b  2""",
             keys, values, not_indexed_same=mutated or self.mutated
         )
 
-    def _iterate_slices(self):
+    def _iterate_slices(self) -> Iterator[Tuple[Hashable, Series]]:
         raise AbstractMethodError(self)
 
     def transform(self, func, *args, **kwargs):


### PR DESCRIPTION
General pre-cursor to getting block management out of groupby. This is also a pre-cursor to fixing #21668 but needs to be coupled with a few more changes as a follow up

On master calls to _iterate_slices look up by label, potentially yielding a DataFrame if there were duplicated columns. This takes the surprise out of that and simply returns a Tuple of label / series for each item along the axis

@jbrockmendel 