### PR TITLE
TST: Split test_offsets.py - Added fixtures for date offsets and business date offsets

### DIFF
--- a/pandas/tests/tseries/offsets/conftest.py
+++ b/pandas/tests/tseries/offsets/conftest.py
@@ -71,7 +71,8 @@ def month_classes(request):
 @pytest.fixture(params=[getattr(offsets, o) for o in DATE_OFFSETS])
 def date_offset_types(request):
     """
-    Fixture for all the datetime offsets available for a time series except business subclasses.
+    Fixture for all the datetime offsets available for a time series except business
+    subclasses.
     """
     return request.param
 
@@ -85,7 +86,8 @@ def date_offset_types(request):
 )
 def date_month_classes(request):
     """
-    Fixture for month based datetime offsets available for a time series except business subclasses.
+    Fixture for month based datetime offsets available for a time series except business
+    subclasses.
     """
     return request.param
 

--- a/pandas/tests/tseries/offsets/conftest.py
+++ b/pandas/tests/tseries/offsets/conftest.py
@@ -2,6 +2,49 @@ import pytest
 
 import pandas.tseries.offsets as offsets
 
+DATE_OFFSETS = {
+    "Day",
+    "MonthBegin",
+    "MonthEnd",
+    "SemiMonthBegin",
+    "SemiMonthEnd",
+    "YearBegin",
+    "YearEnd",
+    "QuarterBegin",
+    "QuarterEnd",
+    "LastWeekOfMonth",
+    "Week",
+    "WeekOfMonth",
+    "Easter",
+    "Hour",
+    "Minute",
+    "Second",
+    "Milli",
+    "Micro",
+    "Nano",
+    "DateOffset",
+}
+
+
+BUSINESS_OFFSETS = {
+    "BusinessDay",
+    "BDay",
+    "CustomBusinessDay",
+    "CBMonthBegin",
+    "CBMonthEnd",
+    "BMonthBegin",
+    "BMonthEnd",
+    "BusinessHour",
+    "CustomBusinessHour",
+    "BYearBegin",
+    "BYearEnd",
+    "CDay",
+    "BQuarterBegin",
+    "BQuarterEnd",
+    "FY5253Quarter",
+    "FY5253",
+}
+
 
 @pytest.fixture(params=[getattr(offsets, o) for o in offsets.__all__])
 def offset_types(request):
@@ -21,5 +64,49 @@ def offset_types(request):
 def month_classes(request):
     """
     Fixture for month based datetime offsets available for a time series.
+    """
+    return request.param
+
+
+@pytest.fixture(params=[getattr(offsets, o) for o in DATE_OFFSETS])
+def date_offset_types(request):
+    """
+    Fixture for all the datetime offsets available for a time series except business subclasses.
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        getattr(offsets, o)
+        for o in DATE_OFFSETS
+        if issubclass(getattr(offsets, o), offsets.MonthOffset) and o != "MonthOffset"
+    ]
+)
+def date_month_classes(request):
+    """
+    Fixture for month based datetime offsets available for a time series except business subclasses.
+    """
+    return request.param
+
+
+@pytest.fixture(params=[getattr(offsets, o) for o in BUSINESS_OFFSETS])
+def business_offset_types(request):
+    """
+    Fixture for all the business datetime offsets available for a time series.
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        getattr(offsets, o)
+        for o in BUSINESS_OFFSETS
+        if issubclass(getattr(offsets, o), offsets.MonthOffset) and o != "MonthOffset"
+    ]
+)
+def business_month_classes(request):
+    """
+    Fixture for month based business datetime offsets available for a time series.
     """
     return request.param


### PR DESCRIPTION
In context of #30194 and #31031
Second part with added (bussiness-)date offsets fixtures
- [ ] closes #27085
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
