### PR TITLE
GH14422: BUG: to_numeric doesn't work uint64 numbers

### DIFF
--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -305,3 +305,17 @@ class TestSeriesReplace:
         result = s.replace(["100000000000000000000"], [1])
         expected = pd.Series([0, 1, "100000000000000000001"])
         tm.assert_series_equal(result, expected)
+
+    def test_replace_no_cast(self):
+        # GH 9113
+        # BUG: replace int64 dtype with bool coerces to int64
+
+        s1 = pd.Series([1, 2, 3])
+        result1 = s1.replace(2, True)
+        expected1 = pd.Series([1, True, 3])
+        tm.assert_series_equal(result1, expected1)
+
+        s2 = pd.Series(["x", 2, 3])
+        result2 = s1.replace(2, True)
+        expected2 = pd.Series(["x", True, 3])
+        tm.assert_series_equal(result2, expected2)

--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -305,17 +305,3 @@ class TestSeriesReplace:
         result = s.replace(["100000000000000000000"], [1])
         expected = pd.Series([0, 1, "100000000000000000001"])
         tm.assert_series_equal(result, expected)
-
-    def test_replace_no_cast(self):
-        # GH 9113
-        # BUG: replace int64 dtype with bool coerces to int64
-
-        s1 = pd.Series([1, 2, 3])
-        result1 = s1.replace(2, True)
-        expected1 = pd.Series([1, True, 3])
-        tm.assert_series_equal(result1, expected1)
-
-        s2 = pd.Series(["x", 2, 3])
-        result2 = s1.replace(2, True)
-        expected2 = pd.Series(["x", True, 3])
-        tm.assert_series_equal(result2, expected2)

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -610,6 +610,7 @@ def test_non_coerce_uint64_conflict(errors, exp):
         result = to_numeric(ser, errors=errors)
         tm.assert_series_equal(result, ser)
 
+
 def test_downcast_uint64_exception():
     # see gh-14422:
     # BUG: to_numeric doesn't work uint64 numbers
@@ -618,6 +619,6 @@ def test_downcast_uint64_exception():
 
     expected = pd.Series([0, 9223372036854775808], dtype=np.uint64)
 
-    result = pd.to_numeric(series, downcast='unsigned')
+    result = pd.to_numeric(series, downcast="unsigned")
 
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -609,3 +609,16 @@ def test_non_coerce_uint64_conflict(errors, exp):
     else:
         result = to_numeric(ser, errors=errors)
         tm.assert_series_equal(result, ser)
+
+# @pytest.mark.parametrize()
+def test_downcast_uint64_exception():
+    # see gh-14422:
+    # BUG: to_numeric doesn't work uint64 numbers
+
+    series = pd.Series([0, 9223372036854775808])
+
+    expected = pd.Series([0, 9223372036854775808], dtype=np.uint64)
+
+    result = pd.to_numeric(series, downcast='unsigned')
+
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -610,7 +610,6 @@ def test_non_coerce_uint64_conflict(errors, exp):
         result = to_numeric(ser, errors=errors)
         tm.assert_series_equal(result, ser)
 
-# @pytest.mark.parametrize()
 def test_downcast_uint64_exception():
     # see gh-14422:
     # BUG: to_numeric doesn't work uint64 numbers

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -568,6 +568,24 @@ def test_downcast_limits(dtype, downcast, min_max):
 
 
 @pytest.mark.parametrize(
+    "ser,expected",
+    [
+        (
+            pd.Series([0, 9223372036854775808]),
+            pd.Series([0, 9223372036854775808], dtype=np.uint64),
+        )
+    ],
+)
+def test_downcast_uint64(ser, expected):
+    # see gh-14422:
+    # BUG: to_numeric doesn't work uint64 numbers
+
+    result = pd.to_numeric(ser, downcast="unsigned")
+
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
     "data,exp_data",
     [
         (
@@ -609,16 +627,3 @@ def test_non_coerce_uint64_conflict(errors, exp):
     else:
         result = to_numeric(ser, errors=errors)
         tm.assert_series_equal(result, ser)
-
-
-def test_downcast_uint64_exception():
-    # see gh-14422:
-    # BUG: to_numeric doesn't work uint64 numbers
-
-    series = pd.Series([0, 9223372036854775808])
-
-    expected = pd.Series([0, 9223372036854775808], dtype=np.uint64)
-
-    result = pd.to_numeric(series, downcast="unsigned")
-
-    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
-closes #14422
-passes `black pandas`
-added test test_downcast_uint64_exception()