### PR TITLE
DOC Remove Python 2 specific comments from documentation

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -146,7 +146,6 @@ Installing using your Linux distribution's package manager.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The commands in this table will install pandas for Python 3 from your distribution.
-To install pandas for Python 2, you may need to use the ``python-pandas`` package.
 
 .. csv-table::
     :header: "Distribution", "Status", "Download / Repository Link", "Install method"

--- a/doc/source/user_guide/enhancingperf.rst
+++ b/doc/source/user_guide/enhancingperf.rst
@@ -78,11 +78,6 @@ four calls) using the `prun ipython magic function <http://ipython.org/ipython-d
 By far the majority of time is spend inside either ``integrate_f`` or ``f``,
 hence we'll concentrate our efforts cythonizing these two functions.
 
-.. note::
-
-  In Python 2 replacing the ``range`` with its generator counterpart (``xrange``)
-  would mean the ``range`` line would vanish. In Python 3 ``range`` is already a generator.
-
 .. _enhancingperf.plain:
 
 Plain Cython

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -39,6 +39,10 @@ The pandas I/O API is a set of top level ``reader`` functions accessed like
 
 :ref:`Here <io.perf>` is an informal performance comparison for some of these IO methods.
 
+.. note::
+   For examples that use the ``StringIO`` class, make sure you import it
+   with ``from io import StringIO`` for Python 3.
+
 .. _io.read_csv_table:
 
 CSV & text files
@@ -905,14 +909,6 @@ data columns:
    e.g "2000-01-01T00:01:02+00:00" and similar variations. If you can arrange
    for your data to store datetimes in this format, load times will be
    significantly faster, ~20x has been observed.
-
-
-.. note::
-
-   When passing a dict as the `parse_dates` argument, the order of
-   the columns prepended is not guaranteed. Because of this, when using a
-   dict for 'parse_dates' in conjunction with the `index_col` argument, it's best to
-   specify `index_col` as a column label rather then as an index on the resulting frame.
 
 
 Date parsing functions

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -39,11 +39,6 @@ The pandas I/O API is a set of top level ``reader`` functions accessed like
 
 :ref:`Here <io.perf>` is an informal performance comparison for some of these IO methods.
 
-.. note::
-   For examples that use the ``StringIO`` class, make sure you import it
-   according to your Python version, i.e. ``from StringIO import StringIO`` for
-   Python 2 and ``from io import StringIO`` for Python 3.
-
 .. _io.read_csv_table:
 
 CSV & text files
@@ -915,9 +910,7 @@ data columns:
 .. note::
 
    When passing a dict as the `parse_dates` argument, the order of
-   the columns prepended is not guaranteed, because `dict` objects do not impose
-   an ordering on their keys. On Python 2.7+ you may use `collections.OrderedDict`
-   instead of a regular `dict` if this matters to you. Because of this, when using a
+   the columns prepended is not guaranteed. Because of this, when using a
    dict for 'parse_dates' in conjunction with the `index_col` argument, it's best to
    specify `index_col` as a column label rather then as an index on the resulting frame.
 
@@ -2453,7 +2446,7 @@ Specify a number of rows to skip:
 
    dfs = pd.read_html(url, skiprows=0)
 
-Specify a number of rows to skip using a list (``xrange`` (Python 2 only) works
+Specify a number of rows to skip using a list (``range`` works
 as well):
 
 .. code-block:: python
@@ -3124,11 +3117,7 @@ Pandas supports writing Excel files to buffer-like objects such as ``StringIO`` 
 
 .. code-block:: python
 
-   # Safe import for either Python 2.x or 3.x
-   try:
-       from io import BytesIO
-   except ImportError:
-       from cStringIO import StringIO as BytesIO
+   from io import BytesIO
 
    bio = BytesIO()
 


### PR DESCRIPTION
A few minor fixes to remove Python 2 specific comments from the documentation, since 1.0 does not support Python 2.
