### PR TITLE
CI: Pin black to version 19.10b0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - cython>=0.29.13
 
   # code checks
-  - black>=19.10b0
+  - black==19.10b0
   - cpplint
   - flake8
   - flake8-comprehensions>=3.1.0  # used by flake8, linting of unnecessary comprehensions

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - cython>=0.29.13
 
   # code checks
-  - black==19.10b0
+  - black=19.10b0
   - cpplint
   - flake8
   - flake8-comprehensions>=3.1.0  # used by flake8, linting of unnecessary comprehensions

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ python-dateutil>=2.6.1
 pytz
 asv
 cython>=0.29.13
-black>=19.10b0
+black==19.10b0
 cpplint
 flake8
 flake8-comprehensions>=3.1.0


### PR DESCRIPTION
This will pin black version in ci and for local dev.
(This will avoid code checks failing when a new black version is released)

As per comment from @jreback here https://github.com/pandas-dev/pandas/pull/29508#discussion_r346316578