### PR TITLE
REF: call _maybe_cast_indexer upfront, better exception messages

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2888,10 +2888,11 @@ class Index(IndexOpsMixin, PandasObject):
                     "tolerance argument only valid if using pad, "
                     "backfill or nearest lookups"
                 )
+            casted_key = self._maybe_cast_indexer(key)
             try:
-                return self._engine.get_loc(key)
+                return self._engine.get_loc(casted_key)
             except KeyError:
-                return self._engine.get_loc(self._maybe_cast_indexer(key))
+                raise KeyError(key)
 
         if tolerance is not None:
             tolerance = self._convert_tolerance(tolerance, np.asarray(key))

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -392,7 +392,7 @@ def test_get_loc_missing_nan():
     # GH 8569
     idx = MultiIndex.from_arrays([[1.0, 2.0], [3.0, 4.0]])
     assert isinstance(idx.get_loc(1), slice)
-    with pytest.raises(KeyError, match=r"^3\.0$"):
+    with pytest.raises(KeyError, match=r"^3$"):
         idx.get_loc(3)
     with pytest.raises(KeyError, match=r"^nan$"):
         idx.get_loc(np.nan)

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -385,7 +385,7 @@ class TestFloat64Index(Numeric):
         # GH 8569
         idx = Float64Index([1, 2])
         assert idx.get_loc(1) == 0
-        with pytest.raises(KeyError, match=r"^3\.0$"):
+        with pytest.raises(KeyError, match=r"^3$"):
             idx.get_loc(3)
         with pytest.raises(KeyError, match="^nan$"):
             idx.get_loc(np.nan)

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -107,7 +107,7 @@ class TestFloatIndexers:
                     "mixed",
                 }:
                     error = KeyError
-                    msg = r"^3$"
+                    msg = r"^3\.0$"
                 else:
                     error = TypeError
                     msg = (
@@ -187,7 +187,7 @@ class TestFloatIndexers:
             with pytest.raises(TypeError, match=msg):
                 idxr(s2)[1.0]
 
-        with pytest.raises(KeyError, match=r"^1$"):
+        with pytest.raises(KeyError, match=r"^1\.0$"):
             s2.loc[1.0]
 
         result = s2.loc["b"]
@@ -213,7 +213,7 @@ class TestFloatIndexers:
         msg = "Cannot index by location index with a non-integer key"
         with pytest.raises(TypeError, match=msg):
             s3.iloc[1.0]
-        with pytest.raises(KeyError, match=r"^1$"):
+        with pytest.raises(KeyError, match=r"^1\.0$"):
             s3.loc[1.0]
 
         result = s3.loc[1.5]
@@ -666,11 +666,11 @@ class TestFloatIndexers:
         # value not found (and no fallbacking at all)
 
         # scalar integers
-        with pytest.raises(KeyError, match=r"^4\.0$"):
+        with pytest.raises(KeyError, match=r"^4$"):
             s.loc[4]
-        with pytest.raises(KeyError, match=r"^4\.0$"):
+        with pytest.raises(KeyError, match=r"^4$"):
             s.loc[4]
-        with pytest.raises(KeyError, match=r"^4\.0$"):
+        with pytest.raises(KeyError, match=r"^4$"):
             s[4]
 
         # fancy floats/integers create the correct entry (as nan)


### PR DESCRIPTION
This will actually allow us to remove e.g. CategoricalIndex.get_loc by moving the 2 relevant lines into CategoricalIndex._maybe_cast_indexer.  Large parts of DTI/TDI/PI.get_loc will also be simplifiable.

We've got both Index._maybe_cast_indexer and Index._convert_scalar_indexer which hopefully we'll only need one of.