### PR TITLE
Update nullable integer docs with None instead of np.nan

### DIFF
--- a/doc/source/user_guide/integer_na.rst
+++ b/doc/source/user_guide/integer_na.rst
@@ -30,7 +30,7 @@ you must explicitly pass the dtype into :meth:`array` or :class:`Series`:
 
 .. ipython:: python
 
-   arr = pd.array([1, 2, np.nan], dtype=pd.Int64Dtype())
+   arr = pd.array([1, 2, None], dtype=pd.Int64Dtype())
    arr
 
 Or the string alias ``"Int64"`` (note the capital ``"I"``, to differentiate from


### PR DESCRIPTION
Update nullable integer docs with None instead of np.nan

- [X] closes #29599 
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
