### PR TITLE
CI: xfail on numpy 1.18

### DIFF
--- a/ci/build38.sh
+++ b/ci/build38.sh
@@ -6,13 +6,7 @@ pip install --no-deps -U pip wheel setuptools
 pip install python-dateutil pytz cython pytest pytest-xdist hypothesis
 
 # Possible alternative for getting numpy:
-# pip install --pre -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com/ numpy
-git clone https://github.com/numpy/numpy
-cd numpy
-python setup.py build_ext --inplace
-python setup.py install
-cd ..
-rm -rf numpy
+pip install --pre -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com/ numpy
 
 python setup.py build_ext -inplace
 python -m pip install --no-build-isolation -e .

--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -12,6 +12,7 @@ _np_version_under1p14 = _nlv < LooseVersion("1.14")
 _np_version_under1p15 = _nlv < LooseVersion("1.15")
 _np_version_under1p16 = _nlv < LooseVersion("1.16")
 _np_version_under1p17 = _nlv < LooseVersion("1.17")
+_np_version_under1p18 = _nlv < LooseVersion("1.18")
 _is_numpy_dev = ".dev" in str(_nlv)
 
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -4,6 +4,7 @@ import operator
 import numpy as np
 import pytest
 
+from pandas.compat.numpy import _np_version_under1p18
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -160,6 +161,9 @@ class TestSeriesAnalytics:
 
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.xfail(
+        not _np_version_under1p18, reason="numpy 1.18 changed min/max behavior for NaT"
+    )
     def test_cummin_datetime64(self):
         s = pd.Series(
             pd.to_datetime(["NaT", "2000-1-2", "NaT", "2000-1-1", "NaT", "2000-1-3"])
@@ -179,6 +183,9 @@ class TestSeriesAnalytics:
         result = s.cummin(skipna=False)
         tm.assert_series_equal(expected, result)
 
+    @pytest.mark.xfail(
+        not _np_version_under1p18, reason="numpy 1.18 changed min/max behavior for NaT"
+    )
     def test_cummax_datetime64(self):
         s = pd.Series(
             pd.to_datetime(["NaT", "2000-1-2", "NaT", "2000-1-1", "NaT", "2000-1-3"])
@@ -198,6 +205,9 @@ class TestSeriesAnalytics:
         result = s.cummax(skipna=False)
         tm.assert_series_equal(expected, result)
 
+    @pytest.mark.xfail(
+        not _np_version_under1p18, reason="numpy 1.18 changed min/max behavior for NaT"
+    )
     def test_cummin_timedelta64(self):
         s = pd.Series(pd.to_timedelta(["NaT", "2 min", "NaT", "1 min", "NaT", "3 min"]))
 
@@ -213,6 +223,9 @@ class TestSeriesAnalytics:
         result = s.cummin(skipna=False)
         tm.assert_series_equal(expected, result)
 
+    @pytest.mark.xfail(
+        not _np_version_under1p18, reason="numpy 1.18 changed min/max behavior for NaT"
+    )
     def test_cummax_timedelta64(self):
         s = pd.Series(pd.to_timedelta(["NaT", "2 min", "NaT", "1 min", "NaT", "3 min"]))
 


### PR DESCRIPTION
xref #29053 

i think this addresses the failing azure builds, not sure about Travis.

Will open an issue for a longer-term fix.