### PR TITLE
BUG: DTI/TDI/PI `where` accepting non-matching dtypes

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -373,7 +373,7 @@ default 'raise'
             naive = self.tz_localize(None)
             result = naive._round(freq, mode, ambiguous, nonexistent)
             aware = result.tz_localize(
-                self.tz, mode=mode, ambiguous=ambiguous, nonexistent=nonexistent
+                self.tz, ambiguous=ambiguous, nonexistent=nonexistent
             )
             return aware
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -34,7 +34,7 @@ from pandas.core.dtypes.common import (
     is_unsigned_integer_dtype,
     pandas_dtype,
 )
-from pandas.core.dtypes.generic import ABCIndexClass, ABCPeriodArray, ABCSeries
+from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.dtypes.inference import is_array_like
 from pandas.core.dtypes.missing import is_valid_nat_for_dtype, isna
 
@@ -368,16 +368,19 @@ default 'raise'
 
     def _round(self, freq, mode, ambiguous, nonexistent):
         # round the local times
-        values = _ensure_datetimelike_to_i8(self)
+        if is_datetime64tz_dtype(self):
+            # operate on naive timestamps, then convert back to aware
+            naive = self.tz_localize(None)
+            result = naive._round(freq, mode, ambiguous, nonexistent)
+            aware = result.tz_localize(
+                self.tz, mode=mode, ambiguous=ambiguous, nonexistent=nonexistent
+            )
+            return aware
+
+        values = self.view("i8")
         result = round_nsint64(values, mode, freq)
         result = self._maybe_mask_results(result, fill_value=NaT)
-
-        dtype = self.dtype
-        if is_datetime64tz_dtype(self):
-            dtype = None
-        return self._ensure_localized(
-            self._simple_new(result, dtype=dtype), ambiguous, nonexistent
-        )
+        return self._simple_new(result, dtype=self.dtype)
 
     @Appender((_round_doc + _round_example).format(op="round"))
     def round(self, freq, ambiguous="raise", nonexistent="raise"):
@@ -1687,38 +1690,3 @@ def maybe_infer_freq(freq):
             freq_infer = True
             freq = None
     return freq, freq_infer
-
-
-def _ensure_datetimelike_to_i8(other, to_utc=False):
-    """
-    Helper for coercing an input scalar or array to i8.
-
-    Parameters
-    ----------
-    other : 1d array
-    to_utc : bool, default False
-        If True, convert the values to UTC before extracting the i8 values
-        If False, extract the i8 values directly.
-
-    Returns
-    -------
-    i8 1d array
-    """
-    from pandas import Index
-
-    if lib.is_scalar(other) and isna(other):
-        return iNaT
-    elif isinstance(other, (ABCPeriodArray, ABCIndexClass, DatetimeLikeArrayMixin)):
-        # convert tz if needed
-        if getattr(other, "tz", None) is not None:
-            if to_utc:
-                other = other.tz_convert("UTC")
-            else:
-                other = other.tz_localize(None)
-    else:
-        try:
-            return np.array(other, copy=False).view("i8")
-        except TypeError:
-            # period array cannot be coerced to int
-            other = Index(other)
-    return other.asi8

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1415,45 +1415,6 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
         return self
 
     # --------------------------------------------------------------
-    # Comparison Methods
-
-    def _ensure_localized(
-        self, arg, ambiguous="raise", nonexistent="raise", from_utc=False
-    ):
-        """
-        Ensure that we are re-localized.
-
-        This is for compat as we can then call this on all datetimelike
-        arrays generally (ignored for Period/Timedelta)
-
-        Parameters
-        ----------
-        arg : Union[DatetimeLikeArray, DatetimeIndexOpsMixin, ndarray]
-        ambiguous : str, bool, or bool-ndarray, default 'raise'
-        nonexistent : str, default 'raise'
-        from_utc : bool, default False
-            If True, localize the i8 ndarray to UTC first before converting to
-            the appropriate tz. If False, localize directly to the tz.
-
-        Returns
-        -------
-        localized array
-        """
-
-        # reconvert to local tz
-        tz = getattr(self, "tz", None)
-        if tz is not None:
-            if not isinstance(arg, type(self)):
-                arg = self._simple_new(arg)
-            if from_utc:
-                arg = arg.tz_localize("UTC").tz_convert(self.tz)
-            else:
-                arg = arg.tz_localize(
-                    self.tz, ambiguous=ambiguous, nonexistent=nonexistent
-                )
-        return arg
-
-    # --------------------------------------------------------------
     # Reductions
 
     def _reduce(self, name, axis=0, skipna=True, **kwargs):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -494,9 +494,9 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
 
         if is_categorical_dtype(other):
             if needs_i8_conversion(other.categories):
