### PR TITLE
Reduce Loosely Typed Functions in objToJSON

### DIFF
--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -555,8 +555,6 @@ static int NpyTypeToJSONType(PyObject *obj, JSONTypeContext *tc, int npyType,
         }
 
         GET_TC(tc)->longValue = (JSINT64)longVal;
-	printf("longval is %ld\n", longVal);
-	printf("stored longval is %lld\n", GET_TC(tc)->longValue);
         GET_TC(tc)->PyTypeToJSON = NpyDatetime64ToJSON;
         return ((PyObjectEncoder *)tc->encoder)->datetimeIso ? JT_UTF8
                                                              : JT_LONG;
@@ -2285,12 +2283,6 @@ JSINT64 Object_getLongValue(JSOBJ obj, JSONTypeContext *tc) {
   return GET_TC(tc)->longValue;
 }
 
-JSINT32 Object_getIntValue(JSOBJ obj, JSONTypeContext *tc) {
-    JSINT32 ret;
-    GET_TC(tc)->PyTypeToJSON(obj, tc, &ret, NULL);
-    return ret;
-}
-
 double Object_getDoubleValue(JSOBJ obj, JSONTypeContext *tc) {
   return GET_TC(tc)->doubleValue;
 }
@@ -2347,7 +2339,7 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
         Object_endTypeContext,
         Object_getStringValue,
         Object_getLongValue,
-        Object_getIntValue,
+        NULL,  // getIntValue is unused
         Object_getDoubleValue,
         Object_iterBegin,
         Object_iterNext,

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -386,7 +386,7 @@ static PyObject *get_item(PyObject *obj, Py_ssize_t i) {
 }
 
 static void *PyBytesToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
