### PR TITLE
BUG: Disable parallel cythonize on Windows (GH 30214)

### DIFF
--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -34,7 +34,7 @@ jobs:
     - bash: |
         source activate pandas-dev
         conda list
-        python setup.py build_ext -q -i
+        python setup.py build_ext -q -i -j 4
         python -m pip install --no-build-isolation -e .
       displayName: 'Build'
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -984,6 +984,7 @@ Other
 ``TypeError`` (:issue:`29069`)
 - Disabled parallel cython builds on Windows (:issue:`30214`)
 
+
 .. _whatsnew_1000.contributors:
 
 Contributors

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -981,7 +981,6 @@ Other
 - Fixed ``pow`` operations for :class:`IntegerArray` when the other value is ``0`` or ``1`` (:issue:`29997`)
 - Bug in :meth:`Series.count` raises if use_inf_as_na is enabled (:issue:`29478`)
 - Bug in :class:`Index` where a non-hashable name could be set without raising ``TypeError`` (:issue:`29069`)
-- Disabled parallel cython builds on Windows (:issue:`30214`)
 
 
 .. _whatsnew_1000.contributors:

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -980,7 +980,9 @@ Other
 - Fixed :class:`IntegerArray` returning ``inf`` rather than ``NaN`` for operations dividing by 0 (:issue:`27398`)
 - Fixed ``pow`` operations for :class:`IntegerArray` when the other value is ``0`` or ``1`` (:issue:`29997`)
 - Bug in :meth:`Series.count` raises if use_inf_as_na is enabled (:issue:`29478`)
-- Bug in :class:`Index` where a non-hashable name could be set without raising ``TypeError`` (:issue:29069`)
+- Bug in :class:`Index` where a non-hashable name could be set without raising
+``TypeError`` (:issue:`29069`)
+- Disabled parallel cython builds on Windows (:issue:`30214`)
 
 .. _whatsnew_1000.contributors:
 

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -980,8 +980,7 @@ Other
 - Fixed :class:`IntegerArray` returning ``inf`` rather than ``NaN`` for operations dividing by 0 (:issue:`27398`)
 - Fixed ``pow`` operations for :class:`IntegerArray` when the other value is ``0`` or ``1`` (:issue:`29997`)
 - Bug in :meth:`Series.count` raises if use_inf_as_na is enabled (:issue:`29478`)
-- Bug in :class:`Index` where a non-hashable name could be set without raising
-``TypeError`` (:issue:`29069`)
+- Bug in :class:`Index` where a non-hashable name could be set without raising ``TypeError`` (:issue:`29069`)
 - Disabled parallel cython builds on Windows (:issue:`30214`)
 
 

--- a/setup.py
+++ b/setup.py
@@ -526,6 +526,10 @@ def maybe_cythonize(extensions, *args, **kwargs):
     elif parsed.j:
         nthreads = parsed.j
 
+    if is_platform_windows() and nthreads > 0:
+        print("Parallel build for cythonize ignored on Windows")
+        nthreads = 0
+
     kwargs["nthreads"] = nthreads
     build_ext.render_templates(_pxifiles)
     return cythonize(extensions, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -526,6 +526,7 @@ def maybe_cythonize(extensions, *args, **kwargs):
     elif parsed.j:
         nthreads = parsed.j
 
+    # GH#30356 Cythonize doesn't support parallel on Windows
     if is_platform_windows() and nthreads > 0:
         print("Parallel build for cythonize ignored on Windows")
         nthreads = 0


### PR DESCRIPTION
- [x ] closes #30356
- [ ] tests added / passed
  - N/A
- [ ] passes `black pandas`
  - Didn't run - changes too many files
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Added test in `setup.py` to check if nthreads is positive and on Windows.
