### PR TITLE
DOC: updated categorical docstring

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -295,7 +295,7 @@ class Categorical(ExtensionArray, PandasObject):
 
     See Also
     --------
-    api.types.CategoricalDtype : Type for categorical data.
+    CategoricalDtype : Type for categorical data.
     CategoricalIndex : An Index with an underlying ``Categorical``.
 
     Notes


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed *(tests failed even on master)*
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I think `api.types.CategoricalDtype` in *see also* section of [pandas.Categorical](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Categorical.html) documentation which does not have any link, is better to point to [pandas.CategoricalDtype](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.CategoricalDtype.html?highlight=categoricaldtype) for better understanding of this type. So I made this change and created a pr.

<img width="960" alt="chrome_2019-10-18_14-22-01" src="https://user-images.githubusercontent.com/7765309/67089231-0746d280-f1b4-11e9-9bba-c88ccfd7fa93.png">
