### PR TITLE
REF/API: String methods refactor

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -347,7 +347,7 @@ Conversion
 Strings
 ^^^^^^^
 
--
+- Fixed the return dtype to be ``bool`` for empty Series and the following methods: ``isalnum``, ``isalpha``, ``isdigit``, ``isspace``, ``islower``, ``isupper``, ``istitle``, ``isnumeric``,, ``isdecimal`` (:issue:`29624`)
 -
 
 


### PR DESCRIPTION
edit: probably closing this: See https://github.com/pandas-dev/pandas/pull/29640 for a simpler alternative.

In preparation for https://github.com/pandas-dev/pandas/pull/29597, this changes the string methods implemetation to

* Use masks to apply the function just to valid values.
* Disables all unnecessary inference on the result.

This works quite well for the new StringDtype, since we know the values are always string. The object-dtype behavior is a bit more complex. I'll note that inline below.

Additionally, it fixes https://github.com/pandas-dev/pandas/issues/29624

edit: Oh, forgot another change. String methods returning numeric values will return a nullable integer type. So `Series[string].str.count('a')` returns an Int64Dtype, rather than a maybe int or maybe float (depending on the presence of NAs). Will document that.