### PR TITLE
CLN: remove kwargs from signature of (Index|MultiIndex).copy

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -823,20 +823,22 @@ class Index(IndexOpsMixin, PandasObject):
     # --------------------------------------------------------------------
     # Copying Methods
 
-    def copy(self, name=None, deep=False, dtype=None, **kwargs):
+    def copy(self, name=None, deep=False, dtype=None, names=None):
         """
         Make a copy of this object.  Name and dtype sets those attributes on
         the new object.
 
         Parameters
         ----------
-        name : str, optional
+        name : Optional[Hashable]
         deep : bool, default False
-        dtype : numpy dtype or pandas type
+        dtype : numpy dtype or pandas type, optional
+        names : list-like, optional
+            Kept for compatibility with MultiIndex. Should not be used.
 
         Returns
         -------
-        copy : Index
+        Index
 
         Notes
         -----
@@ -848,7 +850,6 @@ class Index(IndexOpsMixin, PandasObject):
         else:
             new_index = self._shallow_copy()
 
-        names = kwargs.get("names")
         names = self._validate_names(name=name, names=names, deep=deep)
         new_index = new_index.set_names(names)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -830,7 +830,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        name : Optional[Hashable]
+        name : Label
         deep : bool, default False
         dtype : numpy dtype or pandas type, optional
         names : list-like, optional

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1014,7 +1014,7 @@ class MultiIndex(Index):
         levels : sequence, optional
         codes : sequence, optional
         deep : bool, default False
-        name : Optional[Hashable]
+        name : Label
             Kept for compatibility with 1-dimensional Index. Should not be used.
 
         Returns

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1000,8 +1000,8 @@ class MultiIndex(Index):
         levels=None,
         codes=None,
         deep=False,
+        name=None,
         _set_identity=False,
-        **kwargs,
     ):
         """
         Make a copy of this object. Names, dtype, levels and codes can be
@@ -1013,10 +1013,13 @@ class MultiIndex(Index):
         dtype : numpy dtype or pandas type, optional
         levels : sequence, optional
         codes : sequence, optional
+        deep : bool, default False
+        name : Optional[Hashable]
+            Kept for compatibility with 1-dimensional Index. Should not be used.
 
         Returns
         -------
-        copy : MultiIndex
+        MultiIndex
 
         Notes
         -----
@@ -1024,10 +1027,7 @@ class MultiIndex(Index):
         ``deep``, but if ``deep`` is passed it will attempt to deepcopy.
         This could be potentially expensive on large MultiIndex objects.
         """
-        name = kwargs.get("name")
         names = self._validate_names(name=name, names=names, deep=deep)
-        if "labels" in kwargs:
-            raise TypeError("'labels' argument has been removed; use 'codes' instead")
         if deep:
             from copy import deepcopy
 


### PR DESCRIPTION
Removes ``**kwargs`` from ``Index.copy`` and ``MultiIndex.copy``.
