### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/series/indexing

### DIFF
--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -6,7 +6,6 @@ import pytest
 import pandas as pd
 from pandas import Categorical, Series, date_range, isna
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 
 @pytest.mark.parametrize(
@@ -41,8 +40,8 @@ def test_align(datetime_series, first_slice, second_slice, join_type, fill):
         ea = ea.fillna(fill)
         eb = eb.fillna(fill)
 
-    assert_series_equal(aa, ea)
-    assert_series_equal(ab, eb)
+    tm.assert_series_equal(aa, ea)
+    tm.assert_series_equal(ab, eb)
     assert aa.name == "ts"
     assert ea.name == "ts"
     assert ab.name == "ts"
@@ -75,8 +74,8 @@ def test_align_fill_method(
     ea = ea.fillna(method=method, limit=limit)
     eb = eb.fillna(method=method, limit=limit)
 
-    assert_series_equal(aa, ea)
-    assert_series_equal(ab, eb)
+    tm.assert_series_equal(aa, ea)
+    tm.assert_series_equal(ab, eb)
 
 
 def test_align_nocopy(datetime_series):
@@ -197,12 +196,12 @@ def test_reindex_nan():
     ts = Series([2, 3, 5, 7], index=[1, 4, np.nan, 8])
 
     i, j = [np.nan, 1, np.nan, 8, 4, np.nan], [2, 0, 2, 3, 1, 2]
-    assert_series_equal(ts.reindex(i), ts.iloc[j])
+    tm.assert_series_equal(ts.reindex(i), ts.iloc[j])
 
     ts.index = ts.index.astype("object")
 
     # reindex coerces index.dtype to float, loc/iloc doesn't
-    assert_series_equal(ts.reindex(i), ts.iloc[j], check_index_type=False)
+    tm.assert_series_equal(ts.reindex(i), ts.iloc[j], check_index_type=False)
 
 
 def test_reindex_series_add_nat():
@@ -239,7 +238,7 @@ def test_reindex_corner(datetime_series):
 
     # pass non-Index
     reindexed = datetime_series.reindex(list(datetime_series.index))
-    assert_series_equal(datetime_series, reindexed)
+    tm.assert_series_equal(datetime_series, reindexed)
 
     # bad fill method
     ts = datetime_series[::2]
@@ -257,10 +256,10 @@ def test_reindex_pad():
 
     reindexed = s2.reindex(s.index, method="pad")
     reindexed2 = s2.reindex(s.index, method="ffill")
-    assert_series_equal(reindexed, reindexed2)
+    tm.assert_series_equal(reindexed, reindexed2)
 
     expected = Series([0, 0, 2, 2, 4, 4, 6, 6, 8, 8], index=np.arange(10))
-    assert_series_equal(reindexed, expected)
+    tm.assert_series_equal(reindexed, expected)
 
     # GH4604
     s = Series([1, 2, 3, 4, 5], index=["a", "b", "c", "d", "e"])
@@ -269,27 +268,27 @@ def test_reindex_pad():
 
     # this changes dtype because the ffill happens after
     result = s.reindex(new_index).ffill()
-    assert_series_equal(result, expected.astype("float64"))
+    tm.assert_series_equal(result, expected.astype("float64"))
 
     result = s.reindex(new_index).ffill(downcast="infer")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     expected = Series([1, 5, 3, 5], index=new_index)
     result = s.reindex(new_index, method="ffill")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # inference of new dtype
     s = Series([True, False, False, True], index=list("abcd"))
     new_index = "agc"
     result = s.reindex(list(new_index)).ffill()
     expected = Series([True, True, False], index=list(new_index))
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # GH4618 shifted series downcasting
     s = Series(False, index=range(0, 5))
     result = s.shift(1).fillna(method="bfill")
     expected = Series(False, index=range(0, 5))
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_reindex_nearest():
@@ -297,23 +296,23 @@ def test_reindex_nearest():
     target = [0.1, 0.9, 1.5, 2.0]
     actual = s.reindex(target, method="nearest")
     expected = Series(np.around(target).astype("int64"), target)
-    assert_series_equal(expected, actual)
+    tm.assert_series_equal(expected, actual)
 
     actual = s.reindex_like(actual, method="nearest")
-    assert_series_equal(expected, actual)
+    tm.assert_series_equal(expected, actual)
 
     actual = s.reindex_like(actual, method="nearest", tolerance=1)
-    assert_series_equal(expected, actual)
+    tm.assert_series_equal(expected, actual)
     actual = s.reindex_like(actual, method="nearest", tolerance=[1, 2, 3, 4])
-    assert_series_equal(expected, actual)
+    tm.assert_series_equal(expected, actual)
 
     actual = s.reindex(target, method="nearest", tolerance=0.2)
     expected = Series([0, 1, np.nan, 2], target)
-    assert_series_equal(expected, actual)
+    tm.assert_series_equal(expected, actual)
 
     actual = s.reindex(target, method="nearest", tolerance=[0.3, 0.01, 0.4, 3])
     expected = Series([0, np.nan, np.nan, 2], target)
-    assert_series_equal(expected, actual)
+    tm.assert_series_equal(expected, actual)
 
 
 def test_reindex_backfill():
@@ -385,7 +384,7 @@ def test_reindex_categorical():
 
 def test_reindex_like(datetime_series):
     other = datetime_series[::2]
-    assert_series_equal(
+    tm.assert_series_equal(
         datetime_series.reindex(other.index), datetime_series.reindex_like(other)
     )
 
@@ -399,7 +398,7 @@ def test_reindex_like(datetime_series):
 
     result = series1.reindex_like(series2, method="pad")
     expected = Series([5, np.nan], index=[day1, day3])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_reindex_fill_value():
@@ -408,11 +407,11 @@ def test_reindex_fill_value():
     floats = Series([1.0, 2.0, 3.0])
     result = floats.reindex([1, 2, 3])
     expected = Series([2.0, 3.0, np.nan], index=[1, 2, 3])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = floats.reindex([1, 2, 3], fill_value=0)
     expected = Series([2.0, 3.0, 0], index=[1, 2, 3])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # -----------------------------------------------------------
     # ints
@@ -420,13 +419,13 @@ def test_reindex_fill_value():
 
     result = ints.reindex([1, 2, 3])
     expected = Series([2.0, 3.0, np.nan], index=[1, 2, 3])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # don't upcast
     result = ints.reindex([1, 2, 3], fill_value=0)
     expected = Series([2, 3, 0], index=[1, 2, 3])
     assert issubclass(result.dtype.type, np.integer)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # -----------------------------------------------------------
     # objects
@@ -434,11 +433,11 @@ def test_reindex_fill_value():
 
     result = objects.reindex([1, 2, 3])
     expected = Series([2, 3, np.nan], index=[1, 2, 3], dtype=object)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = objects.reindex([1, 2, 3], fill_value="foo")
     expected = Series([2, 3, "foo"], index=[1, 2, 3], dtype=object)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # ------------------------------------------------------------
     # bools
@@ -446,11 +445,11 @@ def test_reindex_fill_value():
 
     result = bools.reindex([1, 2, 3])
     expected = Series([False, True, np.nan], index=[1, 2, 3], dtype=object)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = bools.reindex([1, 2, 3], fill_value=False)
     expected = Series([False, True, False], index=[1, 2, 3])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_reindex_datetimeindexes_tz_naive_and_aware():
@@ -474,7 +473,7 @@ def test_rename():
     s = Series(range(1, 6), index=pd.Index(range(2, 7), name="IntIndex"))
     result = s.rename(str)
     expected = s.rename(lambda i: str(i))
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     assert result.name == expected.name
 

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -7,7 +7,6 @@ import pandas as pd
 from pandas import Index, Series, Timestamp, date_range, isna
 from pandas.core.indexing import IndexingError
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 from pandas.tseries.offsets import BDay
 
@@ -19,7 +18,7 @@ def test_getitem_boolean(string_series):
     # passing list is OK
     result = s[list(mask)]
     expected = s[mask]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
     tm.assert_index_equal(result.index, s.index[mask])
 
 
@@ -35,12 +34,12 @@ def test_getitem_boolean_empty():
     s = Series(["A", "B"])
     expected = Series(np.nan, index=["C"], dtype=object)
     result = s[Series(["C"], dtype=object)]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     s = Series(["A", "B"])
     expected = Series(dtype=object, index=Index([], dtype="int64"))
     result = s[Series([], dtype=object)]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # invalid because of the boolean indexer
     # that's empty or not-aligned
@@ -65,14 +64,14 @@ def test_getitem_boolean_object(string_series):
     # getitem
     result = s[omask]
     expected = s[mask]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # setitem
     s2 = s.copy()
     cop = s.copy()
     cop[omask] = 5
     s2[mask] = 5
-    assert_series_equal(cop, s2)
+    tm.assert_series_equal(cop, s2)
 
     # nans raise exception
     omask[5:10] = np.nan
@@ -111,14 +110,14 @@ def test_setitem_boolean(string_series):
     result = string_series.copy()
     result[mask] = string_series * 2
     expected = string_series * 2
-    assert_series_equal(result[mask], expected[mask])
+    tm.assert_series_equal(result[mask], expected[mask])
 
     # needs alignment
     result = string_series.copy()
     result[mask] = (string_series * 2)[0:5]
     expected = (string_series * 2)[0:5].reindex_like(string_series)
     expected[-mask] = string_series[mask]
-    assert_series_equal(result[mask], expected[mask])
+    tm.assert_series_equal(result[mask], expected[mask])
 
 
 def test_get_set_boolean_different_order(string_series):
@@ -131,12 +130,12 @@ def test_get_set_boolean_different_order(string_series):
     expected = string_series.copy()
     expected[expected > 0] = 0
 
-    assert_series_equal(copy, expected)
+    tm.assert_series_equal(copy, expected)
 
     # getting
     sel = string_series[ordered > 0]
     exp = string_series[string_series > 0]
-    assert_series_equal(sel, exp)
+    tm.assert_series_equal(sel, exp)
 
 
 def test_where_unsafe_int(sint_dtype):
@@ -146,7 +145,7 @@ def test_where_unsafe_int(sint_dtype):
     s[mask] = range(2, 7)
     expected = Series(list(range(2, 7)) + list(range(5, 10)), dtype=sint_dtype)
 
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
 
 def test_where_unsafe_float(float_dtype):
@@ -157,7 +156,7 @@ def test_where_unsafe_float(float_dtype):
     data = list(range(2, 7)) + list(range(5, 10))
     expected = Series(data, dtype=float_dtype)
 
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
 
 @pytest.mark.parametrize(
@@ -178,7 +177,7 @@ def test_where_unsafe_upcast(dtype, expected_dtype):
     mask = s < 5
     expected = Series(values + list(range(5, 10)), dtype=expected_dtype)
     s[mask] = values
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
 
 def test_where_unsafe():
@@ -190,21 +189,21 @@ def test_where_unsafe():
     expected = Series(list(range(6)) + values, dtype="float64")
 
     s[mask] = values
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     # see gh-3235
     s = Series(np.arange(10), dtype="int64")
     mask = s < 5
     s[mask] = range(2, 7)
     expected = Series(list(range(2, 7)) + list(range(5, 10)), dtype="int64")
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
     assert s.dtype == expected.dtype
 
     s = Series(np.arange(10), dtype="int64")
     mask = s > 5
     s[mask] = [0] * 4
     expected = Series([0, 1, 2, 3, 4, 5] + [0] * 4, dtype="int64")
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     s = Series(np.arange(10))
     mask = s > 5
@@ -220,7 +219,7 @@ def test_where_unsafe():
     s = Series([1, 2, 3, 4])
     result = s.where(s > 2, np.nan)
     expected = Series([np.nan, np.nan, 3, 4])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # GH 4667
     # setting with None changes dtype
@@ -233,7 +232,7 @@ def test_where_unsafe():
     s[s > 8] = None
     result = s[isna(s)]
     expected = Series(np.nan, index=[9])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_where():
@@ -242,10 +241,10 @@ def test_where():
 
     rs = s.where(cond).dropna()
     rs2 = s[cond]
-    assert_series_equal(rs, rs2)
+    tm.assert_series_equal(rs, rs2)
 
     rs = s.where(cond, -s)
-    assert_series_equal(rs, s.abs())
+    tm.assert_series_equal(rs, s.abs())
 
     rs = s.where(cond)
     assert s.shape == rs.shape
@@ -257,12 +256,12 @@ def test_where():
 
     expected = s2[cond].reindex(s2.index[:3]).reindex(s2.index)
     rs = s2.where(cond[:3])
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     expected = s2.abs()
     expected.iloc[0] = s2[0]
     rs = s2.where(cond[:3], -s2)
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
 
 def test_where_error():
@@ -279,7 +278,7 @@ def test_where_error():
     s = Series([1, 2])
     s[[True, False]] = [0, 1]
     expected = Series([0, 2])
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     # failures
     msg = "cannot assign mismatch length to masked array"
@@ -301,7 +300,7 @@ def test_where_array_like(klass):
     expected = Series([np.nan, 2, 3])
 
     result = s.where(klass(cond))
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -363,7 +362,7 @@ def test_where_setitem_invalid():
 
     s[0:3] = list(range(3))
     expected = Series([0, 1, 2])
-    assert_series_equal(s.astype(np.int64), expected)
+    tm.assert_series_equal(s.astype(np.int64), expected)
 
     # slice with step
     s = Series(list("abcdef"))
@@ -374,7 +373,7 @@ def test_where_setitem_invalid():
     s = Series(list("abcdef"))
     s[0:4:2] = list(range(2))
     expected = Series([0, "b", 1, "d", "e", "f"])
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     # neg slices
     s = Series(list("abcdef"))
@@ -384,7 +383,7 @@ def test_where_setitem_invalid():
 
     s[-3:-1] = list(range(2))
     expected = Series(["a", "b", "c", 0, 1, "f"])
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     # list
     s = Series(list("abc"))
@@ -401,7 +400,7 @@ def test_where_setitem_invalid():
     s = Series(list("abc"))
     s[0] = list(range(10))
     expected = Series([list(range(10)), "b", "c"])
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
 
 @pytest.mark.parametrize("size", range(2, 6))
@@ -429,15 +428,15 @@ def test_broadcast(size, mask, item, box):
 
     s = Series(data)
     s[selection] = box(item)
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     s = Series(data)
     result = s.where(~selection, box(item))
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     s = Series(data)
     result = s.mask(selection, box(item))
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_where_inplace():
@@ -447,12 +446,12 @@ def test_where_inplace():
     rs = s.copy()
 
     rs.where(cond, inplace=True)
-    assert_series_equal(rs.dropna(), s[cond])
-    assert_series_equal(rs, s.where(cond))
+    tm.assert_series_equal(rs.dropna(), s[cond])
+    tm.assert_series_equal(rs, s.where(cond))
 
     rs = s.copy()
     rs.where(cond, -s, inplace=True)
-    assert_series_equal(rs, s.where(cond, -s))
+    tm.assert_series_equal(rs, s.where(cond, -s))
 
 
 def test_where_dups():
@@ -463,17 +462,17 @@ def test_where_dups():
     comb = pd.concat([s1, s2])
     result = comb.where(comb < 2)
     expected = Series([0, 1, np.nan, 0, 1, np.nan], index=[0, 1, 2, 0, 1, 2])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # GH 4548
     # inplace updating not working with dups
     comb[comb < 1] = 5
     expected = Series([5, 1, 2, 5, 1, 2], index=[0, 1, 2, 0, 1, 2])
-    assert_series_equal(comb, expected)
+    tm.assert_series_equal(comb, expected)
 
     comb[comb < 2] += 10
     expected = Series([5, 11, 2, 5, 11, 2], index=[0, 1, 2, 0, 1, 2])
-    assert_series_equal(comb, expected)
+    tm.assert_series_equal(comb, expected)
 
 
 def test_where_numeric_with_string():
@@ -508,20 +507,20 @@ def test_where_timedelta_coerce():
     mask = np.array([False, False])
 
     rs = s.where(mask, [10, 10])
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     rs = s.where(mask, 10)
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     rs = s.where(mask, 10.0)
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     rs = s.where(mask, [10.0, 10.0])
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     rs = s.where(mask, [10.0, np.nan])
     expected = Series([10, None], dtype="object")
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
 
 def test_where_datetime_conversion():
@@ -530,27 +529,27 @@ def test_where_datetime_conversion():
     mask = np.array([False, False])
 
     rs = s.where(mask, [10, 10])
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     rs = s.where(mask, 10)
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     rs = s.where(mask, 10.0)
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     rs = s.where(mask, [10.0, 10.0])
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     rs = s.where(mask, [10.0, np.nan])
     expected = Series([10, None], dtype="object")
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
     # GH 15701
     timestamps = ["2016-12-31 12:00:04+00:00", "2016-12-31 12:00:04.010000+00:00"]
     s = Series([pd.Timestamp(t) for t in timestamps])
     rs = s.where(Series([False, True]))
     expected = Series([pd.NaT, s[1]])
-    assert_series_equal(rs, expected)
+    tm.assert_series_equal(rs, expected)
 
 
 def test_where_dt_tz_values(tz_naive_fixture):
@@ -565,7 +564,7 @@ def test_where_dt_tz_values(tz_naive_fixture):
     exp = pd.Series(
         pd.DatetimeIndex(["20150101", "20150102", "20160516"], tz=tz_naive_fixture)
     )
-    assert_series_equal(exp, result)
+    tm.assert_series_equal(exp, result)
 
 
 def test_mask():
@@ -574,25 +573,25 @@ def test_mask():
     cond = s > 0
 
     rs = s.where(~cond, np.nan)
-    assert_series_equal(rs, s.mask(cond))
+    tm.assert_series_equal(rs, s.mask(cond))
 
     rs = s.where(~cond)
     rs2 = s.mask(cond)
-    assert_series_equal(rs, rs2)
+    tm.assert_series_equal(rs, rs2)
 
     rs = s.where(~cond, -s)
     rs2 = s.mask(cond, -s)
-    assert_series_equal(rs, rs2)
+    tm.assert_series_equal(rs, rs2)
 
     cond = Series([True, False, False, True, False], index=s.index)
     s2 = -(s.abs())
     rs = s2.where(~cond[:3])
     rs2 = s2.mask(cond[:3])
-    assert_series_equal(rs, rs2)
+    tm.assert_series_equal(rs, rs2)
 
     rs = s2.where(~cond[:3], -s2)
     rs2 = s2.mask(cond[:3], -s2)
-    assert_series_equal(rs, rs2)
+    tm.assert_series_equal(rs, rs2)
 
     msg = "Array conditional must be same shape as self"
     with pytest.raises(ValueError, match=msg):
@@ -604,7 +603,7 @@ def test_mask():
     s = Series([1, 2, 3, 4])
     result = s.mask(s > 2, np.nan)
     expected = Series([1, 2, np.nan, np.nan])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # see gh-21891
     s = Series([1, 2])
@@ -620,9 +619,9 @@ def test_mask_inplace():
 
     rs = s.copy()
     rs.mask(cond, inplace=True)
-    assert_series_equal(rs.dropna(), s[~cond])
-    assert_series_equal(rs, s.mask(cond))
+    tm.assert_series_equal(rs.dropna(), s[~cond])
+    tm.assert_series_equal(rs, s.mask(cond))
 
     rs = s.copy()
     rs.mask(cond, -s, inplace=True)
-    assert_series_equal(rs, s.mask(cond, -s))
+    tm.assert_series_equal(rs, s.mask(cond, -s))

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -9,11 +9,6 @@ import pandas._libs.index as _index
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex, NaT, Series, Timestamp, date_range
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-)
 
 
 """
@@ -35,7 +30,7 @@ def test_fancy_getitem():
     assert s[Timestamp(datetime(2009, 1, 2))] == 48
     with pytest.raises(KeyError, match=r"^'2009-1-3'$"):
         s["2009-1-3"]
-    assert_series_equal(
+    tm.assert_series_equal(
         s["3/6/2009":"2009-06-05"], s[datetime(2009, 3, 6) : datetime(2009, 6, 5)]
     )
 
@@ -93,7 +88,7 @@ def test_dti_reset_index_round_trip():
     d2 = d1.reset_index()
     assert d2.dtypes[0] == np.dtype("M8[ns]")
     d3 = d2.set_index("index")
-    assert_frame_equal(d1, d3, check_names=False)
+    tm.assert_frame_equal(d1, d3, check_names=False)
 
     # #2329
     stamp = datetime(2012, 11, 22)
@@ -115,7 +110,7 @@ def test_series_set_value():
 
     expected = Series([1.0, np.nan], index=index)
 
-    assert_series_equal(s2, expected)
+    tm.assert_series_equal(s2, expected)
 
     # FIXME: dont leave commented-out
     # s = Series(index[:1], index[:1])
@@ -139,17 +134,17 @@ def test_slicing_datetimes():
         index=[datetime(2001, 1, i, 10, 00) for i in [1, 2, 3, 4]],
     )
     result = df.loc[datetime(2001, 1, 1, 10) :]
-    assert_frame_equal(result, df)
+    tm.assert_frame_equal(result, df)
     result = df.loc[: datetime(2001, 1, 4, 10)]
-    assert_frame_equal(result, df)
+    tm.assert_frame_equal(result, df)
     result = df.loc[datetime(2001, 1, 1, 10) : datetime(2001, 1, 4, 10)]
-    assert_frame_equal(result, df)
+    tm.assert_frame_equal(result, df)
 
     result = df.loc[datetime(2001, 1, 1, 11) :]
     expected = df.iloc[1:]
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
     result = df.loc["20010101 11":]
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     # duplicates
     df = pd.DataFrame(
@@ -158,17 +153,17 @@ def test_slicing_datetimes():
     )
 
     result = df.loc[datetime(2001, 1, 1, 10) :]
-    assert_frame_equal(result, df)
+    tm.assert_frame_equal(result, df)
     result = df.loc[: datetime(2001, 1, 4, 10)]
-    assert_frame_equal(result, df)
+    tm.assert_frame_equal(result, df)
     result = df.loc[datetime(2001, 1, 1, 10) : datetime(2001, 1, 4, 10)]
-    assert_frame_equal(result, df)
+    tm.assert_frame_equal(result, df)
 
     result = df.loc[datetime(2001, 1, 1, 11) :]
     expected = df.iloc[1:]
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
     result = df.loc["20010101 11":]
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_frame_datetime64_duplicated():
@@ -196,18 +191,18 @@ def test_getitem_setitem_datetime_tz_pytz():
     result = ts.copy()
     result["1990-01-01 09:00:00+00:00"] = 0
     result["1990-01-01 09:00:00+00:00"] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     result = ts.copy()
     result["1990-01-01 03:00:00-06:00"] = 0
     result["1990-01-01 03:00:00-06:00"] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     # repeat with datetimes
     result = ts.copy()
     result[datetime(1990, 1, 1, 9, tzinfo=tz("UTC"))] = 0
     result[datetime(1990, 1, 1, 9, tzinfo=tz("UTC"))] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     result = ts.copy()
 
@@ -215,7 +210,7 @@ def test_getitem_setitem_datetime_tz_pytz():
     date = tz("US/Central").localize(datetime(1990, 1, 1, 3))
     result[date] = 0
     result[date] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
 
 def test_getitem_setitem_datetime_tz_dateutil():
@@ -238,23 +233,23 @@ def test_getitem_setitem_datetime_tz_dateutil():
     result = ts.copy()
     result["1990-01-01 09:00:00+00:00"] = 0
     result["1990-01-01 09:00:00+00:00"] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     result = ts.copy()
     result["1990-01-01 03:00:00-06:00"] = 0
     result["1990-01-01 03:00:00-06:00"] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     # repeat with datetimes
     result = ts.copy()
     result[datetime(1990, 1, 1, 9, tzinfo=tz("UTC"))] = 0
     result[datetime(1990, 1, 1, 9, tzinfo=tz("UTC"))] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     result = ts.copy()
     result[datetime(1990, 1, 1, 3, tzinfo=tz("America/Chicago"))] = 0
     result[datetime(1990, 1, 1, 3, tzinfo=tz("America/Chicago"))] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
 
 def test_getitem_setitem_datetimeindex():
@@ -270,29 +265,29 @@ def test_getitem_setitem_datetimeindex():
     result = ts.copy()
     result["1990-01-01 04:00:00"] = 0
     result["1990-01-01 04:00:00"] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     result = ts["1990-01-01 04:00:00":"1990-01-01 07:00:00"]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.copy()
     result["1990-01-01 04:00:00":"1990-01-01 07:00:00"] = 0
     result["1990-01-01 04:00:00":"1990-01-01 07:00:00"] = ts[4:8]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     lb = "1990-01-01 04:00:00"
     rb = "1990-01-01 07:00:00"
     # GH#18435 strings get a pass from tzawareness compat
     result = ts[(ts.index >= lb) & (ts.index <= rb)]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     lb = "1990-01-01 04:00:00-0500"
     rb = "1990-01-01 07:00:00-0500"
     result = ts[(ts.index >= lb) & (ts.index <= rb)]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # repeat all the above with naive datetimes
     result = ts[datetime(1990, 1, 1, 4)]
@@ -302,16 +297,16 @@ def test_getitem_setitem_datetimeindex():
     result = ts.copy()
     result[datetime(1990, 1, 1, 4)] = 0
     result[datetime(1990, 1, 1, 4)] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     result = ts[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.copy()
     result[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)] = 0
     result[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)] = ts[4:8]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     lb = datetime(1990, 1, 1, 4)
     rb = datetime(1990, 1, 1, 7)
@@ -325,7 +320,7 @@ def test_getitem_setitem_datetimeindex():
     rb = pd.Timestamp(datetime(1990, 1, 1, 7)).tz_localize(rng.tzinfo)
     result = ts[(ts.index >= lb) & (ts.index <= rb)]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts[ts.index[4]]
     expected = ts[4]
@@ -333,22 +328,22 @@ def test_getitem_setitem_datetimeindex():
 
     result = ts[ts.index[4:8]]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.copy()
     result[ts.index[4:8]] = 0
     result[4:8] = ts[4:8]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     # also test partial date slicing
     result = ts["1990-01-02"]
     expected = ts[24:48]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.copy()
     result["1990-01-02"] = 0
     result["1990-01-02"] = ts[24:48]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
 
 def test_getitem_setitem_periodindex():
@@ -365,22 +360,22 @@ def test_getitem_setitem_periodindex():
     result = ts.copy()
     result["1990-01-01 04"] = 0
     result["1990-01-01 04"] = ts[4]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     result = ts["1990-01-01 04":"1990-01-01 07"]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.copy()
     result["1990-01-01 04":"1990-01-01 07"] = 0
     result["1990-01-01 04":"1990-01-01 07"] = ts[4:8]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
     lb = "1990-01-01 04"
     rb = "1990-01-01 07"
     result = ts[(ts.index >= lb) & (ts.index <= rb)]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # GH 2782
     result = ts[ts.index[4]]
@@ -389,12 +384,12 @@ def test_getitem_setitem_periodindex():
 
     result = ts[ts.index[4:8]]
     expected = ts[4:8]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.copy()
     result[ts.index[4:8]] = 0
     result[4:8] = ts[4:8]
-    assert_series_equal(result, ts)
+    tm.assert_series_equal(result, ts)
 
 
 # FutureWarning from NumPy.
@@ -406,7 +401,7 @@ def test_getitem_median_slice_bug():
     indexer = [slice(6, 7, None)]
     result = s[indexer]
     expected = s[indexer[0]]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_datetime_indexing():
@@ -524,14 +519,14 @@ def test_duplicate_dates_indexing(dups):
         total = (ts.index == date).sum()
         expected = ts[mask]
         if total > 1:
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
         else:
-            assert_almost_equal(result, expected[0])
+            tm.assert_almost_equal(result, expected[0])
 
         cp = ts.copy()
         cp[date] = 0
         expected = Series(np.where(mask, 0, ts), index=ts.index)
-        assert_series_equal(cp, expected)
+        tm.assert_series_equal(cp, expected)
 
     with pytest.raises(KeyError, match=r"^947116800000000000$"):
         ts[datetime(2000, 1, 6)]
@@ -548,17 +543,17 @@ def test_range_slice():
 
     result = ts["1/2/2000":]
     expected = ts[1:]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts["1/2/2000":"1/3/2000"]
     expected = ts[1:4]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_groupby_average_dup_values(dups):
     result = dups.groupby(level=0).mean()
     expected = dups.groupby(dups.index).mean()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_indexing_over_size_cutoff():
@@ -642,7 +637,7 @@ def test_indexing_unordered():
         result = ts2[slobj].copy()
         result = result.sort_index()
         expected = ts[slobj]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     compare(slice("2011-01-01", "2011-01-15"))
     compare(slice("2010-12-30", "2011-01-15"))
@@ -656,7 +651,7 @@ def test_indexing_unordered():
     # single values
     result = ts2["2011"].sort_index()
     expected = ts["2011"]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # diff freq
     rng = date_range(datetime(2005, 1, 1), periods=20, freq="M")
@@ -680,7 +675,7 @@ def test_indexing():
 
     df = DataFrame(dict(A=ts))
     result = df["2001"]["A"]
-    assert_series_equal(expected, result)
+    tm.assert_series_equal(expected, result)
 
     # setting
     ts["2001"] = 1
@@ -690,18 +685,18 @@ def test_indexing():
     df.loc["2001", "A"] = 1
 
     result = df["2001"]["A"]
-    assert_series_equal(expected, result)
+    tm.assert_series_equal(expected, result)
 
     # GH3546 (not including times on the last day)
     idx = date_range(start="2013-05-31 00:00", end="2013-05-31 23:00", freq="H")
     ts = Series(range(len(idx)), index=idx)
     expected = ts["2013-05"]
-    assert_series_equal(expected, ts)
+    tm.assert_series_equal(expected, ts)
 
     idx = date_range(start="2013-05-31 00:00", end="2013-05-31 23:59", freq="S")
     ts = Series(range(len(idx)), index=idx)
     expected = ts["2013-05"]
-    assert_series_equal(expected, ts)
+    tm.assert_series_equal(expected, ts)
 
     idx = [
         Timestamp("2013-05-31 00:00"),
@@ -709,7 +704,7 @@ def test_indexing():
     ]
     ts = Series(range(len(idx)), index=idx)
     expected = ts["2013"]
-    assert_series_equal(expected, ts)
+    tm.assert_series_equal(expected, ts)
 
     # GH14826, indexing with a seconds resolution string / datetime object
     df = DataFrame(
@@ -763,7 +758,7 @@ def test_round_nat(method, freq):
     s = Series([pd.NaT])
     expected = Series(pd.NaT)
     round_method = getattr(s.dt, method)
-    assert_series_equal(round_method(freq), expected)
+    tm.assert_series_equal(round_method(freq), expected)
 
 
 def test_setitem_tuple_with_datetimetz():
@@ -774,4 +769,4 @@ def test_setitem_tuple_with_datetimetz():
     expected = result.copy()
     result[(0, 1)] = np.nan
     expected.iloc[0] = np.nan
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/indexing/test_iloc.py
+++ b/pandas/tests/series/indexing/test_iloc.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import Series
-from pandas.util.testing import assert_almost_equal, assert_series_equal
+import pandas.util.testing as tm
 
 
 def test_iloc():
@@ -10,12 +10,12 @@ def test_iloc():
     for i in range(len(s)):
         result = s.iloc[i]
         exp = s[s.index[i]]
-        assert_almost_equal(result, exp)
+        tm.assert_almost_equal(result, exp)
 
     # pass a slice
     result = s.iloc[slice(1, 3)]
     expected = s.loc[2:4]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # test slice is a view
     result[:] = 0
@@ -24,7 +24,7 @@ def test_iloc():
     # list of integers
     result = s.iloc[[0, 2, 3, 4, 5]]
     expected = s.reindex(s.index[[0, 2, 3, 4, 5]])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_iloc_nonunique():

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -10,7 +10,6 @@ from pandas.core.dtypes.common import is_scalar
 import pandas as pd
 from pandas import Categorical, DataFrame, MultiIndex, Series, Timedelta, Timestamp
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 from pandas.tseries.offsets import BDay
 
@@ -43,11 +42,11 @@ def test_basic_getitem_with_labels(datetime_series):
 
     result = datetime_series[indices]
     expected = datetime_series.reindex(indices)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = datetime_series[indices[0] : indices[2]]
     expected = datetime_series.loc[indices[0] : indices[2]]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # integer indexes, be careful
     s = Series(np.random.randn(10), index=list(range(0, 20, 2)))
@@ -56,12 +55,12 @@ def test_basic_getitem_with_labels(datetime_series):
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
         result = s[inds]
     expected = s.reindex(inds)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
         result = s[arr_inds]
     expected = s.reindex(arr_inds)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # GH12089
     # with tz for values
@@ -83,7 +82,7 @@ def test_getitem_setitem_ellipsis():
     np.fix(s)
 
     result = s[...]
-    assert_series_equal(result, s)
+    tm.assert_series_equal(result, s)
 
     s[...] = 5
     assert (result == 5).all()
@@ -129,8 +128,8 @@ def test_getitem_generator(string_series):
     result = string_series[gen]
     result2 = string_series[iter(string_series > 0)]
     expected = string_series[string_series > 0]
-    assert_series_equal(result, expected)
-    assert_series_equal(result2, expected)
+    tm.assert_series_equal(result, expected)
+    tm.assert_series_equal(result2, expected)
 
 
 def test_type_promotion():
@@ -140,7 +139,7 @@ def test_type_promotion():
     s["b"] = 3.0
     s["c"] = "foo"
     expected = Series([pd.Timestamp("2016-01-01"), 3.0, "foo"], index=["a", "b", "c"])
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
 
 @pytest.mark.parametrize(
@@ -162,7 +161,7 @@ def test_getitem_with_duplicates_indices(result_1, duplicate_item, expected_1):
     # GH 17610
     result = result_1.append(duplicate_item)
     expected = expected_1.append(duplicate_item)
-    assert_series_equal(result[1], expected)
+    tm.assert_series_equal(result[1], expected)
     assert result[2] == result_1[2]
 
 
@@ -268,14 +267,14 @@ def test_getitem_dups_with_missing():
 
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
         result = s[["foo", "bar", "bah", "bam"]]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_getitem_dups():
     s = Series(range(5), index=["A", "A", "B", "C", "C"], dtype=np.int64)
     expected = Series([3, 4], index=["C", "C"], dtype=np.int64)
     result = s["C"]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_setitem_ambiguous_keyerror():
@@ -285,12 +284,12 @@ def test_setitem_ambiguous_keyerror():
     s2 = s.copy()
     s2[1] = 5
     expected = s.append(Series([5], index=[1]))
-    assert_series_equal(s2, expected)
+    tm.assert_series_equal(s2, expected)
 
     s2 = s.copy()
     s2.loc[1] = 5
     expected = s.append(Series([5], index=[1]))
-    assert_series_equal(s2, expected)
+    tm.assert_series_equal(s2, expected)
 
 
 def test_getitem_dataframe():
@@ -326,19 +325,19 @@ def test_setitem(datetime_series, string_series):
 
     app = Series([1], index=["foobar"], name="series")
     expected = string_series.append(app)
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     # Test for issue #10193
     key = pd.Timestamp("2012-01-01")
     series = pd.Series()
     series[key] = 47
     expected = pd.Series(47, [key])
-    assert_series_equal(series, expected)
+    tm.assert_series_equal(series, expected)
 
     series = pd.Series([], pd.DatetimeIndex([], freq="D"))
     series[key] = 47
     expected = pd.Series(47, pd.DatetimeIndex([key], freq="D"))
-    assert_series_equal(series, expected)
+    tm.assert_series_equal(series, expected)
 
 
 def test_setitem_dtypes():
@@ -348,23 +347,23 @@ def test_setitem_dtypes():
 
     s = Series([1, 2, 3])
     s.iloc[0] = np.nan
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     s = Series([1, 2, 3])
     s.loc[0] = np.nan
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     s = Series([1, 2, 3])
     s[0] = np.nan
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     s = Series([False])
     s.loc[0] = np.nan
-    assert_series_equal(s, Series([np.nan]))
+    tm.assert_series_equal(s, Series([np.nan]))
 
     s = Series([False, True])
     s.loc[0] = np.nan
-    assert_series_equal(s, Series([np.nan, 1.0]))
+    tm.assert_series_equal(s, Series([np.nan, 1.0]))
 
 
 def test_set_value(datetime_series, string_series):
@@ -405,7 +404,7 @@ def test_basic_getitem_setitem_corner(datetime_series):
     # weird lists. [slice(0, 5)] will work but not two slices
     result = datetime_series[[slice(None, 5)]]
     expected = datetime_series[:5]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # OK
     msg = r"unhashable type(: 'slice')?"
@@ -587,17 +586,17 @@ def test_loc_setitem(string_series):
 
     expected = string_series.copy()
     expected[[3, 4, 7]] = 5
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result.iloc[5:10] = 10
     expected[5:10] = 10
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # set slice with indices
     d1, d2 = string_series.index[[5, 15]]
     result.loc[d1:d2] = 6
     expected[5:16] = 6  # because it's inclusive
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # set index value
     string_series.loc[d1] = 4
@@ -611,18 +610,18 @@ def test_setitem_na():
     expected = Series([np.nan, 3, np.nan, 5, np.nan, 7, np.nan, 9, np.nan])
     s = Series([2, 3, 4, 5, 6, 7, 8, 9, 10])
     s[::2] = np.nan
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     # gets coerced to float, right?
     expected = Series([np.nan, 1, np.nan, 0])
     s = Series([True, True, False, False])
     s[::2] = np.nan
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     expected = Series([np.nan, np.nan, np.nan, np.nan, np.nan, 5, 6, 7, 8, 9])
     s = Series(np.arange(10))
     s[:5] = np.nan
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
 
 def test_timedelta_assignment():
@@ -787,7 +786,7 @@ def test_cast_on_putmask():
     s[[True, False]] = Series([0], index=[1], dtype="int64")
     expected = Series([0, 2], index=[1, 2], dtype="int64")
 
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
 
 def test_type_promote_putmask():
@@ -796,19 +795,19 @@ def test_type_promote_putmask():
     left, mask = ts.copy(), ts > 0
     right = ts[mask].copy().map(str)
     left[mask] = right
-    assert_series_equal(left, ts.map(lambda t: str(t) if t > 0 else t))
+    tm.assert_series_equal(left, ts.map(lambda t: str(t) if t > 0 else t))
 
     s = Series([0, 1, 2, 0])
     mask = s > 0
     s2 = s[mask].map(str)
     s[mask] = s2
-    assert_series_equal(s, Series([0, "1", "2", 0]))
+    tm.assert_series_equal(s, Series([0, "1", "2", 0]))
 
     s = Series([0, "foo", "bar", 0])
     mask = Series([False, True, True, False])
     s2 = s[mask]
     s[mask] = s2
-    assert_series_equal(s, Series([0, "foo", "bar", 0]))
+    tm.assert_series_equal(s, Series([0, "foo", "bar", 0]))
 
 
 def test_multilevel_preserve_name():
@@ -868,7 +867,7 @@ def test_pop():
     assert result == 4
 
     expected = Series([0, 0], index=["A", "C"], name=4)
-    assert_series_equal(k, expected)
+    tm.assert_series_equal(k, expected)
 
 
 def test_take():
@@ -896,14 +895,14 @@ def test_take_categorical():
     expected = Series(
         pd.Categorical(["b", "b", "a"], categories=["a", "b", "c"]), index=[1, 1, 0]
     )
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_head_tail(string_series):
-    assert_series_equal(string_series.head(), string_series[:5])
-    assert_series_equal(string_series.head(0), string_series[0:0])
-    assert_series_equal(string_series.tail(), string_series[-5:])
-    assert_series_equal(string_series.tail(0), string_series[0:0])
+    tm.assert_series_equal(string_series.head(), string_series[:5])
+    tm.assert_series_equal(string_series.head(0), string_series[0:0])
+    tm.assert_series_equal(string_series.tail(), string_series[-5:])
+    tm.assert_series_equal(string_series.tail(0), string_series[0:0])
 
 
 def test_uint_drop(any_int_dtype):

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -3,7 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas import Series, Timestamp
-from pandas.util.testing import assert_series_equal
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize("val,expected", [(2 ** 63 - 1, 3), (2 ** 63, 4)])
@@ -15,18 +15,18 @@ def test_loc_uint64(val, expected):
 
 def test_loc_getitem(string_series, datetime_series):
     inds = string_series.index[[3, 4, 7]]
-    assert_series_equal(string_series.loc[inds], string_series.reindex(inds))
-    assert_series_equal(string_series.iloc[5::2], string_series[5::2])
+    tm.assert_series_equal(string_series.loc[inds], string_series.reindex(inds))
+    tm.assert_series_equal(string_series.iloc[5::2], string_series[5::2])
 
     # slice with indices
     d1, d2 = datetime_series.index[[5, 15]]
     result = datetime_series.loc[d1:d2]
     expected = datetime_series.truncate(d1, d2)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # boolean
     mask = string_series > string_series.median()
-    assert_series_equal(string_series.loc[mask], string_series[mask])
+    tm.assert_series_equal(string_series.loc[mask], string_series[mask])
 
     # ask for index value
     assert datetime_series.loc[d1] == datetime_series[d1]
@@ -62,8 +62,8 @@ def test_loc_getitem_setitem_integer_slice_keyerrors():
     result2 = s.loc[3:11]
     expected = s.reindex([4, 6, 8, 10])
 
-    assert_series_equal(result, expected)
-    assert_series_equal(result2, expected)
+    tm.assert_series_equal(result, expected)
+    tm.assert_series_equal(result2, expected)
 
     # non-monotonic, raise KeyError
     s2 = s.iloc[list(range(5)) + list(range(9, 4, -1))]
@@ -76,7 +76,7 @@ def test_loc_getitem_setitem_integer_slice_keyerrors():
 def test_loc_getitem_iterator(string_series):
     idx = iter(string_series.index[:10])
     result = string_series.loc[idx]
-    assert_series_equal(result, string_series[:10])
+    tm.assert_series_equal(result, string_series[:10])
 
 
 def test_loc_setitem_boolean(string_series):
@@ -86,7 +86,7 @@ def test_loc_setitem_boolean(string_series):
     result.loc[mask] = 0
     expected = string_series
     expected[mask] = 0
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_loc_setitem_corner(string_series):
@@ -104,13 +104,13 @@ def test_basic_setitem_with_labels(datetime_series):
     exp = datetime_series.copy()
     cp[indices] = 0
     exp.loc[indices] = 0
-    assert_series_equal(cp, exp)
+    tm.assert_series_equal(cp, exp)
 
     cp = datetime_series.copy()
     exp = datetime_series.copy()
     cp[indices[0] : indices[2]] = 0
     exp.loc[indices[0] : indices[2]] = 0
-    assert_series_equal(cp, exp)
+    tm.assert_series_equal(cp, exp)
 
     # integer indexes, be careful
     s = Series(np.random.randn(10), index=list(range(0, 20, 2)))
@@ -121,13 +121,13 @@ def test_basic_setitem_with_labels(datetime_series):
     exp = s.copy()
     s[inds] = 0
     s.loc[inds] = 0
-    assert_series_equal(cp, exp)
+    tm.assert_series_equal(cp, exp)
 
     cp = s.copy()
     exp = s.copy()
     s[arr_inds] = 0
     s.loc[arr_inds] = 0
-    assert_series_equal(cp, exp)
+    tm.assert_series_equal(cp, exp)
 
     inds_notfound = [0, 4, 5, 6]
     arr_inds_notfound = np.array([0, 4, 5, 6])

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -4,7 +4,6 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Index, Series
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 
 def test_get():
@@ -126,11 +125,11 @@ def test_get_nan_multiple():
 
     idx = [2, 30]
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        assert_series_equal(s.get(idx), Series([2, np.nan], index=idx))
+        tm.assert_series_equal(s.get(idx), Series([2, np.nan], index=idx))
 
     idx = [2, np.nan]
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        assert_series_equal(s.get(idx), Series([2, np.nan], index=idx))
+        tm.assert_series_equal(s.get(idx), Series([2, np.nan], index=idx))
 
     # GH 17295 - all missing keys
     idx = [20, 30]
@@ -147,11 +146,11 @@ def test_delitem():
     del s[0]
 
     expected = Series(range(1, 5), index=range(1, 5))
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     del s[1]
     expected = Series(range(2, 5), index=range(2, 5))
-    assert_series_equal(s, expected)
+    tm.assert_series_equal(s, expected)
 
     # empty
     s = Series()
@@ -162,20 +161,20 @@ def test_delitem():
     # only 1 left, del, add, del
     s = Series(1)
     del s[0]
-    assert_series_equal(s, Series(dtype="int64", index=Index([], dtype="int64")))
+    tm.assert_series_equal(s, Series(dtype="int64", index=Index([], dtype="int64")))
     s[0] = 1
-    assert_series_equal(s, Series(1))
+    tm.assert_series_equal(s, Series(1))
     del s[0]
-    assert_series_equal(s, Series(dtype="int64", index=Index([], dtype="int64")))
+    tm.assert_series_equal(s, Series(dtype="int64", index=Index([], dtype="int64")))
 
     # Index(dtype=object)
     s = Series(1, index=["a"])
     del s["a"]
-    assert_series_equal(s, Series(dtype="int64", index=Index([], dtype="object")))
+    tm.assert_series_equal(s, Series(dtype="int64", index=Index([], dtype="object")))
     s["a"] = 1
-    assert_series_equal(s, Series(1, index=["a"]))
+    tm.assert_series_equal(s, Series(1, index=["a"]))
     del s["a"]
-    assert_series_equal(s, Series(dtype="int64", index=Index([], dtype="object")))
+    tm.assert_series_equal(s, Series(dtype="int64", index=Index([], dtype="object")))
 
 
 def test_slice_float64():
@@ -188,10 +187,10 @@ def test_slice_float64():
 
     result = s[start:end]
     expected = s.iloc[5:16]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = s.loc[start:end]
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     df = DataFrame(np.random.randn(20, 3), index=index)
 
@@ -217,19 +216,19 @@ def test_getitem_negative_out_of_bounds():
 def test_getitem_regression():
     s = Series(range(5), index=list(range(5)))
     result = s[list(range(5))]
-    assert_series_equal(result, s)
+    tm.assert_series_equal(result, s)
 
 
 def test_getitem_setitem_slice_bug():
     s = Series(range(10), index=list(range(10)))
     result = s[-12:]
-    assert_series_equal(result, s)
+    tm.assert_series_equal(result, s)
 
     result = s[-7:]
-    assert_series_equal(result, s[3:])
+    tm.assert_series_equal(result, s[3:])
 
     result = s[:-12]
-    assert_series_equal(result, s[:0])
+    tm.assert_series_equal(result, s[:0])
 
     s = Series(range(10), index=list(range(10)))
     s[-12:] = 0
@@ -244,7 +243,7 @@ def test_getitem_setitem_slice_integers():
 
     result = s[:4]
     expected = s.reindex([2, 4, 6, 8])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     s[:4] = 0
     assert (s[:4] == 0).all()
@@ -259,7 +258,7 @@ def test_setitem_float_labels():
     s.loc[1] = "zoo"
     tmp.iloc[2] = "zoo"
 
-    assert_series_equal(s, tmp)
+    tm.assert_series_equal(s, tmp)
 
 
 def test_slice_float_get_set(datetime_series):


### PR DESCRIPTION
Part of #29272

Fyi: the changes were created via a script posted in the issue

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

