### PR TITLE
CLN: no longer need to catch AttributeError, IndexError

### DIFF
--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -224,6 +224,7 @@ cdef class SeriesBinGrouper(_BaseGrouper):
     def __init__(self, object series, object f, object bins, object dummy):
 
         assert dummy is not None  # always obj[:0]
+        assert len(bins) > 0  # otherwise we get IndexError in get_result
 
         self.bins = bins
         self.f = f

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -262,10 +262,7 @@ class SeriesGroupBy(GroupBy):
 
             try:
                 return self._python_agg_general(func, *args, **kwargs)
-            except (ValueError, KeyError, AttributeError, IndexError):
-                # TODO: IndexError can be removed here following GH#29106
-                # TODO: AttributeError is caused by _index_data hijinx in
-                #  libreduction, can be removed after GH#29160
+            except (ValueError, KeyError):
                 # TODO: KeyError is raised in _python_agg_general,
                 #  see see test_groupby.test_basic
                 result = self._aggregate_named(func, *args, **kwargs)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -721,6 +721,10 @@ class BinGrouper(BaseGrouper):
         self.mutated = mutated
         self.indexer = indexer
 
+        # These lengths must match, otherwise we could call agg_series
+        #  with empty self.bins, which would raise in libreduction.
+        assert len(self.binlabels) == len(self.bins)
+
     @cache_readonly
     def groups(self):
         """ dict {group name -> group labels} """
@@ -828,10 +832,10 @@ class BinGrouper(BaseGrouper):
     def agg_series(self, obj: Series, func):
         # Caller is responsible for checking ngroups != 0
         assert self.ngroups != 0
+        assert len(self.bins) > 0  # otherwise we'd get IndexError in get_result
 
         if is_extension_array_dtype(obj.dtype):
-            # pre-empty SeriesBinGrouper from raising TypeError
-            # TODO: watch out, this can return None
+            # pre-empt SeriesBinGrouper from raising TypeError
             return self._aggregate_series_pure_python(obj, func)
 
         dummy = obj[:0]

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -187,6 +187,7 @@ class Resampler(_GroupBy, ShallowMixin):
         """
 
         binner, bins, binlabels = self._get_binner_for_time()
+        assert len(bins) == len(binlabels)
         bin_grouper = BinGrouper(bins, binlabels, indexer=self.groupby.indexer)
         return binner, bin_grouper
 


### PR DESCRIPTION
cc @jreback @WillAyd 

As of today, we don't call `agg_series` unless `ngroups > 0`, which has the side-benefit that we don't call unless `len(self.bins) > 0`, which means we no longer risk hitting an `IndexError` in libreduction L262.

No longer needing to catch AttributeError is [mumble mumble...] I'll figure out what past-me was thinking after a good night's sleep.