### PR TITLE
API: Disallow NaN in StringArray constructor

### DIFF
--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -162,7 +162,13 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
         result = np.asarray(scalars, dtype=dtype)
         if copy and result is scalars:
             result = result.copy()
+        # Primarily for StringArray
+        result = cls._from_sequence_finalize(result, copy=copy)
         return cls(result)
+
+    @staticmethod
+    def _from_sequence_finalize(values, copy):
+        return values
 
     @classmethod
     def _from_factorized(cls, values, original):

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -166,30 +166,6 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
         result = cls._coerce_from_sequence_values(result, copy=copy)
         return cls(result)
 
-    @staticmethod
-    def _coerce_from_sequence_values(values: np.ndarray, copy: bool):
-        """
-        Coerce the values used in _from_sequence before constructing
-
-        This may mutate `values` inplace.
-
-        Parameters
-        ----------
-        values : ndarray
-            The values to coerce, probably from asarray on the sequence
-            passed to _from_sequence.
-        copy : bool
-            This should be the value of `copy` passed to _from_sequence.
-            It's used to determine if we potentially haven't done a
-            copy, and so a copy will be needed to not mutate the user input.
-
-        Returns
-        -------
-        numpy.ndarray
-            The coerced values.
-        """
-        return values
-
     @classmethod
     def _from_factorized(cls, values, original):
         return cls(values)

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -162,12 +162,32 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
         result = np.asarray(scalars, dtype=dtype)
         if copy and result is scalars:
             result = result.copy()
-        # Primarily for StringArray
-        result = cls._from_sequence_finalize(result, copy=copy)
+        # _coerce_from_sequence_values is useful for StringArray
+        result = cls._coerce_from_sequence_values(result, copy=copy)
         return cls(result)
 
     @staticmethod
-    def _from_sequence_finalize(values, copy):
+    def _coerce_from_sequence_values(values: np.ndarray, copy: bool):
+        """
+        Coerce the values used in _from_sequence before constructing
+
+        This may mutate `values` inplace.
+
+        Parameters
+        ----------
+        values : ndarray
+            The values to coerce, probably from asarray on the sequence
+            passed to _from_sequence.
+        copy : bool
+            This should be the value of `copy` passed to _from_sequence.
+            It's used to determine if we potentially haven't done a
+            copy, and so a copy will be needed to not mutate the user input.
+
+        Returns
+        -------
+        numpy.ndarray
+            The coerced values.
+        """
         return values
 
     @classmethod

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -162,8 +162,6 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
         result = np.asarray(scalars, dtype=dtype)
         if copy and result is scalars:
             result = result.copy()
-        # _coerce_from_sequence_values is useful for StringArray
-        result = cls._coerce_from_sequence_values(result, copy=copy)
         return cls(result)
 
     @classmethod

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -93,9 +93,6 @@ class StringArray(PandasArray):
        StringArray is considered experimental. The implementation and
        parts of the API may change without warning.
 
-       In particular, the NA value used may change to no longer be
-       ``numpy.nan``.
-
     Parameters
     ----------
     values : array-like
@@ -104,8 +101,11 @@ class StringArray(PandasArray):
         .. warning::
 
            Currently, this expects an object-dtype ndarray
-           where the elements are Python strings. This may
-           change without warning in the future.
+           where the elements are Python strings or :attr:`pandas.NA`.
+           This may change without warning in the future. Use
+           :meth:`pandas.array` with ``dtype="string"`` for a stable way of
+           creating a `StringArray` from any sequence.
+
     copy : bool, default False
         Whether to copy the array of data.
 
@@ -119,6 +119,8 @@ class StringArray(PandasArray):
 
     See Also
     --------
+    pandas.array
+        The recommended function for creating a StringArray.
     Series.str
         The string methods are available on Series backed by
         a StringArray.
@@ -164,13 +166,13 @@ class StringArray(PandasArray):
 
     def _validate(self):
         """Validate that we only store NA or strings."""
