### PR TITLE
CLN: Old string formatting: .format() -> f""

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1163,9 +1163,8 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
         if missing:
             if missing == len(indexer):
-                raise KeyError(
-                    f"None of [{key}] are in the [{self.obj._get_axis_name(axis)}]"
-                )
+                axis_name = self.obj._get_axis_name(axis)
+                raise KeyError(f"None of [{key}] are in the [{axis_name}]")
 
             # We (temporarily) allow for some missing keys with .loc, except in
             # some cases (e.g. setting) in which "raise_missing" will be False
@@ -1906,9 +1905,7 @@ class _iLocIndexer(_LocationIndexer):
             if len(arr) and (arr.max() >= len_axis or arr.min() < -len_axis):
                 raise IndexError("positional indexers are out-of-bounds")
         else:
-            raise ValueError(
-                "Can only index by location with " f"a [{self._valid_types}]"
-            )
+            raise ValueError(f"Can only index by location with a [{self._valid_types}]")
 
     def _has_valid_setitem_indexer(self, indexer):
         self._has_valid_positional_setitem_indexer(indexer)
@@ -2055,9 +2052,7 @@ class _iLocIndexer(_LocationIndexer):
             self._validate_key(obj, axis)
             return obj
         except ValueError:
-            raise ValueError(
-                "Can only index by location with " f"a [{self._valid_types}]"
-            )
+            raise ValueError(f"Can only index by location with a [{self._valid_types}]")
 
 
 class _ScalarAccessIndexer(_NDFrameIndexerBase):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -232,7 +232,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             except ValueError:
                 raise ValueError(
                     "Location based indexing can only have "
-                    "[{types}] types".format(types=self._valid_types)
+                    f"[{self._valid_types}] types"
                 )
 
     def _is_nested_tuple_indexer(self, tup: Tuple) -> bool:
