### PR TITLE
Fixing format string in pandas/tests/extension/list/array.py

### DIFF
--- a/pandas/tests/extension/list/array.py
+++ b/pandas/tests/extension/list/array.py
@@ -36,7 +36,7 @@ class ListDtype(ExtensionDtype):
         if string == cls.name:
             return cls()
         else:
-            raise TypeError("Cannot construct a '{}' from '{}'".format(cls, string))
+            raise TypeError(f"Cannot construct a '{cls}' from '{string}'")
 
 
 class ListArray(ExtensionArray):


### PR DESCRIPTION
This is a fix on pandas/tests/extension/list/array.py to utilize python3 format strings
([#29886](https://github.com/pandas-dev/pandas/issues/29886)).