### PR TITLE
CI: Highlighting flake8 and grep errors in GitHub Actions

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -197,8 +197,8 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     MSG='Check that no file in the repo contains trailing whitespaces' ; echo $MSG
     INVGREP_APPEND=" <- trailing whitespaces found"
     invgrep -RI --exclude=\*.{svg,c,cpp,html,js} --exclude-dir=env "\s$" *
-    unset INVGREP_APPEND
     RET=$(($RET + $?)) ; echo $MSG "DONE"
+    unset INVGREP_APPEND
 fi
 
 ### CODE ###

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -34,17 +34,13 @@ function invgrep {
     #
     # This is useful for the CI, as we want to fail if one of the patterns
     # that we want to avoid is found by grep.
-    if [[ "$AZURE" == "true" ]]; then
-        set -o pipefail
-        grep -n "$@" | awk -F ":" '{print "##vso[task.logissue type=error;sourcepath=" $1 ";linenumber=" $2 ";] Found unwanted pattern: " $3}'
-    else
-        grep "$@"
-    fi
-    return $((! $?))
+    grep -n "$@" | sed "s/^/$INVGREP_PREPEND/" | sed "s/$/$INVGREP_APPEND/" ; EXIT_STATUS=${PIPESTATUS[0]}
+    return $((! $EXIT_STATUS))
 }
 
-if [[ "$AZURE" == "true" ]]; then
-    FLAKE8_FORMAT="##vso[task.logissue type=error;sourcepath=%(path)s;linenumber=%(row)s;columnnumber=%(col)s;code=%(code)s;]%(text)s"
+if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+    FLAKE8_FORMAT="##[error]%(path)s:%(row)s:%(col)s:%(code):%(text)s"
+    INVGREP_PREPEND="##[error]"
 else
     FLAKE8_FORMAT="default"
 fi
@@ -199,13 +195,9 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Check that no file in the repo contains trailing whitespaces' ; echo $MSG
-    set -o pipefail
-    if [[ "$AZURE" == "true" ]]; then
-        # we exclude all c/cpp files as the c/cpp files of pandas code base are tested when Linting .c and .h files
-        ! grep -n '--exclude=*.'{svg,c,cpp,html,js} --exclude-dir=env -RI "\s$" * | awk -F ":" '{print "##vso[task.logissue type=error;sourcepath=" $1 ";linenumber=" $2 ";] Tailing whitespaces found: " $3}'
-    else
-        ! grep -n '--exclude=*.'{svg,c,cpp,html,js} --exclude-dir=env -RI "\s$" * | awk -F ":" '{print $1 ":" $2 ":Tailing whitespaces found: " $3}'
-    fi
+    INVGREP_APPEND=" <- trailing whitespaces found"
+    invgrep -RI --exclude=\*.{svg,c,cpp,html,js} --exclude-dir=env "\s$" *
+    unset INVGREP_APPEND
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 fi
 

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -1,5 +1,4 @@
 # flake8: noqa
-from numpy import nan
 
 __docformat__ = "restructuredtext"
 
@@ -17,11 +16,11 @@ if missing_dependencies:
     raise ImportError(
         "Unable to import required dependencies:\n" + "\n".join(missing_dependencies)
     )
-del hard_dependencies, dependency, missing_dependencies 
+del hard_dependencies, dependency, missing_dependencies
 
 # numpy compat
 from pandas.compat.numpy import (
-    _np_version_under1p14,      
+    _np_version_under1p14,
     _np_version_under1p15,
     _np_version_under1p16,
     _np_version_under1p17,

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from numpy import nan
 
 __docformat__ = "restructuredtext"
 
@@ -16,11 +17,11 @@ if missing_dependencies:
     raise ImportError(
         "Unable to import required dependencies:\n" + "\n".join(missing_dependencies)
     )
-del hard_dependencies, dependency, missing_dependencies
+del hard_dependencies, dependency, missing_dependencies 
 
 # numpy compat
 from pandas.compat.numpy import (
-    _np_version_under1p14,
+    _np_version_under1p14,      
     _np_version_under1p15,
     _np_version_under1p16,
     _np_version_under1p17,


### PR DESCRIPTION
Our code checks genereated the output in a way that Azure pipelines was highlighting the errors. In GitHub actions it's possible to do more or less the same, but with a different syntax. Changing the syntax here, and simplifying some tricky parts in the script.

Introducing some errors, so we can see how it looks.