### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/frame - part1

### DIFF
--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -16,11 +16,6 @@ from pandas import (
     timedelta_range,
 )
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-)
 
 
 class SharedWithSparse:
@@ -344,7 +339,7 @@ class SharedWithSparse:
         # single block corner case
         arr = float_frame[["A", "B"]].values
         expected = float_frame.reindex(columns=["A", "B"]).values
-        assert_almost_equal(arr, expected)
+        tm.assert_almost_equal(arr, expected)
 
     def test_to_numpy(self):
         df = pd.DataFrame({"A": [1, 2], "B": [3, 4.5]})
@@ -401,11 +396,11 @@ class SharedWithSparse:
         # reg name
         expected = f.sum(axis=0)
         result = f.sum(axis="index")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = f.sum(axis=1)
         result = f.sum(axis="columns")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_class_axis(self):
         # GH 18147
@@ -474,8 +469,8 @@ class TestDataFrameMisc(SharedWithSparse):
 
     klass = DataFrame
     # SharedWithSparse tests use generic, klass-agnostic assertion
-    _assert_frame_equal = staticmethod(assert_frame_equal)
-    _assert_series_equal = staticmethod(assert_series_equal)
+    _assert_frame_equal = staticmethod(tm.assert_frame_equal)
+    _assert_series_equal = staticmethod(tm.assert_series_equal)
 
     def test_values(self, float_frame):
         float_frame.values[:, 0] = 5.0

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -14,7 +14,6 @@ from pandas import DataFrame, MultiIndex, Series, Timestamp, date_range, notna
 from pandas.conftest import _get_cython_table_params
 from pandas.core.apply import frame_apply
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 @pytest.fixture
@@ -70,7 +69,7 @@ class TestDataFrameApply:
             }
         )
         result = df.apply(lambda x: x, axis=1)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
     def test_apply_empty(self, float_frame):
         # empty
