### PR TITLE
CI: Remove pin google-cloud-bigquery

### DIFF
--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -30,8 +30,6 @@ dependencies:
   - openpyxl<=3.0.1
   # https://github.com/pandas-dev/pandas/pull/30009 openpyxl 3.0.2 broke
   - pandas-gbq
-  # https://github.com/pydata/pandas-gbq/issues/271
-  - google-cloud-bigquery<=1.11
   - psycopg2
   - pyarrow>=0.12.0
   - pymysql


### PR DESCRIPTION
xref: https://github.com/pydata/pandas-gbq/issues/271 is now resolved.

This can be removed since `pandas-gbq` depends on `google-cloud-bigquery` ref: https://github.com/pydata/pandas-gbq/blob/master/setup.py