### PR TITLE
CLN: replacing str.format with f-strings in several files. #29547

### DIFF
--- a/pandas/tests/io/formats/test_css.py
+++ b/pandas/tests/io/formats/test_css.py
@@ -101,29 +101,25 @@ def test_css_side_shorthands(shorthand, expansions):
     top, right, bottom, left = expansions
 
     assert_resolves(
-        "{shorthand}: 1pt".format(shorthand=shorthand),
-        {top: "1pt", right: "1pt", bottom: "1pt", left: "1pt"},
+        f"{shorthand}: 1pt", {top: "1pt", right: "1pt", bottom: "1pt", left: "1pt"},
     )
 
     assert_resolves(
-        "{shorthand}: 1pt 4pt".format(shorthand=shorthand),
-        {top: "1pt", right: "4pt", bottom: "1pt", left: "4pt"},
+        f"{shorthand}: 1pt 4pt", {top: "1pt", right: "4pt", bottom: "1pt", left: "4pt"},
     )
 
     assert_resolves(
-        "{shorthand}: 1pt 4pt 2pt".format(shorthand=shorthand),
+        f"{shorthand}: 1pt 4pt 2pt",
         {top: "1pt", right: "4pt", bottom: "2pt", left: "4pt"},
     )
 
     assert_resolves(
-        "{shorthand}: 1pt 4pt 2pt 0pt".format(shorthand=shorthand),
+        f"{shorthand}: 1pt 4pt 2pt 0pt",
         {top: "1pt", right: "4pt", bottom: "2pt", left: "0pt"},
     )
 
     with tm.assert_produces_warning(CSSWarning):
-        assert_resolves(
-            "{shorthand}: 1pt 1pt 1pt 1pt 1pt".format(shorthand=shorthand), {}
-        )
+        assert_resolves(f"{shorthand}: 1pt 1pt 1pt 1pt 1pt", {})
 
 
 @pytest.mark.parametrize(
@@ -174,10 +170,10 @@ def test_css_none_absent(style, equiv):
     "size,resolved",
     [
         ("xx-small", "6pt"),
-        ("x-small", "{pt:f}pt".format(pt=7.5)),
-        ("small", "{pt:f}pt".format(pt=9.6)),
+        ("x-small", f"{7.5:f}pt"),
+        ("small", f"{9.6:f}pt"),
         ("medium", "12pt"),
-        ("large", "{pt:f}pt".format(pt=13.5)),
+        ("large", f"{13.5:f}pt"),
         ("x-large", "18pt"),
         ("xx-large", "24pt"),
         ("8px", "6pt"),
@@ -196,9 +192,7 @@ def test_css_absolute_font_size(size, relative_to, resolved):
     else:
         inherited = {"font-size": relative_to}
     assert_resolves(
-        "font-size: {size}".format(size=size),
-        {"font-size": resolved},
-        inherited=inherited,
+        f"font-size: {size}", {"font-size": resolved}, inherited=inherited,
     )
 
 
@@ -224,7 +218,7 @@ def test_css_absolute_font_size(size, relative_to, resolved):
         ("inherit", "16pt", "16pt"),
         ("smaller", None, "10pt"),
         ("smaller", "18pt", "15pt"),
-        ("larger", None, "{pt:f}pt".format(pt=14.4)),
+        ("larger", None, f"{14.4:f}pt"),
         ("larger", "15pt", "18pt"),
     ],
 )
@@ -234,7 +228,5 @@ def test_css_relative_font_size(size, relative_to, resolved):
     else:
         inherited = {"font-size": relative_to}
     assert_resolves(
-        "font-size: {size}".format(size=size),
-        {"font-size": resolved},
-        inherited=inherited,
+        f"font-size: {size}", {"font-size": resolved}, inherited=inherited,
     )

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1238,7 +1238,7 @@ class TestDataFrameFormatting:
             set_option("display.expand_frame_repr", False)
             rep_str = repr(df)
 
-            assert f"10 rows x {(max_cols - 1)} columns" in rep_str
+            assert f"10 rows x {max_cols - 1} columns" in rep_str
             set_option("display.expand_frame_repr", True)
             wide_repr = repr(df)
             assert rep_str != wide_repr
@@ -1606,7 +1606,7 @@ class TestDataFrameFormatting:
 
         result = df.to_string()
         # sadness per above
