### PR TITLE
maybe_promote: Restrict fill_value to scalar for non-object dtype

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -339,6 +339,11 @@ def maybe_upcast_putmask(result: np.ndarray, mask: np.ndarray, other):
 
 
 def maybe_promote(dtype, fill_value=np.nan):
+    if not is_scalar(fill_value) and not is_object_dtype(dtype):
+        # with object dtype there is nothing to promote, and the user can
+        #  pass pretty much any weird fill_value they like
+        raise ValueError("fill_value must be a scalar")
+
     # if we passed an array here, determine the fill value by dtype
     if isinstance(fill_value, np.ndarray):
         if issubclass(fill_value.dtype.type, (np.datetime64, np.timedelta64)):
@@ -686,7 +691,8 @@ def maybe_upcast(values, fill_value=np.nan, dtype=None, copy=False):
     dtype : if None, then use the dtype of the values, else coerce to this type
     copy : if True always make a copy even if no upcast is required
     """
-    if not is_scalar(fill_value):
+    if not is_scalar(fill_value) and not is_object_dtype(values.dtype):
+        # We allow arbitrary fill values for object dtype
         raise ValueError("fill_value must be a scalar")
 
     if is_extension_type(values):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1283,10 +1283,6 @@ class Block(PandasObject):
     def shift(self, periods, axis=0, fill_value=None):
         """ shift the block by periods, possibly upcast """
 
-        if not lib.is_scalar(fill_value):
-            # We could go further and require e.g. self._can_hold_element(fv)
-            raise ValueError("fill_value must be a scalar")
-
         # convert integer to float if necessary. need to do a lot more than
         # that, handle boolean etc also
         new_values, fill_value = maybe_upcast(self.values, fill_value)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1028,6 +1028,24 @@ class TestSeriesAnalytics:
         expected = ts.astype(float).shift(1)
         tm.assert_series_equal(shifted, expected)
 
+    def test_shift_object_non_scalar_fill(self):
+        # shift requires scalar fill_value except for object dtype
+        ser = Series(range(3))
+        with pytest.raises(ValueError, match="fill_value must be a scalar"):
+            ser.shift(1, fill_value=[])
+
+        df = ser.to_frame()
+        with pytest.raises(ValueError, match="fill_value must be a scalar"):
+            df.shift(1, fill_value=np.arange(3))
+
+        obj_ser = ser.astype(object)
+        result = obj_ser.shift(1, fill_value={})
+        assert result[0] == {}
+
+        obj_df = obj_ser.to_frame()
+        result = obj_df.shift(1, fill_value={})
+        assert result.iloc[0, 0] == {}
+
     def test_shift_categorical(self):
         # GH 9416
         s = pd.Series(["a", "b", "c", "d"], dtype="category")


### PR DESCRIPTION
Partially reverts #29362 by allowing non-scalar fill_value for _object_ dtypes.  i.e. in 0.25.3 `pd.Series(range(3), dtype=object).shift(1, fill_value={})` would work, #29362 broke that, and this restores it.  Added `test_shift_object_non_scalar_fill` for this.

With the new restriction on `maybe_promote` in place, we can get rid of all the `box` tests and simplify test_promote a _ton_.  This removes about 2500 tests.  This also uncovers the fact that we were failing to run some of the non-box cases, which are now xfailed.