### PR TITLE
ENH: Informative dtype message for for assert_series_equal

### DIFF
--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -141,7 +141,7 @@ def test_empty_dtypes(check_dtype):
     df1["col1"] = df1["col1"].astype("int64")
 
     if check_dtype:
-        msg = "Attributes are different"
+        msg = r"Attributes of DataFrame\..* are different"
         with pytest.raises(AssertionError, match=msg):
             assert_frame_equal(df1, df2, **kwargs)
     else:

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -179,7 +179,7 @@ Series values are different \\(33\\.33333 %\\)
 
 
 def test_series_equal_categorical_mismatch(check_categorical):
-    msg = """Attributes are different
+    msg = """Attributes of Series are different
 
 Attribute "dtype" are different
 \\[left\\]:  CategoricalDtype\\(categories=\\['a', 'b'\\], ordered=False\\)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1156,7 +1156,9 @@ def assert_series_equal(
         ):
             pass
         else:
-            assert_attr_equal("dtype", left, right, obj="Attributes of {obj}".format(obj=obj))
+            assert_attr_equal(
+                "dtype", left, right, obj="Attributes of {obj}".format(obj=obj)
+            )
 
     if check_exact:
         assert_numpy_array_equal(

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1317,8 +1317,9 @@ def assert_frame_equal(
 
     >>> assert_frame_equal(df1, df2)
     Traceback (most recent call last):
-    AssertionError: Attributes are different
     ...
+    AssertionError: Attributes of DataFrame.iloc[:, 1] are different
+
     Attribute "dtype" are different
     [left]:  int64
     [right]: float64

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1156,7 +1156,7 @@ def assert_series_equal(
         ):
             pass
         else:
-            assert_attr_equal("dtype", left, right)
+            assert_attr_equal("dtype", left, right, obj="Attributes of {obj}".format(obj=obj))
 
     if check_exact:
         assert_numpy_array_equal(


### PR DESCRIPTION
Pass obj to assert_attr_equal in assert_series_equal.

- [ ] closes #28991
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
- [x] Fix example in `assert_frame_equal` docstring