### PR TITLE
DEPR: remove stata deprecations from 2015 and 2017

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -779,7 +779,6 @@ generated/pandas.io.formats.style.Styler.use,../reference/api/pandas.io.formats.
 generated/pandas.io.formats.style.Styler.where,../reference/api/pandas.io.formats.style.Styler.where
 generated/pandas.io.json.build_table_schema,../reference/api/pandas.io.json.build_table_schema
 generated/pandas.io.json.json_normalize,../reference/api/pandas.io.json.json_normalize
-generated/pandas.io.stata.StataReader.data,../reference/api/pandas.io.stata.StataReader.data
 generated/pandas.io.stata.StataReader.data_label,../reference/api/pandas.io.stata.StataReader.data_label
 generated/pandas.io.stata.StataReader.value_labels,../reference/api/pandas.io.stata.StataReader.value_labels
 generated/pandas.io.stata.StataReader.variable_labels,../reference/api/pandas.io.stata.StataReader.variable_labels

--- a/doc/source/reference/io.rst
+++ b/doc/source/reference/io.rst
@@ -140,7 +140,6 @@ STATA
 .. autosummary::
    :toctree: api/
 
-   StataReader.data
    StataReader.data_label
    StataReader.value_labels
    StataReader.variable_labels

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -527,6 +527,8 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 
 **Other removals**
 
+- Removed the previously deprecated "index" keyword from :func:`read_stata`, :class:`StataReader`, and :meth:`StataReader.read`, use "index_col" instead (:issue:`17328`)
+- Removed the previously deprecated :meth:`StataReader.data` method, use :meth:`StataReader.read` instead (:issue:`9493`)
 - Removed the previously deprecated :func:`pandas.plotting._matplotlib.tsplot`, use :meth:`Series.plot` instead (:issue:`19980`)
 - :func:`pandas.tseries.converter.register` has been moved to :func:`pandas.plotting.register_matplotlib_converters` (:issue:`18307`)
 - :meth:`Series.plot` no longer accepts positional arguments, pass keyword arguments instead (:issue:`30003`)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from pandas._libs.lib import infer_dtype
 from pandas._libs.writers import max_len_string_array
-from pandas.util._decorators import Appender, deprecate_kwarg
+from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.common import (
     ensure_object,
@@ -132,25 +132,6 @@ Read a Stata dta file in 10,000 line chunks:
     _iterator_params,
 )
 
-_data_method_doc = """
-Read observations from Stata file, converting them into a dataframe.
-
-.. deprecated::
-    This is a legacy method.  Use `read` in new code.
-
-Parameters
-----------
-%s
-%s
-
-Returns
--------
-DataFrame
-""" % (
-    _statafile_processing_params1,
-    _statafile_processing_params2,
-)
-
 _read_method_doc = """\
 Reads observations from Stata file, converting them into a dataframe
 
@@ -191,7 +172,6 @@ path_or_buf : path (string), buffer or path object
 
 
 @Appender(_read_stata_doc)
-@deprecate_kwarg(old_arg_name="index", new_arg_name="index_col")
 def read_stata(
     filepath_or_buffer,
     convert_dates=True,
@@ -1033,7 +1013,6 @@ class StataParser:
 class StataReader(StataParser, BaseIterator):
     __doc__ = _stata_reader_doc
 
-    @deprecate_kwarg(old_arg_name="index", new_arg_name="index_col")
     def __init__(
         self,
         path_or_buf,
@@ -1525,18 +1504,6 @@ the string values returned are correct."""
             # Wrap v_o in a string to allow uint64 values as keys on 32bit OS
             self.GSO[str(v_o)] = va
 
-    # legacy
-    @Appender(_data_method_doc)
-    def data(self, **kwargs):
-
-        warnings.warn("'data' is deprecated, use 'read' instead")
-
-        if self._data_read:
-            raise Exception("Data has already been read.")
-        self._data_read = True
-
-        return self.read(None, **kwargs)
-
     def __next__(self):
         return self.read(nrows=self._chunksize or 1)
 
@@ -1558,7 +1525,6 @@ the string values returned are correct."""
         return self.read(nrows=size)
 
     @Appender(_read_method_doc)
-    @deprecate_kwarg(old_arg_name="index", new_arg_name="index_col")
     def read(
         self,
         nrows=None,

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -120,16 +120,6 @@ class TestStata:
             empty_ds2 = read_stata(path)
             tm.assert_frame_equal(empty_ds, empty_ds2)
 
-    def test_data_method(self):
-        # Minimal testing of legacy data method
-        with StataReader(self.dta1_114) as rdr:
-            with tm.assert_produces_warning(UserWarning):
-                parsed_114_data = rdr.data()
-
-        with StataReader(self.dta1_114) as rdr:
-            parsed_114_read = rdr.read()
-        tm.assert_frame_equal(parsed_114_data, parsed_114_read)
-
     @pytest.mark.parametrize("file", ["dta1_114", "dta1_117"])
     def test_read_dta1(self, file):
 


### PR DESCRIPTION
xref #9493 to remove the `data` method and #17328 to change the "index" kwarg to "index_col"