### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/io

### DIFF
--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pandas import DataFrame
-from pandas.util.testing import ensure_clean
+import pandas.util.testing as tm
 
 from pandas.io.excel import ExcelWriter, _OpenpyxlWriter
 
@@ -65,7 +65,7 @@ def test_write_cells_merge_styled(ext):
         )
     ]
 
-    with ensure_clean(ext) as path:
+    with tm.ensure_clean(ext) as path:
         writer = _OpenpyxlWriter(path)
         writer.write_cells(initial_cells, sheet_name=sheet_name)
         writer.write_cells(merge_cells, sheet_name=sheet_name)
@@ -83,7 +83,7 @@ def test_write_cells_merge_styled(ext):
 def test_write_append_mode(ext, mode, expected):
     df = DataFrame([1], columns=["baz"])
 
-    with ensure_clean(ext) as f:
+    with tm.ensure_clean(ext) as f:
         wb = openpyxl.Workbook()
         wb.worksheets[0].title = "foo"
         wb.worksheets[0]["A1"].value = "foo"

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import DataFrame
-from pandas.util.testing import ensure_clean
+import pandas.util.testing as tm
 
 from pandas.io.excel import ExcelWriter
 from pandas.io.formats.excel import ExcelFormatter
@@ -70,7 +70,7 @@ def test_styler_to_excel(engine):
     # Prepare spreadsheets
 
     df = DataFrame(np.random.randn(11, 3))
-    with ensure_clean(".xlsx" if engine != "xlwt" else ".xls") as path:
+    with tm.ensure_clean(".xlsx" if engine != "xlwt" else ".xls") as path:
         writer = ExcelWriter(path, engine=engine)
         df.to_excel(writer, sheet_name="frame")
         df.style.to_excel(writer, sheet_name="unstyled")

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -2,7 +2,6 @@ import pytest
 
 import pandas as pd
 import pandas.util.testing as tm
-from pandas.util.testing import ensure_clean
 
 from pandas.io.excel import ExcelFile
 
@@ -22,7 +21,7 @@ def test_read_xlrd_book(read_ext, frame):
     engine = "xlrd"
     sheet_name = "SheetA"
 
-    with ensure_clean(read_ext) as pth:
+    with tm.ensure_clean(read_ext) as pth:
         df.to_excel(pth, sheet_name)
         book = xlrd.open_workbook(pth)
 

--- a/pandas/tests/io/excel/test_xlsxwriter.py
+++ b/pandas/tests/io/excel/test_xlsxwriter.py
@@ -3,7 +3,7 @@ import warnings
 import pytest
 
 from pandas import DataFrame
-from pandas.util.testing import ensure_clean
+import pandas.util.testing as tm
 
 from pandas.io.excel import ExcelWriter
 
@@ -20,7 +20,7 @@ def test_column_format(ext):
         warnings.simplefilter("ignore")
         openpyxl = pytest.importorskip("openpyxl")
 
-    with ensure_clean(ext) as path:
+    with tm.ensure_clean(ext) as path:
         frame = DataFrame({"A": [123456, 123456], "B": [123456, 123456]})
 
         writer = ExcelWriter(path)
@@ -59,6 +59,6 @@ def test_column_format(ext):
 def test_write_append_mode_raises(ext):
     msg = "Append mode is not supported with xlsxwriter!"
 
-    with ensure_clean(ext) as f:
+    with tm.ensure_clean(ext) as f:
         with pytest.raises(ValueError, match=msg):
             ExcelWriter(f, engine="xlsxwriter", mode="a")

--- a/pandas/tests/io/excel/test_xlwt.py
+++ b/pandas/tests/io/excel/test_xlwt.py
@@ -3,7 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, MultiIndex
-from pandas.util.testing import ensure_clean
+import pandas.util.testing as tm
 
 from pandas.io.excel import ExcelWriter, _XlwtWriter
 
@@ -19,7 +19,7 @@ def test_excel_raise_error_on_multiindex_columns_and_no_index(ext):
     )
     df = DataFrame(np.random.randn(10, 3), columns=cols)
     with pytest.raises(NotImplementedError):
-        with ensure_clean(ext) as path:
+        with tm.ensure_clean(ext) as path:
             df.to_excel(path, index=False)
 
 
@@ -28,7 +28,7 @@ def test_excel_multiindex_columns_and_index_true(ext):
         [("site", ""), ("2014", "height"), ("2014", "weight")]
     )
     df = pd.DataFrame(np.random.randn(10, 3), columns=cols)
-    with ensure_clean(ext) as path:
+    with tm.ensure_clean(ext) as path:
         df.to_excel(path, index=True)
 
 
@@ -38,7 +38,7 @@ def test_excel_multiindex_index(ext):
         [("site", ""), ("2014", "height"), ("2014", "weight")]
     )
     df = DataFrame(np.random.randn(3, 10), index=cols)
-    with ensure_clean(ext) as path:
+    with tm.ensure_clean(ext) as path:
         df.to_excel(path, index=False)
 
 
@@ -62,6 +62,6 @@ def test_to_excel_styleconverter(ext):
 def test_write_append_mode_raises(ext):
     msg = "Append mode is not supported with xlwt!"
 
-    with ensure_clean(ext) as f:
+    with tm.ensure_clean(ext) as f:
         with pytest.raises(ValueError, match=msg):
             ExcelWriter(f, engine="xlwt", mode="a")

--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -4,7 +4,6 @@ import pandas.util._test_decorators as td
 
 import pandas as pd
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal
 
 
 def test_compression_roundtrip(compression):
@@ -16,12 +15,12 @@ def test_compression_roundtrip(compression):
 
     with tm.ensure_clean() as path:
         df.to_json(path, compression=compression)
-        assert_frame_equal(df, pd.read_json(path, compression=compression))
+        tm.assert_frame_equal(df, pd.read_json(path, compression=compression))
 
         # explicitly ensure file was compressed.
         with tm.decompress_file(path, compression) as fh:
             result = fh.read().decode("utf8")
