### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/util

### DIFF
--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import DataFrame, Index, Series, Timestamp
-from pandas.util.testing import assert_almost_equal
+import pandas.util.testing as tm
 
 
 def _assert_almost_equal_both(a, b, **kwargs):
@@ -18,10 +18,10 @@ def _assert_almost_equal_both(a, b, **kwargs):
     b : object
         The second object to compare.
     kwargs : dict
-        The arguments passed to `assert_almost_equal`.
+        The arguments passed to `tm.assert_almost_equal`.
     """
-    assert_almost_equal(a, b, **kwargs)
-    assert_almost_equal(b, a, **kwargs)
+    tm.assert_almost_equal(a, b, **kwargs)
+    tm.assert_almost_equal(b, a, **kwargs)
 
 
 def _assert_not_almost_equal(a, b, **kwargs):
@@ -35,10 +35,10 @@ def _assert_not_almost_equal(a, b, **kwargs):
     b : object
         The second object to compare.
     kwargs : dict
-        The arguments passed to `assert_almost_equal`.
+        The arguments passed to `tm.assert_almost_equal`.
     """
     try:
-        assert_almost_equal(a, b, **kwargs)
+        tm.assert_almost_equal(a, b, **kwargs)
         msg = (
             "{a} and {b} were approximately equal when they shouldn't have been"
         ).format(a=a, b=b)
@@ -240,7 +240,7 @@ def test_assert_almost_equal_value_mismatch():
     msg = "expected 2\\.00000 but got 1\\.00000, with decimal 5"
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(1, 2)
+        tm.assert_almost_equal(1, 2)
 
 
 @pytest.mark.parametrize(
@@ -257,7 +257,7 @@ numpy array classes are different
     )
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(a, b)
+        tm.assert_almost_equal(a, b)
 
 
 def test_assert_almost_equal_value_mismatch1():
