### PR TITLE
CI: add jinja to deps

### DIFF
--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -20,6 +20,7 @@ dependencies:
   - numexpr
   - numpy=1.15.*
   - openpyxl
+  - jinja2
   - pyarrow>=0.12.0
   - pytables
   - python-dateutil


### PR DESCRIPTION
i think this should fix the failing windows-py36 azure build