### PR TITLE
TST: Adding test to concat where copy=False for ExtensionArrays

### DIFF
--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -94,9 +94,9 @@ class BaseReshapingTests(BaseExtensionTests):
         result = pd.concat([df1["A"], df2["B"]], axis=1)
         self.assert_frame_equal(result, expected)
 
-        # non-aligned
-        # copy=False
+    def test_concat_extension_arrays_copy_false(self, data, na_value):
         # GH 20756
+        df1 = pd.DataFrame({"A": data[:3]})
         df2 = pd.DataFrame({"B": data[3:7]})
         expected = pd.DataFrame(
             {

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -94,6 +94,19 @@ class BaseReshapingTests(BaseExtensionTests):
         result = pd.concat([df1["A"], df2["B"]], axis=1)
         self.assert_frame_equal(result, expected)
 
+        # non-aligned
+        # copy=False
+        # GH 20756
+        df2 = pd.DataFrame({"B": data[3:7]})
+        expected = pd.DataFrame(
+            {
+                "A": data._from_sequence(list(data[:3]) + [na_value], dtype=data.dtype),
+                "B": data[3:7],
+            }
+        )
+        result = pd.concat([df1, df2], axis=1, copy=False)
+        self.assert_frame_equal(result, expected)
+
     def test_align(self, data, na_value):
         a = data[:3]
         b = data[2:5]

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -132,6 +132,10 @@ class TestReshaping(BaseSparseTests, base.BaseReshapingTests):
         self._check_unsupported(data)
         super().test_concat_columns(data, na_value)
 
+    def test_concat_extension_arrays_copy_false(self, data, na_value):
+        self._check_unsupported(data)
+        super().test_concat_extension_arrays_copy_false(data, na_value)
+
     def test_align(self, data, na_value):
         self._check_unsupported(data)
         super().test_align(data, na_value)

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -2730,3 +2730,25 @@ def test_concat_datetimeindex_freq():
     expected = pd.DataFrame(data[50:] + data[:50], index=dr[50:].append(dr[:50]))
     expected.index._data.freq = None
     tm.assert_frame_equal(result, expected)
+
+
+def test_concat_copy_false_extension_array():
+    # GH 20756
+    range_arr = list(range(8))
+    dec_arr = to_decimal(range_arr)
+    df1 = pd.DataFrame({"int1": [1, 2, 3], "key1": [0, 1, 2], "ext1": dec_arr[:3]})
+    df2 = pd.DataFrame(
+        {"int2": [1, 2, 3, 4], "key2": [0, 0, 1, 3], "ext2": dec_arr[3:7]}
+    )
+    expected = pd.DataFrame(
+        {
+            "int1": [1, 2, 3, float("nan")],
+            "key1": [0, 1, 2, float("nan")],
+            "ext1": to_decimal(range_arr[:3] + ["nan"]),
+            "int2": [1, 2, 3, 4],
+            "key2": [0, 0, 1, 3],
+            "ext2": dec_arr[3:7],
+        }
+    )
+    result = pd.concat([df1, df2], axis=1, copy=False)
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -2730,25 +2730,3 @@ def test_concat_datetimeindex_freq():
     expected = pd.DataFrame(data[50:] + data[:50], index=dr[50:].append(dr[:50]))
     expected.index._data.freq = None
     tm.assert_frame_equal(result, expected)
-
-
-def test_concat_copy_false_extension_array():
-    # GH 20756
-    range_arr = list(range(8))
-    dec_arr = to_decimal(range_arr)
-    df1 = pd.DataFrame({"int1": [1, 2, 3], "key1": [0, 1, 2], "ext1": dec_arr[:3]})
-    df2 = pd.DataFrame(
-        {"int2": [1, 2, 3, 4], "key2": [0, 0, 1, 3], "ext2": dec_arr[3:7]}
-    )
-    expected = pd.DataFrame(
-        {
-            "int1": [1, 2, 3, float("nan")],
-            "key1": [0, 1, 2, float("nan")],
-            "ext1": to_decimal(range_arr[:3] + ["nan"]),
-            "int2": [1, 2, 3, 4],
-            "key2": [0, 0, 1, 3],
-            "ext2": dec_arr[3:7],
-        }
-    )
-    result = pd.concat([df1, df2], axis=1, copy=False)
-    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
The test ensures that ExtensionArrays are correctly constructed when
concat(copy=False) is used.

- [x] closes #20756
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
