### PR TITLE
STY - fstring on frame.py & numeric.py #29886

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -913,8 +913,8 @@ class TextFileReader(BaseIterator):
                         pass
                     else:
                         raise ValueError(
-                            "The %r option is not supported with the"
-                            " %r engine" % (argname, engine)
+                            f"The {repr(argname)} option is not supported with the"
+                            f" {repr(engine)} engine"
                         )
             else:
                 value = _deprecated_defaults.get(argname, default)
@@ -3607,8 +3607,8 @@ class FixedWidthReader(BaseIterator):
 
         if not isinstance(self.colspecs, (tuple, list)):
             raise TypeError(
-                "column specifications must be a list or tuple, "
-                "input was a %r" % type(colspecs).__name__
+                f"column specifications must be a list or tuple, "
+                f"input was a {repr(type(colspecs).__name__)}"
             )
 
         for colspec in self.colspecs:


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

#https://github.com/pandas-dev/pandas/issues/29886
