### PR TITLE
BLD: ABCSeries mapper maps unmapped categories to "" instead of NaN

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -415,6 +415,7 @@ Other
 - Fix corrupted error message when calling ``pandas.libs._json.encode()`` on a 0d array (:issue:`18878`)
 - Fix :class:`AbstractHolidayCalendar` to return correct results for
   years after 2030 (now goes up to 2200) (:issue:`27790`)
+- :meth:`IndexOpsMixin._map_values` ABCSeries mapper maps unmapped categories to "" instead of NaN 
 
 
 .. _whatsnew_1000.contributors:

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1267,7 +1267,7 @@ class IndexOpsMixin:
                 values = self.values
 
             indexer = mapper.index.get_indexer(values)
-            new_values = algorithms.take_1d(mapper._values, indexer)
+            new_values = algorithms.take_1d(mapper._values, indexer, fill_value="")
 
             return new_values
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1129,7 +1129,7 @@ class TestIndex(Base):
     )
     def test_map_with_non_function_missing_values(self, mapper):
         # GH 12756
-        expected = Index([2.0, np.nan, "foo"])
+        expected = Index([2.0, "", "foo"])
         result = Index([2, 1, 0]).map(mapper)
 
         tm.assert_index_equal(expected, result)


### PR DESCRIPTION
- [x] closes #29162
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

