### PR TITLE
BUG: loc-indexing with a CategoricalIndex with non-string categories

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -742,7 +742,7 @@ Indexing
 - Fix assignment of column via `.loc` with numpy non-ns datetime type (:issue:`27395`)
 - Bug in :meth:`Float64Index.astype` where ``np.inf`` was not handled properly when casting to an integer dtype (:issue:`28475`)
 - :meth:`Index.union` could fail when the left contained duplicates (:issue:`28257`)
-- Bug when indexing with ``.loc`` where the index was a :class:`CategoricalIndex` with integer or float categories, a ValueError was raised (:issue:`17569`)
+- Bug when indexing with ``.loc`` where the index was a :class:`CategoricalIndex` with integer and float categories, a ValueError was raised (:issue:`17569`)
 - :meth:`Index.get_indexer_non_unique` could fail with `TypeError` in some cases, such as when searching for ints in a string index (:issue:`28257`)
 - Bug in :meth:`Float64Index.get_loc` incorrectly raising ``TypeError`` instead of ``KeyError`` (:issue:`29189`)
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -742,6 +742,7 @@ Indexing
 - Fix assignment of column via `.loc` with numpy non-ns datetime type (:issue:`27395`)
 - Bug in :meth:`Float64Index.astype` where ``np.inf`` was not handled properly when casting to an integer dtype (:issue:`28475`)
 - :meth:`Index.union` could fail when the left contained duplicates (:issue:`28257`)
+- Bug when indexing with ``.loc`` where the index was a :class:`CategoricalIndex` with integer or float categories, a ValueError was raised (:issue:`17569`)
 - :meth:`Index.get_indexer_non_unique` could fail with `TypeError` in some cases, such as when searching for ints in a string index (:issue:`28257`)
 - Bug in :meth:`Float64Index.get_loc` incorrectly raising ``TypeError`` instead of ``KeyError`` (:issue:`29189`)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2953,11 +2953,11 @@ class Index(IndexOpsMixin, PandasObject):
                     "unicode",
                     "mixed",
                 ]:
-                    return self._invalid_indexer("label", key)
+                    self._invalid_indexer("label", key)
 
             elif kind in ["loc"] and is_integer(key):
                 if not self.holds_integer():
-                    return self._invalid_indexer("label", key)
+                    self._invalid_indexer("label", key)
 
         return key
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -696,8 +696,11 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
     @Appender(_index_shared_docs["_convert_scalar_indexer"])
     def _convert_scalar_indexer(self, key, kind=None):
-        if self.categories._defer_to_indexing:
-            return self.categories._convert_scalar_indexer(key, kind=kind)
+        if kind == "loc" or self.categories._defer_to_indexing:
+            try:
+                return self.categories._convert_scalar_indexer(key, kind=kind)
+            except TypeError:
+                self._invalid_indexer("label", key=key)
 
         return super()._convert_scalar_indexer(key, kind=kind)
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -700,8 +700,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             try:
                 return self.categories._convert_scalar_indexer(key, kind=kind)
             except TypeError:
-                self._invalid_indexer("label", key=key)
-
+                self._invalid_indexer("label", key)
         return super()._convert_scalar_indexer(key, kind=kind)
 
     @Appender(_index_shared_docs["_convert_list_indexer"])

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -696,7 +696,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
     @Appender(_index_shared_docs["_convert_scalar_indexer"])
     def _convert_scalar_indexer(self, key, kind=None):
-        if kind == "loc" or self.categories._defer_to_indexing:
+        if kind == "loc":
             try:
                 return self.categories._convert_scalar_indexer(key, kind=kind)
             except TypeError:

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -754,3 +754,29 @@ class TestCategoricalIndex:
         output = cur_index.map(mapper)
         # Order of categories in output can be different
         tm.assert_index_equal(expected, output)
