### PR TITLE
TST: Add docstrings to arithmetic fixtures

### DIFF
--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -58,11 +58,11 @@ zeros.extend([0, 0.0, -0.0])
 @pytest.fixture(params=zeros)
 def zero(request):
     """
-    Several types of scalar zeros and length 5 vectors of zeros. 
-    
+    Several types of scalar zeros and length 5 vectors of zeros.
+ 
     This fixture can be used to check that numeric-dtype indexes handle
     division by any zero numeric-dtype.
-    
+
     Uses vector of length 5 for broadcasting with `numeric_idx` fixture,
     which creates numeric-dtype vectors also of length 5.
 

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -24,6 +24,22 @@ def one(request):
     """
     Several variants of integer value 1. The zero-dim integer array
     behaves like an integer.
+
+    This fixture is used to check that datetimelike indexes handle
+    addition and subtraction of integers and zero-dimensional arrays
+    of integers.
+
+    Examples
+    --------
+
+    >>> dti = pd.date_range('2016-01-01', periods=2, freq='H')
+    >>> dti
+    DatetimeIndex(['2016-01-01 00:00:00', '2016-01-01 01:00:00'],
+    dtype='datetime64[ns]', freq='H')
+    >>> dti + one
+    DatetimeIndex(['2016-01-01 01:00:00', '2016-01-01 02:00:00'],
+    dtype='datetime64[ns]', freq='H')
+
     """
     return request.param
 

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -31,7 +31,6 @@ def one(request):
 
     Examples
     --------
-
     >>> dti = pd.date_range('2016-01-01', periods=2, freq='H')
     >>> dti
     DatetimeIndex(['2016-01-01 00:00:00', '2016-01-01 01:00:00'],
@@ -39,7 +38,6 @@ def one(request):
     >>> dti + one
     DatetimeIndex(['2016-01-01 01:00:00', '2016-01-01 02:00:00'],
     dtype='datetime64[ns]', freq='H')
-
     """
     return request.param
 
@@ -62,6 +60,15 @@ def zero(request):
     """
     Several types of scalar zeros and length 5 vectors of zeros. For
     testing division by (or of) zero.
+
+    Uses vector of length 5 for broadcasting with `numeric_idx` fixture,
+    which creates numerical Indexes vectors also of length 5.
+
+    Examples
+    --------
+    >>> arr = pd.RangeIndex(5)
+    >>> arr / zeros
+    Float64Index([nan, inf, inf, inf, inf], dtype='float64')
     """
     return request.param
 

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -25,7 +25,7 @@ def one(request):
     Several variants of integer value 1. The zero-dim integer array
     behaves like an integer.
 
-    This fixture is used to check that datetimelike indexes handle
+    This fixture can be used to check that datetimelike indexes handle
     addition and subtraction of integers and zero-dimensional arrays
     of integers.
 
@@ -58,11 +58,13 @@ zeros.extend([0, 0.0, -0.0])
 @pytest.fixture(params=zeros)
 def zero(request):
     """
-    Several types of scalar zeros and length 5 vectors of zeros. For
-    testing division by (or of) zero.
-
+    Several types of scalar zeros and length 5 vectors of zeros. 
+    
+    This fixture can be used to check that numeric-dtype indexes handle
+    division by any zero numeric-dtype.
+    
     Uses vector of length 5 for broadcasting with `numeric_idx` fixture,
-    which creates numerical Indexes vectors also of length 5.
+    which creates numeric-dtype vectors also of length 5.
 
     Examples
     --------

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -59,7 +59,7 @@ zeros.extend([0, 0.0, -0.0])
 def zero(request):
     """
     Several types of scalar zeros and length 5 vectors of zeros.
- 
+
     This fixture can be used to check that numeric-dtype indexes handle
     division by any zero numeric-dtype.
 

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -21,7 +21,10 @@ def id_func(x):
 
 @pytest.fixture(params=[1, np.array(1, dtype=np.int64)])
 def one(request):
-    # zero-dim integer array behaves like an integer
+    """
+    Several variants of integer value 1. The zero-dim integer array
+    behaves like an integer.
+    """
     return request.param
 
 
@@ -40,8 +43,10 @@ zeros.extend([0, 0.0, -0.0])
 
 @pytest.fixture(params=zeros)
 def zero(request):
-    # For testing division by (or of) zero for Index with length 5, this
-    # gives several scalar-zeros and length-5 vector-zeros
+    """
+    Several types of scalar zeros and length 5 vectors of zeros. For
+    testing division by (or of) zero.
+    """
     return request.param
 
 


### PR DESCRIPTION
Relates to #19159

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
