### PR TITLE
CI: Adding GitHub action to assign issues based on comment

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,15 @@
+name: Assign
+on:
+  issue_comment:
+    types: created
+
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    steps:
+      - name:
+        run: |
+            if [[ "${{ github.event.comment.body }}" == "take" ]]; then
+                echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+                curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+            fi

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -29,7 +29,7 @@ so nobody else duplicates the work on it. GitHub restricts assigning issues to m
 of the project only. Until recently, contributors added a comment letting others know they
 are working on an issue. But we implemented a workaround consisting of adding
 a comment with the exact text `take`. When you do it, a GitHub action will automatically assign
-you the issue few seconds later. This way, it's possible to filter the list of issues, and find
+you the issue a few seconds later. This way, it's possible to filter the list of issues and find
 only the unassigned ones. Work on assigned issues can be discontinued. Feel free to also
 consider assigned issues. Just kindly ask the current assignee if you can take an issue,
 if it's been inactive for some time (a week at least).

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -25,7 +25,7 @@ where you could start out. Once you've found an interesting issue, you can
 return here to get your development environment setup.
 
 When you start working on an issue, it's a good idea to assign the issue to yourself,
-so nobody else diplicates the work on it. GitHub restricts assigning issues to maintainers
+so nobody else duplicates the work on it. GitHub restricts assigning issues to maintainers
 of the project only. Until recently, contributors added a comment letting others know they
 are working on an issue. But we implemented a workaround consisting of adding
 a comment with the exact text `take`. When you do it, a GitHub action will automatically assign

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -24,6 +24,16 @@ and `good first issue
 where you could start out. Once you've found an interesting issue, you can
 return here to get your development environment setup.
 
+When you start working on an issue, it's a good idea to assign the issue to yourself,
+so nobody else diplicates the work on it. GitHub restricts assigning issues to maintainers
+of the project only. Until recently, contributors added a comment letting others know they
+are working on an issue. But we implemented a workaround consisting of adding
+a comment with the exact text `take`. When you do it, a GitHub action will automatically assign
+you the issue few seconds later. This way, it's possible to filter the list of issues, and find
+only the unassigned ones. Work on assigned issues can be discontinued. Feel free to also
+consider assigned issues. Just kindly ask the current assignee if you can take an issue,
+if it's been inactive for some time (a week at least).
+
 Feel free to ask questions on the `mailing list
 <https://groups.google.com/forum/?fromgroups#!forum/pydata>`_ or on `Gitter`_.
 

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -26,13 +26,24 @@ return here to get your development environment setup.
 
 When you start working on an issue, it's a good idea to assign the issue to yourself,
 so nobody else duplicates the work on it. GitHub restricts assigning issues to maintainers
-of the project only. Until recently, contributors added a comment letting others know they
-are working on an issue. But we implemented a workaround consisting of adding
-a comment with the exact text `take`. When you do it, a GitHub action will automatically assign
-you the issue a few seconds later. This way, it's possible to filter the list of issues and find
-only the unassigned ones. Work on assigned issues can be discontinued. Feel free to also
-consider assigned issues. Just kindly ask the current assignee if you can take an issue,
-if it's been inactive for some time (a week at least).
+of the project only. In most projects, and until recently in pandas, contributors added a
+comment letting others know they are working on an issue. While this is ok, you need to
+check each issue individually, and it's not possible to find the unassigned ones.
+
+For this reason, we implemented a workaround consisting of adding a comment with the exact
+text `take`. When you do it, a GitHub action will automatically assign you the issue
+(this will take seconds, and may require refreshint the page to see it).
+By doing this, it's possible to filter the list of issues and find only the unassigned ones.
+
+So, a good way to find an issue to start contributing to pandas is to check the list of
+`unassigned good first issues <https://github.com/pandas-dev/pandas/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee>`_
+and assign yourself one you like by writing a comment with the exact text `take`.
+
+If for whatever reason you are not able to continue working with the issue, please try to
+unassign it, so other people know it's available again. You can check the list of
+assigned issues, since people may not be working in them anymore. If you want to work on one
+that is assigned, feel free to kindly ask the current assignee if you can take it
+(please allow at least a week on inactivity before considering work in the issue can be discontinued).
 
 Feel free to ask questions on the `mailing list
 <https://groups.google.com/forum/?fromgroups#!forum/pydata>`_ or on `Gitter`_.

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -43,7 +43,7 @@ If for whatever reason you are not able to continue working with the issue, plea
 unassign it, so other people know it's available again. You can check the list of
 assigned issues, since people may not be working in them anymore. If you want to work on one
 that is assigned, feel free to kindly ask the current assignee if you can take it
-(please allow at least a week on inactivity before considering work in the issue can be discontinued).
+(please allow at least a week of inactivity before considering work in the issue discontinued).
 
 Feel free to ask questions on the `mailing list
 <https://groups.google.com/forum/?fromgroups#!forum/pydata>`_ or on `Gitter`_.


### PR DESCRIPTION
Currently, only maintainers and triagers can assign issues.

This implements a hack, so when any contributor writes the keyword `take` in an issue, GitHub actions will automatically assign the issue to the commenter.

I think this should be very helpful once people start to assign issues to themselves, since adding the `Assigned to nobody` filter should let people find issues that nobody is working on. May be in the future we want to implement another action to unassign issues after a period of inactivity, but so far this should be much better than just having people adding comments.

@pandas-dev/pandas-core what do you think?
