### PR TITLE
TYP: Add type hint for BaseGrouper in groupby._Groupby

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -48,7 +48,7 @@ import pandas.core.common as com
 from pandas.core.construction import extract_array
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
-from pandas.core.groupby import base
+from pandas.core.groupby import base, ops
 from pandas.core.index import CategoricalIndex, Index, MultiIndex
 from pandas.core.series import Series
 from pandas.core.sorting import get_group_index_sorter
@@ -345,7 +345,7 @@ class _GroupBy(PandasObject, SelectionMixin):
         keys=None,
         axis: int = 0,
         level=None,
-        grouper=None,
+        grouper: "Optional[ops.BaseGrouper]" = None,
         exclusions=None,
         selection=None,
         as_index: bool = True,
@@ -2480,7 +2480,7 @@ def get_groupby(
     by=None,
     axis: int = 0,
     level=None,
-    grouper=None,
+    grouper: "Optional[ops.BaseGrouper]" = None,
     exclusions=None,
     selection=None,
     as_index: bool = True,

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -26,8 +26,8 @@ import pandas.core.algorithms as algorithms
 from pandas.core.arrays import Categorical, ExtensionArray
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
+from pandas.core.groupby import ops
 from pandas.core.groupby.categorical import recode_for_groupby, recode_from_groupby
-from pandas.core.groupby.ops import BaseGrouper
 from pandas.core.index import CategoricalIndex, Index, MultiIndex
 from pandas.core.series import Series
 
@@ -392,7 +392,7 @@ class Grouping:
     @cache_readonly
     def indices(self):
         # we have a list of groupers
-        if isinstance(self.grouper, BaseGrouper):
+        if isinstance(self.grouper, ops.BaseGrouper):
             return self.grouper.indices
 
         values = ensure_categorical(self.grouper)
@@ -419,7 +419,7 @@ class Grouping:
     def _make_codes(self) -> None:
         if self._codes is None or self._group_index is None:
             # we have a list of groupers
-            if isinstance(self.grouper, BaseGrouper):
+            if isinstance(self.grouper, ops.BaseGrouper):
                 codes = self.grouper.codes_info
                 uniques = self.grouper.result_index
             else:
@@ -442,7 +442,7 @@ def get_grouper(
     observed: bool = False,
     mutated: bool = False,
     validate: bool = True,
-) -> Tuple[BaseGrouper, List[Hashable], FrameOrSeries]:
+) -> "Tuple[ops.BaseGrouper, List[Hashable], FrameOrSeries]":
     """
     Create and return a BaseGrouper, which is an internal
     mapping of how to create the grouper indexers.
@@ -524,7 +524,7 @@ def get_grouper(
             return grouper, [key.key], obj
 
     # already have a BaseGrouper, just return it
-    elif isinstance(key, BaseGrouper):
+    elif isinstance(key, ops.BaseGrouper):
         return key, [], obj
 
     # In the future, a tuple key will always mean an actual key,
@@ -671,7 +671,7 @@ def get_grouper(
         groupings.append(Grouping(Index([], dtype="int"), np.array([], dtype=np.intp)))
 
     # create the internals grouper
-    grouper = BaseGrouper(group_axis, groupings, sort=sort, mutated=mutated)
+    grouper = ops.BaseGrouper(group_axis, groupings, sort=sort, mutated=mutated)
     return grouper, exclusions, obj
 
 


### PR DESCRIPTION
Add a type hint in class ``_Groupby`` for ``BaseGrouper`` to aid navigating the code base.