### PR TITLE
BUG: fix non-existent variable in NDFrame.interpolate

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -249,7 +249,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Bug in :meth:`DataFrame.to_html` when using ``formatters=<list>`` and ``max_cols`` together. (:issue:`25955`)
-- Bug in :func:`pandas.core.generic.NDFrame.interpolate` where specifying axis by name references variable before it is assigned (:issue:`29132`)
+- Bug in :meth:`DataFrame.interpolate` where specifying axis by name references variable before it is assigned (:issue:`29132`)
 
 Categorical
 ^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -248,8 +248,6 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 
-- Bug in :meth:`DataFrame.to_html` when using ``formatters=<list>`` and ``max_cols`` together. (:issue:`25955`)
-- Bug in :meth:`DataFrame.interpolate` where specifying axis by name references variable before it is assigned (:issue:`29132`)
 
 Categorical
 ^^^^^^^^^^^
@@ -297,6 +295,7 @@ Numeric
 - Bug in :meth:`DataFrame.quantile` with zero-column :class:`DataFrame` incorrectly raising (:issue:`23925`)
 - :class:`DataFrame` flex inequality comparisons methods (:meth:`DataFrame.lt`, :meth:`DataFrame.le`, :meth:`DataFrame.gt`, :meth: `DataFrame.ge`) with object-dtype and ``complex`` entries failing to raise ``TypeError`` like their :class:`Series` counterparts (:issue:`28079`)
 - Bug in :class:`DataFrame` logical operations (`&`, `|`, `^`) not matching :class:`Series` behavior by filling NA values (:issue:`28741`)
+- Bug in :meth:`DataFrame.interpolate` where specifying axis by name references variable before it is assigned (:issue:`29142`)
 -
 
 Conversion
@@ -357,6 +356,7 @@ I/O
 - Bug in :meth:`DataFrame.read_json` where using ``orient="index"`` would not maintain the order (:issue:`28557`)
 - Bug in :meth:`DataFrame.to_html` where the length of the ``formatters`` argument was not verified (:issue:`28469`)
 - Bug in :meth:`pandas.io.formats.style.Styler` formatting for floating values not displaying decimals correctly (:issue:`13257`)
