### PR TITLE
in tests, change pd.arrays.SparseArray to SparseArray

### DIFF
--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -11,6 +11,15 @@ import pandas as pd
 import pandas._testing as tm
 from pandas.api.extensions import register_extension_dtype
 from pandas.api.types import is_scalar
+from pandas.arrays import (
+    BooleanArray,
+    DatetimeArray,
+    IntegerArray,
+    IntervalArray,
+    SparseArray,
+    StringArray,
+    TimedeltaArray,
+)
 from pandas.core.arrays import PandasArray, integer_array, period_array
 from pandas.tests.extension.decimal import DecimalArray, DecimalDtype, to_decimal
 
@@ -19,18 +28,14 @@ from pandas.tests.extension.decimal import DecimalArray, DecimalDtype, to_decima
     "data, dtype, expected",
     [
         # Basic NumPy defaults.
-        ([1, 2], None, pd.arrays.IntegerArray._from_sequence([1, 2])),
+        ([1, 2], None, IntegerArray._from_sequence([1, 2])),
         ([1, 2], object, PandasArray(np.array([1, 2], dtype=object))),
         (
             [1, 2],
             np.dtype("float32"),
             PandasArray(np.array([1.0, 2.0], dtype=np.dtype("float32"))),
         ),
-        (
-            np.array([1, 2], dtype="int64"),
-            None,
-            pd.arrays.IntegerArray._from_sequence([1, 2]),
-        ),
+        (np.array([1, 2], dtype="int64"), None, IntegerArray._from_sequence([1, 2]),),
         # String alias passes through to NumPy
         ([1, 2], "float32", PandasArray(np.array([1, 2], dtype="float32"))),
         # Period alias
@@ -49,37 +54,33 @@ from pandas.tests.extension.decimal import DecimalArray, DecimalDtype, to_decima
         (
             [1, 2],
             np.dtype("datetime64[ns]"),
-            pd.arrays.DatetimeArray._from_sequence(
-                np.array([1, 2], dtype="datetime64[ns]")
-            ),
+            DatetimeArray._from_sequence(np.array([1, 2], dtype="datetime64[ns]")),
         ),
         (
             np.array([1, 2], dtype="datetime64[ns]"),
             None,
-            pd.arrays.DatetimeArray._from_sequence(
-                np.array([1, 2], dtype="datetime64[ns]")
-            ),
+            DatetimeArray._from_sequence(np.array([1, 2], dtype="datetime64[ns]")),
         ),
         (
             pd.DatetimeIndex(["2000", "2001"]),
             np.dtype("datetime64[ns]"),
-            pd.arrays.DatetimeArray._from_sequence(["2000", "2001"]),
+            DatetimeArray._from_sequence(["2000", "2001"]),
         ),
         (
             pd.DatetimeIndex(["2000", "2001"]),
             None,
-            pd.arrays.DatetimeArray._from_sequence(["2000", "2001"]),
+            DatetimeArray._from_sequence(["2000", "2001"]),
         ),
         (
             ["2000", "2001"],
             np.dtype("datetime64[ns]"),
-            pd.arrays.DatetimeArray._from_sequence(["2000", "2001"]),
+            DatetimeArray._from_sequence(["2000", "2001"]),
         ),
         # Datetime (tz-aware)
         (
             ["2000", "2001"],
             pd.DatetimeTZDtype(tz="CET"),
-            pd.arrays.DatetimeArray._from_sequence(
+            DatetimeArray._from_sequence(
                 ["2000", "2001"], dtype=pd.DatetimeTZDtype(tz="CET")
             ),
         ),
@@ -87,17 +88,17 @@ from pandas.tests.extension.decimal import DecimalArray, DecimalDtype, to_decima
         (
             ["1H", "2H"],
             np.dtype("timedelta64[ns]"),
-            pd.arrays.TimedeltaArray._from_sequence(["1H", "2H"]),
+            TimedeltaArray._from_sequence(["1H", "2H"]),
         ),
         (
             pd.TimedeltaIndex(["1H", "2H"]),
             np.dtype("timedelta64[ns]"),
-            pd.arrays.TimedeltaArray._from_sequence(["1H", "2H"]),
+            TimedeltaArray._from_sequence(["1H", "2H"]),
         ),
         (
             pd.TimedeltaIndex(["1H", "2H"]),
             None,
-            pd.arrays.TimedeltaArray._from_sequence(["1H", "2H"]),
+            TimedeltaArray._from_sequence(["1H", "2H"]),
         ),
         # Category
         (["a", "b"], "category", pd.Categorical(["a", "b"])),
@@ -110,27 +111,19 @@ from pandas.tests.extension.decimal import DecimalArray, DecimalDtype, to_decima
         (
             [pd.Interval(1, 2), pd.Interval(3, 4)],
             "interval",
-            pd.arrays.IntervalArray.from_tuples([(1, 2), (3, 4)]),
+            IntervalArray.from_tuples([(1, 2), (3, 4)]),
         ),
         # Sparse
-        ([0, 1], "Sparse[int64]", pd.arrays.SparseArray([0, 1], dtype="int64")),
+        ([0, 1], "Sparse[int64]", SparseArray([0, 1], dtype="int64")),
         # IntegerNA
         ([1, None], "Int16", integer_array([1, None], dtype="Int16")),
         (pd.Series([1, 2]), None, PandasArray(np.array([1, 2], dtype=np.int64))),
         # String
-        (["a", None], "string", pd.arrays.StringArray._from_sequence(["a", None])),
-        (
-            ["a", None],
-            pd.StringDtype(),
-            pd.arrays.StringArray._from_sequence(["a", None]),
-        ),
+        (["a", None], "string", StringArray._from_sequence(["a", None])),
+        (["a", None], pd.StringDtype(), StringArray._from_sequence(["a", None]),),
         # Boolean
-        ([True, None], "boolean", pd.arrays.BooleanArray._from_sequence([True, None])),
-        (
-            [True, None],
-            pd.BooleanDtype(),
-            pd.arrays.BooleanArray._from_sequence([True, None]),
-        ),
+        ([True, None], "boolean", BooleanArray._from_sequence([True, None])),
+        ([True, None], pd.BooleanDtype(), BooleanArray._from_sequence([True, None]),),
         # Index
         (pd.Index([1, 2]), None, PandasArray(np.array([1, 2], dtype=np.int64))),
         # Series[EA] returns the EA
@@ -181,31 +174,28 @@ cet = pytz.timezone("CET")
             period_array(["2000", "2001"], freq="D"),
         ),
         # interval
-        (
-            [pd.Interval(0, 1), pd.Interval(1, 2)],
-            pd.arrays.IntervalArray.from_breaks([0, 1, 2]),
-        ),
+        ([pd.Interval(0, 1), pd.Interval(1, 2)], IntervalArray.from_breaks([0, 1, 2]),),
         # datetime
         (
             [pd.Timestamp("2000"), pd.Timestamp("2001")],
-            pd.arrays.DatetimeArray._from_sequence(["2000", "2001"]),
+            DatetimeArray._from_sequence(["2000", "2001"]),
         ),
         (
             [datetime.datetime(2000, 1, 1), datetime.datetime(2001, 1, 1)],
-            pd.arrays.DatetimeArray._from_sequence(["2000", "2001"]),
+            DatetimeArray._from_sequence(["2000", "2001"]),
         ),
         (
             np.array([1, 2], dtype="M8[ns]"),
-            pd.arrays.DatetimeArray(np.array([1, 2], dtype="M8[ns]")),
+            DatetimeArray(np.array([1, 2], dtype="M8[ns]")),
         ),
         (
             np.array([1, 2], dtype="M8[us]"),
-            pd.arrays.DatetimeArray(np.array([1000, 2000], dtype="M8[ns]")),
+            DatetimeArray(np.array([1000, 2000], dtype="M8[ns]")),
         ),
         # datetimetz
         (
             [pd.Timestamp("2000", tz="CET"), pd.Timestamp("2001", tz="CET")],
-            pd.arrays.DatetimeArray._from_sequence(
+            DatetimeArray._from_sequence(
                 ["2000", "2001"], dtype=pd.DatetimeTZDtype(tz="CET")
             ),
         ),
@@ -214,30 +204,30 @@ cet = pytz.timezone("CET")
                 datetime.datetime(2000, 1, 1, tzinfo=cet),
                 datetime.datetime(2001, 1, 1, tzinfo=cet),
             ],
-            pd.arrays.DatetimeArray._from_sequence(["2000", "2001"], tz=cet),
+            DatetimeArray._from_sequence(["2000", "2001"], tz=cet),
         ),
         # timedelta
         (
             [pd.Timedelta("1H"), pd.Timedelta("2H")],
-            pd.arrays.TimedeltaArray._from_sequence(["1H", "2H"]),
+            TimedeltaArray._from_sequence(["1H", "2H"]),
         ),
         (
             np.array([1, 2], dtype="m8[ns]"),
-            pd.arrays.TimedeltaArray(np.array([1, 2], dtype="m8[ns]")),
+            TimedeltaArray(np.array([1, 2], dtype="m8[ns]")),
         ),
         (
             np.array([1, 2], dtype="m8[us]"),
-            pd.arrays.TimedeltaArray(np.array([1000, 2000], dtype="m8[ns]")),
+            TimedeltaArray(np.array([1000, 2000], dtype="m8[ns]")),
         ),
         # integer
