### PR TITLE
Remove TestData from series-tests test_timeseries.py

### DIFF
--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -25,7 +25,6 @@ from pandas import (
 )
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
-from pandas.tests.series.common import TestData
 import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_almost_equal,
@@ -47,32 +46,34 @@ def assert_range_equal(left, right):
     assert left.tz == right.tz
 
 
-class TestTimeSeries(TestData):
-    def test_shift(self):
-        shifted = self.ts.shift(1)
+class TestTimeSeries:
+    def test_shift(self, datetime_series):
+        shifted = datetime_series.shift(1)
         unshifted = shifted.shift(-1)
 
-        tm.assert_index_equal(shifted.index, self.ts.index)
-        tm.assert_index_equal(unshifted.index, self.ts.index)
-        tm.assert_numpy_array_equal(unshifted.dropna().values, self.ts.values[:-1])
+        tm.assert_index_equal(shifted.index, datetime_series.index)
+        tm.assert_index_equal(unshifted.index, datetime_series.index)
+        tm.assert_numpy_array_equal(
+            unshifted.dropna().values, datetime_series.values[:-1]
+        )
 
         offset = BDay()
-        shifted = self.ts.shift(1, freq=offset)
+        shifted = datetime_series.shift(1, freq=offset)
         unshifted = shifted.shift(-1, freq=offset)
 
-        assert_series_equal(unshifted, self.ts)
+        assert_series_equal(unshifted, datetime_series)
 
-        unshifted = self.ts.shift(0, freq=offset)
-        assert_series_equal(unshifted, self.ts)
+        unshifted = datetime_series.shift(0, freq=offset)
+        assert_series_equal(unshifted, datetime_series)
 
-        shifted = self.ts.shift(1, freq="B")
+        shifted = datetime_series.shift(1, freq="B")
         unshifted = shifted.shift(-1, freq="B")
 
-        assert_series_equal(unshifted, self.ts)
+        assert_series_equal(unshifted, datetime_series)
 
         # corner case
-        unshifted = self.ts.shift(0)
-        assert_series_equal(unshifted, self.ts)
+        unshifted = datetime_series.shift(0)
+        assert_series_equal(unshifted, datetime_series)
 
         # Shifting with PeriodIndex
         ps = tm.makePeriodSeries()
@@ -208,7 +209,7 @@ class TestTimeSeries(TestData):
             tm.assert_series_equal(res, exp)
             assert res.dtype == "datetime64[ns, US/Eastern]"
 
-    def test_tshift(self):
+    def test_tshift(self, datetime_series):
         # PeriodIndex
         ps = tm.makePeriodSeries()
         shifted = ps.tshift(1)
@@ -227,34 +228,34 @@ class TestTimeSeries(TestData):
             ps.tshift(freq="M")
 
         # DatetimeIndex
-        shifted = self.ts.tshift(1)
+        shifted = datetime_series.tshift(1)
         unshifted = shifted.tshift(-1)
 
-        assert_series_equal(self.ts, unshifted)
+        assert_series_equal(datetime_series, unshifted)
 
-        shifted2 = self.ts.tshift(freq=self.ts.index.freq)
+        shifted2 = datetime_series.tshift(freq=datetime_series.index.freq)
         assert_series_equal(shifted, shifted2)
 
         inferred_ts = Series(
-            self.ts.values, Index(np.asarray(self.ts.index)), name="ts"
+            datetime_series.values, Index(np.asarray(datetime_series.index)), name="ts"
         )
         shifted = inferred_ts.tshift(1)
         unshifted = shifted.tshift(-1)
-        assert_series_equal(shifted, self.ts.tshift(1))
+        assert_series_equal(shifted, datetime_series.tshift(1))
         assert_series_equal(unshifted, inferred_ts)
 
-        no_freq = self.ts[[0, 5, 7]]
+        no_freq = datetime_series[[0, 5, 7]]
         msg = "Freq was not given and was not set in the index"
         with pytest.raises(ValueError, match=msg):
             no_freq.tshift()
 
-    def test_truncate(self):
+    def test_truncate(self, datetime_series):
         offset = BDay()
 
-        ts = self.ts[::3]
+        ts = datetime_series[::3]
 
-        start, end = self.ts.index[3], self.ts.index[6]
-        start_missing, end_missing = self.ts.index[2], self.ts.index[7]
+        start, end = datetime_series.index[3], datetime_series.index[6]
+        start_missing, end_missing = datetime_series.index[2], datetime_series.index[7]
 
         # neither specified
         truncated = ts.truncate()
@@ -288,16 +289,17 @@ class TestTimeSeries(TestData):
         assert_series_equal(truncated, expected)
 
         # corner case, empty series returned
-        truncated = ts.truncate(after=self.ts.index[0] - offset)
+        truncated = ts.truncate(after=datetime_series.index[0] - offset)
         assert len(truncated) == 0
 
-        truncated = ts.truncate(before=self.ts.index[-1] + offset)
+        truncated = ts.truncate(before=datetime_series.index[-1] + offset)
         assert len(truncated) == 0
 
         msg = "Truncate: 1999-12-31 00:00:00 must be after 2000-02-14 00:00:00"
         with pytest.raises(ValueError, match=msg):
             ts.truncate(
-                before=self.ts.index[-1] + offset, after=self.ts.index[0] - offset
+                before=datetime_series.index[-1] + offset,
+                after=datetime_series.index[0] - offset,
             )
 
     def test_truncate_nonsortedindex(self):
