### PR TITLE
REF: use new pytables helper methods to de-duplicate _convert_index

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -4681,30 +4681,20 @@ def _convert_index(name: str, index: Index, encoding=None, errors="strict"):
         assert kind == "integer", kind
         assert isinstance(atom, _tables().Int64Col), atom.dtype
         return IndexCol(
-            name,
-            values=converted,
-            kind=kind,
-            typ=atom,
-            index_name=index_name,
+            name, values=converted, kind=kind, typ=atom, index_name=index_name,
         )
     elif inferred_type == "floating":
         assert isinstance(converted, np.ndarray) and converted.dtype == "f8"
         assert kind == "float", kind
         assert isinstance(atom, _tables().Float64Col), atom.dtype
         return IndexCol(
-            name,
-            values=converted,
-            kind=kind,
-            typ=atom,
-            index_name=index_name,
+            name, values=converted, kind=kind, typ=atom, index_name=index_name,
         )
     else:
         assert isinstance(converted, np.ndarray) and converted.dtype == object
         assert kind == "object", kind
         atom = _tables().ObjectAtom()
-        return IndexCol(
-            name, converted, kind, atom, index_name=index_name,
-        )
+        return IndexCol(name, converted, kind, atom, index_name=index_name,)
 
 
 def _unconvert_index(data, kind: str, encoding=None, errors="strict"):


### PR DESCRIPTION
The assertions in here are intended to be temporary.  Once reviewers are convinced this is accurate, then the assertions can be removed and a bunch of these blocks can be condensed down to share code.

The new helper func _get_data_and_dtype_name is also going to be used later to pre-empt the need for the state-altering `get_data` method.