@@ -85,17 +84,17 @@ class TestDataFrameApply:
         no_rows = float_frame[:0]
         result = no_rows.apply(lambda x: x.mean())
         expected = Series(np.nan, index=float_frame.columns)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         no_cols = float_frame.loc[:, []]
         result = no_cols.apply(lambda x: x.mean(), axis=1)
         expected = Series(np.nan, index=float_frame.index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 2476
         expected = DataFrame(index=["a"])
         result = expected.apply(lambda x: x["a"], axis=1)
-        assert_frame_equal(expected, result)
+        tm.assert_frame_equal(expected, result)
 
     def test_apply_with_reduce_empty(self):
         # reduce with an empty DataFrame
@@ -103,15 +102,15 @@ class TestDataFrameApply:
 
         x = []
         result = empty_frame.apply(x.append, axis=1, result_type="expand")
-        assert_frame_equal(result, empty_frame)
+        tm.assert_frame_equal(result, empty_frame)
         result = empty_frame.apply(x.append, axis=1, result_type="reduce")
-        assert_series_equal(result, Series([], index=pd.Index([], dtype=object)))
+        tm.assert_series_equal(result, Series([], index=pd.Index([], dtype=object)))
 
         empty_with_cols = DataFrame(columns=["a", "b", "c"])
         result = empty_with_cols.apply(x.append, axis=1, result_type="expand")
-        assert_frame_equal(result, empty_with_cols)
+        tm.assert_frame_equal(result, empty_with_cols)
         result = empty_with_cols.apply(x.append, axis=1, result_type="reduce")
-        assert_series_equal(result, Series([], index=pd.Index([], dtype=object)))
+        tm.assert_series_equal(result, Series([], index=pd.Index([], dtype=object)))
 
         # Ensure that x.append hasn't been called
         assert x == []
@@ -123,7 +122,7 @@ class TestDataFrameApply:
 
         result = df.apply(getattr(np, func))
         expected = getattr(df, func)()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_nunique_empty(self):
         # GH 28213
@@ -131,21 +130,21 @@ class TestDataFrameApply:
 
         result = df.nunique()
         expected = Series(0, index=df.columns)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.T.nunique()
         expected = Series([], index=pd.Index([]))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_apply_standard_nonunique(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], index=["a", "a", "c"])
 
         result = df.apply(lambda s: s[0], axis=1)
         expected = Series([1, 4, 7], ["a", "a", "c"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.T.apply(lambda s: s[0], axis=0)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("func", ["sum", "mean", "min", "max", "std"])
     @pytest.mark.parametrize(
@@ -240,13 +239,13 @@ class TestDataFrameApply:
         expected0 = float_frame.apply(lambda x: x.values.mean())
         expected1 = float_frame.apply(lambda x: x.values.mean(), axis=1)
 
-        assert_series_equal(result0, expected0)
-        assert_series_equal(result1, expected1)
+        tm.assert_series_equal(result0, expected0)
+        tm.assert_series_equal(result1, expected1)
 
         # no reduction
         result = float_frame.apply(lambda x: x * 2, raw=True)
         expected = float_frame * 2
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_apply_axis1(self, float_frame):
         d = float_frame.index[0]
@@ -258,7 +257,7 @@ class TestDataFrameApply:
             float_string_frame, np.mean, 0, ignore_failures=True
         ).apply_standard()
         expected = float_string_frame._get_numeric_data().apply(np.mean)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_apply_mixed_dtype_corner(self):
         df = DataFrame({"A": ["foo"], "B": [1.0]})
@@ -266,16 +265,16 @@ class TestDataFrameApply:
         # the result here is actually kind of ambiguous, should it be a Series
         # or a DataFrame?
         expected = Series(np.nan, index=pd.Index([], dtype="int64"))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": ["foo"], "B": [1.0]})
         result = df.apply(lambda x: x["A"], axis=1)
         expected = Series(["foo"], index=[0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.apply(lambda x: x["B"], axis=1)
         expected = Series([1.0], index=[0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_apply_empty_infer_type(self):
         no_cols = DataFrame(index=["a", "b", "c"])
@@ -322,32 +321,32 @@ class TestDataFrameApply:
 
         result = float_frame.apply(add_some, howmuch=2)
         expected = float_frame.apply(lambda x: x + 2)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = float_frame.apply(agg_and_add, howmuch=2)
         expected = float_frame.apply(lambda x: x.mean() + 2)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = float_frame.apply(subtract_and_divide, args=(2,), divide=2)
         expected = float_frame.apply(lambda x: (x - 2.0) / 2.0)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_apply_yield_list(self, float_frame):
         result = float_frame.apply(list)
-        assert_frame_equal(result, float_frame)
+        tm.assert_frame_equal(result, float_frame)
 
     def test_apply_reduce_Series(self, float_frame):
         float_frame.loc[::2, "A"] = np.nan
         expected = float_frame.mean(1)
         result = float_frame.apply(np.mean, axis=1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_apply_reduce_rows_to_dict(self):
         # GH 25196
         data = pd.DataFrame([[1, 2], [3, 4]])
         expected = pd.Series([{0: 1, 1: 3}, {0: 2, 1: 4}])
         result = data.apply(dict)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_apply_differently_indexed(self):
         df = DataFrame(np.random.randn(20, 10))
@@ -356,13 +355,13 @@ class TestDataFrameApply:
         expected0 = DataFrame(
             {i: v.describe() for i, v in df.items()}, columns=df.columns
         )
-        assert_frame_equal(result0, expected0)
+        tm.assert_frame_equal(result0, expected0)
 
         result1 = df.apply(Series.describe, axis=1)
         expected1 = DataFrame(
             {i: v.describe() for i, v in df.T.items()}, columns=df.index
         ).T
-        assert_frame_equal(result1, expected1)
+        tm.assert_frame_equal(result1, expected1)
 
     def test_apply_modify_traceback(self):
         data = DataFrame(
@@ -463,7 +462,7 @@ class TestDataFrameApply:
             columns=["a", "market", "position"],
         )
         result = positions.apply(f, axis=1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_apply_convert_objects(self):
         data = DataFrame(
@@ -514,16 +513,16 @@ class TestDataFrameApply:
         )
 
         result = data.apply(lambda x: x, axis=1)
-        assert_frame_equal(result._convert(datetime=True), data)
+        tm.assert_frame_equal(result._convert(datetime=True), data)
 
     def test_apply_attach_name(self, float_frame):
         result = float_frame.apply(lambda x: x.name)
         expected = Series(float_frame.columns, index=float_frame.columns)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = float_frame.apply(lambda x: x.name, axis=1)
         expected = Series(float_frame.index, index=float_frame.index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # non-reductions
         result = float_frame.apply(lambda x: np.repeat(x.name, len(x)))
@@ -532,14 +531,14 @@ class TestDataFrameApply:
             index=float_frame.index,
             columns=float_frame.columns,
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = float_frame.apply(lambda x: np.repeat(x.name, len(x)), axis=1)
         expected = Series(
             np.repeat(t[0], len(float_frame.columns)) for t in float_frame.itertuples()
         )
         expected.index = float_frame.index
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_apply_multi_index(self, float_frame):
         index = MultiIndex.from_arrays([["a", "a", "b"], ["c", "d", "d"]])
@@ -548,7 +547,7 @@ class TestDataFrameApply:
         expected = DataFrame(
             [[1, 2], [3, 4], [5, 6]], index=index, columns=["min", "max"]
         )
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     def test_apply_dict(self):
 
@@ -566,9 +565,9 @@ class TestDataFrameApply:
             reduce_false = df.apply(fn, result_type="expand")
             reduce_none = df.apply(fn)
 
-            assert_series_equal(reduce_true, dicts)
-            assert_frame_equal(reduce_false, df)
-            assert_series_equal(reduce_none, dicts)
+            tm.assert_series_equal(reduce_true, dicts)
+            tm.assert_frame_equal(reduce_false, df)
+            tm.assert_series_equal(reduce_none, dicts)
 
     def test_applymap(self, float_frame):
         applied = float_frame.applymap(lambda x: x * 2)
@@ -672,17 +671,17 @@ class TestDataFrameApply:
             {"dt": pd.date_range("2015-01-01", periods=3, tz="Europe/Brussels")}
         )
         result = df.apply(lambda x: x)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         result = df.apply(lambda x: x + pd.Timedelta("1day"))
         expected = DataFrame(
             {"dt": pd.date_range("2015-01-02", periods=3, tz="Europe/Brussels")}
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame({"dt": ["a", "b", "c", "a"]}, dtype="category")
         result = df.apply(lambda x: x)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
     def test_apply_dup_names_multi_agg(self):
         # GH 21063
@@ -713,19 +712,19 @@ class TestInferOutputShape:
         df = DataFrame([[1, 2], [1, 2]], columns=["a", "b"])
         result = df.apply(lambda x: {"s": x["a"] + x["b"]}, axis=1)
         expected = Series([{"s": 3} for t in df.itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df["tm"] = [
             pd.Timestamp("2017-05-01 00:00:00"),
             pd.Timestamp("2017-05-02 00:00:00"),
         ]
         result = df.apply(lambda x: {"s": x["a"] + x["b"]}, axis=1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # compose a series
         result = (df["a"] + df["b"]).apply(lambda x: {"s": x})
         expected = Series([{"s": 3}, {"s": 3}])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 18775
         df = DataFrame()
@@ -736,7 +735,7 @@ class TestInferOutputShape:
         )
         result = df.apply(lambda x: {}, axis=1)
         expected = Series([{}, {}, {}])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_with_dictlike_columns_with_infer(self):
         # GH 17602
@@ -745,7 +744,7 @@ class TestInferOutputShape:
             lambda x: {"s": x["a"] + x["b"]}, axis=1, result_type="expand"
         )
         expected = DataFrame({"s": [3, 3]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df["tm"] = [
             pd.Timestamp("2017-05-01 00:00:00"),
@@ -754,7 +753,7 @@ class TestInferOutputShape:
         result = df.apply(
             lambda x: {"s": x["a"] + x["b"]}, axis=1, result_type="expand"
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_with_listlike_columns(self):
         # GH 17348
@@ -768,11 +767,11 @@ class TestInferOutputShape:
 
         result = df[["a", "b"]].apply(tuple, axis=1)
         expected = Series([t[1:] for t in df[["a", "b"]].itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df[["a", "ts"]].apply(tuple, axis=1)
         expected = Series([t[1:] for t in df[["a", "ts"]].itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 18919
         df = DataFrame(
@@ -782,7 +781,7 @@ class TestInferOutputShape:
 
         result = df.apply(lambda row: [el for el in row["x"] if el in row["y"]], axis=1)
         expected = Series([[], ["q"]], index=df.index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_infer_output_shape_columns(self):
         # GH 18573
@@ -799,7 +798,7 @@ class TestInferOutputShape:
         )
         result = df.apply(lambda row: (row.number, row.string), axis=1)
         expected = Series([(t.number, t.string) for t in df.itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_infer_output_shape_listlike_columns(self):
         # GH 16353
@@ -808,22 +807,22 @@ class TestInferOutputShape:
 
         result = df.apply(lambda x: [1, 2, 3], axis=1)
         expected = Series([[1, 2, 3] for t in df.itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.apply(lambda x: [1, 2], axis=1)
         expected = Series([[1, 2] for t in df.itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 17970
         df = DataFrame({"a": [1, 2, 3]}, index=list("abc"))
 
         result = df.apply(lambda row: np.ones(1), axis=1)
         expected = Series([np.ones(1) for t in df.itertuples()], index=df.index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.apply(lambda row: np.ones(2), axis=1)
         expected = Series([np.ones(2) for t in df.itertuples()], index=df.index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 17892
         df = pd.DataFrame(
@@ -845,7 +844,7 @@ class TestInferOutputShape:
 
         result = df.apply(fun, axis=1)
         expected = Series([(1, 2) for t in df.itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_consistent_coerce_for_shapes(self):
         # we want column names to NOT be propagated
@@ -854,11 +853,11 @@ class TestInferOutputShape:
 
         result = df.apply(lambda x: [1, 2, 3], axis=1)
         expected = Series([[1, 2, 3] for t in df.itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.apply(lambda x: [1, 2], axis=1)
         expected = Series([[1, 2] for t in df.itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_consistent_names(self, int_frame_const_col):
         # if a Series is returned, we should use the resulting index names
@@ -870,11 +869,11 @@ class TestInferOutputShape:
         expected = int_frame_const_col.rename(
             columns={"A": "test", "B": "other", "C": "cols"}
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.apply(lambda x: Series([1, 2], index=["test", "other"]), axis=1)
         expected = expected[["test", "other"]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_result_type(self, int_frame_const_col):
         # result_type should be consistent no matter which
@@ -884,36 +883,36 @@ class TestInferOutputShape:
         result = df.apply(lambda x: [1, 2, 3], axis=1, result_type="expand")
         expected = df.copy()
         expected.columns = [0, 1, 2]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.apply(lambda x: [1, 2], axis=1, result_type="expand")
         expected = df[["A", "B"]].copy()
         expected.columns = [0, 1]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # broadcast result
         result = df.apply(lambda x: [1, 2, 3], axis=1, result_type="broadcast")
         expected = df.copy()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         columns = ["other", "col", "names"]
         result = df.apply(
             lambda x: Series([1, 2, 3], index=columns), axis=1, result_type="broadcast"
         )
         expected = df.copy()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # series result
         result = df.apply(lambda x: Series([1, 2, 3], index=x.index), axis=1)
         expected = df.copy()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # series result with other index
         columns = ["other", "col", "names"]
         result = df.apply(lambda x: Series([1, 2, 3], index=columns), axis=1)
         expected = df.copy()
         expected.columns = columns
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("result_type", ["foo", 1])
     def test_result_type_error(self, result_type, int_frame_const_col):
@@ -934,11 +933,11 @@ class TestInferOutputShape:
 
         result = df.apply(lambda x: box([1, 2]), axis=1)
         expected = Series([box([1, 2]) for t in df.itertuples()])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.apply(lambda x: box([1, 2]), axis=1, result_type="expand")
         expected = int_frame_const_col[["A", "B"]].rename(columns={"A": 0, "B": 1})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
 
 def zip_frames(frames, axis=1):
@@ -972,13 +971,13 @@ class TestDataFrameAggregate:
             # ufunc
             result = float_frame.transform(np.sqrt, axis=axis)
             expected = f_sqrt.copy()
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = float_frame.apply(np.sqrt, axis=axis)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = float_frame.transform(np.sqrt, axis=axis)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # list-like
             result = float_frame.apply([np.sqrt], axis=axis)
@@ -991,10 +990,10 @@ class TestDataFrameAggregate:
                 expected.index = pd.MultiIndex.from_product(
                     [float_frame.index, ["sqrt"]]
                 )
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = float_frame.transform([np.sqrt], axis=axis)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # multiple items in list
             # these are in the order as if we are applying both
@@ -1009,10 +1008,10 @@ class TestDataFrameAggregate:
                 expected.index = pd.MultiIndex.from_product(
                     [float_frame.index, ["absolute", "sqrt"]]
                 )
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = float_frame.transform([np.abs, "sqrt"], axis=axis)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_transform_and_agg_err(self, axis, float_frame):
         # cannot both transform and agg
@@ -1118,7 +1117,7 @@ class TestDataFrameAggregate:
         expected = expected.T if axis in {0, "index"} else expected
 
         result = float_frame.agg(["mean", "max", "sum"], axis=axis)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # dict input with scalars
         func = OrderedDict([(name1, "mean"), (name2, "sum")])
@@ -1130,7 +1129,7 @@ class TestDataFrameAggregate:
             ],
             index=[name1, name2],
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # dict input with lists
         func = OrderedDict([(name1, ["mean"]), (name2, ["sum"])])
@@ -1146,7 +1145,7 @@ class TestDataFrameAggregate:
             }
         )
         expected = expected.T if axis in {1, "columns"} else expected
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # dict input with lists with multiple
         func = OrderedDict([(name1, ["mean", "sum"]), (name2, ["sum", "max"])])
@@ -1178,7 +1177,7 @@ class TestDataFrameAggregate:
             )
         )
         expected = expected.T if axis in {1, "columns"} else expected
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_nuiscance_columns(self):
 
@@ -1194,7 +1193,7 @@ class TestDataFrameAggregate:
 
         result = df.agg("min")
         expected = Series([1, 1.0, "bar", pd.Timestamp("20130101")], index=df.columns)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.agg(["min"])
         expected = DataFrame(
@@ -1202,17 +1201,17 @@ class TestDataFrameAggregate:
             index=["min"],
             columns=df.columns,
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.agg("sum")
         expected = Series([6, 6.0, "foobarbaz"], index=["A", "B", "C"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.agg(["sum"])
         expected = DataFrame(
             [[6, 6.0, "foobarbaz"]], index=["sum"], columns=["A", "B", "C"]
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_non_callable_aggregates(self):
 
@@ -1227,13 +1226,13 @@ class TestDataFrameAggregate:
         result = df.agg({"A": "count"})
         expected = Series({"A": 2})
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # Non-function aggregate
         result = df.agg({"A": "size"})
         expected = Series({"A": 3})
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # Mix function and non-function aggs
         result1 = df.agg(["count", "size"])
@@ -1248,14 +1247,14 @@ class TestDataFrameAggregate:
             }
         )
 
-        assert_frame_equal(result1, result2, check_like=True)
-        assert_frame_equal(result2, expected, check_like=True)
+        tm.assert_frame_equal(result1, result2, check_like=True)
+        tm.assert_frame_equal(result2, expected, check_like=True)
 
         # Just functional string arg is same as calling df.arg()
         result = df.agg("count")
         expected = df.count()
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # Just a string attribute arg same as calling df.arg
         result = df.agg("size")

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -9,7 +9,6 @@ from pandas.errors import PerformanceWarning
 import pandas as pd
 from pandas import Categorical, DataFrame, Index, MultiIndex, Series, date_range, isna
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal
 
 
 class TestDataFrameSelectReindex:
@@ -73,10 +72,10 @@ class TestDataFrameSelectReindex:
 
     def test_drop(self):
         simple = DataFrame({"A": [1, 2, 3, 4], "B": [0, 1, 2, 3]})
-        assert_frame_equal(simple.drop("A", axis=1), simple[["B"]])
-        assert_frame_equal(simple.drop(["A", "B"], axis="columns"), simple[[]])
-        assert_frame_equal(simple.drop([0, 1, 3], axis=0), simple.loc[[2], :])
-        assert_frame_equal(simple.drop([0, 3], axis="index"), simple.loc[[1, 2], :])
+        tm.assert_frame_equal(simple.drop("A", axis=1), simple[["B"]])
+        tm.assert_frame_equal(simple.drop(["A", "B"], axis="columns"), simple[[]])
+        tm.assert_frame_equal(simple.drop([0, 1, 3], axis=0), simple.loc[[2], :])
+        tm.assert_frame_equal(simple.drop([0, 3], axis="index"), simple.loc[[1, 2], :])
 
         with pytest.raises(KeyError, match=r"\[5\] not found in axis"):
             simple.drop(5)
@@ -88,12 +87,12 @@ class TestDataFrameSelectReindex:
             simple.drop(["A", "C"], 1)
 
         # errors = 'ignore'
-        assert_frame_equal(simple.drop(5, errors="ignore"), simple)
-        assert_frame_equal(
+        tm.assert_frame_equal(simple.drop(5, errors="ignore"), simple)
+        tm.assert_frame_equal(
             simple.drop([0, 5], errors="ignore"), simple.loc[[1, 2, 3], :]
         )
-        assert_frame_equal(simple.drop("C", axis=1, errors="ignore"), simple)
-        assert_frame_equal(
+        tm.assert_frame_equal(simple.drop("C", axis=1, errors="ignore"), simple)
+        tm.assert_frame_equal(
             simple.drop(["A", "C"], axis=1, errors="ignore"), simple[["B"]]
         )
 
@@ -101,21 +100,21 @@ class TestDataFrameSelectReindex:
         nu_df = DataFrame(
             list(zip(range(3), range(-3, 1), list("abc"))), columns=["a", "a", "b"]
         )
-        assert_frame_equal(nu_df.drop("a", axis=1), nu_df[["b"]])
-        assert_frame_equal(nu_df.drop("b", axis="columns"), nu_df["a"])
-        assert_frame_equal(nu_df.drop([]), nu_df)  # GH 16398
+        tm.assert_frame_equal(nu_df.drop("a", axis=1), nu_df[["b"]])
+        tm.assert_frame_equal(nu_df.drop("b", axis="columns"), nu_df["a"])
+        tm.assert_frame_equal(nu_df.drop([]), nu_df)  # GH 16398
 
         nu_df = nu_df.set_index(pd.Index(["X", "Y", "X"]))
         nu_df.columns = list("abc")
-        assert_frame_equal(nu_df.drop("X", axis="rows"), nu_df.loc[["Y"], :])
-        assert_frame_equal(nu_df.drop(["X", "Y"], axis=0), nu_df.loc[[], :])
+        tm.assert_frame_equal(nu_df.drop("X", axis="rows"), nu_df.loc[["Y"], :])
+        tm.assert_frame_equal(nu_df.drop(["X", "Y"], axis=0), nu_df.loc[[], :])
 
         # inplace cache issue
         # GH 5628
         df = pd.DataFrame(np.random.randn(10, 3), columns=list("abc"))
         expected = df[~(df.b > 0)]
         df.drop(labels=df[df.b > 0].index, inplace=True)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_drop_multiindex_not_lexsorted(self):
         # GH 11640
@@ -266,7 +265,7 @@ class TestDataFrameSelectReindex:
 
         # copy with no axes
         result = float_frame.reindex()
-        assert_frame_equal(result, float_frame)
+        tm.assert_frame_equal(result, float_frame)
         assert result is not float_frame
 
     def test_reindex_nan(self):
@@ -277,10 +276,10 @@ class TestDataFrameSelectReindex:
         )
 
         i, j = [np.nan, 5, 5, np.nan, 1, 2, np.nan], [1, 3, 3, 1, 2, 0, 1]
-        assert_frame_equal(df.reindex(i), df.iloc[j])
+        tm.assert_frame_equal(df.reindex(i), df.iloc[j])
 
         df.index = df.index.astype("object")
-        assert_frame_equal(df.reindex(i), df.iloc[j], check_index_type=False)
+        tm.assert_frame_equal(df.reindex(i), df.iloc[j], check_index_type=False)
 
         # GH10388
         df = pd.DataFrame(
@@ -296,7 +295,7 @@ class TestDataFrameSelectReindex:
 
         left = df.set_index(["delta", "other", "date"]).reset_index()
         right = df.reindex(columns=["delta", "other", "date", "amount"])
-        assert_frame_equal(left, right)
+        tm.assert_frame_equal(left, right)
 
     def test_reindex_name_remains(self):
         s = Series(np.random.rand(10))
@@ -329,7 +328,7 @@ class TestDataFrameSelectReindex:
     def test_reindex_like(self, float_frame):
         other = float_frame.reindex(index=float_frame.index[:10], columns=["C", "B"])
 
-        assert_frame_equal(other, float_frame.reindex_like(other))
+        tm.assert_frame_equal(other, float_frame.reindex_like(other))
 
     def test_reindex_columns(self, float_frame):
         new_frame = float_frame.reindex(columns=["A", "B", "E"])
@@ -364,7 +363,7 @@ class TestDataFrameSelectReindex:
             columns=range(6),
             dtype=float,
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # method='ffill'
         result = df.reindex(columns=range(6), method="ffill")
@@ -378,7 +377,7 @@ class TestDataFrameSelectReindex:
             columns=range(6),
             dtype=float,
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # method='bfill'
         result = df.reindex(columns=range(6), method="bfill")
@@ -392,7 +391,7 @@ class TestDataFrameSelectReindex:
             columns=range(6),
             dtype=float,
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_reindex_axes(self):
         # GH 3317, reindexing by both axes loses freq of the index
@@ -419,29 +418,29 @@ class TestDataFrameSelectReindex:
 
         result = df.reindex(range(15), fill_value=0)
         expected = df.reindex(range(15)).fillna(0)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # axis=1
         result = df.reindex(columns=range(5), fill_value=0.0)
         expected = df.copy()
         expected[4] = 0.0
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.reindex(columns=range(5), fill_value=0)
         expected = df.copy()
         expected[4] = 0
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.reindex(columns=range(5), fill_value="foo")
         expected = df.copy()
         expected[4] = "foo"
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # other dtypes
         df["foo"] = "foo"
         result = df.reindex(range(15), fill_value=0)
         expected = df.reindex(range(15)).fillna(0)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_reindex_dups(self):
 
@@ -453,7 +452,7 @@ class TestDataFrameSelectReindex:
         result = df.copy()
         result.index = list(range(len(df)))
         expected = DataFrame(arr, index=list(range(len(df))))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # reindex fails
         msg = "cannot reindex from a duplicate axis"
@@ -467,13 +466,13 @@ class TestDataFrameSelectReindex:
             {"A": [1, 2, np.nan], "B": [4, 5, np.nan]}, index=[0, 1, 3]
         )
         result = df.reindex([0, 1, 3])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.reindex([0, 1, 3], axis=0)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.reindex([0, 1, 3], axis="index")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_reindex_positional_warns(self):
         # https://github.com/pandas-dev/pandas/issues/12392
@@ -482,7 +481,7 @@ class TestDataFrameSelectReindex:
         with tm.assert_produces_warning(FutureWarning):
             result = df.reindex([0, 1], ["A", "B", "C"])
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_reindex_axis_style_raises(self):
         # https://github.com/pandas-dev/pandas/issues/12392
@@ -524,7 +523,7 @@ class TestDataFrameSelectReindex:
         df = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]})
         result = df.reindex([0, 1], columns=["A"])
         expected = pd.DataFrame({"A": [1, 2]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_reindex_api_equivalence(self):
         # https://github.com/pandas-dev/pandas/issues/12392
@@ -699,8 +698,8 @@ class TestDataFrameSelectReindex:
         ea = ea.fillna(axis=fill_axis, method=method, limit=limit)
         eb = eb.fillna(axis=fill_axis, method=method, limit=limit)
 
-        assert_frame_equal(aa, ea)
-        assert_frame_equal(ab, eb)
+        tm.assert_frame_equal(aa, ea)
+        tm.assert_frame_equal(ab, eb)
 
     @pytest.mark.parametrize("meth", ["pad", "bfill"])
     @pytest.mark.parametrize("ax", [0, 1, None])
@@ -750,7 +749,7 @@ class TestDataFrameSelectReindex:
 
         result = df1 - df1.mean()
         expected = df2 - df2.mean()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_align_multiindex(self):
         # GH 10665
@@ -768,11 +767,11 @@ class TestDataFrameSelectReindex:
         res2l, res2r = df2.align(df1, join="right")
 
         expl = df1
-        assert_frame_equal(expl, res1l)
-        assert_frame_equal(expl, res2r)
+        tm.assert_frame_equal(expl, res1l)
+        tm.assert_frame_equal(expl, res2r)
         expr = pd.DataFrame([0, 0, 1, 1, np.nan, np.nan] * 2, index=midx)
-        assert_frame_equal(expr, res1r)
-        assert_frame_equal(expr, res2l)
+        tm.assert_frame_equal(expr, res1r)
+        tm.assert_frame_equal(expr, res2l)
 
         res1l, res1r = df1.align(df2, join="right")
         res2l, res2r = df2.align(df1, join="left")
@@ -781,11 +780,11 @@ class TestDataFrameSelectReindex:
             [range(2), range(2), range(2)], names=("a", "b", "c")
         )
         expl = pd.DataFrame([0, 1, 2, 3, 6, 7, 8, 9], index=exp_idx)
-        assert_frame_equal(expl, res1l)
-        assert_frame_equal(expl, res2r)
+        tm.assert_frame_equal(expl, res1l)
+        tm.assert_frame_equal(expl, res2r)
         expr = pd.DataFrame([0, 0, 1, 1] * 2, index=exp_idx)
-        assert_frame_equal(expr, res1r)
-        assert_frame_equal(expr, res2l)
+        tm.assert_frame_equal(expr, res1r)
+        tm.assert_frame_equal(expr, res2l)
 
     def test_align_series_combinations(self):
         df = pd.DataFrame({"a": [1, 3, 5], "b": [1, 3, 5]}, index=list("ACE"))
@@ -895,7 +894,7 @@ class TestDataFrameSelectReindex:
 
         result = df.filter(regex="BB")
         exp = df[[x for x in df.columns if "BB" in x]]
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
     @pytest.mark.parametrize(
         "name,expected",
@@ -909,8 +908,8 @@ class TestDataFrameSelectReindex:
         # GH13101
         df = DataFrame({"a": [1, 2], "あ": [3, 4]})
 
-        assert_frame_equal(df.filter(like=name), expected)
-        assert_frame_equal(df.filter(regex=name), expected)
+        tm.assert_frame_equal(df.filter(like=name), expected)
+        tm.assert_frame_equal(df.filter(regex=name), expected)
 
     @pytest.mark.parametrize("name", ["a", "a"])
     def test_filter_bytestring(self, name):
@@ -918,17 +917,17 @@ class TestDataFrameSelectReindex:
         df = DataFrame({b"a": [1, 2], b"b": [3, 4]})
         expected = DataFrame({b"a": [1, 2]})
 
-        assert_frame_equal(df.filter(like=name), expected)
-        assert_frame_equal(df.filter(regex=name), expected)
+        tm.assert_frame_equal(df.filter(like=name), expected)
+        tm.assert_frame_equal(df.filter(regex=name), expected)
 
     def test_filter_corner(self):
         empty = DataFrame()
 
         result = empty.filter([])
-        assert_frame_equal(result, empty)
+        tm.assert_frame_equal(result, empty)
 
         result = empty.filter(like="foo")
-        assert_frame_equal(result, empty)
+        tm.assert_frame_equal(result, empty)
 
     def test_take(self, float_frame):
         # homogeneous
@@ -937,12 +936,12 @@ class TestDataFrameSelectReindex:
 
             result = df.take(order, axis=0)
             expected = df.reindex(df.index.take(order))
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # axis = 1
             result = df.take(order, axis=1)
             expected = df.loc[:, ["D", "B", "C", "A"]]
-            assert_frame_equal(result, expected, check_names=False)
+            tm.assert_frame_equal(result, expected, check_names=False)
 
         # negative indices
         order = [2, 1, -1]
@@ -950,15 +949,15 @@ class TestDataFrameSelectReindex:
 
             result = df.take(order, axis=0)
             expected = df.reindex(df.index.take(order))
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = df.take(order, axis=0)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # axis = 1
             result = df.take(order, axis=1)
             expected = df.loc[:, ["C", "B", "D"]]
-            assert_frame_equal(result, expected, check_names=False)
+            tm.assert_frame_equal(result, expected, check_names=False)
 
         # illegal indices
         msg = "indices are out-of-bounds"
@@ -979,12 +978,12 @@ class TestDataFrameSelectReindex:
 
             result = df.take(order, axis=0)
             expected = df.reindex(df.index.take(order))
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # axis = 1
             result = df.take(order, axis=1)
             expected = df.loc[:, ["foo", "B", "C", "A", "D"]]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         # negative indices
         order = [4, 1, -2]
@@ -992,12 +991,12 @@ class TestDataFrameSelectReindex:
 
             result = df.take(order, axis=0)
             expected = df.reindex(df.index.take(order))
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # axis = 1
             result = df.take(order, axis=1)
             expected = df.loc[:, ["foo", "B", "D"]]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_take_mixed_numeric(self, mixed_float_frame, mixed_int_frame):
         # by dtype
@@ -1006,12 +1005,12 @@ class TestDataFrameSelectReindex:
 
             result = df.take(order, axis=0)
             expected = df.reindex(df.index.take(order))
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             # axis = 1
             result = df.take(order, axis=1)
             expected = df.loc[:, ["B", "C", "A", "D"]]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_reindex_boolean(self):
         frame = DataFrame(
@@ -1052,15 +1051,15 @@ class TestDataFrameSelectReindex:
 
         result = df.reindex(index=[101.0, 102.0, 103.0])
         expected = df.iloc[[1, 3, 4]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.reindex(index=[103.0])
         expected = df.iloc[[4]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.reindex(index=[101.0])
         expected = df.iloc[[1]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_reindex_multi(self):
         df = DataFrame(np.random.randn(3, 3))
@@ -1068,28 +1067,28 @@ class TestDataFrameSelectReindex:
         result = df.reindex(index=range(4), columns=range(4))
         expected = df.reindex(list(range(4))).reindex(columns=range(4))
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame(np.random.randint(0, 10, (3, 3)))
 
         result = df.reindex(index=range(4), columns=range(4))
         expected = df.reindex(list(range(4))).reindex(columns=range(4))
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame(np.random.randint(0, 10, (3, 3)))
 
         result = df.reindex(index=range(2), columns=range(2))
         expected = df.reindex(range(2)).reindex(columns=range(2))
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame(np.random.randn(5, 3) + 1j, columns=["a", "b", "c"])
 
         result = df.reindex(index=[0, 1], columns=["a", "b"])
         expected = df.reindex([0, 1]).reindex(columns=["a", "b"])
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_reindex_multi_categorical_time(self):
         # https://github.com/pandas-dev/pandas/issues/21390
@@ -1104,7 +1103,7 @@ class TestDataFrameSelectReindex:
 
         result = df2.reindex(midx)
         expected = pd.DataFrame({"a": [0, 1, 2, 3, 4, 5, 6, np.nan, 8]}, index=midx)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     data = [[1, 2, 3], [1, 2, 3]]
 
@@ -1127,9 +1126,9 @@ class TestDataFrameSelectReindex:
         with pytest.raises(KeyError, match=msg):
             actual.T.drop("c", level=level, axis=1)
         expected_no_err = actual.drop("c", axis=0, level=level, errors="ignore")
-        assert_frame_equal(expected_no_err, actual)
+        tm.assert_frame_equal(expected_no_err, actual)
         expected_no_err = actual.T.drop("c", axis=1, level=level, errors="ignore")
-        assert_frame_equal(expected_no_err.T, actual)
+        tm.assert_frame_equal(expected_no_err.T, actual)
 
     @pytest.mark.parametrize("index", [[1, 2, 3], [1, 1, 2]])
     @pytest.mark.parametrize("drop_labels", [[], [1], [2]])

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -19,11 +19,6 @@ from pandas.core.arrays import IntervalArray, integer_array
 from pandas.core.internals import ObjectBlock
 from pandas.core.internals.blocks import IntBlock
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-)
 
 # Segregated collection of methods that require the BlockManager internal data
 # structure
@@ -50,11 +45,11 @@ class TestDataFrameBlockInternals:
     def test_cast_internals(self, float_frame):
         casted = DataFrame(float_frame._data, dtype=int)
         expected = DataFrame(float_frame._series, dtype=int)
-        assert_frame_equal(casted, expected)
+        tm.assert_frame_equal(casted, expected)
 
         casted = DataFrame(float_frame._data, dtype=np.int32)
         expected = DataFrame(float_frame._series, dtype=np.int32)
-        assert_frame_equal(casted, expected)
+        tm.assert_frame_equal(casted, expected)
 
     def test_consolidate(self, float_frame):
         float_frame["E"] = 7.0
@@ -101,7 +96,7 @@ class TestDataFrameBlockInternals:
         expected[expected > 1] = 2
 
         float_frame[float_frame > 1] = 2
-        assert_almost_equal(expected, float_frame.values)
+        tm.assert_almost_equal(expected, float_frame.values)
 
     def test_values_numeric_cols(self, float_frame):
         float_frame["foo"] = "bar"
@@ -155,66 +150,66 @@ class TestDataFrameBlockInternals:
         df = DataFrame({"A": [2 ** 63 - 1]})
         result = df["A"]
         expected = Series(np.asarray([2 ** 63 - 1], np.int64), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [2 ** 63]})
         result = df["A"]
         expected = Series(np.asarray([2 ** 63], np.uint64), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [datetime(2005, 1, 1), True]})
         result = df["A"]
         expected = Series(
             np.asarray([datetime(2005, 1, 1), True], np.object_), name="A"
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [None, 1]})
         result = df["A"]
         expected = Series(np.asarray([np.nan, 1], np.float_), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [1.0, 2]})
         result = df["A"]
         expected = Series(np.asarray([1.0, 2], np.float_), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [1.0 + 2.0j, 3]})
         result = df["A"]
         expected = Series(np.asarray([1.0 + 2.0j, 3], np.complex_), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [1.0 + 2.0j, 3.0]})
         result = df["A"]
         expected = Series(np.asarray([1.0 + 2.0j, 3.0], np.complex_), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [1.0 + 2.0j, True]})
         result = df["A"]
         expected = Series(np.asarray([1.0 + 2.0j, True], np.object_), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [1.0, None]})
         result = df["A"]
         expected = Series(np.asarray([1.0, np.nan], np.float_), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [1.0 + 2.0j, None]})
         result = df["A"]
         expected = Series(np.asarray([1.0 + 2.0j, np.nan], np.complex_), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [2.0, 1, True, None]})
         result = df["A"]
         expected = Series(np.asarray([2.0, 1, True, None], np.object_), name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({"A": [2.0, 1, datetime(2006, 1, 1), None]})
         result = df["A"]
         expected = Series(
             np.asarray([2.0, 1, datetime(2006, 1, 1), None], np.object_), name="A"
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_construction_with_mixed(self, float_string_frame):
         # test construction edge cases with mixed types
@@ -245,7 +240,7 @@ class TestDataFrameBlockInternals:
             ],
             index=list("ABCD") + ["foo", "datetime", "timedelta"],
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_construction_with_conversions(self):
 
@@ -256,7 +251,7 @@ class TestDataFrameBlockInternals:
         expected = DataFrame(
             {"A": pd.timedelta_range("00:00:01", periods=3, freq="s")}, index=range(3)
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         expected = DataFrame(
             {
@@ -276,7 +271,7 @@ class TestDataFrameBlockInternals:
         # df['dt3'] = np.array(['2013-01-01 00:00:01','2013-01-01
         # 00:00:02','2013-01-01 00:00:03'],dtype='datetime64[s]')
 
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_constructor_compound_dtypes(self):
         # GH 5191
@@ -308,7 +303,7 @@ class TestDataFrameBlockInternals:
         assert df0._data.blocks[0].dtype != df1._data.blocks[0].dtype
 
         # do the real tests
-        assert_frame_equal(df0, df1)
+        tm.assert_frame_equal(df0, df1)
         assert df0.equals(df1)
         assert df1.equals(df0)
 
@@ -359,7 +354,7 @@ class TestDataFrameBlockInternals:
         empty_frame = DataFrame()
 
         unpickled = tm.round_trip_pickle(float_string_frame)
-        assert_frame_equal(float_string_frame, unpickled)
+        tm.assert_frame_equal(float_string_frame, unpickled)
 
         # buglet
         float_string_frame._data.ndim
@@ -370,7 +365,7 @@ class TestDataFrameBlockInternals:
 
         # tz frame
         unpickled = tm.round_trip_pickle(timezone_frame)
-        assert_frame_equal(timezone_frame, unpickled)
+        tm.assert_frame_equal(timezone_frame, unpickled)
 
     def test_consolidate_datetime64(self):
         # numpy vstack bug
@@ -429,7 +424,7 @@ starting,ending,measure
             ],
             index=["a", "b", "c", "f"],
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame(
             {
@@ -446,22 +441,22 @@ starting,ending,measure
 
         result = df._get_numeric_data()
         expected = df.loc[:, ["a", "b", "d", "e", "f"]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         only_obj = df.loc[:, ["c", "g"]]
         result = only_obj._get_numeric_data()
         expected = df.loc[:, []]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame.from_dict({"a": [1, 2], "b": ["foo", "bar"], "c": [np.pi, np.e]})
         result = df._get_numeric_data()
         expected = DataFrame.from_dict({"a": [1, 2], "c": [np.pi, np.e]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = result.copy()
         result = df._get_numeric_data()
         expected = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_get_numeric_data_extension_dtype(self):
         # GH 22290
@@ -475,13 +470,13 @@ starting,ending,measure
         )
         result = df._get_numeric_data()
         expected = df.loc[:, ["A", "C"]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_convert_objects(self, float_string_frame):
 
         oops = float_string_frame.T.T
         converted = oops._convert(datetime=True)
-        assert_frame_equal(converted, float_string_frame)
+        tm.assert_frame_equal(converted, float_string_frame)
         assert converted["A"].dtype == np.float64
 
         # force numeric conversion
@@ -517,12 +512,12 @@ starting,ending,measure
         df = DataFrame(dict(s=Series([1, "na", 3, 4])))
         result = df._convert(datetime=True, numeric=True)
         expected = DataFrame(dict(s=Series([1, np.nan, 3, 4])))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_convert_objects_no_conversion(self):
         mixed1 = DataFrame({"a": [1, 2, 3], "b": [4.0, 5, 6], "c": ["x", "y", "z"]})
         mixed2 = mixed1._convert(datetime=True)
-        assert_frame_equal(mixed1, mixed2)
+        tm.assert_frame_equal(mixed1, mixed2)
 
     def test_infer_objects(self):
         # GH 11221
@@ -636,4 +631,4 @@ starting,ending,measure
         )
         assert type(df["c"]._data.blocks[0]) == ObjectBlock
         assert type(df2["c"]._data.blocks[0]) == ObjectBlock
-        assert_frame_equal(df, df2)
+        tm.assert_frame_equal(df, df2)

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -6,7 +6,6 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 class TestDataFrameConcatCommon:
@@ -20,7 +19,7 @@ class TestDataFrameConcatCommon:
             [np.dtype("float64")] * 2 + [np.dtype("float32")] * 2,
             index=["foo", "bar", 0, 1],
         )
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
 
     @pytest.mark.parametrize(
         "data",
@@ -56,15 +55,15 @@ class TestDataFrameConcatCommon:
 
         results = pd.concat([df1, df2]).reset_index(drop=True)
         expected = DataFrame(dict(time=[ts1, ts2]), dtype=object)
-        assert_frame_equal(results, expected)
+        tm.assert_frame_equal(results, expected)
 
         results = pd.concat([df1, df3]).reset_index(drop=True)
         expected = DataFrame(dict(time=[ts1, ts3]), dtype=object)
-        assert_frame_equal(results, expected)
+        tm.assert_frame_equal(results, expected)
 
         results = pd.concat([df2, df3]).reset_index(drop=True)
         expected = DataFrame(dict(time=[ts2, ts3]))
-        assert_frame_equal(results, expected)
+        tm.assert_frame_equal(results, expected)
 
     @pytest.mark.parametrize(
         "t1",
@@ -91,7 +90,7 @@ class TestDataFrameConcatCommon:
         result = pd.concat([df1, df2])
         expected = DataFrame([[ts1, ts2], [ts3, pd.NaT]], index=[0, 0])
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_concat_tz_not_aligned(self):
         # GH 22796
@@ -102,7 +101,7 @@ class TestDataFrameConcatCommon:
         expected = pd.DataFrame(
             {"A": list(ts) + list(ts), "B": [pd.NaT, pd.NaT] + list(ts)}
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_concat_tuple_keys(self):
         # GH 14438
@@ -127,7 +126,7 @@ class TestDataFrameConcatCommon:
                 },
             }
         )
-        assert_frame_equal(results, expected)
+        tm.assert_frame_equal(results, expected)
 
     def test_append_series_dict(self):
         df = DataFrame(np.random.randn(5, 4), columns=["foo", "bar", "baz", "qux"])
@@ -146,24 +145,24 @@ class TestDataFrameConcatCommon:
         expected = df.append(
             DataFrame({0: series[::-1]}, index=df.columns).T, ignore_index=True
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # dict
         result = df.append(series.to_dict(), ignore_index=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.append(series[::-1][:3], ignore_index=True)
         expected = df.append(
             DataFrame({0: series[::-1][:3]}).T, ignore_index=True, sort=True
         )
-        assert_frame_equal(result, expected.loc[:, result.columns])
+        tm.assert_frame_equal(result, expected.loc[:, result.columns])
 
         # can append when name set
         row = df.loc[4]
         row.name = 5
         result = df.append(row)
         expected = df.append(df[-1:], ignore_index=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_append_list_of_series_dicts(self):
         df = DataFrame(np.random.randn(5, 4), columns=["foo", "bar", "baz", "qux"])
@@ -172,7 +171,7 @@ class TestDataFrameConcatCommon:
 
         result = df.append(dicts, ignore_index=True)
         expected = df.append(df, ignore_index=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # different columns
         dicts = [
@@ -181,7 +180,7 @@ class TestDataFrameConcatCommon:
         ]
         result = df.append(dicts, ignore_index=True, sort=True)
         expected = df.append(DataFrame(dicts), ignore_index=True, sort=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_append_missing_cols(self):
         # GH22252
@@ -195,7 +194,7 @@ class TestDataFrameConcatCommon:
             result = df.append(dicts, ignore_index=True, sort=True)
 
         expected = df.append(DataFrame(dicts), ignore_index=True, sort=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_append_empty_dataframe(self):
 
@@ -204,28 +203,28 @@ class TestDataFrameConcatCommon:
         df2 = DataFrame()
         result = df1.append(df2)
         expected = df1.copy()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Non-empty df append empty df
         df1 = DataFrame(np.random.randn(5, 2))
         df2 = DataFrame()
         result = df1.append(df2)
         expected = df1.copy()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Empty df with columns append empty df
         df1 = DataFrame(columns=["bar", "foo"])
         df2 = DataFrame()
         result = df1.append(df2)
         expected = df1.copy()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Non-Empty df with columns append empty df
         df1 = DataFrame(np.random.randn(5, 2), columns=["bar", "foo"])
         df2 = DataFrame()
         result = df1.append(df2)
         expected = df1.copy()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_append_dtypes(self):
 
@@ -237,13 +236,13 @@ class TestDataFrameConcatCommon:
         df2 = DataFrame()
         result = df1.append(df2)
         expected = df1.copy()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df1 = DataFrame({"bar": Timestamp("20130101")}, index=range(1))
         df2 = DataFrame({"bar": "foo"}, index=range(1, 2))
         result = df1.append(df2)
         expected = DataFrame({"bar": [Timestamp("20130101"), "foo"]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df1 = DataFrame({"bar": Timestamp("20130101")}, index=range(1))
         df2 = DataFrame({"bar": np.nan}, index=range(1, 2))
@@ -251,7 +250,7 @@ class TestDataFrameConcatCommon:
         expected = DataFrame(
             {"bar": Series([Timestamp("20130101"), np.nan], dtype="M8[ns]")}
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df1 = DataFrame({"bar": Timestamp("20130101")}, index=range(1))
         df2 = DataFrame({"bar": np.nan}, index=range(1, 2), dtype=object)
@@ -259,7 +258,7 @@ class TestDataFrameConcatCommon:
         expected = DataFrame(
             {"bar": Series([Timestamp("20130101"), np.nan], dtype="M8[ns]")}
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df1 = DataFrame({"bar": np.nan}, index=range(1))
         df2 = DataFrame({"bar": Timestamp("20130101")}, index=range(1, 2))
@@ -267,13 +266,13 @@ class TestDataFrameConcatCommon:
         expected = DataFrame(
             {"bar": Series([np.nan, Timestamp("20130101")], dtype="M8[ns]")}
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df1 = DataFrame({"bar": Timestamp("20130101")}, index=range(1))
         df2 = DataFrame({"bar": 1}, index=range(1, 2), dtype=object)
         result = df1.append(df2)
         expected = DataFrame({"bar": Series([Timestamp("20130101"), 1])})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_update(self):
         df = DataFrame(
@@ -287,7 +286,7 @@ class TestDataFrameConcatCommon:
         expected = DataFrame(
             [[1.5, np.nan, 3], [3.6, 2, 3], [1.5, np.nan, 3], [1.5, np.nan, 7.0]]
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_update_dtypes(self):
 
@@ -304,7 +303,7 @@ class TestDataFrameConcatCommon:
             [[45.0, 45.0, False, True], [4.0, 5.0, True, False]],
             columns=["A", "B", "bool1", "bool2"],
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_update_nooverwrite(self):
         df = DataFrame(
@@ -318,7 +317,7 @@ class TestDataFrameConcatCommon:
         expected = DataFrame(
             [[1.5, np.nan, 3], [1.5, 2, 3], [1.5, np.nan, 3], [1.5, np.nan, 3.0]]
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_update_filtered(self):
         df = DataFrame(
@@ -332,7 +331,7 @@ class TestDataFrameConcatCommon:
         expected = DataFrame(
             [[1.5, np.nan, 3], [1.5, np.nan, 3], [1.5, np.nan, 3], [1.5, np.nan, 7.0]]
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     @pytest.mark.parametrize(
         "bad_kwarg, exception, msg",
@@ -372,7 +371,7 @@ class TestDataFrameConcatCommon:
 
         expected = DataFrame(d)
 
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         d = {"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]}
         df = DataFrame(d)
@@ -382,14 +381,14 @@ class TestDataFrameConcatCommon:
 
         expected = DataFrame(d)
 
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_update_datetime_tz(self):
         # GH 25807
         result = DataFrame([pd.Timestamp("2019", tz="UTC")])
         result.update(result)
         expected = DataFrame([pd.Timestamp("2019", tz="UTC")])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_join_str_datetime(self):
         str_dates = ["20120209", "20120222"]
@@ -440,8 +439,8 @@ class TestDataFrameConcatCommon:
         )
 
         # these must be the same results (but columns are flipped)
-        assert_frame_equal(df1.join(df2, how="left"), exp)
-        assert_frame_equal(df2.join(df1, how="right"), exp[["value2", "value1"]])
+        tm.assert_frame_equal(df1.join(df2, how="left"), exp)
+        tm.assert_frame_equal(df2.join(df1, how="right"), exp[["value2", "value1"]])
 
         exp_idx = pd.MultiIndex.from_product(
             [["a", "b"], ["x", "y", "z"]], names=["first", "second"]
@@ -459,8 +458,8 @@ class TestDataFrameConcatCommon:
             columns=["value1", "value2"],
         )
 
-        assert_frame_equal(df1.join(df2, how="right"), exp)
-        assert_frame_equal(df2.join(df1, how="left"), exp[["value2", "value1"]])
+        tm.assert_frame_equal(df1.join(df2, how="right"), exp)
+        tm.assert_frame_equal(df2.join(df1, how="left"), exp[["value2", "value1"]])
 
     def test_concat_named_keys(self):
         # GH 14252
@@ -471,20 +470,20 @@ class TestDataFrameConcatCommon:
             {"foo": [1, 2, 1, 2], "bar": [0.1, 0.2, 0.1, 0.2]},
             index=pd.MultiIndex.from_product((["a", "b"], [0, 1]), names=["baz", None]),
         )
-        assert_frame_equal(concatted_named_from_keys, expected_named)
+        tm.assert_frame_equal(concatted_named_from_keys, expected_named)
 
         index_no_name = Index(["a", "b"], name=None)
         concatted_named_from_names = pd.concat(
             [df, df], keys=index_no_name, names=["baz"]
         )
-        assert_frame_equal(concatted_named_from_names, expected_named)
+        tm.assert_frame_equal(concatted_named_from_names, expected_named)
 
         concatted_unnamed = pd.concat([df, df], keys=index_no_name)
         expected_unnamed = pd.DataFrame(
             {"foo": [1, 2, 1, 2], "bar": [0.1, 0.2, 0.1, 0.2]},
             index=pd.MultiIndex.from_product((["a", "b"], [0, 1]), names=[None, None]),
         )
-        assert_frame_equal(concatted_unnamed, expected_unnamed)
+        tm.assert_frame_equal(concatted_unnamed, expected_unnamed)
 
     def test_concat_axis_parameter(self):
         # GH 14369
@@ -495,13 +494,13 @@ class TestDataFrameConcatCommon:
         expected_index = pd.DataFrame({"A": [0.1, 0.2, 0.3, 0.4]}, index=[0, 1, 0, 1])
 
         concatted_index = pd.concat([df1, df2], axis="index")
-        assert_frame_equal(concatted_index, expected_index)
+        tm.assert_frame_equal(concatted_index, expected_index)
 
         concatted_row = pd.concat([df1, df2], axis="rows")
-        assert_frame_equal(concatted_row, expected_index)
+        tm.assert_frame_equal(concatted_row, expected_index)
 
         concatted_0 = pd.concat([df1, df2], axis=0)
-        assert_frame_equal(concatted_0, expected_index)
+        tm.assert_frame_equal(concatted_0, expected_index)
 
         # Columns/1 DataFrame
         expected_columns = pd.DataFrame(
@@ -509,10 +508,10 @@ class TestDataFrameConcatCommon:
         )
 
         concatted_columns = pd.concat([df1, df2], axis="columns")
-        assert_frame_equal(concatted_columns, expected_columns)
+        tm.assert_frame_equal(concatted_columns, expected_columns)
 
         concatted_1 = pd.concat([df1, df2], axis=1)
-        assert_frame_equal(concatted_1, expected_columns)
+        tm.assert_frame_equal(concatted_1, expected_columns)
 
         series1 = pd.Series([0.1, 0.2])
         series2 = pd.Series([0.3, 0.4])
@@ -521,13 +520,13 @@ class TestDataFrameConcatCommon:
         expected_index_series = pd.Series([0.1, 0.2, 0.3, 0.4], index=[0, 1, 0, 1])
 
         concatted_index_series = pd.concat([series1, series2], axis="index")
-        assert_series_equal(concatted_index_series, expected_index_series)
+        tm.assert_series_equal(concatted_index_series, expected_index_series)
 
         concatted_row_series = pd.concat([series1, series2], axis="rows")
-        assert_series_equal(concatted_row_series, expected_index_series)
+        tm.assert_series_equal(concatted_row_series, expected_index_series)
 
         concatted_0_series = pd.concat([series1, series2], axis=0)
-        assert_series_equal(concatted_0_series, expected_index_series)
+        tm.assert_series_equal(concatted_0_series, expected_index_series)
 
         # Columns/1 Series
         expected_columns_series = pd.DataFrame(
@@ -535,10 +534,10 @@ class TestDataFrameConcatCommon:
         )
 
         concatted_columns_series = pd.concat([series1, series2], axis="columns")
-        assert_frame_equal(concatted_columns_series, expected_columns_series)
+        tm.assert_frame_equal(concatted_columns_series, expected_columns_series)
 
         concatted_1_series = pd.concat([series1, series2], axis=1)
-        assert_frame_equal(concatted_1_series, expected_columns_series)
+        tm.assert_frame_equal(concatted_1_series, expected_columns_series)
 
         # Testing ValueError
         with pytest.raises(ValueError, match="No axis named"):
@@ -599,9 +598,9 @@ class TestDataFrameCombineFirst:
 
         combined = head.combine_first(tail)
         reordered_frame = float_frame.reindex(combined.index)
-        assert_frame_equal(combined, reordered_frame)
+        tm.assert_frame_equal(combined, reordered_frame)
         assert tm.equalContents(combined.columns, float_frame.columns)
-        assert_series_equal(combined["A"], reordered_frame["A"])
+        tm.assert_series_equal(combined["A"], reordered_frame["A"])
 
         # same index
         fcopy = float_frame.copy()
@@ -615,9 +614,9 @@ class TestDataFrameCombineFirst:
         combined = fcopy.combine_first(fcopy2)
 
         assert (combined["A"] == 1).all()
-        assert_series_equal(combined["B"], fcopy["B"])
-        assert_series_equal(combined["C"], fcopy2["C"])
-        assert_series_equal(combined["D"], fcopy["D"])
+        tm.assert_series_equal(combined["B"], fcopy["B"])
+        tm.assert_series_equal(combined["C"], fcopy2["C"])
+        tm.assert_series_equal(combined["D"], fcopy["D"])
 
         # overlap
         head, tail = reordered_frame[:10].copy(), reordered_frame
@@ -635,15 +634,15 @@ class TestDataFrameCombineFirst:
         f = float_frame[:10]
         g = float_frame[10:]
         combined = f.combine_first(g)
-        assert_series_equal(combined["A"].reindex(f.index), f["A"])
-        assert_series_equal(combined["A"].reindex(g.index), g["A"])
+        tm.assert_series_equal(combined["A"].reindex(f.index), f["A"])
+        tm.assert_series_equal(combined["A"].reindex(g.index), g["A"])
 
         # corner cases
         comb = float_frame.combine_first(DataFrame())
-        assert_frame_equal(comb, float_frame)
+        tm.assert_frame_equal(comb, float_frame)
 
         comb = DataFrame().combine_first(float_frame)
-        assert_frame_equal(comb, float_frame)
+        tm.assert_frame_equal(comb, float_frame)
 
         comb = float_frame.combine_first(DataFrame(index=["faz", "boo"]))
         assert "faz" in comb.index
@@ -680,12 +679,12 @@ class TestDataFrameCombineFirst:
 
         other = DataFrame([[45, 45]], index=[0], columns=["A", "B"])
         result = df.combine_first(other)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         df.loc[0, "A"] = np.nan
         result = df.combine_first(other)
         df.loc[0, "A"] = 45
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         # doc example
         df1 = DataFrame(
@@ -701,7 +700,7 @@ class TestDataFrameCombineFirst:
 
         result = df1.combine_first(df2)
         expected = DataFrame({"A": [1, 2, 3, 5, 3, 7.0], "B": [np.nan, 2, 3, 4, 6, 8]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # GH3552, return object dtype with bools
         df1 = DataFrame(
@@ -711,7 +710,7 @@ class TestDataFrameCombineFirst:
 
         result = df1.combine_first(df2)[2]
         expected = Series([True, True, False], name=2)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 3593, converting datetime64[ns] incorrectly
         df0 = DataFrame(
@@ -719,10 +718,10 @@ class TestDataFrameCombineFirst:
         )
         df1 = DataFrame({"a": [None, None, None]})
         df2 = df1.combine_first(df0)
-        assert_frame_equal(df2, df0)
+        tm.assert_frame_equal(df2, df0)
 
         df2 = df0.combine_first(df1)
-        assert_frame_equal(df2, df0)
+        tm.assert_frame_equal(df2, df0)
 
         df0 = DataFrame(
             {"a": [datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 3)]}
@@ -731,10 +730,10 @@ class TestDataFrameCombineFirst:
         df2 = df1.combine_first(df0)
         result = df0.copy()
         result.iloc[0, :] = df1.iloc[0, :]
-        assert_frame_equal(df2, result)
+        tm.assert_frame_equal(df2, result)
 
         df2 = df0.combine_first(df1)
-        assert_frame_equal(df2, df0)
+        tm.assert_frame_equal(df2, df0)
 
     def test_combine_first_align_nan(self):
         # GH 7509 (not fixed)

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -20,11 +20,6 @@ from pandas import (
 )
 from pandas.core.arrays import integer_array
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_frame_equal,
-    assert_series_equal,
-    makeCustomDataframe as mkdf,
-)
 
 
 def _check_cast(df, v):
@@ -53,35 +48,37 @@ class TestDataFrameDataTypes:
 
     def test_empty_frame_dtypes_ftypes(self):
         empty_df = pd.DataFrame()
-        assert_series_equal(empty_df.dtypes, pd.Series(dtype=np.object))
+        tm.assert_series_equal(empty_df.dtypes, pd.Series(dtype=np.object))
 
         # GH 26705 - Assert .ftypes is deprecated
         with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(empty_df.ftypes, pd.Series(dtype=np.object))
+            tm.assert_series_equal(empty_df.ftypes, pd.Series(dtype=np.object))
 
         nocols_df = pd.DataFrame(index=[1, 2, 3])
-        assert_series_equal(nocols_df.dtypes, pd.Series(dtype=np.object))
+        tm.assert_series_equal(nocols_df.dtypes, pd.Series(dtype=np.object))
 
         # GH 26705 - Assert .ftypes is deprecated
         with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(nocols_df.ftypes, pd.Series(dtype=np.object))
+            tm.assert_series_equal(nocols_df.ftypes, pd.Series(dtype=np.object))
 
         norows_df = pd.DataFrame(columns=list("abc"))
-        assert_series_equal(norows_df.dtypes, pd.Series(np.object, index=list("abc")))
+        tm.assert_series_equal(
+            norows_df.dtypes, pd.Series(np.object, index=list("abc"))
+        )
 
         # GH 26705 - Assert .ftypes is deprecated
         with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(
+            tm.assert_series_equal(
                 norows_df.ftypes, pd.Series("object:dense", index=list("abc"))
             )
 
         norows_int_df = pd.DataFrame(columns=list("abc")).astype(np.int32)
-        assert_series_equal(
+        tm.assert_series_equal(
             norows_int_df.dtypes, pd.Series(np.dtype("int32"), index=list("abc"))
         )
         # GH 26705 - Assert .ftypes is deprecated
         with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(
+            tm.assert_series_equal(
                 norows_int_df.ftypes, pd.Series("int32:dense", index=list("abc"))
             )
 
@@ -93,18 +90,18 @@ class TestDataFrameDataTypes:
         ex_ftypes = pd.Series(
             odict([("a", "int64:dense"), ("b", "bool:dense"), ("c", "float64:dense")])
         )
-        assert_series_equal(df.dtypes, ex_dtypes)
+        tm.assert_series_equal(df.dtypes, ex_dtypes)
 
         # GH 26705 - Assert .ftypes is deprecated
         with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(df.ftypes, ex_ftypes)
+            tm.assert_series_equal(df.ftypes, ex_ftypes)
 
         # same but for empty slice of df
-        assert_series_equal(df[:0].dtypes, ex_dtypes)
+        tm.assert_series_equal(df[:0].dtypes, ex_dtypes)
 
         # GH 26705 - Assert .ftypes is deprecated
         with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(df[:0].ftypes, ex_ftypes)
+            tm.assert_series_equal(df[:0].ftypes, ex_ftypes)
 
     def test_datetime_with_tz_dtypes(self):
         tzframe = DataFrame(
@@ -126,18 +123,20 @@ class TestDataFrameDataTypes:
             ["A", "B", "C"],
         )
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_dtypes_are_correct_after_column_slice(self):
         # GH6525
         df = pd.DataFrame(index=range(5), columns=list("abc"), dtype=np.float_)
         odict = OrderedDict
-        assert_series_equal(
+        tm.assert_series_equal(
             df.dtypes,
             pd.Series(odict([("a", np.float_), ("b", np.float_), ("c", np.float_)])),
         )
-        assert_series_equal(df.iloc[:, 2:].dtypes, pd.Series(odict([("c", np.float_)])))
-        assert_series_equal(
+        tm.assert_series_equal(
+            df.iloc[:, 2:].dtypes, pd.Series(odict([("c", np.float_)]))
+        )
+        tm.assert_series_equal(
             df.dtypes,
             pd.Series(odict([("a", np.float_), ("b", np.float_), ("c", np.float_)])),
         )
@@ -161,27 +160,27 @@ class TestDataFrameDataTypes:
 
         ri = df.select_dtypes(include=[np.number])
         ei = df[["b", "c", "d", "k"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include=[np.number], exclude=["timedelta"])
         ei = df[["b", "c", "d"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include=[np.number, "category"], exclude=["timedelta"])
         ei = df[["b", "c", "d", "f"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include=["datetime"])
         ei = df[["g"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include=["datetime64"])
         ei = df[["g"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include=["datetimetz"])
         ei = df[["h", "i"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         with pytest.raises(NotImplementedError, match=r"^$"):
             df.select_dtypes(include=["period"])
@@ -198,7 +197,7 @@ class TestDataFrameDataTypes:
         )
         re = df.select_dtypes(exclude=[np.number])
         ee = df[["a", "e"]]
-        assert_frame_equal(re, ee)
+        tm.assert_frame_equal(re, ee)
 
     def test_select_dtypes_exclude_include_using_list_like(self):
         df = DataFrame(
@@ -215,13 +214,13 @@ class TestDataFrameDataTypes:
         include = np.bool_, "integer"
         r = df.select_dtypes(include=include, exclude=exclude)
         e = df[["b", "c", "e"]]
-        assert_frame_equal(r, e)
+        tm.assert_frame_equal(r, e)
 
         exclude = ("datetime",)
         include = "bool", "int64", "int32"
         r = df.select_dtypes(include=include, exclude=exclude)
         e = df[["b", "e"]]
-        assert_frame_equal(r, e)
+        tm.assert_frame_equal(r, e)
 
     def test_select_dtypes_include_using_scalars(self):
         df = DataFrame(
@@ -242,19 +241,19 @@ class TestDataFrameDataTypes:
 
         ri = df.select_dtypes(include=np.number)
         ei = df[["b", "c", "d", "k"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include="datetime")
         ei = df[["g"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include="datetime64")
         ei = df[["g"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include="category")
         ei = df[["f"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         with pytest.raises(NotImplementedError, match=r"^$"):
             df.select_dtypes(include="period")
@@ -278,11 +277,11 @@ class TestDataFrameDataTypes:
 
         ri = df.select_dtypes(exclude=np.number)
         ei = df[["a", "e", "f", "g", "h", "i", "j"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(exclude="category")
         ei = df[["a", "b", "c", "d", "e", "g", "h", "i", "j", "k"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         with pytest.raises(NotImplementedError, match=r"^$"):
             df.select_dtypes(exclude="period")
@@ -306,7 +305,7 @@ class TestDataFrameDataTypes:
 
         ri = df.select_dtypes(include=np.number, exclude="floating")
         ei = df[["b", "c", "k"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
     def test_select_dtypes_include_exclude_mixed_scalars_lists(self):
         df = DataFrame(
@@ -327,11 +326,11 @@ class TestDataFrameDataTypes:
 
         ri = df.select_dtypes(include=np.number, exclude=["floating", "timedelta"])
         ei = df[["b", "c"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
         ri = df.select_dtypes(include=[np.number, "category"], exclude="floating")
         ei = df[["b", "c", "f", "k"]]
-        assert_frame_equal(ri, ei)
+        tm.assert_frame_equal(ri, ei)
 
     def test_select_dtypes_duplicate_columns(self):
         # GH20839
@@ -355,7 +354,7 @@ class TestDataFrameDataTypes:
         )
 
         result = df.select_dtypes(include=[np.number], exclude=["floating"])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_select_dtypes_not_an_attr_but_still_valid_dtype(self):
         df = DataFrame(
@@ -372,11 +371,11 @@ class TestDataFrameDataTypes:
         assert not hasattr(np, "u8")
         r = df.select_dtypes(include=["i8", "O"], exclude=["timedelta"])
         e = df[["a", "b"]]
-        assert_frame_equal(r, e)
+        tm.assert_frame_equal(r, e)
 
         r = df.select_dtypes(include=["i8", "O", "timedelta64[ns]"])
         e = df[["a", "b", "g"]]
-        assert_frame_equal(r, e)
+        tm.assert_frame_equal(r, e)
 
     def test_select_dtypes_empty(self):
         df = DataFrame({"a": list("abc"), "b": list(range(1, 4))})
@@ -413,7 +412,7 @@ class TestDataFrameDataTypes:
         df3 = pd.concat([df2.A.to_frame(), df2.B.to_frame()], axis=1)
         result = df3.select_dtypes(include=["datetime64[ns]"])
         expected = df3.reindex(columns=[])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "dtype", [str, "str", np.string_, "S1", "unicode", np.unicode_, "U1"]
@@ -456,10 +455,10 @@ class TestDataFrameDataTypes:
 
     def test_select_dtypes_typecodes(self):
         # GH 11990
-        df = mkdf(30, 3, data_gen_f=lambda x, y: np.random.random())
+        df = tm.makeCustomDataframe(30, 3, data_gen_f=lambda x, y: np.random.random())
         expected = df
         FLOAT_TYPES = list(np.typecodes["AllFloat"])
-        assert_frame_equal(df.select_dtypes(FLOAT_TYPES), expected)
+        tm.assert_frame_equal(df.select_dtypes(FLOAT_TYPES), expected)
 
     def test_dtypes_gh8722(self, float_string_frame):
         float_string_frame["bool"] = float_string_frame["A"] > 0
@@ -467,13 +466,13 @@ class TestDataFrameDataTypes:
         expected = Series(
             {k: v.dtype for k, v in float_string_frame.items()}, index=result.index
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # compat, GH 8722
         with option_context("use_inf_as_na", True):
             df = DataFrame([[1]])
             result = df.dtypes
-            assert_series_equal(result, Series({0: np.dtype("int64")}))
+            tm.assert_series_equal(result, Series({0: np.dtype("int64")}))
 
     def test_ftypes(self, mixed_float_frame):
         frame = mixed_float_frame
@@ -489,7 +488,7 @@ class TestDataFrameDataTypes:
         # GH 26705 - Assert .ftypes is deprecated
         with tm.assert_produces_warning(FutureWarning):
             result = frame.ftypes.sort_values()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_astype_float(self, float_frame):
         casted = float_frame.astype(int)
@@ -498,7 +497,7 @@ class TestDataFrameDataTypes:
             index=float_frame.index,
             columns=float_frame.columns,
         )
-        assert_frame_equal(casted, expected)
+        tm.assert_frame_equal(casted, expected)
 
         casted = float_frame.astype(np.int32)
         expected = DataFrame(
@@ -506,7 +505,7 @@ class TestDataFrameDataTypes:
             index=float_frame.index,
             columns=float_frame.columns,
         )
-        assert_frame_equal(casted, expected)
+        tm.assert_frame_equal(casted, expected)
 
         float_frame["foo"] = "5"
         casted = float_frame.astype(int)
@@ -515,7 +514,7 @@ class TestDataFrameDataTypes:
             index=float_frame.index,
             columns=float_frame.columns,
         )
-        assert_frame_equal(casted, expected)
+        tm.assert_frame_equal(casted, expected)
 
     def test_astype_mixed_float(self, mixed_float_frame):
         # mixed casting
@@ -557,7 +556,7 @@ class TestDataFrameDataTypes:
         casted = df.astype(int, errors="ignore")
 
         expected["string"] = "foo"
-        assert_frame_equal(casted, expected)
+        tm.assert_frame_equal(casted, expected)
 
         df = float_frame.copy()
         expected = float_frame.astype(np.int32)
@@ -565,7 +564,7 @@ class TestDataFrameDataTypes:
         casted = df.astype(np.int32, errors="ignore")
 
         expected["string"] = "foo"
-        assert_frame_equal(casted, expected)
+        tm.assert_frame_equal(casted, expected)
 
     def test_astype_with_view_float(self, float_frame):
 
@@ -624,21 +623,21 @@ class TestDataFrameDataTypes:
             }
         )
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_astype_str_float(self):
         # see gh-11302
         result = DataFrame([np.NaN]).astype(str)
         expected = DataFrame(["nan"])
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = DataFrame([1.12345678901234567890]).astype(str)
 
         # < 1.14 truncates
         # >= 1.14 preserves the full repr
         val = "1.12345678901" if _np_version_under1p14 else "1.1234567890123457"
         expected = DataFrame([val])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("dtype_class", [dict, Series])
     def test_astype_dict_like(self, dtype_class):
@@ -661,8 +660,8 @@ class TestDataFrameDataTypes:
                 "d": Series([1.0, 2.0, 3.14, 4.0, 5.4], dtype="float32"),
             }
         )
-        assert_frame_equal(result, expected)
-        assert_frame_equal(df, original)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(df, original)
 
         dt2 = dtype_class({"b": np.float32, "c": "float32", "d": np.float64})
         result = df.astype(dt2)
@@ -674,13 +673,13 @@ class TestDataFrameDataTypes:
                 "d": Series([1.0, 2.0, 3.14, 4.0, 5.4], dtype="float64"),
             }
         )
-        assert_frame_equal(result, expected)
-        assert_frame_equal(df, original)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(df, original)
 
         # change all columns
         dt3 = dtype_class({"a": str, "b": str, "c": str, "d": str})
-        assert_frame_equal(df.astype(dt3), df.astype(str))
-        assert_frame_equal(df, original)
+        tm.assert_frame_equal(df.astype(dt3), df.astype(str))
+        tm.assert_frame_equal(df, original)
 
         # error should be raised when using something other than column labels
         # in the keys of the dtype dict
@@ -691,22 +690,22 @@ class TestDataFrameDataTypes:
             df.astype(dt4)
         with pytest.raises(KeyError, match=msg):
             df.astype(dt5)
-        assert_frame_equal(df, original)
+        tm.assert_frame_equal(df, original)
 
         # if the dtypes provided are the same as the original dtypes, the
         # resulting DataFrame should be the same as the original DataFrame
         dt6 = dtype_class({col: df[col].dtype for col in df.columns})
         equiv = df.astype(dt6)
-        assert_frame_equal(df, equiv)
-        assert_frame_equal(df, original)
+        tm.assert_frame_equal(df, equiv)
+        tm.assert_frame_equal(df, original)
 
         # GH 16717
         # if dtypes provided is empty, the resulting DataFrame
         # should be the same as the original DataFrame
         dt7 = dtype_class({})
         result = df.astype(dt7)
-        assert_frame_equal(df, equiv)
-        assert_frame_equal(df, original)
+        tm.assert_frame_equal(df, equiv)
+        tm.assert_frame_equal(df, original)
 
     def test_astype_duplicate_col(self):
         a1 = Series([1, 2, 3, 4, 5], name="a")
@@ -719,11 +718,11 @@ class TestDataFrameDataTypes:
         b_str = Series(["0.1", "0.2", "0.4", "0.6", "0.8"], dtype=str, name="b")
         a2_str = Series(["0", "1", "2", "3", "4"], dtype="str", name="a")
         expected = concat([a1_str, b_str, a2_str], axis=1)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.astype({"a": "str"})
         expected = concat([a1_str, b, a2_str], axis=1)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "dtype",
@@ -814,7 +813,7 @@ class TestDataFrameDataTypes:
 
         result = df.astype(dtype)
         expected = concat([a1.astype(dtype), a2.astype(dtype)], axis=1)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "dtype", [{100: "float64", 200: "uint64"}, "category", "float64"]
@@ -926,7 +925,7 @@ class TestDataFrameDataTypes:
         expected = Series(
             [np.dtype("datetime64[ns]"), np.dtype("timedelta64[ns]")], index=list("AB")
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df["C"] = df["A"] + df["B"]
         result = df.dtypes
@@ -938,7 +937,7 @@ class TestDataFrameDataTypes:
             ],
             index=list("ABC"),
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # mixed int types
         df["D"] = 1
@@ -952,7 +951,7 @@ class TestDataFrameDataTypes:
             ],
             index=list("ABCD"),
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_arg_for_errors_in_astype(self):
         # issue #14878
@@ -1001,13 +1000,13 @@ class TestDataFrameDataTypes:
 
         result = DataFrame({"A": input_vals}, dtype=string_dtype)
         expected = DataFrame({"A": input_vals}).astype({"A": string_dtype})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_list_str_na(self, string_dtype):
 
         result = DataFrame({"A": [1.0, 2.0, None]}, dtype=string_dtype)
         expected = DataFrame({"A": ["1.0", "2.0", None]}, dtype=object)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "data, expected",
@@ -1146,7 +1145,7 @@ class TestDataFrameDatetimeWithTZ:
             dtype=object,
         )
         result = timezone_frame.astype(object)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = timezone_frame.astype("datetime64[ns]")
         expected = DataFrame(
@@ -1166,7 +1165,7 @@ class TestDataFrameDatetimeWithTZ:
         )
         expected.iloc[1, 1] = pd.NaT
         expected.iloc[1, 2] = pd.NaT
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_astype_str(self, timezone_frame):
         # str formatting


### PR DESCRIPTION
Part of #29272 

Fyi: All changes are generated from a script posted in the issue.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
