### PR TITLE
CLN: Replace old format strings to f-strings in pandas/tests/base

### DIFF
--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -288,7 +288,7 @@ def test_numpy_array_all_dtypes(any_numpy_dtype):
 def test_array(array, attr, index_or_series):
     box = index_or_series
     if array.dtype.name in ("Int64", "Sparse[int64, 0]") and box is pd.Index:
-        pytest.skip("No index type for {}".format(array.dtype))
+        pytest.skip(f"No index type for {array.dtype}")
     result = box(array, copy=False).array
 
     if attr:
@@ -354,7 +354,7 @@ def test_to_numpy(array, expected, index_or_series):
     thing = box(array)
 
     if array.dtype.name in ("Int64", "Sparse[int64, 0]") and box is pd.Index:
-        pytest.skip("No index type for {}".format(array.dtype))
+        pytest.skip(f"No index type for {array.dtype}")
 
     result = thing.to_numpy()
     tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -62,8 +62,8 @@ class Ops:
         self.unicode_series = Series(arr, index=self.unicode_index, name="a")
 
         types = ["bool", "int", "float", "dt", "dt_tz", "period", "string", "unicode"]
-        self.indexes = [getattr(self, "{}_index".format(t)) for t in types]
-        self.series = [getattr(self, "{}_series".format(t)) for t in types]
+        self.indexes = [getattr(self, f"{t}_index") for t in types]
+        self.series = [getattr(self, f"{t}_series") for t in types]
 
         # To test narrow dtypes, we use narrower *data* elements, not *index* elements
         index = self.int_index
@@ -79,7 +79,7 @@ class Ops:
         self.uint32_series = Series(arr_int.astype(np.uint32), index=index, name="a")
 
         nrw_types = ["float32", "int8", "int16", "int32", "uint8", "uint16", "uint32"]
-        self.narrow_series = [getattr(self, "{}_series".format(t)) for t in nrw_types]
+        self.narrow_series = [getattr(self, f"{t}_series") for t in nrw_types]
 
         self.objs = self.indexes + self.series + self.narrow_series
 


### PR DESCRIPTION
- [x] Contributes to #29547 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
