### PR TITLE
FIX: Added small corrections to the test for interpolate limit_area

### DIFF
--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1347,6 +1347,7 @@ class TestSeriesInterpolateData:
             [np.nan, np.nan, 3.0, 4.0, np.nan, np.nan, 7.0, np.nan, np.nan]
         )
         result = s.interpolate(method="linear", limit_area="inside", limit=1)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([np.nan, np.nan, 3.0, 4.0, np.nan, 6.0, 7.0, np.nan, np.nan])
         result = s.interpolate(
@@ -1362,6 +1363,7 @@ class TestSeriesInterpolateData:
             [np.nan, np.nan, 3.0, np.nan, np.nan, np.nan, 7.0, 7.0, np.nan]
         )
         result = s.interpolate(method="linear", limit_area="outside", limit=1)
+        tm.assert_series_equal(result, expected)
 
         expected = Series([np.nan, 3.0, 3.0, np.nan, np.nan, np.nan, 7.0, 7.0, np.nan])
         result = s.interpolate(
@@ -1371,8 +1373,9 @@ class TestSeriesInterpolateData:
 
         expected = Series([3.0, 3.0, 3.0, np.nan, np.nan, np.nan, 7.0, np.nan, np.nan])
         result = s.interpolate(
-            method="linear", limit_area="outside", direction="backward"
+            method="linear", limit_area="outside", limit_direction="backward"
         )
+        tm.assert_series_equal(result, expected)
 
         # raises an error even if limit type is wrong.
         msg = r"Invalid limit_area: expecting one of \['inside', 'outside'\], got abc"


### PR DESCRIPTION
- [ ] closes # nothing to close here
- [ ] tests added / passed
- [ ] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry # not required for this minor fix

Some `tm.assert_series_equal()` have been forgotten in https://github.com/pandas-dev/pandas/blob/2baf788819cd1073d9c15444ebcefcfab8e4b9c8/pandas/tests/series/test_missing.py#L1338

There was also a typo in https://github.com/pandas-dev/pandas/blob/2baf788819cd1073d9c15444ebcefcfab8e4b9c8/pandas/tests/series/test_missing.py#L1374 where `direction` has to be `limit_direction`.

These things have been fixed in this small PR.