### PR TITLE
GH31391 - Fixed typos and fixed inexistant path in a SAS class comment

### DIFF
--- a/asv_bench/benchmarks/io/sas.py
+++ b/asv_bench/benchmarks/io/sas.py
@@ -9,7 +9,7 @@ class SAS:
     param_names = ["format"]
 
     def setup(self, format):
-        # Read files that are located in 'pandas/io/tests/sas/data'
+        # Read files that are located in 'pandas/tests/io/sas/data'
         files = {"sas7bdat": "test1.sas7bdat", "xport": "paxraw_d_short.xpt"}
         file = files[format]
         paths = [

--- a/doc/source/whatsnew/v0.13.0.rst
+++ b/doc/source/whatsnew/v0.13.0.rst
@@ -214,7 +214,7 @@ These were announced changes in 0.12 or prior that are taking effect as of 0.13.
 - Remove deprecated ``read_clipboard/to_clipboard/ExcelFile/ExcelWriter`` from ``pandas.io.parsers`` (:issue:`3717`)
   These are available as functions in the main pandas namespace (e.g. ``pd.read_clipboard``)
 - default for ``tupleize_cols`` is now ``False`` for both ``to_csv`` and ``read_csv``. Fair warning in 0.12 (:issue:`3604`)
-- default for `display.max_seq_len` is now 100 rather then `None`. This activates
+- default for `display.max_seq_len` is now 100 rather than `None`. This activates
   truncated display ("...") of long sequences in various places. (:issue:`3391`)
 
 Deprecations

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -6,7 +6,7 @@ is invoked inside specific modules, they will not be registered until that
 module is imported, which may or may not be a problem.
 
 If you need to make sure options are available even before a certain
-module is imported, register them here rather then in the module.
+module is imported, register them here rather than in the module.
 
 """
 import pandas._config.config as cf

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -74,7 +74,7 @@ def justify(texts: Iterable[str], max_len: int, mode: str = "right") -> List[str
 #
 # pprinting utility functions for generating Unicode text or
 # bytes(3.x)/str(2.x) representations of objects.
-# Try to use these as much as possible rather then rolling your own.
+# Try to use these as much as possible rather than rolling your own.
 #
 # When to use
 # -----------
@@ -98,7 +98,7 @@ def _pprint_seq(
 ) -> str:
     """
     internal. pprinter for iterables. you should probably use pprint_thing()
-    rather then calling this directly.
+    rather than calling this directly.
 
     bounds length of printed sequence, depending on options
     """
@@ -133,7 +133,7 @@ def _pprint_dict(
 ) -> str:
     """
     internal. pprinter for iterables. you should probably use pprint_thing()
-    rather then calling this directly.
+    rather than calling this directly.
     """
     fmt = "{{{things}}}"
     pairs = []

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -388,7 +388,7 @@ class TestGrouping:
         # if it fails on the elements, map tries it on the entire index as
         # a sequence. That can yield invalid results that cause trouble
         # down the line.
-        # the surprise comes from using key[0:6] rather then str(key)[0:6]
+        # the surprise comes from using key[0:6] rather than str(key)[0:6]
         # when the elements are Timestamp.
         # the result is Index[0:6], very confusing.
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -296,7 +296,7 @@ class TestDataFrameFormatting:
         assert printing.pprint_thing({1}) == "{1}"
 
     def test_repr_is_valid_construction_code(self):
-        # for the case of Index, where the repr is traditional rather then
+        # for the case of Index, where the repr is traditional rather than
         # stylized
         idx = Index(["a", "b"])
         res = eval("pd." + repr(idx))


### PR DESCRIPTION
Simple change: just fixed some typos and incorrect path as reported in #31391 