### PR TITLE
DEPR: remove encoding kwarg from read_stata, DataFrame.to_stata

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -280,6 +280,7 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 - Removed the previously deprecated ``assert_raises_regex`` function in ``pandas.util.testing`` (:issue:`29174`)
 - Removed :meth:`Index.is_lexsorted_for_tuple` (:issue:`29305`)
 - Removed support for nexted renaming in :meth:`DataFrame.aggregate`, :meth:`Series.aggregate`, :meth:`DataFrameGroupBy.aggregate`, :meth:`SeriesGroupBy.aggregate`, :meth:`Rolling.aggregate` (:issue:`29608`)
+- :func:`read_stata` and :meth:`DataFrame.to_stata` no longer supports the "encoding" argument (:issue:`21400`)
 -
 
 .. _whatsnew_1000.performance:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -38,7 +38,6 @@ from pandas.compat.numpy import function as nv
 from pandas.util._decorators import (
     Appender,
     Substitution,
-    deprecate_kwarg,
     rewrite_axis_style_signature,
 )
 from pandas.util._validators import (

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1972,13 +1972,11 @@ class DataFrame(NDFrame):
         mgr = arrays_to_mgr(arrays, columns, index, columns, dtype=dtype)
         return cls(mgr)
 
-    @deprecate_kwarg(old_arg_name="encoding", new_arg_name=None)
     def to_stata(
         self,
         fname,
         convert_dates=None,
         write_index=True,
-        encoding="latin-1",
         byteorder=None,
         time_stamp=None,
         data_label=None,
@@ -2008,8 +2006,6 @@ class DataFrame(NDFrame):
             a datetime column has timezone information.
         write_index : bool
             Write the index to Stata dataset.
-        encoding : str
-            Default is latin-1. Unicode is not supported.
         byteorder : str
             Can be ">", "<", "little", or "big". default is `sys.byteorder`.
         time_stamp : datetime

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -35,11 +35,7 @@ from pandas._config import get_option
 
 from pandas._libs import algos as libalgos, lib
 from pandas.compat.numpy import function as nv
-from pandas.util._decorators import (
-    Appender,
-    Substitution,
-    rewrite_axis_style_signature,
-)
+from pandas.util._decorators import Appender, Substitution, rewrite_axis_style_signature
 from pandas.util._validators import (
     validate_axis_style_args,
     validate_bool_kwarg,

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -58,10 +58,6 @@ convert_dates : bool, default True
 convert_categoricals : bool, default True
     Read value labels and convert columns to Categorical/Factor variables."""
 
-_encoding_params = """\
-encoding : str, None or encoding
-    Encoding used to parse the files. None defaults to latin-1."""
-
 _statafile_processing_params2 = """\
 index_col : str, optional
     Column to set as index.
@@ -108,7 +104,6 @@ filepath_or_buffer : str, path object or file-like object
 %s
 %s
 %s
-%s
 
 Returns
 -------
@@ -132,7 +127,6 @@ Read a Stata dta file in 10,000 line chunks:
 ...     do_something(chunk)
 """ % (
     _statafile_processing_params1,
-    _encoding_params,
     _statafile_processing_params2,
     _chunksize_params,
     _iterator_params,
@@ -189,23 +183,19 @@ path_or_buf : path (string), buffer or path object
 %s
 %s
 %s
-%s
 """ % (
     _statafile_processing_params1,
     _statafile_processing_params2,
-    _encoding_params,
     _chunksize_params,
 )
 
 
 @Appender(_read_stata_doc)
-@deprecate_kwarg(old_arg_name="encoding", new_arg_name=None)
 @deprecate_kwarg(old_arg_name="index", new_arg_name="index_col")
 def read_stata(
     filepath_or_buffer,
     convert_dates=True,
     convert_categoricals=True,
-    encoding=None,
     index_col=None,
     convert_missing=False,
     preserve_dtypes=True,
@@ -1044,7 +1034,6 @@ class StataParser:
 class StataReader(StataParser, BaseIterator):
     __doc__ = _stata_reader_doc
 
-    @deprecate_kwarg(old_arg_name="encoding", new_arg_name=None)
     @deprecate_kwarg(old_arg_name="index", new_arg_name="index_col")
     def __init__(
         self,
@@ -1056,7 +1045,6 @@ class StataReader(StataParser, BaseIterator):
         preserve_dtypes=True,
         columns=None,
         order_categoricals=True,
-        encoding=None,
         chunksize=None,
     ):
         super().__init__()
@@ -2134,14 +2122,12 @@ class StataWriter(StataParser):
 
     _max_string_length = 244
 
-    @deprecate_kwarg(old_arg_name="encoding", new_arg_name=None)
     def __init__(
         self,
         fname,
         data,
         convert_dates=None,
         write_index=True,
-        encoding="latin-1",
         byteorder=None,
         time_stamp=None,
         data_label=None,
@@ -2859,8 +2845,6 @@ class StataWriter117(StataWriter):
         timezone information
     write_index : bool
         Write the index to Stata dataset.
-    encoding : str
-        Default is latin-1. Only latin-1 and ascii are supported.
     byteorder : str
         Can be ">", "<", "little", or "big". default is `sys.byteorder`
     time_stamp : datetime
@@ -2912,14 +2896,12 @@ class StataWriter117(StataWriter):
 
     _max_string_length = 2045
 
-    @deprecate_kwarg(old_arg_name="encoding", new_arg_name=None)
     def __init__(
         self,
         fname,
         data,
         convert_dates=None,
         write_index=True,
-        encoding="latin-1",
         byteorder=None,
         time_stamp=None,
         data_label=None,

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -383,8 +383,7 @@ class TestStata:
 
         # GH 4626, proper encoding handling
         raw = read_stata(self.dta_encoding)
-        with tm.assert_produces_warning(FutureWarning):
-            encoded = read_stata(self.dta_encoding, encoding="latin-1")
+        encoded = read_stata(self.dta_encoding)
         result = encoded.kreis1849[0]
 
         expected = raw.kreis1849[0]
@@ -392,10 +391,7 @@ class TestStata:
         assert isinstance(result, str)
 
         with tm.ensure_clean() as path:
-            with tm.assert_produces_warning(FutureWarning):
-                encoded.to_stata(
-                    path, write_index=False, version=version, encoding="latin-1"
-                )
+            encoded.to_stata(path, write_index=False, version=version)
             reread_encoded = read_stata(path)
             tm.assert_frame_equal(encoded, reread_encoded)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
