### PR TITLE
Implement PeriodIndex.difference without object-dtype cast

### DIFF
--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -619,7 +619,10 @@ def assert_index_equal(
         # accept level number only
         unique = index.levels[level]
         level_codes = index.codes[level]
-        filled = take_1d(unique.values, level_codes, fill_value=unique._na_value)
+        if is_extension_array_dtype(unique):
+            filled = unique.take(level_codes, fill_value=unique._na_value)
+        else:
+            filled = take_1d(unique.values, level_codes, fill_value=unique._na_value)
         values = unique._shallow_copy(filled, name=index.names[level])
         return values
 

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -619,10 +619,7 @@ def assert_index_equal(
         # accept level number only
         unique = index.levels[level]
         level_codes = index.codes[level]
-        if is_extension_array_dtype(unique):
-            filled = unique.take(level_codes, fill_value=unique._na_value)
-        else:
-            filled = take_1d(unique.values, level_codes, fill_value=unique._na_value)
+        filled = take_1d(unique._values, level_codes, fill_value=unique._na_value)
         values = unique._shallow_copy(filled, name=index.names[level])
         return values
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -17,6 +17,7 @@ from pandas.core.dtypes.common import (
     is_float_dtype,
     is_integer,
     is_integer_dtype,
+    is_object_dtype,
     pandas_dtype,
 )
 
@@ -594,13 +595,13 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         return ensure_platform_int(indexer), missing
 
     def _get_unique_index(self, dropna=False):
-        """
-        wrap Index._get_unique_index to handle NaT
-        """
-        res = super()._get_unique_index(dropna=dropna)
-        if dropna:
-            res = res.dropna()
-        return res
+        if self.is_unique and not dropna:
+            return self
+
+        result = self._data.unique()
+        if dropna and self.hasnans:
+            result = result[~result.isna()]
+        return self._shallow_copy(result)
 
     def get_loc(self, key, method=None, tolerance=None):
         """
@@ -814,6 +815,29 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         i8self = Int64Index._simple_new(self.asi8)
         i8other = Int64Index._simple_new(other.asi8)
         i8result = i8self.intersection(i8other, sort=sort)
+
+        result = self._shallow_copy(np.asarray(i8result, dtype=np.int64), name=res_name)
+        return result
+
+    def difference(self, other, sort=None):
+        self._validate_sort_keyword(sort)
+        self._assert_can_do_setop(other)
+        res_name = get_op_result_name(self, other)
+        other = ensure_index(other)
+
+        if self.equals(other):
+            # pass an empty PeriodArray with the appropriate dtype
+            return self._shallow_copy(self._data[:0])
+
+        if is_object_dtype(other):
+            return self.astype(object).difference(other).astype(self.dtype)
+
+        elif not is_dtype_equal(self.dtype, other.dtype):
+            return self
+
+        i8self = Int64Index._simple_new(self.asi8)
+        i8other = Int64Index._simple_new(other.asi8)
+        i8result = i8self.difference(i8other, sort=sort)
 
         result = self._shallow_copy(np.asarray(i8result, dtype=np.int64), name=res_name)
         return result


### PR DESCRIPTION
Analogous to #30666.  After this we'll be able to share some code between the set operations.

The edit in pd._testing is mostly unrelated.  Both are motivated by tracking down the places where object-dtype ndarray is passed to PeriodIndex._shallow_copy.