### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/resample

### DIFF
--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -11,12 +11,6 @@ from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.period import PeriodIndex, period_range
 from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_index_equal,
-    assert_series_equal,
-)
 
 # a fixture value can be overridden by the test parameter value. Note that the
 # value of the fixture can be overridden this way even if the test doesn't use
@@ -53,7 +47,7 @@ def test_asfreq(series_and_frame, freq, create_index):
     result = obj.resample(freq).asfreq()
     new_index = create_index(obj.index[0], obj.index[-1], freq=freq)
     expected = obj.reindex(new_index)
-    assert_almost_equal(result, expected)
+    tm.assert_almost_equal(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -67,21 +61,21 @@ def test_asfreq_fill_value(series, create_index):
     result = s.resample("1H").asfreq()
     new_index = create_index(s.index[0], s.index[-1], freq="1H")
     expected = s.reindex(new_index)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     frame = s.to_frame("value")
     frame.iloc[1] = None
     result = frame.resample("1H").asfreq(fill_value=4.0)
     new_index = create_index(frame.index[0], frame.index[-1], freq="1H")
     expected = frame.reindex(new_index, fill_value=4.0)
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 @all_ts
 def test_resample_interpolate(frame):
     # # 12925
     df = frame
-    assert_frame_equal(
+    tm.assert_frame_equal(
         df.resample("1T").asfreq().interpolate(), df.resample("1T").interpolate()
     )
 
@@ -113,9 +107,9 @@ def test_resample_empty_series(freq, empty_series, resample_method):
         expected.index = s.index.asfreq(freq=freq)
     else:
         expected.index = s.index._shallow_copy(freq=freq)
-    assert_index_equal(result.index, expected.index)
+    tm.assert_index_equal(result.index, expected.index)
     assert result.index.freq == expected.index.freq
-    assert_series_equal(result, expected, check_dtype=False)
+    tm.assert_series_equal(result, expected, check_dtype=False)
 
 
 @all_ts
@@ -135,9 +129,9 @@ def test_resample_empty_dataframe(empty_frame, freq, resample_method):
         expected.index = df.index.asfreq(freq=freq)
     else:
         expected.index = df.index._shallow_copy(freq=freq)
-    assert_index_equal(result.index, expected.index)
+    tm.assert_index_equal(result.index, expected.index)
     assert result.index.freq == expected.index.freq
-    assert_almost_equal(result, expected, check_dtype=False)
+    tm.assert_almost_equal(result, expected, check_dtype=False)
 
     # test size for GH13212 (currently stays as df)
 
@@ -186,12 +180,12 @@ def test_resample_loffset_arg_type(frame, create_index):
         if isinstance(expected.index, TimedeltaIndex):
             msg = "DataFrame are different"
             with pytest.raises(AssertionError, match=msg):
-                assert_frame_equal(result_agg, expected)
+                tm.assert_frame_equal(result_agg, expected)
             with pytest.raises(AssertionError, match=msg):
-                assert_frame_equal(result_how, expected)
+                tm.assert_frame_equal(result_how, expected)
         else:
-            assert_frame_equal(result_agg, expected)
-            assert_frame_equal(result_how, expected)
+            tm.assert_frame_equal(result_agg, expected)
+            tm.assert_frame_equal(result_how, expected)
 
 
 @all_ts
@@ -202,7 +196,7 @@ def test_apply_to_empty_series(empty_series):
         result = s.resample(freq).apply(lambda x: 1)
         expected = s.resample(freq).apply(np.sum)
 
-        assert_series_equal(result, expected, check_dtype=False)
+        tm.assert_series_equal(result, expected, check_dtype=False)
 
 
 @all_ts
@@ -214,7 +208,7 @@ def test_resampler_is_iterable(series):
     resampled = series.resample(freq)
     for (rk, rv), (gk, gv) in zip(resampled, grouped):
         assert rk == gk
-        assert_series_equal(rv, gv)
+        tm.assert_series_equal(rv, gv)
 
 
 @all_ts

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -15,11 +15,6 @@ from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.period import Period, period_range
 from pandas.core.resample import DatetimeIndex, _get_timestamp_range_edges
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-)
 
 import pandas.tseries.offsets as offsets
 from pandas.tseries.offsets import BDay, Minute
@@ -71,7 +66,7 @@ def test_custom_grouper(index):
 
     # GH2763 - return in put dtype if we can
     result = g.agg(np.sum)
-    assert_series_equal(result, expect)
+    tm.assert_series_equal(result, expect)
 
     df = DataFrame(np.random.rand(len(dti), 10), index=dti, dtype="float64")
     r = df.groupby(b).agg(np.sum)
@@ -109,7 +104,7 @@ def test_resample_basic(series, closed, expected):
     s = series
     expected = expected(s)
     result = s.resample("5min", closed=closed, label="right").mean()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_integerarray():
@@ -123,13 +118,13 @@ def test_resample_integerarray():
         index=pd.date_range("1/1/2000", periods=3, freq="3T"),
         dtype="Int64",
     )
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.resample("3T").mean()
     expected = Series(
         [1, 4, 7], index=pd.date_range("1/1/2000", periods=3, freq="3T"), dtype="Int64"
     )
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_basic_grouper(series):
@@ -137,7 +132,7 @@ def test_resample_basic_grouper(series):
     result = s.resample("5Min").last()
     grouper = Grouper(freq=Minute(5), closed="left", label="left")
     expected = s.groupby(grouper).agg(lambda x: x[-1])
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -178,7 +173,7 @@ def test_resample_how(series, downsample_method):
     result = getattr(
         s.resample("5min", closed="right", label="right"), downsample_method
     )()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -205,7 +200,7 @@ def test_resample_how_ohlc(series):
     )
 
     result = s.resample("5min", closed="right", label="right").ohlc()
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize("func", ["min", "max", "sum", "prod", "mean", "var", "std"])
@@ -241,10 +236,10 @@ def test_resample_how_callables():
     df_partial2 = df.resample("M").apply(partial(fn, a=2))
     df_class = df.resample("M").apply(FnClass())
 
-    assert_frame_equal(df_standard, df_lambda)
-    assert_frame_equal(df_standard, df_partial)
-    assert_frame_equal(df_standard, df_partial2)
-    assert_frame_equal(df_standard, df_class)
+    tm.assert_frame_equal(df_standard, df_lambda)
+    tm.assert_frame_equal(df_standard, df_partial)
+    tm.assert_frame_equal(df_standard, df_partial2)
+    tm.assert_frame_equal(df_standard, df_class)
 
 
 def test_resample_rounding():
