### PR TITLE
CLN: move odf import inline in excel benchmark

### DIFF
--- a/asv_bench/benchmarks/io/excel.py
+++ b/asv_bench/benchmarks/io/excel.py
@@ -1,9 +1,6 @@
 from io import BytesIO
 
 import numpy as np
-from odf.opendocument import OpenDocumentSpreadsheet
-from odf.table import Table, TableCell, TableRow
-from odf.text import P
 
 from pandas import DataFrame, ExcelWriter, date_range, read_excel
 import pandas.util.testing as tm
@@ -45,6 +42,10 @@ class ReadExcel:
     fname_odf = "spreadsheet.ods"
 
     def _create_odf(self):
+        from odf.opendocument import OpenDocumentSpreadsheet
+        from odf.table import Table, TableCell, TableRow
+        from odf.text import P
+
         doc = OpenDocumentSpreadsheet()
         table = Table(name="Table1")
         for row in self.df.values:


### PR DESCRIPTION
I know this is an optional dependency, but IMO it's still nice that running a different benchmark still works when you don't have odf installed (noticed this yesterday when running the isnull benchmarks). It's similar to pytest skipping if an optional dependency is not installed.