### PR TITLE
ENH: truncate output of Groupby.groups

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -32,7 +32,7 @@ check each issue individually, and it's not possible to find the unassigned ones
 
 For this reason, we implemented a workaround consisting of adding a comment with the exact
 text `take`. When you do it, a GitHub action will automatically assign you the issue
-(this will take seconds, and may require refreshint the page to see it).
+(this will take seconds, and may require refreshing the page to see it).
 By doing this, it's possible to filter the list of issues and find only the unassigned ones.
 
 So, a good way to find an issue to start contributing to pandas is to check the list of

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -54,7 +54,7 @@ Other API changes
 
 - :meth:`Series.describe` will now show distribution percentiles for ``datetime`` dtypes, statistics ``first`` and ``last``
   will now be ``min`` and ``max`` to match with numeric dtypes in :meth:`DataFrame.describe` (:issue:`30164`)
--
+- :meth:`Groupby.groups` now returns an abbreviated representation when called on large dataframes (:issue:`1135`)
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -607,7 +607,7 @@ class DataFrame(NDFrame):
         Check if full repr fits in horizontal boundaries imposed by the display
         options width and max_columns.
 
-        In case off non-interactive session, no boundaries apply.
+        In case of non-interactive session, no boundaries apply.
 
         `ignore_width` is here so ipnb+HTML output can behave the way
         users expect. display.max_columns remains in effect.

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -56,7 +56,6 @@ import pandas.core.algorithms as algorithms
 from pandas.core.arrays import Categorical, DatetimeArray, try_cast_to_ea
 from pandas.core.base import DataError, PandasObject, SelectionMixin
 import pandas.core.common as com
-from pandas.core.config import option_context
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
 from pandas.core.groupby import base, ops
@@ -2568,25 +2567,3 @@ def get_groupby(
         observed=observed,
         mutated=mutated,
     )
-
-
-class DataFrameGroups(dict):
-    def __repr__(self):
-        from pandas.compat import u
-
-        nitems = get_option('display.max_rows') or len(self)
-
-        fmt = u("{{{things}}}")
-        pfmt = u("{key}: {val}")
-
-        pairs = []
-        for k, v in list(self.items()):
-            pairs.append(pfmt.format(key=k, val=v))
-
-        if nitems < len(self):
-            start_cnt, end_cnt = nitems - int(nitems / 2), int(nitems / 2)
-            return fmt.format(things=", ".join(pairs[:start_cnt]) +
-                                     ", ... , " +
-                                     ", ".join(pairs[-end_cnt:]))
-        else:
-            return fmt.format(things=", ".join(pairs))

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -56,6 +56,7 @@ import pandas.core.algorithms as algorithms
 from pandas.core.arrays import Categorical, DatetimeArray, try_cast_to_ea
 from pandas.core.base import DataError, PandasObject, SelectionMixin
 import pandas.core.common as com
+from pandas.core.config import option_context
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
 from pandas.core.groupby import base, ops
@@ -72,7 +73,7 @@ _common_see_also = """
 
 _apply_docs = dict(
     template="""
-    Apply function `func`  group-wise and combine the results together.
+    Apply function `func` group-wise and combine the results together.
 
     The function passed to `apply` must take a {input} as its first
     argument and return a DataFrame, Series or scalar. `apply` will
@@ -2567,3 +2568,25 @@ def get_groupby(
         observed=observed,
         mutated=mutated,
     )
+
+
+class DataFrameGroups(dict):
+    def __repr__(self):
+        from pandas.compat import u
+
+        nitems = get_option('display.max_rows') or len(self)
+
+        fmt = u("{{{things}}}")
+        pfmt = u("{key}: {val}")
+
+        pairs = []
+        for k, v in list(self.items()):
+            pairs.append(pfmt.format(key=k, val=v))
+
+        if nitems < len(self):
+            start_cnt, end_cnt = nitems - int(nitems / 2), int(nitems / 2)
+            return fmt.format(things=", ".join(pairs[:start_cnt]) +
+                                     ", ... , " +
+                                     ", ".join(pairs[-end_cnt:]))
+        else:
+            return fmt.format(things=", ".join(pairs))

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -246,6 +246,7 @@ class BaseGrouper:
     @cache_readonly
     def groups(self):
         """ dict {group name -> group labels} """
