### PR TITLE
Fix Segfault (maybe)

### DIFF
--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -40,8 +40,7 @@ cdef class BlockPlacement:
                 self._as_array = arr
                 self._has_array = True
         else:
-            # Cython memoryview interface requires ndarray to be writeable.
-            arr = np.require(val, dtype=np.int64, requirements='W')
+            arr = np.require(val, dtype=np.int64)
             assert arr.ndim == 1
             self._as_array = arr
             self._has_array = True


### PR DESCRIPTION
- [X] closes #21824

I have only been able to reproduce this issue once and can't verify that this works, but I think @jorisvandenbossche has had more luck reproducing so maybe can try

I noticed `_as_array` showing up in a core dump I was able to get, and this line seems a little suspect so perhaps removing the writeable requirement fixes
