### PR TITLE
REF: pass dtype and data to pytables IndexCol constructor

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3874,7 +3874,7 @@ class Table(Fixed):
                 meta=meta,
                 metadata=metadata,
                 dtype=dtype_name,
-                data=data
+                data=data,
             )
             col.update_info(self.info)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2207,6 +2207,8 @@ class DataCol(IndexCol):
         table=None,
         meta=None,
         metadata=None,
+        dtype=None,
+        data=None,
     ):
         super().__init__(
             name=name,
@@ -2221,8 +2223,8 @@ class DataCol(IndexCol):
             meta=meta,
             metadata=metadata,
         )
-        self.dtype = None
-        self.data = None
+        self.dtype = dtype
+        self.data = data
 
     @property
     def dtype_attr(self) -> str:
@@ -3858,6 +3860,8 @@ class Table(Fixed):
                 meta = "category"
                 metadata = np.array(data_converted.categories, copy=False).ravel()
 
+            data, dtype_name = _get_data_and_dtype_name(data_converted)
+
             col = klass(
                 name=adj_name,
                 cname=new_name,
@@ -3869,8 +3873,9 @@ class Table(Fixed):
                 ordered=ordered,
                 meta=meta,
                 metadata=metadata,
+                dtype=dtype_name,
+                data=data
             )
-            col.set_data(data_converted)
             col.update_info(self.info)
 
             vaxes.append(col)


### PR DESCRIPTION
Along #30184 we'll be able to get rid of `set_data` and clean up the last remaining state-setting in IndexCol objects.