### PR TITLE
Fix missing tick labels on twinned axes.

### DIFF
--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -289,6 +289,22 @@ def _remove_labels_from_axis(axis):
     axis.get_label().set_visible(False)
 
 
+# If two axes sharing an axis also have the same position, they can be referred to as
+# internally sharing the common axis (a.k.a twinning). _handle_shared_axes() is only
+# interested in axes externally sharing an axis, regardless of whether either of the
+# axes is also internally sharing with a third axes.
+
+
+def _ignore_colocated_axes(ax1, axes):
+    # Remove colocated axes from a list.
+    ax1_points = ax1.get_position().get_points()
+    return [
+        ax2
+        for ax2 in axes
+        if ax1 == ax2 or not np.array_equal(ax1_points, ax2.get_position().get_points())
+    ]
+
+
 def _handle_shared_axes(axarr, nplots, naxes, nrows, ncols, sharex, sharey):
     if nplots > 1:
 
@@ -306,7 +322,15 @@ def _handle_shared_axes(axarr, nplots, naxes, nrows, ncols, sharex, sharey):
                     # the last in the column, because below is no subplot/gap.
                     if not layout[ax.rowNum + 1, ax.colNum]:
                         continue
-                    if sharex or len(ax.get_shared_x_axes().get_siblings(ax)) > 1:
+                    if (
+                        sharex
+                        or len(
+                            _ignore_colocated_axes(
+                                ax, ax.get_shared_x_axes().get_siblings(ax)
+                            )
+                        )
+                        > 1
+                    ):
                         _remove_labels_from_axis(ax.xaxis)
 
             except IndexError:
@@ -315,7 +339,15 @@ def _handle_shared_axes(axarr, nplots, naxes, nrows, ncols, sharex, sharey):
                 for ax in axarr:
                     if ax.is_last_row():
                         continue
-                    if sharex or len(ax.get_shared_x_axes().get_siblings(ax)) > 1:
+                    if (
+                        sharex
+                        or len(
+                            _ignore_colocated_axes(
+                                ax, ax.get_shared_x_axes().get_siblings(ax)
+                            )
+                        )
+                        > 1
+                    ):
                         _remove_labels_from_axis(ax.xaxis)
 
         if ncols > 1:
@@ -325,7 +357,15 @@ def _handle_shared_axes(axarr, nplots, naxes, nrows, ncols, sharex, sharey):
                 # have a subplot there, we can skip the layout test
                 if ax.is_first_col():
                     continue
-                if sharey or len(ax.get_shared_y_axes().get_siblings(ax)) > 1:
+                if (
+                    sharey
+                    or len(
+                        _ignore_colocated_axes(
+                            ax, ax.get_shared_y_axes().get_siblings(ax)
+                        )
+                    )
+                    > 1
+                ):
                     _remove_labels_from_axis(ax.yaxis)
 
 


### PR DESCRIPTION
## Background:

Multi-row and/or multi-column subplots can utilize shared axes.

An external share happens at axis creation when a sharex or sharey
parameter is specified.

An internal share, or twinning, occurs when an overlayed axis is created
by the `Axes.twinx()` or `Axes.twiny()` calls.

The two types of sharing can be distinguished after the fact in the
following manner. If two axes sharing an axis also have the same
position, they are internally sharing an axis, they are twinned. If their positions are different, they are externally sharing the common axis.

For externally shared axes Pandas automatically removes tick labels for
all but the last row and/or first column in
`./pandas/plotting/_matplotlib/tools.py`'s function `_handle_shared_axes()`.

## The problem:

`_handle_shared_axes()` should be interested in externally shared axes,
whether or not they are also twinned. It should, but **does not**, ignore
axes which are only twinned. 

Which means that twinned-only axes wrongly lose their tick labels.

## The cure:

This commit introduces `_ignore_colocated_axes()` which ignores any
axes in a list which have the same position as the given axis. It uses
this function to envelope calls from `_handle_shared_axes()` to
`Axes.get_shared_{x,y}_axes().get_siblings(ax)`.

## The demonstration test case:

Note especially the axis labels (and associated tick labels).

```python
#!/usr/bin/python3

import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

# Create data
df = pd.DataFrame({'a': np.random.randn(1000),
                   'b': np.random.randn(1000)})

# Create figure
fig = plt.figure()
plots = fig.subplots(2, 3)

# Create *externally* shared axes
plots[0][0] = plt.subplot(231, sharex=plots[1][0])
plots[0][2] = plt.subplot(233, sharex=plots[1][2])

# Create *internally* shared axes
twin_ax1 = plots[0][1].twinx()
twin_ax2 = plots[0][2].twinx()

# Plot data to primary axes
df['a'].plot(ax=plots[0][0], title="External share only").set_xlabel("this label should never be visible")
df['a'].plot(ax=plots[1][0])

df['a'].plot(ax=plots[0][1], title="Internal share (twin) only").set_xlabel("this label should always be visible")
df['a'].plot(ax=plots[1][1])

df['a'].plot(ax=plots[0][2], title="Both").set_xlabel("this label should never be visible")
df['a'].plot(ax=plots[1][2])

# Plot data to twinned axes
df['b'].plot(ax=twin_ax1, color='green')
df['b'].plot(ax=twin_ax2, color='yellow')

# Do it
plt.show()
```
---

- [ ] closes #27812
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
