### PR TITLE
numpydev ragged array dtype warning

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2058,7 +2058,7 @@ class MultiIndex(Index):
 
         if not isinstance(codes, (np.ndarray, Index)):
             try:
-                codes = com.index_labels_to_array(codes)
+                codes = com.index_labels_to_array(codes, dtype=object)
             except ValueError:
                 pass
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -79,7 +79,7 @@ def cat_core(list_of_columns: List, sep: str):
         return np.sum(arr_of_cols, axis=0)
     list_with_sep = [sep] * (2 * len(list_of_columns) - 1)
     list_with_sep[::2] = list_of_columns
-    arr_with_sep = np.asarray(list_with_sep)
+    arr_with_sep = np.asarray(list_with_sep, dtype=object)
     return np.sum(arr_with_sep, axis=0)
 
 

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -605,6 +605,6 @@ class TestCategoricalConstructors:
     @pytest.mark.skipif(_np_version_under1p16, reason="Skipping for NumPy <1.16")
     def test_constructor_string_and_tuples(self):
         # GH 21416
-        c = pd.Categorical(["c", ("a", "b"), ("b", "a"), "c"])
+        c = pd.Categorical(np.array(["c", ("a", "b"), ("b", "a"), "c"], dtype=object))
         expected_index = pd.Index([("a", "b"), ("b", "a"), "c"])
         assert c.categories.equals(expected_index)

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -77,7 +77,7 @@ class TestCategoricalMissing:
             Point = collections.namedtuple("Point", "x y")
         else:
             Point = lambda *args: args  # tuple
-        cat = Categorical([Point(0, 0), Point(0, 1), None])
+        cat = Categorical(np.array([Point(0, 0), Point(0, 1), None], dtype=object))
         result = cat.fillna(Point(0, 0))
         expected = Categorical([Point(0, 0), Point(0, 1), Point(0, 0)])
 

--- a/pandas/tests/extension/base/getitem.py
+++ b/pandas/tests/extension/base/getitem.py
@@ -245,7 +245,9 @@ class BaseGetitemTests(BaseExtensionTests):
         fill_value = data_missing[1]  # valid
         na = data_missing[0]
 
-        array = data_missing._from_sequence([na, fill_value, na])
+        array = data_missing._from_sequence(
+            [na, fill_value, na], dtype=data_missing.dtype
+        )
         result = array.take([-1, 1], fill_value=fill_value, allow_fill=True)
         expected = array.take([1, 1])
         self.assert_extension_array_equal(result, expected)
@@ -293,10 +295,12 @@ class BaseGetitemTests(BaseExtensionTests):
         valid = data_missing[1]
         na = data_missing[0]
 
-        array = data_missing._from_sequence([na, valid])
+        array = data_missing._from_sequence([na, valid], dtype=data_missing.dtype)
         ser = pd.Series(array)
         result = ser.reindex([0, 1, 2], fill_value=valid)
-        expected = pd.Series(data_missing._from_sequence([na, valid, valid]))
+        expected = pd.Series(
+            data_missing._from_sequence([na, valid, valid], dtype=data_missing.dtype)
+        )
 
         self.assert_series_equal(result, expected)
 

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -113,6 +113,11 @@ class JSONArray(ExtensionArray):
     def __len__(self) -> int:
         return len(self.data)
 
+    def __array__(self, dtype=None):
+        if dtype is None:
+            dtype = object
+        return np.asarray(self.data, dtype=dtype)
+
     @property
     def nbytes(self) -> int:
         return sys.getsizeof(self.data)

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -163,10 +163,6 @@ class TestReshaping(BaseJSON, base.BaseReshapingTests):
         # this matches otherwise
         return super().test_unstack(data, index)
 
-    @pytest.mark.xfail(reason="Inconsistent sizes.")
-    def test_transpose(self, data):
-        super().test_transpose(data)
-
 
 class TestGetitem(BaseJSON, base.BaseGetitemTests):
     pass


### PR DESCRIPTION
Closes #31201

There are still two failures in the Categorical constructor I'm looking into. Not sure what's best yet.

```python
In [2]: pd.Categorical(['a', ('a', 'b')])
/Users/taugspurger/sandbox/pandas/pandas/core/dtypes/cast.py:1066: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  v = np.array(v, copy=False)
Out[2]:
[a, (a, b)]
Categories (2, object): [(a, b), a]
```

I think that perhaps the user should see this warning, but have an option to pass through a `dtype` to silence it... Not sure yet.

Tagged for backport to keep the CI passing on that branch.