### PR TITLE
TST: Apply method broken for empty integer series with datetime index

### DIFF
--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -170,6 +170,13 @@ class TestSeriesApply:
         expected = expected.astype(object)
         tm.assert_series_equal(result, expected)
 
+    def test_apply_empty_integer_series_with_datetime_index(self):
+        # GH 21245
+        s = pd.Series([],
+                      index=pd.date_range(start="2018-01-01", periods=0),
+                      dtype=int)
+        tm.assert_series_equal(s.apply(lambda x: x), s)
+
 
 class TestSeriesAggregate:
     def test_transform(self, string_series):

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -172,9 +172,7 @@ class TestSeriesApply:
 
     def test_apply_empty_integer_series_with_datetime_index(self):
         # GH 21245
-        s = pd.Series([],
-                      index=pd.date_range(start="2018-01-01", periods=0),
-                      dtype=int)
+        s = pd.Series([], index=pd.date_range(start="2018-01-01", periods=0), dtype=int)
         tm.assert_series_equal(s.apply(lambda x: x), s)
 
 

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -173,7 +173,8 @@ class TestSeriesApply:
     def test_apply_empty_integer_series_with_datetime_index(self):
         # GH 21245
         s = pd.Series([], index=pd.date_range(start="2018-01-01", periods=0), dtype=int)
-        tm.assert_series_equal(s.apply(lambda x: x), s)
+        result = s.apply(lambda x: x)
+        tm.assert_series_equal(result, s)
 
 
 class TestSeriesAggregate:


### PR DESCRIPTION
I added a unit test for an edge case that was failing. Using the apply method on an empty integer series with a datetime index would throw an error.

- [x] closes #21245
- [x] 1 test added
- [x] passes pandas and flake8
