### PR TITLE
CI: Making benchmark errors easier to find

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
             asv machine --yes
             asv dev | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
-            if grep "failed" benchmarks.log; then
+            if grep "failed" benchmarks.log > /dev/null ; then
                 exit 1
             fi
         else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,9 @@ jobs:
         git fetch upstream
         if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
             asv machine --yes
-            asv dev | sed "/failed$/ s/^/##[error]/" > benchmarks.log
-            if grep "failed" benchmarks.log; then
-                cat benchmarks.log
-                echo "##[error]Benchmarks run with errors"
+            asv dev | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+            if grep "^##[error]" benchmarks.log; then
                 exit 1
-            else
-                echo "Benchmarks run without errors"
             fi
         else
             echo "Benchmarks did not run, no changes detected"
@@ -97,5 +93,5 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: Benchmarks log
-        path: benchmarks.json
+        path: asv_bench/benchmarks.log
       if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
             asv machine --yes
             asv dev | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
-            if grep "^##[error]" benchmarks.log; then
+            if grep "failed" benchmarks.log; then
                 exit 1
             fi
         else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,10 @@ jobs:
         git fetch upstream
         if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
             asv machine --yes
-            ASV_OUTPUT="$(asv dev)"
-            if [[ $(echo "$ASV_OUTPUT" | grep "failed") ]]; then
-                echo "##vso[task.logissue type=error]Benchmarks run with errors"
-                echo "$ASV_OUTPUT"
+            asv dev | sed "/failed$/ s/^/##[error]/" > benchmarks.log
+            if grep "failed" benchmarks.log; then
+                cat benchmarks.log
+                echo "##[error]Benchmarks run with errors"
                 exit 1
             else
                 echo "Benchmarks run without errors"
@@ -92,3 +92,10 @@ jobs:
             echo "Benchmarks did not run, no changes detected"
         fi
       if: true
+
+    - name: Publish benchmarks artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: Benchmarks log
+        path: benchmarks.json
+      if: failure()

--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -80,6 +80,7 @@ class TimeseriesPlotting:
         self.df2.plot()
 
     def time_plot_table(self):
+        raise RuntimeError("Seeing how the changes in the CI look like")
         self.df.plot(table=True)
 
 

--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -80,7 +80,6 @@ class TimeseriesPlotting:
         self.df2.plot()
 
     def time_plot_table(self):
-        raise RuntimeError("Seeing how the changes in the CI look like")
         self.df.plot(table=True)
 
 


### PR DESCRIPTION
- [X] xref https://github.com/pandas-dev/pandas/pull/29900#issuecomment-559278405

It takes a while to find the failing line of the benchmarks logs at the moment. This should highlight the failing ones, and also publish the log as an artifact so it can be analyzed easier.

CC: @jbrockmendel 