### PR TITLE
CLN: F-string formatting in pandas/tests/indexes/*.py (#29547)

### DIFF
--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1837,7 +1837,7 @@ class TestIndex(Base):
             tm.assert_index_equal(result, expected)
 
         removed = index.drop(to_drop[1])
-        msg = r"\"\[{}\] not found in axis\"".format(re.escape(to_drop[1].__repr__()))
+        msg = fr"\"\[{re.escape(to_drop[1].__repr__())}\] not found in axis\""
         for drop_me in to_drop[1], [to_drop[1]]:
             with pytest.raises(KeyError, match=msg):
                 removed.drop(drop_me)
@@ -2005,11 +2005,11 @@ class TestIndex(Base):
         index = indices
         if isinstance(index, MultiIndex):
             index = index.rename(["foo", "bar"])
-            msg = "'Level {} not found'"
+            msg = f"'Level {label} not found'"
         else:
             index = index.rename("foo")
-            msg = r"Requested level \({}\) does not match index name \(foo\)"
-        with pytest.raises(KeyError, match=msg.format(label)):
+            msg = fr"Requested level \({label}\) does not match index name \(foo\)"
+        with pytest.raises(KeyError, match=msg):
             index.isin([], level=label)
 
     @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
@@ -2768,7 +2768,7 @@ def test_generated_op_names(opname, indices):
         # pd.Index.__rsub__ does not exist; though the method does exist
         # for subclasses.  see GH#19723
         return
-    opname = "__{name}__".format(name=opname)
+    opname = f"__{opname}__"
     method = getattr(indices, opname)
     assert method.__name__ == opname
 

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -188,8 +188,8 @@ class TestCategoricalIndex(Base):
         # GH 10039
         # set ops (+/-) raise TypeError
         idx = pd.Index(pd.Categorical(["a", "b"]))
-        msg = "cannot perform {} with this index type: CategoricalIndex"
-        with pytest.raises(TypeError, match=msg.format(op_name)):
+        msg = f"cannot perform {op_name} with this index type: CategoricalIndex"
+        with pytest.raises(TypeError, match=msg):
             func(idx)
 
     def test_method_delegation(self):

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -167,7 +167,7 @@ class TestCommon:
     def test_hash_error(self, indices):
         index = indices
         with pytest.raises(
-            TypeError, match=(fr"unhashable type: {type(index).__name__!r}")
+            TypeError, match=(f"unhashable type: {type(index).__name__!r}")
         ):
             hash(indices)
 
@@ -201,8 +201,10 @@ class TestCommon:
         with pytest.raises(IndexError, match=msg):
             indices.unique(level=3)
 
-        msg = fr"Requested level \(wrong\) does not match index name " \
-              fr"\({re.escape(indices.name.__repr__())}\)"
+        msg = (
+            fr"Requested level \(wrong\) does not match index name "
+            fr"\({re.escape(indices.name.__repr__())}\)"
+        )
         with pytest.raises(KeyError, match=msg):
             indices.unique(level="wrong")
 

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -167,7 +167,7 @@ class TestCommon:
     def test_hash_error(self, indices):
         index = indices
         with pytest.raises(
-            TypeError, match=("unhashable type: {0.__name__!r}".format(type(index)))
+            TypeError, match=(fr"unhashable type: {type(index).__name__!r}")
         ):
             hash(indices)
 
@@ -201,9 +201,8 @@ class TestCommon:
         with pytest.raises(IndexError, match=msg):
             indices.unique(level=3)
 
-        msg = r"Requested level \(wrong\) does not match index name \({}\)".format(
-            re.escape(indices.name.__repr__())
-        )
+        msg = fr"Requested level \(wrong\) does not match index name " \
+              fr"\({re.escape(indices.name.__repr__())}\)"
         with pytest.raises(KeyError, match=msg):
             indices.unique(level="wrong")
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -245,9 +245,9 @@ class TestFloat64Index(Numeric):
         # invalid
         for dtype in ["M8[ns]", "m8[ns]"]:
             msg = (
-                "Cannot convert Float64Index to dtype {}; integer values"
-                " are required for conversion"
-            ).format(pandas_dtype(dtype))
+                f"Cannot convert Float64Index to dtype {pandas_dtype(dtype)}; "
+                f"integer values are required for conversion"
+            )
             with pytest.raises(TypeError, match=re.escape(msg)):
                 i.astype(dtype)
 
@@ -588,7 +588,7 @@ class NumericInt(Numeric):
         tm.assert_index_equal(result, expected)
 
         name = self._holder.__name__
-        msg = "Unable to fill values because {name} cannot contain NA".format(name=name)
+        msg = f"Unable to fill values because {name} cannot contain NA"
 
         # fill_value=True
         with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry