### PR TITLE
BUG: fix Series.interpolate(method='index') with unsorted index

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -550,6 +550,7 @@ Numeric
 - Bug in :class:`UInt64Index` precision loss while constructing from a list with values in the ``np.uint64`` range (:issue:`29526`)
 - Bug in :class:`NumericIndex` construction that caused indexing to fail when integers in the ``np.uint64`` range were used (:issue:`28023`)
 - Bug in :class:`NumericIndex` construction that caused :class:`UInt64Index` to be casted to :class:`Float64Index` when integers in the ``np.uint64`` range were used to index a :class:`DataFrame` (:issue:`28279`)
+- Bug in :meth:`Series.interpolate` when using method ``index`` with unsorted index. (:issue:`21037`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -550,7 +550,7 @@ Numeric
 - Bug in :class:`UInt64Index` precision loss while constructing from a list with values in the ``np.uint64`` range (:issue:`29526`)
 - Bug in :class:`NumericIndex` construction that caused indexing to fail when integers in the ``np.uint64`` range were used (:issue:`28023`)
 - Bug in :class:`NumericIndex` construction that caused :class:`UInt64Index` to be casted to :class:`Float64Index` when integers in the ``np.uint64`` range were used to index a :class:`DataFrame` (:issue:`28279`)
-- Bug in :meth:`Series.interpolate` when using method ``index`` with unsorted index. (:issue:`21037`)
+- Bug in :meth:`Series.interpolate` when using method=`index` with an unsorted index, would previously return incorrect results. (:issue:`21037`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -277,9 +277,10 @@ def interpolate_1d(
                 inds = lib.maybe_convert_objects(inds)
         else:
             inds = xvalues
-        seq = np.argsort(inds[valid])
+        # np.interp requires sorted X values, #21037
+        indexer = np.argsort(inds[valid])
         result[invalid] = np.interp(
-            inds[invalid], inds[valid][seq], yvalues[valid][seq]
+            inds[invalid], inds[valid][indexer], yvalues[valid][indexer]
         )
         result[preserve_nans] = np.nan
         return result

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -277,7 +277,10 @@ def interpolate_1d(
                 inds = lib.maybe_convert_objects(inds)
         else:
             inds = xvalues
-        result[invalid] = np.interp(inds[invalid], inds[valid], yvalues[valid])
+        seq = np.argsort(inds[valid])
+        result[invalid] = np.interp(
+            inds[invalid], inds[valid][seq], yvalues[valid][seq]
+        )
         result[preserve_nans] = np.nan
         return result
 

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1656,9 +1656,13 @@ class TestSeriesInterpolateData:
                 "This interpolation method is not supported for Timedelta Index yet."
             )
 
-    def test_interpolate_unsorted_index(self):
+    @pytest.mark.parametrize(
+        "ascending, expected_values",
+        [(True, [1, 2, 3, 9, 10]), (False, [10, 9, 3, 2, 1])],
+    )
+    def test_interpolate_unsorted_index(self, ascending, expected_values):
         # GH 21037
         ts = pd.Series(data=[10, 9, np.nan, 2, 1], index=[10, 9, 3, 2, 1])
-        result = ts.interpolate(method="index").sort_index(ascending=True)
-        expected = ts.sort_index(ascending=True).interpolate(method="index")
+        result = ts.sort_index(ascending=ascending).interpolate(method="index")
+        expected = pd.Series(data=expected_values, index=expected_values, dtype=float)
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1655,3 +1655,10 @@ class TestSeriesInterpolateData:
             pytest.skip(
                 "This interpolation method is not supported for Timedelta Index yet."
             )
+
+    def test_interpolate_unsorted_index(self):
+        # GH 21037
+        ts = pd.Series(data=[10, 9, np.nan, 2, 1], index=[10, 9, 3, 2, 1])
+        result = ts.interpolate(method="index").sort_index(ascending=True)
+        expected = ts.sort_index(ascending=True).interpolate(method="index")
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
`Series.interpolate(method='index')` use [numpy.interp](https://docs.scipy.org/doc/numpy/reference/generated/numpy.interp.html) under the hood, which cannot work with unsorted X values. Here we sort the known data for `numpy.interp`.

- [x] closes #21037
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
