### PR TITLE
TST: add regression test for all-none-groupby

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1944,3 +1944,13 @@ def test_shift_bfill_ffill_tz(tz_naive_fixture, op, expected):
     result = getattr(grouped, op)()
     expected = DataFrame(expected).assign(time=lambda x: x.time.dt.tz_localize(tz))
     assert_frame_equal(result, expected)
+
+
+def test_groupby_only_none_group():
+    # see GH21624
+    # this was crashing with "ValueError: Length of passed values is 1, index implies 0"
+    df = pd.DataFrame({"g": [None], "x": 1})
+    actual = df.groupby("g")["x"].transform("sum")
+    expected = pd.Series([np.nan], name="x")
+
+    assert_series_equal(actual, expected)


### PR DESCRIPTION
- [X] closes #21624 
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Is the whatsnew entry required if the fix was somewhat silent and only a regression test was added?
