### PR TITLE
REF/BUG: DTA/TDA/PA comparison ops inconsistencies

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -140,18 +140,19 @@ def _dt_array_cmp(cls, op):
     @unpack_zerodim_and_defer(opname)
     def wrapper(self, other):
 
-        if isinstance(other, (datetime, np.datetime64, str)):
-            if isinstance(other, (datetime, np.datetime64)):
-                # GH#18435 strings get a pass from tzawareness compat
-                self._assert_tzawareness_compat(other)
-
+        if isinstance(other, str):
             try:
-                other = _to_M8(other, tz=self.tz)
+                # GH#18435 strings get a pass from tzawareness compat
+                other = self._scalar_from_string(other)
             except ValueError:
                 # string that cannot be parsed to Timestamp
                 return invalid_comparison(self, other, op)
 
-            result = op(self.asi8, other.view("i8"))
+        if isinstance(other, (datetime, np.datetime64)):
+            other = Timestamp(other)
+            self._assert_tzawareness_compat(other)
+
+            result = op(self.asi8, other.value)
             if isna(other):
                 result.fill(nat_result)
         elif lib.is_scalar(other) or np.ndim(other) == 0:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -165,9 +165,7 @@ def _dt_array_cmp(cls, op):
                     other = type(self)._from_sequence(other)
                 except ValueError:
                     other = np.array(other, dtype=np.object_)
-            elif not isinstance(
-                other, (np.ndarray, ABCIndexClass, ABCSeries, DatetimeArray)
-            ):
+            elif not isinstance(other, (np.ndarray, DatetimeArray)):
                 # Following Timestamp convention, __eq__ is all-False
                 # and __ne__ is all True, others raise TypeError.
                 return invalid_comparison(self, other, op)
@@ -186,8 +184,6 @@ def _dt_array_cmp(cls, op):
                 return invalid_comparison(self, other, op)
             else:
                 self._assert_tzawareness_compat(other)
-                if isinstance(other, (ABCIndexClass, ABCSeries)):
-                    other = other.array
 
                 if (
                     is_datetime64_dtype(other)

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -45,6 +45,7 @@ import pandas.core.algorithms as algos
 from pandas.core.arrays import datetimelike as dtl
 import pandas.core.common as com
 from pandas.core.ops.common import unpack_zerodim_and_defer
+from pandas.core.ops.invalid import invalid_comparison
 
 from pandas.tseries import frequencies
 from pandas.tseries.offsets import DateOffset, Tick, _delta_to_tick
@@ -75,6 +76,18 @@ def _period_array_cmp(cls, op):
         if is_list_like(other) and len(other) != len(self):
             raise ValueError("Lengths must match")
 
+        if isinstance(other, str):
+            try:
+                other = self._scalar_from_string(other)
+            except ValueError:
+                # string that can't be parsed as Period
+                return invalid_comparison(self, other, op)
+        elif isinstance(other, int):
+            # TODO: sure we want to allow this?  we dont for DTA/TDA
+            #  2 tests rely on this
+            other = Period(other, freq=self.freq)
+            result = ordinal_op(other.ordinal)
+
         if isinstance(other, Period):
             self._check_compatible_with(other)
 
@@ -93,8 +106,7 @@ def _period_array_cmp(cls, op):
             result = np.empty(len(self.asi8), dtype=bool)
             result.fill(nat_result)
         else:
-            other = Period(other, freq=self.freq)
-            result = ordinal_op(other.ordinal)
+            return invalid_comparison(self, other, op)
 
         if self._hasnans:
             result[self._isnan] = nat_result

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -82,12 +82,15 @@ def _td_array_cmp(cls, op):
     @unpack_zerodim_and_defer(opname)
     def wrapper(self, other):
 
-        if _is_convertible_to_td(other) or other is NaT:
+        if isinstance(other, str):
             try:
-                other = Timedelta(other)
+                other = self._scalar_from_string(other)
             except ValueError:
                 # failed to parse as timedelta
                 return invalid_comparison(self, other, op)
+
+        if _is_convertible_to_td(other) or other is NaT:
+            other = Timedelta(other)
 
             result = op(self.view("i8"), other.value)
             if isna(other):

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -17,6 +17,8 @@ import pandas.util.testing as tm
 
 from pandas.tseries.frequencies import to_offset
 
+from .common import assert_invalid_comparison
+
 # ------------------------------------------------------------------
 # Comparisons
 
@@ -38,6 +40,15 @@ class TestPeriodArrayLikeComparisons:
         expected = np.array([True, False, False, False])
         expected = tm.box_expected(expected, xbox)
         tm.assert_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "scalar", ["foo", pd.Timestamp.now(), pd.Timedelta(days=4)]
+    )
+    def test_compare_invalid_scalar(self, box_with_array, scalar):
+        # comparison with scalar that cannot be interpreted as a Period
+        pi = pd.period_range("2000", periods=4)
+        parr = tm.box_expected(pi, box_with_array)
+        assert_invalid_comparison(parr, scalar, box_with_array)
 
 
 class TestPeriodIndexComparisons:


### PR DESCRIPTION
It will take a couple of steps to get these three methods to all behave the same.  Following that we can move to share code between them.

This came up when trying to make the indexes dispatch `searchsorted` and it turns out that the DTI/TDI/PI searchsorted methods are not consistent with their DTA/TDA/PA counterparts.  The fix is to have shared validation/casting methods, which should in turn be consistent with the comparison ops.