### PR TITLE
REF: use fused types for part of hashtables code

### DIFF
--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -4,6 +4,24 @@ Template for each `dtype` helper function for hashtable
 WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 """
 
+ctypedef fused table_t:
+    kh_float64_t
+    kh_uint64_t
+    kh_int64_t
+    kh_pymap_t
+
+
+cdef kh_destroy(table_t *table):
+    if table_t is kh_float64_t:
+        kh_destroy_float64(table)
+    elif table_t is kh_uint64_t:
+        kh_destroy_uint64(table)
+    elif table_t is kh_int64_t:
+        kh_destroy_int64(table)
+    elif table_t is kh_pymap_t:
+        kh_destroy_pymap(table)
+
+
 {{py:
 
 # dtype, ttype, c_type
@@ -111,7 +129,7 @@ cpdef value_count_{{dtype}}({{c_type}}[:] values, bint dropna):
                 i += 1
     {{endif}}
 
-    kh_destroy_{{ttype}}(table)
+    kh_destroy(table)
 
     {{if dtype == 'object'}}
     return result_keys, result_counts
@@ -192,7 +210,8 @@ def duplicated_{{dtype}}({{c_type}}[:] values, object keep='first'):
                     table.vals[k] = i
                     out[i] = 0
         {{endif}}
-    kh_destroy_{{ttype}}(table)
+
+    kh_destroy(table)
     return out
 
 
@@ -258,7 +277,7 @@ def ismember_{{dtype}}({{c_type}}[:] arr, {{c_type}}[:] values):
             result[i] = (k != table.n_buckets)
     {{endif}}
 
-    kh_destroy_{{ttype}}(table)
+    kh_destroy(table)
     return result.view(np.bool_)
 
 {{endfor}}
@@ -334,7 +353,7 @@ def mode_{{dtype}}({{ctype}}[:] values, bint dropna):
             modes[j] = <object>table.keys[k]
     {{endif}}
 
-    kh_destroy_{{table_type}}(table)
+    kh_destroy(table)
 
     return modes[:j + 1]
 

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -22,6 +22,17 @@ cdef kh_destroy(table_t *table):
         kh_destroy_pymap(table)
 
 
+cdef kh_init(table_t **table_ptr):
+    if table_t is kh_float64_t:
+        table_ptr[0] = kh_init_float64()
+    elif table_t is kh_int64_t:
+        table_ptr[0] = kh_init_int64()
+    elif table_t is kh_uint64_t:
+        table_ptr[0] = kh_init_uint64()
+    elif table_t is kh_pymap_t:
+        table_ptr[0] = kh_init_pymap()
+
+
 {{py:
 
 # dtype, ttype, c_type
@@ -104,7 +115,7 @@ cpdef value_count_{{dtype}}({{c_type}}[:] values, bint dropna):
 
         Py_ssize_t k
 
-    table = kh_init_{{ttype}}()
+    kh_init(&table)
     {{if dtype == 'object'}}
     build_count_table_{{dtype}}(values, table, 1)
     {{else}}
@@ -151,9 +162,10 @@ def duplicated_{{dtype}}({{c_type}}[:] values, object keep='first'):
         {{dtype}}_t value
         {{endif}}
         Py_ssize_t k, i, n = len(values)
-        kh_{{ttype}}_t *table = kh_init_{{ttype}}()
+        kh_{{ttype}}_t *table
         ndarray[uint8_t, ndim=1, cast=True] out = np.empty(n, dtype='bool')
 
+    kh_init(&table)
     kh_resize_{{ttype}}(table, min(n, _SIZE_HINT_LIMIT))
 
     if keep not in ('last', 'first', False):
@@ -245,8 +257,9 @@ def ismember_{{dtype}}({{c_type}}[:] arr, {{c_type}}[:] values):
         int ret = 0
         ndarray[uint8_t] result
         {{c_type}} val
-        kh_{{ttype}}_t *table = kh_init_{{ttype}}()
+        kh_{{ttype}}_t *table
 
+    kh_init(&table)
     # construct the table
     n = len(values)
     kh_resize_{{ttype}}(table, n)
@@ -318,7 +331,7 @@ def mode_{{dtype}}({{ctype}}[:] values, bint dropna):
         kh_{{table_type}}_t *table
         ndarray[{{ctype}}] modes
 
-    table = kh_init_{{table_type}}()
+    kh_init(&table)
     build_count_table_{{dtype}}(values, table, dropna)
 
     modes = np.empty(table.n_buckets, dtype=np.{{npy_dtype}})


### PR DESCRIPTION
This implements fused-type functions for the hashtable code that currently uses tempita.  Same idea as #29244, but this breaks off a part that I can confirm is performance-neutral.