### PR TITLE
TST: add new test - check reindex() and astype() order consistency for Series

### DIFF
--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -518,3 +518,13 @@ class TestSeriesDtypes:
         result = pd.Series(data).values
         expected = np.array(data.astype(object))
         tm.assert_numpy_array_equal(result, expected)
+
+    def test_reindex_astype_order_consistency(self):
+        # GH 17444
+        s = Series([1, 2, 3], index=[2, 0, 1])
+        new_index = [0, 1, 2]
+        temp_dtype = "category"
+        new_dtype = str
+        s1 = s.reindex(new_index).astype(temp_dtype).astype(new_dtype)
+        s2 = s.astype(temp_dtype).reindex(new_index).astype(new_dtype)
+        tm.assert_series_equal(s1, s2)


### PR DESCRIPTION
check reindex() and astype() order consistency for Series

- [x] closes #17444
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
