### PR TITLE
BUG: MultiIndex intersection with sort=False  does not preserve order

### DIFF
--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -160,4 +160,30 @@ class Equals:
         self.mi_large_slow.equals(self.idx_non_object)
 
 
+class SetOperations:
+
+    params = [
+        ("monotonic", "non_monotonic"),
+        ("intersection", "union", "symmetric_difference"),
+    ]
+    param_names = ["index_structure", "method"]
+
+    def setup(self, index_structure, method):
+        N = 10 ** 5
+        values = np.arange(N)
+
+        if index_structure == "monotonic":
+            mi = MultiIndex.from_arrays([values, values])
+        else:
+            mi = MultiIndex.from_arrays(
+                [np.concatenate([values[::2], values[1::2]]), values]
+            )
+
+        self.left = mi
+        self.right = mi[:-1]
+
+    def time_operation(self, index_structure, method):
+        getattr(self.left, method)(self.right)
+
+
 from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -176,13 +176,13 @@ MultiIndex
         # Rows are now ordered as the requested keys
         df.loc[(['b', 'a'], [2, 1]), :]
 
-- Bug in :meth:`MultiIndex.intersection` was not preserving order when ``sort=False``. (:issue:`31325`)
+- Bug in :meth:`MultiIndex.intersection` was not guaranteed to preserve order when ``sort=False``. (:issue:`31325`)
 
 .. ipython:: python
 
         left = pd.MultiIndex.from_arrays([["b", "a"], [2, 1]])
         right = pd.MultiIndex.from_arrays([["a", "b", "c"], [1, 2, 3]])
-        # Common elements are now ordered by the left side
+        # Common elements are now guaranteed to be ordered by the left side
         left.intersection(right, sort=False)
 
 -

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -175,6 +175,16 @@ MultiIndex
                           index=[["a", "a", "b", "b"], [1, 2, 1, 2]])
         # Rows are now ordered as the requested keys
         df.loc[(['b', 'a'], [2, 1]), :]
+
+- Bug in :meth:`MultiIndex.intersection` was not preserving order when ``sort=False``. (:issue:`31325`)
+
+.. ipython:: python
+
+        left = pd.MultiIndex.from_arrays([["b", "a"], [2, 1]])
+        right = pd.MultiIndex.from_arrays([["a", "b", "c"], [1, 2, 3]])
+        # Common elements are now ordered by the left side
+        left.intersection(right, sort=False)
+
 -
 
 I/O

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3314,10 +3314,16 @@ class MultiIndex(Index):
         if self.equals(other):
             return self
 
-        uniq_other = set(other.values)
+        lvals = self._ndarray_values
+        rvals = other._ndarray_values
+
+        if self.is_monotonic and other.is_monotonic:
+            return self._inner_indexer(lvals, rvals)[0]
+
+        other_uniq = set(rvals)
         seen = set()
         uniq_tuples = [
-            x for x in self.values if x in uniq_other and not (x in seen or seen.add(x))
+            x for x in lvals if x in other_uniq and not (x in seen or seen.add(x))
         ]
 
         if sort is None:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3321,6 +3321,7 @@ class MultiIndex(Index):
         if self.is_monotonic and other.is_monotonic:
             try:
                 uniq_tuples = self._inner_indexer(lvals, rvals)[0]
+                sort = False  # uniq_tuples is already sorted
             except TypeError:
                 pass
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3317,7 +3317,7 @@ class MultiIndex(Index):
         lvals = self._ndarray_values
         rvals = other._ndarray_values
 
-        uniq_tuples = None
+        uniq_tuples = None  # flag whether _inner_indexer was succesful
         if self.is_monotonic and other.is_monotonic:
             try:
                 uniq_tuples = self._inner_indexer(lvals, rvals)[0]

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3317,14 +3317,19 @@ class MultiIndex(Index):
         lvals = self._ndarray_values
         rvals = other._ndarray_values
 
+        uniq_tuples = None
         if self.is_monotonic and other.is_monotonic:
-            return self._inner_indexer(lvals, rvals)[0]
+            try:
+                uniq_tuples = self._inner_indexer(lvals, rvals)[0]
+            except TypeError:
+                pass
 
-        other_uniq = set(rvals)
-        seen = set()
-        uniq_tuples = [
-            x for x in lvals if x in other_uniq and not (x in seen or seen.add(x))
-        ]
+        if uniq_tuples is None:
+            other_uniq = set(rvals)
+            seen = set()
+            uniq_tuples = [
+                x for x in lvals if x in other_uniq and not (x in seen or seen.add(x))
+            ]
 
         if sort is None:
             uniq_tuples = sorted(uniq_tuples)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3314,9 +3314,11 @@ class MultiIndex(Index):
         if self.equals(other):
             return self
 
-        self_tuples = self._ndarray_values
-        other_tuples = other._ndarray_values
-        uniq_tuples = set(self_tuples) & set(other_tuples)
+        uniq_other = set(other.values)
+        seen = set()
+        uniq_tuples = [
+            x for x in self.values if x in uniq_other and not (x in seen or seen.add(x))
+        ]
 
         if sort is None:
             uniq_tuples = sorted(uniq_tuples)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -19,18 +19,20 @@ def test_set_ops_error_cases(idx, case, sort, method):
 
 
 @pytest.mark.parametrize("sort", [None, False])
-def test_intersection_base(idx, sort):
+@pytest.mark.parametrize("klass", [MultiIndex, np.array, Series, list])
+def test_intersection_base(idx, sort, klass):
     first = idx[2::-1]  # first 3 elements reversed
     second = idx[:5]
 
