### PR TITLE
Removed unsigned parametrization from Intervaltree

### DIFF
--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -11,7 +11,6 @@ ctypedef fused scalar_t:
     float32_t
     int64_t
     int32_t
-    uint64_t
 
 # ----------------------------------------------------------------------
 # IntervalTree
@@ -231,7 +230,7 @@ cdef sort_values_and_indices(all_values, all_indices, subset):
 {{py:
 
 nodes = []
-for dtype in ['float32', 'float64', 'int32', 'int64', 'uint64']:
+for dtype in ['float32', 'float64', 'int32', 'int64']:
     for closed, cmp_left, cmp_right in [
         ('left', '<=', '<'),
         ('right', '<', '<='),


### PR DESCRIPTION
closes #30365 , #27169

Unclear if we currently consider this a feature, but I couldn't find anything explicitly asking for it so trying the removal route first

Not sure what the other alternative would be for parametrization, but I think generally we need to be careful when doing comparisons between signed and unsigned in templating or fused types

Side benefit - this gets rid of 128 build warnings and a slight perf boost to compilation
