### PR TITLE
BUG: Too aggressive typing in NDFrame.align

### DIFF
--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -16,6 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed regression in :meth:`DataFrame.to_excel` when ``columns`` kwarg is passed (:issue:`31677`)
+- Fixed regression in :meth:`Series.align` when ``other`` is a DataFrame and ``method`` is not None (:issue:`31785`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8360,9 +8360,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             left = self._ensure_type(
                 left.fillna(method=method, axis=fill_axis, limit=limit)
             )
-            right = self._ensure_type(
-                right.fillna(method=method, axis=fill_axis, limit=limit)
-            )
+            right = right.fillna(method=method, axis=fill_axis, limit=limit)
 
         # if DatetimeIndex have different tz, convert to UTC
         if is_datetime64tz_dtype(left.index):

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -153,6 +153,17 @@ def test_align_multiindex():
     tm.assert_series_equal(expr, res2l)
 
 
+@pytest.mark.parametrize("method", ["backfill", "bfill", "pad", "ffill", None])
+def test_align_method(method):
+    # GH31788
+    ser = pd.Series(range(3), index=range(3))
+    df = pd.DataFrame(0.0, index=range(3), columns=range(3))
+
+    result_ser, result_df = ser.align(df, method=method)
+    tm.assert_series_equal(result_ser, ser)
+    tm.assert_frame_equal(result_df, df)
+
+
 def test_reindex(datetime_series, string_series):
     identity = string_series.reindex(string_series.index)
 


### PR DESCRIPTION
- [x] closes #31785

The type checking was too aggressive. ``right`` has type ``Any``, so the wrapping in ``_ensure_type`` should not be done.