### PR TITLE
Added io Annotation

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -365,9 +365,9 @@ def _infer_compression(
 
 
 def _get_handle(
-    path_or_buf,
+    path_or_buf: FilePathOrBuffer,
     mode: str,
-    encoding=None,
+    encoding: Optional[str] = None,
     compression: Optional[Union[str, Mapping[str, Any]]] = None,
     memory_map: bool = False,
     is_text: bool = True,

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -365,7 +365,7 @@ def _infer_compression(
 
 
 def _get_handle(
-    path_or_buf: FilePathOrBuffer,
+    path_or_buf,
     mode: str,
     encoding: Optional[str] = None,
     compression: Optional[Union[str, Mapping[str, Any]]] = None,


### PR DESCRIPTION
This is a quick follow up to https://github.com/pandas-dev/pandas/pull/26024/files#r317413254

The last remaining argument still has a slew of issues with it (provided below for reference) so leaving that for now

```sh
pandas/io/common.py:439: error: Incompatible types in assignment (expression has type "GzipFile", variable has type "Union[str, Path, IO[Any]]")
pandas/io/common.py:439: error: Argument "fileobj" to "GzipFile" has incompatible type "Union[str, Path, IO[Any]]"; expected "Optional[IO[bytes]]"
pandas/io/common.py:478: error: Argument 1 to "append" of "list" has incompatible type "Union[str, Path, IO[Any]]"; expected "IO[Any]"
pandas/io/common.py:483: error: Argument 1 to "open" has incompatible type "Union[str, Path, IO[Any]]"; expected "Union[str, bytes, int, _PathLike[Any]]"
pandas/io/common.py:486: error: Argument 1 to "open" has incompatible type "Union[str, Path, IO[Any]]"; expected "Union[str, bytes, int, _PathLike[Any]]"
pandas/io/common.py:489: error: Argument 1 to "open" has incompatible type "Union[str, Path, IO[Any]]"; expected "Union[str, bytes, int, _PathLike[Any]]"
pandas/io/common.py:496: error: Argument 1 to "TextIOWrapper" has incompatible type "Union[str, Path, IO[Any]]"; expected "IO[bytes]"
pandas/io/common.py:503: error: Argument 1 to "MMapWrapper" has incompatible type "Union[str, Path, IO[Any]]"; expected "IO[Any]"
pandas/io/common.py:504: error: Item "str" of "Union[str, Path, IO[Any]]" has no attribute "close"
pandas/io/common.py:504: error: Item "Path" of "Union[str, Path, IO[Any]]" has no attribute "close"
pandas/io/common.py:505: error: Incompatible types in assignment (expression has type "MMapWrapper", variable has type "Union[str, Path, IO[Any]]")
```
