### PR TITLE
REF: delegate attrs for CategoricalIndex, IntervalIndex

### DIFF
--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -10,7 +10,7 @@ from pandas._libs.hashtable import duplicated_int64
 from pandas._typing import AnyArrayLike
 import pandas.compat as compat
 from pandas.compat.numpy import function as nv
-from pandas.util._decorators import Appender, Substitution, cache_readonly
+from pandas.util._decorators import Appender, cache_readonly
 
 from pandas.core.dtypes.common import (
     ensure_platform_int,
@@ -26,7 +26,6 @@ from pandas.core.dtypes.missing import isna
 from pandas.core import accessor
 from pandas.core.algorithms import take_1d
 from pandas.core.arrays.categorical import Categorical, _recode_for_categories, contains
-from pandas.core.base import _shared_docs
 import pandas.core.common as com
 import pandas.core.indexes.base as ibase
 from pandas.core.indexes.base import Index, _index_shared_docs, maybe_extract_name
@@ -37,6 +36,12 @@ _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 _index_doc_kwargs.update(dict(target_klass="CategoricalIndex"))
 
 
+@accessor.delegate_names(
+    delegate=Categorical,
+    accessors=["codes", "categories", "ordered"],
+    typ="property",
+    overwrite=True,
+)
 @accessor.delegate_names(
     delegate=Categorical,
     accessors=[
@@ -50,6 +55,12 @@ _index_doc_kwargs.update(dict(target_klass="CategoricalIndex"))
         "as_unordered",
         "min",
         "max",
+        "is_dtype_equal",
+        "tolist",
+        "_internal_get_values",
+        "_reverse_indexer",
+        "searchsorted",
+        "argsort",
     ],
     typ="method",
     overwrite=True,
@@ -146,6 +157,20 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     """
 
     _typ = "categoricalindex"
+
+    _raw_inherit = {
+        "argsort",
+        "_internal_get_values",
+        "tolist",
+        "codes",
+        "categories",
+        "ordered",
+        "_reverse_indexer",
+        "searchsorted",
+    }
+
+    codes: np.ndarray
+    categories: Index
 
     @property
     def _engine_type(self):
@@ -370,29 +395,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         name = get_op_result_name(self, other)
         return self._shallow_copy(result, name=name)
 
-    def _internal_get_values(self):
-        # override base Index version to get the numpy array representation of
-        # the underlying Categorical
-        return self._data._internal_get_values()
-
-    def tolist(self):
-        return self._data.tolist()
-
-    @property
-    def codes(self):
-        return self._data.codes
-
-    @property
-    def categories(self):
-        return self._data.categories
-
-    @property
-    def ordered(self):
-        return self._data.ordered
-
-    def _reverse_indexer(self):
-        return self._data._reverse_indexer()
-
     @Appender(_index_shared_docs["contains"] % _index_doc_kwargs)
     def __contains__(self, key) -> bool:
         # if key is a NaN, check if any NaN is in self.
@@ -428,9 +430,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     def fillna(self, value, downcast=None):
         self._assert_can_do_op(value)
         return CategoricalIndex(self._data.fillna(value), name=self.name)
-
-    def argsort(self, *args, **kwargs):
-        return self.values.argsort(*args, **kwargs)
 
     @cache_readonly
     def _engine(self):
@@ -538,11 +537,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
         # we might be a positional inexer
         return super().get_value(series, key)
-
-    @Substitution(klass="CategoricalIndex")
-    @Appender(_shared_docs["searchsorted"])
-    def searchsorted(self, value, side="left", sorter=None):
-        return self._data.searchsorted(value, side=side, sorter=sorter)
 
     @Appender(_index_shared_docs["where"])
     def where(self, cond, other=None):
@@ -746,9 +740,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         )
         return self._create_from_codes(taken)
 
-    def is_dtype_equal(self, other):
-        return self._data.is_dtype_equal(other)
-
     take_nd = take
 
     @Appender(_index_shared_docs["_maybe_cast_slice_bound"])
@@ -882,10 +873,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         result.name = name
         return result
 
-    def _codes_for_groupby(self, sort, observed):
-        """ Return a Categorical adjusted for groupby """
-        return self.values._codes_for_groupby(sort, observed)
-
     @classmethod
     def _add_comparison_methods(cls):
         """ add in comparison methods """
@@ -911,13 +898,18 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         cls.__le__ = _make_compare(operator.le)
         cls.__ge__ = _make_compare(operator.ge)
 
+    def _delegate_property_get(self, name, *args, **kwargs):
+        """ method delegation to the ._values """
+        prop = getattr(self._values, name)
+        return prop  # no wrapping for now
+
     def _delegate_method(self, name, *args, **kwargs):
         """ method delegation to the ._values """
         method = getattr(self._values, name)
         if "inplace" in kwargs:
             raise ValueError("cannot use inplace with CategoricalIndex")
         res = method(*args, **kwargs)
-        if is_scalar(res):
+        if is_scalar(res) or name in self._raw_inherit:
             return res
         return CategoricalIndex(res, name=self.name)
 


### PR DESCRIPTION
Working towards creating an ExtensionIndexMixin to be shared by all our backed-be-EA indexes, which would ideally grow into ExtensionIndex.

Removes CategoricalIndex._codes_for_groupby, which would raise AttributeError if it were ever called.