### PR TITLE
[bug] don't remove timezone-awareness when using the  method from Dat…

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -714,6 +714,7 @@ Datetimelike
 - Bug in :func:`pandas.to_datetime` failing for `deques` when using ``cache=True`` (the default) (:issue:`29403`)
 - Bug in :meth:`Series.item` with ``datetime64`` or ``timedelta64`` dtype, :meth:`DatetimeIndex.item`, and :meth:`TimedeltaIndex.item` returning an integer instead of a :class:`Timestamp` or :class:`Timedelta` (:issue:`30175`)
 - Bug in :class:`DatetimeIndex` addition when adding a non-optimized :class:`DateOffset` incorrectly dropping timezone information (:issue:`30336`)
+- Bug in :meth:`DataFrame.append` would remove the timezone-awareness of new data (:issue:`30238`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6757,25 +6757,19 @@ class DataFrame(NDFrame):
                     " or if the Series has a name"
                 )
 
-            if other.name is None:
-                index = None
-            else:
-                # other must have the same index name as self, otherwise
-                # index name will be reset
-                index = Index([other.name], name=self.index.name)
+            index = Index([other.name], name=self.index.name)
 
             idx_diff = other.index.difference(self.columns)
             try:
                 combined_columns = self.columns.append(idx_diff)
             except TypeError:
                 combined_columns = self.columns.astype(object).append(idx_diff)
-            other = other.reindex(combined_columns, copy=False)
-            other = DataFrame(
-                other.values.reshape((1, len(other))),
-                index=index,
-                columns=combined_columns,
+            other = (
+                other.reindex(combined_columns, copy=False)
+                .to_frame()
+                .T.rename_axis(index.names)
+                ._convert(datetime=True, timedelta=True)
             )
-            other = other._convert(datetime=True, timedelta=True)
             if not self.columns.equals(combined_columns):
                 self = self.reindex(columns=combined_columns)
         elif isinstance(other, list):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6767,7 +6767,7 @@ class DataFrame(NDFrame):
                 other.reindex(combined_columns, copy=False)
                 .to_frame()
                 .T.infer_objects()
-                .rename_axis(index.names)
+                .rename_axis(index.names, copy=False)
             )
             if not self.columns.equals(combined_columns):
                 self = self.reindex(columns=combined_columns)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6758,7 +6758,6 @@ class DataFrame(NDFrame):
                 )
 
             index = Index([other.name], name=self.index.name)
-
             idx_diff = other.index.difference(self.columns)
             try:
                 combined_columns = self.columns.append(idx_diff)
@@ -6767,8 +6766,8 @@ class DataFrame(NDFrame):
             other = (
                 other.reindex(combined_columns, copy=False)
                 .to_frame()
-                .T.rename_axis(index.names)
-                ._convert(datetime=True, timedelta=True)
+                .T.infer_objects()
+                .rename_axis(index.names)
             )
             if not self.columns.equals(combined_columns):
                 self = self.reindex(columns=combined_columns)

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import numpy as np
 import pytest
+import pytz
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range
@@ -287,6 +288,20 @@ class TestDataFrameConcatCommon:
         result = df1.append(df2)
         expected = DataFrame({"bar": Series([Timestamp("20130101"), 1])})
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "timestamp, timezone",
+        [
+            ("2019-07-19 07:04:57+0100", pytz.FixedOffset(60)),
+            ("2019-07-19 07:04:57", None),
+        ],
+    )
+    def test_append_timestamps_aware_or_naive(self, timestamp, timezone):
+        # GH 30238
+        df = pd.DataFrame([pd.Timestamp(timestamp, tz=timezone)])
+        result = df.append(df.iloc[0]).iloc[-1]
+        expected = pd.Series(pd.Timestamp(timestamp, tz=timezone), name=0)
+        pd.testing.assert_series_equal(result, expected)
 
     def test_update(self):
         df = DataFrame(

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -297,7 +297,7 @@ class TestDataFrameConcatCommon:
         df = pd.DataFrame([pd.Timestamp(timestamp, tz=tz)])
         result = df.append(df.iloc[0]).iloc[-1]
         expected = pd.Series(pd.Timestamp(timestamp, tz=tz), name=0)
-        pd.testing.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_update(self):
         df = DataFrame(

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import numpy as np
 import pytest
+import pytz
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import numpy as np
 import pytest
-import pytz
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range
@@ -290,17 +289,14 @@ class TestDataFrameConcatCommon:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "timestamp, timezone",
-        [
-            ("2019-07-19 07:04:57+0100", pytz.FixedOffset(60)),
-            ("2019-07-19 07:04:57", None),
-        ],
+        "timestamp", ["2019-07-19 07:04:57+0100", "2019-07-19 07:04:57"]
     )
-    def test_append_timestamps_aware_or_naive(self, timestamp, timezone):
+    def test_append_timestamps_aware_or_naive(self, tz_naive_fixture, timestamp):
         # GH 30238
-        df = pd.DataFrame([pd.Timestamp(timestamp, tz=timezone)])
+        tz = tz_naive_fixture
+        df = pd.DataFrame([pd.Timestamp(timestamp, tz=tz)])
         result = df.append(df.iloc[0]).iloc[-1]
-        expected = pd.Series(pd.Timestamp(timestamp, tz=timezone), name=0)
+        expected = pd.Series(pd.Timestamp(timestamp, tz=tz), name=0)
         pd.testing.assert_series_equal(result, expected)
 
     def test_update(self):

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 import numpy as np
 import pytest
-import pytz
 
 import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp, date_range


### PR DESCRIPTION
…aFrame

- [x] closes #30238
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
