### PR TITLE
Unpin openpyxl

### DIFF
--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -27,8 +27,7 @@ dependencies:
   - numexpr
   - numpy=1.15.*
   - odfpy
-  - openpyxl<=3.0.1
-  # https://github.com/pandas-dev/pandas/pull/30009 openpyxl 3.0.2 broke
+  - openpyxl
   - pandas-gbq
   - psycopg2
   - pyarrow>=0.13.0


### PR DESCRIPTION
I *think* we pinned this originally because of issues with 3.0.2 specifically, but looks like a newer version is available on conda

ref #30009