### PR TITLE
Fix SS06 formatting errors

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5854,8 +5854,8 @@ class DataFrame(NDFrame):
         "pivot_table"
     ] = """
         Create a spreadsheet-style pivot table as a DataFrame.
-        
-        The levels in the pivot table will be stored in MultiIndex objects 
+
+        The levels in the pivot table will be stored in MultiIndex objects
         (hierarchical indexes) on the index and columns of the result DataFrame.
 
         Parameters
@@ -6250,7 +6250,7 @@ class DataFrame(NDFrame):
     def unstack(self, level=-1, fill_value=None):
         """
         Pivot a level of the (necessarily hierarchical) index labels.
-        
+
         Returns a DataFrame having a new level of column labels whose inner-most level
         consists of the pivoted index labels.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5251,8 +5251,7 @@ class DataFrame(NDFrame):
 
     def reorder_levels(self, order, axis=0):
         """
-        Rearrange index levels using input order. May not drop or
-        duplicate levels.
+        Rearrange index levels using input order. May not drop or duplicate levels.
 
         Parameters
         ----------
@@ -5854,9 +5853,10 @@ class DataFrame(NDFrame):
     _shared_docs[
         "pivot_table"
     ] = """
-        Create a spreadsheet-style pivot table as a DataFrame. The levels in
-        the pivot table will be stored in MultiIndex objects (hierarchical
-        indexes) on the index and columns of the result DataFrame.
+        Create a spreadsheet-style pivot table as a DataFrame.
+        
+        The levels in the pivot table will be stored in MultiIndex objects 
+        (hierarchical indexes) on the index and columns of the result DataFrame.
 
         Parameters
         ----------%s
@@ -6249,8 +6249,9 @@ class DataFrame(NDFrame):
 
     def unstack(self, level=-1, fill_value=None):
         """
-        Pivot a level of the (necessarily hierarchical) index labels, returning
-        a DataFrame having a new level of column labels whose inner-most level
+        Pivot a level of the (necessarily hierarchical) index labels.
+        
+        Returns a DataFrame having a new level of column labels whose inner-most level
         consists of the pivoted index labels.
 
         If the index is not a MultiIndex, the output will be a Series
@@ -6312,8 +6313,7 @@ class DataFrame(NDFrame):
     _shared_docs[
         "melt"
     ] = """
-    Unpivot a DataFrame from wide format to long format, optionally
-    leaving identifier variables set.
+    Unpivot a DataFrame from wide to long format, optionally leaving identifiers set.
 
     This function is useful to massage a DataFrame into a format where one
     or more columns are identifier variables (`id_vars`), while all other
@@ -7908,6 +7908,7 @@ class DataFrame(NDFrame):
     def idxmin(self, axis=0, skipna=True):
         """
         Return index of first occurrence of minimum over requested axis.
+
         NA/null values are excluded.
 
         Parameters
@@ -7945,6 +7946,7 @@ class DataFrame(NDFrame):
     def idxmax(self, axis=0, skipna=True):
         """
         Return index of first occurrence of maximum over requested axis.
+
         NA/null values are excluded.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4354,7 +4354,7 @@ class NDFrame(PandasObject, SelectionMixin):
     def reindex(self, *args, **kwargs):
         """
         Conform %(klass)s to new index with optional filling logic.
-        
+
         Places NA/NaN in locations having no value in the previous index. A new object
         is produced unless the new index is equivalent to the current one and
         ``copy=False``.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4353,8 +4353,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def reindex(self, *args, **kwargs):
         """
-        Conform %(klass)s to new index with optional filling logic, placing
-        NA/NaN in locations having no value in the previous index. A new object
+        Conform %(klass)s to new index with optional filling logic.
+        
+        Places NA/NaN in locations having no value in the previous index. A new object
         is produced unless the new index is equivalent to the current one and
         ``copy=False``.
 
@@ -4669,8 +4670,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def filter(self, items=None, like=None, regex=None, axis=None):
         """
-        Subset rows or columns of dataframe according to labels in
-        the specified index.
+        Subsets the dataframe rows or columns according to the specified index labels.
 
         Note that this routine does not filter a dataframe on its
         contents. The filter is applied to the labels of the index.
@@ -8497,8 +8497,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def first(self, offset):
         """
-        Convenience method for subsetting initial periods of time series data
-        based on a date offset.
+        Method to subset initial periods of time series data based on a date offset.
 
         Parameters
         ----------
@@ -8560,8 +8559,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def last(self, offset):
         """
-        Convenience method for subsetting final periods of time series data
-        based on a date offset.
+        Method to subset final periods of time series data based on a date offset.
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4670,7 +4670,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def filter(self, items=None, like=None, regex=None, axis=None):
         """
-        Subsets the dataframe rows or columns according to the specified index labels.
+        Subset the dataframe rows or columns according to the specified index labels.
 
         Note that this routine does not filter a dataframe on its
         contents. The filter is applied to the labels of the index.


### PR DESCRIPTION
Errors resolved (from list in #29254):
pandas.DataFrame.filter
pandas.DataFrame.first
pandas.DataFrame.idxmax
pandas.DataFrame.idxmin
pandas.DataFrame.last
pandas.DataFrame.reindex
pandas.DataFrame.pivot_table
pandas.DataFrame.reorder_levels
pandas.DataFrame.unstack
pandas.DataFrame.melt

Validated with `python scripts/validate_docstrings.py`

Referencing issue: #27977
