### PR TITLE
Replaced !r with repr()

### DIFF
--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -208,7 +208,7 @@ def lexsort_indexer(keys, orders=None, na_position="last"):
             cat = Categorical(key, ordered=True)
 
         if na_position not in ["last", "first"]:
-            raise ValueError("invalid na_position: {!r}".format(na_position))
+            raise ValueError(f"invalid na_position: {repr(na_position)}")
 
         n = len(cat.categories)
         codes = cat.codes.copy()
@@ -264,7 +264,7 @@ def nargsort(items, kind="quicksort", ascending: bool = True, na_position="last"
     elif na_position == "first":
         indexer = np.concatenate([nan_idx, indexer])
     else:
-        raise ValueError("invalid na_position: {!r}".format(na_position))
+        raise ValueError(f"invalid na_position: {repr(na_position)}")
     return indexer
 
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -208,7 +208,7 @@ def lexsort_indexer(keys, orders=None, na_position="last"):
             cat = Categorical(key, ordered=True)
 
         if na_position not in ["last", "first"]:
-            raise ValueError(f"invalid na_position: {repr(na_position)}")
+            raise ValueError(f"invalid na_position: {na_position}")
 
         n = len(cat.categories)
         codes = cat.codes.copy()
@@ -264,7 +264,7 @@ def nargsort(items, kind="quicksort", ascending: bool = True, na_position="last"
     elif na_position == "first":
         indexer = np.concatenate([nan_idx, indexer])
     else:
-        raise ValueError(f"invalid na_position: {repr(na_position)}")
+        raise ValueError(f"invalid na_position: {na_position}")
     return indexer
 
 


### PR DESCRIPTION
- [x] reference #29886
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Issue: https://github.com/pandas-dev/pandas/issues/29886

@WillAyd 