### PR TITLE
Remove TestData in frame tests in multiple files 

### DIFF
--- a/pandas/tests/frame/conftest.py
+++ b/pandas/tests/frame/conftest.py
@@ -6,6 +6,23 @@ import pandas.util.testing as tm
 
 
 @pytest.fixture
+def empty_frame():
+    """
+    Fixture for DataFrame that is empty
+    """
+    return DataFrame()
+
+
+@pytest.fixture
+def float_frame():
+    """
+    Fixture for DataFrame of floats with index of unique strings
+    """
+    df = DataFrame(tm.getSeriesData())
+    return df
+
+
+@pytest.fixture
 def float_frame_with_na():
     """
     Fixture for DataFrame of floats with index of unique strings

--- a/pandas/tests/frame/conftest.py
+++ b/pandas/tests/frame/conftest.py
@@ -6,23 +6,6 @@ import pandas.util.testing as tm
 
 
 @pytest.fixture
-def empty_frame():
-    """
-    Fixture for DataFrame that is empty
-    """
-    return DataFrame()
-
-
-@pytest.fixture
-def float_frame():
-    """
-    Fixture for DataFrame of floats with index of unique strings
-    """
-    df = DataFrame(tm.getSeriesData())
-    return df
-
-
-@pytest.fixture
 def float_frame_with_na():
     """
     Fixture for DataFrame of floats with index of unique strings

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -13,11 +13,10 @@ from pandas import (
     Timestamp,
     date_range,
 )
-from pandas.tests.frame.common import TestData
 import pandas.util.testing as tm
 
 
-class TestDataFrameConvertTo(TestData):
+class TestDataFrameConvertTo:
     def test_to_dict_timestamp(self):
 
         # GH11247

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -3,12 +3,11 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, date_range
-from pandas.tests.frame.common import TestData
 import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
-class TestDataFrameNonuniqueIndexes(TestData):
+class TestDataFrameNonuniqueIndexes:
     def test_column_dups_operations(self):
         def check(result, expected=None):
             if expected is not None:

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -9,7 +9,7 @@ import pandas.util._test_decorators as td
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, date_range
 from pandas.core.computation.check import _NUMEXPR_INSTALLED
