### PR TITLE
TST: regression test for groupby with datetime and timedelta (#15562)

### DIFF
--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -543,6 +543,33 @@ def test_apply_numeric_coercion_when_datetime():
     tm.assert_series_equal(expected, result)
 
 
+def test_apply_aggregating_timedelta_and_datetime():
+    # Regression test for GH 15562
+    # The following groupby caused ValueErrors and IndexErrors pre 0.20.0
+
+    df = pd.DataFrame(
+        {
+            "clientid": ["A", "B", "C"],
+            "datetime": [np.datetime64("2017-02-01 00:00:00")] * 3,
+        }
+    )
+    df["time_delta_zero"] = df.datetime - df.datetime
+    result = df.groupby("clientid").apply(
+        lambda ddf: pd.Series(
+            dict(clientid_age=ddf.time_delta_zero.min(), date=ddf.datetime.min())
+        )
+    )
+    expected = pd.DataFrame(
+        {
+            "clientid": ["A", "B", "C"],
+            "clientid_age": [np.timedelta64(0, "D")] * 3,
+            "date": [np.datetime64("2017-02-01 00:00:00")] * 3,
+        }
+    ).set_index("clientid")
+
+    tm.assert_frame_equal(result, expected)
+
+
 def test_time_field_bug():
     # Test a fix for the following error related to GH issue 11324 When
     # non-key fields in a group-by dataframe contained time-based fields


### PR DESCRIPTION
- [X] closes #15562
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This change doesn't add a new feature but adds an regression test for #15562 which has been fixed with pandas 0.20. Hence there is no whatsnew entry.

The bug was reported for pandas 0.18.1 and persisted until 0.19.2 but was fixed in 0.20.0(-rc1). I managed to reproduce the error (with `numpy==1.12.1` on python 3.6, otherwise some errors unrelated to this bug appear).

I added an regression test to `pandas/tests/groupby/test_apply.py` and verified that the code will fail with 0.19.2 and succeed with 0.20.0 and master.

I wasn't able to further reduce the test provided by @field-cady.