### PR TITLE
Revert "DEPR: is_copy arg of take (#30615)"

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -703,7 +703,6 @@ Deprecations
 - The deprecated internal attributes ``_start``, ``_stop`` and ``_step`` of :class:`RangeIndex` now raise a ``FutureWarning`` instead of a ``DeprecationWarning`` (:issue:`26581`)
 - The ``pandas.util.testing`` module has been deprecated. Use the public API in ``pandas.testing`` documented at :ref:`api.general.testing` (:issue:`16232`).
 - ``pandas.SparseArray`` has been deprecated.  Use ``pandas.arrays.SparseArray`` (:class:`arrays.SparseArray`) instead. (:issue:`30642`)
-- The parameter ``is_copy`` of :meth:`DataFrame.take` has been deprecated and will be removed in a future version. (:issue:`27357`)
 - Support for multi-dimensional indexing (e.g. ``index[:, None]``) on a :class:`Index` is deprecated and will be removed in a future version, convert to a numpy array before indexing instead (:issue:`30588`)
 - The ``pandas.np`` submodule is now deprecated. Import numpy directly instead (:issue:`30296`)
 - The ``pandas.datetime`` class is now deprecated. Import from ``datetime`` instead (:issue:`30610`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3262,7 +3262,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     # Indexing Methods
 
     def take(
-        self: FrameOrSeries, indices, axis=0, is_copy: Optional[bool_t] = None, **kwargs
+        self: FrameOrSeries, indices, axis=0, is_copy: bool_t = True, **kwargs
     ) -> FrameOrSeries:
         """
         Return the elements in the given *positional* indices along an axis.
@@ -3280,8 +3280,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             selecting rows, ``1`` means that we are selecting columns.
         is_copy : bool, default True
             Whether to return a copy of the original object or not.
-
-            .. deprecated:: 1.0.0
         **kwargs
             For compatibility with :meth:`numpy.take`. Has no effect on the
             output.
@@ -3340,16 +3338,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         1  monkey  mammal        NaN
         3    lion  mammal       80.5
         """
-        if is_copy is not None:
-            warnings.warn(
-                "is_copy is deprecated and will be removed in a future version. "
-                "take will always return a copy in the future.",
-                FutureWarning,
-                stacklevel=2,
-            )
-        else:
-            is_copy = True
-
         nv.validate_take(tuple(), kwargs)
 
         self._consolidate_inplace()
@@ -4949,7 +4937,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             )
 
         locs = rs.choice(axis_length, size=n, replace=replace, p=weights)
-        return self.take(locs, axis=axis)
+        return self.take(locs, axis=axis, is_copy=False)
 
     _shared_docs[
         "pipe"
@@ -6934,8 +6922,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         # mask the missing
         missing = locs == -1
-        d = self.take(locs)
-        data = d.copy()
+        data = self.take(locs, is_copy=False)
         data.index = where
         data.loc[missing] = np.nan
         return data if is_list else data.iloc[-1]

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -194,7 +194,7 @@ class Grouper:
             # use stable sort to support first, last, nth
             indexer = self.indexer = ax.argsort(kind="mergesort")
             ax = ax.take(indexer)
-            obj = obj.take(indexer, axis=self.axis)
+            obj = obj.take(indexer, axis=self.axis, is_copy=False)
 
         self.obj = obj
         self.grouper = ax

--- a/pandas/tests/frame/methods/test_asof.py
+++ b/pandas/tests/frame/methods/test_asof.py
@@ -30,7 +30,6 @@ class TestFrameAsof:
         ub = df.index[30]
 
         dates = list(dates)
-
         result = df.asof(dates)
         assert result.notna().all(1).all()
 
@@ -66,7 +65,6 @@ class TestFrameAsof:
         # no match found - `where` value before earliest date in index
         N = 10
         df = date_range_frame.iloc[:N].copy()
-
         result = df.asof("1989-12-31")
 
         expected = Series(
@@ -140,6 +138,5 @@ class TestFrameAsof:
                 Timestamp("2018-01-01 22:35:10.550+00:00"),
             ],
         )
-
         result = df.asof(stamp)
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -817,18 +817,6 @@ class TestNDFrame:
             with pytest.raises(ValueError, match=msg):
                 obj.take(indices, mode="clip")
 
-    def test_depr_take_kwarg_is_copy(self):
-        # GH 27357
-        df = DataFrame({"A": [1, 2, 3]})
-        msg = (
-            "is_copy is deprecated and will be removed in a future version. "
-            "take will always return a copy in the future."
-        )
-        with tm.assert_produces_warning(FutureWarning) as w:
-            df.take([0, 1], is_copy=True)
-
-        assert w[0].message.args[0] == msg
-
     def test_equals(self):
         s1 = pd.Series([1, 2, 3], index=[0, 2, 1])
         s2 = s1.copy()


### PR DESCRIPTION
This reverts commit 7796be6e2c548de0be16e6adf08f5fca2ab9b4bc.

See https://github.com/pandas-dev/pandas/issues/27357#issuecomment-571639242 and https://github.com/pandas-dev/pandas/pull/30615#issuecomment-571637550