### PR TITLE
CLN: Update old .format to f-string

### DIFF
--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -464,13 +464,17 @@ def register_option(key: str, defval: object, doc="", validator=None, cb=None):
 
     for i, p in enumerate(path[:-1]):
         if not isinstance(cursor, dict):
-            raise OptionError(f"Path prefix to option '{'.'.join(path[:i])}' is already an option")
+            raise OptionError(
+                f"Path prefix to option '{'.'.join(path[:i])}' is already an option"
+            )
         if p not in cursor:
             cursor[p] = {}
         cursor = cursor[p]
 
     if not isinstance(cursor, dict):
-        raise OptionError(f"Path prefix to option '{'.'.join(path[:-1])}' is already an option")
+        raise OptionError(
+            f"Path prefix to option '{'.'.join(path[:-1])}' is already an option"
+        )
 
     cursor[path[-1]] = defval  # initialize
 

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -461,20 +461,17 @@ def register_option(key: str, defval: object, doc="", validator=None, cb=None):
             raise ValueError(f"{k} is a python keyword")
 
     cursor = _global_config
+    msg = "Path prefix to option '{option}' is already an option"
 
     for i, p in enumerate(path[:-1]):
         if not isinstance(cursor, dict):
-            raise OptionError(
-                f"Path prefix to option '{'.'.join(path[:i])}' is already an option"
-            )
+            raise OptionError(msg.format(option=".".join(path[:i])))
         if p not in cursor:
             cursor[p] = {}
         cursor = cursor[p]
 
     if not isinstance(cursor, dict):
-        raise OptionError(
-            f"Path prefix to option '{'.'.join(path[:-1])}' is already an option"
-        )
+        raise OptionError(msg.format(option=".".join(path[:-1])))
 
     cursor[path[-1]] = defval  # initialize
 

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -461,17 +461,16 @@ def register_option(key: str, defval: object, doc="", validator=None, cb=None):
             raise ValueError(f"{k} is a python keyword")
 
     cursor = _global_config
-    msg = "Path prefix to option '{option}' is already an option"
 
     for i, p in enumerate(path[:-1]):
         if not isinstance(cursor, dict):
-            raise OptionError(msg.format(option=".".join(path[:i])))
+            raise OptionError(f"Path prefix to option '{'.'.join(path[:i])}' is already an option")
         if p not in cursor:
             cursor[p] = {}
         cursor = cursor[p]
 
     if not isinstance(cursor, dict):
-        raise OptionError(msg.format(option=".".join(path[:-1])))
+        raise OptionError(f"Path prefix to option '{'.'.join(path[:-1])}' is already an option")
 
     cursor[path[-1]] = defval  # initialize
 

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -755,7 +755,7 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
 
             if other_is_scalar and not (other is libmissing.NA or lib.is_bool(other)):
                 raise TypeError(
-                    f"'other' should be pandas.NA or a bool. "
+                    "'other' should be pandas.NA or a bool. "
                     f"Got {type(other).__name__} instead."
                 )
 

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -755,8 +755,8 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
 
             if other_is_scalar and not (other is libmissing.NA or lib.is_bool(other)):
                 raise TypeError(
-                    f"'other' should be pandas.NA or a bool.\
-                        Got {type(other).__name__} instead."
+                    f"'other' should be pandas.NA or a bool. "
+                    f"Got {type(other).__name__} instead."
                 )
 
             if not other_is_scalar and len(self) != len(other):

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -755,9 +755,7 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
 
             if other_is_scalar and not (other is libmissing.NA or lib.is_bool(other)):
                 raise TypeError(
-                    "'other' should be pandas.NA or a bool. Got {} instead.".format(
-                        type(other).__name__
-                    )
+                    f"'other' should be pandas.NA or a bool. Got {type(other).__name__} instead."
                 )
 
             if not other_is_scalar and len(self) != len(other):
@@ -772,7 +770,7 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
 
             return BooleanArray(result, mask)
 
-        name = "__{name}__".format(name=op.__name__)
+        name = f"__{op.__name__}__"
         return set_function_name(logical_method, name, cls)
 
     @classmethod
@@ -819,7 +817,7 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
 
             return BooleanArray(result, mask, copy=False)
 
-        name = "__{name}__".format(name=op.__name__)
+        name = f"__{op.__name__}"
         return set_function_name(cmp_method, name, cls)
 
     def _reduce(self, name, skipna=True, **kwargs):
@@ -922,7 +920,7 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
 
             return self._maybe_mask_result(result, mask, other, op_name)
 
-        name = "__{name}__".format(name=op_name)
+        name = f"__{op_name}__"
         return set_function_name(boolean_arithmetic_method, name, cls)
 
 

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -755,7 +755,8 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
 
             if other_is_scalar and not (other is libmissing.NA or lib.is_bool(other)):
                 raise TypeError(
-                    f"'other' should be pandas.NA or a bool. Got {type(other).__name__} instead."
+                    f"'other' should be pandas.NA or a bool.\
+                        Got {type(other).__name__} instead."
                 )
 
             if not other_is_scalar and len(self) != len(other):


### PR DESCRIPTION
Reviewed and updated to f-string for:
pandas/compat/pickle_compat.py
pandas/_config/config.py
pandas/core/arrays/boolean.py

- [x] Contributes to #29547 
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Marking pickle_compat.py as done but I left the existing `.format` as is, as I believe this is a good use case for `.format`