### PR TITLE
CLN/TYP: Removed redundant 'int' from pandas/_typing.py

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -32,7 +32,7 @@ Dtype = Union[str, np.dtype, "ExtensionDtype"]
 FilePathOrBuffer = Union[str, Path, IO[AnyStr]]
 
 FrameOrSeries = TypeVar("FrameOrSeries", bound="NDFrame")
-Scalar = Union[str, int, float, bool]
+Scalar = Union[str, float, bool]
 Axis = Union[str, int]
 Ordered = Optional[bool]
 JSONSerializable = Union[Scalar, List, Dict]


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

As @simonjayhawkins says [here](https://github.com/pandas-dev/pandas/pull/30403#discussion_r360828949) (comment), having ```Union``` with both ```int``` and ```float``` is redundant.