### PR TITLE
DOC: add back google analytics with the new doc theme

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -209,6 +209,7 @@ html_theme_options = {
     "external_links": [],
     "github_url": "https://github.com/pandas-dev/pandas",
     "twitter_url": "https://twitter.com/pandas_dev",
+    "google_analytics_id": "UA-27880019-2",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
WIth the new theme, we didn't have google analytics anymore (how we had it before https://github.com/pandas-dev/pandas/pull/27662), so did a quick PR to add that to the theme with an option: https://github.com/pandas-dev/pydata-bootstrap-sphinx-theme/pull/84