### PR TITLE
Simplified objToJSON signatures

### DIFF
--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -1797,7 +1797,7 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
             PRINTMARK();
             // TODO: last argument here is unused; should decouple string
             // from long datetimelike conversion routines
-            GET_TC(tc)->longValue = PyDateTimeToJSON(obj, tc, 0);
+            GET_TC(tc)->longValue = (JSINT64)PyDateTimeToJSON(obj, tc, 0);
             tc->type = JT_LONG;
         }
         return;

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -434,7 +434,7 @@ static void *PandasDateTimeStructToJSON(npy_datetimestruct *dts,
         }
     } else {
         PRINTMARK();
-        return npy_datetimestruct_to_datetime(base, dts);
+        return (JSINT64)npy_datetimestruct_to_datetime(base, dts);
     }
 }
 


### PR DESCRIPTION
Pre-cursor to a change that splits datetime functions that return `char *` off from datetime functions that return int.  Right now these are intermixed in functions that return void pointers, which makes type checking and grokking more difficult than they need to be