### PR TITLE
DOC: Fix the string example.

### DIFF
--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -87,8 +87,9 @@ l. For ``StringDtype``, :ref:`string accessor methods<api.series.str>`
 
    .. ipython:: python
 
-      s.astype(object).str.count("a")
-      s.astype(object).dropna().str.count("a")
+      s2 = pd.Series(["a", None, "b"], dtype="object")
+      s2.str.count("a")
+      s2.dropna().str.count("a")
 
    When NA values are present, the output dtype is float64. Similarly for
    methods returning boolean values.


### PR DESCRIPTION
After moving StringArray to use pd.NA `.astype(object)` had
NA instead of NaN, so the output was object rather than float.