### PR TITLE
BUG: Fix DatetimeIndex.strftime with NaT present

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -314,7 +314,7 @@ Datetimelike
 - Bug in :func:`pandas.core.groupby.generic.SeriesGroupBy.apply` raising ``ValueError`` when a column in the original DataFrame is a datetime and the column labels are not standard integers (:issue:`28247`)
 - Bug in :func:`pandas._config.localization.get_locales` where the ``locales -a`` encodes the locales list as windows-1252 (:issue:`23638`, :issue:`24760`, :issue:`27368`)
 - Bug in :meth:`Series.var` failing to raise ``TypeError`` when called with ``timedelta64[ns]`` dtype (:issue:`28289`)
--
+- Bug in :meth:`DatetimeIndex.strftime` and :meth:`Series.dt.strftime` where ``NaT`` was converted to the string ``'NaT'`` instead of ``np.nan`` (:issue:`29578`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -179,7 +179,8 @@ class DatelikeOps:
                'March 10, 2018, 09:00:02 AM'],
               dtype='object')
         """
-        return self._format_native_types(date_format=date_format).astype(object)
+        result = self._format_native_types(date_format=date_format, na_rep=np.nan)
+        return result.astype(object)
 
 
 class TimelikeOps:

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -473,7 +473,15 @@ class TestDatetimeArray(SharedTests):
         arr = DatetimeArray(datetime_index)
 
         result = arr.strftime("%Y %b")
-        expected = np.array(datetime_index.strftime("%Y %b"))
+        expected = np.array([ts.strftime("%Y %b") for ts in arr], dtype=object)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_strftime_nat(self):
+        # GH 29578
+        arr = DatetimeArray(DatetimeIndex(["2019-01-01", pd.NaT]))
+
+        result = arr.strftime("%Y-%m-%d")
+        expected = np.array(["2019-01-01", np.nan], dtype=object)
         tm.assert_numpy_array_equal(result, expected)
 
 
@@ -679,7 +687,15 @@ class TestPeriodArray(SharedTests):
         arr = PeriodArray(period_index)
 
         result = arr.strftime("%Y")
-        expected = np.array(period_index.strftime("%Y"))
+        expected = np.array([per.strftime("%Y") for per in arr], dtype=object)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_strftime_nat(self):
+        # GH 29578
+        arr = PeriodArray(PeriodIndex(["2019-01-01", pd.NaT], dtype="period[D]"))
+
+        result = arr.strftime("%Y-%m-%d")
+        expected = np.array(["2019-01-01", np.nan], dtype=object)
         tm.assert_numpy_array_equal(result, expected)
 
 

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -504,7 +504,7 @@ class TestSeriesDatetimeValues:
         s.iloc[0] = pd.NaT
         result = s.dt.strftime("%Y/%m/%d")
         expected = Series(
-            ["NaT", "2013/01/02", "2013/01/03", "2013/01/04", "2013/01/05"]
+            [np.nan, "2013/01/02", "2013/01/03", "2013/01/04", "2013/01/05"]
         )
         tm.assert_series_equal(result, expected)
 
@@ -552,6 +552,20 @@ class TestSeriesDatetimeValues:
                 "2013/01/01 00:00:00.003",
             ]
         )
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            DatetimeIndex(["2019-01-01", pd.NaT]),
+            PeriodIndex(["2019-01-01", pd.NaT], dtype="period[D]"),
+        ],
+    )
+    def test_strftime_nat(self, data):
+        # GH 29578
+        s = Series(data)
+        result = s.dt.strftime("%Y-%m-%d")
+        expected = Series(["2019-01-01", np.nan])
         tm.assert_series_equal(result, expected)
 
     def test_valid_dt_with_missing_values(self):


### PR DESCRIPTION
- [X] closes #29578
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
