### PR TITLE
POC: docstring inheritance

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -95,6 +95,24 @@ class PandasObject(DirNamesMixin):
         assert isinstance(obj, type(self)), type(obj)
         return obj
 
+    @classmethod
+    def __init_subclass__(cls):
+        """Automatically inherit docstrings."""
+        import types
+
+        for name, attr in cls.__dict__.items():
+            if isinstance(attr, types.FunctionType):
+                # TODO: property/cache_readonly?
+                if attr.__doc__ is None:
+                    for parent in cls.__mro__:
+                        if parent is cls:
+                            continue
+                        if hasattr(parent, name):
+                            sup = getattr(parent, name)
+                            if sup.__doc__ is not None:
+                                attr.__doc__ = sup.__doc__
+                            break
+
 
 class NoNewAttributesMixin:
     """Mixin which prevents adding new attributes.

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -11,6 +11,7 @@ from pandas import DataFrame, Index, Series
 import pandas._testing as tm
 from pandas.core.accessor import PandasDelegate
 from pandas.core.base import NoNewAttributesMixin, PandasObject
+from pandas.core.indexes.extension import ExtensionIndex
 
 
 class TestPandasDelegate:
@@ -140,3 +141,7 @@ class TestConstruction:
         # Forced conversion fails for all -> all cases raise error
         with pytest.raises(pd.errors.OutOfBoundsDatetime):
             klass(a, dtype="datetime64[ns]")
+
+
+def test_docstring_inheritance():
+    assert ExtensionIndex.dropna.__doc__ == Index.dropna.__doc__


### PR DESCRIPTION
Proof of concept for automatically inheriting docstrings, so we dont have to use `@Appender(parent_class.method.__doc__)` quite so much.

This doesnt handle `@Substitution`.  If we can make that work for the common case where we're just putting in the class name, we could get a _lot_ less verbose.

xref #31095, #31060.