### PR TITLE
CLN: Make non-empty **kwargs in Index.__new__ fail instead of silently dropped

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -54,6 +54,7 @@ from pandas.core.dtypes.generic import (
     ABCDatetimeArray,
     ABCDatetimeIndex,
     ABCIndexClass,
+    ABCIntervalIndex,
     ABCMultiIndex,
     ABCPandasArray,
     ABCPeriodIndex,
@@ -450,7 +451,13 @@ class Index(IndexOpsMixin, PandasObject):
                             return PeriodIndex(subarr, name=name, **kwargs)
                         except IncompatibleFrequency:
                             pass
-            return cls._simple_new(subarr, name)
+            if kwargs:
+                if len(kwargs) == 1:
+                    msg = f"Unexpected keyword argument {list(kwargs)[0]!r}"
+                else:
+                    msg = f"Unexpected keyword arguments {set(kwargs)!r}"
+                raise TypeError(msg)
+            return cls._simple_new(subarr, name, **kwargs)
 
         elif hasattr(data, "__array__"):
             return Index(np.asarray(data), dtype=dtype, copy=copy, name=name, **kwargs)
@@ -3391,7 +3398,7 @@ class Index(IndexOpsMixin, PandasObject):
                 new_indexer = np.arange(len(self.take(indexer)))
                 new_indexer[~check] = -1
 
-        new_index = self._shallow_copy_with_infer(new_labels, freq=None)
+        new_index = self._shallow_copy_with_infer(new_labels)
         return new_index, indexer, new_indexer
 
     # --------------------------------------------------------------------
@@ -4254,7 +4261,13 @@ class Index(IndexOpsMixin, PandasObject):
         Concatenate to_concat which has the same class.
         """
         # must be overridden in specific classes
-        klasses = (ABCDatetimeIndex, ABCTimedeltaIndex, ABCPeriodIndex, ExtensionArray)
+        klasses = (
+            ABCDatetimeIndex,
+            ABCTimedeltaIndex,
+            ABCPeriodIndex,
+            ExtensionArray,
+            ABCIntervalIndex,
+        )
         to_concat = [
             x.astype(object) if isinstance(x, klasses) else x for x in to_concat
         ]

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -452,11 +452,7 @@ class Index(IndexOpsMixin, PandasObject):
                         except IncompatibleFrequency:
                             pass
             if kwargs:
-                if len(kwargs) == 1:
-                    msg = f"Unexpected keyword argument {list(kwargs)[0]!r}"
-                else:
-                    msg = f"Unexpected keyword arguments {set(kwargs)!r}"
-                raise TypeError(msg)
+                raise TypeError(f"Unexpected keyword arguments {set(kwargs)!r}")
             return cls._simple_new(subarr, name, **kwargs)
 
         elif hasattr(data, "__array__"):

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -609,12 +609,11 @@ def test_create_index_existing_name(idx):
                 ("qux", "two"),
             ],
             dtype="object",
-        ),
-        names=["foo", "bar"],
+        )
     )
     tm.assert_index_equal(result, expected)
 
-    result = pd.Index(index, names=["A", "B"])
+    result = pd.Index(index, name="A")
     expected = Index(
         Index(
             [
@@ -627,7 +626,7 @@ def test_create_index_existing_name(idx):
             ],
             dtype="object",
         ),
-        names=["A", "B"],
+        name="A",
     )
     tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -146,7 +146,7 @@ def test_identical(idx):
     assert mi.identical(mi2)
 
     mi3 = Index(mi.tolist(), names=mi.names)
-    msg = r"Unexpected keyword argument 'names'"
+    msg = r"Unexpected keyword arguments {'names'}"
     with pytest.raises(TypeError, match=msg):
         Index(mi.tolist(), names=mi.names, tupleize_cols=False)
     mi4 = Index(mi.tolist(), tupleize_cols=False)

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -146,7 +146,10 @@ def test_identical(idx):
     assert mi.identical(mi2)
 
     mi3 = Index(mi.tolist(), names=mi.names)
-    mi4 = Index(mi.tolist(), names=mi.names, tupleize_cols=False)
+    msg = r"Unexpected keyword argument 'names'"
+    with pytest.raises(TypeError, match=msg):
+        Index(mi.tolist(), names=mi.names, tupleize_cols=False)
+    mi4 = Index(mi.tolist(), tupleize_cols=False)
     assert mi.identical(mi3)
     assert not mi.identical(mi4)
     assert mi.equals(mi4)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -350,6 +350,11 @@ class TestIndex(Base):
         result = index._simple_new(index.values, dtype)
         tm.assert_index_equal(result, index)
 
+    def test_constructor_wrong_kwargs(self):
+        # GH #19348
+        with pytest.raises(TypeError, match="Unexpected keyword argument 'foo'"):
+            Index([], foo="bar")
+
     @pytest.mark.parametrize(
         "vals",
         [

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -352,7 +352,7 @@ class TestIndex(Base):
 
     def test_constructor_wrong_kwargs(self):
         # GH #19348
-        with pytest.raises(TypeError, match="Unexpected keyword argument 'foo'"):
+        with pytest.raises(TypeError, match="Unexpected keyword arguments {'foo'}"):
             Index([], foo="bar")
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -479,22 +479,20 @@ class TestInsertIndexCoercion(CoercionBase):
         obj = pd.PeriodIndex(["2011-01", "2011-02", "2011-03", "2011-04"], freq="M")
         assert obj.dtype == "period[M]"
 
+        data = [
+            pd.Period("2011-01", freq="M"),
+            coerced_val,
+            pd.Period("2011-02", freq="M"),
+            pd.Period("2011-03", freq="M"),
+            pd.Period("2011-04", freq="M"),
+        ]
         if isinstance(insert, pd.Period):
-            index_type = pd.PeriodIndex
+            exp = pd.PeriodIndex(data, freq="M")
+            self._assert_insert_conversion(obj, insert, exp, coerced_dtype)
         else:
-            index_type = pd.Index
-
-        exp = index_type(
-            [
-                pd.Period("2011-01", freq="M"),
-                coerced_val,
-                pd.Period("2011-02", freq="M"),
-                pd.Period("2011-03", freq="M"),
-                pd.Period("2011-04", freq="M"),
-            ],
-            freq="M",
-        )
-        self._assert_insert_conversion(obj, insert, exp, coerced_dtype)
+            msg = r"Unexpected keyword argument 'freq'"
+            with pytest.raises(TypeError, match=msg):
+                pd.Index(data, freq="M")
 
     def test_insert_index_complex128(self):
         pass

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -490,7 +490,7 @@ class TestInsertIndexCoercion(CoercionBase):
             exp = pd.PeriodIndex(data, freq="M")
             self._assert_insert_conversion(obj, insert, exp, coerced_dtype)
         else:
-            msg = r"Unexpected keyword argument 'freq'"
+            msg = r"Unexpected keyword arguments {'freq'}"
             with pytest.raises(TypeError, match=msg):
                 pd.Index(data, freq="M")
 

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -893,7 +893,7 @@ class TestExcelFileRead:
     def test_unexpected_kwargs_raises(self, read_ext, arg):
         # gh-17964
         kwarg = {arg: "Sheet1"}
-        msg = "unexpected keyword argument `{}`".format(arg)
+        msg = r"unexpected keyword argument `{}`".format(arg)
 
         with pd.ExcelFile("test1" + read_ext) as excel:
             with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
In #29624 I made change so random kwargs weren't passed to ``Index._simple_new``. I'v found out after merging that the selected solution dropped non-empty kwargs, which isn't great either.

This version ensures that passing non-accepted kwargs raises, so ``pd.Index(['a'], foo="foo")`` raises a TypeError. Instead of raising a TypeError, should we deprecate adding non-accepted kwargs?
