### PR TITLE
REF: implement io.pytables.DataCol._get_atom

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -34,10 +34,12 @@ from pandas.util._decorators import cache_readonly
 from pandas.core.dtypes.common import (
     ensure_object,
     is_categorical_dtype,
+    is_complex_dtype,
     is_datetime64_dtype,
     is_datetime64tz_dtype,
     is_extension_array_dtype,
     is_list_like,
+    is_string_dtype,
     is_timedelta64_dtype,
 )
 from pandas.core.dtypes.generic import ABCExtensionArray
@@ -2370,14 +2372,14 @@ class DataCol(IndexCol):
         if is_categorical_dtype(dtype):
             codes = values.codes
             atom = cls.get_atom_data(shape, kind=codes.dtype.name)
-        elif dtype.kind == "M":
+        elif is_datetime64_dtype(dtype) or is_datetime64tz_dtype(dtype):
             atom = cls.get_atom_datetime64(shape)
-        elif dtype.kind == "m":
+        elif is_timedelta64_dtype(dtype):
             atom = cls.get_atom_timedelta64(shape)
-        elif dtype.kind == "c":
+        elif is_complex_dtype(dtype):
             atom = _tables().ComplexCol(itemsize=itemsize, shape=shape[0])
 
-        elif dtype.kind == "S":
+        elif is_string_dtype(dtype):
             atom = cls.get_atom_string(shape, itemsize)
 
         else:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2389,7 +2389,6 @@ class DataCol(IndexCol):
 
     def set_atom_string(self, data_converted: np.ndarray):
         self.kind = "string"
-        self.typ = self._get_atom(data_converted)
         self.set_data(data_converted)
 
     def get_atom_coltype(self, kind: str) -> Type["Col"]:
@@ -2408,12 +2407,10 @@ class DataCol(IndexCol):
 
     def set_atom_complex(self, block):
         self.kind = block.dtype.name
-        self.typ = self._get_atom(block.values)
         self.set_data(block.values)
 
     def set_atom_data(self, block):
         self.kind = block.dtype.name
-        self.typ = self._get_atom(block.values)
         self.set_data(block.values)
 
     def set_atom_categorical(self, block):
@@ -2430,7 +2427,6 @@ class DataCol(IndexCol):
 
         # write the codes; must be in a block shape
         self.ordered = values.ordered
-        self.typ = self._get_atom(block.values)
         self.set_data(block.values)
 
         # write the categories
@@ -2444,7 +2440,6 @@ class DataCol(IndexCol):
 
     def set_atom_datetime64(self, block):
         self.kind = "datetime64"
-        self.typ = self._get_atom(block.values)
         self.set_data(block.values)
 
     def set_atom_datetime64tz(self, block):
@@ -2453,7 +2448,6 @@ class DataCol(IndexCol):
         self.tz = _get_tz(block.values.tz)
 
         self.kind = "datetime64"
-        self.typ = self._get_atom(block.values)
         self.set_data(block.values)
 
     def get_atom_timedelta64(self, shape):
@@ -2461,7 +2455,6 @@ class DataCol(IndexCol):
 
     def set_atom_timedelta64(self, block):
         self.kind = "timedelta64"
-        self.typ = self._get_atom(block.values)
         self.set_data(block.values)
 
     @property
@@ -3953,6 +3946,7 @@ class Table(Fixed):
 
             col = klass.create_for_block(i=i, name=new_name, version=self.version)
             col.values = list(b_items)
+            col.typ = col._get_atom(data_converted)
             col.set_atom(block=b, data_converted=data_converted, use_str=use_str)
             col.update_info(self.info)
             col.set_pos(j)


### PR DESCRIPTION
companion to #30101 with promised payoff (logically orthgonal, but will have merge conflict when the time comes)

This implements _get_atom and makes only one call to it on 3949.  By making all the relevant methods into classmethods, we can call it before we've instantiated an instance.  Then following #30100, we'll be able to pass `typ` to the constructor instead of pinning it.  This in turn will let us pass `pos` instead of calling `set_pos`.

Also after both this and #30101, we can get to rip out a bunch of no-longer-needed state-altering methods.