### PR TITLE
BUG: Series.xs boxing datetime64 incorrectly

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -155,6 +155,7 @@ Indexing
 - Bug in :meth:`Series.at` and :meth:`DataFrame.at` not matching ``.loc`` behavior when looking up an integer in a :class:`Float64Index` (:issue:`31329`)
 - Bug in :meth:`PeriodIndex.is_monotonic` incorrectly returning ``True`` when containing leading ``NaT`` entries (:issue:`31437`)
 - Bug in :meth:`DatetimeIndex.get_loc` raising ``KeyError`` with converted-integer key instead of the user-passed key (:issue:`31425`)
+- Bug in :meth:`Series.xs` incorrectly returning ``Timestamp`` instead of ``datetime64`` in some object-dtype cases (:issue:`31630`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3442,15 +3442,14 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 new_index = self.index[loc]
 
         if is_scalar(loc):
-            new_values = self._data.fast_xs(loc)
+            # In this case loc should be an integer
+            if self.ndim == 1:
+                # if we encounter an array-like and we only have 1 dim
+                # that means that their are list/ndarrays inside the Series!
+                # so just return them (GH 6394)
+                return self._values[loc]
 
-            # may need to box a datelike-scalar
-            #
-            # if we encounter an array-like and we only have 1 dim
-            # that means that their are list/ndarrays inside the Series!
-            # so just return them (GH 6394)
-            if not is_list_like(new_values) or self.ndim == 1:
-                return com.maybe_box_datetimelike(new_values)
+            new_values = self._data.fast_xs(loc)
 
             result = self._constructor_sliced(
                 new_values,

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1565,7 +1565,7 @@ class SingleBlockManager(BlockManager):
         fast path for getting a cross-section
         return a view of the data
         """
-        return self._block.values[loc]
+        raise NotImplementedError("Use series._values[loc] instead")
 
     def concat(self, to_concat, new_axis) -> "SingleBlockManager":
         """

--- a/pandas/tests/series/indexing/test_xs.py
+++ b/pandas/tests/series/indexing/test_xs.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 
 def test_xs_datetimelike_wrapping():
-    # a case where we shouldn't wrap datetime64 in Timestamp
+    # GH#31630 a case where we shouldn't wrap datetime64 in Timestamp
     arr = pd.date_range("2016-01-01", periods=3)._data._data
 
     ser = pd.Series(arr, dtype=object)

--- a/pandas/tests/series/indexing/test_xs.py
+++ b/pandas/tests/series/indexing/test_xs.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+import pandas as pd
+
+
+def test_xs_datetimelike_wrapping():
+    # a case where we shouldn't wrap datetime64 in Timestamp
+    arr = pd.date_range("2016-01-01", periods=3)._data._data
+
+    ser = pd.Series(arr, dtype=object)
+    for i in range(len(ser)):
+        ser.iloc[i] = arr[i]
+    assert ser.dtype == object
+    assert isinstance(ser[0], np.datetime64)
+
+    result = ser.xs(0)
+    assert isinstance(result, np.datetime64)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
