### PR TITLE
CLN changed .format to f-string for test_converter.py, test_datetimel…

### DIFF
--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -268,7 +268,7 @@ class TestDateTimeConverter:
             val1 = self.dtc.convert(ts1, None, None)
             val2 = self.dtc.convert(ts2, None, None)
             if not val1 < val2:
-                raise AssertionError("{0} is not less than {1}.".format(val1, val2))
+                raise AssertionError(f"{val1} is not less than {val2}.")
 
         # Matplotlib's time representation using floats cannot distinguish
         # intervals smaller than ~10 microsecond in the common range of years.

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1352,7 +1352,7 @@ class TestTSPlot(TestPlotBase):
 
     def test_format_timedelta_ticks_narrow(self):
 
-        expected_labels = ["00:00:00.0000000{:0>2d}".format(i) for i in np.arange(10)]
+        expected_labels = [f"00:00:00.0000000{i:0>2d}" for i in np.arange(10)]
 
         rng = timedelta_range("0", periods=10, freq="ns")
         df = DataFrame(np.random.randn(len(rng), 3), rng)

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -330,7 +330,7 @@ class TestSeriesPlots(TestPlotBase):
         ax = _check_plot_works(
             series.plot.pie, colors=color_args, autopct="%.2f", fontsize=7
         )
-        pcts = [f"{s:.2f}" (s * 100) for s in series.values / float(series.sum())]
+        pcts = [f"{s:.2f}"(s * 100) for s in series.values / float(series.sum())]
         expected_texts = list(chain.from_iterable(zip(series.index, pcts)))
         self._check_text_labels(ax.texts, expected_texts)
         for t in ax.texts:

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -330,7 +330,7 @@ class TestSeriesPlots(TestPlotBase):
         ax = _check_plot_works(
             series.plot.pie, colors=color_args, autopct="%.2f", fontsize=7
         )
-        pcts = [f"{s:.2f}"(s * 100) for s in series.values / float(series.sum())]
+        pcts = [f"{s*100:.2f}" for s in series.values / float(series.sum())]
         expected_texts = list(chain.from_iterable(zip(series.index, pcts)))
         self._check_text_labels(ax.texts, expected_texts)
         for t in ax.texts:

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -330,7 +330,7 @@ class TestSeriesPlots(TestPlotBase):
         ax = _check_plot_works(
             series.plot.pie, colors=color_args, autopct="%.2f", fontsize=7
         )
-        pcts = ["{0:.2f}".format(s * 100) for s in series.values / float(series.sum())]
+        pcts = [f"{s:.2f}" (s * 100) for s in series.values / float(series.sum())]
         expected_texts = list(chain.from_iterable(zip(series.index, pcts)))
         self._check_text_labels(ax.texts, expected_texts)
         for t in ax.texts:
@@ -865,15 +865,15 @@ class TestSeriesPlots(TestPlotBase):
 
     def test_xticklabels(self):
         # GH11529
-        s = Series(np.arange(10), index=["P{i:02d}".format(i=i) for i in range(10)])
+        s = Series(np.arange(10), index=[f"P{i:02d}" for i in range(10)])
         _, ax = self.plt.subplots()
         ax = s.plot(xticks=[0, 3, 5, 9], ax=ax)
-        exp = ["P{i:02d}".format(i=i) for i in [0, 3, 5, 9]]
+        exp = [f"P{i:02d}" for i in [0, 3, 5, 9]]
         self._check_text_labels(ax.get_xticklabels(), exp)
 
     def test_xtick_barPlot(self):
         # GH28172
-        s = pd.Series(range(10), index=["P{i:02d}".format(i=i) for i in range(10)])
+        s = pd.Series(range(10), index=[f"P{i:02d}" for i in range(10)])
         ax = s.plot.bar(xticks=range(0, 11, 2))
         exp = np.array(list(range(0, 11, 2)))
         tm.assert_numpy_array_equal(exp, ax.get_xticks())


### PR DESCRIPTION
…ike.py, test_series.py #29547

https://github.com/pandas-dev/pandas/issues/29547

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry