### PR TITLE
CLN: more consistent error message for ExtensionDtype.construct_from_string

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -72,7 +72,12 @@ class PandasDtype(ExtensionDtype):
 
     @classmethod
     def construct_from_string(cls, string):
-        return cls(np.dtype(string))
+        try:
+            return cls(np.dtype(string))
+        except TypeError as err:
+            raise TypeError(
+                f"Cannot construct a 'PandasDtype' from '{string}'"
+            ) from err
 
     def construct_array_type(cls):
         return PandasArray

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -199,7 +199,7 @@ class SparseDtype(ExtensionDtype):
         -------
         SparseDtype
         """
-        msg = f"Could not construct SparseDtype from '{string}'"
+        msg = f"Cannot construct a 'SparseDtype' from '{string}'"
         if string.startswith("Sparse"):
             try:
                 sub_type, has_fill_value = cls._parse_subtype(string)
@@ -208,7 +208,7 @@ class SparseDtype(ExtensionDtype):
             else:
                 result = SparseDtype(sub_type)
                 msg = (
-                    f"Could not construct SparseDtype from '{string}'.\n\nIt "
+                    f"Cannot construct a 'SparseDtype' from '{string}'.\n\nIt "
                     "looks like the fill_value in the string is not "
                     "the default for the dtype. Non-default fill_values "
                     "are not supported. Use the 'SparseDtype()' "

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -746,7 +746,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
                     raise TypeError(msg) from err
             raise TypeError(msg)
 
-        raise TypeError("Could not construct DatetimeTZDtype")
+        raise TypeError("Cannot construct a 'DatetimeTZDtype'")
 
     def __str__(self) -> str_type:
         return "datetime64[{unit}, {tz}]".format(unit=self.unit, tz=self.tz)

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -732,7 +732,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
         datetime64[ns, UTC]
         """
         if isinstance(string, str):
-            msg = "Could not construct DatetimeTZDtype from '{string}'"
+            msg = f"Cannot construct a 'DatetimeTZDtype' from '{string}'"
             match = cls._match.match(string)
             if match:
                 d = match.groupdict()
@@ -743,8 +743,8 @@ class DatetimeTZDtype(PandasExtensionDtype):
                     #  pytz timezone (actually pytz.UnknownTimeZoneError).
                     # TypeError if we pass a nonsense tz;
                     # ValueError if we pass a unit other than "ns"
-                    raise TypeError(msg.format(string=string)) from err
-            raise TypeError(msg.format(string=string))
+                    raise TypeError(msg) from err
+            raise TypeError(msg)
 
         raise TypeError("Could not construct DatetimeTZDtype")
 
@@ -883,7 +883,7 @@ class PeriodDtype(PandasExtensionDtype):
                 return cls(freq=string)
             except ValueError:
                 pass
-        raise TypeError("could not construct PeriodDtype")
+        raise TypeError(f"Cannot construct a 'PeriodDtype' from '{string}'")
 
     def __str__(self) -> str_type:
         return self.name
@@ -1054,6 +1054,7 @@ class IntervalDtype(PandasExtensionDtype):
             return cls(string)
 
         msg = (
+            f"Cannot construct a 'IntervalDtype' from '{string}'.\n\n"
             "Incorrectly formatted string passed to constructor. "
             "Valid formats include Interval or Interval[dtype] "
             "where dtype is numeric, datetime, or timedelta"

--- a/pandas/tests/arrays/sparse/test_dtype.py
+++ b/pandas/tests/arrays/sparse/test_dtype.py
@@ -83,7 +83,7 @@ def test_not_equal(a, b):
 
 def test_construct_from_string_raises():
     with pytest.raises(
-        TypeError, match="Could not construct SparseDtype from 'not a dtype'"
+        TypeError, match="Cannot construct a 'SparseDtype' from 'not a dtype'"
     ):
         SparseDtype.construct_from_string("not a dtype")
 

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -236,7 +236,7 @@ class TestDatetimeTZDtype(Base):
     def test_construction_from_string(self):
         result = DatetimeTZDtype.construct_from_string("datetime64[ns, US/Eastern]")
         assert is_dtype_equal(self.dtype, result)
-        msg = "Could not construct DatetimeTZDtype from 'foo'"
+        msg = "Cannot construct a 'DatetimeTZDtype' from 'foo'"
         with pytest.raises(TypeError, match=msg):
             DatetimeTZDtype.construct_from_string("foo")
 
@@ -244,7 +244,7 @@ class TestDatetimeTZDtype(Base):
         with pytest.raises(TypeError, match="notatz"):
             DatetimeTZDtype.construct_from_string("datetime64[ns, notatz]")
 
-        msg = "^Could not construct DatetimeTZDtype"
+        msg = "^Cannot construct a 'DatetimeTZDtype'"
         with pytest.raises(TypeError, match=msg):
             # list instead of string
             DatetimeTZDtype.construct_from_string(["datetime64[ns, notatz]"])

--- a/pandas/tests/extension/arrow/arrays.py
+++ b/pandas/tests/extension/arrow/arrays.py
@@ -33,7 +33,7 @@ class ArrowBoolDtype(ExtensionDtype):
         if string == cls.name:
             return cls()
         else:
-            raise TypeError(f"Cannot construct a '{cls}' from '{string}'")
+            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
 
     @classmethod
     def construct_array_type(cls):

--- a/pandas/tests/extension/base/dtype.py
+++ b/pandas/tests/extension/base/dtype.py
@@ -98,5 +98,8 @@ class BaseDtypeTests(BaseExtensionTests):
     def test_construct_from_string(self, dtype):
         dtype_instance = type(dtype).construct_from_string(dtype.name)
         assert isinstance(dtype_instance, type(dtype))
-        with pytest.raises(TypeError):
+
+    def test_construct_from_string_another_type_raises(self, dtype):
+        msg = f"Cannot construct a '{type(dtype).__name__}' from 'another_type'"
+        with pytest.raises(TypeError, match=msg):
             type(dtype).construct_from_string("another_type")

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -40,7 +40,7 @@ class DecimalDtype(ExtensionDtype):
         if string == cls.name:
             return cls()
         else:
-            raise TypeError(f"Cannot construct a '{cls}' from '{string}'")
+            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
 
     @property
     def _is_numeric(self):

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -44,7 +44,7 @@ class JSONDtype(ExtensionDtype):
         if string == cls.name:
             return cls()
         else:
-            raise TypeError("Cannot construct a '{}' from '{}'".format(cls, string))
+            raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
 
 
 class JSONArray(ExtensionArray):


### PR DESCRIPTION
message check added to `test_construct_from_string` in `pandas/tests/extension/base/dtype.py` and error messages changed to be consistent with error message on class method in `pandas/core/dtypes/base.py` xref Provide ExtensionDtype.construct_from_string by default #26562