### PR TITLE
CLN: Use fstring instead of .format in io/excel and test/generic

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -297,9 +297,7 @@ def read_excel(
 
     for arg in ("sheet", "sheetname", "parse_cols"):
         if arg in kwds:
-            raise TypeError(
-                "read_excel() got an unexpected keyword argument `{}`".format(arg)
-            )
+            raise TypeError(f"read_excel() got an unexpected keyword argument `{arg}`")
 
     if not isinstance(io, ExcelFile):
         io = ExcelFile(io, engine=engine)
@@ -429,7 +427,7 @@ class _BaseExcelReader(metaclass=abc.ABCMeta):
 
         for asheetname in sheets:
             if verbose:
-                print("Reading sheet {sheet}".format(sheet=asheetname))
+                print(f"Reading sheet {asheetname}")
 
             if isinstance(asheetname, str):
                 sheet = self.get_sheet_by_name(asheetname)
@@ -622,11 +620,11 @@ class ExcelWriter(metaclass=abc.ABCMeta):
                     ext = "xlsx"
 
                 try:
-                    engine = config.get_option("io.excel.{ext}.writer".format(ext=ext))
+                    engine = config.get_option(f"io.excel.{ext}.writer")
                     if engine == "auto":
                         engine = _get_default_writer(ext)
                 except KeyError:
-                    raise ValueError("No engine for filetype: '{ext}'".format(ext=ext))
+                    raise ValueError(f"No engine for filetype: '{ext}'")
             cls = get_writer(engine)
 
         return object.__new__(cls)
@@ -757,9 +755,8 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         if ext.startswith("."):
             ext = ext[1:]
         if not any(ext in extension for extension in cls.supported_extensions):
-            msg = "Invalid extension for engine '{engine}': '{ext}'".format(
-                engine=pprint_thing(cls.engine), ext=pprint_thing(ext)
-            )
+            msg = "Invalid extension for engine"
+            f"'{pprint_thing(cls.engine)}': '{pprint_thing(ext)}'"
             raise ValueError(msg)
         else:
             return True
@@ -802,7 +799,7 @@ class ExcelFile:
         if engine is None:
             engine = "xlrd"
         if engine not in self._engines:
-            raise ValueError("Unknown engine: {engine}".format(engine=engine))
+            raise ValueError(f"Unknown engine: {engine}")
 
         self.engine = engine
         # could be a str, ExcelFile, Book, etc.

--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -178,4 +178,4 @@ class _ODFReader(_BaseExcelReader):
         elif cell_type == "time":
             return pd.to_datetime(str(cell)).time()
         else:
-            raise ValueError("Unrecognized type {}".format(cell_type))
+            raise ValueError(f"Unrecognized type {cell_type}")

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -99,7 +99,7 @@ class _OpenpyxlWriter(ExcelWriter):
         for k, v in style_dict.items():
             if k in _style_key_map:
                 k = _style_key_map[k]
-            _conv_to_x = getattr(cls, "_convert_to_{k}".format(k=k), lambda x: None)
+            _conv_to_x = getattr(cls, f"_convert_to_{k}", lambda x: None)
             new_v = _conv_to_x(v)
             if new_v:
                 style_kwargs[k] = new_v

--- a/pandas/io/excel/_util.py
+++ b/pandas/io/excel/_util.py
@@ -48,7 +48,7 @@ def get_writer(engine_name):
     try:
         return _writers[engine_name]
     except KeyError:
-        raise ValueError("No Excel writer '{engine}'".format(engine=engine_name))
+        raise ValueError(f"No Excel writer '{engine_name}'")
 
 
 def _excel2num(x):
@@ -76,7 +76,7 @@ def _excel2num(x):
         cp = ord(c)
 
         if cp < ord("A") or cp > ord("Z"):
-            raise ValueError("Invalid column name: {x}".format(x=x))
+            raise ValueError(f"Invalid column name: {x}")
 
         index = index * 26 + cp - ord("A") + 1
 

--- a/pandas/io/excel/_xlwt.py
+++ b/pandas/io/excel/_xlwt.py
@@ -97,20 +97,20 @@ class _XlwtWriter(ExcelWriter):
         if hasattr(item, "items"):
             if firstlevel:
                 it = [
-                    "{key}: {val}".format(key=key, val=cls._style_to_xlwt(value, False))
+                    f"{key}: {cls._style_to_xlwt(value, False)}"
                     for key, value in item.items()
                 ]
-                out = "{sep} ".format(sep=(line_sep).join(it))
+                out = f"{(line_sep).join(it)} "
                 return out
             else:
                 it = [
-                    "{key} {val}".format(key=key, val=cls._style_to_xlwt(value, False))
+                    f"{key} {cls._style_to_xlwt(value, False)}"
                     for key, value in item.items()
                 ]
-                out = "{sep} ".format(sep=(field_sep).join(it))
+                out = f"{(field_sep).join(it)} "
                 return out
         else:
-            item = "{item}".format(item=item)
+            item = f"{item}"
             item = item.replace("True", "on")
             item = item.replace("False", "off")
             return item

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -196,7 +196,7 @@ class TestDataFrame(Generic):
     def test_to_xarray_index_types(self, index):
         from xarray import Dataset
 
-        index = getattr(tm, "make{}".format(index))
+        index = getattr(tm, f"make{index}")
         df = DataFrame(
             {
                 "a": list("abc"),

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -125,7 +125,7 @@ class Generic:
         # GH 4633
         # look at the boolean/nonzero behavior for objects
         obj = self._construct(shape=4)
-        msg = "The truth value of a {} is ambiguous".format(self._typ.__name__)
+        msg = f"The truth value of a {self._typ.__name__} is ambiguous"
         with pytest.raises(ValueError, match=msg):
             bool(obj == 0)
         with pytest.raises(ValueError, match=msg):
@@ -203,9 +203,9 @@ class Generic:
         def f(dtype):
             return self._construct(shape=3, value=1, dtype=dtype)
 
-        msg = "compound dtypes are not implemented in the {} constructor".format(
-            self._typ.__name__
-        )
+        msg = "compound dtypes are not implemented"
+        f"in the {self._typ.__name__} constructor"
+
         with pytest.raises(NotImplementedError, match=msg):
             f([("A", "datetime64[h]"), ("B", "str"), ("C", "int32")])
 

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -205,7 +205,7 @@ class TestSeries(Generic):
     def test_to_xarray_index_types(self, index):
         from xarray import DataArray
 
-        index = getattr(tm, "make{}".format(index))
+        index = getattr(tm, f"make{index}")
         s = Series(range(6), index=index(6))
         s.index.name = "foo"
         result = s.to_xarray()


### PR DESCRIPTION
- [x] Contributes to #29547 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
