### PR TITLE
whatsnew for MultiIndex levels caching

### DIFF
--- a/doc/source/whatsnew/v1.0.1.rst
+++ b/doc/source/whatsnew/v1.0.1.rst
@@ -27,6 +27,7 @@ Fixed regressions
 - Fixed regression in objTOJSON.c fix return-type warning (:issue:`31463`)
 - Fixed regression in :meth:`qcut` when passed a nullable integer. (:issue:`31389`)
 - Fixed regression in assigning to a :class:`Series` using a nullable integer dtype (:issue:`31446`)
+- Fixed performance regression when indexing a ``DataFrame`` or ``Series`` with a :class:`MultiIndex` for the index using a list of labels (:issue:`31648`)
 
 .. ---------------------------------------------------------------------------
 


### PR DESCRIPTION
(cherry picked from commit 103840e974a4c8548fccab86cabc6a3161bd94e8)

Included in https://github.com/pandas-dev/pandas/pull/31664. So this won't need to be backported.