### PR TITLE
ASV: add benchmarks for Series.array and extract_array

### DIFF
--- a/asv_bench/benchmarks/attrs_caching.py
+++ b/asv_bench/benchmarks/attrs_caching.py
@@ -1,11 +1,17 @@
 import numpy as np
 
+import pandas as pd
 from pandas import DataFrame
 
 try:
     from pandas.util import cache_readonly
 except ImportError:
     from pandas.util.decorators import cache_readonly
+
+try:
+    from pandas.core.construction import extract_array
+except ImportError:
+    extract_array = None
 
 
 class DataFrameAttributes:
@@ -18,6 +24,33 @@ class DataFrameAttributes:
 
     def time_set_index(self):
         self.df.index = self.cur_index
+
+
+class SeriesArrayAttribute:
+
+    params = [["numeric", "object", "category", "datetime64", "datetime64tz"]]
+    param_names = ["dtype"]
+
+    def setup(self, dtype):
+        if dtype == "numeric":
+            self.series = pd.Series([1, 2, 3])
+        elif dtype == "object":
+            self.series = pd.Series(["a", "b", "c"], dtype=object)
+        elif dtype == "category":
+            self.series = pd.Series(["a", "b", "c"], dtype="category")
+        elif dtype == "datetime64":
+            self.series = pd.Series(pd.date_range("2013", periods=3))
+        elif dtype == "datetime64tz":
+            self.series = pd.Series(pd.date_range("2013", periods=3, tz="UTC"))
+
+    def time_array(self, dtype):
+        self.series.array
+
+    def time_extract_array(self, dtype):
+        extract_array(self.series)
+
+    def time_extract_array_numpy(self, dtype):
+        extract_array(self.series, extract_numpy=True)
 
 
 class CacheReadonly:


### PR DESCRIPTION
Just thought it would be useful to have a benchmark for `.array` (now the performance regression of https://github.com/pandas-dev/pandas/pull/31037 was caught indirectly through an indexing benchmark)