### PR TITLE
DOC: Document behaviour of head(n), tail(n) for negative values of n except on GroupBy

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4652,7 +4652,7 @@ class NDFrame(PandasObject, SelectionMixin):
         on position. It is useful for quickly testing if your object
         has the right type of data in it.
 
-        For negative values of `n`, this function returns all rows except 
+        For negative values of `n`, this function returns all rows except
         the last `n` rows, equivalent to ``df[:-n]``.
 
         Parameters
@@ -4725,7 +4725,7 @@ class NDFrame(PandasObject, SelectionMixin):
         position. It is useful for quickly verifying data, for example,
         after sorting or appending rows.
 
-        For negative values of `n`, this function returns all rows except 
+        For negative values of `n`, this function returns all rows except
         the first `n` rows, equivalent to ``df[n:]``.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4652,6 +4652,9 @@ class NDFrame(PandasObject, SelectionMixin):
         on position. It is useful for quickly testing if your object
         has the right type of data in it.
 
+        For negative values of `n`, this function returns all rows except 
+        the last `n` rows, equivalent to ``df[:-n]``.
+
         Parameters
         ----------
         n : int, default 5
@@ -4659,7 +4662,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        obj_head : same type as caller
+        same type as caller
             The first `n` rows of the caller object.
 
         See Also
@@ -4699,6 +4702,17 @@ class NDFrame(PandasObject, SelectionMixin):
         0  alligator
         1        bee
         2     falcon
+
+        For negative values of `n`
+
+        >>> df.head(-3)
+              animal
+        0  alligator
+        1        bee
+        2     falcon
+        3       lion
+        4     monkey
+        5     parrot
         """
 
         return self.iloc[:n]
@@ -4710,6 +4724,9 @@ class NDFrame(PandasObject, SelectionMixin):
         This function returns last `n` rows from the object based on
         position. It is useful for quickly verifying data, for example,
         after sorting or appending rows.
+
+        For negative values of `n`, this function returns all rows except 
+        the first `n` rows, equivalent to ``df[n:]``.
 
         Parameters
         ----------
@@ -4758,6 +4775,17 @@ class NDFrame(PandasObject, SelectionMixin):
         6  shark
         7  whale
         8  zebra
+
+        For negative values of `n`
+
+        >>> df.tail(-3)
+           animal
+        3    lion
+        4  monkey
+        5  parrot
+        6   shark
+        7   whale
+        8   zebra
         """
 
         if n == 0:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2377,6 +2377,8 @@ class GroupBy(_GroupBy):
         from the original DataFrame with original index and order preserved
         (``as_index`` flag is ignored).
 
+        Does not work for negative values of `n`.
+
         Returns
         -------
         Series or DataFrame
@@ -2390,6 +2392,10 @@ class GroupBy(_GroupBy):
            A  B
         0  1  2
         2  5  6
+        >>> df.groupby('A').head(-1)
+            Empty DataFrame
+            Columns: [A, B]
+            Index: []
         """
         self._reset_group_selection()
         mask = self._cumcount_array() < n
@@ -2405,6 +2411,8 @@ class GroupBy(_GroupBy):
         from the original DataFrame with original index and order preserved
         (``as_index`` flag is ignored).
 
+        Does not work for negative values of `n`.
+
         Returns
         -------
         Series or DataFrame
@@ -2418,6 +2426,10 @@ class GroupBy(_GroupBy):
            A  B
         1  a  2
         3  b  2
+        >>> df.groupby('A').tail(-1)
+        Empty DataFrame
+        Columns: [A, B]
+        Index: []
         """
         self._reset_group_selection()
         mask = self._cumcount_array(ascending=False) < n

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2393,9 +2393,9 @@ class GroupBy(_GroupBy):
         0  1  2
         2  5  6
         >>> df.groupby('A').head(-1)
-            Empty DataFrame
-            Columns: [A, B]
-            Index: []
+        Empty DataFrame
+        Columns: [A, B]
+        Index: []
         """
         self._reset_group_selection()
         mask = self._cumcount_array() < n


### PR DESCRIPTION
- [x] xref #30192 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Output of `python3 scripts/validate_docstrings.py pandas.DataFrame.head`

```bash
################################################################################
###################### Docstring (pandas.DataFrame.head)  ######################
################################################################################

Return the first `n` rows.

This function returns the first `n` rows for the object based
on position. It is useful for quickly testing if your object
has the right type of data in it.

For negative values of `n`, this function returns all rows except
the last `n` rows, equivalent to ``df[:-n]``.

Parameters
----------
n : int, default 5
    Number of rows to select.

Returns
-------
same type as caller
    The first `n` rows of the caller object.

See Also
--------
DataFrame.tail: Returns the last `n` rows.

Examples
--------
>>> df = pd.DataFrame({'animal': ['alligator', 'bee', 'falcon', 'lion',
...                    'monkey', 'parrot', 'shark', 'whale', 'zebra']})
>>> df
      animal
0  alligator
1        bee
2     falcon
3       lion
4     monkey
5     parrot
6      shark
7      whale
8      zebra

Viewing the first 5 lines

>>> df.head()
      animal
0  alligator
1        bee
2     falcon
3       lion
4     monkey

Viewing the first `n` lines (three in this case)

>>> df.head(3)
      animal
0  alligator
1        bee
2     falcon

For negative values of `n`

>>> df.head(-3)
      animal
0  alligator
1        bee
2     falcon
3       lion
4     monkey
5     parrot

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.head" correct. :)
```

Output of `python3 scripts/validate_docstrings.py pandas.DataFrame.tail`

```bash
################################################################################
###################### Docstring (pandas.DataFrame.tail)  ######################
################################################################################

Return the last `n` rows.

This function returns last `n` rows from the object based on
position. It is useful for quickly verifying data, for example,
after sorting or appending rows.

For negative values of `n`, this function returns all rows except
the first `n` rows, equivalent to ``df[n:]``.

Parameters
----------
n : int, default 5
    Number of rows to select.

Returns
-------
type of caller
    The last `n` rows of the caller object.

See Also
--------
DataFrame.head : The first `n` rows of the caller object.

Examples
--------
>>> df = pd.DataFrame({'animal': ['alligator', 'bee', 'falcon', 'lion',
...                    'monkey', 'parrot', 'shark', 'whale', 'zebra']})
>>> df
      animal
0  alligator
1        bee
2     falcon
3       lion
4     monkey
5     parrot
6      shark
7      whale
8      zebra

Viewing the last 5 lines

>>> df.tail()
   animal
4  monkey
5  parrot
6   shark
7   whale
8   zebra

Viewing the last `n` lines (three in this case)

>>> df.tail(3)
  animal
6  shark
7  whale
8  zebra

For negative values of `n`

>>> df.tail(-3)
   animal
3    lion
4  monkey
5  parrot
6   shark
7   whale
8   zebra

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.tail" correct. :)
```

Output of `./ci/code_checks.sh doctests` passed for `groupby.py`