### PR TITLE
Fix mypy errors for pandas\tests\series\test_operators.py

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -168,8 +168,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         base.IndexOpsMixin.hasnans.func, doc=base.IndexOpsMixin.hasnans.__doc__
     )
     _data: SingleBlockManager
-    div: Callable[["Series"], "Series"]
-    rdiv: Callable[["Series"], "Series"]
+    div: Callable[["Series", Any], "Series"]
+    rdiv: Callable[["Series", Any], "Series"]
 
     # ----------------------------------------------------------------------
     # Constructors

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -168,6 +168,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         base.IndexOpsMixin.hasnans.func, doc=base.IndexOpsMixin.hasnans.__doc__
     )
     _data: SingleBlockManager
+    div: Callable[["Series"], "Series"]
+    rdiv: Callable[["Series"], "Series"]
 
     # ----------------------------------------------------------------------
     # Constructors

--- a/setup.cfg
+++ b/setup.cfg
@@ -153,6 +153,3 @@ ignore_errors=True
 
 [mypy-pandas.tests.scalar.period.test_period]
 ignore_errors=True
-
-[mypy-pandas.tests.series.test_operators]
-ignore_errors=True


### PR DESCRIPTION
part of #28926

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

The errors were:
```
pandas/tests/series/test_operators.py:824: error: "Type[Series]" has no attribute "div"
pandas/tests/series/test_operators.py:824: error: "Type[Series]" has no attribute "rdiv"
```
The problem is that these methods are only added at RunTime, so mypy can't see them. I'm not sure if my solution is the best way to silence these errors though.
