### PR TITLE
ASV: use pandas.util.testing for back compat

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 import pandas as pd
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 try:
     from pandas.api.types import union_categoricals

--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DatetimeIndex, Index, MultiIndex, Series, Timestamp
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 def no_change(arr):

--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DataFrame, MultiIndex, Series, Timestamp, date_range
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 try:
     from pandas.tseries.offsets import Nano, Hour

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 
 from pandas import DataFrame, MultiIndex, NaT, Series, date_range, isnull, period_range
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 class GetNumericData:

--- a/asv_bench/benchmarks/gil.py
+++ b/asv_bench/benchmarks/gil.py
@@ -1,8 +1,8 @@
 import numpy as np
 
 from pandas import DataFrame, Series, date_range, factorize, read_csv
-import pandas._testing as tm
 from pandas.core.algorithms import take_1d
+import pandas.util.testing as tm
 
 try:
     from pandas import (

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -13,7 +13,7 @@ from pandas import (
     date_range,
     period_range,
 )
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 method_blacklist = {
     "object": {

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -12,7 +12,7 @@ from pandas import (
     Series,
     date_range,
 )
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 class SetOperations:

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -17,7 +17,7 @@ from pandas import (
     option_context,
     period_range,
 )
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 class NumericSeriesIndexing:

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DataFrame, Series, to_numeric
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 from .pandas_vb_common import lib, numeric_dtypes
 

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -5,7 +5,7 @@ import string
 import numpy as np
 
 from pandas import Categorical, DataFrame, date_range, read_csv, to_datetime
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 from ..pandas_vb_common import BaseIO
 

--- a/asv_bench/benchmarks/io/excel.py
+++ b/asv_bench/benchmarks/io/excel.py
@@ -6,7 +6,7 @@ from odf.table import Table, TableCell, TableRow
 from odf.text import P
 
 from pandas import DataFrame, ExcelWriter, date_range, read_excel
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 def _generate_dataframe():

--- a/asv_bench/benchmarks/io/hdf.py
+++ b/asv_bench/benchmarks/io/hdf.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DataFrame, HDFStore, date_range, read_hdf
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 from ..pandas_vb_common import BaseIO
 

--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DataFrame, concat, date_range, read_json, timedelta_range
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 from ..pandas_vb_common import BaseIO
 

--- a/asv_bench/benchmarks/io/pickle.py
+++ b/asv_bench/benchmarks/io/pickle.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DataFrame, date_range, read_pickle
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 from ..pandas_vb_common import BaseIO
 

--- a/asv_bench/benchmarks/io/sql.py
+++ b/asv_bench/benchmarks/io/sql.py
@@ -4,7 +4,7 @@ import numpy as np
 from sqlalchemy import create_engine
 
 from pandas import DataFrame, date_range, read_sql_query, read_sql_table
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 class SQL:

--- a/asv_bench/benchmarks/io/stata.py
+++ b/asv_bench/benchmarks/io/stata.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DataFrame, date_range, read_stata
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 from ..pandas_vb_common import BaseIO
 

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -3,7 +3,7 @@ import string
 import numpy as np
 
 from pandas import DataFrame, MultiIndex, Series, concat, date_range, merge, merge_asof
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 try:
     from pandas import merge_ordered

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -3,7 +3,7 @@ import string
 import numpy as np
 
 from pandas import DataFrame, MultiIndex, RangeIndex, date_range
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 class GetLoc:

--- a/asv_bench/benchmarks/reindex.py
+++ b/asv_bench/benchmarks/reindex.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas import DataFrame, Index, MultiIndex, Series, date_range, period_range
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 from .pandas_vb_common import lib
 

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import numpy as np
 
 from pandas import NaT, Series, date_range
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 class SeriesConstructor:

--- a/asv_bench/benchmarks/strings.py
+++ b/asv_bench/benchmarks/strings.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from pandas import DataFrame, Series
-import pandas._testing as tm
+import pandas.util.testing as tm
 
 
 class Methods:


### PR DESCRIPTION
cc @TomAugspurger I propose to keep the old deprecated imports (as long as they are not removed), so the benchmarks can still be run when eg doing a comparison of 0.25 with current master. 