-        assert_frame_equal(df, pd.read_json(result))
+        tm.assert_frame_equal(df, pd.read_json(result))
 
 
 def test_read_zipped_json(datapath):
@@ -31,7 +30,7 @@ def test_read_zipped_json(datapath):
     compressed_path = datapath("io", "json", "data", "tsframe_v012.json.zip")
     compressed_df = pd.read_json(compressed_path, compression="zip")
 
-    assert_frame_equal(uncompressed_df, compressed_df)
+    tm.assert_frame_equal(uncompressed_df, compressed_df)
 
 
 @td.skip_if_not_us_locale
@@ -46,7 +45,7 @@ def test_with_s3_url(compression, s3_resource):
             s3_resource.Bucket("pandas-test").put_object(Key="test-1", Body=f)
 
     roundtripped_df = pd.read_json("s3://pandas-test/test-1", compression=compression)
-    assert_frame_equal(df, roundtripped_df)
+    tm.assert_frame_equal(df, roundtripped_df)
 
 
 def test_lines_with_compression(compression):
@@ -55,7 +54,7 @@ def test_lines_with_compression(compression):
         df = pd.read_json('{"a": [1, 2, 3], "b": [4, 5, 6]}')
         df.to_json(path, orient="records", lines=True, compression=compression)
         roundtripped_df = pd.read_json(path, lines=True, compression=compression)
-        assert_frame_equal(df, roundtripped_df)
+        tm.assert_frame_equal(df, roundtripped_df)
 
 
 def test_chunksize_with_compression(compression):
@@ -66,7 +65,7 @@ def test_chunksize_with_compression(compression):
 
         res = pd.read_json(path, lines=True, chunksize=1, compression=compression)
         roundtripped_df = pd.concat(res)
-        assert_frame_equal(df, roundtripped_df)
+        tm.assert_frame_equal(df, roundtripped_df)
 
 
 def test_write_unsupported_compression_type():

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -5,7 +5,6 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, read_json
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal, ensure_clean
 
 from pandas.io.json._json import JsonReader
 
@@ -20,7 +19,7 @@ def test_read_jsonl():
     # GH9180
     result = read_json('{"a": 1, "b": 2}\n{"b":2, "a" :1}\n', lines=True)
     expected = DataFrame([[1, 2], [1, 2]], columns=["a", "b"])
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_read_jsonl_unicode_chars():
@@ -32,13 +31,13 @@ def test_read_jsonl_unicode_chars():
     json = StringIO(json)
     result = read_json(json, lines=True)
     expected = DataFrame([["foo\u201d", "bar"], ["foo", "bar"]], columns=["a", "b"])
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
     # simulate string
     json = '{"a": "foo”", "b": "bar"}\n{"a": "foo", "b": "bar"}\n'
     result = read_json(json, lines=True)
     expected = DataFrame([["foo\u201d", "bar"], ["foo", "bar"]], columns=["a", "b"])
-    assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_to_jsonl():
@@ -52,14 +51,14 @@ def test_to_jsonl():
     result = df.to_json(orient="records", lines=True)
     expected = '{"a":"foo}","b":"bar"}\n{"a":"foo\\"","b":"bar"}'
     assert result == expected
-    assert_frame_equal(read_json(result, lines=True), df)
+    tm.assert_frame_equal(read_json(result, lines=True), df)
 
     # GH15096: escaped characters in columns and data
     df = DataFrame([["foo\\", "bar"], ['foo"', "bar"]], columns=["a\\", "b"])
     result = df.to_json(orient="records", lines=True)
     expected = '{"a\\\\":"foo\\\\","b":"bar"}\n' '{"a\\\\":"foo\\"","b":"bar"}'
     assert result == expected
-    assert_frame_equal(read_json(result, lines=True), df)
+    tm.assert_frame_equal(read_json(result, lines=True), df)
 
 
 @pytest.mark.parametrize("chunksize", [1, 1.0])
@@ -72,7 +71,7 @@ def test_readjson_chunks(lines_json_df, chunksize):
     reader = read_json(StringIO(lines_json_df), lines=True, chunksize=chunksize)
     chunked = pd.concat(reader)
 
-    assert_frame_equal(chunked, unchunked)
+    tm.assert_frame_equal(chunked, unchunked)
 
 
 def test_readjson_chunksize_requires_lines(lines_json_df):
@@ -91,7 +90,7 @@ def test_readjson_chunks_series():
     strio = StringIO(s.to_json(lines=True, orient="records"))
     chunked = pd.concat(pd.read_json(strio, lines=True, typ="Series", chunksize=1))
 
-    assert_series_equal(chunked, unchunked)
+    tm.assert_series_equal(chunked, unchunked)
 
 
 def test_readjson_each_chunk(lines_json_df):
@@ -103,17 +102,17 @@ def test_readjson_each_chunk(lines_json_df):
 
 
 def test_readjson_chunks_from_file():
-    with ensure_clean("test.json") as path:
+    with tm.ensure_clean("test.json") as path:
         df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         df.to_json(path, lines=True, orient="records")
         chunked = pd.concat(pd.read_json(path, lines=True, chunksize=1))
         unchunked = pd.read_json(path, lines=True)
-        assert_frame_equal(unchunked, chunked)
+        tm.assert_frame_equal(unchunked, chunked)
 
 
 @pytest.mark.parametrize("chunksize", [None, 1])
 def test_readjson_chunks_closes(chunksize):
