### PR TITLE
BLD: Remove mypy from pre-commit as long its always a full run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,15 +16,3 @@ repos:
     -   id: isort
         language: python_venv
         exclude: ^pandas/__init__\.py$|^pandas/core/api\.py$
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.730
-    hooks:
-     -  id: mypy
-        # We run mypy over all files because of:
-        #  * changes in type definitions may affect non-touched files.
-        #  * Running it with `mypy pandas` and the filenames will lead to
-        #    spurious duplicate module errors,
-        #    see also https://github.com/pre-commit/mirrors-mypy/issues/5
-        pass_filenames: false
-        args:
-        - pandas


### PR DESCRIPTION
Without supporting an incremental mode, the runtime overhead (reportably at 20s)
is unacceptable for efficient development. We can reactivate once a stable,
 incremental mode works for `pandas`.