### PR TITLE
BUG: in DataFrame.count not returning subclassed data types.

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -141,6 +141,7 @@ Reshaping
 ^^^^^^^^^
 
 -
+- Bug in :meth:`DataFrame.count` not returning subclassed data types.
 - Bug in :meth:`DataFrame.pivot_table` when only MultiIndexed columns is set (:issue:`17038`)
 - Fix incorrect error message in :meth:`DataFrame.pivot` when ``columns`` is set to ``None``. (:issue:`30924`)
 - Bug in :func:`crosstab` when inputs are two Series and have tuple names, the output will keep dummy MultiIndex as columns. (:issue:`18321`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7811,7 +7811,7 @@ Wild         185.0
 
         # GH #423
         if len(frame._get_axis(axis)) == 0:
-            result = Series(0, index=frame._get_agg_axis(axis))
+            result = frame._constructor_sliced(0, index=frame._get_agg_axis(axis))
         else:
             if frame._is_mixed_type or frame._data.any_extension_types:
                 # the or any_extension_types is really only hit for single-
@@ -7821,7 +7821,9 @@ Wild         185.0
                 # GH13407
                 series_counts = notna(frame).sum(axis=axis)
                 counts = series_counts.values
-                result = Series(counts, index=frame._get_agg_axis(axis))
+                result = frame._constructor_sliced(
+                    counts, index=frame._get_agg_axis(axis)
+                )
 
         return result.astype("int64")
 
@@ -7860,7 +7862,7 @@ Wild         185.0
         level_codes = ensure_int64(count_axis.codes[level])
         counts = lib.count_level_2d(mask, level_codes, len(level_index), axis=0)
 
-        result = DataFrame(counts, index=level_index, columns=agg_axis)
+        result = frame._constructor(counts, index=level_index, columns=agg_axis)
 
         if axis == 1:
             # Undo our earlier transpose

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -559,6 +559,8 @@ class TestDataFrameSubclassing:
         tm.assert_series_equal(result, expected)
 
     def test_subclassed_count(self):
+        # GH 31139
+
         df = tm.SubclassedDataFrame(
             {
                 "Person": ["John", "Myla", "Lewis", "John", "Myla"],

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -557,3 +557,34 @@ class TestDataFrameSubclassing:
         result = df.apply(lambda x: [1, 2, 3], axis=1)
         assert not isinstance(result, tm.SubclassedDataFrame)
         tm.assert_series_equal(result, expected)
+
+    def test_subclassed_count(self):
+        df = tm.SubclassedDataFrame(
+            {
+                "Person": ["John", "Myla", "Lewis", "John", "Myla"],
+                "Age": [24.0, np.nan, 21.0, 33, 26],
+                "Single": [False, True, True, True, False],
+            }
+        )
+        result = df.count()
+        assert isinstance(result, tm.SubclassedSeries)
+
+        df = tm.SubclassedDataFrame({"A": [1, 0, 3], "B": [0, 5, 6], "C": [7, 8, 0]})
+        result = df.count()
+        assert isinstance(result, tm.SubclassedSeries)
+
+        df = tm.SubclassedDataFrame(
+            [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [40, 41, 42, 43]],
+            index=MultiIndex.from_tuples(
+                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
+            ),
+            columns=MultiIndex.from_tuples(
+                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
+            ),
+        )
+        result = df.count(level=1)
+        assert isinstance(result, tm.SubclassedDataFrame)
+
+        df = tm.SubclassedDataFrame()
+        result = df.count()
+        assert isinstance(result, tm.SubclassedSeries)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Once #30945 is merged these tests will pass.

I also, didn't know if a PR without first submitting an issue was appropriate, but to cut down on workload I decided to give it a try. If I'm mistaken please let me know.

As for the test there are four logical branches in df.count() that needed to be address within the test:

1. Non-homogeneous data types (this is the partion of the test that is dependent on #30945 as it uses .sum()).
```
        df = tm.SubclassedDataFrame(
            {
                "Person": ["John", "Myla", "Lewis", "John", "Myla"],
                "Age": [24.0, np.nan, 21.0, 33, 26],
                "Single": [False, True, True, True, False],
            }
        )
        result = df.count()
        assert isinstance(result, tm.SubclassedSeries)
```
2. Homogeneous data.
```
        df = tm.SubclassedDataFrame({"A": [1, 0, 3], "B": [0, 5, 6], "C": [7, 8, 0]})
        result = df.count()
        assert isinstance(result, tm.SubclassedSeries)
```
3. MultiIndex with level kwarg.
```
        df = tm.SubclassedDataFrame(
            [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [40, 41, 42, 43]],
            index=MultiIndex.from_tuples(
                list(zip(list("AABB"), list("cdcd"))), names=["aaa", "ccc"]
            ),
            columns=MultiIndex.from_tuples(
                list(zip(list("WWXX"), list("yzyz"))), names=["www", "yyy"]
            ),
        )
        result = df.count(level=1)
        assert isinstance(result, tm.SubclassedDataFrame)
```
4. Force length of axis to be 0. 
```
        df = tm.SubclassedDataFrame()
        result = df.count()
        assert isinstance(result, tm.SubclassedSeries)
```