### PR TITLE
BUG: partial-timestamp slicing near the end of year/quarter/month

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -102,7 +102,7 @@ Interval
 
 Indexing
 ^^^^^^^^
-- Bug in slicing on a :class:`DatetimeIndex` with a partial-timestamp dropping high-resolution indices near the end of a year, quarter, or month (:issue:`????`)
+- Bug in slicing on a :class:`DatetimeIndex` with a partial-timestamp dropping high-resolution indices near the end of a year, quarter, or month (:issue:`31064`)
 -
 -
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -102,7 +102,7 @@ Interval
 
 Indexing
 ^^^^^^^^
-
+- Bug in slicing on a :class:`DatetimeIndex` with a partial-timestamp dropping high-resolution indices near the end of a year, quarter, or month (:issue:`????`)
 -
 -
 

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -154,6 +154,7 @@ class TestSlicing:
         ],
     )
     def test_slice_end_of_period_resolution(self, partial_dtime):
+        # GH#31064
         dti = date_range("2019-12-31 23:59:55.999999999", periods=10, freq="s")
 
         ser = pd.Series(range(10), index=dti)

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -142,6 +142,25 @@ class TestSlicing:
         expected = slice(3288, 3653)
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "partial_dtime",
+        [
+            "2019",
+            "2019Q4",
+            "Dec 2019",
+            "2019-12-31",
+            "2019-12-31 23",
+            "2019-12-31 23:59",
+        ],
+    )
+    def test_slice_end_of_period_resolution(self, partial_dtime):
+        dti = date_range("2019-12-31 23:59:55.999999999", periods=10, freq="s")
+
+        ser = pd.Series(range(10), index=dti)
+        result = ser[partial_dtime]
+        expected = ser.iloc[:5]
+        tm.assert_series_equal(result, expected)
+
     def test_slice_quarter(self):
         dti = date_range(freq="D", start=datetime(2000, 6, 1), periods=500)
 


### PR DESCRIPTION
I'm fairly confident we can refactor this to be a lot less verbose, but will do that separately from the bugfix.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
