### PR TITLE
Fix SS06 formatting errors

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -310,10 +310,11 @@ ValueError: columns overlap but no suffix specified:
 
 class DataFrame(NDFrame):
     """
-    Two-dimensional size-mutable, potentially heterogeneous tabular data
-    structure with labeled axes (rows and columns). Arithmetic operations
-    align on both row and column labels. Can be thought of as a dict-like
-    container for Series objects. The primary pandas data structure.
+    Two-dimensional size-mutable, potentially heterogeneous tabular data structure with labeled axes (rows and columns). 
+    
+    Arithmetic operations align on both row and column labels. 
+    Can be thought of as a dict-like container for Series objects.
+    The primary pandas data structure.
 
     Parameters
     ----------
@@ -4798,9 +4799,10 @@ class DataFrame(NDFrame):
 
     def drop_duplicates(self, subset=None, keep="first", inplace=False):
         """
-        Return DataFrame with duplicate rows removed, optionally only
-        considering certain columns. Indexes, including time indexes
-        are ignored.
+        Return DataFrame with duplicate rows removed.
+        
+        Optionally only considers certain columns. 
+        Indexes, including time indexes are ignored.
 
         Parameters
         ----------
@@ -4834,8 +4836,9 @@ class DataFrame(NDFrame):
 
     def duplicated(self, subset=None, keep="first"):
         """
-        Return boolean Series denoting duplicate rows, optionally only
-        considering certain columns.
+        Return boolean Series denoting duplicate rows.
+        
+        Optionally only considers certain columns.
 
         Parameters
         ----------
@@ -7536,9 +7539,10 @@ class DataFrame(NDFrame):
 
     def corrwith(self, other, axis=0, drop=False, method="pearson"):
         """
-        Compute pairwise correlation between rows or columns of DataFrame
-        with rows or columns of Series or DataFrame.  DataFrames are first
-        aligned along both axes before computing the correlations.
+        Compute pairwise correlation between rows or columns of DataFrame.
+        
+        Correlation is computed with rows or columns of Series or DataFrame. 
+        DataFrames are first aligned along both axes before computing the correlations.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4838,7 +4838,7 @@ class DataFrame(NDFrame):
     def duplicated(self, subset=None, keep="first"):
         """
         Return boolean Series denoting duplicate rows.
-        
+
         Optionally only considers certain columns.
 
         Parameters

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4803,7 +4803,7 @@ class DataFrame(NDFrame):
         Return DataFrame with duplicate rows removed.
 
         Optionally only considers certain columns.
-        Indexes, including time indexes are ignored.
+        Indexes, including time indexes, are ignored.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -310,11 +310,12 @@ ValueError: columns overlap but no suffix specified:
 
 class DataFrame(NDFrame):
     """
-    Two-dimensional size-mutable, potentially heterogeneous tabular data structure with labeled axes (rows and columns). 
-    
-    Arithmetic operations align on both row and column labels. 
+    Two-dimensional size-mutable, potentially heterogeneous tabular data structure.
+
+    Data Structure has labeled axes (rows and columns).
+    Arithmetic operations align on both row and column labels.
     Can be thought of as a dict-like container for Series objects.
-    The primary pandas data structure.
+    This is the primary pandas data structure.
 
     Parameters
     ----------
@@ -4800,8 +4801,8 @@ class DataFrame(NDFrame):
     def drop_duplicates(self, subset=None, keep="first", inplace=False):
         """
         Return DataFrame with duplicate rows removed.
-        
-        Optionally only considers certain columns. 
+
+        Optionally only considers certain columns.
         Indexes, including time indexes are ignored.
 
         Parameters
@@ -7540,8 +7541,8 @@ class DataFrame(NDFrame):
     def corrwith(self, other, axis=0, drop=False, method="pearson"):
         """
         Compute pairwise correlation between rows or columns of DataFrame.
-        
-        Correlation is computed with rows or columns of Series or DataFrame. 
+
+        Correlation is computed with rows or columns of Series or DataFrame.
         DataFrames are first aligned along both axes before computing the correlations.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5156,8 +5156,7 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "transform"
     ] = """
-    Call ``func`` on self producing a %(klass)s with transformed values
-    and that has the same axis length as self.
+    Call ``func`` on self producing a %(klass)s with transformed values and that has the same axis length as self.
 
     Parameters
     ----------
@@ -8741,8 +8740,7 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "align"
     ] = """
-        Align two objects on their axes with the
-        specified join method for each axis Index.
+        Align two objects on their axes with the specified join method for each axis Index.
 
         Parameters
         ----------
