### PR TITLE
TYPING: change to FrameOrSeries Alias in pandas._typing

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
     from pandas.core.arrays.base import ExtensionArray  # noqa: F401
     from pandas.core.dtypes.dtypes import ExtensionDtype  # noqa: F401
     from pandas.core.indexes.base import Index  # noqa: F401
+    from pandas.core.frame import DataFrame  # noqa: F401
     from pandas.core.series import Series  # noqa: F401
-    from pandas.core.generic import NDFrame  # noqa: F401
 
 
 AnyArrayLike = TypeVar("AnyArrayLike", "ExtensionArray", "Index", "Series", np.ndarray)
@@ -31,7 +31,7 @@ DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", "Period", "Timestamp", "Timed
 Dtype = Union[str, np.dtype, "ExtensionDtype"]
 FilePathOrBuffer = Union[str, Path, IO[AnyStr]]
 
-FrameOrSeries = TypeVar("FrameOrSeries", bound="NDFrame")
+FrameOrSeries = TypeVar("FrameOrSeries", "DataFrame", "Series")
 Scalar = Union[str, int, float, bool]
 Axis = Union[str, int]
 Ordered = Optional[bool]

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -14,7 +14,17 @@ from functools import partial, wraps
 import inspect
 import re
 import types
-from typing import FrozenSet, Hashable, Iterable, List, Optional, Tuple, Type, Union
+from typing import (
+    FrozenSet,
+    Generic,
+    Hashable,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import numpy as np
 
@@ -41,6 +51,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.missing import isna, notna
 
+from pandas._typing import FrameOrSeries
 from pandas.core import nanops
 import pandas.core.algorithms as algorithms
 from pandas.core.arrays import Categorical, try_cast_to_ea
@@ -336,13 +347,13 @@ def _group_selection_context(groupby):
     groupby._reset_group_selection()
 
 
-class _GroupBy(PandasObject, SelectionMixin):
+class _GroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
     _group_selection = None
     _apply_whitelist = frozenset()  # type: FrozenSet[str]
 
     def __init__(
         self,
-        obj: NDFrame,
+        obj: FrameOrSeries,
         keys=None,
         axis: int = 0,
         level=None,
@@ -391,7 +402,7 @@ class _GroupBy(PandasObject, SelectionMixin):
                 mutated=self.mutated,
             )
 
-        self.obj = obj
+        self.obj = obj  # type: FrameOrSeries
         self.axis = obj._get_axis_number(axis)
         self.grouper = grouper
         self.exclusions = set(exclusions) if exclusions else set()
@@ -1662,7 +1673,9 @@ class GroupBy(_GroupBy):
 
     @Substitution(name="groupby")
     @Substitution(see_also=_common_see_also)
-    def nth(self, n: Union[int, List[int]], dropna: Optional[str] = None) -> DataFrame:
+    def nth(
+        self, n: Union[int, List[int]], dropna: Optional[str] = None
+    ) -> FrameOrSeries:
         """
         Take the nth row from each group if n is an int, or a subset of rows
         if n is a list of ints.

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -21,7 +21,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.generic import ABCSeries
 
-from pandas._typing import FrameOrSeries
+from pandas._typing import FrameOrSeries, Union
 import pandas.core.algorithms as algorithms
 from pandas.core.arrays import Categorical, ExtensionArray
 import pandas.core.common as com
@@ -249,7 +249,7 @@ class Grouping:
         self,
         index: Index,
         grouper=None,
-        obj: Optional[FrameOrSeries] = None,
+        obj: Optional[Union[DataFrame, Series]] = None,
         name=None,
         level=None,
         sort: bool = True,
@@ -570,8 +570,7 @@ def get_grouper(
             all_in_columns_index = all(
                 g in obj.columns or g in obj.index.names for g in keys
             )
-        else:
-            assert isinstance(obj, Series)
+        elif isinstance(obj, Series):
             all_in_columns_index = all(g in obj.index.names for g in keys)
 
         if not all_in_columns_index:


### PR DESCRIPTION
@WillAyd 

I think we should discuss reverting #28173 and only use `TypeVar("FrameOrSeries", bound="NDFrame")` in `core.generic`. perhaps call it `_NDFrameT` to avoid confusion.

This PR is to show the changes required to keep mypy green if we wanted to revert.

It also reverts the change in #29458, see https://github.com/pandas-dev/pandas/pull/29458#discussion_r343733263

`_GroupBy` is defined as a generic class, but not sure about `Grouping`

I've created it as a draft PR, since I think we should wait for more issues to surface going forward to help decide. The number of changes needed at this stage is not significant enough to warrant a hasty decision.