### PR TITLE
REF: PeriodIndex.get_loc

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -500,7 +500,7 @@ cdef class TimedeltaEngine(DatetimeEngine):
 cdef class PeriodEngine(Int64Engine):
 
     cdef _get_index_values(self):
-        return super(PeriodEngine, self).vgetter()
+        return super(PeriodEngine, self).vgetter().view("i8")
 
     cdef void _call_map_locations(self, values):
         # super(...) pattern doesn't seem to work with `cdef`

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -507,6 +507,9 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
         Fast lookup of value from 1-dimensional ndarray. Only use this if you
         know what you're doing
         """
+        if is_integer(key):
+            return series.iat[key]
+
         s = com.values_from_object(series)
         try:
             value = super().get_value(s, key)
@@ -604,6 +607,10 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
             except DateParseError:
                 # A string with invalid format
                 raise KeyError(f"Cannot interpret '{key}' as period")
+
+        elif is_integer(key):
+            # Period constructor will cast to string, which we dont want
+            raise KeyError(key)
 
         try:
             key = Period(key, freq=self.freq)

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -540,8 +540,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
             ordinal = key.ordinal if key is not NaT else NaT.value
             loc = self._engine.get_loc(ordinal)
             return series[loc]
-            value = Index.get_value(self, series, key)
-            return com.maybe_box(self, value, series, key)
 
         value = Index.get_value(self, series, key)
         return com.maybe_box(self, value, series, key)

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -532,7 +532,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
             elif grp == freqn:
                 key = Period(asdt, freq=self.freq)
                 loc = self.get_loc(key)
-                return series[loc]
+                return series.iloc[loc]
             else:
                 raise KeyError(key)
 
@@ -541,6 +541,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index, PeriodDelegateMixin):
             loc = self._engine.get_loc(ordinal)
             return series[loc]
 
+        # slice, PeriodIndex, np.ndarray, List[Period]
         value = Index.get_value(self, series, key)
         return com.maybe_box(self, value, series, key)
 

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -452,7 +452,7 @@ class TestIndexing:
         tm.assert_numpy_array_equal(idx2.get_loc(str(p2)), expected_idx2_p2)
 
     def test_get_loc_integer(self):
-        dti = pd.date_range('2016-01-01', periods=3)
+        dti = pd.date_range("2016-01-01", periods=3)
         pi = dti.to_period("D")
         with pytest.raises(KeyError, match="16801"):
             pi.get_loc(16801)
@@ -462,7 +462,7 @@ class TestIndexing:
             pi2.get_loc(46)
 
     def test_get_value_integer(self):
-        dti = pd.date_range('2016-01-01', periods=3)
+        dti = pd.date_range("2016-01-01", periods=3)
         pi = dti.to_period("D")
         ser = pd.Series(range(3), index=pi)
         with pytest.raises(IndexError, match="is out of bounds for axis 0 with size 3"):

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -451,6 +451,28 @@ class TestIndexing:
         tm.assert_numpy_array_equal(idx2.get_loc(p2), expected_idx2_p2)
         tm.assert_numpy_array_equal(idx2.get_loc(str(p2)), expected_idx2_p2)
 
+    def test_get_loc_integer(self):
+        dti = pd.date_range('2016-01-01', periods=3)
+        pi = dti.to_period("D")
+        with pytest.raises(KeyError, match="16801"):
+            pi.get_loc(16801)
+
+        pi2 = dti.to_period("Y")  # duplicates, ordinals are all 46
+        with pytest.raises(KeyError, match="46"):
+            pi2.get_loc(46)
+
+    def test_get_value_integer(self):
+        dti = pd.date_range('2016-01-01', periods=3)
+        pi = dti.to_period("D")
+        ser = pd.Series(range(3), index=pi)
+        with pytest.raises(IndexError, match="is out of bounds for axis 0 with size 3"):
+            pi.get_value(ser, 16801)
+
+        pi2 = dti.to_period("Y")  # duplicates, ordinals are all 46
+        ser2 = pd.Series(range(3), index=pi2)
+        with pytest.raises(IndexError, match="is out of bounds for axis 0 with size 3"):
+            pi2.get_value(ser2, 46)
+
     def test_is_monotonic_increasing(self):
         # GH 17717
         p0 = pd.Period("2017-09-01")


### PR DESCRIPTION
xref #30874 which does similar cleanup for TimedeltaIndex.

Do all parsing/casting/conversion before call to self._engine or super() methods (xref #30948)

Fix+test integers incorrectly getting through.