@@ -286,7 +286,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         bool
         """
         if isinstance(indexer, dict):
-            raise IndexError("{0} cannot enlarge its target object".format(self.name))
+            raise IndexError(f"{self.name} cannot enlarge its target object")
         else:
             if not isinstance(indexer, tuple):
                 indexer = _tuplify(self.ndim, indexer)
@@ -300,12 +300,11 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                 elif is_integer(i):
                     if i >= len(ax):
                         raise IndexError(
-                            "{name} cannot enlarge its target "
-                            "object".format(name=self.name)
+                            f"{self.name} cannot enlarge its target object"
                         )
                 elif isinstance(i, dict):
                     raise IndexError(
-                        "{name} cannot enlarge its target object".format(name=self.name)
+                        f"{self.name} cannot enlarge its target object"
                     )
 
         return True
@@ -1167,16 +1166,14 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         if missing:
             if missing == len(indexer):
                 raise KeyError(
-                    "None of [{key}] are in the [{axis}]".format(
-                        key=key, axis=self.obj._get_axis_name(axis)
+                    f"None of [{key}] are in the [{self.obj._get_axis_name(axis)}]"
                     )
-                )
 
             # We (temporarily) allow for some missing keys with .loc, except in
             # some cases (e.g. setting) in which "raise_missing" will be False
             if not (self.name == "loc" and not raise_missing):
                 not_found = list(set(key) - set(ax))
-                raise KeyError("{} not in index".format(not_found))
+                raise KeyError(f"{not_found} not in index")
 
             # we skip the warning on Categorical/Interval
             # as this check is actually done (check for
@@ -1906,7 +1903,7 @@ class _iLocIndexer(_LocationIndexer):
             # check that the key has a numeric dtype
             if not is_numeric_dtype(arr.dtype):
                 raise IndexError(
-                    ".iloc requires numeric indexers, got {arr}".format(arr=arr)
+                    f".iloc requires numeric indexers, got {arr}"
                 )
 
             # check that the key does not exceed the maximum size of the index
@@ -1915,7 +1912,7 @@ class _iLocIndexer(_LocationIndexer):
         else:
             raise ValueError(
                 "Can only index by location with "
-                "a [{types}]".format(types=self._valid_types)
+                f"a [{self._valid_types}]"
             )
 
     def _has_valid_setitem_indexer(self, indexer):
@@ -2065,7 +2062,7 @@ class _iLocIndexer(_LocationIndexer):
         except ValueError:
             raise ValueError(
                 "Can only index by location with "
-                "a [{types}]".format(types=self._valid_types)
+                f"a [{self._valid_types}]"
             )
 
 
@@ -2327,7 +2324,7 @@ def check_bool_indexer(index: Index, key) -> np.ndarray:
         # GH26658
         if len(result) != len(index):
             raise IndexError(
-                "Item wrong length {} instead of {}.".format(len(result), len(index))
+                f"Item wrong length {len(result)} instead of {len(index)}."
             )
 
     return result

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -303,9 +303,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                             f"{self.name} cannot enlarge its target object"
                         )
                 elif isinstance(i, dict):
-                    raise IndexError(
-                        f"{self.name} cannot enlarge its target object"
-                    )
+                    raise IndexError(f"{self.name} cannot enlarge its target object")
 
         return True
 
@@ -1167,7 +1165,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             if missing == len(indexer):
                 raise KeyError(
                     f"None of [{key}] are in the [{self.obj._get_axis_name(axis)}]"
-                    )
+                )
 
             # We (temporarily) allow for some missing keys with .loc, except in
             # some cases (e.g. setting) in which "raise_missing" will be False
@@ -1902,17 +1900,14 @@ class _iLocIndexer(_LocationIndexer):
 
             # check that the key has a numeric dtype
             if not is_numeric_dtype(arr.dtype):
-                raise IndexError(
-                    f".iloc requires numeric indexers, got {arr}"
-                )
+                raise IndexError(f".iloc requires numeric indexers, got {arr}")
 
             # check that the key does not exceed the maximum size of the index
             if len(arr) and (arr.max() >= len_axis or arr.min() < -len_axis):
                 raise IndexError("positional indexers are out-of-bounds")
         else:
             raise ValueError(
-                "Can only index by location with "
-                f"a [{self._valid_types}]"
+                "Can only index by location with " f"a [{self._valid_types}]"
             )
 
     def _has_valid_setitem_indexer(self, indexer):
@@ -2061,8 +2056,7 @@ class _iLocIndexer(_LocationIndexer):
             return obj
         except ValueError:
             raise ValueError(
-                "Can only index by location with "
-                f"a [{self._valid_types}]"
+                "Can only index by location with " f"a [{self._valid_types}]"
             )
 
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -115,8 +115,8 @@ class Block(PandasObject):
 
         if self._validate_ndim and self.ndim and len(self.mgr_locs) != len(self.values):
             raise ValueError(
-                "Wrong number of items passed {val}, placement implies "
-                "{mgr}".format(val=len(self.values), mgr=len(self.mgr_locs))
+                f"Wrong number of items passed {len(self.values)}, "
+                f"placement implies {len(self.mgr_locs)}"
             )
 
     def _check_ndim(self, values, ndim):
@@ -144,9 +144,8 @@ class Block(PandasObject):
             ndim = values.ndim
 
         if self._validate_ndim and values.ndim != ndim:
-            msg = "Wrong number of dimensions. values.ndim != ndim [{} != {}]"
-            raise ValueError(msg.format(values.ndim, ndim))
-
+            raise ValueError("Wrong number of dimensions. "
+                             f"values.ndim != ndim [{values.ndim} != {ndim}]")
         return ndim
 
     @property
@@ -184,7 +183,7 @@ class Block(PandasObject):
         if dtype is Categorical or dtype is CategoricalDtype:
             # this is a pd.Categorical, but is not
             # a valid type for astypeing
-            raise TypeError("invalid type {0} for astype".format(dtype))
+            raise TypeError(f"invalid type {dtype} for astype")
 
         elif is_categorical_dtype(dtype):
             return True
@@ -264,19 +263,13 @@ class Block(PandasObject):
         name = type(self).__name__
         if self._is_single_block:
 
-            result = "{name}: {len} dtype: {dtype}".format(
-                name=name, len=len(self), dtype=self.dtype
-            )
+            result = f"{name}: {len(self)} dtype: {self.dtype}"
 
         else:
 
             shape = " x ".join(pprint_thing(s) for s in self.shape)
-            result = "{name}: {index}, {shape}, dtype: {dtype}".format(
-                name=name,
-                index=pprint_thing(self.mgr_locs.indexer),
-                shape=shape,
-                dtype=self.dtype,
-            )
+            result = f"{name}: {pprint_thing(self.mgr_locs.indexer)}, " \
+                     f"{shape}, dtype: {self.dtype}"
 
         return result
 
@@ -329,7 +322,7 @@ class Block(PandasObject):
             dtype = self.dtype.subtype
         else:
             dtype = self.dtype
-        return "{dtype}:{ftype}".format(dtype=dtype, ftype=self._ftype)
+        return f"{dtype}:{self._ftype}"
 
     def merge(self, other):
         return _merge_blocks([self, other])
@@ -544,15 +537,15 @@ class Block(PandasObject):
 
         if errors not in errors_legal_values:
             invalid_arg = (
-                "Expected value of kwarg 'errors' to be one of {}. "
-                "Supplied value is '{}'".format(list(errors_legal_values), errors)
+                f"Expected value of kwarg 'errors' to be one of {list(errors_legal_values)}. "
+                f"Supplied value is '{errors}'"
             )
             raise ValueError(invalid_arg)
 
         if inspect.isclass(dtype) and issubclass(dtype, ExtensionDtype):
             msg = (
-                "Expected an instance of {}, but got the class instead. "
-                "Try instantiating 'dtype'.".format(dtype.__name__)
+                f"Expected an instance of {dtype.__name__}, but got the class instead. "
+                "Try instantiating 'dtype'."
             )
             raise TypeError(msg)
 
@@ -613,15 +606,9 @@ class Block(PandasObject):
         if newb.is_numeric and self.is_numeric:
             if newb.shape != self.shape:
                 raise TypeError(
-                    "cannot set astype for copy = [{copy}] for dtype "
-                    "({dtype} [{shape}]) to different shape "
-                    "({newb_dtype} [{newb_shape}])".format(
-                        copy=copy,
-                        dtype=self.dtype.name,
-                        shape=self.shape,
-                        newb_dtype=newb.dtype.name,
-                        newb_shape=newb.shape,
-                    )
+                    f"cannot set astype for copy = [{copy}] for dtype "
+                    f"({self.dtype.name} [{self.shape}]) to different shape "
+                    f"({newb.dtype.name} [{newb.shape}])"
                 )
         return newb
 
@@ -658,7 +645,7 @@ class Block(PandasObject):
 
         if not self.is_object and not quoting:
             itemsize = writers.word_len(na_rep)
-            values = values.astype("<U{size}".format(size=itemsize))
+            values = values.astype(f"<U{itemsize}")
         else:
             values = np.array(values, dtype="object")
 
@@ -1046,7 +1033,7 @@ class Block(PandasObject):
 
             raise AssertionError(
                 "possible recursion in "
-                "coerce_to_target_dtype: {} {}".format(self, other)
+                f"coerce_to_target_dtype: {self} {other}"
             )
 
         elif self.is_timedelta or is_timedelta64_dtype(dtype):
@@ -1057,7 +1044,7 @@ class Block(PandasObject):
 
             raise AssertionError(
                 "possible recursion in "
-                "coerce_to_target_dtype: {} {}".format(self, other)
+                f"coerce_to_target_dtype: {self} {other}"
             )
 
         try:
@@ -1202,8 +1189,8 @@ class Block(PandasObject):
         if method in ("krogh", "piecewise_polynomial", "pchip"):
             if not index.is_monotonic:
                 raise ValueError(
-                    "{0} interpolation requires that the "
-                    "index be monotonic.".format(method)
+                    f"{method} interpolation requires that the "
+                    "index be monotonic."
                 )
         # process 1-d slices in the axis direction
 
@@ -1585,7 +1572,7 @@ class NonConsolidatableMixIn:
         if self.ndim == 2 and isinstance(col, tuple):
             col, loc = col
             if not com.is_null_slice(col) and col != 0:
-                raise IndexError("{0} only contains one item".format(self))
+                raise IndexError(f"{self} only contains one item")
             elif isinstance(col, slice):
                 if col != slice(None):
                     raise NotImplementedError(col)
@@ -1593,7 +1580,7 @@ class NonConsolidatableMixIn:
             return self.values[loc]
         else:
             if col != 0:
-                raise IndexError("{0} only contains one item".format(self))
+                raise IndexError(f"{self} only contains one item")
             return self.values
 
     def should_store(self, value):
@@ -2312,7 +2299,7 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
         if isinstance(slicer, tuple):
             col, loc = slicer
             if not com.is_null_slice(col) and col != 0:
-                raise IndexError("{0} only contains one item".format(self))
+                raise IndexError(f"{self} only contains one item")
             return self.values[loc]
         return self.values[slicer]
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -144,8 +144,10 @@ class Block(PandasObject):
             ndim = values.ndim
 
         if self._validate_ndim and values.ndim != ndim:
-            raise ValueError("Wrong number of dimensions. "
-                             f"values.ndim != ndim [{values.ndim} != {ndim}]")
+            raise ValueError(
+                "Wrong number of dimensions. "
+                f"values.ndim != ndim [{values.ndim} != {ndim}]"
+            )
         return ndim
 
     @property
@@ -268,8 +270,10 @@ class Block(PandasObject):
         else:
 
             shape = " x ".join(pprint_thing(s) for s in self.shape)
-            result = f"{name}: {pprint_thing(self.mgr_locs.indexer)}, " \
-                     f"{shape}, dtype: {self.dtype}"
+            result = (
+                f"{name}: {pprint_thing(self.mgr_locs.indexer)}, "
+                f"{shape}, dtype: {self.dtype}"
+            )
 
         return result
 
@@ -1032,8 +1036,7 @@ class Block(PandasObject):
                 return self.astype(object)
 
             raise AssertionError(
-                "possible recursion in "
-                f"coerce_to_target_dtype: {self} {other}"
+                "possible recursion in " f"coerce_to_target_dtype: {self} {other}"
             )
 
         elif self.is_timedelta or is_timedelta64_dtype(dtype):
@@ -1043,8 +1046,7 @@ class Block(PandasObject):
                 return self.astype(object)
 
             raise AssertionError(
-                "possible recursion in "
-                f"coerce_to_target_dtype: {self} {other}"
+                "possible recursion in " f"coerce_to_target_dtype: {self} {other}"
             )
 
         try:
@@ -1189,8 +1191,7 @@ class Block(PandasObject):
         if method in ("krogh", "piecewise_polynomial", "pchip"):
             if not index.is_monotonic:
                 raise ValueError(
-                    f"{method} interpolation requires that the "
-                    "index be monotonic."
+                    f"{method} interpolation requires that the " "index be monotonic."
                 )
         # process 1-d slices in the axis direction
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -541,7 +541,7 @@ class Block(PandasObject):
 
         if errors not in errors_legal_values:
             invalid_arg = (
-                f"Expected value of kwarg 'errors' to be one of "
+                "Expected value of kwarg 'errors' to be one of "
                 f"{list(errors_legal_values)}. Supplied value is '{errors}'"
             )
             raise ValueError(invalid_arg)
@@ -549,7 +549,7 @@ class Block(PandasObject):
         if inspect.isclass(dtype) and issubclass(dtype, ExtensionDtype):
             msg = (
                 f"Expected an instance of {dtype.__name__}, "
-                f"but got the class instead. Try instantiating 'dtype'."
+                "but got the class instead. Try instantiating 'dtype'."
             )
             raise TypeError(msg)
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -548,8 +548,8 @@ class Block(PandasObject):
 
         if inspect.isclass(dtype) and issubclass(dtype, ExtensionDtype):
             msg = (
-                f"Expected an instance of {dtype.__name__}, but got the class instead. "
-                "Try instantiating 'dtype'."
+                f"Expected an instance of {dtype.__name__}, "
+                f"but got the class instead. Try instantiating 'dtype'."
             )
             raise TypeError(msg)
 
@@ -1036,7 +1036,7 @@ class Block(PandasObject):
                 return self.astype(object)
 
             raise AssertionError(
-                "possible recursion in " f"coerce_to_target_dtype: {self} {other}"
+                f"possible recursion in coerce_to_target_dtype: {self} {other}"
             )
 
         elif self.is_timedelta or is_timedelta64_dtype(dtype):
@@ -1046,7 +1046,7 @@ class Block(PandasObject):
                 return self.astype(object)
 
             raise AssertionError(
-                "possible recursion in " f"coerce_to_target_dtype: {self} {other}"
+                f"possible recursion in coerce_to_target_dtype: {self} {other}"
             )
 
         try:
@@ -1191,7 +1191,7 @@ class Block(PandasObject):
         if method in ("krogh", "piecewise_polynomial", "pchip"):
             if not index.is_monotonic:
                 raise ValueError(
-                    f"{method} interpolation requires that the " "index be monotonic."
+                    f"{method} interpolation requires that the index be monotonic."
                 )
         # process 1-d slices in the axis direction
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -541,8 +541,8 @@ class Block(PandasObject):
 
         if errors not in errors_legal_values:
             invalid_arg = (
-                f"Expected value of kwarg 'errors' to be one of {list(errors_legal_values)}. "
-                f"Supplied value is '{errors}'"
+                f"Expected value of kwarg 'errors' to be one of "
+                f"{list(errors_legal_values)}. Supplied value is '{errors}'"
             )
             raise ValueError(invalid_arg)
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -167,7 +167,7 @@ def init_ndarray(values, index, columns, dtype=None, copy=False):
             except Exception as orig:
                 # e.g. ValueError when trying to cast object dtype to float64
                 raise ValueError(
-                    f"failed to cast to '{dtype}' (Exception " f"was: {orig})"
+                    f"failed to cast to '{dtype}' (Exception was: {orig})"
                 ) from orig
 
     index, columns = _get_axes(*values.shape, index=index, columns=columns)

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -167,8 +167,7 @@ def init_ndarray(values, index, columns, dtype=None, copy=False):
             except Exception as orig:
                 # e.g. ValueError when trying to cast object dtype to float64
                 raise ValueError(
-                    f"failed to cast to '{dtype}' (Exception "
-                    f"was: {orig})"
+                    f"failed to cast to '{dtype}' (Exception " f"was: {orig})"
                 ) from orig
 
     index, columns = _get_axes(*values.shape, index=index, columns=columns)

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -167,8 +167,8 @@ def init_ndarray(values, index, columns, dtype=None, copy=False):
             except Exception as orig:
                 # e.g. ValueError when trying to cast object dtype to float64
                 raise ValueError(
-                    "failed to cast to '{dtype}' (Exception "
-                    "was: {orig})".format(dtype=dtype, orig=orig)
+                    f"failed to cast to '{dtype}' (Exception "
+                    f"was: {orig})"
                 ) from orig
 
     index, columns = _get_axes(*values.shape, index=index, columns=columns)
@@ -365,8 +365,8 @@ def extract_index(data):
             if have_series:
                 if lengths[0] != len(index):
                     msg = (
-                        "array length {length} does not match index "
-                        "length {idx_len}".format(length=lengths[0], idx_len=len(index))
+                        f"array length {lengths[0]} does not match index "
+                        f"length {len(index)}"
                     )
                     raise ValueError(msg)
             else:
@@ -401,7 +401,7 @@ def get_names_from_index(data):
         if n is not None:
             index[i] = n
         else:
-            index[i] = "Unnamed {count}".format(count=count)
+            index[i] = f"Unnamed {count}"
             count += 1
 
     return index
@@ -571,8 +571,8 @@ def _convert_object_array(content, columns, coerce_float=False, dtype=None):
         if len(columns) != len(content):  # pragma: no cover
             # caller's responsibility to check for this...
             raise AssertionError(
-                "{col:d} columns passed, passed data had "
-                "{con} columns".format(col=len(columns), con=len(content))
+                f"{len(columns)} columns passed, passed data had "
+                f"{len(content)} columns"
             )
 
     # provide soft conversion of object dtypes

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1661,9 +1661,7 @@ def construction_error(tot_items, block_shape, axes, e=None):
         raise e
     if block_shape[0] == 0:
         raise ValueError("Empty data passed with indices specified.")
-    raise ValueError(
-        f"Shape of passed values is {passed}, indices imply {implied}"
-    )
+    raise ValueError(f"Shape of passed values is {passed}, indices imply {implied}")
 
 
 # -----------------------------------------------------------------------

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -132,8 +132,8 @@ class BlockManager(PandasObject):
         for block in blocks:
             if self.ndim != block.ndim:
                 raise AssertionError(
-                    "Number of Block dimensions ({block}) must equal "
-                    "number of axes ({self})".format(block=block.ndim, self=self.ndim)
+                    f"Number of Block dimensions ({block.ndim}) must equal "
+                    f"number of axes ({self.ndim})"
                 )
 
         if do_integrity_check:
@@ -176,8 +176,8 @@ class BlockManager(PandasObject):
 
         if new_len != old_len:
             raise ValueError(
-                "Length mismatch: Expected axis has {old} elements, new "
-                "values have {new} elements".format(old=old_len, new=new_len)
+                f"Length mismatch: Expected axis has {old_len} elements, new "
+                f"values have {new_len} elements"
             )
 
         self.axes[axis] = new_labels
@@ -319,12 +319,12 @@ class BlockManager(PandasObject):
         output = type(self).__name__
         for i, ax in enumerate(self.axes):
             if i == 0:
-                output += "\nItems: {ax}".format(ax=ax)
+                output += f"\nItems: {ax}"
             else:
-                output += "\nAxis {i}: {ax}".format(i=i, ax=ax)
+                output += f"\nAxis {i}: {ax}"
 
         for block in self.blocks:
-            output += "\n{block}".format(block=pprint_thing(block))
+            output += f"\n{pprint_thing(block)}"
         return output
 
     def _verify_integrity(self):
@@ -336,8 +336,8 @@ class BlockManager(PandasObject):
         if len(self.items) != tot_items:
             raise AssertionError(
                 "Number of manager items must equal union of "
-                "block items\n# manager items: {0}, # "
-                "tot_items: {1}".format(len(self.items), tot_items)
+                f"block items\n# manager items: {len(self.items)}, # "
+                f"tot_items: {tot_items}"
             )
 
     def apply(self, f: str, filter=None, **kwargs):
@@ -1140,7 +1140,7 @@ class BlockManager(PandasObject):
         """
         if not allow_duplicates and item in self.items:
             # Should this be a different kind of error??
