### PR TITLE
CLN: Remove CategoricalAccessor._deprecations

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2504,10 +2504,6 @@ class CategoricalAccessor(PandasDelegate, PandasObject, NoNewAttributesMixin):
     >>> s.cat.as_unordered()
     """
 
-    _deprecations = PandasObject._deprecations | frozenset(
-        ["categorical", "index", "name"]
-    )
-
     def __init__(self, data):
         self._validate(data)
         self._parent = data.values


### PR DESCRIPTION
These deprecated attributes have all been removed, so ``._deprecated`` is no longer needed.