+
+    @pytest.mark.parametrize(
+        "idx_values", [[1, 2, 3], [-1, -2, -3], [1.5, 2.5, 3.5], [-1.5, -2.5, -3.5]]
+    )
+    def test_loc_with_non_string_categories(self, idx_values, ordered_fixture):
+        # GH-17569
+        cat_idx = CategoricalIndex(idx_values, ordered=ordered_fixture)
+        cat = DataFrame({"A": ["foo", "bar", "baz"]}, index=cat_idx)
+        # scalar
+        result = cat.loc[idx_values[0]]
+        expected = Series(["foo"], index=["A"], name=idx_values[0])
+        tm.assert_series_equal(result, expected)
+        # list
+        result = cat.loc[idx_values[:2]]
+        expected = DataFrame(["foo", "bar"], index=cat_idx[:2], columns=["A"])
+        tm.assert_frame_equal(result, expected)
+        # scalar assignment
+        result = cat.copy()
+        result.loc[idx_values[0]] = "qux"
+        expected = DataFrame({"A": ["qux", "bar", "baz"]}, index=cat_idx)
+        tm.assert_frame_equal(result, expected)
+        # list assignment
+        result = cat.copy()
+        result.loc[idx_values[:2], "A"] = ["qux", "qux2"]
+        expected = DataFrame({"A": ["qux", "qux2", "baz"]}, index=cat_idx)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -12,6 +12,7 @@ from pandas import (
     Index,
     Interval,
     Series,
+    Timedelta,
     Timestamp,
 )
 from pandas.api.types import CategoricalDtype as CDT
@@ -763,27 +764,74 @@ class TestCategoricalIndex:
         tm.assert_index_equal(expected, output)
 
     @pytest.mark.parametrize(
-        "idx_values", [[1, 2, 3], [-1, -2, -3], [1.5, 2.5, 3.5], [-1.5, -2.5, -3.5]]
+        "idx_values",
+        [
+            # python types
+            [1, 2, 3],
+            [-1, -2, -3],
+            [1.5, 2.5, 3.5],
+            [-1.5, -2.5, -3.5],
+            # numpy int/uint
+            *[
+                np.array([1, 2, 3], dtype=dtype)
+                for dtype in [
+                    np.int8,
+                    np.int16,
+                    np.int32,
+                    np.int64,
+                    np.uint8,
+                    np.uint16,
+                    np.uint32,
+                    np.uint64,
+                ]
+            ],
+            # numpy floats
+            *[
+                np.array([1.5, 2.5, 3.5], dtype=dtype)
+                for dtype in (np.float16, np.float32, np.float64)
+            ],
+            # pandas scalars
+            [Interval(1, 4), Interval(4, 6), Interval(6, 9)],
+            [Timestamp(2019, 1, 1), Timestamp(2019, 2, 1), Timestamp(2019, 3, 1)],
+            [Timedelta(1, "d"), Timedelta(2, "d"), Timedelta(3, "D")],
+            # pandas Integer arrays
+            *[
+                pd.array([1, 2, 3], dtype=dtype)
+                for dtype in [
+                    "Int8",
+                    "Int16",
+                    "Int32",
+                    "Int64",
+                    "UInt8",
+                    "UInt32",
+                    "UInt64",
+                ]
+            ],
+            # other pandas arrays
+            pd.IntervalIndex.from_breaks([1, 4, 6, 9]).array,
+            pd.date_range("2019-01-01", periods=3).array,
+            pd.timedelta_range(start="1d", periods=3).array,
+        ],
     )
     def test_loc_with_non_string_categories(self, idx_values, ordered_fixture):
         # GH-17569
         cat_idx = CategoricalIndex(idx_values, ordered=ordered_fixture)
-        cat = DataFrame({"A": ["foo", "bar", "baz"]}, index=cat_idx)
-        # scalar
-        result = cat.loc[idx_values[0]]
+        df = DataFrame({"A": ["foo", "bar", "baz"]}, index=cat_idx)
+        # scalar selection
+        result = df.loc[idx_values[0]]
         expected = Series(["foo"], index=["A"], name=idx_values[0])
         tm.assert_series_equal(result, expected)
-        # list
-        result = cat.loc[idx_values[:2]]
+        # list selection
+        result = df.loc[idx_values[:2]]
         expected = DataFrame(["foo", "bar"], index=cat_idx[:2], columns=["A"])
         tm.assert_frame_equal(result, expected)
         # scalar assignment
-        result = cat.copy()
+        result = df.copy()
         result.loc[idx_values[0]] = "qux"
         expected = DataFrame({"A": ["qux", "bar", "baz"]}, index=cat_idx)
         tm.assert_frame_equal(result, expected)
         # list assignment
-        result = cat.copy()
+        result = df.copy()
         result.loc[idx_values[:2], "A"] = ["qux", "qux2"]
         expected = DataFrame({"A": ["qux", "qux2", "baz"]}, index=cat_idx)
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -80,6 +80,13 @@ class TestCategoricalIndex:
         with pytest.raises(TypeError, match=msg):
             df.loc["d", "C"] = 10
 
