### PR TITLE
TST:Disallow bare pytest raises issue 30999

### DIFF
--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -53,7 +53,7 @@ class TestPandasDelegate:
 
         delegate = self.Delegate(self.Delegator())
 
-        msg = "The delegate method has not been overridden"
+        msg = "You cannot access the property"
 
         with pytest.raises(TypeError, match=msg):
             delegate.foo
@@ -87,7 +87,7 @@ class TestNoNewAttributesMixin:
         t._freeze()
         assert "__frozen" in dir(t)
         assert getattr(t, "__frozen")
-        msg = "No new attribute found"
+        msg = "You cannot add any new attribute"
         with pytest.raises(AttributeError, match=msg):
             t.b = "test"
 
@@ -131,7 +131,7 @@ class TestConstruction:
         # datetime64[non-ns] raise error, other cases result in object dtype
         # and preserve original data
         if a.dtype.kind == "M":
-            msg = "The datatime object is out of bound"
+            msg = "Out of bounds"
             with pytest.raises(pd.errors.OutOfBoundsDatetime, match=msg):
                 klass(a)
         else:

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -56,11 +56,11 @@ class TestPandasDelegate:
         msg = "You cannot access the property foo"
         with pytest.raises(TypeError, match=msg):
             delegate.foo
-        
+
         msg = "The property foo cannot be set"
         with pytest.raises(TypeError, match=msg):
             delegate.foo = 5
-        
+
         msg = "You cannot access the property foo"
         with pytest.raises(TypeError, match=msg):
             delegate.foo()

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -53,14 +53,15 @@ class TestPandasDelegate:
 
         delegate = self.Delegate(self.Delegator())
 
-        msg = "You cannot access the property"
-
+        msg = "You cannot access the property foo"
         with pytest.raises(TypeError, match=msg):
             delegate.foo
-
+        
+        msg = "The property foo cannot be set"
         with pytest.raises(TypeError, match=msg):
             delegate.foo = 5
-
+        
+        msg = "You cannot access the property foo"
         with pytest.raises(TypeError, match=msg):
             delegate.foo()
 
@@ -141,5 +142,6 @@ class TestConstruction:
 
         # Explicit dtype specified
         # Forced conversion fails for all -> all cases raise error
+        msg = "Out of bounds"
         with pytest.raises(pd.errors.OutOfBoundsDatetime, match=msg):
             klass(a, dtype="datetime64[ns]")

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -53,7 +53,7 @@ class TestPandasDelegate:
 
         delegate = self.Delegate(self.Delegator())
 
-        msg= "The delegate method has not been overridden"
+        msg = "The delegate method has not been overridden"
 
         with pytest.raises(TypeError, match=msg):
             delegate.foo
@@ -87,7 +87,7 @@ class TestNoNewAttributesMixin:
         t._freeze()
         assert "__frozen" in dir(t)
         assert getattr(t, "__frozen")
-        msg= "No new attribute found"
+        msg = "No new attribute found"
         with pytest.raises(AttributeError, match=msg):
             t.b = "test"
 
@@ -131,7 +131,7 @@ class TestConstruction:
         # datetime64[non-ns] raise error, other cases result in object dtype
         # and preserve original data
         if a.dtype.kind == "M":
-            msg= "The datatime object is out of bound"
+            msg = "The datatime object is out of bound"
             with pytest.raises(pd.errors.OutOfBoundsDatetime, match=msg):
                 klass(a)
         else:

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -53,13 +53,15 @@ class TestPandasDelegate:
 
         delegate = self.Delegate(self.Delegator())
 
-        with pytest.raises(TypeError):
+        msg="The delegate method has not been overridden"
+
+        with pytest.raises(TypeError, match=msg):
             delegate.foo
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=msg):
             delegate.foo = 5
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=msg):
             delegate.foo()
 
     @pytest.mark.skipif(PYPY, reason="not relevant for PyPy")
