### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/indexing

### DIFF
--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -15,8 +15,7 @@ from pandas import (
     Timestamp,
 )
 from pandas.api.types import CategoricalDtype as CDT
-from pandas.util import testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
+import pandas.util.testing as tm
 
 
 class TestCategoricalIndex:
@@ -52,7 +51,7 @@ class TestCategoricalIndex:
         expected = DataFrame(
             {"A": [0, 1, 5], "B": (Series(list("aaa")).astype(CDT(list("cab"))))}
         ).set_index("B")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = self.df.copy()
         df.loc["a"] = 20
@@ -62,7 +61,7 @@ class TestCategoricalIndex:
                 "B": (Series(list("aabbca")).astype(CDT(list("cab")))),
             }
         ).set_index("B")
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # value not in the categories
         with pytest.raises(KeyError, match=r"^'d'$"):
@@ -329,12 +328,12 @@ class TestCategoricalIndex:
         # list of labels
         result = self.df.loc[["c", "a"]]
         expected = self.df.iloc[[4, 0, 1, 5]]
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = self.df2.loc[["a", "b", "e"]]
         exp_index = CategoricalIndex(list("aaabbe"), categories=list("cabe"), name="B")
         expected = DataFrame({"A": [0, 1, 5, 2, 3, np.nan]}, index=exp_index)
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         # element in the categories but not in the values
         with pytest.raises(KeyError, match=r"^'e'$"):
