### PR TITLE
DEPR: integer add/sub for Timestamp, DatetimeIndex, TimedeltaIndex

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -547,6 +547,7 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 - Removed support for nested renaming in :meth:`DataFrame.aggregate`, :meth:`Series.aggregate`, :meth:`DataFrameGroupBy.aggregate`, :meth:`SeriesGroupBy.aggregate`, :meth:`Rolling.aggregate` (:issue:`18529`)
 - Passing ``datetime64`` data to :class:`TimedeltaIndex` or ``timedelta64`` data to ``DatetimeIndex`` now raises ``TypeError`` (:issue:`23539`, :issue:`23937`)
 - A tuple passed to :meth:`DataFrame.groupby` is now exclusively treated as a single key (:issue:`18314`)
+- Addition and subtraction of ``int`` or integer-arrays is no longer allowed in :class:`Timestamp`, :class:`DatetimeIndex`, :class:`TimedeltaIndex`, use ``obj + n * obj.freq`` instead of ``obj + n`` (:issue:`22535`)
 - Removed :meth:`Series.from_array` (:issue:`18258`)
 - Removed :meth:`DataFrame.from_items` (:issue:`18458`)
 - Removed :meth:`DataFrame.as_matrix`, :meth:`Series.as_matrix` (:issue:`18458`)

--- a/pandas/_libs/tslibs/c_timestamp.pyx
+++ b/pandas/_libs/tslibs/c_timestamp.pyx
@@ -56,10 +56,6 @@ def integer_op_not_supported(obj):
     # Note we return rather than raise the exception so we can raise in
     #  the caller; mypy finds this more palatable.
     cls = type(obj).__name__