@@ -85,8 +87,8 @@ class TestNoNewAttributesMixin:
         t._freeze()
         assert "__frozen" in dir(t)
         assert getattr(t, "__frozen")
-
-        with pytest.raises(AttributeError):
+        msg="No new attribute found"
+        with pytest.raises(AttributeError, match=msg):
             t.b = "test"
 
         assert not hasattr(t, "b")
@@ -129,7 +131,8 @@ class TestConstruction:
         # datetime64[non-ns] raise error, other cases result in object dtype
         # and preserve original data
         if a.dtype.kind == "M":
-            with pytest.raises(pd.errors.OutOfBoundsDatetime):
+            msg="The datatime object is out of bound"
+            with pytest.raises(pd.errors.OutOfBoundsDatetime, match=msg):
                 klass(a)
         else:
             result = klass(a)
@@ -138,5 +141,5 @@ class TestConstruction:
 
         # Explicit dtype specified
         # Forced conversion fails for all -> all cases raise error
-        with pytest.raises(pd.errors.OutOfBoundsDatetime):
+        with pytest.raises(pd.errors.OutOfBoundsDatetime,match=msg):
             klass(a, dtype="datetime64[ns]")

--- a/pandas/tests/base/test_constructors.py
+++ b/pandas/tests/base/test_constructors.py
@@ -53,7 +53,7 @@ class TestPandasDelegate:
 
         delegate = self.Delegate(self.Delegator())
 
-        msg="The delegate method has not been overridden"
+        msg= "The delegate method has not been overridden"
 
         with pytest.raises(TypeError, match=msg):
             delegate.foo
@@ -87,7 +87,7 @@ class TestNoNewAttributesMixin:
         t._freeze()
         assert "__frozen" in dir(t)
         assert getattr(t, "__frozen")
-        msg="No new attribute found"
+        msg= "No new attribute found"
         with pytest.raises(AttributeError, match=msg):
             t.b = "test"
 
@@ -131,7 +131,7 @@ class TestConstruction:
         # datetime64[non-ns] raise error, other cases result in object dtype
         # and preserve original data
         if a.dtype.kind == "M":
-            msg="The datatime object is out of bound"
+            msg= "The datatime object is out of bound"
             with pytest.raises(pd.errors.OutOfBoundsDatetime, match=msg):
                 klass(a)
         else:
@@ -141,5 +141,5 @@ class TestConstruction:
 
         # Explicit dtype specified
         # Forced conversion fails for all -> all cases raise error
-        with pytest.raises(pd.errors.OutOfBoundsDatetime,match=msg):
+        with pytest.raises(pd.errors.OutOfBoundsDatetime, match=msg):
             klass(a, dtype="datetime64[ns]")

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -303,7 +303,7 @@ def test_array(array, attr, index_or_series):
 
 def test_array_multiindex_raises():
     idx = pd.MultiIndex.from_product([["A"], ["a", "b"]])
-    msg = "The array is multiindex and has no single backing array"
+    msg = "MultiIndex has no single backing array"
     with pytest.raises(ValueError, match=msg):
         idx.array
 

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -303,7 +303,7 @@ def test_array(array, attr, index_or_series):
 
 def test_array_multiindex_raises():
     idx = pd.MultiIndex.from_product([["A"], ["a", "b"]])
-    msg= "The array is multiindex and has no single backing array"
+    msg = "The array is multiindex and has no single backing array"
     with pytest.raises(ValueError, match=msg):
         idx.array
 

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -303,7 +303,8 @@ def test_array(array, attr, index_or_series):
 
 def test_array_multiindex_raises():
     idx = pd.MultiIndex.from_product([["A"], ["a", "b"]])
-    with pytest.raises(ValueError, match="MultiIndex"):
+    msg="The array is multiindex and has no single backing array"
+    with pytest.raises(ValueError,match=msg):
         idx.array
 
 