@@ -9966,14 +9964,11 @@ class NDFrame(PandasObject, SelectionMixin):
     def describe(self, percentiles=None, include=None, exclude=None):
         """
         Generate descriptive statistics that summarizes a dataset.
-        
-        Statistics summarizes the central tendency, dispersion and 
+        Statistics summarizes the central tendency, dispersion and
         shape of a dataset's distribution, excluding ``NaN`` values.
 
-        Analyzes both numeric and object series, as well
-        as ``DataFrame`` column sets of mixed data types. The output
-        will vary depending on what is provided. Refer to the notes
-        below for more detail.
+        Analyzes both numeric and object series, as well as ``DataFrame`` column sets of mixed data types.
+        The output will vary depending on what is provided. Refer to the notes below for more detail.
 
         Parameters
         ----------
@@ -10659,9 +10654,8 @@ class NDFrame(PandasObject, SelectionMixin):
             name,
             name2,
             axis_descr,
-            "Return unbiased kurtosis over requested axis using Fisher's "
-            "definition of kurtosis(kurtosis of normal == 0.0).\nNormalized "
-            "by N-1.",
+            "Return unbiased kurtosis over requested axis using Fisher's definition of kurtosis(kurtosis of normal == 0.0)."
+            "\n\nNormalized by N-1.",
             nanops.nankurt,
         )
         cls.kurtosis = cls.kurt

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5156,7 +5156,9 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "transform"
     ] = """
-    Call ``func`` on self producing a %(klass)s with transformed values and that has the same axis length as self.
+    Call ``func`` on self producing a %(klass)s with transformed values.
+
+    %(klass)s has the same axis length as self.
 
     Parameters
     ----------
@@ -8740,7 +8742,7 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "align"
     ] = """
-        Align two objects on their axes with the specified join method for each axis Index.
+        Align two objects on their axes with the specified join for each axis Index.
 
         Parameters
         ----------
@@ -9967,8 +9969,10 @@ class NDFrame(PandasObject, SelectionMixin):
         Statistics summarizes the central tendency, dispersion and
         shape of a dataset's distribution, excluding ``NaN`` values.
 
-        Analyzes both numeric and object series, as well as ``DataFrame`` column sets of mixed data types.
-        The output will vary depending on what is provided. Refer to the notes below for more detail.
+        Analyzes both numeric and object series.
+        In addition, it also analyses ``DataFrame`` column sets of mixed data types.
+        The output will vary depending on what is provided.
+        Refer to the notes below for more detail.
 
         Parameters
         ----------
@@ -10654,8 +10658,9 @@ class NDFrame(PandasObject, SelectionMixin):
             name,
             name2,
             axis_descr,
-            "Return unbiased kurtosis over requested axis using Fisher's definition of kurtosis(kurtosis of normal == 0.0)."
-            "\n\nNormalized by N-1.",
+            "Return unbiased kurtosis over requested axis."
+            "\n\nFisher's definition of kurtosis is used(kurtosis of normal == 0.0)."
+            "\nNormalized by N-1.",
             nanops.nankurt,
         )
         cls.kurtosis = cls.kurt

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5156,7 +5156,7 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "transform"
     ] = """
-    Call ``func`` on self producing a %(klass)s with transformed valuesnd that has the same axis length as self.
+    Call ``func`` on self producing a %(klass)s with transformed values and that has the same axis length as self.
 
     Parameters
     ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5156,7 +5156,7 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs[
         "transform"
     ] = """
-    Call ``func`` on self producing a %(klass)s with transformed values and that has the same axis length as self.
+    Call ``func`` on self producing a %(klass)s with transformed valuesnd that has the same axis length as self.
 
     Parameters
     ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9965,9 +9965,10 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def describe(self, percentiles=None, include=None, exclude=None):
         """
-        Generate descriptive statistics that summarize the central tendency,
-        dispersion and shape of a dataset's distribution, excluding
-        ``NaN`` values.
+        Generate descriptive statistics that summarizes a dataset.
+        
+        Statistics summarizes the central tendency, dispersion and 
+        shape of a dataset's distribution, excluding ``NaN`` values.
 
         Analyzes both numeric and object series, as well
         as ``DataFrame`` column sets of mixed data types. The output
@@ -10649,7 +10650,7 @@ class NDFrame(PandasObject, SelectionMixin):
             name,
             name2,
             axis_descr,
-            "Return unbiased skew over requested axis\nNormalized by N-1.",
+            "Return unbiased skew over requested axis normalized by N-1.",
             nanops.nanskew,
         )
         cls.kurt = _make_stat_function(
@@ -10659,7 +10660,7 @@ class NDFrame(PandasObject, SelectionMixin):
             name2,
             axis_descr,
             "Return unbiased kurtosis over requested axis using Fisher's "
-            "definition of\nkurtosis (kurtosis of normal == 0.0). Normalized "
+            "definition of kurtosis(kurtosis of normal == 0.0).\nNormalized "
             "by N-1.",
             nanops.nankurt,
         )


### PR DESCRIPTION
Fixing more SS06 issues, mentioned in #29254 

Fixed docstrings for the following:
- pandas.DataFrame
- pandas.DataFrame.transform
- pandas.DataFrame.corrwith
- pandas.DataFrame.describe
- pandas.DataFrame.kurt
- pandas.DataFrame.kurtosis
- pandas.DataFrame.skew
- pandas.DataFrame.align
- pandas.DataFrame.drop_duplicates
- pandas.DataFrame.duplicated