### PR TITLE
REGR: Fixed AssertionError in groupby

### DIFF
--- a/doc/source/whatsnew/v1.0.1.rst
+++ b/doc/source/whatsnew/v1.0.1.rst
@@ -19,6 +19,7 @@ Fixed regressions
 - Fixed regression when indexing a ``Series`` or ``DataFrame`` indexed by ``DatetimeIndex`` with a slice containg a :class:`datetime.date` (:issue:`31501`)
 - Fixed regression in :class:`Series` multiplication when multiplying a numeric :class:`Series` with >10000 elements with a timedelta-like scalar (:issue:`31457`)
 - Fixed regression in :meth:`GroupBy.apply` if called with a function which returned a non-pandas non-scalar object (e.g. a list or numpy array) (:issue:`31441`)
+- Fixed regression in ``.groupby().agg()`` raising an ``AssertionError`` for some reductions like ``min`` on object-dtype columns (:issue:`31522`)
 - Fixed regression in :meth:`to_datetime` when parsing non-nanosecond resolution datetimes (:issue:`31491`)
 - Fixed regression in :meth:`~DataFrame.to_csv` where specifying an ``na_rep`` might truncate the values written (:issue:`31447`)
 - Fixed regression where setting :attr:`pd.options.display.max_colwidth` was not accepting negative integer. In addition, this behavior has been deprecated in favor of using ``None`` (:issue:`31532`)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1079,28 +1079,27 @@ class DataFrameGroupBy(GroupBy):
                     if isinstance(result, np.ndarray) and result.ndim == 1:
                         result = result.reshape(1, -1)
 
-            finally:
-                assert not isinstance(result, DataFrame)
+            assert not isinstance(result, DataFrame)
 
-                if result is not no_result:
-                    # see if we can cast the block back to the original dtype
-                    result = maybe_downcast_numeric(result, block.dtype)
+            if result is not no_result:
+                # see if we can cast the block back to the original dtype
+                result = maybe_downcast_numeric(result, block.dtype)
 
-                    if block.is_extension and isinstance(result, np.ndarray):
-                        # e.g. block.values was an IntegerArray
-                        # (1, N) case can occur if block.values was Categorical
-                        #  and result is ndarray[object]
-                        assert result.ndim == 1 or result.shape[0] == 1
-                        try:
-                            # Cast back if feasible
-                            result = type(block.values)._from_sequence(
-                                result.ravel(), dtype=block.values.dtype
-                            )
-                        except ValueError:
-                            # reshape to be valid for non-Extension Block
-                            result = result.reshape(1, -1)
+                if block.is_extension and isinstance(result, np.ndarray):
+                    # e.g. block.values was an IntegerArray
+                    # (1, N) case can occur if block.values was Categorical
+                    #  and result is ndarray[object]
+                    assert result.ndim == 1 or result.shape[0] == 1
+                    try:
+                        # Cast back if feasible
+                        result = type(block.values)._from_sequence(
+                            result.ravel(), dtype=block.values.dtype
+                        )
+                    except ValueError:
+                        # reshape to be valid for non-Extension Block
+                        result = result.reshape(1, -1)
 
-                    agg_block: Block = block.make_block(result)
+                agg_block: Block = block.make_block(result)
 
             new_items.append(locs)
             agg_blocks.append(agg_block)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1061,8 +1061,16 @@ class DataFrameGroupBy(GroupBy):
                 else:
                     result = cast(DataFrame, result)
                     # unwrap DataFrame to get array
-                    assert len(result._data.blocks) == 1
-                    result = result._data.blocks[0].values
+                    if len(result._data.blocks) != 1:
+                        # An input (P, N)-shape block was split into P
+                        # (1, n_groups) blocks. This is problematic since it breaks
+                        # the assumption that one input block is aggregated
+                        # to one output block. We should be OK as long as
+                        # the split output can be put back into a single block below
+                        assert len(result._data.blocks) == result.shape[1]
+                        result = np.asarray(result)
+                    else:
+                        result = result._data.blocks[0].values
                     if isinstance(result, np.ndarray) and result.ndim == 1:
                         result = result.reshape(1, -1)
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1023,7 +1023,8 @@ class DataFrameGroupBy(GroupBy):
         new_items: List[np.ndarray] = []
         deleted_items: List[np.ndarray] = []
         # Some object-dtype blocks might be split into List[Block[T], Block[U]]
