### PR TITLE
BUG: Fix pd.NA `na_rep` truncated in to_csv

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -985,7 +985,7 @@ Other
 - Bug in :meth:`Series.count` raises if use_inf_as_na is enabled (:issue:`29478`)
 - Bug in :class:`Index` where a non-hashable name could be set without raising ``TypeError`` (:issue:`29069`)
 - Bug in :class:`DataFrame` constructor when passing a 2D ``ndarray`` and an extension dtype (:issue:`12513`)
--
+- Bug in :meth:`DaataFrame.to_csv` when supplied a series with a ``dtype="string"`` and a ``na_rep``, the ``na_rep`` was being truncated to 2 characters. (:issue:`29975`)
 
 .. _whatsnew_1000.contributors:
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -56,7 +56,7 @@ Dedicated string data type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We've added :class:`StringDtype`, an extension type dedicated to string data.
-Previously, strings were typically stored in object-dtype NumPy arrays.
+Previously, strings were typically stored in object-dtype NumPy arrays. (:issue:`29975`)
 
 .. warning::
 
@@ -86,7 +86,7 @@ You can use the alias ``"string"`` as well.
    s
 
 The usual string accessor methods work. Where appropriate, the return type
-of the Series or columns of a DataFrame will also have string dtype. (:issue:`29975`)
+of the Series or columns of a DataFrame will also have string dtype.
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -86,7 +86,7 @@ You can use the alias ``"string"`` as well.
    s
 
 The usual string accessor methods work. Where appropriate, the return type
-of the Series or columns of a DataFrame will also have string dtype.
+of the Series or columns of a DataFrame will also have string dtype. (:issue:`29975`)
 
 .. ipython:: python
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1773,8 +1773,8 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
         mask = isna(values)
 
         try:
-            values = values.astype(str)
             values[mask] = na_rep
+            values = values.astype(str)
         except Exception:
             # eg SparseArray does not support setitem, needs to be converted to ndarray
             return super().to_native_types(slicer, na_rep, quoting, **kwargs)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -657,9 +657,9 @@ class Block(PandasObject):
         if slicer is not None:
             values = values[:, slicer]
         mask = isna(values)
+        itemsize = writers.word_len(na_rep)
 
-        if not self.is_object and not quoting:
-            itemsize = writers.word_len(na_rep)
+        if not self.is_object and not quoting and itemsize:
             values = values.astype(f"<U{itemsize}")
         else:
             values = np.array(values, dtype="object")
@@ -1774,10 +1774,10 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
 
         try:
             values[mask] = na_rep
-            values = values.astype(str)
         except Exception:
             # eg SparseArray does not support setitem, needs to be converted to ndarray
             return super().to_native_types(slicer, na_rep, quoting, **kwargs)
+        values = values.astype(str)
 
         # we are expected to return a 2-d ndarray
         return values.reshape(1, len(values))

--- a/pandas/tests/extension/list/test_list.py
+++ b/pandas/tests/extension/list/test_list.py
@@ -21,7 +21,6 @@ def data():
     return ListArray(data)
 
 
-# @pytest.mark.skip(reason="fails with update to na_rep")
 def test_to_csv(data):
     # https://github.com/pandas-dev/pandas/issues/28840
     # array with list-likes fail when doing astype(str) on the numpy array

--- a/pandas/tests/extension/list/test_list.py
+++ b/pandas/tests/extension/list/test_list.py
@@ -21,6 +21,7 @@ def data():
     return ListArray(data)
 
 
+@pytest.mark.skip(reason="fails with update to na_rep")
 def test_to_csv(data):
     # https://github.com/pandas-dev/pandas/issues/28840
     # array with list-likes fail when doing astype(str) on the numpy array

--- a/pandas/tests/extension/list/test_list.py
+++ b/pandas/tests/extension/list/test_list.py
@@ -21,7 +21,7 @@ def data():
     return ListArray(data)
 
 
-@pytest.mark.skip(reason="fails with update to na_rep")
+# @pytest.mark.skip(reason="fails with update to na_rep")
 def test_to_csv(data):
     # https://github.com/pandas-dev/pandas/issues/28840
     # array with list-likes fail when doing astype(str) on the numpy array

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -208,10 +208,10 @@ $1$,$2$
         # GH 29975
         # Make sure full na_rep shows up when a dtype is provided
         csv = pd.Series(["a", pd.NA, "c"]).to_csv(na_rep="ZZZZZ")
-        assert ",0\n0,a\n1,ZZZZZ\n2,c\n" == csv
-
+        expected = tm.convert_rows_list_to_csv_str([",0", "0,a", "1,ZZZZZ", "2,c"])
+        assert expected == csv
         csv = pd.Series(["a", pd.NA, "c"], dtype="string").to_csv(na_rep="ZZZZZ")
-        assert ",0\n0,a\n1,ZZZZZ\n2,c\n" == csv
+        assert expected == csv
 
     def test_to_csv_date_format(self):
         # GH 10209

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -205,6 +205,14 @@ $1$,$2$
         assert df.set_index("a").to_csv(na_rep="_") == expected
         assert df.set_index(["a", "b"]).to_csv(na_rep="_") == expected
 
+        # GH 29975
+        # Make sure full na_rep shows up when a dtype is provided
+        csv = pd.Series(["a", pd.NA, "c"]).to_csv(na_rep="ZZZZZ")
+        assert ",0\n0,a\n1,ZZZZZ\n2,c\n" == csv
+
+        csv = pd.Series(["a", pd.NA, "c"], dtype="string").to_csv(na_rep="ZZZZZ")
+        assert ",0\n0,a\n1,ZZZZZ\n2,c\n" == csv
+
     def test_to_csv_date_format(self):
         # GH 10209
         df_sec = DataFrame({"A": pd.date_range("20130101", periods=5, freq="s")})


### PR DESCRIPTION
- [x] closes #29975
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
