### PR TITLE
CI: Fix numpydev build

### DIFF
--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -176,9 +176,8 @@ void *initObjToJSON(void) {
         Py_DECREF(mod_nattype);
     }
 
-    /* Initialise numpy API and use 2/3 compatible return */
+    /* Initialise numpy API */
     import_array();
-    return NUMPY_IMPORT_ARRAY_RETVAL;
 }
 
 static TypeContext *createTypeContext(void) {


### PR DESCRIPTION
- [x] closes #30709

hmm.. im not sure on this. But don't see any usage of this ret value.

The C extensions now build with this change

Potentially related change on the numpy side:
https://github.com/numpy/numpy/pull/15232

cc. @WillAyd @jreback 