-                            size_t *_outLen) {
+                           size_t *_outLen) {
     PyObject *obj = (PyObject *)_obj;
     *_outLen = PyBytes_GET_SIZE(obj);
     return PyBytes_AS_STRING(obj);
@@ -554,31 +554,31 @@ static int NpyTypeToJSONType(PyObject *obj, JSONTypeContext *tc, int npyType,
             return JT_NULL;
         }
 
-	if (((PyObjectEncoder *)tc->encoder)->datetimeIso) {
-	  GET_TC(tc)->longValue = (JSINT64)longVal;
-	  GET_TC(tc)->PyTypeToJSON = NpyDatetime64ToJSON;
-	  return JT_UTF8;
-	} else {
+        if (((PyObjectEncoder *)tc->encoder)->datetimeIso) {
+            GET_TC(tc)->longValue = (JSINT64)longVal;
+            GET_TC(tc)->PyTypeToJSON = NpyDatetime64ToJSON;
+            return JT_UTF8;
+        } else {
 
-	  // TODO: consolidate uses of this switch
-	  switch (((PyObjectEncoder *)tc->encoder)->datetimeUnit) {
-	  case NPY_FR_ns:
-	    break;
-	  case NPY_FR_us:
-	    longVal /= 1000LL;
-	    break;
-	  case NPY_FR_ms:
-	    longVal /= 1000000LL;
-	    break;
-	  case NPY_FR_s:
-	    longVal /= 1000000000LL;
-	    break;
-	  default:
-	    break;  // TODO: should raise error
-	  }
-	  GET_TC(tc)->longValue = longVal;
-	  return JT_LONG;
-	}
+            // TODO: consolidate uses of this switch
+            switch (((PyObjectEncoder *)tc->encoder)->datetimeUnit) {
+            case NPY_FR_ns:
+                break;
+            case NPY_FR_us:
+                longVal /= 1000LL;
+                break;
+            case NPY_FR_ms:
+                longVal /= 1000000LL;
+                break;
+            case NPY_FR_s:
+                longVal /= 1000000000LL;
+                break;
+            default:
+                break; // TODO: should raise error
+            }
+            GET_TC(tc)->longValue = longVal;
+            return JT_LONG;
+        }
     }
 
     if (PyTypeNum_ISINTEGER(npyType)) {
@@ -1832,7 +1832,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         if (npy_isnan(val) || npy_isinf(val)) {
             tc->type = JT_NULL;
         } else {
-	    GET_TC(tc)->doubleValue = val;
+            GET_TC(tc)->doubleValue = val;
             tc->type = JT_DOUBLE;
         }
         return;
@@ -1848,7 +1848,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         return;
     } else if (PyObject_TypeCheck(obj, type_decimal)) {
         PRINTMARK();
-	GET_TC(tc)->doubleValue = PyFloat_AsDouble(obj);
+        GET_TC(tc)->doubleValue = PyFloat_AsDouble(obj);
         tc->type = JT_DOUBLE;
         return;
     } else if (PyDateTime_Check(obj) || PyDate_Check(obj)) {
@@ -1861,13 +1861,13 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         PRINTMARK();
         if (enc->datetimeIso) {
             PRINTMARK();
-	    pc->PyTypeToJSON = PyDateTimeToJSON;
+            pc->PyTypeToJSON = PyDateTimeToJSON;
             tc->type = JT_UTF8;
         } else {
             PRINTMARK();
-	    // TODO: last argument here is unused; should decouple string
-	    // from long datetimelike conversion routines
-	    PyDateTimeToJSON(obj, tc, &(GET_TC(tc)->longValue), 0);
+            // TODO: last argument here is unused; should decouple string
+            // from long datetimelike conversion routines
+            PyDateTimeToJSON(obj, tc, &(GET_TC(tc)->longValue), 0);
             tc->type = JT_LONG;
         }
         return;
@@ -1952,7 +1952,8 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
         return;
     } else if (PyArray_IsScalar(obj, Float) || PyArray_IsScalar(obj, Double)) {
         PRINTMARK();
-	PyArray_CastScalarToCtype(obj, &(GET_TC(tc)->doubleValue), PyArray_DescrFromType(NPY_DOUBLE));
+        PyArray_CastScalarToCtype(obj, &(GET_TC(tc)->doubleValue),
+                                  PyArray_DescrFromType(NPY_DOUBLE));
         tc->type = JT_DOUBLE;
         return;
     } else if (PyArray_Check(obj) && PyArray_CheckScalar(obj)) {
@@ -2301,11 +2302,11 @@ const char *Object_getStringValue(JSOBJ obj, JSONTypeContext *tc,
 }
 
 JSINT64 Object_getLongValue(JSOBJ obj, JSONTypeContext *tc) {
-  return GET_TC(tc)->longValue;
+    return GET_TC(tc)->longValue;
 }
 
 double Object_getDoubleValue(JSOBJ obj, JSONTypeContext *tc) {
-  return GET_TC(tc)->doubleValue;
+    return GET_TC(tc)->doubleValue;
 }
 
 static void Object_releaseObject(JSOBJ _obj) { Py_DECREF((PyObject *)_obj); }
@@ -2360,7 +2361,7 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
         Object_endTypeContext,
         Object_getStringValue,
         Object_getLongValue,
-        NULL,  // getIntValue is unused
+        NULL, // getIntValue is unused
         Object_getDoubleValue,
         Object_iterBegin,
         Object_iterNext,

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -385,13 +385,6 @@ static PyObject *get_item(PyObject *obj, Py_ssize_t i) {
     return ret;
 }
 
-static void *CLong(JSOBJ obj, JSONTypeContext *tc, void *outValue,
-                   size_t *_outLen) {
-    PRINTMARK();
-    *((JSINT64 *)outValue) = GET_TC(tc)->longValue;
-    return NULL;
-}
-
 static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                            size_t *_outLen) {
     *((JSINT64 *)outValue) = GET_TC(tc)->longValue;
@@ -582,7 +575,6 @@ static int NpyTypeToJSONType(PyObject *obj, JSONTypeContext *tc, int npyType,
         }
         castfunc(value, &longVal, 1, NULL, NULL);
         GET_TC(tc)->longValue = (JSINT64)longVal;
-        GET_TC(tc)->PyTypeToJSON = CLong;
         return JT_LONG;
     }
 


