### PR TITLE
Multi Phase JSON Initialization

### DIFF
--- a/pandas/_libs/src/ujson/python/ujson.c
+++ b/pandas/_libs/src/ujson/python/ujson.c
@@ -65,35 +65,15 @@ static PyMethodDef ujsonMethods[] = {
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_libjson",
-    0,            /* m_doc */
-    -1,           /* m_size */
-    ujsonMethods, /* m_methods */
-    NULL,         /* m_reload */
-    NULL,         /* m_traverse */
-    NULL,         /* m_clear */
-    NULL          /* m_free */
+static PyModuleDef moduledef = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_libjson",
+    .m_methods = ujsonMethods
 };
 
-#define PYMODINITFUNC PyMODINIT_FUNC PyInit_json(void)
-#define PYMODULE_CREATE() PyModule_Create(&moduledef)
-#define MODINITERROR return NULL
 
-PYMODINITFUNC {
-    PyObject *module;
-    PyObject *version_string;
+PyMODINIT_FUNC PyInit_json(void) {
+  initObjToJSON();  // TODO: clean up, maybe via tp_free?
+  return PyModuleDef_Init(&moduledef);
 
-    initObjToJSON();
-    module = PYMODULE_CREATE();
-
-    if (module == NULL) {
-        MODINITERROR;
-    }
-
-    version_string = PyUnicode_FromString(UJSON_VERSION);
-    PyModule_AddObject(module, "__version__", version_string);
-
-    return module;
 }

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -559,11 +559,6 @@ class TestUltraJSONTests:
         with pytest.raises(TypeError, match=msg):
             ujson.loads(None)
 
-    def test_version(self):
-        assert re.match(
-            r"^\d+\.\d+(\.\d+)?$", ujson.__version__
-        ), "ujson.__version__ must be a string like '1.4.0'"
-
     def test_encode_numeric_overflow(self):
         with pytest.raises(OverflowError):
             ujson.encode(12839128391289382193812939)


### PR DESCRIPTION
Feature in Python 3.5 that should simplify instantiation of the JSON module and make it more "pythonic"

https://docs.python.org/3/c-api/module.html?highlight=multi%20phase#multi-phase-initialization
https://www.python.org/dev/peps/pep-0489/

Also removed a version string from within the extension, as I don't see where that is useful
