### PR TITLE
DOC: Add instructions how to activate virtual env under windows with pip

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -243,12 +243,16 @@ You'll need to have at least python3.5 installed on your system.
    # Create a virtual environment
    # Use an ENV_DIR of your choice. We'll use ~/virtualenvs/pandas-dev
    # Any parent directories should already exist
+   # If you are using Windows and command prompt, replace ~ (the tilde sign)
+   # with %userprofile%
    python3 -m venv ~/virtualenvs/pandas-dev
+
    # Activate the virtualenv
-   #    If you are using Windows and Powershell you need to run:
-   #        ~/virtualenvs/pandas-dev/Scripts/Activate.ps1
-   #    or if you are using Windows and command prompt (cmd.exe):
-   #        ~/virtualenvs/pandas-dev/Scripts/activate.bat
+   # If you are using Windows, you can find the activation scripts under
+   #     ~\virtualenvs\pandas-dev\scripts
+   # Please refer to the official user guide at
+   # https://virtualenv.pypa.io/en/stable/userguide/#activate-script
+   # about how to activate your virtual environment under Windows
    . ~/virtualenvs/pandas-dev/bin/activate
 
    # Install the build dependencies

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -254,35 +254,37 @@ You'll need to have at least python3.5 installed on your system.
    python -m pip install -r requirements-dev.txt
 
    # Build and install pandas
-   python setup.py build_ext --inplace -j 4
+   python setup.py build_ext --inplace -j 0
    python -m pip install -e . --no-build-isolation
 
 **Windows**
 
 Below is a brief overview on how to set-up a virtual environment with Powershell
-under Windows. For details please refer to the 
+under Windows. For details please refer to the
 `official virtualenv user guide <https://virtualenv.pypa.io/en/stable/userguide/#activate-script>`__
 
 .. code-block:: powershell
 
    # Create a virtual environment
    # Use an ENV_DIR of your choice. We'll use ~\virtualenvs\pandas-dev where
-   # '~' is the folder pointed to by either $env:USERPROFILE (Powershell) or 
+   # '~' is the folder pointed to by either $env:USERPROFILE (Powershell) or
    # %USERPROFILE% (cmd.exe) environment variable
    # Any parent directories should already exist
 
-   # If you are using cmd.exe, run instead: python -m venv $env:USERPROFILE\virtualenvs\pandas-dev
-   python -m venv $env:USERPROFILE\virtualenvs\pandas-dev 
+   # If you are using cmd.exe, run instead:
+   # python -m venv %USERPROFILE%\virtualenvs\pandas-dev
+   python -m venv $env:USERPROFILE\virtualenvs\pandas-dev
 
    # Activate the virtualenv
-   # If you are using cmd.exe, run instead: %USERPROFILE%\virtualenvs\pandas-dev\Scripts\activate.bat
-   ~\virtualenvs\pandas-dev\Scripts\Activate.ps1 
+   # If you are using cmd.exe, run instead:
+   # %USERPROFILE%\virtualenvs\pandas-dev\Scripts\activate.bat
+   ~\virtualenvs\pandas-dev\Scripts\Activate.ps1
 
    # Install the build dependencies
    python -m pip install -r requirements-dev.txt
 
    # Build and install pandas
-   python setup.py build_ext --inplace -j 4
+   python setup.py build_ext --inplace -j 0
    python -m pip install -e . --no-build-isolation --no-use-pep517
 
 Creating a branch

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -238,22 +238,40 @@ Creating a Python environment (pip)
 If you aren't using conda for your development environment, follow these instructions.
 You'll need to have at least python3.5 installed on your system.
 
+**Unix**/**Mac OS**
+
 .. code-block:: none
 
    # Create a virtual environment
    # Use an ENV_DIR of your choice. We'll use ~/virtualenvs/pandas-dev
    # Any parent directories should already exist
-   # If you are using Windows and command prompt, replace ~ (the tilde sign)
-   # with %userprofile%
    python3 -m venv ~/virtualenvs/pandas-dev
 
    # Activate the virtualenv
-   # If you are using Windows, you can find the activation scripts under
-   #     ~\virtualenvs\pandas-dev\scripts
-   # Please refer to the official user guide at
-   # https://virtualenv.pypa.io/en/stable/userguide/#activate-script
-   # about how to activate your virtual environment under Windows
    . ~/virtualenvs/pandas-dev/bin/activate
+
+   # Install the build dependencies
+   python -m pip install -r requirements-dev.txt
+
+   # Build and install pandas
+   python setup.py build_ext --inplace -j 4
+   python -m pip install -e . --no-build-isolation
+
+**Windows**
+
+Below is a brief overview on how to set-up a virtual environment with Powershell
+under Windows. For details please refer to the \
+`official virtualenv user guide <https://virtualenv.pypa.io/en/stable/userguide/#activate-script>`__
+
+.. code-block:: none
+
+   # Create a virtual environment
+   # Use an ENV_DIR of your choice. We'll use ~\virtualenvs\pandas-dev
+   # Any parent directories should already exist
+   python -m venv ~\virtualenvs\pandas-dev
+
+   # Activate the virtualenv
+   ~\virtualenvs\pandas-dev\Scripts\Activate.ps1
 
    # Install the build dependencies
    python -m pip install -r requirements-dev.txt

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -240,7 +240,7 @@ You'll need to have at least python3.5 installed on your system.
 
 **Unix**/**Mac OS**
 
