### PR TITLE
TST: Insert 'match' to bare pytest raises

### DIFF
--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -60,10 +60,11 @@ def test_random_state():
     assert com.random_state() is np.random
 
     # Error for floats or strings
-    with pytest.raises(ValueError):
+    msg = "random_state must be an integer, a numpy RandomState, or None"
+    with pytest.raises(ValueError, match=msg):
         com.random_state("test")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg):
         com.random_state(5.5)
 
 
@@ -93,15 +94,17 @@ def test_dict_compat():
 
 def test_standardize_mapping():
     # No uninitialized defaultdicts
-    with pytest.raises(TypeError):
+    msg = r"to_dict\(\) only accepts initialized defaultdicts"
+    with pytest.raises(TypeError, match=msg):
         com.standardize_mapping(collections.defaultdict)
 
     # No non-mapping subtypes, instance
-    with pytest.raises(TypeError):
+    msg = "unsupported type: <class 'list'>"
+    with pytest.raises(TypeError, match=msg):
         com.standardize_mapping([])
 
     # No non-mapping subtypes, class
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=msg):
         com.standardize_mapping(list)
 
     fill = {"bad": "data"}

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -136,7 +136,12 @@ def test_missing_required_dependency():
     # https://github.com/MacPython/pandas-wheels/pull/50
     call = ["python", "-sSE", "-c", "import pandas"]
 
-    with pytest.raises(subprocess.CalledProcessError) as exc:
+    msg = (
+        r"Command '\['python', '-sSE', '-c', 'import pandas'\]' "
+        r"returned non-zero exit status 1."
+    )
+
+    with pytest.raises(subprocess.CalledProcessError, match=msg) as exc:
         subprocess.check_output(call, stderr=subprocess.STDOUT)
 
     output = exc.value.stdout.decode()

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -138,7 +138,7 @@ def test_missing_required_dependency():
 
     msg = (
         r"Command '\['python', '-sSE', '-c', 'import pandas'\]' "
-        r"returned non-zero exit status 1."
+        "returned non-zero exit status 1."
     )
 
     with pytest.raises(subprocess.CalledProcessError, match=msg) as exc:

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -26,7 +26,10 @@ def test_exception_importable(exc):
     assert err is not None
 
     # check that we can raise on them
-    with pytest.raises(err, match=""):
+
+    msg = "^$"
+
+    with pytest.raises(err, match=msg):
         raise err()
 
 

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -22,12 +22,12 @@ import pandas as pd  # noqa
 def test_exception_importable(exc):
     from pandas import errors
 
-    e = getattr(errors, exc)
-    assert e is not None
+    err = getattr(errors, exc)
+    assert err is not None
 
     # check that we can raise on them
-    with pytest.raises(e):
-        raise e()
+    with pytest.raises(err, match=""):
+        raise err()
 
 
 def test_catch_oob():

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -101,7 +101,7 @@ class TestIndexing:
         assert not isinstance(maybe_slice, slice)
         tm.assert_numpy_array_equal(maybe_slice, indices)
 
-        msg = r"index 100 is out of bounds for axis \(0|1\) with size 100"
+        msg = "index 100 is out of bounds for axis (0|1) with size 100"
 
         with pytest.raises(IndexError, match=msg):
             target[indices]

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -101,10 +101,7 @@ class TestIndexing:
         assert not isinstance(maybe_slice, slice)
         tm.assert_numpy_array_equal(maybe_slice, indices)
 
-        msg = (
-            "index 100 is out of bounds for axis (0|1) with size 100|"
-            "index 100 is out of bounds for axis 1 with size 100"
-        )
+        msg = r"index 100 is out of bounds for axis \(0|1\) with size 100"
 
         with pytest.raises(IndexError, match=msg):
             target[indices]

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -101,7 +101,11 @@ class TestIndexing:
         assert not isinstance(maybe_slice, slice)
         tm.assert_numpy_array_equal(maybe_slice, indices)
 