+
         if len(self.groupings) == 1:
             return self.groupings[0].groups
         else:
@@ -350,7 +351,7 @@ class BaseGrouper:
 
     def _is_builtin_func(self, arg):
         """
-        if we define an builtin function for this argument, return it,
+        if we define a builtin function for this argument, return it,
         otherwise return the arg
         """
         return SelectionMixin._builtin_table.get(arg, arg)

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -246,7 +246,6 @@ class BaseGrouper:
     @cache_readonly
     def groups(self):
         """ dict {group name -> group labels} """
-
         if len(self.groupings) == 1:
             return self.groupings[0].groups
         else:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -68,6 +68,7 @@ from pandas.core.arrays import ExtensionArray
 from pandas.core.base import IndexOpsMixin, PandasObject
 import pandas.core.common as com
 from pandas.core.indexers import maybe_convert_indices
+from pandas.core.config import get_option
 from pandas.core.indexes.frozen import FrozenList
 import pandas.core.missing as missing
 from pandas.core.ops import get_op_result_name
@@ -4790,7 +4791,7 @@ class Index(IndexOpsMixin, PandasObject):
         # map to the label
         result = {k: self.take(v) for k, v in result.items()}
 
-        return result
+        return IndexGroupbyGroups(result)
 
     def map(self, mapper, na_action=None):
         """
@@ -5499,6 +5500,14 @@ class Index(IndexOpsMixin, PandasObject):
 Index._add_numeric_methods_disabled()
 Index._add_logical_methods()
 Index._add_comparison_methods()
+
+
+class IndexGroupbyGroups(dict):
+    """Dict extension to support abbreviated __repr__"""
+    from pandas.io.formats.printing import pprint_thing
+
+    def __repr__(self):
+        return pprint_thing(self, max_seq_items=get_option('display.max_rows'))
 
 
 def ensure_index_from_sequences(sequences, names=None):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -68,7 +68,6 @@ from pandas.core.arrays import ExtensionArray
 from pandas.core.base import IndexOpsMixin, PandasObject
 import pandas.core.common as com
 from pandas.core.indexers import maybe_convert_indices
-from pandas.core.config import get_option
 from pandas.core.indexes.frozen import FrozenList
 import pandas.core.missing as missing
 from pandas.core.ops import get_op_result_name
@@ -76,6 +75,7 @@ from pandas.core.ops.invalid import make_invalid_op
 from pandas.core.strings import StringMethods
 
 from pandas.io.formats.printing import (
+    PrettyDict,
     default_pprint,
     format_object_attrs,
     format_object_summary,
@@ -4791,7 +4791,7 @@ class Index(IndexOpsMixin, PandasObject):
         # map to the label
         result = {k: self.take(v) for k, v in result.items()}
 
-        return IndexGroupbyGroups(result)
+        return PrettyDict(result)
 
     def map(self, mapper, na_action=None):
         """
@@ -5500,14 +5500,6 @@ class Index(IndexOpsMixin, PandasObject):
 Index._add_numeric_methods_disabled()
 Index._add_logical_methods()
 Index._add_comparison_methods()
-
-
-class IndexGroupbyGroups(dict):
-    """Dict extension to support abbreviated __repr__"""
-    from pandas.io.formats.printing import pprint_thing
-
-    def __repr__(self):
-        return pprint_thing(self, max_seq_items=get_option('display.max_rows'))
 
 
 def ensure_index_from_sequences(sequences, names=None):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4766,7 +4766,7 @@ class Index(IndexOpsMixin, PandasObject):
                 return self.astype("object"), other.astype("object")
         return self, other
 
