### PR TITLE
BUG: Support categorical targets in IntervalIndex.get_indexer

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -710,6 +710,7 @@ Numeric
 - Bug in :class:`NumericIndex` construction that caused indexing to fail when integers in the ``np.uint64`` range were used (:issue:`28023`)
 - Bug in :class:`NumericIndex` construction that caused :class:`UInt64Index` to be casted to :class:`Float64Index` when integers in the ``np.uint64`` range were used to index a :class:`DataFrame` (:issue:`28279`)
 - Bug in :meth:`Series.interpolate` when using method=`index` with an unsorted index, would previously return incorrect results. (:issue:`21037`)
+- Bug in :meth:`DataFrame.round` where a :class:`DataFrame` with a :class:`CategoricalIndex` of :class:`IntervalIndex` columns would incorrectly raise a ``TypeError`` (:issue:`30063`)
 
 Conversion
 ^^^^^^^^^^
@@ -727,7 +728,7 @@ Strings
 Interval
 ^^^^^^^^
 
--
+- Bug in :meth:`IntervalIndex.get_indexer` where a :class:`Categorical` or :class:`CategoricalIndex` ``target`` would incorrectly raise a ``TypeError`` (:issue:`30063`)
 -
 
 Indexing

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -2272,6 +2272,15 @@ class TestDataFrameAnalytics:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_round_interval_category_columns(self):
+        # GH 30063
+        columns = pd.CategoricalIndex(pd.interval_range(0, 2))
+        df = DataFrame([[0.66, 1.1], [0.3, 0.25]], columns=columns)
+
+        result = df.round()
+        expected = DataFrame([[1.0, 1.0], [0.0, 0.0]], columns=columns)
+        tm.assert_frame_equal(result, expected)
+
     # ---------------------------------------------------------------------
     # Clip
 


### PR DESCRIPTION
- [X] closes #30063
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
