### PR TITLE
Fixed tokenizer build warnings

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.h
+++ b/pandas/_libs/src/parser/tokenizer.h
@@ -162,9 +162,9 @@ typedef struct parser_t {
     int64_t skip_footer;
     // pick one, depending on whether the converter requires GIL
     double (*double_converter_nogil)(const char *, char **,
-                                     char, char, char, int);
+                                     char, char, char, int, int *, int *);
     double (*double_converter_withgil)(const char *, char **,
-                                       char, char, char, int);
+                                       char, char, char, int, int *, int *);
 
     // error handling
     char *warn_msg;


### PR DESCRIPTION
Fixes the following warnings:

```sh
pandas/_libs/parsers.c:5873:52: warning: incompatible pointer types assigning to 'double (*)(const char *, char **, char, char, char, int)' from 'double (const char *,
      char **, char, char, char, int, int *, int *)' [-Wincompatible-pointer-types]
    __pyx_v_self->parser->double_converter_withgil = round_trip;
                                                   ^ ~~~~~~~~~~
pandas/_libs/parsers.c:5911:50: warning: incompatible pointer types assigning to 'double (*)(const char *, char **, char, char, char, int)' from 'double (const char *,
      char **, char, char, char, int, int *, int *)' [-Wincompatible-pointer-types]
    __pyx_v_self->parser->double_converter_nogil = precise_xstrtod;
                                                 ^ ~~~~~~~~~~~~~~~
pandas/_libs/parsers.c:5940:50: warning: incompatible pointer types assigning to 'double (*)(const char *, char **, char, char, char, int)' from 'double (const char *,
      char **, char, char, char, int, int *, int *)' [-Wincompatible-pointer-types]
    __pyx_v_self->parser->double_converter_nogil = xstrtod;
                                                 ^ ~~~~~~~
pandas/_libs/parsers.c:23829:93: warning: incompatible function pointer types passing 'double (*)(const char *, char **, char, char, char, int)' to parameter of type
      '__pyx_t_5numpy_float64_t (*)(const char *, char **, char, char, char, int, int *, int *)' (aka 'double (*)(const char *, char **, char, char, char, int, int *, int
      *)') [-Wincompatible-function-pointer-types]
          __pyx_v_error = __pyx_f_6pandas_5_libs_7parsers__try_double_nogil(__pyx_v_parser, __pyx_v_parser->double_converter_nogil, __pyx_v_col, __pyx_v_line_start...
                                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/parsers.c:2716:115: note: passing argument to parameter here
static CYTHON_INLINE int __pyx_f_6pandas_5_libs_7parsers__try_double_nogil(parser_t *, __pyx_t_5numpy_float64_t (*)(char const *, char **, char, char, char, int, i...
                                                                                                                  ^
4 warnings generated.
```