### PR TITLE
TST: new test for subset of a MultiIndex dtype

### DIFF
--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1934,66 +1934,12 @@ Thur,Lunch,Yes,51.51,17"""
 
     def test_subsets_multiindex_dtype(self):
         # GH 20757
-        data = [
-            [
-                "n",
-                1,
-                0,
-                False,
-                2,
-                1,
-                False,
-                0,
-                0,
-                False,
-                2,
-                0,
-                False,
-                0,
-                1,
-                False,
-                1,
-                1,
-                False,
-                "o",
-                1521734085.289453,
-                "p",
-                3233,
-                1521734085.289494,
-            ]
-        ]
-
-        columns = [
-            ("a", "d", "i", np.nan, np.nan),
-            ("a", "d", "j", 0.0, "k"),
-            ("a", "d", "j", 0.0, "l"),
-            ("a", "d", "j", 0.0, "m"),
-            ("a", "d", "j", 1.0, "k"),
-            ("a", "d", "j", 1.0, "l"),
-            ("a", "d", "j", 1.0, "m"),
-            ("a", "d", "j", 2.0, "k"),
-            ("a", "d", "j", 2.0, "l"),
-            ("a", "d", "j", 2.0, "m"),
-            ("a", "d", "j", 3.0, "k"),
-            ("a", "d", "j", 3.0, "l"),
-            ("a", "d", "j", 3.0, "m"),
-            ("a", "d", "j", 4.0, "k"),
-            ("a", "d", "j", 4.0, "l"),
-            ("a", "d", "j", 4.0, "m"),
-            ("a", "d", "j", 5.0, "k"),
-            ("a", "d", "j", 5.0, "l"),
-            ("a", "d", "j", 5.0, "m"),
-            ("b", "f", np.nan, np.nan, np.nan),
-            ("b", "h", np.nan, np.nan, np.nan),
-            ("c", "e", np.nan, np.nan, np.nan),
-            ("c", "g", np.nan, np.nan, np.nan),
-            ("c", "h", np.nan, np.nan, np.nan),
-        ]
-
-        columns = pd.MultiIndex.from_tuples(columns)
-        df = pd.DataFrame(data, columns=columns)
-
-        tm.assert_equal(df.dtypes.a.d.i, df.a.d.i.dtypes)
+        data = [["x", 1]]
+        columns = [("a", "b", np.nan), ("a", "c", 0.0)]
+        df = DataFrame(data, columns=pd.MultiIndex.from_tuples(columns))
+        expected = df.dtypes.a.b
+        result = df.a.b.dtypes
+        tm.assert_series_equal(expected, result)
 
 
 class TestSorted(Base):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1932,6 +1932,14 @@ Thur,Lunch,Yes,51.51,17"""
         m_df = Series(data, index=m_idx)
         assert m_df.repeat(3).shape == (3 * len(data),)
 
+    def test_subsets_multiindex_dtype(self):
+        # GH 20757
+        cols = [(1, 2), (3, 4), (5, 6), (7, 8)]
+        data = ["a", "b", "c", "d"]
+        result = pd.DataFrame(data, columns=MultiIndex.from_tuples(cols)).dtypes.a.d.i
+        expected = pd.DataFrame(data, columns=MultiIndex.from_tuples(cols)).a.d.i.dtypes
+        tm.assert_frame_equal(result, expected)
+
 
 class TestSorted(Base):
     """ everything you wanted to test about sorting """

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1939,7 +1939,7 @@ Thur,Lunch,Yes,51.51,17"""
         df = DataFrame(data, columns=pd.MultiIndex.from_tuples(columns))
         expected = df.dtypes.a.b
         result = df.a.b.dtypes
-        tm.assert_series_equal(expected, result)
+        tm.assert_series_equal(result, expected)
 
 
 class TestSorted(Base):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1934,11 +1934,66 @@ Thur,Lunch,Yes,51.51,17"""
 
     def test_subsets_multiindex_dtype(self):
         # GH 20757
-        cols = [(1, 2), (3, 4), (5, 6), (7, 8)]
-        data = ["a", "b", "c", "d"]
-        result = pd.DataFrame(data, columns=MultiIndex.from_tuples(cols)).dtypes.a.d.i
-        expected = pd.DataFrame(data, columns=MultiIndex.from_tuples(cols)).a.d.i.dtypes
-        tm.assert_frame_equal(result, expected)
+        data = [
+            [
+                "n",
+                1,
+                0,
+                False,
+                2,
+                1,
+                False,
+                0,
+                0,
+                False,
+                2,
+                0,
+                False,
+                0,
+                1,
+                False,
+                1,
+                1,
+                False,
+                "o",
+                1521734085.289453,
+                "p",
+                3233,
+                1521734085.289494,
+            ]
+        ]
+
+        columns = [
+            ("a", "d", "i", np.nan, np.nan),
+            ("a", "d", "j", 0.0, "k"),
+            ("a", "d", "j", 0.0, "l"),
+            ("a", "d", "j", 0.0, "m"),
+            ("a", "d", "j", 1.0, "k"),
+            ("a", "d", "j", 1.0, "l"),
+            ("a", "d", "j", 1.0, "m"),
+            ("a", "d", "j", 2.0, "k"),
+            ("a", "d", "j", 2.0, "l"),
+            ("a", "d", "j", 2.0, "m"),
+            ("a", "d", "j", 3.0, "k"),
+            ("a", "d", "j", 3.0, "l"),
+            ("a", "d", "j", 3.0, "m"),
+            ("a", "d", "j", 4.0, "k"),
+            ("a", "d", "j", 4.0, "l"),
+            ("a", "d", "j", 4.0, "m"),
+            ("a", "d", "j", 5.0, "k"),
+            ("a", "d", "j", 5.0, "l"),
+            ("a", "d", "j", 5.0, "m"),
+            ("b", "f", np.nan, np.nan, np.nan),
+            ("b", "h", np.nan, np.nan, np.nan),
+            ("c", "e", np.nan, np.nan, np.nan),
+            ("c", "g", np.nan, np.nan, np.nan),
+            ("c", "h", np.nan, np.nan, np.nan),
+        ]
+
+        columns = pd.MultiIndex.from_tuples(columns)
+        df = pd.DataFrame(data, columns=columns)
+
+        tm.assert_equal(df.dtypes.a.d.i, df.a.d.i.dtypes)
 
 
 class TestSorted(Base):


### PR DESCRIPTION
Tried unsuccessfully reproducing Issue #20757 on pandas: 0.23.0 and 0.26.0.dev0+734.g0de99558b.dirty. That's why I decided to keep the input data from Issue #20757 unchanged.

- [x] closes #20757
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
