### PR TITLE
Remove TestData from series-tests test_repr.py

### DIFF
--- a/pandas/tests/series/conftest.py
+++ b/pandas/tests/series/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+import pandas as pd
 import pandas.util.testing as tm
 
 
@@ -31,3 +32,11 @@ def object_series():
     s = tm.makeObjectSeries()
     s.name = "objects"
     return s
+
+
+@pytest.fixture
+def empty_series():
+    """
+    Fixture for Series that is empty
+    """
+    return pd.Series([], index=[])

--- a/pandas/tests/series/conftest.py
+++ b/pandas/tests/series/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-import pandas as pd
 import pandas.util.testing as tm
 
 
@@ -32,11 +31,3 @@ def object_series():
     s = tm.makeObjectSeries()
     s.name = "objects"
     return s
-
-
-@pytest.fixture
-def empty_series():
-    """
-    Fixture for Series that is empty
-    """
-    return pd.Series([], index=[])

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -17,10 +17,8 @@ from pandas import (
 from pandas.core.index import MultiIndex
 import pandas.util.testing as tm
 
-from .common import TestData
 
-
-class TestSeriesRepr(TestData):
+class TestSeriesRepr:
     def test_multilevel_name_print(self):
         index = MultiIndex(
             levels=[["foo", "bar", "baz", "qux"], ["one", "two", "three"]],
@@ -67,24 +65,24 @@ class TestSeriesRepr(TestData):
         s = Series(index=date_range("20010101", "20020101"), name="test")
         assert "Name: test" in repr(s)
 
-    def test_repr(self):
-        str(self.ts)
-        str(self.series)
-        str(self.series.astype(int))
-        str(self.objSeries)
+    def test_repr(self, datetime_series, string_series, object_series, empty_series):
+        str(datetime_series)
+        str(string_series)
+        str(string_series.astype(int))
+        str(object_series)
 
         str(Series(tm.randn(1000), index=np.arange(1000)))
         str(Series(tm.randn(1000), index=np.arange(1000, 0, step=-1)))
 
         # empty
-        str(self.empty)
+        str(empty_series)
 
         # with NaNs
-        self.series[5:7] = np.NaN
-        str(self.series)
+        string_series[5:7] = np.NaN
+        str(string_series)
 
         # with Nones
-        ots = self.ts.astype("O")
+        ots = datetime_series.astype("O")
         ots[::2] = None
         repr(ots)
 
@@ -102,8 +100,8 @@ class TestSeriesRepr(TestData):
             ("\u03B1", "\u03B2", "\u03B3"),
             ("\u03B1", "bar"),
         ]:
-            self.series.name = name
-            repr(self.series)
+            string_series.name = name
+            repr(string_series)
 
         biggie = Series(
             tm.randn(1000), index=np.arange(1000), name=("foo", "bar", "baz")

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -65,7 +65,7 @@ class TestSeriesRepr:
         s = Series(index=date_range("20010101", "20020101"), name="test")
         assert "Name: test" in repr(s)
 
-    def test_repr(self, datetime_series, string_series, object_series, empty_series):
+    def test_repr(self, datetime_series, string_series, object_series):
         str(datetime_series)
         str(string_series)
         str(string_series.astype(int))
@@ -75,7 +75,7 @@ class TestSeriesRepr:
         str(Series(tm.randn(1000), index=np.arange(1000, 0, step=-1)))
 
         # empty
-        str(empty_series)
+        str(Series())
 
         # with NaNs
         string_series[5:7] = np.NaN


### PR DESCRIPTION
Part of #22550

* Replaced TestData usage in `pandas/tests/series/test_repr.py` with fixtures

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
