### PR TITLE
TYP: Add mypy as a pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,15 @@ repos:
     -   id: isort
         language: python_venv
         exclude: ^pandas/__init__\.py$|^pandas/core/api\.py$
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.730
+    hooks:
+     -  id: mypy
+        # We run mypy over all files because of:
+        #  * changes in type definitions may affect non-touched files.
+        #  * Running it with `mypy pandas` and the filenames will lead to
+        #    spurious duplicate module errors,
+        #    see also https://github.com/pre-commit/mirrors-mypy/issues/5
+        pass_filenames: false
+        args:
+        - pandas


### PR DESCRIPTION
This is quite helpful in developing with typing, especially if you plan to update the mypy version.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
