### PR TITLE
BUG: min/max on empty categorical fails

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -667,7 +667,7 @@ Categorical
   same type as if one used the :meth:`.str.` / :meth:`.dt.` on a :class:`Series` of that type. E.g. when accessing :meth:`Series.dt.tz_localize` on a
   :class:`Categorical` with duplicate entries, the accessor was skipping duplicates (:issue:`27952`)
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` that would give incorrect results on categorical data (:issue:`26988`)
-- Bug where calling :meth:`Categorical.min` or :meth:`Categorical.max` on an empty Categorical would raise a numpy exception.
+- Bug where calling :meth:`Categorical.min` or :meth:`Categorical.max` on an empty Categorical would raise a numpy exception (:issue:`30227`)
 
 
 Datetimelike

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -667,6 +667,7 @@ Categorical
   same type as if one used the :meth:`.str.` / :meth:`.dt.` on a :class:`Series` of that type. E.g. when accessing :meth:`Series.dt.tz_localize` on a
   :class:`Categorical` with duplicate entries, the accessor was skipping duplicates (:issue:`27952`)
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` that would give incorrect results on categorical data (:issue:`26988`)
+- Bug where calling :meth:`Categorical.min` or :meth:`Categorical.max` on an empty Categorical would raise a numpy exception.
 
 
 Datetimelike

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2132,7 +2132,7 @@ class Categorical(ExtensionArray, PandasObject):
         self.check_for_ordered("min")
 
         if not len(self._codes):
-            return na_value_for_dtype(self.dtype)
+            return self.dtype.na_value
 
         good = self._codes != -1
         if not good.all():
@@ -2167,7 +2167,7 @@ class Categorical(ExtensionArray, PandasObject):
         self.check_for_ordered("max")
 
         if not len(self._codes):
-            return na_value_for_dtype(self.dtype)
+            return self.dtype.na_value
 
         good = self._codes != -1
         if not good.all():

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -39,7 +39,7 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import is_hashable
-from pandas.core.dtypes.missing import isna, notna
+from pandas.core.dtypes.missing import isna, na_value_for_dtype, notna
 
 from pandas._typing import ArrayLike, Dtype, Ordered
 from pandas.core import ops
@@ -2116,6 +2116,10 @@ class Categorical(ExtensionArray, PandasObject):
 
         Only ordered `Categoricals` have a minimum!
 
+        .. versionchanged:: 1.0.0
+
+           Returns an NA value on empty arrays
+
         Raises
         ------
         TypeError
@@ -2128,7 +2132,7 @@ class Categorical(ExtensionArray, PandasObject):
         self.check_for_ordered("min")
 
         if len(self._codes) == 0:
-            return np.nan
+            return na_value_for_dtype(self.dtype)
 
         good = self._codes != -1
         if not good.all():
@@ -2147,6 +2151,10 @@ class Categorical(ExtensionArray, PandasObject):
 
         Only ordered `Categoricals` have a maximum!
 
+        .. versionchanged:: 1.0.0
+
+           Returns an NA value on empty arrays
+
         Raises
         ------
         TypeError
@@ -2159,7 +2167,7 @@ class Categorical(ExtensionArray, PandasObject):
         self.check_for_ordered("max")
 
         if len(self._codes) == 0:
-            return np.nan
+            return na_value_for_dtype(self.dtype)
 
         good = self._codes != -1
         if not good.all():

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2131,7 +2131,7 @@ class Categorical(ExtensionArray, PandasObject):
         """
         self.check_for_ordered("min")
 
-        if len(self._codes) == 0:
+        if not len(self._codes):
             return na_value_for_dtype(self.dtype)
 
         good = self._codes != -1
@@ -2166,7 +2166,7 @@ class Categorical(ExtensionArray, PandasObject):
         """
         self.check_for_ordered("max")
 
-        if len(self._codes) == 0:
+        if not len(self._codes):
             return na_value_for_dtype(self.dtype)
 
         good = self._codes != -1

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2126,6 +2126,10 @@ class Categorical(ExtensionArray, PandasObject):
         min : the minimum of this `Categorical`
         """
         self.check_for_ordered("min")
+
+        if len(self._codes) == 0:
+            return np.nan
+
         good = self._codes != -1
         if not good.all():
             if skipna:
@@ -2153,6 +2157,10 @@ class Categorical(ExtensionArray, PandasObject):
         max : the maximum of this `Categorical`
         """
         self.check_for_ordered("max")
