### PR TITLE
io/parsers: ensure decimal is str on PythonParser

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -487,6 +487,7 @@ I/O
 - Bug in :meth:`Styler.background_gradient` not able to work with dtype ``Int64`` (:issue:`28869`)
 - Bug in :meth:`DataFrame.to_clipboard` which did not work reliably in ipython (:issue:`22707`)
 - Bug in :func:`read_json` where default encoding was not set to ``utf-8`` (:issue:`29565`)
+- Bug in :class:`PythonParser` where str and bytes were being mixed when dealing with the decimal field (:issue:`29650`)
 -
 
 Plotting

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2276,12 +2276,7 @@ class PythonParser(ParserBase):
 
         self.dtype = kwds["dtype"]
         self.thousands = kwds["thousands"]
-
-        if isinstance(kwds["decimal"], bytes):
-            self.decimal = kwds["decimal"].decode()
-        else:
-            self.decimal = kwds["decimal"]
-
+        self.decimal = kwds["decimal"]
         self.comment = kwds["comment"]
         self._comment_lines = []
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2276,7 +2276,11 @@ class PythonParser(ParserBase):
 
         self.dtype = kwds["dtype"]
         self.thousands = kwds["thousands"]
-        self.decimal = kwds["decimal"]
+
+        if isinstance(kwds["decimal"], bytes):
+            self.decimal = kwds["decimal"].decode()
+        else:
+            self.decimal = kwds["decimal"]
 
         self.comment = kwds["comment"]
         self._comment_lines = []
@@ -2343,9 +2347,6 @@ class PythonParser(ParserBase):
 
         if len(self.decimal) != 1:
             raise ValueError("Only length-1 decimal markers supported")
-
-        if isinstance(self.decimal, bytes):
-            self.decimal = self.decimal.decode()
 
         if self.thousands is None:
             self.nonnum = re.compile(

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -568,7 +568,7 @@ def _make_parser_function(name, default_sep=","):
         # Quoting, Compression, and File Format
         compression="infer",
         thousands=None,
-        decimal=".",
+        decimal: str = ".",
         lineterminator=None,
         quotechar='"',
         quoting=csv.QUOTE_MINIMAL,
@@ -2277,6 +2277,7 @@ class PythonParser(ParserBase):
         self.dtype = kwds["dtype"]
         self.thousands = kwds["thousands"]
         self.decimal = kwds["decimal"]
+
         self.comment = kwds["comment"]
         self._comment_lines = []
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -488,7 +488,7 @@ _parser_defaults = {
     "cache_dates": True,
     "thousands": None,
     "comment": None,
-    "decimal": b".",
+    "decimal": ".",
     # 'engine': 'c',
     "parse_dates": False,
     "keep_date_col": False,
@@ -568,7 +568,7 @@ def _make_parser_function(name, default_sep=","):
         # Quoting, Compression, and File Format
         compression="infer",
         thousands=None,
-        decimal=b".",
+        decimal=".",
         lineterminator=None,
         quotechar='"',
         quoting=csv.QUOTE_MINIMAL,
@@ -2343,6 +2343,9 @@ class PythonParser(ParserBase):
 
         if len(self.decimal) != 1:
             raise ValueError("Only length-1 decimal markers supported")
+
+        if isinstance(self.decimal, bytes):
+            self.decimal = self.decimal.decode()
 
         if self.thousands is None:
             self.nonnum = re.compile(

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -185,9 +185,8 @@ def test_read_csv_buglet_4x_multi_index2(python_parser_only):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "add_footer, decimal", [(True, "#"), (False, "#"), (True, b"#"), (False, b"#")],
-)
+@pytest.mark.parametrize("add_footer", [True, False])
+@pytest.mark.parametrize("decimal", ["#", b"#"])
 def test_skipfooter_with_decimal(python_parser_only, add_footer, decimal):
     # see gh-6971
     data = "1#2\n3#4"

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -186,8 +186,7 @@ def test_read_csv_buglet_4x_multi_index2(python_parser_only):
 
 
 @pytest.mark.parametrize("add_footer", [True, False])
-@pytest.mark.parametrize("decimal", ["#", b"#"])
-def test_skipfooter_with_decimal(python_parser_only, add_footer, decimal):
+def test_skipfooter_with_decimal(python_parser_only, add_footer):
     # see gh-6971
     data = "1#2\n3#4"
     parser = python_parser_only
@@ -201,7 +200,7 @@ def test_skipfooter_with_decimal(python_parser_only, add_footer, decimal):
     else:
         kwargs = dict()
 
-    result = parser.read_csv(StringIO(data), names=["a"], decimal=decimal, **kwargs)
+    result = parser.read_csv(StringIO(data), names=["a"], decimal="#", **kwargs)
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -185,8 +185,10 @@ def test_read_csv_buglet_4x_multi_index2(python_parser_only):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("add_footer", [True, False])
-def test_skipfooter_with_decimal(python_parser_only, add_footer):
+@pytest.mark.parametrize(
+    "add_footer, decimal", [(True, "#"), (False, "#"), (True, b"#"), (False, b"#")],
+)
+def test_skipfooter_with_decimal(python_parser_only, add_footer, decimal):
     # see gh-6971
     data = "1#2\n3#4"
     parser = python_parser_only
@@ -200,7 +202,7 @@ def test_skipfooter_with_decimal(python_parser_only, add_footer):
     else:
         kwargs = dict()
 
-    result = parser.read_csv(StringIO(data), names=["a"], decimal="#", **kwargs)
+    result = parser.read_csv(StringIO(data), names=["a"], decimal=decimal, **kwargs)
     tm.assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #29650
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
