### PR TITLE
CLN: Consistent pandas.util.testing imports in remaining test suite

### DIFF
--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pandas as pd
 from pandas import api, compat
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class Base:

--- a/pandas/tests/api/test_types.py
+++ b/pandas/tests/api/test_types.py
@@ -1,5 +1,5 @@
 from pandas.api import types
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 from .test_api import Base
 

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -12,7 +12,6 @@ import pandas as pd
 from pandas import isna
 from pandas.core.arrays.sparse import SparseArray, SparseDtype
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal
 
 
 @pytest.fixture(params=["integer", "block"])
@@ -386,7 +385,7 @@ class TestSparseArray:
     def test_constructor_from_sparse(self):
         res = SparseArray(self.zarr)
         assert res.fill_value == 0
-        assert_almost_equal(res.sp_values, self.zarr.sp_values)
+        tm.assert_almost_equal(res.sp_values, self.zarr.sp_values)
 
     def test_constructor_copy(self):
         cp = SparseArray(self.arr, copy=True)
@@ -586,7 +585,7 @@ class TestSparseArray:
         assert arr2.sp_index is self.arr.sp_index
 
     def test_values_asarray(self):
-        assert_almost_equal(self.arr.to_dense(), self.arr_data)
+        tm.assert_almost_equal(self.arr.to_dense(), self.arr_data)
 
     @pytest.mark.parametrize(
         "data,shape,dtype",
@@ -625,7 +624,7 @@ class TestSparseArray:
 
     def test_getitem(self):
         def _checkit(i):
-            assert_almost_equal(self.arr[i], self.arr.to_dense()[i])
+            tm.assert_almost_equal(self.arr[i], self.arr.to_dense()[i])
 
         for i in range(len(self.arr)):
             _checkit(i)
@@ -703,7 +702,7 @@ class TestSparseArray:
                 op(first.to_dense(), second.to_dense()), fill_value=first.fill_value
             )
             assert isinstance(res, SparseArray)
-            assert_almost_equal(res.to_dense(), exp.to_dense())
+            tm.assert_almost_equal(res.to_dense(), exp.to_dense())
 
             res2 = op(first, second.to_dense())
             assert isinstance(res2, SparseArray)
@@ -723,8 +722,8 @@ class TestSparseArray:
             except ValueError:
                 pass
             else:
