### PR TITLE
Fix docstring for to_markdown buf parameter

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1922,10 +1922,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     Parameters
     ----------
-    buf : writable buffer, defaults to sys.stdout
-        Where to send the output. By default, the output is printed to
-        sys.stdout. Pass a writable buffer if you need to further process
-        the output.
+    buf : str, Path or StringIO-like, optional, default None
+        Buffer to write to. If None, the output is returned as a string.
     mode : str, optional
         Mode in which file is opened.
     **kwargs


### PR DESCRIPTION
- [ ] ~~closes #xxxx~~ (N/A)
- [ ] ~~tests added / passed~~ (N/A)
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] ~~whatsnew entry~~ (N/A)
