### PR TITLE
CI: workaround numpydev bug

### DIFF
--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -53,7 +53,7 @@ jobs:
         #   TEST_ARGS: "-W error"
         #   PANDAS_TESTING_MODE: "deprecate"
         #   EXTRA_APT: "xsel"
-        #   # TODO: 
+        #   # TODO:
         #   continueOnError: true
 
   steps:

--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -52,6 +52,9 @@ jobs:
           TEST_ARGS: "-W error"
           PANDAS_TESTING_MODE: "deprecate"
           EXTRA_APT: "xsel"
+          # https://github.com/pandas-dev/pandas/issues/29432
+          # remove continueOnError
+          continueOnError: true
 
   steps:
     - script: |

--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -45,16 +45,16 @@ jobs:
           PATTERN: "not slow and not network"
           LOCALE_OVERRIDE: "zh_CN.UTF-8"
 
-        py37_np_dev:
-          ENV_FILE: ci/deps/azure-37-numpydev.yaml
-          CONDA_PY: "37"
-          PATTERN: "not slow and not network"
-          TEST_ARGS: "-W error"
-          PANDAS_TESTING_MODE: "deprecate"
-          EXTRA_APT: "xsel"
-          # https://github.com/pandas-dev/pandas/issues/29432
-          # remove continueOnError
-          continueOnError: true
+        # https://github.com/pandas-dev/pandas/issues/29432
+        # py37_np_dev:
+        #   ENV_FILE: ci/deps/azure-37-numpydev.yaml
+        #   CONDA_PY: "37"
+        #   PATTERN: "not slow and not network"
+        #   TEST_ARGS: "-W error"
+        #   PANDAS_TESTING_MODE: "deprecate"
+        #   EXTRA_APT: "xsel"
+        #   # TODO: 
+        #   continueOnError: true
 
   steps:
     - script: |

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1572,9 +1572,6 @@ def make_sparse(arr, kind="block", fill_value=None, dtype=None, copy=False):
             mask = splib.make_mask_object_ndarray(arr, fill_value)
         else:
             mask = arr != fill_value
-            # https://github.com/pandas-dev/pandas/issues/29432
-            # workaround numpydev issue
-            mask = mask.astype(bool)
 
     length = len(arr)
     if length != len(mask):

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1572,6 +1572,9 @@ def make_sparse(arr, kind="block", fill_value=None, dtype=None, copy=False):
             mask = splib.make_mask_object_ndarray(arr, fill_value)
         else:
             mask = arr != fill_value
+            # https://github.com/pandas-dev/pandas/issues/29432
+            # workaround numpydev issue
+            mask = mask.astype(bool)
 
     length = len(arr)
     if length != len(mask):


### PR DESCRIPTION
We don't want this long-term. But there's no easy way
to skip this for numpydev, since it errors in setup.

xref #29432 (keep open till numpydev is fixed)