### PR TITLE
CI: Forcing GitHub actions to activate

### DIFF
--- a/.github/workflows/activate.yml
+++ b/.github/workflows/activate.yml
@@ -1,0 +1,21 @@
+# Simple first task to activate GitHub actions.
+# This won't run until is merged, but future actions will
+# run on PRs, so we can see we don't break things in more
+# complex actions added later, like real builds.
+#
+# TODO: Remove this once another action exists
+name: Activate
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  activate:
+    name: Activate actions
+    runs-on: ubuntu-latest
+    steps:
+    - name: Activate
+      run: echo "GitHub actions ok"


### PR DESCRIPTION
GitHub actions won't start running until the first action is committed.

This PR adds a simple action with an echo, so we can activate GitHub actions risk free, and when we move an actual build, the action will run in the PR, and we can see that it works.

Tested this action in a test repo, to make sure it works: https://github.com/datapythonista/xql/commit/cdc596df626da5f81980c773de94269546880753/checks?check_suite_id=314215608