### PR TITLE
BUG/Compat: dt64/td64 cummin, cummax on np 1.18

### DIFF
--- a/pandas/tests/series/test_cumulative.py
+++ b/pandas/tests/series/test_cumulative.py
@@ -10,8 +10,6 @@ from itertools import product
 import numpy as np
 import pytest
 
-from pandas.compat.numpy import _np_version_under1p18
-
 import pandas as pd
 import pandas.util.testing as tm
 
@@ -63,16 +61,18 @@ class TestSeriesCumulativeOps:
 
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.xfail(
-        not _np_version_under1p18, reason="numpy 1.18 changed min/max behavior for NaT"
-    )
-    def test_cummin_datetime64(self):
+    @pytest.mark.parametrize("tz", [None, "US/Pacific"])
+    def test_cummin_datetime64(self, tz):
         s = pd.Series(
-            pd.to_datetime(["NaT", "2000-1-2", "NaT", "2000-1-1", "NaT", "2000-1-3"])
+            pd.to_datetime(
+                ["NaT", "2000-1-2", "NaT", "2000-1-1", "NaT", "2000-1-3"]
+            ).tz_localize(tz)
         )
 
         expected = pd.Series(
-            pd.to_datetime(["NaT", "2000-1-2", "NaT", "2000-1-1", "NaT", "2000-1-1"])
+            pd.to_datetime(
+                ["NaT", "2000-1-2", "NaT", "2000-1-1", "NaT", "2000-1-1"]
+            ).tz_localize(tz)
         )
         result = s.cummin(skipna=True)
         tm.assert_series_equal(expected, result)
@@ -80,21 +80,23 @@ class TestSeriesCumulativeOps:
         expected = pd.Series(
             pd.to_datetime(
                 ["NaT", "2000-1-2", "2000-1-2", "2000-1-1", "2000-1-1", "2000-1-1"]
-            )
+            ).tz_localize(tz)
         )
         result = s.cummin(skipna=False)
         tm.assert_series_equal(expected, result)
 
-    @pytest.mark.xfail(
-        not _np_version_under1p18, reason="numpy 1.18 changed min/max behavior for NaT"
-    )
-    def test_cummax_datetime64(self):
+    @pytest.mark.parametrize("tz", [None, "US/Pacific"])
+    def test_cummax_datetime64(self, tz):
         s = pd.Series(
-            pd.to_datetime(["NaT", "2000-1-2", "NaT", "2000-1-1", "NaT", "2000-1-3"])
+            pd.to_datetime(
+                ["NaT", "2000-1-2", "NaT", "2000-1-1", "NaT", "2000-1-3"]
+            ).tz_localize(tz)
         )
 
         expected = pd.Series(
-            pd.to_datetime(["NaT", "2000-1-2", "NaT", "2000-1-2", "NaT", "2000-1-3"])
+            pd.to_datetime(
+                ["NaT", "2000-1-2", "NaT", "2000-1-2", "NaT", "2000-1-3"]
+            ).tz_localize(tz)
         )
         result = s.cummax(skipna=True)
         tm.assert_series_equal(expected, result)
@@ -102,14 +104,11 @@ class TestSeriesCumulativeOps:
         expected = pd.Series(
             pd.to_datetime(
                 ["NaT", "2000-1-2", "2000-1-2", "2000-1-2", "2000-1-2", "2000-1-3"]
-            )
+            ).tz_localize(tz)
         )
         result = s.cummax(skipna=False)
         tm.assert_series_equal(expected, result)
 
-    @pytest.mark.xfail(
-        not _np_version_under1p18, reason="numpy 1.18 changed min/max behavior for NaT"
-    )
     def test_cummin_timedelta64(self):
         s = pd.Series(pd.to_timedelta(["NaT", "2 min", "NaT", "1 min", "NaT", "3 min"]))
 
@@ -125,9 +124,6 @@ class TestSeriesCumulativeOps:
         result = s.cummin(skipna=False)
         tm.assert_series_equal(expected, result)
 
-    @pytest.mark.xfail(
-        not _np_version_under1p18, reason="numpy 1.18 changed min/max behavior for NaT"
-    )
     def test_cummax_timedelta64(self):
         s = pd.Series(pd.to_timedelta(["NaT", "2 min", "NaT", "1 min", "NaT", "3 min"]))
 


### PR DESCRIPTION
- [x] closes #29058
- [x] closes #15553
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This also fixes+tests Series cummin/cummax with dt64tz, will have to look to see if there are any GH issues for that.

Following this and #29872 I think we should refactor a bunch of this out into core.nanops.