### PR TITLE
PERF: PeriodEngine.get_loc accept narrow data type

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -40,7 +40,7 @@ Deprecations
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
--
+- Performance improvement in :meth:`PeriodIndex.get_loc` using input from user  (:issue:`29038`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -340,7 +340,7 @@ class Base:
         # RangeIndex, IntervalIndex
         # don't have engines
         if not isinstance(indices, (RangeIndex, IntervalIndex)):
-            assert result2 > result
+            assert result2 >= result
 
         if indices.inferred_type == "object":
             assert result3 > result2


### PR DESCRIPTION
- [x] closes #29038
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

xref #28628. 
I want to refactor `PeriodIndex.get_loc`. Because `PeriodIndex.get_loc` compute twice `Int64index.get_loc` and `PeriodEngine.get_loc`. Problem is only `PeriodEngine.get_loc` accepts `Period.ordinal`. 
I try to change `PeriodIndex.get_loc` in two ways.
First one, I try to remove `PeriodEngine.get_loc` in `PeriodIndex.get_loc`. so just compute `.get_loc` once. I change several ways But always stuck in test cases. So I give it up this way.
Second one, I try to change `PeriodEngine.get_loc` to accept `Period` not only `Period.ordinal`. This way is success in that work successfully and pass all test cases. However Problem is most cases users don't use `Period` using `PeriodIndex.get_loc` and `PeriodEngine.get_loc` can't accept "intolerance" argument. Not using `Int64index.get_loc` can't be possible. 
But I send PR. Little improvement is also improvement. 

---------------------------------------------------------------------------------------------------------------------
improvement : memory usage with Period.get_loc 