-        if len(self._ndarray) and not lib.is_string_array(self._ndarray, skipna=True):
-            raise ValueError(
-                "StringArray requires a sequence of strings or missing values."
-            )
+        if len(self._ndarray) and not lib.is_string_array(
+            self._ndarray, skipna=True, na_only=True
+        ):
+            raise ValueError("StringArray requires a sequence of strings or pandas.NA")
         if self._ndarray.dtype != "object":
             raise ValueError(
-                "StringArray requires a sequence of strings. Got "
+                "StringArray requires a sequence of strings or pandas.NA. Got "
                 f"'{self._ndarray.dtype}' dtype instead."
             )
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -119,7 +119,7 @@ class StringArray(PandasArray):
 
     See Also
     --------
-    pandas.array
+    array
         The recommended function for creating a StringArray.
     Series.str
         The string methods are available on Series backed by

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -178,22 +178,22 @@ class StringArray(PandasArray):
     def _from_sequence(cls, scalars, dtype=None, copy=False):
         if dtype:
             assert dtype == "string"
-        result = super()._from_sequence(scalars, dtype=object, copy=copy)
-        return result
 
-    @staticmethod
-    def _coerce_from_sequence_values(values: np.ndarray, copy: bool):
+        result = np.asarray(scalars, dtype="object")
+        if copy and result is scalars:
+            result = result.copy()
+
         # Standardize all missing-like values to NA
         # TODO: it would be nice to do this in _validate / lib.is_string_array
         # We are already doing a scan over the values there.
-        na_values = isna(values)
+        na_values = isna(result)
         if na_values.any():
-            if not copy:
+            if result is scalars:
                 # force a copy now, if we haven't already
-                values = values.copy()
-            values[na_values] = StringDtype.na_value
+                result = result.copy()
+            result[na_values] = StringDtype.na_value
 
-        return values
+        return cls(result)
 
     @classmethod
     def _from_sequence_of_strings(cls, strings, dtype=None, copy=False):

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -182,7 +182,7 @@ class StringArray(PandasArray):
         return result
 
     @staticmethod
-    def _from_sequence_finalize(values, copy):
+    def _coerce_from_sequence_values(values: np.ndarray, copy: bool):
         # Standardize all missing-like values to NA
         # TODO: it would be nice to do this in _validate / lib.is_string_array
         # We are already doing a scan over the values there.

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 import pandas._libs.lib as lib
+import pandas._libs.missing as libmissing
 import pandas._libs.ops as libops
 from pandas._typing import ArrayLike, Dtype
 from pandas.util._decorators import Appender
@@ -118,12 +119,15 @@ def cat_safe(list_of_columns: List, sep: str):
     return result
 
 
-def _na_map(f, arr, na_result=np.nan, dtype=object):
-    # should really _check_ for NA
+def _na_map(f, arr, na_result=None, dtype=object):
     if is_extension_array_dtype(arr.dtype):
+        if na_result is None:
+            na_result = libmissing.NA
         # just StringDtype
         arr = extract_array(arr)
         return _map_stringarray(f, arr, na_value=na_result, dtype=dtype)
+    if na_result is None:
+        na_result = np.nan
     return _map_object(f, arr, na_mask=True, na_value=na_result, dtype=dtype)
 
 

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -205,7 +205,7 @@ def test_constructor_raises():
 
 
 def test_from_sequnce_no_mutate():
-    a = np.array(["a", pd.NA], dtype=object)
+    a = np.array(["a", np.nan], dtype=object)
     original = a.copy()
     result = pd.arrays.StringArray._from_sequence(a)
     expected = pd.arrays.StringArray(np.array(["a", pd.NA], dtype=object))

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -204,10 +204,11 @@ def test_constructor_raises():
         pd.arrays.StringArray(np.array(["a", pd.NaT], dtype=object))
 
 
-def test_from_sequnce_no_mutate():
+@pytest.mark.parametrize("copy", [True, False])
+def test_from_sequnce_no_mutate(copy):
     a = np.array(["a", np.nan], dtype=object)
     original = a.copy()
