### PR TITLE
ENH:column-wise DataFrame.fillna and duplicated DataFrame.fillna with Series and Dict 

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -51,7 +51,7 @@ For example:
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 - :class:`Index` with object dtype supports division and multiplication (:issue:`34160`)
--
+- :meth:`DataFrame.fillna` can fill NA values column-wise with a dictionary or :class:`Series` (:issue:`4514`)
 -
 
 


### PR DESCRIPTION
- [x] closes #4514
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

description:
Access "DataFrame" each column, fills up NA values using "Series.fillna" 
and what i found is if dataframe is duplicated, ".fillna" not guarantee filling NA. So i change them can fill NA.

Q. Why access column base not index base?
A. problem of Index base f".illna" is not preserve column's dtype. so i use column base.

Q. Why assign in column new values not use inplace=True ?
A. To avoid chained indexing. If column and index are both duplicated, chained indexing happens, i want to avoid this situation.