-    def groupby(self, values) -> PrettyDict:
+    def groupby(self, values) -> PrettyDict[Hashable, np.ndarray]:
         """
         Group the index labels by a given array of values.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import operator
 from textwrap import dedent
-from typing import Any, Dict, FrozenSet, Hashable, Optional, Union
+from typing import Any, FrozenSet, Hashable, Optional, Union
 import warnings
 
 import numpy as np
@@ -4766,7 +4766,7 @@ class Index(IndexOpsMixin, PandasObject):
                 return self.astype("object"), other.astype("object")
         return self, other
 
-    def groupby(self, values) -> Dict[Hashable, np.ndarray]:
+    def groupby(self, values) -> PrettyDict:
         """
         Group the index labels by a given array of values.
 

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -102,7 +102,7 @@ def _pprint_seq(
 ) -> str:
     """
     internal. pprinter for iterables. you should probably use pprint_thing()
-    rather than calling this directly.
+    rather then calling this directly.
 
     bounds length of printed sequence, depending on options
     """
@@ -137,7 +137,7 @@ def _pprint_dict(
 ) -> str:
     """
     internal. pprinter for iterables. you should probably use pprint_thing()
-    rather than calling this directly.
+    rather then calling this directly.
     """
     fmt = "{{{things}}}"
     pairs = []
@@ -538,4 +538,4 @@ class PrettyDict(Dict[_KT, _VT]):
     """Dict extension to support abbreviated __repr__"""
 
     def __repr__(self) -> str:
-        return pprint_thing(self, max_seq_items=get_option("display.max_rows"))
+        return pprint_thing(self)

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -6,12 +6,14 @@ import sys
 from typing import (
     Any,
     Callable,
+    Dict,
     Iterable,
     List,
     Mapping,
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
     Union,
 )
 
@@ -20,6 +22,8 @@ from pandas._config import get_option
 from pandas.core.dtypes.inference import is_sequence
 
 EscapeChars = Union[Mapping[str, str], Iterable[str]]
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
 
 
 def adjoin(space: int, *lists: List[str], **kwargs) -> str:
