### PR TITLE
Removed parallel CI

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -121,7 +121,7 @@ conda list pandas
 # Make sure any error below is reported as such
 
 echo "[Build extensions]"
-python setup.py build_ext -q -i -j4
+python setup.py build_ext -q -i
 
 # XXX: Some of our environments end up with old versions of pip (10.x)
 # Adding a new enough version of pip to the requirements explodes the


### PR DESCRIPTION
I think this was responsible for some of the Py36 failures showing up in CI this morning, so reverting this piece for now (can still locally use parallel build_ext) until investigated further