### PR DESCRIPTION
Part of my perpetual goal to simplify this. Right now we override the built-in capabilities of the JSON encoder and use multiple layers of loosely typed functions. I think this is pretty confusing, so I am trying to reduce the callbacks and set native values directly during iteration

This isn't a full solve - rather just numeric values. I plan on tackling string representations in a follow up; just stopping here because the code movement gets large fast.

In addition to less code, note that this also reduces the amount of compiler warnings from 68 down to 60 when compiling with `-Wextra`

master:

<details>

```sh
 pandas/_libs/src/ujson/python/objToJSON.c:388:28: warning: unused parameter 'obj' [-Wunused-parameter]
static void *CDouble(JSOBJ obj, JSONTypeContext *tc, void *outValue,
                           ^
pandas/_libs/src/ujson/python/objToJSON.c:389:30: warning: unused parameter '_outLen' [-Wunused-parameter]
                     size_t *_outLen) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:395:26: warning: unused parameter 'obj' [-Wunused-parameter]
static void *CLong(JSOBJ obj, JSONTypeContext *tc, void *outValue,
                         ^
pandas/_libs/src/ujson/python/objToJSON.c:396:28: warning: unused parameter '_outLen' [-Wunused-parameter]
                   size_t *_outLen) {
                           ^
pandas/_libs/src/ujson/python/objToJSON.c:402:34: warning: unused parameter '_obj' [-Wunused-parameter]
static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                 ^
pandas/_libs/src/ujson/python/objToJSON.c:403:36: warning: unused parameter '_outLen' [-Wunused-parameter]
                           size_t *_outLen) {
                                   ^
pandas/_libs/src/ujson/python/objToJSON.c:408:60: warning: unused parameter 'tc' [-Wunused-parameter]
static void *NpyFloatToDOUBLE(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                                           ^
pandas/_libs/src/ujson/python/objToJSON.c:409:39: warning: unused parameter '_outLen' [-Wunused-parameter]
                              size_t *_outLen) {
                                      ^
pandas/_libs/src/ujson/python/objToJSON.c:415:59: warning: unused parameter 'tc' [-Wunused-parameter]
static void *PyFloatToDOUBLE(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                                          ^
pandas/_libs/src/ujson/python/objToJSON.c:416:38: warning: unused parameter '_outLen' [-Wunused-parameter]
                             size_t *_outLen) {
                                     ^
pandas/_libs/src/ujson/python/objToJSON.c:422:57: warning: unused parameter 'tc' [-Wunused-parameter]
static void *PyBytesToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                                        ^
pandas/_libs/src/ujson/python/objToJSON.c:422:67: warning: unused parameter 'outValue' [-Wunused-parameter]
static void *PyBytesToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                                                  ^
pandas/_libs/src/ujson/python/objToJSON.c:429:69: warning: unused parameter 'outValue' [-Wunused-parameter]
static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                                                    ^
pandas/_libs/src/ujson/python/objToJSON.c:515:40: warning: unused parameter '_obj' [-Wunused-parameter]
static void *NpyDatetime64ToJSON(JSOBJ _obj, JSONTypeContext *tc,
                                       ^
pandas/_libs/src/ujson/python/objToJSON.c:554:40: warning: unused parameter 'obj' [-Wunused-parameter]
static int NpyTypeToJSONType(PyObject *obj, JSONTypeContext *tc, int npyType,
                                       ^
pandas/_libs/src/ujson/python/objToJSON.c:624:40: warning: unused parameter '_obj' [-Wunused-parameter]
static void NpyArr_freeItemValue(JSOBJ _obj, JSONTypeContext *tc) {
                                       ^
pandas/_libs/src/ujson/python/objToJSON.c:633:31: warning: unused parameter '_obj' [-Wunused-parameter]
int NpyArr_iterNextNone(JSOBJ _obj, JSONTypeContext *tc) { return 0; }
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:633:54: warning: unused parameter 'tc' [-Wunused-parameter]
int NpyArr_iterNextNone(JSOBJ _obj, JSONTypeContext *tc) { return 0; }
                                                     ^
pandas/_libs/src/ujson/python/objToJSON.c:690:37: warning: unused parameter 'obj' [-Wunused-parameter]
void NpyArrPassThru_iterBegin(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
                                    ^
pandas/_libs/src/ujson/python/objToJSON.c:690:59: warning: unused parameter 'tc' [-Wunused-parameter]
void NpyArrPassThru_iterBegin(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
                                                          ^
pandas/_libs/src/ujson/python/objToJSON.c:769:33: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ NpyArr_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                                ^
pandas/_libs/src/ujson/python/objToJSON.c:774:32: warning: unused parameter 'obj' [-Wunused-parameter]
char *NpyArr_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:828:33: warning: unused parameter 'obj' [-Wunused-parameter]
char *PdBlock_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                ^
pandas/_libs/src/ujson/python/objToJSON.c:850:43: warning: unused parameter 'obj' [-Wunused-parameter]
char *PdBlock_iterGetName_Transpose(JSOBJ obj, JSONTypeContext *tc,
                                          ^
pandas/_libs/src/ujson/python/objToJSON.c:896:38: warning: unused parameter 'obj' [-Wunused-parameter]
void PdBlockPassThru_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                                     ^
pandas/_libs/src/ujson/python/objToJSON.c:1128:26: warning: unused parameter 'obj' [-Wunused-parameter]
void Tuple_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
                         ^
pandas/_libs/src/ujson/python/objToJSON.c:1128:48: warning: unused parameter 'tc' [-Wunused-parameter]
void Tuple_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
                                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1130:32: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Tuple_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1134:31: warning: unused parameter 'obj' [-Wunused-parameter]
char *Tuple_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1134:53: warning: unused parameter 'tc' [-Wunused-parameter]
char *Tuple_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                    ^
pandas/_libs/src/ujson/python/objToJSON.c:1134:65: warning: unused parameter 'outLen' [-Wunused-parameter]
char *Tuple_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                                ^
pandas/_libs/src/ujson/python/objToJSON.c:1147:25: warning: unused parameter 'obj' [-Wunused-parameter]
int Iter_iterNext(JSOBJ obj, JSONTypeContext *tc) {
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1165:25: warning: unused parameter 'obj' [-Wunused-parameter]
void Iter_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1177:31: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Iter_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1181:30: warning: unused parameter 'obj' [-Wunused-parameter]
char *Iter_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:1181:52: warning: unused parameter 'tc' [-Wunused-parameter]
char *Iter_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                   ^
pandas/_libs/src/ujson/python/objToJSON.c:1181:64: warning: unused parameter 'outLen' [-Wunused-parameter]
char *Iter_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1197:24: warning: unused parameter 'obj' [-Wunused-parameter]
void Dir_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                       ^
pandas/_libs/src/ujson/python/objToJSON.c:1283:30: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Dir_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:1288:29: warning: unused parameter 'obj' [-Wunused-parameter]
char *Dir_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                            ^
pandas/_libs/src/ujson/python/objToJSON.c:1314:25: warning: unused parameter 'obj' [-Wunused-parameter]
void List_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1314:47: warning: unused parameter 'tc' [-Wunused-parameter]
void List_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
                                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1316:31: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ List_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1320:30: warning: unused parameter 'obj' [-Wunused-parameter]
char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:1320:52: warning: unused parameter 'tc' [-Wunused-parameter]
char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                   ^
pandas/_libs/src/ujson/python/objToJSON.c:1320:64: warning: unused parameter 'outLen' [-Wunused-parameter]
char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1327:28: warning: unused parameter 'obj' [-Wunused-parameter]
void Index_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                           ^
pandas/_libs/src/ujson/python/objToJSON.c:1363:26: warning: unused parameter 'obj' [-Wunused-parameter]
void Index_iterEnd(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
                         ^
pandas/_libs/src/ujson/python/objToJSON.c:1363:48: warning: unused parameter 'tc' [-Wunused-parameter]
void Index_iterEnd(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
                                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1365:32: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Index_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1369:31: warning: unused parameter 'obj' [-Wunused-parameter]
char *Index_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1377:29: warning: unused parameter 'obj' [-Wunused-parameter]
void Series_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                            ^
pandas/_libs/src/ujson/python/objToJSON.c:1418:27: warning: unused parameter 'obj' [-Wunused-parameter]
void Series_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                          ^
pandas/_libs/src/ujson/python/objToJSON.c:1424:33: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Series_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                                ^
pandas/_libs/src/ujson/python/objToJSON.c:1428:32: warning: unused parameter 'obj' [-Wunused-parameter]
char *Series_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1436:32: warning: unused parameter 'obj' [-Wunused-parameter]
void DataFrame_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1482:30: warning: unused parameter 'obj' [-Wunused-parameter]
void DataFrame_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:1488:36: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ DataFrame_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                                   ^
pandas/_libs/src/ujson/python/objToJSON.c:1492:35: warning: unused parameter 'obj' [-Wunused-parameter]
char *DataFrame_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                  ^
pandas/_libs/src/ujson/python/objToJSON.c:1502:27: warning: unused parameter 'obj' [-Wunused-parameter]
void Dict_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                          ^
pandas/_libs/src/ujson/python/objToJSON.c:1507:25: warning: unused parameter 'obj' [-Wunused-parameter]
int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc) {
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1535:25: warning: unused parameter 'obj' [-Wunused-parameter]
void Dict_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1544:31: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Dict_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1548:30: warning: unused parameter 'obj' [-Wunused-parameter]
char *Dict_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:2291:34: warning: unused parameter 'obj' [-Wunused-parameter]
void Object_endTypeContext(JSOBJ obj, JSONTypeContext *tc) {
                                 ^
pandas/_libs/src/ujson/python/objToJSON.c:2403:5: warning: missing field 'errorMsg' initializer [-Wmissing-field-initializers]
    }};
    ^
pandas/_libs/src/ujson/python/objToJSON.c:2403:6: warning: missing field 'npyCtxtPassthru' initializer [-Wmissing-field-initializers]
    }};
     ^
pandas/_libs/src/ujson/python/objToJSON.c:2357:31: warning: unused parameter 'self' [-Wunused-parameter]
PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
                              ^
68 warnings generated.
```

