### PR TITLE
Adding more documentation for upsampling with replacement and error m…

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -334,6 +334,7 @@ Numeric
 - Bug in :class:`DataFrame` logical operations (`&`, `|`, `^`) not matching :class:`Series` behavior by filling NA values (:issue:`28741`)
 - Bug in :meth:`DataFrame.interpolate` where specifying axis by name references variable before it is assigned (:issue:`29142`)
 - Improved error message when using `frac` > 1 and `replace` = False (:issue:`27451`)
+-
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -333,7 +333,7 @@ Numeric
 - :class:`DataFrame` flex inequality comparisons methods (:meth:`DataFrame.lt`, :meth:`DataFrame.le`, :meth:`DataFrame.gt`, :meth: `DataFrame.ge`) with object-dtype and ``complex`` entries failing to raise ``TypeError`` like their :class:`Series` counterparts (:issue:`28079`)
 - Bug in :class:`DataFrame` logical operations (`&`, `|`, `^`) not matching :class:`Series` behavior by filling NA values (:issue:`28741`)
 - Bug in :meth:`DataFrame.interpolate` where specifying axis by name references variable before it is assigned (:issue:`29142`)
--
+- Improved error message when using `frac` > 1 and `replace` = False (:issue:`27451`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5062,7 +5062,7 @@ class NDFrame(PandasObject, SelectionMixin):
         elif frac is not None and frac > 1 and not replace:
             raise ValueError(
                 "Replace has to be set to `True` when "
-                "upsampling the population `frac` > 1"
+                "upsampling the population `frac` > 1."
             )
         elif n is not None and frac is None and n % 1 != 0:
             raise ValueError("Only integers accepted as `n` values")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4933,6 +4933,11 @@ class NDFrame(PandasObject, SelectionMixin):
         --------
         numpy.random.choice: Generates a random sample from a given 1-D numpy
             array.
+        
+        Notes
+        -----
+
+        If `frac` > 1, `replacement` should be set to `True`
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4933,7 +4933,7 @@ class NDFrame(PandasObject, SelectionMixin):
         --------
         numpy.random.choice: Generates a random sample from a given 1-D numpy
             array.
-        
+
         Notes
         -----
         If `frac` > 1, `replacement` should be set to `True`

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4936,7 +4936,6 @@ class NDFrame(PandasObject, SelectionMixin):
         
         Notes
         -----
-
         If `frac` > 1, `replacement` should be set to `True`
 
         Examples

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5056,7 +5056,8 @@ class NDFrame(PandasObject, SelectionMixin):
             n = 1
         elif frac is not None and frac > 1 and not replace:
             raise ValueError(
-                "Replace has to be set to `True` when upsampling the population `frac` > 1"
+                "Replace has to be set to `True` when "
+                "upsampling the population `frac` > 1"
             )
         elif n is not None and frac is None and n % 1 != 0:
             raise ValueError("Only integers accepted as `n` values")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4964,6 +4964,21 @@ class NDFrame(PandasObject, SelectionMixin):
         dog          4          0                  2
         fish         0          0                  8
 
+
+        An upsample sample of the ``DataFrame`` with replacement:
+        Note that `replace` parameter has to be `True` for `frac` parameter > 1.
+
+        >>> df.sample(frac=2, replace=True, random_state=1)
+                num_legs  num_wings  num_specimen_seen
+        dog            4          0                  2
+        fish           0          0                  8
+        falcon         2          2                 10
+        falcon         2          2                 10
+        fish           0          0                  8
+        dog            4          0                  2
+        fish           0          0                  8
+        dog            4          0                  2
+
         Using a DataFrame column as weights. Rows with larger value in the
         `num_specimen_seen` column are more likely to be sampled.
 
@@ -5039,6 +5054,10 @@ class NDFrame(PandasObject, SelectionMixin):
         # If no frac or n, default to n=1.
         if n is None and frac is None:
             n = 1
+        elif frac is not None and frac > 1 and not replace:
+            raise ValueError(
+                "Replace has to be set to `True` when upsampling the population `frac` > 1"
+            )
         elif n is not None and frac is None and n % 1 != 0:
             raise ValueError("Only integers accepted as `n` values")
         elif n is None and frac is not None:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4936,7 +4936,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Notes
         -----
-        If `frac` > 1, `replacement` should be set to `True`
+        If `frac` > 1, `replacement` should be set to `True`.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4968,7 +4968,6 @@ class NDFrame(PandasObject, SelectionMixin):
         dog          4          0                  2
         fish         0          0                  8
 
-
         An upsample sample of the ``DataFrame`` with replacement:
         Note that `replace` parameter has to be `True` for `frac` parameter > 1.
 

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -435,12 +435,13 @@ class Generic:
         self._compare(o.sample(n=1, axis=0, weights=weights_with_None), o.iloc[5:6])
 
     def test_sample_upsampling_without_replacement(self):
+        # GH27451
         df = pd.DataFrame({"A": list("abc")})
         msg = (
             "Replace has to be set to `True` when upsampling the population `frac` > 1"
         )
         with pytest.raises(TypeError, match=msg):
-            hash(df.sample(frac=2, replace=False))
+            df.sample(frac=2, replace=False)
 
     def test_size_compat(self):
         # GH8846

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -322,6 +322,7 @@ class Generic:
             self._compare(
                 o.sample(n=4, random_state=seed), o.sample(n=4, random_state=seed)
             )
+
             self._compare(
                 o.sample(frac=0.7, random_state=seed),
                 o.sample(frac=0.7, random_state=seed),
@@ -335,6 +336,15 @@ class Generic:
             self._compare(
                 o.sample(frac=0.7, random_state=np.random.RandomState(test)),
                 o.sample(frac=0.7, random_state=np.random.RandomState(test)),
+            )
+
+            self._compare(
+                o.sample(
+                    frac=2, replace=True, random_state=np.random.RandomState(test)
+                ),
+                o.sample(
+                    frac=2, replace=True, random_state=np.random.RandomState(test)
+                ),
             )
 
             os1, os2 = [], []
@@ -423,6 +433,14 @@ class Generic:
         weights_with_None = [None] * 10
         weights_with_None[5] = 0.5
         self._compare(o.sample(n=1, axis=0, weights=weights_with_None), o.iloc[5:6])
+
+    def test_sample_upsampling_without_replacement(self):
+        df = pd.DataFrame({"A": list("abc")})
+        msg = (
+            "Replace has to be set to `True` when upsampling the population `frac` > 1"
+        )
+        with pytest.raises(TypeError, match=msg):
+            hash(df.sample(frac=2, replace=False))
 
     def test_size_compat(self):
         # GH8846

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -438,7 +438,8 @@ class Generic:
         # GH27451
         df = pd.DataFrame({"A": list("abc")})
         msg = (
-            "Replace has to be set to `True` when upsampling the population `frac` > 1"
+            "Replace has to be set to `True` when "
+            "upsampling the population `frac` > 1."
         )
         with pytest.raises(TypeError, match=msg):
             df.sample(frac=2, replace=False)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -436,6 +436,7 @@ class Generic:
 
     def test_sample_upsampling_without_replacement(self):
         # GH27451
+
         df = pd.DataFrame({"A": list("abc")})
         msg = (
             "Replace has to be set to `True` when "

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -442,7 +442,7 @@ class Generic:
             "Replace has to be set to `True` when "
             "upsampling the population `frac` > 1."
         )
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(ValueError, match=msg):
             df.sample(frac=2, replace=False)
 
     def test_size_compat(self):


### PR DESCRIPTION
…essage in case replacement is set to False

- [X] closes #27451
- [x] tests added / passed
- [X] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
