### PR TITLE
CLN: remove unnecessary scipy attr checks

### DIFF
--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -12,15 +12,6 @@ from pandas.tests.frame.common import _check_mixed_float
 import pandas.util.testing as tm
 
 
-def _skip_if_no_pchip():
-    try:
-        from scipy.interpolate import pchip_interpolate  # noqa
-    except ImportError:
-        import pytest
-
-        pytest.skip("scipy.interpolate.pchip missing")
-
-
 class TestDataFrameMissingData:
     def test_dropEmptyRows(self, float_frame):
         N = len(float_frame.index)
@@ -836,8 +827,6 @@ class TestDataFrameInterpolate:
         expectedk = df.copy()
         expectedk["A"] = expected["A"]
         tm.assert_frame_equal(result, expectedk)
-
-        _skip_if_no_pchip()
 
         result = df.interpolate(method="pchip")
         expected.loc[2, "A"] = 3

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -24,24 +24,6 @@ from pandas import (
 import pandas.util.testing as tm
 
 
-def _skip_if_no_pchip():
-    try:
-        from scipy.interpolate import pchip_interpolate  # noqa
-    except ImportError:
-        import pytest
-
-        pytest.skip("scipy.interpolate.pchip missing")
-
-
-def _skip_if_no_akima():
-    try:
-        from scipy.interpolate import Akima1DInterpolator  # noqa
-    except ImportError:
-        import pytest
-
-        pytest.skip("scipy.interpolate.Akima1DInterpolator missing")
-
-
 def _simple_ts(start, end, freq="D"):
     rng = date_range(start, end, freq=freq)
     return Series(np.random.randn(len(rng)), index=rng)
@@ -1099,7 +1081,6 @@ class TestSeriesInterpolateData:
 
     @td.skip_if_no_scipy
     def test_interpolate_pchip(self):
-        _skip_if_no_pchip()
 
         ser = Series(np.sort(np.random.uniform(size=100)))
 
@@ -1113,7 +1094,6 @@ class TestSeriesInterpolateData:
 
     @td.skip_if_no_scipy
     def test_interpolate_akima(self):
-        _skip_if_no_akima()
 
         ser = Series([10, 11, 12, 13])
 
@@ -1619,7 +1599,7 @@ class TestSeriesInterpolateData:
 
         method, kwargs = interp_methods_ind
         if method == "pchip":
-            _skip_if_no_pchip()
+            pytest.importorskip("scipy")
 
         if method == "linear":
             result = df[0].interpolate(**kwargs)
@@ -1647,7 +1627,7 @@ class TestSeriesInterpolateData:
 
         method, kwargs = interp_methods_ind
         if method == "pchip":
-            _skip_if_no_pchip()
+            pytest.importorskip("scipy")
 
         if method in {"linear", "pchip"}:
             result = df[0].interpolate(method=method, **kwargs)


### PR DESCRIPTION
- [x] closes #30383

akima and pchip have existed since at least scipy 0.14, and we require 1.1, so these checks are unnecessary.