### PR TITLE
CLN: f-string at pandas/_libs/tslib.pyx

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -266,16 +266,16 @@ def format_array_from_datetime(ndarray[int64_t] values, object tz=None,
         elif basic_format:
 
             dt64_to_dtstruct(val, &dts)
-            res = (f'{dts.year}-{int(dts.month):02}-{int(dts.day):02} '
-                   f'{int(dts.hour):02}:{int(dts.min):02}:{int(dts.sec):02}')
+            res = (f'{dts.year}-{dts.month:02d}-{dts.day:02d} '
+                   f'{dts.hour:02d}:{dts.min:02d}:{dts.sec:02d}')
 
             if show_ns:
                 ns = dts.ps // 1000
-                res += f'.{int(ns + dts.us * 1000):09}'
+                res += f'.{ns + dts.us * 1000:09d}'
             elif show_us:
-                res += f'.{int(dts.us):06}'
+                res += f'.{dts.us:06d}'
             elif show_ms:
-                res += f'.{int(dts.us / 1000):03}'
+                res += f'.{dts.us // 1000:03d}'
 
             result[i] = res
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -275,7 +275,7 @@ def format_array_from_datetime(ndarray[int64_t] values, object tz=None,
             elif show_us:
                 res += f'.{dts.us:06d}'
             elif show_ms:
-                res += f'{dts.us / 1000:03d}'
+                res += f'.{dts.us / 1000:03d}'
 
             result[i] = res
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -266,16 +266,16 @@ def format_array_from_datetime(ndarray[int64_t] values, object tz=None,
         elif basic_format:
 
             dt64_to_dtstruct(val, &dts)
-            res = (f'{dts.year}-{dts.month:02d}-{dts.day:02d} '
-                   f'{dts.hour:02d}:{dts.min:02d}:{dts.sec:02d}')
+            res = (f'{dts.year}-{int(dts.month):02}-{int(dts.day):02} '
+                   f'{int(dts.hour):02}:{int(dts.min):02}:{int(dts.sec):02}')
 
             if show_ns:
                 ns = dts.ps // 1000
-                res += f'.{ns + dts.us * 1000:09d}'
+                res += f'.{int(ns + dts.us * 1000):09}'
             elif show_us:
-                res += f'.{dts.us:06d}'
+                res += f'.{int(dts.us):06}'
             elif show_ms:
-                res += f'.{dts.us / 1000:03d}'
+                res += f'.{int(dts.us / 1000):03}'
 
             result[i] = res
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -266,20 +266,16 @@ def format_array_from_datetime(ndarray[int64_t] values, object tz=None,
         elif basic_format:
 
             dt64_to_dtstruct(val, &dts)
-            res = '%d-%.2d-%.2d %.2d:%.2d:%.2d' % (dts.year,
-                                                   dts.month,
-                                                   dts.day,
-                                                   dts.hour,
-                                                   dts.min,
-                                                   dts.sec)
+            res = (f'{dts.year}-{dts.month:02d}-{dts.day:02d} '
+                   f'{dts.hour:02d}:{dts.min:02d}:{dts.sec:02d}')
 
             if show_ns:
                 ns = dts.ps // 1000
-                res += '.%.9d' % (ns + 1000 * dts.us)
+                res += f'.{ns + dts.us * 1000:09d}'
             elif show_us:
-                res += '.%.6d' % dts.us
+                res += f'.{dts.us:06d}'
             elif show_ms:
-                res += '.%.3d' % (dts.us / 1000)
+                res += f'{dts.us / 1000:03d}'
 
             result[i] = res
 


### PR DESCRIPTION
Continuation of previous [PR](https://github.com/pandas-dev/pandas/pull/29554)

- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

ref to issue #29547 