### PR TITLE
fixed pandas/io/formats/printing.py formatting: replaced %/{}.format …

### DIFF
--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -325,8 +325,8 @@ def format_object_summary(
 
     if indent_for_name:
         name_len = len(name)
-        space1 = "\n%s" % (" " * (name_len + 1))
-        space2 = "\n%s" % (" " * (name_len + 2))
+        space1 = f'\n{(" " * (name_len + 1))}'
+        space2 = f'\n{(" " * (name_len + 2))}'
     else:
         space1 = "\n"
         space2 = "\n "  # space for the opening '['
@@ -363,14 +363,14 @@ def format_object_summary(
     close = ", "
 
     if n == 0:
-        summary = "[]{}".format(close)
+        summary = f"[]{close}"
     elif n == 1 and not line_break_each_value:
         first = formatter(obj[0])
-        summary = "[{}]{}".format(first, close)
+        summary = f"[{first}]{close}"
     elif n == 2 and not line_break_each_value:
         first = formatter(obj[0])
         last = formatter(obj[-1])
-        summary = "[{}, {}]{}".format(first, last, close)
+        summary = f"[{first}, {last}]{close}"
     else:
 
         if n > max_seq_items:
@@ -516,7 +516,7 @@ def format_object_attrs(
     attrs: List[Tuple[str, Union[str, int]]] = []
     if hasattr(obj, "dtype") and include_dtype:
         # error: "Sequence[Any]" has no attribute "dtype"
-        attrs.append(("dtype", "'{}'".format(obj.dtype)))  # type: ignore
+        attrs.append(("dtype", f"'{obj.dtype}'"))  # type: ignore
     if getattr(obj, "name", None) is not None:
         # error: "Sequence[Any]" has no attribute "name"
         attrs.append(("name", default_pprint(obj.name)))  # type: ignore


### PR DESCRIPTION
Updated pandas/io/formats/printing.py formatting.  Replaced % and {}.format() examples to python3 formatting. Ran tests and they passed.  

ref [#29886](https://github.com/pandas-dev/pandas/issues/29886) and [#29547](https://github.com/pandas-dev/pandas/issues/29547).