### PR TITLE
WARN: Ignore NumbaPerformanceWarning in test suite

### DIFF
--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -9,6 +9,7 @@ import pandas.util.testing as tm
 
 @td.skip_if_no("numba", "0.46.0")
 @pytest.mark.filterwarnings("ignore:\\nThe keyword argument")
+# Filter warnings when parallel=True and the function can't be parallelized by Numba
 class TestApply:
     @pytest.mark.parametrize("jit", [True, False])
     def test_numba_vs_cython(self, jit, nogil, parallel, nopython):

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -8,6 +8,7 @@ import pandas.util.testing as tm
 
 
 @td.skip_if_no("numba", "0.46.0")
+@pytest.mark.filterwarnings("ignore:\\nThe keyword argument")
 class TestApply:
     @pytest.mark.parametrize("jit", [True, False])
     def test_numba_vs_cython(self, jit, nogil, parallel, nopython):


### PR DESCRIPTION
Followup to #30151; ignoring `NumbaPerformanceWarning` raised in the test suite when `parallel=True` while the function being tested cannot be parallelized. This behavior is fully intended.
