### PR TITLE
DOC: remove reference to get_value (removed) in DataFrame.lookup docstring

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -374,7 +374,7 @@ For getting values with a boolean array:
    df1.loc['a'] > 0
    df1.loc[:, df1.loc['a'] > 0]
 
-For getting a value explicitly (equivalent to deprecated ``df.get_value('a','A')``):
+For getting a value explicitly:
 
 .. ipython:: python
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3544,13 +3544,6 @@ class DataFrame(NDFrame):
         -------
         numpy.ndarray
 
-        Notes
-        -----
-        Akin to::
-
-            result = [df.get_value(row, col)
-                      for row, col in zip(row_labels, col_labels)]
-
         Examples
         --------
         values : ndarray


### PR DESCRIPTION
DataFrame.get_value was removed. 

(now we should maybe also consider deprecating `lookup`, but that is another issue)