### PR TITLE
29213: Dataframe Constructor from List of List and non-iterables

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -460,21 +460,27 @@ class DataFrame(NDFrame):
                 data = list(data)
             if len(data) > 0:
                 if is_list_like(data[0]) and getattr(data[0], "ndim", 1) == 1:
-                    if is_named_tuple(data[0]) and columns is None:
-                        columns = data[0]._fields
-                    arrays, columns = to_arrays(data, columns, dtype=dtype)
-                    columns = ensure_index(columns)
+                    # try to infer that all elements are list-like as well
+                    try:
+                        if is_named_tuple(data[0]) and columns is None:
+                            columns = data[0]._fields
+                        arrays, columns = to_arrays(data, columns, dtype=dtype)
+                        columns = ensure_index(columns)
 
-                    # set the index
-                    if index is None:
-                        if isinstance(data[0], Series):
-                            index = get_names_from_index(data)
-                        elif isinstance(data[0], Categorical):
-                            index = ibase.default_index(len(data[0]))
-                        else:
-                            index = ibase.default_index(len(data))
+                        # set the index
+                        if index is None:
+                            if isinstance(data[0], Series):
+                                index = get_names_from_index(data)
+                            elif isinstance(data[0], Categorical):
+                                index = ibase.default_index(len(data[0]))
+                            else:
+                                index = ibase.default_index(len(data))
 
-                    mgr = arrays_to_mgr(arrays, columns, index, columns, dtype=dtype)
+                        mgr = arrays_to_mgr(arrays, columns, index, columns, dtype=dtype)
+
+                    except TypeError:
+                        mgr = init_ndarray(data, index, columns, dtype=dtype, copy=copy)
+
                 else:
                     mgr = init_ndarray(data, index, columns, dtype=dtype, copy=copy)
             else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -476,7 +476,9 @@ class DataFrame(NDFrame):
                             else:
                                 index = ibase.default_index(len(data))
 
-                        mgr = arrays_to_mgr(arrays, columns, index, columns, dtype=dtype)
+                        mgr = arrays_to_mgr(
+                            arrays, columns, index, columns, dtype=dtype
+                        )
 
                     except TypeError:
                         mgr = init_ndarray(data, index, columns, dtype=dtype, copy=copy)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1055,6 +1055,18 @@ class TestDataFrameConstructors:
         result = DataFrame(data)
         tm.assert_frame_equal(result, expected)
 
+    def test_constructor_list_containing_lists_and_non_iterables(self):
+        # GH-29213
+        # First element iterable
+        result = pd.DataFrame([[1, 2, 3], 4])
+        expected = pd.DataFrame(pd.Series([[1, 2, 3], 4]))
+        tm.assert_frame_equal(result, expected)
+
+        # First element non-iterable
+        result = pd.DataFrame([4, [1, 2, 3]])
+        expected = pd.DataFrame(pd.Series([4, [1, 2, 3]]))
+        tm.assert_frame_equal(result, expected)
+
     def test_constructor_sequence_like(self):
         # GH 3783
         # collections.Squence like

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1058,25 +1058,27 @@ class TestDataFrameConstructors:
     def test_constructor_list_containing_lists_and_non_iterables(self):
         # GH-29213
         # First element iterable
-        result = pd.DataFrame([[1, 2, 3], 4])
-        expected = pd.DataFrame(pd.Series([[1, 2, 3], 4]))
+        result = DataFrame([[1, 2, 3], 4])
+        expected = DataFrame(Series([[1, 2, 3], 4]))
         tm.assert_frame_equal(result, expected)
 
         # First element non-iterable
-        result = pd.DataFrame([4, [1, 2, 3]])
-        expected = pd.DataFrame(pd.Series([4, [1, 2, 3]]))
+        result = DataFrame([4, [1, 2, 3]])
+        expected = DataFrame(Series([4, [1, 2, 3]]))
         tm.assert_frame_equal(result, expected)
 
     def test_constructor_from_dict_lists_and_non_iterables(self):
         # GH-29213
-        # First dict.values() element iterable
-        result = pd.DataFrame.from_dict({"a": [1, 2, 3], "b": 4}, orient="index")
-        expected = pd.DataFrame(pd.Series([[1, 2, 3], 4], ["a", "b"]))
+        # First dic.values() element iterable
+        dic = OrderedDict([["a", [1, 2, 3]], ["b", 4]])
+        result = DataFrame.from_dict(dic, orient="index")
+        expected = DataFrame(Series([[1, 2, 3], 4], ["a", "b"]))
         tm.assert_frame_equal(result, expected)
 
         # First dict.values() element non-iterable
-        result = pd.DataFrame.from_dict({"b": 4, "a": [1, 2, 3]}, orient="index")
-        expected = pd.DataFrame(pd.Series([4, [1, 2, 3]], ["b", "a"]))
+        dic = OrderedDict([["b", 4], ["a", [1, 2, 3]]])
+        result = DataFrame.from_dict(dic, orient="index")
+        expected = DataFrame(Series([4, [1, 2, 3]], ["b", "a"]))
         tm.assert_frame_equal(result, expected)
 
     def test_constructor_sequence_like(self):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1067,6 +1067,18 @@ class TestDataFrameConstructors:
         expected = pd.DataFrame(pd.Series([4, [1, 2, 3]]))
         tm.assert_frame_equal(result, expected)
 
+    def test_constructor_from_dict_lists_and_non_iterables(self):
+        # GH-29213
+        # First dict.values() element iterable
+        result = pd.DataFrame.from_dict({"a": [1, 2, 3], "b": 4}, orient="index")
+        expected = pd.DataFrame(pd.Series([[1, 2, 3], 4], ["a", "b"]))
+        tm.assert_frame_equal(result, expected)
+
+        # First dict.values() element non-iterable
+        result = pd.DataFrame.from_dict({"b": 4, "a": [1, 2, 3]}, orient="index")
+        expected = pd.DataFrame(pd.Series([4, [1, 2, 3]], ["b", "a"]))
+        tm.assert_frame_equal(result, expected)
+
     def test_constructor_sequence_like(self):
         # GH 3783
         # collections.Squence like


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/issues/29213
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

---
## What
Whilst the original issue is from the factory method `DataFrame.from_dict(d, orient='index')`, the main issue is the *order* of elements within the list in the main constructor:

For example:
```
pd.DataFrame([[1, 2, 3], 4])  # doesn't work
# TypeError: object of type 'int' has no len()

In [2]: pd.DataFrame([4, [1, 2, 3]]) # works, creates a 1D DataFrame
Out[2]:
           0
0          4
1  [1, 2, 3]
```



## Current Constructor Logic on List Argument
- Current logic looks at the [first element](https://github.com/pandas-dev/pandas/blob/master/pandas/core/frame.py#L462-L465), and *infers* that all other elements are iterables as well.
    - if all elements in the list are iterables, it generates a 2D DataFrame.
    - if any element from index-1 onwards is a non-iterable, it doesn't have a len() method and fails.

## Proposed Solution
- Based on the first element, *try* to infer that all elements are iterables as well.
    - If not all subsequent elements are iterables, then return 1D DataFrame. This would be the same behaviour as it would have been if the first element in the list is non-iterable.
    - This should not have performance degradation as there is noneed to check if all elements in the list are iterables.


## Note
- This does not solve the issue whereby we have iterables of different types (such as lists and strings...)
```
In [2]: pd.DataFrame([[1, 2, 3], 'foobar'])
Out[2]:
   0  1  2     3     4     5
0  1  2  3  None  None  None
1  f  o  o     b     a     r
```