### PR TITLE
CI: correct azure-36-locale slow name + move pyarrow

### DIFF
--- a/ci/azure/posix.yml
+++ b/ci/azure/posix.yml
@@ -20,14 +20,14 @@ jobs:
           CONDA_PY: "36"
           PATTERN: "not slow and not network"
         py36_locale_slow_old_np:
-          ENV_FILE: ci/deps/azure-36-locale.yaml
+          ENV_FILE: ci/deps/azure-36-locale_slow.yaml
           CONDA_PY: "36"
           PATTERN: "slow"
           LOCALE_OVERRIDE: "zh_CN.UTF-8"
           EXTRA_APT: "language-pack-zh-hans"
 
-        py36_locale_slow:
-          ENV_FILE: ci/deps/azure-36-locale_slow.yaml
+        py36_locale:
+          ENV_FILE: ci/deps/azure-36-locale.yaml
           CONDA_PY: "36"
           PATTERN: "not slow and not network"
           LOCALE_OVERRIDE: "it_IT.UTF-8"

--- a/ci/deps/azure-36-locale.yaml
+++ b/ci/deps/azure-36-locale.yaml
@@ -13,23 +13,27 @@ dependencies:
   - pytest-azurepipelines
 
   # pandas dependencies
-  - beautifulsoup4==4.6.0
-  - bottleneck=1.2.*
+  - beautifulsoup4
+  - gcsfs
+  - html5lib
+  - ipython
+  - jinja2
   - lxml
-  - matplotlib=2.2.2
-  - numpy=1.14.*
-  - openpyxl=2.4.8
-  - python-dateutil
-  - python-blosc
-  - pytz=2017.2
-  - scipy
-  - sqlalchemy=1.1.4
-  - xlrd=1.1.0
-  - xlsxwriter=0.9.8
-  - xlwt=1.2.0
+  - matplotlib=3.0.*
+  - nomkl
+  - numexpr
+  - numpy=1.15.*
+  - openpyxl
   # lowest supported version of pyarrow (putting it here instead of in
   # azure-36-minimum_versions because it needs numpy >= 1.14)
   - pyarrow=0.12
-  - pip
-  - pip:
-    - html5lib==1.0b2
+  - pytables
+  - python-dateutil
+  - pytz
+  - s3fs
+  - scipy
+  - xarray
+  - xlrd
+  - xlsxwriter
+  - xlwt
+  - moto

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -13,24 +13,20 @@ dependencies:
   - pytest-azurepipelines
 
   # pandas dependencies
-  - beautifulsoup4
-  - gcsfs
-  - html5lib
-  - ipython
-  - jinja2
+  - beautifulsoup4==4.6.0
+  - bottleneck=1.2.*
   - lxml
-  - matplotlib=3.0.*
-  - nomkl
-  - numexpr
-  - numpy=1.15.*
-  - openpyxl
-  - pytables
+  - matplotlib=2.2.2
+  - numpy=1.14.*
+  - openpyxl=2.4.8
   - python-dateutil
-  - pytz
-  - s3fs
+  - python-blosc
+  - pytz=2017.2
   - scipy
-  - xarray
-  - xlrd
-  - xlsxwriter
-  - xlwt
-  - moto
+  - sqlalchemy=1.1.4
+  - xlrd=1.1.0
+  - xlsxwriter=0.9.8
+  - xlwt=1.2.0
+  - pip
+  - pip:
+    - html5lib==1.0b2


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/30039

I put it in the wrong file, because the file names were swapped...

Now, here, I just renamed both files to the other name (the diff apparently cannot the rename, therefore you see a lot of changes, but I can ensure I didn't change anything except for pyarrow). 
But, I could also leave the files as is and switch them in the posix.yml file ? (use the envs for the different build)

I don't know if there was something specific in either environment that was specifically added for the slow tests?

cc @datapythonista 