### PR TITLE
Make DTA _check_compatible_with less strict by default

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -109,7 +109,7 @@ class AttributesMixin:
         raise AbstractMethodError(self)
 
     def _check_compatible_with(
-        self, other: Union[Period, Timestamp, Timedelta, NaTType], strict: bool = False
+        self, other: Union[Period, Timestamp, Timedelta, NaTType], setitem: bool = False
     ) -> None:
         """
         Verify that `self` and `other` are compatible.
@@ -123,7 +123,7 @@ class AttributesMixin:
         Parameters
         ----------
         other
-        strict : bool, default False
+        setitem : bool, default False
             For __setitem__ we may have stricter compatiblity resrictions than
             for comparisons.
 
@@ -503,10 +503,10 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
                     return
 
             value = type(self)._from_sequence(value, dtype=self.dtype)
-            self._check_compatible_with(value, strict=True)
+            self._check_compatible_with(value, setitem=True)
             value = value.asi8
         elif isinstance(value, self._scalar_type):
-            self._check_compatible_with(value, strict=True)
+            self._check_compatible_with(value, setitem=True)
             value = self._unbox_scalar(value)
         elif is_valid_nat_for_dtype(value, self.dtype):
             value = iNaT

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -109,7 +109,7 @@ class AttributesMixin:
         raise AbstractMethodError(self)
 
     def _check_compatible_with(
-        self, other: Union[Period, Timestamp, Timedelta, NaTType]
+        self, other: Union[Period, Timestamp, Timedelta, NaTType], strict: bool = False
     ) -> None:
         """
         Verify that `self` and `other` are compatible.
@@ -123,6 +123,9 @@ class AttributesMixin:
         Parameters
         ----------
         other
+        strict : bool, default False
+            For __setitem__ we may have stricter compatiblity resrictions than
+            for comparisons.
 
         Raises
         ------
@@ -500,10 +503,10 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
                     return
 
             value = type(self)._from_sequence(value, dtype=self.dtype)
-            self._check_compatible_with(value)
+            self._check_compatible_with(value, strict=True)
             value = value.asi8
         elif isinstance(value, self._scalar_type):
-            self._check_compatible_with(value)
+            self._check_compatible_with(value, strict=True)
             value = self._unbox_scalar(value)
         elif is_valid_nat_for_dtype(value, self.dtype):
             value = iNaT

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -554,7 +554,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
     def _scalar_from_string(self, value):
         return Timestamp(value, tz=self.tz)
 
-    def _check_compatible_with(self, other, strict: bool = False):
+    def _check_compatible_with(self, other, setitem: bool = False):
         if other is NaT:
             return
         self._assert_tzawareness_compat(other)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -558,7 +558,8 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
         if other is NaT:
             return
         self._assert_tzawareness_compat(other)
-        if strict:
+        if setitem:
+            # Stricter check for setitem vs comparison methods
             if not timezones.tz_compare(self.tz, other.tz):
                 raise ValueError(f"Timezones don't match. '{self.tz} != {other.tz}'")
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -545,11 +545,13 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
     def _scalar_from_string(self, value):
         return Timestamp(value, tz=self.tz)
 
-    def _check_compatible_with(self, other):
+    def _check_compatible_with(self, other, strict: bool = False):
         if other is NaT:
             return
-        if not timezones.tz_compare(self.tz, other.tz):
-            raise ValueError(f"Timezones don't match. '{self.tz} != {other.tz}'")
+        self._assert_tzawareness_compat(other)
+        if strict:
+            if not timezones.tz_compare(self.tz, other.tz):
+                raise ValueError(f"Timezones don't match. '{self.tz} != {other.tz}'")
 
     def _maybe_clear_freq(self):
         self._freq = None

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -338,7 +338,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
     def _scalar_from_string(self, value: str) -> Period:
         return Period(value, freq=self.freq)
 
-    def _check_compatible_with(self, other):
+    def _check_compatible_with(self, other, strict: bool = False):
         if other is NaT:
             return
         if self.freqstr != other.freqstr:

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -341,7 +341,7 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
     def _scalar_from_string(self, value: str) -> Period:
         return Period(value, freq=self.freq)
 
-    def _check_compatible_with(self, other, strict: bool = False):
+    def _check_compatible_with(self, other, setitem: bool = False):
         if other is NaT:
             return
         if self.freqstr != other.freqstr:

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -357,7 +357,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
     def _scalar_from_string(self, value):
         return Timedelta(value)
 
-    def _check_compatible_with(self, other, strict: bool = False):
+    def _check_compatible_with(self, other, setitem: bool = False):
         # we don't have anything to validate.
         pass
 

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -349,7 +349,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
     def _scalar_from_string(self, value):
         return Timedelta(value)
 
-    def _check_compatible_with(self, other):
+    def _check_compatible_with(self, other, strict: bool = False):
         # we don't have anything to validate.
         pass
 

--- a/pandas/tests/arrays/test_datetimes.py
+++ b/pandas/tests/arrays/test_datetimes.py
@@ -173,7 +173,7 @@ class TestDatetimeArray:
     def test_setitem_different_tz_raises(self):
         data = np.array([1, 2, 3], dtype="M8[ns]")
         arr = DatetimeArray(data, copy=False, dtype=DatetimeTZDtype(tz="US/Central"))
-        with pytest.raises(ValueError, match="None"):
+        with pytest.raises(TypeError, match="Cannot compare tz-naive and tz-aware"):
             arr[0] = pd.Timestamp("2000")
 
         with pytest.raises(ValueError, match="US/Central"):


### PR DESCRIPTION
One of the two non-cosmetic things mentioned in #30720.

There are a bunch of places where DTA or DTI do a compatibility check that for tz_awareness_compat, but not requiring the same tz.  This check is analogous to `PeriodArray._check_compatible_with` and `TimedeltaArray._check_compatible_with`, so this adds a kwarg to _check_compatible_with so that we can use _check_compatible_with in all the relevant places and subsequently de-duplicate a bunch of code.

In addition to the comparisons, this is going to be relevant for searchsorted and insert, where we have slightly different behavior in a bunch of EA/Index subclasses.