### PR TITLE
BENCH: Improve perf of rolling.Apply.time_rolling

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -28,15 +28,15 @@ class Methods:
 class Apply:
     params = (
         ["DataFrame", "Series"],
-        [10, 1000],
+        [3, 300],
         ["int", "float"],
         [sum, np.sum, lambda x: np.sum(x) + 5],
         [True, False],
     )
-    param_names = ["contructor", "window", "dtype", "function", "raw"]
+    param_names = ["constructor", "window", "dtype", "function", "raw"]
 
     def setup(self, constructor, window, dtype, function, raw):
-        N = 10 ** 5
+        N = 10 ** 3
         arr = (100 * np.random.random(N)).astype(dtype)
         self.roll = getattr(pd, constructor)(arr).rolling(window)
 


### PR DESCRIPTION
Per discussion in #29165, this PR significantly reduces the run time of the `rolling.Apply.time_rolling` benchmark from 8 minutes minimum.
```
$ asv dev -b rolling.Apply.time_rolling
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_chris_anaconda3_bin_python
[ 50.00%] ··· Running (rolling.Apply.time_rolling--).
[100.00%] ··· rolling.Apply.time_rolling                                                                                                                                                                  ok
[100.00%] ··· ============= ======== ======= =========================== ============= ============
              --                                                                    raw            
              ---------------------------------------------------------- --------------------------
               constructor   window   dtype            function               True        False    
              ============= ======== ======= =========================== ============= ============
                DataFrame      3       int     <built-in function sum>     1.87±0.1ms    44.8±2ms  
                DataFrame      3       int          <function sum>         3.53±0.2ms    126±3ms   
                DataFrame      3       int    <function Apply.<lambda>>    4.20±0.2ms    126±7ms   
                DataFrame      3      float    <built-in function sum>    1.86±0.07ms    45.1±1ms  
                DataFrame      3      float         <function sum>        3.42±0.03ms    129±5ms   
                DataFrame      3      float   <function Apply.<lambda>>    4.34±0.5ms    133±9ms   
                DataFrame     300      int     <built-in function sum>      31.8±3ms     44.1±2ms  
                DataFrame     300      int          <function sum>         2.90±0.2ms   92.6±10ms  
                DataFrame     300      int    <function Apply.<lambda>>    3.24±0.2ms    93.9±4ms  
                DataFrame     300     float    <built-in function sum>     33.3±20ms    85.4±40ms  
                DataFrame     300     float         <function sum>         3.06±0.3ms    91.0±3ms  
                DataFrame     300     float   <function Apply.<lambda>>    3.19±0.2ms    91.5±4ms  
                  Series       3       int     <built-in function sum>    1.42±0.03ms    43.6±1ms  
                  Series       3       int          <function sum>        3.08±0.06ms    127±2ms   
                  Series       3       int    <function Apply.<lambda>>    3.67±0.2ms    127±20ms  
                  Series       3      float    <built-in function sum>    1.41±0.03ms   43.5±0.5ms 
                  Series       3      float         <function sum>         3.08±0.1ms    123±3ms   
                  Series       3      float   <function Apply.<lambda>>    3.65±0.1ms    129±6ms   
                  Series      300      int     <built-in function sum>      31.2±2ms     43.8±3ms  
                  Series      300      int          <function sum>         2.35±0.1ms    90.4±4ms  
                  Series      300      int    <function Apply.<lambda>>    2.74±0.2ms    93.2±6ms  
                  Series      300     float    <built-in function sum>     31.7±0.8ms    45.6±1ms  
                  Series      300     float         <function sum>         2.36±0.1ms    108±20ms  
                  Series      300     float   <function Apply.<lambda>>   2.82±0.09ms    99.4±2ms  
              ============= ======== ======= =========================== ============= ============
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
