### PR TITLE
ADMIN: Create separate issue templates for different use cases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,22 +1,27 @@
-#### Code Sample, a copy-pastable example if possible
+---
+name: Bug Report
+about: Create a bug report to help us improve pandas
+title: "BUG:"
+labels: ""
+
+---
+
+#### Code Sample, a copy-pastable example
 
 ```python
 # Your code here
 
 ```
+
+**Note**: Please read [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) detailing how to provide the necessary information for us to reproduce your bug.
+
 #### Problem description
 
-[this should explain **why** the current behaviour is a problem and why the expected output is a better solution.]
+[this should explain **why** the current behaviour is a problem and why the expected output is a better solution]
 
 **Note**: We receive a lot of issues on our GitHub tracker, so it is very possible that your issue has been posted before. Please check first before submitting so that we do not have to handle and close duplicates!
 
 **Note**: Many problems can be resolved by simply upgrading `pandas` to the latest version. Before submitting, please check if that solution works for you. If possible, you may want to check if `master` addresses this issue, but that is not necessary.
-
-For documentation-related issues, you can check the latest versions of the docs on `master` here:
-
-https://pandas-docs.github.io/pandas-docs-travis/
-
-If the issue has not been resolved there, go ahead and file it in the issue tracker.
 
 #### Expected Output
 
@@ -24,6 +29,6 @@ If the issue has not been resolved there, go ahead and file it in the issue trac
 
 <details>
 
-[paste the output of ``pd.show_versions()`` here below this line]
+[paste the output of ``pd.show_versions()`` here leaving a blank line after the details tag]
 
 </details>

--- a/.github/ISSUE_TEMPLATE/documentation_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/documentation_enhancement.md
@@ -1,0 +1,17 @@
+---
+name: Documentation Enhancement
+about: Report needed documentation
+title: "DOC:"
+labels: ""
+
+---
+
+#### Report needed documentation
+
+[this should provide a description of what documentation you believe is needed and why]
+
+**Note**: You can check the latest versions of the docs on `master` [here](https://dev.pandas.io/docs).
+
+#### Describe the documentation you'd like
+
+[this should provide a clear and concise description of what you want to happen]

--- a/.github/ISSUE_TEMPLATE/documentation_error.md
+++ b/.github/ISSUE_TEMPLATE/documentation_error.md
@@ -1,0 +1,30 @@
+---
+name: Documentation Error
+about: Report incorrect documentation
+title: "DOC:"
+labels: ""
+
+---
+
+#### Location of incorrect documentation
+
+[this should provide links and line numbers to the incorrect documentation]
+
+**Note**: You can check the latest versions of the docs on `master` [here](https://dev.pandas.io/docs).
+
+#### Describe the problems or issues found in the documentation
+
+[this should explain **why** the current documentation is a problem]
+
+#### Suggested fix for documentation
+
+[this should explain the suggested fix and **why** it's better than the existing documentation]
+
+#### Steps taken to verify documentation is incorrect
+
+[this should detail steps you've taken to verify the documentation is incorrect, with code examples, if applicable]
+
+```python
+# Your code here, if applicable
+
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature Request
+about: Suggest an idea for pandas
+title: "ENH:"
+labels: ""
+
+---
+
+#### Is your feature request related to a problem?
+
+[this should provide a description of what the problem is, e.g. "I wish I could use pandas to do [...]"]
+
+#### Describe the solution you'd like
+
+[this should provide a description of the feature request, e.g. "`DataFrame.foo` should get a new parameter `bar` that [...]"]
+
+#### Describe alternatives you've considered
+
+[this should provide a description of any alternative solutions or features you've considered]
+
+#### Additional context
+
+[add any other context, code examples, or references to existing implementations about the feature request here]
+
+```python
+# Your code here, if applicable
+
+```

--- a/.github/ISSUE_TEMPLATE/submit_question.md
+++ b/.github/ISSUE_TEMPLATE/submit_question.md
@@ -1,0 +1,19 @@
+---
+name: Submit Question
+about: Ask a general question about pandas
+title: "QST:"
+labels: ""
+
+---
+
+#### Question about pandas
+
+**Note**: It's highly recommended that you use [StackOverflow](https://www.stackoverflow.com) for any usage related questions, e.g. "How do I do [...] with pandas?" You are much more likely to receive a quick response to your question on StackOverflow than the GitHub issue tracker. You may also want to search the [pandas tag](https://stackoverflow.com/questions/tagged/pandas) on StackOverflow to see if a similar question has already been asked and answered.
+
+**Note**: If you'd still like to submit a question, please read [this guide](
+https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) detailing how to provide the necessary information for us to reproduce your question.
+
+```python
+# Your code here, if applicable
+
+```


### PR DESCRIPTION
I recall this being mentioned on one of the core dev calls a few months back, and took inspiration from [rapidsai/cudf](https://github.com/rapidsai/cudf) for the various templates.

Added templates for the following use cases:
- Bug Report
  - This is largely the same as the current issue template
- Documentation Enhancement
- Documentation Error
- Feature Request
- Submit Question
  - This attempts to direct users to StackOverflow for usage questions

We could also add a Blank Template for opening an issue without any template provided, but opted not to do that for now, as I don't want to encourage people to bypass these templates.  Could certainly add one if there's a consensus that we want this.

I've created a [local repo](https://github.com/jschendel/pandas-templates/issues) where you can see these templates in action since I couldn't figure out another way to actually display these.  Click the "New Issue" button to see what these changes would look like.

cc @pandas-dev/pandas-core @pandas-dev/pandas-triage 