### PR TITLE
TST: tests for preserving views

### DIFF
--- a/pandas/tests/arrays/test_numpy.py
+++ b/pandas/tests/arrays/test_numpy.py
@@ -226,3 +226,25 @@ def test_setitem_no_coercion():
     arr = PandasArray(np.array([1, 2, 3]))
     with pytest.raises(ValueError, match="int"):
         arr[0] = "a"
+
+    # With a value that we do coerce, check that we coerce the value
+    #  and not the underlying array.
+    arr[0] = 2.5
+    assert isinstance(arr[0], (int, np.integer)), type(arr[0])
+
+
+def test_setitem_preserves_views():
+    # GH#28150, see also extension test of the same name
+    arr = PandasArray(np.array([1, 2, 3]))
+    view1 = arr.view()
+    view2 = arr[:]
+    view3 = np.asarray(arr)
+
+    arr[0] = 9
+    assert view1[0] == 9
+    assert view2[0] == 9
+    assert view3[0] == 9
+
+    arr[-1] = 2.5
+    view1[-1] = 5
+    assert arr[-1] == 5

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -186,3 +186,14 @@ class BaseSetitemTests(BaseExtensionTests):
         arr = data[:5].copy()
         with pytest.raises(ValueError):
             arr[0] = arr[[0, 1]]
+
+    def test_setitem_preserves_views(self, data):
+        # GH#28150 setitem shouldn't swap the underlying data
+        assert data[-1] != data[0]  # otherwise test would not be meaningful
+
+        view1 = data.view()
+        view2 = data[:]
+
+        data[0] = data[-1]
+        assert view1[0] == data[-1]
+        assert view2[0] == data[-1]

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -147,7 +147,9 @@ class TestReshaping(BaseInterval, base.BaseReshapingTests):
 
 
 class TestSetitem(BaseInterval, base.BaseSetitemTests):
-    pass
+    @pytest.mark.xfail(reason="GH#27147 setitem changes underlying index")
+    def test_setitem_preserves_views(self, data):
+        super().test_setitem_preserves_views(data)
 
 
 class TestPrinting(BaseInterval, base.BasePrintingTests):


### PR DESCRIPTION
- [x] xref #28150
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