@@ -530,8 +534,8 @@ def format_object_attrs(
     return attrs
 
 
-class PrettyDict(dict):
+class PrettyDict(Dict[_KT, _VT]):
     """Dict extension to support abbreviated __repr__"""
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return pprint_thing(self, max_seq_items=get_option("display.max_rows"))

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -98,7 +98,7 @@ def _pprint_seq(
 ) -> str:
     """
     internal. pprinter for iterables. you should probably use pprint_thing()
-    rather then calling this directly.
+    rather than calling this directly.
 
     bounds length of printed sequence, depending on options
     """
@@ -133,7 +133,7 @@ def _pprint_dict(
 ) -> str:
     """
     internal. pprinter for iterables. you should probably use pprint_thing()
-    rather then calling this directly.
+    rather than calling this directly.
     """
     fmt = "{{{things}}}"
     pairs = []

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -528,3 +528,10 @@ def format_object_attrs(
     if len(obj) > max_seq_items:
         attrs.append(("length", len(obj)))
     return attrs
+
+
+class PrettyDict(dict):
+    """Dict extension to support abbreviated __repr__"""
+
+    def __repr__(self):
+        return pprint_thing(self, max_seq_items=get_option("display.max_rows"))

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2037,3 +2037,16 @@ def test_groupby_list_level():
     expected = pd.DataFrame(np.arange(0, 9).reshape(3, 3))
     result = expected.groupby(level=[0]).mean()
     tm.assert_frame_equal(result, expected)
+
+
+def test_groups_repr_truncates():
+    # GH 1135
+    df = pd.DataFrame({"a": [1, 1, 1, 2, 2, 3], "b": [1, 2, 3, 4, 5, 6]})
+
+    with pd.option_context("display.max_rows", 2):
+        x = df.groupby("a").groups
+        assert x.__repr__().endswith("...}")
+
+    with pd.option_context("display.max_rows", 5):
+        x = df.groupby(np.array(df.a)).groups
+        assert not x.__repr__().endswith("...}")

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2041,12 +2041,12 @@ def test_groupby_list_level():
 
 def test_groups_repr_truncates():
     # GH 1135
-    df = pd.DataFrame({"a": [1, 1, 1, 2, 2, 3], "b": [1, 2, 3, 4, 5, 6]})
+    df = pd.DataFrame(np.random.randn(61, 1))
+    df["a"] = df.index
 
-    with pd.option_context("display.max_rows", 2):
-        x = df.groupby("a").groups
-        assert x.__repr__().endswith("...}")
+    result = df.groupby("a").groups.__repr__()
+    expected = str({i: [i] for i in range(60)})[:-1] + ", ...}"
+    assert result == expected
 
-    with pd.option_context("display.max_rows", 5):
-        x = df.groupby(np.array(df.a)).groups
-        assert not x.__repr__().endswith("...}")
+    result = df.groupby(np.array(df.a)).groups.__repr__()
+    assert result == expected

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2039,14 +2039,21 @@ def test_groupby_list_level():
     tm.assert_frame_equal(result, expected)
 
 
-def test_groups_repr_truncates():
+@pytest.mark.parametrize(
+    "max_seq_items, expected",
+    [
+        (5, "{0: [0], 1: [1], 2: [2], 3: [3], 4: [4]}"),
+        (4, "{0: [0], 1: [1], 2: [2], 3: [3], ...}"),
+    ],
+)
+def test_groups_repr_truncates(max_seq_items, expected):
     # GH 1135
-    df = pd.DataFrame(np.random.randn(61, 1))
+    df = pd.DataFrame(np.random.randn(5, 1))
     df["a"] = df.index
 
-    result = df.groupby("a").groups.__repr__()
-    expected = str({i: [i] for i in range(60)})[:-1] + ", ...}"
-    assert result == expected
+    with pd.option_context("display.max_seq_items", max_seq_items):
+        result = df.groupby("a").groups.__repr__()
+        assert result == expected
 
-    result = df.groupby(np.array(df.a)).groups.__repr__()
-    assert result == expected
+        result = df.groupby(np.array(df.a)).groups.__repr__()
+        assert result == expected

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -2128,6 +2128,22 @@ c  10  11  12  13  14\
         assert str(df) == exp
 
 
+class TestDataFrameGroupByFormatting(object):
+    def test_groups_repr_truncates(self):
+        df = pd.DataFrame({
+            'a': [1, 1, 1, 2, 2, 3],
+            'b': [1, 2, 3, 4, 5, 6]
+        })
+
+        with option_context('display.max_rows', 2):
+            x = df.groupby('a').groups
+            assert x.__repr__().endswith('...}')
+
+        with option_context('display.max_rows', 5):
+            x = df.groupby('a').groups
+            assert not x.__repr__().endswith('...}')
+
+
 def gen_series_formatting():
     s1 = pd.Series(["a"] * 100)
     s2 = pd.Series(["ab"] * 100)

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -2128,22 +2128,6 @@ c  10  11  12  13  14\
         assert str(df) == exp
 
 
-class TestDataFrameGroupByFormatting(object):
-    def test_groups_repr_truncates(self):
-        df = pd.DataFrame({
-            'a': [1, 1, 1, 2, 2, 3],
-            'b': [1, 2, 3, 4, 5, 6]
-        })
-
-        with option_context('display.max_rows', 2):
-            x = df.groupby('a').groups
-            assert x.__repr__().endswith('...}')
-
-        with option_context('display.max_rows', 5):
-            x = df.groupby('a').groups
-            assert not x.__repr__().endswith('...}')
-
-
 def gen_series_formatting():
     s1 = pd.Series(["a"] * 100)
     s2 = pd.Series(["ab"] * 100)


### PR DESCRIPTION
Resurrection of #24853. Have resolved conflicts and updated according to the last review it received. The original PR fixed some unrelated minor typos, so I've kept them in (and added a fix for another absolutely minor typo I'd noticed)

- [x] closes #1135
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
