### PR TITLE
CLN: Simplify black command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint-diff:
 	git diff upstream/master --name-only -- "*.py" | xargs flake8
 
 black:
-	black . --exclude '(asv_bench/env|\.egg|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|setup.py)'
+	black .
 
 develop: build
 	python -m pip install --no-build-isolation -e .


### PR DESCRIPTION
Follow up to #29607 where `exclude` was added to `pyproject.toml`, so it no longer needs to be explicitly specified.  Missed this reference; checked for additional missed references but didn't find any.