### PR TITLE
DOC: Clarified documentation for convert_dates and use_default_dates params

### DIFF
--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -439,8 +439,18 @@ def read_json(
            Not applicable for ``orient='table'``.
 
     convert_dates : bool or list of str, default True
-        List of columns to parse for dates. If True, then try to parse
-        datelike columns. A column label is datelike if
+        If True then default datelike columns may be converted.
+        If False, no dates will be converted.
+        If a list of column names, then those columns will be converted and
+        default datelike columns may also be converted
+
+        When True or list then keep_default_dates determines whether default
+        datelike columns are converted.
+
+    keep_default_dates : bool, default True
+        If parsing dates (convert_dates is not False), then try to parse the
+        default datelike columns.
+        A column label is datelike if
 
         * it ends with ``'_at'``,
 
@@ -451,9 +461,6 @@ def read_json(
         * it is ``'modified'``, or
 
         * it is ``'date'``.
-
-    keep_default_dates : bool, default True
-        If parsing dates, then parse the default datelike columns.
 
     numpy : bool, default False
         Direct decoding to numpy arrays. Supports numeric data only, but

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -439,13 +439,12 @@ def read_json(
            Not applicable for ``orient='table'``.
 
     convert_dates : bool or list of str, default True
-        If True then default datelike columns may be converted.
+        If True then default datelike columns may be converted (depending on
+        keep_default_dates).
         If False, no dates will be converted.
         If a list of column names, then those columns will be converted and
-        default datelike columns may also be converted
-
-        When True or list then keep_default_dates determines whether default
-        datelike columns are converted.
+        default datelike columns may also be converted (depending on
+        keep_default_dates).
 
     keep_default_dates : bool, default True
         If parsing dates (convert_dates is not False), then try to parse the


### PR DESCRIPTION
This hopefully clarifies the documentation for the behaviour of the convert_dates and keep_default_dates parameters on the read_json function.

I recently had to use this function and found the existing docs a bit confusing.  I actually created a truth table (below), but this is probably a bit much for the docs.

| convert_dates | keep_default_dates | Result                      |
| ------------- | ------------------ | --------------------------- |
| True          | True               | Convert default date fields |
| True          | False              | Don’t convert anything |
| False         | True               | Don’t convert anything |
| False         | False              | Don’t convert anything |
| List          | True               | Convert listed and default date fields |
| List          | False              | Convert just listed date fields |

I hope you agree that my changes make the behaviour clearer - but perhaps people will disagree...