### PR TITLE
Fix PR08 errors

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2673,7 +2673,7 @@ class MultiIndex(Index):
         key : label or sequence of labels
         level : int/level name or list thereof, optional
         drop_level : bool, default True
-            if ``False``, the resulting index will not drop any level.
+            If ``False``, the resulting index will not drop any level.
 
         Returns
         -------

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -244,7 +244,7 @@ def infer_freq(index, warn: bool = True) -> Optional[str]:
     Parameters
     ----------
     index : DatetimeIndex or TimedeltaIndex
-      if passed a Series will use the values of the series (NOT THE INDEX).
+      If passed a Series will use the values of the series (NOT THE INDEX).
     warn : bool, default True
 
     Returns


### PR DESCRIPTION
Fixes PR08 errors. When I ran the script, a lot of them seem to be false positives, these are the ones I'm pretty sure should be fixed:
```
pandas.infer_freq: Parameter "index" description should start with a capital letter
pandas.MultiIndex.get_loc_level: Parameter "drop_level" description should start with a capital letter
```
Related to #27977 cc @datapythonista

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
