### PR TITLE
TYP: annotate _data

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -653,8 +653,6 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Return the length of the Index.
         """
-        # Assertion needed for mypy, see GH#29475
-        assert self._data is not None
         return len(self._data)
 
     def __array__(self, dtype=None):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -230,7 +230,7 @@ class Index(IndexOpsMixin, PandasObject):
         return libjoin.outer_join_indexer(left, right)
 
     _typ = "index"
-    _data = None
+    _data: Union[ExtensionArray, np.ndarray]
     _id = None
     name = None
     _comparables = ["name"]

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -27,7 +27,7 @@ from pandas.core.dtypes.generic import ABCIndex, ABCIndexClass, ABCSeries
 
 from pandas.core import algorithms, ops
 from pandas.core.accessor import PandasDelegate
-from pandas.core.arrays import ExtensionOpsMixin
+from pandas.core.arrays import ExtensionArray, ExtensionOpsMixin
 from pandas.core.arrays.datetimelike import (
     DatetimeLikeArrayMixin,
     _ensure_datetimelike_to_i8,
@@ -78,7 +78,7 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
     common ops mixin to support a unified interface datetimelike Index
     """
 
-    _data = None
+    _data: ExtensionArray
 
     # DatetimeLikeArrayMixin assumes subclasses are mutable, so these are
     # properties there.  They can be made into cache_readonly for Index
@@ -836,7 +836,7 @@ class DatetimelikeDelegateMixin(PandasDelegate):
     # raw_properties : dispatch properties that shouldn't be boxed in an Index
     _raw_properties = set()  # type: Set[str]
     name = None
-    _data = None
+    _data: ExtensionArray
 
     @property
     def _delegate_class(self):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -174,7 +174,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
     _is_numeric_dtype = False
     _infer_as_myclass = True
 
-    _data = None
+    _data: PeriodArray
 
     _engine_type = libindex.PeriodEngine
     _supports_partial_string_indexing = True


### PR DESCRIPTION
NB: this does induce a small behavior change in that `Index` will not have a `_data` attribute until `__init__/__new__`.

I found in #29561 that getting `_data` annotated is necessary before we can annotate most of `core.indexes`.

I'm also not sure what to do about MultiIndex, suggestions welcome.