### PR TITLE
fix type errors in pandas/tests/extension/json/array.py

### DIFF
--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -16,7 +16,7 @@ import numbers
 import random
 import string
 import sys
-from typing import Type
+from typing import Any, Mapping, Type
 
 import numpy as np
 
@@ -27,7 +27,7 @@ from pandas.api.extensions import ExtensionArray, ExtensionDtype
 class JSONDtype(ExtensionDtype):
     type = abc.Mapping
     name = "json"
-    na_value = UserDict()
+    na_value: Mapping[str, Any] = UserDict()
 
     @classmethod
     def construct_array_type(cls) -> Type["JSONArray"]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,9 +138,6 @@ ignore_errors=True
 [mypy-pandas.tests.extension.decimal.test_decimal]
 ignore_errors=True
 
-[mypy-pandas.tests.extension.json.array]
-ignore_errors=True
-
 [mypy-pandas.tests.extension.json.test_json]
 ignore_errors=True
 


### PR DESCRIPTION
Part of #28926

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

