### PR TITLE
PERF: MultiIndex.get_loc

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1981,11 +1981,11 @@ class MultiIndex(Index):
         return result
 
     @property
-    def nlevels(self):
+    def nlevels(self) -> int:
         """
         Integer number of levels in this MultiIndex.
         """
-        return len(self.levels)
+        return len(self._levels)
 
     @property
     def levshape(self):


### PR DESCRIPTION
- [x] closes #29311


```
In [4]: mi_med = pd.MultiIndex.from_product( 
    ...:     [np.arange(1000), np.arange(10), list("A")], names=["one", "two", "three"] 
    ...: ) 

In [5]: %timeit mi_med.get_loc((999, 9, "A"))   
master --> 42.6 µs ± 411 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
PR     --> 11.4 µs ± 120 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
