### PR TITLE
[MRG] f-string updates for issue #29547

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -403,8 +403,7 @@ class _Concatenator:
         self._is_series = isinstance(sample, ABCSeries)
         if not 0 <= axis <= sample.ndim:
             raise AssertionError(
-                f"axis must be between 0 and {sample.ndim}, input was "
-                f"{axis}"
+                f"axis must be between 0 and {sample.ndim}, input was " f"{axis}"
             )
 
         # if we have mixed ndims, then convert to highest ndim
@@ -622,9 +621,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
                 try:
                     i = level.get_loc(key)
                 except KeyError:
-                    raise ValueError(
-                        f"Key {key!s} not in level {level!s}"
-                    )
+                    raise ValueError(f"Key {key!s} not in level {level!s}")
 
                 to_concat.append(np.repeat(i, len(index)))
             codes_list.append(np.concatenate(to_concat))
@@ -675,9 +672,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
 
         mask = mapped == -1
         if mask.any():
-            raise ValueError(
-                f"Values not found in passed level: {hlevel[mask]!s}"
-            )
+            raise ValueError(f"Values not found in passed level: {hlevel[mask]!s}")
 
         new_codes.append(np.repeat(mapped, n))
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -403,7 +403,7 @@ class _Concatenator:
         self._is_series = isinstance(sample, ABCSeries)
         if not 0 <= axis <= sample.ndim:
             raise AssertionError(
-                f"axis must be between 0 and {sample.ndim}, input was " f"{axis}"
+                f"axis must be between 0 and {sample.ndim}, input was {axis}"
             )
 
         # if we have mixed ndims, then convert to highest ndim

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -353,7 +353,7 @@ class _Concatenator:
             if not isinstance(obj, (Series, DataFrame)):
                 msg = (
                     f"cannot concatenate object of type '{type(obj)}'; "
-                    f"only Series and DataFrame objs are valid"
+                    "only Series and DataFrame objs are valid"
                 )
                 raise TypeError(msg)
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -352,8 +352,8 @@ class _Concatenator:
         for obj in objs:
             if not isinstance(obj, (Series, DataFrame)):
                 msg = (
-                    "cannot concatenate object of type '{typ}'; "
-                    "only Series and DataFrame objs are valid".format(typ=type(obj))
+                    f"cannot concatenate object of type '{type(obj)}'; "
+                    f"only Series and DataFrame objs are valid"
                 )
                 raise TypeError(msg)
 
@@ -403,8 +403,8 @@ class _Concatenator:
         self._is_series = isinstance(sample, ABCSeries)
         if not 0 <= axis <= sample.ndim:
             raise AssertionError(
-                "axis must be between 0 and {ndim}, input was "
-                "{axis}".format(ndim=sample.ndim, axis=axis)
+                f"axis must be between 0 and {sample.ndim}, input was "
+                f"{axis}"
             )
 
         # if we have mixed ndims, then convert to highest ndim
@@ -623,9 +623,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
                     i = level.get_loc(key)
                 except KeyError:
                     raise ValueError(
-                        "Key {key!s} not in level {level!s}".format(
-                            key=key, level=level
-                        )
+                        f"Key {key!s} not in level {level!s}"
                     )
 
                 to_concat.append(np.repeat(i, len(index)))
@@ -678,9 +676,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
         mask = mapped == -1
         if mask.any():
             raise ValueError(
-                "Values not found in passed level: {hlevel!s}".format(
-                    hlevel=hlevel[mask]
-                )
+                f"Values not found in passed level: {hlevel[mask]!s}"
             )
 
         new_codes.append(np.repeat(mapped, n))

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -621,7 +621,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
                 try:
                     i = level.get_loc(key)
                 except KeyError:
-                    raise ValueError(f"Key {key!s} not in level {level!s}")
+                    raise ValueError(f"Key {key} not in level {level}")
 
                 to_concat.append(np.repeat(i, len(index)))
             codes_list.append(np.concatenate(to_concat))

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -88,9 +88,7 @@ def melt(
             if len(frame.columns.names) == len(set(frame.columns.names)):
                 var_name = frame.columns.names
             else:
-                var_name = [
-                    f"variable_{i}" for i in range(len(frame.columns.names))
-                ]
+                var_name = [f"variable_{i}" for i in range(len(frame.columns.names))]
         else:
             var_name = [
                 frame.columns.name if frame.columns.name is not None else "variable"

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -417,7 +417,7 @@ def wide_to_long(
     """
 
     def get_var_names(df, stub: str, sep: str, suffix: str) -> List[str]:
-        regex = r"^{re.escape(stub)}{re.escape(sep)}{suffix}$"
+        regex = fr"^{re.escape(stub)}{re.escape(sep)}{suffix}$"
         pattern = re.compile(regex)
         return [col for col in df.columns if pattern.match(col)]
 

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -89,7 +89,7 @@ def melt(
                 var_name = frame.columns.names
             else:
                 var_name = [
-                    "variable_{i}".format(i=i) for i in range(len(frame.columns.names))
+                    f"variable_{i}" for i in range(len(frame.columns.names))
                 ]
         else:
             var_name = [
@@ -417,9 +417,7 @@ def wide_to_long(
     """
 
     def get_var_names(df, stub: str, sep: str, suffix: str) -> List[str]:
-        regex = r"^{stub}{sep}{suffix}$".format(
-            stub=re.escape(stub), sep=re.escape(sep), suffix=suffix
-        )
+        regex = r"^{re.escape(stub)}{re.escape(sep)}{suffix}$"
         pattern = re.compile(regex)
         return [col for col in df.columns if pattern.match(col)]
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -611,7 +611,8 @@ class _MergeOperation:
         if _left.columns.nlevels != _right.columns.nlevels:
             msg = (
                 f"merging between different levels can give an unintended "
-                f"result ({left.columns.nlevels} levels on the left, {right.columns.nlevels} on the right)"
+                f"result ({left.columns.nlevels} levels on the left," 
+                f"{right.columns.nlevels} on the right)"
             )
             warnings.warn(msg, UserWarning)
 
@@ -1185,8 +1186,10 @@ class _MergeOperation:
                 if len(common_cols) == 0:
                     raise MergeError(
                         f"No common columns to perform merge on. "
-                        f"Merge options: left_on={self.left_on}, right_on={self.right_on}, "
-                        f"left_index={self.left_index}, right_index={self.right_index}"
+                        f"Merge options: left_on={self.left_on}," 
+                        f"right_on={self.right_on}, "
+                        f"left_index={self.left_index}, "
+                        f"right_index={self.right_index}"
                     )
                 if not common_cols.is_unique:
                     raise MergeError(f"Data columns not unique: {repr(common_cols)}")
@@ -1669,7 +1672,8 @@ class _AsOfMerge(_OrderedMerge):
 
         # validate allow_exact_matches
         if not is_bool(self.allow_exact_matches):
-            msg = f"allow_exact_matches must be boolean, passed {self.allow_exact_matches}"
+            msg = f"allow_exact_matches must be boolean, " \
+                f"passed {self.allow_exact_matches}"
             raise MergeError(msg)
 
         return left_join_keys, right_join_keys, join_names

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1185,7 +1185,7 @@ class _MergeOperation:
                 common_cols = self.left.columns.intersection(self.right.columns)
                 if len(common_cols) == 0:
                     raise MergeError(
-                        f"No common columns to perform merge on. "
+                        "No common columns to perform merge on. "
                         f"Merge options: left_on={self.left_on},"
                         f"right_on={self.right_on}, "
                         f"left_index={self.left_index}, "

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1671,7 +1671,7 @@ class _AsOfMerge(_OrderedMerge):
         # validate allow_exact_matches
         if not is_bool(self.allow_exact_matches):
             msg = (
-                f"allow_exact_matches must be boolean, "
+                "allow_exact_matches must be boolean, "
                 f"passed {self.allow_exact_matches}"
             )
             raise MergeError(msg)
@@ -1701,23 +1701,20 @@ class _AsOfMerge(_OrderedMerge):
         tolerance = self.tolerance
 
         # we require sortedness and non-null values in the join keys
-        def _msg_sorted(side):
-            return f"{side} keys must be sorted"
-
-        def _msg_missings(side):
-            return f"Merge keys contain null values on {side} side"
+        msg_sorted = "{side} keys must be sorted"
+        msg_missings = "Merge keys contain null values on {side} side"
 
         if not Index(left_values).is_monotonic:
             if isna(left_values).any():
-                raise ValueError(_msg_missings(side="left"))
+                raise ValueError(msg_missings.format(side="left"))
             else:
-                raise ValueError(_msg_sorted(side="left"))
+                raise ValueError(msg_sorted.format(side="left"))
 
         if not Index(right_values).is_monotonic:
             if isna(right_values).any():
-                raise ValueError(_msg_missings(side="right"))
+                raise ValueError(msg_missings.format(side="right"))
             else:
-                raise ValueError(_msg_sorted(side="right"))
+                raise ValueError(msg_sorted.format(side="right"))
 
         # initial type conversion as needed
         if needs_i8_conversion(left_values):

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -679,7 +679,7 @@ class _MergeOperation:
         for i in ["_left_indicator", "_right_indicator"]:
             if i in columns:
                 raise ValueError(
-                    f"Cannot use `indicator=True` option when "
+                    "Cannot use `indicator=True` option when "
                     f"data contains a column named {i}"
                 )
         if self.indicator_name in columns:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1599,9 +1599,7 @@ class _AsOfMerge(_OrderedMerge):
 
         # check 'direction' is valid
         if self.direction not in ["backward", "forward", "nearest"]:
-            raise MergeError(
-                f"direction invalid: {self.direction}"
-            )
+            raise MergeError(f"direction invalid: {self.direction}")
 
     @property
     def _asof_key(self):

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -611,7 +611,7 @@ class _MergeOperation:
         if _left.columns.nlevels != _right.columns.nlevels:
             msg = (
                 f"merging between different levels can give an unintended "
-                f"result ({left.columns.nlevels} levels on the left," 
+                f"result ({left.columns.nlevels} levels on the left,"
                 f"{right.columns.nlevels} on the right)"
             )
             warnings.warn(msg, UserWarning)
@@ -1186,7 +1186,7 @@ class _MergeOperation:
                 if len(common_cols) == 0:
                     raise MergeError(
                         f"No common columns to perform merge on. "
-                        f"Merge options: left_on={self.left_on}," 
+                        f"Merge options: left_on={self.left_on},"
                         f"right_on={self.right_on}, "
                         f"left_index={self.left_index}, "
                         f"right_index={self.right_index}"

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -610,9 +610,9 @@ class _MergeOperation:
         # warn user when merging between different levels
         if _left.columns.nlevels != _right.columns.nlevels:
             msg = (
-                "merging between different levels can give an unintended "
-                "result ({left} levels on the left, {right} on the right)"
-            ).format(left=_left.columns.nlevels, right=_right.columns.nlevels)
+                f"merging between different levels can give an unintended "
+                f"result ({left.columns.nlevels} levels on the left, {right.columns.nlevels} on the right)"
+            )
             warnings.warn(msg, UserWarning)
 
         self._validate_specification()
@@ -678,8 +678,8 @@ class _MergeOperation:
         for i in ["_left_indicator", "_right_indicator"]:
             if i in columns:
                 raise ValueError(
-                    "Cannot use `indicator=True` option when "
-                    "data contains a column named {name}".format(name=i)
+                    f"Cannot use `indicator=True` option when "
+                    f"data contains a column named {i}"
                 )
         if self.indicator_name in columns:
             raise ValueError(
@@ -831,7 +831,7 @@ class _MergeOperation:
                     else:
                         result.index = Index(key_col, name=name)
                 else:
-                    result.insert(i, name or "key_{i}".format(i=i), key_col)
+                    result.insert(i, name or f"key_{i}", key_col)
 
     def _get_join_indexers(self):
         """ return the join indexers """
@@ -1184,14 +1184,9 @@ class _MergeOperation:
                 common_cols = self.left.columns.intersection(self.right.columns)
                 if len(common_cols) == 0:
                     raise MergeError(
-                        "No common columns to perform merge on. "
-                        "Merge options: left_on={lon}, right_on={ron}, "
-                        "left_index={lidx}, right_index={ridx}".format(
-                            lon=self.left_on,
-                            ron=self.right_on,
-                            lidx=self.left_index,
-                            ridx=self.right_index,
-                        )
+                        f"No common columns to perform merge on. "
+                        f"Merge options: left_on={self.left_on}, right_on={self.right_on}, "
+                        f"left_index={self.left_index}, right_index={self.right_index}"
                     )
                 if not common_cols.is_unique:
                     raise MergeError(f"Data columns not unique: {repr(common_cols)}")
@@ -1486,12 +1481,12 @@ class _OrderedMerge(_MergeOperation):
 
 
 def _asof_function(direction: str):
-    name = "asof_join_{dir}".format(dir=direction)
+    name = f"asof_join_{direction}"
     return getattr(libjoin, name, None)
 
 
 def _asof_by_function(direction: str):
-    name = "asof_join_{dir}_on_X_by_Y".format(dir=direction)
+    name = f"asof_join_{direction}_on_X_by_Y"
     return getattr(libjoin, name, None)
 
 
@@ -1602,7 +1597,7 @@ class _AsOfMerge(_OrderedMerge):
         # check 'direction' is valid
         if self.direction not in ["backward", "forward", "nearest"]:
             raise MergeError(
-                "direction invalid: {direction}".format(direction=self.direction)
+                f"direction invalid: {self.direction}"
             )
 
     @property
@@ -1628,17 +1623,13 @@ class _AsOfMerge(_OrderedMerge):
                     # later with a ValueError, so we don't *need* to check
                     # for them here.
                     msg = (
-                        "incompatible merge keys [{i}] {lkdtype} and "
-                        "{rkdtype}, both sides category, but not equal ones".format(
-                            i=i, lkdtype=repr(lk.dtype), rkdtype=repr(rk.dtype)
-                        )
+                        f"incompatible merge keys [{i}] {lk.dtype!r} and "
+                        f"{rk.dtype!r}, both sides category, but not equal ones"
                     )
                 else:
                     msg = (
-                        "incompatible merge keys [{i}] {lkdtype} and "
-                        "{rkdtype}, must be the same type".format(
-                            i=i, lkdtype=repr(lk.dtype), rkdtype=repr(rk.dtype)
-                        )
+                        f"incompatible merge keys [{i}] {lk.dtype!r} and "
+                        f"{rk.dtype!r}, must be the same type"
                     )
                 raise MergeError(msg)
 
@@ -1651,10 +1642,8 @@ class _AsOfMerge(_OrderedMerge):
                 lt = left_join_keys[-1]
 
             msg = (
-                "incompatible tolerance {tolerance}, must be compat "
-                "with type {lkdtype}".format(
-                    tolerance=type(self.tolerance), lkdtype=repr(lt.dtype)
-                )
+                f"incompatible tolerance {self.tolerance}, must be compat "
+                f"with type {lk.dtype!r}"
             )
 
             if needs_i8_conversion(lt):
@@ -1680,8 +1669,8 @@ class _AsOfMerge(_OrderedMerge):
 
         # validate allow_exact_matches
         if not is_bool(self.allow_exact_matches):
-            msg = "allow_exact_matches must be boolean, passed {passed}"
-            raise MergeError(msg.format(passed=self.allow_exact_matches))
+            msg = f"allow_exact_matches must be boolean, passed {self.allow_exact_matches}"
+            raise MergeError(msg)
 
         return left_join_keys, right_join_keys, join_names
 
@@ -1708,20 +1697,23 @@ class _AsOfMerge(_OrderedMerge):
         tolerance = self.tolerance
 
         # we require sortedness and non-null values in the join keys
-        msg_sorted = "{side} keys must be sorted"
-        msg_missings = "Merge keys contain null values on {side} side"
+        def _msg_sorted(side):
+            return f"{side} keys must be sorted"
+
+        def _msg_missings(side):
+            return f"Merge keys contain null values on {side} side"
 
         if not Index(left_values).is_monotonic:
             if isna(left_values).any():
-                raise ValueError(msg_missings.format(side="left"))
+                raise ValueError(_msg_missings(side="left"))
             else:
-                raise ValueError(msg_sorted.format(side="left"))
+                raise ValueError(_msg_sorted(side="left"))
 
         if not Index(right_values).is_monotonic:
             if isna(right_values).any():
-                raise ValueError(msg_missings.format(side="right"))
+                raise ValueError(_msg_missings(side="right"))
             else:
-                raise ValueError(msg_sorted.format(side="right"))
+                raise ValueError(_msg_sorted(side="right"))
 
         # initial type conversion as needed
         if needs_i8_conversion(left_values):

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1186,7 +1186,7 @@ class _MergeOperation:
                 if len(common_cols) == 0:
                     raise MergeError(
                         "No common columns to perform merge on. "
-                        f"Merge options: left_on={self.left_on},"
+                        f"Merge options: left_on={self.left_on}, "
                         f"right_on={self.right_on}, "
                         f"left_index={self.left_index}, "
                         f"right_index={self.right_index}"

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1673,7 +1673,7 @@ class _AsOfMerge(_OrderedMerge):
         # validate allow_exact_matches
         if not is_bool(self.allow_exact_matches):
             msg = (
-                f"allow_exact_matches must be boolean, " 
+                f"allow_exact_matches must be boolean, "
                 f"passed {self.allow_exact_matches}"
             )
             raise MergeError(msg)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -610,7 +610,7 @@ class _MergeOperation:
         # warn user when merging between different levels
         if _left.columns.nlevels != _right.columns.nlevels:
             msg = (
-                f"merging between different levels can give an unintended "
+                "merging between different levels can give an unintended "
                 f"result ({left.columns.nlevels} levels on the left,"
                 f"{right.columns.nlevels} on the right)"
             )

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1626,13 +1626,13 @@ class _AsOfMerge(_OrderedMerge):
                     # later with a ValueError, so we don't *need* to check
                     # for them here.
                     msg = (
-                        f"incompatible merge keys [{i}] {lk.dtype!r} and "
-                        f"{rk.dtype!r}, both sides category, but not equal ones"
+                        f"incompatible merge keys [{i}] {repr(lk.dtype)} and "
+                        f"{repr(rk.dtype)}, both sides category, but not equal ones"
                     )
                 else:
                     msg = (
-                        f"incompatible merge keys [{i}] {lk.dtype!r} and "
-                        f"{rk.dtype!r}, must be the same type"
+                        f"incompatible merge keys [{i}] {repr(lk.dtype)} and "
+                        f"{repr(rk.dtype)}, must be the same type"
                     )
                 raise MergeError(msg)
 
@@ -1646,7 +1646,7 @@ class _AsOfMerge(_OrderedMerge):
 
             msg = (
                 f"incompatible tolerance {self.tolerance}, must be compat "
-                f"with type {lk.dtype!r}"
+                f"with type {repr(lk.dtype)}"
             )
 
             if needs_i8_conversion(lt):

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1672,8 +1672,10 @@ class _AsOfMerge(_OrderedMerge):
 
         # validate allow_exact_matches
         if not is_bool(self.allow_exact_matches):
-            msg = f"allow_exact_matches must be boolean, " \
+            msg = (
+                f"allow_exact_matches must be boolean, " 
                 f"passed {self.allow_exact_matches}"
+            )
             raise MergeError(msg)
 
         return left_join_keys, right_join_keys, join_names

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -200,7 +200,7 @@ def _add_margins(
     if not isinstance(margins_name, str):
         raise ValueError("margins_name argument must be a string")
 
-    msg = 'Conflicting name "{name}" in margins'.format(name=margins_name)
+    msg = f'Conflicting name "{margins_name}" in margins'
     for level in table.index.names:
         if margins_name in table.index.get_level_values(level):
             raise ValueError(msg)
@@ -651,7 +651,7 @@ def _normalize(table, normalize, margins: bool, margins_name="All"):
             margins_name != table.iloc[:, -1].name
         ):
             raise ValueError(
-                "{mname} not in pivoted DataFrame".format(mname=margins_name)
+                f"{margins_name} not in pivoted DataFrame"
             )
         column_margin = table.iloc[:-1, -1]
         index_margin = table.iloc[-1, :-1]
@@ -702,7 +702,7 @@ def _get_names(arrs, names, prefix: str = "row"):
             if isinstance(arr, ABCSeries) and arr.name is not None:
                 names.append(arr.name)
             else:
-                names.append("{prefix}_{i}".format(prefix=prefix, i=i))
+                names.append(f"{prefix}_{i}")
     else:
         if len(names) != len(arrs):
             raise AssertionError("arrays and names must have the same length")

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -650,9 +650,7 @@ def _normalize(table, normalize, margins: bool, margins_name="All"):
         if (margins_name not in table.iloc[-1, :].name) | (
             margins_name != table.iloc[:, -1].name
         ):
-            raise ValueError(
-                f"{margins_name} not in pivoted DataFrame"
-            )
+            raise ValueError(f"{margins_name} not in pivoted DataFrame")
         column_margin = table.iloc[:-1, -1]
         index_margin = table.iloc[-1, :-1]
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -878,7 +878,8 @@ def get_dummies(
                 if not len(item) == data_to_encode.shape[1]:
                     len_msg = (
                         f"Length of '{name}' ({len(item)}) did not match the "
-                        f"length of the columns being encoded ({data_to_encode.shape[1]})."
+                        f"length of the columns being encoded "
+                        f"({data_to_encode.shape[1]})."
                     )
                     raise ValueError(len_msg)
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -878,7 +878,7 @@ def get_dummies(
                 if not len(item) == data_to_encode.shape[1]:
                     len_msg = (
                         f"Length of '{name}' ({len(item)}) did not match the "
-                        f"length of the columns being encoded "
+                        "length of the columns being encoded "
                         f"({data_to_encode.shape[1]})."
                     )
                     raise ValueError(len_msg)

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -873,16 +873,13 @@ def get_dummies(
 
         # validate prefixes and separator to avoid silently dropping cols
         def check_len(item, name):
-            len_msg = (
-                "Length of '{name}' ({len_item}) did not match the "
-                "length of the columns being encoded ({len_enc})."
-            )
 
             if is_list_like(item):
                 if not len(item) == data_to_encode.shape[1]:
-                    len_msg = len_msg.format(
-                        name=name, len_item=len(item), len_enc=data_to_encode.shape[1]
-                    )
+                    len_msg = (
+                f"Length of '{name}' ({len(item)}) did not match the "
+                f"length of the columns being encoded ({data_to_encode.shape[1]})."
+            )
                     raise ValueError(len_msg)
 
         check_len(prefix, "prefix")
@@ -990,8 +987,7 @@ def _get_dummies_1d(
 
         # PY2 embedded unicode, gh-22084
         def _make_col_name(prefix, prefix_sep, level) -> str:
-            fstr = "{prefix}{prefix_sep}{level}"
-            return fstr.format(prefix=prefix, prefix_sep=prefix_sep, level=level)
+            return f"{prefix}{prefix_sep}{level}"
 
         dummy_cols = [_make_col_name(prefix, prefix_sep, level) for level in levels]
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -877,9 +877,9 @@ def get_dummies(
             if is_list_like(item):
                 if not len(item) == data_to_encode.shape[1]:
                     len_msg = (
-                f"Length of '{name}' ({len(item)}) did not match the "
-                f"length of the columns being encoded ({data_to_encode.shape[1]})."
-            )
+                        f"Length of '{name}' ({len(item)}) did not match the "
+                        f"length of the columns being encoded ({data_to_encode.shape[1]})."
+                    )
                     raise ValueError(len_msg)
 
         check_len(prefix, "prefix")

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -370,11 +370,9 @@ class TestMerge:
         df2 = DataFrame({"y": ["b", "c"]}, index=[dt, dt])
 
         msg = (
-            "No common columns to perform merge on. "
-            f"Merge options: left_on={self.left_on},"
-            f"right_on={self.right_on}, "
-            f"left_index={self.left_index}, "
-            f"right_index={self.right_index}"
+            f"No common columns to perform merge on. "
+            f"Merge options: left_on={None}, right_on={None}, "
+            f"left_index={False}, right_index={False}"
         )
 
         with pytest.raises(MergeError, match=msg):

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -370,7 +370,7 @@ class TestMerge:
         df2 = DataFrame({"y": ["b", "c"]}, index=[dt, dt])
 
         msg = (
-            f"No common columns to perform merge on. "
+            "No common columns to perform merge on. "
             f"Merge options: left_on={None}, right_on={None}, "
             f"left_index={False}, right_index={False}"
         )

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -370,12 +370,12 @@ class TestMerge:
         df2 = DataFrame({"y": ["b", "c"]}, index=[dt, dt])
 
         msg = (
-            "No common columns to perform merge on. "
-            "Merge options: left_on={lon}, right_on={ron}, "
-            "left_index={lidx}, right_index={ridx}".format(
-                lon=None, ron=None, lidx=False, ridx=False
+                "No common columns to perform merge on. "
+                f"Merge options: left_on={self.left_on},"
+                f"right_on={self.right_on}, "
+                f"left_index={self.left_index}, "
+                f"right_index={self.right_index}"
             )
-        )
 
         with pytest.raises(MergeError, match=msg):
             merge(df1, df2)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -370,12 +370,12 @@ class TestMerge:
         df2 = DataFrame({"y": ["b", "c"]}, index=[dt, dt])
 
         msg = (
-                "No common columns to perform merge on. "
-                f"Merge options: left_on={self.left_on},"
-                f"right_on={self.right_on}, "
-                f"left_index={self.left_index}, "
-                f"right_index={self.right_index}"
-            )
+            "No common columns to perform merge on. "
+            f"Merge options: left_on={self.left_on},"
+            f"right_on={self.right_on}, "
+            f"left_index={self.left_index}, "
+            f"right_index={self.right_index}"
+        )
 
         with pytest.raises(MergeError, match=msg):
             merge(df1, df2)


### PR DESCRIPTION
Addresses, in part, https://github.com/pandas-dev/pandas/issues/29547 

…ape/pivot, reshape/reshape

- [ x] xref #29547 
- [n/a ] tests added / passed
- [x ] passes `black pandas`
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [n/a ] whatsnew entry
