### PR TITLE
CLN: Replace '.format' with f-strings in some test files #29547

### DIFF
--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -86,9 +86,7 @@ class TestGetDummies:
 
         result = get_dummies(s_df, columns=s_df.columns, sparse=sparse, dtype=dtype)
         if sparse:
-            dtype_name = "Sparse[{}, {}]".format(
-                self.effective_dtype(dtype).name, fill_value
-            )
+            dtype_name = f"Sparse[{self.effective_dtype(dtype).name}, {fill_value}]"
         else:
             dtype_name = self.effective_dtype(dtype).name
 
@@ -163,8 +161,7 @@ class TestGetDummies:
         s = [e, eacute, eacute]
         res = get_dummies(s, prefix="letter", sparse=sparse)
         exp = DataFrame(
-            {"letter_e": [1, 0, 0], "letter_{eacute}".format(eacute=eacute): [0, 1, 1]},
-            dtype=np.uint8,
+            {"letter_e": [1, 0, 0], f"letter_{eacute}": [0, 1, 1]}, dtype=np.uint8,
         )
         if sparse:
             exp = exp.apply(SparseArray, fill_value=0)

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -308,7 +308,7 @@ class TestPeriodConstruction:
     @pytest.mark.parametrize("month", MONTHS)
     def test_period_cons_quarterly(self, month):
         # bugs in scikits.timeseries
-        freq = "Q-{month}".format(month=month)
+        freq = f"Q-{month}"
         exp = Period("1989Q3", freq=freq)
         assert "1989Q3" in str(exp)
         stamp = exp.to_timestamp("D", how="end")
@@ -322,7 +322,7 @@ class TestPeriodConstruction:
     @pytest.mark.parametrize("month", MONTHS)
     def test_period_cons_annual(self, month):
         # bugs in scikits.timeseries
-        freq = "A-{month}".format(month=month)
+        freq = f"A-{month}"
         exp = Period("1989", freq=freq)
         stamp = exp.to_timestamp("D", how="end") + timedelta(days=30)
         p = Period(stamp, freq=freq)
@@ -333,8 +333,8 @@ class TestPeriodConstruction:
     @pytest.mark.parametrize("day", DAYS)
     @pytest.mark.parametrize("num", range(10, 17))
     def test_period_cons_weekly(self, num, day):
-        daystr = "2011-02-{num}".format(num=num)
-        freq = "W-{day}".format(day=day)
+        daystr = f"2011-02-{num}"
+        freq = f"W-{day}"
 
         result = Period(daystr, freq=freq)
         expected = Period(daystr, freq="D").asfreq(freq)


### PR DESCRIPTION
Updates the below 2 test files to use f-strings (fast and preferred) instead of '.format' (old and slow)

1) pandas/tests/reshape/test_reshape.py
2) pandas/tests/scalar/period/test_period.py
 
For more details on the issue, refer: https://github.com/pandas-dev/pandas/issues/29547

- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`