### PR TITLE
CLN: remove kwargs from Index._simple_new

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -506,7 +506,7 @@ class Index(IndexOpsMixin, PandasObject):
         return None
 
     @classmethod
-    def _simple_new(cls, values, name=None, dtype=None, **kwargs):
+    def _simple_new(cls, values, name=None, dtype=None):
         """
         We require that we have a dtype compat for the values. If we are passed
         a non-dtype compat, then coerce using the constructor.
@@ -528,8 +528,7 @@ class Index(IndexOpsMixin, PandasObject):
         # we actually set this value too.
         result._index_data = values
         result.name = name
-        for k, v in kwargs.items():
-            setattr(result, k, v)
+
         return result._reset_identity()
 
     @cache_readonly
@@ -2673,7 +2672,7 @@ class Index(IndexOpsMixin, PandasObject):
             except TypeError:
                 pass
 
-        return this._shallow_copy(the_diff, name=result_name, freq=None)
+        return this._shallow_copy(the_diff, name=result_name)
 
     def symmetric_difference(self, other, result_name=None, sort=None):
         """

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -464,6 +464,11 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
             return _to_M8(value)
         raise ValueError("Passed item and index have different timezone")
 
+    def difference(self, other, sort=None):
+        new_idx = super().difference(other, sort=sort)
+        new_idx.freq = None
+        return new_idx
+
     # --------------------------------------------------------------------
     # Rendering Methods
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -464,6 +464,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
             return _to_M8(value)
         raise ValueError("Passed item and index have different timezone")
 
+    @Appender(Index.difference.__doc__)
     def difference(self, other, sort=None):
         new_idx = super().difference(other, sort=sort)
         new_idx.freq = None

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -146,7 +146,7 @@ class RangeIndex(Int64Index):
         return cls._simple_new(data, dtype=dtype, name=name)
 
     @classmethod
-    def _simple_new(cls, values, name=None, dtype=None, **kwargs):
+    def _simple_new(cls, values, name=None, dtype=None):
         result = object.__new__(cls)
 
         # handle passed None, non-integers
@@ -154,13 +154,10 @@ class RangeIndex(Int64Index):
             # empty
             values = range(0, 0, 1)
         elif not isinstance(values, range):
-            return Index(values, dtype=dtype, name=name, **kwargs)
+            return Index(values, dtype=dtype, name=name)
 
         result._range = values
-
         result.name = name
-        for k, v in kwargs.items():
-            setattr(result, k, v)
 
         result._reset_identity()
         return result

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -406,6 +406,7 @@ class TimedeltaIndex(
         """
         return super().intersection(other, sort=sort)
 
+    @Appender(Index.difference.__doc__)
     def difference(self, other, sort=None):
         new_idx = super().difference(other, sort=sort)
         new_idx.freq = None

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -406,6 +406,11 @@ class TimedeltaIndex(
         """
         return super().intersection(other, sort=sort)
 
+    def difference(self, other, sort=None):
+        new_idx = super().difference(other, sort=sort)
+        new_idx.freq = None
+        return new_idx
+
     def _wrap_joined_index(self, joined, other):
         name = get_op_result_name(self, other)
         if (


### PR DESCRIPTION
Removes kwargs from ``Index._simple_new``.

The kwargs are actually ony used by ``DateTimeIndex.difference`` and ``TimeDeltaIndex.difference``.