### PR TITLE
REF/TST: collect misplaced tests

### DIFF
--- a/pandas/tests/indexes/multi/test_compat.py
+++ b/pandas/tests/indexes/multi/test_compat.py
@@ -112,10 +112,6 @@ def test_ndarray_compat_properties(idx, compat_props):
     idx.values.nbytes
 
 
-def test_compat(indices):
-    assert indices.tolist() == list(indices)
-
-
 def test_pickle_compat_construction(holder):
     # this is testing for pickle compat
     # need an object to create with

--- a/pandas/tests/indexes/multi/test_conversion.py
+++ b/pandas/tests/indexes/multi/test_conversion.py
@@ -142,17 +142,6 @@ def test_roundtrip_pickle_with_tz():
     assert index.equal_levels(unpickled)
 
 
-def test_pickle(indices):
-    return  # FIXME: this can't be right?
-
-    unpickled = tm.round_trip_pickle(indices)
-    assert indices.equals(unpickled)
-    original_name, indices.name = indices.name, "foo"
-    unpickled = tm.round_trip_pickle(indices)
-    assert indices.equals(unpickled)
-    indices.name = original_name
-
-
 def test_to_series(idx):
     # assert that we are creating a copy of the index
 

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -250,25 +250,6 @@ def test_rangeindex_fallback_coercion_bug():
     tm.assert_index_equal(result, expected)
 
 
-def test_hash_error(indices):
-    index = indices
-    with pytest.raises(TypeError, match=f"unhashable type: '{type(index).__name__}'"):
-        hash(indices)
-
-
-def test_mutability(indices):
-    if not len(indices):
-        return
-    msg = "Index does not support mutable operations"
-    with pytest.raises(TypeError, match=msg):
-        indices[0] = indices[0]
-
-
-def test_wrong_number_names(indices):
-    with pytest.raises(ValueError, match="^Length"):
-        indices.names = ["apple", "banana", "carrot"]
-
-
 def test_memory_usage(idx):
     result = idx.memory_usage()
     if len(idx):

--- a/pandas/tests/indexes/multi/test_monotonic.py
+++ b/pandas/tests/indexes/multi/test_monotonic.py
@@ -1,9 +1,7 @@
 import numpy as np
-import pytest
 
 import pandas as pd
-from pandas import Index, IntervalIndex, MultiIndex
-from pandas.api.types import is_scalar
+from pandas import Index, MultiIndex
 
 
 def test_is_monotonic_increasing():
@@ -176,55 +174,3 @@ def test_is_strictly_monotonic_decreasing():
     )
     assert idx.is_monotonic_decreasing is True
     assert idx._is_strictly_monotonic_decreasing is False
-
-
-def test_searchsorted_monotonic(indices):
-    # GH17271
-    # not implemented for tuple searches in MultiIndex
-    # or Intervals searches in IntervalIndex
-    if isinstance(indices, (MultiIndex, IntervalIndex)):
-        return
-
-    # nothing to test if the index is empty
-    if indices.empty:
-        return
-    value = indices[0]
-
-    # determine the expected results (handle dupes for 'right')
-    expected_left, expected_right = 0, (indices == value).argmin()
-    if expected_right == 0:
-        # all values are the same, expected_right should be length
-        expected_right = len(indices)
-
-    # test _searchsorted_monotonic in all cases
-    # test searchsorted only for increasing
-    if indices.is_monotonic_increasing:
-        ssm_left = indices._searchsorted_monotonic(value, side="left")
-        assert is_scalar(ssm_left)
-        assert expected_left == ssm_left
-
-        ssm_right = indices._searchsorted_monotonic(value, side="right")
-        assert is_scalar(ssm_right)
-        assert expected_right == ssm_right
-
-        ss_left = indices.searchsorted(value, side="left")
-        assert is_scalar(ss_left)
-        assert expected_left == ss_left
-
-        ss_right = indices.searchsorted(value, side="right")
-        assert is_scalar(ss_right)
-        assert expected_right == ss_right
-
-    elif indices.is_monotonic_decreasing:
-        ssm_left = indices._searchsorted_monotonic(value, side="left")
-        assert is_scalar(ssm_left)
-        assert expected_left == ssm_left
-
-        ssm_right = indices._searchsorted_monotonic(value, side="right")
-        assert is_scalar(ssm_right)
-        assert expected_right == ssm_right
-
-    else:
-        # non-monotonic should raise.
-        with pytest.raises(ValueError):
-            indices._searchsorted_monotonic(value, side="left")

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -66,11 +66,6 @@ def test_sortlevel_deterministic():
     assert sorted_idx.equals(expected[::-1])
 
 
-def test_sort(indices):
-    with pytest.raises(TypeError):
-        indices.sort()
-
-
 def test_numpy_argsort(idx):
     result = np.argsort(idx)
     expected = idx.argsort()

--- a/pandas/tests/indexes/test_any_index.py
+++ b/pandas/tests/indexes/test_any_index.py
@@ -1,0 +1,34 @@
+"""
+Tests that can be parametrized over _any_ Index object.
+
+TODO: consider using hypothesis for these.
+"""
+import pytest
+
+
+def test_sort(indices):
+    with pytest.raises(TypeError):
+        indices.sort()
+
+
+def test_hash_error(indices):
+    index = indices
+    with pytest.raises(TypeError, match=f"unhashable type: '{type(index).__name__}'"):
+        hash(indices)
+
+
+def test_mutability(indices):
+    if not len(indices):
+        return
+    msg = "Index does not support mutable operations"
+    with pytest.raises(TypeError, match=msg):
+        indices[0] = indices[0]
+
+
+def test_wrong_number_names(indices):
+    with pytest.raises(ValueError, match="^Length"):
+        indices.names = ["apple", "banana", "carrot"]
+
+
+def test_tolist_matches_list(indices):
+    assert indices.tolist() == list(indices)


### PR DESCRIPTION
ATM we are mixing/matching pytest vs UnitTest idioms, which is confusing for me because I have to track down both inheritance and fixtures.  So I'm trying to clean this up, leading to some yak shaving.
