### PR TITLE
DOC: fix typos

### DIFF
--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -75,7 +75,7 @@ def hash_object_array(object[:] arr, object key, object encoding='utf8'):
         lens[i] = l
         cdata = data
 
-        # keep the references alive thru the end of the
+        # keep the references alive through the end of the
         # function
         datas.append(data)
         vecs[i] = cdata

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -144,13 +144,13 @@ def duplicated_{{dtype}}({{c_type}}[:] values, object keep='first'):
     if keep == 'last':
         {{if dtype == 'object'}}
         for i in range(n - 1, -1, -1):
-            # equivalent: range(n)[::-1], which cython doesnt like in nogil
+            # equivalent: range(n)[::-1], which cython doesn't like in nogil
             kh_put_{{ttype}}(table, <PyObject*>values[i], &ret)
             out[i] = ret == 0
         {{else}}
         with nogil:
             for i in range(n - 1, -1, -1):
-                # equivalent: range(n)[::-1], which cython doesnt like in nogil
+                # equivalent: range(n)[::-1], which cython doesn't like in nogil
                 kh_put_{{ttype}}(table, values[i], &ret)
                 out[i] = ret == 0
         {{endif}}

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1914,7 +1914,7 @@ def roll_weighted_var(float64_t[:] values, float64_t[:] weights,
     values: float64_t[:]
         values to roll window over
     weights: float64_t[:]
-        array of weights whose lenght is window size
+        array of weights whose length is window size
     minp: int64_t
         minimum number of observations to calculate
         variance of a window

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -109,7 +109,7 @@ def _ensure_data(values, dtype=None):
 
     except (TypeError, ValueError, OverflowError):
         # if we are trying to coerce to a dtype
-        # and it is incompat this will fall thru to here
+        # and it is incompat this will fall through to here
         return ensure_object(values), "object"
 
     # datetimelike

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1486,7 +1486,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             values = self
 
         if not len(values):
-            # short-circut for empty max / min
+            # short-circuit for empty max / min
             return NaT
 
         result = nanops.nanmean(values.view("i8"), skipna=skipna)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2087,7 +2087,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             will be NA.
         *args, **kwargs
             Additional arguments and keywords have no effect but might be
-            accepted for compatability with NumPy.
+            accepted for compatibility with NumPy.
 
         Returns
         -------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1450,7 +1450,7 @@ def _get_level_lengths(index, hidden_elements=None):
     Optional argument is a list of index positions which
     should not be visible.
 
-    Result is a dictionary of (level, inital_position): span
+    Result is a dictionary of (level, initial_position): span
     """
     sentinel = object()
     levels = index.format(sparsify=sentinel, adjoin=False, names=False)


### PR DESCRIPTION
Changes only words in comments; function names not touched.