### PR TITLE
BUG: :func:'read_pickle' and :func:'to_pickle' now accept URL and buf…

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -797,7 +797,7 @@ I/O
 - Bug in :func:`read_json` where default encoding was not set to ``utf-8`` (:issue:`29565`)
 - Bug in :class:`PythonParser` where str and bytes were being mixed when dealing with the decimal field (:issue:`29650`)
 - :meth:`read_gbq` now accepts ``progress_bar_type`` to display progress bar while the data downloads. (:issue:`29857`)
--
+- :func:'read_pickle' and :func:'to_pickle' now accept URL and buffer as well as file path (:issue:'30163')
 
 Plotting
 ^^^^^^^^


### PR DESCRIPTION
…fer as well as file path GH30163

- [ ] closes #30163
- [ ] tests passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