-                other._internal_get_values()
+                getattr(other, "_data", other)._internal_get_values()
                 assert needs_i8_conversion(other), other.categories.dtype
-                raise TypeError(other.dtype)
+                #raise TypeError(other.dtype)
             else:
                 raise TypeError(other.dtype)
         if not needs_i8_conversion(other):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -499,6 +499,11 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
                 #raise TypeError(other.dtype)
             else:
                 raise TypeError(other.dtype)
+        if is_object_dtype(other):
+            # Try to do inference, e.g. we passed PeriodIndex.values and got
+            #  an ndarray of Periods
+            other = pd.Index(np.asarray(other))
+
         if not is_scalar(other) and not needs_i8_conversion(other):
             # Primarily we want self.dtype, but could also be Categorical
             #  holding self.dtype

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -528,6 +528,8 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
         elif is_float(other) and np.isnan(other):
             other = NaT.value
         else:
+            # We test for error message coming from the Index constructor
+            Index(other)
             raise TypeError(other)
 
         result = np.where(cond, values, other).astype("i8")

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -503,7 +503,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
         if is_object_dtype(other):
             # Try to do inference, e.g. we passed PeriodIndex.values and got
             #  an ndarray of Periods
-            other = pd.Index(np.asarray(other))
+            other = Index(np.asarray(other))
 
         if not is_scalar(other) and not needs_i8_conversion(other):
             # Primarily we want self.dtype, but could also be Categorical

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -513,6 +513,10 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
             if cond.all():
                 # Then it doesnt matter what other is, so go with it
                 other = NaT.value
+            else:
+                raise TypeError(other)
+        else:
+            raise TypeError(other)
 
         result = np.where(cond, values, other).astype("i8")
         return self._shallow_copy(result)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -501,19 +501,14 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
             # e.g. we passed PeriodIndex.values and got an ndarray of Periods
             other = Index(other)
 
-        if is_categorical_dtype(other):
-            # e.g. we have a Categorical holding self.dtype
-            if needs_i8_conversion(other.categories):
-                other = other._internal_get_values()
+            if is_categorical_dtype(other):
+                # e.g. we have a Categorical holding self.dtype
+                if needs_i8_conversion(other.categories):
+                    other = other._internal_get_values()
 
-        if not is_scalar(other) and not is_dtype_equal(self.dtype, other.dtype):
-            # Primarily we want self.dtype, but could also be Categorical
-            #  holding self.dtype
-            raise TypeError(f"Where requires matching dtype, not {other.dtype}")
+            if not is_dtype_equal(self.dtype, other.dtype):
+                raise TypeError(f"Where requires matching dtype, not {other.dtype}")
 
-        if not is_scalar(other):
-            #other = type(self._data)._from_sequence(other)
-            # TODO: require dtype match
             other = other.view("i8")
 
         result = np.where(cond, values, other).astype("i8")

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -493,9 +493,13 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
     def where(self, cond, other=None):
         values = self.view("i8")
 
-        # Do type inference if necessary up front
-        # e.g. we passed PeriodIndex.values and got an ndarray of Periods
-        other = Index(other)
+        if is_scalar(other) and isna(other):
+            other = NaT.value
+
+        else:
+            # Do type inference if necessary up front
+            # e.g. we passed PeriodIndex.values and got an ndarray of Periods
+            other = Index(other)
 
         if is_categorical_dtype(other):
             # e.g. we have a Categorical holding self.dtype
