### PR TITLE
Asset Frame with duplicate index

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3740,7 +3740,7 @@ class DataFrame(NDFrame):
     # ----------------------------------------------------------------------
     # Reindexing and alignment
 
-    def _reindex_axes(self, axes, level, limit, tolerance, method, fill_value, copy):
+    def _reindex_axes(self, axes, level, limit, tolerance, method, fill_value, copy, allow_dups):
         frame = self
 
         columns = axes["columns"]
@@ -3752,7 +3752,7 @@ class DataFrame(NDFrame):
         index = axes["index"]
         if index is not None:
             frame = frame._reindex_index(
-                index, method, copy, level, fill_value, limit, tolerance
+                index, method, copy, level, fill_value, limit, tolerance, allow_dups
             )
 
         return frame
@@ -3766,6 +3766,7 @@ class DataFrame(NDFrame):
         fill_value=np.nan,
         limit=None,
         tolerance=None,
+        allow_dups=False
     ):
         new_index, indexer = self.index.reindex(
             new_index, method=method, level=level, limit=limit, tolerance=tolerance
@@ -3774,7 +3775,7 @@ class DataFrame(NDFrame):
             {0: [new_index, indexer]},
             copy=copy,
             fill_value=fill_value,
-            allow_dups=False,
+            allow_dups=allow_dups
         )
 
     def _reindex_columns(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3829,7 +3829,7 @@ class NDFrame(PandasObject, SelectionMixin):
         """Return boolean indicating if self is view of another array """
         return self._data.is_view
 
-    def reindex_like(self, other, method=None, copy=True, limit=None, tolerance=None):
+    def reindex_like(self, other, method=None, copy=True, limit=None, tolerance=None, allow_dups=False):
         """
         Return an object with matching indices as other object.
 
@@ -3930,6 +3930,7 @@ class NDFrame(PandasObject, SelectionMixin):
             copy=copy,
             limit=limit,
             tolerance=tolerance,
+            allow_dups=allow_dups
         )
 
         return self.reindex(**d)
@@ -4528,6 +4529,7 @@ class NDFrame(PandasObject, SelectionMixin):
         limit = kwargs.pop("limit", None)
         tolerance = kwargs.pop("tolerance", None)
         fill_value = kwargs.pop("fill_value", None)
+        allow_dups = kwargs.pop("allow_dups", False)
 
         # Series.reindex doesn't use / need the axis kwarg
         # We pop and ignore it here, to make writing Series/Frame generic code
@@ -4562,7 +4564,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         # perform the reindex on the axes
         return self._reindex_axes(
-            axes, level, limit, tolerance, method, fill_value, copy
+            axes, level, limit, tolerance, method, fill_value, copy, allow_dups
         ).__finalize__(self)
 
     def _reindex_axes(self, axes, level, limit, tolerance, method, fill_value, copy):
@@ -4583,7 +4585,7 @@ class NDFrame(PandasObject, SelectionMixin):
                 {axis: [new_index, indexer]},
                 fill_value=fill_value,
                 copy=copy,
-                allow_dups=False,
+                allow_dups=allow_dups,
             )
 
         return obj

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1233,6 +1233,7 @@ def assert_frame_equal(
     check_datetimelike_compat=False,
     check_categorical=True,
     check_like=False,
+    check_dups_index=False,
     obj="DataFrame",
 ):
     """
@@ -1344,7 +1345,7 @@ def assert_frame_equal(
         )
 
     if check_like:
-        left, right = left.reindex_like(right), right
+        left, right = left.reindex_like(right,allow_dups=check_dups_index), right
 
     # index comparison
     assert_index_equal(


### PR DESCRIPTION
- [ ] closes #26494
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


Hey guys, I started working on a way to make testing.assert_frame_equal accept an argument so it can test equals a frame with duplicate index just like the issue I marked to close here. For this I had to make a couple of changes in some functions and I think I got to the point that I should ask for a better direction and if this is valid for the project.

The error pointed in the issue is definitely not the best message for this case. I got to the point to not get that error by making clear there is a duplicate index. But I got stuck in this error now:

`ValueError: Shape of passed values is (5, 1), indices imply (3, 1)`