+
+        if len(self._codes) == 0:
+            return np.nan
+
         good = self._codes != -1
         if not good.all():
             if skipna:

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -39,7 +39,7 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import is_hashable
-from pandas.core.dtypes.missing import isna, na_value_for_dtype, notna
+from pandas.core.dtypes.missing import isna, notna
 
 from pandas._typing import ArrayLike, Dtype, Ordered
 from pandas.core import ops

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -11,14 +11,15 @@ import pandas.util.testing as tm
 
 
 class TestCategoricalAnalytics:
-    def test_min_max_not_ordered(self):
+    @pytest.mark.parametrize("aggregation", ["min", "max"])
+    def test_min_max_not_ordered_raises(self, aggregation):
         # unordered cats have no min/max
         cat = Categorical(["a", "b", "c", "d"], ordered=False)
         msg = "Categorical is not ordered for operation {}"
-        with pytest.raises(TypeError, match=msg.format("min")):
-            cat.min()
-        with pytest.raises(TypeError, match=msg.format("max")):
-            cat.max()
+        agg_func = getattr(cat, aggregation)
+
+        with pytest.raises(TypeError, match=msg.format(aggregation)):
+            agg_func()
 
     def test_min_max_ordered(self):
         cat = Categorical(["a", "b", "c", "d"], ordered=True)
@@ -43,14 +44,13 @@ class TestCategoricalAnalytics:
             (Series(date_range("2020-01-01", periods=3), dtype="category"), np.NaN),
         ],
     )
-    def test_min_max_ordered_empty(self, categories, expected):
+    @pytest.mark.parametrize("aggregation", ["min", "max"])
+    def test_min_max_ordered_empty(self, categories, expected, aggregation):
         # GH 30227
         cat = Categorical([], categories=list("ABC"), ordered=True)
 
-        result = cat.min()
-        assert result is expected
-
-        result = cat.max()
+        agg_func = getattr(cat, aggregation)
+        result = agg_func()
         assert result is expected
 
     @pytest.mark.parametrize("skipna", [True, False])

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -5,7 +5,7 @@ import pytest
 
 from pandas.compat import PYPY
 
-from pandas import Categorical, Index, Series, date_range, NaT
+from pandas import Categorical, Index, Series, date_range
 from pandas.api.types import is_scalar
 import pandas.util.testing as tm
 

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -11,8 +11,7 @@ import pandas.util.testing as tm
 
 
 class TestCategoricalAnalytics:
-    def test_min_max(self):
-
+    def test_min_max_not_ordered(self):
         # unordered cats have no min/max
         cat = Categorical(["a", "b", "c", "d"], ordered=False)
         msg = "Categorical is not ordered for operation {}"
@@ -21,6 +20,7 @@ class TestCategoricalAnalytics:
         with pytest.raises(TypeError, match=msg.format("max")):
             cat.max()
 
+    def test_min_max_ordered(self):
         cat = Categorical(["a", "b", "c", "d"], ordered=True)
         _min = cat.min()
         _max = cat.max()
@@ -43,7 +43,7 @@ class TestCategoricalAnalytics:
             (Series(date_range("2020-01-01", periods=3), dtype="category"), NaT),
         ],
     )
-    def test_min_max_empty(self, categories, expected):
+    def test_min_max_ordered_empty(self, categories, expected):
         # GH 30227
         cat = Categorical([], categories=list("ABC"), ordered=True)
 

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -5,7 +5,7 @@ import pytest
 
 from pandas.compat import PYPY
 
-from pandas import Categorical, Index, Series, date_range
+from pandas import Categorical, Index, NaT, Series, date_range
 from pandas.api.types import is_scalar
 import pandas.util.testing as tm
 
@@ -41,7 +41,13 @@ class TestCategoricalAnalytics:
         [
             (list("ABC"), np.NaN),
             ([1, 2, 3], np.NaN),
-            (Series(date_range("2020-01-01", periods=3), dtype="category"), np.NaN),
+            pytest.param(
+                Series(date_range("2020-01-01", periods=3), dtype="category"),
+                NaT,
+                marks=pytest.mark.xfail(
+                    reason="https://github.com/pandas-dev/pandas/issues/29962"
+                ),
+            ),
         ],
     )
     @pytest.mark.parametrize("aggregation", ["min", "max"])

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -35,6 +35,15 @@ class TestCategoricalAnalytics:
         assert _min == "d"
         assert _max == "a"
 
