### PR TITLE
TYP: check_untyped_defs astype_nansafe

### DIFF
--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -524,7 +524,7 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
             na_value = np.nan
         # coerce
         data = self._coerce_to_ndarray(na_value=na_value)
-        return astype_nansafe(data, dtype, copy=None)
+        return astype_nansafe(data, dtype, copy=False)
 
     def value_counts(self, dropna=True):
         """

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -546,7 +546,7 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
 
         # coerce
         data = self._coerce_to_ndarray()
-        return astype_nansafe(data, dtype, copy=None)
+        return astype_nansafe(data, dtype, copy=False)
 
     @property
     def _ndarray_values(self) -> np.ndarray:

--- a/setup.cfg
+++ b/setup.cfg
@@ -151,13 +151,7 @@ ignore_errors=True
 [mypy-pandas._version]
 check_untyped_defs=False
 
-[mypy-pandas.core.arrays.boolean]
-check_untyped_defs=False
-
 [mypy-pandas.core.arrays.categorical]
-check_untyped_defs=False
-
-[mypy-pandas.core.arrays.integer]
 check_untyped_defs=False
 
 [mypy-pandas.core.arrays.interval]


### PR DESCRIPTION
```
pandas\core\arrays\integer.py:549: error: Argument "copy" to "astype_nansafe" has incompatible type "None"; expected "bool"
pandas\core\arrays\boolean.py:527: error: Argument "copy" to "astype_nansafe" has incompatible type "None"; expected "bool"
```