### PR TITLE
CLN: remove unnecessary _date_check_type

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -447,7 +447,6 @@ cdef class DatetimeEngine(Int64Engine):
                 conv = maybe_datetimelike_to_i8(val)
                 loc = values.searchsorted(conv, side='left')
             except TypeError:
-                self._date_check_type(val)
                 raise KeyError(val)
 
             if loc == len(values) or values[loc] != conv:
@@ -470,12 +469,6 @@ cdef class DatetimeEngine(Int64Engine):
             val = maybe_datetimelike_to_i8(val)
             return self.mapping.get_item(val)
         except (TypeError, ValueError):
-            self._date_check_type(val)
-            raise KeyError(val)
-
-    cdef inline _date_check_type(self, object val):
-        hash(val)
-        if not util.is_integer_object(val):
             raise KeyError(val)
 
     def get_indexer(self, values):


### PR DESCRIPTION
The check doesn't do anything, and we still a raise `KeyError` anyways