-        if f"{1.7e8:.4g}" == "1.7e+008":
+        if _three_digit_exp():
             expected = (
                 "               a\n"
                 "0  1.500000e+000\n"
@@ -1935,7 +1935,7 @@ c  10  11  12  13  14\
             ).set_index("idx")
             reg_repr = df._repr_html_()
             assert ".." not in reg_repr
-            assert f"<td>{str(40 + h)}</td>" in reg_repr
+            assert f"<td>{40 + h}</td>" in reg_repr
 
             h = max_rows + 1
             df = DataFrame(
@@ -1947,7 +1947,7 @@ c  10  11  12  13  14\
             ).set_index("idx")
             long_repr = df._repr_html_()
             assert ".." in long_repr
-            assert f"<td>{str(31)}</td>" not in long_repr
+            assert "<td>31</td>" not in long_repr
             assert f"{h} rows " in long_repr
             assert "2 columns" in long_repr
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -709,7 +709,7 @@ class TestDataFrameFormatting:
 
     def test_to_string_with_formatters_unicode(self):
         df = DataFrame({"c/\u03c3": [1, 2, 3]})
-        result = df.to_string(formatters={"c/\u03c3": lambda x: str(x)})
+        result = df.to_string(formatters={"c/\u03c3": str})
         assert result == "  c/\u03c3\n" + "0   1\n1   2\n2   3"
 
     def test_east_asian_unicode_false(self):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -709,7 +709,7 @@ class TestDataFrameFormatting:
 
     def test_to_string_with_formatters_unicode(self):
         df = DataFrame({"c/\u03c3": [1, 2, 3]})
-        result = df.to_string(formatters={"c/\u03c3": lambda x: f"{x}"})
+        result = df.to_string(formatters={"c/\u03c3": lambda x: str(x)})
         assert result == "  c/\u03c3\n" + "0   1\n1   2\n2   3"
 
     def test_east_asian_unicode_false(self):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -421,12 +421,10 @@ class TestDataFrameFormatting:
     def test_repr_max_columns_max_rows(self):
         term_width, term_height = get_terminal_size()
         if term_width < 10 or term_height < 10:
-            pytest.skip(
-                "terminal size too small, {0} x {1}".format(term_width, term_height)
-            )
+            pytest.skip(f"terminal size too small, {term_width} x {term_height}")
 
         def mkframe(n):
-            index = ["{i:05d}".format(i=i) for i in range(n)]
+            index = [f"{i:05d}" for i in range(n)]
             return DataFrame(0, index, index)
 
         df6 = mkframe(6)
@@ -667,9 +665,9 @@ class TestDataFrameFormatting:
         )
 
         formatters = [
-            ("int", lambda x: "0x{x:x}".format(x=x)),
-            ("float", lambda x: "[{x: 4.1f}]".format(x=x)),
-            ("object", lambda x: "-{x!s}-".format(x=x)),
+            ("int", lambda x: f"0x{x:x}"),
+            ("float", lambda x: f"[{x: 4.1f}]"),
+            ("object", lambda x: f"-{x!s}-"),
         ]
         result = df.to_string(formatters=dict(formatters))
         result2 = df.to_string(formatters=list(zip(*formatters))[1])
@@ -711,7 +709,7 @@ class TestDataFrameFormatting:
 
     def test_to_string_with_formatters_unicode(self):
         df = DataFrame({"c/\u03c3": [1, 2, 3]})
-        result = df.to_string(formatters={"c/\u03c3": lambda x: "{x}".format(x=x)})
+        result = df.to_string(formatters={"c/\u03c3": lambda x: f"{x}"})
         assert result == "  c/\u03c3\n" + "0   1\n1   2\n2   3"
 
     def test_east_asian_unicode_false(self):
@@ -1240,7 +1238,7 @@ class TestDataFrameFormatting:
             set_option("display.expand_frame_repr", False)
             rep_str = repr(df)
 
-            assert "10 rows x {c} columns".format(c=max_cols - 1) in rep_str
+            assert f"10 rows x {(max_cols - 1)} columns" in rep_str
             set_option("display.expand_frame_repr", True)
             wide_repr = repr(df)
             assert rep_str != wide_repr
@@ -1351,7 +1349,7 @@ class TestDataFrameFormatting:
         n = 1000
         s = Series(
             np.random.randint(-50, 50, n),
-            index=["s{x:04d}".format(x=x) for x in range(n)],
+            index=[f"s{x:04d}" for x in range(n)],
             dtype="int64",
         )
 