@@ -268,7 +268,7 @@ numpy array values are different \\(66\\.66667 %\\)
 \\[right\\]: \\[1\\.0, nan, 3\\.0\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(np.array([np.nan, 2, 3]), np.array([1, np.nan, 3]))
+        tm.assert_almost_equal(np.array([np.nan, 2, 3]), np.array([1, np.nan, 3]))
 
 
 def test_assert_almost_equal_value_mismatch2():
@@ -279,7 +279,7 @@ numpy array values are different \\(50\\.0 %\\)
 \\[right\\]: \\[1, 3\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(np.array([1, 2]), np.array([1, 3]))
+        tm.assert_almost_equal(np.array([1, 2]), np.array([1, 3]))
 
 
 def test_assert_almost_equal_value_mismatch3():
@@ -290,7 +290,7 @@ numpy array values are different \\(16\\.66667 %\\)
 \\[right\\]: \\[\\[1, 3\\], \\[3, 4\\], \\[5, 6\\]\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(
+        tm.assert_almost_equal(
             np.array([[1, 2], [3, 4], [5, 6]]), np.array([[1, 3], [3, 4], [5, 6]])
         )
 
@@ -303,7 +303,7 @@ numpy array values are different \\(25\\.0 %\\)
 \\[right\\]: \\[\\[1, 3\\], \\[3, 4\\]\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(np.array([[1, 2], [3, 4]]), np.array([[1, 3], [3, 4]]))
+        tm.assert_almost_equal(np.array([[1, 2], [3, 4]]), np.array([[1, 3], [3, 4]]))
 
 
 def test_assert_almost_equal_shape_mismatch_override():
@@ -313,7 +313,7 @@ Index shapes are different
 \\[left\\]:  \\(2L*,\\)
 \\[right\\]: \\(3L*,\\)"""
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(np.array([1, 2]), np.array([3, 4, 5]), obj="Index")
+        tm.assert_almost_equal(np.array([1, 2]), np.array([3, 4, 5]), obj="Index")
 
 
 def test_assert_almost_equal_unicode():
@@ -325,7 +325,7 @@ numpy array values are different \\(33\\.33333 %\\)
 \\[right\\]: \\[á, à, å\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(np.array(["á", "à", "ä"]), np.array(["á", "à", "å"]))
+        tm.assert_almost_equal(np.array(["á", "à", "ä"]), np.array(["á", "à", "å"]))
 
 
 def test_assert_almost_equal_timestamp():
@@ -339,7 +339,7 @@ numpy array values are different \\(50\\.0 %\\)
 \\[right\\]: \\[2011-01-01 00:00:00, 2011-01-02 00:00:00\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal(a, b)
+        tm.assert_almost_equal(a, b)
 
 
 def test_assert_almost_equal_iterable_length_mismatch():
@@ -350,7 +350,7 @@ Iterable length are different
 \\[right\\]: 3"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal([1, 2], [3, 4, 5])
+        tm.assert_almost_equal([1, 2], [3, 4, 5])
 
 
 def test_assert_almost_equal_iterable_values_mismatch():
@@ -361,4 +361,4 @@ Iterable values are different \\(50\\.0 %\\)
 \\[right\\]: \\[1, 3\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_almost_equal([1, 2], [1, 3])
+        tm.assert_almost_equal([1, 2], [1, 3])

--- a/pandas/tests/util/test_assert_categorical_equal.py
+++ b/pandas/tests/util/test_assert_categorical_equal.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pandas import Categorical
-from pandas.util.testing import assert_categorical_equal
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize(
@@ -9,7 +9,7 @@ from pandas.util.testing import assert_categorical_equal
     [Categorical([1, 2, 3, 4]), Categorical([1, 2, 3, 4], categories=[1, 2, 3, 4, 5])],
 )
 def test_categorical_equal(c):
-    assert_categorical_equal(c, c)
+    tm.assert_categorical_equal(c, c)
 
 
 @pytest.mark.parametrize("check_category_order", [True, False])
@@ -25,9 +25,9 @@ Categorical\\.categories values are different \\(100\\.0 %\\)
 \\[left\\]:  Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
 \\[right\\]: Int64Index\\(\\[4, 3, 2, 1\\], dtype='int64'\\)"""
         with pytest.raises(AssertionError, match=msg):
-            assert_categorical_equal(c1, c2, **kwargs)
+            tm.assert_categorical_equal(c1, c2, **kwargs)
     else:
-        assert_categorical_equal(c1, c2, **kwargs)
+        tm.assert_categorical_equal(c1, c2, **kwargs)
 
 
 def test_categorical_equal_categories_mismatch():
@@ -41,7 +41,7 @@ Categorical\\.categories values are different \\(25\\.0 %\\)
     c2 = Categorical([1, 2, 3, 5])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_categorical_equal(c1, c2)
+        tm.assert_categorical_equal(c1, c2)
 
 
 def test_categorical_equal_codes_mismatch():
@@ -56,7 +56,7 @@ Categorical\\.codes values are different \\(50\\.0 %\\)
     c2 = Categorical([1, 2, 3, 4], categories=categories)
 
     with pytest.raises(AssertionError, match=msg):
-        assert_categorical_equal(c1, c2)
+        tm.assert_categorical_equal(c1, c2)
 
 
 def test_categorical_equal_ordered_mismatch():
@@ -71,7 +71,7 @@ Attribute "ordered" are different
     c2 = Categorical(data, ordered=True)
 
     with pytest.raises(AssertionError, match=msg):
-        assert_categorical_equal(c1, c2)
+        tm.assert_categorical_equal(c1, c2)
 
 
 @pytest.mark.parametrize("obj", ["index", "foo", "pandas"])
@@ -89,4 +89,4 @@ Attribute "ordered" are different
     c2 = Categorical(data, ordered=True)
 
     with pytest.raises(AssertionError, match=msg):
-        assert_categorical_equal(c1, c2, obj=obj)
+        tm.assert_categorical_equal(c1, c2, obj=obj)

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas.core.arrays.sparse import SparseArray
-from pandas.util.testing import assert_extension_array_equal
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize(
@@ -27,9 +27,9 @@ ExtensionArray values are different \\(50\\.0 %\\)
 \\[right\\]: \\[-0\\.17387645482.*, 0\\.341414801642.*\\]"""
 
         with pytest.raises(AssertionError, match=msg):
-            assert_extension_array_equal(arr1, arr2, **kwargs)
+            tm.assert_extension_array_equal(arr1, arr2, **kwargs)
     else:
-        assert_extension_array_equal(arr1, arr2, **kwargs)
+        tm.assert_extension_array_equal(arr1, arr2, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -50,9 +50,9 @@ ExtensionArray values are different \\(50\\.0 %\\)
 \\[right\\]: \\[0\\.5, 0\\.123457\\]"""
 
         with pytest.raises(AssertionError, match=msg):
-            assert_extension_array_equal(arr1, arr2, **kwargs)
+            tm.assert_extension_array_equal(arr1, arr2, **kwargs)
     else:
-        assert_extension_array_equal(arr1, arr2, **kwargs)
+        tm.assert_extension_array_equal(arr1, arr2, **kwargs)
 
 
 def test_assert_extension_array_equal_dtype_mismatch(check_dtype):
@@ -71,9 +71,9 @@ Attribute "dtype" are different
 \\[right\\]: Sparse\\[int32, 0\\]"""
 
         with pytest.raises(AssertionError, match=msg):
-            assert_extension_array_equal(arr1, arr2, **kwargs)
+            tm.assert_extension_array_equal(arr1, arr2, **kwargs)
     else:
-        assert_extension_array_equal(arr1, arr2, **kwargs)
+        tm.assert_extension_array_equal(arr1, arr2, **kwargs)
 
 
 def test_assert_extension_array_equal_missing_values():
@@ -88,7 +88,7 @@ ExtensionArray NA mask values are different \\(25\\.0 %\\)
 \\[right\\]: \\[True, False, False, False\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_extension_array_equal(arr1, arr2)
+        tm.assert_extension_array_equal(arr1, arr2)
 
 
 @pytest.mark.parametrize("side", ["left", "right"])
@@ -104,4 +104,4 @@ def test_assert_extension_array_equal_non_extension_array(side):
     )
 
     with pytest.raises(AssertionError, match=msg):
-        assert_extension_array_equal(*args)
+        tm.assert_extension_array_equal(*args)

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pandas import DataFrame
-from pandas.util.testing import assert_frame_equal
+import pandas.util.testing as tm
 
 
 @pytest.fixture(params=[True, False])
@@ -27,10 +27,10 @@ def _assert_frame_equal_both(a, b, **kwargs):
     b : DataFrame
         The second DataFrame to compare.
     kwargs : dict
-        The arguments passed to `assert_frame_equal`.
+        The arguments passed to `tm.assert_frame_equal`.
     """
-    assert_frame_equal(a, b, **kwargs)
-    assert_frame_equal(b, a, **kwargs)
+    tm.assert_frame_equal(a, b, **kwargs)
+    tm.assert_frame_equal(b, a, **kwargs)
 
 
 def _assert_not_frame_equal(a, b, **kwargs):
@@ -44,10 +44,10 @@ def _assert_not_frame_equal(a, b, **kwargs):
     b : DataFrame
         The second DataFrame to compare.
     kwargs : dict
-        The arguments passed to `assert_frame_equal`.
+        The arguments passed to `tm.assert_frame_equal`.
     """
     try:
-        assert_frame_equal(a, b, **kwargs)
+        tm.assert_frame_equal(a, b, **kwargs)
         msg = "The two DataFrames were equal when they shouldn't have been"
 
         pytest.fail(msg=msg)
@@ -68,7 +68,7 @@ def _assert_not_frame_equal_both(a, b, **kwargs):
     b : DataFrame
         The second DataFrame to compare.
     kwargs : dict
-        The arguments passed to `assert_frame_equal`.
+        The arguments passed to `tm.assert_frame_equal`.
     """
     _assert_not_frame_equal(a, b, **kwargs)
     _assert_not_frame_equal(b, a, **kwargs)
@@ -82,7 +82,7 @@ def test_frame_equal_row_order_mismatch(check_like, obj_fixture):
     if not check_like:  # Do not ignore row-column orderings.
         msg = "{obj}.index are different".format(obj=obj_fixture)
         with pytest.raises(AssertionError, match=msg):
-            assert_frame_equal(df1, df2, check_like=check_like, obj=obj_fixture)
+            tm.assert_frame_equal(df1, df2, check_like=check_like, obj=obj_fixture)
     else:
         _assert_frame_equal_both(df1, df2, check_like=check_like, obj=obj_fixture)
 
@@ -98,7 +98,7 @@ def test_frame_equal_shape_mismatch(df1, df2, obj_fixture):
     msg = "{obj} are different".format(obj=obj_fixture)
 
     with pytest.raises(AssertionError, match=msg):
-        assert_frame_equal(df1, df2, obj=obj_fixture)
+        tm.assert_frame_equal(df1, df2, obj=obj_fixture)
 
 
 @pytest.mark.parametrize(
@@ -127,9 +127,9 @@ def test_frame_equal_index_dtype_mismatch(df1, df2, msg, check_index_type):
 
     if check_index_type:
         with pytest.raises(AssertionError, match=msg):
-            assert_frame_equal(df1, df2, **kwargs)
+            tm.assert_frame_equal(df1, df2, **kwargs)
     else:
-        assert_frame_equal(df1, df2, **kwargs)
+        tm.assert_frame_equal(df1, df2, **kwargs)
 
 
 def test_empty_dtypes(check_dtype):
@@ -143,9 +143,9 @@ def test_empty_dtypes(check_dtype):
     if check_dtype:
         msg = r"Attributes of DataFrame\..* are different"
         with pytest.raises(AssertionError, match=msg):
-            assert_frame_equal(df1, df2, **kwargs)
+            tm.assert_frame_equal(df1, df2, **kwargs)
     else:
-        assert_frame_equal(df1, df2, **kwargs)
+        tm.assert_frame_equal(df1, df2, **kwargs)
 
 
 def test_frame_equal_index_mismatch(obj_fixture):
@@ -161,7 +161,7 @@ def test_frame_equal_index_mismatch(obj_fixture):
     df2 = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["a", "b", "d"])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_frame_equal(df1, df2, obj=obj_fixture)
+        tm.assert_frame_equal(df1, df2, obj=obj_fixture)
 
 
 def test_frame_equal_columns_mismatch(obj_fixture):
@@ -177,7 +177,7 @@ def test_frame_equal_columns_mismatch(obj_fixture):
     df2 = DataFrame({"A": [1, 2, 3], "b": [4, 5, 6]}, index=["a", "b", "c"])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_frame_equal(df1, df2, obj=obj_fixture)
+        tm.assert_frame_equal(df1, df2, obj=obj_fixture)
 
 
 def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
@@ -193,7 +193,7 @@ def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
     df2 = DataFrame({"A": [1, 2, 3], "B": [4, 5, 7]})
 
     with pytest.raises(AssertionError, match=msg):
-        assert_frame_equal(df1, df2, by_blocks=by_blocks_fixture, obj=obj_fixture)
+        tm.assert_frame_equal(df1, df2, by_blocks=by_blocks_fixture, obj=obj_fixture)
 
 
 @pytest.mark.parametrize(
@@ -222,8 +222,8 @@ def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
 def test_frame_equal_unicode(df1, df2, msg, by_blocks_fixture, obj_fixture):
     # see gh-20503
     #
-    # Test ensures that `assert_frame_equals` raises the right exception
+    # Test ensures that `tm.assert_frame_equals` raises the right exception
     # when comparing DataFrames containing differing unicode objects.
     msg = msg.format(obj=obj_fixture)
     with pytest.raises(AssertionError, match=msg):
-        assert_frame_equal(df1, df2, by_blocks=by_blocks_fixture, obj=obj_fixture)
+        tm.assert_frame_equal(df1, df2, by_blocks=by_blocks_fixture, obj=obj_fixture)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import Categorical, Index, MultiIndex, NaT
-from pandas.util.testing import assert_index_equal
+import pandas.util.testing as tm
 
 
 def test_index_equal_levels_mismatch():
@@ -20,7 +20,7 @@ Index levels are different
     idx2 = MultiIndex.from_tuples([("A", 1), ("A", 2), ("B", 3), ("B", 4)])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_index_equal(idx1, idx2, exact=False)
+        tm.assert_index_equal(idx1, idx2, exact=False)
 
 
 def test_index_equal_values_mismatch(check_exact):
@@ -34,7 +34,7 @@ MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
     idx2 = MultiIndex.from_tuples([("A", 1), ("A", 2), ("B", 3), ("B", 4)])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_index_equal(idx1, idx2, check_exact=check_exact)
+        tm.assert_index_equal(idx1, idx2, check_exact=check_exact)
 
 
 def test_index_equal_length_mismatch(check_exact):
@@ -48,7 +48,7 @@ Index length are different
     idx2 = Index([1, 2, 3, 4])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_index_equal(idx1, idx2, check_exact=check_exact)
+        tm.assert_index_equal(idx1, idx2, check_exact=check_exact)
 
 
 def test_index_equal_class_mismatch(check_exact):
@@ -62,7 +62,7 @@ Index classes are different
     idx2 = Index([1, 2, 3.0])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_index_equal(idx1, idx2, exact=True, check_exact=check_exact)
+        tm.assert_index_equal(idx1, idx2, exact=True, check_exact=check_exact)
 
 
 def test_index_equal_values_close(check_exact):
@@ -77,9 +77,9 @@ Index values are different \\(33\\.33333 %\\)
 \\[right\\]: Float64Index\\(\\[1.0, 2.0, 3.0000000001\\], dtype='float64'\\)"""
 
         with pytest.raises(AssertionError, match=msg):
-            assert_index_equal(idx1, idx2, check_exact=check_exact)
+            tm.assert_index_equal(idx1, idx2, check_exact=check_exact)
     else:
-        assert_index_equal(idx1, idx2, check_exact=check_exact)
+        tm.assert_index_equal(idx1, idx2, check_exact=check_exact)
 
 
 def test_index_equal_values_less_close(check_exact, check_less_precise):
@@ -95,9 +95,9 @@ Index values are different \\(33\\.33333 %\\)
 \\[right\\]: Float64Index\\(\\[1.0, 2.0, 3.0001\\], dtype='float64'\\)"""
 
         with pytest.raises(AssertionError, match=msg):
-            assert_index_equal(idx1, idx2, **kwargs)
+            tm.assert_index_equal(idx1, idx2, **kwargs)
     else:
-        assert_index_equal(idx1, idx2, **kwargs)
+        tm.assert_index_equal(idx1, idx2, **kwargs)
 
 
 def test_index_equal_values_too_far(check_exact, check_less_precise):
@@ -112,7 +112,7 @@ Index values are different \\(33\\.33333 %\\)
 \\[right\\]: Int64Index\\(\\[1, 2, 4\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_index_equal(idx1, idx2, **kwargs)
+        tm.assert_index_equal(idx1, idx2, **kwargs)
 
 
 def test_index_equal_level_values_mismatch(check_exact, check_less_precise):
@@ -127,7 +127,7 @@ MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
 \\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_index_equal(idx1, idx2, **kwargs)
+        tm.assert_index_equal(idx1, idx2, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -145,14 +145,14 @@ Attribute "names" are different
     idx2 = Index([1, 2, 3], name=name2)
 
     if name1 == name2 or name1 is name2:
-        assert_index_equal(idx1, idx2)
+        tm.assert_index_equal(idx1, idx2)
     else:
         name1 = "'x'" if name1 == "x" else name1
         name2 = "'x'" if name2 == "x" else name2
         msg = msg.format(name1=name1, name2=name2)
 
         with pytest.raises(AssertionError, match=msg):
-            assert_index_equal(idx1, idx2)
+            tm.assert_index_equal(idx1, idx2)
 
 
 def test_index_equal_category_mismatch(check_categorical):
@@ -168,6 +168,6 @@ ordered=False\\)"""
 
     if check_categorical:
         with pytest.raises(AssertionError, match=msg):
-            assert_index_equal(idx1, idx2, check_categorical=check_categorical)
+            tm.assert_index_equal(idx1, idx2, check_categorical=check_categorical)
     else:
-        assert_index_equal(idx1, idx2, check_categorical=check_categorical)
+        tm.assert_index_equal(idx1, idx2, check_categorical=check_categorical)

--- a/pandas/tests/util/test_assert_interval_array_equal.py
+++ b/pandas/tests/util/test_assert_interval_array_equal.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pandas import interval_range
-from pandas.util.testing import assert_interval_array_equal
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize(
@@ -14,7 +14,7 @@ from pandas.util.testing import assert_interval_array_equal
 )
 def test_interval_array_equal(kwargs):
     arr = interval_range(**kwargs).values
-    assert_interval_array_equal(arr, arr)
+    tm.assert_interval_array_equal(arr, arr)
 
 
 def test_interval_array_equal_closed_mismatch():
@@ -30,7 +30,7 @@ Attribute "closed" are different
 \\[right\\]: right"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_interval_array_equal(arr1, arr2)
+        tm.assert_interval_array_equal(arr1, arr2)
 
 
 def test_interval_array_equal_periods_mismatch():
@@ -46,7 +46,7 @@ IntervalArray.left length are different
 \\[right\\]: 6, Int64Index\\(\\[0, 1, 2, 3, 4, 5\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_interval_array_equal(arr1, arr2)
+        tm.assert_interval_array_equal(arr1, arr2)
 
 
 def test_interval_array_equal_end_mismatch():
@@ -62,7 +62,7 @@ IntervalArray.left values are different \\(80.0 %\\)
 \\[right\\]: Int64Index\\(\\[0, 4, 8, 12, 16\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_interval_array_equal(arr1, arr2)
+        tm.assert_interval_array_equal(arr1, arr2)
 
 
 def test_interval_array_equal_start_mismatch():
@@ -78,4 +78,4 @@ IntervalArray.left values are different \\(100.0 %\\)
 \\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_interval_array_equal(arr1, arr2)
+        tm.assert_interval_array_equal(arr1, arr2)

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import Timestamp
-from pandas.util.testing import assert_numpy_array_equal
+import pandas.util.testing as tm
 
 
 def test_assert_numpy_array_equal_shape_mismatch():
@@ -13,14 +13,14 @@ numpy array shapes are different
 \\[right\\]: \\(3L*,\\)"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(np.array([1, 2]), np.array([3, 4, 5]))
+        tm.assert_numpy_array_equal(np.array([1, 2]), np.array([3, 4, 5]))
 
 
 def test_assert_numpy_array_equal_bad_type():
     expected = "Expected type"
 
     with pytest.raises(AssertionError, match=expected):
-        assert_numpy_array_equal(1, 2)
+        tm.assert_numpy_array_equal(1, 2)
 
 
 @pytest.mark.parametrize(
@@ -37,7 +37,7 @@ numpy array classes are different
     )
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(a, b)
+        tm.assert_numpy_array_equal(a, b)
 
 
 def test_assert_numpy_array_equal_value_mismatch1():
@@ -48,7 +48,7 @@ numpy array values are different \\(66\\.66667 %\\)
 \\[right\\]: \\[1\\.0, nan, 3\\.0\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(np.array([np.nan, 2, 3]), np.array([1, np.nan, 3]))
+        tm.assert_numpy_array_equal(np.array([np.nan, 2, 3]), np.array([1, np.nan, 3]))
 
 
 def test_assert_numpy_array_equal_value_mismatch2():
@@ -59,7 +59,7 @@ numpy array values are different \\(50\\.0 %\\)
 \\[right\\]: \\[1, 3\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(np.array([1, 2]), np.array([1, 3]))
+        tm.assert_numpy_array_equal(np.array([1, 2]), np.array([1, 3]))
 
 
 def test_assert_numpy_array_equal_value_mismatch3():
@@ -70,7 +70,7 @@ numpy array values are different \\(16\\.66667 %\\)
 \\[right\\]: \\[\\[1, 3\\], \\[3, 4\\], \\[5, 6\\]\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             np.array([[1, 2], [3, 4], [5, 6]]), np.array([[1, 3], [3, 4], [5, 6]])
         )
 
@@ -83,7 +83,7 @@ numpy array values are different \\(50\\.0 %\\)
 \\[right\\]: \\[1\\.1, 2.0\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(np.array([1.1, 2.000001]), np.array([1.1, 2.0]))
+        tm.assert_numpy_array_equal(np.array([1.1, 2.000001]), np.array([1.1, 2.0]))
 
 
 def test_assert_numpy_array_equal_value_mismatch5():
@@ -94,7 +94,7 @@ numpy array values are different \\(16\\.66667 %\\)
 \\[right\\]: \\[\\[1, 3\\], \\[3, 4\\], \\[5, 6\\]\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             np.array([[1, 2], [3, 4], [5, 6]]), np.array([[1, 3], [3, 4], [5, 6]])
         )
 
@@ -107,7 +107,9 @@ numpy array values are different \\(25\\.0 %\\)
 \\[right\\]: \\[\\[1, 3\\], \\[3, 4\\]\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(np.array([[1, 2], [3, 4]]), np.array([[1, 3], [3, 4]]))
+        tm.assert_numpy_array_equal(
+            np.array([[1, 2], [3, 4]]), np.array([[1, 3], [3, 4]])
+        )
 
 
 def test_assert_numpy_array_equal_shape_mismatch_override():
@@ -118,13 +120,13 @@ Index shapes are different
 \\[right\\]: \\(3L*,\\)"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(np.array([1, 2]), np.array([3, 4, 5]), obj="Index")
+        tm.assert_numpy_array_equal(np.array([1, 2]), np.array([3, 4, 5]), obj="Index")
 
 
 def test_numpy_array_equal_unicode():
     # see gh-20503
     #
-    # Test ensures that `assert_numpy_array_equals` raises the right
+    # Test ensures that `tm.assert_numpy_array_equals` raises the right
     # exception when comparing np.arrays containing differing unicode objects.
     msg = """numpy array are different
 
@@ -133,7 +135,9 @@ numpy array values are different \\(33\\.33333 %\\)
 \\[right\\]: \\[á, à, å\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(np.array(["á", "à", "ä"]), np.array(["á", "à", "å"]))
+        tm.assert_numpy_array_equal(
+            np.array(["á", "à", "ä"]), np.array(["á", "à", "å"])
+        )
 
 
 def test_numpy_array_equal_object():
@@ -147,7 +151,7 @@ numpy array values are different \\(50\\.0 %\\)
 \\[right\\]: \\[2011-01-01 00:00:00, 2011-01-02 00:00:00\\]"""
 
     with pytest.raises(AssertionError, match=msg):
-        assert_numpy_array_equal(a, b)
+        tm.assert_numpy_array_equal(a, b)
 
 
 @pytest.mark.parametrize("other_type", ["same", "copy"])
@@ -170,6 +174,6 @@ def test_numpy_array_equal_copy_flag(other_type, check_same):
 
     if msg is not None:
         with pytest.raises(AssertionError, match=msg):
-            assert_numpy_array_equal(a, other, check_same=check_same)
+            tm.assert_numpy_array_equal(a, other, check_same=check_same)
     else:
-        assert_numpy_array_equal(a, other, check_same=check_same)
+        tm.assert_numpy_array_equal(a, other, check_same=check_same)

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pandas import Categorical, DataFrame, Series
-from pandas.util.testing import assert_series_equal
+import pandas.util.testing as tm
 
 
 def _assert_series_equal_both(a, b, **kwargs):
@@ -17,10 +17,10 @@ def _assert_series_equal_both(a, b, **kwargs):
     b : Series
         The second Series to compare.
     kwargs : dict
-        The arguments passed to `assert_series_equal`.
+        The arguments passed to `tm.assert_series_equal`.
     """
-    assert_series_equal(a, b, **kwargs)
-    assert_series_equal(b, a, **kwargs)
+    tm.assert_series_equal(a, b, **kwargs)
+    tm.assert_series_equal(b, a, **kwargs)
 
 
 def _assert_not_series_equal(a, b, **kwargs):
@@ -34,10 +34,10 @@ def _assert_not_series_equal(a, b, **kwargs):
     b : Series
         The second Series to compare.
     kwargs : dict
-        The arguments passed to `assert_series_equal`.
+        The arguments passed to `tm.assert_series_equal`.
     """
     try:
-        assert_series_equal(a, b, **kwargs)
+        tm.assert_series_equal(a, b, **kwargs)
         msg = "The two Series were equal when they shouldn't have been"
 
         pytest.fail(msg=msg)
@@ -58,7 +58,7 @@ def _assert_not_series_equal_both(a, b, **kwargs):
     b : Series
         The second Series to compare.
     kwargs : dict
-        The arguments passed to `assert_series_equal`.
+        The arguments passed to `tm.assert_series_equal`.
     """
     _assert_not_series_equal(a, b, **kwargs)
     _assert_not_series_equal(b, a, **kwargs)
@@ -114,7 +114,7 @@ def test_less_precise(data1, data2, dtype, check_less_precise):
     ):
         msg = "Series values are different"
         with pytest.raises(AssertionError, match=msg):
-            assert_series_equal(s1, s2, **kwargs)
+            tm.assert_series_equal(s1, s2, **kwargs)
     else:
         _assert_series_equal_both(s1, s2, **kwargs)
 
@@ -145,9 +145,9 @@ def test_series_equal_index_dtype(s1, s2, msg, check_index_type):
 
     if check_index_type:
         with pytest.raises(AssertionError, match=msg):
-            assert_series_equal(s1, s2, **kwargs)
+            tm.assert_series_equal(s1, s2, **kwargs)
     else:
-        assert_series_equal(s1, s2, **kwargs)
+        tm.assert_series_equal(s1, s2, **kwargs)
 
 
 def test_series_equal_length_mismatch(check_less_precise):
@@ -161,7 +161,7 @@ Series length are different
     s2 = Series([1, 2, 3, 4])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_series_equal(s1, s2, check_less_precise=check_less_precise)
+        tm.assert_series_equal(s1, s2, check_less_precise=check_less_precise)
 
 
 def test_series_equal_values_mismatch(check_less_precise):
@@ -175,7 +175,7 @@ Series values are different \\(33\\.33333 %\\)
     s2 = Series([1, 2, 4])
 
     with pytest.raises(AssertionError, match=msg):
-        assert_series_equal(s1, s2, check_less_precise=check_less_precise)
+        tm.assert_series_equal(s1, s2, check_less_precise=check_less_precise)
 
 
 def test_series_equal_categorical_mismatch(check_categorical):
@@ -191,6 +191,6 @@ ordered=False\\)"""
 
     if check_categorical:
         with pytest.raises(AssertionError, match=msg):
-            assert_series_equal(s1, s2, check_categorical=check_categorical)
+            tm.assert_series_equal(s1, s2, check_categorical=check_categorical)
     else:
         _assert_series_equal_both(s1, s2, check_categorical=check_categorical)


### PR DESCRIPTION
Part of #29272 

Fyi: All changes are generated from a script posted in the issue.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

