### PR TITLE
Updated index links for 0.25.3

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -39,7 +39,7 @@ See the :ref:`overview` for more detail about what's in the library.
     :hidden:
 {% endif %}
 {% if not single_doc %}
-    What's New in 0.25.2 <whatsnew/v0.25.2>
+    What's New in 0.25.3 <whatsnew/v0.25.3>
     install
     getting_started/index
     user_guide/index
@@ -53,7 +53,7 @@ See the :ref:`overview` for more detail about what's in the library.
     whatsnew/index
 {% endif %}
 
-* :doc:`whatsnew/v0.25.2`
+* :doc:`whatsnew/v0.25.3`
 * :doc:`install`
 * :doc:`getting_started/index`
 


### PR DESCRIPTION
I think this was supposed to be updated for the release. Might need to retag after repush docs after this

@TomAugspurger 