### PR TITLE
BUG: Categorical.from_codes should not warn on empty codes

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -673,7 +673,7 @@ class Categorical(ExtensionArray, PandasObject):
             raise ValueError(msg)
 
         codes = np.asarray(codes)  # #21767
-        if not is_integer_dtype(codes):
+        if len(codes) and not is_integer_dtype(codes):
             msg = "codes need to be array-like integers"
             if is_float_dtype(codes):
                 icodes = codes.astype("i8")

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -526,6 +526,9 @@ class TestCategoricalConstructors:
         codes = [1.0, 2.0, 0]  # integer, but in float dtype
         dtype = CategoricalDtype(categories=["a", "b", "c"])
 
+        # empty codes should not raise for floats
+        Categorical.from_codes([], dtype.categories)
+
         with tm.assert_produces_warning(FutureWarning):
             cat = Categorical.from_codes(codes, dtype.categories)
         tm.assert_numpy_array_equal(cat.codes, np.array([1, 2, 0], dtype="i1"))


### PR DESCRIPTION
Empty codes should not warn about float codes:

```python
>>> pd.Categorical.from_codes([], ['a', 'b', 'c']) 
C:\Users\TP\Miniconda3\envs\pandas-dev\Scripts\ipython:1: FutureWarning: float codes will be disallowed in the future and raise a ValueError
```
