### PR TITLE
CI: Avoid passing attrs=None

### DIFF
--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -889,6 +889,9 @@ def _parse(flavor, io, match, attrs, encoding, displayed_only, **kwargs):
     flavor = _validate_flavor(flavor)
     compiled_match = re.compile(match)  # you can pass a compiled regex here
 
+    if attrs is None:
+        attrs = {}
+
     # hack around python 3 deleting the exception variable
     retained = None
     for flav in flavor:


### PR DESCRIPTION
Trying to fix the allowed-failure build on Travis; I haven't been able to reproduce that error locally, so this is a shot in the dark.