### PR TITLE
TST: Disallow bare pytest.raises

### DIFF
--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -140,7 +140,8 @@ class TestArithmetic:
         msg = (
             "can only concatenate str|"
             "did not contain a loop with signature matching types|"
-            "unsupported operand type"
+            "unsupported operand type|"
+            "must be str"
         )
         with pytest.raises(TypeError, match=msg):
             "foo_" + ser

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -137,7 +137,12 @@ class TestArithmetic:
         ser = Series(data, dtype=dtype)
 
         ser = tm.box_expected(ser, box_with_array)
-        with pytest.raises(TypeError):
+        msg = (
+            "can only concatenate str|"
+            "did not contain a loop with signature matching types|"
+            "unsupported operand type"
+        )
+        with pytest.raises(TypeError, match=msg):
             "foo_" + ser
 
     @pytest.mark.parametrize("op", [operator.add, ops.radd, operator.sub, ops.rsub])


### PR DESCRIPTION
- [ ] ref #30999 
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This pull request is to add appropriate match arguments to bare pytest.raises listed in the comment https://github.com/pandas-dev/pandas/issues/30999#issuecomment-574174389 as described by the referenced issue.