### PR TITLE
TST: Test for Boolean Series with missing to Categorical dtype

### DIFF
--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -382,7 +382,7 @@ class TestSeriesDtypes:
         s = Series([True, False, np.nan])
         assert s.dtypes == np.object_
 
-        result = s.astype(pd.api.types.CategoricalDtype(categories=[True, False]))
+        result = s.astype(CategoricalDtype(categories=[True, False]))
         expected = Series(Categorical([True, False, np.nan], categories=[True, False]))
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -377,6 +377,15 @@ class TestSeriesDtypes:
             result = s.astype("category")
             tm.assert_series_equal(result, expected)
 
+    def test_astype_bool_missing_to_categorical(self):
+        # GH-19182
+        s = Series([True, False, np.nan])
+        assert s.dtypes == np.object_
+
+        result = s.astype(pd.api.types.CategoricalDtype(categories=[True, False]))
+        expected = Series(Categorical([True, False, np.nan], categories=[True, False]))
+        tm.assert_series_equal(result, expected)
+
     def test_astype_categoricaldtype(self):
         s = Series(["a", "b", "a"])
         result = s.astype(CategoricalDtype(["a", "b"], ordered=True))


### PR DESCRIPTION
- [x] closes #19182
- [x] 1 test added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

