### PR TITLE
added shuffle method to DataFrame

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4893,6 +4893,65 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         locs = rs.choice(axis_length, size=n, replace=replace, p=weights)
         return self.take(locs, axis=axis)
 
+    def shuffle(
+        self: FrameOrSeries,
+        random_state=None,
+        axis=None,
+    ) -> FrameOrSeries:
+        """
+        Return a randomly shuffled dataframe or series
+
+        You can use `random_state` for reproducibility
+
+        Parameters:
+        ----------
+        random_state: int or numpy.random.RandomState, optional
+            Seed for the random number generator (if int), or numpy RandomState
+            object.
+        axis: {0 or ‘index’, 1 or ‘columns’, None}, default None
+            Axis to sample. Accepts axis number or name. Default is stat axis
+            for given data type (0 for Series and DataFrames).
+
+        Returns
+        -------
+        Series or DataFrame
+            A new object of the same type as caller with all the items randomly
+            sampled from the caller object.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'num_legs': [2, 4, 8, 0],
+        ...                    'num_wings': [2, 0, 0, 0],
+        ...                    'num_specimen_seen': [10, 2, 1, 8]},
+        ...                   index=['falcon', 'dog', 'spider', 'fish'])
+        >>> df
+            num_legs  num_wings  num_specimen_seen
+        falcon         2          2                 10
+        dog            4          0                  2
+        spider         8          0                  1
+        fish           0          0                  8
+
+        Shuffle the ``Series`` ``df['num_legs']``:
+        Note that we use `random_state` to ensure the reproducibility of
+        the examples.
+
+        >>> df['num_legs'].shuffle(random_state=1)
+        fish      0
+        spider    8
+        falcon    2
+        dog       4
+        Name: num_legs, dtype: int64
+
+        Shuffling the whole ``DataFrame``:
+        >>> df.shuffle(frac=1, random_state=2)
+                num_legs  num_wings  num_specimen_seen
+        spider         8          0                  1
+        fish           0          0                  8
+        dog            4          0                  2
+        falcon         2          2                 10
+        """
+        return self.sample(frac=1, axis=axis, random_state=random_state)
+
     _shared_docs[
         "pipe"
     ] = r"""

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4939,7 +4939,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Name: num_legs, dtype: int64
 
         Shuffling the whole ``DataFrame``:
-        >>> df.shuffle(frac=1, random_state=2)
+        >>> df.shuffle(random_state=2)
                 num_legs  num_wings  num_specimen_seen
         spider         8          0                  1
         fish           0          0                  8

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4893,11 +4893,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         locs = rs.choice(axis_length, size=n, replace=replace, p=weights)
         return self.take(locs, axis=axis)
 
-    def shuffle(
-        self: FrameOrSeries,
-        random_state=None,
-        axis=None,
-    ) -> FrameOrSeries:
+    def shuffle(self: FrameOrSeries, random_state=None, axis=None,) -> FrameOrSeries:
         """
         Return a randomly shuffled dataframe or series
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I have added a shuffle method to pd.DataFrame, as writing df.sample(frac=1) is not intuitive. The method just calls df.sample with 1 line of code.
To test it, I have added a test, here is the code:
```# flake8: noqa

"""
Public testing utility functions.
"""
import pandas as pd
from pandas.util.testing import (
    assert_frame_equal, assert_index_equal, assert_series_equal)


df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=['a', 'b'])
shuffled = df.shuffle(random_state=1)
expected = pd.DataFrame([[1, 2], [5, 6], [3, 4]], columns=['a', 'b'])
expected.set_index(pd.Series([0, 2, 1]), inplace=True)
assert_frame_equal(shuffled, expected)
```
This PR doesn't resolve any issue, I just thought a shuffle method would make a nice addition to pandas.
Also, I did not understand what you mean by 'whatsnew entry', could you please clarify?