-    if obj.freq is None:
-        return NullFrequencyError(
-            f"Cannot add integral value to {cls} without freq."
-        )
 
     int_addsub_msg = (
         f"Addition/subtraction of integers and integer-arrays with {cls} is "

--- a/pandas/_libs/tslibs/c_timestamp.pyx
+++ b/pandas/_libs/tslibs/c_timestamp.pyx
@@ -51,15 +51,22 @@ class NullFrequencyError(ValueError):
     pass
 
 
-def maybe_integer_op_deprecated(obj):
-    # GH#22535 add/sub of integers and int-arrays is deprecated
-    if obj.freq is not None:
-        warnings.warn("Addition/subtraction of integers and integer-arrays "
-                      f"to {type(obj).__name__} is deprecated, "
-                      "will be removed in a future "
-                      "version.  Instead of adding/subtracting `n`, use "
-                      "`n * self.freq`"
-                      , FutureWarning)
+def integer_op_not_supported(obj):
+    # GH#22535 add/sub of integers and int-arrays is no longer allowed
+    # Note we return rather than raise the exception so we can raise in
+    #  the caller; mypy finds this more palatable.
+    cls = type(obj).__name__
+    if obj.freq is None:
+        return NullFrequencyError(
+            f"Cannot add integral value to {cls} without freq."
+        )
+
+    int_addsub_msg = (
+        f"Addition/subtraction of integers and integer-arrays with {cls} is "
+        "no longer supported.  Instead of adding/subtracting `n`, "
+        "use `n * obj.freq`"
+    )
+    return TypeError(int_addsub_msg)
 
 
 cdef class _Timestamp(datetime):
@@ -229,15 +236,7 @@ cdef class _Timestamp(datetime):
             return type(self)(self.value + other_int, tz=self.tzinfo, freq=self.freq)
 
         elif is_integer_object(other):
-            maybe_integer_op_deprecated(self)
-
-            if self is NaT:
-                # to be compat with Period
-                return NaT
-            elif self.freq is None:
-                raise NullFrequencyError(
-                    "Cannot add integral value to Timestamp without freq.")
-            return type(self)((self.freq * other).apply(self), freq=self.freq)
+            raise integer_op_not_supported(self)
 
         elif PyDelta_Check(other) or hasattr(other, 'delta'):
             # delta --> offsets.Tick
@@ -256,12 +255,7 @@ cdef class _Timestamp(datetime):
 
         elif is_array(other):
             if other.dtype.kind in ['i', 'u']:
-                maybe_integer_op_deprecated(self)
-                if self.freq is None:
-                    raise NullFrequencyError(
-                        "Cannot add integer-dtype array "
-                        "to Timestamp without freq.")
-                return self.freq * other + self
+                raise integer_op_not_supported(self)
 
         # index/series like
         elif hasattr(other, '_typ'):
@@ -283,12 +277,7 @@ cdef class _Timestamp(datetime):
 
         elif is_array(other):
             if other.dtype.kind in ['i', 'u']:
-                maybe_integer_op_deprecated(self)
-                if self.freq is None:
-                    raise NullFrequencyError(
-                        "Cannot subtract integer-dtype array "
-                        "from Timestamp without freq.")
-                return self - self.freq * other
+                raise integer_op_not_supported(self)
 
         typ = getattr(other, '_typ', None)
         if typ is not None:

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1207,7 +1207,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             # This check must come after the check for np.timedelta64
             # as is_integer returns True for these
             if not is_period_dtype(self):
-                raise integer_op_not_supported(self)  # TODO: but not for Period?
+                raise integer_op_not_supported(self)
             result = self._time_shift(other)
 
         # array-like others
@@ -1222,7 +1222,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             return self._add_datetime_arraylike(other)
         elif is_integer_dtype(other):
             if not is_period_dtype(self):
-                raise integer_op_not_supported(self)  # TODO: but not for Period?
+                raise integer_op_not_supported(self)
             result = self._addsub_int_array(other, operator.add)
         else:
             # Includes Categorical, other ExtensionArrays
@@ -1259,7 +1259,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             # This check must come after the check for np.timedelta64
             # as is_integer returns True for these
             if not is_period_dtype(self):
-                raise integer_op_not_supported(self)  # TODO: but not for Period?
+                raise integer_op_not_supported(self)
             result = self._time_shift(-other)
 
         elif isinstance(other, Period):
@@ -1280,7 +1280,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             result = self._sub_period_array(other)
         elif is_integer_dtype(other):
             if not is_period_dtype(self):
-                raise integer_op_not_supported(self)  # TODO: but not for Period?
+                raise integer_op_not_supported(self)
             result = self._addsub_int_array(other, operator.sub)
         else:
             # Includes ExtensionArrays, float_dtype

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 from pandas._libs import NaT, NaTType, Timestamp, algos, iNaT, lib
-from pandas._libs.tslibs.c_timestamp import maybe_integer_op_deprecated
+from pandas._libs.tslibs.c_timestamp import integer_op_not_supported
 from pandas._libs.tslibs.period import DIFFERENT_FREQ, IncompatibleFrequency, Period
 from pandas._libs.tslibs.timedeltas import Timedelta, delta_to_nanoseconds
 from pandas._libs.tslibs.timestamps import RoundTo, round_nsint64
@@ -1207,7 +1207,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             # This check must come after the check for np.timedelta64
             # as is_integer returns True for these
             if not is_period_dtype(self):
-                maybe_integer_op_deprecated(self)
+                raise integer_op_not_supported(self)  # TODO: but not for Period?
             result = self._time_shift(other)
 
         # array-like others
@@ -1222,7 +1222,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             return self._add_datetime_arraylike(other)
         elif is_integer_dtype(other):
             if not is_period_dtype(self):
-                maybe_integer_op_deprecated(self)
+                raise integer_op_not_supported(self)  # TODO: but not for Period?
             result = self._addsub_int_array(other, operator.add)
         else:
             # Includes Categorical, other ExtensionArrays
@@ -1259,7 +1259,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             # This check must come after the check for np.timedelta64
             # as is_integer returns True for these
             if not is_period_dtype(self):
-                maybe_integer_op_deprecated(self)
+                raise integer_op_not_supported(self)  # TODO: but not for Period?
             result = self._time_shift(-other)
 
         elif isinstance(other, Period):
@@ -1280,7 +1280,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             result = self._sub_period_array(other)
         elif is_integer_dtype(other):
             if not is_period_dtype(self):
-                maybe_integer_op_deprecated(self)
+                raise integer_op_not_supported(self)  # TODO: but not for Period?
             result = self._addsub_int_array(other, operator.sub)
         else:
             # Includes ExtensionArrays, float_dtype

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1945,34 +1945,30 @@ class TestDatetimeIndexArithmetic:
         # Variants of `one` for #19012
         tz = tz_naive_fixture
         rng = pd.date_range("2000-01-01 09:00", freq="H", periods=10, tz=tz)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = rng + one
-        expected = pd.date_range("2000-01-01 10:00", freq="H", periods=10, tz=tz)
-        tm.assert_index_equal(result, expected)
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
+            rng + one
 
     def test_dti_iadd_int(self, tz_naive_fixture, one):
         tz = tz_naive_fixture
         rng = pd.date_range("2000-01-01 09:00", freq="H", periods=10, tz=tz)
-        expected = pd.date_range("2000-01-01 10:00", freq="H", periods=10, tz=tz)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
             rng += one
-        tm.assert_index_equal(rng, expected)
 
     def test_dti_sub_int(self, tz_naive_fixture, one):
         tz = tz_naive_fixture
         rng = pd.date_range("2000-01-01 09:00", freq="H", periods=10, tz=tz)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = rng - one
-        expected = pd.date_range("2000-01-01 08:00", freq="H", periods=10, tz=tz)
-        tm.assert_index_equal(result, expected)
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
+            rng - one
 
     def test_dti_isub_int(self, tz_naive_fixture, one):
         tz = tz_naive_fixture
         rng = pd.date_range("2000-01-01 09:00", freq="H", periods=10, tz=tz)
-        expected = pd.date_range("2000-01-01 08:00", freq="H", periods=10, tz=tz)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
             rng -= one
-        tm.assert_index_equal(rng, expected)
 
     # -------------------------------------------------------------
     # __add__/__sub__ with integer arrays
@@ -1984,14 +1980,13 @@ class TestDatetimeIndexArithmetic:
         dti = pd.date_range("2016-01-01", periods=2, freq=freq)
         other = int_holder([4, -1])
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            expected = DatetimeIndex([dti[n] + other[n] for n in range(len(dti))])
-            result = dti + other
-        tm.assert_index_equal(result, expected)
+        msg = "Addition/subtraction of integers"
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = other + dti
-        tm.assert_index_equal(result, expected)
+        with pytest.raises(TypeError, match=msg):
+            dti + other
+
+        with pytest.raises(TypeError, match=msg):
+            other + dti
 
     @pytest.mark.parametrize("freq", ["W", "M", "MS", "Q"])
     @pytest.mark.parametrize("int_holder", [np.array, pd.Index])
@@ -2000,28 +1995,20 @@ class TestDatetimeIndexArithmetic:
         dti = pd.date_range("2016-01-01", periods=2, freq=freq)
         other = int_holder([4, -1])
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            expected = DatetimeIndex([dti[n] + other[n] for n in range(len(dti))])
+        msg = "Addition/subtraction of integers"
 
-        # tm.assert_produces_warning does not handle cases where we expect
-        # two warnings, in this case PerformanceWarning and FutureWarning.
-        # Until that is fixed, we don't catch either
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            result = dti + other
-        tm.assert_index_equal(result, expected)
+        with pytest.raises(TypeError, match=msg):
+            dti + other
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            result = other + dti
-        tm.assert_index_equal(result, expected)
+        with pytest.raises(TypeError, match=msg):
+            other + dti
 
     @pytest.mark.parametrize("int_holder", [np.array, pd.Index])
     def test_dti_add_intarray_no_freq(self, int_holder):
         # GH#19959
         dti = pd.DatetimeIndex(["2016-01-01", "NaT", "2017-04-05 06:07:08"])
         other = int_holder([9, 4, -1])
-        nfmsg = "Cannot shift with no freq"
+        nfmsg = "Cannot add integral value to DatetimeArray without freq"
         tmsg = "cannot subtract DatetimeArray from"
         with pytest.raises(NullFrequencyError, match=nfmsg):
             dti + other

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -13,7 +13,7 @@ import pytz
 from pandas._libs.tslibs.conversion import localize_pydatetime
 from pandas._libs.tslibs.offsets import shift_months
 from pandas.compat.numpy import np_datetime64_compat
-from pandas.errors import NullFrequencyError, PerformanceWarning
+from pandas.errors import PerformanceWarning
 
 import pandas as pd
 from pandas import (
@@ -1856,10 +1856,8 @@ class TestTimestampSeriesArithmetic:
         method = getattr(ser, op)
         msg = "|".join(
             [
-                "incompatible type for a .* operation",
-                "cannot evaluate a numeric op",
-                "ufunc .* cannot use operands",
-                "cannot (add|subtract)",
+                "Addition/subtraction of integers and integer-arrays",
+                "cannot subtract .* from ndarray",
             ]
         )
         with pytest.raises(TypeError, match=msg):
@@ -1941,32 +1939,21 @@ class TestDatetimeIndexArithmetic:
     # -------------------------------------------------------------
     # Binary operations DatetimeIndex and int
 
-    def test_dti_add_int(self, tz_naive_fixture, one):
+    def test_dti_addsub_int(self, tz_naive_fixture, one):
         # Variants of `one` for #19012
         tz = tz_naive_fixture
         rng = pd.date_range("2000-01-01 09:00", freq="H", periods=10, tz=tz)
         msg = "Addition/subtraction of integers"
+
         with pytest.raises(TypeError, match=msg):
             rng + one
 
-    def test_dti_iadd_int(self, tz_naive_fixture, one):
-        tz = tz_naive_fixture
-        rng = pd.date_range("2000-01-01 09:00", freq="H", periods=10, tz=tz)
-        msg = "Addition/subtraction of integers"
         with pytest.raises(TypeError, match=msg):
             rng += one
 
-    def test_dti_sub_int(self, tz_naive_fixture, one):
-        tz = tz_naive_fixture
-        rng = pd.date_range("2000-01-01 09:00", freq="H", periods=10, tz=tz)
-        msg = "Addition/subtraction of integers"
         with pytest.raises(TypeError, match=msg):
             rng - one
 
-    def test_dti_isub_int(self, tz_naive_fixture, one):
-        tz = tz_naive_fixture
-        rng = pd.date_range("2000-01-01 09:00", freq="H", periods=10, tz=tz)
-        msg = "Addition/subtraction of integers"
         with pytest.raises(TypeError, match=msg):
             rng -= one
 
@@ -2008,13 +1995,13 @@ class TestDatetimeIndexArithmetic:
         # GH#19959
         dti = pd.DatetimeIndex(["2016-01-01", "NaT", "2017-04-05 06:07:08"])
         other = int_holder([9, 4, -1])
-        nfmsg = "Cannot add integral value to DatetimeArray without freq"
         tmsg = "cannot subtract DatetimeArray from"
-        with pytest.raises(NullFrequencyError, match=nfmsg):
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
             dti + other
-        with pytest.raises(NullFrequencyError, match=nfmsg):
+        with pytest.raises(TypeError, match=msg):
             other + dti
-        with pytest.raises(NullFrequencyError, match=nfmsg):
+        with pytest.raises(TypeError, match=msg):
             dti - other
         with pytest.raises(TypeError, match=tmsg):
             other - dti

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from pandas.errors import NullFrequencyError, OutOfBoundsDatetime, PerformanceWarning
+from pandas.errors import OutOfBoundsDatetime, PerformanceWarning
 
 import pandas as pd
 from pandas import (
@@ -409,7 +409,7 @@ class TestTimedelta64ArithmeticUnsorted:
             tdi[0:1] + dti
 
         # random indexes
-        with pytest.raises(NullFrequencyError):
+        with pytest.raises(TypeError):
             tdi + pd.Int64Index([1, 2, 3])
 
         # this is a union!
@@ -997,17 +997,13 @@ class TestTimedeltaArraylikeAddSubOps:
         tdser = pd.Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
         tdser = tm.box_expected(tdser, box)
 
-        err = TypeError
-        if box in [pd.Index, tm.to_array] and not isinstance(other, float):
-            err = NullFrequencyError
-
-        with pytest.raises(err):
+        with pytest.raises(TypeError):
             tdser + other
-        with pytest.raises(err):
+        with pytest.raises(TypeError):
             other + tdser
-        with pytest.raises(err):
+        with pytest.raises(TypeError):
             tdser - other
-        with pytest.raises(err):
+        with pytest.raises(TypeError):
             other - tdser
 
     @pytest.mark.parametrize(
@@ -1039,18 +1035,15 @@ class TestTimedeltaArraylikeAddSubOps:
         box = box_with_array
         tdser = pd.Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
         tdser = tm.box_expected(tdser, box)
-        err = TypeError
-        if box in [pd.Index, tm.to_array] and not dtype.startswith("float"):
-            err = NullFrequencyError
 
         vector = vec.astype(dtype)
-        with pytest.raises(err):
+        with pytest.raises(TypeError):
             tdser + vector
-        with pytest.raises(err):
+        with pytest.raises(TypeError):
             vector + tdser
-        with pytest.raises(err):
+        with pytest.raises(TypeError):
             tdser - vector
-        with pytest.raises(err):
+        with pytest.raises(TypeError):
             vector - tdser
 
     # ------------------------------------------------------------------

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -69,17 +69,11 @@ class TestDatetimeIndexArithmetic:
     def test_dti_shift_int(self):
         rng = date_range("1/1/2000", periods=20)
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            # GH#22535
-            result = rng + 5
-
+        result = rng + 5 * rng.freq
         expected = rng.shift(5)
         tm.assert_index_equal(result, expected)
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            # GH#22535
-            result = rng - 5
-
+        result = rng - 5 * rng.freq
         expected = rng.shift(-5)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -100,61 +100,37 @@ class TestTimedeltaIndexArithmetic:
     # -------------------------------------------------------------
     # Binary operations TimedeltaIndex and integer
 
-    def test_tdi_add_int(self, one):
-        # Variants of `one` for #19012
+    def test_tdi_add_sub_int(self, one):
+        # Variants of `one` for #19012, deprecated GH#22535
         rng = timedelta_range("1 days 09:00:00", freq="H", periods=10)
         msg = "Addition/subtraction of integers"
+
         with pytest.raises(TypeError, match=msg):
-            # GH#22535
             rng + one
-
-    def test_tdi_iadd_int(self, one):
-        rng = timedelta_range("1 days 09:00:00", freq="H", periods=10)
-        msg = "Addition/subtraction of integers"
         with pytest.raises(TypeError, match=msg):
-            # GH#22535
             rng += one
-
-    def test_tdi_sub_int(self, one):
-        rng = timedelta_range("1 days 09:00:00", freq="H", periods=10)
-        msg = "Addition/subtraction of integers"
         with pytest.raises(TypeError, match=msg):
-            # GH#22535
             rng - one
-
-    def test_tdi_isub_int(self, one):
-        rng = timedelta_range("1 days 09:00:00", freq="H", periods=10)
-        msg = "Addition/subtraction of integers"
         with pytest.raises(TypeError, match=msg):
-            # GH#22535
             rng -= one
 
     # -------------------------------------------------------------
     # __add__/__sub__ with integer arrays
 
     @pytest.mark.parametrize("box", [np.array, pd.Index])
-    def test_tdi_add_integer_array(self, box):
-        # GH#19959
+    def test_tdi_add_sub_integer_array(self, box):
+        # GH#19959, deprecated GH#22535
         rng = timedelta_range("1 days 09:00:00", freq="H", periods=3)
         other = box([4, 3, 2])
         msg = "Addition/subtraction of integers and integer-arrays"
+
         with pytest.raises(TypeError, match=msg):
-            # GH#22535
             rng + other
 
         with pytest.raises(TypeError, match=msg):
-            # GH#22535
             other + rng
 
-    @pytest.mark.parametrize("box", [np.array, pd.Index])
-    def test_tdi_sub_integer_array(self, box):
-        # GH#19959
-        rng = timedelta_range("9H", freq="H", periods=3)
-        other = box([4, 3, 2])
-        msg = "Addition/subtraction of integers and integer-arrays"
-
         with pytest.raises(TypeError, match=msg):
-            # GH#22535
             rng - other
 
         with pytest.raises(TypeError, match=msg):
@@ -165,13 +141,15 @@ class TestTimedeltaIndexArithmetic:
         # GH#19959
         tdi = TimedeltaIndex(["1 Day", "NaT", "3 Hours"])
         other = box([14, -1, 16])
-        with pytest.raises(NullFrequencyError):
+        msg = "Addition/subtraction of integers"
+
+        with pytest.raises(TypeError, match=msg):
             tdi + other
-        with pytest.raises(NullFrequencyError):
+        with pytest.raises(TypeError, match=msg):
             other + tdi
-        with pytest.raises(NullFrequencyError):
+        with pytest.raises(TypeError, match=msg):
             tdi - other
-        with pytest.raises(NullFrequencyError):
+        with pytest.raises(TypeError, match=msg):
             other - tdi
 
     # -------------------------------------------------------------

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -103,35 +103,31 @@ class TestTimedeltaIndexArithmetic:
     def test_tdi_add_int(self, one):
         # Variants of `one` for #19012
         rng = timedelta_range("1 days 09:00:00", freq="H", periods=10)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
             # GH#22535
-            result = rng + one
-        expected = timedelta_range("1 days 10:00:00", freq="H", periods=10)
-        tm.assert_index_equal(result, expected)
+            rng + one
 
     def test_tdi_iadd_int(self, one):
         rng = timedelta_range("1 days 09:00:00", freq="H", periods=10)
-        expected = timedelta_range("1 days 10:00:00", freq="H", periods=10)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
             # GH#22535
             rng += one
-        tm.assert_index_equal(rng, expected)
 
     def test_tdi_sub_int(self, one):
         rng = timedelta_range("1 days 09:00:00", freq="H", periods=10)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
             # GH#22535
-            result = rng - one
-        expected = timedelta_range("1 days 08:00:00", freq="H", periods=10)
-        tm.assert_index_equal(result, expected)
+            rng - one
 
     def test_tdi_isub_int(self, one):
         rng = timedelta_range("1 days 09:00:00", freq="H", periods=10)
-        expected = timedelta_range("1 days 08:00:00", freq="H", periods=10)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
             # GH#22535
             rng -= one
-        tm.assert_index_equal(rng, expected)
 
     # -------------------------------------------------------------
     # __add__/__sub__ with integer arrays
@@ -141,32 +137,28 @@ class TestTimedeltaIndexArithmetic:
         # GH#19959
         rng = timedelta_range("1 days 09:00:00", freq="H", periods=3)
         other = box([4, 3, 2])
-        expected = TimedeltaIndex(["1 day 13:00:00"] * 3)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        msg = "Addition/subtraction of integers and integer-arrays"
+        with pytest.raises(TypeError, match=msg):
             # GH#22535
-            result = rng + other
-            tm.assert_index_equal(result, expected)
+            rng + other
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with pytest.raises(TypeError, match=msg):
             # GH#22535
-            result = other + rng
-            tm.assert_index_equal(result, expected)
+            other + rng
 
     @pytest.mark.parametrize("box", [np.array, pd.Index])
     def test_tdi_sub_integer_array(self, box):
         # GH#19959
         rng = timedelta_range("9H", freq="H", periods=3)
         other = box([4, 3, 2])
-        expected = TimedeltaIndex(["5H", "7H", "9H"])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            # GH#22535
-            result = rng - other
-            tm.assert_index_equal(result, expected)
+        msg = "Addition/subtraction of integers and integer-arrays"
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with pytest.raises(TypeError, match=msg):
             # GH#22535
-            result = other - rng
-            tm.assert_index_equal(result, -expected)
+            rng - other
+
+        with pytest.raises(TypeError, match=msg):
+            other - rng
 
     @pytest.mark.parametrize("box", [np.array, pd.Index])
     def test_tdi_addsub_integer_array_no_freq(self, box):

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -3,8 +3,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from pandas.errors import NullFrequencyError
-
 from pandas import Timedelta, Timestamp
 
 from pandas.tseries import offsets
@@ -175,12 +173,13 @@ class TestTimestampArithmetic:
         ],
     )
     def test_add_int_no_freq_raises(self, ts, other):
-        with pytest.raises(NullFrequencyError, match="without freq"):
+        msg = "Addition/subtraction of integers and integer-arrays"
+        with pytest.raises(TypeError, match=msg):
             ts + other
-        with pytest.raises(NullFrequencyError, match="without freq"):
+        with pytest.raises(TypeError, match=msg):
             other + ts
 
-        with pytest.raises(NullFrequencyError, match="without freq"):
+        with pytest.raises(TypeError, match=msg):
             ts - other
         with pytest.raises(TypeError):
             other - ts

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -6,7 +6,6 @@ import pytest
 from pandas.errors import NullFrequencyError
 
 from pandas import Timedelta, Timestamp
-import pandas.util.testing as tm
 
 from pandas.tseries import offsets
 from pandas.tseries.frequencies import to_offset
@@ -97,10 +96,12 @@ class TestTimestampArithmetic:
         # addition/subtraction of integers
         ts = Timestamp(dt, freq="D")
 
-        with tm.assert_produces_warning(FutureWarning):
+        msg = "Addition/subtraction of integers"
+        with pytest.raises(TypeError, match=msg):
             # GH#22535 add/sub with integers is deprecated
-            assert type(ts + 1) == Timestamp
-            assert type(ts - 1) == Timestamp
+            ts + 1
+        with pytest.raises(TypeError, match=msg):
+            ts - 1
 
         # Timestamp + datetime not supported, though subtraction is supported
         # and yields timedelta more tests in tseries/base/tests/test_base.py
@@ -128,11 +129,6 @@ class TestTimestampArithmetic:
     def test_addition_subtraction_preserve_frequency(self, freq, td, td64):
         ts = Timestamp("2014-03-05 00:00:00", freq=freq)
         original_freq = ts.freq
-
-        with tm.assert_produces_warning(FutureWarning):
-            # GH#22535 add/sub with integers is deprecated
-            assert (ts + 1).freq == original_freq
-            assert (ts - 1).freq == original_freq
 
         assert (ts + 1 * original_freq).freq == original_freq
         assert (ts - 1 * original_freq).freq == original_freq
@@ -206,17 +202,14 @@ class TestTimestampArithmetic:
         ],
     )
     def test_add_int_with_freq(self, ts, other):
-        with tm.assert_produces_warning(FutureWarning):
-            result1 = ts + other
-        with tm.assert_produces_warning(FutureWarning):
-            result2 = other + ts
 
-        assert np.all(result1 == result2)
+        with pytest.raises(TypeError):
+            ts + other
+        with pytest.raises(TypeError):
+            other + ts
 
-        with tm.assert_produces_warning(FutureWarning):
-            result = result1 - other
-
-        assert np.all(result == ts)
+        with pytest.raises(TypeError):
+            ts - other
 
         with pytest.raises(TypeError):
             other - ts


### PR DESCRIPTION
_lots_ of cleanups become available after this.  I did some of that in the tests here, but left most of it for follow-ups to keep the diff manageable.