### PR TITLE
REF: share `delete` between DTI/TDI/PI

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -841,6 +841,25 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
                 kwargs["tz"] = getattr(other, "tz", None)
             return self._simple_new(joined, name, **kwargs)
 
+    # --------------------------------------------------------------------
+    # List-like Methods
+
+    def delete(self, loc):
+        new_i8s = np.delete(self.asi8, loc)
+
+        freq = None
+        if is_integer(loc):
+            if loc in (0, -len(self), -1, len(self) - 1):
+                freq = self.freq
+        else:
+            if is_list_like(loc):
+                loc = lib.maybe_indices_to_slice(ensure_int64(np.array(loc)), len(self))
+            if isinstance(loc, slice) and loc.step in (1, None):
+                if loc.start in (0, None) or loc.stop in (len(self), None):
+                    freq = self.freq
+
+        return self._shallow_copy(new_i8s, freq=freq)
+
 
 class DatetimelikeDelegateMixin(PandasDelegate):
     """

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -597,6 +597,27 @@ class DatetimeIndexOpsMixin(ExtensionOpsMixin):
         result = self._data._time_shift(periods, freq=freq)
         return type(self)(result, name=self.name)
 
+    # --------------------------------------------------------------------
+    # List-like Methods
+
+    def delete(self, loc):
+        new_i8s = np.delete(self.asi8, loc)
+
+        freq = None
+        if is_period_dtype(self):
+            freq = self.freq
+        elif is_integer(loc):
+            if loc in (0, -len(self), -1, len(self) - 1):
+                freq = self.freq
+        else:
+            if is_list_like(loc):
+                loc = lib.maybe_indices_to_slice(ensure_int64(np.array(loc)), len(self))
+            if isinstance(loc, slice) and loc.step in (1, None):
+                if loc.start in (0, None) or loc.stop in (len(self), None):
+                    freq = self.freq
+
+        return self._shallow_copy(new_i8s, freq=freq)
+
 
 class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
     """
@@ -840,25 +861,6 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
             if hasattr(self, "tz"):
                 kwargs["tz"] = getattr(other, "tz", None)
             return self._simple_new(joined, name, **kwargs)
-
-    # --------------------------------------------------------------------
-    # List-like Methods
-
-    def delete(self, loc):
-        new_i8s = np.delete(self.asi8, loc)
-
-        freq = None
-        if is_integer(loc):
-            if loc in (0, -len(self), -1, len(self) - 1):
-                freq = self.freq
-        else:
-            if is_list_like(loc):
-                loc = lib.maybe_indices_to_slice(ensure_int64(np.array(loc)), len(self))
-            if isinstance(loc, slice) and loc.step in (1, None):
-                if loc.start in (0, None) or loc.stop in (len(self), None):
-                    freq = self.freq
-
-        return self._shallow_copy(new_i8s, freq=freq)
 
 
 class DatetimelikeDelegateMixin(PandasDelegate):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -9,14 +9,7 @@ from pandas._libs import NaT, Timestamp, index as libindex, lib, tslib as libts
 from pandas._libs.tslibs import ccalendar, fields, parsing, timezones
 from pandas.util._decorators import Appender, Substitution, cache_readonly
 
-from pandas.core.dtypes.common import (
-    _NS_DTYPE,
-    ensure_int64,
-    is_float,
-    is_integer,
-    is_list_like,
-    is_scalar,
-)
+from pandas.core.dtypes.common import _NS_DTYPE, is_float, is_integer, is_scalar
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from pandas.core.dtypes.missing import isna
@@ -1030,34 +1023,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
             if isinstance(item, str):
                 return self.astype(object).insert(loc, item)
             raise TypeError("cannot insert DatetimeIndex with incompatible label")
-
-    def delete(self, loc):
-        """
-        Make a new DatetimeIndex with passed location(s) deleted.
-
-        Parameters
-        ----------
-        loc: int, slice or array of ints
-            Indicate which sub-arrays to remove.
-
-        Returns
-        -------
-        new_index : DatetimeIndex
-        """
-        new_dates = np.delete(self.asi8, loc)
-
-        freq = None
-        if is_integer(loc):
-            if loc in (0, -len(self), -1, len(self) - 1):
-                freq = self.freq
-        else:
-            if is_list_like(loc):
-                loc = lib.maybe_indices_to_slice(ensure_int64(np.array(loc)), len(self))
-            if isinstance(loc, slice) and loc.step in (1, None):
-                if loc.start in (0, None) or loc.stop in (len(self), None):
-                    freq = self.freq
-
-        return self._shallow_copy(new_dates, freq=freq)
 
     def indexer_at_time(self, time, asof=False):
         """

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -3,12 +3,11 @@ from datetime import datetime
 
 import numpy as np
 
-from pandas._libs import NaT, Timedelta, index as libindex, lib
+from pandas._libs import NaT, Timedelta, index as libindex
 from pandas.util._decorators import Appender, Substitution
 
 from pandas.core.dtypes.common import (
     _TD_DTYPE,
-    ensure_int64,
     is_float,
     is_integer,
     is_list_like,
@@ -477,34 +476,6 @@ class TimedeltaIndex(
             if isinstance(item, str):
                 return self.astype(object).insert(loc, item)
             raise TypeError("cannot insert TimedeltaIndex with incompatible label")
-
-    def delete(self, loc):
-        """
-        Make a new TimedeltaIndex with passed location(s) deleted.
-
-        Parameters
-        ----------
-        loc: int, slice or array of ints
-            Indicate which sub-arrays to remove.
-
-        Returns
-        -------
-        new_index : TimedeltaIndex
-        """
-        new_tds = np.delete(self.asi8, loc)
-
-        freq = None
-        if is_integer(loc):
-            if loc in (0, -len(self), -1, len(self) - 1):
-                freq = self.freq
-        else:
-            if is_list_like(loc):
-                loc = lib.maybe_indices_to_slice(ensure_int64(np.array(loc)), len(self))
-            if isinstance(loc, slice) and loc.step in (1, None):
-                if loc.start in (0, None) or loc.stop in (len(self), None):
-                    freq = self.freq
-
-        return self._shallow_copy(new_tds, freq=freq)
 
 
 TimedeltaIndex._add_comparison_ops()


### PR DESCRIPTION
Besides de-duplicating, this moves the ball down the field in getting rid of PeriodIndex._shallow_copy cases where we pass an object ndarray