-        ([1, 2], pd.arrays.IntegerArray._from_sequence([1, 2])),
-        ([1, None], pd.arrays.IntegerArray._from_sequence([1, None])),
+        ([1, 2], IntegerArray._from_sequence([1, 2])),
+        ([1, None], IntegerArray._from_sequence([1, None])),
         # string
-        (["a", "b"], pd.arrays.StringArray._from_sequence(["a", "b"])),
-        (["a", None], pd.arrays.StringArray._from_sequence(["a", None])),
+        (["a", "b"], StringArray._from_sequence(["a", "b"])),
+        (["a", None], StringArray._from_sequence(["a", None])),
         # Boolean
-        ([True, False], pd.arrays.BooleanArray._from_sequence([True, False])),
-        ([True, None], pd.arrays.BooleanArray._from_sequence([True, None])),
+        ([True, False], BooleanArray._from_sequence([True, False])),
+        ([True, None], BooleanArray._from_sequence([True, None])),
     ],
 )
 def test_array_inference(data, expected):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -19,6 +19,7 @@ from pandas.core.dtypes.missing import isna
 
 import pandas as pd
 import pandas._testing as tm
+from pandas.arrays import SparseArray
 from pandas.conftest import (
     ALL_EA_INT_DTYPES,
     ALL_INT_DTYPES,
@@ -182,7 +183,7 @@ def test_is_object():
     "check_scipy", [False, pytest.param(True, marks=td.skip_if_no_scipy)]
 )
 def test_is_sparse(check_scipy):
