### PR TITLE
DOC: automatic 'end' year of copyright

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,6 +10,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from datetime import datetime
 import importlib
 import inspect
 import logging
@@ -137,7 +138,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "pandas"
-copyright = "2008-2020, the pandas development team"
+copyright = f"2008-{datetime.now().year}, the pandas development team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
#31022 Updated it after nearly 6 years, I think this will update with each new merge, so that should not be a problem from now on, (I think)
cc (@datapythonista)
