### PR TITLE
replacing '.format' with f-strings in some test files

### DIFF
--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -39,9 +39,7 @@ def _assert_not_almost_equal(a, b, **kwargs):
     """
     try:
         tm.assert_almost_equal(a, b, **kwargs)
-        msg = (
-            f"{a} and {b} were approximately equal when they shouldn't have been"
-        )
+        msg = f"{a} and {b} were approximately equal when they shouldn't have been"
         pytest.fail(msg=msg)
     except AssertionError:
         pass

--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -40,8 +40,8 @@ def _assert_not_almost_equal(a, b, **kwargs):
     try:
         tm.assert_almost_equal(a, b, **kwargs)
         msg = (
-            "{a} and {b} were approximately equal when they shouldn't have been"
-        ).format(a=a, b=b)
+            f"{a} and {b} were approximately equal when they shouldn't have been"
+        )
         pytest.fail(msg=msg)
     except AssertionError:
         pass
@@ -248,13 +248,12 @@ def test_assert_almost_equal_value_mismatch():
     [(np.array([1]), 1, "ndarray", "int"), (1, np.array([1]), "int", "ndarray")],
 )
 def test_assert_almost_equal_class_mismatch(a, b, klass1, klass2):
-    msg = """numpy array are different
+
+    msg = f"""numpy array are different
 
 numpy array classes are different
 \\[left\\]:  {klass1}
-\\[right\\]: {klass2}""".format(
-        klass1=klass1, klass2=klass2
-    )
+\\[right\\]: {klass2}"""
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_almost_equal(a, b)

--- a/pandas/tests/util/test_assert_categorical_equal.py
+++ b/pandas/tests/util/test_assert_categorical_equal.py
@@ -77,13 +77,11 @@ Attribute "ordered" are different
 @pytest.mark.parametrize("obj", ["index", "foo", "pandas"])
 def test_categorical_equal_object_override(obj):
     data = [1, 2, 3, 4]
-    msg = """{obj} are different
+    msg = f"""{obj} are different
 
 Attribute "ordered" are different
 \\[left\\]:  False
-\\[right\\]: True""".format(
-        obj=obj
-    )
+\\[right\\]: True"""
 
     c1 = Categorical(data, ordered=False)
     c2 = Categorical(data, ordered=True)

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -96,7 +96,7 @@ def test_assert_extension_array_equal_non_extension_array(side):
     numpy_array = np.arange(5)
     extension_array = SparseArray(numpy_array)
 
-    msg = "{side} is not an ExtensionArray".format(side=side)
+    msg = f"{side} is not an ExtensionArray"
     args = (
         (numpy_array, extension_array)
         if side == "left"

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -80,7 +80,7 @@ def test_frame_equal_row_order_mismatch(check_like, obj_fixture):
     df2 = DataFrame({"A": [3, 2, 1], "B": [6, 5, 4]}, index=["c", "b", "a"])
 
     if not check_like:  # Do not ignore row-column orderings.
-        msg = "{obj}.index are different".format(obj=obj_fixture)
+        msg = f"{obj_fixture}.index are different"
         with pytest.raises(AssertionError, match=msg):
             tm.assert_frame_equal(df1, df2, check_like=check_like, obj=obj_fixture)
     else:
@@ -95,7 +95,7 @@ def test_frame_equal_row_order_mismatch(check_like, obj_fixture):
     ],
 )
 def test_frame_equal_shape_mismatch(df1, df2, obj_fixture):
-    msg = "{obj} are different".format(obj=obj_fixture)
+    msg = "{obj_fixture} are different"
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_frame_equal(df1, df2, obj=obj_fixture)
@@ -149,13 +149,11 @@ def test_empty_dtypes(check_dtype):
 
 
 def test_frame_equal_index_mismatch(obj_fixture):
-    msg = """{obj}\\.index are different
+    msg = """{obj_fixture}\\.index are different
 
-{obj}\\.index values are different \\(33\\.33333 %\\)
+{obj_fixture}\\.index values are different \\(33\\.33333 %\\)
 \\[left\\]:  Index\\(\\['a', 'b', 'c'\\], dtype='object'\\)
-\\[right\\]: Index\\(\\['a', 'b', 'd'\\], dtype='object'\\)""".format(
-        obj=obj_fixture
-    )
+\\[right\\]: Index\\(\\['a', 'b', 'd'\\], dtype='object'\\)"""
 
     df1 = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["a", "b", "c"])
     df2 = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["a", "b", "d"])
@@ -165,13 +163,11 @@ def test_frame_equal_index_mismatch(obj_fixture):
 
 
 def test_frame_equal_columns_mismatch(obj_fixture):
-    msg = """{obj}\\.columns are different
+    msg = """{obj_fixture}\\.columns are different
 
-{obj}\\.columns values are different \\(50\\.0 %\\)
+{obj_fixture}\\.columns values are different \\(50\\.0 %\\)
 \\[left\\]:  Index\\(\\['A', 'B'\\], dtype='object'\\)
-\\[right\\]: Index\\(\\['A', 'b'\\], dtype='object'\\)""".format(
-        obj=obj_fixture
-    )
+\\[right\\]: Index\\(\\['A', 'b'\\], dtype='object'\\)"""
 
     df1 = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["a", "b", "c"])
     df2 = DataFrame({"A": [1, 2, 3], "b": [4, 5, 6]}, index=["a", "b", "c"])
@@ -181,13 +177,11 @@ def test_frame_equal_columns_mismatch(obj_fixture):
 
 
 def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
-    msg = """{obj}\\.iloc\\[:, 1\\] \\(column name="B"\\) are different
+    msg = """{obj_fixture}\\.iloc\\[:, 1\\] \\(column name="B"\\) are different
 
-{obj}\\.iloc\\[:, 1\\] \\(column name="B"\\) values are different \\(33\\.33333 %\\)
+{obj_fixture}\\.iloc\\[:, 1\\] \\(column name="B"\\) values are different \\(33\\.33333 %\\)
 \\[left\\]:  \\[4, 5, 6\\]
-\\[right\\]: \\[4, 5, 7\\]""".format(
-        obj=obj_fixture
-    )
+\\[right\\]: \\[4, 5, 7\\]"""
 
     df1 = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
     df2 = DataFrame({"A": [1, 2, 3], "B": [4, 5, 7]})

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -95,7 +95,7 @@ def test_frame_equal_row_order_mismatch(check_like, obj_fixture):
     ],
 )
 def test_frame_equal_shape_mismatch(df1, df2, obj_fixture):
-    msg = "{obj_fixture} are different"
+    msg = f"{obj_fixture} are different"
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_frame_equal(df1, df2, obj=obj_fixture)
@@ -149,7 +149,7 @@ def test_empty_dtypes(check_dtype):
 
 
 def test_frame_equal_index_mismatch(obj_fixture):
-    msg = """{obj_fixture}\\.index are different
+    msg = f"""{obj_fixture}\\.index are different
 
 {obj_fixture}\\.index values are different \\(33\\.33333 %\\)
 \\[left\\]:  Index\\(\\['a', 'b', 'c'\\], dtype='object'\\)
@@ -163,7 +163,7 @@ def test_frame_equal_index_mismatch(obj_fixture):
 
 
 def test_frame_equal_columns_mismatch(obj_fixture):
-    msg = """{obj_fixture}\\.columns are different
+    msg = f"""{obj_fixture}\\.columns are different
 
 {obj_fixture}\\.columns values are different \\(50\\.0 %\\)
 \\[left\\]:  Index\\(\\['A', 'B'\\], dtype='object'\\)
@@ -177,7 +177,7 @@ def test_frame_equal_columns_mismatch(obj_fixture):
 
 
 def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
-    msg = """{obj_fixture}\\.iloc\\[:, 1\\] \\(column name="B"\\) are different
+    msg = f"""{obj_fixture}\\.iloc\\[:, 1\\] \\(column name="B"\\) are different
 
 {obj_fixture}\\.iloc\\[:, 1\\] \\(column name="B"\\) values are different \\(33\\.33333 %\\)
 \\[left\\]:  \\[4, 5, 6\\]

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -177,9 +177,10 @@ def test_frame_equal_columns_mismatch(obj_fixture):
 
 
 def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
-    msg = f"""{obj_fixture}\\.iloc\\[:, 1\\] \\(column name="B"\\) are different
+    obj = obj_fixture
+    msg = f"""{obj}\\.iloc\\[:, 1\\] \\(column name="B"\\) are different
 
-{obj_fixture}\\.iloc\\[:, 1\\] \\(column name="B"\\) values are different \\(33\\.33333 %\\)
+{obj}\\.iloc\\[:, 1\\] \\(column name="B"\\) values are different \\(33\\.33333 %\\)
 \\[left\\]:  \\[4, 5, 6\\]
 \\[right\\]: \\[4, 5, 7\\]"""
 

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -146,9 +146,9 @@ def test_index_equal_names(name1, name2):
         name2 = "'x'" if name2 == "x" else name2
         msg = f"""Index are different
 
-    Attribute "names" are different
-    \\[left\\]:  \\[{name1}\\]
-    \\[right\\]: \\[{name2}\\]"""
+Attribute "names" are different
+\\[left\\]:  \\[{name1}\\]
+\\[right\\]: \\[{name2}\\]"""
 
         with pytest.raises(AssertionError, match=msg):
             tm.assert_index_equal(idx1, idx2)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -135,11 +135,6 @@ MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
     [(None, "x"), ("x", "x"), (np.nan, np.nan), (NaT, NaT), (np.nan, NaT)],
 )
 def test_index_equal_names(name1, name2):
-    msg = """Index are different
-
-Attribute "names" are different
-\\[left\\]:  \\[{name1}\\]
-\\[right\\]: \\[{name2}\\]"""
 
     idx1 = Index([1, 2, 3], name=name1)
     idx2 = Index([1, 2, 3], name=name2)
@@ -149,7 +144,11 @@ Attribute "names" are different
     else:
         name1 = "'x'" if name1 == "x" else name1
         name2 = "'x'" if name2 == "x" else name2
-        msg = msg.format(name1=name1, name2=name2)
+        msg = f"""Index are different
+
+    Attribute "names" are different
+    \\[left\\]:  \\[{name1}\\]
+    \\[right\\]: \\[{name2}\\]"""
 
         with pytest.raises(AssertionError, match=msg):
             tm.assert_index_equal(idx1, idx2)

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -28,13 +28,11 @@ def test_assert_numpy_array_equal_bad_type():
     [(np.array([1]), 1, "ndarray", "int"), (1, np.array([1]), "int", "ndarray")],
 )
 def test_assert_numpy_array_equal_class_mismatch(a, b, klass1, klass2):
-    msg = """numpy array are different
+    msg = f"""numpy array are different
 
 numpy array classes are different
 \\[left\\]:  {klass1}
-\\[right\\]: {klass2}""".format(
-        klass1=klass1, klass2=klass2
-    )
+\\[right\\]: {klass2}"""
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_numpy_array_equal(a, b)

--- a/pandas/tests/util/test_validate_args_and_kwargs.py
+++ b/pandas/tests/util/test_validate_args_and_kwargs.py
@@ -15,7 +15,7 @@ def test_invalid_total_length_max_length_one():
     actual_length = len(kwargs) + len(args) + min_fname_arg_count
 
     msg = (
-        fr"{fname}\(\) takes at most {max_length} "
+        fr"{_fname}\(\) takes at most {max_length} "
         fr"argument \({actual_length} given\)"
     )
 
@@ -33,8 +33,8 @@ def test_invalid_total_length_max_length_multiple():
     actual_length = len(kwargs) + len(args) + min_fname_arg_count
 
     msg = (
-        r"{fname}\(\) takes at most {max_length} "
-        r"arguments \({actual_length} given\)"
+        fr"{_fname}\(\) takes at most {max_length} "
+        fr"arguments \({actual_length} given\)"
     )
 
     with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/util/test_validate_args_and_kwargs.py
+++ b/pandas/tests/util/test_validate_args_and_kwargs.py
@@ -15,10 +15,8 @@ def test_invalid_total_length_max_length_one():
     actual_length = len(kwargs) + len(args) + min_fname_arg_count
 
     msg = (
-        r"{fname}\(\) takes at most {max_length} "
-        r"argument \({actual_length} given\)".format(
-            fname=_fname, max_length=max_length, actual_length=actual_length
-        )
+        fr"{fname}\(\) takes at most {max_length} "
+        fr"argument \({actual_length} given\)"
     )
 
     with pytest.raises(TypeError, match=msg):
@@ -36,9 +34,7 @@ def test_invalid_total_length_max_length_multiple():
 
     msg = (
         r"{fname}\(\) takes at most {max_length} "
-        r"arguments \({actual_length} given\)".format(
-            fname=_fname, max_length=max_length, actual_length=actual_length
-        )
+        r"arguments \({actual_length} given\)"
     )
 
     with pytest.raises(TypeError, match=msg):
@@ -53,8 +49,8 @@ def test_missing_args_or_kwargs(args, kwargs):
     compat_args = {"foo": -5, bad_arg: 1}
 
     msg = (
-        r"the '{arg}' parameter is not supported "
-        r"in the pandas implementation of {func}\(\)".format(arg=bad_arg, func=_fname)
+        fr"the '{bad_arg}' parameter is not supported "
+        fr"in the pandas implementation of {_fname}\(\)"
     )
 
     with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
- [X] contributes to #29547
- [ ] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

One format that I left untouched in `pandas/tests/util/test_assert_frame_equal.py`:

```
def test_frame_equal_unicode(df1, df2, msg, by_blocks_fixture, obj_fixture):
    # see gh-20503
    #
    # Test ensures that `tm.assert_frame_equals` raises the right exception
    # when comparing DataFrames containing differing unicode objects.
    msg = msg.format(obj=obj_fixture)
    with pytest.raises(AssertionError, match=msg):
        tm.assert_frame_equal(df1, df2, by_blocks=by_blocks_fixture, obj=obj_fixture)
```

However it looks the the test function isnt being used anywhere:
```
$ grep -rnw . -e "test_frame_equal_unicode"
./pandas/tests/util/test_assert_frame_equal.py:217:def test_frame_equal_unicode(df1, df2, msg, by_blocks_fixture, obj_fixture):
```

Wasn't sure if I should leave as is? or assume person calling the function will format `msg` properly before passing to the test function.