### PR TITLE
[BUG] Series.diff was always setting the dtype to object

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -1146,7 +1146,7 @@ ExtensionArray
 - Bug in :class:`arrays.PandasArray` when setting a scalar string (:issue:`28118`, :issue:`28150`).
 - Bug where nullable integers could not be compared to strings (:issue:`28930`)
 - Bug where :class:`DataFrame` constructor raised ``ValueError`` with list-like data and ``dtype`` specified (:issue:`30280`)
-- Bug in :meth:`Series.diff` was always setting the ``dtype`` to ``Object`` (:issue:`30889`)
+- Bug in :meth:`Series.diff` was always setting the ``dtype`` to ``object`` (:issue:`30889`)
 
 
 Other

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -1146,6 +1146,7 @@ ExtensionArray
 - Bug in :class:`arrays.PandasArray` when setting a scalar string (:issue:`28118`, :issue:`28150`).
 - Bug where nullable integers could not be compared to strings (:issue:`28930`)
 - Bug where :class:`DataFrame` constructor raised ``ValueError`` with list-like data and ``dtype`` specified (:issue:`30280`)
+- Bug in :meth:`Series.diff` was always setting the ``dtype`` to ``Object`` (:issue:`30889`)
 
 
 Other

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -24,7 +24,7 @@ from pandas.core.dtypes.generic import ABCExtensionArray, ABCIndexClass, ABCSeri
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import ops
-from pandas.core.algorithms import _factorize_array, unique
+from pandas.core.algorithms import _factorize_array, diff, unique
 from pandas.core.missing import backfill_1d, pad_1d
 from pandas.core.sorting import nargsort
 
@@ -515,6 +515,27 @@ class ExtensionArray:
 
         result = nargsort(self, kind=kind, ascending=ascending, na_position="last")
         return result
+
+    def diff(self, periods: int = 1):
+        """
+        First discrete difference of element.
+
+        Calculates the difference of a ExtensionArray element compared with another
+        element in the ExtensionArray (default is element in previous row).
+
+        Parameters
+        ----------
+        periods : int, default 1
+            Periods to shift for calculating difference, accepts negative
+            values.
+
+        Returns
+        -------
+        ExtensionArray
+            First differences of the ExtensionArray.
+        """
+
+        return self._from_sequence(diff(self, periods), dtype=self.dtype)
 
     def fillna(self, value=None, method=None, limit=None):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2316,13 +2316,11 @@ Name: Max Speed, dtype: float64
         5    NaN
         dtype: float64
         """
-        result = algorithms.diff(com.values_from_object(self), periods)
         if is_extension_array_dtype(self.dtype) and not is_datetime64tz_dtype(
             self.dtype
         ):
-            return self._constructor(
-                result, index=self.index, dtype=self.dtype
-            ).__finalize__(self)
+            return self.values.diff(periods=periods)
+        result = algorithms.diff(com.values_from_object(self), periods)
         return self._constructor(result, index=self.index).__finalize__(self)
 
     def autocorr(self, lag=1) -> float:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -34,6 +34,7 @@ from pandas.core.dtypes.common import (
     is_bool,
     is_categorical_dtype,
     is_datetime64_dtype,
+    is_datetime64tz_dtype,
     is_dict_like,
     is_extension_array_dtype,
     is_integer,
@@ -2316,6 +2317,12 @@ Name: Max Speed, dtype: float64
         dtype: float64
         """
         result = algorithms.diff(com.values_from_object(self), periods)
+        if is_extension_array_dtype(self.dtype) and not is_datetime64tz_dtype(
+            self.dtype
+        ):
+            return self._constructor(
+                result, index=self.index, dtype=self.dtype
+            ).__finalize__(self)
         return self._constructor(result, index=self.index).__finalize__(self)
 
     def autocorr(self, lag=1) -> float:

--- a/pandas/tests/series/methods/test_diff.py
+++ b/pandas/tests/series/methods/test_diff.py
@@ -75,3 +75,9 @@ class TestSeriesDiff:
         result = s.diff()
         expected = s - s.shift(1)
         tm.assert_series_equal(result, expected)
+
+    def test_nullable_integer(self, any_nullable_int_dtype):
+        # GH 30889
+        dtype = any_nullable_int_dtype
+        result = Series([1, 2, 3], dtype=dtype).diff().dtype
+        assert result == dtype


### PR DESCRIPTION
- [x] closes #30889
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
