### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/series

### DIFF
--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -22,12 +22,6 @@ from pandas.core.index import MultiIndex
 from pandas.core.indexes.datetimes import Timestamp
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_index_equal,
-    assert_series_equal,
-)
 
 
 class TestSeriesAnalytics:
@@ -108,11 +102,11 @@ class TestSeriesAnalytics:
 
         result = s.argsort()
         expected = Series(range(5), dtype="int64")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = shifted.argsort()
         expected = Series(list(range(4)) + [-1], dtype="int64")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_argsort_stable(self):
         s = Series(np.random.randint(0, 100, size=10000))
@@ -248,7 +242,7 @@ class TestSeriesAnalytics:
         s = Series(np.arange(5))
 
         r = np.diff(s)
-        assert_series_equal(Series([np.nan, 0, 0, 0, np.nan]), r)
+        tm.assert_series_equal(Series([np.nan, 0, 0, 0, np.nan]), r)
 
     def test_int_diff(self):
         # int dtype
@@ -267,23 +261,23 @@ class TestSeriesAnalytics:
         # neg n
         result = ts.diff(-1)
         expected = ts - ts.shift(-1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # 0
         result = ts.diff(0)
         expected = ts - ts
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # datetime diff (GH3100)
         s = Series(date_range("20130102", periods=5))
         result = s.diff()
         expected = s - s.shift(1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # timedelta diff
         result = result - result.shift(1)  # previous result
         expected = expected.diff()  # previously expected
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # with tz
         s = Series(
@@ -291,7 +285,7 @@ class TestSeriesAnalytics:
         )
         result = s.diff()
         expected = Series(TimedeltaIndex(["NaT"] + ["1 days"] * 4), name="foo")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "input,output,diff",
@@ -302,14 +296,14 @@ class TestSeriesAnalytics:
         s = Series(input)
         result = s.diff()
         expected = Series(output)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_obj_diff(self):
         # object series
         s = Series([False, True, 5.0, np.nan, True, False])
         result = s.diff()
         expected = s - s.shift(1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def _check_accum_op(self, name, datetime_series_, check_dtype=True):
         func = getattr(np, name)
@@ -358,7 +352,7 @@ class TestSeriesAnalytics:
         expected = Series(
             np.round(datetime_series.values, 2), index=datetime_series.index, name="ts"
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         assert result.name == datetime_series.name
 
     def test_numpy_round(self):
@@ -366,7 +360,7 @@ class TestSeriesAnalytics:
         s = Series([1.53, 1.36, 0.06])
         out = np.round(s, decimals=0)
         expected = Series([2.0, 1.0, 0.0])
-        assert_series_equal(out, expected)
+        tm.assert_series_equal(out, expected)
 
         msg = "the 'out' parameter is not supported"
         with pytest.raises(ValueError, match=msg):
@@ -378,7 +372,7 @@ class TestSeriesAnalytics:
         with tm.assert_produces_warning(None):
             result = s.round()
         expected = Series([2.0, np.nan, 0.0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_built_in_round(self):
         s = Series([1.123, 2.123, 3.123], index=range(3))
@@ -555,10 +549,10 @@ class TestSeriesAnalytics:
 
         left = ts.count(level=1)
         right = Series([2, 3, 1], index=[1, 2, np.nan])
-        assert_series_equal(left, right)
+        tm.assert_series_equal(left, right)
 
         ts.iloc[[0, 3, 5]] = np.nan
-        assert_series_equal(ts.count(level=1), right - 1)
+        tm.assert_series_equal(ts.count(level=1), right - 1)
 
     def test_dot(self):
         a = Series(np.random.randn(4), index=["p", "q", "r", "s"])
@@ -568,21 +562,21 @@ class TestSeriesAnalytics:
 
         result = a.dot(b)
         expected = Series(np.dot(a.values, b.values), index=["1", "2", "3"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # Check index alignment
         b2 = b.reindex(index=reversed(b.index))
         result = a.dot(b)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # Check ndarray argument
         result = a.dot(b.values)
         assert np.all(result == expected.values)
-        assert_almost_equal(a.dot(b["2"].values), expected["2"])
+        tm.assert_almost_equal(a.dot(b["2"].values), expected["2"])
 
         # Check series argument
-        assert_almost_equal(a.dot(b["1"]), expected["1"])
-        assert_almost_equal(a.dot(b2["1"]), expected["1"])
+        tm.assert_almost_equal(a.dot(b["1"]), expected["1"])
+        tm.assert_almost_equal(a.dot(b2["1"]), expected["1"])
 
         msg = r"Dot product shape mismatch, \(4,\) vs \(3,\)"
         # exception raised is of type Exception
@@ -602,53 +596,53 @@ class TestSeriesAnalytics:
         # Series @ DataFrame -> Series
         result = operator.matmul(a, b)
         expected = Series(np.dot(a.values, b.values), index=["1", "2", "3"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # DataFrame @ Series -> Series
         result = operator.matmul(b.T, a)
         expected = Series(np.dot(b.T.values, a.T.values), index=["1", "2", "3"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # Series @ Series -> scalar
         result = operator.matmul(a, a)
         expected = np.dot(a.values, a.values)
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         # GH 21530
         # vector (1D np.array) @ Series (__rmatmul__)
         result = operator.matmul(a.values, a)
         expected = np.dot(a.values, a.values)
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         # GH 21530
         # vector (1D list) @ Series (__rmatmul__)
         result = operator.matmul(a.values.tolist(), a)
         expected = np.dot(a.values, a.values)
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         # GH 21530
         # matrix (2D np.array) @ Series (__rmatmul__)
         result = operator.matmul(b.T.values, a)
         expected = np.dot(b.T.values, a.values)
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         # GH 21530
         # matrix (2D nested lists) @ Series (__rmatmul__)
         result = operator.matmul(b.T.values.tolist(), a)
         expected = np.dot(b.T.values, a.values)
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         # mixed dtype DataFrame @ Series
         a["p"] = int(a.p)
         result = operator.matmul(b.T, a)
         expected = Series(np.dot(b.T.values, a.T.values), index=["1", "2", "3"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # different dtypes DataFrame @ Series
         a = a.astype(int)
         result = operator.matmul(b.T, a)
         expected = Series(np.dot(b.T.values, a.T.values), index=["1", "2", "3"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         msg = r"Dot product shape mismatch, \(4,\) vs \(3,\)"
         # exception raised is of type Exception
@@ -671,7 +665,7 @@ class TestSeriesAnalytics:
 
         result = datetime_series.clip(-0.5, 0.5)
         expected = np.clip(datetime_series, -0.5, 0.5)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         assert isinstance(expected, Series)
 
     def test_clip_types_and_nulls(self):
@@ -698,12 +692,12 @@ class TestSeriesAnalytics:
         # GH # 17276
         s = Series([1, 2, 3])
 
-        assert_series_equal(s.clip(np.nan), Series([1, 2, 3]))
-        assert_series_equal(s.clip(upper=np.nan, lower=np.nan), Series([1, 2, 3]))
+        tm.assert_series_equal(s.clip(np.nan), Series([1, 2, 3]))
+        tm.assert_series_equal(s.clip(upper=np.nan, lower=np.nan), Series([1, 2, 3]))
 
         # GH #19992
-        assert_series_equal(s.clip(lower=[0, 4, np.nan]), Series([1, 4, np.nan]))
-        assert_series_equal(s.clip(upper=[1, np.nan, 1]), Series([1, np.nan, 1]))
+        tm.assert_series_equal(s.clip(lower=[0, 4, np.nan]), Series([1, 4, np.nan]))
+        tm.assert_series_equal(s.clip(upper=[1, np.nan, 1]), Series([1, np.nan, 1]))
 
     def test_clip_against_series(self):
         # GH #6966
@@ -712,15 +706,15 @@ class TestSeriesAnalytics:
         threshold = Series([1.0, 2.0, 3.0])
 
         with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(s.clip_lower(threshold), Series([1.0, 2.0, 4.0]))
+            tm.assert_series_equal(s.clip_lower(threshold), Series([1.0, 2.0, 4.0]))
         with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(s.clip_upper(threshold), Series([1.0, 1.0, 3.0]))
+            tm.assert_series_equal(s.clip_upper(threshold), Series([1.0, 1.0, 3.0]))
 
         lower = Series([1.0, 2.0, 3.0])
         upper = Series([1.5, 2.5, 3.5])
 
-        assert_series_equal(s.clip(lower, upper), Series([1.0, 2.0, 3.5]))
-        assert_series_equal(s.clip(1.5, upper), Series([1.5, 1.5, 3.5]))
+        tm.assert_series_equal(s.clip(lower, upper), Series([1.0, 2.0, 3.5]))
+        tm.assert_series_equal(s.clip(1.5, upper), Series([1.5, 1.5, 3.5]))
 
     @pytest.mark.parametrize("inplace", [True, False])
     @pytest.mark.parametrize("upper", [[1, 2, 3], np.asarray([1, 2, 3])])
@@ -745,7 +739,7 @@ class TestSeriesAnalytics:
         expected = Series(
             [Timestamp("2015-12-01 09:30:00"), Timestamp("2015-12-01 09:30:30")]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         t = Timestamp("2015-12-01 09:30:30", tz="US/Eastern")
         s = Series(
@@ -761,7 +755,7 @@ class TestSeriesAnalytics:
                 Timestamp("2015-12-01 09:30:30", tz="US/Eastern"),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_cummethods_bool(self):
         # GH 6270
@@ -780,7 +774,7 @@ class TestSeriesAnalytics:
         for s, method in args:
             expected = Series(methods[method](s.values))
             result = getattr(s, method)()
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         e = pd.Series([False, True, np.nan, False])
         cse = pd.Series([0, 1, np.nan, 1], dtype=object)
@@ -791,14 +785,14 @@ class TestSeriesAnalytics:
 
         for method in methods:
             res = getattr(e, method)()
-            assert_series_equal(res, expecteds[method])
+            tm.assert_series_equal(res, expecteds[method])
 
     def test_isin(self):
         s = Series(["A", "B", "C", "a", "B", "B", "A", "C"])
 
         result = s.isin(["A", "C"])
         expected = Series([True, False, True, False, False, False, True, True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH: 16012
         # This specific issue has to have a series over 1e6 in len, but the
@@ -835,28 +829,28 @@ class TestSeriesAnalytics:
         s = Series(date_range("jan-01-2013", "jan-05-2013"))
 
         result = s.isin(s[0:2])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.isin(s[0:2].values)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # fails on dtype conversion in the first place
         result = s.isin(s[0:2].values.astype("datetime64[D]"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.isin([s[1]])
-        assert_series_equal(result, expected2)
+        tm.assert_series_equal(result, expected2)
 
         result = s.isin([np.datetime64(s[1])])
-        assert_series_equal(result, expected2)
+        tm.assert_series_equal(result, expected2)
 
         result = s.isin(set(s[0:2]))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # timedelta64[ns]
         s = Series(pd.to_timedelta(range(5), unit="d"))
         result = s.isin(s[0:2])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
     def test_isin_empty(self, empty):
@@ -913,17 +907,17 @@ class TestSeriesAnalytics:
 
         reps = s.repeat(5)
         exp = Series(s.values.repeat(5), index=s.index.values.repeat(5))
-        assert_series_equal(reps, exp)
+        tm.assert_series_equal(reps, exp)
 
         to_rep = [2, 3, 4]
         reps = s.repeat(to_rep)
         exp = Series(s.values.repeat(to_rep), index=s.index.values.repeat(to_rep))
-        assert_series_equal(reps, exp)
+        tm.assert_series_equal(reps, exp)
 
     def test_numpy_repeat(self):
         s = Series(np.arange(3), name="x")
         expected = Series(s.values.repeat(2), name="x", index=s.index.values.repeat(2))
-        assert_series_equal(np.repeat(s, 2), expected)
+        tm.assert_series_equal(np.repeat(s, 2), expected)
 
         msg = "the 'axis' parameter is not supported"
         with pytest.raises(ValueError, match=msg):
@@ -1000,16 +994,16 @@ class TestSeriesAnalytics:
         backwards = s.iloc[[1, 0]]
 
         res = s.sort_index(level="A")
-        assert_series_equal(backwards, res)
+        tm.assert_series_equal(backwards, res)
 
         res = s.sort_index(level=["A", "B"])
-        assert_series_equal(backwards, res)
+        tm.assert_series_equal(backwards, res)
 
         res = s.sort_index(level="A", sort_remaining=False)
-        assert_series_equal(s, res)
+        tm.assert_series_equal(s, res)
 
         res = s.sort_index(level=["A", "B"], sort_remaining=False)
-        assert_series_equal(s, res)
+        tm.assert_series_equal(s, res)
 
     def test_apply_categorical(self):
         values = pd.Categorical(list("ABBABCD"), categories=list("DCBA"), ordered=True)
@@ -1032,26 +1026,26 @@ class TestSeriesAnalytics:
         ts = datetime_series.astype(int)
         shifted = ts.shift(1)
         expected = ts.astype(float).shift(1)
-        assert_series_equal(shifted, expected)
+        tm.assert_series_equal(shifted, expected)
 
     def test_shift_categorical(self):
         # GH 9416
         s = pd.Series(["a", "b", "c", "d"], dtype="category")
 
-        assert_series_equal(s.iloc[:-1], s.shift(1).shift(-1).dropna())
+        tm.assert_series_equal(s.iloc[:-1], s.shift(1).shift(-1).dropna())
 
         sp1 = s.shift(1)
-        assert_index_equal(s.index, sp1.index)
+        tm.assert_index_equal(s.index, sp1.index)
         assert np.all(sp1.values.codes[:1] == -1)
         assert np.all(s.values.codes[:-1] == sp1.values.codes[1:])
 
         sn2 = s.shift(-2)
-        assert_index_equal(s.index, sn2.index)
+        tm.assert_index_equal(s.index, sn2.index)
         assert np.all(sn2.values.codes[-2:] == -1)
         assert np.all(s.values.codes[2:] == sn2.values.codes[:-2])
 
-        assert_index_equal(s.values.categories, sp1.values.categories)
-        assert_index_equal(s.values.categories, sn2.values.categories)
+        tm.assert_index_equal(s.values.categories, sp1.values.categories)
+        tm.assert_index_equal(s.values.categories, sn2.values.categories)
 
     def test_unstack(self):
 
@@ -1069,10 +1063,10 @@ class TestSeriesAnalytics:
             columns=["one", "three", "two"],
         )
 
-        assert_frame_equal(unstacked, expected)
+        tm.assert_frame_equal(unstacked, expected)
 
         unstacked = s.unstack(level=0)
-        assert_frame_equal(unstacked, expected.T)
+        tm.assert_frame_equal(unstacked, expected.T)
 
         index = MultiIndex(
             levels=[["bar"], ["one", "two", "three"], [0, 1]],
@@ -1085,7 +1079,7 @@ class TestSeriesAnalytics:
         )
         expected = DataFrame({"bar": s.values}, index=exp_index).sort_index(level=0)
         unstacked = s.unstack(0).sort_index()
-        assert_frame_equal(unstacked, expected)
+        tm.assert_frame_equal(unstacked, expected)
 
         # GH5873
         idx = pd.MultiIndex.from_arrays([[101, 102], [3.5, np.nan]])
@@ -1094,7 +1088,7 @@ class TestSeriesAnalytics:
         right = DataFrame(
             [[np.nan, 1], [2, np.nan]], index=[101, 102], columns=[np.nan, 3.5]
         )
-        assert_frame_equal(left, right)
+        tm.assert_frame_equal(left, right)
 
         idx = pd.MultiIndex.from_arrays(
             [
@@ -1110,7 +1104,7 @@ class TestSeriesAnalytics:
         )
         tpls = [("a", 1), ("a", 2), ("b", np.nan), ("b", 1)]
         right.index = pd.MultiIndex.from_tuples(tpls)
-        assert_frame_equal(ts.unstack(level=0), right)
+        tm.assert_frame_equal(ts.unstack(level=0), right)
 
     def test_value_counts_datetime(self):
         # most dtypes are tested in test_base.py
@@ -1381,25 +1375,25 @@ class TestNLargestNSmallest:
         # object that are numbers, object that are strings
         s = s_main_dtypes_split
 
-        assert_series_equal(s.nsmallest(2), s.iloc[[2, 1]])
-        assert_series_equal(s.nsmallest(2, keep="last"), s.iloc[[2, 3]])
+        tm.assert_series_equal(s.nsmallest(2), s.iloc[[2, 1]])
+        tm.assert_series_equal(s.nsmallest(2, keep="last"), s.iloc[[2, 3]])
 
         empty = s.iloc[0:0]
-        assert_series_equal(s.nsmallest(0), empty)
-        assert_series_equal(s.nsmallest(-1), empty)
-        assert_series_equal(s.nlargest(0), empty)
-        assert_series_equal(s.nlargest(-1), empty)
+        tm.assert_series_equal(s.nsmallest(0), empty)
+        tm.assert_series_equal(s.nsmallest(-1), empty)
+        tm.assert_series_equal(s.nlargest(0), empty)
+        tm.assert_series_equal(s.nlargest(-1), empty)
 
-        assert_series_equal(s.nsmallest(len(s)), s.sort_values())
-        assert_series_equal(s.nsmallest(len(s) + 1), s.sort_values())
-        assert_series_equal(s.nlargest(len(s)), s.iloc[[4, 0, 1, 3, 2]])
-        assert_series_equal(s.nlargest(len(s) + 1), s.iloc[[4, 0, 1, 3, 2]])
+        tm.assert_series_equal(s.nsmallest(len(s)), s.sort_values())
+        tm.assert_series_equal(s.nsmallest(len(s) + 1), s.sort_values())
+        tm.assert_series_equal(s.nlargest(len(s)), s.iloc[[4, 0, 1, 3, 2]])
+        tm.assert_series_equal(s.nlargest(len(s) + 1), s.iloc[[4, 0, 1, 3, 2]])
 
     def test_misc(self):
 
         s = Series([3.0, np.nan, 1, 2, 5])
-        assert_series_equal(s.nlargest(), s.iloc[[4, 0, 3, 2]])
-        assert_series_equal(s.nsmallest(), s.iloc[[2, 3, 0, 4]])
+        tm.assert_series_equal(s.nlargest(), s.iloc[[4, 0, 3, 2]])
+        tm.assert_series_equal(s.nsmallest(), s.iloc[[2, 3, 0, 4]])
 
         msg = 'keep must be either "first", "last"'
         with pytest.raises(ValueError, match=msg):
@@ -1413,16 +1407,16 @@ class TestNLargestNSmallest:
         expected_last = Series([1] * 3, index=[5, 4, 3])
 
         result = s.nsmallest(3)
-        assert_series_equal(result, expected_first)
+        tm.assert_series_equal(result, expected_first)
 
         result = s.nsmallest(3, keep="last")
-        assert_series_equal(result, expected_last)
+        tm.assert_series_equal(result, expected_last)
 
         result = s.nlargest(3)
-        assert_series_equal(result, expected_first)
+        tm.assert_series_equal(result, expected_first)
 
         result = s.nlargest(3, keep="last")
-        assert_series_equal(result, expected_last)
+        tm.assert_series_equal(result, expected_last)
 
     @pytest.mark.parametrize("n", range(1, 5))
     def test_n(self, n):
@@ -1431,11 +1425,11 @@ class TestNLargestNSmallest:
         s = Series([1, 4, 3, 2], index=[0, 0, 1, 1])
         result = s.nlargest(n)
         expected = s.sort_values(ascending=False).head(n)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.nsmallest(n)
         expected = s.sort_values().head(n)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_boundary_integer(self, nselect_method, any_int_dtype):
         # GH 21426
@@ -1467,11 +1461,11 @@ class TestNLargestNSmallest:
         s = Series([10, 9, 8, 7, 7, 7, 7, 6])
         result = s.nlargest(4, keep="all")
         expected = Series([10, 9, 8, 7, 7, 7, 7])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.nsmallest(2, keep="all")
         expected = Series([6, 7, 7, 7, 7], index=[7, 3, 4, 5, 6])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "data,expected", [([True, False], [True]), ([True, False, True, True], [True])]
@@ -1481,7 +1475,7 @@ class TestNLargestNSmallest:
         s = Series(data)
         result = s.nlargest(1)
         expected = Series(expected)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
 
 class TestCategoricalSeriesAnalytics:

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -20,7 +20,6 @@ from pandas import (
 from pandas.core.arrays import PeriodArray
 from pandas.core.indexes.datetimes import Timestamp
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal, ensure_clean
 
 import pandas.io.formats.printing as printing
 
@@ -110,15 +109,15 @@ class SharedWithSparse:
 
     def test_pickle_datetimes(self, datetime_series):
         unp_ts = self._pickle_roundtrip(datetime_series)
-        assert_series_equal(unp_ts, datetime_series)
+        tm.assert_series_equal(unp_ts, datetime_series)
 
     def test_pickle_strings(self, string_series):
         unp_series = self._pickle_roundtrip(string_series)
-        assert_series_equal(unp_series, string_series)
+        tm.assert_series_equal(unp_series, string_series)
 
     def _pickle_roundtrip(self, obj):
 
-        with ensure_clean() as path:
+        with tm.ensure_clean() as path:
             obj.to_pickle(path)
             unpickled = pd.read_pickle(path)
             return unpickled
@@ -399,16 +398,16 @@ class TestSeriesMisc(SharedWithSparse):
             # default deep is True
             if deep is None or deep is True:
                 # Did not modify original Series
-                assert_series_equal(s2, expected2)
-                assert_series_equal(s, expected)
+                tm.assert_series_equal(s2, expected2)
+                tm.assert_series_equal(s, expected)
             else:
                 # we DID modify the original Series
-                assert_series_equal(s2, expected2)
-                assert_series_equal(s, expected2)
+                tm.assert_series_equal(s2, expected2)
+                tm.assert_series_equal(s, expected2)
 
     def test_axis_alias(self):
         s = Series([1, 2, np.nan])
-        assert_series_equal(s.dropna(axis="rows"), s.dropna(axis="index"))
+        tm.assert_series_equal(s.dropna(axis="rows"), s.dropna(axis="index"))
         assert s.dropna().sum("rows") == 3
         assert s._get_axis_number("rows") == 0
         assert s._get_axis_name("rows") == "index"
@@ -490,7 +489,7 @@ class TestSeriesMisc(SharedWithSparse):
         s = Series([" jack", "jill ", " jesse ", "frank"])
         for method in methods:
             expected = Series([getattr(str, method)(x) for x in s.values])
-            assert_series_equal(getattr(Series.str, method)(s.str), expected)
+            tm.assert_series_equal(getattr(Series.str, method)(s.str), expected)
 
         # str accessor only valid with string values
         s = Series(range(5))

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -8,7 +8,6 @@ import pandas as pd
 from pandas import DataFrame, Index, Series, isna
 from pandas.conftest import _get_cython_table_params
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 class TestSeriesApply:
@@ -47,12 +46,12 @@ class TestSeriesApply:
 
         result = s.apply(f)
         expected = s.map(f)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([1, 2, 3])
         result = s.apply(f)
         expected = s.map(f)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_apply_dont_convert_dtype(self):
         s = Series(np.random.randn(10))
@@ -184,22 +183,22 @@ class TestSeriesAggregate:
             # ufunc
             result = string_series.transform(np.sqrt)
             expected = f_sqrt.copy()
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
             result = string_series.apply(np.sqrt)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
             # list-like
             result = string_series.transform([np.sqrt])
             expected = f_sqrt.to_frame().copy()
             expected.columns = ["sqrt"]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = string_series.transform([np.sqrt])
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = string_series.transform(["sqrt"])
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # multiple items in list
             # these are in the order as if we are applying both functions per
@@ -207,11 +206,11 @@ class TestSeriesAggregate:
             expected = pd.concat([f_sqrt, f_abs], axis=1)
             expected.columns = ["sqrt", "absolute"]
             result = string_series.apply([np.sqrt, np.abs])
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = string_series.transform(["sqrt", "abs"])
             expected.columns = ["sqrt", "abs"]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # dict, provide renaming
             expected = pd.concat([f_sqrt, f_abs], axis=1)
@@ -219,7 +218,7 @@ class TestSeriesAggregate:
             expected = expected.unstack().rename("series")
 
             result = string_series.apply({"foo": np.sqrt, "bar": np.abs})
-            assert_series_equal(result.reindex_like(expected), expected)
+            tm.assert_series_equal(result.reindex_like(expected), expected)
 
     def test_transform_and_agg_error(self, string_series):
         # we are trying to transform with an aggregator
@@ -317,7 +316,7 @@ class TestSeriesAggregate:
                 ]
             )
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_reduce(self, string_series):
         # reductions with named functions
@@ -327,7 +326,7 @@ class TestSeriesAggregate:
             ["sum", "mean"],
             name=string_series.name,
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_non_callable_aggregates(self):
         # test agg using non-callable series attributes
@@ -341,7 +340,7 @@ class TestSeriesAggregate:
         # test when mixed w/ callable reducers
         result = s.agg(["size", "count", "mean"])
         expected = Series(OrderedDict([("size", 3.0), ("count", 2.0), ("mean", 1.5)]))
-        assert_series_equal(result[expected.index], expected)
+        tm.assert_series_equal(result[expected.index], expected)
 
     @pytest.mark.parametrize(
         "series, func, expected",
@@ -516,7 +515,7 @@ class TestSeriesMap:
         s = Series([True, True, False], index=[1, 2, 3])
         result = s.map({True: "foo", False: "bar"})
         expected = Series(["foo", "foo", "bar"], index=[1, 2, 3])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_map_int(self):
         left = Series({"a": 1.0, "b": 2.0, "c": 3.0, "d": 4})
@@ -547,7 +546,7 @@ class TestSeriesMap:
 
         result = s.map(lambda x: x * 2, na_action="ignore")
         exp = s * 2
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
     def test_map_dict_with_tuple_keys(self):
         """
@@ -572,7 +571,7 @@ class TestSeriesMap:
         counter["c"] += 1
         result = s.map(counter)
         expected = Series([0, 5, 1], index=[1, 2, 3])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_map_defaultdict(self):
         s = Series([1, 2, 3], index=["a", "b", "c"])
@@ -580,7 +579,7 @@ class TestSeriesMap:
         default_dict[1] = "stuff"
         result = s.map(default_dict)
         expected = Series(["stuff", "blank", "blank"], index=["a", "b", "c"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_map_dict_subclass_with_missing(self):
         """
@@ -596,7 +595,7 @@ class TestSeriesMap:
         dictionary = DictWithMissing({3: "three"})
         result = s.map(dictionary)
         expected = Series(["missing", "missing", "three"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_map_dict_subclass_without_missing(self):
         class DictWithoutMissing(dict):
@@ -606,7 +605,7 @@ class TestSeriesMap:
         dictionary = DictWithoutMissing({3: "three"})
         result = s.map(dictionary)
         expected = Series([np.nan, np.nan, "three"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_map_box(self):
         vals = [pd.Timestamp("2011-01-01"), pd.Timestamp("2011-01-02")]
@@ -729,11 +728,11 @@ class TestSeriesMap:
         # Calling apply on a localized time series should not cause an error
         index = dti.tz_localize("UTC").index
         result = pd.Series(index).apply(lambda x: pd.Series([1, 2]))
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
     def test_apply_scaler_on_date_time_index_aware_series(self):
         # GH 25959
         # Calling apply on a localized time series should not cause an error
         series = tm.makeTimeSeries(nper=30).tz_localize("UTC")
         result = pd.Series(series.index).apply(lambda x: 1)
-        assert_series_equal(result, pd.Series(np.ones(30), dtype="int64"))
+        tm.assert_series_equal(result, pd.Series(np.ones(30), dtype="int64"))

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -6,7 +6,6 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex, Series, date_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 class TestSeriesCombine:
@@ -28,7 +27,7 @@ class TestSeriesCombine:
         pieces = [datetime_series[:5], datetime_series[5:10], datetime_series[10:]]
 
         result = pieces[0].append(pieces[1:])
-        assert_series_equal(result, datetime_series)
+        tm.assert_series_equal(result, datetime_series)
 
     def test_append_duplicates(self):
         # GH 13677
@@ -110,7 +109,7 @@ class TestSeriesCombine:
         s = Series([1.0, 2, 3], index=[0, 1, 2])
         result = s.combine_first(Series([], index=[]))
         s.index = s.index.astype("O")
-        assert_series_equal(s, result)
+        tm.assert_series_equal(s, result)
 
     def test_update(self):
         s = Series([1.5, np.nan, 3.0, 4.0, np.nan])
@@ -118,7 +117,7 @@ class TestSeriesCombine:
         s.update(s2)
 
         expected = Series([1.5, 3.5, 3.0, 5.0, np.nan])
-        assert_series_equal(s, expected)
+        tm.assert_series_equal(s, expected)
 
         # GH 3217
         df = DataFrame([{"a": 1}, {"a": 3, "b": 2}])
@@ -128,7 +127,7 @@ class TestSeriesCombine:
         expected = DataFrame(
             [[1, np.nan, "foo"], [3, 2.0, np.nan]], columns=["a", "b", "c"]
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     @pytest.mark.parametrize(
         "other, dtype, expected",
@@ -161,7 +160,7 @@ class TestSeriesCombine:
         other = Series(other, index=[1, 3])
         s.update(other)
 
-        assert_series_equal(s, expected)
+        tm.assert_series_equal(s, expected)
 
     def test_concat_empty_series_dtypes_roundtrips(self):
 
@@ -226,7 +225,7 @@ class TestSeriesCombine:
             tz=tz_naive_fixture,
         )
         exp = pd.Series(exp_vals, name="ser1")
-        assert_series_equal(exp, result)
+        tm.assert_series_equal(exp, result)
 
     def test_concat_empty_series_dtypes(self):
 
@@ -324,13 +323,13 @@ class TestSeriesCombine:
         s1 = to_datetime(Series([np.NaN, "2011"]))
         rs = s0.combine_first(s1)
         xp = to_datetime(Series(["2010", "2011"]))
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
         s0 = to_datetime(Series(["2010", np.NaN]))
         s1 = Series([np.NaN, "2011"])
         rs = s0.combine_first(s1)
         xp = Series([datetime(2010, 1, 1), "2011"])
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
 
 class TestTimeseries:

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -29,7 +29,6 @@ from pandas import (
 )
 from pandas.core.arrays import period_array
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 
 class TestSeriesConstructors:
@@ -120,40 +119,40 @@ class TestSeriesConstructors:
 
         # these are Index() and RangeIndex() which don't compare type equal
         # but are just .equals
-        assert_series_equal(empty, empty2, check_index_type=False)
+        tm.assert_series_equal(empty, empty2, check_index_type=False)
 
         # With explicit dtype:
         empty = Series(dtype="float64")
         empty2 = Series(input_class(), dtype="float64")
-        assert_series_equal(empty, empty2, check_index_type=False)
+        tm.assert_series_equal(empty, empty2, check_index_type=False)
 
         # GH 18515 : with dtype=category:
         empty = Series(dtype="category")
         empty2 = Series(input_class(), dtype="category")
-        assert_series_equal(empty, empty2, check_index_type=False)
+        tm.assert_series_equal(empty, empty2, check_index_type=False)
 
         if input_class is not list:
             # With index:
             empty = Series(index=range(10))
             empty2 = Series(input_class(), index=range(10))
-            assert_series_equal(empty, empty2)
+            tm.assert_series_equal(empty, empty2)
 
             # With index and dtype float64:
             empty = Series(np.nan, index=range(10))
             empty2 = Series(input_class(), index=range(10), dtype="float64")
-            assert_series_equal(empty, empty2)
+            tm.assert_series_equal(empty, empty2)
 
             # GH 19853 : with empty string, index and dtype str
             empty = Series("", dtype=str, index=range(3))
             empty2 = Series("", index=range(3))
-            assert_series_equal(empty, empty2)
+            tm.assert_series_equal(empty, empty2)
 
     @pytest.mark.parametrize("input_arg", [np.nan, float("nan")])
     def test_constructor_nan(self, input_arg):
         empty = Series(dtype="float64", index=range(10))
         empty2 = Series(input_arg, index=range(10))
 
-        assert_series_equal(empty, empty2, check_index_type=False)
+        tm.assert_series_equal(empty, empty2, check_index_type=False)
 
     @pytest.mark.parametrize(
         "dtype",
@@ -198,7 +197,7 @@ class TestSeriesConstructors:
         s1 = Series([4, 7, -5, 3], index=index1)
         s2 = Series(s1, index=index2)
 
-        assert_series_equal(s2, s1.sort_index())
+        tm.assert_series_equal(s2, s1.sort_index())
 
     def test_constructor_iterable(self):
         # GH 21987
@@ -209,19 +208,19 @@ class TestSeriesConstructors:
 
         expected = Series(list(range(10)), dtype="int64")
         result = Series(Iter(), dtype="int64")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_sequence(self):
         # GH 21987
         expected = Series(list(range(10)), dtype="int64")
         result = Series(range(10), dtype="int64")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_single_str(self):
         # GH 21987
         expected = Series(["abc"])
         result = Series("abc")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_list_like(self):
 
@@ -231,7 +230,7 @@ class TestSeriesConstructors:
         expected = Series([1, 2, 3], dtype="int64")
         for obj in [[1, 2, 3], (1, 2, 3), np.array([1, 2, 3], dtype="int64")]:
             result = Series(obj, index=[0, 1, 2])
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("dtype", ["bool", "int32", "int64", "float64"])
     def test_constructor_index_dtype(self, dtype):
@@ -256,12 +255,12 @@ class TestSeriesConstructors:
         # when dtype is str, 'str', or 'U'
         result = Series(input_vals, dtype=string_dtype)
         expected = Series(input_vals).astype(string_dtype)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_list_str_na(self, string_dtype):
         result = Series([1.0, 2.0, np.nan], dtype=string_dtype)
         expected = Series(["1.0", "2.0", np.nan], dtype=object)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         assert np.isnan(result[2])
 
     def test_constructor_generator(self):
@@ -269,12 +268,12 @@ class TestSeriesConstructors:
 
         result = Series(gen)
         exp = Series(range(10))
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         gen = (i for i in range(10))
         result = Series(gen, index=range(10, 20))
         exp.index = range(10, 20)
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
     def test_constructor_map(self):
         # GH8909
@@ -282,12 +281,12 @@ class TestSeriesConstructors:
 
         result = Series(m)
         exp = Series(range(10))
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         m = map(lambda x: x, range(10))
         result = Series(m, index=range(10, 20))
         exp.index = range(10, 20)
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
     def test_constructor_categorical(self):
         cat = pd.Categorical([0, 1, 2, 0, 1, 2], ["a", "b", "c"], fastpath=True)
@@ -456,58 +455,58 @@ class TestSeriesConstructors:
         data = ma.masked_all((3,), dtype=float)
         result = Series(data)
         expected = Series([np.nan, np.nan, np.nan])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data[0] = 0.0
         data[2] = 2.0
         index = ["a", "b", "c"]
         result = Series(data, index=index)
         expected = Series([0.0, np.nan, 2.0], index=index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data[1] = 1.0
         result = Series(data, index=index)
         expected = Series([0.0, 1.0, 2.0], index=index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data = ma.masked_all((3,), dtype=int)
         result = Series(data)
         expected = Series([np.nan, np.nan, np.nan], dtype=float)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data[0] = 0
         data[2] = 2
         index = ["a", "b", "c"]
         result = Series(data, index=index)
         expected = Series([0, np.nan, 2], index=index, dtype=float)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data[1] = 1
         result = Series(data, index=index)
         expected = Series([0, 1, 2], index=index, dtype=int)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data = ma.masked_all((3,), dtype=bool)
         result = Series(data)
         expected = Series([np.nan, np.nan, np.nan], dtype=object)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data[0] = True
         data[2] = False
         index = ["a", "b", "c"]
         result = Series(data, index=index)
         expected = Series([True, np.nan, False], index=index, dtype=object)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data[1] = True
         result = Series(data, index=index)
         expected = Series([True, True, False], index=index, dtype=bool)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data = ma.masked_all((3,), dtype="M8[ns]")
         result = Series(data)
         expected = Series([iNaT, iNaT, iNaT], dtype="M8[ns]")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data[0] = datetime(2001, 1, 1)
         data[2] = datetime(2001, 1, 3)
@@ -518,7 +517,7 @@ class TestSeriesConstructors:
             index=index,
             dtype="M8[ns]",
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         data[1] = datetime(2001, 1, 2)
         result = Series(data, index=index)
@@ -527,7 +526,7 @@ class TestSeriesConstructors:
             index=index,
             dtype="M8[ns]",
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_maskedarray_hardened(self):
         # Check numpy masked arrays with hard masks -- from GH24574
@@ -643,7 +642,7 @@ class TestSeriesConstructors:
         # inference on the index
         s = Series(index=np.array([None]))
         expected = Series(index=Index([None]))
-        assert_series_equal(s, expected)
+        tm.assert_series_equal(s, expected)
 
     def test_constructor_pass_nan_nat(self):
         # GH 13467
@@ -683,7 +682,7 @@ class TestSeriesConstructors:
     def test_constructor_coerce_float_valid(self, float_dtype):
         s = Series([1, 2, 3.5], dtype=float_dtype)
         expected = Series([1, 2, 3.5]).astype(float_dtype)
-        assert_series_equal(s, expected)
+        tm.assert_series_equal(s, expected)
 
     def test_constructor_dtype_no_cast(self):
         # see gh-1572
@@ -815,7 +814,7 @@ class TestSeriesConstructors:
         for dtype in ["s", "D", "ms", "us", "ns"]:
             values1 = dates.view(np.ndarray).astype("M8[{0}]".format(dtype))
             result = Series(values1, dates)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         # GH 13876
         # coerce to non-ns to object properly
@@ -823,7 +822,7 @@ class TestSeriesConstructors:
         for dtype in ["s", "D", "ms", "us", "ns"]:
             values1 = dates.view(np.ndarray).astype("M8[{0}]".format(dtype))
             result = Series(values1, index=dates, dtype=object)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         # leave datetime.date alone
         dates2 = np.array([d.date() for d in dates.to_pydatetime()], dtype=object)
@@ -900,14 +899,14 @@ class TestSeriesConstructors:
         )
 
         result = s[Series([True, True, False], index=s.index)]
-        assert_series_equal(result, s[0:2])
+        tm.assert_series_equal(result, s[0:2])
 
         result = s.iloc[0:1]
-        assert_series_equal(result, Series(dr[0:1]))
+        tm.assert_series_equal(result, Series(dr[0:1]))
 
         # concat
         result = pd.concat([s.iloc[0:1], s.iloc[1:]])
-        assert_series_equal(result, s)
+        tm.assert_series_equal(result, s)
 
         # short str
         assert "datetime64[ns, US/Eastern]" in str(s)
@@ -946,7 +945,7 @@ class TestSeriesConstructors:
         # with all NaT
         s = Series(pd.NaT, index=[0, 1], dtype="datetime64[ns, US/Eastern]")
         expected = Series(pd.DatetimeIndex(["NaT", "NaT"], tz="US/Eastern"))
-        assert_series_equal(s, expected)
+        tm.assert_series_equal(s, expected)
 
     @pytest.mark.parametrize("arr_dtype", [np.int64, np.float64])
     @pytest.mark.parametrize("dtype", ["M8", "m8"])
@@ -967,7 +966,7 @@ class TestSeriesConstructors:
         # GH 17415: With naive string
         result = Series([arg], dtype="datetime64[ns, CET]")
         expected = Series(pd.Timestamp(arg)).dt.tz_localize("CET")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_construction_interval(self):
         # construction from interval & array of intervals
@@ -1020,13 +1019,13 @@ class TestSeriesConstructors:
         s = Series(pi)
         assert s.dtype == "Period[D]"
         expected = Series(pi.astype(object))
-        assert_series_equal(s, expected)
+        tm.assert_series_equal(s, expected)
 
     def test_constructor_dict(self):
         d = {"a": 0.0, "b": 1.0, "c": 2.0}
         result = Series(d, index=["b", "c", "d", "a"])
         expected = Series([1, 2, np.nan, 0], index=["b", "c", "d", "a"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         pidx = tm.makePeriodIndex(100)
         d = {pidx[0]: 0, pidx[1]: 1}
@@ -1034,7 +1033,7 @@ class TestSeriesConstructors:
         expected = Series(np.nan, pidx)
         expected.iloc[0] = 0
         expected.iloc[1] = 1
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_dict_order(self):
         # GH19018
@@ -1054,7 +1053,7 @@ class TestSeriesConstructors:
         d = {1: "a", value: "b", float("nan"): "c", 4: "d"}
         result = Series(d).sort_values()
         expected = Series(["a", "b", "c", "d"], index=[1, value, np.nan, 4])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # MultiIndex:
         d = {(1, 1): "a", (2, np.nan): "b", (3, value): "c"}
@@ -1062,7 +1061,7 @@ class TestSeriesConstructors:
         expected = Series(
             ["a", "b", "c"], index=Index([(1, 1), (2, np.nan), (3, value)])
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_dict_datetime64_index(self):
         # GH 9456
@@ -1083,9 +1082,9 @@ class TestSeriesConstructors:
         result_datetime = Series(data_datetime)
         result_Timestamp = Series(data_Timestamp)
 
-        assert_series_equal(result_datetime64, expected)
-        assert_series_equal(result_datetime, expected)
-        assert_series_equal(result_Timestamp, expected)
+        tm.assert_series_equal(result_datetime64, expected)
+        tm.assert_series_equal(result_datetime, expected)
+        tm.assert_series_equal(result_Timestamp, expected)
 
     def test_constructor_list_of_tuples(self):
         data = [(1, 1), (2, 2), (2, 3)]
@@ -1234,7 +1233,7 @@ class TestSeriesConstructors:
             [Timestamp("20130101"), Timestamp("20130101", tz="US/Eastern")],
             dtype="object",
         )
-        assert_series_equal(s, expected)
+        tm.assert_series_equal(s, expected)
 
     def test_NaT_scalar(self):
         series = Series([0, 1000, 2000, iNaT], dtype="M8[ns]")
@@ -1249,7 +1248,7 @@ class TestSeriesConstructors:
         # GH10747
         result = Series([np.nan]).astype("M8[ns]")
         expected = Series([NaT])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_name_hashable(self):
         for n in [777, 777.0, "name", datetime(2001, 11, 11), (1,), "\u05D0"]:
@@ -1273,7 +1272,7 @@ class TestSeriesConstructors:
         arr = np.array([1, 2, 3], dtype="timedelta64[s]")
         s = Series(arr)
         expected = Series(pd.timedelta_range("00:00:01", periods=3, freq="s"))
-        assert_series_equal(s, expected)
+        tm.assert_series_equal(s, expected)
 
         # convert from a numpy array of non-ns datetime64
         # note that creating a numpy datetime64 is in LOCAL time!!!!
@@ -1282,12 +1281,12 @@ class TestSeriesConstructors:
         s = Series(
             np.array(["2013-01-01", "2013-01-02", "2013-01-03"], dtype="datetime64[D]")
         )
-        assert_series_equal(s, Series(date_range("20130101", periods=3, freq="D")))
+        tm.assert_series_equal(s, Series(date_range("20130101", periods=3, freq="D")))
 
         # s = Series(np.array(['2013-01-01 00:00:01','2013-01-01
         # 00:00:02','2013-01-01 00:00:03'],dtype='datetime64[s]'))
 
-        # assert_series_equal(s,date_range('20130101
+        # tm.assert_series_equal(s,date_range('20130101
         # 00:00:01',period=3,freq='s'))
 
     @pytest.mark.parametrize(

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -27,7 +27,6 @@ from pandas import (
 from pandas.core.arrays import PeriodArray
 import pandas.core.common as com
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 
 class TestSeriesDatetimeValues:
@@ -587,11 +586,11 @@ class TestSeriesDatetimeValues:
 
         result = s[s.between(s[3], s[17])]
         expected = s[3:18].dropna()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s[s.between(s[3], s[17], inclusive=False)]
         expected = s[5:16].dropna()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_date_tz(self):
         # GH11757
@@ -601,8 +600,8 @@ class TestSeriesDatetimeValues:
         )
         s = Series(rng)
         expected = Series([date(2014, 4, 4), date(2014, 7, 18), date(2015, 11, 22)])
-        assert_series_equal(s.dt.date, expected)
-        assert_series_equal(s.apply(lambda x: x.date()), expected)
+        tm.assert_series_equal(s.dt.date, expected)
+        tm.assert_series_equal(s.apply(lambda x: x.date()), expected)
 
     def test_datetime_understood(self):
         # Ensures it doesn't fail to create the right series

--- a/pandas/tests/series/test_internals.py
+++ b/pandas/tests/series/test_internals.py
@@ -7,7 +7,6 @@ import pandas as pd
 from pandas import NaT, Series, Timestamp
 from pandas.core.internals.blocks import IntBlock
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 
 class TestSeriesInternals:
@@ -19,15 +18,15 @@ class TestSeriesInternals:
         s = Series(["a", "b", "c"])
         results = s._convert(datetime=True, coerce=True)
         expected = Series([NaT] * 3)
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
 
         results = s._convert(numeric=True, coerce=True)
         expected = Series([np.nan] * 3)
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
 
         expected = Series([NaT] * 3, dtype=np.dtype("m8[ns]"))
         results = s._convert(timedelta=True, coerce=True)
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
 
         dt = datetime(2001, 1, 1, 0, 0)
         td = dt - datetime(2000, 1, 1, 0, 0)
@@ -36,79 +35,79 @@ class TestSeriesInternals:
         s = Series(["a", "3.1415", dt, td])
         results = s._convert(datetime=True, coerce=True)
         expected = Series([NaT, NaT, dt, NaT])
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
 
         results = s._convert(numeric=True, coerce=True)
         expected = Series([np.nan, 3.1415, np.nan, np.nan])
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
 
         results = s._convert(timedelta=True, coerce=True)
         expected = Series([NaT, NaT, NaT, td], dtype=np.dtype("m8[ns]"))
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
 
         # Test standard conversion returns original
         results = s._convert(datetime=True)
-        assert_series_equal(results, s)
+        tm.assert_series_equal(results, s)
         results = s._convert(numeric=True)
         expected = Series([np.nan, 3.1415, np.nan, np.nan])
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
         results = s._convert(timedelta=True)
-        assert_series_equal(results, s)
+        tm.assert_series_equal(results, s)
 
         # test pass-through and non-conversion when other types selected
         s = Series(["1.0", "2.0", "3.0"])
         results = s._convert(datetime=True, numeric=True, timedelta=True)
         expected = Series([1.0, 2.0, 3.0])
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
         results = s._convert(True, False, True)
-        assert_series_equal(results, s)
+        tm.assert_series_equal(results, s)
 
         s = Series([datetime(2001, 1, 1, 0, 0), datetime(2001, 1, 1, 0, 0)], dtype="O")
         results = s._convert(datetime=True, numeric=True, timedelta=True)
         expected = Series([datetime(2001, 1, 1, 0, 0), datetime(2001, 1, 1, 0, 0)])
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
         results = s._convert(datetime=False, numeric=True, timedelta=True)
-        assert_series_equal(results, s)
+        tm.assert_series_equal(results, s)
 
         td = datetime(2001, 1, 1, 0, 0) - datetime(2000, 1, 1, 0, 0)
         s = Series([td, td], dtype="O")
         results = s._convert(datetime=True, numeric=True, timedelta=True)
         expected = Series([td, td])
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
         results = s._convert(True, True, False)
-        assert_series_equal(results, s)
+        tm.assert_series_equal(results, s)
 
         s = Series([1.0, 2, 3], index=["a", "b", "c"])
         result = s._convert(numeric=True)
-        assert_series_equal(result, s)
+        tm.assert_series_equal(result, s)
 
         # force numeric conversion
         r = s.copy().astype("O")
         r["a"] = "1"
         result = r._convert(numeric=True)
-        assert_series_equal(result, s)
+        tm.assert_series_equal(result, s)
 
         r = s.copy().astype("O")
         r["a"] = "1."
         result = r._convert(numeric=True)
-        assert_series_equal(result, s)
+        tm.assert_series_equal(result, s)
 
         r = s.copy().astype("O")
         r["a"] = "garbled"
         result = r._convert(numeric=True)
         expected = s.copy()
         expected["a"] = np.nan
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 4119, not converting a mixed type (e.g.floats and object)
         s = Series([1, "na", 3, 4])
         result = s._convert(datetime=True, numeric=True)
         expected = Series([1, np.nan, 3, 4])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([1, "", 3, 4])
         result = s._convert(datetime=True, numeric=True)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # dates
         s = Series(
@@ -137,10 +136,10 @@ class TestSeriesInternals:
             [Timestamp("20010101"), Timestamp("20010102"), Timestamp("20010103")],
             dtype="M8[ns]",
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s._convert(datetime=True, coerce=True)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series(
             [
@@ -156,19 +155,19 @@ class TestSeriesInternals:
             dtype="M8[ns]",
         )
         result = s2._convert(datetime=True, numeric=False, timedelta=False, coerce=True)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = s2._convert(datetime=True, coerce=True)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series(["foo", "bar", 1, 1.0], dtype="O")
         result = s._convert(datetime=True, coerce=True)
         expected = Series([NaT] * 2 + [Timestamp(1)] * 2)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # preserver if non-object
         s = Series([1], dtype="float32")
         result = s._convert(datetime=True, coerce=True)
-        assert_series_equal(result, s)
+        tm.assert_series_equal(result, s)
 
         # r = s.copy()
         # r[0] = np.nan
@@ -180,10 +179,10 @@ class TestSeriesInternals:
         for x in "abcdefghijklmnopqrstuvwxyz":
             s = Series([x])
             result = s._convert(datetime=True, coerce=True)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
             s = Series([x.upper()])
             result = s._convert(datetime=True, coerce=True)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
     def test_convert_no_arg_error(self):
         s = Series(["1.0", "2"])

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -8,12 +8,6 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Series
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-    ensure_clean,
-)
 
 from pandas.io.common import _get_handle
 
@@ -34,7 +28,7 @@ class TestSeriesToCSV:
     @pytest.mark.parametrize("arg", ["path", "header", "both"])
     def test_to_csv_deprecation(self, arg, datetime_series):
         # see gh-19715
-        with ensure_clean() as path:
+        with tm.ensure_clean() as path:
             if arg == "path":
                 kwargs = dict(path=path, header=False)
             elif arg == "header":
@@ -47,14 +41,14 @@ class TestSeriesToCSV:
 
                 # Make sure roundtrip still works.
                 ts = self.read_csv(path)
-                assert_series_equal(datetime_series, ts, check_names=False)
+                tm.assert_series_equal(datetime_series, ts, check_names=False)
 
     def test_from_csv(self, datetime_series, string_series):
 
-        with ensure_clean() as path:
+        with tm.ensure_clean() as path:
             datetime_series.to_csv(path, header=False)
             ts = self.read_csv(path)
-            assert_series_equal(datetime_series, ts, check_names=False)
+            tm.assert_series_equal(datetime_series, ts, check_names=False)
 
             assert ts.name is None
             assert ts.index.name is None
@@ -66,7 +60,7 @@ class TestSeriesToCSV:
 
             string_series.to_csv(path, header=False)
             series = self.read_csv(path)
-            assert_series_equal(string_series, series, check_names=False)
+            tm.assert_series_equal(string_series, series, check_names=False)
 
             assert series.name is None
             assert series.index.name is None
@@ -82,16 +76,16 @@ class TestSeriesToCSV:
             check_series = Series(
                 {datetime(1998, 1, 1): 1.0, datetime(1999, 1, 1): 2.0}
             )
-            assert_series_equal(check_series, series)
+            tm.assert_series_equal(check_series, series)
 
             series = self.read_csv(path, sep="|", parse_dates=False)
             check_series = Series({"1998-01-01": 1.0, "1999-01-01": 2.0})
-            assert_series_equal(check_series, series)
+            tm.assert_series_equal(check_series, series)
 
     def test_to_csv(self, datetime_series):
         import io
 
-        with ensure_clean() as path:
+        with tm.ensure_clean() as path:
             datetime_series.to_csv(path, header=False)
 
             with io.open(path, newline=None) as f:
@@ -100,7 +94,7 @@ class TestSeriesToCSV:
 
             datetime_series.to_csv(path, index=False, header=False)
             arr = np.loadtxt(path)
-            assert_almost_equal(arr, datetime_series.values)
+            tm.assert_almost_equal(arr, datetime_series.values)
 
     def test_to_csv_unicode_index(self):
         buf = StringIO()
@@ -110,17 +104,17 @@ class TestSeriesToCSV:
         buf.seek(0)
 
         s2 = self.read_csv(buf, index_col=0, encoding="UTF-8")
-        assert_series_equal(s, s2)
+        tm.assert_series_equal(s, s2)
 
     def test_to_csv_float_format(self):
 
-        with ensure_clean() as filename:
+        with tm.ensure_clean() as filename:
             ser = Series([0.123456, 0.234567, 0.567567])
             ser.to_csv(filename, float_format="%.2f", header=False)
 
             rs = self.read_csv(filename)
             xp = Series([0.12, 0.23, 0.57])
-            assert_series_equal(rs, xp)
+            tm.assert_series_equal(rs, xp)
 
     def test_to_csv_list_entries(self):
         s = Series(["jack and jill", "jesse and frank"])
@@ -153,7 +147,7 @@ class TestSeriesToCSV:
     )
     def test_to_csv_compression(self, s, encoding, compression):
 
-        with ensure_clean() as filename:
+        with tm.ensure_clean() as filename:
 
             s.to_csv(filename, compression=compression, encoding=encoding, header=True)
             # test the round trip - to_csv -> read_csv
@@ -164,7 +158,7 @@ class TestSeriesToCSV:
                 index_col=0,
                 squeeze=True,
             )
-            assert_series_equal(s, result)
+            tm.assert_series_equal(s, result)
 
             # test the round trip using file handle - to_csv -> read_csv
             f, _handles = _get_handle(
@@ -179,7 +173,7 @@ class TestSeriesToCSV:
                 index_col=0,
                 squeeze=True,
             )
-            assert_series_equal(s, result)
+            tm.assert_series_equal(s, result)
 
             # explicitly ensure file was compressed
             with tm.decompress_file(filename, compression) as fh:
@@ -187,7 +181,7 @@ class TestSeriesToCSV:
                 assert s.name in text
 
             with tm.decompress_file(filename, compression) as fh:
-                assert_series_equal(
+                tm.assert_series_equal(
                     s, pd.read_csv(fh, index_col=0, squeeze=True, encoding=encoding)
                 )
 
@@ -195,7 +189,7 @@ class TestSeriesToCSV:
         # GH 28210
         s = Series(["foo", "bar", "baz"], index=pd.interval_range(0, 3))
 
-        with ensure_clean("__tmp_to_csv_interval_index__.csv") as path:
+        with tm.ensure_clean("__tmp_to_csv_interval_index__.csv") as path:
             s.to_csv(path, header=False)
             result = self.read_csv(path, index_col=0, squeeze=True)
 
@@ -203,7 +197,7 @@ class TestSeriesToCSV:
             expected = s.copy()
             expected.index = expected.index.astype(str)
 
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
 
 class TestSeriesIO:
@@ -211,20 +205,20 @@ class TestSeriesIO:
         datetime_series.name = None
         rs = datetime_series.to_frame()
         xp = pd.DataFrame(datetime_series.values, index=datetime_series.index)
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
         datetime_series.name = "testname"
         rs = datetime_series.to_frame()
         xp = pd.DataFrame(
             dict(testname=datetime_series.values), index=datetime_series.index
         )
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
         rs = datetime_series.to_frame(name="testdifferent")
         xp = pd.DataFrame(
             dict(testdifferent=datetime_series.values), index=datetime_series.index
         )
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
     def test_timeseries_periodindex(self):
         # GH2891
@@ -251,7 +245,7 @@ class TestSeriesIO:
 
     def _pickle_roundtrip_name(self, obj):
 
-        with ensure_clean() as path:
+        with tm.ensure_clean() as path:
             obj.to_pickle(path)
             unpickled = pd.read_pickle(path)
             return unpickled
@@ -271,7 +265,7 @@ class TestSeriesIO:
         result = s.to_frame()
         assert isinstance(result, SubclassedFrame)
         expected = SubclassedFrame({"X": [1, 2, 3]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "mapping", (dict, collections.defaultdict(list), collections.OrderedDict)

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -22,7 +22,6 @@ from pandas import (
 )
 from pandas.core.series import remove_na
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 def _skip_if_no_pchip():
@@ -77,7 +76,7 @@ class TestSeriesMissingData:
                 timedelta(days=1, seconds=9 * 3600 + 60 + 1),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # interpreted as seconds, deprecated
         with tm.assert_produces_warning(FutureWarning):
@@ -90,7 +89,7 @@ class TestSeriesMissingData:
                 timedelta(days=1, seconds=9 * 3600 + 60 + 1),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = td.fillna(timedelta(days=1, seconds=1))
         expected = Series(
@@ -101,7 +100,7 @@ class TestSeriesMissingData:
                 timedelta(days=1, seconds=9 * 3600 + 60 + 1),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = td.fillna(np.timedelta64(int(1e9)))
         expected = Series(
@@ -112,7 +111,7 @@ class TestSeriesMissingData:
                 timedelta(days=1, seconds=9 * 3600 + 60 + 1),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = td.fillna(NaT)
         expected = Series(
@@ -124,7 +123,7 @@ class TestSeriesMissingData:
             ],
             dtype="m8[ns]",
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # ffill
         td[2] = np.nan
@@ -132,7 +131,7 @@ class TestSeriesMissingData:
         with tm.assert_produces_warning(FutureWarning):
             expected = td.fillna(0)
         expected[0] = np.nan
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # bfill
         td[2] = np.nan
@@ -140,7 +139,7 @@ class TestSeriesMissingData:
         with tm.assert_produces_warning(FutureWarning):
             expected = td.fillna(0)
         expected[2] = timedelta(days=1, seconds=9 * 3600 + 60 + 1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_datetime64_fillna(self):
 
@@ -164,11 +163,11 @@ class TestSeriesMissingData:
                 Timestamp("20130103 9:01:01"),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.fillna(NaT)
         expected = s
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # ffill
         result = s.ffill()
@@ -180,7 +179,7 @@ class TestSeriesMissingData:
                 Timestamp("20130103 9:01:01"),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # bfill
         result = s.bfill()
@@ -192,7 +191,7 @@ class TestSeriesMissingData:
                 Timestamp("20130103 9:01:01"),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 6587
         # make sure that we are treating as integer when filling
@@ -207,7 +206,7 @@ class TestSeriesMissingData:
             dtype="M8[ns]",
         )
         result = s.fillna(method="backfill")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_datetime64_tz_fillna(self):
 
@@ -424,7 +423,7 @@ class TestSeriesMissingData:
                 pd.Timestamp("2012-11-11 00:00:00+01:00"),
             ]
         )
-        assert_series_equal(df.fillna(method="pad"), exp)
+        tm.assert_series_equal(df.fillna(method="pad"), exp)
 
         df = pd.Series([pd.NaT, pd.Timestamp("2012-11-11 00:00:00+01:00")])
         exp = pd.Series(
@@ -433,7 +432,7 @@ class TestSeriesMissingData:
                 pd.Timestamp("2012-11-11 00:00:00+01:00"),
             ]
         )
-        assert_series_equal(df.fillna(method="bfill"), exp)
+        tm.assert_series_equal(df.fillna(method="bfill"), exp)
 
     def test_datetime64_non_nano_fillna(self):
         # GH#27419
@@ -457,28 +456,28 @@ class TestSeriesMissingData:
             [Timestamp("20130101"), Timestamp("2013-01-01", tz="US/Eastern")],
             dtype="object",
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # where (we ignore the errors=)
         result = s.where(
             [True, False], Timestamp("20130101", tz="US/Eastern"), errors="ignore"
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.where(
             [True, False], Timestamp("20130101", tz="US/Eastern"), errors="ignore"
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # with a non-datetime
         result = s.fillna("foo")
         expected = Series([Timestamp("20130101"), "foo"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # assignment
         s2 = s.copy()
         s2[1] = "foo"
-        assert_series_equal(s2, expected)
+        tm.assert_series_equal(s2, expected)
 
     def test_datetime64tz_fillna_round_issue(self):
         # GH 14872
@@ -497,7 +496,7 @@ class TestSeriesMissingData:
             ]
         )
 
-        assert_series_equal(filled, expected)
+        tm.assert_series_equal(filled, expected)
 
     def test_fillna_downcast(self):
         # GH 15277
@@ -505,18 +504,18 @@ class TestSeriesMissingData:
         s = pd.Series([1.0, np.nan])
         result = s.fillna(0, downcast="infer")
         expected = pd.Series([1, 0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # infer int64 from float64 when fillna value is a dict
         s = pd.Series([1.0, np.nan])
         result = s.fillna({1: 0}, downcast="infer")
         expected = pd.Series([1, 0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_fillna_int(self):
         s = Series(np.random.randint(-100, 100, 50))
         s.fillna(method="ffill", inplace=True)
-        assert_series_equal(s.fillna(method="ffill", inplace=False), s)
+        tm.assert_series_equal(s.fillna(method="ffill", inplace=False), s)
 
     def test_fillna_raise(self):
         s = Series(np.random.randint(-100, 100, 50))
@@ -635,15 +634,15 @@ class TestSeriesMissingData:
         expected = series.copy()
         expected.values[3] = expected.values[2]
 
-        assert_series_equal(filled, expected)
-        assert_series_equal(filled2, expected)
+        tm.assert_series_equal(filled, expected)
+        tm.assert_series_equal(filled2, expected)
 
         df = DataFrame({"A": series})
         filled = df.fillna(method="pad")
         filled2 = df.fillna(value=series.values[2])
         expected = DataFrame({"A": expected})
-        assert_frame_equal(filled, expected)
-        assert_frame_equal(filled2, expected)
+        tm.assert_frame_equal(filled, expected)
+        tm.assert_frame_equal(filled2, expected)
 
         series = Series([iNaT, 0, 1, 2], dtype="M8[ns]")
 
@@ -653,15 +652,15 @@ class TestSeriesMissingData:
         expected = series.copy()
         expected[0] = expected[1]
 
-        assert_series_equal(filled, expected)
-        assert_series_equal(filled2, expected)
+        tm.assert_series_equal(filled, expected)
+        tm.assert_series_equal(filled2, expected)
 
         df = DataFrame({"A": series})
         filled = df.fillna(method="bfill")
         filled2 = df.fillna(value=series[1])
         expected = DataFrame({"A": expected})
-        assert_frame_equal(filled, expected)
-        assert_frame_equal(filled2, expected)
+        tm.assert_frame_equal(filled, expected)
+        tm.assert_frame_equal(filled2, expected)
 
     def test_isna_for_inf(self):
         s = Series(["a", np.inf, np.nan, 1.0])
@@ -714,39 +713,39 @@ class TestSeriesMissingData:
         s2 = Series([1])
         result = s1.fillna(s2)
         expected = Series([1.0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = s1.fillna({})
-        assert_series_equal(result, s1)
+        tm.assert_series_equal(result, s1)
         result = s1.fillna(Series(()))
-        assert_series_equal(result, s1)
+        tm.assert_series_equal(result, s1)
         result = s2.fillna(s1)
-        assert_series_equal(result, s2)
+        tm.assert_series_equal(result, s2)
         result = s1.fillna({0: 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = s1.fillna({1: 1})
-        assert_series_equal(result, Series([np.nan]))
+        tm.assert_series_equal(result, Series([np.nan]))
         result = s1.fillna({0: 1, 1: 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = s1.fillna(Series({0: 1, 1: 1}))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = s1.fillna(Series({0: 1, 1: 1}, index=[4, 5]))
-        assert_series_equal(result, s1)
+        tm.assert_series_equal(result, s1)
 
         s1 = Series([0, 1, 2], list("abc"))
         s2 = Series([0, np.nan, 2], list("bac"))
         result = s2.fillna(s1)
         expected = Series([0, 0, 2.0], list("bac"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # limit
         s = Series(np.nan, index=[0, 1, 2])
         result = s.fillna(999, limit=1)
         expected = Series([999, np.nan, np.nan], index=[0, 1, 2])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.fillna(999, limit=2)
         expected = Series([999, 999, np.nan], index=[0, 1, 2])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 9043
         # make sure a string representation of int/float values can be filled
@@ -756,17 +755,17 @@ class TestSeriesMissingData:
             s = Series([0, 1, np.nan, np.nan, 4], dtype="float64")
             result = s.fillna(val)
             expected = Series([0, 1, val, val, 4], dtype="object")
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
     def test_fillna_bug(self):
         x = Series([np.nan, 1.0, np.nan, 3.0, np.nan], ["z", "a", "b", "c", "d"])
         filled = x.fillna(method="ffill")
         expected = Series([np.nan, 1.0, 1.0, 3.0, 3.0], x.index)
-        assert_series_equal(filled, expected)
+        tm.assert_series_equal(filled, expected)
 
         filled = x.fillna(method="bfill")
         expected = Series([1.0, 1.0, 3.0, 3.0, np.nan], x.index)
-        assert_series_equal(filled, expected)
+        tm.assert_series_equal(filled, expected)
 
     def test_fillna_inplace(self):
         x = Series([np.nan, 1.0, np.nan, 3.0, np.nan], ["z", "a", "b", "c", "d"])
@@ -775,7 +774,7 @@ class TestSeriesMissingData:
         y.fillna(value=0, inplace=True)
 
         expected = x.fillna(value=0)
-        assert_series_equal(y, expected)
+        tm.assert_series_equal(y, expected)
 
     def test_fillna_invalid_method(self, datetime_series):
         try:
@@ -786,18 +785,18 @@ class TestSeriesMissingData:
     def test_ffill(self):
         ts = Series([0.0, 1.0, 2.0, 3.0, 4.0], index=tm.makeDateIndex(5))
         ts[2] = np.NaN
-        assert_series_equal(ts.ffill(), ts.fillna(method="ffill"))
+        tm.assert_series_equal(ts.ffill(), ts.fillna(method="ffill"))
 
     def test_ffill_mixed_dtypes_without_missing_data(self):
         # GH14956
         series = pd.Series([datetime(2015, 1, 1, tzinfo=pytz.utc), 1])
         result = series.ffill()
-        assert_series_equal(series, result)
+        tm.assert_series_equal(series, result)
 
     def test_bfill(self):
         ts = Series([0.0, 1.0, 2.0, 3.0, 4.0], index=tm.makeDateIndex(5))
         ts[2] = np.NaN
-        assert_series_equal(ts.bfill(), ts.fillna(method="bfill"))
+        tm.assert_series_equal(ts.bfill(), ts.fillna(method="bfill"))
 
     def test_timedelta64_nan(self):
 
@@ -838,7 +837,7 @@ class TestSeriesMissingData:
         #     np.random.seed(12345)
         #     selector = -0.5 <= datetime_series <= 0.5
         #     expected = (datetime_series >= -0.5) & (datetime_series <= 0.5)
-        #     assert_series_equal(selector, expected)
+        #     tm.assert_series_equal(selector, expected)
 
     def test_dropna_empty(self):
         s = Series([])
@@ -903,7 +902,7 @@ class TestSeriesMissingData:
 
         result = s.dropna()
         expected = s.iloc[1:]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_valid(self, datetime_series):
         ts = datetime_series.copy()
@@ -942,7 +941,7 @@ class TestSeriesMissingData:
         expected = Series(
             [np.nan, 1.0, 1.0, 3.0, 3.0], ["z", "a", "b", "c", "d"], dtype=float
         )
-        assert_series_equal(x[1:], expected[1:])
+        tm.assert_series_equal(x[1:], expected[1:])
         assert np.isnan(x[0]), np.isnan(expected[0])
 
     def test_pad_require_monotonicity(self):
@@ -970,7 +969,7 @@ class TestSeriesMissingData:
 
         exp = s.fillna(0).add(2)
         res = s.add(2, fill_value=0)
-        assert_series_equal(res, exp)
+        tm.assert_series_equal(res, exp)
 
     def test_series_fillna_limit(self):
         index = np.arange(10)
@@ -981,14 +980,14 @@ class TestSeriesMissingData:
 
         expected = s[:2].reindex(index).fillna(method="pad")
         expected[-3:] = np.nan
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s[-2:].reindex(index)
         result = result.fillna(method="bfill", limit=5)
 
         expected = s[-2:].reindex(index).fillna(method="backfill")
         expected[:3] = np.nan
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_series_pad_backfill_limit(self):
         index = np.arange(10)
@@ -998,13 +997,13 @@ class TestSeriesMissingData:
 
         expected = s[:2].reindex(index).fillna(method="pad")
         expected[-3:] = np.nan
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s[-2:].reindex(index, method="backfill", limit=5)
 
         expected = s[-2:].reindex(index).fillna(method="backfill")
         expected[:3] = np.nan
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
 
 @pytest.fixture(
@@ -1125,7 +1124,7 @@ class TestSeriesInterpolateData:
             float
         )
         interp_s = ser.reindex(new_index).interpolate(method="akima")
-        assert_series_equal(interp_s[1:3], expected)
+        tm.assert_series_equal(interp_s[1:3], expected)
 
     @td.skip_if_no_scipy
     def test_interpolate_piecewise_polynomial(self):
@@ -1140,7 +1139,7 @@ class TestSeriesInterpolateData:
             float
         )
         interp_s = ser.reindex(new_index).interpolate(method="piecewise_polynomial")
-        assert_series_equal(interp_s[1:3], expected)
+        tm.assert_series_equal(interp_s[1:3], expected)
 
     @td.skip_if_no_scipy
     def test_interpolate_from_derivatives(self):
@@ -1155,7 +1154,7 @@ class TestSeriesInterpolateData:
             float
         )
         interp_s = ser.reindex(new_index).interpolate(method="from_derivatives")
-        assert_series_equal(interp_s[1:3], expected)
+        tm.assert_series_equal(interp_s[1:3], expected)
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -1168,10 +1167,10 @@ class TestSeriesInterpolateData:
     )
     def test_interpolate_corners(self, kwargs):
         s = Series([np.nan, np.nan])
-        assert_series_equal(s.interpolate(**kwargs), s)
+        tm.assert_series_equal(s.interpolate(**kwargs), s)
 
         s = Series([]).interpolate()
-        assert_series_equal(s.interpolate(**kwargs), s)
+        tm.assert_series_equal(s.interpolate(**kwargs), s)
 
     def test_interpolate_index_values(self):
         s = Series(np.nan, index=np.sort(np.random.rand(30)))
@@ -1188,13 +1187,13 @@ class TestSeriesInterpolateData:
             np.interp(vals[bad], vals[good], s.values[good]), index=s.index[bad]
         )
 
-        assert_series_equal(result[bad], expected)
+        tm.assert_series_equal(result[bad], expected)
 
         # 'values' is synonymous with 'index' for the method kwarg
         other_result = s.interpolate(method="values")
 
-        assert_series_equal(other_result, result)
-        assert_series_equal(other_result[bad], expected)
+        tm.assert_series_equal(other_result, result)
+        tm.assert_series_equal(other_result[bad], expected)
 
     def test_interpolate_non_ts(self):
         s = Series([1, 3, np.nan, np.nan, np.nan, 11])
@@ -1218,26 +1217,26 @@ class TestSeriesInterpolateData:
         s = Series([0, 1, np.nan, 3])
         result = s.interpolate(**kwargs)
         expected = Series([0.0, 1.0, 2.0, 3.0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_nan_irregular_index(self):
         s = Series([1, 2, np.nan, 4], index=[1, 3, 5, 9])
         result = s.interpolate()
         expected = Series([1.0, 2.0, 3.0, 4.0], index=[1, 3, 5, 9])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_nan_str_index(self):
         s = Series([0, 1, 2, np.nan], index=list("abcd"))
         result = s.interpolate()
         expected = Series([0.0, 1.0, 2.0, 2.0], index=list("abcd"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @td.skip_if_no_scipy
     def test_interp_quad(self):
         sq = Series([1, 4, np.nan, 16], index=[1, 2, 3, 4])
         result = sq.interpolate(method="quadratic")
         expected = Series([1.0, 4.0, 9.0, 16.0], index=[1, 2, 3, 4])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @td.skip_if_no_scipy
     def test_interp_scipy_basic(self):
@@ -1245,43 +1244,43 @@ class TestSeriesInterpolateData:
         # slinear
         expected = Series([1.0, 3.0, 7.5, 12.0, 18.5, 25.0])
         result = s.interpolate(method="slinear")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.interpolate(method="slinear", downcast="infer")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         # nearest
         expected = Series([1, 3, 3, 12, 12, 25])
         result = s.interpolate(method="nearest")
-        assert_series_equal(result, expected.astype("float"))
+        tm.assert_series_equal(result, expected.astype("float"))
 
         result = s.interpolate(method="nearest", downcast="infer")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         # zero
         expected = Series([1, 3, 3, 12, 12, 25])
         result = s.interpolate(method="zero")
-        assert_series_equal(result, expected.astype("float"))
+        tm.assert_series_equal(result, expected.astype("float"))
 
         result = s.interpolate(method="zero", downcast="infer")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         # quadratic
         # GH #15662.
         expected = Series([1, 3.0, 6.823529, 12.0, 18.058824, 25.0])
         result = s.interpolate(method="quadratic")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.interpolate(method="quadratic", downcast="infer")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         # cubic
         expected = Series([1.0, 3.0, 6.8, 12.0, 18.2, 25.0])
         result = s.interpolate(method="cubic")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_interp_limit(self):
         s = Series([1, 3, np.nan, np.nan, np.nan, 11])
 
         expected = Series([1.0, 3.0, 5.0, 7.0, np.nan, 11.0])
         result = s.interpolate(method="linear", limit=2)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("limit", [-1, 0])
     def test_interpolate_invalid_nonpositive_limit(self, nontemporal_method, limit):
@@ -1319,25 +1318,25 @@ class TestSeriesInterpolateData:
         expected = Series([1.0, 3.0, 5.0, 7.0, np.nan, 11.0])
 
         result = s.interpolate(method="linear", limit=2, limit_direction="forward")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.interpolate(method="linear", limit=2, limit_direction="FORWARD")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_interp_unlimited(self):
         # these test are for issue #16282 default Limit=None is unlimited
         s = Series([np.nan, 1.0, 3.0, np.nan, np.nan, np.nan, 11.0, np.nan])
         expected = Series([1.0, 1.0, 3.0, 5.0, 7.0, 9.0, 11.0, 11.0])
         result = s.interpolate(method="linear", limit_direction="both")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([np.nan, 1.0, 3.0, 5.0, 7.0, 9.0, 11.0, 11.0])
         result = s.interpolate(method="linear", limit_direction="forward")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([1.0, 1.0, 3.0, 5.0, 7.0, 9.0, 11.0, np.nan])
         result = s.interpolate(method="linear", limit_direction="backward")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_interp_limit_bad_direction(self):
         s = Series([1, 3, np.nan, np.nan, np.nan, 11])
@@ -1360,7 +1359,7 @@ class TestSeriesInterpolateData:
 
         expected = Series([np.nan, np.nan, 3.0, 4.0, 5.0, 6.0, 7.0, np.nan, np.nan])
         result = s.interpolate(method="linear", limit_area="inside")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series(
             [np.nan, np.nan, 3.0, 4.0, np.nan, np.nan, 7.0, np.nan, np.nan]
@@ -1371,11 +1370,11 @@ class TestSeriesInterpolateData:
         result = s.interpolate(
             method="linear", limit_area="inside", limit_direction="both", limit=1
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([np.nan, np.nan, 3.0, np.nan, np.nan, np.nan, 7.0, 7.0, 7.0])
         result = s.interpolate(method="linear", limit_area="outside")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series(
             [np.nan, np.nan, 3.0, np.nan, np.nan, np.nan, 7.0, 7.0, np.nan]
@@ -1386,7 +1385,7 @@ class TestSeriesInterpolateData:
         result = s.interpolate(
             method="linear", limit_area="outside", limit_direction="both", limit=1
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([3.0, 3.0, 3.0, np.nan, np.nan, np.nan, 7.0, np.nan, np.nan])
         result = s.interpolate(
@@ -1404,24 +1403,24 @@ class TestSeriesInterpolateData:
 
         expected = Series([1.0, 3.0, np.nan, 7.0, 9.0, 11.0])
         result = s.interpolate(method="linear", limit=2, limit_direction="backward")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([1.0, 3.0, 5.0, np.nan, 9.0, 11.0])
         result = s.interpolate(method="linear", limit=1, limit_direction="both")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # Check that this works on a longer series of nans.
         s = Series([1, 3, np.nan, np.nan, np.nan, 7, 9, np.nan, np.nan, 12, np.nan])
 
         expected = Series([1.0, 3.0, 4.0, 5.0, 6.0, 7.0, 9.0, 10.0, 11.0, 12.0, 12.0])
         result = s.interpolate(method="linear", limit=2, limit_direction="both")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series(
             [1.0, 3.0, 4.0, np.nan, 6.0, 7.0, 9.0, 10.0, 11.0, 12.0, 12.0]
         )
         result = s.interpolate(method="linear", limit=1, limit_direction="both")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_interp_limit_to_ends(self):
         # These test are for issue #10420 -- flow back to beginning.
@@ -1429,11 +1428,11 @@ class TestSeriesInterpolateData:
 
         expected = Series([5.0, 5.0, 5.0, 7.0, 9.0, np.nan])
         result = s.interpolate(method="linear", limit=2, limit_direction="backward")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([5.0, 5.0, 5.0, 7.0, 9.0, 9.0])
         result = s.interpolate(method="linear", limit=2, limit_direction="both")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_interp_limit_before_ends(self):
         # These test are for issue #11115 -- limit ends properly.
@@ -1441,25 +1440,25 @@ class TestSeriesInterpolateData:
 
         expected = Series([np.nan, np.nan, 5.0, 7.0, 7.0, np.nan])
         result = s.interpolate(method="linear", limit=1, limit_direction="forward")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([np.nan, 5.0, 5.0, 7.0, np.nan, np.nan])
         result = s.interpolate(method="linear", limit=1, limit_direction="backward")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([np.nan, 5.0, 5.0, 7.0, 7.0, np.nan])
         result = s.interpolate(method="linear", limit=1, limit_direction="both")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @td.skip_if_no_scipy
     def test_interp_all_good(self):
         s = Series([1, 2, 3])
         result = s.interpolate(method="polynomial", order=1)
-        assert_series_equal(result, s)
+        tm.assert_series_equal(result, s)
 
         # non-scipy
         result = s.interpolate()
-        assert_series_equal(result, s)
+        tm.assert_series_equal(result, s)
 
     @pytest.mark.parametrize(
         "check_scipy", [False, pytest.param(True, marks=td.skip_if_no_scipy)]
@@ -1471,7 +1470,7 @@ class TestSeriesInterpolateData:
         expected = s.copy()
         expected.loc[2] = 2
         result = s.interpolate()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         msg = "Only `method=linear` interpolation is supported on MultiIndexes"
         if check_scipy:
@@ -1496,7 +1495,7 @@ class TestSeriesInterpolateData:
             [1.0, 1.0, 3.0],
             index=date_range("1/1/2000", periods=3, tz=tz_naive_fixture),
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_interp_pad_datetime64tz_values(self):
         # GH#27628 missing.interpolate_2d should handle datetimetz values
@@ -1514,7 +1513,7 @@ class TestSeriesInterpolateData:
         s = pd.Series([1.0, 2.0, 3.0])
         result = s.interpolate(limit=1)
         expected = s
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @td.skip_if_no_scipy
     @pytest.mark.parametrize("method", ["polynomial", "spline"])
@@ -1538,18 +1537,18 @@ class TestSeriesInterpolateData:
         s = Series([1, 2, np.nan, 4, 5, np.nan, 7])
         result = s.interpolate(method="spline", order=1)
         expected = Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @td.skip_if_no_scipy
     def test_spline_extrapolate(self):
         s = Series([1, 2, 3, 4, np.nan, 6, np.nan])
         result3 = s.interpolate(method="spline", order=1, ext=3)
         expected3 = Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 6.0])
-        assert_series_equal(result3, expected3)
+        tm.assert_series_equal(result3, expected3)
 
         result1 = s.interpolate(method="spline", order=1, ext=0)
         expected1 = Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
-        assert_series_equal(result1, expected1)
+        tm.assert_series_equal(result1, expected1)
 
     @td.skip_if_no_scipy
     def test_spline_smooth(self):
@@ -1565,20 +1564,20 @@ class TestSeriesInterpolateData:
         s[np.random.randint(0, 9, 3)] = np.nan
         result1 = s.interpolate(method="spline", order=1)
         expected1 = s.interpolate(method="spline", order=1)
-        assert_series_equal(result1, expected1)
+        tm.assert_series_equal(result1, expected1)
 
     def test_interp_timedelta64(self):
         # GH 6424
         df = Series([1, np.nan, 3], index=pd.to_timedelta([1, 2, 3]))
         result = df.interpolate(method="time")
         expected = Series([1.0, 2.0, 3.0], index=pd.to_timedelta([1, 2, 3]))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # test for non uniform spacing
         df = Series([1, np.nan, 3], index=pd.to_timedelta([1, 2, 4]))
         result = df.interpolate(method="time")
         expected = Series([1.0, 1.666667, 3.0], index=pd.to_timedelta([1, 2, 4]))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_series_interpolate_method_values(self):
         # #1646
@@ -1587,7 +1586,7 @@ class TestSeriesInterpolateData:
 
         result = ts.interpolate(method="values")
         exp = ts.interpolate()
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
     def test_series_interpolate_intraday(self):
         # #1698
@@ -1629,7 +1628,7 @@ class TestSeriesInterpolateData:
         if method == "linear":
             result = df[0].interpolate(**kwargs)
             expected = pd.Series([0.0, 1.0, 2.0, 3.0], name=0, index=ind)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
         else:
             expected_error = (
                 "Index column must be numeric or datetime type when "
@@ -1657,7 +1656,7 @@ class TestSeriesInterpolateData:
         if method in {"linear", "pchip"}:
             result = df[0].interpolate(method=method, **kwargs)
             expected = pd.Series([0.0, 1.0, 2.0, 3.0], name=0, index=ind)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
         else:
             pytest.skip(
                 "This interpolation method is not supported for Timedelta Index yet."

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -9,12 +9,6 @@ from pandas import Categorical, DataFrame, Index, Series, bdate_range, date_rang
 from pandas.core import ops
 import pandas.core.nanops as nanops
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_index_equal,
-    assert_series_equal,
-)
 
 
 class TestSeriesLogicalOps:
@@ -31,7 +25,7 @@ class TestSeriesLogicalOps:
 
         expected = bool_op(filled < filled[9], filled > filled[3])
         expected[mask] = False
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_logical_operators_bool_dtype_with_empty(self):
         # GH#9016: support bitwise op for integer types
@@ -43,11 +37,11 @@ class TestSeriesLogicalOps:
 
         res = s_tft & s_empty
         expected = s_fff
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
         res = s_tft | s_empty
         expected = s_tft
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
     def test_logical_operators_int_dtype_with_int_dtype(self):
         # GH#9016: support bitwise op for integer types
@@ -61,20 +55,20 @@ class TestSeriesLogicalOps:
 
         res = s_0123 & s_3333
         expected = Series(range(4), dtype="int64")
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
         res = s_0123 | s_4444
         expected = Series(range(4, 8), dtype="int64")
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
         s_1111 = Series([1] * 4, dtype="int8")
         res = s_0123 & s_1111
         expected = Series([0, 1, 0, 1], dtype="int64")
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
         res = s_0123.astype(np.int16) | s_1111.astype(np.int32)
         expected = Series([1, 1, 3, 3], dtype="int32")
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
     def test_logical_operators_int_dtype_with_int_scalar(self):
         # GH#9016: support bitwise op for integer types
@@ -82,11 +76,11 @@ class TestSeriesLogicalOps:
 
         res = s_0123 & 0
         expected = Series([0] * 4)
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
         res = s_0123 & 1
         expected = Series([0, 1, 0, 1])
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
     def test_logical_operators_int_dtype_with_float(self):
         # GH#9016: support bitwise op for integer types
@@ -118,17 +112,17 @@ class TestSeriesLogicalOps:
         expected = Series([False] * 4)
 
         result = s_0123 & False
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s_0123 & [False]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s_0123 & (False,)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s_0123 ^ False
         expected = Series([False, True, True, True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_logical_operators_int_dtype_with_object(self):
         # GH#9016: support bitwise op for integer types
@@ -136,7 +130,7 @@ class TestSeriesLogicalOps:
 
         result = s_0123 & Series([False, np.NaN, False, False])
         expected = Series([False] * 4)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s_abNd = Series(["a", "b", np.NaN, "d"])
         with pytest.raises(TypeError, match="unsupported.* 'int' and 'str'"):
@@ -150,11 +144,11 @@ class TestSeriesLogicalOps:
 
         res = s_tft & 0
         expected = s_fff
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
         res = s_tft & 1
         expected = s_tft
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
     def test_logical_ops_bool_dtype_with_ndarray(self):
         # make sure we operate on ndarray the same as Series
@@ -207,21 +201,21 @@ class TestSeriesLogicalOps:
         # s_0123 will be all false now because of reindexing like s_tft
         expected = Series([False] * 7, index=[0, 1, 2, 3, "a", "b", "c"])
         result = s_tft & s_0123
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([False] * 7, index=[0, 1, 2, 3, "a", "b", "c"])
         result = s_0123 & s_tft
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s_a0b1c0 = Series([1], list("b"))
 
         res = s_tft & s_a0b1c0
         expected = s_tff.reindex(list("abc"))
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
         res = s_tft | s_a0b1c0
         expected = s_tft.reindex(list("abc"))
-        assert_series_equal(res, expected)
+        tm.assert_series_equal(res, expected)
 
     def test_scalar_na_logical_ops_corners(self):
         s = Series([2, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -235,7 +229,7 @@ class TestSeriesLogicalOps:
         expected = Series(True, index=s.index)
         expected[::2] = False
         result = s & list(s)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         d = DataFrame({"A": s})
         # TODO: Fix this exception - needs to be fixed! (see GH5035)
@@ -272,12 +266,12 @@ class TestSeriesLogicalOps:
         expected = Series([op(ser[n], idx1[n]) for n in range(len(ser))])
 
         result = op(ser, idx1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([op(ser[n], idx2[n]) for n in range(len(ser))], dtype=bool)
 
         result = op(ser, idx2)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_reversed_xor_with_index_returns_index(self):
         # GH#22092, GH#19792
@@ -287,11 +281,11 @@ class TestSeriesLogicalOps:
 
         expected = Index.symmetric_difference(idx1, ser)
         result = idx1 ^ ser
-        assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         expected = Index.symmetric_difference(idx2, ser)
         result = idx2 ^ ser
-        assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(
         "op",
@@ -322,11 +316,11 @@ class TestSeriesLogicalOps:
 
         expected = pd.Series(op(idx1.values, ser.values))
         result = op(ser, idx1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = pd.Series(op(idx2.values, ser.values))
         result = op(ser, idx2)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "op, expected",
@@ -353,15 +347,15 @@ class TestSeriesLogicalOps:
 
         expected = Series([False, True, False], list("abc"))
         result = a & b
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([True, True, False], list("abc"))
         result = a | b
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([True, False, False], list("abc"))
         result = a ^ b
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # rhs is bigger
         a = Series([True, False, True], list("bca"))
@@ -369,31 +363,31 @@ class TestSeriesLogicalOps:
 
         expected = Series([False, True, False, False], list("abcd"))
         result = a & b
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([True, True, False, False], list("abcd"))
         result = a | b
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # filling
 
         # vs empty
         result = a & Series([])
         expected = Series([False, False, False], list("bca"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = a | Series([])
         expected = Series([True, False, True], list("bca"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # vs non-matching
         result = a & Series([1], ["z"])
         expected = Series([False, False, False, False], list("abcz"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = a | Series([1], ["z"])
         expected = Series([True, True, False, False], list("abcz"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # identity
         # we would like s[s|e] == s to hold for any e, whether empty or not
@@ -404,11 +398,11 @@ class TestSeriesLogicalOps:
             Series(np.nan, a.index),
         ]:
             result = a[a | e]
-            assert_series_equal(result, a[a])
+            tm.assert_series_equal(result, a[a])
 
         for e in [Series(["z"])]:
             result = a[a | e]
-            assert_series_equal(result, a[a])
+            tm.assert_series_equal(result, a[a])
 
         # vs scalars
         index = list("bca")
@@ -417,7 +411,7 @@ class TestSeriesLogicalOps:
         for v in [True, 1, 2]:
             result = Series([True, False, True], index=index) | v
             expected = Series([True, True, True], index=index)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         for v in [np.nan, "foo"]:
             with pytest.raises(TypeError):
@@ -426,17 +420,17 @@ class TestSeriesLogicalOps:
         for v in [False, 0]:
             result = Series([True, False, True], index=index) | v
             expected = Series([True, False, True], index=index)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         for v in [True, 1]:
             result = Series([True, False, True], index=index) & v
             expected = Series([True, False, True], index=index)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         for v in [False, 0]:
             result = Series([True, False, True], index=index) & v
             expected = Series([False, False, False], index=index)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
         for v in [np.nan]:
             with pytest.raises(TypeError):
                 t & v
@@ -447,44 +441,44 @@ class TestSeriesLogicalOps:
         s2 = pd.Series([True, True, False], index=list("ABD"), name="x")
 
         exp = pd.Series([True, False, False, False], index=list("ABCD"), name="x")
-        assert_series_equal(s1 & s2, exp)
-        assert_series_equal(s2 & s1, exp)
+        tm.assert_series_equal(s1 & s2, exp)
+        tm.assert_series_equal(s2 & s1, exp)
 
         # True | np.nan => True
         exp_or1 = pd.Series([True, True, True, False], index=list("ABCD"), name="x")
-        assert_series_equal(s1 | s2, exp_or1)
+        tm.assert_series_equal(s1 | s2, exp_or1)
         # np.nan | True => np.nan, filled with False
         exp_or = pd.Series([True, True, False, False], index=list("ABCD"), name="x")
-        assert_series_equal(s2 | s1, exp_or)
+        tm.assert_series_equal(s2 | s1, exp_or)
 
         # DataFrame doesn't fill nan with False
-        assert_frame_equal(s1.to_frame() & s2.to_frame(), exp.to_frame())
-        assert_frame_equal(s2.to_frame() & s1.to_frame(), exp.to_frame())
+        tm.assert_frame_equal(s1.to_frame() & s2.to_frame(), exp.to_frame())
+        tm.assert_frame_equal(s2.to_frame() & s1.to_frame(), exp.to_frame())
 
         exp = pd.DataFrame({"x": [True, True, np.nan, np.nan]}, index=list("ABCD"))
-        assert_frame_equal(s1.to_frame() | s2.to_frame(), exp_or1.to_frame())
-        assert_frame_equal(s2.to_frame() | s1.to_frame(), exp_or.to_frame())
+        tm.assert_frame_equal(s1.to_frame() | s2.to_frame(), exp_or1.to_frame())
+        tm.assert_frame_equal(s2.to_frame() | s1.to_frame(), exp_or.to_frame())
 
         # different length
         s3 = pd.Series([True, False, True], index=list("ABC"), name="x")
         s4 = pd.Series([True, True, True, True], index=list("ABCD"), name="x")
 
         exp = pd.Series([True, False, True, False], index=list("ABCD"), name="x")
-        assert_series_equal(s3 & s4, exp)
-        assert_series_equal(s4 & s3, exp)
+        tm.assert_series_equal(s3 & s4, exp)
+        tm.assert_series_equal(s4 & s3, exp)
 
         # np.nan | True => np.nan, filled with False
         exp_or1 = pd.Series([True, True, True, False], index=list("ABCD"), name="x")
-        assert_series_equal(s3 | s4, exp_or1)
+        tm.assert_series_equal(s3 | s4, exp_or1)
         # True | np.nan => True
         exp_or = pd.Series([True, True, True, True], index=list("ABCD"), name="x")
-        assert_series_equal(s4 | s3, exp_or)
+        tm.assert_series_equal(s4 | s3, exp_or)
 
-        assert_frame_equal(s3.to_frame() & s4.to_frame(), exp.to_frame())
-        assert_frame_equal(s4.to_frame() & s3.to_frame(), exp.to_frame())
+        tm.assert_frame_equal(s3.to_frame() & s4.to_frame(), exp.to_frame())
+        tm.assert_frame_equal(s4.to_frame() & s3.to_frame(), exp.to_frame())
 
-        assert_frame_equal(s3.to_frame() | s4.to_frame(), exp_or1.to_frame())
-        assert_frame_equal(s4.to_frame() | s3.to_frame(), exp_or.to_frame())
+        tm.assert_frame_equal(s3.to_frame() | s4.to_frame(), exp_or1.to_frame())
+        tm.assert_frame_equal(s4.to_frame() | s3.to_frame(), exp_or.to_frame())
 
 
 class TestSeriesComparisons:
@@ -498,15 +492,15 @@ class TestSeriesComparisons:
             expected = (left > right).astype("O")
         expected[:3] = np.nan
 
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         s = Series(["a", "b", "c"])
         s2 = Series([False, True, False])
 
         # it works!
         exp = Series([False, False, False])
-        assert_series_equal(s == s2, exp)
-        assert_series_equal(s2 == s, exp)
+        tm.assert_series_equal(s == s2, exp)
+        tm.assert_series_equal(s2 == s, exp)
 
     def test_categorical_comparisons(self):
         # GH 8938
@@ -570,35 +564,35 @@ class TestSeriesComparisons:
 
         result = s == (1, 2)
         expected = Series([False, True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s != (1, 2)
         expected = Series([True, False])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s == (0, 0)
         expected = Series([False, False])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s != (0, 0)
         expected = Series([True, True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([(1, 1), (1, 1)])
 
         result = s == (1, 1)
         expected = Series([True, True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s != (1, 1)
         expected = Series([False, False])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([frozenset([1]), frozenset([1, 2])])
 
         result = s == frozenset([1])
         expected = Series([True, False])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_comparison_operators_with_nas(self):
         ser = Series(bdate_range("1/1/2000", periods=10), dtype=object)
@@ -619,13 +613,13 @@ class TestSeriesComparisons:
             else:
                 expected = expected.fillna(False).astype(bool)
 
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
             # FIXME: dont leave commented-out
             # fffffffuuuuuuuuuuuu
             # result = f(val, s)
             # expected = f(val, s.dropna()).reindex(s.index)
-            # assert_series_equal(result, expected)
+            # tm.assert_series_equal(result, expected)
 
     def test_unequal_categorical_comparison_raises_type_error(self):
         # unequal comparison should raise for unordered cats
@@ -695,7 +689,7 @@ class TestSeriesComparisons:
         s = Series(["IntervalA", "IntervalB", "IntervalC"])
         result = s == "IntervalA"
         expected = Series([True, False, False])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
 
 class TestSeriesFlexComparisonOps:
@@ -704,51 +698,51 @@ class TestSeriesFlexComparisonOps:
         right = Series([2, 2, 2], index=list("bcd"))
 
         exp = pd.Series([False, False, True, False], index=list("abcd"))
-        assert_series_equal(left.eq(right), exp)
+        tm.assert_series_equal(left.eq(right), exp)
 
         exp = pd.Series([True, True, False, True], index=list("abcd"))
-        assert_series_equal(left.ne(right), exp)
+        tm.assert_series_equal(left.ne(right), exp)
 
         exp = pd.Series([False, False, True, False], index=list("abcd"))
-        assert_series_equal(left.le(right), exp)
+        tm.assert_series_equal(left.le(right), exp)
 
         exp = pd.Series([False, False, False, False], index=list("abcd"))
-        assert_series_equal(left.lt(right), exp)
+        tm.assert_series_equal(left.lt(right), exp)
 
         exp = pd.Series([False, True, True, False], index=list("abcd"))
-        assert_series_equal(left.ge(right), exp)
+        tm.assert_series_equal(left.ge(right), exp)
 
         exp = pd.Series([False, True, False, False], index=list("abcd"))
-        assert_series_equal(left.gt(right), exp)
+        tm.assert_series_equal(left.gt(right), exp)
 
     def test_comparison_flex_alignment_fill(self):
         left = Series([1, 3, 2], index=list("abc"))
         right = Series([2, 2, 2], index=list("bcd"))
 
         exp = pd.Series([False, False, True, True], index=list("abcd"))
-        assert_series_equal(left.eq(right, fill_value=2), exp)
+        tm.assert_series_equal(left.eq(right, fill_value=2), exp)
 
         exp = pd.Series([True, True, False, False], index=list("abcd"))
-        assert_series_equal(left.ne(right, fill_value=2), exp)
+        tm.assert_series_equal(left.ne(right, fill_value=2), exp)
 
         exp = pd.Series([False, False, True, True], index=list("abcd"))
-        assert_series_equal(left.le(right, fill_value=0), exp)
+        tm.assert_series_equal(left.le(right, fill_value=0), exp)
 
         exp = pd.Series([False, False, False, True], index=list("abcd"))
-        assert_series_equal(left.lt(right, fill_value=0), exp)
+        tm.assert_series_equal(left.lt(right, fill_value=0), exp)
 
         exp = pd.Series([True, True, True, False], index=list("abcd"))
-        assert_series_equal(left.ge(right, fill_value=0), exp)
+        tm.assert_series_equal(left.ge(right, fill_value=0), exp)
 
         exp = pd.Series([True, True, False, False], index=list("abcd"))
-        assert_series_equal(left.gt(right, fill_value=0), exp)
+        tm.assert_series_equal(left.gt(right, fill_value=0), exp)
 
 
 class TestSeriesOperators:
     def test_operators_empty_int_corner(self):
         s1 = Series([], [], dtype=np.int32)
         s2 = Series({"x": 0.0})
-        assert_series_equal(s1 * s2, Series([np.nan], index=["x"]))
+        tm.assert_series_equal(s1 * s2, Series([np.nan], index=["x"]))
 
     def test_ops_datetimelike_align(self):
         # GH 7500
@@ -760,11 +754,11 @@ class TestSeriesOperators:
         expected = Series([timedelta(0), timedelta(0), pd.NaT])
         # name is reset
         result = dt2 - dt
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = Series(expected, name=0)
         result = (dt2.to_frame() - dt.to_frame())[0]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_operators_corner(self, datetime_series):
         empty = Series([], index=Index([]))
@@ -830,14 +824,14 @@ class TestSeriesOperators:
 
             result = meth(a, b, fill_value=fill_value)
             expected = Series(exp_values, exp_index)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         a = Series([np.nan, 1.0, 2.0, 3.0, np.nan], index=np.arange(5))
         b = Series([np.nan, 1, np.nan, 3, np.nan, 4.0], index=np.arange(6))
 
         result = op(a, b)
         exp = equiv_op(a, b)
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
         _check_fill(op, equiv_op, a, b, fill_value=fv)
         # should accept axis=0 or axis='rows'
         op(a, b, axis=0)
@@ -861,7 +855,7 @@ class TestSeriesOperators:
         s2 = Series([10, 10], index=[1, 2])
         result = s1 + s2
         expected = pd.Series([11, 12, np.nan], index=[1, 1, 2])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_divmod(self):
         # GH25557
@@ -870,13 +864,13 @@ class TestSeriesOperators:
 
         result = a.divmod(b)
         expected = divmod(a, b)
-        assert_series_equal(result[0], expected[0])
-        assert_series_equal(result[1], expected[1])
+        tm.assert_series_equal(result[0], expected[0])
+        tm.assert_series_equal(result[1], expected[1])
 
         result = a.rdivmod(b)
         expected = divmod(b, a)
-        assert_series_equal(result[0], expected[0])
-        assert_series_equal(result[1], expected[1])
+        tm.assert_series_equal(result[0], expected[0])
+        tm.assert_series_equal(result[1], expected[1])
 
     @pytest.mark.parametrize("index", [None, range(9)])
     def test_series_integer_mod(self, index):
@@ -896,9 +890,9 @@ class TestSeriesUnaryOps:
     def test_neg(self):
         ser = tm.makeStringSeries()
         ser.name = "series"
-        assert_series_equal(-ser, -1 * ser)
+        tm.assert_series_equal(-ser, -1 * ser)
 
     def test_invert(self):
         ser = tm.makeStringSeries()
         ser.name = "series"
-        assert_series_equal(-(ser < 0), ~(ser < 0))
+        tm.assert_series_equal(-(ser < 0), ~(ser < 0))

--- a/pandas/tests/series/test_rank.py
+++ b/pandas/tests/series/test_rank.py
@@ -10,7 +10,6 @@ import pandas.util._test_decorators as td
 from pandas import NaT, Series, Timestamp, date_range
 from pandas.api.types import CategoricalDtype
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 
 class TestSeriesRank:
@@ -34,7 +33,7 @@ class TestSeriesRank:
         ranks = datetime_series.rank()
         oranks = datetime_series.astype("O").rank()
 
-        assert_series_equal(ranks, oranks)
+        tm.assert_series_equal(ranks, oranks)
 
         mask = np.isnan(datetime_series)
         filled = datetime_series.fillna(np.inf)
@@ -49,58 +48,58 @@ class TestSeriesRank:
 
         iranks = iseries.rank()
         exp = iseries.astype(float).rank()
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
         iseries = Series(np.arange(5)) + 1.0
         exp = iseries / 5.0
         iranks = iseries.rank(pct=True)
 
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         iseries = Series(np.repeat(1, 100))
         exp = Series(np.repeat(0.505, 100))
         iranks = iseries.rank(pct=True)
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         iseries[1] = np.nan
         exp = Series(np.repeat(50.0 / 99.0, 100))
         exp[1] = np.nan
         iranks = iseries.rank(pct=True)
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         iseries = Series(np.arange(5)) + 1.0
         iseries[4] = np.nan
         exp = iseries / 4.0
         iranks = iseries.rank(pct=True)
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         iseries = Series(np.repeat(np.nan, 100))
         exp = iseries.copy()
         iranks = iseries.rank(pct=True)
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         iseries = Series(np.arange(5)) + 1
         iseries[4] = np.nan
         exp = iseries / 4.0
         iranks = iseries.rank(pct=True)
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         rng = date_range("1/1/1990", periods=5)
         iseries = Series(np.arange(5), rng) + 1
         iseries.iloc[4] = np.nan
         exp = iseries / 4.0
         iranks = iseries.rank(pct=True)
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         iseries = Series([1e-50, 1e-100, 1e-20, 1e-2, 1e-20 + 1e-30, 1e-1])
         exp = Series([2, 1, 3, 5, 4, 6.0])
         iranks = iseries.rank()
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         # GH 5968
         iseries = Series(["3 day", "1 day 10m", "-2 day", NaT], dtype="m8[ns]")
         exp = Series([3, 2, 1, np.nan])
         iranks = iseries.rank()
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
         values = np.array(
             [-50, -1, -1e-20, -1e-25, -1e-50, 0, 1e-40, 1e-20, 1e-10, 2, 40],
@@ -110,7 +109,7 @@ class TestSeriesRank:
         iseries = Series(values[random_order])
         exp = Series(random_order + 1.0, dtype="float64")
         iranks = iseries.rank()
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
     def test_rank_categorical(self):
         # GH issue #15420 rank incorrectly orders ordered categories
@@ -126,8 +125,8 @@ class TestSeriesRank:
                 ordered=True,
             )
         )
-        assert_series_equal(ordered.rank(), exp)
-        assert_series_equal(ordered.rank(ascending=False), exp_desc)
+        tm.assert_series_equal(ordered.rank(), exp)
+        tm.assert_series_equal(ordered.rank(ascending=False), exp_desc)
 
         # Unordered categoricals should be ranked as objects
         unordered = Series(
@@ -140,14 +139,14 @@ class TestSeriesRank:
         )
         exp_unordered = Series([2.0, 4.0, 6.0, 3.0, 1.0, 5.0])
         res = unordered.rank()
-        assert_series_equal(res, exp_unordered)
+        tm.assert_series_equal(res, exp_unordered)
 
         unordered1 = Series([1, 2, 3, 4, 5, 6]).astype(
             CategoricalDtype([1, 2, 3, 4, 5, 6], False)
         )
         exp_unordered1 = Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
         res1 = unordered1.rank()
-        assert_series_equal(res1, exp_unordered1)
+        tm.assert_series_equal(res1, exp_unordered1)
 
         # Test na_option for rank data
         na_ser = Series(
@@ -163,18 +162,20 @@ class TestSeriesRank:
         exp_bot = Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
         exp_keep = Series([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, np.NaN])
 
-        assert_series_equal(na_ser.rank(na_option="top"), exp_top)
-        assert_series_equal(na_ser.rank(na_option="bottom"), exp_bot)
-        assert_series_equal(na_ser.rank(na_option="keep"), exp_keep)
+        tm.assert_series_equal(na_ser.rank(na_option="top"), exp_top)
+        tm.assert_series_equal(na_ser.rank(na_option="bottom"), exp_bot)
+        tm.assert_series_equal(na_ser.rank(na_option="keep"), exp_keep)
 
         # Test na_option for rank data with ascending False
         exp_top = Series([7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0])
         exp_bot = Series([6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 7.0])
         exp_keep = Series([6.0, 5.0, 4.0, 3.0, 2.0, 1.0, np.NaN])
 
-        assert_series_equal(na_ser.rank(na_option="top", ascending=False), exp_top)
-        assert_series_equal(na_ser.rank(na_option="bottom", ascending=False), exp_bot)
-        assert_series_equal(na_ser.rank(na_option="keep", ascending=False), exp_keep)
+        tm.assert_series_equal(na_ser.rank(na_option="top", ascending=False), exp_top)
+        tm.assert_series_equal(
+            na_ser.rank(na_option="bottom", ascending=False), exp_bot
+        )
+        tm.assert_series_equal(na_ser.rank(na_option="keep", ascending=False), exp_keep)
 
         # Test invalid values for na_option
         msg = "na_option must be one of 'keep', 'top', or 'bottom'"
@@ -194,9 +195,9 @@ class TestSeriesRank:
         exp_bot = Series([0.2, 0.4, 0.6, 0.8, 1.0])
         exp_keep = Series([0.25, 0.5, 0.75, 1.0, np.NaN])
 
-        assert_series_equal(na_ser.rank(na_option="top", pct=True), exp_top)
-        assert_series_equal(na_ser.rank(na_option="bottom", pct=True), exp_bot)
-        assert_series_equal(na_ser.rank(na_option="keep", pct=True), exp_keep)
+        tm.assert_series_equal(na_ser.rank(na_option="top", pct=True), exp_top)
+        tm.assert_series_equal(na_ser.rank(na_option="bottom", pct=True), exp_bot)
+        tm.assert_series_equal(na_ser.rank(na_option="keep", pct=True), exp_keep)
 
     def test_rank_signature(self):
         s = Series([0, 1])
@@ -291,7 +292,7 @@ class TestSeriesRank:
         iseries = Series(values[random_order])
         exp = Series(exp_order[random_order], dtype="float64")
         iranks = iseries.rank()
-        assert_series_equal(iranks, exp)
+        tm.assert_series_equal(iranks, exp)
 
     def test_rank_tie_methods(self):
         s = self.s
@@ -394,7 +395,7 @@ class TestSeriesRank:
                 s = Series(ser).astype(dtype)
                 result = s.rank(method="dense")
                 expected = Series(exp).astype(result.dtype)
-                assert_series_equal(result, expected)
+                tm.assert_series_equal(result, expected)
 
     def test_rank_descending(self):
         dtypes = ["O", "f8", "i8"]
@@ -407,14 +408,14 @@ class TestSeriesRank:
 
             res = s.rank(ascending=False)
             expected = (s.max() - s).rank()
-            assert_series_equal(res, expected)
+            tm.assert_series_equal(res, expected)
 
             if method == "first" and dtype == "O":
                 continue
 
             expected = (s.max() - s).rank(method=method)
             res2 = s.rank(method=method, ascending=False)
-            assert_series_equal(res2, expected)
+            tm.assert_series_equal(res2, expected)
 
     def test_rank_int(self):
         s = self.s.dropna().astype("i8")
@@ -423,7 +424,7 @@ class TestSeriesRank:
             result = s.rank(method=method)
             expected = Series(res).dropna()
             expected.index = result.index
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
     def test_rank_object_bug(self):
         # GH 13445
@@ -440,7 +441,7 @@ class TestSeriesRank:
 
         s.rank()
         result = s
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
 
 # GH15630, pct should be on 100% basis when method='dense'
@@ -465,7 +466,7 @@ def test_rank_dense_pct(dtype, ser, exp):
     s = Series(ser).astype(dtype)
     result = s.rank(method="dense", pct=True)
     expected = Series(exp).astype(result.dtype)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
@@ -487,7 +488,7 @@ def test_rank_min_pct(dtype, ser, exp):
     s = Series(ser).astype(dtype)
     result = s.rank(method="min", pct=True)
     expected = Series(exp).astype(result.dtype)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
@@ -509,7 +510,7 @@ def test_rank_max_pct(dtype, ser, exp):
     s = Series(ser).astype(dtype)
     result = s.rank(method="max", pct=True)
     expected = Series(exp).astype(result.dtype)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype", ["O", "f8", "i8"])
@@ -531,7 +532,7 @@ def test_rank_average_pct(dtype, ser, exp):
     s = Series(ser).astype(dtype)
     result = s.rank(method="average", pct=True)
     expected = Series(exp).astype(result.dtype)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype", ["f8", "i8"])
@@ -553,7 +554,7 @@ def test_rank_first_pct(dtype, ser, exp):
     s = Series(ser).astype(dtype)
     result = s.rank(method="first", pct=True)
     expected = Series(exp).astype(result.dtype)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.single

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -5,7 +5,6 @@ import pytest
 
 from pandas import Categorical, DataFrame, IntervalIndex, MultiIndex, Series
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal, assert_series_equal
 
 
 class TestSeriesSorting:
@@ -38,17 +37,17 @@ class TestSeriesSorting:
         # ascending=False
         ordered = ts.sort_values(ascending=False)
         expected = np.sort(ts.dropna().values)[::-1]
-        assert_almost_equal(expected, ordered.dropna().values)
+        tm.assert_almost_equal(expected, ordered.dropna().values)
         ordered = ts.sort_values(ascending=False, na_position="first")
-        assert_almost_equal(expected, ordered.dropna().values)
+        tm.assert_almost_equal(expected, ordered.dropna().values)
 
         # ascending=[False] should behave the same as ascending=False
         ordered = ts.sort_values(ascending=[False])
         expected = ts.sort_values(ascending=False)
-        assert_series_equal(expected, ordered)
+        tm.assert_series_equal(expected, ordered)
         ordered = ts.sort_values(ascending=[False], na_position="first")
         expected = ts.sort_values(ascending=False, na_position="first")
-        assert_series_equal(expected, ordered)
+        tm.assert_series_equal(expected, ordered)
 
         msg = "ascending must be boolean"
         with pytest.raises(ValueError, match=msg):
@@ -92,28 +91,28 @@ class TestSeriesSorting:
 
         random_order = datetime_series.reindex(rindex)
         sorted_series = random_order.sort_index()
-        assert_series_equal(sorted_series, datetime_series)
+        tm.assert_series_equal(sorted_series, datetime_series)
 
         # descending
         sorted_series = random_order.sort_index(ascending=False)
-        assert_series_equal(
+        tm.assert_series_equal(
             sorted_series, datetime_series.reindex(datetime_series.index[::-1])
         )
 
         # compat on level
         sorted_series = random_order.sort_index(level=0)
-        assert_series_equal(sorted_series, datetime_series)
+        tm.assert_series_equal(sorted_series, datetime_series)
 
         # compat on axis
         sorted_series = random_order.sort_index(axis=0)
-        assert_series_equal(sorted_series, datetime_series)
+        tm.assert_series_equal(sorted_series, datetime_series)
 
         msg = "No axis named 1 for object type <class 'pandas.core.series.Series'>"
         with pytest.raises(ValueError, match=msg):
             random_order.sort_values(axis=1)
 
         sorted_series = random_order.sort_index(level=0, axis=0)
-        assert_series_equal(sorted_series, datetime_series)
+        tm.assert_series_equal(sorted_series, datetime_series)
 
         with pytest.raises(ValueError, match=msg):
             random_order.sort_index(level=0, axis=1)
@@ -149,12 +148,12 @@ class TestSeriesSorting:
 
         # implicit sort_remaining=True
         res = s.sort_index(level=level)
-        assert_series_equal(backwards, res)
+        tm.assert_series_equal(backwards, res)
 
         # GH13496
         # sort has no effect without remaining lvls
         res = s.sort_index(level=level, sort_remaining=False)
-        assert_series_equal(s, res)
+        tm.assert_series_equal(s, res)
 
     def test_sort_index_kind(self):
         # GH #14444 & #13589:  Add support for sort algo choosing
@@ -162,24 +161,24 @@ class TestSeriesSorting:
         expected_series = Series(index=[1, 2, 3, 3, 4])
 
         index_sorted_series = series.sort_index(kind="mergesort")
-        assert_series_equal(expected_series, index_sorted_series)
+        tm.assert_series_equal(expected_series, index_sorted_series)
 
         index_sorted_series = series.sort_index(kind="quicksort")
-        assert_series_equal(expected_series, index_sorted_series)
+        tm.assert_series_equal(expected_series, index_sorted_series)
 
         index_sorted_series = series.sort_index(kind="heapsort")
-        assert_series_equal(expected_series, index_sorted_series)
+        tm.assert_series_equal(expected_series, index_sorted_series)
 
     def test_sort_index_na_position(self):
         series = Series(index=[3, 2, 1, 4, 3, np.nan])
 
         expected_series_first = Series(index=[np.nan, 1, 2, 3, 3, 4])
         index_sorted_series = series.sort_index(na_position="first")
-        assert_series_equal(expected_series_first, index_sorted_series)
+        tm.assert_series_equal(expected_series_first, index_sorted_series)
 
         expected_series_last = Series(index=[1, 2, 3, 3, 4, np.nan])
         index_sorted_series = series.sort_index(na_position="last")
-        assert_series_equal(expected_series_last, index_sorted_series)
+        tm.assert_series_equal(expected_series_last, index_sorted_series)
 
     def test_sort_index_intervals(self):
         s = Series(
@@ -188,13 +187,13 @@ class TestSeriesSorting:
 
         result = s.sort_index()
         expected = s
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.sort_index(ascending=False)
         expected = Series(
             [3, 2, 1, np.nan], IntervalIndex.from_arrays([3, 2, 1, 0], [4, 3, 2, 1])
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_sort_values_categorical(self):
 

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -26,11 +26,6 @@ from pandas import (
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-)
 
 from pandas.tseries.offsets import BDay, BMonthEnd
 
@@ -61,19 +56,19 @@ class TestTimeSeries:
         shifted = datetime_series.shift(1, freq=offset)
         unshifted = shifted.shift(-1, freq=offset)
 
-        assert_series_equal(unshifted, datetime_series)
+        tm.assert_series_equal(unshifted, datetime_series)
 
         unshifted = datetime_series.shift(0, freq=offset)
-        assert_series_equal(unshifted, datetime_series)
+        tm.assert_series_equal(unshifted, datetime_series)
 
         shifted = datetime_series.shift(1, freq="B")
         unshifted = shifted.shift(-1, freq="B")
 
-        assert_series_equal(unshifted, datetime_series)
+        tm.assert_series_equal(unshifted, datetime_series)
 
         # corner case
         unshifted = datetime_series.shift(0)
-        assert_series_equal(unshifted, datetime_series)
+        tm.assert_series_equal(unshifted, datetime_series)
 
         # Shifting with PeriodIndex
         ps = tm.makePeriodSeries()
@@ -85,8 +80,8 @@ class TestTimeSeries:
 
         shifted2 = ps.shift(1, "B")
         shifted3 = ps.shift(1, BDay())
-        assert_series_equal(shifted2, shifted3)
-        assert_series_equal(ps, shifted2.shift(-1, "B"))
+        tm.assert_series_equal(shifted2, shifted3)
+        tm.assert_series_equal(ps, shifted2.shift(-1, "B"))
 
         msg = "Given freq D does not match PeriodIndex freq B"
         with pytest.raises(ValueError, match=msg):
@@ -94,10 +89,10 @@ class TestTimeSeries:
 
         # legacy support
         shifted4 = ps.shift(1, freq="B")
-        assert_series_equal(shifted2, shifted4)
+        tm.assert_series_equal(shifted2, shifted4)
 
         shifted5 = ps.shift(1, freq=BDay())
-        assert_series_equal(shifted5, shifted4)
+        tm.assert_series_equal(shifted5, shifted4)
 
         # 32-bit taking
         # GH 8129
@@ -107,7 +102,7 @@ class TestTimeSeries:
             p = s1.iloc[1]
             result = s1.shift(periods=p)
             expected = Series([np.nan, 0, 1, 2, 3], index=index)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         # xref 8260
         # with tz
@@ -117,7 +112,7 @@ class TestTimeSeries:
         result = s - s.shift()
 
         exp = Series(TimedeltaIndex(["NaT"] + ["1 days"] * 4), name="foo")
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         # incompat tz
         s2 = Series(date_range("2000-01-01 09:00:00", periods=5, tz="CET"), name="foo")
@@ -215,13 +210,13 @@ class TestTimeSeries:
         shifted = ps.tshift(1)
         unshifted = shifted.tshift(-1)
 
-        assert_series_equal(unshifted, ps)
+        tm.assert_series_equal(unshifted, ps)
 
         shifted2 = ps.tshift(freq="B")
-        assert_series_equal(shifted, shifted2)
+        tm.assert_series_equal(shifted, shifted2)
 
         shifted3 = ps.tshift(freq=BDay())
-        assert_series_equal(shifted, shifted3)
+        tm.assert_series_equal(shifted, shifted3)
 
         msg = "Given freq M does not match PeriodIndex freq B"
         with pytest.raises(ValueError, match=msg):
@@ -231,18 +226,18 @@ class TestTimeSeries:
         shifted = datetime_series.tshift(1)
         unshifted = shifted.tshift(-1)
 
-        assert_series_equal(datetime_series, unshifted)
+        tm.assert_series_equal(datetime_series, unshifted)
 
         shifted2 = datetime_series.tshift(freq=datetime_series.index.freq)
-        assert_series_equal(shifted, shifted2)
+        tm.assert_series_equal(shifted, shifted2)
 
         inferred_ts = Series(
             datetime_series.values, Index(np.asarray(datetime_series.index)), name="ts"
         )
         shifted = inferred_ts.tshift(1)
         unshifted = shifted.tshift(-1)
-        assert_series_equal(shifted, datetime_series.tshift(1))
-        assert_series_equal(unshifted, inferred_ts)
+        tm.assert_series_equal(shifted, datetime_series.tshift(1))
+        tm.assert_series_equal(unshifted, inferred_ts)
 
         no_freq = datetime_series[[0, 5, 7]]
         msg = "Freq was not given and was not set in the index"
@@ -259,34 +254,34 @@ class TestTimeSeries:
 
         # neither specified
         truncated = ts.truncate()
-        assert_series_equal(truncated, ts)
+        tm.assert_series_equal(truncated, ts)
 
         # both specified
         expected = ts[1:3]
 
         truncated = ts.truncate(start, end)
-        assert_series_equal(truncated, expected)
+        tm.assert_series_equal(truncated, expected)
 
         truncated = ts.truncate(start_missing, end_missing)
-        assert_series_equal(truncated, expected)
+        tm.assert_series_equal(truncated, expected)
 
         # start specified
         expected = ts[1:]
 
         truncated = ts.truncate(before=start)
-        assert_series_equal(truncated, expected)
+        tm.assert_series_equal(truncated, expected)
 
         truncated = ts.truncate(before=start_missing)
-        assert_series_equal(truncated, expected)
+        tm.assert_series_equal(truncated, expected)
 
         # end specified
         expected = ts[:3]
 
         truncated = ts.truncate(after=end)
-        assert_series_equal(truncated, expected)
+        tm.assert_series_equal(truncated, expected)
 
         truncated = ts.truncate(after=end_missing)
-        assert_series_equal(truncated, expected)
+        tm.assert_series_equal(truncated, expected)
 
         # corner case, empty series returned
         truncated = ts.truncate(after=datetime_series.index[0] - offset)
@@ -359,19 +354,19 @@ class TestTimeSeries:
 
     def test_pct_change(self, datetime_series):
         rs = datetime_series.pct_change(fill_method=None)
-        assert_series_equal(rs, datetime_series / datetime_series.shift(1) - 1)
+        tm.assert_series_equal(rs, datetime_series / datetime_series.shift(1) - 1)
 
         rs = datetime_series.pct_change(2)
         filled = datetime_series.fillna(method="pad")
-        assert_series_equal(rs, filled / filled.shift(2) - 1)
+        tm.assert_series_equal(rs, filled / filled.shift(2) - 1)
 
         rs = datetime_series.pct_change(fill_method="bfill", limit=1)
         filled = datetime_series.fillna(method="bfill", limit=1)
-        assert_series_equal(rs, filled / filled.shift(1) - 1)
+        tm.assert_series_equal(rs, filled / filled.shift(1) - 1)
 
         rs = datetime_series.pct_change(freq="5D")
         filled = datetime_series.fillna(method="pad")
-        assert_series_equal(
+        tm.assert_series_equal(
             rs, (filled / filled.shift(freq="5D") - 1).reindex_like(filled)
         )
 
@@ -380,7 +375,7 @@ class TestTimeSeries:
 
         chg = s.pct_change()
         expected = Series([np.nan, 0.5, 0.0, 2.5 / 1.5 - 1, 0.2])
-        assert_series_equal(chg, expected)
+        tm.assert_series_equal(chg, expected)
 
     @pytest.mark.parametrize(
         "freq, periods, fill_method, limit",
@@ -403,12 +398,12 @@ class TestTimeSeries:
         rs_periods = datetime_series.pct_change(
             periods, fill_method=fill_method, limit=limit
         )
-        assert_series_equal(rs_freq, rs_periods)
+        tm.assert_series_equal(rs_freq, rs_periods)
 
         empty_ts = Series(index=datetime_series.index)
         rs_freq = empty_ts.pct_change(freq=freq, fill_method=fill_method, limit=limit)
         rs_periods = empty_ts.pct_change(periods, fill_method=fill_method, limit=limit)
-        assert_series_equal(rs_freq, rs_periods)
+        tm.assert_series_equal(rs_freq, rs_periods)
 
     def test_autocorr(self, datetime_series):
         # Just run the function
@@ -473,7 +468,7 @@ class TestTimeSeries:
     def test_mpl_compat_hack(self, datetime_series):
         result = datetime_series[:, np.newaxis]
         expected = datetime_series.values[:, np.newaxis]
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
     def test_timeseries_coercion(self):
         idx = tm.makeDateIndex(10000)
@@ -504,14 +499,14 @@ class TestTimeSeries:
         expected = Series(
             [Timestamp("2013-06-09 02:42:28") + timedelta(seconds=t) for t in range(20)]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([epoch + t for t in range(20)]).astype(float)
         result = to_datetime(s, unit="s")
         expected = Series(
             [Timestamp("2013-06-09 02:42:28") + timedelta(seconds=t) for t in range(20)]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([epoch + t for t in range(20)] + [iNaT])
         result = to_datetime(s, unit="s")
@@ -519,7 +514,7 @@ class TestTimeSeries:
             [Timestamp("2013-06-09 02:42:28") + timedelta(seconds=t) for t in range(20)]
             + [NaT]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([epoch + t for t in range(20)] + [iNaT]).astype(float)
         result = to_datetime(s, unit="s")
@@ -527,7 +522,7 @@ class TestTimeSeries:
             [Timestamp("2013-06-09 02:42:28") + timedelta(seconds=t) for t in range(20)]
             + [NaT]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH13834
         s = Series([epoch + t for t in np.arange(0, 2, 0.25)] + [iNaT]).astype(float)
@@ -539,7 +534,7 @@ class TestTimeSeries:
             ]
             + [NaT]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = concat(
             [Series([epoch + t for t in range(20)]).astype(float), Series([np.nan])],
@@ -550,7 +545,7 @@ class TestTimeSeries:
             [Timestamp("2013-06-09 02:42:28") + timedelta(seconds=t) for t in range(20)]
             + [NaT]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = to_datetime([1, 2, "NaT", pd.NaT, np.nan], unit="D")
         expected = DatetimeIndex(
@@ -615,13 +610,13 @@ class TestTimeSeries:
         result = ts + ts2
         result2 = ts2 + ts
         expected = ts + ts[5:]
-        assert_series_equal(result, expected)
-        assert_series_equal(result2, expected)
+        tm.assert_series_equal(result, expected)
+        tm.assert_series_equal(result2, expected)
 
         # test asfreq
         result = ts2.asfreq("4H", method="ffill")
         expected = ts[5:].asfreq("4H", method="ffill")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = rng.get_indexer(ts2.index)
         expected = rng.get_indexer(ts_slice.index)
@@ -637,7 +632,7 @@ class TestTimeSeries:
         norm = date_range("1/1/2000", periods=20)
         expected = Series(vals, index=norm)
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         vals = np.random.randn(20, 3)
         ts = DataFrame(vals, index=rng)
@@ -645,7 +640,7 @@ class TestTimeSeries:
         result = ts.asfreq("D", normalize=True)
         expected = DataFrame(vals, index=norm)
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_first_subset(self):
         ts = _simple_ts("1/1/2000", "1/1/2010", freq="12h")
@@ -658,14 +653,14 @@ class TestTimeSeries:
 
         result = ts.first("3M")
         expected = ts[:"3/31/2000"]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = ts.first("21D")
         expected = ts[:21]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = ts[:0].first("3M")
-        assert_series_equal(result, ts[:0])
+        tm.assert_series_equal(result, ts[:0])
 
     def test_first_raises(self):
         # GH20725
@@ -685,14 +680,14 @@ class TestTimeSeries:
 
         result = ts.last("21D")
         expected = ts["12/12/2009":]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = ts.last("21D")
         expected = ts[-21:]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = ts[:0].last("3M")
-        assert_series_equal(result, ts[:0])
+        tm.assert_series_equal(result, ts[:0])
 
     def test_last_raises(self):
         # GH20725
@@ -717,7 +712,7 @@ class TestTimeSeries:
 
         result = ts.at_time("9:30")
         expected = ts.at_time(time(9, 30))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame(np.random.randn(len(rng), 3), index=rng)
 
@@ -728,7 +723,7 @@ class TestTimeSeries:
 
         # expected.index = date_range('1/1/2000', '1/4/2000')
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         tm.assert_frame_equal(result_df, exp_df)
 
         chunk = df.loc["1/4/2000":]
@@ -741,7 +736,7 @@ class TestTimeSeries:
         ts = Series(np.random.randn(len(rng)), index=rng)
 
         result = ts.at_time(time(0, 0))
-        assert_series_equal(result, ts)
+        tm.assert_series_equal(result, ts)
 
         # time doesn't exist
         rng = date_range("1/1/2012", freq="23Min", periods=384)
@@ -762,7 +757,7 @@ class TestTimeSeries:
 
         result = series.between(left, right)
         expected = (series >= left) & (series <= right)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_between_time(self):
         rng = date_range("1/1/2000", "1/5/2000", freq="5min")
@@ -794,7 +789,7 @@ class TestTimeSeries:
 
         result = ts.between_time("00:00", "01:00")
         expected = ts.between_time(stime, etime)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # across midnight
         rng = date_range("1/1/2000", "1/5/2000", freq="5min")
@@ -891,12 +886,12 @@ class TestTimeSeries:
         pts = ts.to_period()
         exp = ts.copy()
         exp.index = period_range("1/1/2000", "1/1/2001")
-        assert_series_equal(pts, exp)
+        tm.assert_series_equal(pts, exp)
 
         pts = ts.to_period("M")
         exp.index = exp.index.asfreq("M")
         tm.assert_index_equal(pts.index, exp.index.asfreq("M"))
-        assert_series_equal(pts, exp)
+        tm.assert_series_equal(pts, exp)
 
         # GH 7606 without freq
         idx = DatetimeIndex(["2011-01-01", "2011-01-02", "2011-01-03", "2011-01-04"])
@@ -907,16 +902,16 @@ class TestTimeSeries:
         s = Series(np.random.randn(4), index=idx)
         expected = s.copy()
         expected.index = exp_idx
-        assert_series_equal(s.to_period(), expected)
+        tm.assert_series_equal(s.to_period(), expected)
 
         df = DataFrame(np.random.randn(4, 4), index=idx, columns=idx)
         expected = df.copy()
         expected.index = exp_idx
-        assert_frame_equal(df.to_period(), expected)
+        tm.assert_frame_equal(df.to_period(), expected)
 
         expected = df.copy()
         expected.columns = exp_idx
-        assert_frame_equal(df.to_period(axis=1), expected)
+        tm.assert_frame_equal(df.to_period(axis=1), expected)
 
     def test_groupby_count_dateparseerror(self):
         dr = date_range(start="1/1/2012", freq="5min", periods=10)
@@ -930,7 +925,7 @@ class TestTimeSeries:
         grouped = s.groupby(lambda x: x[0] % 2 == 0)
         expected = grouped.count()
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_to_csv_numpy_16_bug(self):
         frame = DataFrame({"a": date_range("1/1/2000", periods=10)})


### PR DESCRIPTION
Part of #29272

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

