### PR TITLE
CI: troubleshoot openpyxl failures

### DIFF
--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -27,7 +27,8 @@ dependencies:
   - numexpr
   - numpy=1.15.*
   - odfpy
-  - openpyxl
+  - openpyxl<=3.0.1
+  # https://github.com/pandas-dev/pandas/pull/30009 openpyxl 3.0.2 broke
   - pandas-gbq
   # https://github.com/pydata/pandas-gbq/issues/271
   - google-cloud-bigquery<=1.11

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import PY37
+from pandas.compat import PY37, is_platform_mac
 
 import pandas as pd
 from pandas import DataFrame
@@ -86,7 +86,9 @@ def test_write_cells_merge_styled(ext):
         assert xcell_a2.font == openpyxl_sty_merged
 
 
-@pytest.mark.xfail(openpyxl_gt301 and PY37, reason="broken change in openpyxl")
+@pytest.mark.xfail(
+    openpyxl_gt301 and PY37 and is_platform_mac(), reason="broken change in openpyxl"
+)
 @pytest.mark.parametrize(
     "mode,expected", [("w", ["baz"]), ("a", ["foo", "bar", "baz"])]
 )
@@ -113,7 +115,9 @@ def test_write_append_mode(ext, mode, expected):
             assert wb2.worksheets[index]["A1"].value == cell_value
 
 
-@pytest.mark.xfail(openpyxl_gt301 and PY37, reason="broken change in openpyxl")
+@pytest.mark.xfail(
+    openpyxl_gt301 and PY37 and is_platform_mac(), reason="broken change in openpyxl"
+)
 def test_to_excel_with_openpyxl_engine(ext, tmpdir):
     # GH 29854
     # TODO: Fix this once newer version of openpyxl fixes the bug

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -1,7 +1,10 @@
+from distutils.version import LooseVersion
 import os
 
 import numpy as np
 import pytest
+
+from pandas.compat import PY37
 
 import pandas as pd
 from pandas import DataFrame
@@ -12,6 +15,8 @@ from pandas.io.excel import ExcelWriter, _OpenpyxlWriter
 openpyxl = pytest.importorskip("openpyxl")
 
 pytestmark = pytest.mark.parametrize("ext", [".xlsx"])
+
+openpyxl_gt301 = LooseVersion(openpyxl.__version__) > LooseVersion("3.0.1")
 
 
 def test_to_excel_styleconverter(ext):
@@ -81,6 +86,7 @@ def test_write_cells_merge_styled(ext):
         assert xcell_a2.font == openpyxl_sty_merged
 
 
+@pytest.mark.xfail(openpyxl_gt301 and PY37, reason="broken change in openpyxl")
 @pytest.mark.parametrize(
     "mode,expected", [("w", ["baz"]), ("a", ["foo", "bar", "baz"])]
 )
@@ -107,7 +113,7 @@ def test_write_append_mode(ext, mode, expected):
             assert wb2.worksheets[index]["A1"].value == cell_value
 
 
-@pytest.mark.xfail(openpyxl.__version__ > "3.0.1", reason="broken change in openpyxl")
+@pytest.mark.xfail(openpyxl_gt301 and PY37, reason="broken change in openpyxl")
 def test_to_excel_with_openpyxl_engine(ext, tmpdir):
     # GH 29854
     # TODO: Fix this once newer version of openpyxl fixes the bug


### PR DESCRIPTION
tested on OSX 36 and 37, we'll see if that generalizes