### PR TITLE
Fixes Error thrown when None is passed to pd.to_datetime() with format as %Y%m%d

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -652,7 +652,7 @@ Datetimelike
 - Bug in :meth:`Series.var` failing to raise ``TypeError`` when called with ``timedelta64[ns]`` dtype (:issue:`28289`)
 - Bug in :meth:`DatetimeIndex.strftime` and :meth:`Series.dt.strftime` where ``NaT`` was converted to the string ``'NaT'`` instead of ``np.nan`` (:issue:`29578`)
 - Bug in :attr:`Timestamp.resolution` being a property instead of a class attribute (:issue:`29910`)
-- Bug in :func:`pandas.core.tools.datetimes._attempt_YYYYMMDD` to_datetime() when called with ``None`` raising ``TypeError`` instead of returning ``NaT``. After changes it will return ``NaT`` (:issue:`30011`)
+- Bug in :func:`pandas.to_datetime` when called with ``None`` raising ``TypeError`` instead of returning ``NaT`` (:issue:`30011`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -652,6 +652,7 @@ Datetimelike
 - Bug in :meth:`Series.var` failing to raise ``TypeError`` when called with ``timedelta64[ns]`` dtype (:issue:`28289`)
 - Bug in :meth:`DatetimeIndex.strftime` and :meth:`Series.dt.strftime` where ``NaT`` was converted to the string ``'NaT'`` instead of ``np.nan`` (:issue:`29578`)
 - Bug in :attr:`Timestamp.resolution` being a property instead of a class attribute (:issue:`29910`)
+- Bug in :func:`pandas.core.tools.datetimes._attempt_YYYYMMDD` to_datetime() when called with ``None`` raising ``TypeError`` instead of returning ``NaT``. After changes it will return ``NaT`` (:issue:`30011`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -947,14 +947,14 @@ def _attempt_YYYYMMDD(arg, errors):
     try:
         carg = arg.astype(np.float64)
         return calc_with_mask(carg, notna(carg))
-    except (ValueError, OverflowError):
+    except (ValueError, OverflowError, TypeError):
         pass
 
     # string with NaN-like
     try:
         mask = ~algorithms.isin(arg, list(tslib.nat_strings))
         return calc_with_mask(arg, mask)
-    except (ValueError, OverflowError):
+    except (ValueError, OverflowError, TypeError):
         pass
 
     return None

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -940,7 +940,7 @@ def _attempt_YYYYMMDD(arg, errors):
     # try intlike / strings that are ints
     try:
         return calc(arg.astype(np.int64))
-    except (ValueError, OverflowError):
+    except (ValueError, OverflowError, TypeError):
         pass
 
     # a float with actual np.nan

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -107,15 +107,16 @@ class TestTimeConversionFormats:
             # None with Strings
             Series(["19801222", None, "20010112"]),
             # None with Integers
-            Series([19801222, None, 20010112])
+            Series([19801222, None, 20010112]),
         ],
     )
     def test_to_datetime_format_YYYYMMDD_with_none(self, input_s):
         # GH 30011
         # format='%Y%m%d'
         # with None
-        expected = Series([Timestamp("19801222"), Timestamp(None),
-                           Timestamp("20010112")])
+        expected = Series(
+            [Timestamp("19801222"), Timestamp(None), Timestamp("20010112")]
+        )
         result = pd.to_datetime(input_s, format="%Y%m%d")
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -105,9 +105,9 @@ class TestTimeConversionFormats:
         "input_s",
         [
             # None with Strings
-            Series(["19801222", None, "20010112"]),
+            Series(["19801222", None, "20010112", np.nan, "NaT", pd.NaT]),
             # None with Integers
-            Series([19801222, None, 20010112]),
+            Series([19801222, None, 20010112, np.nan, "NaT", pd.NaT]),
         ],
     )
     def test_to_datetime_format_YYYYMMDD_with_none(self, input_s):
@@ -115,7 +115,14 @@ class TestTimeConversionFormats:
         # format='%Y%m%d'
         # with None
         expected = Series(
-            [Timestamp("19801222"), Timestamp(None), Timestamp("20010112")]
+            [
+                Timestamp("19801222"),
+                Timestamp(None),
+                Timestamp("20010112"),
+                Timestamp(np.nan),
+                Timestamp("NaT"),
+                Timestamp(pd.NaT),
+            ]
         )
         result = pd.to_datetime(input_s, format="%Y%m%d")
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -104,27 +104,24 @@ class TestTimeConversionFormats:
     @pytest.mark.parametrize(
         "input_s",
         [
-            # None with Strings
-            Series(["19801222", None, "20010112", np.nan, "NaT", pd.NaT]),
-            # None with Integers
-            Series([19801222, None, 20010112, np.nan, "NaT", pd.NaT]),
+            # Null values with Strings
+            ["19801222", "20010112", None],
+            ["19801222", "20010112", np.nan],
+            ["19801222", "20010112", pd.NaT],
+            ["19801222", "20010112", "NaT"],
+            # Null values with Integers
+            [19801222, 20010112, None],
+            [19801222, 20010112, np.nan],
+            [19801222, 20010112, pd.NaT],
+            [19801222, 20010112, "NaT"],
         ],
     )
     def test_to_datetime_format_YYYYMMDD_with_none(self, input_s):
         # GH 30011
         # format='%Y%m%d'
         # with None
-        expected = Series(
-            [
-                Timestamp("19801222"),
-                Timestamp(None),
-                Timestamp("20010112"),
-                Timestamp(np.nan),
-                Timestamp("NaT"),
-                Timestamp(pd.NaT),
-            ]
-        )
-        result = pd.to_datetime(input_s, format="%Y%m%d")
+        expected = Series([Timestamp("19801222"), Timestamp("20010112"), pd.NaT])
+        result = Series(pd.to_datetime(input_s, format="%Y%m%d"))
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -104,6 +104,25 @@ class TestTimeConversionFormats:
     @pytest.mark.parametrize(
         "input_s, expected",
         [
+            # strings with None
+            [
+                Series(["19801222", None, "20010112"]),
+                Series([Timestamp("19801222"), Timestamp(None), Timestamp("20010112")]),
+            ],
+            # Integers with None
+            [
+                Series([19801222, None, 20010112]),
+                Series([Timestamp("19801222"), Timestamp(None), Timestamp("20010112")]),
+            ],
+        ],
+    )
+    def test_to_datetime_format_YYYYMMDD_with_none(self, input_s, expected):
+        result = pd.to_datetime(input_s, format="%Y%m%d")
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "input_s, expected",
+        [
             # NaN before strings with invalid date values
             [
                 Series(["19801222", np.nan, "20010012", "10019999"]),

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -102,6 +102,24 @@ class TestTimeConversionFormats:
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
+        "input_s",
+        [
+            # None with Strings
+            Series(["19801222", None, "20010112"]),
+            # None with Integers
+            Series([19801222, None, 20010112])
+        ],
+    )
+    def test_to_datetime_format_YYYYMMDD_with_none(self,input_s):
+        # GH 30011
+        # format='%Y%m%d'
+        # with None
+        expected = Series([Timestamp("19801222"), Timestamp(None),Timestamp("20010112")])
+
+        result = pd.to_datetime(input_s, format="%Y%m%d")
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
         "input_s, expected",
         [
             # NaN before strings with invalid date values


### PR DESCRIPTION
- [ ] closes #30011 
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry `bug fix of to_datetime for pandas versions >0.24. Now the change will avoid error even when value passed None to to_datetime`
