### PR TITLE
DOC: Remove reference to moving windows regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Here are just a few of the things that pandas does well:
     and saving/loading data from the ultrafast [**HDF5 format**][hdfstore]
   - [**Time series**][timeseries]-specific functionality: date range
     generation and frequency conversion, moving window statistics,
-    moving window linear regressions, date shifting and lagging, etc.
+    date shifting and lagging.
 
 
    [missing-data]: https://pandas.pydata.org/pandas-docs/stable/missing_data.html#working-with-missing-data

--- a/doc/source/getting_started/overview.rst
+++ b/doc/source/getting_started/overview.rst
@@ -57,8 +57,7 @@ Here are just a few of the things that pandas does well:
     Excel files, databases, and saving / loading data from the ultrafast **HDF5
     format**
   - **Time series**-specific functionality: date range generation and frequency
-    conversion, moving window statistics, moving window linear regressions,
-    date shifting and lagging, etc.
+    conversion, moving window statistics, date shifting and lagging.
 
 Many of these principles are here to address the shortcomings frequently
 experienced using other languages / scientific research environments. For data

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -273,6 +273,5 @@ Here are just a few of the things that pandas does well:
     Excel files, databases, and saving/loading data from the ultrafast HDF5
     format.
   - Time series-specific functionality: date range generation and frequency
-    conversion, moving window statistics, moving window linear regressions,
-    date shifting and lagging, etc.
+    conversion, moving window statistics, date shifting and lagging.
 """

--- a/setup.py
+++ b/setup.py
@@ -187,8 +187,7 @@ Here are just a few of the things that pandas does well:
     Excel files, databases, and saving / loading data from the ultrafast **HDF5
     format**
   - **Time series**-specific functionality: date range generation and frequency
-    conversion, moving window statistics, moving window linear regressions,
-    date shifting and lagging, etc.
+    conversion, moving window statistics, date shifting and lagging.
 
 Many of these principles are here to address the shortcomings frequently
 experienced using other languages / scientific research environments. For data

--- a/web/pandas/about/index.md
+++ b/web/pandas/about/index.md
@@ -49,8 +49,8 @@ This will help ensure the success of development of _pandas_ as a world-class op
   high-dimensional data in a lower-dimensional data structure;
 
 - **Time series**-functionality: date range generation and frequency
-  conversion, moving window statistics, moving window linear regressions, date
-  shifting and lagging. Even create domain-specific time offsets and join time
+  conversion, moving window statistics, date shifting and lagging.
+  Even create domain-specific time offsets and join time
   series without losing data;
 
 - Highly **optimized for performance**, with critical code paths written in


### PR DESCRIPTION
Remove outdated reference to moving regression which was dropped

- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
