### PR TITLE
API: Limit assert_*_equal functions in public API

### DIFF
--- a/doc/source/reference/general_utility_functions.rst
+++ b/doc/source/reference/general_utility_functions.rst
@@ -28,16 +28,7 @@ Testing functions
    testing.assert_frame_equal
    testing.assert_series_equal
    testing.assert_index_equal
-   testing.assert_equal
-   testing.assert_almost_equal
-   testing.assert_categorical_equal
-   testing.assert_datetime_array_equal
    testing.assert_extension_array_equal
-   testing.assert_interval_array_equal
-   testing.assert_numpy_array_equal
-   testing.assert_period_array_equal
-   testing.assert_sp_array_equal
-   testing.assert_timedelta_array_equal
 
 Exceptions and warnings
 -----------------------

--- a/pandas/testing.py
+++ b/pandas/testing.py
@@ -3,33 +3,15 @@ Public testing utility functions.
 """
 
 from pandas._testing import (
-    assert_almost_equal,
-    assert_categorical_equal,
-    assert_datetime_array_equal,
-    assert_equal,
     assert_extension_array_equal,
     assert_frame_equal,
     assert_index_equal,
-    assert_interval_array_equal,
-    assert_numpy_array_equal,
-    assert_period_array_equal,
     assert_series_equal,
-    assert_sp_array_equal,
-    assert_timedelta_array_equal,
 )
 
 __all__ = [
+    "assert_extension_array_equal",
     "assert_frame_equal",
     "assert_series_equal",
     "assert_index_equal",
-    "assert_equal",
-    "assert_almost_equal",
-    "assert_categorical_equal",
-    "assert_datetime_array_equal",
-    "assert_extension_array_equal",
-    "assert_interval_array_equal",
-    "assert_numpy_array_equal",
-    "assert_period_array_equal",
-    "assert_sp_array_equal",
-    "assert_timedelta_array_equal",
 ]

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -271,16 +271,7 @@ class TestTesting(Base):
         "assert_frame_equal",
         "assert_series_equal",
         "assert_index_equal",
-        "assert_equal",
-        "assert_almost_equal",
-        "assert_categorical_equal",
-        "assert_datetime_array_equal",
         "assert_extension_array_equal",
-        "assert_interval_array_equal",
-        "assert_numpy_array_equal",
-        "assert_period_array_equal",
-        "assert_sp_array_equal",
-        "assert_timedelta_array_equal",
     ]
 
     def test_testing(self):


### PR DESCRIPTION
As discussed on today's call. Just adding `assert_extension_array_equal` relative to 0.25.