### PR TITLE
Mark unused parameters in objToJSON

### DIFF
--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -396,18 +396,21 @@ static PyObject *get_item(PyObject *obj, Py_ssize_t i) {
     return ret;
 }
 
-static char *PyBytesToUTF8(JSOBJ _obj, JSONTypeContext *tc, size_t *_outLen) {
+static char *PyBytesToUTF8(JSOBJ _obj, JSONTypeContext *Py_UNUSED(tc),
+                           size_t *_outLen) {
     PyObject *obj = (PyObject *)_obj;
     *_outLen = PyBytes_GET_SIZE(obj);
     return PyBytes_AS_STRING(obj);
 }
 
-static char *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, size_t *_outLen) {
+static char *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *Py_UNUSED(tc),
+                             size_t *_outLen) {
     return (char *)PyUnicode_AsUTF8AndSize(_obj, (Py_ssize_t *)_outLen);
 }
 
 /* returns a char* and mutates the pointer to *len */
-static char *NpyDateTimeToIso(JSOBJ unused, JSONTypeContext *tc, size_t *len) {
+static char *NpyDateTimeToIso(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                              size_t *len) {
     npy_datetimestruct dts;
     int ret_code;
     int64_t longVal = GET_TC(tc)->longValue;
@@ -537,7 +540,7 @@ static char *PyTimeToJSON(JSOBJ _obj, JSONTypeContext *tc, size_t *outLen) {
 // Numpy array iteration functions
 //=============================================================================
 
-static void NpyArr_freeItemValue(JSOBJ _obj, JSONTypeContext *tc) {
+static void NpyArr_freeItemValue(JSOBJ Py_UNUSED(_obj), JSONTypeContext *tc) {
     if (GET_TC(tc)->npyarr &&
         GET_TC(tc)->itemValue != GET_TC(tc)->npyarr->array) {
         PRINTMARK();
@@ -546,7 +549,9 @@ static void NpyArr_freeItemValue(JSOBJ _obj, JSONTypeContext *tc) {
     }
 }
 
-int NpyArr_iterNextNone(JSOBJ _obj, JSONTypeContext *tc) { return 0; }
+int NpyArr_iterNextNone(JSOBJ Py_UNUSED(_obj), JSONTypeContext *Py_UNUSED(tc)) {
+    return 0;
+}
 
 void NpyArr_iterBegin(JSOBJ _obj, JSONTypeContext *tc) {
     PyArrayObject *obj;
@@ -603,7 +608,10 @@ void NpyArr_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
     }
 }
 
-void NpyArrPassThru_iterBegin(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
+void NpyArrPassThru_iterBegin(JSOBJ Py_UNUSED(obj),
+                              JSONTypeContext *Py_UNUSED(tc)) {
+    PRINTMARK();
+}
 
 void NpyArrPassThru_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
     NpyArrContext *npyarr = GET_TC(tc)->npyarr;
@@ -682,12 +690,13 @@ int NpyArr_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
     return 1;
 }
 
-JSOBJ NpyArr_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ NpyArr_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PRINTMARK();
     return GET_TC(tc)->itemValue;
 }
 
-char *NpyArr_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *NpyArr_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                         size_t *outLen) {
     NpyArrContext *npyarr = GET_TC(tc)->npyarr;
     npy_intp idx;
     PRINTMARK();
@@ -741,7 +750,8 @@ int PdBlock_iterNextItem(JSOBJ obj, JSONTypeContext *tc) {
     return NpyArr_iterNextItem(obj, tc);
 }
 
-char *PdBlock_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *PdBlock_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                          size_t *outLen) {
     PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
     NpyArrContext *npyarr = blkCtxt->npyCtxts[0];
     npy_intp idx;
@@ -763,7 +773,7 @@ char *PdBlock_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
     return cStr;
 }
 
-char *PdBlock_iterGetName_Transpose(JSOBJ obj, JSONTypeContext *tc,
+char *PdBlock_iterGetName_Transpose(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
                                     size_t *outLen) {
     PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
     NpyArrContext *npyarr = blkCtxt->npyCtxts[blkCtxt->colIdx];
@@ -809,7 +819,7 @@ int PdBlock_iterNext(JSOBJ obj, JSONTypeContext *tc) {
     return 1;
 }
 
-void PdBlockPassThru_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+void PdBlockPassThru_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PdBlockContext *blkCtxt = GET_TC(tc)->pdblock;
     PRINTMARK();
 
@@ -1041,13 +1051,14 @@ int Tuple_iterNext(JSOBJ obj, JSONTypeContext *tc) {
     return 1;
 }
 
-void Tuple_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
+void Tuple_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc)) {}
 
-JSOBJ Tuple_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ Tuple_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->itemValue;
 }
 
-char *Tuple_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *Tuple_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc),
+                        size_t *Py_UNUSED(outLen)) {
     return NULL;
 }
 