@@ -429,11 +430,11 @@ def test_to_numpy_na_value_numpy_dtype(container, values, dtype, na_value, expec
 def test_to_numpy_kwargs_raises():
     # numpy
     s = pd.Series([1, 2, 3])
-    match = r"to_numpy\(\) got an unexpected keyword argument 'foo'"
-    with pytest.raises(TypeError, match=match):
+    msg = r"to_numpy\(\) got an unexpected keyword argument 'foo'"
+    with pytest.raises(TypeError, match=msg):
         s.to_numpy(foo=True)
 
     # extension
     s = pd.Series([1, 2, 3], dtype="Int64")
-    with pytest.raises(TypeError, match=match):
+    with pytest.raises(TypeError, match=msg):
         s.to_numpy(foo=True)

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -303,8 +303,8 @@ def test_array(array, attr, index_or_series):
 
 def test_array_multiindex_raises():
     idx = pd.MultiIndex.from_product([["A"], ["a", "b"]])
-    msg="The array is multiindex and has no single backing array"
-    with pytest.raises(ValueError,match=msg):
+    msg= "The array is multiindex and has no single backing array"
+    with pytest.raises(ValueError, match=msg):
         idx.array
 
 

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -123,7 +123,7 @@ class Ops:
 
                     # an object that is datetimelike will raise a TypeError,
                     # otherwise an AttributeError
-                    msg = "'Index' object has no attribute 'year'"
+                    msg = "object has no attribute 'year'"
                     err = AttributeError
                     if issubclass(type(o), DatetimeIndexOpsMixin):
                         err = TypeError

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -123,11 +123,10 @@ class Ops:
 
                     # an object that is datetimelike will raise a TypeError,
                     # otherwise an AttributeError
+                    msg = "The object cannot be datetimelike"
                     err = AttributeError
                     if issubclass(type(o), DatetimeIndexOpsMixin):
                         err = TypeError
-                        msg = "The object cannot be datatimelike"
-
                     with pytest.raises(err, match=msg):
                         getattr(o, op)
 

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -123,7 +123,7 @@ class Ops:
 
                     # an object that is datetimelike will raise a TypeError,
                     # otherwise an AttributeError
-                    msg = "object has no attribute 'year'"
+                    msg = "no attribute"
                     err = AttributeError
                     if issubclass(type(o), DatetimeIndexOpsMixin):
                         err = TypeError

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -123,7 +123,7 @@ class Ops:
 
                     # an object that is datetimelike will raise a TypeError,
                     # otherwise an AttributeError
-                    msg = "The object cannot be datetimelike"
+                    msg = "'Index' object has no attribute 'year'"
                     err = AttributeError
                     if issubclass(type(o), DatetimeIndexOpsMixin):
                         err = TypeError

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -211,7 +211,7 @@ class TestIndexOps(Ops):
                 if is_datetime64_dtype(o) or is_datetime64tz_dtype(o):
                     # Following DatetimeIndex (and Timestamp) convention,
                     # inequality comparisons with Series[datetime64] raise
-                    msg = "The dtype cannot be datetime64 or datetime64tz"
+                    msg = "Invalid comparison"
                     with pytest.raises(TypeError, match=msg):
                         None > o
                     with pytest.raises(TypeError, match=msg):
@@ -236,7 +236,7 @@ class TestIndexOps(Ops):
             for p in ["flags", "strides", "itemsize", "base", "data"]:
                 assert not hasattr(o, p)
 
-            msg = "Ndarray not compatible"
+            msg = "can only convert an array of size 1 to a Python scalar"
             with pytest.raises(ValueError, match=msg):
                 o.item()  # len > 1
 
@@ -440,7 +440,7 @@ class TestIndexOps(Ops):
         s = klass(s_values)
 
         # bins
-        msg = "No value counts for the corresponding object type"
+        msg = "bins argument only works with numeric data"
         with pytest.raises(TypeError, match=msg):
             s.value_counts(bins=1)
 
@@ -860,7 +860,7 @@ class TestIndexOps(Ops):
         invalid_values = [1, "True", [1, 2, 3], 5.0]
 
         for value in invalid_values:
-            msg = "Boolean(True/False) argument needed but not provided"
+            msg = "expected type bool"
             with pytest.raises(ValueError, match=msg):
                 self.int_series.drop_duplicates(inplace=value)
 
@@ -874,9 +874,10 @@ class TestIndexOps(Ops):
 
             assert i[-1] == i[9]
 
-            msg = "Index out of bounds"
+            msg = "index 20 is out of bounds for axis 0 with size 10"
             with pytest.raises(IndexError, match=msg):
                 i[20]
+            msg = "single positional indexer is out-of-bounds"
             with pytest.raises(IndexError, match=msg):
                 s.iloc[20]
 

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -126,9 +126,9 @@ class Ops:
                     err = AttributeError
                     if issubclass(type(o), DatetimeIndexOpsMixin):
                         err = TypeError
-                        msg="The object cannot be datatimelike"
+                        msg= "The object cannot be datatimelike"
 
-                    with pytest.raises(err,match=msg):
+                    with pytest.raises(err, match=msg):
                         getattr(o, op)
 
     @pytest.mark.parametrize("klass", [Series, DataFrame])
@@ -212,10 +212,10 @@ class TestIndexOps(Ops):
                 if is_datetime64_dtype(o) or is_datetime64tz_dtype(o):
                     # Following DatetimeIndex (and Timestamp) convention,
                     # inequality comparisons with Series[datetime64] raise
-                    msg="The dtype cannot be datetime64 or datetime64tz"
-                    with pytest.raises(TypeError,match=msg):
+                    msg= "The dtype cannot be datetime64 or datetime64tz"
+                    with pytest.raises(TypeError, match=msg):
                         None > o
-                    with pytest.raises(TypeError,match=msg):
+                    with pytest.raises(TypeError, match=msg):
                         o > None
                 else:
                     result = None > o
@@ -237,7 +237,8 @@ class TestIndexOps(Ops):
             for p in ["flags", "strides", "itemsize", "base", "data"]:
                 assert not hasattr(o, p)
 
-            with pytest.raises(ValueError):
+            msg="Ndarray not compatible"
+            with pytest.raises(ValueError,match=msg):
                 o.item()  # len > 1
 
             assert o.ndim == 1
@@ -440,7 +441,8 @@ class TestIndexOps(Ops):
         s = klass(s_values)
 
         # bins
-        with pytest.raises(TypeError):
+        msg="No value counts for the corresponding object type"
+        with pytest.raises(TypeError,match=msg):
             s.value_counts(bins=1)
 
         s1 = Series([1, 1, 2, 3])
@@ -859,7 +861,8 @@ class TestIndexOps(Ops):
         invalid_values = [1, "True", [1, 2, 3], 5.0]
 
         for value in invalid_values:
-            with pytest.raises(ValueError):
+            msg="Boolean(True/False) argument needed but not provided"
+            with pytest.raises(ValueError,match=msg):
                 self.int_series.drop_duplicates(inplace=value)
 
     def test_getitem(self):
@@ -872,9 +875,10 @@ class TestIndexOps(Ops):
 
             assert i[-1] == i[9]
 
-            with pytest.raises(IndexError):
+            msg="Index out of bounds"
+            with pytest.raises(IndexError,match=msg):
                 i[20]
-            with pytest.raises(IndexError):
+            with pytest.raises(IndexError),match=msg:
                 s.iloc[20]
 
     @pytest.mark.parametrize("indexer_klass", [list, pd.Index])

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -126,7 +126,7 @@ class Ops:
                     err = AttributeError
                     if issubclass(type(o), DatetimeIndexOpsMixin):
                         err = TypeError
-                        msg= "The object cannot be datatimelike"
+                        msg = "The object cannot be datatimelike"
 
                     with pytest.raises(err, match=msg):
                         getattr(o, op)
@@ -212,7 +212,7 @@ class TestIndexOps(Ops):
                 if is_datetime64_dtype(o) or is_datetime64tz_dtype(o):
                     # Following DatetimeIndex (and Timestamp) convention,
                     # inequality comparisons with Series[datetime64] raise
-                    msg= "The dtype cannot be datetime64 or datetime64tz"
+                    msg = "The dtype cannot be datetime64 or datetime64tz"
                     with pytest.raises(TypeError, match=msg):
                         None > o
                     with pytest.raises(TypeError, match=msg):
@@ -237,8 +237,8 @@ class TestIndexOps(Ops):
             for p in ["flags", "strides", "itemsize", "base", "data"]:
                 assert not hasattr(o, p)
 
-            msg="Ndarray not compatible"
-            with pytest.raises(ValueError,match=msg):
+            msg = "Ndarray not compatible"
+            with pytest.raises(ValueError, match=msg):
                 o.item()  # len > 1
 
             assert o.ndim == 1
@@ -441,8 +441,8 @@ class TestIndexOps(Ops):
         s = klass(s_values)
 
         # bins
-        msg="No value counts for the corresponding object type"
-        with pytest.raises(TypeError,match=msg):
+        msg = "No value counts for the corresponding object type"
+        with pytest.raises(TypeError, match=msg):
             s.value_counts(bins=1)
 
         s1 = Series([1, 1, 2, 3])
@@ -861,8 +861,8 @@ class TestIndexOps(Ops):
         invalid_values = [1, "True", [1, 2, 3], 5.0]
 
         for value in invalid_values:
-            msg="Boolean(True/False) argument needed but not provided"
-            with pytest.raises(ValueError,match=msg):
+            msg = "Boolean(True/False) argument needed but not provided"
+            with pytest.raises(ValueError, match=msg):
                 self.int_series.drop_duplicates(inplace=value)
 
     def test_getitem(self):
@@ -875,10 +875,10 @@ class TestIndexOps(Ops):
 
             assert i[-1] == i[9]
 
-            msg="Index out of bounds"
-            with pytest.raises(IndexError,match=msg):
+            msg = "Index out of bounds"
+            with pytest.raises(IndexError, match=msg):
                 i[20]
-            with pytest.raises(IndexError),match=msg:
+            with pytest.raises(IndexError, match=msg):
                 s.iloc[20]
 
     @pytest.mark.parametrize("indexer_klass", [list, pd.Index])

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -126,8 +126,9 @@ class Ops:
                     err = AttributeError
                     if issubclass(type(o), DatetimeIndexOpsMixin):
                         err = TypeError
+                        msg="The object cannot be datatimelike"
 
-                    with pytest.raises(err):
+                    with pytest.raises(err,match=msg):
                         getattr(o, op)
 
     @pytest.mark.parametrize("klass", [Series, DataFrame])
@@ -211,9 +212,10 @@ class TestIndexOps(Ops):
                 if is_datetime64_dtype(o) or is_datetime64tz_dtype(o):
                     # Following DatetimeIndex (and Timestamp) convention,
                     # inequality comparisons with Series[datetime64] raise
-                    with pytest.raises(TypeError):
+                    msg="The dtype cannot be datetime64 or datetime64tz"
+                    with pytest.raises(TypeError,match=msg):
                         None > o
-                    with pytest.raises(TypeError):
+                    with pytest.raises(TypeError,match=msg):
                         o > None
                 else:
                     result = None > o


### PR DESCRIPTION
- [x] refers #30999 
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This pull request is to add appropriate match arguments to bare pytest.raises listed in #30999 [Comment](https://github.com/pandas-dev/pandas/issues/30999#issuecomment-574339599)