### PR TITLE
BUG: .count() raises if use_inf_as_na is enabled

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -674,6 +674,7 @@ Other
 - Bug in :meth:`DataFrame.append` that raised ``IndexError`` when appending with empty list (:issue:`28769`)
 - Fix :class:`AbstractHolidayCalendar` to return correct results for
   years after 2030 (now goes up to 2200) (:issue:`27790`)
+- Bug in :meth:`Series.count` raises if use_inf_as_na is enabled (:issue:`29478`)
 
 
 .. _whatsnew_1000.contributors:

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -176,7 +176,7 @@ def _isna_old(obj):
         raise NotImplementedError("isna is not defined for MultiIndex")
     elif isinstance(obj, type):
         return False
-    elif isinstance(obj, (ABCSeries, np.ndarray, ABCIndexClass)):
+    elif isinstance(obj, (ABCSeries, np.ndarray, ABCIndexClass, ABCExtensionArray)):
         return _isna_ndarraylike_old(obj)
     elif isinstance(obj, ABCGeneric):
         return obj._constructor(obj._data.isna(func=_isna_old))

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -554,6 +554,10 @@ class TestSeriesAnalytics:
         ts.iloc[[0, 3, 5]] = np.nan
         tm.assert_series_equal(ts.count(level=1), right - 1)
 
+        # GH29478
+        with pd.option_context("use_inf_as_na", True):
+            assert pd.Series([pd.Timestamp("1990/1/1")]).count() == 1
+
     def test_dot(self):
         a = Series(np.random.randn(4), index=["p", "q", "r", "s"])
         b = DataFrame(


### PR DESCRIPTION
- [x] closes #29478
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
