### PR TITLE
Improve ASV Environment Creation Performance

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -122,5 +122,8 @@
         ".*": "0409521665"
     },
     "regression_thresholds": {
-    }
+    },
+    "build_command":
+    ["python setup.py build -j4",
+     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"],
 }


### PR DESCRIPTION
...by leveraging a lot of the recent work to enable parallel CI

Overriding default values documented here:

https://asv.readthedocs.io/en/stable/asv.conf.json.html#build-command-install-command-uninstall-command

I've picked 4 as the value assuming most people running benchmarks will have 2-4 cores. YMMV 