-    assert com.is_sparse(pd.arrays.SparseArray([1, 2, 3]))
+    assert com.is_sparse(SparseArray([1, 2, 3]))
 
     assert not com.is_sparse(np.array([1, 2, 3]))
 
@@ -198,7 +199,7 @@ def test_is_scipy_sparse():
 
     assert com.is_scipy_sparse(bsr_matrix([1, 2, 3]))
 
-    assert not com.is_scipy_sparse(pd.arrays.SparseArray([1, 2, 3]))
+    assert not com.is_scipy_sparse(SparseArray([1, 2, 3]))
 
 
 def test_is_categorical():
@@ -576,7 +577,7 @@ def test_is_extension_type(check_scipy):
     cat = pd.Categorical([1, 2, 3])
     assert com.is_extension_type(cat)
     assert com.is_extension_type(pd.Series(cat))
-    assert com.is_extension_type(pd.arrays.SparseArray([1, 2, 3]))
+    assert com.is_extension_type(SparseArray([1, 2, 3]))
     assert com.is_extension_type(pd.DatetimeIndex(["2000"], tz="US/Eastern"))
 
     dtype = DatetimeTZDtype("ns", tz="US/Eastern")
@@ -605,7 +606,7 @@ def test_is_extension_array_dtype(check_scipy):
     cat = pd.Categorical([1, 2, 3])
     assert com.is_extension_array_dtype(cat)
     assert com.is_extension_array_dtype(pd.Series(cat))