@@ -512,22 +516,22 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
             other = type(self._data)._from_sequence(other)
             # TODO: require dtype match
             other = other.view("i8")
-        elif other is None:
-            if not hasattr(cond, "all"):
-                other = NaT.value
-            elif cond.all():
-                # Then it doesnt matter what other is, so go with it
-                other = NaT.value
-            else:
-                # 7 tests
-                other = NaT.value
-                #raise TypeError(other)
-        elif is_float(other) and np.isnan(other):
-            other = NaT.value
-        else:
-            # We test for error message coming from the Index constructor
-            Index(other)
-            raise TypeError(other)
+        #elif other is None:
+        #    if not hasattr(cond, "all"):
+        #        other = NaT.value
+        #    elif cond.all():
+        #        # Then it doesnt matter what other is, so go with it
+        #        other = NaT.value
+        #    else:
+        #        # 7 tests
+        #        other = NaT.value
+        #        #raise TypeError(other)
+        #elif is_float(other) and np.isnan(other):
+        #    other = NaT.value
+        #else:
+        #    # We test for error message coming from the Index constructor
+        #    Index(other)
+        #    raise TypeError(other)
 
         result = np.where(cond, values, other).astype("i8")
         return self._shallow_copy(result)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -499,15 +499,16 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
                 #raise TypeError(other.dtype)
             else:
                 raise TypeError(other.dtype)
-        if not needs_i8_conversion(other):
+        if not is_scalar(other) and not needs_i8_conversion(other):
             # Primarily we want self.dtype, but could also be Categorical
             #  holding self.dtype
             odtype = getattr(other, "dtype", None)
             raise TypeError(f"Where requires matching dtype, not {odtype}", type(other))
 
-        other = type(self._data)._from_sequence(other)
-        # TODO: require dtype match
-        other = other.view("i8")
+        if not is_scalar(other):
+            other = type(self._data)._from_sequence(other)
+            # TODO: require dtype match
+            other = other.view("i8")
 
         result = np.where(cond, values, other).astype("i8")
         return self._shallow_copy(result)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -495,7 +495,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
         if is_categorical_dtype(other):
             if needs_i8_conversion(other.categories):
                 other = other._internal_get_values()
-                assert needs_i8_conversion
+                assert needs_i8_conversion(other)
                 #raise TypeError(other.dtype)
             else:
                 raise TypeError(other.dtype)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -519,6 +519,8 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
                 # 7 tests
                 other = NaT.value
                 #raise TypeError(other)
+        elif is_scalar(other) and np.isnan(other):
+            other = NaT.value
         else:
             raise TypeError(other)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -503,7 +503,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
             # Primarily we want self.dtype, but could also be Categorical
             #  holding self.dtype
             odtype = getattr(other, "dtype", None)
-            raise TypeError(f"Where requires matching dtype, not {odtype}")
+            raise TypeError(f"Where requires matching dtype, not {odtype}", type(other))
 
         other = type(self._data)._from_sequence(other)
         # TODO: require dtype match

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -495,7 +495,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
         if is_categorical_dtype(other):
             if needs_i8_conversion(other.categories):
                 other._internal_get_values()
-                assert needs_i8_conversion(other), other.dtype
+                assert needs_i8_conversion(other), other.categories.dtype
                 raise TypeError(other.dtype)
             else:
                 raise TypeError(other.dtype)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -495,6 +495,8 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
         if is_categorical_dtype(other):
             if needs_i8_conversion(other.categories):
                 other._internal_get_values()
+            else:
+                raise TypeError(other.dtype)
         if not needs_i8_conversion(other):
             # Primarily we want self.dtype, but could also be Categorical
             #  holding self.dtype

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -510,10 +510,13 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
             # TODO: require dtype match
             other = other.view("i8")
         elif other is None:
-            if cond.all():
+            if not hasattr(cond, "all"):
+                other = NaT.value
+            elif cond.all():
                 # Then it doesnt matter what other is, so go with it
                 other = NaT.value
             else:
