### PR TITLE
STYLE: Specify target-version for black

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -56,7 +56,7 @@ if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
     black --version
 
     MSG='Checking black formatting' ; echo $MSG
-	black . --check --exclude '(asv_bench/env|\.egg|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|setup.py)'
+	black . --check
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     # `setup.cfg` contains the list of error codes that are being ignored in flake8

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2082,7 +2082,7 @@ class DataFrame(NDFrame):
             data_label=data_label,
             write_index=write_index,
             variable_labels=variable_labels,
-            **kwargs
+            **kwargs,
         )
         writer.write_file()
 
@@ -2106,7 +2106,7 @@ class DataFrame(NDFrame):
         compression="snappy",
         index=None,
         partition_cols=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Write a DataFrame to the binary parquet format.
@@ -2186,7 +2186,7 @@ class DataFrame(NDFrame):
             compression=compression,
             index=index,
             partition_cols=partition_cols,
-            **kwargs
+            **kwargs,
         )
 
     @Substitution(
@@ -4110,7 +4110,7 @@ class DataFrame(NDFrame):
         inplace=False,
         limit=None,
         downcast=None,
-        **kwargs
+        **kwargs,
     ):
         return super().fillna(
             value=value,
@@ -4119,7 +4119,7 @@ class DataFrame(NDFrame):
             inplace=inplace,
             limit=limit,
             downcast=downcast,
-            **kwargs
+            **kwargs,
         )
 
     @Appender(_shared_docs["replace"] % _shared_doc_kwargs)
@@ -6566,7 +6566,7 @@ class DataFrame(NDFrame):
         see_also=_agg_summary_and_see_also_doc,
         examples=_agg_examples_doc,
         versionadded="\n.. versionadded:: 0.20.0\n",
-        **_shared_doc_kwargs
+        **_shared_doc_kwargs,
     )
     @Appender(_shared_docs["aggregate"])
     def aggregate(self, func, axis=0, *args, **kwargs):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2055,7 +2055,7 @@ class NDFrame(PandasObject, SelectionMixin):
             _typ=self._typ,
             _metadata=self._metadata,
             attrs=self.attrs,
-            **meta
+            **meta,
         )
 
     def __setstate__(self, state):
@@ -7050,7 +7050,7 @@ class NDFrame(PandasObject, SelectionMixin):
         limit_direction="forward",
         limit_area=None,
         downcast=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Interpolate values according to different methods.
@@ -7124,7 +7124,7 @@ class NDFrame(PandasObject, SelectionMixin):
             limit_area=limit_area,
             inplace=inplace,
             downcast=downcast,
-            **kwargs
+            **kwargs,
         )
 
         if inplace:
@@ -11572,7 +11572,7 @@ def _make_min_count_stat_function(
         level=None,
         numeric_only=None,
         min_count=0,
-        **kwargs
+        **kwargs,
     ):
         if name == "sum":
             nv.validate_sum(tuple(), kwargs)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1214,7 +1214,7 @@ class GroupBy(_GroupBy):
         return self._cython_agg_general(
             "median",
             alt=lambda x, axis: Series(x).median(axis=axis, **kwargs),
-            **kwargs
+            **kwargs,
         )
 
     @Substitution(name="groupby")
@@ -2181,7 +2181,7 @@ class GroupBy(_GroupBy):
         result_is_index: bool = False,
         pre_processing=None,
         post_processing=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Get result for Cythonized functions.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -265,7 +265,7 @@ class Index(IndexOpsMixin, PandasObject):
         name=None,
         fastpath=None,
         tupleize_cols=True,
