### PR TITLE
TYPING: Added types for some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ doc/build/html/index.html
 doc/tmp.sv
 env/
 doc/source/savefig/
+.dmypy.json

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from pandas.core.indexes.base import Index  # noqa: F401
     from pandas.core.series import Series  # noqa: F401
     from pandas.core.generic import NDFrame  # noqa: F401
+    from pandas.core.base import IndexOpsMixin  # noqa: F401
 
 
 AnyArrayLike = TypeVar("AnyArrayLike", "ExtensionArray", "Index", "Series", np.ndarray)
@@ -32,6 +33,7 @@ Dtype = Union[str, np.dtype, "ExtensionDtype"]
 FilePathOrBuffer = Union[str, Path, IO[AnyStr]]
 
 FrameOrSeries = TypeVar("FrameOrSeries", bound="NDFrame")
+IndexOrSeries = TypeVar("IndexOrSeries", bound="IndexOpsMixin")
 Scalar = Union[str, int, float, bool]
 Axis = Union[str, int]
 Ordered = Optional[bool]

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -14,6 +14,7 @@ import pandas.util._test_decorators as td
 
 import pandas as pd
 from pandas import DataFrame
+from pandas._typing import IndexOrSeries
 from pandas.core import ops
 import pandas.util.testing as tm
 
@@ -786,6 +787,17 @@ def any_skipna_inferred_dtype(request):
 def tick_classes(request):
     """
     Fixture for Tick based datetime offsets available for a time series.
+    """
+    return request.param
+
+
+index_or_series_params = [pd.Index, pd.Series]  # type: IndexOrSeries
+
+
+@pytest.fixture(params=index_or_series_params, ids=["series", "index"])
+def index_or_series(request) -> IndexOrSeries:
+    """
+    Parametrized fixture providing the Index or Series class.
     """
     return request.param
 

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -5,13 +5,14 @@ from collections import abc
 from decimal import Decimal
 from itertools import combinations
 import operator
-from typing import List, Type, Union
+from typing import List, Sequence, Type, Union
 
 import numpy as np
 import pytest
 
 import pandas as pd
 from pandas import Index, Series, Timedelta, TimedeltaIndex
+from pandas.conftest import ALL_REAL_DTYPES
 from pandas.core import ops
 import pandas.util.testing as tm
 
@@ -78,10 +79,10 @@ class TestNumericComparisons:
 index_or_series_params = [
     pd.Series,
     pd.Index,
-]  # type: List[Union[Type[pd.Index], Type[pd.RangeIndex], Type[pd.Series]]]
+]  # type: Sequence[Type[Union[pd.Index, pd.Series]]]
 left = [pd.RangeIndex(10, 40, 10)]  # type: List[Union[Index, Series]]
 for cls in index_or_series_params:
-    for dtype in ["i1", "i2", "i4", "i8", "u1", "u2", "u4", "u8", "f2", "f4", "f8"]:
+    for dtype in ALL_REAL_DTYPES:
         left.append(cls([10, 20, 30], dtype=dtype))
 
 

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -5,6 +5,7 @@ from collections import abc
 from decimal import Decimal
 from itertools import combinations
 import operator
+from typing import List, Type, Union
 
 import numpy as np
 import pytest
@@ -74,6 +75,14 @@ class TestNumericComparisons:
 
 # ------------------------------------------------------------------
 # Numeric dtypes Arithmetic with Datetime/Timedelta Scalar
+index_or_series_params = [
+    pd.Series,
+    pd.Index,
+]  # type: List[Union[Type[pd.Index], Type[pd.RangeIndex], Type[pd.Series]]]
+left = [pd.RangeIndex(10, 40, 10)]  # type: List[Union[Index, Series]]
+for cls in index_or_series_params:
+    for dtype in ["i1", "i2", "i4", "i8", "u1", "u2", "u4", "u8", "f2", "f4", "f8"]:
+        left.append(cls([10, 20, 30], dtype=dtype))
 
 
 class TestNumericArraylikeArithmeticWithDatetimeLike:
@@ -81,26 +90,7 @@ class TestNumericArraylikeArithmeticWithDatetimeLike:
     # TODO: also check name retentention
     @pytest.mark.parametrize("box_cls", [np.array, pd.Index, pd.Series])
     @pytest.mark.parametrize(
-        "left",
-        [pd.RangeIndex(10, 40, 10)]
-        + [
-            cls([10, 20, 30], dtype=dtype)
-            for dtype in [
-                "i1",
-                "i2",
-                "i4",
-                "i8",
-                "u1",
-                "u2",
-                "u4",
-                "u8",
-                "f2",
-                "f4",
-                "f8",
-            ]
-            for cls in [pd.Series, pd.Index]
-        ],
-        ids=lambda x: type(x).__name__ + str(x.dtype),
+        "left", left, ids=lambda x: type(x).__name__ + str(x.dtype)
     )
     def test_mul_td64arr(self, left, box_cls):
         # GH#22390
