### PR TITLE
PERF: postpone imports in Index constructor

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -277,10 +277,6 @@ class Index(IndexOpsMixin, PandasObject):
     ) -> "Index":
 
         from pandas.core.indexes.range import RangeIndex
-        from pandas import PeriodIndex, DatetimeIndex, TimedeltaIndex
-        from pandas.core.indexes.numeric import Float64Index, Int64Index, UInt64Index
-        from pandas.core.indexes.interval import IntervalIndex
-        from pandas.core.indexes.category import CategoricalIndex
 
         name = maybe_extract_name(name, data, cls)
 
@@ -296,10 +292,14 @@ class Index(IndexOpsMixin, PandasObject):
 
         # categorical
         elif is_categorical_dtype(data) or is_categorical_dtype(dtype):
+            from pandas.core.indexes.category import CategoricalIndex
+
             return CategoricalIndex(data, dtype=dtype, copy=copy, name=name, **kwargs)
 
         # interval
         elif is_interval_dtype(data) or is_interval_dtype(dtype):
+            from pandas.core.indexes.interval import IntervalIndex
+
             closed = kwargs.pop("closed", None)
             if is_dtype_equal(_o_dtype, dtype):
                 return IntervalIndex(
@@ -314,6 +314,8 @@ class Index(IndexOpsMixin, PandasObject):
             or is_datetime64_any_dtype(dtype)
             or "tz" in kwargs
         ):
+            from pandas import DatetimeIndex
+
             if is_dtype_equal(_o_dtype, dtype):
                 # GH#23524 passing `dtype=object` to DatetimeIndex is invalid,
                 #  will raise in the where `data` is already tz-aware.  So
@@ -328,6 +330,8 @@ class Index(IndexOpsMixin, PandasObject):
                 return DatetimeIndex(data, copy=copy, name=name, dtype=dtype, **kwargs)
 
         elif is_timedelta64_dtype(data) or is_timedelta64_dtype(dtype):
+            from pandas import TimedeltaIndex
+
             if is_dtype_equal(_o_dtype, dtype):
                 # Note we can pass copy=False because the .astype below
                 #  will always make a copy
@@ -338,6 +342,8 @@ class Index(IndexOpsMixin, PandasObject):
                 return TimedeltaIndex(data, copy=copy, name=name, dtype=dtype, **kwargs)
 
         elif is_period_dtype(data) or is_period_dtype(dtype):
+            from pandas import PeriodIndex
+
             if is_dtype_equal(_o_dtype, dtype):
                 return PeriodIndex(data, copy=False, name=name, **kwargs).astype(object)
             return PeriodIndex(data, dtype=dtype, copy=copy, name=name, **kwargs)
@@ -357,6 +363,12 @@ class Index(IndexOpsMixin, PandasObject):
 
         # index-like
         elif isinstance(data, (np.ndarray, Index, ABCSeries)):
+            from pandas.core.indexes.numeric import (
+                Float64Index,
+                Int64Index,
+                UInt64Index,
+            )
+
             if dtype is not None:
                 # we need to avoid having numpy coerce
                 # things that look like ints/floats to ints unless

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -292,12 +292,14 @@ class Index(IndexOpsMixin, PandasObject):
 
         # categorical
         elif is_categorical_dtype(data) or is_categorical_dtype(dtype):
+            # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
             from pandas.core.indexes.category import CategoricalIndex
 
             return CategoricalIndex(data, dtype=dtype, copy=copy, name=name, **kwargs)
 
         # interval
         elif is_interval_dtype(data) or is_interval_dtype(dtype):
+            # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
             from pandas.core.indexes.interval import IntervalIndex
 
             closed = kwargs.pop("closed", None)
@@ -314,6 +316,7 @@ class Index(IndexOpsMixin, PandasObject):
             or is_datetime64_any_dtype(dtype)
             or "tz" in kwargs
         ):
+            # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
             from pandas import DatetimeIndex
 
             if is_dtype_equal(_o_dtype, dtype):
@@ -330,6 +333,7 @@ class Index(IndexOpsMixin, PandasObject):
                 return DatetimeIndex(data, copy=copy, name=name, dtype=dtype, **kwargs)
 
         elif is_timedelta64_dtype(data) or is_timedelta64_dtype(dtype):
+            # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
             from pandas import TimedeltaIndex
 
             if is_dtype_equal(_o_dtype, dtype):
@@ -342,6 +346,7 @@ class Index(IndexOpsMixin, PandasObject):
                 return TimedeltaIndex(data, copy=copy, name=name, dtype=dtype, **kwargs)
 
         elif is_period_dtype(data) or is_period_dtype(dtype):
+            # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
             from pandas import PeriodIndex
 
             if is_dtype_equal(_o_dtype, dtype):
@@ -363,6 +368,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         # index-like
         elif isinstance(data, (np.ndarray, Index, ABCSeries)):
+            # Delay import for perf. https://github.com/pandas-dev/pandas/pull/31423
             from pandas.core.indexes.numeric import (
                 Float64Index,
                 Int64Index,


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/30790, it's for improving this one mentioned in that issue:

```
arr_str = np.array(["foo", "bar", "baz"], dtype=object)
%timeit pd.Index(arr_str)
```

Only importing the index classes when we actually need them gives a 15-20% speedup.

Last week when profiling the Index constructor, I noticed that those imports actually take quite a bit of time (and it's a change that was introduced after 0.25, https://github.com/pandas-dev/pandas/pull/28141). I didn't get any further with profiling (this alone doesn't explain the full slowdown), but thought it's an easy one to already do anyway.