### PR TITLE
Cleanup env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,10 @@
 name: pandas-dev
 channels:
-  - defaults
   - conda-forge
 dependencies:
   # required
   - numpy>=1.15
-  - python=3
+  - python=3.7
   - python-dateutil>=2.6.1
   - pytz
 
@@ -54,7 +53,6 @@ dependencies:
   - moto  # mock S3
   - pytest>=4.0.2
   - pytest-cov
-  - pytest-mock
   - pytest-xdist
   - seaborn
   - statsmodels

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - flake8-comprehensions  # used by flake8, linting of unnecessary comprehensions
   - flake8-rst>=0.6.0,<=0.7.0  # linting of code blocks in rst files
   - isort  # check that imports are in the right order
-  - mypy
+  - mypy=0.720
   - pycodestyle  # used by flake8
 
   # documentation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ flake8
 flake8-comprehensions
 flake8-rst>=0.6.0,<=0.7.0
 isort
-mypy
+mypy==0.720
 pycodestyle
 gitpython
 sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 numpy>=1.15
+python==3.7
 python-dateutil>=2.6.1
 pytz
 asv
@@ -32,7 +33,6 @@ hypothesis>=3.82
 moto
 pytest>=4.0.2
 pytest-cov
-pytest-mock
 pytest-xdist
 seaborn
 statsmodels


### PR DESCRIPTION
Closes #29330 

This was most likely due to inconsistent constraints between conda-forge & defaults.

Also, pinning to 3.7 for now until the 3.8 buildout is done to make the solver's life a bit easier.