### PR TITLE
Fixed IntegerArray division by 0

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -856,6 +856,7 @@ Other
 - Bug in :meth:`DataFrame.append` that raised ``IndexError`` when appending with empty list (:issue:`28769`)
 - Fix :class:`AbstractHolidayCalendar` to return correct results for
   years after 2030 (now goes up to 2200) (:issue:`27790`)
+- Fixed :class:`IntegerArray` returning ``NA`` rather than ``inf`` for operations dividing by 0 (:issue:`27398`)
 - Bug in :meth:`Series.count` raises if use_inf_as_na is enabled (:issue:`29478`)
 
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -700,11 +700,6 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
         op_name : str
         """
 
-        # may need to fill infs
-        # and mask wraparound
-        if is_float_dtype(result):
-            mask |= (result == np.inf) | (result == -np.inf)
-
         # if we have a float operand we are by-definition
         # a float result
         # or our op is a divide
@@ -748,7 +743,7 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
 
             # nans propagate
             if mask is None:
-                mask = self._mask
+                mask = self._mask.copy()
             else:
                 mask = self._mask | mask
 

--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -339,6 +339,13 @@ class TestArithmeticOps(BaseOpsUtil):
         with pytest.raises(NotImplementedError):
             opa(np.arange(len(s)).reshape(-1, len(s)))
 
+    def test_divide_by_zero(self):
+        # https://github.com/pandas-dev/pandas/issues/27398
+        a = pd.array([0, 1, -1, None], dtype="Int64")
+        result = a / 0
+        expected = np.array([np.nan, np.inf, -np.inf, np.nan])
+        tm.assert_numpy_array_equal(result, expected)
+
     def test_pow(self):
         # https://github.com/pandas-dev/pandas/issues/22022
         a = integer_array([1, np.nan, np.nan, 1])
@@ -388,6 +395,10 @@ class TestComparisonOps(BaseOpsUtil):
         op_name = all_compare_operators
         other = pd.Series([0] * len(data))
         self._compare_other(data, op_name, other)
+
+    def test_no_shared_mask(self, data):
+        result = data + 1
+        assert np.shares_memory(result._mask, data._mask) is False
 
 
 class TestCasting:

--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -339,11 +339,17 @@ class TestArithmeticOps(BaseOpsUtil):
         with pytest.raises(NotImplementedError):
             opa(np.arange(len(s)).reshape(-1, len(s)))
 
-    def test_divide_by_zero(self):
+    @pytest.mark.parametrize("zero, negative", [(0, False), (0.0, False), (-0.0, True)])
+    def test_divide_by_zero(self, zero, negative):
         # https://github.com/pandas-dev/pandas/issues/27398
         a = pd.array([0, 1, -1, None], dtype="Int64")
-        result = a / 0
+        result = a / zero
         expected = np.array([np.nan, np.inf, -np.inf, np.nan])
+        if negative:
+            values = [np.nan, -np.inf, np.inf, np.nan]
+        else:
+            values = [np.nan, np.inf, -np.inf, np.nan]
+        expected = np.array(values)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_pow(self):


### PR DESCRIPTION
When dividing by 0, the result should be `inf`, not `NaN`.

closes https://github.com/pandas-dev/pandas/issues/27398
closes https://github.com/pandas-dev/pandas/issues/27829