### PR TITLE
TST: add test for df.where() with category dtype

### DIFF
--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -815,6 +815,19 @@ class TestDataFrameDataTypes:
         expected = concat([a1.astype(dtype), a2.astype(dtype)], axis=1)
         tm.assert_frame_equal(result, expected)
 
+    def test_df_where_with_category(self):
+        # GH 16979
+        df = DataFrame(np.arange(2 * 3).reshape(2, 3), columns=list("ABC"))
+        mask = np.array([[True, False, True], [False, True, True]])
+        # change type to category
+        df.A = df.A.astype("category")
+        df.B = df.B.astype("category")
+        df.C = df.C.astype("category")
+
+        expected = df.A.where(mask[:, 0])
+        result = df.A.where(mask[:, 0], other=None)
+        tm.assert_series_equal(result, expected)
+
     @pytest.mark.parametrize(
         "dtype", [{100: "float64", 200: "uint64"}, "category", "float64"]
     )

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -815,7 +815,8 @@ class TestDataFrameDataTypes:
         expected = concat([a1.astype(dtype), a2.astype(dtype)], axis=1)
         tm.assert_frame_equal(result, expected)
 
-    def test_df_where_with_category(self):
+    @pytest.mark.parametrize("kwargs", [dict(), dict(other=None)])
+    def test_df_where_with_category(self, kwargs):
         # GH 16979
         df = DataFrame(np.arange(2 * 3).reshape(2, 3), columns=list("ABC"))
         mask = np.array([[True, False, True], [False, True, True]])
@@ -824,8 +825,8 @@ class TestDataFrameDataTypes:
         df.B = df.B.astype("category")
         df.C = df.C.astype("category")
 
-        expected = df.A.where(mask[:, 0])
-        result = df.A.where(mask[:, 0], other=None)
+        result = df.A.where(mask[:, 0], **kwargs)
+        expected = Series(pd.Categorical([0, np.nan], categories=[0, 3]), name="A")
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -843,6 +843,7 @@ class TestDataFrameDataTypes:
         # GH 16979
         df = DataFrame(np.arange(2 * 3).reshape(2, 3), columns=list("ABC"))
         mask = np.array([[True, False, True], [False, True, True]])
+
         # change type to category
         df.A = df.A.astype("category")
         df.B = df.B.astype("category")

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -815,29 +815,6 @@ class TestDataFrameDataTypes:
         expected = concat([a1.astype(dtype), a2.astype(dtype)], axis=1)
         tm.assert_frame_equal(result, expected)
 
-    def test_df_where_change_dtype(self):
-        # GH 16979
-        df = DataFrame(np.arange(2 * 3).reshape(2, 3), columns=list("ABC"))
-        mask = np.array([[True, False, True], [False, True, True]])
-
-        result = df.where(mask)
-        expected = DataFrame([[0, np.nan, 2], [np.nan, 4, 5]], columns=list("ABC"))
-
-        tm.assert_frame_equal(result, expected)
-
-        # change type to category
-        df.A = df.A.astype("category")
-        df.B = df.B.astype("category")
-        df.C = df.C.astype("category")
-
-        result = df.where(mask)
-        A = pd.Categorical([0, np.nan], categories=[0, 3])
-        B = pd.Categorical([np.nan, 4], categories=[1, 4])
-        C = pd.Categorical([2, 5], categories=[2, 5])
-        expected = DataFrame({"A": A, "B": B, "C": C})
-
-        tm.assert_frame_equal(result, expected)
-
     @pytest.mark.parametrize("kwargs", [dict(), dict(other=None)])
     def test_df_where_with_category(self, kwargs):
         # GH 16979


### PR DESCRIPTION
- [x] xref #16979
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
