### PR TITLE
BUG: DataFrame constructor raised ValueError with list-like data and …

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -861,7 +861,7 @@ ExtensionArray
 
 - Bug in :class:`arrays.PandasArray` when setting a scalar string (:issue:`28118`, :issue:`28150`).
 - Bug where nullable integers could not be compared to strings (:issue:`28930`)
--
+- Bug where :class:`DataFrame` constructor raised ValueError with list-like data and ``dtype`` specified (:issue:`30280`)
 
 
 Other

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -150,7 +150,7 @@ def init_ndarray(values, index, columns, dtype=None, copy=False):
 
         index, columns = _get_axes(len(values), 1, index, columns)
         return arrays_to_mgr([values], columns, index, columns, dtype=dtype)
-    elif is_extension_array_dtype(values):
+    elif is_extension_array_dtype(values) or is_extension_array_dtype(dtype):
         # GH#19157
         if columns is None:
             columns = [0]

--- a/pandas/tests/extension/base/constructors.py
+++ b/pandas/tests/extension/base/constructors.py
@@ -64,6 +64,15 @@ class BaseConstructorsTests(BaseExtensionTests):
         result = pd.Series(list(data), dtype=str(dtype))
         self.assert_series_equal(result, expected)
 
+        # gh-30280
+
+        expected = pd.DataFrame(data).astype(dtype)
+        result = pd.DataFrame(list(data), dtype=dtype)
+        self.assert_frame_equal(result, expected)
+
+        result = pd.DataFrame(list(data), dtype=str(dtype))
+        self.assert_frame_equal(result, expected)
+
     def test_pandas_array(self, data):
         # pd.array(extension_array) should be idempotent...
         result = pd.array(data)


### PR DESCRIPTION
…dtype specified

- [ ] closes #30280
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
