### PR TITLE
BUG: string methods with NA

### DIFF
--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -29,6 +29,10 @@ Bug fixes
 
 - Using ``pd.NA`` with :meth:`DataFrame.to_json` now correctly outputs a null value instead of an empty object (:issue:`31615`)
 
+**Strings**
+
+- Using ``pd.NA`` with :meth:`Series.str.repeat` now correctly outputs a null value instead of raising error for vector inputs (:issue:`31632`)
+
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_102.contributors:

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -778,6 +778,8 @@ def str_repeat(arr, repeats):
     else:
 
         def rep(x, r):
+            if isinstance(x, libmissing.NAType):
+                return x
             try:
                 return bytes.__mul__(x, r)
             except TypeError:

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -778,7 +778,7 @@ def str_repeat(arr, repeats):
     else:
 
         def rep(x, r):
-            if isinstance(x, libmissing.NAType):
+            if x is libmissing.NA:
                 return x
             try:
                 return bytes.__mul__(x, r)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1155,14 +1155,14 @@ class TestStringMethods:
 
     def test_repeat_with_null(self):
         # GH: 31632
-        values = Series(["a", None])
+        values = Series(["a", None], dtype='string')
         result = values.str.repeat([3, 4])
-        exp = Series(["aaa", None])
+        exp = Series(["aaa", None], dtype='string')
         tm.assert_series_equal(result, exp)
 
-        values = Series(["a", "b"])
+        values = Series(["a", "b"], dtype='string')
         result = values.str.repeat([3, None])
-        exp = Series(["aaa", None])
+        exp = Series(["aaa", None], dtype='string')
         tm.assert_series_equal(result, exp)
 
     def test_match(self):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1153,6 +1153,12 @@ class TestStringMethods:
         assert isinstance(rs, Series)
         tm.assert_series_equal(rs, xp)
 
+        # GH: 31632
+        values = Series(["a", None])
+        result = values.str.repeat([3, 4])
+        exp = Series(["aaa", None])
+        tm.assert_series_equal(result, exp)
+
     def test_match(self):
         # New match behavior introduced in 0.13
         values = Series(["fooBAD__barBAD", np.nan, "foo"])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1155,14 +1155,14 @@ class TestStringMethods:
 
     def test_repeat_with_null(self):
         # GH: 31632
-        values = Series(["a", None], dtype='string')
+        values = Series(["a", None], dtype="string")
         result = values.str.repeat([3, 4])
-        exp = Series(["aaa", None], dtype='string')
+        exp = Series(["aaa", None], dtype="string")
         tm.assert_series_equal(result, exp)
 
-        values = Series(["a", "b"], dtype='string')
+        values = Series(["a", "b"], dtype="string")
         result = values.str.repeat([3, None])
-        exp = Series(["aaa", None], dtype='string')
+        exp = Series(["aaa", None], dtype="string")
         tm.assert_series_equal(result, exp)
 
     def test_match(self):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1153,9 +1153,15 @@ class TestStringMethods:
         assert isinstance(rs, Series)
         tm.assert_series_equal(rs, xp)
 
+    def test_repeat_with_null(self):
         # GH: 31632
         values = Series(["a", None])
         result = values.str.repeat([3, 4])
+        exp = Series(["aaa", None])
+        tm.assert_series_equal(result, exp)
+
+        values = Series(["a", "b"])
+        result = values.str.repeat([3, None])
         exp = Series(["aaa", None])
         tm.assert_series_equal(result, exp)
 


### PR DESCRIPTION
- [x] closes #31632 
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

