### PR TITLE
DOC: link on nullables in indexing

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -920,6 +920,10 @@ and :ref:`Advanced Indexing <advanced>` you may select along more than one axis 
 
    df2.loc[criterion & (df2['b'] == 'x'), 'b':'c']
 
+Note- pandas does not allow indexing with NA values. Attempting to do so
+will raise a ``ValueError``.
+For more information refer to Nullable Boolean data type.
+
 .. _indexing.basics.indexing_isin:
 
 Indexing with isin

--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -809,6 +809,10 @@ a DataFrame or Series, or when reading in data), so you need to specify
 the dtype explicitly.  An easy way to convert to those dtypes is explained
 :ref:`here <missing_data.NA.conversion>`.
 
+Note - Pandas does not allow indexing with NA values. Attempting to do so will 
+raise a ``ValueError``.
+For more information refer to Nullable boolean data type.
+
 Propagation in arithmetic and comparison operations
 ---------------------------------------------------
 


### PR DESCRIPTION
DOC: Mention that boolean indexing is impossible for new nullable integer/boolean and string data types when they contain missing values

closes #31537 