### PR TITLE
CLN: Condense PR style checklist into one script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
 - [ ] closes #xxxx
 - [ ] tests added / passed
-- [ ] passes `black pandas`
-- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
+- [ ] passes `./scripts/quick_style_check.sh`
 - [ ] whatsnew entry

--- a/scripts/quick_style_check.sh
+++ b/scripts/quick_style_check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+lint_files() {
+    git diff upstream/master --name-only -u -- "*.py" | xargs -r $1
+}
+
+echo "FLAKE8 check: it passes if no errors are reported"
+echo ""
+
+lint_files flake8
+
+echo ""
+echo "ISORT check: it passes if no files need to be fixed"
+echo "If fixes are made, please commit those with your changes"
+echo ""
+
+lint_files isort
+
+echo ""
+echo "BLACK check: it passes if no files need to be reformatted"
+echo "If reformats are done, please commit those with your changes"
+echo ""
+
+lint_files black


### PR DESCRIPTION
A script is easier to execute and manage as we manage our style-checking tools.

Started with `flake8`, `black`, and `isort`, as those are the main ones for Python-related changes (for reference, we didn't even have `isort` in the checklist beforehand).

If we're happy with the structure, we can always add more OR modify checks if we want going forward while keeping it easy for folks to check their PR's.