### PR TITLE
DOC: move convert_dtypes whatsnew to 1.0

### DIFF
--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -157,6 +157,36 @@ You can use the alias ``"boolean"`` as well.
    s = pd.Series([True, False, None], dtype="boolean")
    s
 
+.. _whatsnew_100.convert_dtypes:
+
+``convert_dtypes`` method to ease use of supported extension dtypes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to encourage use of the extension dtypes ``StringDtype``,
+``BooleanDtype``, ``Int64Dtype``, ``Int32Dtype``, etc., that support ``pd.NA``, the
+methods :meth:`DataFrame.convert_dtypes` and :meth:`Series.convert_dtypes`
+have been introduced. (:issue:`29752`) (:issue:`30929`)
+
+Example:
+
+.. ipython:: python
+
+   df = pd.DataFrame({'x': ['abc', None, 'def'],
+                      'y': [1, 2, np.nan],
+                      'z': [True, False, True]})
+   df
+   df.dtypes
+
+.. ipython:: python
+
+   converted = df.convert_dtypes()
+   converted
+   converted.dtypes
+
+This is especially useful after reading in data using readers such as :func:`read_csv`
+and :func:`read_excel`.
+See :ref:`here <missing_data.NA.conversion>` for a description.
+
 .. _whatsnew_100.numba_rolling_apply:
 
 Using Numba in ``rolling.apply`` and ``expanding.apply``

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -13,36 +13,6 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
-.. _whatsnew_100.convert_dtypes:
-
-``convert_dtypes`` method to ease use of supported extension dtypes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In order to encourage use of the extension dtypes ``StringDtype``,
-``BooleanDtype``, ``Int64Dtype``, ``Int32Dtype``, etc., that support ``pd.NA``, the
-methods :meth:`DataFrame.convert_dtypes` and :meth:`Series.convert_dtypes`
-have been introduced. (:issue:`29752`) (:issue:`30929`)
-
-Example:
-
-.. ipython:: python
-
-   df = pd.DataFrame({'x': ['abc', None, 'def'],
-                      'y': [1, 2, np.nan],
-                      'z': [True, False, True]})
-   df
-   df.dtypes
-
-.. ipython:: python
-
-   converted = df.convert_dtypes()
-   converted
-   converted.dtypes
-
-This is especially useful after reading in data using readers such as :func:`read_csv`
-and :func:`read_excel`.
-See :ref:`here <missing_data.NA.conversion>` for a description.
-
 .. _whatsnew_110.period_index_partial_string_slicing:
 
 Nonmonotonic PeriodIndex Partial String Slicing

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5741,7 +5741,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         Convert columns to best possible dtypes using dtypes supporting ``pd.NA``.
 
-        .. versionadded:: 1.1.0
+        .. versionadded:: 1.0.0
 
         Parameters
         ----------


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
   - moved whatsnew entry from 1.1 to 1.0

Per comment here from @jreback: https://github.com/pandas-dev/pandas/pull/30929#issuecomment-577989924
