### PR TITLE
TST: Test Groupby with Categoricals consistent for Series and DataFrame results

### DIFF
--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1193,6 +1193,13 @@ def test_seriesgroupby_observed_apply_dict(df_cat, observed, index, data):
     tm.assert_series_equal(result, expected)
 
 
+def test_groupby_categorical_series_dataframe_consistent(df_cat):
+    # GH 20416
+    expected = df_cat.groupby(['A', 'B'])['C'].mean()
+    result = df_cat.groupby(['A', 'B']).mean()['C']
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize("code", [([1, 0, 0]), ([0, 0, 0])])
 def test_groupby_categorical_axis_1(code):
     # GH 13420

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1195,8 +1195,8 @@ def test_seriesgroupby_observed_apply_dict(df_cat, observed, index, data):
 
 def test_groupby_categorical_series_dataframe_consistent(df_cat):
     # GH 20416
-    expected = df_cat.groupby(['A', 'B'])['C'].mean()
-    result = df_cat.groupby(['A', 'B']).mean()['C']
+    expected = df_cat.groupby(["A", "B"])["C"].mean()
+    result = df_cat.groupby(["A", "B"]).mean()["C"]
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [ ] closes https://github.com/pandas-dev/pandas/issues/20416
- [ ] 1 test added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