+                # 7 tests
                 other = NaT.value
                 #raise TypeError(other)
         else:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -19,6 +19,7 @@ from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_dtype_equal,
     is_float,
+    is_object_dtype,
     is_integer,
     is_list_like,
     is_period_dtype,

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -495,6 +495,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
         if is_categorical_dtype(other):
             if needs_i8_conversion(other.categories):
                 other._internal_get_values()
+                assert needs_i8_conversion(other), other.dtype
                 raise TypeError(other.dtype)
             else:
                 raise TypeError(other.dtype)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -21,7 +21,6 @@ from pandas.core.dtypes.common import (
     is_float,
     is_integer,
     is_list_like,
-    is_object_dtype,
     is_period_dtype,
     is_scalar,
     needs_i8_conversion,
@@ -507,32 +506,15 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
             if needs_i8_conversion(other.categories):
                 other = other._internal_get_values()
 
-        if not is_scalar(other) and not needs_i8_conversion(other):
+        if not is_scalar(other) and not is_dtype_equal(self.dtype, other.dtype):
             # Primarily we want self.dtype, but could also be Categorical
             #  holding self.dtype
-            odtype = getattr(other, "dtype", None)
-            raise TypeError(f"Where requires matching dtype, not {odtype}", type(other))
+            raise TypeError(f"Where requires matching dtype, not {other.dtype}")
 
         if not is_scalar(other):
-            other = type(self._data)._from_sequence(other)
+            #other = type(self._data)._from_sequence(other)
             # TODO: require dtype match
             other = other.view("i8")
-        #elif other is None:
-        #    if not hasattr(cond, "all"):
-        #        other = NaT.value
-        #    elif cond.all():
-        #        # Then it doesnt matter what other is, so go with it
-        #        other = NaT.value
-        #    else:
-        #        # 7 tests
-        #        other = NaT.value
-        #        #raise TypeError(other)
-        #elif is_float(other) and np.isnan(other):
-        #    other = NaT.value
-        #else:
-        #    # We test for error message coming from the Index constructor
-        #    Index(other)
-        #    raise TypeError(other)
 
         result = np.where(cond, values, other).astype("i8")
         return self._shallow_copy(result)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -177,18 +177,6 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
 
         return np.array_equal(self.asi8, other.asi8)
 
-    def _ensure_localized(
-        self, arg, ambiguous="raise", nonexistent="raise", from_utc=False
-    ):
-        # See DatetimeLikeArrayMixin._ensure_localized.__doc__
-        if getattr(self, "tz", None):
-            # ensure_localized is only relevant for tz-aware DTI
-            result = self._data._ensure_localized(
-                arg, ambiguous=ambiguous, nonexistent=nonexistent, from_utc=from_utc
-            )
-            return type(self)._simple_new(result, name=self.name)
-        return arg
-
     @Appender(_index_shared_docs["contains"] % _index_doc_kwargs)
     def __contains__(self, key):
         try:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -19,15 +19,16 @@ from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_dtype_equal,
     is_float,
-    is_object_dtype,
     is_integer,
     is_list_like,
+    is_object_dtype,
     is_period_dtype,
     is_scalar,
     needs_i8_conversion,
 )
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.generic import ABCIndex, ABCIndexClass, ABCSeries
+from pandas.core.dtypes.missing import isna
 
 from pandas.core import algorithms
 from pandas.core.accessor import PandasDelegate

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -493,17 +493,14 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
     def where(self, cond, other=None):
         values = self.view("i8")
 
+        # Do type inference if necessary up front
+        # e.g. we passed PeriodIndex.values and got an ndarray of Periods
+        other = Index(other)
+
         if is_categorical_dtype(other):
+            # e.g. we have a Categorical holding self.dtype
             if needs_i8_conversion(other.categories):
                 other = other._internal_get_values()