@@ -120,26 +110,7 @@ class TestNumericArraylikeArithmeticWithDatetimeLike:
     # TODO: also check name retentention
     @pytest.mark.parametrize("box_cls", [np.array, pd.Index, pd.Series])
     @pytest.mark.parametrize(
-        "left",
-        [pd.RangeIndex(10, 40, 10)]
-        + [
-            cls([10, 20, 30], dtype=dtype)
-            for dtype in [
-                "i1",
-                "i2",
-                "i4",
-                "i8",
-                "u1",
-                "u2",
-                "u4",
-                "u8",
-                "f2",
-                "f4",
-                "f8",
-            ]
-            for cls in [pd.Series, pd.Index]
-        ],
-        ids=lambda x: type(x).__name__ + str(x.dtype),
+        "left", left, ids=lambda x: type(x).__name__ + str(x.dtype)
     )
     def test_div_td64arr(self, left, box_cls):
         # GH#22390

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -272,9 +272,8 @@ class DecimalArray2(DecimalArray):
         return super()._from_sequence(scalars, dtype=dtype, copy=copy)
 
 
-@pytest.mark.parametrize("box", [pd.Series, pd.Index])
-def test_array_unboxes(box):
-    data = box([decimal.Decimal("1"), decimal.Decimal("2")])
+def test_array_unboxes(index_or_series):
+    data = index_or_series([decimal.Decimal("1"), decimal.Decimal("2")])
     # make sure it works
     with pytest.raises(TypeError):
         DecimalArray2._from_sequence(data)

--- a/pandas/tests/dtypes/test_concat.py
+++ b/pandas/tests/dtypes/test_concat.py
@@ -2,7 +2,7 @@ import pytest
 
 import pandas.core.dtypes.concat as _concat
 
-from pandas import DatetimeIndex, Index, Period, PeriodIndex, Series, TimedeltaIndex
+from pandas import DatetimeIndex, Period, PeriodIndex, Series, TimedeltaIndex
 
 
 @pytest.mark.parametrize(
@@ -40,9 +40,8 @@ from pandas import DatetimeIndex, Index, Period, PeriodIndex, Series, TimedeltaI
         ),
     ],
 )
-@pytest.mark.parametrize("klass", [Index, Series])
-def test_get_dtype_kinds(klass, to_concat, expected):
-    to_concat_klass = [klass(c) for c in to_concat]
+def test_get_dtype_kinds(index_or_series, to_concat, expected):
+    to_concat_klass = [index_or_series(c) for c in to_concat]
     result = _concat.get_dtype_kinds(to_concat_klass)
     assert result == set(expected)
 

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -515,55 +515,52 @@ class TestWhereCoercion(CoercionBase):
         res = target.where(cond, values)
         self._assert(res, expected, expected_dtype)
 
-    @pytest.mark.parametrize("klass", [pd.Series, pd.Index], ids=["series", "index"])
     @pytest.mark.parametrize(
         "fill_val,exp_dtype",
         [(1, np.object), (1.1, np.object), (1 + 1j, np.object), (True, np.object)],
     )
-    def test_where_object(self, klass, fill_val, exp_dtype):
-        obj = klass(list("abcd"))
+    def test_where_object(self, index_or_series, fill_val, exp_dtype):
+        obj = index_or_series(list("abcd"))
         assert obj.dtype == np.object
-        cond = klass([True, False, True, False])
+        cond = index_or_series([True, False, True, False])
 
-        if fill_val is True and klass is pd.Series:
+        if fill_val is True and index_or_series is pd.Series:
             ret_val = 1
         else:
             ret_val = fill_val
 
-        exp = klass(["a", ret_val, "c", ret_val])
+        exp = index_or_series(["a", ret_val, "c", ret_val])
         self._assert_where_conversion(obj, cond, fill_val, exp, exp_dtype)
 
         if fill_val is True:
-            values = klass([True, False, True, True])
+            values = index_or_series([True, False, True, True])
         else:
-            values = klass(fill_val * x for x in [5, 6, 7, 8])
+            values = index_or_series(fill_val * x for x in [5, 6, 7, 8])
 
