### PR TITLE
CI: Fix Assign CI not working with quotes

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -7,8 +7,8 @@ jobs:
   one:
     runs-on: ubuntu-latest
     steps:
-      - name:
-        if: github.event.comment.body == "take"
-          run: |
-            echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
-            curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+    - if: github.event.comment.body == 'take'
+      name:
+      run: |
+        echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name:
-        run: |
-            if [[ "${{ github.event.comment.body == "take" }}" == "true" ]]; then
-                echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
-                curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
-            fi
+        if: github.event.comment.body == "take"
+          run: |
+            echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+            curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name:
         run: |
-            if [[ "${{ github.event.comment.body }}" == "take" ]]; then
+            if [[ "${{ github.event.comment.body == "take" }}" == "true" ]]; then
                 echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
                 curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
             fi


### PR DESCRIPTION
- [x] closes #29768 
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Examples(all three passed)
![image](https://user-images.githubusercontent.com/47963215/72952081-a6481100-3d45-11ea-8845-338f2a2f17a4.png)

