### PR TITLE
solve "Int64 with null value mangles large-ish integers" problem

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1190,6 +1190,7 @@ ExtensionArray
 - Fixed bug where the constructor of :class:`DataFrame` with ``dtype='string'`` would fail (:issue:`27953`, :issue:`33623`)
 - Bug where :class:`DataFrame` column set to scalar extension type was considered an object type rather than the extension type (:issue:`34832`)
 - Fixed bug in :meth:`IntegerArray.astype` to correctly copy the mask as well (:issue:`34931`).
+- Bug in creating nullable integer ``Series`` while using large-ish integers with ``NaN`` values (:issue:`30268`)
 
 Other
 ^^^^^

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -227,9 +227,8 @@ def coerce_to_array(
             mask = mask.copy()
         return values, mask
 
-    typ = dtype.numpy_dtype()
-    values = np.asarray(values, dtype=typ)
-    if copy and hasattr(values, 'dtype'):
+    values = np.asarray(values, dtype=getattr(values, "dtype", object))
+    if copy and hasattr(values, "dtype"):
         values = values.copy()
 
     if is_object_dtype(values):

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -227,7 +227,11 @@ def coerce_to_array(
             mask = mask.copy()
         return values, mask
 
-    values = np.array(values, copy=copy)
+    typ = dtype.numpy_dtype()
+    values = np.asarray(values, dtype=typ)
+    if copy and hasattr(values, 'dtype'):
+        values = values.copy()
+
     if is_object_dtype(values):
         inferred_type = lib.infer_dtype(values, skipna=True)
         if inferred_type == "empty":
@@ -239,6 +243,7 @@ def coerce_to_array(
             "mixed-integer",
             "integer-na",
             "mixed-integer-float",
+            "boolean",
         ]:
             raise TypeError(f"{values.dtype} cannot be converted to an IntegerDtype")
 

--- a/pandas/tests/arrays/integer/test_construction.py
+++ b/pandas/tests/arrays/integer/test_construction.py
@@ -197,3 +197,19 @@ def test_to_integer_array(values, to_dtype, result_dtype):
     assert result.dtype == result_dtype()
     expected = integer_array(values, dtype=result_dtype())
     tm.assert_extension_array_equal(result, expected)
+
+
+def test_construction_large_numbers():
+    # issue 30268
+    values = [9999999999999999, 123123123123123123, 10000000000000543, np.nan]
+    expected = pd.Series(
+        IntegerArray(
+            np.array(
+                [9999999999999999, 123123123123123123, 10000000000000543, 0],
+                dtype="int64",
+            ),
+            np.array([False, False, False, True]),
+        )
+    )
+    result = pd.Series(values, dtype="Int64")
+    tm.assert_series_equal(result, expected, check_exact=True)


### PR DESCRIPTION
- [x] closes #30268 
- [ ] tests added/passed
- [x] passes black pandas
- [x] passes git diff upstream/master -u -- "*.py" | flake8 --diff
- [x] whatsnew entry
The `pd.Series` was giving less precise output when inputting a list containing large integers and np.nan values and passing `dtype="Int64"`. Which was due to converting it to `np.array`. This PR aims to solve that bug.