### PR TITLE
BUG: avoid specifying default coerce_timestamps in to_parquet

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -180,7 +180,9 @@ I/O
 - Bug in :meth:`read_json` where integer overflow was occuring when json contains big number strings. (:issue:`30320`)
 - `read_csv` will now raise a ``ValueError`` when the arguments `header` and `prefix` both are not `None`. (:issue:`27394`)
 - Bug in :meth:`DataFrame.to_json` was raising ``NotFoundError`` when ``path_or_buf`` was an S3 URI (:issue:`28375`)
--
+- Bug in :meth:`DataFrame.to_parquet` overwriting pyarrow's default for
+  ``coerce_timestamps``; following pyarrow's default allow to write nanosecond
+  timestamps with ``version="2.0"`` (:issue:`31652`).
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -181,7 +181,7 @@ I/O
 - `read_csv` will now raise a ``ValueError`` when the arguments `header` and `prefix` both are not `None`. (:issue:`27394`)
 - Bug in :meth:`DataFrame.to_json` was raising ``NotFoundError`` when ``path_or_buf`` was an S3 URI (:issue:`28375`)
 - Bug in :meth:`DataFrame.to_parquet` overwriting pyarrow's default for
-  ``coerce_timestamps``; following pyarrow's default allow to write nanosecond
+  ``coerce_timestamps``; following pyarrow's default allows writing nanosecond
   timestamps with ``version="2.0"`` (:issue:`31652`).
 
 Plotting

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -85,7 +85,6 @@ class PyArrowImpl(BaseImpl):
         df: DataFrame,
         path,
         compression="snappy",
-        coerce_timestamps="ms",
         index: Optional[bool] = None,
         partition_cols=None,
         **kwargs,
@@ -103,17 +102,12 @@ class PyArrowImpl(BaseImpl):
                 table,
                 path,
                 compression=compression,
-                coerce_timestamps=coerce_timestamps,
                 partition_cols=partition_cols,
                 **kwargs,
             )
         else:
             self.api.parquet.write_table(
-                table,
-                path,
-                compression=compression,
-                coerce_timestamps=coerce_timestamps,
-                **kwargs,
+                table, path, compression=compression, **kwargs,
             )
 
     def read(self, path, columns=None, **kwargs):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -567,7 +567,7 @@ class TestParquetPyArrow(Base):
     @td.skip_if_no("pyarrow", min_version="0.14")
     def test_timestamp_nanoseconds(self, pa):
         # with version 2.0, pyarrow defaults to writing the nanoseconds, so
-        # this should work with error
+        # this should work without error
         df = pd.DataFrame({"a": pd.date_range("2017-01-01", freq="1n", periods=10)})
         check_round_trip(df, pa, write_kwargs={"version": "2.0"})
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -564,6 +564,13 @@ class TestParquetPyArrow(Base):
         )
         check_round_trip(df, pa)
 
+    @td.skip_if_no("pyarrow", min_version="0.14")
+    def test_timestamp_nanoseconds(self, pa):
+        # with version 2.0, pyarrow defaults to writing the nanoseconds, so
+        # this should work with error
+        df = pd.DataFrame({"a": pd.date_range("2017-01-01", freq="1n", periods=10)})
+        check_round_trip(df, pa, write_kwargs={"version": "2.0"})
+
 
 class TestParquetFastParquet(Base):
     @td.skip_if_no("fastparquet", min_version="0.3.2")


### PR DESCRIPTION
Looking into the usage question of https://github.com/pandas-dev/pandas/issues/31572, I noticed that specifying the version to allow writing nanoseconds to parquet worked in plain pyarrow code, but not with pandas' `to_parquet`. 
This is because we hardcode `coerce_timestamps="ms"` while the default is `None`, which has version-dependent behaviour (eg if version="2.0", actually write the nanosecond data)