### PR TITLE
CLN: remove warnings clearing

### DIFF
--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -26,7 +26,6 @@ from pandas import (
     Timestamp,
     date_range,
 )
-import pandas.core.arrays.datetimelike as dtl
 from pandas.core.indexes.datetimes import _to_M8
 from pandas.core.ops import roperator
 from pandas.tests.arithmetic.common import (

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1332,7 +1332,7 @@ class TestDatetime64DateOffsetArithmetic:
         s = tm.box_expected(s, box_with_array)
 
         warn = None if box_with_array is pd.DataFrame else PerformanceWarning
-        with tm.assert_produces_warning(warn, clear=[dtl]):
+        with tm.assert_produces_warning(warn):
             other = pd.Index([pd.offsets.DateOffset(years=1), pd.offsets.MonthEnd()])
             other = tm.box_expected(other, box_with_array)
             result = s + other
@@ -1361,7 +1361,7 @@ class TestDatetime64DateOffsetArithmetic:
         other = np.array([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)])
 
         warn = None if box_with_array is pd.DataFrame else PerformanceWarning
-        with tm.assert_produces_warning(warn, clear=[dtl]):
+        with tm.assert_produces_warning(warn):
             res = dtarr + other
         expected = DatetimeIndex(
             [dti[n] + other[n] for n in range(len(dti))], name=dti.name, freq="infer"
@@ -1369,11 +1369,11 @@ class TestDatetime64DateOffsetArithmetic:
         expected = tm.box_expected(expected, box_with_array)
         tm.assert_equal(res, expected)
 
-        with tm.assert_produces_warning(warn, clear=[dtl]):
+        with tm.assert_produces_warning(warn):
             res2 = other + dtarr
         tm.assert_equal(res2, expected)
 
-        with tm.assert_produces_warning(warn, clear=[dtl]):
+        with tm.assert_produces_warning(warn):
             res = dtarr - other
         expected = DatetimeIndex(
             [dti[n] - other[n] for n in range(len(dti))], name=dti.name, freq="infer"
@@ -2298,7 +2298,7 @@ class TestDatetimeIndexArithmetic:
 
         xbox = get_upcast_box(box, other)
 
-        with tm.assert_produces_warning(PerformanceWarning, clear=[dtl]):
+        with tm.assert_produces_warning(PerformanceWarning):
             res = op(dti, other)
 
         expected = DatetimeIndex(


### PR DESCRIPTION
the tm.assert_produces_warning `clear` kwarg is no longer used, we could consider removing it