-            raise ValueError("cannot insert {}, already exists".format(item))
+            raise ValueError(f"cannot insert {item}, already exists")
 
         if not isinstance(loc, int):
             raise TypeError("loc must be int")
@@ -1662,7 +1662,7 @@ def construction_error(tot_items, block_shape, axes, e=None):
     if block_shape[0] == 0:
         raise ValueError("Empty data passed with indices specified.")
     raise ValueError(
-        "Shape of passed values is {0}, indices imply {1}".format(passed, implied)
+        f"Shape of passed values is {passed}, indices imply {implied}"
     )
 
 
@@ -1899,10 +1899,10 @@ def _compare_or_regex_search(a, b, regex=False):
         type_names = [type(a).__name__, type(b).__name__]
 
         if is_a_array:
-            type_names[0] = "ndarray(dtype={dtype})".format(dtype=a.dtype)
+            type_names[0] = f"ndarray(dtype={a.dtype})"
 
         if is_b_array:
-            type_names[1] = "ndarray(dtype={dtype})".format(dtype=b.dtype)
+            type_names[1] = f"ndarray(dtype={b.dtype})"
 
         raise TypeError(
             f"Cannot compare types {repr(type_names[0])} and {repr(type_names[1])}"

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1187,7 +1187,7 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
         raise IncompatibleFrequency(
             f"Frequency {ax.freq} cannot be resampled to {self.freq}, "
-            f"as they are not sub or super periods"
+            "as they are not sub or super periods"
         )
 
     def _upsample(self, method, limit=None, fill_value=None):

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -90,13 +90,11 @@ class Resampler(_GroupBy, ShallowMixin):
         Provide a nice str repr of our rolling object.
         """
         attrs = (
-            "{k}={v}".format(k=k, v=getattr(self.groupby, k))
+            f"{k}={getattr(self.groupby, k)}"
             for k in self._attributes
             if getattr(self.groupby, k, None) is not None
         )
-        return "{klass} [{attrs}]".format(
-            klass=type(self).__name__, attrs=", ".join(attrs)
-        )
+        return f"{type(self).__name__} [{', '.join(attrs)}]"
 
     def __getattr__(self, attr):
         if attr in self._internal_names_set:
@@ -1188,9 +1186,8 @@ class PeriodIndexResampler(DatetimeIndexResampler):
             return self.asfreq()
 
         raise IncompatibleFrequency(
-            "Frequency {} cannot be resampled to {}, as they are not "
-            "sub or super periods".format(ax.freq, self.freq)
-        )
+            f"Frequency {ax.freq} cannot be resampled to {self.freq}, "
+            f"as they are not sub or super periods")
 
     def _upsample(self, method, limit=None, fill_value=None):
         """
@@ -1333,11 +1330,11 @@ class TimeGrouper(Grouper):
         # Check for correctness of the keyword arguments which would
         # otherwise silently use the default if misspelled
         if label not in {None, "left", "right"}:
-            raise ValueError("Unsupported value {} for `label`".format(label))
+            raise ValueError(f"Unsupported value {label} for `label`")
         if closed not in {None, "left", "right"}:
-            raise ValueError("Unsupported value {} for `closed`".format(closed))
+            raise ValueError(f"Unsupported value {closed} for `closed`")
         if convention not in {None, "start", "end", "e", "s"}:
-            raise ValueError("Unsupported value {} for `convention`".format(convention))
+            raise ValueError(f"Unsupported value {convention} for `convention`")
 
         freq = to_offset(freq)
 
@@ -1407,7 +1404,7 @@ class TimeGrouper(Grouper):
         raise TypeError(
             "Only valid with DatetimeIndex, "
             "TimedeltaIndex or PeriodIndex, "
-            "but got an instance of '{typ}'".format(typ=type(ax).__name__)
+            f"but got an instance of '{type(ax).__name__}'"
         )
 
     def _get_grouper(self, obj, validate=True):
@@ -1420,7 +1417,7 @@ class TimeGrouper(Grouper):
         if not isinstance(ax, DatetimeIndex):
             raise TypeError(
                 "axis must be a DatetimeIndex, but got "
-                "an instance of {typ}".format(typ=type(ax).__name__)
+                f"an instance of {type(ax).__name__}"
             )
 
         if len(ax) == 0:
@@ -1496,7 +1493,7 @@ class TimeGrouper(Grouper):
         if not isinstance(ax, TimedeltaIndex):
             raise TypeError(
                 "axis must be a TimedeltaIndex, but got "
-                "an instance of {typ}".format(typ=type(ax).__name__)
+                f"an instance of {type(ax).__name__}"
             )
 
         if not len(ax):
@@ -1521,7 +1518,7 @@ class TimeGrouper(Grouper):
         if not isinstance(ax, DatetimeIndex):
             raise TypeError(
                 "axis must be a DatetimeIndex, but got "
-                "an instance of {typ}".format(typ=type(ax).__name__)
+                f"an instance of {type(ax).__name__}"
             )
 
         freq = self.freq
@@ -1543,7 +1540,7 @@ class TimeGrouper(Grouper):
         if not isinstance(ax, PeriodIndex):
             raise TypeError(
                 "axis must be a PeriodIndex, but got "
-                "an instance of {typ}".format(typ=type(ax).__name__)
+                f"an instance of {type(ax).__name__}"
             )
 
         memb = ax.asfreq(self.freq, how=self.convention)

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1187,7 +1187,8 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
         raise IncompatibleFrequency(
             f"Frequency {ax.freq} cannot be resampled to {self.freq}, "
-            f"as they are not sub or super periods")
+            f"as they are not sub or super periods"
+        )
 
     def _upsample(self, method, limit=None, fill_value=None):
         """


### PR DESCRIPTION
- [x] xref #29547
- [x] passes `black pandas`
Old style % formatting to f-strings