### PR TITLE
TST: DataFrame.interpolate(axis='columns') throws exception while DataFrame.interpolate(axis=1) not (#25190)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -158,6 +158,7 @@ Indexing
 - Bug in :meth:`PeriodIndex.is_monotonic` incorrectly returning ``True`` when containing leading ``NaT`` entries (:issue:`31437`)
 - Bug in :meth:`DatetimeIndex.get_loc` raising ``KeyError`` with converted-integer key instead of the user-passed key (:issue:`31425`)
 - Bug in :meth:`Series.xs` incorrectly returning ``Timestamp`` instead of ``datetime64`` in some object-dtype cases (:issue:`31630`)
+- Bug in :meth:`DataFrame.interpolate` raising ``UnboundLocalError`` when specifying the ``axis`` with a string (:issue:`25190`)
 
 Missing
 ^^^^^^^

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -983,3 +983,11 @@ class TestDataFrameInterpolate:
         result = expected.interpolate(axis=0, method="time")
         expected.interpolate(axis=0, method="time", inplace=True)
         tm.assert_frame_equal(result, expected)
+
+    def test_interp_string_axis(self):
+        # GH 25190
+        x = np.linspace(0, 100, 1000)
+        y = np.sin(x)
+        df = pd.DataFrame(data=np.tile(y, (10, 1)), index=np.arange(10), columns=x)
+        df.reindex(columns=x * 1.005).interpolate(method="linear", axis="columns")
+        df.reindex(columns=x * 1.005).interpolate(method="linear", axis="index")


### PR DESCRIPTION
Make sure that DataFrame.interpolate allows setting having "columns" or "index" as the `axis` argument.

I included the `whatsnew` entry as well. However, since the bug was already fixed in v1.0.0, it might be reasonable to just drop it. I leave it to the reviewer's discretion, that's why I've put it in a separate commit.

- [x] closes #25190
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
