### PR TITLE
TST: add test for regression in groupby with empty MultiIndex level

### DIFF
--- a/doc/source/whatsnew/v1.0.1.rst
+++ b/doc/source/whatsnew/v1.0.1.rst
@@ -22,6 +22,7 @@ Fixed regressions
 - Fixed regression in ``.groupby()`` aggregations with categorical dtype using Cythonized reduction functions (e.g. ``first``) (:issue:`31450`)
 - Fixed regression in :meth:`GroupBy.apply` if called with a function which returned a non-pandas non-scalar object (e.g. a list or numpy array) (:issue:`31441`)
 - Fixed regression in :meth:`DataFrame.groupby` whereby taking the minimum or maximum of a column with period dtype would raise a ``TypeError``. (:issue:`31471`)
+- Fixed regression in :meth:`DataFrame.groupby` with an empty DataFrame grouping by a level of a MultiIndex (:issue:`31670`).
 - Fixed regression in :meth:`DataFrame.apply` with object dtype and non-reducing function (:issue:`31505`)
 - Fixed regression in :meth:`to_datetime` when parsing non-nanosecond resolution datetimes (:issue:`31491`)
 - Fixed regression in :meth:`~DataFrame.to_csv` where specifying an ``na_rep`` might truncate the values written (:issue:`31447`)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -676,6 +676,19 @@ class TestGrouping:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_groupby_multiindex_level_empty(self):
+        # https://github.com/pandas-dev/pandas/issues/31670
+        df = pd.DataFrame(
+            [[123, "a", 1.0], [123, "b", 2.0]], columns=["id", "category", "value"]
+        )
+        df = df.set_index(["id", "category"])
+        empty = df[df.value < 0]
+        result = empty.groupby("id").sum()
+        expected = pd.DataFrame(
+            dtype="float64", columns=["value"], index=pd.Int64Index([], name="id")
+        )
+        tm.assert_frame_equal(result, expected)
+
 
 # get_group
 # --------------------------------


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/31670 (the actual fix was already in #29243)