### PR TITLE
Fixed more SS03 errors

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -121,7 +121,7 @@ def _get_interval_closed_bounds(interval):
 def _new_IntervalIndex(cls, d):
     """
     This is called upon unpickling, rather than the default which doesn't have
-    arguments and breaks __new__
+    arguments and breaks __new__.
     """
     return cls.from_arrays(**d)
 
@@ -392,7 +392,7 @@ class IntervalIndex(IntervalMixin, Index):
     def left(self):
         """
         Return the left endpoints of each Interval in the IntervalIndex as
-        an Index
+        an Index.
         """
         return self._data._left
 
@@ -400,7 +400,7 @@ class IntervalIndex(IntervalMixin, Index):
     def right(self):
         """
         Return the right endpoints of each Interval in the IntervalIndex as
-        an Index
+        an Index.
         """
         return self._data._right
 
@@ -408,7 +408,7 @@ class IntervalIndex(IntervalMixin, Index):
     def closed(self):
         """
         Whether the intervals are closed on the left-side, right-side, both or
-        neither
+        neither.
         """
         return self._data._closed
 
@@ -446,7 +446,7 @@ class IntervalIndex(IntervalMixin, Index):
     def length(self):
         """
         Return an Index with entries denoting the length of each Interval in
-        the IntervalIndex
+        the IntervalIndex.
         """
         return self._data.length
 
@@ -537,7 +537,7 @@ class IntervalIndex(IntervalMixin, Index):
     @cache_readonly
     def mid(self):
         """
-        Return the midpoint of each Interval in the IntervalIndex as an Index
+        Return the midpoint of each Interval in the IntervalIndex as an Index.
         """
         return self._data.mid
 

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -36,10 +36,9 @@ _num_index_shared_docs = dict()
 
 class NumericIndex(Index):
     """
-    Provide numeric type operations
+    Provide numeric type operations.
 
-    This is an abstract class
-
+    This is an abstract class.
     """
 
     _is_numeric_dtype = True
@@ -87,7 +86,9 @@ class NumericIndex(Index):
         return super()._shallow_copy(values=values, **kwargs)
 
     def _convert_for_op(self, value):
-        """ Convert value to be insertable to ndarray """
+        """
+        Convert value to be insertable to ndarray.
+        """
 
         if is_bool(value) or is_bool_dtype(value):
             # force conversion to object
@@ -135,7 +136,7 @@ class NumericIndex(Index):
     @property
     def is_all_dates(self):
         """
-        Checks that all the labels are datetime objects
+        Checks that all the labels are datetime objects.
         """
         return False
 
@@ -169,7 +170,7 @@ _num_index_shared_docs[
 ] = """
     Immutable ndarray implementing an ordered, sliceable set. The basic object
     storing axis labels for all pandas objects. %(klass)s is a special case
-    of `Index` with purely %(ltype)s labels. %(extra)s
+    of `Index` with purely %(ltype)s labels. %(extra)s.
 
     Parameters
     ----------
@@ -412,7 +413,9 @@ class Float64Index(NumericIndex):
         return formatter.get_result_as_array()
 
     def get_value(self, series, key):
-        """ we always want to get an index value, never a value """
+        """
+        We always want to get an index value, never a value.
+        """
         if not is_scalar(key):
             raise InvalidIndexError
 

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -139,7 +139,7 @@ Read a Stata dta file in 10,000 line chunks:
 )
 
 _data_method_doc = """
-Read observations from Stata file, converting them into a dataframe
+Read observations from Stata file, converting them into a dataframe.
 
 .. deprecated::
     This is a legacy method.  Use `read` in new code.

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -455,9 +455,10 @@ def tsplot(series, plotf, ax=None, **kwargs):
 class _Options(dict):
     """
     Stores pandas plotting options.
+
     Allows for parameter aliasing so you can just use parameter names that are
     the same as the plot function parameters, but is stored in a canonical
-    format that makes it easy to breakdown into groups later
+    format that makes it easy to breakdown into groups later.
     """
 
     # alias so the names are same as plotting method parameter names

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -71,7 +71,7 @@ _name_to_offset_map = {
 def to_offset(freq):
     """
     Return DateOffset object from string or tuple representation
-    or datetime.timedelta object
+    or datetime.timedelta object.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixed SS03 errors in the docstrings for `pandas.tseries.frequencies.to_offset`; `pandas.Int64Index`; `pandas.UInt64Index`; `pandas.Float64Index`; `pandas.IntervalIndex`; `pandas.plotting.plot_params`; `pandas.io.formats.style.Styler.loader`.

- [x] xref #29315
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is part of the docstring errors in #27977.
