### PR TITLE
make TDI.get_value use get_loc, fix wrong-dtype NaT

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -44,10 +44,6 @@ from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import Tick
 
 
-def _is_convertible_to_td(key):
-    return isinstance(key, (Tick, timedelta, np.timedelta64, str))
-
-
 def _field_accessor(name, alias, docstring=None):
     def f(self):
         values = self.asi8

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1608,19 +1608,22 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         is_int_index = labels.is_integer()
         is_int_positional = is_integer(obj) and not is_int_index
 
-        # if we are a label return me
-        try:
-            return labels.get_loc(obj)
-        except LookupError:
-            if isinstance(obj, tuple) and isinstance(labels, ABCMultiIndex):
-                if len(obj) == labels.nlevels:
-                    return {"key": obj}
-                raise
-        except TypeError:
-            pass
-        except ValueError:
-            if not is_int_positional:
-                raise
+        if is_scalar(obj) or isinstance(labels, ABCMultiIndex):
+            # Otherwise get_loc will raise InvalidIndexError
+
+            # if we are a label return me
+            try:
+                return labels.get_loc(obj)
+            except LookupError:
+                if isinstance(obj, tuple) and isinstance(labels, ABCMultiIndex):
+                    if len(obj) == labels.nlevels:
+                        return {"key": obj}
+                    raise
+            except TypeError:
+                pass
+            except ValueError:
+                if not is_int_positional:
+                    raise
 
         # a positional
         if is_int_positional:

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import re
 
 import numpy as np
 import pytest
@@ -48,12 +49,19 @@ class TestGetItem:
 
     @pytest.mark.parametrize(
         "key",
-        [pd.Timestamp("1970-01-01"), pd.Timestamp("1970-01-02"), datetime(1970, 1, 1)],
+        [
+            pd.Timestamp("1970-01-01"),
+            pd.Timestamp("1970-01-02"),
+            datetime(1970, 1, 1),
+            pd.Timestamp("1970-01-03").to_datetime64(),
+            # non-matching NA values
+            np.datetime64("NaT"),
+        ],
     )
     def test_timestamp_invalid_key(self, key):
         # GH#20464
         tdi = pd.timedelta_range(0, periods=10)
-        with pytest.raises(TypeError):
+        with pytest.raises(KeyError, match=re.escape(repr(key))):
             tdi.get_loc(key)
 
 


### PR DESCRIPTION
the wrong-dtype NaT is a bug, the DTI analogue is fixed in #31163.

The refactor to make get_value is get_loc is basically what we want all of them index subclasses to do (at which point we de-duplicate and possibly get rid of get_value altogether)

cc @jreback 