### PR TITLE
Refresh Aptitude Package Lists in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ jobs:
     condition: true
 
   - script: |
+      sudo apt-get update
       sudo apt-get install -y libc6-dev-i386
       ci/setup_env.sh
     displayName: 'Setup environment and build pandas'


### PR DESCRIPTION
This might fix the intermittent build failures by updating the package lists before trying to install anything via aptitude