### PR TITLE
REF: restructure api import

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -138,7 +138,7 @@ from pandas.core.reshape.api import (
     qcut,
 )
 
-from pandas.api import extensions, indexers, types
+import pandas.api
 from pandas.util._print_versions import show_versions
 
 from pandas.io.api import (

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -138,6 +138,7 @@ from pandas.core.reshape.api import (
     qcut,
 )
 
+from pandas.api import extensions, indexers, types
 from pandas.util._print_versions import show_versions
 
 from pandas.io.api import (

--- a/pandas/io/json/_table_schema.py
+++ b/pandas/io/json/_table_schema.py
@@ -18,9 +18,9 @@ from pandas.core.dtypes.common import (
     is_string_dtype,
     is_timedelta64_dtype,
 )
+from pandas.core.dtypes.dtypes import CategoricalDtype
 
 from pandas import DataFrame
-from pandas.api.types import CategoricalDtype
 import pandas.core.common as com
 
 loads = json.loads

--- a/pandas/io/spss.py
+++ b/pandas/io/spss.py
@@ -3,7 +3,8 @@ from typing import Optional, Sequence, Union
 
 from pandas.compat._optional import import_optional_dependency
 
-from pandas.api.types import is_list_like
+from pandas.core.dtypes.inference import is_list_like
+
 from pandas.core.api import DataFrame
 
 


### PR DESCRIPTION
Previously, `pandas.api` was imported indirectly via `pandas.io.json._table_schema`. This makes things a bit more direct.

I think we'll want a code check for importing from `pandas.api` within `pandas.core` but I wasn't able to easily write one (things like docstrings may want to have `import pandas.api` for example).