### PR TITLE
DEPR: tz-aware array

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -725,7 +725,9 @@ or ``matplotlib.Axes.plot``. See :ref:`plotting.formatters` for more.
 - Removed the previously deprecated keyword "data" from :func:`parallel_coordinates`, use "frame" instead (:issue:`6956`)
 - Removed the previously deprecated keyword "colors" from :func:`parallel_coordinates`, use "color" instead (:issue:`6956`)
 - Removed the previously deprecated keywords "verbose" and "private_key" from :func:`read_gbq` (:issue:`30200`)
--
+- Removed the previously deprecated behavior of timezone-aware ``Series`` and ``Index`` being converted to UTC and
+  returning a ``datetime64[ns]`` dtype ndarray when converted to an array. Now an ``object`` dtype ndarray
+  containing :class:`Timestamp` with the original timezone is returned (:issue:`24596`)
 
 .. _whatsnew_1000.performance:
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -310,21 +310,6 @@ class DatetimeIndex(
     # --------------------------------------------------------------------
 
     def __array__(self, dtype=None):
-        if (
-            dtype is None
-            and isinstance(self._data, DatetimeArray)
-            and getattr(self.dtype, "tz", None)
-        ):
-            msg = (
-                "Converting timezone-aware DatetimeArray to timezone-naive "
-                "ndarray with 'datetime64[ns]' dtype. In the future, this "
-                "will return an ndarray with 'object' dtype where each "
-                "element is a 'pandas.Timestamp' with the correct 'tz'.\n\t"
-                "To accept the future behavior, pass 'dtype=object'.\n\t"
-                "To keep the old behavior, pass 'dtype=\"datetime64[ns]\"'."
-            )
-            warnings.warn(msg, FutureWarning, stacklevel=3)
-            dtype = "M8[ns]"
         return np.asarray(self._data, dtype=dtype)
 
     @property

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -33,7 +33,6 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
-    ABCDatetimeArray,
     ABCDatetimeIndex,
     ABCSeries,
     ABCSparseArray,
@@ -716,21 +715,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         array(['1999-12-31T23:00:00.000000000', ...],
               dtype='datetime64[ns]')
         """
-        if (
-            dtype is None
-            and isinstance(self.array, ABCDatetimeArray)
-            and getattr(self.dtype, "tz", None)
-        ):
-            msg = (
-                "Converting timezone-aware DatetimeArray to timezone-naive "
-                "ndarray with 'datetime64[ns]' dtype. In the future, this "
-                "will return an ndarray with 'object' dtype where each "
-                "element is a 'pandas.Timestamp' with the correct 'tz'.\n\t"
-                "To accept the future behavior, pass 'dtype=object'.\n\t"
-                "To keep the old behavior, pass 'dtype=\"datetime64[ns]\"'."
-            )
-            warnings.warn(msg, FutureWarning, stacklevel=3)
-            dtype = "M8[ns]"
         return np.asarray(self.array, dtype)
 
     # ----------------------------------------------------------------------

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -568,7 +568,6 @@ class TestDatetimeIndexComparisons:
     # Raising in __eq__ will fallback to NumPy, which warns, fails,
     # then re-raises the original exception. So we just need to ignore.
     @pytest.mark.filterwarnings("ignore:elementwise comp:DeprecationWarning")
-    @pytest.mark.filterwarnings("ignore:Converting timezone-aware:FutureWarning")
     def test_scalar_comparison_tzawareness(
         self, op, other, tz_aware_fixture, box_with_array
     ):

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from decimal import Decimal
-from warnings import catch_warnings, filterwarnings
 
 import numpy as np
 import pytest
@@ -315,23 +314,21 @@ def test_array_equivalent():
     assert not array_equivalent(
         TimedeltaIndex([0, np.nan]), TimedeltaIndex([1, np.nan])
     )
-    with catch_warnings():
-        filterwarnings("ignore", "Converting timezone", FutureWarning)
-        assert array_equivalent(
-            DatetimeIndex([0, np.nan], tz="US/Eastern"),
-            DatetimeIndex([0, np.nan], tz="US/Eastern"),
-        )
-        assert not array_equivalent(
-            DatetimeIndex([0, np.nan], tz="US/Eastern"),
-            DatetimeIndex([1, np.nan], tz="US/Eastern"),
-        )
-        assert not array_equivalent(
-            DatetimeIndex([0, np.nan]), DatetimeIndex([0, np.nan], tz="US/Eastern")
-        )
-        assert not array_equivalent(
-            DatetimeIndex([0, np.nan], tz="CET"),
-            DatetimeIndex([0, np.nan], tz="US/Eastern"),
-        )
+    assert array_equivalent(
+        DatetimeIndex([0, np.nan], tz="US/Eastern"),
+        DatetimeIndex([0, np.nan], tz="US/Eastern"),
+    )
+    assert not array_equivalent(
+        DatetimeIndex([0, np.nan], tz="US/Eastern"),
+        DatetimeIndex([1, np.nan], tz="US/Eastern"),
+    )
+    assert not array_equivalent(
+        DatetimeIndex([0, np.nan]), DatetimeIndex([0, np.nan], tz="US/Eastern")
+    )
+    assert not array_equivalent(
+        DatetimeIndex([0, np.nan], tz="CET"),
+        DatetimeIndex([0, np.nan], tz="US/Eastern"),
+    )
 
     assert not array_equivalent(DatetimeIndex([0, np.nan]), TimedeltaIndex([0, np.nan]))
 

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -393,15 +393,13 @@ class TestDatetimeIndex:
         # This shouldn't produce a warning.
         idx = pd.date_range("2000", periods=2)
         # M8[ns] by default
-        with tm.assert_produces_warning(None):
-            result = np.asarray(idx)
+        result = np.asarray(idx)
 
         expected = np.array(["2000-01-01", "2000-01-02"], dtype="M8[ns]")
         tm.assert_numpy_array_equal(result, expected)
 
         # optionally, object
-        with tm.assert_produces_warning(None):
-            result = np.asarray(idx, dtype=object)
+        result = np.asarray(idx, dtype=object)
 
         expected = np.array([pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")])
         tm.assert_numpy_array_equal(result, expected)
@@ -409,26 +407,19 @@ class TestDatetimeIndex:
     def test_asarray_tz_aware(self):
         tz = "US/Central"
         idx = pd.date_range("2000", periods=2, tz=tz)
+
         expected = np.array(["2000-01-01T06", "2000-01-02T06"], dtype="M8[ns]")
-        # We warn by default and return an ndarray[M8[ns]]
-        with tm.assert_produces_warning(FutureWarning):
-            result = np.asarray(idx)
-
+        result = np.asarray(idx, dtype="M8[ns]")
         tm.assert_numpy_array_equal(result, expected)
 
-        # Old behavior with no warning
-        with tm.assert_produces_warning(None):
-            result = np.asarray(idx, dtype="M8[ns]")
-
-        tm.assert_numpy_array_equal(result, expected)
-
-        # Future behavior with no warning
+        # object-dtype with a tz by default
         expected = np.array(
             [pd.Timestamp("2000-01-01", tz=tz), pd.Timestamp("2000-01-02", tz=tz)]
         )
-        with tm.assert_produces_warning(None):
-            result = np.asarray(idx, dtype=object)
+        result = np.asarray(idx)
+        tm.assert_numpy_array_equal(result, expected)
 
+        result = np.asarray(idx, dtype=object)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_to_frame_datetime_tz(self):

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -728,17 +728,14 @@ class TestTimeSeries:
         tm.assert_series_equal(result, expected)
 
     def test_asarray_tz_naive(self):
-        # This shouldn't produce a warning.
         ser = pd.Series(pd.date_range("2000", periods=2))
         expected = np.array(["2000-01-01", "2000-01-02"], dtype="M8[ns]")
-        with tm.assert_produces_warning(None):
-            result = np.asarray(ser)
+        result = np.asarray(ser)
 
         tm.assert_numpy_array_equal(result, expected)
 
         # optionally, object
-        with tm.assert_produces_warning(None):
-            result = np.asarray(ser, dtype=object)
+        result = np.asarray(ser, dtype=object)
 
         expected = np.array([pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")])
         tm.assert_numpy_array_equal(result, expected)
@@ -747,23 +744,15 @@ class TestTimeSeries:
         tz = "US/Central"
         ser = pd.Series(pd.date_range("2000", periods=2, tz=tz))
         expected = np.array(["2000-01-01T06", "2000-01-02T06"], dtype="M8[ns]")
-        # We warn by default and return an ndarray[M8[ns]]
-        with tm.assert_produces_warning(FutureWarning):
-            result = np.asarray(ser)
-
+        result = np.asarray(ser, dtype="M8[ns]")
         tm.assert_numpy_array_equal(result, expected)
 
-        # Old behavior with no warning
-        with tm.assert_produces_warning(None):
-            result = np.asarray(ser, dtype="M8[ns]")
-
-        tm.assert_numpy_array_equal(result, expected)
-
-        # Future behavior with no warning
         expected = np.array(
             [pd.Timestamp("2000-01-01", tz=tz), pd.Timestamp("2000-01-02", tz=tz)]
         )
-        with tm.assert_produces_warning(None):
-            result = np.asarray(ser, dtype=object)
+        # object-dtype with a tz by default
+        result = np.asarray(ser)
+        tm.assert_numpy_array_equal(result, expected)
 
+        result = np.asarray(ser, dtype=object)
         tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
Enforces the deprecation on tz-aware series / index
converting to UTC and returning a datetime64[ns] ndarray.

Closes https://github.com/pandas-dev/pandas/issues/6581 (this is the last one).