### PR TITLE
Reenabled no-unused-function in setup.py

### DIFF
--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -399,22 +399,6 @@ static void *CLong(JSOBJ obj, JSONTypeContext *tc, void *outValue,
     return NULL;
 }
 
-#ifdef _LP64
-static void *PyIntToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
-                          size_t *_outLen) {
-    PyObject *obj = (PyObject *)_obj;
-    *((JSINT64 *)outValue) = PyLong_AsLong(obj);
-    return NULL;
-}
-#else
-static void *PyIntToINT32(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
-                          size_t *_outLen) {
-    PyObject *obj = (PyObject *)_obj;
-    *((JSINT32 *)outValue) = PyLong_AsLong(obj);
-    return NULL;
-}
-#endif
-
 static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                            size_t *_outLen) {
     *((JSINT64 *)outValue) = GET_TC(tc)->longValue;

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -95,10 +95,6 @@ cdef class _NaT(datetime):
     # higher than np.ndarray and np.matrix
     __array_priority__ = 100
 
-    def __hash__(_NaT self):
-        # py3k needs this defined here
-        return hash(self.value)
-
     def __richcmp__(_NaT self, object other, int op):
         cdef:
             int ndim = getattr(other, 'ndim', -1)

--- a/setup.py
+++ b/setup.py
@@ -462,7 +462,7 @@ if is_platform_windows():
         extra_link_args.append("/DEBUG")
 else:
     # args to ignore warnings
-    extra_compile_args = ["-Wno-unused-function"]
+    extra_compile_args = []
     extra_link_args = []
     if debugging_symbols_requested:
         extra_compile_args.append("-g")


### PR DESCRIPTION
This enables a flag that was disabled 4 years ago in https://github.com/pandas-dev/pandas/commit/e9fde88c47aab023cafa6c98d5654db9dc89197f but maybe worth reconsidering, even though we don't fail on warnings for extensions in CI

This yielded the following on master:

```sh
pandas/_libs/hashing.c:25313:20: warning: unused function '__pyx_memview_get_object' [-Wunused-function]
pandas/_libs/hashing.c:25318:12: warning: unused function '__pyx_memview_set_object' [-Wunused-function]
pandas/_libs/hashtable.c:63342:20: warning: unused function '__pyx_memview_get_object' [-Wunused-function]
pandas/_libs/hashtable.c:63347:12: warning: unused function '__pyx_memview_set_object' [-Wunused-function]
pandas/_libs/parsers.c:21453:18: warning: unused function '__pyx_f_6pandas_5_libs_7parsers__string_box_factorize' [-Wunused-function]
pandas/_libs/tslibs/conversion.c:33247:20: warning: unused function '__pyx_memview_get_object' [-Wunused-function]
pandas/_libs/tslibs/conversion.c:33252:12: warning: unused function '__pyx_memview_set_object' [-Wunused-function]
pandas/_libs/tslibs/nattype.c:3496:18: warning: unused function '__pyx_pw_6pandas_5_libs_6tslibs_7nattype_4_NaT_1__hash__' [-Wunused-function]
pandas/_libs/src/ujson/python/objToJSON.c:403:14: warning: unused function 'PyIntToINT64' [-Wunused-function]
```

I'm not sure what the `memview_set_object` and `memview_get_object` complaints are coming from just yet, but the rest are cleaned up in this PR