### PR TITLE
Clarify referred command for flake8 caveat

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -618,7 +618,8 @@ from the root of the pandas repository. Now ``black`` and ``flake8`` will be run
 each time you commit changes. You can skip these checks with
 ``git commit --no-verify``.
 
-This command will catch any stylistic errors in your changes specifically, but
+One caveat about ``git diff upstream/master -u -- "*.py" | flake8 --diff``: this
+command will catch any stylistic errors in your changes specifically, but
 be beware it may not catch all of them. For example, if you delete the only
 usage of an imported function, it is stylistically incorrect to import an
 unused function. However, style-checking the diff will not catch this because


### PR DESCRIPTION
Follow-up to: https://github.com/pandas-dev/pandas/pull/27233

With all of the content in-between about pre-commit hooks, the phrase `"This command"` does not make sense any more in the documentation about this `flake8` caveat.