### PR TITLE
PERF: RangeIndex.get_loc

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -112,7 +112,7 @@ class RangeIndex(Int64Index):
         return cls._simple_new(rng, dtype=dtype, name=name)
 
     @classmethod
-    def from_range(cls, data: range, name=None, dtype=None):
+    def from_range(cls, data, name=None, dtype=None):
         """
         Create RangeIndex from a range object.
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -14,6 +14,7 @@ from pandas.util._decorators import Appender, cache_readonly
 from pandas.core.dtypes.common import (
     ensure_platform_int,
     ensure_python_int,
+    is_float,
     is_integer,
     is_integer_dtype,
     is_list_like,
@@ -111,7 +112,7 @@ class RangeIndex(Int64Index):
         return cls._simple_new(rng, dtype=dtype, name=name)
 
     @classmethod
-    def from_range(cls, data, name=None, dtype=None):
+    def from_range(cls, data: range, name=None, dtype=None):
         """
         Create RangeIndex from a range object.
 
@@ -344,12 +345,14 @@ class RangeIndex(Int64Index):
 
     @Appender(_index_shared_docs["get_loc"])
     def get_loc(self, key, method=None, tolerance=None):
-        if is_integer(key) and method is None and tolerance is None:
-            new_key = int(key)
-            try:
-                return self._range.index(new_key)
-            except ValueError:
-                raise KeyError(key)
+        if method is None and tolerance is None:
+            if is_integer(key) or (is_float(key) and key.is_integer()):
+                new_key = int(key)
+                try:
+                    return self._range.index(new_key)
+                except ValueError:
+                    raise KeyError(key)
+            raise KeyError(key)
         return super().get_loc(key, method=method, tolerance=tolerance)
 
     @Appender(_index_shared_docs["get_indexer"])

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -735,8 +735,9 @@ class TestRangeIndex(Numeric):
 
         assert "_engine" not in idx._cache
 
-        # The engine is still required for lookup of a different dtype scalar:
+        # Different types of scalars can be excluded immediately, no need to
+        #  use the _engine
         with pytest.raises(KeyError, match="'a'"):
-            assert idx.get_loc("a") == -1
+            idx.get_loc("a")
 
-        assert "_engine" in idx._cache
+        assert "_engine" not in idx._cache


### PR DESCRIPTION
Small simplification gives a small speedup

```
In [2]: rng = pd.Index(range(10**5)) 

In [3]: %timeit rng.get_loc(5.0)                                                
6.38 µs ± 381 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  <-- master
1.15 µs ± 40.9 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  <-- PR

In [5]: %timeit rng.get_loc(5)                                                  
845 ns ± 5.71 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  <--master
In [5]: %timeit rng.get_loc(5)                                                                                                                                                                            
860 ns ± 16.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  <-- PR

In [9]: def foo(): 
   ...:     try: 
   ...:         return rng.get_loc(None) 
   ...:     except KeyError: 
   ...:         pass 
   ...:                                                                         

In [10]: %timeit foo()                                                          
6.72 µs ± 656 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  <-- master
1.11 µs ± 94 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  <-- PR
```