### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/indexes

### DIFF
--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -7,7 +7,6 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex, Index, Timestamp, date_range, offsets
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal
 
 randn = np.random.randn
 
@@ -262,7 +261,7 @@ class TestDatetimeIndex:
         result = index.isin(list(index))
         assert result.all()
 
-        assert_almost_equal(
+        tm.assert_almost_equal(
             index.isin([index[2], 5]), np.array([False, False, True, False])
         )
 

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -31,8 +31,7 @@ from pandas import (
 )
 from pandas.core.arrays import DatetimeArray
 from pandas.core.tools import datetimes as tools
-from pandas.util import testing as tm
-from pandas.util.testing import assert_series_equal
+import pandas.util.testing as tm
 
 
 class TestTimeConversionFormats:
@@ -55,7 +54,7 @@ class TestTimeConversionFormats:
                 expected = expecteds[i]
 
                 if isinstance(expected, Series):
-                    assert_series_equal(result, Series(expected))
+                    tm.assert_series_equal(result, Series(expected))
                 elif isinstance(expected, Timestamp):
                     assert result == expected
                 else:
@@ -67,10 +66,10 @@ class TestTimeConversionFormats:
         expected = Series([Timestamp(x) for x in s.apply(str)])
 
         result = to_datetime(s, format="%Y%m%d", cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = to_datetime(s.apply(str), format="%Y%m%d", cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # with NaT
         expected = Series(
@@ -80,13 +79,13 @@ class TestTimeConversionFormats:
         s[2] = np.nan
 
         result = to_datetime(s, format="%Y%m%d", cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # string with NaT
         s = s.apply(str)
         s[2] = "nat"
         result = to_datetime(s, format="%Y%m%d", cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # coercion
         # GH 7930
@@ -131,7 +130,7 @@ class TestTimeConversionFormats:
         # GH 25512
         # format='%Y%m%d', errors='coerce'
         result = pd.to_datetime(input_s, format="%Y%m%d", errors="coerce")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("cache", [True, False])
     def test_to_datetime_format_integer(self, cache):
@@ -140,13 +139,13 @@ class TestTimeConversionFormats:
         expected = Series([Timestamp(x) for x in s.apply(str)])
 
         result = to_datetime(s, format="%Y", cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([200001, 200105, 200206])
         expected = Series([Timestamp(x[:4] + "-" + x[4:]) for x in s.apply(str)])
 
         result = to_datetime(s, format="%Y%m", cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "int_date, expected",
@@ -216,7 +215,7 @@ class TestTimeConversionFormats:
         expected = to_datetime(
             s.str.extract(r"(\d+\w+\d+)", expand=False), format="%d%b%y", cache=cache
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("cache", [True, False])
     def test_parse_nanoseconds_with_formula(self, cache):
@@ -1204,11 +1203,11 @@ class TestToDatetimeUnit:
         expected = Series(
             [Timestamp("20150204 00:00:00"), Timestamp("20160305 00:0:00")]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # dict-like
         result = to_datetime(df[["year", "month", "day"]].to_dict(), cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # dict but with constructable
         df2 = df[["year", "month", "day"]].to_dict()
@@ -1217,7 +1216,7 @@ class TestToDatetimeUnit:
         expected2 = Series(
             [Timestamp("20150204 00:00:00"), Timestamp("20160205 00:0:00")]
         )
-        assert_series_equal(result, expected2)
+        tm.assert_series_equal(result, expected2)
 
         # unit mappings
         units = [
@@ -1244,7 +1243,7 @@ class TestToDatetimeUnit:
             expected = Series(
                 [Timestamp("20150204 06:58:10"), Timestamp("20160305 07:59:11")]
             )
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         d = {
             "year": "year",
@@ -1265,11 +1264,11 @@ class TestToDatetimeUnit:
                 Timestamp("20160305 07:59:11.001002003"),
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # coerce back to int
         result = to_datetime(df.astype(str), cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # passing coerce
         df2 = DataFrame({"year": [2015, 2016], "month": [2, 20], "day": [4, 5]})
@@ -1282,7 +1281,7 @@ class TestToDatetimeUnit:
             to_datetime(df2, cache=cache)
         result = to_datetime(df2, errors="coerce", cache=cache)
         expected = Series([Timestamp("20150204 00:00:00"), NaT])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # extra columns
         msg = "extra keys have been passed to the datetime assemblage: " r"\[foo\]"
@@ -1330,7 +1329,7 @@ class TestToDatetimeUnit:
         expected = Series(
             [Timestamp("20150204 00:00:00"), Timestamp("20160305 00:00:00")]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # mixed dtypes
         df["month"] = df["month"].astype("int8")
@@ -1339,7 +1338,7 @@ class TestToDatetimeUnit:
         expected = Series(
             [Timestamp("20150204 00:00:00"), Timestamp("20160305 00:00:00")]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # float
         df = DataFrame({"year": [2000, 2001], "month": [1.5, 1], "day": [1, 1]})
@@ -1434,7 +1433,7 @@ class TestToDatetimeMisc:
         td = Series(["May 04", "Jun 02", "Dec 11"], index=[1, 2, 3])
         expected = pd.to_datetime(td, format="%b %y", cache=cache)
         result = td.apply(pd.to_datetime, format="%b %y", cache=cache)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         td = pd.Series(["May 04", "Jun 02", ""], index=[1, 2, 3])
         msg = r"time data '' does not match format '%b %y' \(match\)"
@@ -1447,7 +1446,7 @@ class TestToDatetimeMisc:
         result = td.apply(
             lambda x: pd.to_datetime(x, format="%b %y", errors="coerce", cache=cache)
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("cache", [True, False])
     def test_to_datetime_types(self, cache):
@@ -1584,10 +1583,10 @@ class TestToDatetimeMisc:
             else:
                 expected[i] = to_datetime(x, cache=cache)
 
-        assert_series_equal(result, expected, check_names=False)
+        tm.assert_series_equal(result, expected, check_names=False)
         assert result.name == "foo"
 
-        assert_series_equal(dresult, expected, check_names=False)
+        tm.assert_series_equal(dresult, expected, check_names=False)
         assert dresult.name == "foo"
 
     @pytest.mark.parametrize(
@@ -2158,20 +2157,20 @@ class TestOrigin:
         expected = Series(
             pd.to_datetime(julian_dates - pd.Timestamp(0).to_julian_date(), unit="D")
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = Series(pd.to_datetime([0, 1, 2], unit="D", origin="unix"))
         expected = Series(
             [Timestamp("1970-01-01"), Timestamp("1970-01-02"), Timestamp("1970-01-03")]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # default
         result = Series(pd.to_datetime([0, 1, 2], unit="D"))
         expected = Series(
             [Timestamp("1970-01-01"), Timestamp("1970-01-02"), Timestamp("1970-01-03")]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_julian_round_trip(self):
         result = pd.to_datetime(2456658, origin="julian", unit="D")
@@ -2204,7 +2203,7 @@ class TestOrigin:
         )
 
         result = Series(pd.to_datetime(units_from_epochs, unit=units, origin=epochs))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "origin, exc",

--- a/pandas/tests/indexes/multi/test_astype.py
+++ b/pandas/tests/indexes/multi/test_astype.py
@@ -3,14 +3,14 @@ import pytest
 
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
-from pandas.util.testing import assert_copy
+import pandas.util.testing as tm
 
 
 def test_astype(idx):
     expected = idx.copy()
     actual = idx.astype("O")
-    assert_copy(actual.levels, expected.levels)
-    assert_copy(actual.codes, expected.codes)
+    tm.assert_copy(actual.levels, expected.levels)
+    tm.assert_copy(actual.codes, expected.codes)
     assert actual.names == list(expected.names)
 
     with pytest.raises(TypeError, match="^Setting.*dtype.*object"):

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -14,7 +14,6 @@ from pandas import (
 )
 from pandas.core.indexes.base import InvalidIndexError
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal
 
 
 def test_slice_locs_partial(idx):
@@ -145,32 +144,32 @@ def test_get_indexer():
     idx2 = index[[1, 3, 5]]
 
     r1 = idx1.get_indexer(idx2)
-    assert_almost_equal(r1, np.array([1, 3, -1], dtype=np.intp))
+    tm.assert_almost_equal(r1, np.array([1, 3, -1], dtype=np.intp))
 
     r1 = idx2.get_indexer(idx1, method="pad")
     e1 = np.array([-1, 0, 0, 1, 1], dtype=np.intp)
-    assert_almost_equal(r1, e1)
+    tm.assert_almost_equal(r1, e1)
 
     r2 = idx2.get_indexer(idx1[::-1], method="pad")
-    assert_almost_equal(r2, e1[::-1])
+    tm.assert_almost_equal(r2, e1[::-1])
 
     rffill1 = idx2.get_indexer(idx1, method="ffill")
-    assert_almost_equal(r1, rffill1)
+    tm.assert_almost_equal(r1, rffill1)
 
     r1 = idx2.get_indexer(idx1, method="backfill")
     e1 = np.array([0, 0, 1, 1, 2], dtype=np.intp)
-    assert_almost_equal(r1, e1)
+    tm.assert_almost_equal(r1, e1)
 
     r2 = idx2.get_indexer(idx1[::-1], method="backfill")
-    assert_almost_equal(r2, e1[::-1])
+    tm.assert_almost_equal(r2, e1[::-1])
 
     rbfill1 = idx2.get_indexer(idx1, method="bfill")
-    assert_almost_equal(r1, rbfill1)
+    tm.assert_almost_equal(r1, rbfill1)
 
     # pass non-MultiIndex
     r1 = idx1.get_indexer(idx2.values)
     rexp1 = idx1.get_indexer(idx2)
-    assert_almost_equal(r1, rexp1)
+    tm.assert_almost_equal(r1, rexp1)
 
     r1 = idx1.get_indexer([1, 2, 3])
     assert (r1 == [-1, -1, -1]).all()

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -43,7 +43,6 @@ from pandas.core.sorting import safe_sort
 from pandas.tests.indexes.common import Base
 from pandas.tests.indexes.conftest import indices_dict
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal
 
 
 class TestIndex(Base):
@@ -1452,7 +1451,7 @@ class TestIndex(Base):
 
         r1 = index1.get_indexer(index2)
         e1 = np.array([1, 3, -1], dtype=np.intp)
-        assert_almost_equal(r1, e1)
+        tm.assert_almost_equal(r1, e1)
 
     @pytest.mark.parametrize("reverse", [True, False])
     @pytest.mark.parametrize(
@@ -1473,7 +1472,7 @@ class TestIndex(Base):
             expected = expected[::-1]
 
         result = index2.get_indexer(index1, method=method)
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
     def test_get_indexer_invalid(self):
         # GH10411
@@ -1921,7 +1920,7 @@ class TestIndex(Base):
         values = np.random.randn(100)
         value = index[67]
 
-        assert_almost_equal(index.get_value(values, value), values[67])
+        tm.assert_almost_equal(index.get_value(values, value), values[67])
 
     @pytest.mark.parametrize("values", [["foo", "bar", "quux"], {"foo", "bar", "quux"}])
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -11,7 +11,6 @@ import pandas as pd
 from pandas import Categorical, IntervalIndex
 from pandas.core.indexes.api import CategoricalIndex, Index
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal
 
 from .common import Base
 
@@ -678,7 +677,7 @@ class TestCategoricalIndex(Base):
 
         for indexer in [idx2, list("abf"), Index(list("abf"))]:
             r1 = idx1.get_indexer(idx2)
-            assert_almost_equal(r1, np.array([0, 1, 2, -1], dtype=np.intp))
+            tm.assert_almost_equal(r1, np.array([0, 1, 2, -1], dtype=np.intp))
 
         msg = (
             "method='pad' and method='backfill' not implemented yet for"

--- a/pandas/tests/indexes/timedeltas/test_partial_slicing.py
+++ b/pandas/tests/indexes/timedeltas/test_partial_slicing.py
@@ -3,7 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas import Series, Timedelta, timedelta_range
-from pandas.util.testing import assert_series_equal
+import pandas.util.testing as tm
 
 
 class TestSlicing:
@@ -18,15 +18,15 @@ class TestSlicing:
 
         result = s["5 day":"6 day"]
         expected = s.iloc[86:134]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s["5 day":]
         expected = s.iloc[86:]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s[:"6 day"]
         expected = s.iloc[:134]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s["6 days, 23:11:12"]
         assert result == s.iloc[133]
@@ -43,11 +43,11 @@ class TestSlicing:
 
         result = s["1 day 10:11:12":]
         expected = s.iloc[0:]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s["1 day 10:11:12.001":]
         expected = s.iloc[1000:]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s["1 days, 10:11:12.001001"]
         assert result == s.iloc[1001]
@@ -57,9 +57,9 @@ class TestSlicing:
         SLC = pd.IndexSlice
 
         def assert_slices_equivalent(l_slc, i_slc):
-            assert_series_equal(ts[l_slc], ts.iloc[i_slc])
-            assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
-            assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
+            tm.assert_series_equal(ts[l_slc], ts.iloc[i_slc])
+            tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
+            tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
 
         assert_slices_equivalent(SLC[Timedelta(hours=7) :: -1], SLC[7::-1])
         assert_slices_equivalent(SLC["7 hours"::-1], SLC[7::-1])

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -16,11 +16,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_index_equal,
-    assert_series_equal,
-)
 
 from ..datetimelike import DatetimeLike
 
@@ -118,7 +113,7 @@ class TestTimedeltaIndex(DatetimeLike):
         result = index.isin(list(index))
         assert result.all()
 
-        assert_almost_equal(
+        tm.assert_almost_equal(
             index.isin([index[2], 5]), np.array([False, False, True, False])
         )
 
@@ -309,36 +304,36 @@ class TestTimedeltaIndex(DatetimeLike):
 
         result = td / np.timedelta64(1, "D")
         expected = Series([31, 31, (31 * 86400 + 5 * 60 + 3) / 86400.0, np.nan])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = td.astype("timedelta64[D]")
         expected = Series([31, 31, 31, np.nan])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = td / np.timedelta64(1, "s")
         expected = Series([31 * 86400, 31 * 86400, 31 * 86400 + 5 * 60 + 3, np.nan])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = td.astype("timedelta64[s]")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # tdi
         td = TimedeltaIndex(td)
 
         result = td / np.timedelta64(1, "D")
         expected = Index([31, 31, (31 * 86400 + 5 * 60 + 3) / 86400.0, np.nan])
-        assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = td.astype("timedelta64[D]")
         expected = Index([31, 31, 31, np.nan])
-        assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = td / np.timedelta64(1, "s")
         expected = Index([31 * 86400, 31 * 86400, 31 * 86400 + 5 * 60 + 3, np.nan])
-        assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = td.astype("timedelta64[s]")
-        assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("unit", ["Y", "y", "M"])
     def test_unit_m_y_deprecated(self, unit):

--- a/pandas/tests/indexes/timedeltas/test_tools.py
+++ b/pandas/tests/indexes/timedeltas/test_tools.py
@@ -8,7 +8,6 @@ from pandas._libs.tslib import iNaT
 import pandas as pd
 from pandas import Series, TimedeltaIndex, isna, to_timedelta
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal
 
 
 class TestTimedeltas:
@@ -192,10 +191,10 @@ class TestTimedeltas:
         expected = Series(
             [np.timedelta64(1000000000, "ns"), timedelta_NaT], dtype="<m8[ns]"
         )
-        assert_series_equal(actual, expected)
+        tm.assert_series_equal(actual, expected)
 
         actual = pd.to_timedelta(Series(["00:00:01", pd.NaT]))
-        assert_series_equal(actual, expected)
+        tm.assert_series_equal(actual, expected)
 
         actual = pd.to_timedelta(np.nan)
         assert actual.value == timedelta_NaT.astype("int64")


### PR DESCRIPTION
Part of #29272 

Fyi: All changes are generated from a script posted in the issue.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
