### PR TITLE
fix mypy errors in pandas/tests/arithmetic/test_datetime64.py

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, time, timedelta, tzinfo
 import operator
-from typing import Optional
+from typing import Callable, Optional
 import warnings
 
 import numpy as np
@@ -191,6 +191,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
     _data: DatetimeArray
     tz: Optional[tzinfo]
+    tz_localize: Callable[..., "DatetimeIndex"]
 
     # --------------------------------------------------------------------
     # Constructors

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,9 +132,6 @@ check_untyped_defs=False
 [mypy-pandas.conftest]
 ignore_errors=True
 
-[mypy-pandas.tests.arithmetic.test_datetime64]
-ignore_errors=True
-
 [mypy-pandas.tests.indexes.datetimes.test_tools]
 ignore_errors=True
 


### PR DESCRIPTION
Part of #28926
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
