### PR TITLE
CLN: format replaced with f-strings #29547

### DIFF
--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -144,9 +144,7 @@ def validate_indices(indices: np.ndarray, n: int) -> None:
     if len(indices):
         min_idx = indices.min()
         if min_idx < -1:
-            msg = "'indices' contains values less than allowed ({} < {})".format(
-                min_idx, -1
-            )
+            msg = f"'indices' contains values less than allowed ({min_idx} < {-1})"
             raise ValueError(msg)
 
         max_idx = indices.max()

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -144,7 +144,7 @@ def validate_indices(indices: np.ndarray, n: int) -> None:
     if len(indices):
         min_idx = indices.min()
         if min_idx < -1:
-            msg = f"'indices' contains values less than allowed ({min_idx} < {-1})"
+            msg = f"'indices' contains values less than allowed ({min_idx} < -1)"
             raise ValueError(msg)
 
         max_idx = indices.max()


### PR DESCRIPTION
- [x] ref #29547
- [x] passes `black pandas`
- [x] passes git diff upstream/master -u -- "*.py" | flake8 --diff