### PR TITLE
Pin dateutil to 2.8.0 in requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   # required
   - numpy>=1.15
   - python=3.7
-  - python-dateutil>=2.6.1
+  - python-dateutil>=2.6.1,<=2.8.0
   - pytz
 
   # benchmarks

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy>=1.15
-python-dateutil>=2.6.1
+python-dateutil>=2.6.1,<=2.8.0
 pytz
 asv
 cython>=0.29.13


### PR DESCRIPTION
botocore has pinned dateutil to <=2.8.0, which conflicts with our dateutil here and leads to 

```
ERROR: botocore 1.13.12 has requirement python-dateutil<2.8.1,>=2.1; python_version >= "2.7", but you'll have python-dateutil 2.8.1 which is incompatible.
```

See https://github.com/boto/botocore/commit/e87e7a745fd972815b235a9ee685232745aa94f9

Closes #29465 