### PR TITLE
Parallelized Build / CI

### DIFF
--- a/ci/incremental/build.cmd
+++ b/ci/incremental/build.cmd
@@ -1,7 +1,7 @@
 @rem https://github.com/numba/numba/blob/master/buildscripts/incremental/build.cmd
 
 @rem Build extensions
-python setup.py build_ext -q -i
+python setup.py build_ext -q -i -j4
 
 @rem Install pandas
 python -m pip install --no-build-isolation -e .

--- a/ci/incremental/build.cmd
+++ b/ci/incremental/build.cmd
@@ -1,7 +1,7 @@
 @rem https://github.com/numba/numba/blob/master/buildscripts/incremental/build.cmd
 
 @rem Build extensions
-python setup.py build_ext -q -i -j4
+python setup.py build_ext -q -i
 
 @rem Install pandas
 python -m pip install --no-build-isolation -e .

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -121,7 +121,7 @@ conda list pandas
 # Make sure any error below is reported as such
 
 echo "[Build extensions]"
-python setup.py build_ext -q -i
+python setup.py build_ext -q -i -j4
 
 # XXX: Some of our environments end up with old versions of pip (10.x)
 # Adding a new enough version of pip to the requirements explodes the

--- a/setup.py
+++ b/setup.py
@@ -129,12 +129,7 @@ class build_ext(_build_ext):
         if cython:
             self.render_templates(_pxifiles)
 
-        numpy_incl = pkg_resources.resource_filename("numpy", "core/include")
-
-        for ext in self.extensions:
-            if hasattr(ext, "include_dirs") and numpy_incl not in ext.include_dirs:
-                ext.include_dirs.append(numpy_incl)
-        _build_ext.build_extensions(self)
+        super().build_extensions()
 
 
 DESCRIPTION = "Powerful data structures for data analysis, time series, and statistics"

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ Parts of this file were taken from the pyzmq project
 BSD license. Parts are from lxml (https://github.com/lxml/lxml)
 """
 
+import argparse
 from distutils.sysconfig import get_config_vars
 from distutils.version import LooseVersion
 import os
@@ -525,6 +526,19 @@ def maybe_cythonize(extensions, *args, **kwargs):
         if hasattr(ext, "include_dirs") and numpy_incl not in ext.include_dirs:
             ext.include_dirs.append(numpy_incl)
 
+    # reuse any parallel arguments provided for compliation to cythonize
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-j", type=int)
+    parser.add_argument("--parallel", type=int)
+    parsed, _ = parser.parse_known_args()
+
+    nthreads = 0
+    if "parallel" in parsed:
+        nthreads = parsed.parallel
+    elif "j" is parsed:
+        nthreads = parsed.j
+
+    kwargs["nthreads"] = nthreads
     build_ext.render_templates(_pxifiles)
     return cythonize(extensions, *args, **kwargs)
 
@@ -681,7 +695,7 @@ ext_data = {
     "_libs.window.aggregations": {
         "pyxfile": "_libs/window/aggregations",
         "language": "c++",
-        "suffix": ".cpp"
+        "suffix": ".cpp",
     },
     "_libs.window.indexers": {"pyxfile": "_libs/window/indexers"},
     "_libs.writers": {"pyxfile": "_libs/writers"},

--- a/setup.py
+++ b/setup.py
@@ -533,9 +533,9 @@ def maybe_cythonize(extensions, *args, **kwargs):
     parsed, _ = parser.parse_known_args()
 
     nthreads = 0
-    if "parallel" in parsed and parsed.parallel is not None:
+    if parsed.parallel:
         nthreads = parsed.parallel
-    elif "j" in parsed and parsed.j is not None:
+    elif parsed.j:
         nthreads = parsed.j
 
     kwargs["nthreads"] = nthreads

--- a/setup.py
+++ b/setup.py
@@ -533,9 +533,9 @@ def maybe_cythonize(extensions, *args, **kwargs):
     parsed, _ = parser.parse_known_args()
 
     nthreads = 0
-    if "parallel" in parsed:
+    if "parallel" in parsed and parsed.parallel is not None:
         nthreads = parsed.parallel
-    elif "j" is parsed:
+    elif "j" in parsed and parsed.j is not None:
         nthreads = parsed.j
 
     kwargs["nthreads"] = nthreads


### PR DESCRIPTION
Modeled after https://github.com/cython/cython/pull/3187 which in 0.29.14 added parallel support

A very slight boost to timing from a clean directory (bottleneck is in the Cythonize calls in both cases)

```sh
# Master
$ time python setup.py build_ext --inplace -j 4 : 
62.93s user 3.18s system 97% cpu 1:07.77 total

# this branch
$ time python setup.py build_ext --inplace -j 4:
58.87s user 3.32s system 105% cpu 59.030 total
```