-                assert_almost_equal(res4.fill_value, exp_fv)
-                assert_almost_equal(res4.to_dense(), exp)
+                tm.assert_almost_equal(res4.fill_value, exp_fv)
+                tm.assert_almost_equal(res4.to_dense(), exp)
 
         with np.errstate(all="ignore"):
             for first_arr, second_arr in [(arr1, arr2), (farr1, farr2)]:

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -34,14 +34,6 @@ from pandas.core.computation.ops import (
     _unary_math_ops,
 )
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_frame_equal,
-    assert_numpy_array_equal,
-    assert_produces_warning,
-    assert_series_equal,
-    makeCustomDataframe as mkdf,
-    randbool,
-)
 
 
 @pytest.fixture(
@@ -205,14 +197,14 @@ class TestEvalNumexprPandas:
 
     def test_simple_cmp_ops(self):
         bool_lhses = (
-            DataFrame(randbool(size=(10, 5))),
-            Series(randbool((5,))),
-            randbool(),
+            DataFrame(tm.randbool(size=(10, 5))),
+            Series(tm.randbool((5,))),
+            tm.randbool(),
         )
         bool_rhses = (
-            DataFrame(randbool(size=(10, 5))),
-            Series(randbool((5,))),
-            randbool(),
+            DataFrame(tm.randbool(size=(10, 5))),
+            Series(tm.randbool((5,))),
+            tm.randbool(),
         )
         for lhs, rhs, cmp_op in product(bool_lhses, bool_rhses, self.cmp_ops):
             self.check_simple_cmp_op(lhs, cmp_op, rhs)
@@ -475,13 +467,13 @@ class TestEvalNumexprPandas:
         else:
             expect = ~lhs
             result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_frame_equal(expect, result)
+            tm.assert_frame_equal(expect, result)
 
         # bool always works
         lhs = DataFrame(rand(5, 2) > 0.5)
         expect = ~lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_frame_equal(expect, result)
+        tm.assert_frame_equal(expect, result)
 
         # object raises
         lhs = DataFrame({"b": ["a", 1, 2.0], "c": rand(3) > 0.5})
@@ -514,13 +506,13 @@ class TestEvalNumexprPandas:
         else:
             expect = ~lhs
             result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_series_equal(expect, result)
+            tm.assert_series_equal(expect, result)
 
         # bool
         lhs = Series(rand(5) > 0.5)
         expect = ~lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_series_equal(expect, result)
+        tm.assert_series_equal(expect, result)
 
         # float
         # int
@@ -542,13 +534,13 @@ class TestEvalNumexprPandas:
         lhs = DataFrame(randn(5, 2))
         expect = -lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_frame_equal(expect, result)
+        tm.assert_frame_equal(expect, result)
 
         # int
         lhs = DataFrame(randint(5, size=(5, 2)))
         expect = -lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_frame_equal(expect, result)
+        tm.assert_frame_equal(expect, result)
 
         # bool doesn't work with numexpr but works elsewhere
         lhs = DataFrame(rand(5, 2) > 0.5)
@@ -558,7 +550,7 @@ class TestEvalNumexprPandas:
         else:
             expect = -lhs
             result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_frame_equal(expect, result)
+            tm.assert_frame_equal(expect, result)
 
     def test_series_negate(self):
         expr = self.ex("-")
@@ -567,13 +559,13 @@ class TestEvalNumexprPandas:
         lhs = Series(randn(5))
         expect = -lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_series_equal(expect, result)
+        tm.assert_series_equal(expect, result)
 
         # int
         lhs = Series(randint(5, size=5))
         expect = -lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_series_equal(expect, result)
+        tm.assert_series_equal(expect, result)
 
         # bool doesn't work with numexpr but works elsewhere
         lhs = Series(rand(5) > 0.5)
@@ -583,7 +575,7 @@ class TestEvalNumexprPandas:
         else:
             expect = -lhs
             result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_series_equal(expect, result)
+            tm.assert_series_equal(expect, result)
 
     def test_frame_pos(self):
         expr = self.ex("+")
@@ -592,19 +584,19 @@ class TestEvalNumexprPandas:
         lhs = DataFrame(randn(5, 2))
         expect = lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_frame_equal(expect, result)
+        tm.assert_frame_equal(expect, result)
 
         # int
         lhs = DataFrame(randint(5, size=(5, 2)))
         expect = lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_frame_equal(expect, result)
+        tm.assert_frame_equal(expect, result)
 
         # bool doesn't work with numexpr but works elsewhere
         lhs = DataFrame(rand(5, 2) > 0.5)
         expect = lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_frame_equal(expect, result)
+        tm.assert_frame_equal(expect, result)
 
     def test_series_pos(self):
         expr = self.ex("+")
@@ -613,19 +605,19 @@ class TestEvalNumexprPandas:
         lhs = Series(randn(5))
         expect = lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_series_equal(expect, result)
+        tm.assert_series_equal(expect, result)
 
         # int
         lhs = Series(randint(5, size=5))
         expect = lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_series_equal(expect, result)
+        tm.assert_series_equal(expect, result)
 
         # bool doesn't work with numexpr but works elsewhere
         lhs = Series(rand(5) > 0.5)
         expect = lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        assert_series_equal(expect, result)
+        tm.assert_series_equal(expect, result)
 
     def test_scalar_unary(self):
         with pytest.raises(TypeError):
@@ -645,7 +637,7 @@ class TestEvalNumexprPandas:
 
     def test_unary_in_array(self):
         # GH 11235
-        assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             pd.eval(
                 "[-True, True, ~True, +True,"
                 "-False, False, ~False, +False,"
@@ -847,18 +839,18 @@ class TestTypeCasting:
     # chain(*(np.sctypes[x] for x in ['uint', 'int', 'float']))
     @pytest.mark.parametrize("dt", [np.float32, np.float64])
     def test_binop_typecasting(self, engine, parser, op, dt):
-        df = mkdf(5, 3, data_gen_f=f, dtype=dt)
+        df = tm.makeCustomDataframe(5, 3, data_gen_f=f, dtype=dt)
         s = "df {} 3".format(op)
         res = pd.eval(s, engine=engine, parser=parser)
         assert df.values.dtype == dt
         assert res.values.dtype == dt
-        assert_frame_equal(res, eval(s))
+        tm.assert_frame_equal(res, eval(s))
 
         s = "3 {} df".format(op)
         res = pd.eval(s, engine=engine, parser=parser)
         assert df.values.dtype == dt
         assert res.values.dtype == dt
-        assert_frame_equal(res, eval(s))
+        tm.assert_frame_equal(res, eval(s))
 
 
 # -------------------------------------
@@ -882,19 +874,19 @@ class TestAlignment:
 
     def test_align_nested_unary_op(self, engine, parser):
         s = "df * ~2"
-        df = mkdf(5, 3, data_gen_f=f)
+        df = tm.makeCustomDataframe(5, 3, data_gen_f=f)
         res = pd.eval(s, engine=engine, parser=parser)
-        assert_frame_equal(res, df * ~2)
+        tm.assert_frame_equal(res, df * ~2)
 
     def test_basic_frame_alignment(self, engine, parser):
         args = product(self.lhs_index_types, self.index_types, self.index_types)
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always", RuntimeWarning)
             for lr_idx_type, rr_idx_type, c_idx_type in args:
-                df = mkdf(
+                df = tm.makeCustomDataframe(
                     10, 10, data_gen_f=f, r_idx_type=lr_idx_type, c_idx_type=c_idx_type
                 )
-                df2 = mkdf(
+                df2 = tm.makeCustomDataframe(
                     20, 10, data_gen_f=f, r_idx_type=rr_idx_type, c_idx_type=c_idx_type
                 )
                 # only warns if not monotonic and not sortable
@@ -903,20 +895,20 @@ class TestAlignment:
                         res = pd.eval("df + df2", engine=engine, parser=parser)
                 else:
                     res = pd.eval("df + df2", engine=engine, parser=parser)
-                assert_frame_equal(res, df + df2)
+                tm.assert_frame_equal(res, df + df2)
 
     def test_frame_comparison(self, engine, parser):
         args = product(self.lhs_index_types, repeat=2)
         for r_idx_type, c_idx_type in args:
-            df = mkdf(
+            df = tm.makeCustomDataframe(
                 10, 10, data_gen_f=f, r_idx_type=r_idx_type, c_idx_type=c_idx_type
             )
             res = pd.eval("df < 2", engine=engine, parser=parser)
-            assert_frame_equal(res, df < 2)
+            tm.assert_frame_equal(res, df < 2)
 
             df3 = DataFrame(randn(*df.shape), index=df.index, columns=df.columns)
             res = pd.eval("df < df3", engine=engine, parser=parser)
-            assert_frame_equal(res, df < df3)
+            tm.assert_frame_equal(res, df < df3)
 
     @pytest.mark.slow
     def test_medium_complex_frame_alignment(self, engine, parser):
@@ -928,19 +920,25 @@ class TestAlignment:
             warnings.simplefilter("always", RuntimeWarning)
 
             for r1, c1, r2, c2 in args:
-                df = mkdf(3, 2, data_gen_f=f, r_idx_type=r1, c_idx_type=c1)
-                df2 = mkdf(4, 2, data_gen_f=f, r_idx_type=r2, c_idx_type=c2)
-                df3 = mkdf(5, 2, data_gen_f=f, r_idx_type=r2, c_idx_type=c2)
+                df = tm.makeCustomDataframe(
+                    3, 2, data_gen_f=f, r_idx_type=r1, c_idx_type=c1
+                )
+                df2 = tm.makeCustomDataframe(
+                    4, 2, data_gen_f=f, r_idx_type=r2, c_idx_type=c2
+                )
+                df3 = tm.makeCustomDataframe(
+                    5, 2, data_gen_f=f, r_idx_type=r2, c_idx_type=c2
+                )
                 if should_warn(df.index, df2.index, df3.index):
                     with tm.assert_produces_warning(RuntimeWarning):
                         res = pd.eval("df + df2 + df3", engine=engine, parser=parser)
                 else:
                     res = pd.eval("df + df2 + df3", engine=engine, parser=parser)
-                assert_frame_equal(res, df + df2 + df3)
+                tm.assert_frame_equal(res, df + df2 + df3)
 
     def test_basic_frame_series_alignment(self, engine, parser):
         def testit(r_idx_type, c_idx_type, index_name):
-            df = mkdf(
+            df = tm.makeCustomDataframe(
                 10, 10, data_gen_f=f, r_idx_type=r_idx_type, c_idx_type=c_idx_type
             )
             index = getattr(df, index_name)
@@ -956,7 +954,7 @@ class TestAlignment:
                 expected = df.add(s) if engine == "numexpr" else df + s
             else:
                 expected = df + s
-            assert_frame_equal(res, expected)
+            tm.assert_frame_equal(res, expected)
 
         args = product(self.lhs_index_types, self.index_types, ("index", "columns"))
         with warnings.catch_warnings(record=True):
@@ -966,7 +964,9 @@ class TestAlignment:
 
     def test_basic_series_frame_alignment(self, engine, parser):
         def testit(r_idx_type, c_idx_type, index_name):
-            df = mkdf(10, 7, data_gen_f=f, r_idx_type=r_idx_type, c_idx_type=c_idx_type)
+            df = tm.makeCustomDataframe(
+                10, 7, data_gen_f=f, r_idx_type=r_idx_type, c_idx_type=c_idx_type
+            )
             index = getattr(df, index_name)
             s = Series(np.random.randn(5), index[:5])
             if should_warn(s.index, df.index):
@@ -979,7 +979,7 @@ class TestAlignment:
                 expected = df.add(s) if engine == "numexpr" else s + df
             else:
                 expected = s + df
-            assert_frame_equal(res, expected)
+            tm.assert_frame_equal(res, expected)
 
         # only test dt with dt, otherwise weird joins result
         args = product(["i", "u", "s"], ["i", "u", "s"], ("index", "columns"))
@@ -1007,7 +1007,7 @@ class TestAlignment:
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always", RuntimeWarning)
             for r_idx_type, c_idx_type, op, index_name in args:
-                df = mkdf(
+                df = tm.makeCustomDataframe(
                     10, 10, data_gen_f=f, r_idx_type=r_idx_type, c_idx_type=c_idx_type
                 )
                 index = getattr(df, index_name)
@@ -1026,7 +1026,7 @@ class TestAlignment:
 
                 if r_idx_type != "dt" and c_idx_type != "dt":
                     if engine == "numexpr":
-                        assert_frame_equal(a, b)
+                        tm.assert_frame_equal(a, b)
 
     @pytest.mark.slow
     def test_complex_series_frame_alignment(self, engine, parser):
@@ -1045,8 +1045,12 @@ class TestAlignment:
                 index_name = random.choice(["index", "columns"])
                 obj_name = random.choice(["df", "df2"])
 
-                df = mkdf(m1, n, data_gen_f=f, r_idx_type=r1, c_idx_type=c1)
-                df2 = mkdf(m2, n, data_gen_f=f, r_idx_type=r2, c_idx_type=c2)
+                df = tm.makeCustomDataframe(
+                    m1, n, data_gen_f=f, r_idx_type=r1, c_idx_type=c1
+                )
+                df2 = tm.makeCustomDataframe(
+                    m2, n, data_gen_f=f, r_idx_type=r2, c_idx_type=c2
+                )
                 index = getattr(locals().get(obj_name), index_name)
                 s = Series(np.random.randn(n), index[:n])
 
@@ -1072,7 +1076,7 @@ class TestAlignment:
                 else:
                     res = pd.eval("df2 + s + df", engine=engine, parser=parser)
                 assert res.shape == expected.shape
-                assert_frame_equal(res, expected)
+                tm.assert_frame_equal(res, expected)
 
     def test_performance_warning_for_poor_alignment(self, engine, parser):
         df = DataFrame(randn(1000, 10))
@@ -1082,16 +1086,16 @@ class TestAlignment:
         else:
             seen = False
 
-        with assert_produces_warning(seen):
+        with tm.assert_produces_warning(seen):
             pd.eval("df + s", engine=engine, parser=parser)
 
         s = Series(randn(1000))
-        with assert_produces_warning(False):
+        with tm.assert_produces_warning(False):
             pd.eval("df + s", engine=engine, parser=parser)
 
         df = DataFrame(randn(10, 10000))
         s = Series(randn(10000))
-        with assert_produces_warning(False):
+        with tm.assert_produces_warning(False):
             pd.eval("df + s", engine=engine, parser=parser)
 
         df = DataFrame(randn(10, 10))
@@ -1104,7 +1108,7 @@ class TestAlignment:
         else:
             wrn = False
 
-        with assert_produces_warning(wrn) as w:
+        with tm.assert_produces_warning(wrn) as w:
             pd.eval("df + s", engine=engine, parser=parser)
 
             if not is_python_engine:
@@ -1199,7 +1203,7 @@ class TestOperationsNumExprPandas:
     def test_single_variable(self):
         df = DataFrame(randn(10, 2))
         df2 = self.eval("df", local_dict={"df": df})
-        assert_frame_equal(df, df2)
+        tm.assert_frame_equal(df, df2)
 
     def test_truediv(self):
         s = np.array([1])
@@ -1237,7 +1241,7 @@ class TestOperationsNumExprPandas:
         df = DataFrame(np.random.randn(5, 3))
         result = self.eval("(df + 1)[df > 2]", local_dict={"df": df})
         expected = (df + 1)[df > 2]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_attr_expression(self):
         df = DataFrame(np.random.randn(5, 3), columns=list("abc"))
@@ -1250,7 +1254,7 @@ class TestOperationsNumExprPandas:
         exprs = expr1, expr2, expr3
         expecs = expec1, expec2, expec3
         for e, expec in zip(exprs, expecs):
-            assert_series_equal(expec, self.eval(e, local_dict={"df": df}))
+            tm.assert_series_equal(expec, self.eval(e, local_dict={"df": df}))
 
     def test_assignment_fails(self):
         df = DataFrame(np.random.randn(5, 3), columns=list("abc"))
@@ -1284,14 +1288,14 @@ class TestOperationsNumExprPandas:
         expected["a"] = expected["a"] + expected["b"]
         df = orig_df.copy()
         df.eval("a = a + b", inplace=True)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # single assignment - new variable
         expected = orig_df.copy()
         expected["c"] = expected["a"] + expected["b"]
         df = orig_df.copy()
         df.eval("c = a + b", inplace=True)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # with a local name overlap
         def f():
@@ -1303,7 +1307,7 @@ class TestOperationsNumExprPandas:
         df = f()
         expected = orig_df.copy()
         expected["a"] = 1 + expected["b"]
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         df = orig_df.copy()
 
@@ -1312,7 +1316,7 @@ class TestOperationsNumExprPandas:
             old_a = df.a.copy()
             df.eval("a = a + b", inplace=True)
             result = old_a + df.b
-            assert_series_equal(result, df.a, check_names=False)
+            tm.assert_series_equal(result, df.a, check_names=False)
             assert result.name is None
 
         f()
@@ -1329,14 +1333,14 @@ class TestOperationsNumExprPandas:
         self.eval("c = df.a + df.b", local_dict={"df": df}, target=df, inplace=True)
         expected = orig_df.copy()
         expected["c"] = expected["a"] + expected["b"]
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_column_in(self):
         # GH 11235
         df = DataFrame({"a": [11], "b": [-32]})
         result = df.eval("a in [11, -32]")
         expected = Series([True])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def assignment_not_inplace(self):
         # see gh-9297
@@ -1362,7 +1366,7 @@ class TestOperationsNumExprPandas:
         d = c + b""",
             inplace=True,
         )
-        assert_frame_equal(expected, df)
+        tm.assert_frame_equal(expected, df)
         assert ans is None
 
         expected["a"] = expected["a"] - 1
@@ -1373,7 +1377,7 @@ class TestOperationsNumExprPandas:
         e = a + 2""",
             inplace=True,
         )
-        assert_frame_equal(expected, df)
+        tm.assert_frame_equal(expected, df)
         assert ans is None
 
         # multi-line not valid if not all assignments
@@ -1398,7 +1402,7 @@ class TestOperationsNumExprPandas:
         d = c + b""",
             inplace=False,
         )
-        assert_frame_equal(expected, df)
+        tm.assert_frame_equal(expected, df)
 
         expected["a"] = expected["a"] - 1
         expected["e"] = expected["a"] + 2
@@ -1408,7 +1412,7 @@ class TestOperationsNumExprPandas:
         e = a + 2""",
             inplace=False,
         )
-        assert_frame_equal(expected, df)
+        tm.assert_frame_equal(expected, df)
 
     def test_multi_line_expression_local_variable(self):
         # GH 15342
@@ -1425,7 +1429,7 @@ class TestOperationsNumExprPandas:
         """,
             inplace=True,
         )
-        assert_frame_equal(expected, df)
+        tm.assert_frame_equal(expected, df)
         assert ans is None
 
     def test_multi_line_expression_callable_local_variable(self):
@@ -1445,7 +1449,7 @@ class TestOperationsNumExprPandas:
         """,
             inplace=True,
         )
-        assert_frame_equal(expected, df)
+        tm.assert_frame_equal(expected, df)
         assert ans is None
 
     def test_multi_line_expression_callable_local_variable_with_kwargs(self):
@@ -1465,7 +1469,7 @@ class TestOperationsNumExprPandas:
         """,
             inplace=True,
         )
-        assert_frame_equal(expected, df)
+        tm.assert_frame_equal(expected, df)
         assert ans is None
 
     def test_assignment_in_query(self):
@@ -1474,7 +1478,7 @@ class TestOperationsNumExprPandas:
         df_orig = df.copy()
         with pytest.raises(ValueError):
             df.query("a = 1")
-        assert_frame_equal(df, df_orig)
+        tm.assert_frame_equal(df, df_orig)
 
     def test_query_inplace(self):
         # see gh-11149
@@ -1482,7 +1486,7 @@ class TestOperationsNumExprPandas:
         expected = df.copy()
         expected = expected[expected["a"] == 2]
         df.query("a == 2", inplace=True)
-        assert_frame_equal(expected, df)
+        tm.assert_frame_equal(expected, df)
 
         df = {}
         expected = {"a": 3}
@@ -1522,26 +1526,26 @@ class TestOperationsNumExprPandas:
             self.eval(expression, target=target, inplace=True)
 
     def test_basic_period_index_boolean_expression(self):
-        df = mkdf(2, 2, data_gen_f=f, c_idx_type="p", r_idx_type="i")
+        df = tm.makeCustomDataframe(2, 2, data_gen_f=f, c_idx_type="p", r_idx_type="i")
 
         e = df < 2
         r = self.eval("df < 2", local_dict={"df": df})
         x = df < 2
 
-        assert_frame_equal(r, e)
-        assert_frame_equal(x, e)
+        tm.assert_frame_equal(r, e)
+        tm.assert_frame_equal(x, e)
 
     def test_basic_period_index_subscript_expression(self):
-        df = mkdf(2, 2, data_gen_f=f, c_idx_type="p", r_idx_type="i")
+        df = tm.makeCustomDataframe(2, 2, data_gen_f=f, c_idx_type="p", r_idx_type="i")
         r = self.eval("df[df < 2 + 3]", local_dict={"df": df})
         e = df[df < 2 + 3]
-        assert_frame_equal(r, e)
+        tm.assert_frame_equal(r, e)
 
     def test_nested_period_index_subscript_expression(self):
-        df = mkdf(2, 2, data_gen_f=f, c_idx_type="p", r_idx_type="i")
+        df = tm.makeCustomDataframe(2, 2, data_gen_f=f, c_idx_type="p", r_idx_type="i")
         r = self.eval("df[df[df < 2] < 2] + df * 2", local_dict={"df": df})
         e = df[df[df < 2] < 2] + df * 2
-        assert_frame_equal(r, e)
+        tm.assert_frame_equal(r, e)
 
     def test_date_boolean(self):
         df = DataFrame(randn(5, 3))
@@ -1553,7 +1557,7 @@ class TestOperationsNumExprPandas:
             parser=self.parser,
         )
         expec = df.dates1 < "20130101"
-        assert_series_equal(res, expec, check_names=False)
+        tm.assert_series_equal(res, expec, check_names=False)
 
     def test_simple_in_ops(self):
         if self.parser != "python":

--- a/pandas/tests/dtypes/cast/test_construct_from_scalar.py
+++ b/pandas/tests/dtypes/cast/test_construct_from_scalar.py
@@ -2,7 +2,7 @@ from pandas.core.dtypes.cast import construct_1d_arraylike_from_scalar
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 from pandas import Categorical
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 def test_cast_1d_array_like_from_scalar_categorical():

--- a/pandas/tests/dtypes/cast/test_construct_ndarray.py
+++ b/pandas/tests/dtypes/cast/test_construct_ndarray.py
@@ -3,7 +3,7 @@ import pytest
 
 from pandas.core.dtypes.cast import construct_1d_ndarray_preserving_na
 
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/dtypes/cast/test_downcast.py
+++ b/pandas/tests/dtypes/cast/test_downcast.py
@@ -6,7 +6,7 @@ import pytest
 from pandas.core.dtypes.cast import maybe_downcast_to_dtype
 
 from pandas import DatetimeIndex, Series, Timestamp
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/dtypes/cast/test_infer_dtype.py
+++ b/pandas/tests/dtypes/cast/test_infer_dtype.py
@@ -11,7 +11,7 @@ from pandas.core.dtypes.cast import (
 from pandas.core.dtypes.common import is_dtype_equal
 
 from pandas import Categorical, Period, Series, Timedelta, Timestamp, date_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.fixture(params=[True, False])

--- a/pandas/tests/dtypes/cast/test_upcast.py
+++ b/pandas/tests/dtypes/cast/test_upcast.py
@@ -4,7 +4,7 @@ import pytest
 from pandas.core.dtypes.cast import maybe_upcast_putmask
 
 from pandas import Series
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize("result", [Series([10, 11, 12]), [10, 11, 12], (10, 11, 12)])

--- a/pandas/tests/dtypes/test_generic.py
+++ b/pandas/tests/dtypes/test_generic.py
@@ -5,7 +5,7 @@ import numpy as np
 from pandas.core.dtypes import generic as gt
 
 import pandas as pd
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestABCClasses:

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -51,7 +51,7 @@ from pandas import (
     Timestamp,
     isna,
 )
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.fixture(params=[True, False], ids=str)

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -23,7 +23,7 @@ from pandas.core.dtypes.missing import (
 
 import pandas as pd
 from pandas import DatetimeIndex, Float64Index, NaT, Series, TimedeltaIndex, date_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 now = pd.Timestamp.now()
 utcnow = pd.Timestamp.now("UTC")

--- a/pandas/tests/frame/test_explode.py
+++ b/pandas/tests/frame/test_explode.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 def test_error():

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -10,11 +10,6 @@ import pandas.util._test_decorators as td
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, date_range
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-)
 
 from .test_generic import Generic
 
@@ -28,7 +23,7 @@ except ImportError:
 
 class TestDataFrame(Generic):
     _typ = DataFrame
-    _comparator = lambda self, x, y: assert_frame_equal(x, y)
+    _comparator = lambda self, x, y: tm.assert_frame_equal(x, y)
 
     def test_rename_mi(self):
         df = DataFrame(
@@ -177,7 +172,7 @@ class TestDataFrame(Generic):
         df.y = 5
 
         assert df.y == 5
-        assert_series_equal(df["y"], Series([2, 4, 6], name="y"))
+        tm.assert_series_equal(df["y"], Series([2, 4, 6], name="y"))
 
     @pytest.mark.skipif(
         not _XARRAY_INSTALLED
@@ -222,7 +217,7 @@ class TestDataFrame(Generic):
         assert result.dims["foo"] == 3
         assert len(result.coords) == 1
         assert len(result.data_vars) == 8
-        assert_almost_equal(list(result.coords.keys()), ["foo"])
+        tm.assert_almost_equal(list(result.coords.keys()), ["foo"])
         assert isinstance(result, Dataset)
 
         # idempotency
@@ -233,7 +228,7 @@ class TestDataFrame(Generic):
         expected["f"] = expected["f"].astype(object)
         expected["h"] = expected["h"].astype("datetime64[ns]")
         expected.columns.name = None
-        assert_frame_equal(
+        tm.assert_frame_equal(
             result.to_dataframe(),
             expected,
             check_index_type=False,
@@ -270,7 +265,7 @@ class TestDataFrame(Generic):
         assert result.dims["two"] == 3
         assert len(result.coords) == 2
         assert len(result.data_vars) == 8
-        assert_almost_equal(list(result.coords.keys()), ["one", "two"])
+        tm.assert_almost_equal(list(result.coords.keys()), ["one", "two"])
         assert isinstance(result, Dataset)
 
         result = result.to_dataframe()
@@ -278,7 +273,7 @@ class TestDataFrame(Generic):
         expected["f"] = expected["f"].astype(object)
         expected["h"] = expected["h"].astype("datetime64[ns]")
         expected.columns.name = None
-        assert_frame_equal(result, expected, check_index_type=False)
+        tm.assert_frame_equal(result, expected, check_index_type=False)
 
     def test_deepcopy_empty(self):
         # This test covers empty frame copying with non-empty column sets

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -8,7 +8,6 @@ from pandas.core.dtypes.common import is_scalar
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, date_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 # ----------------------------------------------------------------------
 # Generic types test cases
@@ -606,7 +605,7 @@ class TestNDFrame:
             }
         )
         sample1 = df.sample(n=1, weights="easyweights")
-        assert_frame_equal(sample1, df.iloc[5:6])
+        tm.assert_frame_equal(sample1, df.iloc[5:6])
 
         # Ensure proper error if string given as weight for Series or
         # DataFrame with axis = 1.
@@ -635,19 +634,21 @@ class TestNDFrame:
         # Test axis argument
         df = pd.DataFrame({"col1": range(10), "col2": ["a"] * 10})
         second_column_weight = [0, 1]
-        assert_frame_equal(
+        tm.assert_frame_equal(
             df.sample(n=1, axis=1, weights=second_column_weight), df[["col2"]]
         )
 
         # Different axis arg types
-        assert_frame_equal(
+        tm.assert_frame_equal(
             df.sample(n=1, axis="columns", weights=second_column_weight), df[["col2"]]
         )
 
         weight = [0] * 10
         weight[5] = 0.5
-        assert_frame_equal(df.sample(n=1, axis="rows", weights=weight), df.iloc[5:6])
-        assert_frame_equal(df.sample(n=1, axis="index", weights=weight), df.iloc[5:6])
+        tm.assert_frame_equal(df.sample(n=1, axis="rows", weights=weight), df.iloc[5:6])
+        tm.assert_frame_equal(
+            df.sample(n=1, axis="index", weights=weight), df.iloc[5:6]
+        )
 
         # Check out of range axis values
         with pytest.raises(ValueError):
@@ -672,26 +673,26 @@ class TestNDFrame:
             {"col1": range(10, 20), "col2": range(20, 30), "colString": ["a"] * 10}
         )
         sample1 = df.sample(n=1, axis=1, weights=easy_weight_list)
-        assert_frame_equal(sample1, df[["colString"]])
+        tm.assert_frame_equal(sample1, df[["colString"]])
 
         # Test default axes
-        assert_frame_equal(
+        tm.assert_frame_equal(
             df.sample(n=3, random_state=42), df.sample(n=3, axis=0, random_state=42)
         )
 
         # Test that function aligns weights with frame
         df = DataFrame({"col1": [5, 6, 7], "col2": ["a", "b", "c"]}, index=[9, 5, 3])
         s = Series([1, 0, 0], index=[3, 5, 9])
-        assert_frame_equal(df.loc[[3]], df.sample(1, weights=s))
+        tm.assert_frame_equal(df.loc[[3]], df.sample(1, weights=s))
 
         # Weights have index values to be dropped because not in
         # sampled DataFrame
         s2 = Series([0.001, 0, 10000], index=[3, 5, 10])
-        assert_frame_equal(df.loc[[3]], df.sample(1, weights=s2))
+        tm.assert_frame_equal(df.loc[[3]], df.sample(1, weights=s2))
 
         # Weights have empty values to be filed with zeros
         s3 = Series([0.01, 0], index=[3, 5])
-        assert_frame_equal(df.loc[[3]], df.sample(1, weights=s3))
+        tm.assert_frame_equal(df.loc[[3]], df.sample(1, weights=s3))
 
         # No overlap in weight and sampled DataFrame indices
         s4 = Series([1, 0], index=[1, 2])
@@ -893,19 +894,19 @@ class TestNDFrame:
         f = lambda x, y: x ** y
         result = df.pipe(f, 2)
         expected = DataFrame({"A": [1, 4, 9]})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.A.pipe(f, 2)
-        assert_series_equal(result, expected.A)
+        tm.assert_series_equal(result, expected.A)
 
     def test_pipe_tuple(self):
         df = DataFrame({"A": [1, 2, 3]})
         f = lambda x, y: y
         result = df.pipe((f, "y"), 0)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         result = df.A.pipe((f, "y"), 0)
-        assert_series_equal(result, df.A)
+        tm.assert_series_equal(result, df.A)
 
     def test_pipe_tuple_error(self):
         df = DataFrame({"A": [1, 2, 3]})

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -9,7 +9,6 @@ import pandas.util._test_decorators as td
 import pandas as pd
 from pandas import MultiIndex, Series, date_range
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal, assert_series_equal
 
 from .test_generic import Generic
 
@@ -23,7 +22,7 @@ except ImportError:
 
 class TestSeries(Generic):
     _typ = Series
-    _comparator = lambda self, x, y: assert_series_equal(x, y)
+    _comparator = lambda self, x, y: tm.assert_series_equal(x, y)
 
     def setup_method(self):
         self.ts = tm.makeTimeSeries()  # Was at top level in test_series
@@ -213,11 +212,11 @@ class TestSeries(Generic):
         repr(result)
         assert len(result) == 6
         assert len(result.coords) == 1
-        assert_almost_equal(list(result.coords.keys()), ["foo"])
+        tm.assert_almost_equal(list(result.coords.keys()), ["foo"])
         assert isinstance(result, DataArray)
 
         # idempotency
-        assert_series_equal(
+        tm.assert_series_equal(
             result.to_series(), s, check_index_type=False, check_categorical=True
         )
 
@@ -230,7 +229,7 @@ class TestSeries(Generic):
         result = s.to_xarray()
         assert len(result) == 0
         assert len(result.coords) == 1
-        assert_almost_equal(list(result.coords.keys()), ["foo"])
+        tm.assert_almost_equal(list(result.coords.keys()), ["foo"])
         assert isinstance(result, DataArray)
 
         s = Series(range(6))
@@ -240,9 +239,9 @@ class TestSeries(Generic):
         )
         result = s.to_xarray()
         assert len(result) == 2
-        assert_almost_equal(list(result.coords.keys()), ["one", "two"])
+        tm.assert_almost_equal(list(result.coords.keys()), ["one", "two"])
         assert isinstance(result, DataArray)
-        assert_series_equal(result.to_series(), s)
+        tm.assert_series_equal(result.to_series(), s)
 
     def test_valid_deprecated(self):
         # GH18800

--- a/pandas/tests/groupby/conftest.py
+++ b/pandas/tests/groupby/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 from pandas import DataFrame, MultiIndex
 from pandas.core.groupby.base import reduction_kernels
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.fixture

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -6,7 +6,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, bdate_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 def test_apply_issues():

--- a/pandas/tests/groupby/test_rank.py
+++ b/pandas/tests/groupby/test_rank.py
@@ -4,7 +4,7 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Series, concat
 from pandas.core.base import DataError
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 def test_rank_apply():

--- a/pandas/tests/groupby/test_value_counts.py
+++ b/pandas/tests/groupby/test_value_counts.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from pandas import DataFrame, MultiIndex, Series, date_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 # our starting frame

--- a/pandas/tests/groupby/test_whitelist.py
+++ b/pandas/tests/groupby/test_whitelist.py
@@ -14,7 +14,7 @@ from pandas.core.groupby.base import (
     reduction_kernels,
     transformation_kernels,
 )
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 AGG_FUNCTIONS = [
     "sum",

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -2,7 +2,7 @@
 import pytest
 
 from pandas import DatetimeIndex, date_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 from ..datetimelike import DatetimeLike
 

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -17,7 +17,7 @@ from pandas import (
     date_range,
 )
 from pandas.core.indexing import IndexingError
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestSlicing:

--- a/pandas/tests/indexes/period/test_asfreq.py
+++ b/pandas/tests/indexes/period/test_asfreq.py
@@ -3,7 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, PeriodIndex, Series, period_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestPeriodIndex:

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -7,7 +7,7 @@ from pandas._libs.tslibs import period as libperiod
 
 import pandas as pd
 from pandas import DatetimeIndex, Period, PeriodIndex, Series, notna, period_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestGetItem:

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -3,7 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Period, Series, period_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestPeriodIndex:

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -17,7 +17,7 @@ from pandas import (
     offsets,
     period_range,
 )
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 from ..datetimelike import DatetimeLike
 

--- a/pandas/tests/indexes/test_frozen.py
+++ b/pandas/tests/indexes/test_frozen.py
@@ -5,7 +5,7 @@ import pytest
 
 from pandas.core.indexes.frozen import FrozenList, FrozenNDArray
 from pandas.tests.test_base import CheckImmutable, CheckStringMixin
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestFrozenList(CheckImmutable, CheckStringMixin):

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -11,7 +11,7 @@ from pandas import (
     _np_version_under1p17,
 )
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -7,7 +7,7 @@ import numpy as np
 from pandas.core.dtypes.common import is_scalar
 
 from pandas import DataFrame, Float64Index, MultiIndex, Series, UInt64Index, date_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 from pandas.io.formats.printing import pprint_thing
 

--- a/pandas/tests/indexing/multiindex/conftest.py
+++ b/pandas/tests/indexing/multiindex/conftest.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import DataFrame, Index, MultiIndex
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.fixture

--- a/pandas/tests/indexing/multiindex/test_getitem.py
+++ b/pandas/tests/indexing/multiindex/test_getitem.py
@@ -3,7 +3,7 @@ import pytest
 
 from pandas import DataFrame, Index, MultiIndex, Series
 from pandas.core.indexing import IndexingError
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 # ----------------------------------------------------------------------------
 # test indexing of Series with multi-level Index

--- a/pandas/tests/indexing/multiindex/test_iloc.py
+++ b/pandas/tests/indexing/multiindex/test_iloc.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import DataFrame, MultiIndex, Series
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.fixture

--- a/pandas/tests/indexing/multiindex/test_ix.py
+++ b/pandas/tests/indexing/multiindex/test_ix.py
@@ -4,7 +4,7 @@ import pytest
 from pandas.errors import PerformanceWarning
 
 from pandas import DataFrame, MultiIndex
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestMultiIndex:

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -6,7 +6,7 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
 from pandas.core.indexing import IndexingError
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.fixture

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -6,7 +6,7 @@ from pandas.errors import PerformanceWarning
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestMultiIndexBasic:

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import DataFrame, MultiIndex
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestMultiIndexPartial:

--- a/pandas/tests/indexing/multiindex/test_set_ops.py
+++ b/pandas/tests/indexing/multiindex/test_set_ops.py
@@ -1,7 +1,7 @@
 from numpy.random import randn
 
 from pandas import DataFrame, MultiIndex, Series
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestMultiIndexSetOps:

--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -5,7 +5,7 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, Timestamp, date_range, isna, notna
 import pandas.core.common as com
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestMultiIndexSetItem:

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -9,7 +9,7 @@ import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, Series, Timestamp
 from pandas.core.indexing import _non_reducing_slice
 from pandas.tests.indexing.common import _mklbl
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.mark.filterwarnings("ignore:\\n.ix:FutureWarning")

--- a/pandas/tests/indexing/multiindex/test_sorted.py
+++ b/pandas/tests/indexing/multiindex/test_sorted.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.random import randn
 
 from pandas import DataFrame, MultiIndex, Series
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestMultiIndexSorted:

--- a/pandas/tests/indexing/multiindex/test_xs.py
+++ b/pandas/tests/indexing/multiindex/test_xs.py
@@ -5,7 +5,7 @@ import pytest
 
 from pandas import DataFrame, Index, MultiIndex, Series, concat, date_range
 import pandas.core.common as com
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.fixture

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -4,7 +4,7 @@ import pytest
 import pandas as pd
 from pandas import DataFrame, Series, Timestamp, date_range, option_context
 from pandas.core import common as com
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestCaching:

--- a/pandas/tests/indexing/test_datetime.py
+++ b/pandas/tests/indexing/test_datetime.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestDatetimeIndex:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -10,7 +10,7 @@ from pandas import DataFrame, Series, concat, date_range, isna
 from pandas.api.types import is_scalar
 from pandas.core.indexing import IndexingError
 from pandas.tests.indexing.common import Base
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestiLoc(Base):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -10,7 +10,7 @@ import pandas as pd
 from pandas import DataFrame, Series, Timestamp, date_range
 from pandas.api.types import is_scalar
 from pandas.tests.indexing.common import Base
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestLoc(Base):

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -11,7 +11,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, date_range
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestPartialSetting:

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -5,7 +5,7 @@ import pytest
 
 from pandas import DataFrame, Series, Timedelta, Timestamp, date_range
 from pandas.tests.indexing.common import Base
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestScalar(Base):

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestTimedeltaIndexing:

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -25,12 +25,6 @@ import pandas.core.algorithms as algos
 from pandas.core.arrays import DatetimeArray, TimedeltaArray
 from pandas.core.internals import BlockManager, SingleBlockManager, make_block
 import pandas.util.testing as tm
-from pandas.util.testing import (
-    assert_almost_equal,
-    assert_frame_equal,
-    assert_series_equal,
-    randn,
-)
 
 # in 3.6.1 a c-api slicing function changed, see src/compat_helper.h
 PY361 = LooseVersion(sys.version) >= LooseVersion("3.6.1")
@@ -261,8 +255,8 @@ class TestBlock:
         assert len(self.fblock) == len(self.fblock.values)
 
     def test_merge(self):
-        avals = randn(2, 10)
-        bvals = randn(2, 10)
+        avals = tm.randn(2, 10)
+        bvals = tm.randn(2, 10)
 
         ref_cols = Index(["e", "a", "b", "d", "f"])
 
@@ -390,7 +384,7 @@ class TestBlockManager:
     def test_pickle(self, mgr):
 
         mgr2 = tm.round_trip_pickle(mgr)
-        assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
+        tm.assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
 
         # share ref_items
         # assert mgr2.blocks[0].ref_items is mgr2.blocks[1].ref_items
@@ -407,20 +401,20 @@ class TestBlockManager:
 
         mgr = create_mgr("a,a,a:f8")
         mgr2 = tm.round_trip_pickle(mgr)
-        assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
+        tm.assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
 
         mgr = create_mgr("a: f8; a: i8")
         mgr2 = tm.round_trip_pickle(mgr)
-        assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
+        tm.assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
 
     def test_categorical_block_pickle(self):
         mgr = create_mgr("a: category")
         mgr2 = tm.round_trip_pickle(mgr)
-        assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
+        tm.assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
 
         smgr = create_single_mgr("category")
         smgr2 = tm.round_trip_pickle(smgr)
-        assert_series_equal(Series(smgr), Series(smgr2))
+        tm.assert_series_equal(Series(smgr), Series(smgr2))
 
     def test_get(self):
         cols = Index(list("abc"))
@@ -428,9 +422,9 @@ class TestBlockManager:
         block = make_block(values=values.copy(), placement=np.arange(3))
         mgr = BlockManager(blocks=[block], axes=[cols, np.arange(3)])
 
-        assert_almost_equal(mgr.get("a").internal_values(), values[0])
-        assert_almost_equal(mgr.get("b").internal_values(), values[1])
-        assert_almost_equal(mgr.get("c").internal_values(), values[2])
+        tm.assert_almost_equal(mgr.get("a").internal_values(), values[0])
+        tm.assert_almost_equal(mgr.get("b").internal_values(), values[1])
+        tm.assert_almost_equal(mgr.get("c").internal_values(), values[2])
 
     def test_set(self):
         mgr = create_mgr("a,b,c: int", item_shape=(3,))
@@ -456,10 +450,10 @@ class TestBlockManager:
         mgr2.set("baz", np.repeat("foo", N))
         assert mgr2.get("baz").dtype == np.object_
 
-        mgr2.set("quux", randn(N).astype(int))
+        mgr2.set("quux", tm.randn(N).astype(int))
         assert mgr2.get("quux").dtype == np.int_
 
-        mgr2.set("quux", randn(N))
+        mgr2.set("quux", tm.randn(N))
         assert mgr2.get("quux").dtype == np.float_
 
     def test_set_change_dtype_slice(self):  # GH8850
@@ -469,10 +463,10 @@ class TestBlockManager:
 
         blocks = df._to_dict_of_blocks()
         assert sorted(blocks.keys()) == ["float64", "int64"]
-        assert_frame_equal(
+        tm.assert_frame_equal(
             blocks["float64"], DataFrame([[1.0, 4.0], [4.0, 10.0]], columns=cols[:2])
         )
-        assert_frame_equal(blocks["int64"], DataFrame([[3], [6]], columns=cols[2:]))
+        tm.assert_frame_equal(blocks["int64"], DataFrame([[3], [6]], columns=cols[2:]))
 
     def test_copy(self, mgr):
         cp = mgr.copy(deep=False)
@@ -688,11 +682,11 @@ class TestBlockManager:
         pass
 
     def test_consolidate_ordering_issues(self, mgr):
-        mgr.set("f", randn(N))
-        mgr.set("d", randn(N))
-        mgr.set("b", randn(N))
-        mgr.set("g", randn(N))
-        mgr.set("h", randn(N))
+        mgr.set("f", tm.randn(N))
+        mgr.set("d", tm.randn(N))
+        mgr.set("b", tm.randn(N))
+        mgr.set("g", tm.randn(N))
+        mgr.set("h", tm.randn(N))
 
         # we have datetime/tz blocks in mgr
         cons = mgr.consolidate()
@@ -715,16 +709,16 @@ class TestBlockManager:
         reindexed = mgr.reindex_axis(["g", "c", "a", "d"], axis=0)
         assert reindexed.nblocks == 2
         tm.assert_index_equal(reindexed.items, pd.Index(["g", "c", "a", "d"]))
-        assert_almost_equal(
+        tm.assert_almost_equal(
             mgr.get("g").internal_values(), reindexed.get("g").internal_values()
         )
-        assert_almost_equal(
+        tm.assert_almost_equal(
             mgr.get("c").internal_values(), reindexed.get("c").internal_values()
         )
-        assert_almost_equal(
+        tm.assert_almost_equal(
             mgr.get("a").internal_values(), reindexed.get("a").internal_values()
         )
-        assert_almost_equal(
+        tm.assert_almost_equal(
             mgr.get("d").internal_values(), reindexed.get("d").internal_values()
         )
 
@@ -740,13 +734,13 @@ class TestBlockManager:
         tm.assert_index_equal(
             numeric.items, pd.Index(["int", "float", "complex", "bool"])
         )
-        assert_almost_equal(
+        tm.assert_almost_equal(
             mgr.get("float").internal_values(), numeric.get("float").internal_values()
         )
 
         # Check sharing
         numeric.set("float", np.array([100.0, 200.0, 300.0]))
-        assert_almost_equal(
+        tm.assert_almost_equal(
             mgr.get("float").internal_values(), np.array([100.0, 200.0, 300.0])
         )
 
@@ -755,7 +749,7 @@ class TestBlockManager:
             numeric.items, pd.Index(["int", "float", "complex", "bool"])
         )
         numeric2.set("float", np.array([1000.0, 2000.0, 3000.0]))
-        assert_almost_equal(
+        tm.assert_almost_equal(
             mgr.get("float").internal_values(), np.array([100.0, 200.0, 300.0])
         )
 
@@ -769,7 +763,7 @@ class TestBlockManager:
 
         bools = mgr.get_bool_data()
         tm.assert_index_equal(bools.items, pd.Index(["bool"]))
-        assert_almost_equal(
+        tm.assert_almost_equal(
             mgr.get("bool").internal_values(), bools.get("bool").internal_values()
         )
 
@@ -1268,7 +1262,7 @@ class TestCanHoldElement:
             # asserts anything meaningful
             result = op(s, e.value).dtypes
             expected = op(s, value).dtypes
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/io/formats/test_css.py
+++ b/pandas/tests/io/formats/test_css.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 from pandas.io.formats.css import CSSResolver, CSSWarning
 

--- a/pandas/tests/io/formats/test_eng_formatting.py
+++ b/pandas/tests/io/formats/test_eng_formatting.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import pandas as pd
 from pandas import DataFrame
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 import pandas.io.formats.format as fmt
 

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -6,7 +6,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, compat
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestToCSV:

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -7,7 +7,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex, option_context
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 import pandas.io.formats.format as fmt
 

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -5,7 +5,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Series
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestToLatex:

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -10,7 +10,7 @@ import pytest
 import pandas.util._test_decorators as td
 
 import pandas as pd
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 from pandas.io.parquet import (
     FastParquetImpl,

--- a/pandas/tests/io/test_spss.py
+++ b/pandas/tests/io/test_spss.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 pyreadstat = pytest.importorskip("pyreadstat")
 

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -15,7 +15,6 @@ from pandas.core.dtypes.api import is_list_like
 import pandas as pd
 from pandas import DataFrame, Series
 import pandas.util.testing as tm
-from pandas.util.testing import assert_is_valid_plot_return_object, ensure_clean
 
 
 """
@@ -540,7 +539,7 @@ def _check_plot_works(f, filterwarnings="always", **kwargs):
             kwargs.get("ax", fig.add_subplot(211))
             ret = f(**kwargs)
 
-            assert_is_valid_plot_return_object(ret)
+            tm.assert_is_valid_plot_return_object(ret)
 
             if f is pd.plotting.bootstrap_plot:
                 assert "ax" not in kwargs
@@ -548,9 +547,9 @@ def _check_plot_works(f, filterwarnings="always", **kwargs):
                 kwargs["ax"] = fig.add_subplot(212)
 
             ret = f(**kwargs)
-            assert_is_valid_plot_return_object(ret)
+            tm.assert_is_valid_plot_return_object(ret)
 
-            with ensure_clean(return_filelike=True) as path:
+            with tm.ensure_clean(return_filelike=True) as path:
                 plt.savefig(path)
         finally:
             tm.close(fig)

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -15,7 +15,6 @@ from pandas.core.indexes.timedeltas import timedelta_range
 from pandas.core.resample import DatetimeIndex
 from pandas.tests.plotting.common import TestPlotBase
 import pandas.util.testing as tm
-from pandas.util.testing import assert_series_equal, ensure_clean
 
 from pandas.tseries.offsets import DateOffset
 
@@ -628,7 +627,7 @@ class TestTSPlot(TestPlotBase):
         axes = fig.get_axes()
         line = ax.get_lines()[0]
         xp = Series(line.get_ydata(), line.get_xdata())
-        assert_series_equal(ser, xp)
+        tm.assert_series_equal(ser, xp)
         assert ax.get_yaxis().get_ticks_position() == "right"
         assert not axes[0].get_yaxis().get_visible()
         self.plt.close(fig)
@@ -658,7 +657,7 @@ class TestTSPlot(TestPlotBase):
         axes = fig.get_axes()
         line = ax.get_lines()[0]
         xp = Series(line.get_ydata(), line.get_xdata()).to_timestamp()
-        assert_series_equal(ser, xp)
+        tm.assert_series_equal(ser, xp)
         assert ax.get_yaxis().get_ticks_position() == "right"
         assert not axes[0].get_yaxis().get_visible()
         self.plt.close(fig)
@@ -1557,7 +1556,7 @@ def _check_plot_works(f, freq=None, series=None, *args, **kwargs):
         ret = f(*args, **kwargs)
         assert ret is not None  # TODO: do something more intelligent
 
-        with ensure_clean(return_filelike=True) as path:
+        with tm.ensure_clean(return_filelike=True) as path:
             plt.savefig(path)
 
         # GH18439
@@ -1567,7 +1566,7 @@ def _check_plot_works(f, freq=None, series=None, *args, **kwargs):
         # https://github.com/pandas-dev/pandas/issues/24088
         # https://github.com/statsmodels/statsmodels/issues/4772
         if "statsmodels" not in sys.modules:
-            with ensure_clean(return_filelike=True) as path:
+            with tm.ensure_clean(return_filelike=True) as path:
                 pickle.dump(fig, path)
     finally:
         plt.close(fig)

--- a/pandas/tests/reshape/test_union_categoricals.py
+++ b/pandas/tests/reshape/test_union_categoricals.py
@@ -5,7 +5,7 @@ from pandas.core.dtypes.concat import union_categoricals
 
 import pandas as pd
 from pandas import Categorical, CategoricalIndex, Series
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 class TestUnionCategoricals:

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -23,7 +23,7 @@ from pandas import (
 )
 from pandas.core.arrays import DatetimeArray, PeriodArray, TimedeltaArray
 from pandas.core.ops import roperator
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/series/test_explode.py
+++ b/pandas/tests/series/test_explode.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 def test_basic():

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -28,7 +28,6 @@ from pandas.core.arrays import DatetimeArray
 import pandas.core.common as com
 from pandas.core.sorting import safe_sort
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal
 
 
 class TestFactorize:
@@ -1588,7 +1587,7 @@ class TestRank:
             arr[mask] = np.inf
             exp = rankdata(arr)
             exp[mask] = np.nan
-            assert_almost_equal(result, exp)
+            tm.assert_almost_equal(result, exp)
 
         _check(np.array([np.nan, np.nan, 5.0, 5.0, 5.0, np.nan, 1, 2, 3, np.nan]))
         _check(np.array([4.0, np.nan, 5.0, 5.0, 5.0, np.nan, 1, 2, 4.0, np.nan]))

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -11,7 +11,7 @@ import pytest
 from pandas.compat import PY36
 
 from pandas import DataFrame, Series
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 def import_module(name):

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -8,7 +8,6 @@ import pytest
 from pandas.core.api import DataFrame
 from pandas.core.computation import expressions as expr
 import pandas.util.testing as tm
-from pandas.util.testing import assert_frame_equal
 
 _frame = DataFrame(randn(10000, 4), columns=list("ABCD"), dtype="float64")
 _frame2 = DataFrame(randn(100, 4), columns=list("ABCD"), dtype="float64")
@@ -356,7 +355,7 @@ class TestExpressions:
     def test_bool_ops_column_name_dtype(self, test_input, expected):
         # GH 22383 - .ne fails if columns containing column name 'dtype'
         result = test_input.loc[:, ["a", "dtype"]].ne(test_input.loc[:, ["a", "dtype"]])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
         "arith", ("add", "sub", "mul", "mod", "truediv", "floordiv")
@@ -382,4 +381,4 @@ class TestExpressions:
         expr.set_use_numexpr(True)
 
         result = op_func(other, axis=axis)
-        assert_frame_equal(expected, result)
+        tm.assert_frame_equal(expected, result)

--- a/pandas/tests/test_join.py
+++ b/pandas/tests/test_join.py
@@ -5,7 +5,6 @@ from pandas._libs import join as _join
 
 from pandas import Categorical, DataFrame, Index, merge
 import pandas.util.testing as tm
-from pandas.util.testing import assert_almost_equal, assert_frame_equal
 
 
 class TestIndexer:
@@ -182,12 +181,12 @@ def test_inner_join_indexer():
     index, ares, bres = _join.inner_join_indexer(a, b)
 
     index_exp = np.array([3, 5], dtype=np.int64)
-    assert_almost_equal(index, index_exp)
+    tm.assert_almost_equal(index, index_exp)
 
     aexp = np.array([2, 4], dtype=np.int64)
     bexp = np.array([1, 2], dtype=np.int64)
-    assert_almost_equal(ares, aexp)
-    assert_almost_equal(bres, bexp)
+    tm.assert_almost_equal(ares, aexp)
+    tm.assert_almost_equal(bres, bexp)
 
     a = np.array([5], dtype=np.int64)
     b = np.array([5], dtype=np.int64)
@@ -205,12 +204,12 @@ def test_outer_join_indexer():
     index, ares, bres = _join.outer_join_indexer(a, b)
 
     index_exp = np.array([0, 1, 2, 3, 4, 5, 7, 9], dtype=np.int64)
-    assert_almost_equal(index, index_exp)
+    tm.assert_almost_equal(index, index_exp)
 
     aexp = np.array([-1, 0, 1, 2, 3, 4, -1, -1], dtype=np.int64)
     bexp = np.array([0, -1, -1, 1, -1, 2, 3, 4], dtype=np.int64)
-    assert_almost_equal(ares, aexp)
-    assert_almost_equal(bres, bexp)
+    tm.assert_almost_equal(ares, aexp)
+    tm.assert_almost_equal(bres, bexp)
 
     a = np.array([5], dtype=np.int64)
     b = np.array([5], dtype=np.int64)
@@ -227,12 +226,12 @@ def test_left_join_indexer():
 
     index, ares, bres = _join.left_join_indexer(a, b)
 
-    assert_almost_equal(index, a)
+    tm.assert_almost_equal(index, a)
 
     aexp = np.array([0, 1, 2, 3, 4], dtype=np.int64)
     bexp = np.array([-1, -1, 1, -1, 2], dtype=np.int64)
-    assert_almost_equal(ares, aexp)
-    assert_almost_equal(bres, bexp)
+    tm.assert_almost_equal(ares, aexp)
+    tm.assert_almost_equal(bres, bexp)
 
     a = np.array([5], dtype=np.int64)
     b = np.array([5], dtype=np.int64)
@@ -250,13 +249,13 @@ def test_left_join_indexer2():
     res, lidx, ridx = _join.left_join_indexer(idx2.values, idx.values)
 
     exp_res = np.array([1, 1, 2, 5, 7, 9], dtype=np.int64)
-    assert_almost_equal(res, exp_res)
+    tm.assert_almost_equal(res, exp_res)
 
     exp_lidx = np.array([0, 0, 1, 2, 3, 4], dtype=np.int64)
-    assert_almost_equal(lidx, exp_lidx)
+    tm.assert_almost_equal(lidx, exp_lidx)
 
     exp_ridx = np.array([0, 1, 2, 3, -1, -1], dtype=np.int64)
-    assert_almost_equal(ridx, exp_ridx)
+    tm.assert_almost_equal(ridx, exp_ridx)
 
 
 def test_outer_join_indexer2():
@@ -266,13 +265,13 @@ def test_outer_join_indexer2():
     res, lidx, ridx = _join.outer_join_indexer(idx2.values, idx.values)
 
     exp_res = np.array([1, 1, 2, 5, 7, 9], dtype=np.int64)
-    assert_almost_equal(res, exp_res)
+    tm.assert_almost_equal(res, exp_res)
 
     exp_lidx = np.array([0, 0, 1, 2, 3, 4], dtype=np.int64)
-    assert_almost_equal(lidx, exp_lidx)
+    tm.assert_almost_equal(lidx, exp_lidx)
 
     exp_ridx = np.array([0, 1, 2, 3, -1, -1], dtype=np.int64)
-    assert_almost_equal(ridx, exp_ridx)
+    tm.assert_almost_equal(ridx, exp_ridx)
 
 
 def test_inner_join_indexer2():
@@ -282,13 +281,13 @@ def test_inner_join_indexer2():
     res, lidx, ridx = _join.inner_join_indexer(idx2.values, idx.values)
 
     exp_res = np.array([1, 1, 2, 5], dtype=np.int64)
-    assert_almost_equal(res, exp_res)
+    tm.assert_almost_equal(res, exp_res)
 
     exp_lidx = np.array([0, 0, 1, 2], dtype=np.int64)
-    assert_almost_equal(lidx, exp_lidx)
+    tm.assert_almost_equal(lidx, exp_lidx)
 
     exp_ridx = np.array([0, 1, 2, 3], dtype=np.int64)
-    assert_almost_equal(ridx, exp_ridx)
+    tm.assert_almost_equal(ridx, exp_ridx)
 
 
 def test_merge_join_categorical_multiindex():
@@ -315,7 +314,7 @@ def test_merge_join_categorical_multiindex():
     )
     result = a.join(b, on=["Cat1", "Int1"])
     expected = expected.drop(["Cat", "Int"], axis=1)
-    assert_frame_equal(expected, result)
+    tm.assert_frame_equal(expected, result)
 
     # Same test, but with ordered categorical
     a = {
@@ -344,4 +343,4 @@ def test_merge_join_categorical_multiindex():
     )
     result = a.join(b, on=["Cat1", "Int1"])
     expected = expected.drop(["Cat", "Int"], axis=1)
-    assert_frame_equal(expected, result)
+    tm.assert_frame_equal(expected, result)

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -15,8 +15,7 @@ from pandas.core.sorting import (
     nargsort,
     safe_sort,
 )
-from pandas.util import testing as tm
-from pandas.util.testing import assert_frame_equal, assert_series_equal
+import pandas.util.testing as tm
 
 
 class TestSorting:
@@ -98,8 +97,8 @@ class TestSorting:
             res = DataFrame(arr, columns=["jim", "joe"], index=mi)
             return res.sort_index()
 
-        assert_frame_equal(gr.mean(), aggr(np.mean))
-        assert_frame_equal(gr.median(), aggr(np.median))
+        tm.assert_frame_equal(gr.mean(), aggr(np.mean))
+        tm.assert_frame_equal(gr.median(), aggr(np.median))
 
     def test_lexsort_indexer(self):
         keys = [[np.nan] * 5 + list(range(100)) + [np.nan] * 5]
@@ -205,22 +204,22 @@ class TestMerge:
 
         out = merge(left, right, how="outer")
         assert len(out) == len(left)
-        assert_series_equal(out["left"], -out["right"], check_names=False)
+        tm.assert_series_equal(out["left"], -out["right"], check_names=False)
         result = out.iloc[:, :-2].sum(axis=1)
-        assert_series_equal(out["left"], result, check_names=False)
+        tm.assert_series_equal(out["left"], result, check_names=False)
         assert result.name is None
 
         out.sort_values(out.columns.tolist(), inplace=True)
         out.index = np.arange(len(out))
         for how in ["left", "right", "outer", "inner"]:
-            assert_frame_equal(out, merge(left, right, how=how, sort=True))
+            tm.assert_frame_equal(out, merge(left, right, how=how, sort=True))
 
         # check that left merge w/ sort=False maintains left frame order
         out = merge(left, right, how="left", sort=False)
-        assert_frame_equal(left, out[left.columns.tolist()])
+        tm.assert_frame_equal(left, out[left.columns.tolist()])
 
         out = merge(right, left, how="left", sort=False)
-        assert_frame_equal(right, out[right.columns.tolist()])
+        tm.assert_frame_equal(right, out[right.columns.tolist()])
 
         # one-2-many/none match
         n = 1 << 11
@@ -284,7 +283,7 @@ class TestMerge:
 
         def verify_order(df):
             kcols = list("ABCDEFG")
-            assert_frame_equal(
+            tm.assert_frame_equal(
                 df[kcols].copy(), df[kcols].sort_values(kcols, kind="mergesort")
             )
 
@@ -309,7 +308,7 @@ class TestMerge:
                     verify_order(res)
 
                 # as in GH9092 dtypes break with outer/right join
-                assert_frame_equal(
+                tm.assert_frame_equal(
                     frame, align(res), check_dtype=how not in ("right", "outer")
                 )
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -10,14 +10,13 @@ from pandas._libs import lib
 from pandas import DataFrame, Index, MultiIndex, Series, concat, isna, notna
 import pandas.core.strings as strings
 import pandas.util.testing as tm
-from pandas.util.testing import assert_index_equal, assert_series_equal
 
 
 def assert_series_or_index_equal(left, right):
     if isinstance(left, Series):
-        assert_series_equal(left, right)
+        tm.assert_series_equal(left, right)
     else:  # Index
-        assert_index_equal(left, right)
+        tm.assert_index_equal(left, right)
 
 
 _any_string_method = [
@@ -363,7 +362,7 @@ class TestStringMethods:
             pass
 
         assert not i
-        assert_series_equal(ds, s)
+        tm.assert_series_equal(ds, s)
 
     def test_iter_object_try_string(self):
         ds = Series([slice(None, randint(10), randint(10, 20)) for _ in range(4)])
@@ -1165,10 +1164,10 @@ class TestStringMethods:
         # na GH #6609
         res = Series(["a", 0, np.nan]).str.match("a", na=False)
         exp = Series([True, False, False])
-        assert_series_equal(exp, res)
+        tm.assert_series_equal(exp, res)
         res = Series(["a", 0, np.nan]).str.match("a")
         exp = Series([True, np.nan, np.nan])
-        assert_series_equal(exp, res)
+        tm.assert_series_equal(exp, res)
 
     def test_extract_expand_None(self):
         values = Series(["fooBAD__barBAD", np.nan, "foo"])
@@ -1399,7 +1398,7 @@ class TestStringMethods:
             result_df = s_or_idx.str.extract(r"(?P<uno>A)\d", expand=True)
             assert isinstance(result_df, DataFrame)
             result_series = result_df["uno"]
-            assert_series_equal(result_series, Series(["A", "A"], name="uno"))
+            tm.assert_series_equal(result_series, Series(["A", "A"], name="uno"))
 
     def test_extract_series(self):
         # extract should give the same result whether or not the
@@ -3087,15 +3086,15 @@ class TestStringMethods:
 
         rs = values.str.strip("x")
         xp = Series(["ABC", " BNSD", "LDFJH "])
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
         rs = values.str.lstrip("x")
         xp = Series(["ABCxx", " BNSD", "LDFJH xx"])
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
         rs = values.str.rstrip("x")
         xp = Series(["xxABC", "xx BNSD", "LDFJH "])
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
     def test_wrap(self):
         # test values are: two words less than width, two words equal to width,
@@ -3132,14 +3131,14 @@ class TestStringMethods:
         )
 
         rs = values.str.wrap(12, break_long_words=True)
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
         # test with pre and post whitespace (non-unicode), NaN, and non-ascii
         # Unicode
         values = Series(["  pre  ", np.nan, "\xac\u20ac\U00008000 abadcafe"])
         xp = Series(["  pre", np.nan, "\xac\u20ac\U00008000 ab\nadcafe"])
         rs = values.str.wrap(6)
-        assert_series_equal(rs, xp)
+        tm.assert_series_equal(rs, xp)
 
     def test_get(self):
         values = Series(["a_b_c", "c_d_e", np.nan, "f_g_h"])
@@ -3202,31 +3201,31 @@ class TestStringMethods:
         expected = Series(
             [False, False, False, True, True, False, np.nan, False, False, True]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.contains("a", case=False)
         expected = Series(
             [True, False, False, True, True, False, np.nan, True, False, True]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.contains("Aa")
         expected = Series(
             [False, False, False, True, False, False, np.nan, False, False, False]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.contains("ba")
         expected = Series(
             [False, False, False, True, False, False, np.nan, False, False, False]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.contains("ba", case=False)
         expected = Series(
             [False, False, False, True, True, False, np.nan, True, False, False]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_contains_nan(self):
         # PR #14171
@@ -3234,19 +3233,19 @@ class TestStringMethods:
 
         result = s.str.contains("foo", na=False)
         expected = Series([False, False, False], dtype=np.bool_)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.contains("foo", na=True)
         expected = Series([True, True, True], dtype=np.bool_)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.contains("foo", na="foo")
         expected = Series(["foo", "foo", "foo"], dtype=np.object_)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.contains("foo")
         expected = Series([np.nan, np.nan, np.nan], dtype=np.object_)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_replace_moar(self):
         # PR #1179
@@ -3256,7 +3255,7 @@ class TestStringMethods:
         expected = Series(
             ["YYY", "B", "C", "YYYaba", "Baca", "", np.nan, "CYYYBYYY", "dog", "cat"]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.replace("A", "YYY", case=False)
         expected = Series(
@@ -3273,7 +3272,7 @@ class TestStringMethods:
                 "cYYYt",
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str.replace("^.a|dog", "XX-XX ", case=False)
         expected = Series(
@@ -3290,7 +3289,7 @@ class TestStringMethods:
                 "XX-XX t",
             ]
         )
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_string_slice_get_syntax(self):
         s = Series(
@@ -3309,15 +3308,15 @@ class TestStringMethods:
 
         result = s.str[0]
         expected = s.str.get(0)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str[:3]
         expected = s.str.slice(stop=3)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.str[2::-1]
         expected = s.str.slice(start=2, step=-1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_string_slice_out_of_bounds(self):
         s = Series([(1, 2), (1,), (3, 4, 5)])
@@ -3325,12 +3324,12 @@ class TestStringMethods:
         result = s.str[1]
         expected = Series([2, np.nan, 4])
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series(["foo", "b", "ba"])
         result = s.str[1]
         expected = Series(["o", np.nan, "a"])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_match_findall_flags(self):
         data = {

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -6,7 +6,7 @@ import pytest
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, to_numeric
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 @pytest.fixture(params=[None, "ignore", "raise", "coerce"])

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -11,7 +11,7 @@ from pandas._libs.tslibs import parsing
 from pandas._libs.tslibs.parsing import parse_time_string
 import pandas.util._test_decorators as td
 
-from pandas.util import testing as tm
+import pandas.util.testing as tm
 
 
 def test_parse_time_string():


### PR DESCRIPTION
Part of #29272 

Fyi: All changes are generated from a script posted in the issue.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Fyi: When the remaining PRs of this are merged, I'll add another one to add the linting rule - then we can close the issue