### PR TITLE
BUG: Fixed encoding of pd.NA with to_json

### DIFF
--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -25,8 +25,9 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
--
--
+**I/O**
+
+- Using ``pd.NA`` with :meth:`DataFrame.to_json` now correctly outputs a null value instead of an empty object (:issue:`31615`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -25,7 +25,8 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
-**I/O**
+I/O
+^^^
 
 - Using ``pd.NA`` with :meth:`DataFrame.to_json` now correctly outputs a null value instead of an empty object (:issue:`31615`)
 

--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -25,8 +25,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
-I/O
-^^^
+**I/O**
 
 - Using ``pd.NA`` with :meth:`DataFrame.to_json` now correctly outputs a null value instead of an empty object (:issue:`31615`)
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1677,21 +1677,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         result = pd.DataFrame([[pd.NA]]).to_json()
         assert result == '{"0":{"0":null}}'
 
-    def test_json_pandas_na_label(self):
-        # GH 31615
-        result = pd.DataFrame({pd.NA: ["a"]}).to_json()
-        assert result == '{"<NA>":{"0":"a"}}'
-
     def test_json_pandas_nulls(self, nulls_fixture):
         # GH 31615
         result = pd.DataFrame([[nulls_fixture]]).to_json()
         assert result == '{"0":{"0":null}}'
-
-    def test_json_pandas_nulls_labels(self, nulls_fixture):
-        # GH 31615
-        result = pd.DataFrame({nulls_fixture: ["a"]}).to_json()
-        if nulls_fixture is pd.NaT:
-            null_string = "null"
-        else:
-            null_string = str(nulls_fixture)
-        assert result == '{"' + null_string + '":{"0":"a"}}'

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1671,3 +1671,11 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert target_file in (
             obj.key for obj in s3_resource.Bucket("pandas-test").objects.all()
         )
+
+    @pytest.mark.parametrize(
+        "dataframe,expected", [(pd.DataFrame([[pd.NA]]), '{"0":{"0":null}}',)],
+    )
+    def test_json_pandas_na(self, dataframe, expected):
+        # GH 31615
+        result = dataframe.to_json()
+        assert result == expected

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1673,7 +1673,11 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         )
 
     @pytest.mark.parametrize(
-        "dataframe,expected", [(pd.DataFrame([[pd.NA]]), '{"0":{"0":null}}',)],
+        "dataframe,expected",
+        [
+            (pd.DataFrame([[pd.NA]]), '{"0":{"0":null}}',),
+            (pd.DataFrame({pd.NA: ["a"]}), '{"<NA>":{"0":"a"}}',),
+        ],
     )
     def test_json_pandas_na(self, dataframe, expected):
         # GH 31615

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1672,14 +1672,26 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
             obj.key for obj in s3_resource.Bucket("pandas-test").objects.all()
         )
 
-    @pytest.mark.parametrize(
-        "dataframe,expected",
-        [
-            (pd.DataFrame([[pd.NA]]), '{"0":{"0":null}}',),
-            (pd.DataFrame({pd.NA: ["a"]}), '{"<NA>":{"0":"a"}}',),
-        ],
-    )
-    def test_json_pandas_na(self, dataframe, expected):
+    def test_json_pandas_na(self):
         # GH 31615
-        result = dataframe.to_json()
-        assert result == expected
+        result = pd.DataFrame([[pd.NA]]).to_json()
+        assert result == '{"0":{"0":null}}'
+
+    def test_json_pandas_na_label(self):
+        # GH 31615
+        result = pd.DataFrame({pd.NA: ["a"]}).to_json()
+        assert result == '{"<NA>":{"0":"a"}}'
+
+    def test_json_pandas_nulls(self, nulls_fixture):
+        # GH 31615
+        result = pd.DataFrame([[nulls_fixture]]).to_json()
+        assert result == '{"0":{"0":null}}'
+
+    def test_json_pandas_nulls_labels(self, nulls_fixture):
+        # GH 31615
+        result = pd.DataFrame({nulls_fixture: ["a"]}).to_json()
+        if nulls_fixture is pd.NaT:
+            null_string = "null"
+        else:
+            null_string = str(nulls_fixture)
+        assert result == '{"' + null_string + '":{"0":"a"}}'


### PR DESCRIPTION
- [x] closes #31615
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
