### PR TITLE
REF: move attribute setting towards the constructor

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3905,7 +3905,7 @@ class Table(Fixed):
                 existing_col = None
 
             col = klass.create_for_block(i=i, name=name, version=self.version)
-            self.values = list(b_items)
+            col.values = list(b_items)
             col.set_atom(
                 block=b,
                 existing_col=existing_col,


### PR DESCRIPTION
The end goal is to minimize the amount of attribute setting that is done outside of the constructor (or create_for_block which is a classmethod and ill give it a pass).

create_for_block is called in one place, and immediately after that set_atom is called on the result.  set_atom does a ton of attribute setting, so the idea here is to gradually move that attribute setting up into create_for_block.

Related but kept for a separate branch, most of the affected methods have `block` arguments, these can all be changed to operate on block.values, which will narrow the exposure to internals.