-    result = pd.arrays.StringArray._from_sequence(a)
+    result = pd.arrays.StringArray._from_sequence(a, copy=copy)
     expected = pd.arrays.StringArray(np.array(["a", pd.NA], dtype=object))
     tm.assert_extension_array_equal(result, expected)
     tm.assert_numpy_array_equal(a, original)

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -194,6 +194,12 @@ def test_constructor_raises():
     with pytest.raises(ValueError, match="sequence of strings"):
         pd.arrays.StringArray(np.array([]))
 
+    with pytest.raises(ValueError, match="strings or pandas.NA"):
+        pd.arrays.StringArray(np.array(["a", np.nan], dtype=object))
+
+    with pytest.raises(ValueError, match="strings or pandas.NA"):
+        pd.arrays.StringArray(np.array(["a", None], dtype=object))
+
 
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.xfail(reason="Not implemented StringArray.sum")

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -201,6 +201,15 @@ def test_constructor_raises():
         pd.arrays.StringArray(np.array(["a", None], dtype=object))
 
 
+def test_from_sequnce_no_mutate():
+    a = np.array(["a", pd.NA], dtype=object)
+    original = a.copy()
+    result = pd.arrays.StringArray._from_sequence(a)
+    expected = pd.arrays.StringArray(np.array(["a", pd.NA], dtype=object))
+    tm.assert_extension_array_equal(result, expected)
+    tm.assert_numpy_array_equal(a, original)
+
+
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.xfail(reason="Not implemented StringArray.sum")
 def test_reduce(skipna):

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -200,6 +200,9 @@ def test_constructor_raises():
     with pytest.raises(ValueError, match="strings or pandas.NA"):
         pd.arrays.StringArray(np.array(["a", None], dtype=object))
 
+    with pytest.raises(ValueError, match="strings or pandas.NA"):
+        pd.arrays.StringArray(np.array(["a", pd.NaT], dtype=object))
+
 
 def test_from_sequnce_no_mutate():
     a = np.array(["a", pd.NA], dtype=object)

--- a/pandas/tests/arrays/string_/test_string.py
+++ b/pandas/tests/arrays/string_/test_string.py
@@ -205,7 +205,7 @@ def test_constructor_raises():
 
 
 @pytest.mark.parametrize("copy", [True, False])
-def test_from_sequnce_no_mutate(copy):
+def test_from_sequence_no_mutate(copy):
     a = np.array(["a", np.nan], dtype=object)
     original = a.copy()
     result = pd.arrays.StringArray._from_sequence(a, copy=copy)

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1114,11 +1114,16 @@ class TestTypeInference:
 
         assert lib.is_string_array(np.array(["foo", "bar"]))
         assert not lib.is_string_array(
-            np.array(["foo", "bar", np.nan], dtype=object), skipna=False
+            np.array(["foo", "bar", pd.NA], dtype=object), skipna=False
         )
         assert lib.is_string_array(
+            np.array(["foo", "bar", pd.NA], dtype=object), skipna=True
+        )
+        # NaN is not valid for string array, just NA
+        assert not lib.is_string_array(
             np.array(["foo", "bar", np.nan], dtype=object), skipna=True
         )
+
         assert not lib.is_string_array(np.array([1, 2]))
 
     def test_to_object_array_tuples(self):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -3521,7 +3521,7 @@ def test_string_array(any_string_method):
 
     if isinstance(expected, Series):
         if expected.dtype == "object" and lib.is_string_array(
-            expected.values, skipna=True
+            expected.dropna().values,
         ):
             assert result.dtype == "string"
             result = result.astype(object)


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/30966

~There were a few ways we could have done this. I opted for this way since it still only requires a single pass over the data to validate the values. Other ways like checking for `np.isnan` after checking `is_string_array` would have required a second pass.~

I changed the implementation in subsequent commits. The basic idea is the same, don't allow NaN in the array passed to StringArray, so that we only make a single pass over the data. We do this by changing `StringValidator.is_valid_null` to only allow NA. This required a small change to `PandasArray._from_sequence`, since previously we relied on creating a temporarily invalid StringArray before doing an inplace `__setitem__` to replace NaNs with NA.

cc @tsvikas.
