### PR TITLE
Replaced .format{}/% with f-strings in core/tools/datetime.py

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -475,8 +475,8 @@ def _adjust_to_origin(arg, origin, unit):
         j_min = Timestamp.min.to_julian_date() - j0
         if np.any(arg > j_max) or np.any(arg < j_min):
             raise tslibs.OutOfBoundsDatetime(
-                "{original} is Out of Bounds for "
-                "origin='julian'".format(original=original)
+                f"{original} is Out of Bounds for "
+                "origin='julian'"
             )
     else:
         # arg must be numeric
@@ -485,10 +485,8 @@ def _adjust_to_origin(arg, origin, unit):
             or is_numeric_dtype(np.asarray(arg))
         ):
             raise ValueError(
-                "'{arg}' is not compatible with origin='{origin}'; "
-                "it must be numeric with a unit specified ".format(
-                    arg=arg, origin=origin
-                )
+                f"'{arg}' is not compatible with origin='{origin}'; "
+                "it must be numeric with a unit specified "
             )
 
         # we are going to offset back to unix / epoch time
@@ -496,16 +494,16 @@ def _adjust_to_origin(arg, origin, unit):
             offset = Timestamp(origin)
         except tslibs.OutOfBoundsDatetime:
             raise tslibs.OutOfBoundsDatetime(
-                "origin {origin} is Out of Bounds".format(origin=origin)
+                f"origin {origin} is Out of Bounds"
             )
         except ValueError:
             raise ValueError(
-                "origin {origin} cannot be converted "
-                "to a Timestamp".format(origin=origin)
+                f"origin {origin} cannot be converted "
+                "to a Timestamp"
             )
 
         if offset.tz is not None:
-            raise ValueError("origin offset {} must be tz-naive".format(offset))
+            raise ValueError(f"origin offset {offset} must be tz-naive")
         offset -= Timestamp(0)
 
         # convert the offset to the unit of the arg
@@ -810,8 +808,8 @@ def _assemble_from_unit_mappings(arg, errors, tz):
     if len(req):
         raise ValueError(
             "to assemble mappings requires at least that "
-            "[year, month, day] be specified: [{required}] "
-            "is missing".format(required=",".join(req))
+            f"[year, month, day] be specified: [{','.join(req)}] "
+            "is missing"
         )
 
     # keys we don't recognize
@@ -820,7 +818,7 @@ def _assemble_from_unit_mappings(arg, errors, tz):
         raise ValueError(
             "extra keys have been passed "
             "to the datetime assemblage: "
-            "[{excess}]".format(excess=",".join(excess))
+            f"[{','.join(excess)}]"
         )
 
     def coerce(values):
@@ -983,9 +981,9 @@ def to_time(arg, format=None, infer_time_format=False, errors="raise"):
                 except (ValueError, TypeError):
                     if errors == "raise":
                         msg = (
-                            "Cannot convert {element} to a time with given "
-                            "format {format}"
-                        ).format(element=element, format=format)
+                            f"Cannot convert {element} to a time with given "
+                            f"format {format}"
+                        )
                         raise ValueError(msg)
                     elif errors == "ignore":
                         return arg
@@ -1012,7 +1010,7 @@ def to_time(arg, format=None, infer_time_format=False, errors="raise"):
                     times.append(time_object)
                 elif errors == "raise":
                     raise ValueError(
-                        "Cannot convert arg {arg} to a time".format(arg=arg)
+                        f"Cannot convert arg {arg} to a time"
                     )
                 elif errors == "ignore":
                     return arg

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -485,7 +485,7 @@ def _adjust_to_origin(arg, origin, unit):
         ):
             raise ValueError(
                 f"'{arg}' is not compatible with origin='{origin}'; "
-                "it must be numeric with a unit specified "
+                "it must be numeric with a unit specified"
             )
 
         # we are going to offset back to unix / epoch time
@@ -800,19 +800,19 @@ def _assemble_from_unit_mappings(arg, errors, tz):
     required = ["year", "month", "day"]
     req = sorted(set(required) - set(unit_rev.keys()))
     if len(req):
+        required = ",".join(req)
         raise ValueError(
             "to assemble mappings requires at least that "
-            f"[year, month, day] be specified: [{','.join(req)}] "
+            f"[year, month, day] be specified: [{required}] "
             "is missing"
         )
 
     # keys we don't recognize
     excess = sorted(set(unit_rev.keys()) - set(_unit_map.values()))
     if len(excess):
+        excess = ",".join(excess)
         raise ValueError(
-            "extra keys have been passed "
-            "to the datetime assemblage: "
-            f"[{','.join(excess)}]"
+            f"extra keys have been passed to the datetime assemblage: [{excess}]"
         )
 
     def coerce(values):

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -475,8 +475,7 @@ def _adjust_to_origin(arg, origin, unit):
         j_min = Timestamp.min.to_julian_date() - j0
         if np.any(arg > j_max) or np.any(arg < j_min):
             raise tslibs.OutOfBoundsDatetime(
-                f"{original} is Out of Bounds for "
-                "origin='julian'"
+                f"{original} is Out of Bounds for origin='julian'"
             )
     else:
         # arg must be numeric
