### PR TITLE
[Doc Fix] Fix typo from Jupyter Notebook to Jupyter Lab in Ecosystem Doc.

### DIFF
--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -137,7 +137,7 @@ attributes like DataFrame columns.
 
 ### [Jupyter Notebook / Jupyter Lab](https://jupyter.org)
 
-Jupyter Notebook is a web application for creating Jupyter notebooks. A
+Jupyter Lab is a web application for creating Jupyter notebooks. A
 Jupyter notebook is a JSON document containing an ordered list of
 input/output cells which can contain code, text, mathematics, plots and
 rich media. Jupyter notebooks can be converted to a number of open


### PR DESCRIPTION
I saw this typo in the [doc](https://pandas.pydata.org/pandas-docs/stable/ecosystem.html#jupyter-notebook-jupyter-lab).
Decided to create a PR for it. ;)