-.. code-block:: none
+.. code-block:: bash
 
    # Create a virtual environment
    # Use an ENV_DIR of your choice. We'll use ~/virtualenvs/pandas-dev
@@ -260,25 +260,30 @@ You'll need to have at least python3.5 installed on your system.
 **Windows**
 
 Below is a brief overview on how to set-up a virtual environment with Powershell
-under Windows. For details please refer to the \
+under Windows. For details please refer to the 
 `official virtualenv user guide <https://virtualenv.pypa.io/en/stable/userguide/#activate-script>`__
 
-.. code-block:: none
+.. code-block:: powershell
 
    # Create a virtual environment
-   # Use an ENV_DIR of your choice. We'll use ~\virtualenvs\pandas-dev
+   # Use an ENV_DIR of your choice. We'll use ~\virtualenvs\pandas-dev where
+   # '~' is the folder pointed to by either $env:USERPROFILE (Powershell) or 
+   # %USERPROFILE% (cmd.exe) environment variable
    # Any parent directories should already exist
-   python -m venv ~\virtualenvs\pandas-dev
+
+   # If you are using cmd.exe, run instead: python -m venv $env:USERPROFILE\virtualenvs\pandas-dev
+   python -m venv $env:USERPROFILE\virtualenvs\pandas-dev 
 
    # Activate the virtualenv
-   ~\virtualenvs\pandas-dev\Scripts\Activate.ps1
+   # If you are using cmd.exe, run instead: %USERPROFILE%\virtualenvs\pandas-dev\Scripts\activate.bat
+   ~\virtualenvs\pandas-dev\Scripts\Activate.ps1 
 
    # Install the build dependencies
    python -m pip install -r requirements-dev.txt
 
    # Build and install pandas
    python setup.py build_ext --inplace -j 4
-   python -m pip install -e . --no-build-isolation
+   python -m pip install -e . --no-build-isolation --no-use-pep517
 
 Creating a branch
 -----------------

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -245,6 +245,10 @@ You'll need to have at least python3.5 installed on your system.
    # Any parent directories should already exist
    python3 -m venv ~/virtualenvs/pandas-dev
    # Activate the virtualenv
+   #    If you are using Windows and Powershell you need to run:
+   #        ~/virtualenvs/pandas-dev/Scripts/Activate.ps1
+   #    or if you are using Windows and command prompt (cmd.exe):
+   #        ~/virtualenvs/pandas-dev/Scripts/activate.bat
    . ~/virtualenvs/pandas-dev/bin/activate
 
    # Install the build dependencies

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -263,21 +263,17 @@ Below is a brief overview on how to set-up a virtual environment with Powershell
 under Windows. For details please refer to the
 `official virtualenv user guide <https://virtualenv.pypa.io/en/stable/userguide/#activate-script>`__
 
+Use an ENV_DIR of your choice. We'll use ~\virtualenvs\pandas-dev where
+'~' is the folder pointed to by either $env:USERPROFILE (Powershell) or
+%USERPROFILE% (cmd.exe) environment variable. Any parent directories
+should already exist.
+
 .. code-block:: powershell
 
    # Create a virtual environment
-   # Use an ENV_DIR of your choice. We'll use ~\virtualenvs\pandas-dev where
-   # '~' is the folder pointed to by either $env:USERPROFILE (Powershell) or
-   # %USERPROFILE% (cmd.exe) environment variable
-   # Any parent directories should already exist
-
-   # If you are using cmd.exe, run instead:
-   # python -m venv %USERPROFILE%\virtualenvs\pandas-dev
    python -m venv $env:USERPROFILE\virtualenvs\pandas-dev
 
-   # Activate the virtualenv
-   # If you are using cmd.exe, run instead:
-   # %USERPROFILE%\virtualenvs\pandas-dev\Scripts\activate.bat
+   # Activate the virtualenv. Use activate.bat for cmd.exe
    ~\virtualenvs\pandas-dev\Scripts\Activate.ps1
 
    # Install the build dependencies

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -195,6 +195,7 @@ Documentation Improvements
 
 - Added new section on :ref:`scale` (:issue:`28315`).
 - Added sub-section Query MultiIndex in IO tools user guide (:issue:`28791`)
+- Added hints how setup a dev environment under Windows when using pip only (:issue:`29112`)
 
 .. _whatsnew_1000.deprecations:
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -195,7 +195,6 @@ Documentation Improvements
 
 - Added new section on :ref:`scale` (:issue:`28315`).
 - Added sub-section Query MultiIndex in IO tools user guide (:issue:`28791`)
-- Added hints how setup a dev environment under Windows when using pip only (:issue:`29112`)
 
 .. _whatsnew_1000.deprecations:
 


### PR DESCRIPTION
Contributing.rst now correctly describes how to setup dev environment
under Windows when using pip and not conda.

Closes #29112

- [x] closes #29112 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
