### PR TITLE
DEPR: remove previously-deprecated broadcast/reduce kwargs from DataFrame.apply

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -195,6 +195,8 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated ``IntervalIndex.from_intervals`` in favor of the :class:`IntervalIndex` constructor (:issue:`19263`)
 - Ability to read pickles containing :class:`Categorical` instances created with pre-0.16 version of pandas has been removed (:issue:`27538`)
 -
+- Removed the previously deprecated ``reduce`` and ``broadcast`` arguments from :method:`DataFrame.apply` (:issue:`18577`)
+-
 
 .. _whatsnew_1000.performance:
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -227,7 +227,6 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated :meth:`ExtensionArray._formatting_values`. Use :attr:`ExtensionArray._formatter` instead. (:issue:`23601`)
 - Removed the previously deprecated ``IntervalIndex.from_intervals`` in favor of the :class:`IntervalIndex` constructor (:issue:`19263`)
 - Ability to read pickles containing :class:`Categorical` instances created with pre-0.16 version of pandas has been removed (:issue:`27538`)
--
 - Removed the previously deprecated ``reduce`` and ``broadcast`` arguments from :method:`DataFrame.apply` (:issue:`18577`)
 -
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -227,7 +227,7 @@ Removal of prior version deprecations/changes
 - Removed the previously deprecated :meth:`ExtensionArray._formatting_values`. Use :attr:`ExtensionArray._formatter` instead. (:issue:`23601`)
 - Removed the previously deprecated ``IntervalIndex.from_intervals`` in favor of the :class:`IntervalIndex` constructor (:issue:`19263`)
 - Ability to read pickles containing :class:`Categorical` instances created with pre-0.16 version of pandas has been removed (:issue:`27538`)
-- Removed the previously deprecated ``reduce`` and ``broadcast`` arguments from :method:`DataFrame.apply` (:issue:`18577`)
+- Removed the previously deprecated ``reduce`` and ``broadcast`` arguments from :meth:`DataFrame.apply` (:issue:`18577`)
 -
 
 .. _whatsnew_1000.performance:

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 
 import numpy as np
 
@@ -21,9 +20,7 @@ def frame_apply(
     obj,
     func,
     axis=0,
-    broadcast=None,
     raw=False,
-    reduce=None,
     result_type=None,
     ignore_failures=False,
     args=None,
@@ -40,9 +37,7 @@ def frame_apply(
     return klass(
         obj,
         func,
-        broadcast=broadcast,
         raw=raw,
-        reduce=reduce,
         result_type=result_type,
         ignore_failures=ignore_failures,
         args=args,
@@ -51,18 +46,7 @@ def frame_apply(
 
 
 class FrameApply:
-    def __init__(
-        self,
-        obj,
-        func,
-        broadcast,
-        raw,
-        reduce,
-        result_type,
-        ignore_failures,
-        args,
-        kwds,
-    ):
+    def __init__(self, obj, func, raw, result_type, ignore_failures, args, kwds):
         self.obj = obj
         self.raw = raw
         self.ignore_failures = ignore_failures
@@ -74,34 +58,6 @@ class FrameApply:
                 "invalid value for result_type, must be one "
                 "of {None, 'reduce', 'broadcast', 'expand'}"
             )
-
-        if broadcast is not None:
-            warnings.warn(
-                "The broadcast argument is deprecated and will "
-                "be removed in a future version. You can specify "
-                "result_type='broadcast' to broadcast the result "
-                "to the original dimensions",
-                FutureWarning,
-                stacklevel=4,
-            )
-            if broadcast:
-                result_type = "broadcast"
-
-        if reduce is not None:
-            warnings.warn(
-                "The reduce argument is deprecated and will "
-                "be removed in a future version. You can specify "
-                "result_type='reduce' to try to reduce the result "
-                "to the original dimensions",
-                FutureWarning,
-                stacklevel=4,
-            )
-            if reduce:
-
-                if result_type is not None:
-                    raise ValueError("cannot pass both reduce=True and result_type")
-
-                result_type = "reduce"
 
         self.result_type = result_type
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6628,15 +6628,7 @@ class DataFrame(NDFrame):
         return super().transform(func, *args, **kwargs)
 
     def apply(
-        self,
-        func,
-        axis=0,
-        broadcast=None,
-        raw=False,
-        reduce=None,
-        result_type=None,
-        args=(),
-        **kwds
+        self, func, axis=0, raw=False, reduce=None, result_type=None, args=(), **kwds
     ):
         """
         Apply a function along an axis of the DataFrame.
@@ -6656,21 +6648,9 @@ class DataFrame(NDFrame):
 
             * 0 or 'index': apply function to each column.
             * 1 or 'columns': apply function to each row.
-        broadcast : bool, optional
-            Only relevant for aggregation functions:
-
-            * ``False`` or ``None`` : returns a Series whose length is the
-              length of the index or the number of columns (based on the
-              `axis` parameter)
-            * ``True`` : results will be broadcast to the original shape
-              of the frame, the original index and columns will be retained.
-
-            .. deprecated:: 0.23.0
-               This argument will be removed in a future version, replaced
-               by result_type='broadcast'.
 
         raw : bool, default False
-            Determines if row or column is passed as a Series or ndarry object:
+            Determines if row or column is passed as a Series or ndarray object:
 
             * ``False`` : passes each row or column as a Series to the
               function.
@@ -6678,20 +6658,6 @@ class DataFrame(NDFrame):
               instead.
               If you are just applying a NumPy reduction function this will
               achieve much better performance.
-        reduce : bool or None, default None
-            Try to apply reduction procedures. If the DataFrame is empty,
-            `apply` will use `reduce` to determine whether the result
-            should be a Series or a DataFrame. If ``reduce=None`` (the
-            default), `apply`'s return value will be guessed by calling
-            `func` on an empty Series
-            (note: while guessing, exceptions raised by `func` will be
-            ignored).
-            If ``reduce=True`` a Series will always be returned, and if
-            ``reduce=False`` a DataFrame will always be returned.
-
-            .. deprecated:: 0.23.0
-               This argument will be removed in a future version, replaced
-               by ``result_type='reduce'``.
 
         result_type : {'expand', 'reduce', 'broadcast', None}, default None
             These only act when ``axis=1`` (columns):
@@ -6805,9 +6771,7 @@ class DataFrame(NDFrame):
             self,
             func=func,
             axis=axis,
-            broadcast=broadcast,
             raw=raw,
-            reduce=reduce,
             result_type=result_type,
             args=args,
             kwds=kwds,

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -137,13 +137,6 @@ class TestDataFrameApply:
         expected = Series([], index=pd.Index([]))
         assert_series_equal(result, expected)
 
-    def test_apply_deprecate_reduce(self):
-        empty_frame = DataFrame()
-
-        x = []
-        with tm.assert_produces_warning(FutureWarning):
-            empty_frame.apply(x.append, axis=1, reduce=True)
-
     def test_apply_standard_nonunique(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], index=["a", "a", "c"])
 
@@ -169,10 +162,6 @@ class TestDataFrameApply:
         result = float_frame.apply(func, *args, **kwds)
         expected = getattr(float_frame, func)(*args, **kwds)
         tm.assert_series_equal(result, expected)
-
-    def test_apply_broadcast_deprecated(self, float_frame):
-        with tm.assert_produces_warning(FutureWarning):
-            float_frame.apply(np.mean, broadcast=True)
 
     def test_apply_broadcast(self, float_frame, int_frame_const_col):
 


### PR DESCRIPTION
xref #18577 (Nov 2017)