### PR TITLE
CI: Using more appropriate GitHub Actions syntax to set path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Setting conda path
+      run: echo "::add-path::${HOME}/miniconda3/bin"
+
     - name: Checkout
       uses: actions/checkout@v1
-
-    - name: Setting conda path
-      run: echo "::set-env name=PATH::${HOME}/miniconda3/bin:${PATH}"
 
     - name: Looking for unwanted patterns
       run: ci/code_checks.sh patterns


### PR DESCRIPTION
Looks like GitHub Actions provides a specific command to add to the PATH, which is simpler (and also works on Windows, which is not required in this case, but will be when we add the test jobs).