### PR TITLE
BUG: ExtensionArray._formatter does not need to handle nulls

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1230,7 +1230,7 @@ class GenericArrayFormatter:
                     if x is None:
                         return "None"
                     elif x is NA:
-                        return formatter(x)
+                        return str(NA)
                     elif x is NaT or np.isnat(x):
                         return "NaT"
                 except (TypeError, ValueError):


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/pull/30821/files#r364917242

Currently, I don't think this is really specified whether the `_formatter` of ExtensionArray should be able to handle NAs/nulls or not, but in practice, it didn't need to do that. And eg the geopandas one is also implemented right now that it would fail if passed a NA (https://github.com/geopandas/geopandas/blob/add5fe9139883fa54d14fa28426478619948349c/geopandas/array.py#L1026-L1047)

This is certainly something that can be discussed how to specify this, but for now I think it is best to preserve the existing behaviour.