### PR TITLE
PERF: Fixed performance regression in Series init

### DIFF
--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -276,10 +276,12 @@ class ExtensionDtype:
             return False
         elif isinstance(dtype, cls):
             return True
-        try:
-            return cls.construct_from_string(dtype) is not None
-        except TypeError:
-            return False
+        if isinstance(dtype, str):
+            try:
+                return cls.construct_from_string(dtype) is not None
+            except TypeError:
+                return False
+        return False
 
     @property
     def _is_numeric(self) -> bool:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -882,7 +882,11 @@ class PeriodDtype(PandasExtensionDtype):
                 return cls(freq=string)
             except ValueError:
                 pass
-        raise TypeError(f"Cannot construct a 'PeriodDtype' from '{string}'")
+        if isinstance(string, str):
+            msg = f"Cannot construct a 'PeriodDtype' from '{string}'"
+        else:
+            msg = f"'construct_from_string' expects a string, got {type(string)}"
+        raise TypeError(msg)
 
     def __str__(self) -> str_type:
         return self.name

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -408,6 +408,9 @@ class TestPeriodDtype(Base):
         with pytest.raises(TypeError):
             PeriodDtype.construct_from_string("datetime64[ns, US/Eastern]")
 
+        with pytest.raises(TypeError, match="list"):
+            PeriodDtype.construct_from_string([1, 2, 3])
+
     def test_is_dtype(self):
         assert PeriodDtype.is_dtype(self.dtype)
         assert PeriodDtype.is_dtype("period[D]")

--- a/pandas/tests/extension/base/dtype.py
+++ b/pandas/tests/extension/base/dtype.py
@@ -38,6 +38,9 @@ class BaseDtypeTests(BaseExtensionTests):
         result = type(dtype).is_dtype(dtype)
         assert result is True
 
+    def test_is_dtype_other_input(self, dtype):
+        assert dtype.is_dtype([1, 2, 3]) is False
+
     def test_is_not_string_type(self, dtype):
         return not pd.api.types.is_string_dtype(dtype)
 


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/30564

PR

```
[ 50.00%] ··· series_methods.SeriesConstructor.time_constructor                                                                                                                   ok
[ 50.00%] ··· ====== ==========
               data
              ------ ----------
               None   670±0μs
               dict   84.4±0ms
              ====== ==========


```

master

```
[ 50.00%] ··· series_methods.SeriesConstructor.time_constructor                                                                                                                   ok
[ 50.00%] ··· ====== =========
               data
              ------ ---------
               None   756±0μs
               dict   725±0ms
              ====== =========
```

No whatsnew, since the regression was only on master.