@@ -282,31 +277,31 @@ def test_resample_rounding():
     expected = DataFrame(
         {"value": [4, 9, 4, 2]}, index=date_range("2014-11-08", freq="6s", periods=4)
     )
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     result = df.resample("7s").sum()
     expected = DataFrame(
         {"value": [4, 10, 4, 1]}, index=date_range("2014-11-08", freq="7s", periods=4)
     )
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     result = df.resample("11s").sum()
     expected = DataFrame(
         {"value": [11, 8]}, index=date_range("2014-11-08", freq="11s", periods=2)
     )
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     result = df.resample("13s").sum()
     expected = DataFrame(
         {"value": [13, 6]}, index=date_range("2014-11-08", freq="13s", periods=2)
     )
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     result = df.resample("17s").sum()
     expected = DataFrame(
         {"value": [16, 3]}, index=date_range("2014-11-08", freq="17s", periods=2)
     )
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_resample_basic_from_daily():
@@ -388,12 +383,12 @@ def test_resample_upsampling_picked_but_not_correct():
     )
 
     result = s.resample("D").count()
-    assert_series_equal(result, Series(1, index=expected.index))
+    tm.assert_series_equal(result, Series(1, index=expected.index))
 
     result1 = s.resample("D").sum()
     result2 = s.resample("D").mean()
-    assert_series_equal(result1, expected)
-    assert_series_equal(result2, expected)
+    tm.assert_series_equal(result1, expected)
+    tm.assert_series_equal(result2, expected)
 
 
 def test_resample_frame_basic():
@@ -408,10 +403,10 @@ def test_resample_frame_basic():
         g._cython_agg_general(f)
 
     result = df.resample("A").mean()
-    assert_series_equal(result["A"], df["A"].resample("A").mean())
+    tm.assert_series_equal(result["A"], df["A"].resample("A").mean())
 
     result = df.resample("M").mean()
-    assert_series_equal(result["A"], df["A"].resample("M").mean())
+    tm.assert_series_equal(result["A"], df["A"].resample("M").mean())
 
     df.resample("M", kind="period").mean()
     df.resample("W-WED", kind="period").mean()
@@ -431,7 +426,7 @@ def test_resample_loffset(loffset):
         [s[0], s[1:6].mean(), s[6:11].mean(), s[11:].mean()],
         index=idx + timedelta(minutes=1),
     )
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
     assert result.index.freq == Minute(5)
 
     # from daily
@@ -456,7 +451,7 @@ def test_resample_loffset_upsample():
     idx = date_range("1/1/2000", periods=4, freq="5min")
     expected = Series([s[0], s[5], s[10], s[-1]], index=idx + timedelta(minutes=1))
 
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_loffset_count():
@@ -472,13 +467,13 @@ def test_resample_loffset_count():
     )
     expected = Series(10, index=expected_index)
 
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     # Same issue should apply to .size() since it goes through
     #   same code path
     result = ts.resample("10S", loffset="1s").size()
 
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_upsample():
@@ -519,7 +514,7 @@ def test_resample_how_method():
             Timestamp("2015-03-31 21:49:50"),
         ],
     )
-    assert_series_equal(s.resample("10S").mean(), expected)
+    tm.assert_series_equal(s.resample("10S").mean(), expected)
 
 
 def test_resample_extra_index_point():
@@ -530,7 +525,7 @@ def test_resample_extra_index_point():
     index = date_range(start="20150101", end="20150331", freq="B")
     df = DataFrame({"A": Series(range(len(index)), index=index)}, dtype="int64")
     result = df.resample("BM").last()
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_upsample_with_limit():
@@ -539,7 +534,7 @@ def test_upsample_with_limit():
 
     result = ts.resample("t").ffill(limit=2)
     expected = ts.reindex(result.index, method="ffill", limit=2)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_nearest_upsample_with_limit():
@@ -548,7 +543,7 @@ def test_nearest_upsample_with_limit():
 
     result = ts.resample("t").nearest(limit=2)
     expected = ts.reindex(result.index, method="nearest", limit=2)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_ohlc(series):
@@ -601,7 +596,7 @@ def test_resample_ohlc_result():
     df = DataFrame(data=np.arange(len(index)), index=index)
     result = df.resample("B").mean()
     expected = df.reindex(index=date_range(rng[0], rng[-1], freq="B"))
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_resample_ohlc_dataframe():
@@ -627,7 +622,7 @@ def test_resample_ohlc_dataframe():
         axis=1,
         keys=["VOLUME", "PRICE"],
     )
-    assert_frame_equal(exp, res)
+    tm.assert_frame_equal(exp, res)
 
     df.columns = [["a", "b"], ["c", "d"]]
     res = df.resample("H").ohlc()
@@ -643,7 +638,7 @@ def test_resample_ohlc_dataframe():
             ("b", "d", "close"),
         ]
     )
-    assert_frame_equal(exp, res)
+    tm.assert_frame_equal(exp, res)
 
     # dupe columns fail atm
     # df.columns = ['PRICE', 'PRICE']
@@ -662,7 +657,7 @@ def test_resample_dup_index():
     result = df.resample("Q", axis=1).mean()
     expected = df.groupby(lambda x: int((x.month - 1) / 3), axis=1).mean()
     expected.columns = [Period(year=2000, quarter=i + 1, freq="Q") for i in range(4)]
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_resample_reresample():
@@ -681,22 +676,22 @@ def test_resample_timestamp_to_period(simple_date_range_series):
     result = ts.resample("A-DEC", kind="period").mean()
     expected = ts.resample("A-DEC").mean()
     expected.index = period_range("1990", "2000", freq="a-dec")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.resample("A-JUN", kind="period").mean()
     expected = ts.resample("A-JUN").mean()
     expected.index = period_range("1990", "2000", freq="a-jun")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.resample("M", kind="period").mean()
     expected = ts.resample("M").mean()
     expected.index = period_range("1990-01", "2000-01", freq="M")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = ts.resample("M", kind="period").mean()
     expected = ts.resample("M").mean()
     expected.index = period_range("1990-01", "2000-01", freq="M")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_ohlc_5min():
@@ -728,8 +723,8 @@ def test_downsample_non_unique():
 
     expected = ts.groupby(lambda x: x.month).mean()
     assert len(result) == 2
-    assert_almost_equal(result[0], expected[1])
-    assert_almost_equal(result[1], expected[2])
+    tm.assert_almost_equal(result[0], expected[1])
+    tm.assert_almost_equal(result[1], expected[2])
 
 
 def test_asfreq_non_unique():
@@ -766,7 +761,7 @@ def test_resample_anchored_ticks():
     for freq in freqs:
         result = ts[2:].resample(freq, closed="left", label="left").mean()
         expected = ts.resample(freq, closed="left", label="left").mean()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
 
 def test_resample_single_group():
@@ -774,11 +769,11 @@ def test_resample_single_group():
 
     rng = date_range("2000-1-1", "2000-2-10", freq="D")
     ts = Series(np.random.randn(len(rng)), index=rng)