-                assert needs_i8_conversion(other)
-                #raise TypeError(other.dtype)
-            else:
-                raise TypeError(other.dtype)
-        if is_object_dtype(other):
-            # Try to do inference, e.g. we passed PeriodIndex.values and got
-            #  an ndarray of Periods
-            other = Index(np.asarray(other))
 
         if not is_scalar(other) and not needs_i8_conversion(other):
             # Primarily we want self.dtype, but could also be Categorical

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -514,7 +514,8 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
                 # Then it doesnt matter what other is, so go with it
                 other = NaT.value
             else:
-                raise TypeError(other)
+                other = NaT.value
+                #raise TypeError(other)
         else:
             raise TypeError(other)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -525,7 +525,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
                 # 7 tests
                 other = NaT.value
                 #raise TypeError(other)
-        elif is_scalar(other) and np.isnan(other):
+        elif is_float(other) and np.isnan(other):
             other = NaT.value
         else:
             raise TypeError(other)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -16,6 +16,7 @@ from pandas.util._decorators import Appender, cache_readonly
 from pandas.core.dtypes.common import (
     ensure_int64,
     is_bool_dtype,
+    is_categorical_dtype,
     is_dtype_equal,
     is_float,
     is_integer,
@@ -490,6 +491,10 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
     @Appender(_index_shared_docs["where"] % _index_doc_kwargs)
     def where(self, cond, other=None):
         values = self.view("i8")
+
+        if is_categorical_dtype(other):
+            if needs_i8_conversion(other.categories):
+                other._internal_get_values()
         if not needs_i8_conversion(other):
             # Primarily we want self.dtype, but could also be Categorical
             #  holding self.dtype

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -494,8 +494,8 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
 
         if is_categorical_dtype(other):
             if needs_i8_conversion(other.categories):
-                getattr(other, "_data", other)._internal_get_values()
-                assert needs_i8_conversion(other), other.categories.dtype
+                other = other._internal_get_values()
+                assert needs_i8_conversion
                 #raise TypeError(other.dtype)
             else:
                 raise TypeError(other.dtype)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -495,6 +495,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
         if is_categorical_dtype(other):
             if needs_i8_conversion(other.categories):
                 other._internal_get_values()
+                raise TypeError(other.dtype)
             else:
                 raise TypeError(other.dtype)
         if not needs_i8_conversion(other):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -509,6 +509,10 @@ class DatetimeIndexOpsMixin(ExtensionIndex, ExtensionOpsMixin):
             other = type(self._data)._from_sequence(other)
             # TODO: require dtype match
             other = other.view("i8")
+        elif other is None:
+            if cond.all():
+                # Then it doesnt matter what other is, so go with it
+                other = NaT.value
 
         result = np.where(cond, values, other).astype("i8")
         return self._shallow_copy(result)

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -135,6 +135,20 @@ class TestWhere:
         result = i.where(notna(i2), i2._values)
         tm.assert_index_equal(result, i2)
 
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            # passing tz-naive ndarray to tzaware DTI
+            i.where(notna(i2), i2.values)
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            # passing tz-aware DTI to tznaive DTI
+            i.tz_localize(None).where(notna(i2), i2)
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            i.where(notna(i2), i2.to_period("D"))
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            i.where(notna(i2), i2.asi8.view("timedelta64[ns]")
+
     def test_where_tz(self):
         i = pd.date_range("20130101", periods=3, tz="US/Eastern")
         result = i.where(notna(i))

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -147,7 +147,7 @@ class TestWhere:
             i.where(notna(i2), i2.to_period("D"))
 
         with pytest.raises(TypeError, match="Where requires matching dtype"):
-            i.where(notna(i2), i2.asi8.view("timedelta64[ns]")
+            i.where(notna(i2), i2.asi8.view("timedelta64[ns]"))
 
     def test_where_tz(self):
         i = pd.date_range("20130101", periods=3, tz="US/Eastern")

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -132,7 +132,7 @@ class TestWhere:
 
         i2 = i.copy()
         i2 = Index([pd.NaT, pd.NaT] + i[2:].tolist())
-        result = i.where(notna(i2), i2.values)
+        result = i.where(notna(i2), i2._values)
         tm.assert_index_equal(result, i2)
 
     def test_where_tz(self):

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -135,19 +135,28 @@ class TestWhere:
         result = i.where(notna(i2), i2._values)
         tm.assert_index_equal(result, i2)
 
+    def test_where_invalid_dtypes(self):
+        dti = pd.date_range("20130101", periods=3, tz="US/Eastern")
+
+        i2 = dti.copy()
+        i2 = Index([pd.NaT, pd.NaT] + dti[2:].tolist())
+
         with pytest.raises(TypeError, match="Where requires matching dtype"):
             # passing tz-naive ndarray to tzaware DTI
-            i.where(notna(i2), i2.values)
+            dti.where(notna(i2), i2.values)
 
         with pytest.raises(TypeError, match="Where requires matching dtype"):
             # passing tz-aware DTI to tznaive DTI
-            i.tz_localize(None).where(notna(i2), i2)
+            dti.tz_localize(None).where(notna(i2), i2)
 
         with pytest.raises(TypeError, match="Where requires matching dtype"):
-            i.where(notna(i2), i2.to_period("D"))
+            dti.where(notna(i2), i2.tz_localize(None).to_period("D"))
 
         with pytest.raises(TypeError, match="Where requires matching dtype"):
-            i.where(notna(i2), i2.asi8.view("timedelta64[ns]"))
+            dti.where(notna(i2), i2.asi8.view("timedelta64[ns]"))
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            dti.where(notna(i2), i2.asi8)
 
     def test_where_tz(self):
         i = pd.date_range("20130101", periods=3, tz="US/Eastern")

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -235,6 +235,21 @@ class TestWhere:
         result = i.where(notna(i2), i2.values)
         tm.assert_index_equal(result, i2)
 
+    def test_where_invalid_dtypes(self):
+        pi = period_range("20130101", periods=5, freq="D")
+
+        i2 = pi.copy()
+        i2 = pd.PeriodIndex([pd.NaT, pd.NaT] + pi[2:].tolist(), freq="D")
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            pi.where(notna(i2), i2.asi8)
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            pi.where(notna(i2), i2.asi8.view("timedelta64[ns]"))
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            pi.where(notna(i2), i2.to_timestamp("S"))
+
 
 class TestTake:
     def test_take(self):

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import Index, Timedelta, TimedeltaIndex, timedelta_range, notna
+from pandas import Index, Timedelta, TimedeltaIndex, notna, timedelta_range
 import pandas._testing as tm
 
 
@@ -58,7 +58,6 @@ class TestGetItem:
 
 
 class TestWhere:
-
     def test_where_invalid_dtypes(self):
         tdi = timedelta_range("1 day", periods=3, freq="D", name="idx")
 

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas import Index, Timedelta, TimedeltaIndex, timedelta_range
+from pandas import Index, Timedelta, TimedeltaIndex, timedelta_range, notna
 import pandas._testing as tm
 
 
@@ -58,8 +58,21 @@ class TestGetItem:
 
 
 class TestWhere:
-    # placeholder for symmetry with DatetimeIndex and PeriodIndex tests
-    pass
+
+    def test_where_invalid_dtypes(self):
+        tdi = timedelta_range("1 day", periods=3, freq="D", name="idx")
+
+        i2 = tdi.copy()
+        i2 = Index([pd.NaT, pd.NaT] + tdi[2:].tolist())
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            tdi.where(notna(i2), i2.asi8)
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            tdi.where(notna(i2), i2 + pd.Timestamp.now())
+
+        with pytest.raises(TypeError, match="Where requires matching dtype"):
+            tdi.where(notna(i2), (i2 + pd.Timestamp.now()).to_period("D"))
 
 
 class TestTake:


### PR DESCRIPTION
This bug was hidden by _ensure_datetimelike_to_i8, and the only other place where that is used is in _round.  _round is clearer without using it, so ensure_datetimelike_to_i8 gets ripped out, and with it we can get rid of _ensure_localized.