### PR TITLE
PERF: optimize is_scalar, is_iterator

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -11,6 +11,9 @@ from cython import Py_ssize_t
 from cpython.object cimport PyObject_RichCompareBool, Py_EQ
 from cpython.ref cimport Py_INCREF
 from cpython.tuple cimport PyTuple_SET_ITEM, PyTuple_New
+from cpython.iterator cimport PyIter_Check
+from cpython.sequence cimport PySequence_Check
+from cpython.number cimport PyNumber_Check
 
 from cpython.datetime cimport (PyDateTime_Check, PyDate_Check,
                                PyTime_Check, PyDelta_Check,
@@ -156,7 +159,8 @@ def is_scalar(val: object) -> bool:
     True
     """
 
-    return (cnp.PyArray_IsAnyScalar(val)
+    # Start with C-optimized checks
+    if (cnp.PyArray_IsAnyScalar(val)
             # PyArray_IsAnyScalar is always False for bytearrays on Py3
             or PyDate_Check(val)
             or PyDelta_Check(val)
@@ -164,12 +168,52 @@ def is_scalar(val: object) -> bool:
             # We differ from numpy, which claims that None is not scalar;
             # see np.isscalar
             or val is C_NA
-            or val is None
-            or isinstance(val, (Fraction, Number))
+            or val is None):
+        return True
+
+    # Next use C-optimized checks to exclude common non-scalars before falling
+    #  back to non-optimized checks.
+    if PySequence_Check(val):
+        # e.g. list, tuple
+        # includes np.ndarray, Series which PyNumber_Check can return True for
+        return False
+
+    # Note: PyNumber_Check check includes Decimal, Fraction, numbers.Number
+    return (PyNumber_Check(val)
             or util.is_period_object(val)
-            or is_decimal(val)
             or is_interval(val)
             or util.is_offset_object(val))
+
+
+def is_iterator(obj: object) -> bool:
+    """
+    Check if the object is an iterator.
+
+    This is intended for generators, not list-like objects.
+
+    Parameters
+    ----------
+    obj : The object to check
+
+    Returns
+    -------
+    is_iter : bool
+        Whether `obj` is an iterator.
+
+    Examples
+    --------
+    >>> is_iterator((x for x in []))
+    True
+    >>> is_iterator([1, 2, 3])
+    False
+    >>> is_iterator(datetime(2017, 1, 1))
+    False
+    >>> is_iterator("foo")
+    False
+    >>> is_iterator(1)
+    False
+    """
+    return PyIter_Check(obj)
 
 
 def item_from_zerodim(val: object) -> object:

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -25,6 +25,8 @@ is_interval = lib.is_interval
 
 is_list_like = lib.is_list_like
 
+is_iterator = lib.is_iterator
+
 
 def is_number(obj) -> bool:
     """
@@ -91,40 +93,6 @@ def _iterable_not_string(obj) -> bool:
     """
 
     return isinstance(obj, abc.Iterable) and not isinstance(obj, str)
-
-
-def is_iterator(obj) -> bool:
-    """
-    Check if the object is an iterator.
-
-    For example, lists are considered iterators
-    but not strings or datetime objects.
-
-    Parameters
-    ----------
-    obj : The object to check
-
-    Returns
-    -------
-    is_iter : bool
-        Whether `obj` is an iterator.
-
-    Examples
-    --------
-    >>> is_iterator([1, 2, 3])
-    True
-    >>> is_iterator(datetime(2017, 1, 1))
-    False
-    >>> is_iterator("foo")
-    False
-    >>> is_iterator(1)
-    False
-    """
-
-    if not hasattr(obj, "__iter__"):
-        return False
-
-    return hasattr(obj, "__next__")
 
 
 def is_file_like(obj) -> bool:

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1346,9 +1346,11 @@ class TestIsScalar:
         assert is_scalar(None)
         assert is_scalar(True)
         assert is_scalar(False)
-        assert is_scalar(Number())
         assert is_scalar(Fraction())
         assert is_scalar(0.0)
+        assert is_scalar(1)
+        assert is_scalar(complex(2))
+        assert is_scalar(float("NaN"))
         assert is_scalar(np.nan)
         assert is_scalar("foobar")
         assert is_scalar(b"foobar")
@@ -1357,6 +1359,7 @@ class TestIsScalar:
         assert is_scalar(time(12, 0))
         assert is_scalar(timedelta(hours=1))
         assert is_scalar(pd.NaT)
+        assert is_scalar(pd.NA)
 
     def test_is_scalar_builtin_nonscalars(self):
         assert not is_scalar({})
@@ -1371,6 +1374,7 @@ class TestIsScalar:
         assert is_scalar(np.int64(1))
         assert is_scalar(np.float64(1.0))
         assert is_scalar(np.int32(1))
+        assert is_scalar(np.complex64(2))
         assert is_scalar(np.object_("foobar"))
         assert is_scalar(np.str_("foobar"))
         assert is_scalar(np.unicode_("foobar"))
@@ -1409,6 +1413,21 @@ class TestIsScalar:
         assert not is_scalar(DataFrame([[1]]))
         assert not is_scalar(Index([]))
         assert not is_scalar(Index([1]))
+
+    def test_is_scalar_number(self):
+        # Number() is not recognied by PyNumber_Check, so by extension
+        #  is not recognized by is_scalar, but instances of non-abstract
+        #  subclasses are.
+
+        class Numeric(Number):
+            def __init__(self, value):
+                self.value = value
+
+            def __int__(self):
+                return self.value
+
+        num = Numeric(1)
+        assert is_scalar(num)
 
 
 def test_datetimeindex_from_empty_datetime64_array():


### PR DESCRIPTION
While working on #30349 I noticed that `is_scalar` is pretty slow for non-scalar args, turns out we can get a 9-19x improvement for listlike cases, 5-10x improvement for Decimal/Period/DateOffset/Interval, with small improvements in nearly every other case while we're at it (the fractions.Fraction object is the only one where i found a small decrease in perf, within the margin of error)

xref #31291, assuming this is the desired behavior for is_iterator, this closes that.
 
Setup:
```
import pandas as pd                                                     
from pandas.core.dtypes.common import *                                 
import decimal, fractions

dec = decimal.Decimal(19.45678)
frac = fractions.Fraction(1)
i64 = np.int64(-1)
arr = np.arange(5)
ser = pd.Series(arr)
idx = pd.Index(arr)
interval = pd.Interval(0, 1)
per = pd.Period("2017")
offset = per - per
iterator = (x for x in [])
```

Non-Scalar Cases
```
In [6]: %timeit is_scalar([])
1.53 µs ± 36.4 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
79.7 ns ± 5.26 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [7]: %timeit is_scalar(arr)
1.58 µs ± 43.8 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
77.6 ns ± 5.02 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [8]: %timeit is_scalar(ser)
1.01 µs ± 51.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
92.3 ns ± 0.505 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [9]: %timeit is_scalar(idx)
876 ns ± 4.86 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
92.7 ns ± 1.47 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [10]: %timeit is_scalar(iterator)
2.08 µs ± 22.9 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- master
869 ns ± 20.9 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- PR
```

Non-Built-In Scalar Cases
```
In [10]: %timeit is_scalar(dec)
1.05 µs ± 9.75 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
79.5 ns ± 2.16 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [12]: %timeit is_scalar(interval)
748 ns ± 22.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
139 ns ± 5.38 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [13]: %timeit is_scalar(per)
706 ns ± 24.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
127 ns ± 14.2 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [14]: %timeit is_scalar(offset)
930 ns ± 40.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
211 ns ± 2.45 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- PR
```

Built-In Scalar Cases
```
In [3]: %timeit is_scalar(4)
60.1 ns ± 2.39 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- master
54.9 ns ± 1.15 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [4]: %timeit is_scalar(4.0)
53 ns ± 4.94 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- master
48.2 ns ± 0.613 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [5]: %timeit is_scalar(i64)
58.5 ns ± 1.39 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- master
58.1 ns ± 5.88 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [11]: %timeit is_scalar(frac)
93.5 ns ± 2.05 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- master
94.1 ns ± 6.4 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR
```

is_iterator check
```
In [16] %timeit is_iterator(iterator)
283 ns ± 5.35 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
58.9 ns ± 2.31 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [17] %timeit is_iterator(arr)
228 ns ± 3.98 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
55 ns ± 3.53 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR

In [17] %timeit is_iterator("foo")
231 ns ± 15.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master
49.4 ns ± 5.08 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR
```