### PR TITLE
revert openpyxl test changes

### DIFF
--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -4,8 +4,6 @@ import os
 import numpy as np
 import pytest
 
-from pandas.compat import PY37, is_platform_mac
-
 import pandas as pd
 from pandas import DataFrame
 import pandas.util.testing as tm
@@ -15,8 +13,6 @@ from pandas.io.excel import ExcelWriter, _OpenpyxlWriter
 openpyxl = pytest.importorskip("openpyxl")
 
 pytestmark = pytest.mark.parametrize("ext", [".xlsx"])
-
-openpyxl_gt301 = LooseVersion(openpyxl.__version__) > LooseVersion("3.0.1")
 
 
 def test_to_excel_styleconverter(ext):
@@ -86,9 +82,6 @@ def test_write_cells_merge_styled(ext):
         assert xcell_a2.font == openpyxl_sty_merged
 
 
-@pytest.mark.xfail(
-    openpyxl_gt301 and PY37 and is_platform_mac(), reason="broken change in openpyxl"
-)
 @pytest.mark.parametrize(
     "mode,expected", [("w", ["baz"]), ("a", ["foo", "bar", "baz"])]
 )
@@ -115,9 +108,6 @@ def test_write_append_mode(ext, mode, expected):
             assert wb2.worksheets[index]["A1"].value == cell_value
 
 
-@pytest.mark.xfail(
-    openpyxl_gt301 and PY37 and is_platform_mac(), reason="broken change in openpyxl"
-)
 def test_to_excel_with_openpyxl_engine(ext, tmpdir):
     # GH 29854
     # TODO: Fix this once newer version of openpyxl fixes the bug

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 import os
 
 import numpy as np


### PR DESCRIPTION
follow up to #30009 - thanks @jbrockmendel for fixing it and sorry I wasn't able to review more. I *think* the root cause though is just defusedxml being installed alongside things, which is only prevalent in our 3.6 build.

pinning openpyxl version alone I think is fine, but let's see...note that this same defusedxml issue causes a lot of warnings to be captured for xlrd in the excel tests