### PR TITLE
DEPR: remove deprecated keywords in read_excel, to_records

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -280,7 +280,8 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 - Removed the previously deprecated ``assert_raises_regex`` function in ``pandas.util.testing`` (:issue:`29174`)
 - Removed :meth:`Index.is_lexsorted_for_tuple` (:issue:`29305`)
 - Removed support for nexted renaming in :meth:`DataFrame.aggregate`, :meth:`Series.aggregate`, :meth:`DataFrameGroupBy.aggregate`, :meth:`SeriesGroupBy.aggregate`, :meth:`Rolling.aggregate` (:issue:`29608`)
--
+- :func:`read_excel` removed support for "skip_footer" argument, use "skipfooter" instead (:issue:`18836`)
+- :meth:`DataFrame.to_records` no longer supports the argument "convert_datetime64" (:issue:`18902`)
 
 .. _whatsnew_1000.performance:
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -8,7 +8,7 @@ from textwrap import fill
 from pandas._config import config
 
 from pandas.errors import EmptyDataError
-from pandas.util._decorators import Appender, deprecate_kwarg
+from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.common import is_bool, is_float, is_integer, is_list_like
 
@@ -188,11 +188,6 @@ comment : str, default None
     Comments out remainder of line. Pass a character or characters to this
     argument to indicate comments in the input file. Any data between the
     comment string and the end of the current line is ignored.
-skip_footer : int, default 0
-    Alias of `skipfooter`.
-
-    .. deprecated:: 0.23.0
-       Use `skipfooter` instead.
 skipfooter : int, default 0
     Rows at the end to skip (0-indexed).
 convert_float : bool, default True
@@ -277,7 +272,6 @@ Comment lines in the excel input file can be skipped using the `comment` kwarg
 
 
 @Appender(_read_excel_doc)
-@deprecate_kwarg("skip_footer", "skipfooter")
 def read_excel(
     io,
     sheet_name=0,
@@ -300,7 +294,6 @@ def read_excel(
     date_parser=None,
     thousands=None,
     comment=None,
-    skip_footer=0,
     skipfooter=0,
     convert_float=True,
     mangle_dupe_cols=True,

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -83,22 +83,9 @@ class TestDataFrameConvertTo:
             index=date_range("2012-01-01", "2012-01-02"),
         )
 
-        # convert_datetime64 defaults to None
         expected = df.index.values[0]
         result = df.to_records()["index"][0]
         assert expected == result
-
-        # check for FutureWarning if convert_datetime64=False is passed
-        with tm.assert_produces_warning(FutureWarning):
-            expected = df.index.values[0]
-            result = df.to_records(convert_datetime64=False)["index"][0]
-            assert expected == result
-
-        # check for FutureWarning if convert_datetime64=True is passed
-        with tm.assert_produces_warning(FutureWarning):
-            expected = df.index[0]
-            result = df.to_records(convert_datetime64=True)["index"][0]
-            assert expected == result
 
     def test_to_records_with_multindex(self):
         # GH3189

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -917,14 +917,6 @@ class TestExcelFileRead:
             df3 = pd.read_excel(excel, 0, index_col=0, skipfooter=1)
         tm.assert_frame_equal(df3, df1.iloc[:-1])
 
-        with tm.assert_produces_warning(
-            FutureWarning, check_stacklevel=False, raise_on_extra_warnings=False
-        ):
-            with pd.ExcelFile("test1" + read_ext) as excel:
-                df4 = pd.read_excel(excel, 0, index_col=0, skip_footer=1)
-
-            tm.assert_frame_equal(df3, df4)
-
         with pd.ExcelFile("test1" + read_ext) as excel:
             df3 = excel.parse(0, index_col=0, skipfooter=1)
 


### PR DESCRIPTION
There are a handful of these PRs on the way and they're inevitably going to have whatsnew conflicts.  I'm trying to group together related deprecations so as to have a single-digit number of PRs for these.