### PR TITLE
REF: move convert_scalar out of cython

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -535,48 +535,6 @@ cdef class PeriodEngine(Int64Engine):
         return super(PeriodEngine, self).get_indexer_non_unique(ordinal_array)
 
 
-cpdef convert_scalar(ndarray arr, object value):
-    # we don't turn integers
-    # into datetimes/timedeltas
-
-    # we don't turn bools into int/float/complex
-
-    if arr.descr.type_num == NPY_DATETIME:
-        if util.is_array(value):
-            pass
-        elif isinstance(value, (datetime, np.datetime64, date)):
-            return Timestamp(value).to_datetime64()
-        elif util.is_timedelta64_object(value):
-            # exclude np.timedelta64("NaT") from value != value below
-            pass
-        elif value is None or value != value:
-            return np.datetime64("NaT", "ns")
-        raise ValueError("cannot set a Timestamp with a non-timestamp "
-                         f"{type(value).__name__}")
-
-    elif arr.descr.type_num == NPY_TIMEDELTA:
-        if util.is_array(value):
-            pass
-        elif isinstance(value, timedelta) or util.is_timedelta64_object(value):
-            value = Timedelta(value)
-            if value is NaT:
-                return np.timedelta64("NaT", "ns")
-            return value.to_timedelta64()
-        elif util.is_datetime64_object(value):
-            # exclude np.datetime64("NaT") which would otherwise be picked up
-            #  by the `value != value check below
-            pass
-        elif value is None or value != value:
-            return np.timedelta64("NaT", "ns")
-        raise ValueError("cannot set a Timedelta with a non-timedelta "
-                         f"{type(value).__name__}")
-
-    else:
-        validate_numeric_casting(arr.dtype, value)
-
-    return value
-
-
 cpdef validate_numeric_casting(dtype, object value):
     # Note: we can't annotate dtype as cnp.dtype because that cases dtype.type
     #  to integer

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -535,19 +535,6 @@ cdef class PeriodEngine(Int64Engine):
         return super(PeriodEngine, self).get_indexer_non_unique(ordinal_array)
 
 
-cpdef validate_numeric_casting(dtype, object value):
-    # Note: we can't annotate dtype as cnp.dtype because that cases dtype.type
-    #  to integer
-    if issubclass(dtype.type, (np.integer, np.bool_)):
-        if util.is_float_object(value) and value != value:
-            raise ValueError("Cannot assign nan to integer series")
-
-    if (issubclass(dtype.type, (np.integer, np.floating, np.complex)) and
-            not issubclass(dtype.type, np.bool_)):
-        if util.is_bool_object(value):
-            raise ValueError("Cannot assign bool to float/integer series")
-
-
 cdef class BaseMultiIndexCodesEngine:
     """
     Base class for MultiIndexUIntEngine and MultiIndexPyIntEngine, which

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -40,7 +40,7 @@ import numpy.ma as ma
 
 from pandas._config import get_option
 
-from pandas._libs import algos as libalgos, index as libindex, lib, properties
+from pandas._libs import algos as libalgos, lib, properties
 from pandas._typing import Axes, Axis, Dtype, FilePathOrBuffer, Label, Level, Renamer
 from pandas.compat import PY37
 from pandas.compat._optional import import_optional_dependency
@@ -69,6 +69,7 @@ from pandas.core.dtypes.cast import (
     maybe_infer_to_datetimelike,
     maybe_upcast,
     maybe_upcast_putmask,
+    validate_numeric_casting,
 )
 from pandas.core.dtypes.common import (
     ensure_float64,
@@ -3025,7 +3026,7 @@ class DataFrame(NDFrame):
             series = self._get_item_cache(col)
             engine = self.index._engine
             loc = engine.get_loc(index)
-            libindex.validate_numeric_casting(series.dtype, value)
+            validate_numeric_casting(series.dtype, value)
 
             series._values[loc] = value
             # Note: trying to use series._set_value breaks tests in

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -18,7 +18,10 @@ from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, Substitution, cache_readonly
 
 from pandas.core.dtypes import concat as _concat
-from pandas.core.dtypes.cast import maybe_cast_to_integer_array
+from pandas.core.dtypes.cast import (
+    maybe_cast_to_integer_array,
+    validate_numeric_casting,
+)
 from pandas.core.dtypes.common import (
     ensure_categorical,
     ensure_int64,
@@ -4653,7 +4656,7 @@ class Index(IndexOpsMixin, PandasObject):
             stacklevel=2,
         )
         loc = self._engine.get_loc(key)
-        libindex.validate_numeric_casting(arr.dtype, value)
+        validate_numeric_casting(arr.dtype, value)
         arr[loc] = value
 
     _index_shared_docs[

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -12,7 +12,6 @@ from pandas._libs.index import validate_numeric_casting
 import pandas._libs.internals as libinternals
 from pandas._libs.tslibs import Timedelta, conversion
 from pandas._libs.tslibs.timezones import tz_compare
-from pandas._typing import DtypeObj
 from pandas.util._validators import validate_bool_kwarg
 
 from pandas.core.dtypes.cast import (
@@ -3208,7 +3207,7 @@ def _putmask_smart(v, mask, n):
     return _putmask_preserve(v, n)
 
 
-def _convert_scalar_for_putitemlike(scalar, dtype: DtypeObj):
+def _convert_scalar_for_putitemlike(scalar, dtype: np.dtype):
     """
     Convert datetimelike scalar if we are setting into a datetime64
     or timedelta64 ndarray.
