### PR TITLE
Dispatch IntervalIndex.argsort to IntervalArray

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -701,6 +701,15 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             msg = f"Cannot cast {type(self).__name__} to dtype {dtype}"
             raise TypeError(msg)
 
+    def argsort(self, ascending: bool = True, kind: str = "quicksort", *args, **kwargs):
+        ascending = nv.validate_argsort_with_ascending(ascending, args, kwargs)
+
+        if not ascending or kind != "quicksort":
+            # fall back to base class implementation
+            return super().argsort(ascending, kind)
+
+        return np.lexsort((self.right, self.left))
+
     @classmethod
     def _concat_same_type(cls, to_concat):
         """

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1033,7 +1033,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
     # --------------------------------------------------------------------
 
     def argsort(self, *args, **kwargs) -> np.ndarray:
-        return np.lexsort((self.right, self.left))
+        return self._data.argsort()
 
     def equals(self, other) -> bool:
         """


### PR DESCRIPTION
cc @jschendel thoughts on if we can do better in the non-ascending/"quicksort" case?