### PR TITLE
[BUG] -1 to the power of pd.NA was returning -1

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -831,7 +831,6 @@ Operation        Result
 ================ ======
 ``pd.NA ** 0``   0
 ``1 ** pd.NA``   1
-``-1 ** pd.NA``  -1
 ================ ======
 
 In equality and comparison operations, ``pd.NA`` also propagates. This deviates

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -417,12 +417,12 @@ class NAType(C_NAType):
         if other is C_NA:
             return NA
         elif isinstance(other, (numbers.Number, np.bool_)):
-            if other == 1 or other == -1:
+            if other == 1:
                 return other
             else:
                 return NA
         elif isinstance(other, np.ndarray):
-            return np.where((other == 1) | (other == -1), other, NA)
+            return np.where(other == 1, other, NA)
 
         return NotImplemented
 

--- a/pandas/tests/arrays/test_integer.py
+++ b/pandas/tests/arrays/test_integer.py
@@ -363,24 +363,26 @@ class TestArithmeticOps(BaseOpsUtil):
         tm.assert_numpy_array_equal(result, expected)
 
     def test_pow_scalar(self):
-        a = pd.array([0, 1, None, 2], dtype="Int64")
+        a = pd.array([-1, 0, 1, None, 2], dtype="Int64")
         result = a ** 0
-        expected = pd.array([1, 1, 1, 1], dtype="Int64")
+        expected = pd.array([1, 1, 1, 1, 1], dtype="Int64")
         tm.assert_extension_array_equal(result, expected)
 
         result = a ** 1
-        expected = pd.array([0, 1, None, 2], dtype="Int64")
+        expected = pd.array([-1, 0, 1, None, 2], dtype="Int64")
         tm.assert_extension_array_equal(result, expected)
 
         result = a ** pd.NA
-        expected = pd.array([None, 1, None, None], dtype="Int64")
+        expected = pd.array([None, None, 1, None, None], dtype="Int64")
         tm.assert_extension_array_equal(result, expected)
 
         result = a ** np.nan
-        expected = np.array([np.nan, 1, np.nan, np.nan], dtype="float64")
+        expected = np.array([np.nan, np.nan, 1, np.nan, np.nan], dtype="float64")
         tm.assert_numpy_array_equal(result, expected)
 
         # reversed
+        a = a[1:]  # Can't raise integers to negative powers.
+
         result = 0 ** a
         expected = pd.array([1, 0, None, 0], dtype="Int64")
         tm.assert_extension_array_equal(result, expected)

--- a/pandas/tests/scalar/test_na_scalar.py
+++ b/pandas/tests/scalar/test_na_scalar.py
@@ -96,19 +96,7 @@ def test_pow_special(value, asarray):
 
 
 @pytest.mark.parametrize(
-    "value",
-    [
-        1,
-        1.0,
-        -1,
-        -1.0,
-        True,
-        np.bool_(True),
-        np.int_(1),
-        np.float_(1),
-        np.int_(-1),
-        np.float_(-1),
-    ],
+    "value", [1, 1.0, True, np.bool_(True), np.int_(1), np.float_(1)],
 )
 @pytest.mark.parametrize("asarray", [True, False])
 def test_rpow_special(value, asarray):
@@ -123,6 +111,21 @@ def test_rpow_special(value, asarray):
         assert isinstance(result, type(value))
 
     assert result == value
+
+
+@pytest.mark.parametrize(
+    "value", [-1, -1.0, np.int_(-1), np.float_(-1)],
+)
+@pytest.mark.parametrize("asarray", [True, False])
+def test_rpow_minus_one(value, asarray):
+    if asarray:
+        value = np.array([value])
+    result = value ** pd.NA
+
+    if asarray:
+        result = result[0]
+
+    assert pd.isna(result)
 
 
 def test_unary_ops():


### PR DESCRIPTION
- [x] closes #30956 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
