### PR TITLE
TST: Check error raised when inserting wrong length categorical column

### DIFF
--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -725,6 +725,7 @@ class TestDataFrameDataTypes:
         tm.assert_frame_equal(result, expected)
 
     def test_wrong_length_cat_dtype_raises(self):
+        # GH29523
         cat = pd.Categorical.from_codes([0, 1, 1, 0, 1, 2], ["a", "b", "c"])
         df = pd.DataFrame({"bar": range(10)})
         err = "Length of values does not match length of index"

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -724,6 +724,13 @@ class TestDataFrameDataTypes:
         expected = concat([a1_str, b, a2_str], axis=1)
         tm.assert_frame_equal(result, expected)
 
+    def test_wrong_length_cat_dtype_raises(self):
+        cat = pd.Categorical.from_codes([0, 1, 1, 0, 1, 2], ["a", "b", "c"])
+        df = pd.DataFrame({"bar": range(10)})
+        err = "Length of values does not match length of index"
+        with pytest.raises(ValueError, match=err):
+            df["foo"] = cat
+
     @pytest.mark.parametrize(
         "dtype",
         [

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -724,14 +724,6 @@ class TestDataFrameDataTypes:
         expected = concat([a1_str, b, a2_str], axis=1)
         tm.assert_frame_equal(result, expected)
 
-    def test_wrong_length_cat_dtype_raises(self):
-        # GH29523
-        cat = pd.Categorical.from_codes([0, 1, 1, 0, 1, 2], ["a", "b", "c"])
-        df = pd.DataFrame({"bar": range(10)})
-        err = "Length of values does not match length of index"
-        with pytest.raises(ValueError, match=err):
-            df["foo"] = cat
-
     @pytest.mark.parametrize(
         "dtype",
         [

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3881,3 +3881,11 @@ class TestDataFrameIndexingCategorical:
 
         result = df.loc[["a"]].index.levels[0]
         tm.assert_index_equal(result, expected)
+
+    def test_wrong_length_cat_dtype_raises(self):
+        # GH29523
+        cat = pd.Categorical.from_codes([0, 1, 1, 0, 1, 2], ["a", "b", "c"])
+        df = pd.DataFrame({"bar": range(10)})
+        err = "Length of values does not match length of index"
+        with pytest.raises(ValueError, match=err):
+            df["foo"] = cat


### PR DESCRIPTION
- [x] closes #9374
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
