### PR TITLE
Fix flakey base setitem test

### DIFF
--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -189,11 +189,9 @@ class BaseSetitemTests(BaseExtensionTests):
 
     def test_setitem_preserves_views(self, data):
         # GH#28150 setitem shouldn't swap the underlying data
-        assert data[-1] != data[0]  # otherwise test would not be meaningful
-
         view1 = data.view()
         view2 = data[:]
 
-        data[0] = data[-1]
-        assert view1[0] == data[-1]
-        assert view2[0] == data[-1]
+        data[0] = data[1]
+        assert view1[0] == data[1]
+        assert view2[0] == data[1]


### PR DESCRIPTION
This test makes a potentially incorrect assertion about the data provided to the test. We already require that `data[0] != data[1]`, so it can be used instead.

This failed in https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=24731&view=logs&j=a67b4c4c-cd2e-5e3c-a361-de73ac9c05f9&t=33d2fdd0-c376-5f94-e6d3-957bdd23a3b8.