@@ -1060,7 +1071,7 @@ void Iter_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
     GET_TC(tc)->iterator = PyObject_GetIter(obj);
 }
 
-int Iter_iterNext(JSOBJ obj, JSONTypeContext *tc) {
+int Iter_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PyObject *item;
 
     if (GET_TC(tc)->itemValue) {
@@ -1078,7 +1089,7 @@ int Iter_iterNext(JSOBJ obj, JSONTypeContext *tc) {
     return 1;
 }
 
-void Iter_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+void Iter_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     if (GET_TC(tc)->itemValue) {
         Py_DECREF(GET_TC(tc)->itemValue);
         GET_TC(tc)->itemValue = NULL;
@@ -1090,11 +1101,12 @@ void Iter_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
     }
 }
 
-JSOBJ Iter_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ Iter_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->itemValue;
 }
 
-char *Iter_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *Iter_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc),
+                       size_t *Py_UNUSED(outLen)) {
     return NULL;
 }
 
@@ -1110,7 +1122,7 @@ void Dir_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
     PRINTMARK();
 }
 
-void Dir_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     if (GET_TC(tc)->itemValue) {
         Py_DECREF(GET_TC(tc)->itemValue);
         GET_TC(tc)->itemValue = NULL;
@@ -1196,12 +1208,13 @@ int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
     return 1;
 }
 
-JSOBJ Dir_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ Dir_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PRINTMARK();
     return GET_TC(tc)->itemValue;
 }
 
-char *Dir_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *Dir_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                      size_t *outLen) {
     PRINTMARK();
     *outLen = PyBytes_GET_SIZE(GET_TC(tc)->itemName);
     return PyBytes_AS_STRING(GET_TC(tc)->itemName);
@@ -1227,20 +1240,21 @@ int List_iterNext(JSOBJ obj, JSONTypeContext *tc) {
     return 1;
 }
 
-void List_iterEnd(JSOBJ obj, JSONTypeContext *tc) {}
+void List_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc)) {}
 
-JSOBJ List_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ List_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->itemValue;
 }
 
-char *List_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *List_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc),
+                       size_t *Py_UNUSED(outLen)) {
     return NULL;
 }
 
 //=============================================================================
 // pandas Index iteration functions
 //=============================================================================
-void Index_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+void Index_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     GET_TC(tc)->index = 0;
     GET_TC(tc)->cStr = PyObject_Malloc(20 * sizeof(char));
     if (!GET_TC(tc)->cStr) {
@@ -1276,13 +1290,16 @@ int Index_iterNext(JSOBJ obj, JSONTypeContext *tc) {
     return 1;
 }
 
-void Index_iterEnd(JSOBJ obj, JSONTypeContext *tc) { PRINTMARK(); }
+void Index_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *Py_UNUSED(tc)) {
+    PRINTMARK();
+}
 
-JSOBJ Index_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ Index_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->itemValue;
 }
 
-char *Index_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *Index_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                        size_t *outLen) {
     *outLen = strlen(GET_TC(tc)->cStr);
     return GET_TC(tc)->cStr;
 }
@@ -1290,7 +1307,7 @@ char *Index_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
 //=============================================================================
 // pandas Series iteration functions
 //=============================================================================
-void Series_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+void Series_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
     GET_TC(tc)->index = 0;
     GET_TC(tc)->cStr = PyObject_Malloc(20 * sizeof(char));
@@ -1331,17 +1348,18 @@ int Series_iterNext(JSOBJ obj, JSONTypeContext *tc) {
     return 1;
 }
 
