### PR TITLE
CLN: de-duplicate boxing in DTI.get_value

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -641,7 +641,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
         know what you're doing
         """
 
-        if isinstance(key, datetime):
+        if isinstance(key, (datetime, np.datetime64)):
 
             # needed to localize naive datetimes
             if self.tz is not None:

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -642,15 +642,6 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
         """
 
         if isinstance(key, (datetime, np.datetime64)):
-            key = Timestamp(key)
-
-            # needed to localize naive datetimes
-            if self.tz is not None:
-                if key.tzinfo is not None:
-                    key = key.tz_convert(self.tz)
-                else:
-                    key = key.tz_localize(self.tz)
-
             return self.get_value_maybe_box(series, key)
 
         if isinstance(key, time):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -642,13 +642,14 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
         """
 
         if isinstance(key, (datetime, np.datetime64)):
+            key = Timestamp(key)
 
             # needed to localize naive datetimes
             if self.tz is not None:
                 if key.tzinfo is not None:
-                    key = Timestamp(key).tz_convert(self.tz)
+                    key = key.tz_convert(self.tz)
                 else:
-                    key = Timestamp(key).tz_localize(self.tz)
+                    key = key.tz_localize(self.tz)
 
             return self.get_value_maybe_box(series, key)
 

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -613,6 +613,23 @@ class TestDatetimeIndex:
             assert result.freq == expected.freq
             assert result.tz == expected.tz
 
+    def test_get_value(self):
+        # specifically make sure we have test for np.datetime64 key
+        dti = pd.date_range("2016-01-01", periods=3)
+
+        arr = np.arange(6, 8)
+
+        key = dti[1]
+
+        result = dti.get_value(arr, key)
+        assert result == 7
+
+        result = dti.get_value(arr, key.to_pydatetime())
+        assert result == 7
+
+        result = dti.get_value(arr, key.to_datetime64())
+        assert result == 7
+
     def test_get_loc(self):
         idx = pd.date_range("2000-01-01", periods=3)
 


### PR DESCRIPTION
Also add a dedicated test or it to hit currently un-covered case of np.datetime64 key.  That case works in master, but doesn't go through the expected code path