### PR TITLE
PERF: avoid copies if possible in fill_binop

### DIFF
--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -335,8 +335,6 @@ def fill_binop(left, right, fill_value):
         left_mask = isna(left)
         right_mask = isna(right)
 
-        right = right.copy()
-
         # one but not both
         mask = left_mask ^ right_mask
 

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -329,19 +329,27 @@ def fill_binop(left, right, fill_value):
 
     Notes
     -----
-    Makes copies if fill_value is not None
+    Makes copies if fill_value is not None and NAs are present.
     """
-    # TODO: can we make a no-copy implementation?
     if fill_value is not None:
         left_mask = isna(left)
         right_mask = isna(right)
-        left = left.copy()
+
         right = right.copy()
 
         # one but not both
         mask = left_mask ^ right_mask
-        left[left_mask & mask] = fill_value
-        right[right_mask & mask] = fill_value
+
+        if left_mask.any():
+            # Avoid making a copy if we can
+            left = left.copy()
+            left[left_mask & mask] = fill_value
+
+        if right_mask.any():
+            # Avoid making a copy if we can
+            right = right.copy()
+            right[right_mask & mask] = fill_value
+
     return left, right
 
 


### PR DESCRIPTION
This has a small perf bump, but more importantly is necessary for the blockwise frame-with-frame PR that is coming up.

```
import pandas as pd
from pandas.core.ops import *

arr = np.arange(10**6)
df = pd.DataFrame({"A": arr})
ser = df["A"]

%timeit result = df.add(df, fill_value=4)
7.77 ms ± 20.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- master
5.46 ms ± 36.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- PR

%timeit result = ser.add(ser, fill_value=1)
6.79 ms ± 56.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- master
4.65 ms ± 82.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)  <-- PR
```
