### PR TITLE
CI: Fix print skipped tests

### DIFF
--- a/ci/print_skipped.py
+++ b/ci/print_skipped.py
@@ -5,12 +5,12 @@ import xml.etree.ElementTree as et
 
 def main(filename):
     if not os.path.isfile(filename):
-        return
+        raise RuntimeError(f"Could not find junit file {filename!r}")
 
     tree = et.parse(filename)
     root = tree.getroot()
     current_class = ""
-    for el in root.findall("testcase"):
+    for el in root.iter("testcase"):
         cn = el.attrib["classname"]
         for sk in el.findall("skipped"):
             old_class = current_class


### PR DESCRIPTION
- [X] closes #30040
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Looks like the format of the junit file that pytest generates has changed, and now tests are inside a `testsuite` tag, which makes the script to not find any tests. Instead of looking for them as immediate children of `testcase`, I look for them in all the tree (including subchildren).

CC: @jorisvandenbossche 