-    assert_series_equal(ts.resample("M").sum(), ts.resample("M").apply(mysum))
+    tm.assert_series_equal(ts.resample("M").sum(), ts.resample("M").apply(mysum))
 
     rng = date_range("2000-1-1", "2000-1-10", freq="D")
     ts = Series(np.random.randn(len(rng)), index=rng)
-    assert_series_equal(ts.resample("M").sum(), ts.resample("M").apply(mysum))
+    tm.assert_series_equal(ts.resample("M").sum(), ts.resample("M").apply(mysum))
 
     # GH 3849
     s = Series(
@@ -787,7 +782,7 @@ def test_resample_single_group():
     )
     expected = Series([0.75], index=[Timestamp("20070915")])
     result = s.resample("D").apply(lambda x: np.std(x))
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_base():
@@ -809,7 +804,7 @@ def test_resample_float_base():
     base = 17 + 43.51 / 60
     result = s.resample("3min", base=base).size()
     expected = Series(3, index=pd.DatetimeIndex(["2018-11-26 16:17:43.51"]))
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_daily_anchored():
@@ -819,7 +814,7 @@ def test_resample_daily_anchored():
 
     result = ts[2:].resample("D", closed="left", label="left").mean()
     expected = ts.resample("D", closed="left", label="left").mean()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_to_period_monthly_buglet():
@@ -844,7 +839,7 @@ def test_period_with_agg():
 
     expected = s2.to_timestamp().resample("D").mean().to_period()
     result = s2.resample("D").agg(lambda x: x.mean())
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_segfault():
@@ -862,7 +857,7 @@ def test_resample_segfault():
     ).set_index("timestamp")
     result = df.groupby("ID").resample("5min").sum()
     expected = df.groupby("ID").apply(lambda x: x.resample("5min").sum())
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_resample_dtype_preservation():
@@ -909,7 +904,7 @@ def test_weekly_resample_buglet():
 
     resampled = ts.resample("W").mean()
     expected = ts.resample("W-SUN").mean()
-    assert_series_equal(resampled, expected)
+    tm.assert_series_equal(resampled, expected)
 
 
 def test_monthly_resample_error():
@@ -933,7 +928,7 @@ def test_nanosecond_resample_error():
     exp_indx = pd.date_range(start=pd.to_datetime(exp_start), periods=10, freq="100n")
     exp = Series(range(len(exp_indx)), index=exp_indx)
 
-    assert_series_equal(result, exp)
+    tm.assert_series_equal(result, exp)
 
 
 def test_resample_anchored_intraday(simple_date_range_series):
@@ -1051,7 +1046,7 @@ def test_resample_not_monotonic():
 
     result = ts.resample("D").sum()
     exp = ts.sort_index().resample("D").sum()
-    assert_series_equal(result, exp)
+    tm.assert_series_equal(result, exp)
 
 
 def test_resample_median_bug_1688():
@@ -1130,9 +1125,9 @@ def test_resample_consistency():
     r10 = s.resample("10Min").bfill()
 
     # s10_2, r10, r10_2, rl should all be equal
-    assert_series_equal(s10_2, r10)
-    assert_series_equal(s10_2, r10_2)
-    assert_series_equal(s10_2, rl)
+    tm.assert_series_equal(s10_2, r10)
+    tm.assert_series_equal(s10_2, r10_2)
+    tm.assert_series_equal(s10_2, rl)
 
 
 def test_resample_timegrouper():
@@ -1158,10 +1153,10 @@ def test_resample_timegrouper():
             name="A",
         )
         expected = DataFrame({"B": [1, 0, 2, 2, 1]}, index=exp_idx)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.groupby(pd.Grouper(freq="M", key="A")).count()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame(dict(A=dates, B=np.arange(len(dates)), C=np.arange(len(dates))))
         result = df.set_index("A").resample("M").count()
@@ -1170,10 +1165,10 @@ def test_resample_timegrouper():
             index=exp_idx,
             columns=["B", "C"],
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.groupby(pd.Grouper(freq="M", key="A")).count()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
 
 def test_resample_nunique():
@@ -1198,13 +1193,13 @@ def test_resample_nunique():
 
     for t in [r, g]:
         result = r.ID.nunique()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     result = df.ID.resample("D").nunique()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = df.ID.groupby(pd.Grouper(freq="D")).nunique()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_nunique_preserves_column_level_names():
@@ -1228,9 +1223,9 @@ def test_resample_nunique_with_date_gap():
     # Since all elements are unique, these should all be the same
     results = [r.count(), r.nunique(), r.agg(Series.nunique), r.agg("nunique")]
 
-    assert_series_equal(results[0], results[1])
-    assert_series_equal(results[0], results[2])
-    assert_series_equal(results[0], results[3])
+    tm.assert_series_equal(results[0], results[1])
+    tm.assert_series_equal(results[0], results[2])
+    tm.assert_series_equal(results[0], results[3])
 
 
 @pytest.mark.parametrize("n", [10000, 100000])
@@ -1259,7 +1254,7 @@ def test_resample_group_info(n, k):
     arr = np.bincount(bins[mask] - 1, minlength=len(ix)).astype("int64", copy=False)
     right = Series(arr, index=ix)
 
-    assert_series_equal(left, right)
+    tm.assert_series_equal(left, right)
 
 
 def test_resample_size():
@@ -1274,7 +1269,7 @@ def test_resample_size():
     val = np.bincount(bins, minlength=len(ix) + 1)[1:].astype("int64", copy=False)
 
     right = Series(val, index=ix)
-    assert_series_equal(left, right)
+    tm.assert_series_equal(left, right)
 
 
 def test_resample_across_dst():
@@ -1305,7 +1300,7 @@ def test_resample_across_dst():
     result = df.resample(rule="H").sum()
     expected = DataFrame([5, 5], index=dti2)
 
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_groupby_with_dst_time_change():
@@ -1322,18 +1317,18 @@ def test_groupby_with_dst_time_change():
 
     index = pd.DatetimeIndex(expected_index_values)
     expected = pd.DataFrame([1.0] + ([np.nan] * 21) + [2.0], index=index)
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_resample_dst_anchor():
     # 5172
     dti = DatetimeIndex([datetime(2012, 11, 4, 23)], tz="US/Eastern")
     df = DataFrame([5], index=dti)
