### PR TITLE
TST: add test for empty frame groupby dtypes consistency

### DIFF
--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1490,6 +1490,19 @@ Thur,Lunch,Yes,51.51,17"""
         DataFrame({"foo": s1, "bar": s2, "baz": s3})
         DataFrame.from_dict({"foo": s1, "baz": s3, "bar": s2})
 
+    def test_empty_frame_groupby_dtypes_consistency(self):
+        # GH 20888
+        group_keys = ["a", "b", "c"]
+        df = DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
+        g = df[df.a == 2].groupby(group_keys)
+        expected = g.first().index
+
+        df = DataFrame({"a": [1], "b": [2], "c": [3], "d": ["d"]})
+        g = df[df.a == 2].groupby(group_keys)
+        result = g.first().index
+
+        tm.assert_index_equal(result, expected)
+
     def test_multiindex_na_repr(self):
         # only an issue with long columns
         df3 = DataFrame(

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1493,11 +1493,15 @@ Thur,Lunch,Yes,51.51,17"""
     @pytest.mark.parametrize("d", [4, "d"])
     def test_empty_frame_groupby_dtypes_consistency(self, d):
         # GH 20888
-        group_keys = [...]
+        group_keys = ["a", "b", "c"]
         df = DataFrame({"a": [1], "b": [2], "c": [3], "d": [d]})
+
         g = df[df.a == 2].groupby(group_keys)
         result = g.first().index
-        expected = Index([], dtype=int)
+        expected = MultiIndex(
+            levels=[[1], [2], [3]], codes=[[], [], []], names=["a", "b", "c"]
+        )
+
         tm.assert_index_equal(result, expected)
 
     def test_multiindex_na_repr(self):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1490,17 +1490,14 @@ Thur,Lunch,Yes,51.51,17"""
         DataFrame({"foo": s1, "bar": s2, "baz": s3})
         DataFrame.from_dict({"foo": s1, "baz": s3, "bar": s2})
 
-    def test_empty_frame_groupby_dtypes_consistency(self):
+    @pytest.mark.parametrize("d", [4, "d"])
+    def test_empty_frame_groupby_dtypes_consistency(self, d):
         # GH 20888
-        group_keys = ["a", "b", "c"]
-        df = DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
-        g = df[df.a == 2].groupby(group_keys)
-        expected = g.first().index
-
-        df = DataFrame({"a": [1], "b": [2], "c": [3], "d": ["d"]})
+        group_keys = [...]
+        df = DataFrame({"a": [1], "b": [2], "c": [3], "d": [d]})
         g = df[df.a == 2].groupby(group_keys)
         result = g.first().index
-
+        expected = Index([], dtype=int)
         tm.assert_index_equal(result, expected)
 
     def test_multiindex_na_repr(self):


### PR DESCRIPTION
- [x] closes #20888
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
