### PR TITLE
DOC: update bottleneck repo and documentation urls

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -218,7 +218,7 @@ Recommended dependencies
   ``numexpr`` uses multiple cores as well as smart chunking and caching to achieve large speedups.
   If installed, must be Version 2.6.2 or higher.
 
-* `bottleneck <https://github.com/kwgoodman/bottleneck>`__: for accelerating certain types of ``nan``
+* `bottleneck <https://github.com/pydata/bottleneck>`__: for accelerating certain types of ``nan``
   evaluations. ``bottleneck`` uses specialized cython routines to achieve large speedups. If installed,
   must be Version 1.2.1 or higher.
 

--- a/doc/source/whatsnew/v0.21.0.rst
+++ b/doc/source/whatsnew/v0.21.0.rst
@@ -20,7 +20,7 @@ Highlights include:
 - Integration with `Apache Parquet <https://parquet.apache.org/>`__, including a new top-level :func:`read_parquet` function and :meth:`DataFrame.to_parquet` method, see :ref:`here <whatsnew_0210.enhancements.parquet>`.
 - New user-facing :class:`pandas.api.types.CategoricalDtype` for specifying
   categoricals independent of the data, see :ref:`here <whatsnew_0210.enhancements.categorical_dtype>`.
-- The behavior of ``sum`` and ``prod`` on all-NaN Series/DataFrames is now consistent and no longer depends on whether `bottleneck <http://berkeleyanalytics.com/bottleneck>`__ is installed, and ``sum`` and ``prod`` on empty Series now return NaN instead of 0, see :ref:`here <whatsnew_0210.api_breaking.bottleneck>`.
+- The behavior of ``sum`` and ``prod`` on all-NaN Series/DataFrames is now consistent and no longer depends on whether `bottleneck <https://bottleneck.readthedocs.io>`__ is installed, and ``sum`` and ``prod`` on empty Series now return NaN instead of 0, see :ref:`here <whatsnew_0210.api_breaking.bottleneck>`.
 - Compatibility fixes for pypy, see :ref:`here <whatsnew_0210.pypy>`.
 - Additions to the ``drop``, ``reindex`` and ``rename`` API to make them more consistent, see :ref:`here <whatsnew_0210.enhancements.drop_api>`.
 - Addition of the new methods ``DataFrame.infer_objects`` (see :ref:`here <whatsnew_0210.enhancements.infer_objects>`) and ``GroupBy.pipe`` (see :ref:`here <whatsnew_0210.enhancements.GroupBy_pipe>`).
@@ -390,7 +390,7 @@ Sum/Prod of all-NaN or empty Series/DataFrames is now consistently NaN
 
 
 The behavior of ``sum`` and ``prod`` on all-NaN Series/DataFrames no longer depends on
-whether `bottleneck <http://berkeleyanalytics.com/bottleneck>`__ is installed, and return value of ``sum`` and ``prod`` on an empty Series has changed (:issue:`9422`, :issue:`15507`).
+whether `bottleneck <https://bottleneck.readthedocs.io>`__ is installed, and return value of ``sum`` and ``prod`` on an empty Series has changed (:issue:`9422`, :issue:`15507`).
 
 Calling ``sum`` or ``prod`` on an empty or all-``NaN`` ``Series``, or columns of a ``DataFrame``, will result in ``NaN``. See the :ref:`docs <missing_data.numeric_sum>`.
 

--- a/doc/source/whatsnew/v0.8.1.rst
+++ b/doc/source/whatsnew/v0.8.1.rst
@@ -29,7 +29,7 @@ Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
   - Improved implementation of rolling min and max (thanks to `Bottleneck
-    <http://berkeleyanalytics.com/bottleneck/>`__ !)
+    <https://bottleneck.readthedocs.io>`__ !)
   - Add accelerated ``'median'`` GroupBy option (:issue:`1358`)
   - Significantly improve the performance of parsing ISO8601-format date
     strings with ``DatetimeIndex`` or ``to_datetime`` (:issue:`1571`)

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1162,7 +1162,7 @@ def roll_median_c(ndarray[float64_t] values, int64_t win, int64_t minp,
 
 # Moving maximum / minimum code taken from Bottleneck under the terms
 # of its Simplified BSD license
-# https://github.com/kwgoodman/bottleneck
+# https://github.com/pydata/bottleneck
 
 
 cdef inline numeric init_mm(numeric ai, Py_ssize_t *nobs, bint is_max) nogil:


### PR DESCRIPTION
As part of my taking over maintainership of bottleneck, the repo url has changed (old one redirects correctly) and documentation is now hosted on ReadTheDocs (old url has been down for some time).