### PR TITLE
CLN: tslibs.parsing

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -188,7 +188,7 @@ def ints_to_pydatetime(const int64_t[:] arr, object tz=None, object freq=None,
     return result
 
 
-def _test_parse_iso8601(object ts):
+def _test_parse_iso8601(ts: str):
     """
     TESTING ONLY: Parse string into Timestamp using iso8601 parser. Used
     only for testing, actual construction uses `convert_str_to_tsobject`

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -444,15 +444,15 @@ cdef _TSObject convert_str_to_tsobject(object ts, object tz, object unit,
                                        bint dayfirst=False,
                                        bint yearfirst=False):
     """
-    Convert a string-like (bytes or unicode) input `ts`, along with optional
-    timezone object `tz` to a _TSObject.
+    Convert a string input `ts`, along with optional timezone object`tz`
+    to a _TSObject.
 
     The optional arguments `dayfirst` and `yearfirst` are passed to the
     dateutil parser.
 
     Parameters
     ----------
-    ts : bytes or unicode
+    ts : str
         Value to be converted to _TSObject
     tz : tzinfo or None
         timezone for the timezone-aware output

--- a/pandas/_libs/tslibs/frequencies.pxd
+++ b/pandas/_libs/tslibs/frequencies.pxd
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-cpdef object get_rule_month(object source, object default=*)
+cpdef str get_rule_month(object source, str default=*)
 
 cpdef get_freq_code(freqstr)
 cpdef object get_freq(object freq)

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -485,18 +485,18 @@ cdef bint _is_weekly(str rule):
 
 # ----------------------------------------------------------------------
 
-cpdef object get_rule_month(object source, object default='DEC'):
+cpdef str get_rule_month(object source, str default="DEC"):
     """
     Return starting month of given freq, default is December.
 
     Parameters
     ----------
     source : object
-    default : object (default "DEC")
+    default : str, default "DEC"
 
     Returns
     -------
-    rule_month: object (usually string)
+    rule_month: str
 
     Examples
     --------

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -72,6 +72,6 @@ cdef npy_datetime get_datetime64_value(object obj) nogil
 cdef npy_timedelta get_timedelta64_value(object obj) nogil
 cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil
 
-cdef int _string_to_dts(object val, npy_datetimestruct* dts,
+cdef int _string_to_dts(str val, npy_datetimestruct* dts,
                         int* out_local, int* out_tzoffset,
                         bint want_exc) except? -1

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -167,7 +167,7 @@ cdef inline int64_t pydate_to_dt64(date val, npy_datetimestruct *dts):
     return dtstruct_to_dt64(dts)
 
 
-cdef inline int _string_to_dts(object val, npy_datetimestruct* dts,
+cdef inline int _string_to_dts(str val, npy_datetimestruct* dts,
                                int* out_local, int* out_tzoffset,
                                bint want_exc) except? -1:
     cdef:

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -106,7 +106,7 @@ cdef inline object _parse_delimited_date(str date_string, bint dayfirst):
 
     Returns:
     --------
-    datetime or Nont
+    datetime or None
     str or None
         Describing resolution of the parsed string.
     """
@@ -477,11 +477,7 @@ cdef dateutil_parse(str timestr, object default, ignoretz=False,
         object reso = None
         dict repl = {}
 
-    res = DEFAULTPARSER._parse(timestr, dayfirst=dayfirst, yearfirst=yearfirst)
-
-    # dateutil 2.2 compat
-    if isinstance(res, tuple):
-        res, _ = res
+    res, _ = DEFAULTPARSER._parse(timestr, dayfirst=dayfirst, yearfirst=yearfirst)
 
     if res is None:
         raise ValueError(f"Unknown datetime string format, unable to parse: {timestr}")

--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -1097,6 +1097,8 @@ class TimeSeries_DateFormatter(Formatter):
             return ""
         else:
             fmt = self.formatdict.pop(x, "")
+            if isinstance(fmt, np.bytes_):
+                fmt = fmt.decode("utf-8")
             return Period(ordinal=int(x), freq=self.freq).strftime(fmt)
 
 


### PR DESCRIPTION
- [x] closes #22234

Non-segfault-related pieces broken off from #30374.  Fix a (not-reachable-but-thats-another-conversation) tzinfo check closing #22234.

De-duplicates get_rule_month in tslibs.frequencies and tslibs.parsing

pythonizes a PyUnicode_Join usage because cython does that optimization already.