+        msg = (
+            r"cannot do label indexing on <class 'pandas\.core\.indexes\.category"
+            r"\.CategoricalIndex'> with these indexers \[1\] of <class 'int'>"
+        )
+        with pytest.raises(TypeError, match=msg):
+            df.loc[1]
+
     def test_getitem_scalar(self):
 
         cats = Categorical([Timestamp("12-31-1999"), Timestamp("12-31-2000")])

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -5,6 +5,7 @@ from pandas.core.dtypes.common import is_categorical_dtype
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 import pandas as pd
+from pandas import conftest
 from pandas import (
     Categorical,
     CategoricalIndex,
@@ -772,41 +773,17 @@ class TestCategoricalIndex:
             [1.5, 2.5, 3.5],
             [-1.5, -2.5, -3.5],
             # numpy int/uint
-            *[
-                np.array([1, 2, 3], dtype=dtype)
-                for dtype in [
-                    np.int8,
-                    np.int16,
-                    np.int32,
-                    np.int64,
-                    np.uint8,
-                    np.uint16,
-                    np.uint32,
-                    np.uint64,
-                ]
-            ],
+            *[np.array([1, 2, 3], dtype=dtype) for dtype in conftest.ALL_INT_DTYPES],
             # numpy floats
-            *[
-                np.array([1.5, 2.5, 3.5], dtype=dtype)
-                for dtype in (np.float16, np.float32, np.float64)
-            ],
+            *[np.array([1.5, 2.5, 3.5], dtype=dtyp) for dtyp in conftest.FLOAT_DTYPES],
+            # numpy object
+            np.array([1, "b", 3.5], dtype=object),
             # pandas scalars
             [Interval(1, 4), Interval(4, 6), Interval(6, 9)],
             [Timestamp(2019, 1, 1), Timestamp(2019, 2, 1), Timestamp(2019, 3, 1)],
             [Timedelta(1, "d"), Timedelta(2, "d"), Timedelta(3, "D")],
             # pandas Integer arrays
-            *[
-                pd.array([1, 2, 3], dtype=dtype)
-                for dtype in [
-                    "Int8",
-                    "Int16",
-                    "Int32",
-                    "Int64",
-                    "UInt8",
-                    "UInt32",
-                    "UInt64",
-                ]
-            ],
+            *[pd.array([1, 2, 3], dtype=dtype) for dtype in conftest.ALL_EA_INT_DTYPES],
             # other pandas arrays
             pd.IntervalIndex.from_breaks([1, 4, 6, 9]).array,
             pd.date_range("2019-01-01", periods=3).array,
@@ -817,19 +794,23 @@ class TestCategoricalIndex:
         # GH-17569
         cat_idx = CategoricalIndex(idx_values, ordered=ordered_fixture)
         df = DataFrame({"A": ["foo", "bar", "baz"]}, index=cat_idx)
+
         # scalar selection
         result = df.loc[idx_values[0]]
         expected = Series(["foo"], index=["A"], name=idx_values[0])
         tm.assert_series_equal(result, expected)
+
         # list selection
         result = df.loc[idx_values[:2]]
         expected = DataFrame(["foo", "bar"], index=cat_idx[:2], columns=["A"])
         tm.assert_frame_equal(result, expected)
+
         # scalar assignment
         result = df.copy()
         result.loc[idx_values[0]] = "qux"
         expected = DataFrame({"A": ["qux", "bar", "baz"]}, index=cat_idx)
         tm.assert_frame_equal(result, expected)
+
         # list assignment
         result = df.copy()
         result.loc[idx_values[:2], "A"] = ["qux", "qux2"]

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -5,7 +5,6 @@ from pandas.core.dtypes.common import is_categorical_dtype
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 import pandas as pd
-from pandas import conftest
 from pandas import (
     Categorical,
     CategoricalIndex,
@@ -15,6 +14,7 @@ from pandas import (
     Series,
     Timedelta,
     Timestamp,
+    conftest,
 )
 from pandas.api.types import CategoricalDtype as CDT
 import pandas.util.testing as tm

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -100,7 +100,12 @@ class TestFloatIndexers:
                         idxr(s)[3.0]
 
                 # label based can be a TypeError or KeyError
-                if s.index.inferred_type in ["string", "unicode", "mixed"]:
+                if s.index.inferred_type in {
+                    "categorical",
+                    "string",
+                    "unicode",
+                    "mixed",
+                }:
                     error = KeyError
                     msg = r"^3$"
                 else:


### PR DESCRIPTION
- [x] closes #17569
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Bug when indexing with ``.loc`` and the index is a CategoricalIndex with integer or float categories.