### PR TITLE
DEPS: Unifying version of pytest-xdist across builds

### DIFF
--- a/ci/deps/travis-38.yaml
+++ b/ci/deps/travis-38.yaml
@@ -8,7 +8,7 @@ dependencies:
   # tools
   - cython>=0.29.13
   - pytest>=5.0.1
-  - pytest-xdist>=1.29.0  # The rest of the builds use >=1.21, and use pytest-mock
+  - pytest-xdist>=1.21
   - hypothesis>=3.58.0
 
   # pandas dependencies


### PR DESCRIPTION
We use `pytest-xdist>=1.21` in all builds except this one. Using the same for the 3.8 build, which was introduced in parallel as the standardization of dependencies.

xref: https://github.com/pandas-dev/pandas/pull/29678#discussion_r348873095