### PR TITLE
Check for pyarrow not feather before pyarrow tests

### DIFF
--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -153,10 +153,7 @@ bar2,12,13,14,15
         msg7 = (
             fr"\[Errno 2\] File o directory non esistente: '.+does_not_exist\.{fn_ext}'"
         )
-        msg8 = (
-            fr"Failed to open local file.+does_not_exist\.{fn_ext}.?,"
-            fr" error: .*"
-        )
+        msg8 = fr"Failed to open local file.+does_not_exist\.{fn_ext}.?, error: .*"
 
         with pytest.raises(
             error_class,
@@ -199,10 +196,7 @@ bar2,12,13,14,15
         msg7 = (
             fr"\[Errno 2\] File o directory non esistente: '.+does_not_exist\.{fn_ext}'"
         )
-        msg8 = (
-            fr"Failed to open local file.+does_not_exist\.{fn_ext}.?,"
-            fr" error: .*"
-        )
+        msg8 = fr"Failed to open local file.+does_not_exist\.{fn_ext}.?, error: .*"
 
         with pytest.raises(
             error_class,

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -129,7 +129,7 @@ bar2,12,13,14,15
             (pd.read_csv, "os", FileNotFoundError, "csv"),
             (pd.read_fwf, "os", FileNotFoundError, "txt"),
             (pd.read_excel, "xlrd", FileNotFoundError, "xlsx"),
-            (pd.read_feather, "pyarrow", Exception, "feather"),
+            (pd.read_feather, "pyarrow", IOError, "feather"),
             (pd.read_hdf, "tables", FileNotFoundError, "h5"),
             (pd.read_stata, "os", FileNotFoundError, "dta"),
             (pd.read_sas, "os", FileNotFoundError, "sas7bdat"),
@@ -154,12 +154,12 @@ bar2,12,13,14,15
             fr"\[Errno 2\] File o directory non esistente: '.+does_not_exist\.{fn_ext}'"
         )
         msg8 = (
-            fr"Failed to open local file '.+does_not_exist\.{fn_ext}',"
+            fr"Failed to open local file .+does_not_exist\.{fn_ext}.?,"
             fr" error: No such file or directory"
         )
 
-        with pytest.raises(
-            error_class, match=fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})"
+        with pytest.raises(error_class, match=
+            fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})"
         ):
             reader(path)
 
@@ -170,7 +170,7 @@ bar2,12,13,14,15
             (pd.read_table, "os", FileNotFoundError, "csv"),
             (pd.read_fwf, "os", FileNotFoundError, "txt"),
             (pd.read_excel, "xlrd", FileNotFoundError, "xlsx"),
-            (pd.read_feather, "pyarrow", Exception, "feather"),
+            (pd.read_feather, "pyarrow", IOError, "feather"),
             (pd.read_hdf, "tables", FileNotFoundError, "h5"),
             (pd.read_stata, "os", FileNotFoundError, "dta"),
             (pd.read_sas, "os", FileNotFoundError, "sas7bdat"),
@@ -199,12 +199,12 @@ bar2,12,13,14,15
             fr"\[Errno 2\] File o directory non esistente: '.+does_not_exist\.{fn_ext}'"
         )
         msg8 = (
-            fr"Failed to open local file '.+does_not_exist\.{fn_ext}',"
+            fr"Failed to open local file .+does_not_exist\.{fn_ext}.?,"
             fr" error: No such file or directory"
         )
 
-        with pytest.raises(
-            error_class, match=fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})"
+        with pytest.raises(error_class, match=
+            fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})"
         ):
             reader(path)
 

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -158,10 +158,10 @@ bar2,12,13,14,15
             fr" error: No such file or directory"
         )
 
-        with pytest.raises(error_class,
-                           match=(fr"({msg1}|{msg2}|{msg3}|{msg4}"
-                                  fr"|{msg5}|{msg6}|{msg7}|{msg8})")
-                           ):
+        with pytest.raises(
+            error_class,
+            match=fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})",
+        ):
             reader(path)
 
     @pytest.mark.parametrize(
@@ -204,10 +204,10 @@ bar2,12,13,14,15
             fr" error: No such file or directory"
         )
 
-        with pytest.raises(error_class,
-                           match=(fr"({msg1}|{msg2}|{msg3}|{msg4}"
-                                  fr"|{msg5}|{msg6}|{msg7}|{msg8})")
-                           ):
+        with pytest.raises(
+            error_class,
+            match=fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})",
+        ):
             reader(path)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -154,8 +154,8 @@ bar2,12,13,14,15
             fr"\[Errno 2\] File o directory non esistente: '.+does_not_exist\.{fn_ext}'"
         )
         msg8 = (
-            fr"Failed to open local file .+does_not_exist\.{fn_ext}.?,"
-            fr" error: No such file or directory"
+            fr"Failed to open local file.+does_not_exist\.{fn_ext}.?,"
+            fr" error: .*"
         )
 
         with pytest.raises(
@@ -200,8 +200,8 @@ bar2,12,13,14,15
             fr"\[Errno 2\] File o directory non esistente: '.+does_not_exist\.{fn_ext}'"
         )
         msg8 = (
-            fr"Failed to open local file .+does_not_exist\.{fn_ext}.?,"
-            fr" error: No such file or directory"
+            fr"Failed to open local file.+does_not_exist\.{fn_ext}.?,"
+            fr" error: .*"
         )
 
         with pytest.raises(

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -158,9 +158,10 @@ bar2,12,13,14,15
             fr" error: No such file or directory"
         )
 
