### PR TITLE
BUG: file leak in read_excel

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -892,6 +892,12 @@ class ExcelFile:
 
     def close(self):
         """close io if necessary"""
+        if self.engine == "openpyxl":
+            # https://stackoverflow.com/questions/31416842/
+            #  openpyxl-does-not-close-excel-workbook-in-read-only-mode
+            wb = self.book
+            wb._archive.close()
+
         if hasattr(self.io, "close"):
             self.io.close()
 
@@ -899,4 +905,8 @@ class ExcelFile:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def __del__(self):
+        # Ensure we don't leak file descriptors
         self.close()

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -543,6 +543,7 @@ class TestReaders:
         tm.assert_frame_equal(expected, actual)
 
     @td.skip_if_no("py.path")
+    @td.check_file_leaks
     def test_read_from_py_localpath(self, read_ext):
 
         # GH12655
@@ -881,6 +882,7 @@ class TestExcelFileRead:
         tm.assert_frame_equal(parsed, expected)
 
     @pytest.mark.parametrize("arg", ["sheet", "sheetname", "parse_cols"])
+    @td.check_file_leaks
     def test_unexpected_kwargs_raises(self, read_ext, arg):
         # gh-17964
         kwarg = {arg: "Sheet1"}

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -809,6 +809,7 @@ class TestExcelWriter:
             )
             tm.assert_frame_equal(result, expected)
 
+    # FIXME: dont leave commented-out
     # def test_to_excel_header_styling_xls(self, engine, ext):
 
     #     import StringIO


### PR DESCRIPTION
I _think_ this 
closes #30031
closes #29514 
 we'll probably want to wait a few days to make it official.

To make the new test decorator useful in the CI we'll need to add psutil to the environment (unless someone knows of a stdlib way of doing the same check?)

One more note, the check in check_no_file_leaks depends on `__del__` having been called, which in turn depends on the gc.  I'm not sure, but that might induce another layer of flakiness.  If so, I think that can be fixed by calling `gc.collect()` before doing the `flist == flist2` check