### PR TITLE
REF: avoid getattr pattern for unstack, assorted cleanups

### DIFF
--- a/pandas/_libs/algos_take_helper.pxi.in
+++ b/pandas/_libs/algos_take_helper.pxi.in
@@ -146,13 +146,13 @@ def get_dispatch(dtypes):
         inner_take_2d_axis0 = inner_take_2d_axis0_template % args
         inner_take_2d_axis1 = inner_take_2d_axis1_template % args
 
-        yield (name, dest, c_type_in, c_type_out, preval, postval, can_copy,
+        yield (name, dest, c_type_in, c_type_out, preval, postval,
                inner_take_1d, inner_take_2d_axis0, inner_take_2d_axis1)
 
 }}
 
 
-{{for name, dest, c_type_in, c_type_out, preval, postval, can_copy,
+{{for name, dest, c_type_in, c_type_out, preval, postval,
       inner_take_1d, inner_take_2d_axis0, inner_take_2d_axis1
       in get_dispatch(dtypes)}}
 

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -441,24 +441,21 @@ def get_blkno_indexers(int64_t[:] blknos, bint group=True):
                 yield blkno, result
 
 
-def get_blkno_placements(blknos, blk_count, group=True):
+def get_blkno_placements(blknos, group=True):
     """
 
     Parameters
     ----------
     blknos : array of int64
-    blk_count : int
     group : bool
 
     Returns
     -------
     iterator
         yield (BlockPlacement, blkno)
-
     """
 
     blknos = ensure_int64(blknos)
 
-    # FIXME: blk_count is unused, but it may avoid the use of dicts in cython
     for blkno, indexer in get_blkno_indexers(blknos, group):
         yield blkno, BlockPlacement(indexer)

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -25,9 +25,9 @@ cdef class IntervalTree(IntervalMixin):
 
     we are emulating the IndexEngine interface
     """
-    cdef:
-        readonly object left, right, root, dtype
-        readonly str closed
+    cdef readonly:
+        object left, right, root, dtype
+        str closed
         object _is_overlapping, _left_sorter, _right_sorter
 
     def __init__(self, left, right, closed='right', leaf_size=100):
@@ -259,14 +259,14 @@ cdef class {{dtype_title}}Closed{{closed_title}}IntervalNode:
     Categorizes intervals by those that fall to the left, those that fall to
     the right, and those that overlap with the pivot.
     """
-    cdef:
+    cdef readonly:
         {{dtype_title}}Closed{{closed_title}}IntervalNode left_node, right_node
         {{dtype}}_t[:] center_left_values, center_right_values, left, right
         int64_t[:] center_left_indices, center_right_indices, indices
         {{dtype}}_t min_left, max_right
-        readonly {{dtype}}_t pivot
-        readonly int64_t n_elements, n_center, leaf_size
-        readonly bint is_leaf_node
+        {{dtype}}_t pivot
+        int64_t n_elements, n_center, leaf_size
+        bint is_leaf_node
 
     def __init__(self,
                  ndarray[{{dtype}}_t, ndim=1] left,

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -83,19 +83,6 @@ def unstack(reshape_t[:, :] values, uint8_t[:] mask,
                         nulls += 1
 
 
-unstack_uint8 = unstack["uint8_t"]
-unstack_uint16 = unstack["uint16_t"]
-unstack_uint32 = unstack["uint32_t"]
-unstack_uint64 = unstack["uint64_t"]
-unstack_int8 = unstack["int8_t"]
-unstack_int16 = unstack["int16_t"]
-unstack_int32 = unstack["int32_t"]
-unstack_int64 = unstack["int64_t"]
-unstack_float32 = unstack["float32_t"]
-unstack_float64 = unstack["float64_t"]
-unstack_object = unstack["object"]
-
-
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def explode(ndarray[object] values):

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -61,9 +61,7 @@ def get_mgr_concatenation_plan(mgr, indexers):
         blklocs = mgr._blklocs
 
     plan = []
-    for blkno, placements in libinternals.get_blkno_placements(
-        blknos, mgr.nblocks, group=False
-    ):
+    for blkno, placements in libinternals.get_blkno_placements(blknos, group=False):
 
         assert placements.is_slice_like
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1079,9 +1079,7 @@ class BlockManager(PandasObject):
         unfit_mgr_locs = []
         unfit_val_locs = []
         removed_blknos = []
-        for blkno, val_locs in libinternals.get_blkno_placements(
-            blknos, self.nblocks, group=True
-        ):
+        for blkno, val_locs in libinternals.get_blkno_placements(blknos, group=True):
             blk = self.blocks[blkno]
             blk_locs = blklocs[val_locs.indexer]
             if blk.should_store(value):
@@ -1323,9 +1321,7 @@ class BlockManager(PandasObject):
         # FIXME: mgr_groupby_blknos must return mgr_locs in ascending order,
         # pytables serialization will break otherwise.
         blocks = []
-        for blkno, mgr_locs in libinternals.get_blkno_placements(
-            blknos, self.nblocks, group=True
-        ):
+        for blkno, mgr_locs in libinternals.get_blkno_placements(blknos, group=True):
             if blkno == -1:
                 # If we've got here, fill_tuple was not None.
                 fill_value = fill_tuple[0]

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -239,8 +239,7 @@ class _Unstacker:
             sorted_values = sorted_values.astype(name, copy=False)
 
         # fill in our values & mask
-        f = getattr(libreshape, "unstack_{name}".format(name=name))
-        f(
+        libreshape.unstack(
             sorted_values,
             mask.view("u1"),
             stride,


### PR DESCRIPTION
Remove the only "FIXME" left in the cython code