@@ -346,13 +345,13 @@ class TestCategoricalIndex:
         result = df.loc[["a", "b", "e"]]
         exp_index = CategoricalIndex(list("aaabbe"), categories=list("cabe"), name="B")
         expected = DataFrame({"A": [0, 1, 5, 2, 3, 20]}, index=exp_index)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = self.df2.copy()
         result = df.loc[["a", "b", "e"]]
         exp_index = CategoricalIndex(list("aaabbe"), categories=list("cabe"), name="B")
         expected = DataFrame({"A": [0, 1, 5, 2, 3, np.nan]}, index=exp_index)
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         # not all labels in the categories
         with pytest.raises(
@@ -474,7 +473,7 @@ class TestCategoricalIndex:
         )
         dummies = pd.get_dummies(cats)
         result = dummies[[c for c in dummies.columns]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_setitem_listlike(self):
 
@@ -500,18 +499,18 @@ class TestCategoricalIndex:
         cdf.columns = CategoricalIndex(df.columns)
 
         expect = Series(df.loc["A", :], index=cdf.columns, name="A")
-        assert_series_equal(cdf.loc["A", :], expect)
+        tm.assert_series_equal(cdf.loc["A", :], expect)
 
         expect = Series(df.loc[:, "X"], index=cdf.index, name="X")
-        assert_series_equal(cdf.loc[:, "X"], expect)
+        tm.assert_series_equal(cdf.loc[:, "X"], expect)
 
         exp_index = CategoricalIndex(list("AB"), categories=["A", "B", "C"])
         expect = DataFrame(df.loc[["A", "B"], :], columns=cdf.columns, index=exp_index)
-        assert_frame_equal(cdf.loc[["A", "B"], :], expect)
+        tm.assert_frame_equal(cdf.loc[["A", "B"], :], expect)
 
         exp_columns = CategoricalIndex(list("XY"), categories=["X", "Y", "Z"])
         expect = DataFrame(df.loc[:, ["X", "Y"]], index=cdf.index, columns=exp_columns)
-        assert_frame_equal(cdf.loc[:, ["X", "Y"]], expect)
+        tm.assert_frame_equal(cdf.loc[:, ["X", "Y"]], expect)
 
         # non-unique
         df = DataFrame(np.random.randn(3, 3), index=list("ABA"), columns=list("XYX"))
@@ -521,25 +520,25 @@ class TestCategoricalIndex:
 
         exp_index = CategoricalIndex(list("AA"), categories=["A", "B"])
         expect = DataFrame(df.loc["A", :], columns=cdf.columns, index=exp_index)
-        assert_frame_equal(cdf.loc["A", :], expect)
+        tm.assert_frame_equal(cdf.loc["A", :], expect)
 
         exp_columns = CategoricalIndex(list("XX"), categories=["X", "Y"])
         expect = DataFrame(df.loc[:, "X"], index=cdf.index, columns=exp_columns)
-        assert_frame_equal(cdf.loc[:, "X"], expect)
+        tm.assert_frame_equal(cdf.loc[:, "X"], expect)
 
         expect = DataFrame(
             df.loc[["A", "B"], :],
             columns=cdf.columns,
             index=CategoricalIndex(list("AAB")),
         )
-        assert_frame_equal(cdf.loc[["A", "B"], :], expect)
+        tm.assert_frame_equal(cdf.loc[["A", "B"], :], expect)
 
         expect = DataFrame(
             df.loc[:, ["X", "Y"]],
             index=cdf.index,
             columns=CategoricalIndex(list("XXY")),
         )
-        assert_frame_equal(cdf.loc[:, ["X", "Y"]], expect)
+        tm.assert_frame_equal(cdf.loc[:, ["X", "Y"]], expect)
 
     def test_read_only_source(self):
         # GH 10043
@@ -550,15 +549,15 @@ class TestCategoricalIndex:
         ro_array.setflags(write=False)
         ro_df = DataFrame(ro_array)
 
-        assert_frame_equal(rw_df.iloc[[1, 2, 3]], ro_df.iloc[[1, 2, 3]])
-        assert_frame_equal(rw_df.iloc[[1]], ro_df.iloc[[1]])
-        assert_series_equal(rw_df.iloc[1], ro_df.iloc[1])
-        assert_frame_equal(rw_df.iloc[1:3], ro_df.iloc[1:3])
+        tm.assert_frame_equal(rw_df.iloc[[1, 2, 3]], ro_df.iloc[[1, 2, 3]])
+        tm.assert_frame_equal(rw_df.iloc[[1]], ro_df.iloc[[1]])
+        tm.assert_series_equal(rw_df.iloc[1], ro_df.iloc[1])
+        tm.assert_frame_equal(rw_df.iloc[1:3], ro_df.iloc[1:3])
 
-        assert_frame_equal(rw_df.loc[[1, 2, 3]], ro_df.loc[[1, 2, 3]])
-        assert_frame_equal(rw_df.loc[[1]], ro_df.loc[[1]])
-        assert_series_equal(rw_df.loc[1], ro_df.loc[1])
-        assert_frame_equal(rw_df.loc[1:3], ro_df.loc[1:3])
+        tm.assert_frame_equal(rw_df.loc[[1, 2, 3]], ro_df.loc[[1, 2, 3]])
+        tm.assert_frame_equal(rw_df.loc[[1]], ro_df.loc[[1]])
+        tm.assert_series_equal(rw_df.loc[1], ro_df.loc[1])
+        tm.assert_frame_equal(rw_df.loc[1:3], ro_df.loc[1:3])
 
     def test_reindexing(self):
         df = DataFrame(
@@ -574,19 +573,19 @@ class TestCategoricalIndex:
         expected = DataFrame({"A": [0, 1, np.nan], "B": Series(list("abe"))}).set_index(
             "B"
         )
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(["a", "b"])
         expected = DataFrame({"A": [0, 1], "B": Series(list("ab"))}).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(["e"])
         expected = DataFrame({"A": [np.nan], "B": Series(["e"])}).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(["d"])
         expected = DataFrame({"A": [np.nan], "B": Series(["d"])}).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         # since we are actually reindexing with a Categorical
         # then return a Categorical
@@ -596,40 +595,40 @@ class TestCategoricalIndex:
         expected = DataFrame(
             {"A": [0, np.nan], "B": Series(list("ae")).astype(CDT(cats))}
         ).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(Categorical(["a"], categories=cats))
         expected = DataFrame(
             {"A": [0], "B": Series(list("a")).astype(CDT(cats))}
         ).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(["a", "b", "e"])
         expected = DataFrame({"A": [0, 1, np.nan], "B": Series(list("abe"))}).set_index(
             "B"
         )
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(["a", "b"])
         expected = DataFrame({"A": [0, 1], "B": Series(list("ab"))}).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(["e"])
         expected = DataFrame({"A": [np.nan], "B": Series(["e"])}).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         # give back the type of categorical that we received
         result = df.reindex(Categorical(["a", "e"], categories=cats, ordered=True))
         expected = DataFrame(
             {"A": [0, np.nan], "B": Series(list("ae")).astype(CDT(cats, ordered=True))}
         ).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         result = df.reindex(Categorical(["a", "d"], categories=["a", "d"]))
         expected = DataFrame(
             {"A": [0, np.nan], "B": Series(list("ad")).astype(CDT(["a", "d"]))}
         ).set_index("B")
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         # passed duplicate indexers are not allowed
         msg = "cannot reindex from a duplicate axis"
@@ -661,7 +660,7 @@ class TestCategoricalIndex:
 
         # result = df.loc[1:5]
         # expected = df.iloc[[1,2,3,4]]
-        # assert_frame_equal(result, expected)
+        # tm.assert_frame_equal(result, expected)
 
     def test_loc_and_at_with_categorical_index(self):
         # GH 20629
@@ -681,19 +680,19 @@ class TestCategoricalIndex:
 
         result = df3[df3.index == "a"]
         expected = df3.iloc[[]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df4[df4.index == "a"]
         expected = df4.iloc[[]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df3[df3.index == 1]
         expected = df3.iloc[[0, 1, 3]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df4[df4.index == 1]
         expected = df4.iloc[[0, 1, 3]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # since we have an ordered categorical
 
@@ -703,11 +702,11 @@ class TestCategoricalIndex:
         #         name='B')
         result = df3[df3.index < 2]
         expected = df3.iloc[[4]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df3[df3.index > 1]
         expected = df3.iloc[[]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # unordered
         # cannot be compared

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -3,7 +3,6 @@ import pytest
 
 from pandas import DataFrame, Float64Index, Index, Int64Index, RangeIndex, Series
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal, assert_series_equal
 
 
 class TestFloatIndexers:
@@ -21,7 +20,7 @@ class TestFloatIndexers:
             else:
                 expected = original.iloc[indexer]
 
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
     def test_scalar_error(self):
 
@@ -504,7 +503,7 @@ class TestFloatIndexers:
 
         result = s[2:4]
         expected = s.iloc[2:4]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         for idxr in [lambda x: x, lambda x: x.iloc]:
 
@@ -642,8 +641,8 @@ class TestFloatIndexers:
         result1 = s[1.0:3.0]
         result2 = s.loc[1.0:3.0]
         result3 = s.loc[1.0:3.0]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
 
         # exact indexing when found
         result1 = s[5.0]
@@ -674,58 +673,58 @@ class TestFloatIndexers:
         # fancy tests
         expected = Series([2, 0], index=Float64Index([5.0, 0.0]))
         for fancy_idx in [[5.0, 0.0], np.array([5.0, 0.0])]:  # float
-            assert_series_equal(s[fancy_idx], expected)
-            assert_series_equal(s.loc[fancy_idx], expected)
-            assert_series_equal(s.loc[fancy_idx], expected)
+            tm.assert_series_equal(s[fancy_idx], expected)
+            tm.assert_series_equal(s.loc[fancy_idx], expected)
+            tm.assert_series_equal(s.loc[fancy_idx], expected)
 
         expected = Series([2, 0], index=Index([5, 0], dtype="int64"))
         for fancy_idx in [[5, 0], np.array([5, 0])]:  # int
-            assert_series_equal(s[fancy_idx], expected)
-            assert_series_equal(s.loc[fancy_idx], expected)
-            assert_series_equal(s.loc[fancy_idx], expected)
+            tm.assert_series_equal(s[fancy_idx], expected)
+            tm.assert_series_equal(s.loc[fancy_idx], expected)
+            tm.assert_series_equal(s.loc[fancy_idx], expected)
 
         # all should return the same as we are slicing 'the same'
         result1 = s.loc[2:5]
         result2 = s.loc[2.0:5.0]
         result3 = s.loc[2.0:5]
         result4 = s.loc[2.1:5]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
-        assert_series_equal(result1, result4)
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, result4)
 
         # previously this did fallback indexing
         result1 = s[2:5]
         result2 = s[2.0:5.0]
         result3 = s[2.0:5]
         result4 = s[2.1:5]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
-        assert_series_equal(result1, result4)
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, result4)
 
         result1 = s.loc[2:5]
         result2 = s.loc[2.0:5.0]
         result3 = s.loc[2.0:5]
         result4 = s.loc[2.1:5]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
-        assert_series_equal(result1, result4)
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, result4)
 
         # combined test
         result1 = s.loc[2:5]
         result2 = s.loc[2:5]
         result3 = s[2:5]
 
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
 
         # list selection
         result1 = s[[0.0, 5, 10]]
         result2 = s.loc[[0.0, 5, 10]]
         result3 = s.loc[[0.0, 5, 10]]
         result4 = s.iloc[[0, 2, 4]]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
-        assert_series_equal(result1, result4)
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, result4)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result1 = s[[1.6, 5, 10]]
@@ -733,9 +732,9 @@ class TestFloatIndexers:
             result2 = s.loc[[1.6, 5, 10]]
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result3 = s.loc[[1.6, 5, 10]]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
-        assert_series_equal(result1, Series([np.nan, 2, 4], index=[1.6, 5, 10]))
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, Series([np.nan, 2, 4], index=[1.6, 5, 10]))
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result1 = s[[0, 1, 2]]
@@ -743,21 +742,21 @@ class TestFloatIndexers:
             result2 = s.loc[[0, 1, 2]]
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result3 = s.loc[[0, 1, 2]]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
-        assert_series_equal(result1, Series([0.0, np.nan, np.nan], index=[0, 1, 2]))
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, Series([0.0, np.nan, np.nan], index=[0, 1, 2]))
 
         result1 = s.loc[[2.5, 5]]
         result2 = s.loc[[2.5, 5]]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, Series([1, 2], index=[2.5, 5.0]))
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, Series([1, 2], index=[2.5, 5.0]))
 
         result1 = s[[2.5]]
         result2 = s.loc[[2.5]]
         result3 = s.loc[[2.5]]
