### PR TITLE
Fix SS06 formatting errors 

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -310,6 +310,8 @@ ValueError: columns overlap but no suffix specified:
 
 class DataFrame(NDFrame):
     """
+    Two-dimensional size-mutable, potentially heterogeneous tabular data structure.
+
     Two-dimensional size-mutable, potentially heterogeneous tabular data
     structure with labeled axes (rows and columns). Arithmetic operations
     align on both row and column labels. Can be thought of as a dict-like
@@ -4798,8 +4800,9 @@ class DataFrame(NDFrame):
 
     def drop_duplicates(self, subset=None, keep="first", inplace=False):
         """
-        Return DataFrame with duplicate rows removed, optionally only
-        considering certain columns. Indexes, including time indexes
+        Return DataFrame with duplicate rows removed.
+
+        Considering certain columns is optional. Indexes, including time indexes
         are ignored.
 
         Parameters
@@ -4834,8 +4837,7 @@ class DataFrame(NDFrame):
 
     def duplicated(self, subset=None, keep="first"):
         """
-        Return boolean Series denoting duplicate rows, optionally only
-        considering certain columns.
+        Return boolean Series denoting duplicate rows, optionally only considering certain columns.
 
         Parameters
         ----------
@@ -7536,9 +7538,10 @@ class DataFrame(NDFrame):
 
     def corrwith(self, other, axis=0, drop=False, method="pearson"):
         """
-        Compute pairwise correlation between rows or columns of DataFrame
-        with rows or columns of Series or DataFrame.  DataFrames are first
-        aligned along both axes before computing the correlations.
+        Compute pairwise correlation between rows or columns of DataFrame with rows or columns of Series or DataFrame.
+
+        DataFrames are first aligned along both axes before computing the
+        correlations.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -310,12 +310,11 @@ ValueError: columns overlap but no suffix specified:
 
 class DataFrame(NDFrame):
     """
-    Two-dimensional size-mutable, potentially heterogeneous tabular data structure.
+    Two-dimensional size-mutable, potentially heterogeneous tabular data structure with labeled axes (rows and columns). .
 
-    Two-dimensional size-mutable, potentially heterogeneous tabular data
-    structure with labeled axes (rows and columns). Arithmetic operations
-    align on both row and column labels. Can be thought of as a dict-like
-    container for Series objects. The primary pandas data structure.
+    Arithmetic operations align on both row and column labels. Can be
+    thought of as a dict-like container for Series objects. The primary
+    pandas data structure.
 
     Parameters
     ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -310,8 +310,9 @@ ValueError: columns overlap but no suffix specified:
 
 class DataFrame(NDFrame):
     """
-    Two-dimensional size-mutable, potentially heterogeneous tabular data structure with labeled axes (rows and columns). .
+    Two-dimensional, size-mutable, potentially heterogeneous tabular data.
 
+    Data structure also contains labeled axes (rows and columns).
     Arithmetic operations align on both row and column labels. Can be
     thought of as a dict-like container for Series objects. The primary
     pandas data structure.
@@ -4836,7 +4837,9 @@ class DataFrame(NDFrame):
 
     def duplicated(self, subset=None, keep="first"):
         """
-        Return boolean Series denoting duplicate rows, optionally only considering certain columns.
+        Return boolean Series denoting duplicate rows.
+
+        Considering certain columns is optional.
 
         Parameters
         ----------
@@ -7537,9 +7540,11 @@ class DataFrame(NDFrame):
 
     def corrwith(self, other, axis=0, drop=False, method="pearson"):
         """
-        Compute pairwise correlation between rows or columns of DataFrame with rows or columns of Series or DataFrame.
+        Compute pairwise correlation.
 
-        DataFrames are first aligned along both axes before computing the
+        Pairwise correlation is computed between rows or columns of
+        DataFrame with rows or columns of Series or DataFrame. DataFrames
+        are first aligned along both axes before computing the
         correlations.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8743,7 +8743,7 @@ class NDFrame(PandasObject, SelectionMixin):
         "align"
     ] = """
         Align two objects on their axes with the specified join method.
-         
+
         Join method is specified for each axis Index.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5156,8 +5156,9 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "transform"
     ] = """
-    Call ``func`` on self producing a %(klass)s with transformed values
-    and that has the same axis length as self.
+    Call ``func`` on self producing a %(klass)s with transformed values.
+    
+    Produced %(klass)s will have same axis length as self.
 
     Parameters
     ----------
@@ -8741,8 +8742,7 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "align"
     ] = """
-        Align two objects on their axes with the
-        specified join method for each axis Index.
+        Align two objects on their axes with the specified join method for each axis Index.
 
         Parameters
         ----------
@@ -9965,9 +9965,11 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def describe(self, percentiles=None, include=None, exclude=None):
         """
-        Generate descriptive statistics that summarize the central tendency,
-        dispersion and shape of a dataset's distribution, excluding
-        ``NaN`` values.
+        Generate descriptive statistics.
+
+        Descriptive statistics include those that summarize the central
+        tendency, dispersion and shape of a
+        dataset's distribution, excluding ``NaN`` values.
 
         Analyzes both numeric and object series, as well
         as ``DataFrame`` column sets of mixed data types. The output
@@ -10649,7 +10651,7 @@ class NDFrame(PandasObject, SelectionMixin):
             name,
             name2,
             axis_descr,
-            "Return unbiased skew over requested axis\nNormalized by N-1.",
+            "Return unbiased skew over requested axis.\n\nNormalized by N-1.",
             nanops.nanskew,
         )
         cls.kurt = _make_stat_function(
@@ -10658,8 +10660,9 @@ class NDFrame(PandasObject, SelectionMixin):
             name,
             name2,
             axis_descr,
-            "Return unbiased kurtosis over requested axis using Fisher's "
-            "definition of\nkurtosis (kurtosis of normal == 0.0). Normalized "
+            "Return unbiased kurtosis over requested axis.\n\n"
+            "Kurtosis obtained using Fisher's definition of\n"
+            "kurtosis (kurtosis of normal == 0.0). Normalized "
             "by N-1.",
             nanops.nankurt,
         )

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5157,7 +5157,7 @@ class NDFrame(PandasObject, SelectionMixin):
         "transform"
     ] = """
     Call ``func`` on self producing a %(klass)s with transformed values.
-    
+
     Produced %(klass)s will have same axis length as self.
 
     Parameters
@@ -8742,7 +8742,9 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "align"
     ] = """
-        Align two objects on their axes with the specified join method for each axis Index.
+        Align two objects on their axes with the specified join method.
+         
+        Join method is specified for each axis Index.
 
         Parameters
         ----------


### PR DESCRIPTION
More SS06 (Summary should fit in a single line) errors fixed (#29254):

The following docstrings were examined and fixed:
```
pandas.DataFrame
pandas.DataFrame.transform
pandas.DataFrame.corrwith
pandas.DataFrame.describe
pandas.DataFrame.kurt
pandas.DataFrame.kurtosis
pandas.DataFrame.skew
pandas.DataFrame.align
pandas.DataFrame.drop_duplicates
pandas.DataFrame.duplicated

```

Validated with python scripts/validate_docstrings.py

Also referencing issue: #27977