### PR TITLE
TYP: check_untyped_defs core.computation.eval

### DIFF
--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -3,6 +3,7 @@ Engine classes for :func:`~pandas.eval`
 """
 
 import abc
+from typing import Dict, Type
 
 from pandas.core.computation.align import align_terms, reconstruct_object
 from pandas.core.computation.ops import _mathops, _reductions
@@ -53,7 +54,7 @@ class AbstractEngine(metaclass=abc.ABCMeta):
         """
         return printing.pprint_thing(self.expr)
 
-    def evaluate(self):
+    def evaluate(self) -> object:
         """
         Run the engine on the expression.
 
@@ -62,7 +63,7 @@ class AbstractEngine(metaclass=abc.ABCMeta):
 
         Returns
         -------
-        obj : object
+        object
             The result of the passed expression.
         """
         if not self._is_aligned:
@@ -101,12 +102,6 @@ class NumExprEngine(AbstractEngine):
 
     has_neg_frac = True
 
-    def __init__(self, expr):
-        super().__init__(expr)
-
-    def convert(self) -> str:
-        return str(super().convert())
-
     def _evaluate(self):
         import numexpr as ne
 
@@ -128,14 +123,14 @@ class PythonEngine(AbstractEngine):
 
     has_neg_frac = False
 
-    def __init__(self, expr):
-        super().__init__(expr)
-
     def evaluate(self):
         return self.expr()
 
-    def _evaluate(self):
+    def _evaluate(self) -> None:
         pass
 
 
-_engines = {"numexpr": NumExprEngine, "python": PythonEngine}
+_engines: Dict[str, Type[AbstractEngine]] = {
+    "numexpr": NumExprEngine,
+    "python": PythonEngine,
+}

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -5,6 +5,7 @@ Top level ``eval`` module.
 """
 
 import tokenize
+from typing import Optional
 import warnings
 
 from pandas._libs.lib import _no_default
@@ -17,7 +18,7 @@ from pandas.core.computation.scope import ensure_scope
 from pandas.io.formats.printing import pprint_thing
 
 
-def _check_engine(engine):
+def _check_engine(engine: Optional[str]) -> str:
     """
     Make sure a valid engine is passed.
 
@@ -168,7 +169,7 @@ def _check_for_locals(expr: str, stack_level: int, parser: str):
 def eval(
     expr,
     parser="pandas",
-    engine=None,
+    engine: Optional[str] = None,
     truediv=_no_default,
     local_dict=None,
     global_dict=None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -172,9 +172,6 @@ check_untyped_defs=False
 [mypy-pandas.core.computation.align]
 check_untyped_defs=False
 
-[mypy-pandas.core.computation.eval]
-check_untyped_defs=False
-
 [mypy-pandas.core.computation.expr]
 check_untyped_defs=False
 


### PR DESCRIPTION
pandas\core\computation\eval.py:334: error: Cannot instantiate abstract class 'AbstractEngine' with abstract attribute '_evaluate'