@@ -355,20 +357,20 @@ class TestTimeSeries(TestData):
         )
         tm.assert_index_equal(expected.index, result.index)
 
-    def test_pct_change(self):
-        rs = self.ts.pct_change(fill_method=None)
-        assert_series_equal(rs, self.ts / self.ts.shift(1) - 1)
+    def test_pct_change(self, datetime_series):
+        rs = datetime_series.pct_change(fill_method=None)
+        assert_series_equal(rs, datetime_series / datetime_series.shift(1) - 1)
 
-        rs = self.ts.pct_change(2)
-        filled = self.ts.fillna(method="pad")
+        rs = datetime_series.pct_change(2)
+        filled = datetime_series.fillna(method="pad")
         assert_series_equal(rs, filled / filled.shift(2) - 1)
 
-        rs = self.ts.pct_change(fill_method="bfill", limit=1)
-        filled = self.ts.fillna(method="bfill", limit=1)
+        rs = datetime_series.pct_change(fill_method="bfill", limit=1)
+        filled = datetime_series.fillna(method="bfill", limit=1)
         assert_series_equal(rs, filled / filled.shift(1) - 1)
 
-        rs = self.ts.pct_change(freq="5D")
-        filled = self.ts.fillna(method="pad")
+        rs = datetime_series.pct_change(freq="5D")
+        filled = datetime_series.fillna(method="pad")
         assert_series_equal(
             rs, (filled / filled.shift(freq="5D") - 1).reindex_like(filled)
         )
@@ -391,26 +393,32 @@ class TestTimeSeries(TestData):
             ("14B", 14, None, None),
         ],
     )
-    def test_pct_change_periods_freq(self, freq, periods, fill_method, limit):
+    def test_pct_change_periods_freq(
+        self, freq, periods, fill_method, limit, datetime_series
+    ):
         # GH 7292
-        rs_freq = self.ts.pct_change(freq=freq, fill_method=fill_method, limit=limit)
-        rs_periods = self.ts.pct_change(periods, fill_method=fill_method, limit=limit)
+        rs_freq = datetime_series.pct_change(
+            freq=freq, fill_method=fill_method, limit=limit
+        )
+        rs_periods = datetime_series.pct_change(
+            periods, fill_method=fill_method, limit=limit
+        )
         assert_series_equal(rs_freq, rs_periods)
 
-        empty_ts = Series(index=self.ts.index)
+        empty_ts = Series(index=datetime_series.index)
         rs_freq = empty_ts.pct_change(freq=freq, fill_method=fill_method, limit=limit)
         rs_periods = empty_ts.pct_change(periods, fill_method=fill_method, limit=limit)
         assert_series_equal(rs_freq, rs_periods)
 
-    def test_autocorr(self):
+    def test_autocorr(self, datetime_series):
         # Just run the function
-        corr1 = self.ts.autocorr()
+        corr1 = datetime_series.autocorr()
 
         # Now run it with the lag parameter
-        corr2 = self.ts.autocorr(lag=1)
+        corr2 = datetime_series.autocorr(lag=1)
 
         # corr() with lag needs Series of at least length 2
-        if len(self.ts) <= 2:
+        if len(datetime_series) <= 2:
             assert np.isnan(corr1)
             assert np.isnan(corr2)
         else:
@@ -418,19 +426,19 @@ class TestTimeSeries(TestData):
 
         # Choose a random lag between 1 and length of Series - 2
         # and compare the result with the Series corr() function
-        n = 1 + np.random.randint(max(1, len(self.ts) - 2))
-        corr1 = self.ts.corr(self.ts.shift(n))
-        corr2 = self.ts.autocorr(lag=n)
+        n = 1 + np.random.randint(max(1, len(datetime_series) - 2))
+        corr1 = datetime_series.corr(datetime_series.shift(n))
+        corr2 = datetime_series.autocorr(lag=n)
 
         # corr() with lag needs Series of at least length 2
-        if len(self.ts) <= 2:
+        if len(datetime_series) <= 2:
             assert np.isnan(corr1)
             assert np.isnan(corr2)
         else:
             assert corr1 == corr2
 
-    def test_first_last_valid(self):
-        ts = self.ts.copy()
+    def test_first_last_valid(self, datetime_series):
+        ts = datetime_series.copy()
         ts[:5] = np.NaN
 
         index = ts.first_valid_index()
@@ -462,9 +470,9 @@ class TestTimeSeries(TestData):
         assert ts.first_valid_index().freq == ts.index.freq
         assert ts.last_valid_index().freq == ts.index.freq
 
-    def test_mpl_compat_hack(self):
-        result = self.ts[:, np.newaxis]
-        expected = self.ts.values[:, np.newaxis]
+    def test_mpl_compat_hack(self, datetime_series):
+        result = datetime_series[:, np.newaxis]
+        expected = datetime_series.values[:, np.newaxis]
         assert_almost_equal(result, expected)
 
     def test_timeseries_coercion(self):


### PR DESCRIPTION
Part of #22550

* Replaced TestData usage in `pandas/tests/series/test_timeseries.py` with fixtures

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
