### PR TITLE
CI: Fix spelling in requirements-dev generator script

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # This file is auto-generated from environment.yml, do not modify.
-# See that file for comments about the need/usage of each depdendency.
+# See that file for comments about the need/usage of each dependency.
 
 numpy>=1.15
 python-dateutil>=2.6.1

--- a/scripts/generate_pip_deps_from_conda.py
+++ b/scripts/generate_pip_deps_from_conda.py
@@ -92,7 +92,7 @@ def main(conda_fname, pip_fname, compare=False):
     fname = os.path.split(conda_fname)[1]
     header = (
         f"# This file is auto-generated from {fname}, do not modify.\n"
-        "# See that file for comments about the need/usage of each depdendency.\n\n"
+        "# See that file for comments about the need/usage of each dependency.\n\n"
     )
     pip_content = header + "\n".join(pip_deps)
 


### PR DESCRIPTION
Fixes the spelling of _dependency_ in `script/generate_pip_deps_from_conda.py`.

This script creates `requirements-dev.txt` which contains the spelling mistake, so is also fixed (using the updated script).