### PR TITLE
DEPR: Index.contains, DatetimeIndex.offset

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -618,7 +618,6 @@ generated/pandas.Index.asi8,../reference/api/pandas.Index.asi8
 generated/pandas.Index.asof,../reference/api/pandas.Index.asof
 generated/pandas.Index.asof_locs,../reference/api/pandas.Index.asof_locs
 generated/pandas.Index.astype,../reference/api/pandas.Index.astype
-generated/pandas.Index.contains,../reference/api/pandas.Index.contains
 generated/pandas.Index.copy,../reference/api/pandas.Index.copy
 generated/pandas.Index.data,../reference/api/pandas.Index.data
 generated/pandas.Index.delete,../reference/api/pandas.Index.delete

--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -151,7 +151,6 @@ Selecting
 
    Index.asof
    Index.asof_locs
-   Index.contains
    Index.get_indexer
    Index.get_indexer_for
    Index.get_indexer_non_unique

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -546,6 +546,8 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 - Removed support for nested renaming in :meth:`DataFrame.aggregate`, :meth:`Series.aggregate`, :meth:`DataFrameGroupBy.aggregate`, :meth:`SeriesGroupBy.aggregate`, :meth:`Rolling.aggregate` (:issue:`18529`)
 - Passing ``datetime64`` data to :class:`TimedeltaIndex` or ``timedelta64`` data to ``DatetimeIndex`` now raises ``TypeError`` (:issue:`23539`, :issue:`23937`)
 - A tuple passed to :meth:`DataFrame.groupby` is now exclusively treated as a single key (:issue:`18314`)
+- Removed the previously deprecated :meth:`Index.contains`, use ``key in index`` instead (:issue:`?????`)
+- Removed the previously deprecated :attr:`RangeIndex._start`, :attr:`RangeIndex._stop`, :atttr:`RangeIndex._step` (:issue:`26581`)
 - Removed :meth:`Series.from_array` (:issue:`18258`)
 - Removed :meth:`DataFrame.from_items` (:issue:`18458`)
 - Removed :meth:`DataFrame.as_matrix`, :meth:`Series.as_matrix` (:issue:`18458`)

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -546,7 +546,7 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 - Removed support for nested renaming in :meth:`DataFrame.aggregate`, :meth:`Series.aggregate`, :meth:`DataFrameGroupBy.aggregate`, :meth:`SeriesGroupBy.aggregate`, :meth:`Rolling.aggregate` (:issue:`18529`)
 - Passing ``datetime64`` data to :class:`TimedeltaIndex` or ``timedelta64`` data to ``DatetimeIndex`` now raises ``TypeError`` (:issue:`23539`, :issue:`23937`)
 - A tuple passed to :meth:`DataFrame.groupby` is now exclusively treated as a single key (:issue:`18314`)
-- Removed the previously deprecated :meth:`Index.contains`, use ``key in index`` instead (:issue:`?????`)
+- Removed the previously deprecated :meth:`Index.contains`, use ``key in index`` instead (:issue:`30103`)
 - Removed the previously deprecated :attr:`RangeIndex._start`, :attr:`RangeIndex._stop`, :atttr:`RangeIndex._step` (:issue:`26581`)
 - Removed :meth:`Series.from_array` (:issue:`18258`)
 - Removed :meth:`DataFrame.from_items` (:issue:`18458`)

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -547,7 +547,6 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 - Passing ``datetime64`` data to :class:`TimedeltaIndex` or ``timedelta64`` data to ``DatetimeIndex`` now raises ``TypeError`` (:issue:`23539`, :issue:`23937`)
 - A tuple passed to :meth:`DataFrame.groupby` is now exclusively treated as a single key (:issue:`18314`)
 - Removed the previously deprecated :meth:`Index.contains`, use ``key in index`` instead (:issue:`30103`)
