### PR TITLE
DEPR: deprecate label kwarg to lreshape, closes #29742

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -490,6 +490,7 @@ Deprecations
 - :func:`eval` keyword argument "truediv" is deprecated and will be removed in a future version (:issue:`29812`)
 - :meth:`Categorical.take_nd` is deprecated, use :meth:`Categorical.take` instead (:issue:`27745`)
 - The parameter ``numeric_only`` of :meth:`Categorical.min` and :meth:`Categorical.max` is deprecated and replaced with ``skipna`` (:issue:`25303`)
+- The parameter ``label`` in :func:`lreshape` has been deprecated and will be removed in a future version (:issue:`29742`)
 -
 
 .. _whatsnew_1000.prior_deprecations:

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -3,7 +3,7 @@ from typing import List
 
 import numpy as np
 
-from pandas.util._decorators import Appender
+from pandas.util._decorators import Appender, deprecate_kwarg
 
 from pandas.core.dtypes.common import is_extension_array_dtype, is_list_like
 from pandas.core.dtypes.concat import concat_compat
@@ -122,6 +122,7 @@ def melt(
     return frame._constructor(mdata, columns=mcolumns)
 
 
+@deprecate_kwarg(old_arg_name="label", new_arg_name=None)
 def lreshape(data: DataFrame, groups, dropna: bool = True, label=None) -> DataFrame:
     """
     Reshape long-format data to wide. Generalized inverse of DataFrame.pivot
@@ -132,8 +133,6 @@ def lreshape(data: DataFrame, groups, dropna: bool = True, label=None) -> DataFr
     groups : dict
         {new_name : list_of_columns}
     dropna : boolean, default True
-    label : object, default None
-        Dummy kwarg, not used.
 
     Examples
     --------

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -553,6 +553,9 @@ class TestLreshape:
         exp = DataFrame(exp_data, columns=result.columns)
         tm.assert_frame_equal(result, exp)
 
+        with tm.assert_produces_warning(FutureWarning):
+            result = lreshape(df, spec, dropna=False, label="foo")
+
         spec = {
             "visitdt": ["visitdt{i:d}".format(i=i) for i in range(1, 3)],
             "wt": ["wt{i:d}".format(i=i) for i in range(1, 4)],


### PR DESCRIPTION
- [x] closes #29742
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
