### PR TITLE
DOC: Fix HDF5 complevel and complib formatting

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -4220,46 +4220,49 @@ Compression
 all kinds of stores, not just tables. Two parameters are used to
 control compression: ``complevel`` and ``complib``.
 
-``complevel`` specifies if and how hard data is to be compressed.
-              ``complevel=0`` and ``complevel=None`` disables
-              compression and ``0<complevel<10`` enables compression.
+complevel : specifies if and how hard data is to be compressed.
+  ``complevel=0`` and ``complevel=None`` disables compression and 
+  ``0<complevel<10`` enables compression.
 
-``complib`` specifies which compression library to use. If nothing is
-            specified the default library ``zlib`` is used. A
-            compression library usually optimizes for either good
-            compression rates or speed and the results will depend on
-            the type of data. Which type of
-            compression to choose depends on your specific needs and
-            data. The list of supported compression libraries:
+complib : specifies which compression library to use. 
+  If nothing is  specified the default library ``zlib`` is used. A 
+  compression library usually optimizes for either good compression rates
+  or speed and the results will depend on the type of data. Which type of
+  compression to choose depends on your specific needs and data. The list
+  of supported compression libraries:
 
-             - `zlib <https://zlib.net/>`_: The default compression library. A classic in terms of compression, achieves good compression rates but is somewhat slow.
-             - `lzo <https://www.oberhumer.com/opensource/lzo/>`_: Fast compression and decompression.
-             - `bzip2 <http://bzip.org/>`_: Good compression rates.
-             - `blosc <http://www.blosc.org/>`_: Fast compression and decompression.
+  - `zlib <https://zlib.net/>`_: The default compression library. 
+    A classic in terms of compression, achieves good compression 
+    rates but is somewhat slow.
+  - `lzo <https://www.oberhumer.com/opensource/lzo/>`_: Fast 
+    compression and decompression.
+  - `bzip2 <http://bzip.org/>`_: Good compression rates.
+  - `blosc <http://www.blosc.org/>`_: Fast compression and 
+    decompression.
 
-                Support for alternative blosc compressors:
+    Support for alternative blosc compressors:
 
-                - `blosc:blosclz <http://www.blosc.org/>`_ This is the
-                  default compressor for ``blosc``
-                - `blosc:lz4
-                  <https://fastcompression.blogspot.dk/p/lz4.html>`_:
-                  A compact, very popular and fast compressor.
-                - `blosc:lz4hc
-                  <https://fastcompression.blogspot.dk/p/lz4.html>`_:
-                  A tweaked version of LZ4, produces better
-                  compression ratios at the expense of speed.
-                - `blosc:snappy <https://google.github.io/snappy/>`_:
-                  A popular compressor used in many places.
-                - `blosc:zlib <https://zlib.net/>`_: A classic;
-                  somewhat slower than the previous ones, but
-                  achieving better compression ratios.
-                - `blosc:zstd <https://facebook.github.io/zstd/>`_: An
-                  extremely well balanced codec; it provides the best
-                  compression ratios among the others above, and at
-                  reasonably fast speed.
+    - `blosc:blosclz <http://www.blosc.org/>`_ This is the
+      default compressor for ``blosc``
+    - `blosc:lz4
+      <https://fastcompression.blogspot.dk/p/lz4.html>`_:
+      A compact, very popular and fast compressor.
+    - `blosc:lz4hc
+      <https://fastcompression.blogspot.dk/p/lz4.html>`_:
+      A tweaked version of LZ4, produces better
+      compression ratios at the expense of speed.
+    - `blosc:snappy <https://google.github.io/snappy/>`_:
+      A popular compressor used in many places.
+    - `blosc:zlib <https://zlib.net/>`_: A classic;
+      somewhat slower than the previous ones, but
+      achieving better compression ratios.
+    - `blosc:zstd <https://facebook.github.io/zstd/>`_: An
+      extremely well balanced codec; it provides the best
+      compression ratios among the others above, and at
+      reasonably fast speed.
 
-             If ``complib`` is defined as something other than the
-             listed libraries a ``ValueError`` exception is issued.
+  If ``complib`` is defined as something other than the listed libraries a 
+  ``ValueError`` exception is issued.
 
 .. note::
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -4220,11 +4220,11 @@ Compression
 all kinds of stores, not just tables. Two parameters are used to
 control compression: ``complevel`` and ``complib``.
 
-complevel : specifies if and how hard data is to be compressed.
+* ``complevel`` specifies if and how hard data is to be compressed.
   ``complevel=0`` and ``complevel=None`` disables compression and
   ``0<complevel<10`` enables compression.
 
-complib : specifies which compression library to use.
+* ``complib`` specifies which compression library to use.
   If nothing is  specified the default library ``zlib`` is used. A
   compression library usually optimizes for either good compression rates
   or speed and the results will depend on the type of data. Which type of

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -4221,23 +4221,23 @@ all kinds of stores, not just tables. Two parameters are used to
 control compression: ``complevel`` and ``complib``.
 
 complevel : specifies if and how hard data is to be compressed.
-  ``complevel=0`` and ``complevel=None`` disables compression and 
+  ``complevel=0`` and ``complevel=None`` disables compression and
   ``0<complevel<10`` enables compression.
 
-complib : specifies which compression library to use. 
-  If nothing is  specified the default library ``zlib`` is used. A 
+complib : specifies which compression library to use.
+  If nothing is  specified the default library ``zlib`` is used. A
   compression library usually optimizes for either good compression rates
   or speed and the results will depend on the type of data. Which type of
   compression to choose depends on your specific needs and data. The list
   of supported compression libraries:
 
-  - `zlib <https://zlib.net/>`_: The default compression library. 
-    A classic in terms of compression, achieves good compression 
+  - `zlib <https://zlib.net/>`_: The default compression library.
+    A classic in terms of compression, achieves good compression
     rates but is somewhat slow.
-  - `lzo <https://www.oberhumer.com/opensource/lzo/>`_: Fast 
+  - `lzo <https://www.oberhumer.com/opensource/lzo/>`_: Fast
     compression and decompression.
   - `bzip2 <http://bzip.org/>`_: Good compression rates.
-  - `blosc <http://www.blosc.org/>`_: Fast compression and 
+  - `blosc <http://www.blosc.org/>`_: Fast compression and
     decompression.
 
     Support for alternative blosc compressors:
@@ -4261,7 +4261,7 @@ complib : specifies which compression library to use.
       compression ratios among the others above, and at
       reasonably fast speed.
 
-  If ``complib`` is defined as something other than the listed libraries a 
+  If ``complib`` is defined as something other than the listed libraries a
   ``ValueError`` exception is issued.
 
 .. note::


### PR DESCRIPTION
Fixes formatting of these params.

- [x] closes #31052
- [ ] tests added / passed (N/A)
- [ ] passes `black pandas` (N/A)
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff` (N/A)
- [ ] whatsnew entry (N/A)

N/A as this PR only updates an rst file for the docs.