### PR TITLE
REF: do alignment before _combine_series_frame

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -772,7 +772,6 @@ def _comp_method_FRAME(cls, op, special):
                     "Can only compare identically-labeled DataFrame objects"
                 )
             new_data = dispatch_to_series(self, other, op, str_rep)
-            return self._construct_result(new_data)
 
         elif isinstance(other, ABCSeries):
             # axis=1 is default for DataFrame-with-Series op
@@ -780,14 +779,14 @@ def _comp_method_FRAME(cls, op, special):
                 other, join="outer", axis=1, level=None, copy=False
             )
             new_data = dispatch_to_series(self, other, op, axis="columns")
-            return self._construct_result(new_data)
 
         else:
 
             # straight boolean comparisons we want to allow all columns
             # (regardless of dtype to pass thru) See #4537 for discussion.
             new_data = dispatch_to_series(self, other, op)
-            return self._construct_result(new_data)
+
+        return self._construct_result(new_data)
 
     f.__name__ = op_name
 

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -702,7 +702,9 @@ def _arith_method_FRAME(cls, op, special):
                 raise NotImplementedError(f"fill_value {fill_value} not supported.")
 
             axis = self._get_axis_number(axis) if axis is not None else 1
-            self, other = self.align(other, join="outer", axis=axis, level=level, copy=False)
+            self, other = self.align(
+                other, join="outer", axis=axis, level=level, copy=False
+            )
             return _combine_series_frame(self, other, pass_op, axis=axis)
         else:
             # in this case we always have `np.ndim(other) == 0`
@@ -740,7 +742,9 @@ def _flex_comp_method_FRAME(cls, op, special):
 
         elif isinstance(other, ABCSeries):
             axis = self._get_axis_number(axis) if axis is not None else 1
-            self, other = self.align(other, join="outer", axis=axis, level=level, copy=False)
+            self, other = self.align(
+                other, join="outer", axis=axis, level=level, copy=False
+            )
             return _combine_series_frame(self, other, op, axis=axis)
         else:
             # in this case we always have `np.ndim(other) == 0`
@@ -772,8 +776,12 @@ def _comp_method_FRAME(cls, op, special):
 
         elif isinstance(other, ABCSeries):
             # axis=1 is default for DataFrame-with-Series op
-            self, other = self.align(other, join="outer", axis=1, level=None, copy=False)
-            return _combine_series_frame(self, other, op, axis=1)
+            self, other = self.align(
+                other, join="outer", axis=1, level=None, copy=False
+            )
+            new_data = dispatch_to_series(self, other, op, axis="columns")
+            return self._construct_result(new_data)
+
         else:
 
             # straight boolean comparisons we want to allow all columns


### PR DESCRIPTION
This will allow us to de-duplicate _construct_result calls (this does so for _comp_method_FRAME) and ultimately move all of the alignment into _align_method_FRAME