-    assert_frame_equal(
+    tm.assert_frame_equal(
         df.resample(rule="D").sum(), DataFrame([5], index=df.index.normalize())
     )
     df.resample(rule="MS").sum()
-    assert_frame_equal(
+    tm.assert_frame_equal(
         df.resample(rule="MS").sum(),
         DataFrame([5], index=DatetimeIndex([datetime(2012, 11, 1)], tz="US/Eastern")),
     )
@@ -1343,7 +1338,7 @@ def test_resample_dst_anchor():
     df = DataFrame({"a": values, "b": values, "c": values}, index=dti, dtype="int64")
     how = {"a": "min", "b": "max", "c": "count"}
 
-    assert_frame_equal(
+    tm.assert_frame_equal(
         df.resample("W-MON").agg(how)[["a", "b", "c"]],
         DataFrame(
             {
@@ -1356,7 +1351,7 @@ def test_resample_dst_anchor():
         "W-MON Frequency",
     )
 
-    assert_frame_equal(
+    tm.assert_frame_equal(
         df.resample("2W-MON").agg(how)[["a", "b", "c"]],
         DataFrame(
             {
@@ -1371,7 +1366,7 @@ def test_resample_dst_anchor():
         "2W-MON Frequency",
     )
 
-    assert_frame_equal(
+    tm.assert_frame_equal(
         df.resample("MS").agg(how)[["a", "b", "c"]],
         DataFrame(
             {"a": [0, 48, 1538], "b": [47, 1537, 1586], "c": [48, 1490, 49]},
@@ -1380,7 +1375,7 @@ def test_resample_dst_anchor():
         "MS Frequency",
     )
 
-    assert_frame_equal(
+    tm.assert_frame_equal(
         df.resample("2MS").agg(how)[["a", "b", "c"]],
         DataFrame(
             {"a": [0, 1538], "b": [1537, 1586], "c": [1538, 49]},
@@ -1390,7 +1385,7 @@ def test_resample_dst_anchor():
     )
 
     df_daily = df["10/26/2013":"10/29/2013"]
-    assert_frame_equal(
+    tm.assert_frame_equal(
         df_daily.resample("D").agg({"a": "min", "b": "max", "c": "count"})[
             ["a", "b", "c"]
         ],
@@ -1461,17 +1456,17 @@ def test_resample_with_nat():
         ["1970-01-01 00:00:00", "1970-01-01 00:00:01", "1970-01-01 00:00:02"]
     )
     frame_1s = DataFrame([3, 7, 11], index=index_1s)
-    assert_frame_equal(frame.resample("1s").mean(), frame_1s)
+    tm.assert_frame_equal(frame.resample("1s").mean(), frame_1s)
 
     index_2s = DatetimeIndex(["1970-01-01 00:00:00", "1970-01-01 00:00:02"])
     frame_2s = DataFrame([5, 11], index=index_2s)
-    assert_frame_equal(frame.resample("2s").mean(), frame_2s)
+    tm.assert_frame_equal(frame.resample("2s").mean(), frame_2s)
 
     index_3s = DatetimeIndex(["1970-01-01 00:00:00"])
     frame_3s = DataFrame([7], index=index_3s)
-    assert_frame_equal(frame.resample("3s").mean(), frame_3s)
+    tm.assert_frame_equal(frame.resample("3s").mean(), frame_3s)
 
-    assert_frame_equal(frame.resample("60s").mean(), frame_3s)
+    tm.assert_frame_equal(frame.resample("60s").mean(), frame_3s)
 
 
 def test_resample_datetime_values():
@@ -1513,7 +1508,7 @@ def test_resample_apply_with_additional_args(series):
     df = pd.DataFrame({"A": 1, "B": 2}, index=pd.date_range("2017", periods=10))
     result = df.groupby("A").resample("D").agg(f, multiplier)
     expected = df.groupby("A").resample("D").mean().multiply(multiplier)
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize("k", [1, 2, 3])
@@ -1543,7 +1538,7 @@ def test_resample_equivalent_offsets(n1, freq1, n2, freq2, k):
 
     result1 = s.resample(str(n1_) + freq1).mean()
     result2 = s.resample(str(n2_) + freq2).mean()
-    assert_series_equal(result1, result2)
+    tm.assert_series_equal(result1, result2)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -15,11 +15,6 @@ from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.period import Period, PeriodIndex, period_range
 from pandas.core.resample import _get_period_range_edges
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-)
 
 import pandas.tseries.offsets as offsets
 
@@ -50,7 +45,7 @@ class TestPeriodIndex:
             new_index = date_range(start=start, end=end, freq=freq, closed="left")
             expected = obj.to_timestamp().reindex(new_index).to_period(freq)
         result = obj.resample(freq, kind=kind).asfreq()
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
     def test_asfreq_fill_value(self, series):
         # test for fill value during resampling, issue 3715
@@ -63,7 +58,7 @@ class TestPeriodIndex:
         )
         expected = s.to_timestamp().reindex(new_index, fill_value=4.0)
         result = s.resample("1H", kind="timestamp").asfreq(fill_value=4.0)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         frame = s.to_frame("value")
         new_index = date_range(
@@ -73,7 +68,7 @@ class TestPeriodIndex:
         )
         expected = frame.to_timestamp().reindex(new_index, fill_value=3.0)
         result = frame.resample("1H", kind="timestamp").asfreq(fill_value=3.0)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("freq", ["H", "12H", "2D", "W"])
     @pytest.mark.parametrize("kind", [None, "period", "timestamp"])
@@ -108,7 +103,7 @@ class TestPeriodIndex:
         result = getattr(ts.resample(targ, convention=conv), meth)()
         expected = result.to_timestamp(targ, how=conv)
         expected = expected.asfreq(targ, meth).to_period()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_basic_downsample(self, simple_period_range_series):
         ts = simple_period_range_series("1/1/1990", "6/30/1995", freq="M")
@@ -116,11 +111,11 @@ class TestPeriodIndex:
 
         expected = ts.groupby(ts.index.year).mean()
         expected.index = period_range("1/1/1990", "6/30/1995", freq="a-dec")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # this is ok
-        assert_series_equal(ts.resample("a-dec").mean(), result)
-        assert_series_equal(ts.resample("a").mean(), result)
+        tm.assert_series_equal(ts.resample("a-dec").mean(), result)
+        tm.assert_series_equal(ts.resample("a").mean(), result)
 
     @pytest.mark.parametrize(
         "rule,expected_error_msg",
@@ -149,7 +144,7 @@ class TestPeriodIndex:
         resampled = result.resample(freq, convention="end").ffill()
         expected = result.to_timestamp(freq, how="end")
         expected = expected.asfreq(freq, "ffill").to_period(freq)
-        assert_series_equal(resampled, expected)
+        tm.assert_series_equal(resampled, expected)
 
     def test_upsample_with_limit(self):
         rng = period_range("1/1/2000", periods=5, freq="A")
@@ -157,14 +152,14 @@ class TestPeriodIndex:
 
         result = ts.resample("M", convention="end").ffill(limit=2)
         expected = ts.asfreq("M").reindex(result.index, method="ffill", limit=2)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_annual_upsample(self, simple_period_range_series):
         ts = simple_period_range_series("1/1/1990", "12/31/1995", freq="A-DEC")
         df = DataFrame({"a": ts})
         rdf = df.resample("D").ffill()
         exp = df["a"].resample("D").ffill()
-        assert_series_equal(rdf["a"], exp)
+        tm.assert_series_equal(rdf["a"], exp)
 
         rng = period_range("2000", "2003", freq="A-DEC")
         ts = Series([1, 2, 3, 4], index=rng)
@@ -173,7 +168,7 @@ class TestPeriodIndex:
         ex_index = period_range("2000-01", "2003-12", freq="M")
 
         expected = ts.asfreq("M", how="start").reindex(ex_index, method="ffill")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("month", MONTHS)
     @pytest.mark.parametrize("target", ["D", "B", "M"])
@@ -186,7 +181,7 @@ class TestPeriodIndex:
         result = ts.resample(target, convention=convention).ffill()
         expected = result.to_timestamp(target, how=convention)
         expected = expected.asfreq(target, "ffill").to_period()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("target", ["D", "B"])
     @pytest.mark.parametrize("convention", ["start", "end"])
@@ -195,7 +190,7 @@ class TestPeriodIndex:
         result = ts.resample(target, convention=convention).ffill()
         expected = result.to_timestamp(target, how=convention)
         expected = expected.asfreq(target, "ffill").to_period()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_basic(self):
         # GH3609
@@ -211,9 +206,9 @@ class TestPeriodIndex:
         )
         expected = Series([34.5, 79.5], index=index)
         result = s.to_period().resample("T", kind="period").mean()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result2 = s.resample("T", kind="period").mean()
-        assert_series_equal(result2, expected)
+        tm.assert_series_equal(result2, expected)
 
     @pytest.mark.parametrize(
         "freq,expected_vals", [("M", [31, 29, 31, 9]), ("2M", [31 + 29, 31 + 9])]
@@ -226,7 +221,7 @@ class TestPeriodIndex:
             start="2000", freq=freq, periods=len(expected_vals)
         )
         expected = Series(expected_vals, index=expected_index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_same_freq(self, resample_method):
 
@@ -237,7 +232,7 @@ class TestPeriodIndex:
         expected = series
 
         result = getattr(series.resample("M"), resample_method)()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_incompat_freq(self):
         msg = (
@@ -268,7 +263,7 @@ class TestPeriodIndex:
         # Pacific
         expected_index = pd.period_range(start=start, end=end, freq="D") - offsets.Day()
         expected = Series(1, index=expected_index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_with_pytz(self):
         # GH 13238
@@ -279,7 +274,7 @@ class TestPeriodIndex:
         expected = Series(
             2, index=pd.DatetimeIndex(["2017-01-01", "2017-01-02"], tz="US/Eastern")
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         # Especially assert that the timezone is LMT for pytz
         assert result.index.tz == pytz.timezone("US/Eastern")
 
@@ -308,7 +303,7 @@ class TestPeriodIndex:
             pd.period_range(start=start, end=end, freq="D", name="idx") - offsets.Day()
         )
         expected = Series(1, index=expected_index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_nonexistent_time_bin_edge(self):
         # GH 19375
@@ -350,7 +345,7 @@ class TestPeriodIndex:
         )
         last = s.resample("M").ffill()
         both = s.resample("M").ffill().resample("M").last().astype("int64")
-        assert_series_equal(last, both)
+        tm.assert_series_equal(last, both)
 
     @pytest.mark.parametrize("day", DAYS)
     @pytest.mark.parametrize("target", ["D", "B"])
@@ -361,14 +356,14 @@ class TestPeriodIndex:
         result = ts.resample(target, convention=convention).ffill()
         expected = result.to_timestamp(target, how=convention)
         expected = expected.asfreq(target, "ffill").to_period()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_to_timestamps(self, simple_period_range_series):
         ts = simple_period_range_series("1/1/1990", "12/31/1995", freq="M")
 
         result = ts.resample("A-DEC", kind="timestamp").mean()
         expected = ts.to_timestamp(how="start").resample("A-DEC").mean()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_to_quarterly(self, simple_period_range_series):
         for month in MONTHS:
@@ -387,7 +382,7 @@ class TestPeriodIndex:
             expected = stamps.reindex(qdates.to_timestamp("D", "s"), method="ffill")
             expected.index = qdates
 
-            assert_series_equal(quar_ts, expected)
+            tm.assert_series_equal(quar_ts, expected)
 
         # conforms, but different month
         ts = simple_period_range_series("1990", "1992", freq="A-JUN")
@@ -400,7 +395,7 @@ class TestPeriodIndex:
             # .to_timestamp('D')
             # expected = expected.resample('Q-MAR').ffill()
 
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
     def test_resample_fill_missing(self):
         rng = PeriodIndex([2000, 2005, 2007, 2009], freq="A")
@@ -410,7 +405,7 @@ class TestPeriodIndex:
         stamps = s.to_timestamp()
         filled = s.resample("A").ffill()
         expected = stamps.resample("A").ffill().to_period("A")
-        assert_series_equal(filled, expected)
+        tm.assert_series_equal(filled, expected)
 
     def test_cant_fill_missing_dups(self):
         rng = PeriodIndex([2000, 2005, 2005, 2007, 2007], freq="A")
@@ -428,20 +423,20 @@ class TestPeriodIndex:
         if kind != "timestamp":
             expected = expected.to_period(freq)
         result = ts.resample(freq, kind=kind).mean()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_upsample_daily_business_daily(self, simple_period_range_series):
         ts = simple_period_range_series("1/1/2000", "2/1/2000", freq="B")
 
         result = ts.resample("D").asfreq()
         expected = ts.asfreq("D").reindex(period_range("1/3/2000", "2/1/2000"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         ts = simple_period_range_series("1/1/2000", "2/1/2000")
         result = ts.resample("H", convention="s").asfreq()
         exp_rng = period_range("1/1/2000", "2/1/2000 23:00", freq="H")
         expected = ts.asfreq("H", how="s").reindex(exp_rng)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_irregular_sparse(self):
         dr = date_range(start="1/1/2012", freq="5min", periods=1000)
@@ -451,7 +446,7 @@ class TestPeriodIndex:
 
         result = subset.resample("10min").apply(len)
         expected = s.resample("10min").apply(len).loc[result.index]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_weekly_all_na(self):
         rng = date_range("1/1/2000", periods=10, freq="W-WED")
@@ -463,7 +458,7 @@ class TestPeriodIndex:
 
         result = ts.resample("W-THU").asfreq().ffill()[:-1]
         expected = ts.asfreq("W-THU").ffill()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_resample_tz_localized(self):
         dr = date_range(start="2012-4-13", end="2012-5-1")
@@ -481,7 +476,7 @@ class TestPeriodIndex:
 
         exp = ts_local_naive.resample("W").mean().tz_localize("America/Los_Angeles")
 
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         # it works
         result = ts_local.resample("D").mean()
@@ -496,13 +491,13 @@ class TestPeriodIndex:
         ex_index = date_range("2001-09-21", periods=1, freq="D", tz="Australia/Sydney")
         expected = Series([1.5], index=ex_index)
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # for good measure
         result = s.resample("D", kind="period").mean()
         ex_index = period_range("2001-09-20", periods=1, freq="D")
         expected = Series([1.5], index=ex_index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 6397
         # comparing an offset that doesn't propagate tz's
@@ -523,7 +518,7 @@ class TestPeriodIndex:
             .agg({"first": np.sum, "second": np.mean})
             .reindex(columns=["first", "second"])
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_closed_left_corner(self):
         # #1465
@@ -535,7 +530,7 @@ class TestPeriodIndex:
 
         result = s.resample("10min", closed="left", label="right").mean()
         exp = s[1:].resample("10min", closed="left", label="right").mean()
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         result = s.resample("10min", closed="left", label="left").mean()
         exp = s[1:].resample("10min", closed="left", label="left").mean()
@@ -543,7 +538,7 @@ class TestPeriodIndex:
         ex_index = date_range(start="1/1/2012 9:30", freq="10min", periods=3)
 
         tm.assert_index_equal(result.index, ex_index)
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
     def test_quarterly_resampling(self):
         rng = period_range("2000Q1", periods=10, freq="Q-DEC")
@@ -551,7 +546,7 @@ class TestPeriodIndex:
 
         result = ts.resample("A").mean()
         exp = ts.to_timestamp().resample("A").mean().to_period()
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
     def test_resample_weekly_bug_1726(self):
         # 8/6/12 is a Monday
@@ -595,7 +590,7 @@ class TestPeriodIndex:
             [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0],
             index=index,
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_resample_bms_2752(self):
         # GH2753
@@ -616,7 +611,7 @@ class TestPeriodIndex:
 
     #     result = ts.resample('D', convention='span').mean()
 
-    #     assert_series_equal(result, expected)
+    #     tm.assert_series_equal(result, expected)
 
     def test_default_right_closed_label(self):
         end_freq = ["D", "Q", "M", "D"]
@@ -627,7 +622,7 @@ class TestPeriodIndex:
             df = DataFrame(np.random.randn(len(idx), 2), idx)
 
             resampled = df.resample(to_freq).mean()
-            assert_frame_equal(
+            tm.assert_frame_equal(
                 resampled, df.resample(to_freq, closed="right", label="right").mean()
             )
 
@@ -640,7 +635,7 @@ class TestPeriodIndex:
             df = DataFrame(np.random.randn(len(idx), 2), idx)
 
             resampled = df.resample(to_freq).mean()
-            assert_frame_equal(
+            tm.assert_frame_equal(
                 resampled, df.resample(to_freq, closed="left", label="left").mean()
             )
 
@@ -660,7 +655,7 @@ class TestPeriodIndex:
         result = df.resample("5D").mean()
         expected = pd.concat([df.iloc[0:5].mean(), df.iloc[5:].mean()], axis=1).T
         expected.index = [Timestamp("2000-1-1"), Timestamp("2000-1-6")]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         index = date_range(start="2001-5-4", periods=28)
         df = DataFrame(
@@ -702,7 +697,7 @@ class TestPeriodIndex:
             index=index,
         )
         result = df.resample("7D").count()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = DataFrame(
             [
@@ -718,7 +713,7 @@ class TestPeriodIndex:
             index=index,
         )
         result = df.resample("7D").sum()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("kind", ["period", None, "timestamp"])
     @pytest.mark.parametrize("agg_arg", ["mean", {"value": "mean"}, ["mean"]])
@@ -741,8 +736,8 @@ class TestPeriodIndex:
             result_how = df.resample("2D", how=agg_arg, loffset="2H", kind=kind)
         if isinstance(agg_arg, list):
             expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
-        assert_frame_equal(result_agg, expected)
-        assert_frame_equal(result_how, expected)
+        tm.assert_frame_equal(result_agg, expected)
+        tm.assert_frame_equal(result_how, expected)
 
     @pytest.mark.parametrize("freq, period_mult", [("H", 24), ("12H", 2)])
     @pytest.mark.parametrize("kind", [None, "period"])
@@ -757,7 +752,7 @@ class TestPeriodIndex:
         new_index = period_range(start="2000", freq=freq, periods=period_mult * len(pi))
         expected = expected.reindex(new_index)
         result = s.resample(freq, kind=kind).ohlc()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "periods, values",
@@ -807,7 +802,7 @@ class TestPeriodIndex:
         )
         expected = DataFrame(expected_values, index=expected_index)
         result = frame.resample(freq).mean()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_resample_with_only_nat(self):
         # GH 13224
@@ -816,7 +811,7 @@ class TestPeriodIndex:
         expected_index = PeriodIndex(data=[], freq=pi.freq)
         expected = DataFrame(index=expected_index)
         result = frame.resample("1s").mean()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "start,end,start_freq,end_freq,base",
@@ -848,7 +843,7 @@ class TestPeriodIndex:
         # to_timestamp casts 24H -> D
         result = result.asfreq(end_freq) if end_freq == "24H" else result
         expected = s.to_timestamp().resample(end_freq, base=base).mean()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "first,last,offset,exp_first,exp_last",

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -8,7 +8,6 @@ import pandas as pd
 from pandas import DataFrame, Series
 from pandas.core.indexes.datetimes import date_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 dti = date_range(start=datetime(2005, 1, 1), end=datetime(2005, 1, 10), freq="Min")
 
@@ -64,7 +63,7 @@ def test_groupby_resample_api():
     index = pd.MultiIndex.from_arrays([[1] * 8 + [2] * 8, i], names=["group", "date"])
     expected = DataFrame({"val": [5] * 7 + [6] + [7] * 7 + [8]}, index=index)
     result = df.groupby("group").apply(lambda x: x.resample("1D").ffill())[["val"]]
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_groupby_resample_on_api():
@@ -83,7 +82,7 @@ def test_groupby_resample_on_api():
     expected = df.set_index("dates").groupby("key").resample("D").mean()
 
     result = df.groupby("key").resample("D", on="dates").mean()
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_pipe(test_frame):
@@ -158,11 +157,11 @@ def tests_skip_nuisance(test_frame):
     r = df.resample("H")
     result = r[["A", "B"]].sum()
     expected = pd.concat([r.A.sum(), r.B.sum()], axis=1)
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     expected = r[["A", "B", "C"]].sum()
     result = r.sum()
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_downsample_but_actually_upsampling():
@@ -175,7 +174,7 @@ def test_downsample_but_actually_upsampling():
         [0, 20, 40, 60, 80],
         index=pd.date_range("2012-01-01 00:00:00", freq="20s", periods=5),
     )
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_combined_up_downsampling_of_irregular():
@@ -191,7 +190,7 @@ def test_combined_up_downsampling_of_irregular():
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
         result = ts2.resample("2s", how="mean", fill_method="ffill")
     expected = ts2.resample("2s").mean().ffill()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_transform():
@@ -199,7 +198,7 @@ def test_transform():
     r = test_series.resample("20min")
     expected = test_series.groupby(pd.Grouper(freq="20min")).transform("mean")
     result = r.transform("mean")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_fillna():
@@ -211,11 +210,11 @@ def test_fillna():
 
     expected = r.ffill()
     result = r.fillna(method="ffill")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     expected = r.bfill()
     result = r.fillna(method="bfill")
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     msg = (
         r"Invalid fill method\. Expecting pad \(ffill\), backfill"
@@ -233,7 +232,7 @@ def test_apply_without_aggregation():
 
     for t in [g, r]:
         result = t.apply(lambda x: x)
-        assert_series_equal(result, test_series)
+        tm.assert_series_equal(result, test_series)
 
 
 def test_agg_consistency():
@@ -251,7 +250,7 @@ def test_agg_consistency():
     with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
         expected = r[["A", "B", "C"]].agg({"r1": "mean", "r2": "sum"})
         result = r.agg({"r1": "mean", "r2": "sum"})
-    assert_frame_equal(result, expected, check_like=True)
+    tm.assert_frame_equal(result, expected, check_like=True)
 
 
 # TODO: once GH 14008 is fixed, move these tests into
@@ -289,31 +288,31 @@ def test_agg():
     expected.columns = pd.MultiIndex.from_product([["A", "B"], ["mean", "std"]])
     for t in cases:
         result = t.aggregate([np.mean, np.std])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     expected = pd.concat([a_mean, b_std], axis=1)
     for t in cases:
         result = t.aggregate({"A": np.mean, "B": np.std})
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     expected = pd.concat([a_mean, a_std], axis=1)
     expected.columns = pd.MultiIndex.from_tuples([("A", "mean"), ("A", "std")])
     for t in cases:
         result = t.aggregate({"A": ["mean", "std"]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     expected = pd.concat([a_mean, a_sum], axis=1)
     expected.columns = ["mean", "sum"]
     for t in cases:
         result = t["A"].aggregate(["mean", "sum"])
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     expected = pd.concat([a_mean, a_sum], axis=1)
     expected.columns = pd.MultiIndex.from_tuples([("A", "mean"), ("A", "sum")])
     for t in cases:
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = t.aggregate({"A": {"mean": "mean", "sum": "sum"}})
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
     expected.columns = pd.MultiIndex.from_tuples(
@@ -327,7 +326,7 @@ def test_agg():
                     "B": {"mean2": "mean", "sum2": "sum"},
                 }
             )
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
     expected.columns = pd.MultiIndex.from_tuples(
@@ -335,7 +334,7 @@ def test_agg():
     )
     for t in cases:
         result = t.aggregate({"A": ["mean", "std"], "B": ["mean", "std"]})
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
     expected.columns = pd.MultiIndex.from_tuples(
@@ -374,7 +373,7 @@ def test_agg_misc():
         result = t.agg({"A": np.sum, "B": lambda x: np.std(x, ddof=1)})
         rcustom = t["B"].apply(lambda x: np.std(x, ddof=1))
         expected = pd.concat([r["A"].sum(), rcustom], axis=1)
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     # agg with renamers
     expected = pd.concat(
@@ -389,7 +388,7 @@ def test_agg_misc():
             result = t[["A", "B"]].agg(
                 OrderedDict([("result1", np.sum), ("result2", np.mean)])
             )
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     # agg with different hows
     expected = pd.concat(
@@ -400,12 +399,12 @@ def test_agg_misc():
     )
     for t in cases:
         result = t.agg(OrderedDict([("A", ["sum", "std"]), ("B", ["mean", "std"])]))
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     # equivalent of using a selection list / or not
     for t in cases:
         result = t[["A", "B"]].agg({"A": ["sum", "std"], "B": ["mean", "std"]})
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     # series like aggs
     for t in cases:
@@ -413,7 +412,7 @@ def test_agg_misc():
             result = t["A"].agg({"A": ["sum", "std"]})
         expected = pd.concat([t["A"].sum(), t["A"].std()], axis=1)
         expected.columns = pd.MultiIndex.from_tuples([("A", "sum"), ("A", "std")])
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
         expected = pd.concat(
             [t["A"].agg(["sum", "std"]), t["A"].agg(["mean", "std"])], axis=1
@@ -423,7 +422,7 @@ def test_agg_misc():
         )
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = t["A"].agg({"A": ["sum", "std"], "B": ["mean", "std"]})
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     # errors
     # invalid names in the agg specification
@@ -469,11 +468,11 @@ def test_agg_nested_dicts():
             result = t[["A", "B"]].agg(
                 {"A": {"ra": ["mean", "std"]}, "B": {"rb": ["mean", "std"]}}
             )
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = t.agg({"A": {"ra": ["mean", "std"]}, "B": {"rb": ["mean", "std"]}})
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
 
 def test_try_aggregate_non_existing_column():
@@ -534,10 +533,10 @@ def test_selection_api_validation():
 
     exp = df_exp.resample("2D").sum()
     exp.index.name = "date"
-    assert_frame_equal(exp, df.resample("2D", on="date").sum())
+    tm.assert_frame_equal(exp, df.resample("2D", on="date").sum())
 
     exp.index.name = "d"
-    assert_frame_equal(exp, df.resample("2D", level="d").sum())
+    tm.assert_frame_equal(exp, df.resample("2D", level="d").sum())
 
 
 @pytest.mark.parametrize(
@@ -564,4 +563,4 @@ def test_agg_with_datetime_index_list_agg_func(col_name):
         ),
         columns=pd.MultiIndex(levels=[[col_name], ["mean"]], codes=[[0], [0]]),
     )
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -6,7 +6,6 @@ import pandas as pd
 from pandas import DataFrame, Series, Timestamp
 from pandas.core.indexes.datetimes import date_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 test_frame = DataFrame(
     {"A": [1] * 20 + [2] * 12 + [3] * 8, "B": np.arange(40)},
@@ -56,7 +55,7 @@ def test_deferred_with_groupby():
 
     expected = df.groupby("id").apply(f)
     result = df.set_index("date").groupby("id").resample("D").asfreq()
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     df = DataFrame(
         {
@@ -71,7 +70,7 @@ def test_deferred_with_groupby():
 
     expected = df.groupby("group").apply(f)
     result = df.groupby("group").resample("1D").ffill()
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_getitem():
@@ -80,13 +79,13 @@ def test_getitem():
     expected = g.B.apply(lambda x: x.resample("2s").mean())
 
     result = g.resample("2s").B.mean()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = g.B.resample("2s").mean()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = g.resample("2s").mean().B
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_getitem_multiple():
@@ -105,10 +104,10 @@ def test_getitem_multiple():
         ),
         name="buyer",
     )
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = r["buyer"].count()
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_groupby_resample_on_api_with_getitem():
@@ -118,7 +117,7 @@ def test_groupby_resample_on_api_with_getitem():
     )
     exp = df.set_index("date").groupby("id").resample("2D")["data"].sum()
     result = df.groupby("id").resample("2D", on="date")["data"].sum()
-    assert_series_equal(result, exp)
+    tm.assert_series_equal(result, exp)
 
 
 def test_nearest():
@@ -144,7 +143,7 @@ def test_nearest():
             freq="20S",
         ),
     )
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_methods():
@@ -154,37 +153,37 @@ def test_methods():
     for f in ["first", "last", "median", "sem", "sum", "mean", "min", "max"]:
         result = getattr(r, f)()
         expected = g.apply(lambda x: getattr(x.resample("2s"), f)())
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     for f in ["size"]:
         result = getattr(r, f)()
         expected = g.apply(lambda x: getattr(x.resample("2s"), f)())
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     for f in ["count"]:
         result = getattr(r, f)()
         expected = g.apply(lambda x: getattr(x.resample("2s"), f)())
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     # series only
     for f in ["nunique"]:
         result = getattr(r.B, f)()
         expected = g.B.apply(lambda x: getattr(x.resample("2s"), f)())
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     for f in ["nearest", "backfill", "ffill", "asfreq"]:
         result = getattr(r, f)()
         expected = g.apply(lambda x: getattr(x.resample("2s"), f)())
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     result = r.ohlc()
     expected = g.apply(lambda x: x.resample("2s").ohlc())
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     for f in ["std", "var"]:
         result = getattr(r, f)(ddof=1)
         expected = g.apply(lambda x: getattr(x.resample("2s"), f)(ddof=1))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
 
 def test_apply():
@@ -199,13 +198,13 @@ def test_apply():
         return x.resample("2s").sum()
 
     result = r.apply(f)
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     def f(x):
         return x.resample("2s").apply(lambda y: y.sum())
 
     result = g.apply(f)
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_apply_with_mutated_index():
@@ -220,12 +219,12 @@ def test_apply_with_mutated_index():
     expected = df.groupby(pd.Grouper(freq="M")).apply(f)
 
     result = df.resample("M").apply(f)
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     # A case for series
     expected = df["col1"].groupby(pd.Grouper(freq="M")).apply(f)
     result = df["col1"].resample("M").apply(f)
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_groupby_with_label():
@@ -245,7 +244,7 @@ def test_resample_groupby_with_label():
         data={"col0": [0, 0, 2, 2], "col1": [1, 1, 2, 1]}, index=mindex
     )
 
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_consistency_with_window():
@@ -275,4 +274,4 @@ def test_median_duplicate_columns():
     expected = df2.resample("5s").median()
     result = df.resample("5s").median()
     expected.columns = result.columns
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -9,7 +9,6 @@ from pandas import DataFrame, Series
 from pandas.core.groupby.grouper import Grouper
 from pandas.core.indexes.datetimes import date_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 test_series = Series(np.random.randn(1000), index=date_range("1/1/2000", periods=1000))
 
@@ -27,7 +26,7 @@ def test_apply():
 
     applied.index = applied.index.droplevel(0)
     expected.index = expected.index.droplevel(0)
-    assert_series_equal(applied, expected)
+    tm.assert_series_equal(applied, expected)
 
 
 def test_count():
@@ -38,11 +37,11 @@ def test_count():
     grouper = Grouper(freq="A", label="right", closed="right")
     result = test_series.groupby(grouper).count()
     expected.index = result.index
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
     result = test_series.resample("A").count()
     expected.index = result.index
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_numpy_reduction():
@@ -51,7 +50,7 @@ def test_numpy_reduction():
     expected = test_series.groupby(lambda x: x.year).agg(np.prod)
     expected.index = result.index
 
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_apply_iteration():
@@ -153,7 +152,7 @@ def test_aggregate_normal(resample_method):
         expected.index = date_range(start='2013-01-01',
                                     freq='D', periods=5, name='key')
         dt_result = getattr(dt_grouped, func)(3)
-        assert_frame_equal(expected, dt_result)
+        tm.assert_frame_equal(expected, dt_result)
     """
 
 
@@ -210,7 +209,7 @@ def test_aggregate_with_nat(func, fill_value):
     expected = normal_result.append(pad)
     expected = expected.sort_index()
     expected.index = date_range(start="2013-01-01", freq="D", periods=5, name="key")
-    assert_frame_equal(expected, dt_result)
+    tm.assert_frame_equal(expected, dt_result)
     assert dt_result.index.name == "key"
 
 
@@ -240,7 +239,7 @@ def test_aggregate_with_nat_size():
     expected = normal_result.append(pad)
     expected = expected.sort_index()
     expected.index = date_range(start="2013-01-01", freq="D", periods=5, name="key")
-    assert_series_equal(expected, dt_result)
+    tm.assert_series_equal(expected, dt_result)
     assert dt_result.index.name == "key"
 
 

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -6,7 +6,6 @@ import pandas as pd
 from pandas import DataFrame, Series
 from pandas.core.indexes.timedeltas import timedelta_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 def test_asfreq_bug():
@@ -16,7 +15,7 @@ def test_asfreq_bug():
         data=[1, np.nan, np.nan, 3],
         index=timedelta_range("0 day", periods=4, freq="1T"),
     )
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_resample_with_nat():
@@ -27,7 +26,7 @@ def test_resample_with_nat():
         {"value": [2.5, np.nan, 5.0]},
         index=timedelta_range("0 day", periods=3, freq="1S"),
     )
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_resample_as_freq_with_subperiod():
@@ -53,11 +52,11 @@ def test_resample_with_timedeltas():
     )
     result = df.resample("30T").sum()
 
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     s = df["A"]
     result = s.resample("30T").sum()
-    assert_series_equal(result, expected["A"])
+    tm.assert_series_equal(result, expected["A"])
 
 
 def test_resample_single_period_timedelta():
@@ -67,7 +66,7 @@ def test_resample_single_period_timedelta():
     expected = Series(
         [1, 5, 4], index=pd.timedelta_range("1 day", freq="2s", periods=3)
     )
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_timedelta_idempotency():
@@ -77,7 +76,7 @@ def test_resample_timedelta_idempotency():
     series = Series(range(9), index=index)
     result = series.resample("10L").mean()
     expected = series
-    assert_series_equal(result, expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_base_with_timedeltaindex():


### PR DESCRIPTION
Part of #29272

Fyi: the changes were created via a script posted in the issue

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