-        **kwargs
+        **kwargs,
     ) -> "Index":
 
         from .range import RangeIndex

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1422,7 +1422,7 @@ def date_range(
     normalize=False,
     name=None,
     closed=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Return a fixed frequency DatetimeIndex.
@@ -1572,7 +1572,7 @@ def date_range(
         tz=tz,
         normalize=normalize,
         closed=closed,
-        **kwargs
+        **kwargs,
     )
     return DatetimeIndex._simple_new(dtarr, tz=dtarr.tz, freq=dtarr.freq, name=name)
 
@@ -1588,7 +1588,7 @@ def bdate_range(
     weekmask=None,
     holidays=None,
     closed=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Return a fixed frequency DatetimeIndex, with business day as the default
@@ -1681,7 +1681,7 @@ def bdate_range(
         normalize=normalize,
         name=name,
         closed=closed,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -935,7 +935,7 @@ class IntervalIndex(IntervalMixin, Index):
             None is specified as these are not yet implemented.
         """
                 )
-            }
+            },
         )
     )
     @Appender(_index_shared_docs["get_indexer"])

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -956,7 +956,7 @@ class MultiIndex(Index):
         codes=None,
         deep=False,
         _set_identity=False,
-        **kwargs
+        **kwargs,
     ):
         """
         Make a copy of this object. Names, dtype, levels and codes can be
@@ -1020,7 +1020,7 @@ class MultiIndex(Index):
             return MultiIndex(
                 levels=[[] for _ in range(self.nlevels)],
                 codes=[[] for _ in range(self.nlevels)],
-                **kwargs
+                **kwargs,
             )
         return self._shallow_copy(values, **kwargs)
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -194,7 +194,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         dtype=None,
         copy=False,
         name=None,
-        **fields
+        **fields,
     ):
 
         valid_field_set = {

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1088,7 +1088,7 @@ class Block(PandasObject):
         fill_value=None,
         coerce=False,
         downcast=None,
-        **kwargs
+        **kwargs,
     ):
 
         inplace = validate_bool_kwarg(inplace, "inplace")
@@ -1138,7 +1138,7 @@ class Block(PandasObject):
             fill_value=fill_value,
             inplace=inplace,
             downcast=downcast,
-            **kwargs
+            **kwargs,
         )
 
     def _interpolate_with_fill(
@@ -1193,7 +1193,7 @@ class Block(PandasObject):
         limit_area=None,
         inplace=False,
         downcast=None,
-        **kwargs
+        **kwargs,
     ):
         """ interpolate using scipy wrappers """
 
@@ -1231,7 +1231,7 @@ class Block(PandasObject):
                 limit_area=limit_area,
                 fill_value=fill_value,
                 bounds_error=False,
-                **kwargs
+                **kwargs,
             )
 
         # interp each column independently
@@ -2016,7 +2016,7 @@ class FloatBlock(FloatOrComplexBlock):
         float_format=None,
         decimal=".",
         quoting=None,
-        **kwargs
+        **kwargs,
     ):
         """ convert to our native types format, slicing if desired """
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -354,7 +354,7 @@ class BlockManager(PandasObject):
         filter=None,
         do_integrity_check=False,
         consolidate=True,
-        **kwargs
+        **kwargs,
     ):
         """
         iterate over the blocks, collect and create a new block manager

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -164,7 +164,7 @@ def interpolate_1d(
     fill_value=None,
     bounds_error=False,
     order=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Logic for the 1-d interpolation.  The result should be 1-d, inputs
@@ -300,7 +300,7 @@ def interpolate_1d(
             fill_value=fill_value,
             bounds_error=bounds_error,
             order=order,
-            **kwargs
+            **kwargs,
         )
         result[preserve_nans] = np.nan
         return result

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -793,7 +793,7 @@ class Resampler(_GroupBy, ShallowMixin):
         limit_direction="forward",
         limit_area=None,
         downcast=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Interpolate values according to different methods.
@@ -807,7 +807,7 @@ class Resampler(_GroupBy, ShallowMixin):
             limit_direction=limit_direction,
             limit_area=limit_area,
             downcast=downcast,
-            **kwargs
+            **kwargs,
         )
 
     def asfreq(self, fill_value=None):
@@ -1369,7 +1369,7 @@ class TimeGrouper(Grouper):
         kind=None,
         convention=None,
         base=0,
-        **kwargs
+        **kwargs,
     ):
         # Check for correctness of the keyword arguments which would
         # otherwise silently use the default if misspelled

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -570,7 +570,7 @@ def crosstab(
         margins=margins,
         margins_name=margins_name,
         dropna=dropna,
-        **kwargs
+        **kwargs,
     )
 
     # Post-process

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3788,7 +3788,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         see_also=_agg_see_also_doc,
         examples=_agg_examples_doc,
         versionadded="\n.. versionadded:: 0.20.0\n",
-        **_shared_doc_kwargs
+        **_shared_doc_kwargs,
     )
     @Appender(generic._shared_docs["aggregate"])
     def aggregate(self, func, axis=0, *args, **kwargs):
@@ -4012,7 +4012,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             skipna=skipna,
             numeric_only=numeric_only,
             filter_type=filter_type,
-            **kwds
+            **kwds,
         )
 
     def _reindex_indexer(self, new_index, indexer, copy):
@@ -4249,7 +4249,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         inplace=False,
         limit=None,
         downcast=None,
-        **kwargs
+        **kwargs,
     ):
         return super().fillna(
             value=value,
@@ -4258,7 +4258,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             inplace=inplace,
             limit=limit,
             downcast=downcast,
-            **kwargs
+            **kwargs,
         )
 
     @Appender(generic._shared_docs["replace"] % _shared_doc_kwargs)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1875,7 +1875,7 @@ def _noarg_wrapper(
     docstring=None,
     forbidden_types=["bytes"],
     returns_string=True,
-    **kargs
+    **kargs,
 ):
     @forbid_nonstring_types(forbidden_types, name=name)
     def wrapper(self):
@@ -1898,7 +1898,7 @@ def _pat_wrapper(
     name=None,
     forbidden_types=["bytes"],
     returns_string=True,
-    **kwargs
+    **kwargs,
 ):
     @forbid_nonstring_types(forbidden_types, name=name)
     def wrapper1(self, pat):

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -72,7 +72,7 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
         axis: Axis = 0,
         on: Optional[Union[str, Index]] = None,
         closed: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
 
         self.__dict__.update(kwargs)
@@ -399,7 +399,7 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
         window: Optional[Union[int, str]] = None,
         center: Optional[bool] = None,
         check_minp: Optional[Callable] = None,
-        **kwargs
+        **kwargs,
     ):
         """
         Rolling statistical measure using supplied function.

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -528,7 +528,7 @@ class BytesZipFile(zipfile.ZipFile, BytesIO):  # type: ignore
         file: FilePathOrBuffer,
         mode: str,
         archive_name: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
         if mode in ["wb", "rb"]:
             mode = mode.replace("b", "")

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -304,7 +304,7 @@ def read_excel(
     skipfooter=0,
     convert_float=True,
     mangle_dupe_cols=True,
-    **kwds
+    **kwds,
 ):
 
     for arg in ("sheet", "sheetname", "parse_cols"):
