### PR TITLE
WEB: Link from the website to the docs

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -35,15 +35,7 @@ navbar:
   - name: "Getting started"
     target: /getting_started.html
   - name: "Documentation"
-    target:
-    - name: "User guide"
-      target: /docs/user_guide/index.html
-    - name: "API reference"
-      target: /docs/reference/index.html
-    - name: "Release notes"
-      target: /docs/whatsnew/index.html
-    - name: "Older versions"
-      target: https://pandas.pydata.org/pandas-docs/version/
+    target: /docs/
   - name: "Community"
     target:
     - name: "Blog"


### PR DESCRIPTION
The navigation of the web was implemented assuming the docs will render with the same layout. Since this is not finally the case, and the website and the docs are finally independent, I guess it makes more sense to simply link to the home of the docs.

Otherwise, we'd need to rethink those links, since the last one is broken, and the rest are inconsistent with the navigation of the docs.

Closes https://github.com/pandas-dev/pandas/issues/31657
