### PR TITLE
CI: Fixing error in code checks in GitHub actions

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -190,9 +190,9 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -R --include="*.rst" ".. ipython ::" doc/source
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
-    MSG='Check for extra blank lines after the class definition' ; echo $MSG
-    invgrep -R --include="*.py" --include="*.pyx" -E 'class.*:\n\n( )+"""' .
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
+    MSG='Check for extra blank lines after the class definition' ; echo $MSG
+    invgrep -R --include="*.py" --include="*.pyx" -E 'class.*:\n\n( )+"""' .
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Check that no file in the repo contains trailing whitespaces' ; echo $MSG
     set -o pipefail


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/29546#issuecomment-554807243

Looks like the code in one of the checks in `ci/code_checks.sh` uses another encoding for spaces and other characters. I guess it was generated from Windows, Azure-pipelines is not sensitive to the different encoding, but GitHub actions is.

Probably worth doing some more research and adding a check that makes sure this new encoding is not introduced anymore.

CC: @gfyoung @jreback 