### PR TITLE
Fix SS06 formatting errors

### DIFF
--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -308,8 +308,10 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
     @property
     def density(self) -> float:
         """
-        Ratio of non-sparse points to total (dense) data points
-        represented in the DataFrame.
+        Ratio of non-sparse points to total (dense) data points.
+
+        Ratio of non-sparse points to total (dense) data points represented
+        in the DataFrame.
         """
         return np.mean([column.array.density for _, column in self._parent.items()])
 

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -309,9 +309,6 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
     def density(self) -> float:
         """
         Ratio of non-sparse points to total (dense) data points.
-
-        Ratio of non-sparse points to total (dense) data points represented
-        in the DataFrame.
         """
         return np.mean([column.array.density for _, column in self._parent.items()])
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -814,8 +814,10 @@ class DataFrame(NDFrame):
     @property
     def style(self):
         """
-        Property returning a Styler object containing methods for
-        building a styled HTML representation fo the DataFrame.
+        Returns a Styler object.
+
+        Property returning a Styler object containing methods for building
+        a styled HTML representation fo the DataFrame.
 
         See Also
         --------
@@ -8207,6 +8209,8 @@ class DataFrame(NDFrame):
 
     def to_period(self, freq=None, axis=0, copy=True):
         """
+        Convert DataFrame from DatetimeIndex to PeriodIndex.
+
         Convert DataFrame from DatetimeIndex to PeriodIndex with desired
         frequency (inferred from index if not passed).
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -816,7 +816,7 @@ class DataFrame(NDFrame):
         """
         Returns a Styler object.
 
-        Property returning a Styler object containing methods for building
+        Contains methods for building a styled HTML representation of the DataFrame.
         a styled HTML representation fo the DataFrame.
 
         See Also

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5770,9 +5770,6 @@ class NDFrame(PandasObject, SelectionMixin):
 
         .. deprecated:: 0.21.0
 
-        Convert the frame to a dict of dtype-> Constructor Types that each
-        has a homogeneous dtype.
-
         NOTE: the dtypes of the blocks WILL BE PRESERVED HERE (unlike in
               as_matrix)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5766,7 +5766,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def as_blocks(self, copy=True):
         """
-        Convert the frame to a dict of dtype.
+        Convert the frame to a dict of dtype -> Constructor Types.
 
         .. deprecated:: 0.21.0
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10742,12 +10742,11 @@ class NDFrame(PandasObject, SelectionMixin):
             name,
             name2,
             axis_descr,
-            """Return the difference between the max and min value in the object.\n
-            .. deprecated:: 0.24.0\n
-            Return the difference between the maximum value and the minimum value in\n
-            the object. This is the equivalent of the ``numpy.ndarray`` method \n
-            ``ptp``.\n
-            Use numpy.ptp instead""",
+            """Return the difference between the min and max value.
+            \n.. deprecated:: 0.24.0 Use numpy.ptp instead
+            \nReturn the difference between the maximum value and the
+            minimum value in the object. This is the equivalent of the
+            ``numpy.ndarray`` method ``ptp``.""",
             nanptp,
         )
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5766,10 +5766,12 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def as_blocks(self, copy=True):
         """
-        Convert the frame to a dict of dtype -> Constructor Types that each has
-        a homogeneous dtype.
+        Convert the frame to a dict of dtype.
 
         .. deprecated:: 0.21.0
+
+        Convert the frame to a dict of dtype-> Constructor Types that each
+        has a homogeneous dtype.
 
         NOTE: the dtypes of the blocks WILL BE PRESERVED HERE (unlike in
               as_matrix)
@@ -9428,9 +9430,10 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def slice_shift(self, periods=1, axis=0):
         """
-        Equivalent to `shift` without copying data. The shifted data will
-        not include the dropped periods and the shifted axis will be smaller
-        than the original.
+        Equivalent to `shift` without copying data.
+
+        The shifted data will not include the dropped periods and the
+        shifted axis will be smaller than the original.
 
         Parameters
         ----------
@@ -10739,10 +10742,12 @@ class NDFrame(PandasObject, SelectionMixin):
             name,
             name2,
             axis_descr,
-            """Return the difference between the maximum value and the
-            minimum value in the object. This is the equivalent of the
-            ``numpy.ndarray`` method ``ptp``.\n\n.. deprecated:: 0.24.0
-                Use numpy.ptp instead""",
+            """Return the difference between the max and min value in the object.\n
+            .. deprecated:: 0.24.0\n
+            Return the difference between the maximum value and the minimum value in\n
+            the object. This is the equivalent of the ``numpy.ndarray`` method \n
+            ``ptp``.\n
+            Use numpy.ptp instead""",
             nanptp,
         )
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1291,8 +1291,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
 class _IXIndexer(_NDFrameIndexer):
     """
-    A primarily label-location based indexer, with integer position
-    fallback.
+    A primarily label-location based indexer, with integer position fallback.
 
     Warning: Starting in 0.20.0, the .ix indexer is deprecated, in
     favor of the more strict .iloc and .loc indexers.

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -496,6 +496,8 @@ def boxplot_frame_groupby(
 
 class PlotAccessor(PandasObject):
     """
+    Make plots of Series or DataFrame.
+
     Make plots of Series or DataFrame using the backend specified by the
     option ``plotting.backend``. By default, matplotlib is used.
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -498,7 +498,7 @@ class PlotAccessor(PandasObject):
     """
     Make plots of Series or DataFrame.
 
-    Make plots of Series or DataFrame using the backend specified by the
+    Uses the backend specified by the
     option ``plotting.backend``. By default, matplotlib is used.
 
     Parameters


### PR DESCRIPTION
SS06 (Summary should fit in a single line) errors fixed (#29254) for the following:

```
 pandas.DataFrame.slice_shift
 pandas.DataFrame.to_period
 pandas.DataFrame.plot
 pandas.DataFrame.sparse.density
 pandas.DataFrame.style
 pandas.Series.as_blocks
 pandas.Series.ix
 pandas.Series.ptp
 pandas.DataFrame.as_blocks
 pandas.DataFrame.ix
```
Validated with `python scripts/validate_docstrings.py`

Also referencing issue: #27977