### PR TITLE
PERF/CLN: float-to-int casting

### DIFF
--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -25,6 +25,7 @@ from pandas.core.dtypes.dtypes import register_extension_dtype
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import nanops, ops
+import pandas.core.common as com
 from pandas.core.ops import invalid_comparison
 from pandas.core.ops.common import unpack_zerodim_and_defer
 from pandas.core.tools.numeric import to_numeric
@@ -573,9 +574,8 @@ class IntegerArray(BaseMaskedArray):
         # if we have a preservable numeric op,
         # provide coercion back to an integer type if possible
         elif name in ["sum", "min", "max", "prod"]:
-            int_result = int(result)
-            if int_result == result:
-                result = int_result
+            # GH#31409 more performant than casting-then-checking
+            result = com.cast_scalar_indexer(result)
 
         return result
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -166,7 +166,7 @@ def cast_scalar_indexer(val):
     outval : scalar
     """
     # assumes lib.is_scalar(val)
-    if lib.is_float(val) and val == int(val):
+    if lib.is_float(val) and val.is_integer():
         return int(val)
     return val
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4978,13 +4978,8 @@ class Index(IndexOpsMixin, PandasObject):
         to an int if equivalent.
         """
 
-        if is_float(key) and not self.is_floating():
-            try:
-                ckey = int(key)
-                if ckey == key:
-                    key = ckey
-            except (OverflowError, ValueError, TypeError):
-                pass
+        if not self.is_floating():
+            return com.cast_scalar_indexer(key)
         return key
 
     def _validate_indexer(self, form, key, kind: str_t):


### PR DESCRIPTION
using float.is_integer is apparently much faster than casting and checking equality, especially for values between int32max and int64max (anecdotal based on small sample size)

```
cast1 = com.cast_scalar_indexer_master
cast2 = com.cast_scalar_indexer_PR

def cast3(key):
    # Effectively what we have in _maybe_cast_indexer in master
    if lib.is_float(key):
        try:
            ckey = int(key)
            if ckey == key:
                key = ckey
        except (OverflowError, ValueError, TypeError):
            pass
    return key

key1 = np.float64(17179869184.0)
key2 = float(key1) * 2**30             
key3 = np.float64(np.iinfo(np.int64).max)

In [87]: for func in [cast1, cast2, cast3]: 
    ...:     for key in [key1, key2, key3]: 
    ...:                 %timeit func(key) 
    ...:                                                                                                                                                                                                                                          

647 ns ± 3.71 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
559 ns ± 27.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
1.98 µs ± 19.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

360 ns ± 4.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
353 ns ± 3.11 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
377 ns ± 6.54 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

568 ns ± 3.92 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
445 ns ± 15 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
1.91 µs ± 36.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

The middle three timeit results are the ones we get from this PR.