### PR TITLE
BUG: List indexer on PeriodIndex doesn't coerce strings

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -635,6 +635,7 @@ Indexing
 - Bug in :meth:`Series.__setitem__` with an :class:`IntervalIndex` and a list-like key of integers (:issue:`33473`)
 - Bug in :meth:`Series.__getitem__` allowing missing labels with ``np.ndarray``, :class:`Index`, :class:`Series` indexers but not ``list``, these now all raise ``KeyError`` (:issue:`33646`)
 - Bug in :meth:`DataFrame.truncate` and :meth:`Series.truncate` where index was assumed to be monotone increasing (:issue:`33756`)
+- Indexing with a list of strings representing datetimes failed on :class:`DatetimeIndex` or :class:`PeriodIndex`(:issue:`11278`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1228,11 +1228,13 @@ class _LocIndexer(_LocationIndexer):
         indexer, keyarr = ax._convert_listlike_indexer(key)
         # We only act on all found values:
         if indexer is not None and (indexer != -1).all():
-            self._validate_read_indexer(key, indexer, axis, raise_missing=raise_missing)
+            self._validate_read_indexer(
+                keyarr, indexer, axis, raise_missing=raise_missing
+            )
             return ax[indexer], indexer
 
         if ax.is_unique and not getattr(ax, "is_overlapping", False):
-            indexer = ax.get_indexer_for(key)
+            indexer = ax.get_indexer_for(keyarr)
             keyarr = ax.reindex(keyarr)[0]
         else:
             keyarr, indexer, new_indexer = ax._reindex_non_unique(keyarr)

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import DataFrame, Index, Series, date_range
+from pandas import DataFrame, Index, Period, Series, Timestamp, date_range, period_range
 import pandas._testing as tm
 
 
@@ -535,3 +535,118 @@ class TestPartialSetting:
         df.loc[0, "x"] = 1
         expected = DataFrame(dict(x=[1], y=[np.nan]))
         tm.assert_frame_equal(df, expected, check_dtype=False)
+
+    @pytest.mark.parametrize(
+        "idx,labels,expected_idx",
+        [
+            (
+                period_range(start="2000", periods=20, freq="D"),
+                ["2000-01-04", "2000-01-08", "2000-01-12"],
+                [
+                    Period("2000-01-04", freq="D"),
+                    Period("2000-01-08", freq="D"),
+                    Period("2000-01-12", freq="D"),
+                ],
+            ),
+            (
+                date_range(start="2000", periods=20, freq="D"),
+                ["2000-01-04", "2000-01-08", "2000-01-12"],
+                [
+                    Timestamp("2000-01-04", freq="D"),
+                    Timestamp("2000-01-08", freq="D"),
+                    Timestamp("2000-01-12", freq="D"),
+                ],
+            ),
+            (
+                pd.timedelta_range(start="1 day", periods=20),
+                ["4D", "8D", "12D"],
+                [pd.Timedelta("4 day"), pd.Timedelta("8 day"), pd.Timedelta("12 day")],
+            ),
+        ],
+    )
+    def test_loc_with_list_of_strings_representing_datetimes(
+        self, idx, labels, expected_idx
+    ):
+        # GH 11278
+        s = Series(range(20), index=idx)
+        df = DataFrame(range(20), index=idx)
+
+        expected_value = [3, 7, 11]
+        expected_s = Series(expected_value, expected_idx)
+        expected_df = DataFrame(expected_value, expected_idx)
+
+        tm.assert_series_equal(expected_s, s.loc[labels])
+        tm.assert_series_equal(expected_s, s[labels])
+        tm.assert_frame_equal(expected_df, df.loc[labels])
+
+    @pytest.mark.parametrize(
+        "idx,labels",
+        [
+            (
+                period_range(start="2000", periods=20, freq="D"),
+                ["2000-01-04", "2000-01-30"],
+            ),
+            (
+                date_range(start="2000", periods=20, freq="D"),
+                ["2000-01-04", "2000-01-30"],
+            ),
+            (pd.timedelta_range(start="1 day", periods=20), ["3 day", "30 day"]),
+        ],
+    )
+    def test_loc_with_list_of_strings_representing_datetimes_missing_value(
+        self, idx, labels
+    ):
+        # GH 11278
+        s = Series(range(20), index=idx)
+        df = DataFrame(range(20), index=idx)
+        msg = r"with any missing labels"
+
+        with pytest.raises(KeyError, match=msg):
+            s.loc[labels]
+        with pytest.raises(KeyError, match=msg):
+            s[labels]
+        with pytest.raises(KeyError, match=msg):
+            df.loc[labels]
+
+    @pytest.mark.parametrize(
+        "idx,labels,msg",
+        [
+            (
+                period_range(start="2000", periods=20, freq="D"),
+                ["4D", "8D"],
+                (
+                    r"None of \[Index\(\['4D', '8D'\], dtype='object'\)\] "
+                    r"are in the \[index\]"
+                ),
+            ),
+            (
+                date_range(start="2000", periods=20, freq="D"),
+                ["4D", "8D"],
+                (
+                    r"None of \[Index\(\['4D', '8D'\], dtype='object'\)\] "
+                    r"are in the \[index\]"
+                ),
+            ),
+            (
+                pd.timedelta_range(start="1 day", periods=20),
+                ["2000-01-04", "2000-01-08"],
+                (
+                    r"None of \[Index\(\['2000-01-04', '2000-01-08'\], "
+                    r"dtype='object'\)\] are in the \[index\]"
+                ),
+            ),
+        ],
+    )
+    def test_loc_with_list_of_strings_representing_datetimes_not_matched_type(
+        self, idx, labels, msg
+    ):
+        # GH 11278
+        s = Series(range(20), index=idx)
+        df = DataFrame(range(20), index=idx)
+
+        with pytest.raises(KeyError, match=msg):
+            s.loc[labels]
+        with pytest.raises(KeyError, match=msg):
+            s[labels]
+        with pytest.raises(KeyError, match=msg):
+            df.loc[labels]


### PR DESCRIPTION
- [x] closes #11278
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Description:
In single object indexer case,
datetime string converted to datetime-like object. Because indexing use ".xs" which is ".get_loc" that has type casting labels code. 

But in list indexer, 
there is no type check and casting code. So i add them.

this bug happen not only series but also dataframe And "datetimeindex" as well as "periodIndex"
