### PR TITLE
TST: Adding map test for dict with np.nan key [Ref 17648]

### DIFF
--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -581,6 +581,14 @@ class TestSeriesMap:
         expected = Series(["stuff", "blank", "blank"], index=["a", "b", "c"])
         tm.assert_series_equal(result, expected)
 
+    def test_map_dict_na_key(self):
+        # https://github.com/pandas-dev/pandas/issues/17648
+        # Checks that np.nan key is appropriately mapped
+        s = Series([1, 2, np.nan])
+        expected = Series(["a", "b", "c"])
+        result = s.map({1: "a", 2: "b", np.nan: "c"})
+        tm.assert_series_equal(result, expected)
+
     def test_map_dict_subclass_with_missing(self):
         """
         Test Series.map with a dictionary subclass that defines __missing__,


### PR DESCRIPTION
- [x] closes #17648
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
