### PR TITLE
REF: remove iloc case from _convert_slice_indexer

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3147,9 +3147,9 @@ class Index(IndexOpsMixin, PandasObject):
         For positional indexing, a slice must have either int or None
         for each of start, stop, and step.
         """
-        self._validate_indexer("slice", key.start, "iloc")
-        self._validate_indexer("slice", key.stop, "iloc")
-        self._validate_indexer("slice", key.step, "iloc")
+        self._validate_indexer("positional", key.start, "iloc")
+        self._validate_indexer("positional", key.stop, "iloc")
+        self._validate_indexer("positional", key.step, "iloc")
 
     def _convert_slice_indexer(self, key: slice, kind=None):
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3142,6 +3142,15 @@ class Index(IndexOpsMixin, PandasObject):
 
         return key
 
+    def _validate_positional_slice(self, key: slice):
+        """
+        For positional indexing, a slice must have either int or None
+        for each of start, stop, and step.
+        """
+        self._validate_indexer("slice", key.start, "iloc")
+        self._validate_indexer("slice", key.stop, "iloc")
+        self._validate_indexer("slice", key.step, "iloc")
+
     def _convert_slice_indexer(self, key: slice, kind=None):
         """
         Convert a slice indexer.
@@ -3152,16 +3161,9 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         key : label of the slice bound
-        kind : {'loc', 'getitem', 'iloc'} or None
+        kind : {'loc', 'getitem'} or None
         """
-        assert kind in ["loc", "getitem", "iloc", None]
-
-        # validate iloc
-        if kind == "iloc":
-            self._validate_indexer("slice", key.start, "iloc")
-            self._validate_indexer("slice", key.stop, "iloc")
-            self._validate_indexer("slice", key.step, "iloc")
-            return key
+        assert kind in ["loc", "getitem", None], kind
 
         # potentially cast the bounds to integers
         start, stop, step = key.start, key.stop, key.step

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -394,10 +394,9 @@ class Float64Index(NumericIndex):
 
     @Appender(Index._convert_slice_indexer.__doc__)
     def _convert_slice_indexer(self, key: slice, kind=None):
+        assert kind in ["loc", "getitem", None]
 
-        if kind == "iloc":
-            return super()._convert_slice_indexer(key, kind=kind)
-
+        # We always treat __getitem__ slicing as label-based
         # translate to locations
         return self.slice_indexer(key.start, key.stop, key.step, kind=kind)
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1752,7 +1752,7 @@ class _LocIndexer(_LocationIndexer):
 
         labels = obj._get_axis(axis)
         indexer = labels.slice_indexer(
-            slice_obj.start, slice_obj.stop, slice_obj.step, kind=self.name
+            slice_obj.start, slice_obj.stop, slice_obj.step, kind="loc"
         )
 
         if isinstance(indexer, slice):
@@ -2019,8 +2019,8 @@ class _iLocIndexer(_LocationIndexer):
             return obj.copy(deep=False)
 
         labels = obj._get_axis(axis)
-        indexer = labels._convert_slice_indexer(slice_obj, kind="iloc")
-        return self.obj._slice(indexer, axis=axis, kind="iloc")
+        labels._validate_positional_slice(slice_obj)
+        return self.obj._slice(slice_obj, axis=axis, kind="iloc")
 
     def _convert_to_indexer(self, key, axis: int, is_setter: bool = False):
         """
@@ -2030,7 +2030,8 @@ class _iLocIndexer(_LocationIndexer):
 
         # make need to convert a float key
         if isinstance(key, slice):
-            return labels._convert_slice_indexer(key, kind="iloc")
+            labels._validate_positional_slice(key)
+            return key
 
         elif is_float(key):
             labels._validate_indexer("positional", key, "iloc")

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -842,7 +842,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def _slice(self, slobj: slice, axis: int = 0, kind: str = "getitem") -> "Series":
         assert kind in ["getitem", "iloc"]
-        slobj = self.index._convert_slice_indexer(slobj, kind=kind)
+        if kind == "getitem":
+            # If called from getitem, we need to determine whether
+            #  this slice is positional or label-based.
+            slobj = self.index._convert_slice_indexer(slobj, kind="getitem")
         return self._get_values(slobj)
 
     def __getitem__(self, key):
@@ -884,7 +887,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def _get_with(self, key):
         # other: fancy integer or otherwise
         if isinstance(key, slice):
-            return self._slice(key)
+            return self._slice(key, kind="getitem")
         elif isinstance(key, ABCDataFrame):
             raise TypeError(
                 "Indexing a Series with DataFrame is not "


### PR DESCRIPTION
_convert_slice_indexer is turning out to be one of the stickier methods to figure out, xref #31658.

The case with kind=None is only called from one place in core.indexing, and that is not reached in the tests.  I'd like to either a) figure out a non-None kind to pass to it, or b) determine that it can never be reached so can be removed.  Any thoughts on this are very welcome.