### PR TITLE
BUG: merge_asof with tz_aware left index and right column

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -664,7 +664,7 @@ Reshaping
 - Bug where :meth:`DataFrame.equals` returned True incorrectly in some cases when two DataFrames had the same columns in different orders (:issue:`28839`)
 - Bug in :meth:`DataFrame.replace` that caused non-numeric replacer's dtype not respected (:issue:`26632`)
 - Bug in :func:`melt` where supplying mixed strings and numeric values for ``id_vars`` or ``value_vars`` would incorrectly raise a ``ValueError`` (:issue:`29718`)
-
+- Bug in :func:`merge_asof` merging on a tz-aware ``left_index`` and ``right_on`` a tz-aware column (:issue:`29864`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -665,6 +665,7 @@ Reshaping
 - Bug in :meth:`DataFrame.replace` that caused non-numeric replacer's dtype not respected (:issue:`26632`)
 - Bug in :func:`melt` where supplying mixed strings and numeric values for ``id_vars`` or ``value_vars`` would incorrectly raise a ``ValueError`` (:issue:`29718`)
 - Bug in :func:`merge_asof` merging on a tz-aware ``left_index`` and ``right_on`` a tz-aware column (:issue:`29864`)
+-
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1027,7 +1027,7 @@ class _MergeOperation:
                     )
                 ]
             else:
-                left_keys = [self.left.index.values]
+                left_keys = [self.left.index._values]
 
         if left_drop:
             self.left = self.left._drop_labels_or_levels(left_drop)

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -1303,3 +1303,21 @@ class TestAsOfMerge:
 
         result = pd.merge_asof(left, right, on="a", tolerance=10)
         tm.assert_frame_equal(result, expected)
+
+    def test_left_index_right_on_column_tz(self):
+        # GH 29864
+        index = pd.date_range("2019-10-01", freq="30min", periods=5, tz="UTC")
+        left = pd.DataFrame([0.9, 0.8, 0.7, 0.6], columns=["xyz"], index=index[1:])
+        right = pd.DataFrame({"from_date": index, "abc": [2.46] * 4 + [2.19]})
+        result = pd.merge_asof(
+            left=left, right=right, left_index=True, right_on=["from_date"]
+        )
+        expected = pd.DataFrame(
+            {
+                "xyz": [0.9, 0.8, 0.7, 0.6],
+                "from_date": index[1:],
+                "abc": [2.46] * 3 + [2.19],
+            },
+            index=pd.Index([1, 2, 3, 4]),
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -1304,7 +1304,7 @@ class TestAsOfMerge:
         result = pd.merge_asof(left, right, on="a", tolerance=10)
         tm.assert_frame_equal(result, expected)
 
-    def test_left_index_right_on_column_tz(self):
+    def test_merge_index_column_tz(self):
         # GH 29864
         index = pd.date_range("2019-10-01", freq="30min", periods=5, tz="UTC")
         left = pd.DataFrame([0.9, 0.8, 0.7, 0.6], columns=["xyz"], index=index[1:])
@@ -1319,5 +1319,18 @@ class TestAsOfMerge:
                 "abc": [2.46] * 3 + [2.19],
             },
             index=pd.Index([1, 2, 3, 4]),
+        )
+        tm.assert_frame_equal(result, expected)
+
+        result = pd.merge_asof(
+            left=right, right=left, right_index=True, left_on=["from_date"]
+        )
+        expected = pd.DataFrame(
+            {
+                "from_date": index,
+                "abc": [2.46] * 4 + [2.19],
+                "xyz": [np.nan, 0.9, 0.8, 0.7, 0.6],
+            },
+            index=pd.Index([0, 1, 2, 3, 4]),
         )
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #29864
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
