### PR TITLE
ENH: Support for column specific col_space argument for frame.to_html…

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -583,9 +583,14 @@ class DataFrameFormatter(TableFormatter):
                     f" number of DataFrame columns ({len(frame.columns)})"
                 )
             )
+        self.col_space = (
+            col_space
+            if isinstance(col_space, int) or isinstance(col_space, str)
+            else None
+        )
         self.na_rep = na_rep
         self.decimal = decimal
-        self.col_space = col_space
+        self.specific_col_space = col_space
         self.header = header
         self.index = index
         self.line_width = line_width

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -579,10 +579,8 @@ class DataFrameFormatter(TableFormatter):
         if isinstance(col_space, list) and len(col_space) != len(frame.columns):
             raise ValueError(
                 (
-                    "Length of col_space list ({clen}) should match"
-                    " number of DataFrame columns ({dlen})".format(
-                        clen=len(col_space), dlen=len(frame.columns)
-                    )
+                    f"Length of col_space list ({len(col_space)}) should match"
+                    f" number of DataFrame columns ({len(frame.columns)})"
                 )
             )
         self.na_rep = na_rep
@@ -1447,7 +1445,7 @@ class Datetime64Formatter(GenericArrayFormatter):
         values: Union[np.ndarray, "Series", DatetimeIndex, DatetimeArray],
         nat_rep: str = "NaT",
         date_format: None = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(values, **kwargs)
         self.nat_rep = nat_rep
@@ -1668,7 +1666,7 @@ class Timedelta64Formatter(GenericArrayFormatter):
         values: Union[np.ndarray, TimedeltaIndex],
         nat_rep: str = "NaT",
         box: bool = False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(values, **kwargs)
         self.nat_rep = nat_rep

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -535,7 +535,7 @@ class DataFrameFormatter(TableFormatter):
         self,
         frame: "DataFrame",
         columns: Optional[Sequence[str]] = None,
-        col_space: Optional[Union[str, int]] = None,
+        col_space: Optional[Union[str, int, Dict, List]] = None,
         header: Union[bool, Sequence[str]] = True,
         index: bool = True,
         na_rep: str = "NaN",
@@ -574,6 +574,16 @@ class DataFrameFormatter(TableFormatter):
                     "Formatters length({flen}) should match"
                     " DataFrame number of columns({dlen})"
                 ).format(flen=len(formatters), dlen=len(frame.columns))
+            )
+
+        if isinstance(col_space, list) and len(col_space) != len(frame.columns):
+            raise ValueError(
+                (
+                    "Length of col_space list ({clen}) should match"
+                    " number of DataFrame columns ({dlen})".format(
+                        clen=len(col_space), dlen=len(frame.columns)
+                    )
+                )
             )
         self.na_rep = na_rep
         self.decimal = decimal

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -67,10 +67,14 @@ class HTMLFormatter(TableFormatter):
                 )
             )
         elif isinstance(self.fmt.col_space, int) or isinstance(self.fmt.col_space, str):
-            self.fmt.col_space = {
-                column: self._convert_to_px(self.fmt.col_space)
-                for column in self.frame.columns
-            }
+            self.fmt.col_space = {"": self._convert_to_px(self.fmt.col_space)}
+            self.fmt.col_space.update(
+                {
+                    column: self._convert_to_px(self.fmt.col_space)
+                    for column in self.frame.columns
+                }
+            )
+
         else:
             self.fmt.col_space = {}
 

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -54,27 +54,32 @@ class HTMLFormatter(TableFormatter):
         self.border = border
         self.table_id = self.fmt.table_id
         self.render_links = self.fmt.render_links
-        if isinstance(self.fmt.col_space, dict):
-            self.fmt.col_space = {
+        if isinstance(self.fmt.specific_col_space, dict):
+            self.specific_col_space = {
                 column: self._convert_to_px(value)
-                for column, value in self.fmt.col_space.items()
+                for column, value in self.fmt.specific_col_space.items()
             }
-        elif isinstance(self.fmt.col_space, list):
-            self.fmt.col_space = dict(
+        elif isinstance(self.fmt.specific_col_space, list):
+            self.specific_col_space = dict(
                 zip(
                     self.frame.columns,
-                    [self._convert_to_px(value) for value in self.fmt.col_space],
+                    [
+                        self._convert_to_px(value)
+                        for value in self.fmt.specific_col_space
+                    ],
                 )
             )
-        elif isinstance(self.fmt.col_space, int) or isinstance(self.fmt.col_space, str):
-            col_space = self._convert_to_px(self.fmt.col_space)
-            self.fmt.col_space = {"": col_space}
-            self.fmt.col_space.update(
+        elif isinstance(self.fmt.specific_col_space, int) or isinstance(
+            self.fmt.specific_col_space, str
+        ):
+            col_space = self._convert_to_px(self.fmt.specific_col_space)
+            self.specific_col_space = {"": col_space}
+            self.specific_col_space.update(
                 {column: col_space for column in self.frame.columns}
             )
 
         else:
-            self.fmt.col_space = {}
+            self.specific_col_space = {}
 
     @staticmethod
     def _convert_to_px(value: Union[int, str]) -> str:
@@ -146,10 +151,10 @@ class HTMLFormatter(TableFormatter):
         -------
         A written <th> cell.
         """
-        if header and self.fmt.col_space is not None and self.fmt.col_space.get(s):
+        if header and self.fmt.col_space is not None and self.specific_col_space.get(s):
             tags = tags or ""
             tags += 'style="min-width: {colspace};"'.format(
-                colspace=self.fmt.col_space.get(s)
+                colspace=self.specific_col_space.get(s)
             )
 
         self._write_cell(s, kind="th", indent=indent, tags=tags)

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -67,12 +67,10 @@ class HTMLFormatter(TableFormatter):
                 )
             )
         elif isinstance(self.fmt.col_space, int) or isinstance(self.fmt.col_space, str):
-            self.fmt.col_space = {"": self._convert_to_px(self.fmt.col_space)}
+            col_space = self._convert_to_px(self.fmt.col_space)
+            self.fmt.col_space = {"": col_space}
             self.fmt.col_space.update(
-                {
-                    column: self._convert_to_px(self.fmt.col_space)
-                    for column in self.frame.columns
-                }
+                {column: col_space for column in self.frame.columns}
             )
 
         else:


### PR DESCRIPTION
…() method (#28917)

- [ ] closes #28917
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] what's new: the col_space argument of to_html() can also take a dict or list to specify different col_space for different columns. 
