### PR TITLE
Fixed SS03 errors

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -94,7 +94,7 @@ cdef class IntervalMixin:
     @property
     def mid(self):
         """
-        Return the midpoint of the Interval
+        Return the midpoint of the Interval.
         """
         try:
             return 0.5 * (self.left + self.right)
@@ -104,7 +104,9 @@ cdef class IntervalMixin:
 
     @property
     def length(self):
-        """Return the length of the Interval"""
+        """
+        Return the length of the Interval.
+        """
         return self.right - self.left
 
     @property
@@ -283,15 +285,19 @@ cdef class Interval(IntervalMixin):
     _typ = "interval"
 
     cdef readonly object left
-    """Left bound for the interval"""
+    """
+    Left bound for the interval.
+    """
 
     cdef readonly object right
-    """Right bound for the interval"""
+    """
+    Right bound for the interval.
+    """
 
     cdef readonly str closed
     """
     Whether the interval is closed on the left-side, right-side, both or
-    neither
+    neither.
     """
 
     def __init__(self, left, right, str closed='right'):

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -464,7 +464,7 @@ class NaTType(_NaT):
         """
         Timestamp.combine(date, time)
 
-        date, time -> datetime with same date and time fields
+        date, time -> datetime with same date and time fields.
         """
     )
     utcnow = _make_error_func('utcnow',  # noqa:E128
@@ -503,8 +503,8 @@ class NaTType(_NaT):
         """
         Timestamp.fromordinal(ordinal, freq=None, tz=None)
 
-        passed an ordinal, translate and convert to a ts
-        note: by definition there cannot be any tz info on the ordinal itself
+        Passed an ordinal, translate and convert to a ts.
+        Note: by definition there cannot be any tz info on the ordinal itself.
 
         Parameters
         ----------

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2244,7 +2244,7 @@ cdef class _Period:
         containing one or several directives.  The method recognizes the same
         directives as the :func:`time.strftime` function of the standard Python
         distribution, as well as the specific additional directives ``%f``,
-        ``%F``, ``%q``. (formatting & docs originally from scikits.timeries)
+        ``%F``, ``%q``. (formatting & docs originally from scikits.timeries).
 
         +-----------+--------------------------------+-------+
         | Directive | Meaning                        | Notes |

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -242,8 +242,8 @@ class Timestamp(_Timestamp):
         """
         Timestamp.fromordinal(ordinal, freq=None, tz=None)
 
-        passed an ordinal, translate and convert to a ts
-        note: by definition there cannot be any tz info on the ordinal itself
+        Passed an ordinal, translate and convert to a ts.
+        Note: by definition there cannot be any tz info on the ordinal itself.
 
         Parameters
         ----------
@@ -333,7 +333,7 @@ class Timestamp(_Timestamp):
         """
         Timestamp.combine(date, time)
 
-        date, time -> datetime with same date and time fields
+        date, time -> datetime with same date and time fields.
         """
         return cls(datetime.combine(date, time))
 
@@ -601,7 +601,7 @@ timedelta}, default 'raise'
     @property
     def dayofweek(self):
         """
-        Return day of whe week.
+        Return day of the week.
         """
         return self.weekday()
 


### PR DESCRIPTION
Fixed SS03 errors for:
`pandas.Timestamp.combine`; `pandas.Timestamp.fromordinal`; `pandas.Period.strftime`; `pandas.Interval.closed`; `pandas.Interval.left`; `pandas.Interval.length`; `pandas.Interval.mid`; `pandas.Interval.right`.

- [x] xref to #29315
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Similar to #28053 I could not find methods for `pandas.Timestamp.isoweekday` or `pandas.Timestamp.weekday`. This was not resolved in #28053. I think this may be due to docstrings in the original python datetime file.
Timestamp import _Timestamp which imports datetime. Neither Timestamp nor _Timestamp have `isoweekday` or `weekday` methods.
@datapythonista 