### PR TITLE
CLN: fix mypy error pandas/tests/plotting/test_backend.py

### DIFF
--- a/pandas/tests/plotting/test_backend.py
+++ b/pandas/tests/plotting/test_backend.py
@@ -9,7 +9,7 @@ import pandas.util._test_decorators as td
 import pandas
 
 dummy_backend = types.ModuleType("pandas_dummy_backend")
-dummy_backend.__setattr__("plot", lambda *args, **kwargs: None)
+setattr(dummy_backend, "plot", lambda *args, **kwargs: None)
 
 
 @pytest.fixture

--- a/pandas/tests/plotting/test_backend.py
+++ b/pandas/tests/plotting/test_backend.py
@@ -9,7 +9,7 @@ import pandas.util._test_decorators as td
 import pandas
 
 dummy_backend = types.ModuleType("pandas_dummy_backend")
-dummy_backend.plot = lambda *args, **kwargs: None
+dummy_backend.__setattr__("plot", lambda *args, **kwargs: None)
 
 
 @pytest.fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -208,9 +208,6 @@ ignore_errors=True
 [mypy-pandas.tests.io.test_sql]
 ignore_errors=True
 
-[mypy-pandas.tests.plotting.test_backend]
-ignore_errors=True
-
 [mypy-pandas.tests.series.test_constructors]
 ignore_errors=True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -205,9 +205,6 @@ ignore_errors=True
 [mypy-pandas.tests.io.json.test_ujson]
 ignore_errors=True
 
-[mypy-pandas.tests.io.test_sql]
-ignore_errors=True
-
 [mypy-pandas.tests.series.test_constructors]
 ignore_errors=True
 


### PR DESCRIPTION
GH28926, mypy didn't like setting non-existant attribute on module.
Dummy function, circumvented with `__setattr__`

- [x] addresses part of #28926
- [x] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
