### PR TITLE
REF/CLN: Index.get_value wrapping incorrectly

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -815,18 +815,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         try:
             result = self.index.get_value(self, key)
 
-            if not is_scalar(result):
-                if is_list_like(result) and not isinstance(result, Series):
-
-                    # we need to box if loc of the key isn't scalar here
-                    # otherwise have inline ndarray/lists
-                    try:
-                        if not is_scalar(self.index.get_loc(key)):
-                            result = self._constructor(
-                                result, index=[key] * len(result), dtype=self.dtype
-                            ).__finalize__(self)
-                    except KeyError:
-                        pass
             return result
         except InvalidIndexError:
             pass


### PR DESCRIPTION
Index.get_value isn't wrapping non-scalar results correctly, as a result of which we have an ugly kludge in `Series.__getitem__` to do that wrapping.  This fixes that.