### PR TITLE
API: rename labels to codes in core/groupby

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2349,7 +2349,7 @@ class GroupBy(_GroupBy):
                 )
             )
         filled = getattr(self, fill_method)(limit=limit)
-        fill_grp = filled.groupby(self.grouper.labels)
+        fill_grp = filled.groupby(self.grouper.codes)
         shifted = fill_grp.shift(periods=periods, freq=freq)
         return (filled / shifted) - 1
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -3,7 +3,7 @@ Provide user facing operators for doing the split part of the
 split-apply-combine paradigm.
 """
 
-from typing import Tuple
+from typing import Optional, Tuple
 import warnings
 
 import numpy as np
@@ -21,6 +21,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.generic import ABCSeries
 
+from pandas._typing import FrameOrSeries
 import pandas.core.algorithms as algorithms
 from pandas.core.arrays import Categorical, ExtensionArray
 import pandas.core.common as com
@@ -228,7 +229,7 @@ class Grouping:
     ----------
     index : Index
     grouper :
-    obj :
+    obj Union[DataFrame, Series]:
     name :
     level :
     observed : bool, default False
@@ -247,16 +248,15 @@ class Grouping:
 
     def __init__(
         self,
-        index,
+        index: Index,
         grouper=None,
-        obj=None,
+        obj: Optional[FrameOrSeries] = None,
         name=None,
         level=None,
-        sort=True,
-        observed=False,
-        in_axis=False,
+        sort: bool = True,
+        observed: bool = False,
+        in_axis: bool = False,
     ):
-
         self.name = name
         self.level = level
         self.grouper = _convert_grouper(index, grouper)
@@ -306,7 +306,7 @@ class Grouping:
             self.grouper = grouper._get_grouper()
 
         else:
-            if self.grouper is None and self.name is not None:
+            if self.grouper is None and self.name is not None and self.obj is not None:
                 self.grouper = self.obj[self.name]
 
             elif isinstance(self.grouper, (list, tuple)):
@@ -676,7 +676,7 @@ def _is_label_like(val):
     return isinstance(val, (str, tuple)) or (val is not None and is_scalar(val))
 
 
-def _convert_grouper(axis, grouper):
+def _convert_grouper(axis: Index, grouper):
     if isinstance(grouper, dict):
         return grouper.get
     elif isinstance(grouper, Series):

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -59,7 +59,7 @@ class Grouper:
         <http://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`_.
     axis : number/name of the axis, defaults to 0
     sort : bool, default to False
-        whether to sort the resulting codes
+        whether to sort the resulting labels
     closed : {'left' or 'right'}
         Closed end of interval. Only when `freq` parameter is passed.
     label : {'left' or 'right'}
@@ -378,11 +378,11 @@ class Grouping:
     def __iter__(self):
         return iter(self.indices)
 
-    _codes = None
-    _group_index = None
+    _codes = None  # type: np.ndarray
+    _group_index = None  # type: Index
 
     @property
-    def ngroups(self):
+    def ngroups(self) -> int:
         return len(self.group_index)
 
     @cache_readonly
@@ -395,24 +395,24 @@ class Grouping:
         return values._reverse_indexer()
 
     @property
-    def codes(self):
+    def codes(self) -> np.ndarray:
         if self._codes is None:
             self._make_codes()
         return self._codes
 
     @cache_readonly
-    def result_index(self):
+    def result_index(self) -> Index:
         if self.all_grouper is not None:
             return recode_from_groupby(self.all_grouper, self.sort, self.group_index)
         return self.group_index
 
     @property
-    def group_index(self):
+    def group_index(self) -> Index:
         if self._group_index is None:
             self._make_codes()
         return self._group_index
 
-    def _make_codes(self):
+    def _make_codes(self) -> None:
         if self._codes is None or self._group_index is None:
             # we have a list of groupers
             if isinstance(self.grouper, BaseGrouper):
@@ -425,7 +425,7 @@ class Grouping:
             self._group_index = uniques
 
     @cache_readonly
-    def groups(self):
+    def groups(self) -> dict:
         return self.index.groupby(Categorical.from_codes(self.codes, self.group_index))
 
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -7,7 +7,7 @@ are contained *in* the SeriesGroupBy and DataFrameGroupBy objects.
 """
 
 import collections
-from typing import List, Optional, Type
+from typing import List, Optional, Sequence, Type
 
 import numpy as np
 
@@ -41,7 +41,7 @@ from pandas.core.base import SelectionMixin
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
-from pandas.core.groupby import base
+from pandas.core.groupby import base, grouper
 from pandas.core.index import Index, MultiIndex, ensure_index
 from pandas.core.series import Series
 from pandas.core.sorting import (
@@ -62,13 +62,13 @@ class BaseGrouper:
     Parameters
     ----------
     axis : Index
-    groupings : array of grouping
+    groupings : Sequence[Grouping]
         all the grouping instances to handle in this grouper
         for example for grouper list to groupby, need to pass the list
-    sort : boolean, default True
+    sort : bool, default True
         whether this grouper will give sorted result or not
-    group_keys : boolean, default True
-    mutated : boolean, default False
+    group_keys : bool, default True
+    mutated : bool, default False
     indexer : intp array, optional
         the indexer created by Grouper
         some groupers (TimeGrouper) will sort its axis and its
@@ -79,16 +79,17 @@ class BaseGrouper:
     def __init__(
         self,
         axis: Index,
-        groupings,
-        sort=True,
-        group_keys=True,
-        mutated=False,
-        indexer=None,
+        groupings: "Sequence[grouper.Grouping]",
+        sort: bool = True,
+        group_keys: bool = True,
+        mutated: bool = False,
+        indexer: Optional[np.ndarray] = None,
     ):
         assert isinstance(axis, Index), axis
+
         self._filter_empty_groups = self.compressed = len(groupings) != 1
         self.axis = axis
-        self.groupings = groupings
+        self.groupings = groupings  # type: Sequence[grouper.Grouping]
         self.sort = sort
         self.group_keys = group_keys
         self.mutated = mutated

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -559,12 +559,12 @@ class TestGrouping:
         # GH 17537
         grouped = mframe.groupby(level=0, sort=sort)
         exp_labels = np.array(labels, np.intp)
-        tm.assert_almost_equal(grouped.grouper.labels[0], exp_labels)
+        tm.assert_almost_equal(grouped.grouper.codes[0], exp_labels)
 
     def test_grouping_labels(self, mframe):
         grouped = mframe.groupby(mframe.index.get_level_values(0))
         exp_labels = np.array([2, 2, 2, 0, 0, 1, 1, 3, 3, 3], dtype=np.intp)
-        tm.assert_almost_equal(grouped.grouper.labels[0], exp_labels)
+        tm.assert_almost_equal(grouped.grouper.codes[0], exp_labels)
 
     def test_list_grouper_with_nat(self):
         # GH 14715

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -621,8 +621,8 @@ def assert_index_equal(
     def _get_ilevel_values(index, level):
         # accept level number only
         unique = index.levels[level]
-        labels = index.codes[level]
-        filled = take_1d(unique.values, labels, fill_value=unique._na_value)
+        level_codes = index.codes[level]
+        filled = take_1d(unique.values, level_codes, fill_value=unique._na_value)
         values = unique._shallow_copy(filled, name=index.names[level])
         return values
 


### PR DESCRIPTION
This PR renames the various ``*label*`` names in core/groupby to like-named ``*codes*``.

I think the name ``label`` can be confused by the single values in a index, and ``codes`` sound smore like an array of ints, so by renaming we get a cleaner nomenclature, IMO.

All these attributes/methods are internal, so no deprecations needed.