### PR TITLE
CI: fix mypy complaint introduced in #29873

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2641,7 +2641,9 @@ class Fixed:
             "cannot write on an abstract storer: sublcasses should implement"
         )
 
-    def delete(self, where=None, start=None, stop=None, **kwargs):
+    def delete(
+        self, where=None, start: Optional[int] = None, stop: Optional[int] = None
+    ):
         """
         support fully deleting the node in its entirety (only) - where
         specification must be None


### PR DESCRIPTION
@jreback the pertinent `delete` methods are never hit in tests.  any chance we can rip them out?