### PR TITLE
CI: Setting path only once in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
 
 env:
   ENV_FILE: environment.yml
-  # TODO: remove export PATH=... in each step once this works
-  # PATH: $HOME/miniconda3/bin:$PATH
 
 jobs:
   checks:
@@ -20,68 +18,61 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
+    - name: Setting conda path
+      run: echo "::set-env name=PATH::${HOME}/miniconda3/bin:${PATH}"
+
     - name: Looking for unwanted patterns
       run: ci/code_checks.sh patterns
       if: true
 
     - name: Setup environment and build pandas
-      run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
-        ci/setup_env.sh
+      run: ci/setup_env.sh
       if: true
 
     - name: Linting
       run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         source activate pandas-dev
         ci/code_checks.sh lint
       if: true
 
     - name: Dependencies consistency
       run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         source activate pandas-dev
         ci/code_checks.sh dependencies
       if: true
 
     - name: Checks on imported code
       run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         source activate pandas-dev
         ci/code_checks.sh code
       if: true
 
     - name: Running doctests
       run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         source activate pandas-dev
         ci/code_checks.sh doctests
       if: true
 
     - name: Docstring validation
       run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         source activate pandas-dev
         ci/code_checks.sh docstrings
       if: true
 
     - name: Typing validation
       run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         source activate pandas-dev
         ci/code_checks.sh typing
       if: true
 
     - name: Testing docstring validation script
       run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         source activate pandas-dev
         pytest --capture=no --strict scripts
       if: true
 
     - name: Running benchmarks
       run: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         source activate pandas-dev
         cd asv_bench
         asv check -E existing


### PR DESCRIPTION
Updating PATH only once for the whole job, so it doesn't need to be set at every step.
