### PR TITLE
DOC: use new logo in the sphinx theme as well

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -218,7 +218,7 @@ html_theme = "pandas_sphinx_theme"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-# html_logo = None
+html_logo = "../../web/pandas/static/img/pandas.png"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -218,7 +218,7 @@ html_theme = "pandas_sphinx_theme"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = "../../web/pandas/static/img/pandas.png"
+html_logo = "../../web/pandas/static/img/pandas.svg"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
With this change (https://github.com/pandas-dev/pandas-sphinx-theme/commit/84134e0804325538918324246f449e694466929b) in the theme, that should work.

However, locally, I am running into the problem that sphinx/html doesn't seem to like the svg logo's .. For local testing I added a converted png which works, but just replacing `.png` with `.svg` makes that the html does not include the image (at least in firefox).

cc @datapythonista 
