### PR TITLE
Fix read_json category dtype

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -12,7 +12,12 @@ from pandas._libs.tslibs import iNaT
 from pandas._typing import JSONSerializable
 from pandas.errors import AbstractMethodError
 
-from pandas.core.dtypes.common import ensure_str, is_period_dtype, is_categorical_dtype
+from pandas.core.dtypes.common import (
+    ensure_str,
+    is_period_dtype,
+    is_categorical_dtype,
+    pandas_dtype,
+)
 
 from pandas import DataFrame, MultiIndex, Series, isna, to_datetime
 from pandas.core.construction import create_series_with_explicit_dtype
@@ -893,7 +898,7 @@ class Parser:
                 if dtype is not None:
                     try:
                         if not is_categorical_dtype(dtype):
-                            dtype = np.dtype(dtype)
+                            dtype = pandas_dtype(dtype)
                         return data.astype(dtype), True
                     except (TypeError, ValueError):
                         return data, False

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -12,7 +12,7 @@ from pandas._libs.tslibs import iNaT
 from pandas._typing import JSONSerializable
 from pandas.errors import AbstractMethodError
 
-from pandas.core.dtypes.common import ensure_str, is_period_dtype
+from pandas.core.dtypes.common import ensure_str, is_period_dtype, is_categorical_dtype
 
 from pandas import DataFrame, MultiIndex, Series, isna, to_datetime
 from pandas.core.construction import create_series_with_explicit_dtype
@@ -892,7 +892,8 @@ class Parser:
                 )
                 if dtype is not None:
                     try:
-                        dtype = np.dtype(dtype)
+                        if not is_categorical_dtype(dtype):
+                            dtype = np.dtype(dtype)
                         return data.astype(dtype), True
                     except (TypeError, ValueError):
                         return data, False

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -13,10 +13,10 @@ from pandas._typing import JSONSerializable
 from pandas.errors import AbstractMethodError
 
 from pandas.core.dtypes.common import (
+    pandas_dtype,
     ensure_str,
     is_period_dtype,
     is_categorical_dtype,
-    pandas_dtype,
 )
 
 from pandas import DataFrame, MultiIndex, Series, isna, to_datetime

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import is_platform_32bit, is_platform_windows
+from pandas.core.dtypes.common import is_categorical
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -1201,13 +1202,12 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         json = (
             '{"a": 0, "b": "A"}\n'
             '{"a": 1, "b": "B"}\n'
-            '{"a": 2, "b": "B"}\n'
+            '{"a": 2, "b": "A"}\n'
             '{"a": 3, "b": "B"}\n'
         )
         json = StringIO(json)
-        result = read_json(json, lines=True, dtype={"a": "category"})
-        expected = DataFrame([[0, "foo"], [1, "bar"], [2, "foo"], [3, "bar"]])
-        tm.assert_frame_equal(result, expected)
+        result = read_json(json, lines=True, dtype={"b": "category"})
+        assert is_categorical(result["b"])
 
     def test_read_jsonl_unicode_chars(self):
         # GH15132: non-ascii unicode characters

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1197,6 +1197,18 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
             expected = DataFrame([[1, 2], [1, 2]], columns=["a", "b"])
             tm.assert_frame_equal(result, expected)
 
+    def test_read_json_category_dtype(self):
+        json = (
+            '{"a": 0, "b": "A"}\n'
+            '{"a": 1, "b": "B"}\n'
+            '{"a": 2, "b": "B"}\n'
+            '{"a": 3, "b": "B"}\n'
+        )
+        json = StringIO(json)
+        result = read_json(json, lines=True, dtype={"a": "category"})
+        expected = DataFrame([[0, "foo"], [1, "bar"], [2, "foo"], [3, "bar"]])
+        tm.assert_frame_equal(result, expected)
+
     def test_read_jsonl_unicode_chars(self):
         # GH15132: non-ascii unicode characters
         # \u201d == RIGHT DOUBLE QUOTATION MARK


### PR DESCRIPTION
- [X] closes #21892
- [ ] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] Add support for "category" dtype in read_json