@@ -1477,9 +1475,7 @@ class TestDataFrameFormatting:
         expected = ["A"]
         assert header == expected
 
-        biggie.to_string(
-            columns=["B", "A"], formatters={"A": lambda x: "{x:.1f}".format(x=x)}
-        )
+        biggie.to_string(columns=["B", "A"], formatters={"A": lambda x: f"{x:.1f}"})
 
         biggie.to_string(columns=["B", "A"], float_format=str)
         biggie.to_string(columns=["B", "A"], col_space=12, float_format=str)
@@ -1610,7 +1606,7 @@ class TestDataFrameFormatting:
 
         result = df.to_string()
         # sadness per above
-        if "{x:.4g}".format(x=1.7e8) == "1.7e+008":
+        if f"{1.7e8:.4g}" == "1.7e+008":
             expected = (
                 "               a\n"
                 "0  1.500000e+000\n"
@@ -1922,7 +1918,7 @@ c  10  11  12  13  14\
             long_repr = df._repr_html_()
             assert ".." in long_repr
             assert str(41 + max_rows // 2) not in long_repr
-            assert "{h} rows ".format(h=h) in long_repr
+            assert f"{h} rows " in long_repr
             assert "2 columns" in long_repr
 
     def test_repr_html_float(self):
@@ -1939,7 +1935,7 @@ c  10  11  12  13  14\
             ).set_index("idx")
             reg_repr = df._repr_html_()
             assert ".." not in reg_repr
-            assert "<td>{val}</td>".format(val=str(40 + h)) in reg_repr
+            assert f"<td>{str(40 + h)}</td>" in reg_repr
 
             h = max_rows + 1
             df = DataFrame(
@@ -1951,8 +1947,8 @@ c  10  11  12  13  14\
             ).set_index("idx")
             long_repr = df._repr_html_()
             assert ".." in long_repr
-            assert "<td>{val}</td>".format(val="31") not in long_repr
-            assert "{h} rows ".format(h=h) in long_repr
+            assert f"<td>{str(31)}</td>" not in long_repr
+            assert f"{h} rows " in long_repr
             assert "2 columns" in long_repr
 
     def test_repr_html_long_multiindex(self):
@@ -2181,9 +2177,7 @@ class TestSeriesFormatting:
         cp.name = "foo"
         result = cp.to_string(length=True, name=True, dtype=True)
         last_line = result.split("\n")[-1].strip()
-        assert last_line == (
-            "Freq: B, Name: foo, Length: {cp}, dtype: float64".format(cp=len(cp))
-        )
+        assert last_line == (f"Freq: B, Name: foo, Length: {len(cp)}, dtype: float64")
 
     def test_freq_name_separation(self):
         s = Series(
@@ -2782,7 +2776,7 @@ class TestSeriesFormatting:
 
     def test_to_string_float_format(self):
         s = pd.Series(range(10), dtype="float64")
-        res = s.to_string(float_format=lambda x: "{0:2.1f}".format(x), max_rows=2)
+        res = s.to_string(float_format=lambda x: f"{x:2.1f}", max_rows=2)
         exp = "0   0.0\n     ..\n9   9.0"
         assert res == exp
 
@@ -2807,7 +2801,7 @@ class TestSeriesFormatting:
 
 
 def _three_digit_exp():
-    return "{x:.4g}".format(x=1.7e8) == "1.7e+008"
+    return f"{1.7e8:.4g}" == "1.7e+008"
 
 
 class TestFloatArrayFormatter:

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -24,7 +24,7 @@ class TestStyler:
         self.g = lambda x: x
 
         def h(x, foo="bar"):
-            return pd.Series("color: {foo}".format(foo=foo), index=x.index, name=x.name)
+            return pd.Series(f"color: {foo}", index=x.index, name=x.name)
 
         self.h = h
         self.styler = Styler(self.df)
@@ -278,7 +278,7 @@ class TestStyler:
 
     def test_apply_axis(self):
         df = pd.DataFrame({"A": [0, 0], "B": [1, 1]})
-        f = lambda x: ["val: {max}".format(max=x.max()) for v in x]
+        f = lambda x: [f"val: {x.max()}" for v in x]
         result = df.style.apply(f, axis=1)
         assert len(result._todo) == 1
         assert len(result.ctx) == 0
@@ -362,7 +362,7 @@ class TestStyler:
             strings, black otherwise.
             """
             color = "red" if val < 0 else "black"
-            return "color: {color}".format(color=color)
+            return f"color: {color}"
 
         dic = {
             ("a", "d"): [-1.12, 2.11],
@@ -1215,11 +1215,7 @@ class TestStyler:
 
     def test_export(self):
         f = lambda x: "color: red" if x > 0 else "color: blue"
-        g = (
-            lambda x, y, z: "color: {z}".format(z=z)
-            if x > 0
-            else "color: {z}".format(z=z)
-        )
+        g = lambda x, y, z: f"color: {z}" if x > 0 else f"color: {z}"
         style1 = self.styler
         style1.applymap(f).applymap(g, y="a", z="b").highlight_max()
         result = style1.export()
@@ -1645,9 +1641,7 @@ class TestStyler:
 
     def test_pipe(self):
         def set_caption_from_template(styler, a, b):
-            return styler.set_caption(
-                "Dataframe with a = {a} and b = {b}".format(a=a, b=b)
-            )
+            return styler.set_caption(f"Dataframe with a = {a} and b = {b}")
 
         styler = self.df.style.pipe(set_caption_from_template, "A", b="B")
         assert "Dataframe with a = A and b = B" in styler.render()

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1215,9 +1215,9 @@ class TestStyler:
 
     def test_export(self):
         f = lambda x: "color: red" if x > 0 else "color: blue"
-        g = lambda x, y, z: f"color: {z}" if x > 0 else f"color: {z}"
+        g = lambda x, z: f"color: {z}" if x > 0 else f"color: {z}"
         style1 = self.styler
-        style1.applymap(f).applymap(g, y="a", z="b").highlight_max()
+        style1.applymap(f).applymap(g, z="b").highlight_max()
         result = style1.export()
         style2 = self.df.style
         style2.use(result)

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -486,7 +486,8 @@ z
         compression = compression_only
 
         if compression == "zip":
-            pytest.skip(f"{compression} is not supported " f"for to_csv")
+            pytest.skip(f"{compression} is not supported "
+                        f"for to_csv")
 
         # We'll complete file extension subsequently.
         filename = "test."

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -486,8 +486,7 @@ z
         compression = compression_only
 
         if compression == "zip":
-            pytest.skip(f"{compression} is not supported "
-                        f"for to_csv")
+            pytest.skip(f"{compression} is not supported for to_csv")
 
         # We'll complete file extension subsequently.
         filename = "test."

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -486,10 +486,7 @@ z
         compression = compression_only
 
         if compression == "zip":
-            pytest.skip(
-                "{compression} is not supported "
-                "for to_csv".format(compression=compression)
-            )
+            pytest.skip(f"{compression} is not supported " f"for to_csv")
 
         # We'll complete file extension subsequently.
         filename = "test."

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -270,13 +270,13 @@ def test_css_to_excel_inherited(css, inherited, expected):
 def test_css_to_excel_good_colors(input_color, output_color):
     # see gh-18392
     css = (
-        "border-top-color: {color}; "
-        "border-right-color: {color}; "
-        "border-bottom-color: {color}; "
-        "border-left-color: {color}; "
-        "background-color: {color}; "
-        "color: {color}"
-    ).format(color=input_color)
+        f"border-top-color: {input_color}; "
+        f"border-right-color: {input_color}; "
+        f"border-bottom-color: {input_color}; "
+        f"border-left-color: {input_color}; "
+        f"background-color: {input_color}; "
+        f"color: {input_color}"
+    )
 
     expected = dict()
 
@@ -297,13 +297,13 @@ def test_css_to_excel_good_colors(input_color, output_color):
 def test_css_to_excel_bad_colors(input_color):
     # see gh-18392
     css = (
-        "border-top-color: {color}; "
-        "border-right-color: {color}; "
-        "border-bottom-color: {color}; "
-        "border-left-color: {color}; "
-        "background-color: {color}; "
-        "color: {color}"
-    ).format(color=input_color)
+        f"border-top-color: {input_color}; "
+        f"border-right-color: {input_color}; "
+        f"border-bottom-color: {input_color}; "
+        f"border-left-color: {input_color}; "
+        f"background-color: {input_color}; "
+        f"color: {input_color}"
+    )
 
     expected = dict()
 


### PR DESCRIPTION
- [ ] xref #29547 
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