</details>

This PR

<details>

```sh
pandas/_libs/src/ujson/python/objToJSON.c:388:57: warning: unused parameter 'tc' [-Wunused-parameter]
static void *PyBytesToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                                        ^
pandas/_libs/src/ujson/python/objToJSON.c:388:67: warning: unused parameter 'outValue' [-Wunused-parameter]
static void *PyBytesToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                                                  ^
pandas/_libs/src/ujson/python/objToJSON.c:395:69: warning: unused parameter 'outValue' [-Wunused-parameter]
static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                                                                    ^
pandas/_libs/src/ujson/python/objToJSON.c:481:40: warning: unused parameter '_obj' [-Wunused-parameter]
static void *NpyDatetime64ToJSON(JSOBJ _obj, JSONTypeContext *tc,
                                       ^
pandas/_libs/src/ujson/python/objToJSON.c:520:40: warning: unused parameter 'obj' [-Wunused-parameter]
static int NpyTypeToJSONType(PyObject *obj, JSONTypeContext *tc, int npyType,
                                       ^
pandas/_libs/src/ujson/python/objToJSON.c:610:40: warning: unused parameter '_obj' [-Wunused-parameter]
static void NpyArr_freeItemValue(JSOBJ _obj, JSONTypeContext *tc) {
                                       ^
pandas/_libs/src/ujson/python/objToJSON.c:619:31: warning: unused parameter '_obj' [-Wunused-parameter]
int NpyArr_iterNextNone(JSOBJ _obj, JSONTypeContext *tc) { return 0; }
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:619:54: warning: unused parameter 'tc' [-Wunused-parameter]
int NpyArr_iterNextNone(JSOBJ _obj, JSONTypeContext *tc) { return 0; }
                                                     ^
pandas/_libs/src/ujson/python/objToJSON.c:676:37: warning: unused parameter 'obj' [-Wunused-parameter]
void NpyArrPassThru_iterBegin(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
                                    ^
pandas/_libs/src/ujson/python/objToJSON.c:676:59: warning: unused parameter 'tc' [-Wunused-parameter]
void NpyArrPassThru_iterBegin(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
                                                          ^
pandas/_libs/src/ujson/python/objToJSON.c:755:33: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ NpyArr_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                                ^
pandas/_libs/src/ujson/python/objToJSON.c:760:32: warning: unused parameter 'obj' [-Wunused-parameter]
char *NpyArr_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:814:33: warning: unused parameter 'obj' [-Wunused-parameter]
char *PdBlock_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                ^
pandas/_libs/src/ujson/python/objToJSON.c:836:43: warning: unused parameter 'obj' [-Wunused-parameter]
char *PdBlock_iterGetName_Transpose(JSOBJ obj, JSONTypeContext *tc,
                                          ^
pandas/_libs/src/ujson/python/objToJSON.c:882:38: warning: unused parameter 'obj' [-Wunused-parameter]
void PdBlockPassThru_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                                     ^
pandas/_libs/src/ujson/python/objToJSON.c:1114:26: warning: unused parameter 'obj' [-Wunused-parameter]
void Tuple_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
                         ^
pandas/_libs/src/ujson/python/objToJSON.c:1114:48: warning: unused parameter 'tc' [-Wunused-parameter]
void Tuple_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
                                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1116:32: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Tuple_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1120:31: warning: unused parameter 'obj' [-Wunused-parameter]
char *Tuple_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1120:53: warning: unused parameter 'tc' [-Wunused-parameter]
char *Tuple_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                    ^
pandas/_libs/src/ujson/python/objToJSON.c:1120:65: warning: unused parameter 'outLen' [-Wunused-parameter]
char *Tuple_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                                ^
pandas/_libs/src/ujson/python/objToJSON.c:1133:25: warning: unused parameter 'obj' [-Wunused-parameter]
int Iter_iterNext(JSOBJ obj, JSONTypeContext *tc) {
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1151:25: warning: unused parameter 'obj' [-Wunused-parameter]
void Iter_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1163:31: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Iter_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1167:30: warning: unused parameter 'obj' [-Wunused-parameter]
char *Iter_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:1167:52: warning: unused parameter 'tc' [-Wunused-parameter]
char *Iter_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                   ^
pandas/_libs/src/ujson/python/objToJSON.c:1167:64: warning: unused parameter 'outLen' [-Wunused-parameter]
char *Iter_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1183:24: warning: unused parameter 'obj' [-Wunused-parameter]
void Dir_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                       ^
pandas/_libs/src/ujson/python/objToJSON.c:1269:30: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Dir_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:1274:29: warning: unused parameter 'obj' [-Wunused-parameter]
char *Dir_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                            ^
pandas/_libs/src/ujson/python/objToJSON.c:1300:25: warning: unused parameter 'obj' [-Wunused-parameter]
void List_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1300:47: warning: unused parameter 'tc' [-Wunused-parameter]
void List_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
                                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1302:31: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ List_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1306:30: warning: unused parameter 'obj' [-Wunused-parameter]
char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:1306:52: warning: unused parameter 'tc' [-Wunused-parameter]
char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                   ^
pandas/_libs/src/ujson/python/objToJSON.c:1306:64: warning: unused parameter 'outLen' [-Wunused-parameter]
char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1313:28: warning: unused parameter 'obj' [-Wunused-parameter]
void Index_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                           ^
pandas/_libs/src/ujson/python/objToJSON.c:1349:26: warning: unused parameter 'obj' [-Wunused-parameter]
void Index_iterEnd(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
                         ^
pandas/_libs/src/ujson/python/objToJSON.c:1349:48: warning: unused parameter 'tc' [-Wunused-parameter]
void Index_iterEnd(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
                                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1351:32: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Index_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1355:31: warning: unused parameter 'obj' [-Wunused-parameter]
char *Index_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1363:29: warning: unused parameter 'obj' [-Wunused-parameter]
void Series_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                            ^
pandas/_libs/src/ujson/python/objToJSON.c:1404:27: warning: unused parameter 'obj' [-Wunused-parameter]
void Series_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                          ^
pandas/_libs/src/ujson/python/objToJSON.c:1410:33: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Series_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                                ^
pandas/_libs/src/ujson/python/objToJSON.c:1414:32: warning: unused parameter 'obj' [-Wunused-parameter]
char *Series_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1422:32: warning: unused parameter 'obj' [-Wunused-parameter]
void DataFrame_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                               ^
pandas/_libs/src/ujson/python/objToJSON.c:1468:30: warning: unused parameter 'obj' [-Wunused-parameter]
void DataFrame_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:1474:36: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ DataFrame_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                                   ^
pandas/_libs/src/ujson/python/objToJSON.c:1478:35: warning: unused parameter 'obj' [-Wunused-parameter]
char *DataFrame_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                                  ^
pandas/_libs/src/ujson/python/objToJSON.c:1488:27: warning: unused parameter 'obj' [-Wunused-parameter]
void Dict_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
                          ^
pandas/_libs/src/ujson/python/objToJSON.c:1493:25: warning: unused parameter 'obj' [-Wunused-parameter]
int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc) {
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1521:25: warning: unused parameter 'obj' [-Wunused-parameter]
void Dict_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
                        ^
pandas/_libs/src/ujson/python/objToJSON.c:1530:31: warning: unused parameter 'obj' [-Wunused-parameter]
JSOBJ Dict_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
                              ^
pandas/_libs/src/ujson/python/objToJSON.c:1534:30: warning: unused parameter 'obj' [-Wunused-parameter]
char *Dict_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
                             ^
pandas/_libs/src/ujson/python/objToJSON.c:2278:34: warning: unused parameter 'obj' [-Wunused-parameter]
void Object_endTypeContext(JSOBJ obj, JSONTypeContext *tc) {
                                 ^
pandas/_libs/src/ujson/python/objToJSON.c:2304:35: warning: unused parameter 'obj' [-Wunused-parameter]
JSINT64 Object_getLongValue(JSOBJ obj, JSONTypeContext *tc) {
                                  ^
pandas/_libs/src/ujson/python/objToJSON.c:2308:36: warning: unused parameter 'obj' [-Wunused-parameter]
double Object_getDoubleValue(JSOBJ obj, JSONTypeContext *tc) {
                                   ^
pandas/_libs/src/ujson/python/objToJSON.c:2380:5: warning: missing field 'errorMsg' initializer [-Wmissing-field-initializers]
    }};
    ^
pandas/_libs/src/ujson/python/objToJSON.c:2380:6: warning: missing field 'npyCtxtPassthru' initializer [-Wmissing-field-initializers]
    }};
     ^
pandas/_libs/src/ujson/python/objToJSON.c:2334:31: warning: unused parameter 'self' [-Wunused-parameter]
PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
                              ^
60 warnings generated.

```
</details>