### PR TITLE
Fixing pandas/tests/indexes/datetimes/test_ops.py to utilize python3 …

### DIFF
--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -41,9 +41,9 @@ class TestDatetimeIndexOps(Ops):
 
         # sanity check that the behavior didn't change
         # GH#7206
-        msg = "'Series' object has no attribute '{}'"
         for op in ["year", "day", "second", "weekday"]:
-            with pytest.raises(AttributeError, match=msg.format(op)):
+            msg = f"'Series' object has no attribute '{op}'"
+            with pytest.raises(AttributeError, match=msg):
                 getattr(self.dt_series, op)
 
         # attribute access should still work!


### PR DESCRIPTION
Updated pandas/tests/indexes/datetimes/test_ops.py to utilize python3 format strings.  Ran the test and it seems good.  I moved the msg into the for loop because it seems cleaner with the new format string logic. 
ref [#29886](https://github.com/pandas-dev/pandas/issues/29886) and [#29547](https://github.com/pandas-dev/pandas/issues/29547).