### PR TITLE
Support customised S3 servers endpoint URL

### DIFF
--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -1,6 +1,6 @@
 """ s3 support for remote file interactivity """
 import os
-from typing import IO, Any, Optional, Tuple, Dict
+from typing import IO, Any, Dict, Optional, Tuple
 from urllib.parse import urlparse as parse_url
 
 from pandas.compat._optional import import_optional_dependency

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -29,11 +29,10 @@ def get_file_and_filesystem(
     # Support customised S3 servers endpoint URL via environment variable
     # The S3_ENDPOINT should be the complete URL to S3 service following
     # the format: http(s)://{host}:{port}
-    s3_endpoint = os.environ.get('S3_ENDPOINT')
-    if s3_endpoint:
-        client_kwargs = {'endpoint_url': s3_endpoint}
-    else:
-        client_kwargs = None
+    s3_endpoint = os.environ.get("S3_ENDPOINT")
+    client_kwargs: Optional[Dict[str, str]] = {
+        "endpoint_url": s3_endpoint
+    } if s3_endpoint else None
     fs = s3fs.S3FileSystem(anon=False, client_kwargs=client_kwargs)
     try:
         file = fs.open(_strip_schema(filepath_or_buffer), mode)

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -1,6 +1,6 @@
 """ s3 support for remote file interactivity """
 import os
-from typing import IO, Any, Optional, Tuple
+from typing import IO, Any, Optional, Tuple, Dict
 from urllib.parse import urlparse as parse_url
 
 from pandas.compat._optional import import_optional_dependency

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -28,7 +28,8 @@ def get_file_and_filesystem(
 
     # Support customised S3 servers endpoint URL via environment variable
     # The S3_ENDPOINT should be the complete URL to S3 service following
-    # the format: http(s)://{host}:{port}
+    # the format: http(s)://{host}:{port}. If S3_ENDPOINT is undefined, it will
+    # fallback to use the default AWS S3 endpoint as determined by boto3.
     s3_endpoint = os.environ.get("S3_ENDPOINT")
     client_kwargs: Optional[Dict[str, str]] = {
         "endpoint_url": s3_endpoint


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Add support for customised S3 servers via checking the environment variable `S3_ENDPOINT`.

If set, the value of `S3_ENDPOINT` will be passed to the `endpoint_url` parameter for `boto3.Session`. It should be the complete URL to S3 service following the format: http(s)://{host}:{port}.

This feature is useful for companies who use their own S3 servers like MinIO, Ceph etc, as mentioned in issue  #26195