### PR TITLE
BUG: ensure_datetime64ns with bigendian array

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -82,7 +82,7 @@ Numeric
 
 Conversion
 ^^^^^^^^^^
-
+- Bug in :class:`Series` construction from NumPy array with big-endian ``datetime64`` dtype (:issue:`29684`)
 -
 -
 

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -99,6 +99,11 @@ def ensure_datetime64ns(arr: ndarray, copy: bool=True):
 
     shape = (<object>arr).shape
 
+    if (<object>arr).dtype.byteorder == ">":
+        # GH#29684 we incorrectly get OutOfBoundsDatetime if we dont swap
+        dtype = arr.dtype
+        arr = arr.astype(dtype.newbyteorder("<"))
+
     ivalues = arr.view(np.int64).ravel()
 
     result = np.empty(shape, dtype=NS_DTYPE)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -967,6 +967,15 @@ class TestSeriesConstructors:
         expected = Series(pd.Timestamp(arg)).dt.tz_localize("CET")
         tm.assert_series_equal(result, expected)
 
+    def test_constructor_datetime64_bigendian(self):
+        # GH#30976
+        ms = np.datetime64(1, "ms")
+        arr = np.array([np.datetime64(1, "ms")], dtype=">M8[ms]")
+
+        result = Series(arr)
+        expected = Series([Timestamp(ms)])
+        tm.assert_series_equal(result, expected)
+
     @pytest.mark.parametrize("interval_constructor", [IntervalIndex, IntervalArray])
     def test_construction_interval(self, interval_constructor):
         # construction from interval & array of intervals

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -72,6 +72,15 @@ def test_length_zero_copy(dtype, copy):
     assert result.base is (None if copy else arr)
 
 
+def test_ensure_datetime64ns_bigendian():
+    # GH#29684
+    arr = np.array([np.datetime64(1, "ms")], dtype=">M8[ms]")
+    result = conversion.ensure_datetime64ns(arr)
+
+    expected = np.array([np.datetime64(1, "ms")], dtype="M8[ns]")
+    tm.assert_numpy_array_equal(result, expected)
+
+
 class SubDatetime(datetime):
     pass
 


### PR DESCRIPTION
- [x] closes #29684
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
