### PR TITLE
ENH: Added index to testing assert message when series values differ

### DIFF
--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -65,7 +65,7 @@ cpdef assert_dict_equal(a, b, bint compare_keys=True):
 cpdef assert_almost_equal(a, b,
                           check_less_precise=False,
                           bint check_dtype=True,
-                          obj=None, lobj=None, robj=None):
+                          obj=None, lobj=None, robj=None, index=None):
     """
     Check that left and right objects are almost equal.
 
@@ -89,6 +89,9 @@ cpdef assert_almost_equal(a, b,
     robj : str, default None
         Specify right object name being compared, internally used to show
         appropriate assertion message
+    index : str, default None
+        Specify shared index of objects being compared, internally used to
+        show appropriate assertion message
     """
     cdef:
         int decimal
@@ -171,7 +174,7 @@ cpdef assert_almost_equal(a, b,
             from pandas._testing import raise_assert_detail
             msg = (f"{obj} values are different "
                    f"({np.round(diff * 100.0 / na, 5)} %)")
-            raise_assert_detail(obj, msg, lobj, robj)
+            raise_assert_detail(obj, msg, lobj, robj, index=index)
 
         return True
 

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -65,7 +65,7 @@ cpdef assert_dict_equal(a, b, bint compare_keys=True):
 cpdef assert_almost_equal(a, b,
                           check_less_precise=False,
                           bint check_dtype=True,
-                          obj=None, lobj=None, robj=None, index=None):
+                          obj=None, lobj=None, robj=None, index_values=None):
     """
     Check that left and right objects are almost equal.
 
@@ -89,9 +89,9 @@ cpdef assert_almost_equal(a, b,
     robj : str, default None
         Specify right object name being compared, internally used to show
         appropriate assertion message
-    index : str, default None
-        Specify shared index of objects being compared, internally used to
-        show appropriate assertion message
+    index_values : ndarray, default None
+        Specify shared index values of objects being compared, internally used
+        to show appropriate assertion message
 
         .. versionadded:: 1.1.0
 
@@ -177,7 +177,7 @@ cpdef assert_almost_equal(a, b,
             from pandas._testing import raise_assert_detail
             msg = (f"{obj} values are different "
                    f"({np.round(diff * 100.0 / na, 5)} %)")
-            raise_assert_detail(obj, msg, lobj, robj, index=index)
+            raise_assert_detail(obj, msg, lobj, robj, index_values=index_values)
 
         return True
 

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -92,6 +92,9 @@ cpdef assert_almost_equal(a, b,
     index : str, default None
         Specify shared index of objects being compared, internally used to
         show appropriate assertion message
+
+        .. versionadded:: 1.1.0
+
     """
     cdef:
         int decimal

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -949,7 +949,7 @@ def assert_numpy_array_equal(
     obj : str, default 'numpy array'
         Specify object name being compared, internally used to show appropriate
         assertion message.
-    index : numpy.ndarray
+    index : numpy.ndarray, default None
         optional index (shared by both left and right), used in output.
     """
     __tracebackhide__ = True

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -908,9 +908,6 @@ def raise_assert_detail(obj, message, left, right, diff=None, index=None):
     elif is_categorical_dtype(right):
         right = repr(right)
 
-    if isinstance(index, np.ndarray):
-        index = pprint_thing(index)
-
     msg += f"""
 [left]:  {left}
 [right]: {right}"""

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1150,8 +1150,11 @@ def assert_series_equal(
             raise AssertionError("check_exact may only be used with numeric Series")
 
         assert_numpy_array_equal(
-            left._values, right._values, check_dtype=check_dtype, obj=str(obj),
-            index = left.index._internal_get_values()
+            left._values,
+            right._values,
+            check_dtype=check_dtype,
+            obj=str(obj),
+            index=left.index._internal_get_values(),
         )
     elif check_datetimelike_compat and (
         needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype)

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1154,7 +1154,7 @@ def assert_series_equal(
             right._values,
             check_dtype=check_dtype,
             obj=str(obj),
-            index=left.index._internal_get_values(),
+            index=np.asarray(left.index),
         )
     elif check_datetimelike_compat and (
         needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype)
@@ -1193,7 +1193,7 @@ def assert_series_equal(
             check_less_precise=check_less_precise,
             check_dtype=check_dtype,
             obj=str(obj),
-            index=left.index._internal_get_values(),
+            index=np.asarray(left.index),
         )
 
     # metadata comparison

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -888,15 +888,15 @@ def assert_timedelta_array_equal(left, right, obj="TimedeltaArray"):
     assert_attr_equal("freq", left, right, obj=obj)
 
 
-def raise_assert_detail(obj, message, left, right, diff=None, index=None):
+def raise_assert_detail(obj, message, left, right, diff=None, index_values=None):
     __tracebackhide__ = True
 
     msg = f"""{obj} are different
 
 {message}"""
 
-    if isinstance(index, np.ndarray):
-        msg += f"\n[index]: {pprint_thing(index)}"
+    if isinstance(index_values, np.ndarray):
+        msg += f"\n[index]: {pprint_thing(index_values)}"
 
     if isinstance(left, np.ndarray):
         left = pprint_thing(left)
@@ -926,7 +926,7 @@ def assert_numpy_array_equal(
     err_msg=None,
     check_same=None,
     obj="numpy array",
-    index=None,
+    index_values=None,
 ):
     """
     Check that 'np.ndarray' is equivalent.
@@ -946,7 +946,7 @@ def assert_numpy_array_equal(
     obj : str, default 'numpy array'
         Specify object name being compared, internally used to show appropriate
         assertion message.
-    index : numpy.ndarray, default None
+    index_values : numpy.ndarray, default None
         optional index (shared by both left and right), used in output.
     """
     __tracebackhide__ = True
@@ -985,7 +985,7 @@ def assert_numpy_array_equal(
 
             diff = diff * 100.0 / left.size
             msg = f"{obj} values are different ({np.round(diff, 5)} %)"
-            raise_assert_detail(obj, msg, left, right, index=index)
+            raise_assert_detail(obj, msg, left, right, index_values=index_values)
 
         raise AssertionError(err_msg)
 
@@ -1154,7 +1154,7 @@ def assert_series_equal(
             right._values,
             check_dtype=check_dtype,
             obj=str(obj),
-            index=np.asarray(left.index),
+            index_values=np.asarray(left.index),
         )
     elif check_datetimelike_compat and (
         needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype)
@@ -1193,7 +1193,7 @@ def assert_series_equal(
             check_less_precise=check_less_precise,
             check_dtype=check_dtype,
             obj=str(obj),
-            index=np.asarray(left.index),
+            index_values=np.asarray(left.index),
         )
 
     # metadata comparison

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -177,6 +177,7 @@ def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
     msg = f"""{obj}\\.iloc\\[:, 1\\] \\(column name="B"\\) are different
 
 {obj}\\.iloc\\[:, 1\\] \\(column name="B"\\) values are different \\(33\\.33333 %\\)
+\\[index\\]: \\[0, 1, 2\\]
 \\[left\\]:  \\[4, 5, 6\\]
 \\[right\\]: \\[4, 5, 7\\]"""
 
@@ -196,6 +197,7 @@ def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
             """{obj}\\.iloc\\[:, 1\\] \\(column name="E"\\) are different
 
 {obj}\\.iloc\\[:, 1\\] \\(column name="E"\\) values are different \\(33\\.33333 %\\)
+\\[index\\]: \\[0, 1, 2\\]
 \\[left\\]:  \\[é, è, ë\\]
 \\[right\\]: \\[é, è, e̊\\]""",
         ),
@@ -205,6 +207,7 @@ def test_frame_equal_block_mismatch(by_blocks_fixture, obj_fixture):
             """{obj}\\.iloc\\[:, 0\\] \\(column name="A"\\) are different
 
 {obj}\\.iloc\\[:, 0\\] \\(column name="A"\\) values are different \\(100\\.0 %\\)
+\\[index\\]: \\[0, 1, 2\\]
 \\[left\\]:  \\[á, à, ä\\]
 \\[right\\]: \\[a, a, a\\]""",
         ),

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -162,7 +162,6 @@ Series length are different
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_series_equal(s1, s2, check_less_precise=check_less_precise)
-        print("No Exception")
 
 
 def test_series_equal_values_mismatch(check_less_precise):

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -162,12 +162,14 @@ Series length are different
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_series_equal(s1, s2, check_less_precise=check_less_precise)
+        print("No Exception")
 
 
 def test_series_equal_values_mismatch(check_less_precise):
     msg = """Series are different
 
 Series values are different \\(33\\.33333 %\\)
+\\[index\\]: \\[0, 1, 2\\]
 \\[left\\]:  \\[1, 2, 3\\]
 \\[right\\]: \\[1, 2, 4\\]"""
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This implements the suggestion made in #31190 
In short, where the values in 2 series differ, the assert exception message includes the index as well as the values.  This helps when using assert_frame_equal with check_like=True, since the index may be reordered, making the output hard to understand.