### PR TITLE
Revert "DOC: removed wrong value of `pd.NA ** 0`"

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -825,10 +825,13 @@ For example, ``pd.NA`` propagates in arithmetic operations, similarly to
 There are a few special cases when the result is known, even when one of the
 operands is ``NA``.
 
-.. ipython:: python
 
-   pd.NA ** 0
-   1 ** pd.NA
+================ ======
+Operation        Result
+================ ======
+``pd.NA ** 0``   0
+``1 ** pd.NA``   1
+================ ======
 
 In equality and comparison operations, ``pd.NA`` also propagates. This deviates
 from the behaviour of ``np.nan``, where comparisons with ``np.nan`` always


### PR DESCRIPTION
Reverts pandas-dev/pandas#31005

Made to the wrong branch.