### PR TITLE
JSON Date Handling 1.0 Regressions

### DIFF
--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -457,7 +457,7 @@ static char *PyDateTimeToIsoCallback(JSOBJ obj, JSONTypeContext *tc,
                                      size_t *len) {
 
     if (!PyDate_Check(obj)) {
-        PyErr_SetString(PyExc_TypeError, "Expected datetime object");
+        PyErr_SetString(PyExc_TypeError, "Expected date object");
         return NULL;
     }
 
@@ -469,7 +469,7 @@ static npy_datetime PyDateTimeToEpoch(PyObject *obj, NPY_DATETIMEUNIT base) {
     npy_datetimestruct dts;
     int ret;
 
-    if (!PyDateTime_Check(obj)) {
+    if (!PyDate_Check(obj)) {
         // TODO: raise TypeError
     }
     PyDateTime_Date *dt = (PyDateTime_Date *)obj;

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -456,7 +456,7 @@ static char *PyDateTimeToIso(PyDateTime_Date *obj, NPY_DATETIMEUNIT base,
 static char *PyDateTimeToIsoCallback(JSOBJ obj, JSONTypeContext *tc,
                                      size_t *len) {
 
-    if (!PyDateTime_Check(obj)) {
+    if (!PyDate_Check(obj)) {
         PyErr_SetString(PyExc_TypeError, "Expected datetime object");
         return NULL;
     }

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -813,7 +813,9 @@ class TestPandasContainer:
 
     @pytest.mark.parametrize("date_format", ["epoch", "iso"])
     @pytest.mark.parametrize("as_object", [True, False])
-    @pytest.mark.parametrize("date_typ", [datetime.date, datetime.datetime, pd.Timestamp])
+    @pytest.mark.parametrize(
+        "date_typ", [datetime.date, datetime.datetime, pd.Timestamp]
+    )
     def test_date_index_and_values(self, date_format, as_object, date_typ):
         data = [date_typ(year=2020, month=1, day=1), pd.NaT]
         if as_object:
@@ -832,7 +834,7 @@ class TestPandasContainer:
         if as_object:
             expected = expected.replace("}", ',"a":"a"}')
 
-        assert result == expected        
+        assert result == expected
 
     @pytest.mark.parametrize(
         "infer_word",

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -815,7 +815,7 @@ class TestPandasContainer:
     @pytest.mark.parametrize("as_object", [True, False])
     @pytest.mark.parametrize("date_typ", [datetime.date, datetime.datetime, pd.Timestamp])
     def test_date_index_and_values(self, date_format, as_object, date_typ):
-        data = [date_typ(year=2020, month=1, day=1)]
+        data = [date_typ(year=2020, month=1, day=1), pd.NaT]
         if as_object:
             data.append("a")
 
@@ -823,10 +823,10 @@ class TestPandasContainer:
         result = ser.to_json(date_format=date_format)
 
         if date_format == "epoch":
-            expected = '{"1577836800000":1577836800000}'
+            expected = '{"1577836800000":1577836800000,"null":null}'
         else:
             expected = (
-                '{"2020-01-01T00:00:00.000Z":"2020-01-01T00:00:00.000Z"}'
+                '{"2020-01-01T00:00:00.000Z":"2020-01-01T00:00:00.000Z","null":null}'
             )
 
         if as_object:

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import datetime
 from datetime import timedelta
 from io import StringIO
 import json
@@ -809,6 +810,29 @@ class TestPandasContainer:
         json = ts.to_json()
         result = read_json(json, typ="series")
         tm.assert_series_equal(result, ts)
+
+    @pytest.mark.parametrize("date_format", ["epoch", "iso"])
+    @pytest.mark.parametrize("as_object", [True, False])
+    @pytest.mark.parametrize("date_typ", [datetime.date, datetime.datetime, pd.Timestamp])
+    def test_date_index_and_values(self, date_format, as_object, date_typ):
+        data = [date_typ(year=2020, month=1, day=1)]
+        if as_object:
+            data.append("a")
+
+        ser = pd.Series(data, index=data)
+        result = ser.to_json(date_format=date_format)
+
+        if date_format == "epoch":
+            expected = '{"1577836800000":1577836800000}'
+        else:
+            expected = (
+                '{"2020-01-01T00:00:00.000Z":"2020-01-01T00:00:00.000Z"}'
+            )
+
+        if as_object:
+            expected = expected.replace("}", ',"a":"a"}')
+
+        assert result == expected        
 
     @pytest.mark.parametrize(
         "infer_word",


### PR DESCRIPTION
closes #30904

Came across these adding parametrized tests in #30903 which this pulls some elements from but which will also ultimately refactor to avoid duplication; just getting this to work as is

To be clear the regressions were:

1. ISO dates with datetime.date objects was broken

```python
>>> import pandas as pd
>>> import datetime
>>> data = [datetime.date(year=2020, month=1, day=1), "a"]
>>> pd.Series(data).to_json(date_format="iso")
TypeError: Expected datetime object
```

2. `pd.NaT` labels would now yield the sentinel value instead of writing "null"

```python
>>> data = [pd.Timestamp("2020-01-01"), pd.NaT]
>>> pd.Series(data, index=data).to_json()
'{"1577836800000":1577836800000,"-9223372036854":null}'
```

Both have been fixed here