### PR TITLE
CLN/BUG: Float64Index.get_loc

### DIFF
--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -481,17 +481,18 @@ class Float64Index(NumericIndex):
 
     @Appender(_index_shared_docs["get_loc"])
     def get_loc(self, key, method=None, tolerance=None):
-        try:
-            if np.all(np.isnan(key)) or is_bool(key):
-                nan_idxs = self._nan_idxs
-                try:
-                    return nan_idxs.item()
-                except ValueError:
-                    if not len(nan_idxs):
-                        raise KeyError(key)
-                    return nan_idxs
-        except (TypeError, NotImplementedError):
-            pass
+        if is_bool(key):
+            # Catch this to avoid accidentally casting to 1.0
+            raise KeyError(key)
+
+        if is_float(key) and np.isnan(key):
+            nan_idxs = self._nan_idxs
+            if not len(nan_idxs):
+                raise KeyError(key)
+            elif len(nan_idxs) == 1:
+                return nan_idxs[0]
+            return nan_idxs
+
         return super().get_loc(key, method=method, tolerance=tolerance)
 
     @cache_readonly

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -396,7 +396,8 @@ def test_get_loc_missing_nan():
         idx.get_loc(3)
     with pytest.raises(KeyError, match=r"^nan$"):
         idx.get_loc(np.nan)
-    with pytest.raises(KeyError, match=r"^\[nan\]$"):
+    with pytest.raises(TypeError, match=r"'\[nan\]' is an invalid key"):
+        # listlike/non-hashable raises TypeError
         idx.get_loc([np.nan])
 
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -389,7 +389,8 @@ class TestFloat64Index(Numeric):
             idx.get_loc(3)
         with pytest.raises(KeyError, match="^nan$"):
             idx.get_loc(np.nan)
-        with pytest.raises(KeyError, match=r"^\[nan\]$"):
+        with pytest.raises(TypeError, match=r"'\[nan\]' is an invalid key"):
+            # listlike/non-hashable raises TypeError
             idx.get_loc([np.nan])
 
     def test_contains_nans(self):


### PR DESCRIPTION
- clean up unnecessary try/except
- the "bug" part is that ATM we incorrectly raise KeyError instead of TypeError on non-hashable.