### PR TITLE
BUG: na_logical_op with 2D inputs

### DIFF
--- a/pandas/core/ops/array_ops.py
+++ b/pandas/core/ops/array_ops.py
@@ -277,7 +277,7 @@ def na_logical_op(x: np.ndarray, y, op):
             assert not (is_bool_dtype(x.dtype) and is_bool_dtype(y.dtype))
             x = ensure_object(x)
             y = ensure_object(y)
-            result = libops.vec_binop(x, y, op)
+            result = libops.vec_binop(x.ravel(), y.ravel(), op)
         else:
             # let null fall thru
             assert lib.is_scalar(y)
@@ -298,7 +298,7 @@ def na_logical_op(x: np.ndarray, y, op):
                     f"and scalar of type [{typ}]"
                 )
 
-    return result
+    return result.reshape(x.shape)
 
 
 def logical_op(

--- a/pandas/tests/arithmetic/test_array_ops.py
+++ b/pandas/tests/arithmetic/test_array_ops.py
@@ -1,0 +1,21 @@
+import operator
+
+import numpy as np
+import pytest
+
+import pandas._testing as tm
+from pandas.core.ops.array_ops import na_logical_op
+
+
+def test_na_logical_op_2d():
+    left = np.arange(8).reshape(4, 2)
+    right = left.astype(object)
+    right[0, 0] = np.nan
+
+    # Check that we fall back to the vec_binop branch
+    with pytest.raises(TypeError, match="unsupported operand type"):
+        operator.or_(left, right)
+
+    result = na_logical_op(left, right, operator.or_)
+    expected = right
+    tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
Broken off from a branch implementing block-wise ops for op(dataframe, dataframe)