-        exp = klass(["a", values[1], "c", values[3]])
+        exp = index_or_series(["a", values[1], "c", values[3]])
         self._assert_where_conversion(obj, cond, values, exp, exp_dtype)
 
-    @pytest.mark.parametrize("klass", [pd.Series, pd.Index], ids=["series", "index"])
     @pytest.mark.parametrize(
         "fill_val,exp_dtype",
         [(1, np.int64), (1.1, np.float64), (1 + 1j, np.complex128), (True, np.object)],
     )
-    def test_where_int64(self, klass, fill_val, exp_dtype):
-        if klass is pd.Index and exp_dtype is np.complex128:
+    def test_where_int64(self, index_or_series, fill_val, exp_dtype):
+        if index_or_series is pd.Index and exp_dtype is np.complex128:
             pytest.skip("Complex Index not supported")
-        obj = klass([1, 2, 3, 4])
+        obj = index_or_series([1, 2, 3, 4])
         assert obj.dtype == np.int64
-        cond = klass([True, False, True, False])
+        cond = index_or_series([True, False, True, False])
 
-        exp = klass([1, fill_val, 3, fill_val])
+        exp = index_or_series([1, fill_val, 3, fill_val])
         self._assert_where_conversion(obj, cond, fill_val, exp, exp_dtype)
 
         if fill_val is True:
-            values = klass([True, False, True, True])
+            values = index_or_series([True, False, True, True])
         else:
-            values = klass(x * fill_val for x in [5, 6, 7, 8])
-        exp = klass([1, values[1], 3, values[3]])
+            values = index_or_series(x * fill_val for x in [5, 6, 7, 8])
+        exp = index_or_series([1, values[1], 3, values[3]])
         self._assert_where_conversion(obj, cond, values, exp, exp_dtype)
 
-    @pytest.mark.parametrize("klass", [pd.Series, pd.Index], ids=["series", "index"])
     @pytest.mark.parametrize(
         "fill_val, exp_dtype",
         [
@@ -573,21 +570,21 @@ class TestWhereCoercion(CoercionBase):
             (True, np.object),
         ],
     )
-    def test_where_float64(self, klass, fill_val, exp_dtype):
-        if klass is pd.Index and exp_dtype is np.complex128:
+    def test_where_float64(self, index_or_series, fill_val, exp_dtype):
+        if index_or_series is pd.Index and exp_dtype is np.complex128:
             pytest.skip("Complex Index not supported")
-        obj = klass([1.1, 2.2, 3.3, 4.4])
+        obj = index_or_series([1.1, 2.2, 3.3, 4.4])
         assert obj.dtype == np.float64
-        cond = klass([True, False, True, False])
+        cond = index_or_series([True, False, True, False])
 
-        exp = klass([1.1, fill_val, 3.3, fill_val])
+        exp = index_or_series([1.1, fill_val, 3.3, fill_val])
         self._assert_where_conversion(obj, cond, fill_val, exp, exp_dtype)
 
         if fill_val is True:
-            values = klass([True, False, True, True])
+            values = index_or_series([True, False, True, True])
         else:
