### PR TITLE
ERR: better error message on unparseable datetimes

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1848,14 +1848,19 @@ def objects_to_datetime64ns(
             yearfirst=yearfirst,
             require_iso8601=require_iso8601,
         )
-    except ValueError as e:
+    except ValueError as err:
         try:
             values, tz_parsed = conversion.datetime_to_datetime64(data)
             # If tzaware, these values represent unix timestamps, so we
             #  return them as i8 to distinguish from wall times
             return values.view("i8"), tz_parsed
         except (ValueError, TypeError):
-            raise e
+            if "Unknown string format" in err.args[0]:
+                msg = " ".join(err.args[1:])
+                msg = f"Unknown string format: {msg}"
+                msg = f"{msg}. You can coerce to NaT by passing errors='coerce'"
+                raise ValueError(msg) from err
+            raise err
 
     if tz_parsed is not None:
         # We can take a shortcut since the datetime64 numpy array

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1856,8 +1856,7 @@ def objects_to_datetime64ns(
             return values.view("i8"), tz_parsed
         except (ValueError, TypeError):
             if "Unknown string format" in err.args[0]:
-                msg = " ".join(err.args[1:])
-                msg = f"Unknown string format: {msg}"
+                msg = " ".join(err.args)
                 msg = f"{msg}. You can coerce to NaT by passing errors='coerce'"
                 raise ValueError(msg) from err
             raise err

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -115,6 +115,7 @@ def _coerce_scalar_to_timedelta_type(r, unit="ns", errors="raise"):
         result = Timedelta(r, unit)
     except ValueError as err:
         if errors == "raise":
+            # GH#10720
             msg = f"{err.args[0]}. You can coerce to NaT by passing errors='coerce'"
             raise ValueError(msg) from err
         elif errors == "ignore":

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -113,9 +113,10 @@ def _coerce_scalar_to_timedelta_type(r, unit="ns", errors="raise"):
 
     try:
         result = Timedelta(r, unit)
-    except ValueError:
+    except ValueError as err:
         if errors == "raise":
-            raise
+            msg = f"{err.args[0]}. You can coerce to NaT by passing errors='coerce'"
+            raise ValueError(msg) from err
         elif errors == "ignore":
             return r
 

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -482,14 +482,14 @@ class TestToDatetime:
 
     def test_to_datetime_unparseable_raise(self):
         # GH#10720
-        date = "Month 1, 1999"
+        msg = "Month 1, 1999"
         expected_args = (
-            f"Unknown string format: %s {date}. "
+            f"Unknown string format: %s {msg}. "
             "You can coerce to NaT by passing errors='coerce'"
         )
 
         with pytest.raises(ValueError, match=expected_args):
-            pd.to_datetime(date, errors="raise")
+            pd.to_datetime(msg, errors="raise")
 
     @td.skip_if_windows  # `tm.set_timezone` does not work in windows
     def test_to_datetime_now(self):

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -484,12 +484,12 @@ class TestToDatetime:
         # GH#10720
         s = "Month 1, 1999"
         expected_args = (
-                f"Unknown string format: {s}. "
-                "You can coerce to NaT by passing errors='coerce'")
+            f"Unknown string format: {s}. "
+            "You can coerce to NaT by passing errors='coerce'"
+        )
 
         with pytest.raises(ValueError, match=expected_args):
             pd.to_datetime(s, errors="raise")
-
 
     @td.skip_if_windows  # `tm.set_timezone` does not work in windows
     def test_to_datetime_now(self):

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -480,6 +480,17 @@ class TestToDatetime:
         s = "Month 1, 1999"
         assert pd.to_datetime(s, errors="ignore") == s
 
+    def test_to_datetime_unparseable_raise(self):
+        # GH#10720
+        s = "Month 1, 1999"
+        expected_args = (
+                f"Unknown string format: {s}. "
+                "You can coerce to NaT by passing errors='coerce'")
+
+        with pytest.raises(ValueError, match=expected_args):
+            pd.to_datetime(s, errors="raise")
+
+
     @td.skip_if_windows  # `tm.set_timezone` does not work in windows
     def test_to_datetime_now(self):
         # See GH#18666

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -482,14 +482,14 @@ class TestToDatetime:
 
     def test_to_datetime_unparseable_raise(self):
         # GH#10720
-        s = "Month 1, 1999"
+        date = "Month 1, 1999"
         expected_args = (
-            f"Unknown string format: {s}. "
+            f"Unknown string format: %s {date}. "
             "You can coerce to NaT by passing errors='coerce'"
         )
 
         with pytest.raises(ValueError, match=expected_args):
-            pd.to_datetime(s, errors="raise")
+            pd.to_datetime(date, errors="raise")
 
     @td.skip_if_windows  # `tm.set_timezone` does not work in windows
     def test_to_datetime_now(self):

--- a/pandas/tests/indexes/timedeltas/test_tools.py
+++ b/pandas/tests/indexes/timedeltas/test_tools.py
@@ -92,6 +92,16 @@ class TestTimedeltas:
             to_timedelta(["1 day", "bar", "1 min"], errors="coerce"),
         )
 
+        # GH#10720
+        invalid_data = "some_nonesense"
+        expected_msg = (
+            "unit abbreviation w/o a number. "
+            "You can coerce to NaT by passing errors='coerce'"
+        )
+
+        with pytest.raises(ValueError, match=expected_msg):
+            pd.to_timedelta(invalid_data, errors="raise")
+
         # gh-13613: these should not error because errors='ignore'
         invalid_data = "apple"
         assert invalid_data == to_timedelta(invalid_data, errors="ignore")
@@ -109,16 +119,6 @@ class TestTimedeltas:
         tm.assert_series_equal(
             invalid_data, to_timedelta(invalid_data, errors="ignore")
         )
-
-        # GH#10720
-        invalid_data = "some_nonesense"
-        expected_msg = (
-            "unit abbreviation w/o a number. "
-            "You can coerce to NaT by passing errors='coerce'"
-        )
-
-        with pytest.raises(ValueError, match=expected_msg):
-            to_timedelta(invalid_data, errors="raise")
 
     def test_to_timedelta_via_apply(self):
         # GH 5458

--- a/pandas/tests/indexes/timedeltas/test_tools.py
+++ b/pandas/tests/indexes/timedeltas/test_tools.py
@@ -116,6 +116,7 @@ class TestTimedeltas:
             "unit abbreviation w/o a number. "
             "You can coerce to NaT by passing errors='coerce'"
         )
+
         with pytest.raises(ValueError, match=expected_msg):
             to_timedelta(invalid_data, errors="raise")
 

--- a/pandas/tests/indexes/timedeltas/test_tools.py
+++ b/pandas/tests/indexes/timedeltas/test_tools.py
@@ -110,6 +110,15 @@ class TestTimedeltas:
             invalid_data, to_timedelta(invalid_data, errors="ignore")
         )
 
+        # GH#10720
+        invalid_data = "some_nonesense"
+        expected_msg = (
+            "unit abbreviation w/o a number. "
+            "You can coerce to NaT by passing errors='coerce'"
+        )
+        with pytest.raises(ValueError, match=expected_msg):
+            to_timedelta(invalid_data, errors="raise")
+
     def test_to_timedelta_via_apply(self):
         # GH 5458
         expected = Series([np.timedelta64(1, "s")])


### PR DESCRIPTION
- [ ] closes #10720
- [ ] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`