### PR TITLE
Fixing pandas/tests/indexes/multi/test_analytics.py to utilize python…

### DIFF
--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -334,7 +334,7 @@ def test_numpy_ufuncs(idx, func):
     else:
         expected_exception = TypeError
         msg = (
-            f"loop of ufunc does not support argument 0 of type tuple which"
+            "loop of ufunc does not support argument 0 of type tuple which"
             f" has no callable {func.__name__} method"
         )
     with pytest.raises(expected_exception, match=msg):

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -349,8 +349,8 @@ def test_numpy_ufuncs(idx, func):
 def test_numpy_type_funcs(idx, func):
     msg = (
         f"ufunc '{func.__name__}' not supported for the input types, and the inputs"
-        f" could not be safely coerced to any supported types according to"
-        f" the casting rule ''safe''"
+        " could not be safely coerced to any supported types according to"
+        " the casting rule ''safe''"
     )
     with pytest.raises(TypeError, match=msg):
         func(idx)

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -277,7 +277,7 @@ def test_map(idx):
 def test_map_dictlike(idx, mapper):
 
     if isinstance(idx, (pd.CategoricalIndex, pd.IntervalIndex)):
-        pytest.skip("skipping tests for {}".format(type(idx)))
+        pytest.skip(f"skipping tests for {type(idx)}")
 
     identity = mapper(idx.values, idx)
 
@@ -330,13 +330,13 @@ def test_numpy_ufuncs(idx, func):
 
     if _np_version_under1p17:
         expected_exception = AttributeError
-        msg = "'tuple' object has no attribute '{}'".format(func.__name__)
+        msg = f"'tuple' object has no attribute '{func.__name__}'"
     else:
         expected_exception = TypeError
         msg = (
-            "loop of ufunc does not support argument 0 of type tuple which"
-            " has no callable {} method"
-        ).format(func.__name__)
+            f"loop of ufunc does not support argument 0 of type tuple which"
+            f" has no callable {func.__name__} method"
+        )
     with pytest.raises(expected_exception, match=msg):
         func(idx)
 
@@ -348,9 +348,9 @@ def test_numpy_ufuncs(idx, func):
 )
 def test_numpy_type_funcs(idx, func):
     msg = (
-        "ufunc '{}' not supported for the input types, and the inputs"
-        " could not be safely coerced to any supported types according to"
-        " the casting rule ''safe''"
-    ).format(func.__name__)
+        f"ufunc '{func.__name__}' not supported for the input types, and the inputs"
+        f" could not be safely coerced to any supported types according to"
+        f" the casting rule ''safe''"
+    )
     with pytest.raises(TypeError, match=msg):
         func(idx)


### PR DESCRIPTION
Modified reflect python3 format strings on pandas/tests/indexes/multi/test_analytics.py.  I ran the test and it passed like before.  ref [#29886](https://github.com/pandas-dev/pandas/issues/29886) and [#29547](https://github.com/pandas-dev/pandas/issues/29547).