@@ -344,7 +344,7 @@ def read_excel(
         skipfooter=skipfooter,
         convert_float=convert_float,
         mangle_dupe_cols=mangle_dupe_cols,
-        **kwds
+        **kwds,
     )
 
 
@@ -417,7 +417,7 @@ class _BaseExcelReader(metaclass=abc.ABCMeta):
         skipfooter=0,
         convert_float=True,
         mangle_dupe_cols=True,
-        **kwds
+        **kwds,
     ):
 
         _validate_header_arg(header)
@@ -517,7 +517,7 @@ class _BaseExcelReader(metaclass=abc.ABCMeta):
                     skipfooter=skipfooter,
                     usecols=usecols,
                     mangle_dupe_cols=mangle_dupe_cols,
-                    **kwds
+                    **kwds,
                 )
 
                 output[asheetname] = parser.read(nrows=nrows)
@@ -694,7 +694,7 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         date_format=None,
         datetime_format=None,
         mode="w",
-        **engine_kwargs
+        **engine_kwargs,
     ):
         # validate that this engine can handle the extension
         if isinstance(path, str):
@@ -848,7 +848,7 @@ class ExcelFile:
         skipfooter=0,
         convert_float=True,
         mangle_dupe_cols=True,
-        **kwds
+        **kwds,
     ):
         """
         Parse specified sheet(s) into a DataFrame.
@@ -886,7 +886,7 @@ class ExcelFile:
             skipfooter=skipfooter,
             convert_float=convert_float,
             mangle_dupe_cols=mangle_dupe_cols,
-            **kwds
+            **kwds,
         )
 
     @property

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -168,7 +168,7 @@ class _XlsxWriter(ExcelWriter):
         date_format=None,
         datetime_format=None,
         mode="w",
-        **engine_kwargs
+        **engine_kwargs,
     ):
         # Use the xlsxwriter module as the Excel writer.
         import xlsxwriter
@@ -182,7 +182,7 @@ class _XlsxWriter(ExcelWriter):
             date_format=date_format,
             datetime_format=datetime_format,
             mode=mode,
-            **engine_kwargs
+            **engine_kwargs,
         )
 
         self.book = xlsxwriter.Workbook(path, **engine_kwargs)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1437,7 +1437,7 @@ class Datetime64Formatter(GenericArrayFormatter):
         values: Union[np.ndarray, "Series", DatetimeIndex, DatetimeArray],
         nat_rep: str = "NaT",
         date_format: None = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(values, **kwargs)
         self.nat_rep = nat_rep
@@ -1658,7 +1658,7 @@ class Timedelta64Formatter(GenericArrayFormatter):
         values: Union[np.ndarray, TimedeltaIndex],
         nat_rep: str = "NaT",
         box: bool = False,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(values, **kwargs)
         self.nat_rep = nat_rep

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -173,7 +173,7 @@ def read_gbq(
         location=location,
         configuration=configuration,
         credentials=credentials,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -89,7 +89,7 @@ class PyArrowImpl(BaseImpl):
         coerce_timestamps="ms",
         index=None,
         partition_cols=None,
-        **kwargs
+        **kwargs,
     ):
         self.validate_dataframe(df)
         path, _, _, _ = get_filepath_or_buffer(path, mode="wb")
@@ -106,7 +106,7 @@ class PyArrowImpl(BaseImpl):
                 compression=compression,
                 coerce_timestamps=coerce_timestamps,
                 partition_cols=partition_cols,
-                **kwargs
+                **kwargs,
             )
         else:
             self.api.parquet.write_table(
@@ -114,7 +114,7 @@ class PyArrowImpl(BaseImpl):
                 path,
                 compression=compression,
                 coerce_timestamps=coerce_timestamps,
-                **kwargs
+                **kwargs,
             )
 
     def read(self, path, columns=None, **kwargs):
@@ -176,7 +176,7 @@ class FastParquetImpl(BaseImpl):
                 compression=compression,
                 write_index=index,
                 partition_on=partition_cols,
-                **kwargs
+                **kwargs,
             )
 
     def read(self, path, columns=None, **kwargs):
@@ -205,7 +205,7 @@ def to_parquet(
     compression="snappy",
     index=None,
     partition_cols=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Write a DataFrame to the parquet format.
@@ -252,7 +252,7 @@ def to_parquet(
         compression=compression,
         index=index,
         partition_cols=partition_cols,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -707,7 +707,7 @@ def read_fwf(
     colspecs="infer",
     widths=None,
     infer_nrows=100,
-    **kwds
+    **kwds,
 ):
 
     r"""

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -252,7 +252,7 @@ def to_hdf(
     complevel=None,
     complib=None,
     append=None,
-    **kwargs
+    **kwargs,
 ):
     """ store this object, close it if we opened it """
 
