### PR TITLE
Remove TestData from series-tests test_replace.py

### DIFF
--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -4,11 +4,9 @@ import pytest
 import pandas as pd
 import pandas.util.testing as tm
 
-from .common import TestData
 
-
-class TestSeriesReplace(TestData):
-    def test_replace(self):
+class TestSeriesReplace:
+    def test_replace(self, datetime_series):
         N = 100
         ser = pd.Series(np.random.randn(N))
         ser[0:4] = np.nan
@@ -65,7 +63,7 @@ class TestSeriesReplace(TestData):
         filled[4] = 0
         tm.assert_series_equal(ser.replace(np.inf, 0), filled)
 
-        ser = pd.Series(self.ts.index)
+        ser = pd.Series(datetime_series.index)
         tm.assert_series_equal(ser.replace(np.nan, 0), ser.fillna(0))
 
         # malformed


### PR DESCRIPTION
Part of #22550

* Replaced TestData usage in `pandas/tests/series/test_replace.py` with fixtures

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
