### PR TITLE
(Fixes CI) Replaced set comprehension with a generator

### DIFF
--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -205,7 +205,7 @@ class TestS3:
         with caplog.at_level(logging.DEBUG, logger="s3fs"):
             read_csv("s3://pandas-test/large-file.csv", nrows=5)
             # log of fetch_range (start, stop)
-            assert (0, 5505024) in {x.args[-2:] for x in caplog.records}
+            assert (0, 5505024) in (x.args[-2:] for x in caplog.records)
 
     def test_read_s3_with_hash_in_key(self, tips_df):
         # GH 25945


### PR DESCRIPTION
- [x] closes #31149
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
