### PR TITLE
REF: remove PeriodIndex._coerce_scalar_to_index

### DIFF
--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -391,16 +391,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
     # ------------------------------------------------------------------------
     # Index Methods
 
-    def _coerce_scalar_to_index(self, item):
-        """
-        we need to coerce a scalar to a compat for our index type
-
-        Parameters
-        ----------
-        item : scalar item to coerce
-        """
-        return PeriodIndex([item], **self._get_attributes_dict())
-
     def __array__(self, dtype=None):
         if is_integer_dtype(dtype):
             return self.asi8


### PR DESCRIPTION
It is only used by Index.insert, but PeriodIndex now overrides insert.