### PR TITLE
Removed dead intervaltree code

### DIFF
--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -114,43 +114,6 @@ cdef class IntervalTree(IntervalMixin):
         sort_order = np.lexsort(values)
         return is_monotonic(sort_order, False)[0]
 
-    def get_loc(self, scalar_t key):
-        """Return all positions corresponding to intervals that overlap with
-        the given scalar key
-        """
-        result = Int64Vector()
-        self.root.query(result, key)
-        if not result.data.n:
-            raise KeyError(key)
-        return result.to_array().astype('intp')
-
-    def _get_partial_overlap(self, key_left, key_right, side):
-        """Return all positions corresponding to intervals with the given side
-        falling between the left and right bounds of an interval query
-        """
-        if side == 'left':
-            values = self.left
-            sorter = self.left_sorter
-        else:
-            values = self.right
-            sorter = self.right_sorter
-        key = [key_left, key_right]
-        i, j = values.searchsorted(key, sorter=sorter)
-        return sorter[i:j]
-
-    def get_loc_interval(self, key_left, key_right):
-        """Lookup the intervals enclosed in the given interval bounds
-
-        The given interval is presumed to have closed bounds.
-        """
-        import pandas as pd
-        left_overlap = self._get_partial_overlap(key_left, key_right, 'left')
-        right_overlap = self._get_partial_overlap(key_left, key_right, 'right')
-        enclosing = self.get_loc(0.5 * (key_left + key_right))
-        combined = np.concatenate([left_overlap, right_overlap, enclosing])
-        uniques = pd.unique(combined)
-        return uniques.astype('intp')
-
     def get_indexer(self, scalar_t[:] target):
         """Return the positions corresponding to unique intervals that overlap
         with the given array of scalar targets.

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -53,18 +53,6 @@ def tree(request, leaf_size):
 
 
 class TestIntervalTree:
-    def test_get_loc(self, tree):
-        result = tree.get_loc(1)
-        expected = np.array([0], dtype="intp")
-        tm.assert_numpy_array_equal(result, expected)
-
-        result = np.sort(tree.get_loc(2))
-        expected = np.array([0, 1], dtype="intp")
-        tm.assert_numpy_array_equal(result, expected)
-
-        with pytest.raises(KeyError, match="-1"):
-            tree.get_loc(-1)
-
     def test_get_indexer(self, tree):
         result = tree.get_indexer(np.array([1.0, 5.5, 6.5]))
         expected = np.array([0, 4, -1], dtype="intp")
@@ -98,10 +86,6 @@ class TestIntervalTree:
         left = np.array([0, 0, 0], dtype=dtype)
         tree = IntervalTree(left, left + 1)
 
-        result = np.sort(tree.get_loc(0.5))
-        expected = np.array([0, 1, 2], dtype="intp")
-        tm.assert_numpy_array_equal(result, expected)
-
         with pytest.raises(
             KeyError, match="'indexer does not intersect a unique set of intervals'"
         ):
@@ -115,17 +99,6 @@ class TestIntervalTree:
         result = missing
         expected = np.array([], dtype="intp")
         tm.assert_numpy_array_equal(result, expected)
-
-    def test_get_loc_closed(self, closed):
-        tree = IntervalTree([0], [1], closed=closed)
-        for p, errors in [(0, tree.open_left), (1, tree.open_right)]:
-            if errors:
-                with pytest.raises(KeyError, match=str(p)):
-                    tree.get_loc(p)
-            else:
-                result = tree.get_loc(p)
-                expected = np.array([0], dtype="intp")
-                tm.assert_numpy_array_equal(result, expected)
 
     @pytest.mark.parametrize(
         "leaf_size", [skipif_32bit(1), skipif_32bit(10), skipif_32bit(100), 10000]


### PR DESCRIPTION
While looking to reduce build warnings I came across these methods and couldn't find any public use to them. The only one that seems to get hit is `get_loc` and that is in tests only so I think dead code