### PR TITLE
DEPR: remove statsmodels/seaborn compat shims

### DIFF
--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -10,7 +10,6 @@ from pandas.core.dtypes.dtypes import (
 )
 from pandas.core.dtypes.missing import isna, isnull, notna, notnull
 
-# TODO: Remove get_dummies import when statsmodels updates #18264
 from pandas.core.algorithms import factorize, unique, value_counts
 from pandas.core.arrays import Categorical
 from pandas.core.arrays.integer import (
@@ -45,7 +44,6 @@ from pandas.core.indexes.interval import Interval, interval_range
 from pandas.core.indexes.period import Period, period_range
 from pandas.core.indexes.timedeltas import Timedelta, timedelta_range
 from pandas.core.indexing import IndexSlice
-from pandas.core.reshape.reshape import get_dummies
 from pandas.core.series import Series
 from pandas.core.tools.datetimes import to_datetime
 from pandas.core.tools.numeric import to_numeric

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -96,23 +96,6 @@ _shared_doc_kwargs = dict(
 )
 
 
-# see gh-16971
-def remove_na(arr):
-    """
-    Remove null values from array like structure.
-
-    .. deprecated:: 0.21.0
-        Use s[s.notnull()] instead.
-    """
-
-    warnings.warn(
-        "remove_na is deprecated and is a private function. Do not use.",
-        FutureWarning,
-        stacklevel=2,
-    )
-    return remove_na_arraylike(arr)
-
-
 def _coerce_method(converter):
     """
     Install the scalar coercion methods.

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -20,7 +20,6 @@ from pandas import (
     date_range,
     isna,
 )
-from pandas.core.series import remove_na
 import pandas.util.testing as tm
 
 
@@ -48,10 +47,6 @@ def _simple_ts(start, end, freq="D"):
 
 
 class TestSeriesMissingData:
-    def test_remove_na_deprecation(self):
-        # see gh-16971
-        with tm.assert_produces_warning(FutureWarning):
-            remove_na(Series([]))
 
     def test_timedelta_fillna(self):
         # GH 3371

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -47,7 +47,6 @@ def _simple_ts(start, end, freq="D"):
 
 
 class TestSeriesMissingData:
-
     def test_timedelta_fillna(self):
         # GH 3371
         s = Series(


### PR DESCRIPTION
xref #18264, #16971

Looks like seaborn updated their usage in https://github.com/mwaskom/seaborn/pull/1241
and statsmodels https://github.com/statsmodels/statsmodels/pull/3618 both in 2017.