### PR TITLE
BUG: Fix melt with mixed int/str columns

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -535,6 +535,7 @@ Reshaping
 - Bug :meth:`Series.pct_change` where supplying an anchored frequency would throw a ValueError (:issue:`28664`)
 - Bug where :meth:`DataFrame.equals` returned True incorrectly in some cases when two DataFrames had the same columns in different orders (:issue:`28839`)
 - Bug in :meth:`DataFrame.replace` that caused non-numeric replacer's dtype not respected (:issue:`26632`)
+- Bug in :func:`melt` where supplying mixed strings and numeric values for ``id_vars`` or ``value_vars`` would incorrectly raise a ``ValueError`` (:issue:`29718`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -11,6 +11,7 @@ from pandas.core.dtypes.generic import ABCMultiIndex
 from pandas.core.dtypes.missing import notna
 
 from pandas.core.arrays import Categorical
+import pandas.core.common as com
 from pandas.core.frame import DataFrame, _shared_docs
 from pandas.core.indexes.base import Index
 from pandas.core.reshape.concat import concat
@@ -47,7 +48,7 @@ def melt(
         else:
             # Check that `id_vars` are in frame
             id_vars = list(id_vars)
-            missing = Index(np.ravel(id_vars)).difference(cols)
+            missing = Index(com.flatten(id_vars)).difference(cols)
             if not missing.empty:
                 raise KeyError(
                     "The following 'id_vars' are not present"
@@ -69,7 +70,7 @@ def melt(
         else:
             value_vars = list(value_vars)
             # Check that `value_vars` are in frame
-            missing = Index(np.ravel(value_vars)).difference(cols)
+            missing = Index(com.flatten(value_vars)).difference(cols)
             if not missing.empty:
                 raise KeyError(
                     "The following 'value_vars' are not present in"

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -289,36 +289,33 @@ class TestMelt:
         df = pd.DataFrame(np.random.randn(5, 4), columns=list("abcd"))
 
         # Try to melt with missing `value_vars` column name
-        msg = r"The following '{var}' are not present in the DataFrame: \[{col}\]"
-        with pytest.raises(KeyError, match=msg.format(var="value_vars", col="'C'")):
+        msg = "The following '{Var}' are not present in the DataFrame: {Col}"
+        with pytest.raises(
+            KeyError, match=msg.format(Var="value_vars", Col="\\['C'\\]")
+        ):
             df.melt(["a", "b"], ["C", "d"])
 
         # Try to melt with missing `id_vars` column name
-        with pytest.raises(KeyError, match=msg.format(var="id_vars", col="'A'")):
+        with pytest.raises(KeyError, match=msg.format(Var="id_vars", Col="\\['A'\\]")):
             df.melt(["A", "b"], ["c", "d"])
 
         # Multiple missing
         with pytest.raises(
-            KeyError, match=msg.format(var="id_vars", col="'not_here', 'or_there'"),
+            KeyError,
+            match=msg.format(Var="id_vars", Col="\\['not_here', 'or_there'\\]"),
         ):
             df.melt(["a", "b", "not_here", "or_there"], ["c", "d"])
 
         # Multiindex melt fails if column is missing from multilevel melt
         multi = df.copy()
         multi.columns = [list("ABCD"), list("abcd")]
-        with pytest.raises(KeyError, match=msg.format(var="id_vars", col="'E'")):
+        with pytest.raises(KeyError, match=msg.format(Var="id_vars", Col="\\['E'\\]")):
             multi.melt([("E", "a")], [("B", "b")])
         # Multiindex fails if column is missing from single level melt
-        with pytest.raises(KeyError, match=msg.format(var="value_vars", col="'F'")):
+        with pytest.raises(
+            KeyError, match=msg.format(Var="value_vars", Col="\\['F'\\]")
+        ):
             multi.melt(["A"], ["F"], col_level=0)
-
-        # GH 29718: mixed int/str
-        df_mixed = DataFrame(columns=[0, "a"])
-        with pytest.raises(KeyError, match=msg.format(var="id_vars", col="'0'")):
-            df_mixed.melt(id_vars=["0", "a"])
-
-        with pytest.raises(KeyError, match=msg.format(var="value_vars", col="'0'")):
-            df_mixed.melt(value_vars=["0", "a"])
 
     def test_melt_mixed_int_str_id_vars(self):
         # GH 29718


### PR DESCRIPTION
- [X] closes #29718
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
