### PR TITLE
DOC: Fix SS03 docstring error

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -920,7 +920,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
     @property
     def freqstr(self):
         """
-        Return the frequency object as a string if its set, otherwise None
+        Return the frequency object as a string if its set, otherwise None.
         """
         if self.freq is None:
             return None

--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -32,7 +32,7 @@ window
 
 
 class BaseIndexer:
-    """Base class for window bounds calculations"""
+    """Base class for window bounds calculations."""
 
     def __init__(
         self, index_array: Optional[np.ndarray] = None, window_size: int = 0, **kwargs,


### PR DESCRIPTION
Fixes SS03 errors. 

```
None:None:SS03:pandas.DatetimeIndex.freqstr:Summary does not end with a period
None:None:SS03:pandas.PeriodIndex.freqstr:Summary does not end with a period
pandas/pandas/core/window/indexers.py:34:SS03:pandas.api.indexers.BaseIndexer:Summary does not end with a period
```

Related to #27977, #30733 cc @datapythonista

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes black pandas
- [x] passes git diff upstream/master -u -- "*.py" | flake8 --diff
- [ ] whatsnew entry

When I ran the script, there are others left, but they might be false positives since I can't find them in the codebase.