### PR TITLE
API: drop kwargs from Series.dropna, add explicit `how` parameter

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -192,6 +192,8 @@ Other API changes
   Now, pandas custom formatters will only be applied to plots created by pandas, through :meth:`~DataFrame.plot`.
   Previously, pandas' formatters would be applied to all plots created *after* a :meth:`~DataFrame.plot`.
   See :ref:`units registration <whatsnew_1000.matplotlib_units>` for more.
+- :meth:`Series.dropna` has dropped its ``**kwargs`` argument in favor of a single ``how`` parameter.
+  Supplying anything else than ``how`` to ``**kwargs`` raised a ``TypeError`` previously (:issue:`29388`)
 -
 
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4609,7 +4609,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         inplace : bool, default False
             If True, do operation inplace and return None.
         how : str, optional
-            Not in use.
+            Not in use. Kept for compatibility.
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4595,7 +4595,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def notnull(self):
         return super().notnull()
 
-    def dropna(self, axis=0, inplace=False, **kwargs):
+    def dropna(self, axis=0, inplace=False, how=None):
         """
         Return a new Series with missing values removed.
 
@@ -4608,7 +4608,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             There is only one axis to drop values from.
         inplace : bool, default False
             If True, do operation inplace and return None.
-        **kwargs
+        how : str, optional
             Not in use.
 
         Returns
@@ -4667,12 +4667,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         dtype: object
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        kwargs.pop("how", None)
-        if kwargs:
-            raise TypeError(
-                "dropna() got an unexpected keyword "
-                'argument "{0}"'.format(list(kwargs.keys())[0])
-            )
         # Validate the axis parameter
         self._get_axis_number(axis or 0)
 


### PR DESCRIPTION
Using ``**kwargs`` gave false type hints on what the dropna method could take for arguments, and supplying anything but ``how`` raised a TypeError already.
