### PR TITLE
CLN: Consistent pandas.util.testing imports in pandas/tests/frame - part 2

### DIFF
--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -26,11 +26,6 @@ from pandas import (
 import pandas.core.common as com
 from pandas.core.indexing import IndexingError
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-)
 
 from pandas.tseries.offsets import BDay
 
@@ -73,10 +68,12 @@ class TestDataFrameIndexing:
 
     def test_get(self, float_frame):
         b = float_frame.get("B")
-        assert_series_equal(b, float_frame["B"])
+        tm.assert_series_equal(b, float_frame["B"])
 
         assert float_frame.get("foo") is None
-        assert_series_equal(float_frame.get("foo", float_frame["B"]), float_frame["B"])
+        tm.assert_series_equal(
+            float_frame.get("foo", float_frame["B"]), float_frame["B"]
+        )
 
     @pytest.mark.parametrize(
         "df",
@@ -95,7 +92,7 @@ class TestDataFrameIndexing:
         idx = key_type(["A", "B", "C"])
         result = float_frame.loc[:, idx]
         expected = float_frame.loc[:, ["A", "B", "C"]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "idx_type",
@@ -135,7 +132,7 @@ class TestDataFrameIndexing:
         expected = frame.loc[:, idx_check]
         expected.columns.names = frame.columns.names
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         idx = idx_type(keys + [missing])
         with pytest.raises(KeyError, match="not in index"):
@@ -170,8 +167,8 @@ class TestDataFrameIndexing:
         data = float_frame[["A", "B"]]
         float_frame[["B", "A"]] = data
 
-        assert_series_equal(float_frame["B"], data["A"], check_names=False)
-        assert_series_equal(float_frame["A"], data["B"], check_names=False)
+        tm.assert_series_equal(float_frame["B"], data["A"], check_names=False)
+        tm.assert_series_equal(float_frame["A"], data["B"], check_names=False)
 
         msg = "Columns must be same length as key"
         with pytest.raises(ValueError, match=msg):
@@ -186,18 +183,18 @@ class TestDataFrameIndexing:
 
         result = df.loc[df.index[1], ["tt1", "tt2"]]
         expected = Series([1, 2], df.columns, dtype=np.int_, name=1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df["tt1"] = df["tt2"] = "0"
         df.loc[df.index[1], ["tt1", "tt2"]] = ["1", "2"]
         result = df.loc[df.index[1], ["tt1", "tt2"]]
         expected = Series(["1", "2"], df.columns, name=1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_setitem_list_not_dataframe(self, float_frame):
         data = np.random.randn(len(float_frame), 2)
         float_frame[["A", "B"]] = data
-        assert_almost_equal(float_frame[["A", "B"]].values, data)
+        tm.assert_almost_equal(float_frame[["A", "B"]].values, data)
 
     def test_setitem_list_of_tuples(self, float_frame):
         tuples = list(zip(float_frame["A"], float_frame["B"]))
@@ -205,7 +202,7 @@ class TestDataFrameIndexing:
 
         result = float_frame["tuples"]
         expected = Series(tuples, index=float_frame.index, name="tuples")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_setitem_mulit_index(self):
         # GH7655, test that assigning to a sub-frame of a frame
@@ -221,15 +218,15 @@ class TestDataFrameIndexing:
 
         np.random.shuffle(i)
         df["jim"] = df["jolie"].loc[i, ::-1]
-        assert_frame_equal(df["jim"], df["jolie"])
+        tm.assert_frame_equal(df["jim"], df["jolie"])
 
         np.random.shuffle(j)
         df[("joe", "first")] = df[("jolie", "last")].loc[i, j]
-        assert_frame_equal(df[("joe", "first")], df[("jolie", "last")])
+        tm.assert_frame_equal(df[("joe", "first")], df[("jolie", "last")])
 
         np.random.shuffle(j)
         df[("joe", "last")] = df[("jolie", "first")].loc[i, j]
-        assert_frame_equal(df[("joe", "last")], df[("jolie", "first")])
+        tm.assert_frame_equal(df[("joe", "last")], df[("jolie", "first")])
 
     def test_setitem_callable(self):
         # GH 12533
@@ -266,7 +263,7 @@ class TestDataFrameIndexing:
             datetime_frame[indexer[:-1]]
 
         subframe_obj = datetime_frame[indexer_obj]
-        assert_frame_equal(subframe_obj, subframe)
+        tm.assert_frame_equal(subframe_obj, subframe)
 
         with pytest.raises(ValueError, match="Boolean array expected"):
             datetime_frame[datetime_frame]
@@ -275,7 +272,7 @@ class TestDataFrameIndexing:
         indexer_obj = Series(indexer_obj, datetime_frame.index)
 
         subframe_obj = datetime_frame[indexer_obj]
-        assert_frame_equal(subframe_obj, subframe)
+        tm.assert_frame_equal(subframe_obj, subframe)
 
         # test that Series indexers reindex
         # we are producing a warning that since the passed boolean
@@ -284,7 +281,7 @@ class TestDataFrameIndexing:
         with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
             indexer_obj = indexer_obj.reindex(datetime_frame.index[::-1])
             subframe_obj = datetime_frame[indexer_obj]
-            assert_frame_equal(subframe_obj, subframe)
+            tm.assert_frame_equal(subframe_obj, subframe)
 
         # test df[df > 0]
         for df in [
@@ -310,7 +307,7 @@ class TestDataFrameIndexing:
                     bifw[c] = df[c]
             bifw = bifw.reindex(columns=df.columns)
 
-            assert_frame_equal(bif, bifw, check_dtype=False)
+            tm.assert_frame_equal(bif, bifw, check_dtype=False)
             for c in df.columns:
                 if bif[c].dtype != bifw[c].dtype:
                     assert bif[c].dtype == df[c].dtype
@@ -334,7 +331,7 @@ class TestDataFrameIndexing:
             + [np.dtype("int64")] * 2,
             index=["A", "B", "C", "D", "E", "E1", "F", "F1"],
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # int block splitting
         df.loc[df.index[1:3], ["E1", "F1"]] = 0
@@ -348,7 +345,7 @@ class TestDataFrameIndexing:
             + [np.dtype("float64")],
             index=["A", "B", "C", "D", "E", "E1", "F", "F1"],
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # where dtype conversions
         # GH 3733
@@ -358,7 +355,7 @@ class TestDataFrameIndexing:
         mask = isna(df)
         expected = bools.astype(float).mask(mask)
         result = bools.mask(mask)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_getitem_boolean_list(self):
         df = DataFrame(np.arange(12).reshape(3, 4))
@@ -366,7 +363,7 @@ class TestDataFrameIndexing:
         def _checkit(lst):
             result = df[lst]
             expected = df.loc[df.index[lst]]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         _checkit([True, False, True])
         _checkit([True, True, True])
@@ -380,7 +377,7 @@ class TestDataFrameIndexing:
         df[df < 0] += 1
         arr[arr < 0] += 1
 
-        assert_almost_equal(df.values, arr)
+        tm.assert_almost_equal(df.values, arr)
 
     def test_boolean_index_empty_corner(self):
         # #2096
@@ -399,13 +396,13 @@ class TestDataFrameIndexing:
 
         result = df.iloc[:-1]
         expected = df.loc[df.index[:-1]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = df.ix[[1, 10]]
             expected = df.ix[Index([1, 10], dtype=object)]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # 11320
         df = pd.DataFrame(
@@ -419,26 +416,26 @@ class TestDataFrameIndexing:
         )
         result = df[[1000]]
         expected = df.iloc[:, [3]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df[[-1000]]
         expected = df.iloc[:, [1]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_getitem_setitem_ix_negative_integers(self, float_frame):
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = float_frame.ix[:, -1]
-        assert_series_equal(result, float_frame["D"])
+        tm.assert_series_equal(result, float_frame["D"])
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = float_frame.ix[:, [-1]]
-        assert_frame_equal(result, float_frame[["D"]])
+        tm.assert_frame_equal(result, float_frame[["D"]])
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = float_frame.ix[:, [-1, -2]]
-        assert_frame_equal(result, float_frame[["D", "C"]])
+        tm.assert_frame_equal(result, float_frame[["D", "C"]])
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
@@ -467,12 +464,12 @@ class TestDataFrameIndexing:
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_series_equal(a.ix[-1], a.ix[-2], check_names=False)
+            tm.assert_series_equal(a.ix[-1], a.ix[-2], check_names=False)
             assert a.ix[-1].name == "T"
             assert a.ix[-2].name == "S"
 
     def test_getattr(self, float_frame):
-        assert_series_equal(float_frame.A, float_frame["A"])
+        tm.assert_series_equal(float_frame.A, float_frame["A"])
         msg = "'DataFrame' object has no attribute 'NONEXISTENT_NAME'"
         with pytest.raises(AttributeError, match=msg):
             float_frame.NONEXISTENT_NAME
@@ -535,11 +532,11 @@ class TestDataFrameIndexing:
         df = DataFrame([[0, 0]])
         df.iloc[0] = np.nan
         expected = DataFrame([[np.nan, np.nan]])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         df = DataFrame([[0, 0]])
         df.loc[0] = np.nan
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     @pytest.mark.parametrize("dtype", ["int32", "int64", "float32", "float64"])
     def test_setitem_dtype(self, dtype, float_frame):
@@ -550,7 +547,9 @@ class TestDataFrameIndexing:
 
     def test_setitem_tuple(self, float_frame):
         float_frame["A", "B"] = float_frame["A"]
-        assert_series_equal(float_frame["A", "B"], float_frame["A"], check_names=False)
+        tm.assert_series_equal(
+            float_frame["A", "B"], float_frame["A"], check_names=False
+        )
 
     def test_setitem_always_copy(self, float_frame):
         s = float_frame["A"].copy()
@@ -565,32 +564,32 @@ class TestDataFrameIndexing:
 
         df[df["A"] > 0] = 4
         values[values[:, 0] > 0] = 4
-        assert_almost_equal(df.values, values)
+        tm.assert_almost_equal(df.values, values)
 
         # test that column reindexing works
         series = df["A"] == 4
         series = series.reindex(df.index[::-1])
         df[series] = 1
         values[values[:, 0] == 4] = 1
-        assert_almost_equal(df.values, values)
+        tm.assert_almost_equal(df.values, values)
 
         df[df > 0] = 5
         values[values > 0] = 5
-        assert_almost_equal(df.values, values)
+        tm.assert_almost_equal(df.values, values)
 
         df[df == 5] = 0
         values[values == 5] = 0
-        assert_almost_equal(df.values, values)
+        tm.assert_almost_equal(df.values, values)
 
         # a df that needs alignment first
         df[df[:-1] < 0] = 2
         np.putmask(values[:-1], values[:-1] < 0, 2)
-        assert_almost_equal(df.values, values)
+        tm.assert_almost_equal(df.values, values)
 
         # indexed with same shape but rows-reversed df
         df[df[::-1] == 2] = 3
         values[values == 2] = 3
-        assert_almost_equal(df.values, values)
+        tm.assert_almost_equal(df.values, values)
 
         msg = "Must pass DataFrame or 2-d ndarray with boolean values only"
         with pytest.raises(TypeError, match=msg):
@@ -601,13 +600,13 @@ class TestDataFrameIndexing:
         expected = df.copy()
         df[df > np.abs(df)] = np.nan
         expected.values[mask.values] = np.nan
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # set from DataFrame
         expected = df.copy()
         df[df > np.abs(df)] = df * 2
         np.putmask(expected.values, mask.values, df.values * 2)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     @pytest.mark.parametrize(
         "mask_type",
@@ -626,7 +625,7 @@ class TestDataFrameIndexing:
 
         expected = df.copy()
         expected.values[np.array(mask)] = np.nan
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_setitem_cast(self, float_frame):
         float_frame["D"] = float_frame["D"].astype("i8")
@@ -667,7 +666,7 @@ class TestDataFrameIndexing:
             [np.dtype("float64")] * 3 + [np.dtype("object")],
             index=["A", "B", "C", "event"],
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # Test that data type is preserved . #5782
         df = DataFrame({"one": np.arange(6, dtype=np.int8)})
@@ -683,7 +682,7 @@ class TestDataFrameIndexing:
         float_frame.loc[mask, "B"] = 0
         expected.values[mask.values, 1] = 0
 
-        assert_frame_equal(float_frame, expected)
+        tm.assert_frame_equal(float_frame, expected)
 
     def test_frame_setitem_timestamp(self):
         # GH#2155
@@ -790,13 +789,13 @@ class TestDataFrameIndexing:
     def test_setitem_None(self, float_frame):
         # GH #766
         float_frame[None] = float_frame["A"]
-        assert_series_equal(
+        tm.assert_series_equal(
             float_frame.iloc[:, -1], float_frame["A"], check_names=False
         )
-        assert_series_equal(
+        tm.assert_series_equal(
             float_frame.loc[:, None], float_frame["A"], check_names=False
         )
-        assert_series_equal(float_frame[None], float_frame["A"], check_names=False)
+        tm.assert_series_equal(float_frame[None], float_frame["A"], check_names=False)
         repr(float_frame)
 
     def test_setitem_empty(self):
@@ -807,7 +806,7 @@ class TestDataFrameIndexing:
 
         result = df.copy()
         result.loc[result.b.isna(), "a"] = result.a
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
     @pytest.mark.parametrize("dtype", ["float", "int64"])
     @pytest.mark.parametrize("kwargs", [dict(), dict(index=[1]), dict(columns=["A"])])
@@ -818,7 +817,7 @@ class TestDataFrameIndexing:
 
         df2 = df.copy()
         df[df > df2] = 47
-        assert_frame_equal(df, df2)
+        tm.assert_frame_equal(df, df2)
 
     def test_setitem_with_empty_listlike(self):
         # GH #17101
@@ -833,14 +832,14 @@ class TestDataFrameIndexing:
         df = DataFrame()
         df["foo"] = 1
         expected = DataFrame(columns=["foo"]).astype(np.int64)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_getitem_empty_frame_with_boolean(self):
         # Test for issue #11859
 
         df = pd.DataFrame()
         df2 = df[df > 0]
-        assert_frame_equal(df, df2)
+        tm.assert_frame_equal(df, df2)
 
     def test_delitem_corner(self, float_frame):
         f = float_frame.copy()
@@ -856,21 +855,21 @@ class TestDataFrameIndexing:
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_frame_equal(f.ix[:, ["B", "A"]], f.reindex(columns=["B", "A"]))
+            tm.assert_frame_equal(f.ix[:, ["B", "A"]], f.reindex(columns=["B", "A"]))
 
         subidx = float_frame.index[[5, 4, 1]]
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_frame_equal(
+            tm.assert_frame_equal(
                 f.ix[subidx, ["B", "A"]], f.reindex(index=subidx, columns=["B", "A"])
             )
 
         # slicing rows, etc.
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_frame_equal(f.ix[5:10], f[5:10])
-            assert_frame_equal(f.ix[5:10, :], f[5:10])
-            assert_frame_equal(
+            tm.assert_frame_equal(f.ix[5:10], f[5:10])
+            tm.assert_frame_equal(f.ix[5:10, :], f[5:10])
+            tm.assert_frame_equal(
                 f.ix[:5, ["A", "B"]], f.reindex(index=f.index[:5], columns=["A", "B"])
             )
 
@@ -879,12 +878,12 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             expected = f.ix[5:11]
             result = f.ix[f.index[5] : f.index[10]]
-        assert_frame_equal(expected, result)
+        tm.assert_frame_equal(expected, result)
 
         # slice columns
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_frame_equal(f.ix[:, :2], f.reindex(columns=["A", "B"]))
+            tm.assert_frame_equal(f.ix[:, :2], f.reindex(columns=["A", "B"]))
 
         # get view
         with catch_warnings(record=True):
@@ -892,7 +891,7 @@ class TestDataFrameIndexing:
             exp = f.copy()
             f.ix[5:10].values[:] = 5
             exp.values[5:10] = 5
-            assert_frame_equal(f, exp)
+            tm.assert_frame_equal(f, exp)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
@@ -938,8 +937,8 @@ class TestDataFrameIndexing:
         result2 = df.loc[3:11]
         expected = df.reindex([4, 6, 8, 10])
 
-        assert_frame_equal(result, expected)
-        assert_frame_equal(result2, expected)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result2, expected)
 
         # non-monotonic, raise KeyError
         df2 = df.iloc[list(range(5)) + list(range(5, 10))[::-1]]
@@ -959,7 +958,7 @@ class TestDataFrameIndexing:
             frame.ix[:, ["B", "A"]] = 1
         expected["B"] = 1.0
         expected["A"] = 1.0
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         # case 2
         frame = float_frame.copy()
@@ -978,8 +977,8 @@ class TestDataFrameIndexing:
             expected["B"].ix[subidx] = values[:, 0]
             expected["A"].ix[subidx] = values[:, 1]
 
-        assert_frame_equal(frame, expected)
-        assert_frame_equal(frame2, expected)
+        tm.assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame2, expected)
 
         # case 3: slicing rows, etc.
         frame = float_frame.copy()
@@ -989,7 +988,7 @@ class TestDataFrameIndexing:
             expected1 = float_frame.copy()
             frame.ix[5:10] = 1.0
             expected1.values[5:10] = 1.0
-        assert_frame_equal(frame, expected1)
+        tm.assert_frame_equal(frame, expected1)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
@@ -997,16 +996,16 @@ class TestDataFrameIndexing:
             arr = np.random.randn(5, len(frame.columns))
             frame.ix[5:10] = arr
             expected2.values[5:10] = arr
-        assert_frame_equal(frame, expected2)
+        tm.assert_frame_equal(frame, expected2)
 
         # case 4
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             frame = float_frame.copy()
             frame.ix[5:10, :] = 1.0
-            assert_frame_equal(frame, expected1)
+            tm.assert_frame_equal(frame, expected1)
             frame.ix[5:10, :] = arr
-        assert_frame_equal(frame, expected2)
+        tm.assert_frame_equal(frame, expected2)
 
         # case 5
         with catch_warnings(record=True):
@@ -1020,12 +1019,12 @@ class TestDataFrameIndexing:
             frame.ix[:5, ["A", "B"]] = values
             expected["A"][:5] = values[:, 0]
             expected["B"][:5] = values[:, 1]
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             frame2.ix[:5, [0, 1]] = values
-        assert_frame_equal(frame2, expected)
+        tm.assert_frame_equal(frame2, expected)
 
         # case 6: slice rows with labels, inclusive!
         with catch_warnings(record=True):
@@ -1035,7 +1034,7 @@ class TestDataFrameIndexing:
 
             frame.ix[frame.index[5] : frame.index[10]] = 5.0
             expected.values[5:11] = 5
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         # case 7: slice columns
         with catch_warnings(record=True):
@@ -1047,11 +1046,11 @@ class TestDataFrameIndexing:
             # slice indices
             frame.ix[:, 1:3] = 4.0
             expected.values[:, 1:3] = 4.0
-            assert_frame_equal(frame, expected)
+            tm.assert_frame_equal(frame, expected)
 
             # slice with labels
             frame.ix[:, "B":"C"] = 4.0
-            assert_frame_equal(frame, expected)
+            tm.assert_frame_equal(frame, expected)
 
         # new corner case of boolean slicing / setting
         frame = DataFrame(zip([2, 3, 9, 6, 7], [np.nan] * 5), columns=["a", "b"])
@@ -1059,7 +1058,7 @@ class TestDataFrameIndexing:
         lst.extend([np.nan] * 4)
         expected = DataFrame(zip([100, 3, 9, 6, 7], lst), columns=["a", "b"])
         frame[frame["a"] == 2] = 100
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
     def test_fancy_getitem_slice_mixed(self, float_frame, float_string_frame):
         sliced = float_string_frame.iloc[:, -3:]
@@ -1085,7 +1084,7 @@ class TestDataFrameIndexing:
             exp = df.copy()
             tmp.ix[[0, 2, 4]] = 5
             exp.values[:3] = 5
-        assert_frame_equal(tmp, exp)
+        tm.assert_frame_equal(tmp, exp)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
@@ -1093,7 +1092,7 @@ class TestDataFrameIndexing:
             exp = df.copy()
             tmp.ix[6] = 5
             exp.values[3] = 5
-        assert_frame_equal(tmp, exp)
+        tm.assert_frame_equal(tmp, exp)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
@@ -1104,7 +1103,7 @@ class TestDataFrameIndexing:
         # tmp correctly sets the dtype
         # so match the exp way
         exp[2] = 5
-        assert_frame_equal(tmp, exp)
+        tm.assert_frame_equal(tmp, exp)
 
     def test_fancy_getitem_int_labels(self):
         df = DataFrame(np.random.randn(10, 5), index=np.arange(0, 20, 2))
@@ -1113,25 +1112,25 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             result = df.ix[[4, 2, 0], [2, 0]]
             expected = df.reindex(index=[4, 2, 0], columns=[2, 0])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = df.ix[[4, 2, 0]]
             expected = df.reindex(index=[4, 2, 0])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = df.ix[4]
             expected = df.xs(4)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = df.ix[:, 3]
             expected = df[3]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_fancy_index_int_labels_exceptions(self, float_frame):
         df = DataFrame(np.random.randn(10, 5), index=np.arange(0, 20, 2))
@@ -1174,7 +1173,7 @@ class TestDataFrameIndexing:
             assert isna(float_string_frame.ix[5]).all()
 
             float_string_frame.ix[5] = float_string_frame.ix[6]
-            assert_series_equal(
+            tm.assert_series_equal(
                 float_string_frame.ix[5], float_string_frame.ix[6], check_names=False
             )
 
@@ -1188,7 +1187,7 @@ class TestDataFrameIndexing:
 
             expected = DataFrame({1: [1.0, 5.0, 3.0], 2: [3, 10, 5]})
 
-            assert_frame_equal(df, expected)
+            tm.assert_frame_equal(df, expected)
 
     def test_ix_align(self):
         b = Series(np.random.randn(10), name=0).sort_values()
@@ -1198,27 +1197,27 @@ class TestDataFrameIndexing:
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             df.ix[:, 0] = b
-            assert_series_equal(df.ix[:, 0].reindex(b.index), b)
+            tm.assert_series_equal(df.ix[:, 0].reindex(b.index), b)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             dft = df_orig.T
             dft.ix[0, :] = b
-            assert_series_equal(dft.ix[0, :].reindex(b.index), b)
+            tm.assert_series_equal(dft.ix[0, :].reindex(b.index), b)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             df = df_orig.copy()
             df.ix[:5, 0] = b
             s = df.ix[:5, 0]
-            assert_series_equal(s, b.reindex(s.index))
+            tm.assert_series_equal(s, b.reindex(s.index))
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             dft = df_orig.T
             dft.ix[0, :5] = b
             s = dft.ix[0, :5]
-            assert_series_equal(s, b.reindex(s.index))
+            tm.assert_series_equal(s, b.reindex(s.index))
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
@@ -1226,14 +1225,14 @@ class TestDataFrameIndexing:
             idx = [0, 1, 3, 5]
             df.ix[idx, 0] = b
             s = df.ix[idx, 0]
-            assert_series_equal(s, b.reindex(s.index))
+            tm.assert_series_equal(s, b.reindex(s.index))
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             dft = df_orig.T
             dft.ix[0, idx] = b
             s = dft.ix[0, idx]
-            assert_series_equal(s, b.reindex(s.index))
+            tm.assert_series_equal(s, b.reindex(s.index))
 
     def test_ix_frame_align(self):
         b = DataFrame(np.random.randn(3, 4))
@@ -1244,7 +1243,7 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             df.ix[:3] = b
             out = b.ix[:3]
-            assert_frame_equal(out, b)
+            tm.assert_frame_equal(out, b)
 
         b.sort_index(inplace=True)
 
@@ -1253,14 +1252,14 @@ class TestDataFrameIndexing:
             df = df_orig.copy()
             df.ix[[0, 1, 2]] = b
             out = df.ix[[0, 1, 2]].reindex(b.index)
-            assert_frame_equal(out, b)
+            tm.assert_frame_equal(out, b)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             df = df_orig.copy()
             df.ix[:3] = b
             out = df.ix[:3]
-            assert_frame_equal(out, b.reindex(out.index))
+            tm.assert_frame_equal(out, b.reindex(out.index))
 
     def test_getitem_setitem_non_ix_labels(self):
         df = tm.makeTimeDataFrame()
@@ -1270,8 +1269,8 @@ class TestDataFrameIndexing:
         result = df.loc[start:end]
         result2 = df[start:end]
         expected = df[5:11]
-        assert_frame_equal(result, expected)
-        assert_frame_equal(result2, expected)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result2, expected)
 
         result = df.copy()
         result.loc[start:end] = 0
@@ -1279,20 +1278,20 @@ class TestDataFrameIndexing:
         result2[start:end] = 0
         expected = df.copy()
         expected[5:11] = 0
-        assert_frame_equal(result, expected)
-        assert_frame_equal(result2, expected)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result2, expected)
 
     def test_ix_multi_take(self):
         df = DataFrame(np.random.randn(3, 2))
         rs = df.loc[df.index == 0, :]
         xp = df.reindex([0])
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
         """ #1321
         df = DataFrame(np.random.randn(3, 2))
         rs = df.loc[df.index==0, df.columns==1]
         xp = df.reindex([0], [1])
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
         """
 
     def test_ix_multi_take_nonint_index(self):
@@ -1301,7 +1300,7 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             rs = df.ix[[0], [0]]
         xp = df.reindex(["x"], columns=["a"])
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
     def test_ix_multi_take_multiindex(self):
         df = DataFrame(
@@ -1313,7 +1312,7 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             rs = df.ix[[0], [0]]
         xp = df.reindex(["x"], columns=[("a", "1")])
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
     def test_ix_dup(self):
         idx = Index(["a", "a", "b", "c", "d", "d"])
@@ -1322,17 +1321,17 @@ class TestDataFrameIndexing:
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             sub = df.ix[:"d"]
-            assert_frame_equal(sub, df)
+            tm.assert_frame_equal(sub, df)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             sub = df.ix["a":"c"]
-            assert_frame_equal(sub, df.ix[0:4])
+            tm.assert_frame_equal(sub, df.ix[0:4])
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             sub = df.ix["b":"d"]
-            assert_frame_equal(sub, df.ix[2:])
+            tm.assert_frame_equal(sub, df.ix[2:])
 
     def test_getitem_fancy_1d(self, float_frame, float_string_frame):
         f = float_frame
@@ -1371,7 +1370,7 @@ class TestDataFrameIndexing:
         # single column
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_series_equal(f.ix[:, "A"], f["A"])
+            tm.assert_series_equal(f.ix[:, "A"], f["A"])
 
         # return view
         with catch_warnings(record=True):
@@ -1406,13 +1405,13 @@ class TestDataFrameIndexing:
         expected["C"][2] = 1.0
         expected["B"][2] = 2.0
         expected["A"][2] = 3.0
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             frame2 = float_frame.copy()
             frame2.ix[2, [3, 2, 1]] = [1.0, 2.0, 3.0]
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         # case 2, set a section of a column
         frame = float_frame.copy()
@@ -1423,13 +1422,13 @@ class TestDataFrameIndexing:
             vals = np.random.randn(5)
             expected.values[5:10, 2] = vals
             frame.ix[5:10, 2] = vals
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             frame2 = float_frame.copy()
             frame2.ix[5:10, "B"] = vals
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         # case 3: full xs
         frame = float_frame.copy()
@@ -1439,13 +1438,13 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             frame.ix[4] = 5.0
             expected.values[4] = 5.0
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             frame.ix[frame.index[4]] = 6.0
             expected.values[4] = 6.0
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         # single column
         frame = float_frame.copy()
@@ -1455,7 +1454,7 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             frame.ix[:, "A"] = 7.0
             expected["A"] = 7.0
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
     def test_getitem_fancy_scalar(self, float_frame):
         f = float_frame
@@ -1481,7 +1480,7 @@ class TestDataFrameIndexing:
                 expected.values[i, j] = val
 
                 ix[idx, col] = val
-                assert_frame_equal(f, expected)
+                tm.assert_frame_equal(f, expected)
 
     def test_getitem_fancy_boolean(self, float_frame):
         f = float_frame
@@ -1489,22 +1488,22 @@ class TestDataFrameIndexing:
 
         expected = f.reindex(columns=["B", "D"])
         result = ix[:, [False, True, False, True]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = f.reindex(index=f.index[5:10], columns=["B", "D"])
         result = ix[f.index[5:10], [False, True, False, True]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         boolvec = f.index > f.index[7]
         expected = f.reindex(index=f.index[boolvec])
         result = ix[boolvec]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = ix[boolvec, :]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = ix[boolvec, f.columns[2:]]
         expected = f.reindex(index=f.index[boolvec], columns=["C", "D"])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_setitem_fancy_boolean(self, float_frame):
         # from 2d, set with booleans
@@ -1514,22 +1513,22 @@ class TestDataFrameIndexing:
         mask = frame["A"] > 0
         frame.loc[mask] = 0.0
         expected.values[mask.values] = 0.0
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
         frame = float_frame.copy()
         expected = float_frame.copy()
         frame.loc[mask, ["A", "B"]] = 0.0
         expected.values[mask.values, :2] = 0.0
-        assert_frame_equal(frame, expected)
+        tm.assert_frame_equal(frame, expected)
 
     def test_getitem_fancy_ints(self, float_frame):
         result = float_frame.iloc[[1, 4, 7]]
         expected = float_frame.loc[float_frame.index[[1, 4, 7]]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = float_frame.iloc[:, [2, 0, 1]]
         expected = float_frame.loc[:, float_frame.columns[[2, 0, 1]]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_getitem_setitem_fancy_exceptions(self, float_frame):
         ix = float_frame.iloc
@@ -1545,13 +1544,13 @@ class TestDataFrameIndexing:
 
         result = float_frame.loc[mask]
         expected = float_frame.loc[mask[::-1]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         cp = float_frame.copy()
         expected = float_frame.copy()
         cp.loc[mask] = 0
         expected.loc[mask] = 0
-        assert_frame_equal(cp, expected)
+        tm.assert_frame_equal(cp, expected)
 
     def test_getitem_setitem_boolean_multi(self):
         df = DataFrame(np.random.randn(3, 2))
@@ -1561,12 +1560,12 @@ class TestDataFrameIndexing:
         k2 = np.array([False, True])
         result = df.loc[k1, k2]
         expected = df.loc[[0, 2], [1]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = df.copy()
         df.loc[np.array([True, False, True]), np.array([False, True])] = 5
         expected.loc[[0, 2], [1]] = 5
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_getitem_setitem_float_labels(self):
         index = Index([1.5, 2, 3, 4, 5])
@@ -1574,23 +1573,23 @@ class TestDataFrameIndexing:
 
         result = df.loc[1.5:4]
         expected = df.reindex([1.5, 2, 3, 4])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         assert len(result) == 4
 
         result = df.loc[4:5]
         expected = df.reindex([4, 5])  # reindex with int
-        assert_frame_equal(result, expected, check_index_type=False)
+        tm.assert_frame_equal(result, expected, check_index_type=False)
         assert len(result) == 2
 
         result = df.loc[4:5]
         expected = df.reindex([4.0, 5.0])  # reindex with float
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         assert len(result) == 2
 
         # loc_float changes this to work properly
         result = df.loc[1:2]
         expected = df.iloc[0:2]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df.loc[1:2] = 0
         result = df[1:2]
@@ -1611,7 +1610,7 @@ class TestDataFrameIndexing:
 
         result = df.iloc[4:5]
         expected = df.reindex([5.0])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         assert len(result) == 1
 
         cp = df.copy()
@@ -1633,22 +1632,22 @@ class TestDataFrameIndexing:
         # float slicing
         result = df.loc[1.0:5]
         expected = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         assert len(result) == 5
 
         result = df.loc[1.1:5]
         expected = df.reindex([2.5, 3.5, 4.5, 5.0])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         assert len(result) == 4
 
         result = df.loc[4.51:5]
         expected = df.reindex([5.0])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         assert len(result) == 1
 
         result = df.loc[1.0:5.0]
         expected = df.reindex([1.0, 2.5, 3.5, 4.5, 5.0])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         assert len(result) == 5
 
         cp = df.copy()
@@ -1665,7 +1664,7 @@ class TestDataFrameIndexing:
         df["str"] = "qux"
         df.loc[df.index[::2], "str"] = np.nan
         expected = np.array([np.nan, "qux", np.nan, "qux", np.nan], dtype=object)
-        assert_almost_equal(df["str"].values, expected)
+        tm.assert_almost_equal(df["str"].values, expected)
 
     def test_setitem_single_column_mixed_datetime(self):
         df = DataFrame(
@@ -1682,7 +1681,7 @@ class TestDataFrameIndexing:
             [np.dtype("float64")] * 3 + [np.dtype("datetime64[ns]")],
             index=["foo", "bar", "baz", "timestamp"],
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH#16674 iNaT is treated as an integer when given by the user
         df.loc["b", "timestamp"] = iNaT
@@ -1731,14 +1730,14 @@ class TestDataFrameIndexing:
             ]
         )
         df.loc[[4, 5], ["a", "b"]] = A
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_setitem_frame_float(self, float_frame):
         piece = float_frame.loc[float_frame.index[:2], ["A", "B"]]
         float_frame.loc[float_frame.index[-2] :, ["A", "B"]] = piece.values
         result = float_frame.loc[float_frame.index[-2:], ["A", "B"]].values
         expected = piece.values
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
     def test_setitem_frame_mixed(self, float_string_frame):
         # GH 3216
@@ -1750,7 +1749,7 @@ class TestDataFrameIndexing:
         )
         key = (slice(None, 2), ["A", "B"])
         f.loc[key] = piece
-        assert_almost_equal(f.loc[f.index[0:2], ["A", "B"]].values, piece.values)
+        tm.assert_almost_equal(f.loc[f.index[0:2], ["A", "B"]].values, piece.values)
 
         # rows unaligned
         f = float_string_frame.copy()
@@ -1761,7 +1760,9 @@ class TestDataFrameIndexing:
         )
         key = (slice(None, 2), ["A", "B"])
         f.loc[key] = piece
-        assert_almost_equal(f.loc[f.index[0:2:], ["A", "B"]].values, piece.values[0:2])
+        tm.assert_almost_equal(
+            f.loc[f.index[0:2:], ["A", "B"]].values, piece.values[0:2]
+        )
 
         # key is unaligned with values
         f = float_string_frame.copy()
@@ -1770,14 +1771,14 @@ class TestDataFrameIndexing:
         key = (slice(-2, None), ["A", "B"])
         f.loc[key] = piece
         piece["B"] = np.nan
-        assert_almost_equal(f.loc[f.index[-2:], ["A", "B"]].values, piece.values)
+        tm.assert_almost_equal(f.loc[f.index[-2:], ["A", "B"]].values, piece.values)
 
         # ndarray
         f = float_string_frame.copy()
         piece = float_string_frame.loc[f.index[:2], ["A", "B"]]
         key = (slice(-2, None), ["A", "B"])
         f.loc[key] = piece.values
-        assert_almost_equal(f.loc[f.index[-2:], ["A", "B"]].values, piece.values)
+        tm.assert_almost_equal(f.loc[f.index[-2:], ["A", "B"]].values, piece.values)
 
     def test_setitem_frame_upcast(self):
         # needs upcasting
@@ -1787,7 +1788,7 @@ class TestDataFrameIndexing:
         expected = df.reindex(columns=["A", "B"])
         expected += 0.5
         expected["C"] = df["C"]
-        assert_frame_equal(df2, expected)
+        tm.assert_frame_equal(df2, expected)
 
     def test_setitem_frame_align(self, float_frame):
         piece = float_frame.loc[float_frame.index[:2], ["A", "B"]]
@@ -1796,7 +1797,7 @@ class TestDataFrameIndexing:
         float_frame.loc[float_frame.index[-2:], ["A", "B"]] = piece
         result = float_frame.loc[float_frame.index[-2:], ["A", "B"]].values
         expected = piece.values
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
     def test_getitem_setitem_ix_duplicates(self):
         # #1201
@@ -1804,15 +1805,15 @@ class TestDataFrameIndexing:
 
         result = df.loc["foo"]
         expected = df[:2]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.loc["bar"]
         expected = df.iloc[[2, 4]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.loc["baz"]
         expected = df.iloc[3]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_getitem_ix_boolean_duplicates_multiple(self):
         # #1201
@@ -1820,15 +1821,15 @@ class TestDataFrameIndexing:
 
         result = df.loc[["bar"]]
         exp = df.iloc[[2, 4]]
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
         result = df.loc[df[1] > 0]
         exp = df[df[1] > 0]
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
         result = df.loc[df[0] > 0]
         exp = df[df[0] > 0]
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
     def test_getitem_setitem_ix_bool_keyerror(self):
         # #2199
@@ -1854,7 +1855,7 @@ class TestDataFrameIndexing:
         assert result.columns.name == "foo"
 
         expected = df.iloc[:, 2:]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_get_value(self, float_frame):
         for idx in float_frame.index:
@@ -2003,25 +2004,25 @@ class TestDataFrameIndexing:
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = df.ix[[0], "b"]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = df.loc[[0], "b"]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_iloc_row(self):
         df = DataFrame(np.random.randn(10, 4), index=range(0, 20, 2))
 
         result = df.iloc[1]
         exp = df.loc[2]
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         result = df.iloc[2]
         exp = df.loc[4]
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         # slice
         result = df.iloc[slice(4, 8)]
         expected = df.loc[8:14]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # verify slice is view
         # setting it makes it raise/warn
@@ -2030,12 +2031,12 @@ class TestDataFrameIndexing:
 
         exp_col = df[2].copy()
         exp_col[4:8] = 0.0
-        assert_series_equal(df[2], exp_col)
+        tm.assert_series_equal(df[2], exp_col)
 
         # list of integers
         result = df.iloc[[1, 2, 4, 6]]
         expected = df.reindex(df.index[[1, 2, 4, 6]])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_iloc_col(self):
 
@@ -2043,16 +2044,16 @@ class TestDataFrameIndexing:
 
         result = df.iloc[:, 1]
         exp = df.loc[:, 2]
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         result = df.iloc[:, 2]
         exp = df.loc[:, 4]
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
         # slice
         result = df.iloc[:, slice(4, 8)]
         expected = df.loc[:, 8:14]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # verify slice is view
         # and that we are setting a copy
@@ -2064,7 +2065,7 @@ class TestDataFrameIndexing:
         # list of integers
         result = df.iloc[:, [1, 2, 4, 6]]
         expected = df.reindex(columns=df.columns[[1, 2, 4, 6]])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_iloc_duplicates(self):
 
@@ -2075,16 +2076,16 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             result2 = df.ix[0]
         assert isinstance(result, Series)
-        assert_almost_equal(result.values, df.values[0])
-        assert_series_equal(result, result2)
+        tm.assert_almost_equal(result.values, df.values[0])
+        tm.assert_series_equal(result, result2)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             result = df.T.iloc[:, 0]
             result2 = df.T.ix[:, 0]
         assert isinstance(result, Series)
-        assert_almost_equal(result.values, df.values[0])
-        assert_series_equal(result, result2)
+        tm.assert_almost_equal(result.values, df.values[0])
+        tm.assert_series_equal(result, result2)
 
         # multiindex
         df = DataFrame(
@@ -2097,25 +2098,25 @@ class TestDataFrameIndexing:
             simplefilter("ignore", FutureWarning)
             rs = df.iloc[0]
             xp = df.ix[0]
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             rs = df.iloc[:, 0]
             xp = df.T.ix[0]
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
             rs = df.iloc[:, [0]]
             xp = df.ix[:, [0]]
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
         # #2259
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=[1, 1, 2])
         result = df.iloc[:, [0]]
         expected = df.take([0], axis=1)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_loc_duplicates(self):
         # gh-17105
@@ -2166,32 +2167,32 @@ class TestDataFrameIndexing:
 
         expected = pd.DataFrame({"x": expected_values}, index=target)
         actual = df.reindex(target, method=method)
-        assert_frame_equal(expected, actual)
+        tm.assert_frame_equal(expected, actual)
 
         actual = df.reindex_like(df, method=method, tolerance=0)
-        assert_frame_equal(df, actual)
+        tm.assert_frame_equal(df, actual)
         actual = df.reindex_like(df, method=method, tolerance=[0, 0, 0, 0])
-        assert_frame_equal(df, actual)
+        tm.assert_frame_equal(df, actual)
 
         actual = df.reindex(target, method=method, tolerance=1)
-        assert_frame_equal(expected, actual)
+        tm.assert_frame_equal(expected, actual)
         actual = df.reindex(target, method=method, tolerance=[1, 1, 1, 1])
-        assert_frame_equal(expected, actual)
+        tm.assert_frame_equal(expected, actual)
 
         e2 = expected[::-1]
         actual = df.reindex(target[::-1], method=method)
-        assert_frame_equal(e2, actual)
+        tm.assert_frame_equal(e2, actual)
 
         new_order = [3, 0, 2, 1]
         e2 = expected.iloc[new_order]
         actual = df.reindex(target[new_order], method=method)
-        assert_frame_equal(e2, actual)
+        tm.assert_frame_equal(e2, actual)
 
         switched_method = (
             "pad" if method == "backfill" else "backfill" if method == "pad" else method
         )
         actual = df[::-1].reindex(target, method=switched_method)
-        assert_frame_equal(expected, actual)
+        tm.assert_frame_equal(expected, actual)
 
     def test_reindex_methods_nearest_special(self):
         df = pd.DataFrame({"x": list(range(5))})
@@ -2199,11 +2200,11 @@ class TestDataFrameIndexing:
 
         expected = pd.DataFrame({"x": [0, 1, 1, np.nan]}, index=target)
         actual = df.reindex(target, method="nearest", tolerance=0.2)
-        assert_frame_equal(expected, actual)
+        tm.assert_frame_equal(expected, actual)
 
         expected = pd.DataFrame({"x": [0, np.nan, 1, np.nan]}, index=target)
         actual = df.reindex(target, method="nearest", tolerance=[0.5, 0.01, 0.4, 0.1])
-        assert_frame_equal(expected, actual)
+        tm.assert_frame_equal(expected, actual)
 
     def test_reindex_frame_add_nat(self):
         rng = date_range("1/1/2000 00:00:00", periods=10, freq="10s")
@@ -2264,12 +2265,12 @@ class TestDataFrameIndexing:
             i = np.concatenate(list(map(f, idx)))
             left = df.set_index(icol).reindex(idx, level=level)
             right = df.iloc[i].set_index(icol)
-            assert_frame_equal(left, right, check_index_type=check_index_type)
+            tm.assert_frame_equal(left, right, check_index_type=check_index_type)
 
         def verify(df, level, idx, indexer, check_index_type=True):
             left = df.set_index(icol).reindex(idx, level=level)
             right = df.iloc[indexer].set_index(icol)
-            assert_frame_equal(left, right, check_index_type=check_index_type)
+            tm.assert_frame_equal(left, right, check_index_type=check_index_type)
 
         df = pd.DataFrame(
             {
@@ -2353,45 +2354,45 @@ class TestDataFrameIndexing:
             np.random.randn(3, 3), index=[0.1, 0.2, 0.2], columns=list("abc")
         )
         expect = df.iloc[1:]
-        assert_frame_equal(df.loc[0.2], expect)
+        tm.assert_frame_equal(df.loc[0.2], expect)
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_frame_equal(df.ix[0.2], expect)
+            tm.assert_frame_equal(df.ix[0.2], expect)
 
         expect = df.iloc[1:, 0]
-        assert_series_equal(df.loc[0.2, "a"], expect)
+        tm.assert_series_equal(df.loc[0.2, "a"], expect)
 
         df.index = [1, 0.2, 0.2]
         expect = df.iloc[1:]
-        assert_frame_equal(df.loc[0.2], expect)
+        tm.assert_frame_equal(df.loc[0.2], expect)
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_frame_equal(df.ix[0.2], expect)
+            tm.assert_frame_equal(df.ix[0.2], expect)
 
         expect = df.iloc[1:, 0]
-        assert_series_equal(df.loc[0.2, "a"], expect)
+        tm.assert_series_equal(df.loc[0.2, "a"], expect)
 
         df = pd.DataFrame(
             np.random.randn(4, 3), index=[1, 0.2, 0.2, 1], columns=list("abc")
         )
         expect = df.iloc[1:-1]
-        assert_frame_equal(df.loc[0.2], expect)
+        tm.assert_frame_equal(df.loc[0.2], expect)
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_frame_equal(df.ix[0.2], expect)
+            tm.assert_frame_equal(df.ix[0.2], expect)
 
         expect = df.iloc[1:-1, 0]
-        assert_series_equal(df.loc[0.2, "a"], expect)
+        tm.assert_series_equal(df.loc[0.2, "a"], expect)
 
         df.index = [0.1, 0.2, 2, 0.2]
         expect = df.iloc[[1, -1]]
-        assert_frame_equal(df.loc[0.2], expect)
+        tm.assert_frame_equal(df.loc[0.2], expect)
         with catch_warnings(record=True):
             simplefilter("ignore", FutureWarning)
-            assert_frame_equal(df.ix[0.2], expect)
+            tm.assert_frame_equal(df.ix[0.2], expect)
 
         expect = df.iloc[[1, -1], 0]
-        assert_series_equal(df.loc[0.2, "a"], expect)
+        tm.assert_series_equal(df.loc[0.2, "a"], expect)
 
     def test_getitem_sparse_column(self):
         # https://github.com/pandas-dev/pandas/issues/23559
@@ -2412,7 +2413,7 @@ class TestDataFrameIndexing:
         df = pd.DataFrame({"c_1": ["a", "b", "c"], "n_1": [1.0, 2.0, 3.0]})
         sp_array = pd.SparseArray([0, 0, 1])
         df["new_column"] = sp_array
-        assert_series_equal(
+        tm.assert_series_equal(
             df["new_column"], pd.Series(sp_array, name="new_column"), check_names=False
         )
 
@@ -2421,7 +2422,7 @@ class TestDataFrameIndexing:
         sp_series = pd.Series(pd.SparseArray([0, 0, 1]), index=[2, 1, 0])
         df["new_column"] = sp_series
         exp = pd.Series(pd.SparseArray([1, 0, 0]), name="new_column")
-        assert_series_equal(df["new_column"], exp)
+        tm.assert_series_equal(df["new_column"], exp)
 
     def test_setitem_with_unaligned_tz_aware_datetime_column(self):
         # GH 12981
@@ -2432,11 +2433,11 @@ class TestDataFrameIndexing:
         )
         df = pd.DataFrame({"dates": column})
         df["dates"] = column[[1, 0, 2]]
-        assert_series_equal(df["dates"], column)
+        tm.assert_series_equal(df["dates"], column)
 
         df = pd.DataFrame({"dates": column})
         df.loc[[0, 1, 2], "dates"] = column[[1, 0, 2]]
-        assert_series_equal(df["dates"], column)
+        tm.assert_series_equal(df["dates"], column)
 
     def test_setitem_datetime_coercion(self):
         # gh-1048
@@ -2467,7 +2468,7 @@ class TestDataFrameIndexing:
             [np.dtype("timedelta64[ns]")] * 6 + [np.dtype("datetime64[ns]")] * 2,
             index=list("ABCDEFGH"),
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("idxer", ["var", ["var"]])
     def test_setitem_datetimeindex_tz(self, idxer, tz_naive_fixture):
@@ -2490,15 +2491,15 @@ class TestDataFrameIndexing:
         result = df.at_time(akey)
         expected = df.loc[akey]
         expected2 = df.iloc[ainds]
-        assert_frame_equal(result, expected)
-        assert_frame_equal(result, expected2)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected2)
         assert len(result) == 4
 
         result = df.between_time(bkey.start, bkey.stop)
         expected = df.loc[bkey]
         expected2 = df.iloc[binds]
-        assert_frame_equal(result, expected)
-        assert_frame_equal(result, expected2)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected2)
         assert len(result) == 12
 
         result = df.copy()
@@ -2506,24 +2507,24 @@ class TestDataFrameIndexing:
         result = result.loc[akey]
         expected = df.loc[akey].copy()
         expected.loc[:] = 0
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.loc[akey] = 0
         result.loc[akey] = df.iloc[ainds]
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         result = df.copy()
         result.loc[bkey] = 0
         result = result.loc[bkey]
         expected = df.loc[bkey].copy()
         expected.loc[:] = 0
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.loc[bkey] = 0
         result.loc[bkey] = df.iloc[binds]
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
     def test_xs(self, float_frame, datetime_frame):
         idx = float_frame.index[5]
@@ -2550,7 +2551,7 @@ class TestDataFrameIndexing:
         # xs get column
         series = float_frame.xs("A", axis=1)
         expected = float_frame["A"]
-        assert_series_equal(series, expected)
+        tm.assert_series_equal(series, expected)
 
         # view is returned if possible
         series = float_frame.xs("A", axis=1)
@@ -2574,14 +2575,14 @@ class TestDataFrameIndexing:
         df = DataFrame(index=["a", "b", "c"])
         result = df.xs("a")
         expected = Series([], name="a", index=pd.Index([], dtype=object))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_xs_duplicates(self):
         df = DataFrame(np.random.randn(5, 2), index=["b", "b", "c", "b", "a"])
 
         cross = df.xs("c")
         exp = df.iloc[2]
-        assert_series_equal(cross, exp)
+        tm.assert_series_equal(cross, exp)
 
     def test_xs_keep_level(self):
         df = DataFrame(
@@ -2594,10 +2595,10 @@ class TestDataFrameIndexing:
         ).set_index(["year", "flavour", "day"])
         result = df.xs("sat", level="day", drop_level=False)
         expected = df[:1]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.xs([2008, "sat"], level=["year", "day"], drop_level=False)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_xs_view(self):
         # in 0.14 this will return a view if possible a copy otherwise, but
@@ -2644,7 +2645,7 @@ class TestDataFrameIndexing:
         )
 
         df1[df1 > 2.0 * df2] = -1
-        assert_frame_equal(df1, expected)
+        tm.assert_frame_equal(df1, expected)
         with pytest.raises(ValueError, match="Item wrong length"):
             df1[df1.index[:-1] > 2] = -1
 
@@ -2686,7 +2687,7 @@ class TestDataFrameIndexing:
         expected.loc[49, 1] = 1
         expected.loc[50, 1] = 1
         expected.loc[35, 4] = 1
-        assert_frame_equal(df2, expected)
+        tm.assert_frame_equal(df2, expected)
 
         df["foo"] = "test"
         msg = "not supported between instances|unorderable types"
@@ -2715,8 +2716,8 @@ class TestDataFrameIndexing:
             rs2 = df.where(cond.values, other1)
             for k, v in rs.items():
                 exp = Series(np.where(cond[k], df[k], other1[k]), index=v.index)
-                assert_series_equal(v, exp, check_names=False)
-            assert_frame_equal(rs, rs2)
+                tm.assert_series_equal(v, exp, check_names=False)
+            tm.assert_frame_equal(rs, rs2)
 
             # dtypes
             if check_dtypes:
@@ -2759,7 +2760,7 @@ class TestDataFrameIndexing:
         #
         # expected = Series({ 'float32' : 1, 'float64' : 3 })
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # aligning
         def _check_align(df, cond, other, check_dtypes=True):
@@ -2782,7 +2783,7 @@ class TestDataFrameIndexing:
 
                 # since we can't always have the correct numpy dtype
                 # as numpy doesn't know how to downcast, don't check
-                assert_series_equal(result, expected, check_dtype=False)
+                tm.assert_series_equal(result, expected, check_dtype=False)
 
             # dtypes
             # can't check dtype when other is an ndarray
@@ -2834,7 +2835,7 @@ class TestDataFrameIndexing:
             expected = dfi.mask(~econd)
 
             dfi.where(cond, np.nan, inplace=True)
-            assert_frame_equal(dfi, expected)
+            tm.assert_frame_equal(dfi, expected)
 
             # dtypes (and confirm upcasts)x
             if check_dtypes:
@@ -2869,7 +2870,7 @@ class TestDataFrameIndexing:
         df = DataFrame({"a": range(3), "b": range(4, 7)})
         result = df.where(df["a"] == 1)
         expected = df[df["a"] == 1].reindex(df.index)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("klass", [list, tuple, np.array])
     def test_where_array_like(self, klass):
@@ -2879,14 +2880,14 @@ class TestDataFrameIndexing:
         expected = DataFrame({"a": [np.nan, 2, 3]})
 
         result = df.where(klass(cond))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df["b"] = 2
         expected["b"] = [2, np.nan, 2]
         cond = [[False, True], [True, False], [True, True]]
 
         result = df.where(klass(cond))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "cond",
@@ -2974,11 +2975,11 @@ class TestDataFrameIndexing:
             dtype="float64",
         )
         result = df.where(df > 2, np.nan)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.where(result > 2, np.nan, inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_where_bug_mixed(self, sint_dtype):
         # see gh-2793
@@ -2995,11 +2996,11 @@ class TestDataFrameIndexing:
         )
 
         result = df.where(df > 2, np.nan)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.where(result > 2, np.nan, inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_where_bug_transposition(self):
         # see gh-7506
@@ -3011,7 +3012,7 @@ class TestDataFrameIndexing:
         expected[~do_not_replace] = b
 
         result = a.where(do_not_replace, b)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         a = DataFrame({0: [4, 6], 1: [1, 0]})
         b = DataFrame({0: [np.nan, 3], 1: [3, np.nan]})
@@ -3021,7 +3022,7 @@ class TestDataFrameIndexing:
         expected[~do_not_replace] = b
 
         result = a.where(do_not_replace, b)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_where_datetime(self):
 
@@ -3043,7 +3044,7 @@ class TestDataFrameIndexing:
         expected = df.copy()
         expected.loc[[0, 1], "A"] = np.nan
         expected.loc[:, "C"] = np.nan
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_where_none(self):
         # GH 4667
@@ -3053,7 +3054,7 @@ class TestDataFrameIndexing:
         expected = DataFrame(
             {"series": Series([0, 1, 2, 3, 4, 5, 6, 7, np.nan, np.nan])}
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # GH 7656
         df = DataFrame(
@@ -3087,17 +3088,17 @@ class TestDataFrameIndexing:
         df = create()
         expected = df.fillna(df.mean())
         result = df.where(pd.notna(df), df.mean(), axis="columns")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df.where(pd.notna(df), df.mean(), inplace=True, axis="columns")
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         df = create().fillna(0)
         expected = df.apply(lambda x, y: x.where(x > 0, y), y=df[0])
         result = df.where(df > 0, df[0], axis="index")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.where(df > 0, df[0], axis="rows")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # frame
         df = create()
@@ -3105,14 +3106,14 @@ class TestDataFrameIndexing:
         result = df.where(
             pd.notna(df), DataFrame(1, index=df.index, columns=df.columns)
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_where_complex(self):
         # GH 6345
         expected = DataFrame([[1 + 1j, 2], [np.nan, 4 + 1j]], columns=["a", "b"])
         df = DataFrame([[1 + 1j, 2], [5 + 1j, 4 + 1j]], columns=["a", "b"])
         df[df.abs() >= 5] = np.nan
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_where_axis(self):
         # GH 9736
@@ -3122,19 +3123,19 @@ class TestDataFrameIndexing:
 
         expected = DataFrame([[0, 0], [1, 1]], dtype="float64")
         result = df.where(mask, s, axis="index")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.where(mask, s, axis="index", inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = DataFrame([[0, 1], [0, 1]], dtype="float64")
         result = df.where(mask, s, axis="columns")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.where(mask, s, axis="columns", inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Upcast needed
         df = DataFrame([[1, 2], [3, 4]], dtype="int64")
@@ -3143,15 +3144,15 @@ class TestDataFrameIndexing:
 
         expected = DataFrame([[0, 0], [np.nan, np.nan]], dtype="float64")
         result = df.where(mask, s, axis="index")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.where(mask, s, axis="index", inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = DataFrame([[0, np.nan], [0, np.nan]])
         result = df.where(mask, s, axis="columns")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = DataFrame(
             {
@@ -3161,7 +3162,7 @@ class TestDataFrameIndexing:
         )
         result = df.copy()
         result.where(mask, s, axis="columns", inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Multiple dtypes (=> multiple Blocks)
         df = pd.concat(
@@ -3180,21 +3181,21 @@ class TestDataFrameIndexing:
         expected = DataFrame(1.0, columns=df.columns, index=df.index)
         expected[2] = expected[2].astype("int64")
         expected[3] = expected[3].astype("int64")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.where(mask, s1, axis="columns", inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.where(mask, s2, axis="index")
         expected = DataFrame(2.0, columns=df.columns, index=df.index)
         expected[2] = expected[2].astype("int64")
         expected[3] = expected[3].astype("int64")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result.where(mask, s2, axis="index", inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # DataFrame vs DataFrame
         d1 = df.copy().drop(1, axis=0)
@@ -3202,30 +3203,30 @@ class TestDataFrameIndexing:
         expected.loc[1, :] = np.nan
 
         result = df.where(mask, d1)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.where(mask, d1, axis="index")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.copy()
         result.where(mask, d1, inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.copy()
         result.where(mask, d1, inplace=True, axis="index")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         d2 = df.copy().drop(1, axis=1)
         expected = df.copy()
         expected.loc[:, 1] = np.nan
 
         result = df.where(mask, d2)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.where(mask, d2, axis="columns")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.copy()
         result.where(mask, d2, inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.copy()
         result.where(mask, d2, inplace=True, axis="columns")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_where_callable(self):
         # GH 12533
@@ -3262,20 +3263,20 @@ class TestDataFrameIndexing:
             columns=["date"],
         )
         result = df1.where(mask, df2)
-        assert_frame_equal(exp, result)
+        tm.assert_frame_equal(exp, result)
 
     def test_mask(self):
         df = DataFrame(np.random.randn(5, 3))
         cond = df > 0
 
         rs = df.where(cond, np.nan)
-        assert_frame_equal(rs, df.mask(df <= 0))
-        assert_frame_equal(rs, df.mask(~cond))
+        tm.assert_frame_equal(rs, df.mask(df <= 0))
+        tm.assert_frame_equal(rs, df.mask(~cond))
 
         other = DataFrame(np.random.randn(5, 3))
         rs = df.where(cond, other)
-        assert_frame_equal(rs, df.mask(df <= 0, other))
-        assert_frame_equal(rs, df.mask(~cond, other))
+        tm.assert_frame_equal(rs, df.mask(df <= 0, other))
+        tm.assert_frame_equal(rs, df.mask(~cond, other))
 
         # see gh-21891
         df = DataFrame([1, 2])
@@ -3292,20 +3293,20 @@ class TestDataFrameIndexing:
         rdf = df.copy()
 
         rdf.where(cond, inplace=True)
-        assert_frame_equal(rdf, df.where(cond))
-        assert_frame_equal(rdf, df.mask(~cond))
+        tm.assert_frame_equal(rdf, df.where(cond))
+        tm.assert_frame_equal(rdf, df.mask(~cond))
 
         rdf = df.copy()
         rdf.where(cond, -df, inplace=True)
-        assert_frame_equal(rdf, df.where(cond, -df))
-        assert_frame_equal(rdf, df.mask(~cond, -df))
+        tm.assert_frame_equal(rdf, df.where(cond, -df))
+        tm.assert_frame_equal(rdf, df.mask(~cond, -df))
 
     def test_mask_edge_case_1xN_frame(self):
         # GH4071
         df = DataFrame([[1, 2]])
         res = df.mask(DataFrame([[True, False]]))
         expec = DataFrame([[np.nan, 2]])
-        assert_frame_equal(res, expec)
+        tm.assert_frame_equal(res, expec)
 
     def test_mask_callable(self):
         # GH 12533
@@ -3328,29 +3329,29 @@ class TestDataFrameIndexing:
         tm.assert_frame_equal(result, (df + 2).mask((df + 2) > 8, (df + 2) + 10))
 
     def test_head_tail(self, float_frame):
-        assert_frame_equal(float_frame.head(), float_frame[:5])
-        assert_frame_equal(float_frame.tail(), float_frame[-5:])
+        tm.assert_frame_equal(float_frame.head(), float_frame[:5])
+        tm.assert_frame_equal(float_frame.tail(), float_frame[-5:])
 
-        assert_frame_equal(float_frame.head(0), float_frame[0:0])
-        assert_frame_equal(float_frame.tail(0), float_frame[0:0])
+        tm.assert_frame_equal(float_frame.head(0), float_frame[0:0])
+        tm.assert_frame_equal(float_frame.tail(0), float_frame[0:0])
 
-        assert_frame_equal(float_frame.head(-1), float_frame[:-1])
-        assert_frame_equal(float_frame.tail(-1), float_frame[1:])
-        assert_frame_equal(float_frame.head(1), float_frame[:1])
-        assert_frame_equal(float_frame.tail(1), float_frame[-1:])
+        tm.assert_frame_equal(float_frame.head(-1), float_frame[:-1])
+        tm.assert_frame_equal(float_frame.tail(-1), float_frame[1:])
+        tm.assert_frame_equal(float_frame.head(1), float_frame[:1])
+        tm.assert_frame_equal(float_frame.tail(1), float_frame[-1:])
         # with a float index
         df = float_frame.copy()
         df.index = np.arange(len(float_frame)) + 0.1
-        assert_frame_equal(df.head(), df.iloc[:5])
-        assert_frame_equal(df.tail(), df.iloc[-5:])
-        assert_frame_equal(df.head(0), df[0:0])
-        assert_frame_equal(df.tail(0), df[0:0])
-        assert_frame_equal(df.head(-1), df.iloc[:-1])
-        assert_frame_equal(df.tail(-1), df.iloc[1:])
+        tm.assert_frame_equal(df.head(), df.iloc[:5])
+        tm.assert_frame_equal(df.tail(), df.iloc[-5:])
+        tm.assert_frame_equal(df.head(0), df[0:0])
+        tm.assert_frame_equal(df.tail(0), df[0:0])
+        tm.assert_frame_equal(df.head(-1), df.iloc[:-1])
+        tm.assert_frame_equal(df.tail(-1), df.iloc[1:])
         # test empty dataframe
         empty_df = DataFrame()
-        assert_frame_equal(empty_df.tail(), empty_df)
-        assert_frame_equal(empty_df.head(), empty_df)
+        tm.assert_frame_equal(empty_df.tail(), empty_df)
+        tm.assert_frame_equal(empty_df.head(), empty_df)
 
     def test_type_error_multiindex(self):
         # See gh-12218
@@ -3370,14 +3371,14 @@ class TestDataFrameIndexing:
         expected = DataFrame([[1, 2], [3, 4]], columns=columns, index=index)
 
         result = dg.loc[:, (slice(None), 0)]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         name = ("x", 0)
         index = Index(range(2), name="i")
         expected = Series([1, 3], index=index, name=name)
 
         result = dg["x", 0]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_interval_index(self):
         # GH 19977
@@ -3388,7 +3389,7 @@ class TestDataFrameIndexing:
 
         expected = 1
         result = df.loc[0.5, "A"]
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         index = pd.interval_range(start=0, periods=3, closed="both")
         df = pd.DataFrame(
@@ -3398,7 +3399,7 @@ class TestDataFrameIndexing:
         index_exp = pd.interval_range(start=0, periods=2, freq=1, closed="both")
         expected = pd.Series([1, 4], index=index_exp, name="A")
         result = df.loc[1, "A"]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
 
 class TestDataFrameIndexingDatetimeWithTZ:
@@ -3409,11 +3410,11 @@ class TestDataFrameIndexingDatetimeWithTZ:
 
         # setitem
         df["C"] = idx
-        assert_series_equal(df["C"], Series(idx, name="C"))
+        tm.assert_series_equal(df["C"], Series(idx, name="C"))
 
         df["D"] = "foo"
         df["D"] = idx
-        assert_series_equal(df["D"], Series(idx, name="D"))
+        tm.assert_series_equal(df["D"], Series(idx, name="D"))
         del df["D"]
 
         # assert that A & C are not sharing the same base (e.g. they
@@ -3428,8 +3429,8 @@ class TestDataFrameIndexingDatetimeWithTZ:
         df2.iloc[1, 1] = pd.NaT
         df2.iloc[1, 2] = pd.NaT
         result = df2["B"]
-        assert_series_equal(notna(result), Series([True, False, True], name="B"))
-        assert_series_equal(df2.dtypes, df.dtypes)
+        tm.assert_series_equal(notna(result), Series([True, False, True], name="B"))
+        tm.assert_series_equal(df2.dtypes, df.dtypes)
 
     def test_set_reset(self):
 
@@ -3448,7 +3449,7 @@ class TestDataFrameIndexingDatetimeWithTZ:
         result = timezone_frame.T
         expected = DataFrame(timezone_frame.values.T)
         expected.index = ["A", "B", "C"]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_scalar_assignment(self):
         # issue #19843
@@ -3468,11 +3469,11 @@ class TestDataFrameIndexingUInt64:
 
         # setitem
         df["C"] = idx
-        assert_series_equal(df["C"], Series(idx, name="C"))
+        tm.assert_series_equal(df["C"], Series(idx, name="C"))
 
         df["D"] = "foo"
         df["D"] = idx
-        assert_series_equal(df["D"], Series(idx, name="D"))
+        tm.assert_series_equal(df["D"], Series(idx, name="D"))
         del df["D"]
 
         # With NaN: because uint64 has no NaN element,
@@ -3481,8 +3482,8 @@ class TestDataFrameIndexingUInt64:
         df2.iloc[1, 1] = pd.NaT
         df2.iloc[1, 2] = pd.NaT
         result = df2["B"]
-        assert_series_equal(notna(result), Series([True, False, True], name="B"))
-        assert_series_equal(
+        tm.assert_series_equal(notna(result), Series([True, False, True], name="B"))
+        tm.assert_series_equal(
             df2.dtypes,
             Series(
                 [np.dtype("uint64"), np.dtype("O"), np.dtype("O")],
@@ -3507,7 +3508,7 @@ class TestDataFrameIndexingUInt64:
         result = uint64_frame.T
         expected = DataFrame(uint64_frame.values.T)
         expected.index = ["A", "B"]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
 
 class TestDataFrameIndexingCategorical:

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -10,7 +10,6 @@ import pandas as pd
 from pandas import Categorical, DataFrame, Series, Timestamp, date_range
 from pandas.tests.frame.common import _check_mixed_float
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 def _skip_if_no_pchip():
@@ -35,15 +34,15 @@ class TestDataFrameMissingData:
 
         smaller_frame = frame.dropna(how="all")
         # check that original was preserved
-        assert_series_equal(frame["foo"], original)
+        tm.assert_series_equal(frame["foo"], original)
         inplace_frame1.dropna(how="all", inplace=True)
-        assert_series_equal(smaller_frame["foo"], expected)
-        assert_series_equal(inplace_frame1["foo"], expected)
+        tm.assert_series_equal(smaller_frame["foo"], expected)
+        tm.assert_series_equal(inplace_frame1["foo"], expected)
 
         smaller_frame = frame.dropna(how="all", subset=["foo"])
         inplace_frame2.dropna(how="all", subset=["foo"], inplace=True)
-        assert_series_equal(smaller_frame["foo"], expected)
-        assert_series_equal(inplace_frame2["foo"], expected)
+        tm.assert_series_equal(smaller_frame["foo"], expected)
+        tm.assert_series_equal(inplace_frame2["foo"], expected)
 
     def test_dropIncompleteRows(self, float_frame):
         N = len(float_frame.index)
@@ -56,7 +55,7 @@ class TestDataFrameMissingData:
         inp_frame1, inp_frame2 = frame.copy(), frame.copy()
 
         smaller_frame = frame.dropna()
-        assert_series_equal(frame["foo"], original)
+        tm.assert_series_equal(frame["foo"], original)
         inp_frame1.dropna(inplace=True)
 
         exp = Series(mat[5:], index=float_frame.index[5:], name="foo")
@@ -64,7 +63,7 @@ class TestDataFrameMissingData:
         tm.assert_series_equal(inp_frame1["foo"], exp)
 
         samesize_frame = frame.dropna(subset=["bar"])
-        assert_series_equal(frame["foo"], original)
+        tm.assert_series_equal(frame["foo"], original)
         assert (frame["bar"] == 5).all()
         inp_frame2.dropna(subset=["bar"], inplace=True)
         tm.assert_index_equal(samesize_frame.index, float_frame.index)
@@ -78,52 +77,52 @@ class TestDataFrameMissingData:
         expected = df.loc[:, [0, 1, 3]]
         inp = df.copy()
         inp.dropna(axis=1, inplace=True)
-        assert_frame_equal(dropped, expected)
-        assert_frame_equal(inp, expected)
+        tm.assert_frame_equal(dropped, expected)
+        tm.assert_frame_equal(inp, expected)
 
         dropped = df.dropna(axis=0)
         expected = df.loc[list(range(2, 6))]
         inp = df.copy()
         inp.dropna(axis=0, inplace=True)
-        assert_frame_equal(dropped, expected)
-        assert_frame_equal(inp, expected)
+        tm.assert_frame_equal(dropped, expected)
+        tm.assert_frame_equal(inp, expected)
 
         # threshold
         dropped = df.dropna(axis=1, thresh=5)
         expected = df.loc[:, [0, 1, 3]]
         inp = df.copy()
         inp.dropna(axis=1, thresh=5, inplace=True)
-        assert_frame_equal(dropped, expected)
-        assert_frame_equal(inp, expected)
+        tm.assert_frame_equal(dropped, expected)
+        tm.assert_frame_equal(inp, expected)
 
         dropped = df.dropna(axis=0, thresh=4)
         expected = df.loc[range(2, 6)]
         inp = df.copy()
         inp.dropna(axis=0, thresh=4, inplace=True)
-        assert_frame_equal(dropped, expected)
-        assert_frame_equal(inp, expected)
+        tm.assert_frame_equal(dropped, expected)
+        tm.assert_frame_equal(inp, expected)
 
         dropped = df.dropna(axis=1, thresh=4)
-        assert_frame_equal(dropped, df)
+        tm.assert_frame_equal(dropped, df)
 
         dropped = df.dropna(axis=1, thresh=3)
-        assert_frame_equal(dropped, df)
+        tm.assert_frame_equal(dropped, df)
 
         # subset
         dropped = df.dropna(axis=0, subset=[0, 1, 3])
         inp = df.copy()
         inp.dropna(axis=0, subset=[0, 1, 3], inplace=True)
-        assert_frame_equal(dropped, df)
-        assert_frame_equal(inp, df)
+        tm.assert_frame_equal(dropped, df)
+        tm.assert_frame_equal(inp, df)
 
         # all
         dropped = df.dropna(axis=1, how="all")
-        assert_frame_equal(dropped, df)
+        tm.assert_frame_equal(dropped, df)
 
         df[2] = np.nan
         dropped = df.dropna(axis=1, how="all")
         expected = df.loc[:, [0, 1, 3]]
-        assert_frame_equal(dropped, expected)
+        tm.assert_frame_equal(dropped, expected)
 
         # bad input
         msg = "No axis named 3 for object type <class 'pandas.core.frame.DataFrame'>"
@@ -137,13 +136,13 @@ class TestDataFrameMissingData:
         df = pd.DataFrame({"A": original.values.copy()})
         df2 = df.copy()
         df["A"].dropna()
-        assert_series_equal(df["A"], original)
+        tm.assert_series_equal(df["A"], original)
         df["A"].dropna(inplace=True)
-        assert_series_equal(df["A"], expected)
+        tm.assert_series_equal(df["A"], expected)
         df2["A"].drop([1])
-        assert_series_equal(df2["A"], original)
+        tm.assert_series_equal(df2["A"], original)
         df2["A"].drop([1], inplace=True)
-        assert_series_equal(df2["A"], original.drop([1]))
+        tm.assert_series_equal(df2["A"], original.drop([1]))
 
     def test_dropna_corner(self, float_frame):
         # bad input
@@ -175,14 +174,14 @@ class TestDataFrameMissingData:
             result2 = df.dropna(how="all", axis=(0, 1))
         expected = df.dropna(how="all").dropna(how="all", axis=1)
 
-        assert_frame_equal(result, expected)
-        assert_frame_equal(result2, expected)
-        assert_frame_equal(df, cp)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result2, expected)
+        tm.assert_frame_equal(df, cp)
 
         inp = df.copy()
         with tm.assert_produces_warning(FutureWarning):
             inp.dropna(how="all", axis=(0, 1), inplace=True)
-        assert_frame_equal(inp, expected)
+        tm.assert_frame_equal(inp, expected)
 
     def test_dropna_tz_aware_datetime(self):
         # GH13407
@@ -192,13 +191,13 @@ class TestDataFrameMissingData:
         df["Time"] = [dt1]
         result = df.dropna(axis=0)
         expected = DataFrame({"Time": [dt1]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Ex2
         df = DataFrame({"Time": [dt1, None, np.nan, dt2]})
         result = df.dropna(axis=0)
         expected = DataFrame([dt1, dt2], columns=["Time"], index=[0, 3])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_dropna_categorical_interval_index(self):
         # GH 25087
@@ -268,10 +267,10 @@ class TestDataFrameMissingData:
         expected = DataFrame(
             [["a", "a", "foo", "a"], ["b", "b", "foo", "b"], ["c", "c", "foo", "c"]]
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df.fillna({2: "foo"}, inplace=True)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_fillna_limit_and_value(self):
         # limit and value
@@ -283,7 +282,7 @@ class TestDataFrameMissingData:
         expected.iloc[2, 0] = 999
         expected.iloc[3, 2] = 999
         result = df.fillna(999, limit=1)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_fillna_datelike(self):
         # with datelike
@@ -298,7 +297,7 @@ class TestDataFrameMissingData:
         expected = df.copy()
         expected["Date"] = expected["Date"].fillna(df.loc[df.index[0], "Date2"])
         result = df.fillna(value={"Date": df["Date2"]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_fillna_tzaware(self):
         # with timezone
@@ -312,7 +311,7 @@ class TestDataFrameMissingData:
                 ]
             }
         )
-        assert_frame_equal(df.fillna(method="pad"), exp)
+        tm.assert_frame_equal(df.fillna(method="pad"), exp)
 
         df = pd.DataFrame({"A": [pd.NaT, pd.Timestamp("2012-11-11 00:00:00+01:00")]})
         exp = pd.DataFrame(
@@ -323,7 +322,7 @@ class TestDataFrameMissingData:
                 ]
             }
         )
-        assert_frame_equal(df.fillna(method="bfill"), exp)
+        tm.assert_frame_equal(df.fillna(method="bfill"), exp)
 
     def test_fillna_tzaware_different_column(self):
         # with timezone in another column
@@ -341,7 +340,7 @@ class TestDataFrameMissingData:
                 "B": [1.0, 2.0, 2.0, 2.0],
             }
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_na_actions_categorical(self):
 
@@ -425,37 +424,37 @@ class TestDataFrameMissingData:
         df = pd.DataFrame({"a": [1.0, np.nan]})
         result = df.fillna(0, downcast="infer")
         expected = pd.DataFrame({"a": [1, 0]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # infer int64 from float64 when fillna value is a dict
         df = pd.DataFrame({"a": [1.0, np.nan]})
         result = df.fillna({"a": 0}, downcast="infer")
         expected = pd.DataFrame({"a": [1, 0]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_fillna_dtype_conversion(self):
         # make sure that fillna on an empty frame works
         df = DataFrame(index=["A", "B", "C"], columns=[1, 2, 3, 4, 5])
         result = df.dtypes
         expected = Series([np.dtype("object")] * 5, index=[1, 2, 3, 4, 5])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.fillna(1)
         expected = DataFrame(1, index=["A", "B", "C"], columns=[1, 2, 3, 4, 5])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # empty block
         df = DataFrame(index=range(3), columns=["A", "B"], dtype="float64")
         result = df.fillna("nan")
         expected = DataFrame("nan", index=range(3), columns=["A", "B"])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # equiv of replace
         df = DataFrame(dict(A=[1, np.nan], B=[1.0, 2.0]))
         for v in ["", 1, np.nan, 1.0]:
             expected = df.replace(np.nan, v)
             result = df.fillna(v)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_fillna_datetime_columns(self):
         # GH 7095
@@ -505,7 +504,7 @@ class TestDataFrameMissingData:
         datetime_frame["A"][:5] = np.nan
         datetime_frame["A"][-5:] = np.nan
 
-        assert_frame_equal(
+        tm.assert_frame_equal(
             datetime_frame.ffill(), datetime_frame.fillna(method="ffill")
         )
 
@@ -513,7 +512,7 @@ class TestDataFrameMissingData:
         datetime_frame["A"][:5] = np.nan
         datetime_frame["A"][-5:] = np.nan
 
-        assert_frame_equal(
+        tm.assert_frame_equal(
             datetime_frame.bfill(), datetime_frame.fillna(method="bfill")
         )
 
@@ -611,7 +610,7 @@ class TestDataFrameMissingData:
         expected = df.copy()
         expected["a"] = expected["a"].fillna(0)
         expected["b"] = expected["b"].fillna(5)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # it works
         result = df.fillna({"a": 0, "b": 5, "d": 7})
@@ -619,7 +618,7 @@ class TestDataFrameMissingData:
         # Series treated same as dict
         result = df.fillna(df.max())
         expected = df.fillna(df.max().to_dict())
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # disable this for now
         with pytest.raises(NotImplementedError, match="column by column"):
@@ -658,7 +657,7 @@ class TestDataFrameMissingData:
             index=list("VWXYZ"),
         )
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_fillna_columns(self):
         df = DataFrame(np.random.randn(10, 10))
@@ -666,12 +665,12 @@ class TestDataFrameMissingData:
 
         result = df.fillna(method="ffill", axis=1)
         expected = df.T.fillna(method="pad").T
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df.insert(6, "foo", 5)
         result = df.fillna(method="ffill", axis=1)
         expected = df.astype(float).fillna(method="ffill", axis=1)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_fillna_invalid_method(self, float_frame):
         with pytest.raises(ValueError, match="ffil"):
@@ -721,7 +720,7 @@ class TestDataFrameMissingData:
 
         exp = df.fillna(0).add(2)
         res = df.add(2, fill_value=0)
-        assert_frame_equal(res, exp)
+        tm.assert_frame_equal(res, exp)
 
 
 class TestDataFrameInterpolate:
@@ -743,13 +742,13 @@ class TestDataFrameInterpolate:
             }
         )
         result = df.interpolate()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.set_index("C").interpolate()
         expected = df.set_index("C")
         expected.loc[3, "A"] = 3
         expected.loc[5, "B"] = 9
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_interp_bad_method(self):
         df = DataFrame(
@@ -775,11 +774,11 @@ class TestDataFrameInterpolate:
 
         result = df["A"].interpolate()
         expected = Series([1.0, 2.0, 3.0, 4.0], name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df["A"].interpolate(downcast="infer")
         expected = Series([1, 2, 3, 4], name="A")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_interp_nan_idx(self):
         df = DataFrame({"A": [1, 2, np.nan, 4], "B": [np.nan, 2, 3, 4]})
@@ -798,33 +797,33 @@ class TestDataFrameInterpolate:
 
         expected.A.loc[3] = 2.66666667
         expected.A.loc[13] = 5.76923076
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="cubic")
         # GH #15662.
         expected.A.loc[3] = 2.81547781
         expected.A.loc[13] = 5.52964175
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="nearest")
         expected.A.loc[3] = 2
         expected.A.loc[13] = 5
-        assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
         result = df.interpolate(method="quadratic")
         expected.A.loc[3] = 2.82150771
         expected.A.loc[13] = 6.12648668
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="slinear")
         expected.A.loc[3] = 2.66666667
         expected.A.loc[13] = 5.76923077
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="zero")
         expected.A.loc[3] = 2.0
         expected.A.loc[13] = 5
-        assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
     @td.skip_if_no_scipy
     def test_interp_alt_scipy(self):
@@ -835,15 +834,15 @@ class TestDataFrameInterpolate:
         expected = df.copy()
         expected.loc[2, "A"] = 3
         expected.loc[5, "A"] = 6
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(method="barycentric", downcast="infer")
-        assert_frame_equal(result, expected.astype(np.int64))
+        tm.assert_frame_equal(result, expected.astype(np.int64))
 
         result = df.interpolate(method="krogh")
         expectedk = df.copy()
         expectedk["A"] = expected["A"]
-        assert_frame_equal(result, expectedk)
+        tm.assert_frame_equal(result, expectedk)
 
         _skip_if_no_pchip()
 
@@ -851,7 +850,7 @@ class TestDataFrameInterpolate:
         expected.loc[2, "A"] = 3
         expected.loc[5, "A"] = 6.0
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_interp_rowwise(self):
         df = DataFrame(
@@ -869,14 +868,14 @@ class TestDataFrameInterpolate:
         expected.loc[0, 2] = 3
         expected.loc[1, 3] = 3
         expected[4] = expected[4].astype(np.float64)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(axis=1, method="values")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.interpolate(axis=0)
         expected = df.interpolate()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "axis_name, axis_number",
@@ -893,7 +892,7 @@ class TestDataFrameInterpolate:
         df = DataFrame(data, dtype=np.float64)
         result = df.interpolate(axis=axis_name, method="linear")
         expected = df.interpolate(axis=axis_number, method="linear")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_rowwise_alt(self):
         df = DataFrame(
@@ -914,11 +913,11 @@ class TestDataFrameInterpolate:
         result = df.interpolate()
         expected = df.copy()
         expected["B"].loc[3] = -3.75
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         if check_scipy:
             result = df.interpolate(method="polynomial", order=1)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_interp_raise_on_only_mixed(self):
         df = DataFrame(
@@ -949,11 +948,11 @@ class TestDataFrameInterpolate:
         expected = DataFrame({"a": [1.0, 2.0, 3.0, 4.0]})
         result = df.copy()
         result["a"].interpolate(inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.copy()
         result["a"].interpolate(inplace=True, downcast="infer")
-        assert_frame_equal(result, expected.astype("int64"))
+        tm.assert_frame_equal(result, expected.astype("int64"))
 
     def test_interp_inplace_row(self):
         # GH 10395
@@ -962,7 +961,7 @@ class TestDataFrameInterpolate:
         )
         expected = result.interpolate(method="linear", axis=1, inplace=False)
         result.interpolate(method="linear", axis=1, inplace=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_interp_ignore_all_good(self):
         # GH
@@ -984,8 +983,8 @@ class TestDataFrameInterpolate:
         )
 
         result = df.interpolate(downcast=None)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # all good
         result = df[["B", "D"]].interpolate(downcast=None)
-        assert_frame_equal(result, df[["B", "D"]])
+        tm.assert_frame_equal(result, df[["B", "D"]])

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -7,7 +7,6 @@ from pandas.compat import PY36
 
 from pandas import DataFrame, Index, MultiIndex, Series
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal
 
 # Column add, remove, delete.
 
@@ -19,34 +18,34 @@ class TestDataFrameMutateColumns:
         result = df.assign(C=df.B / df.A)
         expected = df.copy()
         expected["C"] = [4, 2.5, 2]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # lambda syntax
         result = df.assign(C=lambda x: x.B / x.A)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # original is unmodified
-        assert_frame_equal(df, original)
+        tm.assert_frame_equal(df, original)
 
         # Non-Series array-like
         result = df.assign(C=[4, 2.5, 2])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         # original is unmodified
-        assert_frame_equal(df, original)
+        tm.assert_frame_equal(df, original)
 
         result = df.assign(B=df.B / df.A)
         expected = expected.drop("B", axis=1).rename(columns={"C": "B"})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # overwrite
         result = df.assign(A=df.A + df.B)
         expected = df.copy()
         expected["A"] = [5, 7, 9]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # lambda
         result = df.assign(A=lambda x: x.A + x.B)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_assign_multiple(self):
         df = DataFrame([[1, 4], [2, 5], [3, 6]], columns=["A", "B"])
@@ -54,7 +53,7 @@ class TestDataFrameMutateColumns:
         expected = DataFrame(
             [[1, 4, 7, 1, 4], [2, 5, 8, 2, 5], [3, 6, 9, 3, 6]], columns=list("ABCDE")
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_assign_order(self):
         # GH 9818
@@ -65,12 +64,12 @@ class TestDataFrameMutateColumns:
             expected = DataFrame([[1, 2, 3, -1], [3, 4, 7, -1]], columns=list("ABDC"))
         else:
             expected = DataFrame([[1, 2, -1, 3], [3, 4, -1, 7]], columns=list("ABCD"))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.assign(C=df.A - df.B, D=df.A + df.B)
 
         expected = DataFrame([[1, 2, -1, 3], [3, 4, -1, 7]], columns=list("ABCD"))
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_assign_bad(self):
         df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
@@ -105,11 +104,11 @@ class TestDataFrameMutateColumns:
 
         result = df.assign(C=df.A, D=lambda x: x["A"] + x["C"])
         expected = DataFrame([[1, 3, 1, 2], [2, 4, 2, 4]], columns=list("ABCD"))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.assign(C=lambda df: df.A, D=lambda df: df["A"] + df["C"])
         expected = DataFrame([[1, 3, 1, 2], [2, 4, 2, 4]], columns=list("ABCD"))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_insert_error_msmgs(self):
 
@@ -140,7 +139,7 @@ class TestDataFrameMutateColumns:
         for i in range(K):
             df[i] = new_col
         expected = DataFrame(np.repeat(new_col, K).reshape(N, K), index=range(N))
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_insert(self):
         df = DataFrame(
@@ -199,7 +198,7 @@ class TestDataFrameMutateColumns:
         df["X"] = df.index
         df["X"] = ["x", "y", "z"]
         exp = DataFrame(data={"X": ["x", "y", "z"]}, index=["A", "B", "C"])
-        assert_frame_equal(df, exp)
+        tm.assert_frame_equal(df, exp)
 
     def test_delitem(self, float_frame):
         del float_frame["A"]
@@ -277,11 +276,11 @@ class TestDataFrameMutateColumns:
         result = df.rename(columns={})
         str(result)
         expected = DataFrame([[1, 1.1], [2, 2.2]], columns=["a", "b"])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         df.insert(0, "c", [1.3, 2.3])
 
         result = df.rename(columns={})
         str(result)
 
         expected = DataFrame([[1.3, 1, 1.1], [2.3, 2, 2.2]], columns=["c", "a", "b"])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -4,14 +4,13 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, date_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 class TestDataFrameNonuniqueIndexes:
     def test_column_dups_operations(self):
         def check(result, expected=None):
             if expected is not None:
-                assert_frame_equal(result, expected)
+                tm.assert_frame_equal(result, expected)
             result.dtypes
             str(result)
 
@@ -116,7 +115,7 @@ class TestDataFrameNonuniqueIndexes:
             [[4.0, 5.0, "bah", 3], [4.0, 5.0, "bah", 3], [4.0, 5.0, "bah", 3]],
             columns=["new_col", "new_col", "string", "foo2"],
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # dup across dtypes
         df = DataFrame(
@@ -198,7 +197,7 @@ class TestDataFrameNonuniqueIndexes:
                 "QT_Close",
             ],
         ).set_index(["STK_ID", "RPT_Date"], drop=False)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # reindex is invalid!
         df = DataFrame(
@@ -286,7 +285,7 @@ class TestDataFrameNonuniqueIndexes:
         expected = df.take([0, 1, 1], axis=1)
         df2 = df.take([2, 0, 1, 2, 1], axis=1)
         result = df2.drop("C", axis=1)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # dropna
         df = DataFrame(
@@ -307,12 +306,12 @@ class TestDataFrameNonuniqueIndexes:
         df.columns = ["A", "A", "B", "C"]
 
         result = df.dropna(subset=["A", "C"], how="all")
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_column_dups_indexing(self):
         def check(result, expected=None):
             if expected is not None:
-                assert_frame_equal(result, expected)
+                tm.assert_frame_equal(result, expected)
             result.dtypes
             str(result)
 
@@ -350,7 +349,7 @@ class TestDataFrameNonuniqueIndexes:
         df2 = DataFrame([1, 2, 3], index=[1, 2, 3])
         expected = DataFrame([0, 2, 0, 2, 2], index=[1, 1, 2, 2, 3])
         result = df1.sub(df2)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # equality
         df1 = DataFrame([[1, 2], [2, np.nan], [3, 4], [4, 4]], columns=["A", "B"])
@@ -367,7 +366,7 @@ class TestDataFrameNonuniqueIndexes:
             [[False, True], [True, False], [False, False], [True, False]],
             columns=["A", "A"],
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # mixed column selection
         # GH 5639
@@ -411,7 +410,7 @@ class TestDataFrameNonuniqueIndexes:
         )
         result = df.B - df.A
         expected = Series(1, index=[2, 2, 3, 3, 4])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame(
             {
@@ -422,7 +421,7 @@ class TestDataFrameNonuniqueIndexes:
         )
         result = df.B - df.A
         expected = Series(pd.Timedelta("9 hours"), index=[2, 2, 3, 3, 4])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_columns_with_dups(self):
         # GH 3468 related
@@ -432,20 +431,20 @@ class TestDataFrameNonuniqueIndexes:
         df.columns = ["a", "a.1"]
         str(df)
         expected = DataFrame([[1, 2]], columns=["a", "a.1"])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         df = DataFrame([[1, 2, 3]], columns=["b", "a", "a"])
         df.columns = ["b", "a", "a.1"]
         str(df)
         expected = DataFrame([[1, 2, 3]], columns=["b", "a", "a.1"])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # with a dup index
         df = DataFrame([[1, 2]], columns=["a", "a"])
         df.columns = ["b", "b"]
         str(df)
         expected = DataFrame([[1, 2]], columns=["b", "b"])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # multi-dtype
         df = DataFrame(
@@ -457,13 +456,13 @@ class TestDataFrameNonuniqueIndexes:
         expected = DataFrame(
             [[1, 2, 1.0, 2.0, 3.0, "foo", "bar"]], columns=list("ABCDEFG")
         )
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         df = DataFrame([[1, 2, "foo", "bar"]], columns=["a", "a", "a", "a"])
         df.columns = ["a", "a.1", "a.2", "a.3"]
         str(df)
         expected = DataFrame([[1, 2, "foo", "bar"]], columns=["a", "a.1", "a.2", "a.3"])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # dups across blocks
         df_float = DataFrame(np.random.randn(10, 3), dtype="float64")
@@ -487,7 +486,7 @@ class TestDataFrameNonuniqueIndexes:
         rs = DataFrame(vals, columns=["A", "A", "B"])
         xp = DataFrame(vals)
         xp.columns = ["A", "A", "B"]
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
     def test_values_duplicates(self):
         df = DataFrame(
@@ -506,14 +505,14 @@ class TestDataFrameNonuniqueIndexes:
         expected = df.iloc[:, 2]
 
         df.iloc[:, 0] = 3
-        assert_series_equal(df.iloc[:, 2], expected)
+        tm.assert_series_equal(df.iloc[:, 2], expected)
 
         df = DataFrame(np.arange(9).reshape(3, 3).T)
         df.columns = [2, float(2), str(2)]
         expected = df.iloc[:, 1]
 
         df.iloc[:, 0] = 3
-        assert_series_equal(df.iloc[:, 1], expected)
+        tm.assert_series_equal(df.iloc[:, 1], expected)
 
     def test_insert_with_columns_dups(self):
         # GH 14291
@@ -524,4 +523,4 @@ class TestDataFrameNonuniqueIndexes:
         exp = pd.DataFrame(
             [["a", "d", "g"], ["b", "e", "h"], ["c", "f", "i"]], columns=["A", "A", "A"]
         )
-        assert_frame_equal(df, exp)
+        tm.assert_frame_equal(df, exp)

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -9,11 +9,6 @@ from pandas import DataFrame, MultiIndex, Series
 import pandas.core.common as com
 from pandas.tests.frame.common import _check_mixed_float
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_frame_equal,
-    assert_numpy_array_equal,
-    assert_series_equal,
-)
 
 
 class TestDataFrameUnaryOperators:
@@ -31,8 +26,8 @@ class TestDataFrameUnaryOperators:
         ],
     )
     def test_neg_numeric(self, df, expected):
-        assert_frame_equal(-df, expected)
-        assert_series_equal(-df["a"], expected["a"])
+        tm.assert_frame_equal(-df, expected)
+        tm.assert_series_equal(-df["a"], expected["a"])
 
     @pytest.mark.parametrize(
         "df, expected",
@@ -45,8 +40,8 @@ class TestDataFrameUnaryOperators:
         # GH#21380
         df = pd.DataFrame({"a": df})
         expected = pd.DataFrame({"a": expected})
-        assert_frame_equal(-df, expected)
-        assert_series_equal(-df["a"], expected["a"])
+        tm.assert_frame_equal(-df, expected)
+        tm.assert_series_equal(-df["a"], expected["a"])
 
     @pytest.mark.parametrize(
         "df",
@@ -64,7 +59,7 @@ class TestDataFrameUnaryOperators:
     def test_invert(self, float_frame):
         df = float_frame
 
-        assert_frame_equal(-(df < 0), ~(df < 0))
+        tm.assert_frame_equal(-(df < 0), ~(df < 0))
 
     @pytest.mark.parametrize(
         "df",
@@ -76,8 +71,8 @@ class TestDataFrameUnaryOperators:
     )
     def test_pos_numeric(self, df):
         # GH#16073
-        assert_frame_equal(+df, df)
-        assert_series_equal(+df["a"], df["a"])
+        tm.assert_frame_equal(+df, df)
+        tm.assert_series_equal(+df["a"], df["a"])
 
     @pytest.mark.parametrize(
         "df",
@@ -93,8 +88,8 @@ class TestDataFrameUnaryOperators:
     )
     def test_pos_object(self, df):
         # GH#21380
-        assert_frame_equal(+df, df)
-        assert_series_equal(+df["a"], df["a"])
+        tm.assert_frame_equal(+df, df)
+        tm.assert_series_equal(+df["a"], df["a"])
 
     @pytest.mark.parametrize(
         "df", [pd.DataFrame({"a": pd.to_datetime(["2017-01-22", "1970-01-01"])})]
@@ -115,30 +110,30 @@ class TestDataFrameLogicalOperators:
         df = DataFrame(index=[1])
 
         result = df & df
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         result = df | df
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         df2 = DataFrame(index=[1, 2])
         result = df & df2
-        assert_frame_equal(result, df2)
+        tm.assert_frame_equal(result, df2)
 
         dfa = DataFrame(index=[1], columns=["A"])
 
         result = dfa & dfa
         expected = DataFrame(False, index=[1], columns=["A"])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_logical_ops_bool_frame(self):
         # GH#5808
         df1a_bool = DataFrame(True, index=[1], columns=["A"])
 
         result = df1a_bool & df1a_bool
-        assert_frame_equal(result, df1a_bool)
+        tm.assert_frame_equal(result, df1a_bool)
 
         result = df1a_bool | df1a_bool
-        assert_frame_equal(result, df1a_bool)
+        tm.assert_frame_equal(result, df1a_bool)
 
     def test_logical_ops_int_frame(self):
         # GH#5808
@@ -146,11 +141,11 @@ class TestDataFrameLogicalOperators:
         df1a_bool = DataFrame(True, index=[1], columns=["A"])
 
         result = df1a_int | df1a_bool
-        assert_frame_equal(result, df1a_bool)
+        tm.assert_frame_equal(result, df1a_bool)
 
         # Check that this matches Series behavior
         res_ser = df1a_int["A"] | df1a_bool["A"]
-        assert_series_equal(res_ser, df1a_bool["A"])
+        tm.assert_series_equal(res_ser, df1a_bool["A"])
 
     def test_logical_ops_invalid(self):
         # GH#5808
@@ -172,13 +167,13 @@ class TestDataFrameLogicalOperators:
                 op(df1.values, df2.values), index=df1.index, columns=df1.columns
             )
             assert result.values.dtype == np.bool_
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         def _check_unary_op(op):
             result = op(df1)
             expected = DataFrame(op(df1.values), index=df1.index, columns=df1.columns)
             assert result.values.dtype == np.bool_
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         df1 = {
             "a": {"a": True, "b": False, "c": False, "d": True, "e": True},
@@ -212,16 +207,16 @@ class TestDataFrameLogicalOperators:
         # bool comparisons should return bool
         result = d["a"] | d["b"]
         expected = Series([False, True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH4604, automatic casting here
         result = d["a"].fillna(False) | d["b"]
         expected = Series([True, True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = d["a"].fillna(False, downcast=False) | d["b"]
         expected = Series([True, True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
 
 class TestDataFrameOperators:
@@ -239,18 +234,18 @@ class TestDataFrameOperators:
         result = op(df, 3)
         expected = op(filled, 3).astype(object)
         expected[com.isna(expected)] = None
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = op(df, df)
         expected = op(filled, filled).astype(object)
         expected[com.isna(expected)] = None
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = op(df, df.fillna(7))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = op(df.fillna(7), df)
-        assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
     @pytest.mark.parametrize("op,res", [("__eq__", False), ("__ne__", True)])
     # TODO: not sure what's correct here.
@@ -288,7 +283,7 @@ class TestDataFrameOperators:
             expected = pd.concat(
                 [opa(df.loc[idx[:, :, i], :], v) for i, v in x.items()]
             ).sort_index()
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             x = Series([1.0, 10.0], ["two", "three"])
             result = getattr(df, op)(x, level="second", axis=0)
@@ -298,7 +293,7 @@ class TestDataFrameOperators:
                 .reindex_like(df)
                 .sort_index()
             )
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         # GH9463 (alignment level of dataframe with series)
 
@@ -324,11 +319,11 @@ class TestDataFrameOperators:
         )
 
         for res in [res1, res2]:
-            assert_frame_equal(res, exp)
+            tm.assert_frame_equal(res, exp)
 
         exp.columns.names = ["lvl0", "lvl1"]
         for res in [res3, res4, res5, res6]:
-            assert_frame_equal(res, exp)
+            tm.assert_frame_equal(res, exp)
 
     def test_dti_tz_convert_to_utc(self):
         base = pd.DatetimeIndex(["2011-01-01", "2011-01-02", "2011-01-03"], tz="UTC")
@@ -338,7 +333,7 @@ class TestDataFrameOperators:
         df1 = DataFrame({"A": [1, 2]}, index=idx1)
         df2 = DataFrame({"A": [1, 1]}, index=idx2)
         exp = DataFrame({"A": [np.nan, 3, np.nan]}, index=base)
-        assert_frame_equal(df1 + df2, exp)
+        tm.assert_frame_equal(df1 + df2, exp)
 
     def test_combineFrame(self, float_frame, mixed_float_frame, mixed_int_frame):
         frame_copy = float_frame.reindex(float_frame.index[::2])
@@ -384,7 +379,7 @@ class TestDataFrameOperators:
         # out of order
         reverse = float_frame.reindex(columns=float_frame.columns[::-1])
 
-        assert_frame_equal(reverse + float_frame, float_frame * 2)
+        tm.assert_frame_equal(reverse + float_frame, float_frame * 2)
 
         # mix vs float64, upcast
         added = float_frame + mixed_float_frame
@@ -410,7 +405,7 @@ class TestDataFrameOperators:
         added = float_frame + series
 
         for key, s in added.items():
-            assert_series_equal(s, float_frame[key] + series[key])
+            tm.assert_series_equal(s, float_frame[key] + series[key])
 
         larger_series = series.to_dict()
         larger_series["E"] = 1
@@ -418,7 +413,7 @@ class TestDataFrameOperators:
         larger_added = float_frame + larger_series
 
         for key, s in float_frame.items():
-            assert_series_equal(larger_added[key], s + series[key])
+            tm.assert_series_equal(larger_added[key], s + series[key])
         assert "E" in larger_added
         assert np.isnan(larger_added["E"]).all()
 
@@ -453,7 +448,7 @@ class TestDataFrameOperators:
 
         for key, col in datetime_frame.items():
             result = col + ts
-            assert_series_equal(added[key], result, check_names=False)
+            tm.assert_series_equal(added[key], result, check_names=False)
             assert added[key].name == key
             if col.name == ts.name:
                 assert result.name == "A"
@@ -467,21 +462,21 @@ class TestDataFrameOperators:
 
         smaller_ts = ts[:-5]
         smaller_added2 = datetime_frame.add(smaller_ts, axis="index")
-        assert_frame_equal(smaller_added, smaller_added2)
+        tm.assert_frame_equal(smaller_added, smaller_added2)
 
         # length 0, result is all-nan
         result = datetime_frame.add(ts[:0], axis="index")
         expected = DataFrame(
             np.nan, index=datetime_frame.index, columns=datetime_frame.columns
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Frame is all-nan
         result = datetime_frame[:0].add(ts, axis="index")
         expected = DataFrame(
             np.nan, index=datetime_frame.index, columns=datetime_frame.columns
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # empty but with non-empty index
         frame = datetime_frame[:1].reindex(columns=[])
@@ -558,10 +553,10 @@ class TestDataFrameOperators:
         # gt
         expected = DataFrame([[False, False], [False, True], [True, True]])
         result = df > b
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.values > b
-        assert_numpy_array_equal(result, expected.values)
+        tm.assert_numpy_array_equal(result, expected.values)
 
         msg1d = "Unable to coerce to Series, length must be 2: given 3"
         msg2d = "Unable to coerce to DataFrame, shape must be"
@@ -576,10 +571,10 @@ class TestDataFrameOperators:
 
         # broadcasts like ndarray (GH#23000)
         result = df > b_r
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.values > b_r
-        assert_numpy_array_equal(result, expected.values)
+        tm.assert_numpy_array_equal(result, expected.values)
 
         with pytest.raises(ValueError, match=msg2d):
             df > b_c
@@ -590,7 +585,7 @@ class TestDataFrameOperators:
         # ==
         expected = DataFrame([[False, False], [True, False], [False, False]])
         result = df == b
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         with pytest.raises(ValueError, match=msg1d):
             result = df == lst
@@ -600,10 +595,10 @@ class TestDataFrameOperators:
 
         # broadcasts like ndarray (GH#23000)
         result = df == b_r
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.values == b_r
-        assert_numpy_array_equal(result, expected.values)
+        tm.assert_numpy_array_equal(result, expected.values)
 
         with pytest.raises(ValueError, match=msg2d):
             df == b_c
@@ -639,8 +634,8 @@ class TestDataFrameOperators:
             float_frame.loc[float_frame.index[:-5], ["A", "B", "C"]].reindex_like(chunk)
             * 2
         )
-        assert_frame_equal(chunk, exp)
-        assert_frame_equal(chunk2, exp)
+        tm.assert_frame_equal(chunk, exp)
+        tm.assert_frame_equal(chunk2, exp)
 
     def test_inplace_ops_alignment(self):
 
@@ -670,9 +665,9 @@ class TestDataFrameOperators:
         X[block1] += Z[block1]
         result4 = X.reindex(columns=subs)
 
-        assert_frame_equal(result1, result2)
-        assert_frame_equal(result1, result3)
-        assert_frame_equal(result1, result4)
+        tm.assert_frame_equal(result1, result2)
+        tm.assert_frame_equal(result1, result3)
+        tm.assert_frame_equal(result1, result4)
 
         # sub
         X = X_orig.copy()
@@ -687,9 +682,9 @@ class TestDataFrameOperators:
         X[block1] -= Z[block1]
         result4 = X.reindex(columns=subs)
 
-        assert_frame_equal(result1, result2)
-        assert_frame_equal(result1, result3)
-        assert_frame_equal(result1, result4)
+        tm.assert_frame_equal(result1, result2)
+        tm.assert_frame_equal(result1, result3)
+        tm.assert_frame_equal(result1, result4)
 
     def test_inplace_ops_identity(self):
 
@@ -702,16 +697,16 @@ class TestDataFrameOperators:
         s = s_orig.copy()
         s2 = s
         s += 1
-        assert_series_equal(s, s2)
-        assert_series_equal(s_orig + 1, s)
+        tm.assert_series_equal(s, s2)
+        tm.assert_series_equal(s_orig + 1, s)
         assert s is s2
         assert s._data is s2._data
 
         df = df_orig.copy()
         df2 = df
         df += 1
-        assert_frame_equal(df, df2)
-        assert_frame_equal(df_orig + 1, df)
+        tm.assert_frame_equal(df, df2)
+        tm.assert_frame_equal(df_orig + 1, df)
         assert df is df2
         assert df._data is df2._data
 
@@ -719,14 +714,14 @@ class TestDataFrameOperators:
         s = s_orig.copy()
         s2 = s
         s += 1.5
-        assert_series_equal(s, s2)
-        assert_series_equal(s_orig + 1.5, s)
+        tm.assert_series_equal(s, s2)
+        tm.assert_series_equal(s_orig + 1.5, s)
 
         df = df_orig.copy()
         df2 = df
         df += 1.5
-        assert_frame_equal(df, df2)
-        assert_frame_equal(df_orig + 1.5, df)
+        tm.assert_frame_equal(df, df2)
+        tm.assert_frame_equal(df_orig + 1.5, df)
         assert df is df2
         assert df._data is df2._data
 
@@ -737,16 +732,16 @@ class TestDataFrameOperators:
         df2 = df
         df["A"] += 1
         expected = DataFrame({"A": arr.copy() + 1, "B": "foo"})
-        assert_frame_equal(df, expected)
-        assert_frame_equal(df2, expected)
+        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df2, expected)
         assert df._data is df2._data
 
         df = df_orig.copy()
         df2 = df
         df["A"] += 1.5
         expected = DataFrame({"A": arr.copy() + 1.5, "B": "foo"})
-        assert_frame_equal(df, expected)
-        assert_frame_equal(df2, expected)
+        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df2, expected)
         assert df._data is df2._data
 
     @pytest.mark.parametrize(
@@ -784,7 +779,7 @@ class TestDataFrameOperators:
         # no id change and value is correct
         getattr(df, iop)(operand)
         expected = getattr(df_copy, op)(operand)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
         expected = id(df)
         assert id(df) == expected
 

--- a/pandas/tests/frame/test_quantile.py
+++ b/pandas/tests/frame/test_quantile.py
@@ -4,7 +4,6 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Series, Timestamp
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 
 class TestDataFrameQuantile:
@@ -28,19 +27,19 @@ class TestDataFrameQuantile:
         df = DataFrame({"col1": ["A", "A", "B", "B"], "col2": [1, 2, 3, 4]})
         rs = df.quantile(0.5)
         xp = df.median().rename(0.5)
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
         # axis
         df = DataFrame({"A": [1, 2, 3], "B": [2, 3, 4]}, index=[1, 2, 3])
         result = df.quantile(0.5, axis=1)
         expected = Series([1.5, 2.5, 3.5], index=[1, 2, 3], name=0.5)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.quantile([0.5, 0.75], axis=1)
         expected = DataFrame(
             {1: [1.5, 1.75], 2: [2.5, 2.75], 3: [3.5, 3.75]}, index=[0.5, 0.75]
         )
-        assert_frame_equal(result, expected, check_index_type=True)
+        tm.assert_frame_equal(result, expected, check_index_type=True)
 
         # We may want to break API in the future to change this
         # so that we exclude non-numeric along the same axis
@@ -48,7 +47,7 @@ class TestDataFrameQuantile:
         df = DataFrame([[1, 2, 3], ["a", "b", 4]])
         result = df.quantile(0.5, axis=1)
         expected = Series([3.0, 4.0], index=[0, 1], name=0.5)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_quantile_axis_mixed(self):
 
@@ -63,7 +62,7 @@ class TestDataFrameQuantile:
         )
         result = df.quantile(0.5, axis=1)
         expected = Series([1.5, 2.5, 3.5], name=0.5)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # must raise
         with pytest.raises(TypeError):
@@ -77,18 +76,18 @@ class TestDataFrameQuantile:
         result = df.quantile(0.5, axis=0)
 
         expected = Series([2.0, 3.0], index=["A", "B"], name=0.5)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         expected = df.quantile(0.5, axis="index")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.quantile(0.5, axis=1)
 
         expected = Series([1.5, 2.5, 3.5], index=[1, 2, 3], name=0.5)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df.quantile(0.5, axis="columns")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         msg = "No axis named -1 for object type <class 'pandas.core.frame.DataFrame'>"
         with pytest.raises(ValueError, match=msg):
@@ -128,14 +127,14 @@ class TestDataFrameQuantile:
             interpolation="nearest",
         )
         expected = Series(exp, index=[1, 2, 3], name=0.5, dtype="float64")
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # axis
         result = df.quantile([0.5, 0.75], axis=1, interpolation="lower")
         expected = DataFrame(
             {1: [1.0, 1.0], 2: [2.0, 2.0], 3: [3.0, 3.0]}, index=[0.5, 0.75]
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # test degenerate case
         df = DataFrame({"x": [], "y": []})
@@ -152,7 +151,7 @@ class TestDataFrameQuantile:
             index=[0.25, 0.5],
             columns=["a", "b", "c"],
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_quantile_interpolation_datetime(self, datetime_frame):
         # see gh-10174
@@ -183,7 +182,7 @@ class TestDataFrameQuantile:
             index=[0.25, 0.5],
             columns=["a", "b", "c"],
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # axis = 1
         result = df.quantile([0.25, 0.5], axis=1)
@@ -196,7 +195,7 @@ class TestDataFrameQuantile:
         expected = DataFrame(
             {"x": [np.nan, np.nan], "y": [np.nan, np.nan]}, index=[0.1, 0.9]
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_quantile_datetime(self):
         df = DataFrame({"a": pd.to_datetime(["2010", "2011"]), "b": [0, 5]})
@@ -210,14 +209,14 @@ class TestDataFrameQuantile:
         expected = Series(
             [Timestamp("2010-07-02 12:00:00"), 2.5], index=["a", "b"], name=0.5
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # datetime w/ multi
         result = df.quantile([0.5], numeric_only=False)
         expected = DataFrame(
             [[Timestamp("2010-07-02 12:00:00"), 2.5]], index=[0.5], columns=["a", "b"]
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # axis = 1
         df["c"] = pd.to_datetime(["2011", "2012"])
@@ -227,7 +226,7 @@ class TestDataFrameQuantile:
             index=[0, 1],
             name=0.5,
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df[["a", "c"]].quantile([0.5], axis=1, numeric_only=False)
         expected = DataFrame(
@@ -235,7 +234,7 @@ class TestDataFrameQuantile:
             index=[0.5],
             columns=[0, 1],
         )
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # empty when numeric_only=True
         # FIXME (gives empty frame in 0.18.1, broken in 0.19.0)


### PR DESCRIPTION
Part of #29272 

Fyi: All changes are generated from a script posted in the issue.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