-        msg = "index 100 is out of bounds for axis 0 with size 100"
+        msg = (
+            "index 100 is out of bounds for axis 0 with size 100|"
+            "index 100 is out of bounds for axis 1 with size 100"
+        )
+
         with pytest.raises(IndexError, match=msg):
             target[indices]
         with pytest.raises(IndexError, match=msg):

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -102,7 +102,7 @@ class TestIndexing:
         tm.assert_numpy_array_equal(maybe_slice, indices)
 
         msg = (
-            "index 100 is out of bounds for axis 0 with size 100|"
+            "index 100 is out of bounds for axis (0|1) with size 100|"
             "index 100 is out of bounds for axis 1 with size 100"
         )
 

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -22,7 +22,8 @@ class TestMisc:
         assert libwriters.max_len_string_array(arr) == 3
 
         # raises
-        with pytest.raises(TypeError):
+        msg = "No matching signature found"
+        with pytest.raises(TypeError, match=msg):
             libwriters.max_len_string_array(arr.astype("U"))
 
     def test_fast_unique_multiple_list_gen_sort(self):
@@ -100,9 +101,10 @@ class TestIndexing:
         assert not isinstance(maybe_slice, slice)
         tm.assert_numpy_array_equal(maybe_slice, indices)
 
-        with pytest.raises(IndexError):
+        msg = "index 100 is out of bounds for axis 0 with size 100"
+        with pytest.raises(IndexError, match=msg):
             target[indices]
-        with pytest.raises(IndexError):
+        with pytest.raises(IndexError, match=msg):
             target[maybe_slice]
 
         indices = np.array([100, 99, 98, 97], dtype=np.int64)
@@ -111,9 +113,9 @@ class TestIndexing:
         assert not isinstance(maybe_slice, slice)
         tm.assert_numpy_array_equal(maybe_slice, indices)
 
-        with pytest.raises(IndexError):
+        with pytest.raises(IndexError, match=msg):
             target[indices]
-        with pytest.raises(IndexError):
+        with pytest.raises(IndexError, match=msg):
             target[maybe_slice]
 
         for case in [[99, 97, 99, 96], [99, 99, 98, 97], [98, 98, 97, 96]]:

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -453,7 +453,7 @@ class TestExtensionTake:
 
         msg = (
             r"cannot do a non-empty take from an empty axes.|"
-            r"indices are out-of-bounds"
+            "indices are out-of-bounds"
         )
         with pytest.raises(IndexError, match=msg):
             algos.take(arr, [0], allow_fill=allow_fill)

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -423,16 +423,21 @@ class TestExtensionTake:
 
     def test_bounds_check_large(self):
         arr = np.array([1, 2])
-        with pytest.raises(IndexError):
+
+        msg = "indices are out-of-bounds"
+        with pytest.raises(IndexError, match=msg):
             algos.take(arr, [2, 3], allow_fill=True)
 
-        with pytest.raises(IndexError):
+        msg = "index 2 is out of bounds for size 2"
+        with pytest.raises(IndexError, match=msg):
             algos.take(arr, [2, 3], allow_fill=False)
 
     def test_bounds_check_small(self):
         arr = np.array([1, 2, 3], dtype=np.int64)
         indexer = [0, -1, -2]
-        with pytest.raises(ValueError):
+
+        msg = r"'indices' contains values less than allowed \(-2 < -1\)"
+        with pytest.raises(ValueError, match=msg):
             algos.take(arr, indexer, allow_fill=True)
 
         result = algos.take(arr, indexer)
@@ -446,7 +451,11 @@ class TestExtensionTake:
         result = algos.take(arr, [], allow_fill=allow_fill)
         tm.assert_numpy_array_equal(arr, result)
 
-        with pytest.raises(IndexError):
+        msg = (
+            r"cannot do a non-empty take from an empty axes.|"
+            r"indices are out-of-bounds"
+        )
+        with pytest.raises(IndexError, match=msg):
             algos.take(arr, [0], allow_fill=allow_fill)
 
     def test_take_na_empty(self):


### PR DESCRIPTION
- [x] ref #30999
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