-        assert_series_equal(result1, result2)
-        assert_series_equal(result1, result3)
-        assert_series_equal(result1, Series([1], index=[2.5]))
+        tm.assert_series_equal(result1, result2)
+        tm.assert_series_equal(result1, result3)
+        tm.assert_series_equal(result1, Series([1], index=[2.5]))
 
     def test_floating_tuples(self):
         # see gh-13509

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -766,9 +766,8 @@ class TestiLoc(Base):
         tm.assert_frame_equal(result, expected, check_index_type=False)
 
     def test_iloc_empty_list_indexer_is_ok(self):
-        from pandas.util.testing import makeCustomDataframe as mkdf
 
-        df = mkdf(5, 2)
+        df = tm.makeCustomDataframe(5, 2)
         # vertical empty
         tm.assert_frame_equal(
             df.iloc[:, []],

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -264,9 +264,8 @@ class TestFancy(Base):
     def test_dups_fancy_indexing(self):
 
         # GH 3455
-        from pandas.util.testing import makeCustomDataframe as mkdf
 
-        df = mkdf(10, 3)
+        df = tm.makeCustomDataframe(10, 3)
         df.columns = ["a", "a", "b"]
         result = df[["b", "a"]].columns
         expected = Index(["b", "a", "a"])

--- a/pandas/tests/indexing/test_ix.py
+++ b/pandas/tests/indexing/test_ix.py
@@ -9,7 +9,7 @@ from pandas.core.dtypes.common import is_scalar
 
 import pandas as pd
 from pandas import DataFrame, Series, option_context
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 def test_ix_deprecation():
@@ -313,9 +313,8 @@ class TestIX:
 
     def test_ix_empty_list_indexer_is_ok(self):
         with catch_warnings(record=True):
-            from pandas.util.testing import makeCustomDataframe as mkdf
 
-            df = mkdf(5, 2)
+            df = tm.makeCustomDataframe(5, 2)
             # vertical empty
             tm.assert_frame_equal(
                 df.ix[:, []],

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1013,9 +1013,8 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         assert result == "index_name"
 
     def test_loc_empty_list_indexer_is_ok(self):
-        from pandas.util.testing import makeCustomDataframe as mkdf
 
-        df = mkdf(5, 2)
+        df = tm.makeCustomDataframe(5, 2)
         # vertical empty
         tm.assert_frame_equal(
             df.loc[:, []], df.iloc[:, :0], check_index_type=True, check_column_type=True


### PR DESCRIPTION
Part of #29272 

Fyi: All changes are generated from a script posted in the issue.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
