### PR TITLE
format replaced with f-strings

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -303,8 +303,7 @@ class SeriesGroupBy(GroupBy):
             obj = self
             if name in results:
                 raise SpecificationError(
-                    "Function names must be unique, found multiple named "
-                    "{name}".format(name=name)
+                    f"Function names must be unique, found multiple named {name}"
                 )
 
             # reset the cache so that we
@@ -528,7 +527,7 @@ class SeriesGroupBy(GroupBy):
         try:
             sorter = np.lexsort((val, ids))
         except TypeError:  # catches object dtypes
-            msg = "val.dtype must be object, got {}".format(val.dtype)
+            msg = f"val.dtype must be object, got {val.dtype}"
             assert val.dtype == object, msg
             val, _ = algorithms.factorize(val, sort=False)
             sorter = np.lexsort((val, ids))
@@ -1502,8 +1501,8 @@ class DataFrameGroupBy(GroupBy):
             else:
                 # non scalars aren't allowed
                 raise TypeError(
-                    "filter function returned a {typ}, "
-                    "but expected a scalar bool".format(typ=type(res).__name__)
+                    f"filter function returned a {type(res).__name__}, "
+                    "but expected a scalar bool"
                 )
 
         return self._apply_filter(indices, dropna)
@@ -1865,7 +1864,7 @@ def _managle_lambda_list(aggfuncs: Sequence[Any]) -> Sequence[Any]:
     for aggfunc in aggfuncs:
         if com.get_callable_name(aggfunc) == "<lambda>":
             aggfunc = partial(aggfunc)
