### PR TITLE
Make color validation more forgiving

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -410,7 +410,7 @@ Plotting
 - Bug in the ``xticks`` argument being ignored for :meth:`DataFrame.plot.bar` (:issue:`14119`)
 - :func:`set_option` now validates that the plot backend provided to ``'plotting.backend'`` implements the backend when the option is set, rather than when a plot is created (:issue:`28163`)
 - :meth:`DataFrame.plot` now allow a ``backend`` keyword arugment to allow changing between backends in one session (:issue:`28619`).
-- Bug in color validation incorrectly raising for non-color styles :issue:`29122`).
+- Bug in color validation incorrectly raising for non-color styles (:issue:`29122`).
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -410,6 +410,7 @@ Plotting
 - Bug in the ``xticks`` argument being ignored for :meth:`DataFrame.plot.bar` (:issue:`14119`)
 - :func:`set_option` now validates that the plot backend provided to ``'plotting.backend'`` implements the backend when the option is set, rather than when a plot is created (:issue:`28163`)
 - :meth:`DataFrame.plot` now allow a ``backend`` keyword arugment to allow changing between backends in one session (:issue:`28619`).
+- Bug in color validation incorrectly raising for non-color styles :issue:`29122`).
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -193,6 +193,8 @@ class MPLPlot:
         self._validate_color_args()
 
     def _validate_color_args(self):
+        import matplotlib.colors
+
         if "color" not in self.kwds and "colors" in self.kwds:
             warnings.warn(
                 (
@@ -234,7 +236,7 @@ class MPLPlot:
                 styles = [self.style]
             # need only a single match
             for s in styles:
-                if re.match("^[a-z]+?", s) is not None:
+                if s in matplotlib.colors.BASE_COLORS:
                     raise ValueError(
                         "Cannot pass 'style' string with a color "
                         "symbol and 'color' keyword argument. Please"

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -236,13 +236,14 @@ class MPLPlot:
                 styles = [self.style]
             # need only a single match
             for s in styles:
-                if s in matplotlib.colors.BASE_COLORS:
-                    raise ValueError(
-                        "Cannot pass 'style' string with a color "
-                        "symbol and 'color' keyword argument. Please"
-                        " use one or the other or pass 'style' "
-                        "without a color symbol"
-                    )
+                for char in s:
+                    if char in matplotlib.colors.BASE_COLORS:
+                        raise ValueError(
+                            "Cannot pass 'style' string with a color "
+                            "symbol and 'color' keyword argument. Please"
+                            " use one or the other or pass 'style' "
+                            "without a color symbol"
+                        )
 
     def _iter_data(self, data=None, keep_index=False, fillna=None):
         if data is None:

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -931,3 +931,7 @@ class TestSeriesPlots(TestPlotBase):
         df = pd.Series(["a", "b", "c"])
         with pytest.raises(TypeError):
             df.plot()
+
+    def test_style_single_ok(self):
+        s = pd.Series([1, 2])
+        s.plot(style="s", color="C3")

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -934,4 +934,5 @@ class TestSeriesPlots(TestPlotBase):
 
     def test_style_single_ok(self):
         s = pd.Series([1, 2])
-        s.plot(style="s", color="C3")
+        ax = s.plot(style="s", color="C3")
+        assert ax.lines[0].get_color() == ["C3"]


### PR DESCRIPTION
The current version throws a false positive if the style string contains `s` or `o`, which are valid marker styles and not colors.  For example:

```
style='s', color='C3'
```

should be legal, but currently throws an error.

My suggestion is to check for only the letters that are color codes.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