-            values = klass(x * fill_val for x in [5, 6, 7, 8])
-        exp = klass([1.1, values[1], 3.3, values[3]])
+            values = index_or_series(x * fill_val for x in [5, 6, 7, 8])
+        exp = index_or_series([1.1, values[1], 3.3, values[3]])
         self._assert_where_conversion(obj, cond, values, exp, exp_dtype)
 
     @pytest.mark.parametrize(
@@ -783,19 +780,17 @@ class TestFillnaSeriesCoercion(CoercionBase):
         res = target.fillna(value)
         self._assert(res, expected, expected_dtype)
 
-    @pytest.mark.parametrize("klass", [pd.Series, pd.Index], ids=["series", "index"])
     @pytest.mark.parametrize(
         "fill_val, fill_dtype",
         [(1, np.object), (1.1, np.object), (1 + 1j, np.object), (True, np.object)],
     )
-    def test_fillna_object(self, klass, fill_val, fill_dtype):
-        obj = klass(["a", np.nan, "c", "d"])
+    def test_fillna_object(self, index_or_series, fill_val, fill_dtype):
+        obj = index_or_series(["a", np.nan, "c", "d"])
         assert obj.dtype == np.object
 
-        exp = klass(["a", fill_val, "c", "d"])
+        exp = index_or_series(["a", fill_val, "c", "d"])
         self._assert_fillna_conversion(obj, fill_val, exp, fill_dtype)
 
-    @pytest.mark.parametrize("klass", [pd.Series, pd.Index], ids=["series", "index"])
     @pytest.mark.parametrize(
         "fill_val,fill_dtype",
         [
@@ -805,15 +800,15 @@ class TestFillnaSeriesCoercion(CoercionBase):
             (True, np.object),
         ],
     )
-    def test_fillna_float64(self, klass, fill_val, fill_dtype):
-        obj = klass([1.1, np.nan, 3.3, 4.4])
+    def test_fillna_float64(self, index_or_series, fill_val, fill_dtype):
+        obj = index_or_series([1.1, np.nan, 3.3, 4.4])
         assert obj.dtype == np.float64
 
-        exp = klass([1.1, fill_val, 3.3, 4.4])
+        exp = index_or_series([1.1, fill_val, 3.3, 4.4])
         # float + complex -> we don't support a complex Index
         # complex for Series,
         # object for Index
-        if fill_dtype == np.complex128 and klass == pd.Index:
+        if fill_dtype == np.complex128 and index_or_series == pd.Index:
             fill_dtype = np.object
         self._assert_fillna_conversion(obj, fill_val, exp, fill_dtype)
 
@@ -833,7 +828,6 @@ class TestFillnaSeriesCoercion(CoercionBase):
         exp = pd.Series([1 + 1j, fill_val, 3 + 3j, 4 + 4j])
         self._assert_fillna_conversion(obj, fill_val, exp, fill_dtype)
 
-    @pytest.mark.parametrize("klass", [pd.Series, pd.Index], ids=["series", "index"])
     @pytest.mark.parametrize(
         "fill_val,fill_dtype",
         [
@@ -844,8 +838,8 @@ class TestFillnaSeriesCoercion(CoercionBase):
         ],
         ids=["datetime64", "datetime64tz", "object", "object"],
     )
-    def test_fillna_datetime(self, klass, fill_val, fill_dtype):
-        obj = klass(
+    def test_fillna_datetime(self, index_or_series, fill_val, fill_dtype):
+        obj = index_or_series(
             [
                 pd.Timestamp("2011-01-01"),
                 pd.NaT,
@@ -855,7 +849,7 @@ class TestFillnaSeriesCoercion(CoercionBase):
         )
         assert obj.dtype == "datetime64[ns]"
 
-        exp = klass(
+        exp = index_or_series(
             [
                 pd.Timestamp("2011-01-01"),
                 fill_val,
@@ -865,7 +859,6 @@ class TestFillnaSeriesCoercion(CoercionBase):
         )
         self._assert_fillna_conversion(obj, fill_val, exp, fill_dtype)
 
-    @pytest.mark.parametrize("klass", [pd.Series, pd.Index])
     @pytest.mark.parametrize(
         "fill_val,fill_dtype",
         [
@@ -876,10 +869,10 @@ class TestFillnaSeriesCoercion(CoercionBase):
             ("x", np.object),
         ],
     )
-    def test_fillna_datetime64tz(self, klass, fill_val, fill_dtype):
+    def test_fillna_datetime64tz(self, index_or_series, fill_val, fill_dtype):
         tz = "US/Eastern"
 
-        obj = klass(
+        obj = index_or_series(
             [
                 pd.Timestamp("2011-01-01", tz=tz),
                 pd.NaT,
@@ -889,7 +882,7 @@ class TestFillnaSeriesCoercion(CoercionBase):
         )
         assert obj.dtype == "datetime64[ns, US/Eastern]"
 
-        exp = klass(
+        exp = index_or_series(
             [
                 pd.Timestamp("2011-01-01", tz=tz),
                 fill_val,

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -431,17 +431,15 @@ class TestTableOrient:
         self.df.to_json(orient="table", date_format="iso")
         self.df.to_json(orient="table")
 
-    @pytest.mark.parametrize("kind", [pd.Series, pd.Index])
-    def test_convert_pandas_type_to_json_field_int(self, kind):
+    def test_convert_pandas_type_to_json_field_int(self, index_or_series):
         data = [1, 2, 3]
-        result = convert_pandas_type_to_json_field(kind(data, name="name"))
+        result = convert_pandas_type_to_json_field(index_or_series(data, name="name"))
         expected = {"name": "name", "type": "integer"}
         assert result == expected
 
-    @pytest.mark.parametrize("kind", [pd.Series, pd.Index])
-    def test_convert_pandas_type_to_json_field_float(self, kind):
+    def test_convert_pandas_type_to_json_field_float(self, index_or_series):
         data = [1.0, 2.0, 3.0]
-        result = convert_pandas_type_to_json_field(kind(data, name="name"))
+        result = convert_pandas_type_to_json_field(index_or_series(data, name="name"))
         expected = {"name": "name", "type": "number"}
         assert result == expected
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from io import StringIO
 import re
 import sys
+from typing import List, Type
 
 import numpy as np
 import pytest
@@ -35,9 +36,11 @@ from pandas import (
 )
 from pandas.core.accessor import PandasDelegate
 from pandas.core.arrays import DatetimeArray, PandasArray, TimedeltaArray
-from pandas.core.base import NoNewAttributesMixin, PandasObject
+from pandas.core.base import IndexOpsMixin, NoNewAttributesMixin, PandasObject
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 import pandas.util.testing as tm
+
+index_or_series = [Index, Series]  # type: List[Type[IndexOpsMixin]]
 
 
 class CheckStringMixin:
@@ -516,7 +519,7 @@ class TestIndexOps(Ops):
             assert o.nunique() == 8
             assert o.nunique(dropna=False) == 9
 
-    @pytest.mark.parametrize("klass", [Index, Series])
+    @pytest.mark.parametrize("klass", index_or_series)
     def test_value_counts_inferred(self, klass):
         s_values = ["a", "b", "b", "b", "b", "c", "d", "d", "a", "a"]
         s = klass(s_values)
@@ -547,7 +550,7 @@ class TestIndexOps(Ops):
         expected = Series([0.4, 0.3, 0.2, 0.1], index=["b", "a", "d", "c"])
         tm.assert_series_equal(hist, expected)
 
-    @pytest.mark.parametrize("klass", [Index, Series])
+    @pytest.mark.parametrize("klass", index_or_series)
     def test_value_counts_bins(self, klass):
         s_values = ["a", "b", "b", "b", "b", "c", "d", "d", "a", "a"]
         s = klass(s_values)
@@ -612,7 +615,7 @@ class TestIndexOps(Ops):
 
         assert s.nunique() == 0
 
-    @pytest.mark.parametrize("klass", [Index, Series])
+    @pytest.mark.parametrize("klass", index_or_series)
     def test_value_counts_datetime64(self, klass):
 
         # GH 3002, datetime64[ns]
@@ -1090,7 +1093,7 @@ class TestToIterable:
         ],
         ids=["tolist", "to_list", "list", "iter"],
     )
-    @pytest.mark.parametrize("typ", [Series, Index])
+    @pytest.mark.parametrize("typ", index_or_series)
     @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
     # TODO(GH-24559): Remove the filterwarnings
     def test_iterable(self, typ, method, dtype, rdtype):
@@ -1120,7 +1123,7 @@ class TestToIterable:
         ],
         ids=["tolist", "to_list", "list", "iter"],
     )
-    @pytest.mark.parametrize("typ", [Series, Index])
+    @pytest.mark.parametrize("typ", index_or_series)
     def test_iterable_object_and_category(self, typ, method, dtype, rdtype, obj):
         # gh-10904
         # gh-13258
@@ -1144,7 +1147,7 @@ class TestToIterable:
     @pytest.mark.parametrize(
         "dtype, rdtype", dtypes + [("object", int), ("category", int)]
     )
-    @pytest.mark.parametrize("typ", [Series, Index])
+    @pytest.mark.parametrize("typ", index_or_series)
     @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
     # TODO(GH-24559): Remove the filterwarnings
     def test_iterable_map(self, typ, dtype, rdtype):
@@ -1332,7 +1335,7 @@ def test_numpy_array_all_dtypes(any_numpy_dtype):
         ),
     ],
 )
-@pytest.mark.parametrize("box", [pd.Series, pd.Index])
+@pytest.mark.parametrize("box", index_or_series)
 def test_array(array, attr, box):
     if array.dtype.name in ("Int64", "Sparse[int64, 0]") and box is pd.Index:
         pytest.skip("No index type for {}".format(array.dtype))
@@ -1396,7 +1399,7 @@ def test_array_multiindex_raises():
         ),
     ],
 )
-@pytest.mark.parametrize("box", [pd.Series, pd.Index])
+@pytest.mark.parametrize("box", index_or_series)
 def test_to_numpy(array, expected, box):
     thing = box(array)
 


### PR DESCRIPTION
Working around a strange typing issue. See
https://github.com/pandas-dev/pandas/pull/28394#issuecomment-5456527290
for more, but the types on these were being inferred incorrectly by
mypy with just the addition of the `allows_duplicate_labels` kwarg.

cc @simonjayhawkins & @WillAyd. Hopefully I got things correct. I copied the use of TypeVar for FrameOrSeries with IndexOrSeries.
