### PR TITLE
WIP/TST: add dt64tz to indices fixture

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -660,7 +660,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         result = getattr(ufunc, method)(*inputs, **kwargs)
 
         name: Optional[Hashable]
-        if len(set(names)) == 1:
+        if len(set(names)) == 1:  # TODO: we have a func in ops for this
             name = names[0]
         else:
             name = None

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -1278,6 +1278,7 @@ class TestPeriodIndexSeriesMethods:
         )
         obj = tm.box_expected(idx, box_with_array)
         msg = (
+            "cannot use operands with types|"
             r"unsupported operand type\(s\)|can only concatenate|"
             r"must be str|object to str implicitly"
         )

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -9,6 +9,7 @@ indices_dict = {
     "unicode": tm.makeUnicodeIndex(100),
     "string": tm.makeStringIndex(100),
     "datetime": tm.makeDateIndex(100),
+    "datetime-tz": tm.makeDateIndex(100, tz="US/Pacific"),
     "period": tm.makePeriodIndex(100),
     "timedelta": tm.makeTimedeltaIndex(100),
     "int": tm.makeIntIndex(100),

--- a/pandas/tests/indexes/test_numpy_compat.py
+++ b/pandas/tests/indexes/test_numpy_compat.py
@@ -99,8 +99,12 @@ def test_numpy_ufuncs_other(indices, func):
 
     elif isinstance(idx, PeriodIndex):
         # raise TypeError or ValueError (PeriodIndex)
-        with pytest.raises(Exception):
-            func(idx)
+        if func in [np.isfinite]:
+            result = func(idx)
+            assert isinstance(result, np.ndarray)
+        else:
+            with pytest.raises(Exception):
+                func(idx)
 
     elif isinstance(idx, (Float64Index, Int64Index, UInt64Index)):
         # Results in bool array


### PR DESCRIPTION
@TomAugspurger @jorisvandenbossche as you can see, the `__array_ufunc__` that this implements is an unholy mess.  This all came from a much smaller goal: I wanted to add the "datetime-tz" key in tests.indexes.conftest.

That broke a test for `np.isfinite`, so I started implementing `array_ufunc`.  Then that broke other ufuncs, and so on and so on.

I guess I could just xfail the one isfinite test.  In retrospect that would have saved a lot of effort.  Woops.

Anyhow, we probably want/need to implement this eventually anyway, so any ideas on how to do it but less awful?

xref #31219.