### PR TITLE
Make DTI.get_loc/get_value require tzawareness-compat for datetimes

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -719,12 +719,19 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
 
     def _maybe_cast_for_get_loc(self, key):
         # needed to localize naive datetimes
-        key = Timestamp(key)
-        if key.tzinfo is None:
-            key = key.tz_localize(self.tz)
+        stamp = Timestamp(key)
+        if not isinstance(key, str):
+            # strings get a pass on tzawareness compat, see GH#????
+            try:
+                self._data._check_compatible_with(stamp)
+            except TypeError:
+                raise KeyError(key)
+
+        if stamp.tzinfo is None:
+            stamp = stamp.tz_localize(self.tz)
         else:
-            key = key.tz_convert(self.tz)
-        return key
+            stamp = stamp.tz_convert(self.tz)
+        return stamp
 
     def _maybe_cast_slice_bound(self, label, side, kind):
         """

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import re
 
 import numpy as np
 import pytest
@@ -289,24 +290,27 @@ def test_getitem_setitem_datetimeindex():
     expected = ts[4:8]
     tm.assert_series_equal(result, expected)
 
-    # repeat all the above with naive datetimes
-    result = ts[datetime(1990, 1, 1, 4)]
-    expected = ts[4]
-    assert result == expected
+    # But we do not give datetimes a pass on tzawareness compat
+    # TODO: do the same with Timestamps and dt64
+    msg = "Cannot compare tz-naive and tz-aware datetime-like objects"
+    naive = datetime(1990, 1, 1, 4)
+    with pytest.raises(KeyError, match=re.escape(repr(naive))):
+        ts[naive]
 
     result = ts.copy()
-    result[datetime(1990, 1, 1, 4)] = 0
-    result[datetime(1990, 1, 1, 4)] = ts[4]
-    tm.assert_series_equal(result, ts)
+    with pytest.raises(TypeError, match=msg):
+        result[datetime(1990, 1, 1, 4)] = 0
+    with pytest.raises(TypeError, match=msg):
+        result[datetime(1990, 1, 1, 4)] = ts[4]
 
-    result = ts[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)]
-    expected = ts[4:8]
-    tm.assert_series_equal(result, expected)
+    with pytest.raises(TypeError, match=msg):
+        ts[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)]
 
     result = ts.copy()
-    result[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)] = 0
-    result[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)] = ts[4:8]
-    tm.assert_series_equal(result, ts)
+    with pytest.raises(TypeError, match=msg):
+        result[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)] = 0
+    with pytest.raises(TypeError, match=msg):
+        result[datetime(1990, 1, 1, 4) : datetime(1990, 1, 1, 7)] = ts[4:8]
 
     lb = datetime(1990, 1, 1, 4)
     rb = datetime(1990, 1, 1, 7)

--- a/pandas/tests/series/test_timezones.py
+++ b/pandas/tests/series/test_timezones.py
@@ -339,7 +339,13 @@ class TestSeriesTimezones:
         # GH 9243
         idx = date_range("4/1/2005", "4/30/2005", freq="D", tz="US/Pacific")
         s = Series(range(len(idx)), index=idx)
-        result = s.truncate(datetime(2005, 4, 2), datetime(2005, 4, 4))
+        msg = "Cannot compare tz-naive and tz-aware datetime-like objects"
+        with pytest.raises(TypeError, match=msg):
+            s.truncate(datetime(2005, 4, 2), datetime(2005, 4, 4))
+
+        lb = idx[1]
+        ub = idx[3]
+        result = s.truncate(lb.to_pydatetime(), ub.to_pydatetime())
         expected = Series([1, 2, 3], index=idx[1:4])
         tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
- [x] closes #30994 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
