### PR TITLE
API/DOC: an ExtensionDtype.__from_arrow__ method to convert pyarrow.Array into ExtensionArray

### DIFF
--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -66,7 +66,12 @@ class ExtensionDtype:
     For interaction with Apache Arrow (pyarrow), a ``__from_arrow__`` method
     can be implemented: this method receives a pyarrow Array as only argument
     and is expected to return the appropriate pandas ExtensionArray for this
-    dtype and the passed values.
+    dtype and the passed values::
+
+        class ExtensionDtype:
+
+            def __from_arrow__(self, array: pyarrow.Array) -> ExtensionArray:
+                ...
 
     This class does not inherit from 'abc.ABCMeta' for performance reasons.
     Methods and properties required by the interface raise

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -64,13 +64,15 @@ class ExtensionDtype:
        of ``__eq__``.
 
     For interaction with Apache Arrow (pyarrow), a ``__from_arrow__`` method
-    can be implemented: this method receives a pyarrow Array as only argument
-    and is expected to return the appropriate pandas ExtensionArray for this
-    dtype and the passed values::
+    can be implemented: this method receives a pyarrow Array or ChunkedArray
+    as only argument and is expected to return the appropriate pandas
+    ExtensionArray for this dtype and the passed values::
 
         class ExtensionDtype:
 
-            def __from_arrow__(self, array: pyarrow.Array) -> ExtensionArray:
+            def __from_arrow__(
+                self, array: pyarrow.Array/ChunkedArray
+            ) -> ExtensionArray:
                 ...
 
     This class does not inherit from 'abc.ABCMeta' for performance reasons.

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -63,6 +63,11 @@ class ExtensionDtype:
        Added ``_metadata``, ``__hash__``, and changed the default definition
        of ``__eq__``.
 
+    For interaction with Apache Arrow (pyarrow), a ``__from_arrow__`` method
+    can be implemented: this method receives a pyarrow Array as only argument
+    and is expected to return the appropriate pandas ExtensionArray for this
+    dtype and the passed values.
+
     This class does not inherit from 'abc.ABCMeta' for performance reasons.
     Methods and properties required by the interface raise
     ``pandas.errors.AbstractMethodError`` and no ``register`` method is


### PR DESCRIPTION
xref the discussion in https://github.com/pandas-dev/pandas/issues/20612, and a companion to my PR in Arrow: https://github.com/apache/arrow/pull/5512

Summary: to support ExtensionArrays in the conversion of an arrow table into a pandas DataFrame, we need some way to convert pyarrow Arrays into pandas ExtensionArrays, given a certain pandas dtype (in pyarrow, we can for example know the resulting dtype from the stored metadata).

For that, I propose to add the `ExtensionDtype.__from_arrow__` method, with the following signature:

```
class ExtensionDtype:

    def __from_arrow__(self, array: pyarrow.Array) -> pandas.ExtensionArray:
        ...
```

Note: I only added documentation about it (which should still be expanded) for now, and not a method in the base class (eg a NotImplementedError), because in pyarrow we use `hasattr` to see if this is supported (see the linked arrow PR).