### PR TITLE
[WIP]: Indexing with BooleanArray propagates NA

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -46,6 +46,7 @@ from pandas.core import ops
 from pandas.core.accessor import PandasDelegate, delegate_names
 import pandas.core.algorithms as algorithms
 from pandas.core.algorithms import _get_data_algo, factorize, take, take_1d, unique1d
+from pandas.core.arrays import BooleanArray
 from pandas.core.base import NoNewAttributesMixin, PandasObject, _shared_docs
 import pandas.core.common as com
 from pandas.core.construction import array, extract_array, sanitize_array
@@ -1996,10 +1997,14 @@ class Categorical(ExtensionArray, PandasObject):
                 return np.nan
             else:
                 return self.categories[i]
+        elif com.is_bool_indexer(key) and isinstance(key, BooleanArray):
+            take = key._data | key._mask
+            values = self._codes[take]
+            values[key._mask[take]] = -1
         else:
-            return self._constructor(
-                values=self._codes[key], dtype=self.dtype, fastpath=True
-            )
+            values = self._codes[key]
+
+        return self._constructor(values=values, dtype=self.dtype, fastpath=True)
 
     def __setitem__(self, key, value):
         """

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -21,6 +21,7 @@ from pandas.core.dtypes.common import (
     is_scalar,
 )
 from pandas.core.dtypes.dtypes import register_extension_dtype
+from pandas.core.dtypes.inference import is_array_like
 from pandas.core.dtypes.missing import isna, notna
 
 from pandas.core import nanops, ops
@@ -366,10 +367,20 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
         return fmt
 
     def __getitem__(self, item):
+        from pandas.core.arrays import BooleanArray
+
         if is_integer(item):
             if self._mask[item]:
                 return self.dtype.na_value
             return self._data[item]
+        elif is_array_like(item) and is_bool_dtype(item.dtype):
+            if isinstance(item, BooleanArray):
+                # items, mask = item._data, item._mask
+                take = item._data | item._mask
+                result = self._data[take]
+                # output masked anywhere where self is masked, or the input was masked
+                omask = (self._mask | item._mask)[take]
+                return type(self)(result, omask)
         return type(self)(self._data[item], self._mask[item])
 
     def _coerce_to_ndarray(self):

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -132,9 +132,9 @@ def is_bool_indexer(key: Any) -> bool:
         elif is_bool_dtype(key.dtype):
             # an ndarray with bool-dtype by definition has no missing values.
             # So we only need to check for NAs in ExtensionArrays
-            if is_extension_array_dtype(key.dtype):
-                if np.any(key.isna()):
-                    raise ValueError(na_msg)
+            # if is_extension_array_dtype(key.dtype):
+            #     if np.any(key.isna()):
+            #         raise ValueError(na_msg)
             return True
     elif isinstance(key, list):
         try:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -65,7 +65,7 @@ from pandas.core.dtypes.missing import array_equivalent, isna
 from pandas.core import ops
 from pandas.core.accessor import CachedAccessor
 import pandas.core.algorithms as algos
-from pandas.core.arrays import ExtensionArray
+from pandas.core.arrays import BooleanArray, ExtensionArray
 from pandas.core.base import IndexOpsMixin, PandasObject
 import pandas.core.common as com
 from pandas.core.construction import extract_array
@@ -4014,7 +4014,11 @@ class Index(IndexOpsMixin, PandasObject):
             return promote(getitem(key))
 
         if com.is_bool_indexer(key):
-            key = np.asarray(key, dtype=bool)
+            if isinstance(key, BooleanArray):
+                # TODO: Handle all boolean indexers.
+                key = key._data | key._mask
+            else:
+                key = np.asarray(key, dtype=bool)
 
         key = com.values_from_object(key)
         result = getitem(key)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -291,7 +291,7 @@ class Block(PandasObject):
         self.values = state[1]
         self.ndim = self.values.ndim
 
-    def _slice(self, slicer):
+    def _slice(self, slicer, mask=None):
         """ return a slice of my values """
         return self.values[slicer]
 
@@ -1810,7 +1810,7 @@ class ExtensionBlock(NonConsolidatableMixIn, Block):
         # We're doing the same as CategoricalBlock here.
         return True
 
-    def _slice(self, slicer):
+    def _slice(self, slicer, mask=None):
         """ return a slice of my values """
 
         # slice the category
@@ -2307,7 +2307,7 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
         # expects that behavior.
         return np.asarray(self.values, dtype=_NS_DTYPE)
 
-    def _slice(self, slicer):
+    def _slice(self, slicer, mask=None):
         """ return a slice of my values """
         if isinstance(slicer, tuple):
             col, loc = slicer

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -709,7 +709,7 @@ class BlockManager(PandasObject):
 
         return type(self)(new_blocks, axes, do_integrity_check=False)
 
-    def get_slice(self, slobj, axis=0):
+    def get_slice(self, slobj, axis=0, mask=None):
         if axis >= self.ndim:
             raise IndexError("Requested axis not found in manager")
 
@@ -1505,11 +1505,13 @@ class SingleBlockManager(BlockManager):
         """ compat with BlockManager """
         return None
 
-    def get_slice(self, slobj, axis=0):
+    def get_slice(self, slobj, axis=0, mask=None):
         if axis >= self.ndim:
             raise IndexError("Requested axis not found in manager")
 
-        return type(self)(self._block._slice(slobj), self.index[slobj], fastpath=True)
+        return type(self)(
+            self._block._slice(slobj, mask=mask), self.index[slobj], fastpath=True
+        )
 
     @property
     def index(self):

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -2013,6 +2013,7 @@ class TestDataFrameIndexing:
         tm.assert_frame_equal(result, expected)
 
     def test_boolean_indexing(self):
+        # TODO: parametrize
         idx = list(range(3))
         cols = ["A", "B", "C"]
         df1 = DataFrame(
@@ -2036,6 +2037,7 @@ class TestDataFrameIndexing:
             df1[df1.index[:-1] > 2] = -1
 
     def test_boolean_indexing_mixed(self):
+        # TODO: parametrize?
         df = DataFrame(
             {
                 0: {35: np.nan, 40: np.nan, 43: np.nan, 49: np.nan, 50: np.nan},

--- a/pandas/tests/indexing/test_na_indexing.py
+++ b/pandas/tests/indexing/test_na_indexing.py
@@ -1,0 +1,58 @@
+import pytest
+
+import pandas as pd
+import pandas.util.testing as tm
+
+
+@pytest.mark.parametrize(
+    "values, expected, dtype",
+    [
+        ([1, 2, 3], [1, None], "Int64"),
+        (["a", "b", "c"], ["a", pd.NA], "string"),
+        ([None, "b", "c"], [pd.NA, pd.NA], "string"),
+        ([True, False, None], [True, pd.NA], "boolean"),
+        ([None, False, None], [pd.NA, pd.NA], "boolean"),
+        pytest.param(
+            [pd.Timestamp("2000"), pd.Timestamp("2001"), pd.Timestamp("2002")],
+            [pd.Timestamp("2000"), pd.NaT],
+            "datetime64[ns]",
+            marks=pytest.mark.xfail(reson="TODO. Change DatetimeBlock._slice"),
+        ),
+        (
+            [
+                pd.Timestamp("2000", tz="CET"),
+                pd.Timestamp("2001", tz="CET"),
+                pd.Timestamp("2002", tz="CET"),
+            ],
+            [pd.Timestamp("2000", tz="CET"), pd.NaT],
+            "datetime64[ns, cet]",
+        ),
+        pytest.param(
+            [pd.Timedelta("1H"), pd.Timedelta("2H"), pd.Timedelta("3H")],
+            [pd.Timedelta("1H"), pd.NaT],
+            "timedelta64[ns]",
+            marks=pytest.mark.xfail(reson="TODO. Change TimeDeltaBlock._slice"),
+        ),
+        (
+            [pd.Period("2000"), pd.Period("2001"), pd.Period("2002")],
+            [pd.Period("2000"), pd.NaT],
+            "period[A-DEC]",
+        ),
+        (["a", "b", "c"], ["a", None], pd.CategoricalDtype(["a", "b", "c"])),
+    ],
+)
+def test_mask_series(values, expected, dtype):
+    s = pd.Series(values, dtype=dtype, name="name")
+    orig = pd.Series(values, dtype=dtype, name="name")
+    mask = pd.array([True, False, None], dtype="boolean")
+    result = s[mask]
+    # expected = pd.Series([1, pd.NA], index=[0, 2], dtype="Int64")
+    expected = pd.Series(expected, dtype=dtype, name="name", index=[0, 2])
+    tm.assert_series_equal(result, expected)
+    assert result.dtype == s.dtype
+    assert pd.isna(result.iloc[-1])
+
+    tm.assert_equal(s.array[mask], expected.array)
+
+    # ensure no mutation
+    tm.assert_series_equal(s, orig)


### PR DESCRIPTION
This implements indexing a Series with a BooleanArray for some
dtypes. NA values in the mask propagate. It's not clear that we want to propagate NAs.

This required updating each EA's `__getitem__` to correctly propagate
NA. Doing the same for ndarray-backed Series is possible, but will require
some additional hacking and we first need to determine the result dtype.

No need to review in detail. The primary motivation for pushing this up
is to better understand what indexing with NA values will look like in
practice.

xref https://github.com/pandas-dev/pandas/issues/28778, and https://github.com/pandas-dev/pandas/issues/28778#issuecomment-565538145 in particular.

---

(copied from https://github.com/pandas-dev/pandas/issues/28778#issuecomment-565538145)

On indexing, propagating NAs presents some challenging dtype casting issues. For example, what is the dtype on the output of

```python
In [3]: s = pd.Series([1, 2, 3])

In [4]: mask = pd.array([True, False, None])

In [5]: s[mask]
```

Would that be an Int64 dtype, with the last value being NA? Would we cast to float64 and use `np.nan`? object-dtype?

And what if the original series was float dtype? A float-dtype with NaN is about the only option we have right now, since we lack a float64 array that can hold NA.

I don't think that an indexing operation that introduces missing values should change the dtype of the array. I don't think anyone would realistically want that. So... do we just raise for now?

What about cases when we are able to index without changing the dtype? Those would be

1. Indexing with a BooleanArray with no missing values.
2. Indexing a dtype that supports missing values (datetime, timedelta, string, object, Int64, boolean...). Basically anything but NumPy's bool, int float.

IMO, which shouldn't have value-dependent behavior, so if

```python
>>> pd.Series([1, 2])[pd.array([True, None])
```

raises, then so should `pd.Series([1, 2])[pd.array([True, False])` (no missing values).

I think supporting 2 is fine, since it just depends on the dtypes.

```python
>>> pd.Series([1, 2], dtype="Int64")[pd.array([True, None])]
Series([1, NA], dtype="Int64")
>>> pd.Series([1, 2], dtype="Int64")[pd.array([True, False])]
Series([1], dtype="Int64")
```