### PR TITLE
Remove legacy scipy compat

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1248,10 +1248,9 @@ def get_corr_func(method):
         return np.corrcoef(a, b)[0, 1]
 
     def _kendall(a, b):
+        # kendallttau returns a tuple of the tau statistic and pvalue
         rs = kendalltau(a, b)
-        if isinstance(rs, tuple):
-            return rs[0]
-        return rs
+        return rs[0]
 
     def _spearman(a, b):
         return spearmanr(a, b)[0]


### PR DESCRIPTION
AFAICT from the scipy blame, it has been at least 16 years since scipy.stats.kendalltau returned anything but a tuple