+- Bug in :meth:`DataFrame.to_html` when using ``formatters=<list>`` and ``max_cols`` together. (:issue:`25955`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -249,6 +249,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Bug in :meth:`DataFrame.to_html` when using ``formatters=<list>`` and ``max_cols`` together. (:issue:`25955`)
+- Bug in :func:`pandas.core.generic.NDFrame.interpolate` where specifying axis by name references variable before it is assigned (:issue:`29132`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7023,6 +7023,8 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
 
+        axis = self._get_axis_number(axis)
+
         if axis == 0:
             ax = self._info_axis_name
             _maybe_transposed_self = self
@@ -7030,6 +7032,7 @@ class NDFrame(PandasObject, SelectionMixin):
             _maybe_transposed_self = self.T
             ax = 1
         else:
+            ax = axis
             _maybe_transposed_self = self
         ax = _maybe_transposed_self._get_axis_number(ax)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7031,9 +7031,7 @@ class NDFrame(PandasObject, SelectionMixin):
         elif axis == 1:
             _maybe_transposed_self = self.T
             ax = 1
-        else:
-            ax = axis
-            _maybe_transposed_self = self
+
         ax = _maybe_transposed_self._get_axis_number(ax)
 
         if _maybe_transposed_self.ndim == 2:

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -391,7 +391,8 @@ class TestDataFrameMissingData:
         cat = Categorical([np.nan, 2, np.nan])
         val = Categorical([np.nan, np.nan, np.nan])
         df = DataFrame({"cats": cat, "vals": val})
-        res = df.fillna(df.median())
+        with tm.assert_produces_warning(RuntimeWarning):
+            res = df.fillna(df.median())
         v_exp = [np.nan, np.nan, np.nan]
         df_exp = DataFrame({"cats": [2, 2, 2], "vals": v_exp}, dtype="category")
         tm.assert_frame_equal(res, df_exp)

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -873,20 +873,25 @@ class TestDataFrameInterpolate:
         result = df.interpolate(axis=1, method="values")
         assert_frame_equal(result, expected)
 
-        # GH 29142: test axis names
-        result = df.interpolate(axis="columns", method="values")
-        assert_frame_equal(result, expected)
-
         result = df.interpolate(axis=0)
         expected = df.interpolate()
         assert_frame_equal(result, expected)
 
-        # GH 29142: test axis names
-        result = df.interpolate(axis="rows", method="values")
-        assert_frame_equal(result, expected)
+    @pytest.mark.parametrize(
+        "axis_name, axis_number",
+        [
+            pytest.param("rows", 0, id="rows_0"),
+            pytest.param("index", 0, id="index_0"),
+            pytest.param("columns", 1, id="columns_1"),
+        ],
+    )
+    def test_interp_axis_names(self, axis_name, axis_number):
+        # GH 29132: test axis names
+        data = {0: [0, np.nan, 6], 1: [1, np.nan, 7], 2: [2, 5, 8]}
 
-        # GH 29142: test axis names
-        result = df.interpolate(axis="index", method="values")
+        df = DataFrame(data, dtype=np.float64)
+        result = df.interpolate(axis=axis_name, method="linear")
+        expected = df.interpolate(axis=axis_number, method="linear")
         assert_frame_equal(result, expected)
 
     def test_rowwise_alt(self):

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -398,6 +398,7 @@ class TestDataFrameMissingData:
 
         result = df.cats.fillna(np.nan)
         tm.assert_series_equal(result, df.cats)
+
         result = df.vals.fillna(np.nan)
         tm.assert_series_equal(result, df.vals)
 
@@ -872,8 +873,20 @@ class TestDataFrameInterpolate:
         result = df.interpolate(axis=1, method="values")
         assert_frame_equal(result, expected)
 
+        # GH 29142: test axis names
+        result = df.interpolate(axis="columns", method="values")
+        assert_frame_equal(result, expected)
+
         result = df.interpolate(axis=0)
         expected = df.interpolate()
+        assert_frame_equal(result, expected)
+
+        # GH 29142: test axis names
+        result = df.interpolate(axis="rows", method="values")
+        assert_frame_equal(result, expected)
+
+        # GH 29142: test axis names
+        result = df.interpolate(axis="index", method="values")
         assert_frame_equal(result, expected)
 
     def test_rowwise_alt(self):

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -951,4 +951,4 @@ class TestNDFrame:
 
     @pytest.mark.parametrize("axis", [0, 1, "index", "columns", "rows"])
     def test_interpolate_axis_argument(self, axis):
-        DataFrame([0]).interpolate(axis=axis)
+        assert DataFrame([0]).interpolate(axis=axis)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -948,3 +948,7 @@ class TestNDFrame:
         df = DataFrame([1])
         with tm.assert_produces_warning(FutureWarning):
             df.get_dtype_counts()
+
+    @pytest.mark.parametrize("axis", [0, 1, "index", "columns", "rows"])
+    def test_interpolate_axis_argument(self, axis):
+        DataFrame([0]).interpolate(axis=axis)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -952,4 +952,6 @@ class TestNDFrame:
     @pytest.mark.parametrize("axis", [0, 1, "index", "columns", "rows"])
     def test_interpolate_axis_argument(self, axis):
         # GH 29142
-        assert DataFrame([0]).interpolate(axis=axis)
+        df = pd.DataFrame([0])
+        result = df.interpolate(axis=axis)
+        tm.assert_frame_equal(result, df)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -948,10 +948,3 @@ class TestNDFrame:
         df = DataFrame([1])
         with tm.assert_produces_warning(FutureWarning):
             df.get_dtype_counts()
-
-    @pytest.mark.parametrize("axis", [0, 1, "index", "columns", "rows"])
-    def test_interpolate_axis_argument(self, axis):
-        # GH 29142
-        df = pd.DataFrame([0])
-        result = df.interpolate(axis=axis)
-        tm.assert_frame_equal(result, df)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -951,4 +951,5 @@ class TestNDFrame:
 
     @pytest.mark.parametrize("axis", [0, 1, "index", "columns", "rows"])
     def test_interpolate_axis_argument(self, axis):
+        # GH 29142
         assert DataFrame([0]).interpolate(axis=axis)


### PR DESCRIPTION
- [x] closes #29132
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