-            aggfunc.__name__ = "<lambda_{}>".format(i)
+            aggfunc.__name__ = f"<lambda_{i}>"
             i += 1
         mangled_aggfuncs.append(aggfunc)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -556,9 +556,7 @@ class _GroupBy(PandasObject, SelectionMixin):
             return self[attr]
 
         raise AttributeError(
-            "'{typ}' object has no attribute '{attr}'".format(
-                typ=type(self).__name__, attr=attr
-            )
+            f"'{type(self).__name__}' object has no attribute '{attr}'"
         )
 
     @Substitution(
@@ -1751,7 +1749,7 @@ class GroupBy(_GroupBy):
             raise ValueError(
                 "For a DataFrame groupby, dropna must be "
                 "either None, 'any' or 'all', "
-                "(was passed {dropna}).".format(dropna=dropna)
+                f"(was passed {dropna})."
             )
 
         # old behaviour, but with all and any support for DataFrames.
@@ -2488,7 +2486,7 @@ def get_groupby(
 
         klass = DataFrameGroupBy
     else:
-        raise TypeError("invalid type: {obj}".format(obj=obj))
+        raise TypeError(f"invalid type: {obj}")
 
     return klass(
         obj=obj,

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -174,7 +174,7 @@ class Grouper:
             else:
                 if key not in obj._info_axis:
                     raise KeyError(
-                        "The grouper name {key} is not found".format(key=key)
+                        f"The grouper name {key} is not found"
                     )
                 ax = Index(obj[key], name=key)
 
@@ -192,7 +192,7 @@ class Grouper:
                 else:
                     if level not in (0, ax.name):
                         raise ValueError(
-                            "The level {level} is not valid".format(level=level)
+                            f"The level {level} is not valid"
                         )
 
         # possibly sort
@@ -212,13 +212,13 @@ class Grouper:
 
     def __repr__(self) -> str:
         attrs_list = (
-            "{name}={val!r}".format(name=attr_name, val=getattr(self, attr_name))
+            f"{attr_name}={getattr(self, attr_name)!r}"
             for attr_name in self._attributes
             if getattr(self, attr_name) is not None
         )
         attrs = ", ".join(attrs_list)
         cls_name = self.__class__.__name__
-        return "{cls}({attrs})".format(cls=cls_name, attrs=attrs)
+        return f"{cls_name}({attrs})"
 
 
 class Grouping:
@@ -281,7 +281,7 @@ class Grouping:
             if not isinstance(level, int):
                 if level not in index.names:
                     raise AssertionError(
-                        "Level {level} not in index".format(level=level)
+                        f"Level {level} not in index"
                     )
                 level = index.names.index(level)
 
@@ -350,7 +350,7 @@ class Grouping:
             ):
                 if getattr(self.grouper, "ndim", 1) != 1:
                     t = self.name or str(type(self.grouper))
-                    raise ValueError("Grouper for '{t}' not 1-dimensional".format(t=t))
+                    raise ValueError(f"Grouper for '{t}' not 1-dimensional")
                 self.grouper = self.index.map(self.grouper)
                 if not (
                     hasattr(self.grouper, "__len__")
@@ -358,9 +358,7 @@ class Grouping:
                 ):
                     errmsg = (
                         "Grouper result violates len(labels) == "
-                        "len(data)\nresult: {grper}".format(
-                            grper=pprint_thing(self.grouper)
-                        )
+                        f"len(data)\nresult: {pprint_thing(self.grouper)}"
                     )
                     self.grouper = None  # Try for sanity
                     raise AssertionError(errmsg)
@@ -375,7 +373,7 @@ class Grouping:
                 self.grouper = self.grouper.astype("timedelta64[ns]")
 
     def __repr__(self) -> str:
-        return "Grouping({name})".format(name=self.name)
+        return f"Grouping({self.name})"
 
     def __iter__(self):
         return iter(self.indices)
@@ -501,9 +499,7 @@ def get_grouper(
             if isinstance(level, str):
                 if obj.index.name != level:
                     raise ValueError(
-                        "level name {level} is not the name of the index".format(
-                            level=level
-                        )
+                        f"level name {level} is not the name of the index"
                     )
             elif level > 0 or level < -1:
                 raise ValueError("level > 0 or level < -1 only valid with MultiIndex")
@@ -636,12 +632,8 @@ def get_grouper(
 
         if is_categorical_dtype(gpr) and len(gpr) != obj.shape[axis]:
             raise ValueError(
-                (
-                    "Length of grouper ({len_gpr}) and axis ({len_axis})"
-                    " must be same length".format(
-                        len_gpr=len(gpr), len_axis=obj.shape[axis]
-                    )
-                )
+                f"Length of grouper ({len(gpr)}) and axis ({obj.shape[axis]})"
+                " must be same length"
             )
 
         # create the Grouping

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -173,9 +173,7 @@ class Grouper:
                 ax = self._grouper.take(obj.index)
             else:
                 if key not in obj._info_axis:
-                    raise KeyError(
-                        f"The grouper name {key} is not found"
-                    )
+                    raise KeyError(f"The grouper name {key} is not found")
                 ax = Index(obj[key], name=key)
 
         else:
@@ -191,9 +189,7 @@ class Grouper:
 
                 else:
                     if level not in (0, ax.name):
-                        raise ValueError(
-                            f"The level {level} is not valid"
-                        )
+                        raise ValueError(f"The level {level} is not valid")
 
         # possibly sort
         if (self.sort or sort) and not ax.is_monotonic:
@@ -280,9 +276,7 @@ class Grouping:
         if level is not None:
             if not isinstance(level, int):
                 if level not in index.names:
-                    raise AssertionError(
-                        f"Level {level} not in index"
-                    )
+                    raise AssertionError(f"Level {level} not in index")
                 level = index.names.index(level)
 
             if self.name is None:
@@ -498,9 +492,7 @@ def get_grouper(
 
             if isinstance(level, str):
                 if obj.index.name != level:
-                    raise ValueError(
-                        f"level name {level} is not the name of the index"
-                    )
+                    raise ValueError(f"level name {level} is not the name of the index")
             elif level > 0 or level < -1:
                 raise ValueError("level > 0 or level < -1 only valid with MultiIndex")
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -350,9 +350,10 @@ class Grouping:
                     hasattr(self.grouper, "__len__")
                     and len(self.grouper) == len(self.index)
                 ):
+                    grper = pprint_thing(self.grouper)
                     errmsg = (
                         "Grouper result violates len(labels) == "
-                        f"len(data)\nresult: {pprint_thing(self.grouper)}"
+                        f"len(data)\nresult: {grper}"
                     )
                     self.grouper = None  # Try for sanity
                     raise AssertionError(errmsg)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -446,17 +446,17 @@ class BaseGrouper:
         # are not setup for dim transforming
         if is_categorical_dtype(values) or is_sparse(values):
             raise NotImplementedError(
-                "{dtype} dtype not supported".format(dtype=values.dtype)
+                f"{values.dtype} dtype not supported"
             )
         elif is_datetime64_any_dtype(values):
             if how in ["add", "prod", "cumsum", "cumprod"]:
                 raise NotImplementedError(
-                    "datetime64 type does not support {how} operations".format(how=how)
+                    f"datetime64 type does not support {how} operations"
                 )
         elif is_timedelta64_dtype(values):
             if how in ["prod", "cumprod"]:
                 raise NotImplementedError(
-                    "timedelta64 type does not support {how} operations".format(how=how)
+                    f"timedelta64 type does not support {how} operations"
                 )
 
         if is_datetime64tz_dtype(values.dtype):
@@ -509,9 +509,7 @@ class BaseGrouper:
             out_dtype = "float"
         else:
             if is_numeric:
-                out_dtype = "{kind}{itemsize}".format(
-                    kind=values.dtype.kind, itemsize=values.dtype.itemsize
-                )
+                out_dtype = f"{values.dtype.kind}{values.dtype.itemsize}"
             else:
                 out_dtype = "object"
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -445,9 +445,7 @@ class BaseGrouper:
         # categoricals are only 1d, so we
         # are not setup for dim transforming
         if is_categorical_dtype(values) or is_sparse(values):
-            raise NotImplementedError(
-                f"{values.dtype} dtype not supported"
-            )
+            raise NotImplementedError(f"{values.dtype} dtype not supported")
         elif is_datetime64_any_dtype(values):
             if how in ["add", "prod", "cumsum", "cumprod"]:
                 raise NotImplementedError(


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

ref #29547 