### PR TITLE
Fix mypy in pandas/tests/arithmetic/test_datetime64.py

### DIFF
--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -2161,7 +2161,7 @@ class TestDatetimeIndexArithmetic:
         [
             datetime(2011, 1, 1),
             DatetimeIndex(["2011-01-01", "2011-01-02"]),
-            getattr(DatetimeIndex(["2011-01-01", "2011-01-02"]), "tz_localize")(
+            DatetimeIndex(["2011-01-01", "2011-01-02"]).__getattribute__("tz_localize")(
                 "US/Eastern"
             ),
             np.datetime64("2011-01-01"),

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -2161,7 +2161,9 @@ class TestDatetimeIndexArithmetic:
         [
             datetime(2011, 1, 1),
             DatetimeIndex(["2011-01-01", "2011-01-02"]),
-            DatetimeIndex(["2011-01-01", "2011-01-02"]).tz_localize("US/Eastern"),
+            getattr(DatetimeIndex(["2011-01-01", "2011-01-02"]), "tz_localize")(
+                "US/Eastern"
+            ),
             np.datetime64("2011-01-01"),
             Timestamp("2011-01-01"),
         ],

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,9 +133,6 @@ no_implicit_optional=True
 [mypy-pandas.conftest]
 ignore_errors=True
 
-[mypy-pandas.tests.arithmetic.test_datetime64]
-ignore_errors=True
-
 [mypy-pandas.tests.dtypes.test_common]
 ignore_errors=True
 


### PR DESCRIPTION
GH28926, mypy did not like DatetimeIndex's __new__,
and couldn't find a method

- [x] addresses part of #28926
- [x] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
