### PR TITLE
IntegerArray.to_numpy

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -387,7 +387,36 @@ As a reminder, you can specify the ``dtype`` to disable all inference.
 .. ipython:: python
 
    a = pd.array([1, 2, None], dtype="Int64")
+   a
    a[2]
+
+This has a few API-breaking consequences.
+
+**Converting to a NumPy ndarray**
+
+When converting to a NumPy array missing values will be ``pd.NA``, which cannot
+be converted to a float. So calling ``np.asarray(integer_array, dtype="float")``
+will now raise.
+
+*pandas 0.25.x*
+
+.. code-block:: python
+
+    >>> np.asarray(a, dtype="float")
+    array([ 1.,  2., nan])
+
+*pandas 1.0.0*
+
+.. ipython:: python
+   :okexcept:
+
+   np.asarray(a, dtype="float")
+
+Use :meth:`arrays.IntegerArray.to_numpy` with an explicit ``na_value`` instead.
+
+.. ipython:: python
+
+   a.to_numpy(dtype="float", na_value=np.nan)
 
 See :ref:`missing_data.NA` for more on the differences between :attr:`pandas.NA`
 and :attr:`numpy.nan`.

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -19,7 +19,9 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_list_like,
     is_numeric_dtype,
+    is_object_dtype,
     is_scalar,
+    is_string_dtype,
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import register_extension_dtype
@@ -382,9 +384,14 @@ class BooleanArray(ExtensionArray, ExtensionOpsMixin):
         if dtype is None:
             dtype = object
         if self._hasna:
-            if is_bool_dtype(dtype) and na_value is libmissing.NA:
+            if (
+                not (is_object_dtype(dtype) or is_string_dtype(dtype))
+                and na_value is libmissing.NA
+            ):
                 raise ValueError(
-                    "cannot convert to bool numpy array in presence of missing values"
+                    f"cannot convert to '{dtype}'-dtype NumPy array "
+                    "with missing values. Specify an appropriate 'na_value' "
+                    "for this dtype."
                 )
             # don't pass copy to astype -> always need a copy since we are mutating
             data = self._data.astype(dtype)

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -171,6 +171,8 @@ def ensure_int_or_float(arr: ArrayLike, copy: bool = False) -> np.array:
     try:
         return arr.astype("uint64", copy=copy, casting="safe")  # type: ignore
     except TypeError:
+        if is_extension_array_dtype(arr.dtype):
+            return arr.to_numpy(dtype="float64", na_value=np.nan)
         return arr.astype("float64", copy=copy)
 
 

--- a/pandas/tests/arrays/test_boolean.py
+++ b/pandas/tests/arrays/test_boolean.py
@@ -265,6 +265,11 @@ def test_to_numpy(box):
     expected = np.array([True, False, pd.NA], dtype="object")
     tm.assert_numpy_array_equal(result, expected)
 
+    arr = con([True, False, None], dtype="boolean")
+    result = arr.to_numpy(dtype="str")
+    expected = np.array([True, False, pd.NA], dtype="<U5")
+    tm.assert_numpy_array_equal(result, expected)
+
     # no missing values -> can convert to bool, otherwise raises
     arr = con([True, False, True], dtype="boolean")
     result = arr.to_numpy(dtype="bool")
@@ -272,7 +277,7 @@ def test_to_numpy(box):
     tm.assert_numpy_array_equal(result, expected)
 
     arr = con([True, False, None], dtype="boolean")
-    with pytest.raises(ValueError, match="cannot convert to bool numpy"):
+    with pytest.raises(ValueError, match="cannot convert to 'bool'-dtype"):
         result = arr.to_numpy(dtype="bool")
 
     # specify dtype and na_value
@@ -294,9 +299,9 @@ def test_to_numpy(box):
     tm.assert_numpy_array_equal(result, expected)
 
     # converting to int or float without specifying na_value raises
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError, match="cannot convert to 'int64'-dtype"):
         arr.to_numpy(dtype="int64")
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError, match="cannot convert to 'float64'-dtype"):
         arr.to_numpy(dtype="float64")
 
 
@@ -327,6 +332,10 @@ def test_astype():
 
     result = arr.astype("float64")
     expected = np.array([1, 0, np.nan], dtype="float64")
+    tm.assert_numpy_array_equal(result, expected)
+
+    result = arr.astype("str")
+    expected = np.array(["True", "False", "NA"], dtype="object")
     tm.assert_numpy_array_equal(result, expected)
 
     # no missing values


### PR DESCRIPTION
This implements IntegerArray.to_numpy with similar semantics to BooleanArray.to_numpy. The implementation is now identical between BooleanArray & IntegerArray. #30789 will merge them.

1. `.to_numpy(dtype=float/bool/int)` will raise if there are missing values
2. `.astype(float)` will convert NA to NaN.

I've made a slight change from the BooleanArray implementation on master, which I'll annotate inline.

Closes https://github.com/pandas-dev/pandas/issues/30038