### PR TITLE
BUG: Styling user guide points to a wrong nbviewer link

### DIFF
--- a/doc/source/user_guide/style.ipynb
+++ b/doc/source/user_guide/style.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Styling\n",
     "\n",
-    "This document is written as a Jupyter Notebook, and can be viewed or downloaded [here](http://nbviewer.ipython.org/github/pandas-dev/pandas/blob/master/doc/source/style.ipynb).\n",
+    "This document is written as a Jupyter Notebook, and can be viewed or downloaded [here](http://nbviewer.ipython.org/github/pandas-dev/pandas/blob/master/doc/source/user_guide/style.ipynb).\n",
     "\n",
     "You can apply **conditional formatting**, the visual styling of a DataFrame\n",
     "depending on the data within, by using the ``DataFrame.style`` property.\n",


### PR DESCRIPTION
Just missing the 'user_guide' part => one line change.

- [ ] closes #xxxx   (NOT THAT I KNOW)
- [ ] tests added / passed   (NO CODE CHANGE)
- [ ] passes `black pandas`   (NO CODE CHANGE)
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`   (NO CODE CHANGE)
- [ ] whatsnew entry   (NO CHANGE)
