### PR TITLE
REF: delegate more IntervalIndex methods

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -199,7 +199,14 @@ class SetopCheck:
 )
 @accessor.delegate_names(
     delegate=IntervalArray,
-    accessors=["__array__", "overlaps", "contains"],
+    accessors=[
+        "__array__",
+        "overlaps",
+        "contains",
+        "set_closed",
+        "to_tuples",
+        "__len__",
+    ],
     typ="method",
     overwrite=True,
 )
@@ -389,56 +396,9 @@ class IntervalIndex(IntervalMixin, Index, accessor.PandasDelegate):
         except KeyError:
             return False
 
-    @Appender(
-        _interval_shared_docs["to_tuples"]
-        % dict(
-            return_type="Index",
-            examples="""
-        Examples
-        --------
-        >>> idx = pd.IntervalIndex.from_arrays([0, np.nan, 2], [1, np.nan, 3])
-        >>> idx.to_tuples()
-        Index([(0.0, 1.0), (nan, nan), (2.0, 3.0)], dtype='object')
-        >>> idx.to_tuples(na_tuple=False)
-        Index([(0.0, 1.0), nan, (2.0, 3.0)], dtype='object')
-        """,
-        )
-    )
-    def to_tuples(self, na_tuple=True):
-        tuples = self._data.to_tuples(na_tuple=na_tuple)
-        return Index(tuples)
-
     @cache_readonly
     def _multiindex(self):
         return MultiIndex.from_arrays([self.left, self.right], names=["left", "right"])
-
-    @Appender(
-        _interval_shared_docs["set_closed"]
-        % dict(
-            klass="IntervalIndex",
-            examples=textwrap.dedent(
-                """\
-        Examples
-        --------
-        >>> index = pd.interval_range(0, 3)
-        >>> index
-        IntervalIndex([(0, 1], (1, 2], (2, 3]],
-                      closed='right',
-                      dtype='interval[int64]')
-        >>> index.set_closed('both')
-        IntervalIndex([[0, 1], [1, 2], [2, 3]],
-                      closed='both',
-                      dtype='interval[int64]')
-        """
-            ),
-        )
-    )
-    def set_closed(self, closed):
-        array = self._data.set_closed(closed)
-        return self._simple_new(array, self.name)  # TODO: can we use _shallow_copy?
-
-    def __len__(self) -> int:
-        return len(self.left)
 
     @cache_readonly
     def values(self):
@@ -1051,8 +1011,7 @@ class IntervalIndex(IntervalMixin, Index, accessor.PandasDelegate):
         result = self._data.take(
             indices, axis=axis, allow_fill=allow_fill, fill_value=fill_value, **kwargs
         )
-        attributes = self._get_attributes_dict()
-        return self._simple_new(result, **attributes)
+        return self._shallow_copy(result)
 
     def __getitem__(self, value):
         result = self._data[value]
@@ -1253,7 +1212,9 @@ class IntervalIndex(IntervalMixin, Index, accessor.PandasDelegate):
         res = method(*args, **kwargs)
         if is_scalar(res) or name in self._raw_inherit:
             return res
-        return type(self)(res, name=self.name)
+        if isinstance(res, IntervalArray):
+            return type(self)._simple_new(res, name=self.name)
+        return Index(res)
 
 
 IntervalIndex._add_logical_methods_disabled()


### PR DESCRIPTION
cc @jschendel is the usage of _simple_new instead of _shallow_copy `take` important?  Should it always be the case that `idx.close == idx._data.closed`?