### PR TITLE
BUG: loc setitem with missing integer slices does not raise

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -1036,6 +1036,7 @@ Indexing
 - :meth:`MultiIndex.get_loc` can't find missing values when input includes missing values (:issue:`19132`)
 - Bug in :meth:`Series.__setitem__` incorrectly assigning values with boolean indexer when the length of new data matches the number of ``True`` values and new data is not a ``Series`` or an ``np.array`` (:issue:`30567`)
 - Bug in indexing with a :class:`PeriodIndex` incorrectly accepting integers representing years, use e.g. ``ser.loc["2007"]`` instead of ``ser.loc[2007]`` (:issue:`30763`)
+- Bug in :meth:`DataFrame.loc.__setitem__` and :meth:`Series.loc.__setitem__` not raising error when given integer slice does not exist in index (:issue:`26412`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2922,6 +2922,9 @@ class Index(IndexOpsMixin, PandasObject):
                     self._validate_indexer("slice", key.step, kind),
                 )
 
+        if kind == "loc" and not is_null_slicer:
+            return self.slice_indexer(key.start, key.stop, key.step, kind=kind)
+
         # convert the slice to an indexer here
 
         # if we are mixed and have integers

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -915,8 +915,8 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         with pytest.raises(KeyError, match=msg):
             df.loc[[0, 1], "x"] = data
 
-        msg = "cannot copy sequence with size 2 to array axis with dimension 0"
-        with pytest.raises(ValueError, match=msg):
+        msg = "cannot do slice indexing on .* with these indexers"
+        with pytest.raises(TypeError, match=msg):
             df.loc[0:2, "x"] = data
 
     def test_indexing_zerodim_np_array(self):
@@ -983,6 +983,19 @@ def test_loc_setitem_float_intindex():
     result = pd.DataFrame(rand_data)
     result.loc[:, 0.5] = np.nan
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("test_series", [False, True])
+def test_loc_setitem_missing_integer_slice(test_series):
+    # GH 26412
+    df = DataFrame({"col1": [1, 2, 3]}, index=["a", "b", "c"])
+    msg = "cannot do slice indexing on .* with these indexers"
+    with pytest.raises(TypeError, match=msg):
+        if test_series:
+            s = df["col1"]
+            s.loc[0:2] = 10
+        else:
+            df.loc[0:2] = 10
 
 
 def test_loc_axis_1_slice():


### PR DESCRIPTION
- [ ] closes #26412
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
