### PR TITLE
DOC: Documentation for MultiIndex.get_locs() is missing in v0.25 docs

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -191,6 +191,7 @@ class MultiIndex(Index):
     swaplevel
     reorder_levels
     remove_unused_levels
+    get_locs
 
     See Also
     --------


### PR DESCRIPTION
Like a comment in #30056. I add "get_locs" to method

- [ ] closes #30056
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