@@ -720,7 +720,7 @@ class HDFStore:
         iterator=False,
         chunksize=None,
         auto_close=False,
-        **kwargs
+        **kwargs,
     ):
         """
         Retrieve pandas object stored in file, optionally based on where criteria.
@@ -825,7 +825,7 @@ class HDFStore:
         iterator=False,
         chunksize=None,
         auto_close=False,
-        **kwargs
+        **kwargs,
     ):
         """ Retrieve pandas objects from multiple tables
 
@@ -860,7 +860,7 @@ class HDFStore:
                 stop=stop,
                 iterator=iterator,
                 chunksize=chunksize,
-                **kwargs
+                **kwargs,
             )
 
         if not isinstance(keys, (list, tuple)):
@@ -1478,7 +1478,7 @@ class HDFStore:
         append=False,
         complib=None,
         encoding=None,
-        **kwargs
+        **kwargs,
     ):
         group = self.get_node(key)
 
@@ -1676,7 +1676,7 @@ class IndexCol:
         freq=None,
         tz=None,
         index_name=None,
-        **kwargs
+        **kwargs,
     ):
         self.values = values
         self.kind = kind
@@ -2042,7 +2042,7 @@ class DataCol(IndexCol):
         meta=None,
         metadata=None,
         block=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(values=values, kind=kind, typ=typ, cname=cname, **kwargs)
         self.dtype = None
@@ -2908,14 +2908,14 @@ class GenericFixed(Fixed):
                     data, kind, encoding=self.encoding, errors=self.errors
                 ),
                 dtype=object,
-                **kwargs
+                **kwargs,
             )
         else:
             index = factory(
                 _unconvert_index(
                     data, kind, encoding=self.encoding, errors=self.errors
                 ),
-                **kwargs
+                **kwargs,
             )
 
         index.name = name
@@ -3654,7 +3654,7 @@ class Table(Fixed):
         nan_rep=None,
         data_columns=None,
         min_itemsize=None,
