### PR TITLE
CLN: derivation of nogil param

### DIFF
--- a/pandas/_libs/algos_take_helper.pxi.in
+++ b/pandas/_libs/algos_take_helper.pxi.in
@@ -12,26 +12,26 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 
 # name, dest, c_type_in, c_type_out, preval, postval, can_copy, nogil
 dtypes = [
-    ('bool', 'bool', 'uint8_t', 'uint8_t', '', '', True, True),
+    ('bool', 'bool', 'uint8_t', 'uint8_t', '', '', True),
     ('bool', 'object', 'uint8_t', 'object',
-     'True if ', ' > 0 else False', False, False),
-    ('int8', 'int8', 'int8_t', 'int8_t', '', '', True, False),
-    ('int8', 'int32', 'int8_t', 'int32_t', '', '', False, True),
-    ('int8', 'int64', 'int8_t', 'int64_t', '', '', False, True),
-    ('int8', 'float64', 'int8_t', 'float64_t', '', '', False, True),
-    ('int16', 'int16', 'int16_t', 'int16_t', '', '', True, True),
-    ('int16', 'int32', 'int16_t', 'int32_t', '', '', False, True),
-    ('int16', 'int64', 'int16_t', 'int64_t', '', '', False, True),
-    ('int16', 'float64', 'int16_t', 'float64_t', '', '', False, True),
-    ('int32', 'int32', 'int32_t', 'int32_t', '', '', True, True),
-    ('int32', 'int64', 'int32_t', 'int64_t', '', '', False, True),
-    ('int32', 'float64', 'int32_t', 'float64_t', '', '', False, True),
-    ('int64', 'int64', 'int64_t', 'int64_t', '', '', True, True),
-    ('int64', 'float64', 'int64_t', 'float64_t', '', '', False, True),
-    ('float32', 'float32', 'float32_t', 'float32_t', '', '', True, True),
-    ('float32', 'float64', 'float32_t', 'float64_t', '', '', False, True),
-    ('float64', 'float64', 'float64_t', 'float64_t', '', '', True, True),
-    ('object', 'object', 'object', 'object', '', '', False, False)]
+     'True if ', ' > 0 else False', False),
+    ('int8', 'int8', 'int8_t', 'int8_t', '', '', True),
+    ('int8', 'int32', 'int8_t', 'int32_t', '', '', False),
+    ('int8', 'int64', 'int8_t', 'int64_t', '', '', False),
+    ('int8', 'float64', 'int8_t', 'float64_t', '', '', False),
+    ('int16', 'int16', 'int16_t', 'int16_t', '', '', True),
+    ('int16', 'int32', 'int16_t', 'int32_t', '', '', False),
+    ('int16', 'int64', 'int16_t', 'int64_t', '', '', False),
+    ('int16', 'float64', 'int16_t', 'float64_t', '', '', False),
+    ('int32', 'int32', 'int32_t', 'int32_t', '', '', True),
+    ('int32', 'int64', 'int32_t', 'int64_t', '', '', False),
+    ('int32', 'float64', 'int32_t', 'float64_t', '', '', False),
+    ('int64', 'int64', 'int64_t', 'int64_t', '', '', True),
+    ('int64', 'float64', 'int64_t', 'float64_t', '', '', False),
+    ('float32', 'float32', 'float32_t', 'float32_t', '', '', True),
+    ('float32', 'float64', 'float32_t', 'float64_t', '', '', False),
+    ('float64', 'float64', 'float64_t', 'float64_t', '', '', True),
+    ('object', 'object', 'object', 'object', '', '', False)]
 
 
 def get_dispatch(dtypes):
@@ -118,7 +118,9 @@ def get_dispatch(dtypes):
 """
 
     for (name, dest, c_type_in, c_type_out, preval, postval,
-         can_copy, nogil) in dtypes:
+         can_copy) in dtypes:
+
+        nogil = c_type_out != "object"
         if nogil:
             nogil_str = "with nogil:"
             tab = '    '


### PR DESCRIPTION
This moves the `nogil` parameter of in the template from being hard-coded to being derived from the other parameters.

This changes the parameter value on line 18 (int8/int8) which currently has `nogil=False` which I think is incorrect.