-        # split_items: List[np.ndarray] = []
+        split_items: List[np.ndarray] = []
+        split_frames: List[DataFrame] = []
 
         no_result = object()
         for block in data.blocks:
@@ -1065,40 +1066,55 @@ class DataFrameGroupBy(GroupBy):
                     result = cast(DataFrame, result)
                     # unwrap DataFrame to get array
                     if len(result._data.blocks) != 1:
-                        result._consolidate_inplace()
+                        # We've split an object block! Everything we've assumed
+                        # about a single block input returning a single block output
+                        # is a lie. To keep the code-path for the typical non-split case
+                        # clean, we choose to clean up this mess later on.
+                        split_items.append(locs)
+                        split_frames.append(result)
+                        continue
 
                     assert len(result._data.blocks) == 1
                     result = result._data.blocks[0].values
                     if isinstance(result, np.ndarray) and result.ndim == 1:
                         result = result.reshape(1, -1)
 
-            assert not isinstance(result, DataFrame)
+            finally:
+                assert not isinstance(result, DataFrame)
 
-            if result is not no_result:
-                # see if we can cast the block back to the original dtype
-                result = maybe_downcast_numeric(result, block.dtype)
+                if result is not no_result:
+                    # see if we can cast the block back to the original dtype
+                    result = maybe_downcast_numeric(result, block.dtype)
 
-                if block.is_extension and isinstance(result, np.ndarray):
-                    # e.g. block.values was an IntegerArray
-                    # (1, N) case can occur if block.values was Categorical
-                    #  and result is ndarray[object]
-                    assert result.ndim == 1 or result.shape[0] == 1
-                    try:
-                        # Cast back if feasible
-                        result = type(block.values)._from_sequence(
-                            result.ravel(), dtype=block.values.dtype
-                        )
-                    except ValueError:
-                        # reshape to be valid for non-Extension Block
-                        result = result.reshape(1, -1)
+                    if block.is_extension and isinstance(result, np.ndarray):
+                        # e.g. block.values was an IntegerArray
+                        # (1, N) case can occur if block.values was Categorical
+                        #  and result is ndarray[object]
+                        assert result.ndim == 1 or result.shape[0] == 1
+                        try:
+                            # Cast back if feasible
+                            result = type(block.values)._from_sequence(
+                                result.ravel(), dtype=block.values.dtype
+                            )
+                        except ValueError:
+                            # reshape to be valid for non-Extension Block
+                            result = result.reshape(1, -1)
 
-                agg_block: Block = block.make_block(result)
+                    agg_block: Block = block.make_block(result)
 
             new_items.append(locs)
             agg_blocks.append(agg_block)
 
-        if not agg_blocks:
+        if not (agg_blocks or split_frames):
             raise DataError("No numeric types to aggregate")
+
+        if split_items:
+            # Clean up the mess left over from split blocks.
+            for locs, result in zip(split_items, split_frames):
+                assert len(locs) == result.shape[1]
+                for i, loc in enumerate(locs):
+                    new_items.append(np.array([loc], dtype=locs.dtype))
+                    agg_blocks.append(result.iloc[:, [i]]._data.blocks[0])
 
         # reset the locs in the blocks to correspond to our
         # current ordering

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1062,15 +1062,10 @@ class DataFrameGroupBy(GroupBy):
                     result = cast(DataFrame, result)
                     # unwrap DataFrame to get array
                     if len(result._data.blocks) != 1:
-                        # An input (P, N)-shape block was split into P
-                        # (1, n_groups) blocks. This is problematic since it breaks
-                        # the assumption that one input block is aggregated
-                        # to one output block. We should be OK as long as
-                        # the split output can be put back into a single block below
-                        assert len(result._data.blocks) == result.shape[1]
-                        result = np.asarray(result)
-                    else:
-                        result = result._data.blocks[0].values
+                        result._consolidate_inplace()
+
+                    assert len(result._data.blocks) == 1
+                    result = result._data.blocks[0].values
                     if isinstance(result, np.ndarray) and result.ndim == 1:
                         result = result.reshape(1, -1)
 

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -407,12 +407,23 @@ def test_agg_split_object_part_datetime():
         {
             "A": pd.date_range("2000", periods=4),
             "B": ["a", "b", "c", "d"],
-            "C": ["b", "c", "d", "e"],
-            "D": pd.date_range("2000", periods=4),
+            "C": [1, 2, 3, 4],
+            "D": ["b", "c", "d", "e"],
+            "E": pd.date_range("2000", periods=4),
+            "F": [1, 2, 3, 4],
         }
     ).astype(object)
     result = df.groupby([0, 0, 0, 0]).min()
