### PR TITLE
CI: Travis Remove Unrequired Exclude

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ git:
 
 matrix:
     fast_finish: true
-    exclude:
-      # Exclude the default Python 3.5 build
-      - python: 3.5
 
     include:
     - env:


### PR DESCRIPTION
Follow up from #30540 this exclusion is no longer required.

I checked the build config is the same using
https://config.travis-ci.com/explore