### PR TITLE
PERF: speed-up when scalar not found in Categorical's categories

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -343,6 +343,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.replace` when provided a list of values to replace (:issue:`28099`)
 - Performance improvement in :meth:`DataFrame.select_dtypes` by using vectorization instead of iterating over a loop (:issue:`28317`)
 - Performance improvement in :meth:`Categorical.searchsorted` and  :meth:`CategoricalIndex.searchsorted` (:issue:`28795`)
+- Performance improvement when searching for a scalar in a :meth:`Categorical` and the scalar is not found in the categories (:issue:`29750`)
 
 .. _whatsnew_1000.bug_fixes:
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -133,9 +133,9 @@ def _cat_compare_op(op):
                 return ret
             else:
                 if opname == "__eq__":
-                    return np.repeat(False, len(self))
+                    return np.zeros(len(self), dtype=bool)
                 elif opname == "__ne__":
-                    return np.repeat(True, len(self))
+                    return np.ones(len(self), dtype=bool)
                 else:
                     msg = (
                         "Cannot compare a Categorical for op {op} with a "

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -48,7 +48,7 @@ class TestCategoricalOpsWithFactor(TestCategorical):
         tm.assert_numpy_array_equal(result, expected)
 
         result = self.factor == "d"
-        expected = np.repeat(False, len(self.factor))
+        expected = np.zeros(len(self.factor), dtype=bool)
         tm.assert_numpy_array_equal(result, expected)
 
         # comparisons with categoricals

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -105,11 +105,11 @@ class TestIntervalIndex:
         assert index.hasnans is False
 
         result = index.isna()
-        expected = np.repeat(False, len(index))
+        expected = np.zeros(len(index), dtype=bool)
         tm.assert_numpy_array_equal(result, expected)
 
         result = index.notna()
-        expected = np.repeat(True, len(index))
+        expected = np.ones(len(index), dtype=bool)
         tm.assert_numpy_array_equal(result, expected)
 
         index = self.create_index_with_nan(closed=closed)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -730,7 +730,7 @@ class TestIndex(Base):
         assert first_value == x[Timestamp(expected_ts)]
 
     def test_booleanindex(self, index):
-        bool_index = np.repeat(True, len(index)).astype(bool)
+        bool_index = np.ones(len(index), dtype=bool)
         bool_index[5:30:2] = False
 
         sub_index = index[bool_index]


### PR DESCRIPTION
I took a look at the code in core/category.py and found a usage of np.repeat for creating boolean arrays. np.repeat is much slower than np.zeros/np.ones for that purpose.

```python
>>> n = 1_000_000
>>> c = pd.Categorical(['a'] * n + ['b'] * n + ['c'] * n)
>>> %timeit c == 'x'
17 ms ± 270 µs per loop  # master
82.6 µs ± 488 ns per loop  # this PR
```