-        **kwargs
+        **kwargs,
     ):
         """ create and return the axes
         legacy tables create an indexable column, indexable index,
@@ -4104,7 +4104,7 @@ class AppendableTable(LegacyTable):
         chunksize=None,
         expectedrows=None,
         dropna=False,
-        **kwargs
+        **kwargs,
     ):
 
         if not append and self.is_exists:

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -23,7 +23,7 @@ def hist_series(
     figsize=None,
     bins=10,
     backend=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Draw histogram of the input series using matplotlib.
@@ -83,7 +83,7 @@ def hist_series(
         yrot=yrot,
         figsize=figsize,
         bins=bins,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -103,7 +103,7 @@ def hist_frame(
     layout=None,
     bins=10,
     backend=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Make a histogram of the DataFrame's.
@@ -206,7 +206,7 @@ def hist_frame(
         figsize=figsize,
         layout=layout,
         bins=bins,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -400,7 +400,7 @@ def boxplot(
     figsize=None,
     layout=None,
     return_type=None,
-    **kwargs
+    **kwargs,
 ):
     plot_backend = _get_plot_backend("matplotlib")
     return plot_backend.boxplot(
@@ -414,7 +414,7 @@ def boxplot(
         figsize=figsize,
         layout=layout,
         return_type=return_type,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -432,7 +432,7 @@ def boxplot_frame(
     layout=None,
     return_type=None,
     backend=None,
-    **kwargs
+    **kwargs,
 ):
     plot_backend = _get_plot_backend(backend)
     return plot_backend.boxplot_frame(
@@ -446,7 +446,7 @@ def boxplot_frame(
         figsize=figsize,
         layout=layout,
         return_type=return_type,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -463,7 +463,7 @@ def boxplot_frame_groupby(
     sharex=False,
     sharey=True,
     backend=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Make box plots from DataFrameGroupBy data.
@@ -536,7 +536,7 @@ def boxplot_frame_groupby(
         layout=layout,
         sharex=sharex,
         sharey=sharey,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -184,7 +184,7 @@ def _grouped_plot_by_column(
     ax=None,
     layout=None,
     return_type=None,
-    **kwargs
+    **kwargs,
 ):
     grouped = data.groupby(by)
     if columns is None:
@@ -234,7 +234,7 @@ def boxplot(
     figsize=None,
     layout=None,
     return_type=None,
-    **kwds
+    **kwds,
 ):
 
     import matplotlib.pyplot as plt
@@ -359,7 +359,7 @@ def boxplot_frame(
     figsize=None,
     layout=None,
     return_type=None,
-    **kwds
+    **kwds,
 ):
     import matplotlib.pyplot as plt
 
@@ -374,7 +374,7 @@ def boxplot_frame(
         figsize=figsize,
         layout=layout,
         return_type=return_type,
-        **kwds
+        **kwds,
     )
     plt.draw_if_interactive()
     return ax
@@ -392,7 +392,7 @@ def boxplot_frame_groupby(
     layout=None,
     sharex=False,
     sharey=True,
-    **kwds
+    **kwds,
 ):
     if subplots is True:
         naxes = len(grouped)
@@ -432,6 +432,6 @@ def boxplot_frame_groupby(
             ax=ax,
             figsize=figsize,
             layout=layout,
-            **kwds
+            **kwds,
         )
     return ret

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -102,7 +102,7 @@ class MPLPlot:
         table=False,
         layout=None,
         include_bool=False,
-        **kwds
+        **kwds,
     ):
 
         import matplotlib.pyplot as plt
@@ -985,7 +985,7 @@ class ScatterPlot(PlanePlot):
             c=c_values,
             label=label,
             cmap=cmap,
-            **self.kwds
+            **self.kwds,
         )
         if cb:
             cbar_label = c if c_is_column else ""
@@ -1095,7 +1095,7 @@ class LinePlot(MPLPlot):
                 column_num=i,
                 stacking_id=stacking_id,
                 is_errorbar=is_errorbar,
-                **kwds
+                **kwds,
             )
             self._add_legend_handle(newlines[0], label, index=i)
 
@@ -1250,7 +1250,7 @@ class AreaPlot(LinePlot):
         column_num=None,
         stacking_id=None,
         is_errorbar=False,
-        **kwds
+        **kwds,
     ):
 
         if column_num == 0:
@@ -1386,7 +1386,7 @@ class BarPlot(MPLPlot):
                     start=start,
                     label=label,
                     log=self.log,
-                    **kwds
+                    **kwds,
                 )
                 ax.set_title(label)
             elif self.stacked:
@@ -1401,7 +1401,7 @@ class BarPlot(MPLPlot):
                     start=start,
                     label=label,
                     log=self.log,
-                    **kwds
+                    **kwds,
                 )
                 pos_prior = pos_prior + np.where(mask, y, 0)
                 neg_prior = neg_prior + np.where(mask, 0, y)
@@ -1415,7 +1415,7 @@ class BarPlot(MPLPlot):
                     start=start,
                     label=label,
                     log=self.log,
-                    **kwds
+                    **kwds,
                 )
             self._add_legend_handle(rect, label, index=i)
 

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -49,7 +49,7 @@ class HistPlot(LinePlot):
         bottom=0,
         column_num=0,
         stacking_id=None,
-        **kwds
+        **kwds,
     ):
         if column_num == 0:
             cls._initialize_stacker(ax, stacking_id, len(bins) - 1)
@@ -145,7 +145,7 @@ class KdePlot(HistPlot):
         ind=None,
         column_num=None,
         stacking_id=None,
-        **kwds
+        **kwds,
     ):
         from scipy.stats import gaussian_kde
 
@@ -177,7 +177,7 @@ def _grouped_plot(
     layout=None,
     rot=0,
     ax=None,
-    **kwargs
+    **kwargs,
 ):
 
     if figsize == "default":
@@ -226,7 +226,7 @@ def _grouped_hist(
     xrot=None,
     ylabelsize=None,
     yrot=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Grouped histogram
@@ -290,7 +290,7 @@ def hist_series(
     yrot=None,
     figsize=None,
     bins=10,
-    **kwds
+    **kwds,
 ):
     import matplotlib.pyplot as plt
 
@@ -335,7 +335,7 @@ def hist_series(
             xrot=xrot,
             ylabelsize=ylabelsize,
             yrot=yrot,
-            **kwds
+            **kwds,
         )
 
     if hasattr(axes, "ndim"):
@@ -359,7 +359,7 @@ def hist_frame(
     figsize=None,
     layout=None,
     bins=10,
-    **kwds
+    **kwds,
 ):
     if by is not None:
         axes = _grouped_hist(
@@ -377,7 +377,7 @@ def hist_frame(
             xrot=xrot,
             ylabelsize=ylabelsize,
             yrot=yrot,
-            **kwds
+            **kwds,
         )
         return axes
 

--- a/pandas/plotting/_matplotlib/misc.py
+++ b/pandas/plotting/_matplotlib/misc.py
@@ -22,7 +22,7 @@ def scatter_matrix(
     density_kwds=None,
     hist_kwds=None,
     range_padding=0.05,
-    **kwds
+    **kwds,
 ):
     df = frame._get_numeric_data()
     n = df.columns.size
@@ -160,7 +160,7 @@ def radviz(frame, class_column, ax=None, color=None, colormap=None, **kwds):
             to_plot[kls][1],
             color=colors[i],
             label=pprint_thing(kls),
-            **kwds
+            **kwds,
         )
     ax.legend()
 
@@ -315,7 +315,7 @@ def parallel_coordinates(
     axvlines=True,
     axvlines_kwds=None,
     sort_labels=False,
-    **kwds
+    **kwds,
 ):
     import matplotlib.pyplot as plt
 

--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -101,7 +101,7 @@ def _subplots(
     ax=None,
     layout=None,
     layout_type="box",
-    **fig_kw
+    **fig_kw,
 ):
     """Create a figure with a set of subplots already made.
 

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -82,7 +82,7 @@ def scatter_matrix(
     density_kwds=None,
     hist_kwds=None,
     range_padding=0.05,
-    **kwargs
+    **kwargs,
 ):
     """
     Draw a matrix of scatter plots.
@@ -134,7 +134,7 @@ def scatter_matrix(
         density_kwds=density_kwds,
         hist_kwds=hist_kwds,
         range_padding=range_padding,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -207,7 +207,7 @@ def radviz(frame, class_column, ax=None, color=None, colormap=None, **kwds):
         ax=ax,
         color=color,
         colormap=colormap,
-        **kwds
+        **kwds,
     )
 
 
@@ -255,7 +255,7 @@ def andrews_curves(
         samples=samples,
         color=color,
         colormap=colormap,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -325,7 +325,7 @@ def parallel_coordinates(
     axvlines=True,
     axvlines_kwds=None,
     sort_labels=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Parallel coordinates plotting.
@@ -383,7 +383,7 @@ def parallel_coordinates(
         axvlines=axvlines,
         axvlines_kwds=axvlines_kwds,
         sort_labels=sort_labels,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1127,7 +1127,7 @@ def test_seriesgroupby_observed_true(df_cat, operation, kwargs):
     index = MultiIndex.from_frame(
         DataFrame(
             {"A": ["foo", "foo", "bar", "bar"], "B": ["one", "two", "one", "three"]},
-            **kwargs
+            **kwargs,
         )
     )
     expected = Series(data=[1, 3, 2, 4], index=index, name="C")

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -581,23 +581,23 @@ class TestPivotTable:
         df = pd.DataFrame(
             [
                 {
-                    "uid": u"aa",
+                    "uid": "aa",
                     "ts": pd.Timestamp("2016-08-12 13:00:00-0700", tz="US/Pacific"),
                 },
                 {
-                    "uid": u"aa",
+                    "uid": "aa",
                     "ts": pd.Timestamp("2016-08-12 08:00:00-0700", tz="US/Pacific"),
                 },
                 {
-                    "uid": u"aa",
+                    "uid": "aa",
                     "ts": pd.Timestamp("2016-08-12 14:00:00-0700", tz="US/Pacific"),
                 },
                 {
-                    "uid": u"aa",
+                    "uid": "aa",
                     "ts": pd.Timestamp("2016-08-25 11:00:00-0700", tz="US/Pacific"),
                 },
                 {
-                    "uid": u"aa",
+                    "uid": "aa",
                     "ts": pd.Timestamp("2016-08-25 13:00:00-0700", tz="US/Pacific"),
                 },
             ]

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -363,19 +363,19 @@ class TestMultiLevel(Base):
         [
             (
                 [[1, 1, None, None, 30.0, None], [2, 2, None, None, 30.0, None]],
-                [u"ix1", u"ix2", u"col1", u"col2", u"col3", u"col4"],
+                ["ix1", "ix2", "col1", "col2", "col3", "col4"],
                 2,
                 [None, None, 30.0, None],
             ),
             (
                 [[1, 1, None, None, 30.0], [2, 2, None, None, 30.0]],
-                [u"ix1", u"ix2", u"col1", u"col2", u"col3"],
+                ["ix1", "ix2", "col1", "col2", "col3"],
                 2,
                 [None, None, 30.0],
             ),
             (
                 [[1, 1, None, None, 30.0], [2, None, None, None, 30.0]],
-                [u"ix1", u"ix2", u"col1", u"col2", u"col3"],
+                ["ix1", "ix2", "col1", "col2", "col3"],
                 None,
                 [None, None, 30.0],
             ),
@@ -389,7 +389,7 @@ class TestMultiLevel(Base):
         # make sure DataFrame.unstack() works when its run on a subset of the DataFrame
         # and the Index levels contain values that are not present in the subset
         result = pd.DataFrame(result_rows, columns=result_columns).set_index(
-            [u"ix1", "ix2"]
+            ["ix1", "ix2"]
         )
         result = result.iloc[1:2].unstack("ix2")
         expected = pd.DataFrame(

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -151,7 +151,7 @@ class TestnanopsDataFrame:
         targarval,
         check_dtype=True,
         empty_targfunc=None,
-        **kwargs
+        **kwargs,
     ):
         for axis in list(range(targarval.ndim)) + [None]:
             for skipna in [False, True]:
@@ -186,7 +186,7 @@ class TestnanopsDataFrame:
             targarval2,
             check_dtype=check_dtype,
             empty_targfunc=empty_targfunc,
-            **kwargs
+            **kwargs,
         )
 
     def check_fun(self, testfunc, targfunc, testar, empty_targfunc=None, **kwargs):
@@ -203,7 +203,7 @@ class TestnanopsDataFrame:
             testarval,
             targarval,
             empty_targfunc=empty_targfunc,
-            **kwargs
+            **kwargs,
         )
 
     def check_funs(
@@ -215,7 +215,7 @@ class TestnanopsDataFrame:
         allow_date=True,
         allow_tdelta=True,
         allow_obj=True,
-        **kwargs
+        **kwargs,
     ):
         self.check_fun(testfunc, targfunc, "arr_float", **kwargs)
         self.check_fun(testfunc, targfunc, "arr_float_nan", **kwargs)
@@ -476,7 +476,7 @@ class TestnanopsDataFrame:
             self.arr_float_2d,
             self.arr_float1_2d,
             min_periods=len(self.arr_float_2d) - 1,
-            **kwargs
+            **kwargs,
         )
         tm.assert_almost_equal(targ0, res00)
         tm.assert_almost_equal(targ0, res01)
@@ -486,7 +486,7 @@ class TestnanopsDataFrame:
             self.arr_float_nan_2d,
             self.arr_float1_nan_2d,
             min_periods=len(self.arr_float_2d) - 1,
-            **kwargs
+            **kwargs,
         )
         tm.assert_almost_equal(targ1, res10)
         tm.assert_almost_equal(targ1, res11)
@@ -500,13 +500,13 @@ class TestnanopsDataFrame:
             self.arr_float_nan_2d,
             self.arr_nan_float1_2d,
             min_periods=len(self.arr_float_2d) - 1,
-            **kwargs
+            **kwargs,
         )
         res25 = checkfun(
             self.arr_float_2d,
             self.arr_float1_2d,
             min_periods=len(self.arr_float_2d) + 1,
-            **kwargs
+            **kwargs,
         )
         tm.assert_almost_equal(targ2, res20)
         tm.assert_almost_equal(targ2, res21)
@@ -521,7 +521,7 @@ class TestnanopsDataFrame:
             self.arr_float_1d,
             self.arr_float1_1d,
             min_periods=len(self.arr_float_1d) - 1,
-            **kwargs
+            **kwargs,
         )
         tm.assert_almost_equal(targ0, res00)
         tm.assert_almost_equal(targ0, res01)
@@ -531,7 +531,7 @@ class TestnanopsDataFrame:
             self.arr_float_nan_1d,
             self.arr_float1_nan_1d,
             min_periods=len(self.arr_float_1d) - 1,
-            **kwargs
+            **kwargs,
         )
         tm.assert_almost_equal(targ1, res10)
         tm.assert_almost_equal(targ1, res11)
@@ -545,13 +545,13 @@ class TestnanopsDataFrame:
             self.arr_float_nan_1d,
             self.arr_nan_float1_1d,
             min_periods=len(self.arr_float_1d) - 1,
-            **kwargs
+            **kwargs,
         )
         res25 = checkfun(
             self.arr_float_1d,
             self.arr_float1_1d,
             min_periods=len(self.arr_float_1d) + 1,
-            **kwargs
+            **kwargs,
         )
         tm.assert_almost_equal(targ2, res20)
         tm.assert_almost_equal(targ2, res21)

--- a/pandas/tests/window/test_moments.py
+++ b/pandas/tests/window/test_moments.py
@@ -800,7 +800,7 @@ class TestMoments(Base):
         has_time_rule=True,
         fill_value=None,
         zero_min_periods_equal=True,
-        **kwargs
+        **kwargs,
     ):
 
         # inject raw

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -316,7 +316,7 @@ def assert_almost_equal(
             check_exact=False,
             exact=check_dtype,
             check_less_precise=check_less_precise,
-            **kwargs
+            **kwargs,
         )
 
     elif isinstance(left, pd.Series):
@@ -326,7 +326,7 @@ def assert_almost_equal(
             check_exact=False,
             check_dtype=check_dtype,
             check_less_precise=check_less_precise,
-            **kwargs
+            **kwargs,
         )
 
     elif isinstance(left, pd.DataFrame):
@@ -336,7 +336,7 @@ def assert_almost_equal(
             check_exact=False,
             check_dtype=check_dtype,
             check_less_precise=check_less_precise,
-            **kwargs
+            **kwargs,
         )
 
     else:
@@ -359,7 +359,7 @@ def assert_almost_equal(
             right,
             check_dtype=check_dtype,
             check_less_precise=check_less_precise,
-            **kwargs
+            **kwargs,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,23 @@ requires = [
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
     "numpy==1.16.0; python_version>='3.7' and platform_system=='AIX'",
 ]
+
+[tool.black]
+target-version = ['py36', 'py37', 'py38']
+exclude = '''
+(
+    asv_bench/env
+  | \.egg
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.nox
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | setup.py
+)
+'''


### PR DESCRIPTION
The `target-version` option explicitly tells `black` that it can use Python features from the supplied versions.  The default is per-file detection by looking for the presence specific syntax, e.g. f-strings would indicate py36.

Currently `black` does not detect this for us since we just bumped to py36, so detection will not occur until f-strings are added, which would in turn necessitate these changes as part of the f-string PRs, making them a bit more convoluted than needed.  This resolves that issue by explicitly telling `black` our supported versions and enforcing those changes for the entire codebase in this PR.