-    expected = pd.DataFrame({"A": [pd.Timestamp("2000")], "B": ["a"]})
+    expected = pd.DataFrame(
+        {
+            "A": [pd.Timestamp("2000")],
+            "B": ["a"],
+            "C": [1],
+            "D": ["b"],
+            "E": [pd.Timestamp("2000")],
+            "F": [1],
+        }
+    )
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -377,6 +377,30 @@ def test_agg_index_has_complex_internals(index):
     tm.assert_frame_equal(result, expected)
 
 
+def test_agg_split_block():
+    # https://github.com/pandas-dev/pandas/issues/31522
+    df = pd.DataFrame(
+        {
+            "key1": ["a", "a", "b", "b", "a"],
+            "key2": ["one", "two", "one", "two", "one"],
+            "key3": ["three", "three", "three", "six", "six"],
+            "data1": [0.0, 1, 2, 3, 4],
+            "data2": [0.0, 1, 2, 3, 4],
+        }
+    )
+    result = df.groupby("key1").min()
+    expected = pd.DataFrame(
+        {
+            "key2": ["one", "six"],
+            "key3": ["one", "six"],
+            "data1": [0.0, 2.0],
+            "data2": [0.0, 2.0],
+        },
+        index=pd.Index(["a", "b"], name="key1"),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 class TestNamedAggregationSeries:
     def test_series_named_agg(self):
         df = pd.Series([1, 2, 3, 4])

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -384,18 +384,11 @@ def test_agg_split_block():
             "key1": ["a", "a", "b", "b", "a"],
             "key2": ["one", "two", "one", "two", "one"],
             "key3": ["three", "three", "three", "six", "six"],
-            "data1": [0.0, 1, 2, 3, 4],
-            "data2": [0.0, 1, 2, 3, 4],
         }
     )
     result = df.groupby("key1").min()
     expected = pd.DataFrame(
-        {
-            "key2": ["one", "one"],
-            "key3": ["six", "six"],
-            "data1": [0.0, 2.0],
-            "data2": [0.0, 2.0],
-        },
+        {"key2": ["one", "one"], "key3": ["six", "six"]},
         index=pd.Index(["a", "b"], name="key1"),
     )
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -391,8 +391,8 @@ def test_agg_split_block():
     result = df.groupby("key1").min()
     expected = pd.DataFrame(
         {
-            "key2": ["one", "six"],
-            "key3": ["one", "six"],
+            "key2": ["one", "one"],
+            "key3": ["six", "six"],
             "data1": [0.0, 2.0],
             "data2": [0.0, 2.0],
         },

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -401,6 +401,21 @@ def test_agg_split_block():
     tm.assert_frame_equal(result, expected)
 
 
+def test_agg_split_object_part_datetime():
+    # https://github.com/pandas-dev/pandas/pull/31616
+    df = pd.DataFrame(
+        {
+            "A": pd.date_range("2000", periods=4),
+            "B": ["a", "b", "c", "d"],
+            "C": ["b", "c", "d", "e"],
+            "D": pd.date_range("2000", periods=4),
+        }
+    ).astype(object)
+    result = df.groupby([0, 0, 0, 0]).min()
+    expected = pd.DataFrame({"A": [pd.Timestamp("2000")], "B": ["a"]})
+    tm.assert_frame_equal(result, expected)
+
+
 class TestNamedAggregationSeries:
     def test_series_named_agg(self):
         df = pd.Series([1, 2, 3, 4])


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/31522


cc @jbrockmendel. Just raising a `TypeError` when that assert failed didn't work. The `finally` still runs, which raised an assertion error.

It seemed easier to try to just support this case. IIUC, it only occurs when an `(P, n_rows)` input block gets split into `P` result blocks. I believe that

1. The result blocks should all have the same dtype
2. The input block must not have been an extension block, since it's 2d

So it *should* be safe to just cast the result values into an ndarray. Hopefully...

Are there any edge cases I'm not considering? Some kind of `agg` that returns a result that can't be put in a 2D block? Even something like `.agg(lambda x: pd.Period())` 
won't hit this, since it has to be a Cython function. 