### PR TITLE
DOC: Fix SS06 formatting errors in Styler docstrings

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -574,6 +574,7 @@ class Styler:
     def clear(self):
         """
         Reset the styler, removing any previously applied styles.
+
         Returns None.
         """
         self.ctx.clear()
@@ -632,8 +633,9 @@ class Styler:
 
     def apply(self, func, axis=0, subset=None, **kwargs):
         """
-        Apply a function column-wise, row-wise, or table-wise,
-        updating the HTML representation with the result.
+        Apply a function column-wise, row-wise, or table-wise.
+
+        Updating the HTML representation with the result.
 
         Parameters
         ----------
@@ -691,8 +693,9 @@ class Styler:
 
     def applymap(self, func, subset=None, **kwargs):
         """
-        Apply a function elementwise, updating the HTML
-        representation with the result.
+        Apply a function elementwise.
+
+        Updating the HTML representation with the result.
 
         Parameters
         ----------
@@ -719,9 +722,10 @@ class Styler:
 
     def where(self, cond, value, other=None, subset=None, **kwargs):
         """
-        Apply a function elementwise, updating the HTML
-        representation with a style which is selected in
-        accordance with the return value of a function.
+        Apply a function elementwise.
+
+        Updating the HTML representation with a style which is
+        selected in accordance with the return value of a function.
 
         .. versionadded:: 0.21.0
 
@@ -812,8 +816,9 @@ class Styler:
 
     def use(self, styles):
         """
-        Set the styles on the current Styler, possibly using styles
-        from ``Styler.export``.
+        Set the styles on the current Styler.
+
+        Possibly using styles from ``Styler.export``.
 
         Parameters
         ----------
@@ -960,10 +965,10 @@ class Styler:
         text_color_threshold=0.408,
     ):
         """
-        Color the background in a gradient according to
-        the data in each column (optionally row).
+        Color the background in a gradient style.
 
-        Requires matplotlib.
+        The background color is determined according
+        to the data in each column (optionally row). Requires matplotlib.
 
         Parameters
         ----------
@@ -1077,8 +1082,7 @@ class Styler:
 
     def set_properties(self, subset=None, **kwargs):
         """
-        Convenience method for setting one or more non-data dependent
-        properties or each cell.
+        Method to set one or more non-data dependent properties or each cell.
 
         Parameters
         ----------
@@ -1318,8 +1322,9 @@ class Styler:
     @classmethod
     def from_custom_template(cls, searchpath, name):
         """
-        Factory function for creating a subclass of ``Styler``
-        with a custom template and Jinja environment.
+        Factory function for creating a subclass of ``Styler``.
+
+        Uses a custom template and Jinja environment.
 
         Parameters
         ----------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -635,7 +635,7 @@ class Styler:
         """
         Apply a function column-wise, row-wise, or table-wise.
 
-        Updating the HTML representation with the result.
+        Updates the HTML representation with the result.
 
         Parameters
         ----------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -724,7 +724,7 @@ class Styler:
         """
         Apply a function elementwise.
 
-        Updating the HTML representation with a style which is
+        Updates the HTML representation with a style which is
         selected in accordance with the return value of a function.
 
         .. versionadded:: 0.21.0

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -818,7 +818,7 @@ class Styler:
         """
         Set the styles on the current Styler.
 
-        Possibly using styles from ``Styler.export``.
+        Possibly uses styles from ``Styler.export``.
 
         Parameters
         ----------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -695,7 +695,7 @@ class Styler:
         """
         Apply a function elementwise.
 
-        Updating the HTML representation with the result.
+        Updates the HTML representation with the result.
 
         Parameters
         ----------


### PR DESCRIPTION
Errors fixed (from the list in #29254 ):
pandas.io.formats.style.Styler.from_custom_template
pandas.io.formats.style.Styler.apply
pandas.io.formats.style.Styler.applymap
pandas.io.formats.style.Styler.set_properties
pandas.io.formats.style.Styler.clear
pandas.io.formats.style.Styler.background_gradient
pandas.io.formats.style.Styler.use
pandas.io.formats.style.Styler.where

Validated the fixes with ```python scripts/validate_docstrings.py```
Refrencing issue: #29254 