### PR TITLE
BUG/CLN: use more-correct isinstance check

### DIFF
--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -347,8 +347,7 @@ class UInt64Index(IntegerIndex):
 
     def _is_compatible_with_other(self, other):
         return super()._is_compatible_with_other(other) or all(
-            isinstance(obj, (ABCUInt64Index, ABCFloat64Index))
-            for obj in [self, other]
+            isinstance(obj, (ABCUInt64Index, ABCFloat64Index)) for obj in [self, other]
         )
 
 
@@ -497,8 +496,7 @@ class Float64Index(NumericIndex):
     def _is_compatible_with_other(self, other):
         return super()._is_compatible_with_other(other) or all(
             isinstance(
-                obj,
-                (ABCInt64Index, ABCFloat64Index, ABCUInt64Index, ABCRangeIndex),
+                obj, (ABCInt64Index, ABCFloat64Index, ABCUInt64Index, ABCRangeIndex),
             )
             for obj in [self, other]
         )

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -347,7 +347,7 @@ class UInt64Index(IntegerIndex):
 
     def _is_compatible_with_other(self, other):
         return super()._is_compatible_with_other(other) or all(
-            isinstance(type(obj), (ABCUInt64Index, ABCFloat64Index))
+            isinstance(obj, (ABCUInt64Index, ABCFloat64Index))
             for obj in [self, other]
         )
 
@@ -497,7 +497,7 @@ class Float64Index(NumericIndex):
     def _is_compatible_with_other(self, other):
         return super()._is_compatible_with_other(other) or all(
             isinstance(
-                type(obj),
+                obj,
                 (ABCInt64Index, ABCFloat64Index, ABCUInt64Index, ABCRangeIndex),
             )
             for obj in [self, other]


### PR DESCRIPTION
this is only kind of a bug, since the isinstance check still returns True on the `type(obj)`