### PR TITLE
Stable python 3.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ matrix:
     include:
     - dist: bionic
       # 18.04
-      python: 3.8-dev
+      python: 3.8.0
       env:
-        - JOB="3.8-dev" PATTERN="(not slow and not network)"
+        - JOB="3.8.0" PATTERN="(not slow and not network)"
 
     - dist: trusty
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       # 18.04
       python: 3.8.0
       env:
-        - JOB="3.8.0" PATTERN="(not slow and not network)"
+        - JOB="3.8-dev" PATTERN="(not slow and not network)"
 
     - dist: trusty
       env:


### PR DESCRIPTION
Python 3.8.0 stable release is now available on travis https://travis-ci.community/t/add-python-3-8-support/5463 we can use it?

The 3.8-dev snapshot seemed to cause some issues here:
https://travis-ci.org/pandas-dev/pandas/jobs/606411398?utm_medium=notification&utm_source=github_status

related - https://github.com/pandas-dev/pandas/issues/26626