-- Removed the previously deprecated :attr:`RangeIndex._start`, :attr:`RangeIndex._stop`, :atttr:`RangeIndex._step` (:issue:`26581`)
 - Removed :meth:`Series.from_array` (:issue:`18258`)
 - Removed :meth:`DataFrame.from_items` (:issue:`18458`)
 - Removed :meth:`DataFrame.as_matrix`, :meth:`Series.as_matrix` (:issue:`18458`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3994,26 +3994,6 @@ class Index(IndexOpsMixin, PandasObject):
         except (OverflowError, TypeError, ValueError):
             return False
 
-    def contains(self, key) -> bool:
-        """
-        Return a boolean indicating whether the provided key is in the index.
-
-        .. deprecated:: 0.25.0
-            Use ``key in index`` instead of ``index.contains(key)``.
-
-        Returns
-        -------
-        bool
-        """
-        warnings.warn(
-            "The 'contains' method is deprecated and will be removed in a "
-            "future version. Use 'key in index' instead of "
-            "'index.contains(key)'",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return key in self
-
     def __hash__(self):
         raise TypeError(f"unhashable type: {repr(type(self).__name__)}")
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1147,34 +1147,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index, DatetimeDelegateMixin):
 
     _has_same_tz = ea_passthrough(DatetimeArray._has_same_tz)
 
-    @property
-    def offset(self):
-        """
-        get/set the frequency of the instance
-        """
-        msg = (
-            "{cls}.offset has been deprecated and will be removed "
-            "in a future version; use {cls}.freq instead.".format(
-                cls=type(self).__name__
-            )
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-        return self.freq
-
-    @offset.setter
-    def offset(self, value):
-        """
-        get/set the frequency of the instance
-        """
-        msg = (
-            "{cls}.offset has been deprecated and will be removed "
-            "in a future version; use {cls}.freq instead.".format(
-                cls=type(self).__name__
-            )
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-        self._data.freq = value
-
     def __getitem__(self, key):
         result = self._data.__getitem__(key)
         if is_scalar(result):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 import operator
 from sys import getsizeof
 from typing import Optional, Union
+import warnings
 
 import numpy as np
 
@@ -214,12 +215,43 @@ class RangeIndex(Int64Index):
         # GH 25710
         return self._range.start
 
+    @property
+    def _start(self):
+        """
+        The value of the `start` parameter (``0`` if this was not supplied).
+
+         .. deprecated:: 0.25.0
+            Use ``start`` instead.
+        """
+        warnings.warn(
+            self._deprecation_message.format("_start", "start"),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.start
+
     @cache_readonly
     def stop(self):
         """
         The value of the `stop` parameter.
         """
         return self._range.stop
+
+    @property
+    def _stop(self):
+        """
+        The value of the `stop` parameter.
+
+         .. deprecated:: 0.25.0
+            Use ``stop`` instead.
+        """
+        # GH 25710
+        warnings.warn(
+            self._deprecation_message.format("_stop", "stop"),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.stop
 
     @cache_readonly
     def step(self):
@@ -228,6 +260,22 @@ class RangeIndex(Int64Index):
         """
         # GH 25710
         return self._range.step
+
+    @property
+    def _step(self):
+        """
+        The value of the `step` parameter (``1`` if this was not supplied).
+
+         .. deprecated:: 0.25.0
+            Use ``step`` instead.
+        """
+        # GH 25710
+        warnings.warn(
+            self._deprecation_message.format("_step", "step"),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.step
 
     @cache_readonly
     def nbytes(self) -> int:

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 import operator
 from sys import getsizeof
 from typing import Optional, Union
-import warnings
 
 import numpy as np
 
@@ -215,43 +214,12 @@ class RangeIndex(Int64Index):
         # GH 25710
         return self._range.start
 
-    @property
-    def _start(self):
-        """
-        The value of the `start` parameter (``0`` if this was not supplied).
-
-         .. deprecated:: 0.25.0
-            Use ``start`` instead.
-        """
-        warnings.warn(
-            self._deprecation_message.format("_start", "start"),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.start
-
     @cache_readonly
     def stop(self):
         """
         The value of the `stop` parameter.
         """
         return self._range.stop
-
-    @property
-    def _stop(self):
-        """
-        The value of the `stop` parameter.
-
-         .. deprecated:: 0.25.0
-            Use ``stop`` instead.
-        """
-        # GH 25710
-        warnings.warn(
-            self._deprecation_message.format("_stop", "stop"),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.stop
 
     @cache_readonly
     def step(self):
@@ -260,22 +228,6 @@ class RangeIndex(Int64Index):
         """
         # GH 25710
         return self._range.step
-
-    @property
-    def _step(self):
-        """
-        The value of the `step` parameter (``1`` if this was not supplied).
-
-         .. deprecated:: 0.25.0
-            Use ``step`` instead.
-        """
-        # GH 25710
-        warnings.warn(
-            self._deprecation_message.format("_step", "step"),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.step
 
     @cache_readonly
     def nbytes(self) -> int:

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -437,18 +437,6 @@ class TestDatetimeIndexOps(Ops):
         with pytest.raises(ValueError, match="Invalid frequency"):
             idx._data.freq = "foo"
 
-    def test_offset_deprecated(self):
-        # GH 20716
-        idx = pd.DatetimeIndex(["20180101", "20180102"])
-
-        # getter deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            idx.offset
-
-        # setter deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            idx.offset = BDay()
-
 
 class TestBusinessDatetimeIndex:
     def setup_method(self, method):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2405,10 +2405,10 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
             with provisionalcompleter("ignore"):
                 list(ip.Completer.completions("idx.", 4))
 
-    def test_deprecated_contains(self, indices):
-        # deprecated for all types except IntervalIndex
-        warning = FutureWarning if not isinstance(indices, pd.IntervalIndex) else None
-        with tm.assert_produces_warning(warning):
+    def test_contains_method_removed(self, indices):
+        # method removed for all types except IntervalIndex
+        err = AttributeError if not isinstance(indices, pd.IntervalIndex) else None
+        with pytest.raises(err):
             indices.contains(1)
 
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2407,9 +2407,11 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
 
     def test_contains_method_removed(self, indices):
         # GH#30103 method removed for all types except IntervalIndex
-        err = AttributeError if not isinstance(indices, pd.IntervalIndex) else None
-        with pytest.raises(err):
+        if isinstance(indices, pd.IntervalIndex):
             indices.contains(1)
+        else:
+            with pytest.raises(AttributeError):
+                indices.contains(1)
 
 
 class TestMixedIntIndex(Base):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2406,7 +2406,7 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
                 list(ip.Completer.completions("idx.", 4))
 
     def test_contains_method_removed(self, indices):
-        # method removed for all types except IntervalIndex
+        # GH#30103 method removed for all types except IntervalIndex
         err = AttributeError if not isinstance(indices, pd.IntervalIndex) else None
         with pytest.raises(err):
             indices.contains(1)

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -205,13 +205,6 @@ class TestRangeIndex(Numeric):
         assert index.stop == stop
         assert index.step == step
 
-    @pytest.mark.parametrize("attr_name", ["_start", "_stop", "_step"])
-    def test_deprecated_start_stop_step_attrs(self, attr_name):
-        # GH 26581
-        idx = self.create_index()
-        with tm.assert_produces_warning(DeprecationWarning):
-            getattr(idx, attr_name)
-
     def test_copy(self):
         i = RangeIndex(5, name="Foo")
         i_copy = i.copy()
@@ -304,14 +297,6 @@ class TestRangeIndex(Numeric):
         assert idx._cached_data is None
 
         91 in idx
-        assert idx._cached_data is None
-
-        with tm.assert_produces_warning(FutureWarning):
-            idx.contains(90)
-        assert idx._cached_data is None
-
-        with tm.assert_produces_warning(FutureWarning):
-            idx.contains(91)
         assert idx._cached_data is None
 
         idx.all()

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -205,6 +205,13 @@ class TestRangeIndex(Numeric):
         assert index.stop == stop
         assert index.step == step
 
+    @pytest.mark.parametrize("attr_name", ["_start", "_stop", "_step"])
+    def test_deprecated_start_stop_step_attrs(self, attr_name):
+        # GH 26581
+        idx = self.create_index()
+        with tm.assert_produces_warning(DeprecationWarning):
+            getattr(idx, attr_name)
+
     def test_copy(self):
         i = RangeIndex(5, name="Foo")
         i_copy = i.copy()


### PR DESCRIPTION
DatetimeIndex.offset I thought was removed in #29801, but apparently slipped through the cracks.