### PR TITLE
BLD: more informative error message when trying to cythonize with old cython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,12 @@ setuptools_kwargs = {
 try:
     import Cython
 
-    ver = Cython.__version__
+    _CYTHON_VERSION = Cython.__version__
     from Cython.Build import cythonize
 
-    _CYTHON_INSTALLED = ver >= LooseVersion(min_cython_ver)
+    _CYTHON_INSTALLED = _CYTHON_VERSION >= LooseVersion(min_cython_ver)
 except ImportError:
+    _CYTHON_VERSION = None
     _CYTHON_INSTALLED = False
     cythonize = lambda x, *args, **kwargs: x  # dummy func
 
@@ -506,6 +507,11 @@ def maybe_cythonize(extensions, *args, **kwargs):
 
     elif not cython:
         # GH#28836 raise a helfpul error message
+        if _CYTHON_VERSION:
+            raise RuntimeError(
+                f"Cannot cythonize with old Cython version ({_CYTHON_VERSION} "
+                f"installed, needs {min_cython_ver})"
+            )
         raise RuntimeError("Cannot cythonize without Cython installed.")
 
     numpy_incl = pkg_resources.resource_filename("numpy", "core/include")


### PR DESCRIPTION
cc @jbrockmendel building upon your https://github.com/pandas-dev/pandas/pull/30498, but making the error message more specific when cython is actually installed but too old.