### PR TITLE
TST: make sure fixture params are sorted list

### DIFF
--- a/pandas/tests/groupby/conftest.py
+++ b/pandas/tests/groupby/conftest.py
@@ -112,7 +112,7 @@ def reduction_func(request):
     return request.param
 
 
-@pytest.fixture(params=transformation_kernels)
+@pytest.fixture(params=sorted(transformation_kernels))
 def transformation_func(request):
     """yields the string names of all groupby transformation functions."""
     return request.param


### PR DESCRIPTION
ATM running tests with --n 4 breaks locally because the tests that get collected dont match across processes.