### PR TITLE
changed "fun !r" -> "repr(fun)"

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2944,7 +2944,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             sortedIdx[n:] = idx[good][argsorted]
             sortedIdx[:n] = idx[bad]
         else:
-            raise ValueError("invalid na_position: {!r}".format(na_position))
+            raise ValueError(f"invalid na_position: {repr(na_position)}")
 
         result = self._constructor(arr[sortedIdx], index=self.index[sortedIdx])
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -208,7 +208,7 @@ def lexsort_indexer(keys, orders=None, na_position="last"):
             cat = Categorical(key, ordered=True)
 
         if na_position not in ["last", "first"]:
-            raise ValueError("invalid na_position: {!r}".format(na_position))
+            raise ValueError(f"invalid na_position: {repr(na_position)}")
 
         n = len(cat.categories)
         codes = cat.codes.copy()
@@ -264,7 +264,7 @@ def nargsort(items, kind="quicksort", ascending: bool = True, na_position="last"
     elif na_position == "first":
         indexer = np.concatenate([nan_idx, indexer])
     else:
-        raise ValueError("invalid na_position: {!r}".format(na_position))
+        raise ValueError(f"invalid na_position: {repr(na_position)}")
     return indexer
 
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1933,10 +1933,8 @@ def forbid_nonstring_types(forbidden, name=None):
         def wrapper(self, *args, **kwargs):
             if self._inferred_dtype not in allowed_types:
                 msg = (
-                    "Cannot use .str.{name} with values of inferred dtype "
-                    "{inf_type!r}.".format(
-                        name=func_name, inf_type=self._inferred_dtype
-                    )
+                    f"Cannot use .str.{func_name} with values of inferred dtype "
+                    f"{repr(self._inferred_dtype)}."
                 )
                 raise TypeError(msg)
             return func(self, *args, **kwargs)


### PR DESCRIPTION
As described in the following issue
, usage of !r is currently redundant and so changing to f strings in place of it.

- [x] ref https://github.com/pandas-dev/pandas/issues/29886
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
