### PR TITLE
TST: Add a regression test for the timezone issue

### DIFF
--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -1346,3 +1346,17 @@ class TestDataFrameAggregate:
         df = DataFrame(1, index=index, columns=range(num_cols))
         df.apply(lambda x: x)
         assert index.freq == original.freq
+
+    def test_apply_datetime_tz_issue(self):
+        # GH 29052
+
+        timestamps = [
+            pd.Timestamp("2019-03-15 12:34:31.909000+0000", tz="UTC"),
+            pd.Timestamp("2019-03-15 12:34:34.359000+0000", tz="UTC"),
+            pd.Timestamp("2019-03-15 12:34:34.660000+0000", tz="UTC"),
+        ]
+        df = DataFrame(data=[0, 1, 2], index=timestamps)
+        result = df.apply(lambda x: x.name, axis=1)
+        expected = pd.Series(index=timestamps, data=timestamps)
+
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Add a regression test to ensure that the timezone doesn't get removed
when using `df.apply`.

- [x] closes #29052
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
