### PR TITLE
REF: use _data.take for CI/DTI/TDI/PI.take

### DIFF
--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -728,13 +728,13 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         nv.validate_take(tuple(), kwargs)
         indices = ensure_platform_int(indices)
         taken = self._assert_take_fillable(
-            self.codes,
+            self._data,
             indices,
             allow_fill=allow_fill,
             fill_value=fill_value,
-            na_value=-1,
+            na_value=self._data.dtype.na_value
         )
-        return self._create_from_codes(taken)
+        return self._shallow_copy(taken)
 
     take_nd = take
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -732,7 +732,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             indices,
             allow_fill=allow_fill,
             fill_value=fill_value,
-            na_value=self._data.dtype.na_value
+            na_value=self._data.dtype.na_value,
         )
         return self._shallow_copy(taken)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -274,11 +274,11 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
             return self[maybe_slice]
 
         taken = self._assert_take_fillable(
-            self.asi8,
+            self._data,
             indices,
             allow_fill=allow_fill,
             fill_value=fill_value,
-            na_value=iNaT,
+            na_value=NaT,
         )
 
         # keep freq in PeriodArray/Index, reset otherwise

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1004,8 +1004,7 @@ class IntervalIndex(IntervalMixin, Index, accessor.PandasDelegate):
         result = self._data.take(
             indices, axis=axis, allow_fill=allow_fill, fill_value=fill_value, **kwargs
         )
-        attributes = self._get_attributes_dict()
-        return self._simple_new(result, **attributes)
+        return self._shallow_copy(result)
 
     def __getitem__(self, value):
         result = self._data[value]


### PR DESCRIPTION
cc @jschendel @jreback any idea why IntervalIndex doesn't use _assert_take_fillable like the others?  If it can/should, then we can share this method between all of our EA-backed indexes.  (Actually also need to make sure the slice behavior in the DTI/TDI/PI is OK to do for all of them)