### PR TITLE
BUG: qcut can fail for highly discontinuous data distributions

### DIFF
--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -354,9 +354,9 @@ def qcut(
         if(b in unique_bins):
             unique_bins.remove(b)
         else:
-            bins[i] = np.nextafter(x[x>bins[i]].min(), bins[i])
+            bins[i] = np.nextafter(x[x > bins[i]].min(), bins[i])
     # ------------------------------
-    
+
     fac, bins = _bins_to_cuts(
         x,
         bins,

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -345,6 +345,18 @@ def qcut(
     else:
         quantiles = q
     bins = algos.quantile(x, quantiles)
+
+    # Added code
+    # ------------------------------
+    unique_bins = set(bins)
+
+    for i, b in enumerate(bins):
+        if(b in unique_bins):
+            unique_bins.remove(b)
+        else:
+            bins[i] = np.nextafter(x[x>bins[i]].min(), bins[i])
+    # ------------------------------
+    
     fac, bins = _bins_to_cuts(
         x,
         bins,


### PR DESCRIPTION
Fixes #15069. Needs refactoring

- [x] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
