### PR TITLE
REF: separate out ShallowMixin

### DIFF
--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1581,11 +1581,6 @@ def make_sparse(arr, kind="block", fill_value=None, dtype=None, copy=False):
         indices = mask.nonzero()[0].astype(np.int32)
 
     index = _make_index(length, indices, kind)
-
-    if mask.dtype == object:
-        # numpy 1.18 requires that we do this explicitly
-        mask = mask.astype(bool)
-
     sparsified_values = arr[mask]
     if dtype is not None:
         sparsified_values = astype_nansafe(sparsified_values, dtype=dtype)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1582,8 +1582,10 @@ def make_sparse(arr, kind="block", fill_value=None, dtype=None, copy=False):
 
     index = _make_index(length, indices, kind)
 
-    assert isinstance(mask, np.ndarray), type(mask)
-    assert mask.dtype == bool, mask.dtype
+    if mask.dtype == object:
+        # numpy 1.18 requires that we do this explicitly
+        mask = mask.astype(bool)
+
     sparsified_values = arr[mask]
     if dtype is not None:
         sparsified_values = astype_nansafe(sparsified_values, dtype=dtype)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1581,6 +1581,9 @@ def make_sparse(arr, kind="block", fill_value=None, dtype=None, copy=False):
         indices = mask.nonzero()[0].astype(np.int32)
 
     index = _make_index(length, indices, kind)
+
+    assert isinstance(mask, np.ndarray), type(mask)
+    assert mask.dtype == bool, mask.dtype
     sparsified_values = arr[mask]
     if dtype is not None:
         sparsified_values = astype_nansafe(sparsified_values, dtype=dtype)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -4,7 +4,7 @@ Base and utility classes for pandas objects.
 import builtins
 from collections import OrderedDict
 import textwrap
-from typing import Dict, FrozenSet, Optional
+from typing import Dict, FrozenSet, List, Optional
 import warnings
 
 import numpy as np
@@ -569,7 +569,7 @@ class SelectionMixin:
                 try:
                     new_res = colg.aggregate(a)
 
-                except (TypeError, DataError):
+                except TypeError:
                     pass
                 else:
                     results.append(new_res)
@@ -618,6 +618,23 @@ class SelectionMixin:
                 raise ValueError("cannot combine transform and aggregation operations")
             return result
 
+    def _get_cython_func(self, arg: str) -> Optional[str]:
+        """
+        if we define an internal function for this argument, return it
+        """
+        return self._cython_table.get(arg)
+
+    def _is_builtin_func(self, arg):
+        """
+        if we define an builtin function for this argument, return it,
+        otherwise return the arg
+        """
+        return self._builtin_table.get(arg, arg)
+
+
+class ShallowMixin:
+    _attributes = []  # type: List[str]
+
     def _shallow_copy(self, obj=None, obj_type=None, **kwargs):
         """
         return a new object with the replacement attributes
@@ -632,19 +649,6 @@ class SelectionMixin:
             if attr not in kwargs:
                 kwargs[attr] = getattr(self, attr)
         return obj_type(obj, **kwargs)
-
-    def _get_cython_func(self, arg: str) -> Optional[str]:
-        """
-        if we define an internal function for this argument, return it
-        """
-        return self._cython_table.get(arg)
-
-    def _is_builtin_func(self, arg):
-        """
-        if we define an builtin function for this argument, return it,
-        otherwise return the arg
-        """
-        return self._builtin_table.get(arg, arg)
 
 
 class IndexOpsMixin:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -17,7 +17,7 @@ from pandas.util._decorators import Appender, Substitution
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 
 import pandas.core.algorithms as algos
-from pandas.core.base import DataError
+from pandas.core.base import DataError, ShallowMixin
 from pandas.core.generic import _shared_docs
 from pandas.core.groupby.base import GroupByMixin
 from pandas.core.groupby.generic import SeriesGroupBy
@@ -34,7 +34,7 @@ from pandas.tseries.offsets import DateOffset, Day, Nano, Tick
 _shared_docs_kwargs = dict()  # type: Dict[str, str]
 
 
-class Resampler(_GroupBy):
+class Resampler(_GroupBy, ShallowMixin):
     """
     Class for resampling datetimelike data, a groupby-like operation.
     See aggregate, transform, and apply functions on this object.

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -91,21 +91,6 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
     def _constructor(self):
         return Window
 
-    def _shallow_copy(self, obj=None, obj_type=None, **kwargs):
-        """
-        return a new object with the replacement attributes
-        """
-        if obj is None:
-            obj = self._selected_obj.copy()
-        if obj_type is None:
-            obj_type = self._constructor
-        if isinstance(obj, obj_type):
-            obj = obj.obj
-        for attr in self._attributes:
-            if attr not in kwargs:
-                kwargs[attr] = getattr(self, attr)
-        return obj_type(obj, **kwargs)
-
     @property
     def is_datetimelike(self) -> Optional[bool]:
         return None


### PR DESCRIPTION
- [x] closes #28938
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Stops catching DataError in the 1D case for _aggregate_multiple_funcs.  This change is mostly unrelated, but shares the process of reasoning about what cases need _shallow_copy/DataError.