### PR TITLE
Fix DataFrame.info() range summary for DatetimeIndex

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -485,7 +485,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
         """
         formatter = self._formatter_func
         if len(self) > 0:
-            index_summary = f", {formatter(self[0])} to {formatter(self[-1])}"
+            index_summary = f", {formatter(self.min())} to {formatter(self.max())}"
         else:
             index_summary = ""
 


### PR DESCRIPTION
**Fix `DataFrame.info()` range summary for DatetimeIndex**

This PR aims to provide better description of [DatetimeIndex](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DatetimeIndex.html) within [DataFrame.info](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.info.html) in relation to the display of the range of unsorted indexes, by replacing the original first to last element values with "min date" to "max date" values.

Fixes https://github.com/pandas-dev/pandas/issues/31116

<del>
This PR fixes range display errors that might occur when [DataFrame.info](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.info.html) describes a [DatetimeIndex](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DatetimeIndex.html) of big dataframes: depending on the dataframe structure, related *"min date" to "max date"* values can be wrong.

Example of output produced by `DataFrame.info()`:

```python
import pandas as pd
idx = pd.date_range('2020-01-15 01:03:05',
                    periods=1000004, freq='ms')
df = pd.DataFrame({'count': range(len(idx))}, index=idx)
df
df.info()
```

`df` output:
```
                           count
2020-01-15 01:03:05.000        0
2020-01-15 01:03:05.001        1
2020-01-15 01:03:05.002        2
2020-01-15 01:03:05.003        3
2020-01-15 01:03:05.004        4
...                          ...
2020-01-15 01:19:44.999   999999
2020-01-15 01:19:45.000  1000000
2020-01-15 01:19:45.001  1000001
2020-01-15 01:19:45.002  1000002
2020-01-15 01:19:45.003  1000003
```

`df.info()` output:
```
<class 'pandas.core.frame.DataFrame'>
DatetimeIndex: 1000004 entries, 2020-01-15 01:03:05 to 2020-01-15 01:19:45.003000
Freq: L
Data columns (total 1 columns):
count    1000004 non-null int64
dtypes: int64(1)
memory usage: 15.3 MB
```

This PR fixes possible errors within the description: `"DatetimeIndex: ... entries, `*date_a*` to `*date_b* output, where *date_a* and *date_b* should respectively show minimum and maximum date range values.
</del>