### PR TITLE
DOC: Fix whatsnew contributors section

### DIFF
--- a/doc/source/whatsnew/v0.25.3.rst
+++ b/doc/source/whatsnew/v0.25.3.rst
@@ -19,4 +19,4 @@ Groupby/resample/rolling
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v0.25.2..HEAD
+.. contributors:: v0.25.2..v0.25.3

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -1178,4 +1178,4 @@ Other
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v0.25.3..v1.0.0rc
+.. contributors:: v0.25.3..v1.0.0rc0

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -1178,4 +1178,4 @@ Other
 Contributors
 ~~~~~~~~~~~~
 
-.. contributors:: v0.25.3..HEAD
+.. contributors:: v0.25.3..v1.0.0rc

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -1177,3 +1177,5 @@ Other
 
 Contributors
 ~~~~~~~~~~~~
+
+.. contributors:: v0.25.3..HEAD


### PR DESCRIPTION
Was reading over the whatsnew and noticed that the [1.0 Contributors section 
](https://dev.pandas.io/docs/whatsnew/v1.0.0.html#contributors) is empty, and the [0.25.3 Contributors section](https://dev.pandas.io/docs/whatsnew/v0.25.3.html#contributors) looks way to big.