-    array_like_cases = [klass(second.values) for klass in [np.array, Series, list]]
-    for case in [second, *array_like_cases]:
-        intersect = first.intersection(case, sort=sort)
-        if sort is None:
-            expected = first.sort_values()
-        else:
-            expected = first
-        tm.assert_index_equal(intersect, expected)
+    if klass is not MultiIndex:
+        second = klass(second.values)
+
+    intersect = first.intersection(second, sort=sort)
+    if sort is None:
+        expected = first.sort_values()
+    else:
+        expected = first
+    tm.assert_index_equal(intersect, expected)
 
     msg = "other must be a MultiIndex or a list of tuples"
     with pytest.raises(TypeError, match=msg):
@@ -38,18 +40,20 @@ def test_intersection_base(idx, sort):
 
 
 @pytest.mark.parametrize("sort", [None, False])
-def test_union_base(idx, sort):
+@pytest.mark.parametrize("klass", [MultiIndex, np.array, Series, list])
+def test_union_base(idx, sort, klass):
     first = idx[::-1]
     second = idx[:5]
 
-    array_like_cases = [klass(second.values) for klass in [np.array, Series, list]]
-    for case in [second, *array_like_cases]:
-        union = first.union(case, sort=sort)
-        if sort is None:
-            expected = first.sort_values()
-        else:
-            expected = first
-        tm.assert_index_equal(union, expected)
+    if klass is not MultiIndex:
+        second = klass(second.values)
+
+    union = first.union(second, sort=sort)
+    if sort is None:
+        expected = first.sort_values()
+    else:
+        expected = first
+    tm.assert_index_equal(union, expected)
 
     msg = "other must be a MultiIndex or a list of tuples"
     with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -39,21 +39,17 @@ def test_intersection_base(idx, sort):
 
 @pytest.mark.parametrize("sort", [None, False])
 def test_union_base(idx, sort):
-    first = idx[3:]
+    first = idx[::-1]
     second = idx[:5]
-    everything = idx
-    union = first.union(second, sort=sort)
-    if sort is None:
-        tm.assert_index_equal(union, everything.sort_values())
-    assert tm.equalContents(union, everything)
 
-    # GH 10149
-    cases = [klass(second.values) for klass in [np.array, Series, list]]
-    for case in cases:
-        result = first.union(case, sort=sort)
+    array_like_cases = [klass(second.values) for klass in [np.array, Series, list]]
+    for case in [second, *array_like_cases]:
+        union = first.union(case, sort=sort)
         if sort is None:
-            tm.assert_index_equal(result, everything.sort_values())
-        assert tm.equalContents(result, everything)
+            expected = first.sort_values()
+        else:
+            expected = first
+        tm.assert_index_equal(union, expected)
 
     msg = "other must be a MultiIndex or a list of tuples"
     with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -20,21 +20,17 @@ def test_set_ops_error_cases(idx, case, sort, method):
 
 @pytest.mark.parametrize("sort", [None, False])
 def test_intersection_base(idx, sort):
-    first = idx[:5]
-    second = idx[:3]
-    intersect = first.intersection(second, sort=sort)
+    first = idx[2::-1]  # first 3 elements reversed
+    second = idx[:5]
 
-    if sort is None:
-        tm.assert_index_equal(intersect, second.sort_values())
-    assert tm.equalContents(intersect, second)
-
-    # GH 10149
-    cases = [klass(second.values) for klass in [np.array, Series, list]]
-    for case in cases:
-        result = first.intersection(case, sort=sort)
+    array_like_cases = [klass(second.values) for klass in [np.array, Series, list]]
+    for case in [second, *array_like_cases]:
+        intersect = first.intersection(case, sort=sort)
         if sort is None:
-            tm.assert_index_equal(result, second.sort_values())
-        assert tm.equalContents(result, second)
+            expected = first.sort_values()
+        else:
+            expected = first
+        tm.assert_index_equal(intersect, expected)
 
     msg = "other must be a MultiIndex or a list of tuples"
     with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
- [x] closes #31325
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The intersection of 2 `MultiIndex` with `sort=False` does not preserve the order, whereas `Index. intersection()` does. This behavior does not seem to be intentional since the tests for `difference` and `symmetric_difference` are testing for order preservation.

For example:
```python
import pandas as pd

arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],
          ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two']]
tuples = list(zip(*arrays))
idx = pd.MultiIndex.from_tuples(tuples, names=['first', 'second'])

left = idx[2::-1]
print(left)
#> MultiIndex([('baz', 'one'),
#>             ('bar', 'two'),
#>             ('bar', 'one')],
#>            names=['first', 'second'])
right = idx[:5]
print(right)
#> MultiIndex([('bar', 'one'),
#>             ('bar', 'two'),
#>             ('baz', 'one'),
#>             ('baz', 'two'),
#>             ('foo', 'one')],
#>            names=['first', 'second'])

# expected same order as left
intersect = left.intersection(right, sort=False)
print(intersect)
#> MultiIndex([('bar', 'two'),
#>             ('baz', 'one'),
#>             ('bar', 'one')],
#>            names=['first', 'second'])
```
<sup>Created on 2020-01-25 by the [reprexpy package](https://github.com/crew102/reprexpy)</sup>

I verified that my PR does not decrease performances. 

I also modified the test for `union`. The implementation was preserving the order with `sort=False` but the tests were not verifying it.