### PR TITLE
Document S3 and GCS path functionality of DataFrame.to_csv()

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -34,7 +34,7 @@ The pandas I/O API is a set of top level ``reader`` functions accessed like
     binary;`SPSS <https://en.wikipedia.org/wiki/SPSS>`__;:ref:`read_spss<io.spss_reader>`;
     binary;`Python Pickle Format <https://docs.python.org/3/library/pickle.html>`__;:ref:`read_pickle<io.pickle>`;:ref:`to_pickle<io.pickle>`
     SQL;`SQL <https://en.wikipedia.org/wiki/SQL>`__;:ref:`read_sql<io.sql>`;:ref:`to_sql<io.sql>`
-    SQL;`Google Big Query <https://en.wikipedia.org/wiki/BigQuery>`__;:ref:`read_gbq<io.bigquery>`;:ref:`to_gbq<io.bigquery>`
+    SQL;`Google BigQuery <https://en.wikipedia.org/wiki/BigQuery>`__;:ref:`read_gbq<io.bigquery>`;:ref:`to_gbq<io.bigquery>`
 
 :ref:`Here <io.perf>` is an informal performance comparison for some of these IO methods.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3128,10 +3128,12 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        path_or_buf : str or file handle, default None
-            File path or object, if None is provided the result is returned as
-            a string.  If a file object is passed it should be opened with
-            `newline=''`, disabling universal newlines.
+        path_or_buf : str, path object, file-like object, default None
+            If a string is passed, it can be an existing local file path, as
+            well as a gcs:// or s3:// path. If a file object is passed it
+            should be opened with `newline=''`, disabling universal newlines.
+            If a path object is preferred, pandas accepts any ``os.PathLike``.
+            If None is provided the string representation is returned.
 
             .. versionchanged:: 0.24.0
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3128,12 +3128,10 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        path_or_buf : str, path object, file-like object, default None
-            If a string is passed, it can be an existing local file path, as
-            well as a gcs:// or s3:// path. If a file object is passed it
-            should be opened with `newline=''`, disabling universal newlines.
-            If a path object is preferred, pandas accepts any ``os.PathLike``.
-            If None is provided the string representation is returned.
+        path_or_buf : str or file handle, default None
+            File path or object, if None is provided the result is returned as
+            a string.  If a file object is passed it should be opened with
+            `newline=''`, disabling universal newlines.
 
             .. versionchanged:: 0.24.0
 


### PR DESCRIPTION
- [x] closes #8508 

I made more changes than absolutely necessary for documenting this. It's a bit more complete and it reads a more similar to `pd.read_csv()`