-        with pytest.raises(error_class, match=
-            fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})"
-        ):
+        with pytest.raises(error_class,
+                           match=(fr"({msg1}|{msg2}|{msg3}|{msg4}"
+                                  fr"|{msg5}|{msg6}|{msg7}|{msg8})")
+                           ):
             reader(path)
 
     @pytest.mark.parametrize(
@@ -203,9 +204,10 @@ bar2,12,13,14,15
             fr" error: No such file or directory"
         )
 
-        with pytest.raises(error_class, match=
-            fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})"
-        ):
+        with pytest.raises(error_class,
+                           match=(fr"({msg1}|{msg2}|{msg3}|{msg4}"
+                                  fr"|{msg5}|{msg6}|{msg7}|{msg8})")
+                           ):
             reader(path)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -129,7 +129,7 @@ bar2,12,13,14,15
             (pd.read_csv, "os", FileNotFoundError, "csv"),
             (pd.read_fwf, "os", FileNotFoundError, "txt"),
             (pd.read_excel, "xlrd", FileNotFoundError, "xlsx"),
-            (pd.read_feather, "feather", Exception, "feather"),
+            (pd.read_feather, "pyarrow", Exception, "feather"),
             (pd.read_hdf, "tables", FileNotFoundError, "h5"),
             (pd.read_stata, "os", FileNotFoundError, "dta"),
             (pd.read_sas, "os", FileNotFoundError, "sas7bdat"),
@@ -165,7 +165,7 @@ bar2,12,13,14,15
             (pd.read_table, "os", FileNotFoundError, "csv"),
             (pd.read_fwf, "os", FileNotFoundError, "txt"),
             (pd.read_excel, "xlrd", FileNotFoundError, "xlsx"),
-            (pd.read_feather, "feather", Exception, "feather"),
+            (pd.read_feather, "pyarrow", Exception, "feather"),
             (pd.read_hdf, "tables", FileNotFoundError, "h5"),
             (pd.read_stata, "os", FileNotFoundError, "dta"),
             (pd.read_sas, "os", FileNotFoundError, "sas7bdat"),
@@ -212,7 +212,7 @@ bar2,12,13,14,15
             (pd.read_excel, "xlrd", ("io", "data", "excel", "test1.xlsx")),
             (
                 pd.read_feather,
-                "feather",
+                "pyarrow",
                 ("io", "data", "feather", "feather-0_3_1.feather"),
             ),
             (
@@ -249,7 +249,7 @@ bar2,12,13,14,15
         [
             ("to_csv", {}, "os"),
             ("to_excel", {"engine": "xlwt"}, "xlwt"),
-            ("to_feather", {}, "feather"),
+            ("to_feather", {}, "pyarrow"),
             ("to_html", {}, "os"),
             ("to_json", {}, "os"),
             ("to_latex", {}, "os"),

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -153,8 +153,13 @@ bar2,12,13,14,15
         msg7 = (
             fr"\[Errno 2\] File o directory non esistente: '.+does_not_exist\.{fn_ext}'"
         )
+        msg8 = (
+            fr"Failed to open local file '.+does_not_exist\.{fn_ext}',"
+            fr" error: No such file or directory"
+        )
+
         with pytest.raises(
-            error_class, match=fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7})"
+            error_class, match=fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})"
         ):
             reader(path)
 
@@ -193,9 +198,13 @@ bar2,12,13,14,15
         msg7 = (
             fr"\[Errno 2\] File o directory non esistente: '.+does_not_exist\.{fn_ext}'"
         )
+        msg8 = (
+            fr"Failed to open local file '.+does_not_exist\.{fn_ext}',"
+            fr" error: No such file or directory"
+        )
 
         with pytest.raises(
-            error_class, match=fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7})"
+            error_class, match=fr"({msg1}|{msg2}|{msg3}|{msg4}|{msg5}|{msg6}|{msg7}|{msg8})"
         ):
             reader(path)
 


### PR DESCRIPTION
read_feather/to_feather now use pyarrow.feather, not top-level (feather-format) feather, but some of their tests were still looking for top-level feather.

Two of them that deliberately cause a file not found error were also looking for the wrong form of error message.  (Probably nobody noticed because the above was skipping them.)