-void Series_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+void Series_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
     enc->outputFormat = enc->originalOutputFormat;
     PRINTMARK();
 }
 
-JSOBJ Series_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ Series_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->itemValue;
 }
 
-char *Series_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *Series_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                         size_t *outLen) {
     *outLen = strlen(GET_TC(tc)->cStr);
     return GET_TC(tc)->cStr;
 }
@@ -1349,7 +1367,7 @@ char *Series_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
 //=============================================================================
 // pandas DataFrame iteration functions
 //=============================================================================
-void DataFrame_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+void DataFrame_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
     GET_TC(tc)->index = 0;
     GET_TC(tc)->cStr = PyObject_Malloc(20 * sizeof(char));
@@ -1395,17 +1413,18 @@ int DataFrame_iterNext(JSOBJ obj, JSONTypeContext *tc) {
     return 1;
 }
 
-void DataFrame_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+void DataFrame_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PyObjectEncoder *enc = (PyObjectEncoder *)tc->encoder;
     enc->outputFormat = enc->originalOutputFormat;
     PRINTMARK();
 }
 
-JSOBJ DataFrame_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ DataFrame_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->itemValue;
 }
 
-char *DataFrame_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *DataFrame_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                            size_t *outLen) {
     *outLen = strlen(GET_TC(tc)->cStr);
     return GET_TC(tc)->cStr;
 }
@@ -1415,12 +1434,12 @@ char *DataFrame_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
 // itemName might converted to string (Python_Str). Do refCounting
 // itemValue is borrowed from object (which is dict). No refCounting
 //=============================================================================
-void Dict_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
+void Dict_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     GET_TC(tc)->index = 0;
     PRINTMARK();
 }
 
-int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc) {
+int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PyObject *itemNameTmp;
 
     if (GET_TC(tc)->itemName) {
@@ -1448,7 +1467,7 @@ int Dict_iterNext(JSOBJ obj, JSONTypeContext *tc) {
     return 1;
 }
 
-void Dict_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
+void Dict_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     if (GET_TC(tc)->itemName) {
         Py_DECREF(GET_TC(tc)->itemName);
         GET_TC(tc)->itemName = NULL;
@@ -1457,11 +1476,12 @@ void Dict_iterEnd(JSOBJ obj, JSONTypeContext *tc) {
     PRINTMARK();
 }
 
-JSOBJ Dict_iterGetValue(JSOBJ obj, JSONTypeContext *tc) {
+JSOBJ Dict_iterGetValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->itemValue;
 }
 
-char *Dict_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
+char *Dict_iterGetName(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc,
+                       size_t *outLen) {
     *outLen = PyBytes_GET_SIZE(GET_TC(tc)->itemName);
     return PyBytes_AS_STRING(GET_TC(tc)->itemName);
 }
@@ -2208,7 +2228,7 @@ INVALID:
     return;
 }
 
-void Object_endTypeContext(JSOBJ obj, JSONTypeContext *tc) {
+void Object_endTypeContext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     PRINTMARK();
     if (tc->prv) {
         Py_XDECREF(GET_TC(tc)->newObj);
@@ -2234,11 +2254,11 @@ const char *Object_getStringValue(JSOBJ obj, JSONTypeContext *tc,
     return GET_TC(tc)->PyTypeToUTF8(obj, tc, _outLen);
 }
 
-JSINT64 Object_getLongValue(JSOBJ obj, JSONTypeContext *tc) {
+JSINT64 Object_getLongValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->longValue;
 }
 
-double Object_getDoubleValue(JSOBJ obj, JSONTypeContext *tc) {
+double Object_getDoubleValue(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     return GET_TC(tc)->doubleValue;
 }
 
@@ -2264,7 +2284,8 @@ char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen) {
     return GET_TC(tc)->iterGetName(obj, tc, outLen);
 }
 
-PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
+PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
+                    PyObject *kwargs) {
     static char *kwlist[] = {"obj",
                              "ensure_ascii",
                              "double_precision",


### PR DESCRIPTION
If compiled with `-Wextra` you get 58 warnings; this brings things down to 2 and I think helps the reader