### PR TITLE
Timedelta index 29236

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1457,15 +1457,16 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
         Parameters
         ----------
         skipna : bool, default True
-            Whether to ignore any NaT elements
+            Whether to ignore any NaT elements.
 
         Returns
         -------
-        scalar (Timestamp or Timedelta)
+        scalar
+            Timestamp or Timedelta.
 
         See Also
         --------
-        numpy.ndarray.mean
+        numpy.ndarray.mean : Returns the average of the array elements along a given axis.
         Series.mean : Return the mean value in a Series.
 
         Notes

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1466,7 +1466,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
 
         See Also
         --------
-        numpy.ndarray.mean : Returns the average of the array elements along a given axis.
+        numpy.ndarray.mean : Returns the average of array elements along a given axis.
         Series.mean : Return the mean value in a Series.
 
         Notes

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1170,7 +1170,7 @@ class Index(IndexOpsMixin, PandasObject):
     def to_series(self, index=None, name=None):
         """
         Create a Series with both index and values equal to the index keys.
-        
+
         Useful with map for returning an indexer based on an index.
 
         Parameters

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1169,20 +1169,22 @@ class Index(IndexOpsMixin, PandasObject):
 
     def to_series(self, index=None, name=None):
         """
-        Create a Series with both index and values equal to the index keys
-        useful with map for returning an indexer based on an index.
+        Create a Series with both index and values equal to the index keys.
+        
+        Useful with map for returning an indexer based on an index.
 
         Parameters
         ----------
         index : Index, optional
-            index of resulting Series. If None, defaults to original index
+            Index of resulting Series. If None, defaults to original index.
         name : str, optional
-            name of resulting Series. If None, defaults to name of original
-            index
+            Dame of resulting Series. If None, defaults to name of original
+            index.
 
         Returns
         -------
-        Series : dtype will be based on the type of the Index values.
+        Series
+            The dtype will be based on the type of the Index values.
         """
 
         from pandas import Series


### PR DESCRIPTION
- [ ] closes #29236 

only remaining docstring errors are for `TimedeltaIndex.mean`

    Parameters {*args, **kwargs} not documented
    Unknown parameters {skipna}


