### PR TITLE
BUG: objToJson.c - fix return value

### DIFF
--- a/doc/source/whatsnew/v1.0.1.rst
+++ b/doc/source/whatsnew/v1.0.1.rst
@@ -123,7 +123,7 @@ ExtensionArray
 
 Other
 ^^^^^
--
+- Regression fixed in objTOJSON.c fix return-type warning (:issue:`31463`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -147,7 +147,7 @@ enum PANDAS_FORMAT { SPLIT, RECORDS, INDEX, COLUMNS, VALUES };
 
 int PdBlock_iterNext(JSOBJ, JSONTypeContext *);
 
-void initObjToJSON(void) {
+void *initObjToJSON(void) {
     PyObject *mod_pandas;
     PyObject *mod_nattype;
     PyObject *mod_decimal = PyImport_ImportModule("decimal");
@@ -177,6 +177,8 @@ void initObjToJSON(void) {
 
     /* Initialise numpy API */
     import_array();
+    // GH 31463
+    return NULL;
 }
 
 static TypeContext *createTypeContext(void) {

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -147,7 +147,7 @@ enum PANDAS_FORMAT { SPLIT, RECORDS, INDEX, COLUMNS, VALUES };
 
 int PdBlock_iterNext(JSOBJ, JSONTypeContext *);
 
-void *initObjToJSON(void) {
+void initObjToJSON(void) {
     PyObject *mod_pandas;
     PyObject *mod_nattype;
     PyObject *mod_decimal = PyImport_ImportModule("decimal");


### PR DESCRIPTION
- [x] closes #31463

https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=27217&view=logs&j=3a03f79d-0b41-5610-1aa4-b4a014d0bc70&t=fe74a338-551b-5fbb-553d-25f48b1836e8&l=687

Seems like this warning is somehow causing an error in the users builds of pandas