### PR TITLE
Move DataFrame.info() to live with similar functions

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -28,6 +28,7 @@ Attributes and underlying data
    :toctree: api/
 
    DataFrame.dtypes
+   DataFrame.info
    DataFrame.select_dtypes
    DataFrame.values
    DataFrame.axes
@@ -347,7 +348,6 @@ Serialization / IO / conversion
 
    DataFrame.from_dict
    DataFrame.from_records
-   DataFrame.info
    DataFrame.to_parquet
    DataFrame.to_pickle
    DataFrame.to_csv


### PR DESCRIPTION
#31233

- [x ] closes #31233
(Not sure these are relevant for a doc change?)
- [ ] tests added / passed
- [ ] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
