### PR TITLE
DOC: Add pandas_path to the accesor list in the documentation

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -41,6 +41,16 @@ Pyjanitor provides a clean API for cleaning data, using method chaining.
 Engarde is a lightweight library used to explicitly state assumptions about your datasets
 and check that they're *actually* true.
 
+`pandas-path <https://github.com/drivendataorg/pandas-path/>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since Python 3.4, `pathlib <https://docs.python.org/3/library/pathlib.html>`_ has been 
+included in the Python standard library. Path objects provide a simple 
+and delightful way to interact with the file system. The pandas-path package enables the 
+Path API for pandas through a custom accessor ``.path``. Getting just the filenames from 
+a series of full file paths is as simple as ``my_files.path.name``. Other convenient operations like 
+joining paths, replacing file extensions, and checking if files exist are also available.
+
 .. _ecosystem.stats:
 
 Statistics and machine learning

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -386,12 +386,16 @@ A directory of projects providing
 :ref:`extension accessors <extending.register-accessors>`. This is for users to
 discover new accessors and for library authors to coordinate on the namespace.
 
-============== ========== =========================
-Library        Accessor   Classes
-============== ========== =========================
-`cyberpandas`_ ``ip``     ``Series``
-`pdvega`_      ``vgplot`` ``Series``, ``DataFrame``
-============== ========== =========================
+=============== ========== ========================= ===============================================================
+Library         Accessor   Classes                   Description
+=============== ========== ========================= ===============================================================
+`cyberpandas`_  ``ip``     ``Series``                Provides common operations for working with IP addresses.
+`pdvega`_       ``vgplot`` ``Series``, ``DataFrame`` Provides plotting functions from the Altair_ library.
+`pandas_path`_  ``path``   ``Index``, ``Series``     Provides `pathlib.Path`_ functions for Series.
+=============== ========== ========================= ===============================================================
 
 .. _cyberpandas: https://cyberpandas.readthedocs.io/en/latest
 .. _pdvega: https://altair-viz.github.io/pdvega/
+.. _Altair: https://altair-viz.github.io/
+.. _pandas_path: https://github.com/drivendataorg/pandas-path/
+.. _pathlib.Path: https://docs.python.org/3/library/pathlib.html

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -44,11 +44,11 @@ and check that they're *actually* true.
 `pandas-path <https://github.com/drivendataorg/pandas-path/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since Python 3.4, `pathlib <https://docs.python.org/3/library/pathlib.html>`_ has been 
-included in the Python standard library. Path objects provide a simple 
-and delightful way to interact with the file system. The pandas-path package enables the 
-Path API for pandas through a custom accessor ``.path``. Getting just the filenames from 
-a series of full file paths is as simple as ``my_files.path.name``. Other convenient operations like 
+Since Python 3.4, `pathlib <https://docs.python.org/3/library/pathlib.html>`_ has been
+included in the Python standard library. Path objects provide a simple
+and delightful way to interact with the file system. The pandas-path package enables the
+Path API for pandas through a custom accessor ``.path``. Getting just the filenames from
+a series of full file paths is as simple as ``my_files.path.name``. Other convenient operations like
 joining paths, replacing file extensions, and checking if files exist are also available.
 
 .. _ecosystem.stats:


### PR DESCRIPTION
Added the [`pandas_path`](https://github.com/drivendataorg/pandas-path/) package that I just released to the list of third-party accessor extensions.

As a bonus, added a Description column for the existing libraries.