### PR TITLE
BUG: np.datetime64 - TimedeltaArray

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -318,7 +318,7 @@ Datetimelike
 
 Timedelta
 ^^^^^^^^^
-
+- Bug in subtracting a :class:`TimedeltaIndex` or :class:`TimedeltaArray` from a ``np.datetime64`` object (:issue:`29558`)
 -
 -
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1303,6 +1303,9 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
         if is_datetime64_any_dtype(other) and is_timedelta64_dtype(self.dtype):
             # ndarray[datetime64] cannot be subtracted from self, so
             # we need to wrap in DatetimeArray/Index and flip the operation
+            if lib.is_scalar(other):
+                # i.e. np.datetime64 object
+                return Timestamp(other) - self
             if not isinstance(other, DatetimeLikeArrayMixin):
                 # Avoid down-casting DatetimeIndex
                 from pandas.core.arrays import DatetimeArray

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -905,7 +905,7 @@ class TestTimedeltaArraylikeAddSubOps:
         ],
     )
     def test_td64arr_add_sub_datetimelike_scalar(self, ts, box_with_array):
-        # GH#11925
+        # GH#11925, GH#29558
         tdi = timedelta_range("1 day", periods=3)
         expected = pd.date_range("2012-01-02", periods=3)
 

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -896,11 +896,16 @@ class TestTimedeltaArraylikeAddSubOps:
         result = other + idx
         tm.assert_equal(result, expected)
 
-    def test_td64arr_add_sub_timestamp(self, box_with_array):
+    @pytest.mark.parametrize(
+        "ts",
+        [
+            Timestamp("2012-01-01"),
+            Timestamp("2012-01-01").to_pydatetime(),
+            Timestamp("2012-01-01").to_datetime64(),
+        ],
+    )
+    def test_td64arr_add_sub_datetimelike_scalar(self, ts, box_with_array):
         # GH#11925
-        ts = Timestamp("2012-01-01")
-        # TODO: parametrize over types of datetime scalar?
-
         tdi = timedelta_range("1 day", periods=3)
         expected = pd.date_range("2012-01-02", periods=3)
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