-    assert com.is_extension_array_dtype(pd.arrays.SparseArray([1, 2, 3]))
+    assert com.is_extension_array_dtype(SparseArray([1, 2, 3]))
     assert com.is_extension_array_dtype(pd.DatetimeIndex(["2000"], tz="US/Eastern"))
 
     dtype = DatetimeTZDtype("ns", tz="US/Eastern")

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -28,7 +28,7 @@ from pandas.core.dtypes.dtypes import (
 import pandas as pd
 from pandas import Categorical, CategoricalIndex, IntervalIndex, Series, date_range
 import pandas._testing as tm
-from pandas.core.arrays.sparse import SparseDtype
+from pandas.core.arrays.sparse import SparseArray, SparseDtype
 
 
 class Base:
@@ -914,7 +914,7 @@ def test_registry_find(dtype, expected):
         (pd.Series([1, 2]), False),
         (np.array([True, False]), True),
         (pd.Series([True, False]), True),
-        (pd.arrays.SparseArray([True, False]), True),
+        (SparseArray([True, False]), True),
         (SparseDtype(bool), True),
     ],
 )
@@ -924,7 +924,7 @@ def test_is_bool_dtype(dtype, expected):
 
 
 def test_is_bool_dtype_sparse():
-    result = is_bool_dtype(pd.Series(pd.arrays.SparseArray([True, False])))
+    result = is_bool_dtype(pd.Series(SparseArray([True, False])))
     assert result is True
 
 

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -21,6 +21,7 @@ from pandas import (
     notna,
 )
 import pandas._testing as tm
+from pandas.arrays import SparseArray
 import pandas.core.common as com
 from pandas.core.indexing import IndexingError
 
@@ -1776,7 +1777,7 @@ class TestDataFrameIndexing:
 
     def test_getitem_sparse_column(self):
         # https://github.com/pandas-dev/pandas/issues/23559
-        data = pd.arrays.SparseArray([0, 1])
+        data = SparseArray([0, 1])
         df = pd.DataFrame({"A": data})
         expected = pd.Series(data, name="A")
         result = df["A"]
@@ -1791,7 +1792,7 @@ class TestDataFrameIndexing:
     def test_setitem_with_sparse_value(self):
         # GH8131
         df = pd.DataFrame({"c_1": ["a", "b", "c"], "n_1": [1.0, 2.0, 3.0]})
