### PR TITLE
TST: ignore _version.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ branch = False
 omit =
      */tests/*
      pandas/_typing.py
+     pandas/_version.py
 plugins = Cython.Coverage
 
 [coverage:report]


### PR DESCRIPTION
- [x] closes #26877

The file is auto-generated, not something for us to worry about