### PR TITLE
CLN: Replace format with f-strings in test_repr_info

### DIFF
--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -223,8 +223,7 @@ class TestDataFrameReprInfoEtc:
 
         for i, line in enumerate(lines):
             if i >= start and i < start + size:
-                index = i - start
-                line_nr = " {} ".format(index)
+                line_nr = f" {i - start} "
                 assert line.startswith(line_nr)
 
     def test_info_memory(self):
@@ -236,7 +235,7 @@ class TestDataFrameReprInfoEtc:
         bytes = float(df.memory_usage().sum())
 
         expected = textwrap.dedent(
-            """\
+            f"""\
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 2 entries, 0 to 1
         Data columns (total 1 columns):
@@ -244,10 +243,8 @@ class TestDataFrameReprInfoEtc:
         ---  ------  --------------  -----
          0   a       2 non-null      int64
         dtypes: int64(1)
-        memory usage: {} bytes
-        """.format(
-                bytes
-            )
+        memory usage: {bytes} bytes
+        """
         )
 
         assert result == expected
@@ -313,9 +310,7 @@ class TestDataFrameReprInfoEtc:
         )
         assert header in res
         for i, dtype in enumerate(dtypes):
-            name = " {i:d}   {i:d}       {n:d} non-null     {dtype}".format(
-                i=i, n=n, dtype=dtype
-            )
+            name = f" {i:d}   {i:d}       {n:d} non-null     {dtype}"
             assert name in res
 
     def test_info_max_cols(self):


### PR DESCRIPTION
Updated `pandas/tests/frame/test_repr_info.py` to use f-strings

ref: https://github.com/pandas-dev/pandas/issues/29547

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
