### PR TITLE
TST: Fix locale test that fails in GitHub actions

### DIFF
--- a/pandas/tests/config/test_localization.py
+++ b/pandas/tests/config/test_localization.py
@@ -62,12 +62,18 @@ def test_set_locale():
         #  getlocale() returned (None, None).
         pytest.skip("Current locale is not set.")
 
-    locale_override = os.environ.get("LOCALE_OVERRIDE", None)
+    locale_override = os.environ.get("LOCALE_OVERRIDE")
 
-    if locale_override is None:
+    if not locale_override:
         lang, enc = "it_CH", "UTF-8"
     elif locale_override == "C":
         lang, enc = "en_US", "ascii"
+    elif len(locale_override.split(".")) != 2:
+        raise ValueError(
+            "Unknown format for LOCALE_OVERRIDE, "
+            "expected country_VARIANT.ENCODING "
+            f"(e.g. en_US.UTF-8), found {locale_override!r}"
+        )
     else:
         lang, enc = locale_override.split(".")
 


### PR DESCRIPTION
xref #29715

Looks like in GitHub actions this test is receiving an empty string for the environment variable `LOCALE_OVERRIDE` instead of `None`. Not sure why, but I guess they should be equivalent, and we don't want to fail when an empty string is provided.

The change also makes the test return a descriptive error message if an unexpected value is set in that environment variable.