### PR TITLE
BUG: Fix Timestamp constructor changes value on ambiguous DST

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -968,6 +968,7 @@ Datetimelike
 - Bug in :func:`date_range` with custom business hours as ``freq`` and given number of ``periods`` (:issue:`30593`)
 - Bug in :class:`PeriodIndex` comparisons with incorrectly casting integers to :class:`Period` objects, inconsistent with the :class:`Period` comparison behavior (:issue:`30722`)
 - Bug in :meth:`DatetimeIndex.insert` raising a ``ValueError`` instead of a ``TypeError`` when trying to insert a timezone-aware :class:`Timestamp` into a timezone-naive :class:`DatetimeIndex`, or vice-versa (:issue:`30806`)
+- Bug in :class:`Timestamp` where constructing :class:`Timestamp` from ambiguous epoch time and calling constructor again changed :meth:`Timestamp.value` property (:issue:`24329`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -968,7 +968,6 @@ Datetimelike
 - Bug in :func:`date_range` with custom business hours as ``freq`` and given number of ``periods`` (:issue:`30593`)
 - Bug in :class:`PeriodIndex` comparisons with incorrectly casting integers to :class:`Period` objects, inconsistent with the :class:`Period` comparison behavior (:issue:`30722`)
 - Bug in :meth:`DatetimeIndex.insert` raising a ``ValueError`` instead of a ``TypeError`` when trying to insert a timezone-aware :class:`Timestamp` into a timezone-naive :class:`DatetimeIndex`, or vice-versa (:issue:`30806`)
-- Bug in :class:`Timestamp` where constructing :class:`Timestamp` from ambiguous epoch time and calling constructor again changed :meth:`Timestamp.value` property (:issue:`24329`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -59,6 +59,7 @@ Categorical
 
 Datetimelike
 ^^^^^^^^^^^^
+- Bug in :class:`Timestamp` where constructing :class:`Timestamp` from ambiguous epoch time and calling constructor again changed :meth:`Timestamp.value` property (:issue:`24329`)
 -
 -
 

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -5,7 +5,8 @@ cimport numpy as cnp
 from numpy cimport int64_t, int32_t, intp_t, ndarray
 cnp.import_array()
 
-from dateutil import zoneinfo
+from dateutil.zoneinfo import tzfile as du_tzfile1
+from dateutil.tz.tz import tzfile as du_tzfile2
 
 import pytz
 
@@ -365,7 +366,10 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
     else:
         obj.value = pydatetime_to_dt64(ts, &obj.dts)
         # GH 24329 Take DST offset into account
-        if isinstance(ts.tzinfo, zoneinfo.tzfile):
+        # Two check in if necessary because class
+        # differs on Windows and Linux
+        if (isinstance(ts.tzinfo, du_tzfile1) or
+                isinstance(ts.tzinfo, du_tzfile2)):
             if ts.tzinfo.is_ambiguous(ts):
                 dst_offset = ts.tzinfo.dst(ts)
                 obj.value += int(dst_offset.total_seconds() * 1e9)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -362,10 +362,10 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
             obj.tzinfo = tz
     else:
         obj.value = pydatetime_to_dt64(ts, &obj.dts)
-        # GH 24329 Take DST offset into account
+        # GH 24329 When datetime is ambiguous,
         # pydatetime_to_dt64 doesn't take DST into account
-        # but get_utcoffset does. dateutil assumes DST
-        # when time is ambiguous, so we need to correct for it
+        # but with dateutil timezone, get_utcoffset does
+        # so we need to correct for it
         if treat_tz_as_dateutil(ts.tzinfo):
             if ts.tzinfo.is_ambiguous(ts):
                 dst_offset = ts.tzinfo.dst(ts)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -363,6 +363,9 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
     else:
         obj.value = pydatetime_to_dt64(ts, &obj.dts)
         # GH 24329 Take DST offset into account
+        # pydatetime_to_dt64 doesn't take DST into account
+        # but get_utcoffset does. dateutil assumes DST
+        # when time is ambiguous, so we need to correct for it
         if treat_tz_as_dateutil(ts.tzinfo):
             if ts.tzinfo.is_ambiguous(ts):
                 dst_offset = ts.tzinfo.dst(ts)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -5,9 +5,6 @@ cimport numpy as cnp
 from numpy cimport int64_t, int32_t, intp_t, ndarray
 cnp.import_array()
 
-from dateutil.zoneinfo import tzfile as du_tzfile1
-from dateutil.tz.tz import tzfile as du_tzfile2
-
 import pytz
 
 # stdlib datetime imports
@@ -32,7 +29,7 @@ from pandas._libs.tslibs.util cimport (
 from pandas._libs.tslibs.timedeltas cimport cast_from_unit
 from pandas._libs.tslibs.timezones cimport (
     is_utc, is_tzlocal, is_fixed_offset, get_utcoffset, get_dst_info,
-    get_timezone, maybe_get_tz, tz_compare)
+    get_timezone, maybe_get_tz, tz_compare, treat_tz_as_dateutil)
 from pandas._libs.tslibs.timezones import UTC
 from pandas._libs.tslibs.parsing import parse_datetime_string
 
@@ -366,10 +363,7 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
     else:
         obj.value = pydatetime_to_dt64(ts, &obj.dts)
         # GH 24329 Take DST offset into account
-        # Two check in if necessary because class
-        # differs on Windows and Linux
-        if (isinstance(ts.tzinfo, du_tzfile1) or
-                isinstance(ts.tzinfo, du_tzfile2)):
+        if treat_tz_as_dateutil(ts.tzinfo):
             if ts.tzinfo.is_ambiguous(ts):
                 dst_offset = ts.tzinfo.dst(ts)
                 obj.value += int(dst_offset.total_seconds() * 1e9)

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -573,13 +573,7 @@ class TestDatetimeIndexTimezones:
             "2013-10-26 23:00", "2013-10-27 01:00", freq="H", tz=tz, ambiguous="infer"
         )
         assert times[0] == Timestamp("2013-10-26 23:00", tz=tz, freq="H")
-
-        if str(tz).startswith("dateutil"):
-            # fixed ambiguous behavior
-            # see GH#14621
-            assert times[-1] == Timestamp("2013-10-27 01:00:00+0100", tz=tz, freq="H")
-        else:
-            assert times[-1] == Timestamp("2013-10-27 01:00:00+0000", tz=tz, freq="H")
+        assert times[-1] == Timestamp("2013-10-27 01:00:00+0000", tz=tz, freq="H")
 
     @pytest.mark.parametrize(
         "tz, option, expected",

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -1081,3 +1081,14 @@ def test_dt_subclass_add_timedelta(lh, rh):
     result = lh + rh
     expected = SubDatetime(2000, 1, 1, 1)
     assert result == expected
+
+
+def test_constructor_ambigous_dst():
+    # GH 24329
+    # Make sure that calling Timestamp constructor
+    # on Timestamp created from ambiguous time
+    # doesn't change Timestamp.value
+    ts = Timestamp(1382835600000000000, tz="dateutil/Europe/London")
+    expected = ts.value
+    result = Timestamp(ts).value
+    assert result == expected


### PR DESCRIPTION
- [X] closes #24329
- [X] 1 tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
