### PR TITLE
TYP: Fix chainmap typing for mypy 0.740+

### DIFF
--- a/pandas/compat/chainmap.py
+++ b/pandas/compat/chainmap.py
@@ -1,15 +1,24 @@
-from collections import ChainMap
+from typing import ChainMap, MutableMapping, TypeVar, cast
+
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
 
 
-class DeepChainMap(ChainMap):
-    def __setitem__(self, key, value):
+class DeepChainMap(ChainMap[_KT, _VT]):
+    """Variant of ChainMap that allows direct updates to inner scopes.
+
+    Only works when all passed mapping are mutable.
+    """
+
+    def __setitem__(self, key: _KT, value: _VT) -> None:
         for mapping in self.maps:
-            if key in mapping:
-                mapping[key] = value
+            mutable_mapping = cast(MutableMapping[_KT, _VT], mapping)
+            if key in mutable_mapping:
+                mutable_mapping[key] = value
                 return
-        self.maps[0][key] = value
+        cast(MutableMapping[_KT, _VT], self.maps[0])[key] = value
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: _KT) -> None:
         """
         Raises
         ------
@@ -17,7 +26,8 @@ class DeepChainMap(ChainMap):
             If `key` doesn't exist.
         """
         for mapping in self.maps:
+            mutable_mapping = cast(MutableMapping[_KT, _VT], mapping)
             if key in mapping:
-                del mapping[key]
+                del mutable_mapping[key]
                 return
         raise KeyError(key)

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -533,7 +533,7 @@ class PyTablesExpr(expr.Expr):
         self._visitor = None
 
         # capture the environment if needed
-        local_dict = DeepChainMap()
+        local_dict: DeepChainMap[Any, Any] = DeepChainMap()
 
         if isinstance(where, PyTablesExpr):
             local_dict = where.env.scope


### PR DESCRIPTION
This will otherwise raise a failure during a `mypy` update. Also increase type precision of this file to 100%.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

cc @simonjayhawkins 