### PR TITLE
BUG: The setting xrot=0 in DataFrame.hist() doesn't work with by and subplots #30288

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -828,6 +828,7 @@ Plotting
 - :func:`set_option` now validates that the plot backend provided to ``'plotting.backend'`` implements the backend when the option is set, rather than when a plot is created (:issue:`28163`)
 - :meth:`DataFrame.plot` now allow a ``backend`` keyword argument to allow changing between backends in one session (:issue:`28619`).
 - Bug in color validation incorrectly raising for non-color styles (:issue:`29122`).
+- Bug in :meth:`DataFrame.hist`, ``xrot=0`` does not work with ``by`` and subplots (:issue:`30288`).
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/hist.py
+++ b/pandas/plotting/_matplotlib/hist.py
@@ -250,7 +250,8 @@ def _grouped_hist(
     def plot_group(group, ax):
         ax.hist(group.dropna().values, bins=bins, **kwargs)
 
-    xrot = xrot or rot
+    if xrot is None:
+        xrot = rot
 
     fig, axes = _grouped_plot(
         plot_group,

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -254,17 +254,19 @@ class TestDataFramePlots(TestPlotBase):
         tm.close()
 
     def test_hist_subplot_xrot(self):
-        df = DataFrame({
-            'length': [1.5, 0.5, 1.2, 0.9, 3],
-            'animal': ['pig', 'rabbit', 'pig', 'pig', 'rabbit']
-        })
+        df = DataFrame(
+            {
+                "length": [1.5, 0.5, 1.2, 0.9, 3],
+                "animal": ["pig", "rabbit", "pig", "pig", "rabbit"],
+            }
+        )
         axes = _check_plot_works(
             df.hist,
             filterwarnings="always",
-            column='length',
-            by='animal',
+            column="length",
+            by="animal",
             bins=5,
-            xrot=0
+            xrot=0,
         )
         self._check_ticks_props(axes, xrot=0)
 

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -266,7 +266,8 @@ class TestDataFramePlots(TestPlotBase):
             bins=5,
             xrot=0
         )
-        self._check_ticks_props(axes,xrot=0)
+        self._check_ticks_props(axes, xrot=0)
+
 
 @td.skip_if_no_mpl
 class TestDataFrameGroupByPlots(TestPlotBase):

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -254,6 +254,7 @@ class TestDataFramePlots(TestPlotBase):
         tm.close()
 
     def test_hist_subplot_xrot(self):
+        # GH 30288
         df = DataFrame(
             {
                 "length": [1.5, 0.5, 1.2, 0.9, 3],

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -253,6 +253,20 @@ class TestDataFramePlots(TestPlotBase):
 
         tm.close()
 
+    def test_hist_subplot_xrot(self):
+        df = DataFrame({
+            'length': [1.5, 0.5, 1.2, 0.9, 3],
+            'animal': ['pig', 'rabbit', 'pig', 'pig', 'rabbit']
+        })
+        axes = _check_plot_works(
+            df.hist,
+            filterwarnings="always",
+            column='length',
+            by='animal',
+            bins=5,
+            xrot=0
+        )
+        self._check_ticks_props(axes,xrot=0)
 
 @td.skip_if_no_mpl
 class TestDataFrameGroupByPlots(TestPlotBase):


### PR DESCRIPTION
- [x] closes #30288
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