-        sp_array = pd.arrays.SparseArray([0, 0, 1])
+        sp_array = SparseArray([0, 0, 1])
         df["new_column"] = sp_array
         tm.assert_series_equal(
             df["new_column"], pd.Series(sp_array, name="new_column"), check_names=False
@@ -1799,9 +1800,9 @@ class TestDataFrameIndexing:
 
     def test_setitem_with_unaligned_sparse_value(self):
         df = pd.DataFrame({"c_1": ["a", "b", "c"], "n_1": [1.0, 2.0, 3.0]})
-        sp_series = pd.Series(pd.arrays.SparseArray([0, 0, 1]), index=[2, 1, 0])
+        sp_series = pd.Series(SparseArray([0, 0, 1]), index=[2, 1, 0])
         df["new_column"] = sp_series
-        exp = pd.Series(pd.arrays.SparseArray([1, 0, 0]), name="new_column")
+        exp = pd.Series(SparseArray([1, 0, 0]), name="new_column")
         tm.assert_series_equal(df["new_column"], exp)
 
     def test_setitem_with_unaligned_tz_aware_datetime_column(self):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -26,7 +26,7 @@ from pandas import (
     isna,
 )
 import pandas._testing as tm
-from pandas.arrays import IntervalArray, PeriodArray
+from pandas.arrays import IntervalArray, PeriodArray, SparseArray
 from pandas.core.construction import create_series_with_explicit_dtype
 
 MIXED_FLOAT_DTYPES = ["float16", "float32", "float64"]
@@ -2414,7 +2414,7 @@ class TestDataFrameConstructors:
         "extension_arr",
         [
             Categorical(list("aabbc")),
-            pd.arrays.SparseArray([1, np.nan, np.nan, np.nan]),
+            SparseArray([1, np.nan, np.nan, np.nan]),
             IntervalArray([pd.Interval(0, 1), pd.Interval(1, 5)]),
             PeriodArray(pd.period_range(start="1/1/2017", end="1/1/2018", freq="M")),
         ],

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -45,7 +45,7 @@ class TestGetDummies:
             dtype=self.effective_dtype(dtype),
         )
         if sparse:
-            expected = expected.apply(pd.arrays.SparseArray, fill_value=0.0)
+            expected = expected.apply(SparseArray, fill_value=0.0)
         result = get_dummies(s_list, sparse=sparse, dtype=dtype)
         tm.assert_frame_equal(result, expected)
 
@@ -132,7 +132,7 @@ class TestGetDummies:
             {"a": [1, 0, 0], "b": [0, 1, 0]}, dtype=self.effective_dtype(dtype)
         )
         if sparse:
-            exp = exp.apply(pd.arrays.SparseArray, fill_value=0.0)
+            exp = exp.apply(SparseArray, fill_value=0.0)
         tm.assert_frame_equal(res, exp)
 
         # Sparse dataframes do not allow nan labelled columns, see #GH8822
@@ -145,7 +145,7 @@ class TestGetDummies:
         # hack (NaN handling in assert_index_equal)
         exp_na.columns = res_na.columns
         if sparse:
-            exp_na = exp_na.apply(pd.arrays.SparseArray, fill_value=0.0)
+            exp_na = exp_na.apply(SparseArray, fill_value=0.0)
         tm.assert_frame_equal(res_na, exp_na)
 
         res_just_na = get_dummies([np.nan], dummy_na=True, sparse=sparse, dtype=dtype)
@@ -167,7 +167,7 @@ class TestGetDummies:
             dtype=np.uint8,
         )
         if sparse:
-            exp = exp.apply(pd.arrays.SparseArray, fill_value=0)
+            exp = exp.apply(SparseArray, fill_value=0)
         tm.assert_frame_equal(res, exp)
 
     def test_dataframe_dummies_all_obj(self, df, sparse):
@@ -180,10 +180,10 @@ class TestGetDummies:
         if sparse:
             expected = pd.DataFrame(
                 {
-                    "A_a": pd.arrays.SparseArray([1, 0, 1], dtype="uint8"),
-                    "A_b": pd.arrays.SparseArray([0, 1, 0], dtype="uint8"),
-                    "B_b": pd.arrays.SparseArray([1, 1, 0], dtype="uint8"),
-                    "B_c": pd.arrays.SparseArray([0, 0, 1], dtype="uint8"),
+                    "A_a": SparseArray([1, 0, 1], dtype="uint8"),
+                    "A_b": SparseArray([0, 1, 0], dtype="uint8"),
+                    "B_b": SparseArray([1, 1, 0], dtype="uint8"),
+                    "B_c": SparseArray([0, 0, 1], dtype="uint8"),
                 }
             )
 
