### PR TITLE
REF: share _wrap_joined_index

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -632,20 +632,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
         # we know it conforms; skip check
         return DatetimeIndex._simple_new(snapped, name=self.name, tz=self.tz, freq=freq)
 
-    def _wrap_joined_index(self, joined, other):
-        name = get_op_result_name(self, other)
-        if (
-            isinstance(other, DatetimeIndex)
-            and self.freq == other.freq
-            and self._can_fast_union(other)
-        ):
-            joined = self._shallow_copy(joined)
-            joined.name = name
-            return joined
-        else:
-            tz = getattr(other, "tz", None)
-            return self._simple_new(joined, name, tz=tz)
-
     def _parsed_string_to_bounds(self, reso, parsed):
         """
         Calculate datetime bounds for parsed time string and its resolution.

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -31,7 +31,6 @@ from pandas.core.indexes.datetimelike import (
     DatetimelikeDelegateMixin,
     DatetimeTimedeltaMixin,
 )
-from pandas.core.ops import get_op_result_name
 
 from pandas.tseries.frequencies import to_offset
 
@@ -282,18 +281,6 @@ class TimedeltaIndex(
                 if result.freq is None:
                     result._set_freq("infer")
             return result
-
-    def _wrap_joined_index(self, joined, other):
-        name = get_op_result_name(self, other)
-        if (
-            isinstance(other, TimedeltaIndex)
-            and self.freq == other.freq
-            and self._can_fast_union(other)
-        ):
-            joined = self._shallow_copy(joined, name=name)
-            return joined
-        else:
-            return self._simple_new(joined, name)
 
     def _fast_union(self, other):
         if len(other) == 0:


### PR DESCRIPTION
this is the last of the trivial ones AFAICT.  To get the others we're going to have to smooth out small differences in behavior, which should happen in non-refactoring PRs.