### PR TITLE
CLN: Removed outdated comment

### DIFF
--- a/pandas/tests/arrays/categorical/test_repr.py
+++ b/pandas/tests/arrays/categorical/test_repr.py
@@ -147,8 +147,6 @@ Categories (20, int64): [0 < 1 < 2 < 3 ... 16 < 17 < 18 < 19]"""
         idx = date_range("2011-01-01 09:00", freq="H", periods=5)
         c = Categorical(idx)
 
-        # TODO(wesm): exceeding 80 characters in the console is not good
-        # behavior
         exp = (
             "[2011-01-01 09:00:00, 2011-01-01 10:00:00, 2011-01-01 11:00:00, "
             "2011-01-01 12:00:00, 2011-01-01 13:00:00]\n"


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I think this is a bit outdated, since we are using black and it's doing the work for us, right?

according to git blame, this is 2 years old.