@@ -226,7 +226,7 @@ class TestGetDummies:
         cols = ["from_A_a", "from_A_b", "from_B_b", "from_B_c"]
         expected = expected[["C"] + cols]
 
-        typ = pd.arrays.SparseArray if sparse else pd.Series
+        typ = SparseArray if sparse else pd.Series
         expected[cols] = expected[cols].apply(lambda x: typ(x))
         tm.assert_frame_equal(result, expected)
 
@@ -423,7 +423,7 @@ class TestGetDummies:
 
         result = get_dummies(s_list, drop_first=True, sparse=sparse)
         if sparse:
-            expected = expected.apply(pd.arrays.SparseArray, fill_value=0)
+            expected = expected.apply(SparseArray, fill_value=0)
         tm.assert_frame_equal(result, expected)
 
         result = get_dummies(s_series, drop_first=True, sparse=sparse)
@@ -457,7 +457,7 @@ class TestGetDummies:
         res = get_dummies(s_NA, drop_first=True, sparse=sparse)
         exp = DataFrame({"b": [0, 1, 0]}, dtype=np.uint8)
         if sparse:
-            exp = exp.apply(pd.arrays.SparseArray, fill_value=0)
+            exp = exp.apply(SparseArray, fill_value=0)
 
         tm.assert_frame_equal(res, exp)
 
@@ -466,7 +466,7 @@ class TestGetDummies:
             ["b", np.nan], axis=1
         )
         if sparse:
