### PR TITLE
[DOC] add example of rolling with win_type gaussian

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -872,6 +872,17 @@ class Window(_Window):
     3  NaN
     4  NaN
 
+    Rolling sum with a window length of 2, using the 'gaussian'
+    window type (note how we need to specify std).
+
+    >>> df.rolling(2, win_type='gaussian').sum(std=3)
+              B
+    0       NaN
+    1  0.986207
+    2  2.958621
+    3       NaN
+    4       NaN
+
     Rolling sum with a window length of 2, min_periods defaults
     to the window length.
 


### PR DESCRIPTION
Admittedly this is not the first issue I address, but this one's been open for several months now and so I figured I'd take it

- [x] closes #26462
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
