### PR TITLE
ERR: improve error message for invalid indexer

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3158,9 +3158,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         # validate iloc
         if kind == "iloc":
-            self._validate_indexer("slice", key.start, "iloc")
-            self._validate_indexer("slice", key.stop, "iloc")
-            self._validate_indexer("slice", key.step, "iloc")
+            self._validate_indexer("positional", key.start, "iloc")
+            self._validate_indexer("positional", key.stop, "iloc")
+            self._validate_indexer("positional", key.step, "iloc")
             return key
 
         # potentially cast the bounds to integers
@@ -3285,8 +3285,8 @@ class Index(IndexOpsMixin, PandasObject):
         Consistent invalid indexer message.
         """
         raise TypeError(
-            f"cannot do {form} indexing on {type(self)} with these "
-            f"indexers [{key}] of {type(key)}"
+            f"cannot do {form} indexing on {type(self).__name__} with these "
+            f"indexers [{key}] of type {type(key).__name__}"
         )
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -406,9 +406,9 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
         is_int = is_integer(key)
         is_flt = is_float(key)
         if kind == "loc" and (is_int or is_flt):
-            self._invalid_indexer("index", key)
+            self._invalid_indexer("label", key)
         elif kind == "getitem" and is_flt:
-            self._invalid_indexer("index", key)
+            self._invalid_indexer("label", key)
 
         return super()._convert_scalar_indexer(key, kind=kind)
 

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1050,9 +1050,8 @@ class TestDataFrameIndexing:
 
         # positional slicing only via iloc!
         msg = (
-            "cannot do slice indexing on "
-            r"<class 'pandas\.core\.indexes\.numeric\.Float64Index'> with "
-            r"these indexers \[1.0\] of <class 'float'>"
+            "cannot do positional indexing on Float64Index with "
+            r"these indexers \[1.0\] of type float"
         )
         with pytest.raises(TypeError, match=msg):
             df.iloc[1.0:5]

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1860,9 +1860,8 @@ class TestDataFrameConstructors:
             # No NaN found -> error
             if len(indexer) == 0:
                 msg = (
-                    "cannot do label indexing on "
-                    r"<class 'pandas\.core\.indexes\.range\.RangeIndex'> "
-                    r"with these indexers \[nan\] of <class 'float'>"
+                    "cannot do label indexing on RangeIndex "
+                    r"with these indexers \[nan\] of type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     df.loc[:, np.nan]

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -83,8 +83,8 @@ class TestCategoricalIndex:
             df.loc["d", "C"] = 10
 
         msg = (
-            r"cannot do label indexing on <class 'pandas\.core\.indexes\.category"
-            r"\.CategoricalIndex'> with these indexers \[1\] of <class 'int'>"
+            "cannot do label indexing on CategoricalIndex with these "
+            r"indexers \[1\] of type int"
         )
         with pytest.raises(TypeError, match=msg):
             df.loc[1]

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -54,7 +54,7 @@ class TestFloatIndexers:
 
         msg = (
             "cannot do positional indexing on {klass} with these "
-            r"indexers \[3\.0\] of {kind}".format(klass=type(i), kind=str(float))
+            r"indexers \[3\.0\] of type float".format(klass=type(i).__name__)
         )
         with pytest.raises(TypeError, match=msg):
             s.iloc[3.0] = 0
@@ -92,11 +92,11 @@ class TestFloatIndexers:
                     else:
                         error = TypeError
                         msg = (
-                            r"cannot do (label|index|positional) indexing "
+                            r"cannot do (label|positional) indexing "
                             r"on {klass} with these indexers \[3\.0\] of "
-                            r"{kind}|"
+                            r"type float|"
                             "Cannot index by location index with a "
-                            "non-integer key".format(klass=type(i), kind=str(float))
+                            "non-integer key".format(klass=type(i).__name__)
                         )
                     with pytest.raises(error, match=msg):
                         idxr(s)[3.0]
@@ -113,9 +113,9 @@ class TestFloatIndexers:
                 else:
                     error = TypeError
                     msg = (
-                        r"cannot do (label|index) indexing "
+                        r"cannot do label indexing "
                         r"on {klass} with these indexers \[3\.0\] of "
-                        r"{kind}".format(klass=type(i), kind=str(float))
+                        r"type float".format(klass=type(i).__name__)
                     )
                 with pytest.raises(error, match=msg):
                     s.loc[3.0]
@@ -125,9 +125,9 @@ class TestFloatIndexers:
 
                 # setting with a float fails with iloc
                 msg = (
-                    r"cannot do (label|index|positional) indexing "
+                    r"cannot do (label|positional) indexing "
                     r"on {klass} with these indexers \[3\.0\] of "
-                    r"{kind}".format(klass=type(i), kind=str(float))
+                    r"type float".format(klass=type(i).__name__)
                 )
                 with pytest.raises(TypeError, match=msg):
                     s.iloc[3.0] = 0
@@ -162,9 +162,9 @@ class TestFloatIndexers:
             s = Series(np.arange(len(i)), index=i)
             s[3]
             msg = (
-                r"cannot do (label|index) indexing "
+                r"cannot do label indexing "
                 r"on {klass} with these indexers \[3\.0\] of "
-                r"{kind}".format(klass=type(i), kind=str(float))
+                r"type float".format(klass=type(i).__name__)
             )
             with pytest.raises(TypeError, match=msg):
                 s[3.0]
@@ -181,9 +181,9 @@ class TestFloatIndexers:
             msg = (
                 r"cannot do label indexing "
                 r"on {klass} with these indexers \[1\.0\] of "
-                r"{kind}|"
+                r"type float|"
                 "Cannot index by location index with a non-integer key".format(
-                    klass=str(Index), kind=str(float)
+                    klass=Index.__name__
                 )
             )
             with pytest.raises(TypeError, match=msg):
@@ -203,7 +203,7 @@ class TestFloatIndexers:
             msg = (
                 r"cannot do label indexing "
                 r"on {klass} with these indexers \[1\.0\] of "
-                r"{kind}".format(klass=str(Index), kind=str(float))
+                r"type float".format(klass=Index.__name__)
             )
             with pytest.raises(TypeError, match=msg):
                 idxr(s3)[1.0]
@@ -317,7 +317,7 @@ class TestFloatIndexers:
             msg = (
                 r"cannot do positional indexing "
                 r"on {klass} with these indexers \[3\.0\] of "
-                r"{kind}".format(klass=str(Float64Index), kind=str(float))
+                r"type float".format(klass=Float64Index.__name__)
             )
             with pytest.raises(TypeError, match=msg):
                 s2.iloc[3.0] = 0
@@ -346,9 +346,9 @@ class TestFloatIndexers:
                 for l in [slice(3.0, 4), slice(3, 4.0), slice(3.0, 4.0)]:
 
                     msg = (
-                        "cannot do slice indexing "
+                        "cannot do positional indexing "
                         r"on {klass} with these indexers \[(3|4)\.0\] of "
-                        "{kind}".format(klass=type(index), kind=str(float))
+                        "type float".format(klass=type(index).__name__)
                     )
                     with pytest.raises(TypeError, match=msg):
                         s.iloc[l]
@@ -356,14 +356,10 @@ class TestFloatIndexers:
                     for idxr in [lambda x: x.loc, lambda x: x.iloc, lambda x: x]:
 
                         msg = (
-                            "cannot do slice indexing "
+                            "cannot do (slice|positional) indexing "
                             r"on {klass} with these indexers "
                             r"\[(3|4)(\.0)?\] "
-                            r"of ({kind_float}|{kind_int})".format(
-                                klass=type(index),
-                                kind_float=str(float),
-                                kind_int=str(int),
-                            )
+                            r"of type (float|int)".format(klass=type(index).__name__)
                         )
                         with pytest.raises(TypeError, match=msg):
                             idxr(s)[l]
@@ -372,23 +368,19 @@ class TestFloatIndexers:
                 for l in [slice(3.0, 4), slice(3, 4.0), slice(3.0, 4.0)]:
 
                     msg = (
-                        "cannot do slice indexing "
+                        "cannot do positional indexing "
                         r"on {klass} with these indexers \[(3|4)\.0\] of "
-                        "{kind}".format(klass=type(index), kind=str(float))
+                        "type float".format(klass=type(index).__name__)
                     )
                     with pytest.raises(TypeError, match=msg):
                         s.iloc[l] = 0
 
                     for idxr in [lambda x: x.loc, lambda x: x.iloc, lambda x: x]:
                         msg = (
-                            "cannot do slice indexing "
+                            "cannot do (slice|positional) indexing "
                             r"on {klass} with these indexers "
                             r"\[(3|4)(\.0)?\] "
-                            r"of ({kind_float}|{kind_int})".format(
-                                klass=type(index),
-                                kind_float=str(float),
-                                kind_int=str(int),
-                            )
+                            r"of type (float|int)".format(klass=type(index).__name__)
                         )
                         with pytest.raises(TypeError, match=msg):
                             idxr(s)[l] = 0
@@ -428,7 +420,7 @@ class TestFloatIndexers:
                 msg = (
                     "cannot do slice indexing "
                     r"on {klass} with these indexers \[(3|4)\.0\] of "
-                    "{kind}".format(klass=type(index), kind=str(float))
+                    "type float".format(klass=type(index).__name__)
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -452,7 +444,7 @@ class TestFloatIndexers:
             msg = (
                 "cannot do slice indexing "
                 r"on {klass} with these indexers \[-6\.0\] of "
-                "{kind}".format(klass=type(index), kind=str(float))
+                "type float".format(klass=type(index).__name__)
             )
             with pytest.raises(TypeError, match=msg):
                 s[slice(-6.0, 6.0)]
@@ -478,7 +470,7 @@ class TestFloatIndexers:
                 msg = (
                     "cannot do slice indexing "
                     r"on {klass} with these indexers \[(2|3)\.5\] of "
-                    "{kind}".format(klass=type(index), kind=str(float))
+                    "type float".format(klass=type(index).__name__)
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -496,7 +488,7 @@ class TestFloatIndexers:
                 msg = (
                     "cannot do slice indexing "
                     r"on {klass} with these indexers \[(3|4)\.0\] of "
-                    "{kind}".format(klass=type(index), kind=str(float))
+                    "type float".format(klass=type(index).__name__)
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l] = 0
@@ -517,9 +509,9 @@ class TestFloatIndexers:
 
                 klass = RangeIndex
                 msg = (
-                    "cannot do slice indexing "
+                    "cannot do (slice|positional) indexing "
                     r"on {klass} with these indexers \[(2|4)\.0\] of "
-                    "{kind}".format(klass=str(klass), kind=str(float))
+                    "type float".format(klass=klass.__name__)
                 )
                 with pytest.raises(TypeError, match=msg):
                     idxr(s)[l]
@@ -544,7 +536,7 @@ class TestFloatIndexers:
                     msg = (
                         "cannot do slice indexing "
                         r"on {klass} with these indexers \[(0|1)\.0\] of "
-                        "{kind}".format(klass=type(index), kind=str(float))
+                        "type float".format(klass=type(index).__name__)
                     )
                     with pytest.raises(TypeError, match=msg):
                         s[l]
@@ -559,7 +551,7 @@ class TestFloatIndexers:
                 msg = (
                     "cannot do slice indexing "
                     r"on {klass} with these indexers \[-10\.0\] of "
-                    "{kind}".format(klass=type(index), kind=str(float))
+                    "type float".format(klass=type(index).__name__)
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[slice(-10.0, 10.0)]
@@ -578,7 +570,7 @@ class TestFloatIndexers:
                     msg = (
                         "cannot do slice indexing "
                         r"on {klass} with these indexers \[0\.5\] of "
-                        "{kind}".format(klass=type(index), kind=str(float))
+                        "type float".format(klass=type(index).__name__)
                     )
                     with pytest.raises(TypeError, match=msg):
                         s[l]
@@ -595,7 +587,7 @@ class TestFloatIndexers:
                     msg = (
                         "cannot do slice indexing "
                         r"on {klass} with these indexers \[(3|4)\.0\] of "
-                        "{kind}".format(klass=type(index), kind=str(float))
+                        "type float".format(klass=type(index).__name__)
                     )
                     with pytest.raises(TypeError, match=msg):
                         s[l] = 0

--- a/pandas/tests/indexing/test_scalar.py
+++ b/pandas/tests/indexing/test_scalar.py
@@ -140,8 +140,8 @@ class TestScalar2:
         assert result == 1
 
         msg = (
-            "cannot do label indexing on <class 'pandas.core.indexes.base.Index'> "
-            r"with these indexers \[0\] of <class 'int'>"
+            "cannot do label indexing on Index "
+            r"with these indexers \[0\] of type int"
         )
         with pytest.raises(TypeError, match=msg):
             ser.at[0]
@@ -157,8 +157,8 @@ class TestScalar2:
         assert result == 1
 
         msg = (
-            "cannot do label indexing on <class 'pandas.core.indexes.base.Index'> "
-            r"with these indexers \[0\] of <class 'int'>"
+            "cannot do label indexing on Index "
+            r"with these indexers \[0\] of type int"
         )
         with pytest.raises(TypeError, match=msg):
             df.at["a", 0]

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -128,9 +128,8 @@ def test_setitem_float_labels():
 
 def test_slice_float_get_set(datetime_series):
     msg = (
-        r"cannot do slice indexing on <class 'pandas\.core\.indexes"
-        r"\.datetimes\.DatetimeIndex'> with these indexers \[{key}\] "
-        r"of <class 'float'>"
+        "cannot do slice indexing on DatetimeIndex with these indexers "
+        r"\[{key}\] of type float"
     )
     with pytest.raises(TypeError, match=msg.format(key=r"4\.0")):
         datetime_series[4.0:10.0]


### PR DESCRIPTION
Convert the long repr of the Index into just the name. So something like

```
cannot do slice indexing on <class 'pandas.core.indexes.datetimes.DatetimeIndex'> with these indexers [key] of <class 'float'>
```

becomes

```
cannot do slice indexing on DatetimeIndex with these indexers [key] of type float"
```