-import pandas.util.testing as tm
+from pandas.tests.frame.common import TestData
 from pandas.util.testing import (
     assert_frame_equal,
     assert_series_equal,
@@ -704,7 +704,7 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
         super().setup_class()
         cls.engine = "numexpr"
         cls.parser = "python"
-        cls.frame = tm.makeDataFrame()
+        cls.frame = TestData().frame
 
     def test_date_query_no_attribute_access(self):
         engine, parser = self.engine, self.parser
@@ -808,7 +808,7 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
         super().setup_class()
         cls.engine = "python"
         cls.parser = "pandas"
-        cls.frame = tm.makeDataFrame()
+        cls.frame = TestData().frame
 
     def test_query_builtin(self):
         engine, parser = self.engine, self.parser
@@ -827,7 +827,7 @@ class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
     def setup_class(cls):
         super().setup_class()
         cls.engine = cls.parser = "python"
-        cls.frame = tm.makeDataFrame()
+        cls.frame = TestData().frame
 
     def test_query_builtin(self):
         engine, parser = self.engine, self.parser

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -9,7 +9,7 @@ import pandas.util._test_decorators as td
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, date_range
 from pandas.core.computation.check import _NUMEXPR_INSTALLED
-from pandas.tests.frame.common import TestData
+import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_frame_equal,
     assert_series_equal,
@@ -82,7 +82,7 @@ class TestCompat:
                 df.eval("A+1", engine="numexpr")
 
 
-class TestDataFrameEval(TestData):
+class TestDataFrameEval:
     def test_ops(self):
 
         # tst ops and reversed ops in evaluation
@@ -704,7 +704,7 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
         super().setup_class()
         cls.engine = "numexpr"
         cls.parser = "python"
-        cls.frame = TestData().frame
+        cls.frame = tm.makeDataFrame()
 
     def test_date_query_no_attribute_access(self):
         engine, parser = self.engine, self.parser
@@ -808,7 +808,7 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
         super().setup_class()
         cls.engine = "python"
         cls.parser = "pandas"
-        cls.frame = TestData().frame
+        cls.frame = tm.makeDataFrame()
 
     def test_query_builtin(self):
         engine, parser = self.engine, self.parser
@@ -827,7 +827,7 @@ class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
     def setup_class(cls):
         super().setup_class()
         cls.engine = cls.parser = "python"
-        cls.frame = TestData().frame
+        cls.frame = tm.makeDataFrame()
 
     def test_query_builtin(self):
         engine, parser = self.engine, self.parser

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -8,7 +8,6 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range
-from pandas.tests.frame.common import TestData
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
@@ -22,27 +21,27 @@ def mix_abc() -> Dict[str, list]:
     return {"a": list(range(4)), "b": list("ab.."), "c": ["a", "b", np.nan, "d"]}
 
 
-class TestDataFrameReplace(TestData):
-    def test_replace_inplace(self):
-        self.tsframe["A"][:5] = np.nan
-        self.tsframe["A"][-5:] = np.nan
+class TestDataFrameReplace:
+    def test_replace_inplace(self, datetime_frame, float_string_frame):
+        datetime_frame["A"][:5] = np.nan
+        datetime_frame["A"][-5:] = np.nan
 
-        tsframe = self.tsframe.copy()
+        tsframe = datetime_frame.copy()
         tsframe.replace(np.nan, 0, inplace=True)
-        assert_frame_equal(tsframe, self.tsframe.fillna(0))
+        assert_frame_equal(tsframe, datetime_frame.fillna(0))
 
         # mixed type
-        mf = self.mixed_frame
+        mf = float_string_frame
         mf.iloc[5:20, mf.columns.get_loc("foo")] = np.nan
         mf.iloc[-10:, mf.columns.get_loc("A")] = np.nan
 
-        result = self.mixed_frame.replace(np.nan, 0)
-        expected = self.mixed_frame.fillna(value=0)
+        result = float_string_frame.replace(np.nan, 0)
+        expected = float_string_frame.fillna(value=0)
         assert_frame_equal(result, expected)
 
-        tsframe = self.tsframe.copy()
+        tsframe = datetime_frame.copy()
         tsframe.replace([np.nan], [0], inplace=True)
-        assert_frame_equal(tsframe, self.tsframe.fillna(0))
+        assert_frame_equal(tsframe, datetime_frame.fillna(0))
 
     def test_regex_replace_scalar(self, mix_ab):
         obj = {"a": list("ab.."), "b": list("efgh")}
@@ -583,17 +582,17 @@ class TestDataFrameReplace(TestData):
         expected = DataFrame({"a": ["paren", "else"]})
         assert_frame_equal(result, expected)
 
-    def test_replace(self):
-        self.tsframe["A"][:5] = np.nan
-        self.tsframe["A"][-5:] = np.nan
+    def test_replace(self, datetime_frame):
+        datetime_frame["A"][:5] = np.nan
+        datetime_frame["A"][-5:] = np.nan
 
-        zero_filled = self.tsframe.replace(np.nan, -1e8)
-        assert_frame_equal(zero_filled, self.tsframe.fillna(-1e8))
-        assert_frame_equal(zero_filled.replace(-1e8, np.nan), self.tsframe)
+        zero_filled = datetime_frame.replace(np.nan, -1e8)
+        assert_frame_equal(zero_filled, datetime_frame.fillna(-1e8))
+        assert_frame_equal(zero_filled.replace(-1e8, np.nan), datetime_frame)
 
-        self.tsframe["A"][:5] = np.nan
-        self.tsframe["A"][-5:] = np.nan
-        self.tsframe["B"][:5] = -1e8
+        datetime_frame["A"][:5] = np.nan
+        datetime_frame["A"][-5:] = np.nan
+        datetime_frame["B"][:5] = -1e8
 
         # empty
         df = DataFrame(index=["a", "b"])
@@ -684,20 +683,20 @@ class TestDataFrameReplace(TestData):
         res = rep.dtypes
         assert_series_equal(expec, res)
 
-    def test_replace_mixed(self):
-        mf = self.mixed_frame
+    def test_replace_mixed(self, float_string_frame):
+        mf = float_string_frame
         mf.iloc[5:20, mf.columns.get_loc("foo")] = np.nan
         mf.iloc[-10:, mf.columns.get_loc("A")] = np.nan
 
-        result = self.mixed_frame.replace(np.nan, -18)
-        expected = self.mixed_frame.fillna(value=-18)
+        result = float_string_frame.replace(np.nan, -18)
+        expected = float_string_frame.fillna(value=-18)
         assert_frame_equal(result, expected)
-        assert_frame_equal(result.replace(-18, np.nan), self.mixed_frame)
+        assert_frame_equal(result.replace(-18, np.nan), float_string_frame)
 
-        result = self.mixed_frame.replace(np.nan, -1e8)
-        expected = self.mixed_frame.fillna(value=-1e8)
+        result = float_string_frame.replace(np.nan, -1e8)
+        expected = float_string_frame.fillna(value=-1e8)
         assert_frame_equal(result, expected)
-        assert_frame_equal(result.replace(-1e8, np.nan), self.mixed_frame)
+        assert_frame_equal(result.replace(-1e8, np.nan), float_string_frame)
 
         # int block upcasting
         df = DataFrame(
@@ -793,30 +792,30 @@ class TestDataFrameReplace(TestData):
         result = df.replace({"col": {-1: "-", 1: "a", 4: "b"}})
         assert_frame_equal(expected, result)
 
-    def test_replace_value_is_none(self):
-        orig_value = self.tsframe.iloc[0, 0]
-        orig2 = self.tsframe.iloc[1, 0]
+    def test_replace_value_is_none(self, datetime_frame):
+        orig_value = datetime_frame.iloc[0, 0]
+        orig2 = datetime_frame.iloc[1, 0]
 
-        self.tsframe.iloc[0, 0] = np.nan
-        self.tsframe.iloc[1, 0] = 1
+        datetime_frame.iloc[0, 0] = np.nan
+        datetime_frame.iloc[1, 0] = 1
 
-        result = self.tsframe.replace(to_replace={np.nan: 0})
-        expected = self.tsframe.T.replace(to_replace={np.nan: 0}).T
+        result = datetime_frame.replace(to_replace={np.nan: 0})
+        expected = datetime_frame.T.replace(to_replace={np.nan: 0}).T
         assert_frame_equal(result, expected)
 
-        result = self.tsframe.replace(to_replace={np.nan: 0, 1: -1e8})
-        tsframe = self.tsframe.copy()
+        result = datetime_frame.replace(to_replace={np.nan: 0, 1: -1e8})
+        tsframe = datetime_frame.copy()
         tsframe.iloc[0, 0] = 0
         tsframe.iloc[1, 0] = -1e8
         expected = tsframe
         assert_frame_equal(expected, result)
-        self.tsframe.iloc[0, 0] = orig_value
-        self.tsframe.iloc[1, 0] = orig2
+        datetime_frame.iloc[0, 0] = orig_value
+        datetime_frame.iloc[1, 0] = orig2
 
-    def test_replace_for_new_dtypes(self):
+    def test_replace_for_new_dtypes(self, datetime_frame):
 
         # dtypes
-        tsframe = self.tsframe.copy().astype(np.float32)
+        tsframe = datetime_frame.copy().astype(np.float32)
         tsframe["A"][:5] = np.nan
         tsframe["A"][-5:] = np.nan
 

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -18,7 +18,6 @@ from pandas import (
     option_context,
     period_range,
 )
-from pandas.tests.frame.common import TestData
 import pandas.util.testing as tm
 
 import pandas.io.formats.format as fmt
@@ -27,21 +26,21 @@ import pandas.io.formats.format as fmt
 # structure
 
 
-class TestDataFrameReprInfoEtc(TestData):
-    def test_repr_empty(self):
+class TestDataFrameReprInfoEtc:
+    def test_repr_empty(self, empty_frame):
         # empty
-        foo = repr(self.empty)  # noqa
+        foo = repr(empty_frame)  # noqa
 
         # empty with index
         frame = DataFrame(index=np.arange(1000))
         foo = repr(frame)  # noqa
 
-    def test_repr_mixed(self):
+    def test_repr_mixed(self, float_string_frame):
         buf = StringIO()
 
         # mixed
-        foo = repr(self.mixed_frame)  # noqa
-        self.mixed_frame.info(verbose=False, buf=buf)
+        foo = repr(float_string_frame)  # noqa
+        float_string_frame.info(verbose=False, buf=buf)
 
     @pytest.mark.slow
     def test_repr_mixed_big(self):
@@ -54,16 +53,16 @@ class TestDataFrameReprInfoEtc(TestData):
 
         foo = repr(biggie)  # noqa
 
-    def test_repr(self):
+    def test_repr(self, float_frame, empty_frame):
         buf = StringIO()
 
         # small one
-        foo = repr(self.frame)
-        self.frame.info(verbose=False, buf=buf)
+        foo = repr(float_frame)
+        float_frame.info(verbose=False, buf=buf)
 
         # even smaller
-        self.frame.reindex(columns=["A"]).info(verbose=False, buf=buf)
-        self.frame.reindex(columns=["A", "B"]).info(verbose=False, buf=buf)
+        float_frame.reindex(columns=["A"]).info(verbose=False, buf=buf)
+        float_frame.reindex(columns=["A", "B"]).info(verbose=False, buf=buf)
 
         # exhausting cases in DataFrame.info
 
@@ -72,7 +71,7 @@ class TestDataFrameReprInfoEtc(TestData):
         foo = repr(no_index)  # noqa
 
         # no columns or index
-        self.empty.info(buf=buf)
+        empty_frame.info(buf=buf)
 
         df = DataFrame(["a\n\r\tb"], columns=["a\n\r\td"], index=["a\n\r\tf"])
         assert "\t" not in repr(df)
@@ -96,7 +95,7 @@ class TestDataFrameReprInfoEtc(TestData):
         biggie = DataFrame(np.zeros((200, 4)), columns=range(4), index=range(200))
         repr(biggie)
 
-    def test_repr_unsortable(self):
+    def test_repr_unsortable(self, float_frame):
         # columns are not sortable
         import warnings
 
@@ -115,13 +114,13 @@ class TestDataFrameReprInfoEtc(TestData):
         repr(unsortable)
 
         fmt.set_option("display.precision", 3, "display.column_space", 10)
-        repr(self.frame)
+        repr(float_frame)
 
         fmt.set_option("display.max_rows", 10, "display.max_columns", 2)
-        repr(self.frame)
+        repr(float_frame)
 
         fmt.set_option("display.max_rows", 1000, "display.max_columns", 1000)
-        repr(self.frame)
+        repr(float_frame)
 
         tm.reset_display_options()
 
@@ -196,10 +195,10 @@ class TestDataFrameReprInfoEtc(TestData):
         # GH 12182
         assert df._repr_latex_() is None
 
-    def test_info(self):
+    def test_info(self, float_frame, datetime_frame):
         io = StringIO()
-        self.frame.info(buf=io)
-        self.tsframe.info(buf=io)
+        float_frame.info(buf=io)
+        datetime_frame.info(buf=io)
 
         frame = DataFrame(np.random.randn(5, 3))
 

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -27,9 +27,9 @@ import pandas.io.formats.format as fmt
 
 
 class TestDataFrameReprInfoEtc:
-    def test_repr_empty(self, empty_frame):
+    def test_repr_empty(self):
         # empty
-        foo = repr(empty_frame)  # noqa
+        foo = repr(DataFrame())  # noqa
 
         # empty with index
         frame = DataFrame(index=np.arange(1000))
@@ -53,7 +53,7 @@ class TestDataFrameReprInfoEtc:
 
         foo = repr(biggie)  # noqa
 
-    def test_repr(self, float_frame, empty_frame):
+    def test_repr(self, float_frame):
         buf = StringIO()
 
         # small one
@@ -71,7 +71,7 @@ class TestDataFrameReprInfoEtc:
         foo = repr(no_index)  # noqa
 
         # no columns or index
-        empty_frame.info(buf=buf)
+        DataFrame().info(buf=buf)
 
         df = DataFrame(["a\n\r\tb"], columns=["a\n\r\td"], index=["a\n\r\tf"])
         assert "\t" not in repr(df)


### PR DESCRIPTION
Part of #22471 

This is removing/replacing TestData usage in the following files:
* `test_convert_to.py`
* `test_nonunique_indexes.py`
* `test_query_eval.py`
* `test_replace.py`
* `test_repr_info.py`


--------
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
