### PR TITLE
CLN: remove kwargs from (DataFrame|Series).fillna

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4014,8 +4014,7 @@ class DataFrame(NDFrame):
         inplace=False,
         limit=None,
         downcast=None,
-        **kwargs,
-    ):
+    ) -> Optional["DataFrame"]:
         return super().fillna(
             value=value,
             method=method,
@@ -4023,7 +4022,6 @@ class DataFrame(NDFrame):
             inplace=inplace,
             limit=limit,
             downcast=downcast,
-            **kwargs,
         )
 
     @Appender(_shared_docs["replace"] % _shared_doc_kwargs)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4005,8 +4005,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         inplace=False,
         limit=None,
         downcast=None,
-        **kwargs,
-    ):
+    ) -> Optional["Series"]:
         return super().fillna(
             value=value,
             method=method,
@@ -4014,7 +4013,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             inplace=inplace,
             limit=limit,
             downcast=downcast,
-            **kwargs,
         )
 
     @Appender(generic._shared_docs["replace"] % _shared_doc_kwargs)


### PR DESCRIPTION
(DataFrame|Series).fillna  have the same parameters as NDFrame.fillna, so the **kwargs is not needed. Also make the return type more specific.