-    with ensure_clean("test.json") as path:
+    with tm.ensure_clean("test.json") as path:
         df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
         df.to_json(path, lines=True, orient="records")
         reader = JsonReader(

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -13,7 +13,6 @@ from pandas._libs.parsers import TextReader
 
 from pandas import DataFrame
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal
 
 from pandas.io.parsers import TextFileReader, read_csv
 
@@ -323,19 +322,19 @@ a,b,c
 
         for _ in range(100):
             df = read_csv(StringIO("a,b\nc\n"), skiprows=0, names=["a"], engine="c")
-            assert_frame_equal(df, a)
+            tm.assert_frame_equal(df, a)
 
             df = read_csv(
                 StringIO("1,1,1,1,0\n" * 2 + "\n" * 2), names=list("abcd"), engine="c"
             )
-            assert_frame_equal(df, b)
+            tm.assert_frame_equal(df, b)
 
             df = read_csv(
                 StringIO("0,1,2,3,4\n5,6\n7,8,9,10,11\n12,13,14"),
                 names=list("abcd"),
                 engine="c",
             )
-            assert_frame_equal(df, c)
+            tm.assert_frame_equal(df, c)
 
     def test_empty_csv_input(self):
         # GH14867

--- a/pandas/tests/io/pytables/test_compat.py
+++ b/pandas/tests/io/pytables/test_compat.py
@@ -2,7 +2,7 @@ import pytest
 
 import pandas as pd
 from pandas.tests.io.pytables.common import ensure_clean_path
-from pandas.util.testing import assert_frame_equal
+import pandas.util.testing as tm
 
 tables = pytest.importorskip("tables")
 
@@ -52,25 +52,25 @@ class TestReadPyTablesHDF5:
         path, objname, df = pytables_hdf5_file
         result = pd.read_hdf(path, key=objname)
         expected = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_read_with_start(self, pytables_hdf5_file):
         path, objname, df = pytables_hdf5_file
         # This is a regression test for pandas-dev/pandas/issues/11188
         result = pd.read_hdf(path, key=objname, start=1)
         expected = df[1:].reset_index(drop=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_read_with_stop(self, pytables_hdf5_file):
         path, objname, df = pytables_hdf5_file
         # This is a regression test for pandas-dev/pandas/issues/11188
         result = pd.read_hdf(path, key=objname, stop=1)
         expected = df[:1].reset_index(drop=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_read_with_startstop(self, pytables_hdf5_file):
         path, objname, df = pytables_hdf5_file
         # This is a regression test for pandas-dev/pandas/issues/11188
         result = pd.read_hdf(path, key=objname, start=1, stop=2)
         expected = df[1:2].reset_index(drop=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/pytables/test_complex.py
+++ b/pandas/tests/io/pytables/test_complex.py
@@ -9,7 +9,6 @@ import pandas as pd
 from pandas import DataFrame, Series
 from pandas.tests.io.pytables.common import ensure_clean_path, ensure_clean_store
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal
 
 from pandas.io.pytables import read_hdf
 
@@ -26,7 +25,7 @@ def test_complex_fixed(setup_path):
     with ensure_clean_path(setup_path) as path:
         df.to_hdf(path, "df")
         reread = read_hdf(path, "df")
-        assert_frame_equal(df, reread)
+        tm.assert_frame_equal(df, reread)
 
     df = DataFrame(
         np.random.rand(4, 5).astype(np.complex128),
@@ -36,7 +35,7 @@ def test_complex_fixed(setup_path):
     with ensure_clean_path(setup_path) as path:
         df.to_hdf(path, "df")
         reread = read_hdf(path, "df")
-        assert_frame_equal(df, reread)
+        tm.assert_frame_equal(df, reread)
 
 
 def test_complex_table(setup_path):
@@ -49,7 +48,7 @@ def test_complex_table(setup_path):
     with ensure_clean_path(setup_path) as path:
         df.to_hdf(path, "df", format="table")
         reread = read_hdf(path, "df")
-        assert_frame_equal(df, reread)
+        tm.assert_frame_equal(df, reread)
 
     df = DataFrame(
         np.random.rand(4, 5).astype(np.complex128),
@@ -60,7 +59,7 @@ def test_complex_table(setup_path):
     with ensure_clean_path(setup_path) as path:
         df.to_hdf(path, "df", format="table", mode="w")
         reread = read_hdf(path, "df")
-        assert_frame_equal(df, reread)
+        tm.assert_frame_equal(df, reread)
 
 
 @td.xfail_non_writeable
@@ -84,7 +83,7 @@ def test_complex_mixed_fixed(setup_path):
     with ensure_clean_path(setup_path) as path:
         df.to_hdf(path, "df")
         reread = read_hdf(path, "df")
-        assert_frame_equal(df, reread)
+        tm.assert_frame_equal(df, reread)
 
 
 def test_complex_mixed_table(setup_path):
@@ -108,12 +107,12 @@ def test_complex_mixed_table(setup_path):
     with ensure_clean_store(setup_path) as store:
         store.append("df", df, data_columns=["A", "B"])
         result = store.select("df", where="A>2")
-        assert_frame_equal(df.loc[df.A > 2], result)
+        tm.assert_frame_equal(df.loc[df.A > 2], result)
 
     with ensure_clean_path(setup_path) as path:
         df.to_hdf(path, "df", format="table")
         reread = read_hdf(path, "df")
-        assert_frame_equal(df, reread)
+        tm.assert_frame_equal(df, reread)
 
 
 def test_complex_across_dimensions_fixed(setup_path):
@@ -183,4 +182,4 @@ def test_complex_append(setup_path):
         store.append("df", df, data_columns=["b"])
         store.append("df", df)
         result = store.select("df")
-        assert_frame_equal(pd.concat([df, df], 0), result)
+        tm.assert_frame_equal(pd.concat([df, df], 0), result)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -42,7 +42,6 @@ from pandas.tests.io.pytables.common import (
     tables,
 )
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 from pandas.io.pytables import (
     ClosedFileError,
@@ -99,19 +98,19 @@ class TestHDFStore:
                 return read_hdf(path, key)
 
             o = tm.makeTimeSeries()
-            assert_series_equal(o, roundtrip("series", o))
+            tm.assert_series_equal(o, roundtrip("series", o))
 
             o = tm.makeStringSeries()
-            assert_series_equal(o, roundtrip("string_series", o))
+            tm.assert_series_equal(o, roundtrip("string_series", o))
 
             o = tm.makeDataFrame()
-            assert_frame_equal(o, roundtrip("frame", o))
+            tm.assert_frame_equal(o, roundtrip("frame", o))
 
             # table
             df = DataFrame(dict(A=range(5), B=range(5)))
             df.to_hdf(path, "table", append=True)
             result = read_hdf(path, "table", where=["index>2"])
-            assert_frame_equal(df[df.index > 2], result)
+            tm.assert_frame_equal(df[df.index > 2], result)
 
         finally:
             safe_remove(path)
@@ -127,7 +126,7 @@ class TestHDFStore:
             store.append("df", df, data_columns=["a"])
 
             result = store.select("df")
-            assert_frame_equal(df, result)
+            tm.assert_frame_equal(df, result)
 
     def test_api(self, setup_path):
 
@@ -138,39 +137,39 @@ class TestHDFStore:
             df = tm.makeDataFrame()
             df.iloc[:10].to_hdf(path, "df", append=True, format="table")
             df.iloc[10:].to_hdf(path, "df", append=True, format="table")
-            assert_frame_equal(read_hdf(path, "df"), df)
+            tm.assert_frame_equal(read_hdf(path, "df"), df)
 
             # append to False
             df.iloc[:10].to_hdf(path, "df", append=False, format="table")
             df.iloc[10:].to_hdf(path, "df", append=True, format="table")
-            assert_frame_equal(read_hdf(path, "df"), df)
+            tm.assert_frame_equal(read_hdf(path, "df"), df)
 
         with ensure_clean_path(setup_path) as path:
 
             df = tm.makeDataFrame()
             df.iloc[:10].to_hdf(path, "df", append=True)
             df.iloc[10:].to_hdf(path, "df", append=True, format="table")
-            assert_frame_equal(read_hdf(path, "df"), df)
+            tm.assert_frame_equal(read_hdf(path, "df"), df)
 
             # append to False
             df.iloc[:10].to_hdf(path, "df", append=False, format="table")
             df.iloc[10:].to_hdf(path, "df", append=True)
-            assert_frame_equal(read_hdf(path, "df"), df)
+            tm.assert_frame_equal(read_hdf(path, "df"), df)
 
         with ensure_clean_path(setup_path) as path:
 
             df = tm.makeDataFrame()
             df.to_hdf(path, "df", append=False, format="fixed")
-            assert_frame_equal(read_hdf(path, "df"), df)
+            tm.assert_frame_equal(read_hdf(path, "df"), df)
 
             df.to_hdf(path, "df", append=False, format="f")
-            assert_frame_equal(read_hdf(path, "df"), df)
+            tm.assert_frame_equal(read_hdf(path, "df"), df)
 
             df.to_hdf(path, "df", append=False)
-            assert_frame_equal(read_hdf(path, "df"), df)
+            tm.assert_frame_equal(read_hdf(path, "df"), df)
 
             df.to_hdf(path, "df")
-            assert_frame_equal(read_hdf(path, "df"), df)
+            tm.assert_frame_equal(read_hdf(path, "df"), df)
 
         with ensure_clean_store(setup_path) as store:
 
@@ -180,24 +179,24 @@ class TestHDFStore:
             _maybe_remove(store, "df")
             store.append("df", df.iloc[:10], append=True, format="table")
             store.append("df", df.iloc[10:], append=True, format="table")
-            assert_frame_equal(store.select("df"), df)
+            tm.assert_frame_equal(store.select("df"), df)
 
             # append to False
             _maybe_remove(store, "df")
             store.append("df", df.iloc[:10], append=False, format="table")
             store.append("df", df.iloc[10:], append=True, format="table")
-            assert_frame_equal(store.select("df"), df)
+            tm.assert_frame_equal(store.select("df"), df)
 
             # formats
             _maybe_remove(store, "df")
             store.append("df", df.iloc[:10], append=False, format="table")
             store.append("df", df.iloc[10:], append=True, format="table")
-            assert_frame_equal(store.select("df"), df)
+            tm.assert_frame_equal(store.select("df"), df)
 
             _maybe_remove(store, "df")
             store.append("df", df.iloc[:10], append=False, format="table")
             store.append("df", df.iloc[10:], append=True, format=None)
-            assert_frame_equal(store.select("df"), df)
+            tm.assert_frame_equal(store.select("df"), df)
 
         with ensure_clean_path(setup_path) as path:
             # Invalid.
@@ -432,7 +431,7 @@ class TestHDFStore:
                         read_hdf(path, "df", mode=mode)
                 else:
                     result = read_hdf(path, "df", mode=mode)
-                    assert_frame_equal(result, df)
+                    tm.assert_frame_equal(result, df)
 
         def check_default_mode():
 
@@ -440,7 +439,7 @@ class TestHDFStore:
             with ensure_clean_path(setup_path) as path:
                 df.to_hdf(path, "df", mode="w")
                 result = read_hdf(path, "df")
-                assert_frame_equal(result, df)
+                tm.assert_frame_equal(result, df)
 
         check("r")
         check("r+")
@@ -962,7 +961,7 @@ class TestHDFStore:
 
                 _maybe_remove(store, "df")
                 store.put("df", df, format=format)
-                assert_frame_equal(df, store["df"])
+                tm.assert_frame_equal(df, store["df"])
 
             for index in [
                 tm.makeFloatIndex,
@@ -1032,9 +1031,11 @@ class TestHDFStore:
 
         if is_categorical_dtype(s_nan):
             assert is_categorical_dtype(retr)
-            assert_series_equal(s_nan, retr, check_dtype=False, check_categorical=False)
+            tm.assert_series_equal(
+                s_nan, retr, check_dtype=False, check_categorical=False
+            )
         else:
-            assert_series_equal(s_nan, retr)
+            tm.assert_series_equal(s_nan, retr)
 
         # FIXME: don't leave commented-out
         # fails:
@@ -1861,14 +1862,14 @@ class TestHDFStore:
             # repeated append of 0/non-zero frames
             df = DataFrame(np.random.rand(10, 3), columns=list("ABC"))
             store.append("df", df)
-            assert_frame_equal(store.select("df"), df)
+            tm.assert_frame_equal(store.select("df"), df)
             store.append("df", df_empty)
-            assert_frame_equal(store.select("df"), df)
+            tm.assert_frame_equal(store.select("df"), df)
 
             # store
             df = DataFrame(columns=list("ABC"))
             store.put("df2", df)
-            assert_frame_equal(store.select("df2"), df)
+            tm.assert_frame_equal(store.select("df2"), df)
 
     def test_append_raise(self, setup_path):
 
@@ -1929,11 +1930,11 @@ class TestHDFStore:
         with ensure_clean_store(setup_path) as store:
             df1 = DataFrame({"a": [1, 2, 3]}, dtype="f8")
             store.append("df_f8", df1)
-            assert_series_equal(df1.dtypes, store["df_f8"].dtypes)
+            tm.assert_series_equal(df1.dtypes, store["df_f8"].dtypes)
 
             df2 = DataFrame({"a": [1, 2, 3]}, dtype="i8")
             store.append("df_i8", df2)
-            assert_series_equal(df2.dtypes, store["df_i8"].dtypes)
+            tm.assert_series_equal(df2.dtypes, store["df_i8"].dtypes)
 
             # incompatible dtype
             with pytest.raises(ValueError):
@@ -1943,7 +1944,7 @@ class TestHDFStore:
             # actually create them thought)
             df1 = DataFrame(np.array([[1], [2], [3]], dtype="f4"), columns=["A"])
             store.append("df_f4", df1)
-            assert_series_equal(df1.dtypes, store["df_f4"].dtypes)
+            tm.assert_series_equal(df1.dtypes, store["df_f4"].dtypes)
             assert df1.dtypes[0] == "float32"
 
             # check with mixed dtypes
@@ -2057,11 +2058,11 @@ class TestHDFStore:
 
             store.put("fixed", s)
             result = store.select("fixed")
-            assert_series_equal(result, s)
+            tm.assert_series_equal(result, s)
 
             store.append("table", s)
             result = store.select("table")
-            assert_series_equal(result, s)
+            tm.assert_series_equal(result, s)
 
     def test_roundtrip_tz_aware_index(self, setup_path):
         # GH 17618
@@ -2096,32 +2097,32 @@ class TestHDFStore:
             _maybe_remove(store, "df")
             store.append("df", df, data_columns=True)
             result = store.select("df")
-            assert_frame_equal(result, df)
+            tm.assert_frame_equal(result, df)
 
             result = store.select("df", where="C<100000")
-            assert_frame_equal(result, df)
+            tm.assert_frame_equal(result, df)
 
             result = store.select("df", where="C<pd.Timedelta('-3D')")
-            assert_frame_equal(result, df.iloc[3:])
+            tm.assert_frame_equal(result, df.iloc[3:])
 
             result = store.select("df", "C<'-3D'")
-            assert_frame_equal(result, df.iloc[3:])
+            tm.assert_frame_equal(result, df.iloc[3:])
 
             # a bit hacky here as we don't really deal with the NaT properly
 
             result = store.select("df", "C<'-500000s'")
             result = result.dropna(subset=["C"])
-            assert_frame_equal(result, df.iloc[6:])
+            tm.assert_frame_equal(result, df.iloc[6:])
 
             result = store.select("df", "C<'-3.5D'")
             result = result.iloc[1:]
-            assert_frame_equal(result, df.iloc[4:])
+            tm.assert_frame_equal(result, df.iloc[4:])
 
             # fixed
             _maybe_remove(store, "df2")
             store.put("df2", df)
             result = store.select("df2")
-            assert_frame_equal(result, df)
+            tm.assert_frame_equal(result, df)
 
     def test_remove(self, setup_path):
 
@@ -2228,16 +2229,16 @@ class TestHDFStore:
             import datetime  # noqa
 
             result = store.select("df", "index>datetime.datetime(2013,1,5)")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             from datetime import datetime  # noqa
 
             # technically an error, but allow it
             result = store.select("df", "index>datetime.datetime(2013,1,5)")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = store.select("df", "index>datetime(2013,1,5)")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_series(self, setup_path):
 
@@ -2459,7 +2460,7 @@ class TestHDFStore:
             df.to_hdf(path, "df", format=table_format)
             df2 = read_hdf(path, "df")
 
-            assert_frame_equal(df, df2, check_names=True)
+            tm.assert_frame_equal(df, df2, check_names=True)
 
             assert type(df2.index.name) == str
             assert type(df2.columns.name) == str
@@ -2534,15 +2535,15 @@ class TestHDFStore:
 
             result = store.select("df")
             expected = df
-            assert_frame_equal(result, expected, by_blocks=True)
+            tm.assert_frame_equal(result, expected, by_blocks=True)
 
             result = store.select("df", columns=df.columns)
             expected = df
-            assert_frame_equal(result, expected, by_blocks=True)
+            tm.assert_frame_equal(result, expected, by_blocks=True)
 
             result = store.select("df", columns=["A"])
             expected = df.loc[:, ["A"]]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         # dups across dtypes
         df = concat(
@@ -2561,19 +2562,19 @@ class TestHDFStore:
 
             result = store.select("df")
             expected = df
-            assert_frame_equal(result, expected, by_blocks=True)
+            tm.assert_frame_equal(result, expected, by_blocks=True)
 
             result = store.select("df", columns=df.columns)
             expected = df
-            assert_frame_equal(result, expected, by_blocks=True)
+            tm.assert_frame_equal(result, expected, by_blocks=True)
 
             expected = df.loc[:, ["A"]]
             result = store.select("df", columns=["A"])
-            assert_frame_equal(result, expected, by_blocks=True)
+            tm.assert_frame_equal(result, expected, by_blocks=True)
 
             expected = df.loc[:, ["B", "A"]]
             result = store.select("df", columns=["B", "A"])
-            assert_frame_equal(result, expected, by_blocks=True)
+            tm.assert_frame_equal(result, expected, by_blocks=True)
 
         # duplicates on both index and columns
         with ensure_clean_store(setup_path) as store:
@@ -2583,7 +2584,7 @@ class TestHDFStore:
             expected = df.loc[:, ["B", "A"]]
             expected = concat([expected, expected])
             result = store.select("df", columns=["B", "A"])
-            assert_frame_equal(result, expected, by_blocks=True)
+            tm.assert_frame_equal(result, expected, by_blocks=True)
 
     def test_overwrite_node(self, setup_path):
 
@@ -3269,40 +3270,40 @@ class TestHDFStore:
             l = selection.index.tolist()  # noqa
             store = HDFStore(hh)
             result = store.select("df", where="l1=l")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
             store.close()
 
             result = read_hdf(hh, "df", where="l1=l")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # index
             index = selection.index  # noqa
             result = read_hdf(hh, "df", where="l1=index")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = read_hdf(hh, "df", where="l1=selection.index")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = read_hdf(hh, "df", where="l1=selection.index.tolist()")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = read_hdf(hh, "df", where="l1=list(selection.index)")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # scope with index
             store = HDFStore(hh)
 
             result = store.select("df", where="l1=index")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = store.select("df", where="l1=selection.index")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = store.select("df", where="l1=selection.index.tolist()")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = store.select("df", where="l1=list(selection.index)")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             store.close()
 
@@ -3337,11 +3338,11 @@ class TestHDFStore:
 
             result = store.select("df", "x=none")
             expected = df[df.x == "none"]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = store.select("df", "x!=none")
             expected = df[df.x != "none"]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             df2 = df.copy()
             df2.loc[df2.x == "", "x"] = np.nan
@@ -3349,7 +3350,7 @@ class TestHDFStore:
             store.append("df2", df2, data_columns=["x"])
             result = store.select("df2", "x!=none")
             expected = df2[isna(df2.x)]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # int ==/!=
             df["int"] = 1
@@ -3359,11 +3360,11 @@ class TestHDFStore:
 
             result = store.select("df3", "int=2")
             expected = df[df.int == 2]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = store.select("df3", "int!=2")
             expected = df[df.int != 2]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_read_column(self, setup_path):
 
@@ -3700,7 +3701,7 @@ class TestHDFStore:
             # write w/o the index on that particular column
             store.append("df", df, data_columns=True, index=["cols"])
             result = store.select("df", where="values>2.0")
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_start_stop_table(self, setup_path):
 
@@ -3816,7 +3817,7 @@ class TestHDFStore:
             store.append("test_dataset", df)
 
             result = store.select("test_dataset", start=start, stop=stop)
-            assert_frame_equal(df[start:stop], result)
+            tm.assert_frame_equal(df[start:stop], result)
 
     def test_path_pathlib_hdfstore(self, setup_path):
         df = tm.makeDataFrame()
@@ -4044,7 +4045,7 @@ class TestHDFStore:
                 columns=["A", "B", "C", "D"],
                 index=pd.Index(["ABC"], name="INDEX_NAME"),
             )
-            assert_frame_equal(expected, result)
+            tm.assert_frame_equal(expected, result)
 
     def test_legacy_table_read_py2(self, datapath, setup_path):
         # issue: 24925
@@ -4055,7 +4056,7 @@ class TestHDFStore:
             result = store.select("table")
 
         expected = pd.DataFrame({"a": ["a", "b"], "b": [2, 3]})
-        assert_frame_equal(expected, result)
+        tm.assert_frame_equal(expected, result)
 
     def test_copy(self, setup_path):
 
@@ -4152,7 +4153,7 @@ class TestHDFStore:
             store["a"] = df
             result = store["a"]
 
-            assert_frame_equal(result, df)
+            tm.assert_frame_equal(result, df)
             assert result.index.freq == df.index.freq
             tm.assert_class_equal(result.index, df.index, obj="dataframe index")
 
@@ -4161,7 +4162,7 @@ class TestHDFStore:
             store["a"] = df
             result = store["a"]
 
-            assert_frame_equal(result, df)
+            tm.assert_frame_equal(result, df)
             assert result.index.freq == df.index.freq
             tm.assert_class_equal(result.index, df.index, obj="dataframe index")
 
@@ -4442,7 +4443,7 @@ class TestHDFStore:
         with ensure_clean_store(setup_path) as store:
 
             store["df"] = df
-            assert_frame_equal(store["df"], df)
+            tm.assert_frame_equal(store["df"], df)
 
     def test_columns_multiindex_modified(self, setup_path):
         # BUG: 7212
@@ -4569,7 +4570,7 @@ class TestHDFStore:
         with ensure_clean_path(setup_path) as path:
             df.to_hdf(path, "df", mode="a")
             reread = read_hdf(path)
-            assert_frame_equal(df, reread)
+            tm.assert_frame_equal(df, reread)
             df.to_hdf(path, "df2", mode="a")
 
             with pytest.raises(ValueError):
@@ -4582,7 +4583,7 @@ class TestHDFStore:
         with ensure_clean_path(setup_path) as path:
             df.to_hdf(path, "df", mode="a", format="table")
             reread = read_hdf(path)
-            assert_frame_equal(df, reread)
+            tm.assert_frame_equal(df, reread)
             df.to_hdf(path, "df2", mode="a", format="table")
 
             with pytest.raises(ValueError):
@@ -4739,7 +4740,7 @@ class TestHDFStore:
             mode="r",
         ) as store:
             result = store["p"]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("where", ["", (), (None,), [], [None]])
     def test_select_empty_where(self, where):
@@ -4754,7 +4755,7 @@ class TestHDFStore:
             with pd.HDFStore(path) as store:
                 store.put("df", df, "t")
                 result = pd.read_hdf(store, "df", where=where)
-                assert_frame_equal(result, df)
+                tm.assert_frame_equal(result, df)
 
     @pytest.mark.parametrize(
         "idx",

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -13,7 +13,6 @@ from pandas.tests.io.pytables.common import (
     ensure_clean_store,
 )
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, set_timezone
 
 
 def _compare_with_tz(a, b):
@@ -57,7 +56,7 @@ def test_append_with_timezones_dateutil(setup_path):
         store.append("df_tz", df, data_columns=["A"])
         result = store["df_tz"]
         _compare_with_tz(result, df)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         # select with tz aware
         expected = df[df.A >= df.A[3]]
@@ -76,7 +75,7 @@ def test_append_with_timezones_dateutil(setup_path):
         store.append("df_tz", df)
         result = store["df_tz"]
         _compare_with_tz(result, df)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         df = DataFrame(
             dict(
@@ -93,7 +92,7 @@ def test_append_with_timezones_dateutil(setup_path):
         store.append("df_tz", df, data_columns=["A", "B"])
         result = store["df_tz"]
         _compare_with_tz(result, df)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         # can't append with diff timezone
         df = DataFrame(
@@ -124,12 +123,12 @@ def test_append_with_timezones_dateutil(setup_path):
         _maybe_remove(store, "df")
         store.put("df", df)
         result = store.select("df")
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         _maybe_remove(store, "df")
         store.append("df", df)
         result = store.select("df")
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
 
 def test_append_with_timezones_pytz(setup_path):
@@ -152,7 +151,7 @@ def test_append_with_timezones_pytz(setup_path):
         store.append("df_tz", df, data_columns=["A"])
         result = store["df_tz"]
         _compare_with_tz(result, df)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         # select with tz aware
         _compare_with_tz(store.select("df_tz", where="A>=df.A[3]"), df[df.A >= df.A[3]])
@@ -169,7 +168,7 @@ def test_append_with_timezones_pytz(setup_path):
         store.append("df_tz", df)
         result = store["df_tz"]
         _compare_with_tz(result, df)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         df = DataFrame(
             dict(
@@ -186,7 +185,7 @@ def test_append_with_timezones_pytz(setup_path):
         store.append("df_tz", df, data_columns=["A", "B"])
         result = store["df_tz"]
         _compare_with_tz(result, df)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         # can't append with diff timezone
         df = DataFrame(
@@ -215,12 +214,12 @@ def test_append_with_timezones_pytz(setup_path):
         _maybe_remove(store, "df")
         store.put("df", df)
         result = store.select("df")
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         _maybe_remove(store, "df")
         store.append("df", df)
         result = store.select("df")
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
 
 def test_tseries_select_index_column(setup_path):
@@ -264,7 +263,7 @@ def test_timezones_fixed(setup_path):
         df = DataFrame(np.random.randn(len(rng), 4), index=rng)
         store["df"] = df
         result = store["df"]
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         # as data
         # GH11411
@@ -280,7 +279,7 @@ def test_timezones_fixed(setup_path):
         )
         store["df"] = df
         result = store["df"]
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
 
 def test_fixed_offset_tz(setup_path):
@@ -307,20 +306,20 @@ def test_store_timezone(setup_path):
         df = DataFrame([1, 2, 3], index=[today, today, today])
         store["obj1"] = df
         result = store["obj1"]
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
     # with tz setting
     with ensure_clean_store(setup_path) as store:
 
-        with set_timezone("EST5EDT"):
+        with tm.set_timezone("EST5EDT"):
             today = datetime.date(2013, 9, 10)
             df = DataFrame([1, 2, 3], index=[today, today, today])
             store["obj1"] = df
 
-        with set_timezone("CST6CDT"):
+        with tm.set_timezone("CST6CDT"):
             result = store["obj1"]
 
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
 
 def test_legacy_datetimetz_object(datapath, setup_path):
@@ -336,7 +335,7 @@ def test_legacy_datetimetz_object(datapath, setup_path):
         datapath("io", "data", "legacy_hdf", "datetimetz_object.h5"), mode="r"
     ) as store:
         result = store["df"]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
 
 def test_dst_transitions(setup_path):
@@ -355,7 +354,7 @@ def test_dst_transitions(setup_path):
             df = DataFrame({"A": range(len(i)), "B": i}, index=i)
             store.append("df", df)
             result = store.select("df")
-            assert_frame_equal(result, df)
+            tm.assert_frame_equal(result, df)
 
 
 def test_read_with_where_tz_aware_index(setup_path):
@@ -370,7 +369,7 @@ def test_read_with_where_tz_aware_index(setup_path):
         with pd.HDFStore(path) as store:
             store.append(key, expected, format="table", append=True)
         result = pd.read_hdf(path, key, where="DATE > 20151130")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
 
 def test_py2_created_with_datetimez(datapath, setup_path):
@@ -384,4 +383,4 @@ def test_py2_created_with_datetimez(datapath, setup_path):
         datapath("io", "data", "legacy_hdf", "gh26443.h5"), mode="r"
     ) as store:
         result = store["key"]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -6,8 +6,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, get_option, read_clipboard
-from pandas.util import testing as tm
-from pandas.util.testing import makeCustomDataframe as mkdf
+import pandas.util.testing as tm
 
 from pandas.io.clipboard import clipboard_get, clipboard_set
 from pandas.io.clipboard.exceptions import PyperclipException
@@ -54,12 +53,12 @@ def df(request):
             {"a": ["\U0001f44d\U0001f44d", "\U0001f44d\U0001f44d"], "b": ["abc", "def"]}
         )
     elif data_type == "string":
-        return mkdf(
+        return tm.makeCustomDataframe(
             5, 3, c_idx_type="s", r_idx_type="i", c_idx_names=[None], r_idx_names=[None]
         )
     elif data_type == "long":
         max_rows = get_option("display.max_rows")
-        return mkdf(
+        return tm.makeCustomDataframe(
             max_rows + 1,
             3,
             data_gen_f=lambda *args: randint(2),
@@ -72,7 +71,7 @@ def df(request):
         return pd.DataFrame({"en": "in English".split(), "es": "en español".split()})
     elif data_type == "colwidth":
         _cw = get_option("display.max_colwidth") + 1
-        return mkdf(
+        return tm.makeCustomDataframe(
             5,
             3,
             data_gen_f=lambda *args: "x" * _cw,
@@ -86,7 +85,7 @@ def df(request):
             {"a": np.arange(1.0, 6.0) + 0.01, "b": np.arange(1, 6), "c": list("abcde")}
         )
     elif data_type == "float":
-        return mkdf(
+        return tm.makeCustomDataframe(
             5,
             3,
             data_gen_f=lambda r, c: float(r) + 0.01,
@@ -96,7 +95,7 @@ def df(request):
             r_idx_names=[None],
         )
     elif data_type == "int":
-        return mkdf(
+        return tm.makeCustomDataframe(
             5,
             3,
             data_gen_f=lambda *args: randint(2),

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -6,7 +6,6 @@ import pytest
 
 import pandas as pd
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, ensure_clean
 
 from pandas.io.feather_format import read_feather, to_feather  # noqa: E402 isort:skip
 
@@ -25,7 +24,7 @@ class TestFeather:
         # on writing
 
         with pytest.raises(exc):
-            with ensure_clean() as path:
+            with tm.ensure_clean() as path:
                 to_feather(df, path)
 
     def check_round_trip(self, df, expected=None, **kwargs):
@@ -33,11 +32,11 @@ class TestFeather:
         if expected is None:
             expected = df
 
-        with ensure_clean() as path:
+        with tm.ensure_clean() as path:
             to_feather(df, path)
 
             result = read_feather(path, **kwargs)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_error(self):
 

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -6,7 +6,7 @@ import pytest
 
 from pandas import DataFrame, date_range, read_csv
 from pandas.util import _test_decorators as td
-from pandas.util.testing import assert_frame_equal
+import pandas.util.testing as tm
 
 from pandas.io.common import is_gcs_url
 
@@ -35,7 +35,7 @@ def test_read_csv_gcs(monkeypatch):
     monkeypatch.setattr("gcsfs.GCSFileSystem", MockGCSFileSystem)
     df2 = read_csv("gs://test/test.csv", parse_dates=["dt"])
 
-    assert_frame_equal(df1, df2)
+    tm.assert_frame_equal(df1, df2)
 
 
 @td.skip_if_no("gcsfs")
@@ -58,7 +58,7 @@ def test_to_csv_gcs(monkeypatch):
     df1.to_csv("gs://test/test.csv", index=True)
     df2 = read_csv(StringIO(s.getvalue()), parse_dates=["dt"], index_col=0)
 
-    assert_frame_equal(df1, df2)
+    tm.assert_frame_equal(df1, df2)
 
 
 @td.skip_if_no("fastparquet")
@@ -105,7 +105,7 @@ def test_gcs_get_filepath_or_buffer(monkeypatch):
     )
     df2 = read_csv("gs://test/test.csv", parse_dates=["dt"])
 
-    assert_frame_equal(df1, df2)
+    tm.assert_frame_equal(df1, df2)
 
 
 @td.skip_if_installed("gcsfs")

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -16,7 +16,6 @@ import pandas.util._test_decorators as td
 
 from pandas import DataFrame, Index, MultiIndex, Series, Timestamp, date_range, read_csv
 import pandas.util.testing as tm
-from pandas.util.testing import makeCustomDataframe as mkdf, network
 
 from pandas.io.common import file_path_to_url
 import pandas.io.html
@@ -108,7 +107,7 @@ class TestReadHtml:
 
     def test_to_html_compat(self):
         df = (
-            mkdf(
+            tm.makeCustomDataframe(
                 4,
                 3,
                 data_gen_f=lambda *args: rand(),
@@ -122,7 +121,7 @@ class TestReadHtml:
         res = self.read_html(out, attrs={"class": "dataframe"}, index_col=0)[0]
         tm.assert_frame_equal(res, df)
 
-    @network
+    @tm.network
     def test_banklist_url(self):
         url = "http://www.fdic.gov/bank/individual/failed/banklist.html"
         df1 = self.read_html(
@@ -132,7 +131,7 @@ class TestReadHtml:
 
         assert_framelist_equal(df1, df2)
 
-    @network
+    @tm.network
     def test_spam_url(self):
         url = (
             "https://raw.githubusercontent.com/pandas-dev/pandas/master/"
@@ -275,12 +274,12 @@ class TestReadHtml:
 
         assert_framelist_equal(df1, df2)
 
-    @network
+    @tm.network
     def test_bad_url_protocol(self):
         with pytest.raises(URLError):
             self.read_html("git://github.com", match=".*Water.*")
 
-    @network
+    @tm.network
     @pytest.mark.slow
     def test_invalid_url(self):
         try:
@@ -361,13 +360,13 @@ class TestReadHtml:
         with pytest.raises(ValueError, match=msg):
             self.read_html(self.spam_data, "Water", skiprows=-1)
 
-    @network
+    @tm.network
     def test_multiple_matches(self):
         url = "https://docs.python.org/2/"
         dfs = self.read_html(url, match="Python")
         assert len(dfs) > 1
 
-    @network
+    @tm.network
     def test_python_docs_table(self):
         url = "https://docs.python.org/2/"
         dfs = self.read_html(url, match="Python")


### PR DESCRIPTION
Part of #29272 

Fyi: All changes are generated from a script posted in the issue.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
