### PR TITLE
CI: Fix tests broken by np 1.18 sorting change

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -284,7 +284,10 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
             sorted_index = self.take(_as)
             return sorted_index, _as
         else:
-            sorted_values = np.sort(self._ndarray_values)
+            # NB: using asi8 instead of _ndarray_values matters in numpy 1.18
+            #  because the treatment of NaT has been changed to put NaT last
+            #  instead of first.
+            sorted_values = np.sort(self.asi8)
             attribs = self._get_attributes_dict()
             freq = attribs["freq"]
 

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -13,7 +13,6 @@ from pandas import (
     PeriodIndex,
     Series,
     Timestamp,
-    _np_version_under1p18,
     bdate_range,
     date_range,
 )
@@ -255,20 +254,9 @@ class TestDatetimeIndexOps(Ops):
     def test_order_without_freq(self, index_dates, expected_dates, tz_naive_fixture):
         tz = tz_naive_fixture
 
-        # FIXME: kludge since sort_values wih return_indexer==True uses the
-        #  i8 values instead of the M8 values, so the np 1.18 behavior change
-        #  does not affect it
-        orig_expected = expected_dates
-
-        if not _np_version_under1p18 and expected_dates[0] is pd.NaT:
-            # numpy 1.18.0 sorts NaT to the end instead of the beginning,
-            #  which matches float treatment of NaN
-            expected_dates = expected_dates[2:] + [pd.NaT, pd.NaT]
-
         # without freq
         index = DatetimeIndex(index_dates, tz=tz, name="idx")
         expected = DatetimeIndex(expected_dates, tz=tz, name="idx")
-        expected_with_indexer = DatetimeIndex(orig_expected, tz=tz, name="idx")
 
         ordered = index.sort_values()
         tm.assert_index_equal(ordered, expected)
@@ -279,14 +267,14 @@ class TestDatetimeIndexOps(Ops):
         assert ordered.freq is None
 
         ordered, indexer = index.sort_values(return_indexer=True)
-        tm.assert_index_equal(ordered, expected_with_indexer)
+        tm.assert_index_equal(ordered, expected)
 
         exp = np.array([0, 4, 3, 1, 2])
         tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
         assert ordered.freq is None
 
         ordered, indexer = index.sort_values(return_indexer=True, ascending=False)
-        tm.assert_index_equal(ordered, expected_with_indexer[::-1])
+        tm.assert_index_equal(ordered, expected[::-1])
 
         exp = np.array([2, 1, 3, 4, 0])
         tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)


### PR DESCRIPTION
Longer-term, do we want to use numpy's new behavior?

cc @TomAugspurger 

<b>Update</b> A little more background: consider two ndarrays in np<1.18

```
arr1 = np.array([1, 2, np.nan, 3, 4])
arr2 = np.array([1, 2, np.datetime64("NaT"), 3, 4], dtype="datetime64[ns]")

>>> np.sort(arr1)
array([ 1.,  2.,  3.,  4., nan])
>>> np.sort(arr2)
array([                          'NaT', '1970-01-01T00:00:00.000000001',
       '1970-01-01T00:00:00.000000002', '1970-01-01T00:00:00.000000003',
       '1970-01-01T00:00:00.000000004'], dtype='datetime64[ns]')
```

In numpy 1.18, the behavior of `np.sort(arr2)` is changing to put the NaT at the end instead of at the beginning, to behave more like NaN.  This breaks a few tests, which this PR fixes.

Side-note: as of now, 1.18 changes the behavior for datetime64, but not timedelta64.