### PR TITLE
CLN: unnecessary exception catching

### DIFF
--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -170,10 +170,6 @@ cdef class Reducer:
                 PyArray_SETITEM(result, PyArray_ITER_DATA(it), res)
                 chunk.data = chunk.data + self.increment
                 PyArray_ITER_NEXT(it)
-        except Exception as err:
-            if hasattr(err, 'args'):
-                err.args = err.args + (i,)
-            raise
         finally:
             # so we don't free the wrong memory
             chunk.data = dummy_buf

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -13,8 +13,6 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.generic import ABCSeries
 
-from pandas.io.formats.printing import pprint_thing
-
 
 def frame_apply(
     obj,
@@ -293,20 +291,9 @@ class FrameApply:
                 res_index = res_index.take(successes)
 
         else:
-            try:
-                for i, v in enumerate(series_gen):
-                    results[i] = self.f(v)
-                    keys.append(v.name)
-            except Exception as err:
-                if hasattr(err, "args"):
-
-                    # make sure i is defined
-                    if i is not None:
-                        k = res_index[i]
-                        err.args = err.args + (
-                            "occurred at index %s" % pprint_thing(k),
-                        )
-                raise
+            for i, v in enumerate(series_gen):
+                results[i] = self.f(v)
+                keys.append(v.name)
 
         self.results = results
         self.res_index = res_index

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -262,8 +262,6 @@ class SeriesGroupBy(GroupBy):
 
             try:
                 return self._python_agg_general(func, *args, **kwargs)
-            except (AssertionError, TypeError):
-                raise
             except (ValueError, KeyError, AttributeError, IndexError):
                 # TODO: IndexError can be removed here following GH#29106
                 # TODO: AttributeError is caused by _index_data hijinx in
@@ -1465,8 +1463,6 @@ class DataFrameGroupBy(GroupBy):
         for i, col in enumerate(obj):
             try:
                 output[col] = self[col].transform(wrapper)
-            except AssertionError:
-                raise
             except TypeError:
                 # e.g. trying to call nanmean with string values
                 pass

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -361,8 +361,6 @@ class Resampler(_GroupBy):
                 result = grouped._aggregate_item_by_item(how, *args, **kwargs)
             else:
                 result = grouped.aggregate(how, *args, **kwargs)
-        except AssertionError:
-            raise
         except DataError:
             # we have a non-reducing function; try to evaluate
             result = grouped.apply(how, *args, **kwargs)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -424,12 +424,9 @@ class TestDataFrameApply:
                 row["D"] = 7
             return row
 
-        try:
+        msg = "'float' object has no attribute 'startswith'"
+        with pytest.raises(AttributeError, match=msg):
             data.apply(transform, axis=1)
-        except AttributeError as e:
-            assert len(e.args) == 2
-            assert e.args[1] == "occurred at index 4"
-            assert e.args[0] == "'float' object has no attribute 'startswith'"
 
     def test_apply_bug(self):
 


### PR DESCRIPTION
adding an index to the exception is a nice thought, but ultimately adds more complication than information.

The `except AssertionError`s were needed back when the lines below were `except Exception`, but those have been made more specific, so these are no longer needed