### PR TITLE
DOC: remove Table of Contents on the contributing page

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -6,9 +6,6 @@
 Contributing to pandas
 **********************
 
-.. contents:: Table of contents:
-   :local:
-
 Where to start?
 ===============
 


### PR DESCRIPTION
Currently, the contributing page (https://pandas.pydata.org/pandas-docs/version/1.0.0/development/contributing.html) starts with "Table of Contents". 
This PR removes that, because 1) we do that on none of the other pages in our docs and 2) with the new theme, there is a page table of contents in the right sidebar as well (although this shows, when landing on the page, only the first level)