### PR TITLE
CI: Fix pytest junit_family warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ xfail_strict = True
 filterwarnings =
     error:Sparse:FutureWarning
     error:The SparseArray:FutureWarning
+junit_family=xunit2
 
 [coverage:run]
 branch = False


### PR DESCRIPTION
- [x] closes #30433

As per https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2

This will mean we produce xml output with xsd as per: (opposed to old legacy v1)
https://github.com/jenkinsci/xunit-plugin/blob/xunit-2.3.2/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd

Done following check
- [x] Warning no longer present in builds -> checked [here](https://travis-ci.org/pandas-dev/pandas/jobs/632732296?utm_medium=notification&utm_source=github_status)
- [x] CodeCov unaffected since it uses the output xml -> [here](https://codecov.io/gh/pandas-dev/pandas/compare/b29d58d1a3e0ebb1ed3bf3bed1e1cf4848092c77...2a2d21a14a78e028e8e9a9c3bbf815ea76501036)
