### PR TITLE
DOC: Fix the description of the 'day' field accessor in DatetimeArray

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1262,7 +1262,7 @@ default 'raise'
         "day",
         "D",
         """
-        The month as January=1, December=12.
+        The day of the datetime.
         """,
     )
     hour = _field_accessor(


### PR DESCRIPTION
Fix a wrong description in the field accessor `day` of the DatetimeArray class