### PR TITLE
DEPR: Deprecate core

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -69,7 +69,8 @@ Backwards incompatible API changes
 Deprecations
 ~~~~~~~~~~~~
 
--
+- Access to the ``pandas.core`` submodule is now deprecated, and the module will be moving to ``pandas._core`` in the future.
+  Please import all classes/methods from the top level pandas namespace instead.
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -395,9 +395,8 @@ else:
             )
             return attr
 
-    _core = __core()
+    _core: __core = __core()  # type: ignore
     core: __core = __core()
-
 
 # module level doc-string
 __doc__ = """

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -46,7 +46,7 @@ class TestPDApi(Base):
     ]
 
     # these are already deprecated; awaiting removal
-    deprecated_modules: List[str] = ["np", "datetime"]
+    deprecated_modules: List[str] = ["np", "datetime", "core"]
 
     # misc
     misc = ["IndexSlice", "NaT", "NA"]
@@ -190,6 +190,7 @@ class TestPDApi(Base):
     # private modules in pandas namespace
     private_modules = [
         "_config",
+        "_core",
         "_hashtable",
         "_lib",
         "_libs",
@@ -241,11 +242,11 @@ class TestPDApi(Base):
                 deprecated = getattr(pd, depr)
                 if not compat.PY37:
                     if depr == "datetime":
-                        deprecated.__getattr__(dir(pd.datetime.datetime)[-1])
+                        deprecated.__getattr__(dir(pd.datetime.datetime)[0])
                     elif depr == "SparseArray":
                         deprecated([])
                     else:
-                        deprecated.__getattr__(dir(deprecated)[-1])
+                        deprecated.__getattr__(dir(deprecated)[0])
 
 
 def test_datetime():

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -33,7 +33,6 @@ class TestPDApi(Base):
         "api",
         "arrays",
         "compat",
-        "core",
         "errors",
         "pandas",
         "plotting",


### PR DESCRIPTION
- [x] closes #27522 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I haven't actually performed the refactor(pandas.core -> pandas._core) yet so tests are failing because of the warnings. 
