### PR TITLE
Fix mypy error message in `pandas/tests/indexes/test_numeric.py` …

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -1,4 +1,5 @@
 import gc
+from typing import Optional, Type
 
 import numpy as np
 import pytest
@@ -30,7 +31,7 @@ import pandas.util.testing as tm
 class Base:
     """ base class for index sub-class tests """
 
-    _holder = None
+    _holder = None  # type: Optional[Type[Index]]
     _compat_props = ["shape", "ndim", "size", "nbytes"]
 
     def test_pickle_compat_construction(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -187,9 +187,6 @@ ignore_errors=True
 [mypy-pandas.tests.indexes.test_category]
 ignore_errors=True
 
-[mypy-pandas.tests.indexes.test_numeric]
-ignore_errors=True
-
 [mypy-pandas.tests.indexes.test_range]
 ignore_errors=True
 


### PR DESCRIPTION
Use Optional to signal that the value may be either an `Index` or `None`.

- [X] Relates to #28926
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
