### PR TITLE
BUG: DTA/TDA/PA add/sub object-dtype

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -510,13 +510,13 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         dtype = DatetimeTZDtype(tz=other.tz) if other.tz else _NS_DTYPE
         return DatetimeArray(result, dtype=dtype, freq=self.freq)
 
-    def _addsub_offset_array(self, other, op):
-        # Add or subtract Array-like of DateOffset objects
+    def _addsub_object_array(self, other, op):
+        # Add or subtract Array-like of objects
         try:
             # TimedeltaIndex can only operate with a subset of DateOffset
             # subclasses.  Incompatible classes will raise AttributeError,
             # which we re-raise as TypeError
-            return super()._addsub_offset_array(other, op)
+            return super()._addsub_object_array(other, op)
         except AttributeError:
             raise TypeError(
                 f"Cannot add/subtract non-tick DateOffset to {type(self).__name__}"

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -18,7 +18,6 @@ from pandas.core.dtypes.dtypes import (
 )
 from pandas.core.dtypes.generic import (
     ABCCategorical,
-    ABCDateOffset,
     ABCDatetimeIndex,
     ABCIndexClass,
     ABCPeriodArray,
@@ -366,37 +365,6 @@ def is_categorical(arr) -> bool:
     """
 
     return isinstance(arr, ABCCategorical) or is_categorical_dtype(arr)
-
-
-def is_offsetlike(arr_or_obj) -> bool:
-    """
-    Check if obj or all elements of list-like is DateOffset
-
-    Parameters
-    ----------
-    arr_or_obj : object
-
-    Returns
-    -------
-    boolean
-        Whether the object is a DateOffset or listlike of DatetOffsets
-
-    Examples
-    --------
-    >>> is_offsetlike(pd.DateOffset(days=1))
-    True
-    >>> is_offsetlike('offset')
-    False
-    >>> is_offsetlike([pd.offsets.Minute(4), pd.offsets.MonthEnd()])
-    True
-    >>> is_offsetlike(np.array([pd.DateOffset(months=3), pd.Timestamp.now()]))
-    False
-    """
-    if isinstance(arr_or_obj, ABCDateOffset):
-        return True
-    elif is_list_like(arr_or_obj) and len(arr_or_obj) and is_object_dtype(arr_or_obj):
-        return all(isinstance(x, ABCDateOffset) for x in arr_or_obj)
-    return False
 
 
 def is_datetime64_dtype(arr_or_dtype) -> bool:

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -2307,6 +2307,32 @@ class TestDatetimeIndexArithmetic:
         expected = tm.box_expected(expected, xbox)
         tm.assert_equal(res, expected)
 
+    @pytest.mark.parametrize("other_box", [pd.Index, np.array])
+    def test_dti_addsub_object_arraylike(
+        self, tz_naive_fixture, box_with_array, other_box
+    ):
+        tz = tz_naive_fixture
+
+        dti = pd.date_range("2017-01-01", periods=2, tz=tz)
+        dtarr = tm.box_expected(dti, box_with_array)
+        other = other_box([pd.offsets.MonthEnd(), pd.Timedelta(days=4)])
+        xbox = get_upcast_box(box_with_array, other)
+
+        expected = pd.DatetimeIndex(["2017-01-31", "2017-01-06"], tz=tz_naive_fixture)
+        expected = tm.box_expected(expected, xbox)
+
+        warn = None if box_with_array is pd.DataFrame else PerformanceWarning
+        with tm.assert_produces_warning(warn):
+            result = dtarr + other
+        tm.assert_equal(result, expected)
+
+        expected = pd.DatetimeIndex(["2016-12-31", "2016-12-29"], tz=tz_naive_fixture)
+        expected = tm.box_expected(expected, xbox)
+
+        with tm.assert_produces_warning(warn):
+            result = dtarr - other
+        tm.assert_equal(result, expected)
+
 
 @pytest.mark.parametrize("years", [-1, 0, 1])
 @pytest.mark.parametrize("months", [-2, 0, 2])

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -1036,6 +1036,26 @@ class TestPeriodIndexArithmetic:
         expected = pi - pi
         tm.assert_index_equal(result, expected)
 
+    def test_parr_add_sub_object_array(self):
+        pi = pd.period_range("2000-12-31", periods=3, freq="D")
+        parr = pi.array
+
+        other = np.array([pd.Timedelta(days=1), pd.offsets.Day(2), 3])
+
+        with tm.assert_produces_warning(PerformanceWarning):
+            result = parr + other
+
+        expected = pd.PeriodIndex(
+            ["2001-01-01", "2001-01-03", "2001-01-05"], freq="D"
+        ).array
+        tm.assert_equal(result, expected)
+
+        with tm.assert_produces_warning(PerformanceWarning):
+            result = parr - other
+
+        expected = pd.PeriodIndex(["2000-12-30"] * 3, freq="D").array
+        tm.assert_equal(result, expected)
+
 
 class TestPeriodSeriesArithmetic:
     def test_ops_series_timedelta(self):

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1469,6 +1469,40 @@ class TestTimedeltaArraylikeAddSubOps:
             with tm.assert_produces_warning(PerformanceWarning):
                 anchored - tdi
 
+    # ------------------------------------------------------------------
+    # Unsorted
+
+    def test_td64arr_add_sub_object_array(self, box_with_array):
+        tdi = pd.timedelta_range("1 day", periods=3, freq="D")
+        tdarr = tm.box_expected(tdi, box_with_array)
+
+        other = np.array(
+            [pd.Timedelta(days=1), pd.offsets.Day(2), pd.Timestamp("2000-01-04")]
+        )
+
+        warn = PerformanceWarning if box_with_array is not pd.DataFrame else None
+        with tm.assert_produces_warning(warn):
+            result = tdarr + other
+
+        expected = pd.Index(
+            [pd.Timedelta(days=2), pd.Timedelta(days=4), pd.Timestamp("2000-01-07")]
+        )
+        expected = tm.box_expected(expected, box_with_array)
+        tm.assert_equal(result, expected)
+
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(warn):
+                tdarr - other
+
+        with tm.assert_produces_warning(warn):
+            result = other - tdarr
+
+        expected = pd.Index(
+            [pd.Timedelta(0), pd.Timedelta(0), pd.Timestamp("2000-01-01")]
+        )
+        expected = tm.box_expected(expected, box_with_array)
+        tm.assert_equal(result, expected)
+
 
 class TestTimedeltaArraylikeMulDivOps:
     # Tests for timedelta64[ns]

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -625,18 +625,6 @@ def test_is_complex_dtype():
     assert com.is_complex_dtype(np.array([1 + 1j, 5]))
 
 
-def test_is_offsetlike():
-    assert com.is_offsetlike(np.array([pd.DateOffset(month=3), pd.offsets.Nano()]))
-    assert com.is_offsetlike(pd.offsets.MonthEnd())
-    assert com.is_offsetlike(pd.Index([pd.DateOffset(second=1)]))
-
-    assert not com.is_offsetlike(pd.Timedelta(1))
-    assert not com.is_offsetlike(np.array([1 + 1j, 5]))
-
-    # mixed case
-    assert not com.is_offsetlike(np.array([pd.DateOffset(), pd.Timestamp(0)]))
-
-
 @pytest.mark.parametrize(
     "input_param,result",
     [


### PR DESCRIPTION
Bonus: we get to get rid of is_offsetlike