### PR TITLE
DOC: Updating documentation of new required pytest version

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -946,7 +946,7 @@ extensions in `numpy.testing
 
 .. note::
 
-   The earliest supported pytest version is 4.0.2.
+   The earliest supported pytest version is 5.0.1.
 
 Writing tests
 ~~~~~~~~~~~~~

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -177,7 +177,7 @@ pandas is equipped with an exhaustive set of unit tests, covering about 97% of
 the code base as of this writing. To run it on your machine to verify that
 everything is working (and that you have all of the dependencies, soft and hard,
 installed), make sure you have `pytest
-<http://docs.pytest.org/en/latest/>`__ >= 4.0.2 and `Hypothesis
+<http://docs.pytest.org/en/latest/>`__ >= 5.0.1 and `Hypothesis
 <https://hypothesis.readthedocs.io/>`__ >= 3.58, then run:
 
 ::

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -253,6 +253,7 @@ Other API changes
   See :ref:`units registration <whatsnew_1000.matplotlib_units>` for more.
 - :meth:`Series.dropna` has dropped its ``**kwargs`` argument in favor of a single ``how`` parameter.
   Supplying anything else than ``how`` to ``**kwargs`` raised a ``TypeError`` previously (:issue:`29388`)
+- When testing pandas, the new minimum required version of pytest is 5.0.1 (:issue:`29664`)
 -
 
 

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -18,6 +18,7 @@ VERSIONS = {
     "pandas_gbq": "0.8.0",
     "pyarrow": "0.9.0",
     "pytables": "3.4.2",
+    "pytest": "5.0.1",
     "s3fs": "0.3.0",
     "scipy": "0.19.0",
     "sqlalchemy": "1.1.4",

--- a/pandas/util/_tester.py
+++ b/pandas/util/_tester.py
@@ -11,7 +11,7 @@ def test(extra_args=None):
     try:
         import pytest
     except ImportError:
-        raise ImportError("Need pytest>=4.0.2 to run tests")
+        raise ImportError("Need pytest>=5.0.1 to run tests")
     try:
         import hypothesis  # noqa
     except ImportError:


### PR DESCRIPTION
Follow up of #29678

@jreback I think `show_versions` gets the version by importing the module. Correct me if I'm wrong, but I didn't see anything to update there.