### PR TITLE
DEPR: Remove Series.compress

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -646,7 +646,7 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 - Changed the default "ordered" argument in :class:`CategoricalDtype` from ``None`` to ``False`` (:issue:`26336`)
 - :meth:`Series.set_axis` and :meth:`DataFrame.set_axis` now require "labels" as the first argument and "axis" as an optional named parameter (:issue:`30089`)
 - Removed :func:`to_msgpack`, :func:`read_msgpack`, :meth:`DataFrame.to_msgpack`, :meth:`Series.to_msgpack` (:issue:`27103`)
--
+- Removed :meth:`Series.compress` (:issue:`21930`)
 - Removed the previously deprecated keyword "fill_value" from :meth:`Categorical.fillna`, use "value" instead (:issue:`19269`)
 - Removed the previously deprecated keyword "data" from :func:`andrews_curves`, use "frame" instead (:issue:`6956`)
 - Removed the previously deprecated keyword "data" from :func:`parallel_coordinates`, use "frame" instead (:issue:`6956`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -510,30 +510,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         return self._values.ravel(order=order)
 
-    def compress(self, condition, *args, **kwargs):
-        """
-        Return selected slices of an array along given axis as a Series.
-
-        .. deprecated:: 0.24.0
-
-        Returns
-        -------
-        Series
-            Series without the slices for which condition is false.
-
-        See Also
-        --------
-        numpy.ndarray.compress
-        """
-        msg = (
-            "Series.compress(condition) is deprecated. "
-            "Use 'Series[condition]' or "
-            "'np.asarray(series).compress(condition)' instead."
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-        nv.validate_compress(args, kwargs)
-        return self[condition]
-
     def __len__(self) -> int:
         """
         Return the length of the Series.

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -11,30 +11,6 @@ import pandas.util.testing as tm
 
 
 class TestSeriesAnalytics:
-    def test_compress(self):
-        cond = [True, False, True, False, False]
-        s = Series([1, -1, 5, 8, 7], index=list("abcde"), name="foo")
-        expected = Series(s.values.compress(cond), index=list("ac"), name="foo")
-        with tm.assert_produces_warning(FutureWarning):
-            result = s.compress(cond)
-        tm.assert_series_equal(result, expected)
-
-    def test_numpy_compress(self):
-        cond = [True, False, True, False, False]
-        s = Series([1, -1, 5, 8, 7], index=list("abcde"), name="foo")
-        expected = Series(s.values.compress(cond), index=list("ac"), name="foo")
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            tm.assert_series_equal(np.compress(cond, s), expected)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            msg = "the 'axis' parameter is not supported"
-            with pytest.raises(ValueError, match=msg):
-                np.compress(cond, s, axis=1)
-
-            msg = "the 'out' parameter is not supported"
-            with pytest.raises(ValueError, match=msg):
-                np.compress(cond, s, out=s)
-
     def test_prod_numpy16_bug(self):
         s = Series([1.0, 1.0, 1.0], index=range(3))
         result = s.prod()

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -465,30 +465,6 @@ class TestSeriesMisc:
         s = Series(np.random.randn(10))
         tm.assert_almost_equal(s.ravel(order="F"), s.values.ravel(order="F"))
 
-        # compress
-        # GH 6658
-        s = Series([0, 1.0, -1], index=list("abc"))
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = np.compress(s > 0, s)
-        tm.assert_series_equal(result, Series([1.0], index=["b"]))
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = np.compress(s < -1, s)
-        # result empty Index(dtype=object) as the same as original
-        exp = Series([], dtype="float64", index=Index([], dtype="object"))
-        tm.assert_series_equal(result, exp)
-
-        s = Series([0, 1.0, -1], index=[0.1, 0.2, 0.3])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = np.compress(s > 0, s)
-        tm.assert_series_equal(result, Series([1.0], index=[0.2]))
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = np.compress(s < -1, s)
-        # result empty Float64Index as the same as original
-        exp = Series([], dtype="float64", index=Index([], dtype="float64"))
-        tm.assert_series_equal(result, exp)
-
     def test_str_accessor_updates_on_inplace(self):
         s = pd.Series(list("abc"))
         s.drop([0], inplace=True)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

As noted in https://github.com/pandas-dev/pandas/issues/6581, sounds like we are okay breaking compatibility with `np.compress`