### PR TITLE
REF: use shareable code for DTI/TDI.insert

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -872,6 +872,7 @@ Datetimelike
 - Bug in :func:`pandas.to_datetime` when called with ``Series`` storing ``IntegerArray`` raising ``TypeError`` instead of returning ``Series`` (:issue:`30050`)
 - Bug in :func:`date_range` with custom business hours as ``freq`` and given number of ``periods`` (:issue:`30593`)
 - Bug in :class:`PeriodIndex` comparisons with incorrectly casting integers to :class:`Period` objects, inconsistent with the :class:`Period` comparison behavior (:issue:`30722`)
+- Bug in :meth:`DatetimeIndex.insert` raising a ``ValueError`` instead of a ``TypeError`` when trying to insert a timezone-aware :class:`Timestamp` into a timezone-naive :class:`DatetimeIndex`, or vice-versa (:issue:`30806`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -922,7 +922,9 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
         -------
         new_index : Index
         """
-        if is_valid_nat_for_dtype(item, self.dtype):
+        if isinstance(item, self._data._recognized_scalars):
+            item = self._data._scalar_type(item)
+        elif is_valid_nat_for_dtype(item, self.dtype):
             # GH 18295
             item = self._na_value
         elif is_scalar(item) and isna(item):
@@ -932,11 +934,8 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
             )
 
         freq = None
-
-        if isinstance(item, (datetime, np.datetime64)):
-            self._assert_can_do_op(item)
-            if not self._has_same_tz(item) and not isna(item):
-                raise ValueError("Passed item and index have different timezone")
+        if isinstance(item, self._data._scalar_type) or item is NaT:
+            self._data._check_compatible_with(item, setitem=True)
 
             # check freq can be preserved on edge cases
             if self.size and self.freq is not None:
@@ -946,19 +945,19 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
                     freq = self.freq
                 elif (loc == len(self)) and item - self.freq == self[-1]:
                     freq = self.freq
-            item = _to_M8(item, tz=self.tz)
+            item = item.asm8
 
         try:
-            new_dates = np.concatenate(
+            new_i8s = np.concatenate(
                 (self[:loc].asi8, [item.view(np.int64)], self[loc:].asi8)
             )
-            return self._shallow_copy(new_dates, freq=freq)
+            return self._shallow_copy(new_i8s, freq=freq)
         except (AttributeError, TypeError):
 
             # fall back to object index
             if isinstance(item, str):
                 return self.astype(object).insert(loc, item)
-            raise TypeError("cannot insert DatetimeIndex with incompatible label")
+            raise TypeError(f"cannot insert {type(self).__name__} with incompatible label")
 
     def indexer_at_time(self, time, asof=False):
         """

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -957,7 +957,9 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
             # fall back to object index
             if isinstance(item, str):
                 return self.astype(object).insert(loc, item)
-            raise TypeError(f"cannot insert {type(self).__name__} with incompatible label")
+            raise TypeError(
+                f"cannot insert {type(self).__name__} with incompatible label"
+            )
 
     def indexer_at_time(self, time, asof=False):
         """

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -398,7 +398,7 @@ class TimedeltaIndex(
         """
         # try to convert if possible
         if isinstance(item, self._data._recognized_scalars):
-            item = Timedelta(item)
+            item = self._data._scalar_type(item)
         elif is_valid_nat_for_dtype(item, self.dtype):
             # GH 18295
             item = self._na_value
@@ -409,28 +409,30 @@ class TimedeltaIndex(
             )
 
         freq = None
-        if isinstance(item, Timedelta) or (is_scalar(item) and isna(item)):
+        if isinstance(item, self._data._scalar_type) or item is NaT:
+            self._data._check_compatible_with(item, setitem=True)
 
             # check freq can be preserved on edge cases
-            if self.freq is not None:
-                if (loc == 0 or loc == -len(self)) and item + self.freq == self[0]:
+            if self.size and self.freq is not None:
+                if item is NaT:
+                    pass
+                elif (loc == 0 or loc == -len(self)) and item + self.freq == self[0]:
                     freq = self.freq
                 elif (loc == len(self)) and item - self.freq == self[-1]:
                     freq = self.freq
-            item = Timedelta(item).asm8.view(_TD_DTYPE)
+            item = item.asm8
 
         try:
-            new_tds = np.concatenate(
+            new_i8s = np.concatenate(
                 (self[:loc].asi8, [item.view(np.int64)], self[loc:].asi8)
             )
-            return self._shallow_copy(new_tds, freq=freq)
-
+            return self._shallow_copy(new_i8s, freq=freq)
         except (AttributeError, TypeError):
 
             # fall back to object index
             if isinstance(item, str):
                 return self.astype(object).insert(loc, item)
-            raise TypeError("cannot insert TimedeltaIndex with incompatible label")
+            raise TypeError(f"cannot insert {type(self).__name__} with incompatible label")
 
 
 TimedeltaIndex._add_comparison_ops()

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -432,7 +432,9 @@ class TimedeltaIndex(
             # fall back to object index
             if isinstance(item, str):
                 return self.astype(object).insert(loc, item)
-            raise TypeError(f"cannot insert {type(self).__name__} with incompatible label")
+            raise TypeError(
+                f"cannot insert {type(self).__name__} with incompatible label"
+            )
 
 
 TimedeltaIndex._add_comparison_ops()

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -27,7 +27,6 @@ from pandas import (
     date_range,
 )
 import pandas._testing as tm
-from pandas.core.indexes.datetimes import _to_M8
 from pandas.core.ops import roperator
 from pandas.tests.arithmetic.common import (
     assert_invalid_addsub_type,
@@ -341,7 +340,7 @@ class TestDatetimeIndexComparisons:
     def test_comparators(self, op):
         index = tm.makeDateIndex(100)
         element = index[len(index) // 2]
-        element = _to_M8(element)
+        element = Timestamp(element).to_datetime64()
 
         arr = np.array(index)
         arr_result = op(arr, element)

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -434,9 +434,9 @@ class TestDatetimeIndex:
 
         # see gh-7299
         idx = date_range("1/1/2000", periods=3, freq="D", tz="Asia/Tokyo", name="idx")
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="Cannot compare tz-naive and tz-aware"):
             idx.insert(3, pd.Timestamp("2000-01-04"))
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="Cannot compare tz-naive and tz-aware"):
             idx.insert(3, datetime(2000, 1, 4))
         with pytest.raises(ValueError):
             idx.insert(3, pd.Timestamp("2000-01-04", tz="US/Eastern"))

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -432,13 +432,19 @@ class TestInsertIndexCoercion(CoercionBase):
         )
         self._assert_insert_conversion(obj, fill_val, exp, exp_dtype)
 
-        msg = "Passed item and index have different timezone"
         if fill_val.tz:
-            with pytest.raises(ValueError, match=msg):
+            msg = "Cannot compare tz-naive and tz-aware"
+            with pytest.raises(TypeError, match=msg):
                 obj.insert(1, pd.Timestamp("2012-01-01"))
 
-        with pytest.raises(ValueError, match=msg):
-            obj.insert(1, pd.Timestamp("2012-01-01", tz="Asia/Tokyo"))
+            msg = "Timezones don't match"
+            with pytest.raises(ValueError, match=msg):
+                obj.insert(1, pd.Timestamp("2012-01-01", tz="Asia/Tokyo"))
+
+        else:
+            msg = "Cannot compare tz-naive and tz-aware"
+            with pytest.raises(TypeError, match=msg):
+                obj.insert(1, pd.Timestamp("2012-01-01", tz="Asia/Tokyo"))
 
         msg = "cannot insert DatetimeIndex with incompatible label"
         with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
xref #30757 should go in before this because it contains the tests.  After this, we'll be able to de-duplicate the two methods.