### PR TITLE
TYP: enable strict_equality to prohibit comparisons of non-overlappin…

### DIFF
--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -59,6 +59,7 @@ class BooleanDtype(ExtensionDtype):
     >>> pd.BooleanDtype()
     BooleanDtype
     """
+
     name = "boolean"
 
     @property

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -59,6 +59,7 @@ class BooleanDtype(ExtensionDtype):
     >>> pd.BooleanDtype()
     BooleanDtype
     """
+    name = "boolean"
 
     @property
     def na_value(self) -> "Scalar":
@@ -78,19 +79,6 @@ class BooleanDtype(ExtensionDtype):
     @property
     def kind(self) -> str:
         return "b"
-
-    @property
-    def name(self) -> str:
-        """
-        The alias for BooleanDtype is ``'boolean'``.
-        """
-        return "boolean"
-
-    @classmethod
-    def construct_from_string(cls, string: str) -> ExtensionDtype:
-        if string == "boolean":
-            return cls()
-        return super().construct_from_string(string)
 
     @classmethod
     def construct_array_type(cls) -> "Type[BooleanArray]":

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -320,7 +320,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
     def dtype(self):
         return self._dtype
 
-    # read-only property overwriting read/write
+    # error: Read-only property cannot override read-write property  [misc]
     @property  # type: ignore
     def freq(self):
         """
@@ -638,7 +638,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         return new_data
 
     def _addsub_int_array(
-        self, other: np.ndarray, op: Callable[[Any], Any],
+        self, other: np.ndarray, op: Callable[[Any, Any], Any],
     ) -> "PeriodArray":
         """
         Add or subtract array of integers; equivalent to applying

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -46,6 +46,7 @@ class StringDtype(ExtensionDtype):
     >>> pd.StringDtype()
     StringDtype
     """
+
     name = "string"
 
     #: StringDtype.na_value uses pandas.NA

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -46,6 +46,7 @@ class StringDtype(ExtensionDtype):
     >>> pd.StringDtype()
     StringDtype
     """
+    name = "string"
 
     #: StringDtype.na_value uses pandas.NA
     na_value = libmissing.NA
@@ -53,19 +54,6 @@ class StringDtype(ExtensionDtype):
     @property
     def type(self) -> Type:
         return str
-
-    @property
-    def name(self) -> str:
-        """
-        The alias for StringDtype is ``'string'``.
-        """
-        return "string"
-
-    @classmethod
-    def construct_from_string(cls, string: str) -> ExtensionDtype:
-        if string == "string":
-            return cls()
-        return super().construct_from_string(string)
 
     @classmethod
     def construct_array_type(cls) -> "Type[StringArray]":

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -236,6 +236,10 @@ class ExtensionDtype:
         """
         if not isinstance(string, str):
             raise TypeError(f"Expects a string, got {type(string).__name__}")
+
+        # error: Non-overlapping equality check (left operand type: "str", right
+        #  operand type: "Callable[[ExtensionDtype], str]")  [comparison-overlap]
+        assert isinstance(cls.name, str), (cls, type(cls.name))
         if string != cls.name:
             raise TypeError(f"Cannot construct a '{cls.__name__}' from '{string}'")
         return cls()

--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -156,7 +156,7 @@ class _ODFReader(_BaseExcelReader):
             # GH5394
             cell_value = float(cell.attributes.get((OFFICENS, "value")))
 
-            if cell_value == 0.0 and str(cell) != cell_value:  # NA handling
+            if cell_value == 0.0:  # NA handling
                 return str(cell)
 
             if convert_float:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -231,7 +231,7 @@ class SeriesFormatter:
         self,
         series: "Series",
         buf: Optional[IO[str]] = None,
-        length: bool = True,
+        length: Union[bool, str] = True,
         header: bool = True,
         index: bool = True,
         na_rep: str = "NaN",
@@ -450,7 +450,7 @@ def _get_adjustment() -> TextAdjustment:
 
 class TableFormatter:
 
-    show_dimensions: bool
+    show_dimensions: Union[bool, str]
     is_truncated: bool
     formatters: formatters_type
     columns: Index
@@ -554,7 +554,7 @@ class DataFrameFormatter(TableFormatter):
         max_rows: Optional[int] = None,
         min_rows: Optional[int] = None,
         max_cols: Optional[int] = None,
-        show_dimensions: bool = False,
+        show_dimensions: Union[bool, str] = False,
         decimal: str = ".",
         table_id: Optional[str] = None,
         render_links: bool = False,
@@ -1276,7 +1276,7 @@ class FloatArrayFormatter(GenericArrayFormatter):
     """
 
     def __init__(self, *args, **kwargs):
-        GenericArrayFormatter.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # float_format is expected to be a string
         # formatter should be used to pass a function

--- a/setup.cfg
+++ b/setup.cfg
@@ -123,6 +123,7 @@ skip = pandas/__init__.py,pandas/core/api.py
 ignore_missing_imports=True
 no_implicit_optional=True
 check_untyped_defs=True
+strict_equality=True
 
 [mypy-pandas.tests.*]
 check_untyped_defs=False


### PR DESCRIPTION
…g types

By default, mypy allows always-false comparisons like 42 == 'no'. Use this flag to prohibit such comparisons of non-overlapping types, and similar identity and container checks
```
pandas\core\dtypes\base.py:239: error: Non-overlapping equality check (left operand type: "str", right operand type: "Callable[[ExtensionDtype], str]")      
pandas\core\arrays\period.py:657: error: Non-overlapping container check (element type: "Callable[[Any], Any]", container item type: "Callable[[Any, Any], Any]")
pandas\core\arrays\period.py:658: error: Non-overlapping identity check (left operand type: "Callable[[Any], Any]", right operand type: "Callable[[Any, Any], Any]")
pandas\io\formats\format.py:307: error: Non-overlapping equality check (left operand type: "bool", right operand type: "Literal['truncate']")
pandas\io\formats\format.py:461: error: Non-overlapping equality check (left operand type: "bool", right operand type: "Literal['truncate']")
pandas\io\excel\_odfreader.py:159: error: Non-overlapping equality check (left operand type: "str", right operand type: "float")
```