@@ -3216,7 +3215,7 @@ def _convert_scalar_for_putitemlike(scalar, dtype: DtypeObj):
     Parameters
     ----------
     scalar : scalar
-    dtype : np.dtpye or ExtensionDtype
+    dtype : np.dtpye
 
     Returns
     -------

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 import functools
 import inspect
 import re
@@ -8,7 +8,6 @@ import warnings
 import numpy as np
 
 from pandas._libs import NaT, Timestamp, algos as libalgos, lib, tslib, writers
-from pandas._libs.index import validate_numeric_casting
 import pandas._libs.internals as libinternals
 from pandas._libs.tslibs import Timedelta, conversion
 from pandas._libs.tslibs.timezones import tz_compare
@@ -16,6 +15,7 @@ from pandas.util._validators import validate_bool_kwarg
 
 from pandas.core.dtypes.cast import (
     astype_nansafe,
+    convert_scalar_for_putitemlike,
     find_common_type,
     infer_dtype_from,
     infer_dtype_from_scalar,
@@ -37,7 +37,6 @@ from pandas.core.dtypes.common import (
     is_datetime64tz_dtype,
     is_dtype_equal,
     is_extension_array_dtype,
-    is_float,
     is_float_dtype,
     is_integer,
     is_integer_dtype,
@@ -763,7 +762,7 @@ class Block(PandasObject):
             # The only non-DatetimeLike class that also has a non-trivial
             #  try_coerce_args is ObjectBlock, but that overrides replace,
             #  so does not get here.
-            to_replace = _convert_scalar_for_putitemlike(to_replace, values.dtype)
+            to_replace = convert_scalar_for_putitemlike(to_replace, values.dtype)
 
         mask = missing.mask_missing(values, to_replace)
         if filter is not None:
@@ -842,7 +841,7 @@ class Block(PandasObject):
             # We only get here for non-Extension Blocks, so _try_coerce_args
             #  is only relevant for DatetimeBlock and TimedeltaBlock
             if lib.is_scalar(value):
-                value = _convert_scalar_for_putitemlike(value, values.dtype)
+                value = convert_scalar_for_putitemlike(value, values.dtype)
 
         else:
             # current dtype cannot store value, coerce to common dtype
@@ -958,7 +957,7 @@ class Block(PandasObject):
             # We only get here for non-Extension Blocks, so _try_coerce_args
             #  is only relevant for DatetimeBlock and TimedeltaBlock
             if lib.is_scalar(new):
-                new = _convert_scalar_for_putitemlike(new, new_values.dtype)
+                new = convert_scalar_for_putitemlike(new, new_values.dtype)
 
             if transpose:
                 new_values = new_values.T
@@ -1201,7 +1200,7 @@ class Block(PandasObject):
         values = self.values if inplace else self.values.copy()
 
         # We only get here for non-ExtensionBlock
-        fill_value = _convert_scalar_for_putitemlike(fill_value, self.values.dtype)
+        fill_value = convert_scalar_for_putitemlike(fill_value, self.values.dtype)
 
         values = missing.interpolate_2d(
             values,
@@ -1406,7 +1405,7 @@ class Block(PandasObject):
                     raise TypeError
                 if lib.is_scalar(other) and isinstance(values, np.ndarray):
                     # convert datetime to datetime64, timedelta to timedelta64
-                    other = _convert_scalar_for_putitemlike(other, values.dtype)
+                    other = convert_scalar_for_putitemlike(other, values.dtype)
 
             # By the time we get here, we should have all Series/Index
             #  args extracted to  ndarray
@@ -3215,34 +3214,3 @@ def _putmask_smart(v, mask, n):
         v = v.astype(dtype)
 
     return _putmask_preserve(v, n)
-
-
-def _convert_scalar_for_putitemlike(scalar, dtype: np.dtype):
-    """
-    Convert datetimelike scalar if we are setting into a datetime64
-    or timedelta64 ndarray.
-
-    Parameters
-    ----------
-    scalar : scalar
-    dtype : np.dtpye
-
-    Returns
-    -------
-    scalar
-    """
-    if dtype.kind == "m":
-        if isinstance(scalar, (timedelta, np.timedelta64)):
-            # We have to cast after asm8 in case we have NaT
-            return Timedelta(scalar).asm8.view("timedelta64[ns]")
-        elif scalar is None or scalar is NaT or (is_float(scalar) and np.isnan(scalar)):
-            return np.timedelta64("NaT", "ns")
-    if dtype.kind == "M":
-        if isinstance(scalar, (date, np.datetime64)):
-            # Note: we include date, not just datetime
-            return Timestamp(scalar).to_datetime64()
-        elif scalar is None or scalar is NaT or (is_float(scalar) and np.isnan(scalar)):
-            return np.datetime64("NaT", "ns")
-    else:
-        validate_numeric_casting(dtype, scalar)
-    return scalar

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -23,13 +23,12 @@ import numpy as np
 from pandas._config import get_option
 
 from pandas._libs import lib, properties, reshape, tslibs
-from pandas._libs.index import validate_numeric_casting
 from pandas._typing import Label
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, Substitution
 from pandas.util._validators import validate_bool_kwarg, validate_percentile
 
-from pandas.core.dtypes.cast import convert_dtypes
+from pandas.core.dtypes.cast import convert_dtypes, validate_numeric_casting
 from pandas.core.dtypes.common import (
     _is_unorderable_exception,
     ensure_platform_int,


### PR DESCRIPTION
There's nothing about this that particularly benefits from being in cython (I think until recently this was used within index.pyx) and its clearer in python.  Plus we get a slightly smaller/faster build.