### PR TITLE
DEPS: Removing unused pytest-mock

### DIFF
--- a/ci/deps/azure-36-32bit.yaml
+++ b/ci/deps/azure-36-32bit.yaml
@@ -8,7 +8,6 @@ dependencies:
   # tools
   ### Cython 0.29.13 and pytest 5.0.1 for 32 bits are not available with conda, installing below with pip instead
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/azure-36-locale.yaml
+++ b/ci/deps/azure-36-locale.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/azure-36-minimum_versions.yaml
+++ b/ci/deps/azure-36-minimum_versions.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython=0.29.13
   - pytest=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/azure-37-locale.yaml
+++ b/ci/deps/azure-37-locale.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -8,7 +8,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/azure-macos-36.yaml
+++ b/ci/deps/azure-macos-36.yaml
@@ -8,7 +8,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/azure-windows-37.yaml
+++ b/ci/deps/azure-windows-37.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-azurepipelines
 

--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
   - pytest-cov  # this is only needed in the coverage build
 

--- a/ci/deps/travis-36-locale.yaml
+++ b/ci/deps/travis-36-locale.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
 
   # pandas dependencies

--- a/ci/deps/travis-36-slow.yaml
+++ b/ci/deps/travis-36-slow.yaml
@@ -9,7 +9,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
 
   # pandas dependencies

--- a/ci/deps/travis-37.yaml
+++ b/ci/deps/travis-37.yaml
@@ -10,7 +10,6 @@ dependencies:
   - cython>=0.29.13
   - pytest>=5.0.1
   - pytest-xdist>=1.21
-  - pytest-mock
   - hypothesis>=3.58.0
 
   # pandas dependencies


### PR DESCRIPTION
May be I'm missing something, but I don't think we use `pytest-mock` (a grep didn't find anything by `mocker`), but we have it in almost all builds.

The CI should tell if I'm wrong.