-            exp_na = exp_na.apply(pd.arrays.SparseArray, fill_value=0)
+            exp_na = exp_na.apply(SparseArray, fill_value=0)
         tm.assert_frame_equal(res_na, exp_na)
 
         res_just_na = get_dummies(
@@ -480,7 +480,7 @@ class TestGetDummies:
         result = get_dummies(df, drop_first=True, sparse=sparse)
         expected = DataFrame({"A_b": [0, 1, 0], "B_c": [0, 0, 1]}, dtype=np.uint8)
         if sparse:
-            expected = expected.apply(pd.arrays.SparseArray, fill_value=0)
+            expected = expected.apply(SparseArray, fill_value=0)
         tm.assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_drop_first_with_categorical(self, df, sparse, dtype):
@@ -494,7 +494,7 @@ class TestGetDummies:
         expected = expected[["C", "A_b", "B_c", "cat_y"]]
         if sparse:
             for col in cols:
-                expected[col] = pd.arrays.SparseArray(expected[col])
+                expected[col] = SparseArray(expected[col])
         tm.assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_drop_first_with_na(self, df, sparse):
@@ -516,7 +516,7 @@ class TestGetDummies:
         expected = expected.sort_index(axis=1)
         if sparse:
             for col in cols:
-                expected[col] = pd.arrays.SparseArray(expected[col])
+                expected[col] = SparseArray(expected[col])
 
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -6,6 +6,7 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
+from pandas.arrays import SparseArray
 
 UNARY_UFUNCS = [np.positive, np.floor, np.exp]
 BINARY_UFUNCS = [np.add, np.logaddexp]  # dunder op
@@ -33,7 +34,7 @@ def test_unary_ufunc(ufunc, sparse):
     array = np.random.randint(0, 10, 10, dtype="int64")
     array[::2] = 0
     if sparse:
-        array = pd.arrays.SparseArray(array, dtype=pd.SparseDtype("int64", 0))
+        array = SparseArray(array, dtype=pd.SparseDtype("int64", 0))
 
     index = list(string.ascii_letters[:10])
     name = "name"
@@ -51,8 +52,8 @@ def test_binary_ufunc_with_array(flip, sparse, ufunc, arrays_for_binary_ufunc):
     # Test that ufunc(Series(a), array) == Series(ufunc(a, b))
     a1, a2 = arrays_for_binary_ufunc
     if sparse:
-        a1 = pd.arrays.SparseArray(a1, dtype=pd.SparseDtype("int64", 0))
-        a2 = pd.arrays.SparseArray(a2, dtype=pd.SparseDtype("int64", 0))
+        a1 = SparseArray(a1, dtype=pd.SparseDtype("int64", 0))
+        a2 = SparseArray(a2, dtype=pd.SparseDtype("int64", 0))
 
     name = "name"  # op(Series, array) preserves the name.
     series = pd.Series(a1, name=name)
@@ -79,8 +80,8 @@ def test_binary_ufunc_with_index(flip, sparse, ufunc, arrays_for_binary_ufunc):
     #   * ufunc(Index, Series) dispatches to Series (returns a Series)
     a1, a2 = arrays_for_binary_ufunc
     if sparse:
-        a1 = pd.arrays.SparseArray(a1, dtype=pd.SparseDtype("int64", 0))
-        a2 = pd.arrays.SparseArray(a2, dtype=pd.SparseDtype("int64", 0))
+        a1 = SparseArray(a1, dtype=pd.SparseDtype("int64", 0))
+        a2 = SparseArray(a2, dtype=pd.SparseDtype("int64", 0))
 
     name = "name"  # op(Series, array) preserves the name.
     series = pd.Series(a1, name=name)
@@ -110,8 +111,8 @@ def test_binary_ufunc_with_series(
     #   with alignment between the indices
     a1, a2 = arrays_for_binary_ufunc
     if sparse:
-        a1 = pd.arrays.SparseArray(a1, dtype=pd.SparseDtype("int64", 0))
-        a2 = pd.arrays.SparseArray(a2, dtype=pd.SparseDtype("int64", 0))
+        a1 = SparseArray(a1, dtype=pd.SparseDtype("int64", 0))
+        a2 = SparseArray(a2, dtype=pd.SparseDtype("int64", 0))
 
     name = "name"  # op(Series, array) preserves the name.
     series = pd.Series(a1, name=name)
@@ -149,7 +150,7 @@ def test_binary_ufunc_scalar(ufunc, sparse, flip, arrays_for_binary_ufunc):
     #   * ufunc(Series, scalar) == ufunc(scalar, Series)
     array, _ = arrays_for_binary_ufunc
     if sparse:
-        array = pd.arrays.SparseArray(array)
+        array = SparseArray(array)
     other = 2
     series = pd.Series(array, name="name")
 
@@ -183,8 +184,8 @@ def test_multiple_ouput_binary_ufuncs(ufunc, sparse, shuffle, arrays_for_binary_
     a2[a2 == 0] = 1
 
     if sparse:
-        a1 = pd.arrays.SparseArray(a1, dtype=pd.SparseDtype("int64", 0))
-        a2 = pd.arrays.SparseArray(a2, dtype=pd.SparseDtype("int64", 0))
+        a1 = SparseArray(a1, dtype=pd.SparseDtype("int64", 0))
+        a2 = SparseArray(a2, dtype=pd.SparseDtype("int64", 0))
 
     s1 = pd.Series(a1)
     s2 = pd.Series(a2)
@@ -209,7 +210,7 @@ def test_multiple_ouput_ufunc(sparse, arrays_for_binary_ufunc):
     array, _ = arrays_for_binary_ufunc
 
     if sparse:
-        array = pd.arrays.SparseArray(array)
+        array = SparseArray(array)
 
     series = pd.Series(array, name="name")
     result = np.modf(series)


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/pull/30656#discussion_r363060184
- [x] tests added / passed
    - modified most tests that use `pd.arrays.SparseArray` to just import `SparseArray`
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
    - N/A

For @jreback to review based on his comment previous PR #30656 

In a few files (see below), left it as is because usage was pretty local (and allows `pd.arrays.SparseArray` reference to be tested in code)
```bash
$ grep -c -r arrays.SparseArray . | grep -v ":0"
./dtypes/test_generic.py:1
./frame/methods/test_quantile.py:2
./series/test_missing.py:2
```