+    def test_min_max_empty(self):
+        cat = Categorical([], categories=list("ABC"), ordered=True)
+
+        result = cat.min()
+        assert isinstance(result, float) and np.isnan(result)
+
+        result = cat.max()
+        assert isinstance(result, float) and np.isnan(result)
+
     @pytest.mark.parametrize("skipna", [True, False])
     def test_min_max_with_nan(self, skipna):
         # GH 25303

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -36,6 +36,7 @@ class TestCategoricalAnalytics:
         assert _max == "a"
 
     def test_min_max_empty(self):
+        # GH 30227
         cat = Categorical([], categories=list("ABC"), ordered=True)
 
         result = cat.min()

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -40,7 +40,7 @@ class TestCategoricalAnalytics:
         [
             (list("ABC"), np.NaN),
             ([1, 2, 3], np.NaN),
-            (Series(date_range("2020-01-01", periods=3), dtype="category"), NaT),
+            (Series(date_range("2020-01-01", periods=3), dtype="category"), np.NaN),
         ],
     )
     def test_min_max_ordered_empty(self, categories, expected):

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -5,7 +5,7 @@ import pytest
 
 from pandas.compat import PYPY
 
-from pandas import Categorical, Index, Series
+from pandas import Categorical, Index, Series, date_range, NaT
 from pandas.api.types import is_scalar
 import pandas.util.testing as tm
 
@@ -35,15 +35,23 @@ class TestCategoricalAnalytics:
         assert _min == "d"
         assert _max == "a"
 
-    def test_min_max_empty(self):
+    @pytest.mark.parametrize(
+        "categories,expected",
+        [
+            (list("ABC"), np.NaN),
+            ([1, 2, 3], np.NaN),
+            (Series(date_range("2020-01-01", periods=3), dtype="category"), NaT),
+        ],
+    )
+    def test_min_max_empty(self, categories, expected):
         # GH 30227
         cat = Categorical([], categories=list("ABC"), ordered=True)
 
         result = cat.min()
-        assert isinstance(result, float) and np.isnan(result)
+        assert result is expected
 
         result = cat.max()
-        assert isinstance(result, float) and np.isnan(result)
+        assert result is expected
 
     @pytest.mark.parametrize("skipna", [True, False])
     def test_min_max_with_nan(self, skipna):

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1060,6 +1060,14 @@ class TestCategoricalSeriesReductions:
             assert np.isnan(_min)
             assert np.isnan(_max)
 
+    def test_min_max_empty(self):
+        cat = Series(
+            Categorical([], categories=list("ABC"), ordered=True)
+        )
+
+        assert isna(cat.min())
+        assert isna(cat.max())
+
 
 class TestSeriesMode:
     # Note: the name TestSeriesMode indicates these tests

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1061,9 +1061,7 @@ class TestCategoricalSeriesReductions:
             assert np.isnan(_max)
 
     def test_min_max_empty(self):
-        cat = Series(
-            Categorical([], categories=list("ABC"), ordered=True)
-        )
+        cat = Series(Categorical([], categories=list("ABC"), ordered=True))
 
         assert isna(cat.min())
         assert isna(cat.max())

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1060,12 +1060,6 @@ class TestCategoricalSeriesReductions:
             assert np.isnan(_min)
             assert np.isnan(_max)
 
-    def test_min_max_empty(self):
-        cat = Series(Categorical([], categories=list("ABC"), ordered=True))
-
-        assert isna(cat.min())
-        assert isna(cat.max())
-
 
 class TestSeriesMode:
     # Note: the name TestSeriesMode indicates these tests


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Currently on master, the following fails:
```python
import pandas as pd

# Empty Dataframe
df = pd.DataFrame({
    "cat": pd.Categorical([], categories=list("ABC"), ordered=True),
    "val": pd.Series([], dtype="int64")
})

df["cat"].max()
```
`ValueError: zero-size array to reduction operation maximum which has no identity`

Other dtypes return `NaN` when calling `min()` or `max()` on an empty Series. This PR changes the behavior of Categoricals to be the same. 

Note that current behavior causes a downstream bug in Dask here: https://github.com/dask/dask/issues/5645, so this PR could fix that bug as well.