### PR TITLE
BUG: to_datetime with unit with Int64

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -796,6 +796,7 @@ Datetimelike
 - Bug in :meth:`DataFrame.append` would remove the timezone-awareness of new data (:issue:`30238`)
 - Bug in :meth:`Series.cummin` and :meth:`Series.cummax` with timezone-aware dtype incorrectly dropping its timezone (:issue:`15553`)
 - Bug in :class:`DatetimeArray`, :class:`TimedeltaArray`, and :class:`PeriodArray` where inplace addition and subtraction did not actually operate inplace (:issue:`24115`)
+- Bug in :func:`pandas.to_datetime` when called with ``Series`` storing ``IntegerArray`` raising ``TypeError`` instead of returning ``Series`` (:issue:`30050`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -296,16 +296,33 @@ def format_array_from_datetime(ndarray[int64_t] values, object tz=None,
     return result
 
 
-def array_with_unit_to_datetime(ndarray values, object unit,
+def array_with_unit_to_datetime(ndarray values, ndarray mask, object unit,
                                 str errors='coerce'):
     """
-    convert the ndarray according to the unit
+    Convert the ndarray to datetime according to the time unit.
+
+    This function converts an array of objects into a numpy array of
+    datetime64[ns]. It returns the converted array
+    and also returns the timezone offset
+
     if errors:
       - raise: return converted values or raise OutOfBoundsDatetime
           if out of range on the conversion or
           ValueError for other conversions (e.g. a string)
       - ignore: return non-convertible values as the same unit
       - coerce: NaT for non-convertibles
+
+    Parameters
+    ----------
+    values : ndarray of object
+         Date-like objects to convert
+    mask : ndarray of bool
+         Not-a-time mask for non-nullable integer types conversion,
+         can be None
+    unit : object
+         Time unit to use during conversion
+    errors : str, default 'raise'
+         Error behavior when parsing
 
     Returns
     -------
@@ -316,7 +333,6 @@ def array_with_unit_to_datetime(ndarray values, object unit,
         Py_ssize_t i, j, n=len(values)
         int64_t m
         ndarray[float64_t] fvalues
-        ndarray mask
         bint is_ignore = errors=='ignore'
         bint is_coerce = errors=='coerce'
         bint is_raise = errors=='raise'
@@ -329,9 +345,13 @@ def array_with_unit_to_datetime(ndarray values, object unit,
 
     if unit == 'ns':
         if issubclass(values.dtype.type, np.integer):
-            return values.astype('M8[ns]'), tz
-        # This will return a tz
-        return array_to_datetime(values.astype(object), errors=errors)
+            result = values.astype('M8[ns]')
+        else:
+            result, tz = array_to_datetime(values.astype(object), errors=errors)
+        if mask is not None:
+            iresult = result.view('i8')
+            iresult[mask] = NPY_NAT
+        return result, tz
 
     m = cast_from_unit(None, unit)
 
@@ -343,7 +363,9 @@ def array_with_unit_to_datetime(ndarray values, object unit,
         if values.dtype.kind == "i":
             # Note: this condition makes the casting="same_kind" redundant
             iresult = values.astype('i8', casting='same_kind', copy=False)
-            mask = iresult == NPY_NAT
+            # If no mask, fill mask by comparing to NPY_NAT constant
+            if mask is None:
+                mask = iresult == NPY_NAT
             iresult[mask] = 0
             fvalues = iresult.astype('f8') * m
             need_to_iterate = False

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -2291,3 +2291,21 @@ def test_should_cache_errors(unique_share, check_count, err_message):
 
     with pytest.raises(AssertionError, match=err_message):
         tools.should_cache(arg, unique_share, check_count)
+
+def test_intarray_to_datetime():
+    # Test for #30050
+    ser = pd.Series([1, 2, None, 2 ** 61, None])
+    ser = ser.astype("Int64")
+
+    res = pd.to_datetime(ser, unit="ns")
+
+    expected = pd.Series(
+        [
+            np.datetime64("1970-01-01 00:00:00.000000001"),
+            np.datetime64("1970-01-01 00:00:00.000000002"),
+            np.datetime64("NaT"),
+            np.datetime64("2043-01-25 23:56:49.213693952"),
+            np.datetime64("NaT"),
+        ]
+    )
+    tm.assert_series_equal(res, expected)

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -2292,6 +2292,7 @@ def test_should_cache_errors(unique_share, check_count, err_message):
     with pytest.raises(AssertionError, match=err_message):
         tools.should_cache(arg, unique_share, check_count)
 
+
 def test_intarray_to_datetime():
     # Test for #30050
     ser = pd.Series([1, 2, None, 2 ** 61, None])

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -2293,10 +2293,11 @@ def test_should_cache_errors(unique_share, check_count, err_message):
         tools.should_cache(arg, unique_share, check_count)
 
 
-def test_intarray_to_datetime():
+def test_nullable_integer_to_datetime():
     # Test for #30050
     ser = pd.Series([1, 2, None, 2 ** 61, None])
     ser = ser.astype("Int64")
+    ser_copy = ser.copy()
 
     res = pd.to_datetime(ser, unit="ns")
 
@@ -2310,3 +2311,5 @@ def test_intarray_to_datetime():
         ]
     )
     tm.assert_series_equal(res, expected)
+    # Check that ser isn't mutated
+    tm.assert_series_equal(ser, ser_copy)


### PR DESCRIPTION
- [X] closes #30050
- [X] tests added 1 / passed 1
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Test output:
```
$ py.test pandas/tests/tools/test_datetime.py
============================= test session starts =============================
platform win32 -- Python 3.7.3, pytest-5.3.1, py-1.8.0, pluggy-0.13.0
rootdir: C:\git_contrib\pandas\pandas, inifile: setup.cfg
plugins: hypothesis-4.50.6, cov-2.8.1, forked-1.1.2, xdist-1.30.0
collected 1 item

pandas\tests\tools\test_datetime.py .                                    [100%]

============================== 1 passed in 0.03s ==============================

```

Notes: Hello. The fix introduces one additional type check if the Series passed to `to_datetime` stores anything except and IntegerArray. It does nothing else in this case. If we try to pass an IntegerArray, it pulls all the values that aren't NaN into an ndarray, converts that into datetime and adds NaT in the places where NaNs were. No precision is lost.