### PR TITLE
Switching %r for repr(op_str) in test-expressions.py for issue 29886

### DIFF
--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -261,9 +261,9 @@ class TestExpressions:
     def test_bool_ops_raise_on_arithmetic(self, op_str, opname):
         df = DataFrame({"a": np.random.rand(10) > 0.5, "b": np.random.rand(10) > 0.5})
 
-        msg = "operator %r not implemented for bool dtypes"
+        msg = f"operator {repr(op_str)} not implemented for bool dtypes"
         f = getattr(operator, opname)
-        err_msg = re.escape(msg % op_str)
+        err_msg = re.escape(msg)
 
         with pytest.raises(NotImplementedError, match=err_msg):
             f(df, df)


### PR DESCRIPTION
Swaps the following in pandas/tests/test_expressions.py:
From:
    `msg = "operator %r not implemented for bool dtypes"`
    `f = getattr(operator, opname)`
    `err_msg = re.escape(msg % op_str)`
To:
    `msg = f"operator {repr(op_str)} not implemented for bool dtypes"`
    `f = getattr(operator, opname)`
    `err_msg = re.escape(msg)`

This is for [#29886](https://github.com/pandas-dev/pandas/issues/29886)