### PR TITLE
WEB: Removing Discourse links

### DIFF
--- a/web/pandas/_templates/layout.html
+++ b/web/pandas/_templates/layout.html
@@ -84,11 +84,6 @@
                         <i class="fab fa-stack-overflow"></i>
                     </a>
                 </li>
-                <li class="list-inline-item">
-                    <a href="https://pandas.discourse.group">
-                        <i class="fab fa-discourse"></i>
-                    </a>
-                </li>
             </ul>
             <p>
                 pandas is a fiscally sponsored project of <a href="https://numfocus.org">NumFOCUS</a>

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -50,8 +50,6 @@ navbar:
       target: /community/blog.html
     - name: "Ask a question (StackOverflow)"
       target: https://stackoverflow.com/questions/tagged/pandas
-    - name: "Discuss"
-      target: https://pandas.discourse.group
     - name: "Code of conduct"
       target: /community/coc.html
     - name: "Ecosystem"


### PR DESCRIPTION
Just realized that the discourse links are still in the web. They should be removed, since we're not planning to use discourse for now.