### PR TITLE
TST: 2d index when constructing dataframe (#25416).

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -424,6 +424,25 @@ class TestDataFrameConstructors:
         df = DataFrame(index=mi, columns=mi)
         assert pd.isna(df).values.ravel().all()
 
+    def test_constructor_2d_index(self):
+        # GH 25416
+        # handling of 2d index in construction
+        df = pd.DataFrame([[1]], columns=[[1]], index=[1, 2])
+        expected = pd.DataFrame(
+            [1, 1],
+            index=pd.Int64Index([1, 2], dtype="int64"),
+            columns=pd.MultiIndex(levels=[[1]], codes=[[0]]),
+        )
+        tm.assert_frame_equal(df, expected)
+
+        df = pd.DataFrame([[1]], columns=[[1]], index=[[1, 2]])
+        expected = pd.DataFrame(
+            [1, 1],
+            index=pd.MultiIndex(levels=[[1, 2]], codes=[[0, 1]]),
+            columns=pd.MultiIndex(levels=[[1]], codes=[[0]]),
+        )
+        tm.assert_frame_equal(df, expected)
+
     def test_constructor_error_msgs(self):
         msg = "Empty data passed with indices specified."
         # passing an empty array with columns specified.


### PR DESCRIPTION
- [X] closes #25416
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This change adds a regression test to check for the handling of 2d index when creating a dataframe (#25416).

Since there is no visible change no whatsnew entry has been added.