@@ -493,14 +492,9 @@ def _adjust_to_origin(arg, origin, unit):
         try:
             offset = Timestamp(origin)
         except tslibs.OutOfBoundsDatetime:
-            raise tslibs.OutOfBoundsDatetime(
-                f"origin {origin} is Out of Bounds"
-            )
+            raise tslibs.OutOfBoundsDatetime(f"origin {origin} is Out of Bounds")
         except ValueError:
-            raise ValueError(
-                f"origin {origin} cannot be converted "
-                "to a Timestamp"
-            )
+            raise ValueError(f"origin {origin} cannot be converted to a Timestamp")
 
         if offset.tz is not None:
             raise ValueError(f"origin offset {offset} must be tz-naive")
@@ -1009,9 +1003,7 @@ def to_time(arg, format=None, infer_time_format=False, errors="raise"):
                 if time_object is not None:
                     times.append(time_object)
                 elif errors == "raise":
-                    raise ValueError(
-                        f"Cannot convert arg {arg} to a time"
-                    )
+                    raise ValueError(f"Cannot convert arg {arg} to a time")
                 elif errors == "ignore":
                     return arg
                 else:

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -475,8 +475,7 @@ def _adjust_to_origin(arg, origin, unit):
         j_min = Timestamp.min.to_julian_date() - j0
         if np.any(arg > j_max) or np.any(arg < j_min):
             raise tslibs.OutOfBoundsDatetime(
-                f"{original} is Out of Bounds for "
-                "origin='julian'"
+                f"{original} is Out of Bounds for " "origin='julian'"
             )
     else:
         # arg must be numeric
@@ -493,14 +492,9 @@ def _adjust_to_origin(arg, origin, unit):
         try:
             offset = Timestamp(origin)
         except tslibs.OutOfBoundsDatetime:
-            raise tslibs.OutOfBoundsDatetime(
-                f"origin {origin} is Out of Bounds"
-            )
+            raise tslibs.OutOfBoundsDatetime(f"origin {origin} is Out of Bounds")
         except ValueError:
-            raise ValueError(
-                f"origin {origin} cannot be converted "
-                "to a Timestamp"
-            )
+            raise ValueError(f"origin {origin} cannot be converted " "to a Timestamp")
 
         if offset.tz is not None:
             raise ValueError(f"origin offset {offset} must be tz-naive")
@@ -1009,9 +1003,7 @@ def to_time(arg, format=None, infer_time_format=False, errors="raise"):
                 if time_object is not None:
                     times.append(time_object)
                 elif errors == "raise":
-                    raise ValueError(
-                        f"Cannot convert arg {arg} to a time"
-                    )
+                    raise ValueError(f"Cannot convert arg {arg} to a time")
                 elif errors == "ignore":
                     return arg
                 else:

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -475,7 +475,8 @@ def _adjust_to_origin(arg, origin, unit):
         j_min = Timestamp.min.to_julian_date() - j0
         if np.any(arg > j_max) or np.any(arg < j_min):
             raise tslibs.OutOfBoundsDatetime(
-                f"{original} is Out of Bounds for " "origin='julian'"
+                f"{original} is Out of Bounds for "
+                "origin='julian'"
             )
     else:
         # arg must be numeric
@@ -492,9 +493,14 @@ def _adjust_to_origin(arg, origin, unit):
         try:
             offset = Timestamp(origin)
         except tslibs.OutOfBoundsDatetime:
-            raise tslibs.OutOfBoundsDatetime(f"origin {origin} is Out of Bounds")
+            raise tslibs.OutOfBoundsDatetime(
+                f"origin {origin} is Out of Bounds"
+            )
         except ValueError:
-            raise ValueError(f"origin {origin} cannot be converted " "to a Timestamp")
+            raise ValueError(
+                f"origin {origin} cannot be converted "
+                "to a Timestamp"
+            )
 
         if offset.tz is not None:
             raise ValueError(f"origin offset {offset} must be tz-naive")
@@ -1003,7 +1009,9 @@ def to_time(arg, format=None, infer_time_format=False, errors="raise"):
                 if time_object is not None:
                     times.append(time_object)
                 elif errors == "raise":
-                    raise ValueError(f"Cannot convert arg {arg} to a time")
+                    raise ValueError(
+                        f"Cannot convert arg {arg} to a time"
+                    )
                 elif errors == "ignore":
                     return arg
                 else:


### PR DESCRIPTION
Modified to python3 format strings
ref: https://github.com/pandas-dev/pandas/issues/29547


- [x] contributes to fstring corrections in  #29547
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
~~whatsnew entry~~ (will not add now. I think the full set of changes in #29547 should get a single update entry rather than a piecemeal one)
