### PR TITLE
TST: Making use of tm.external_error_raised

### DIFF
--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -298,7 +298,7 @@ class TestBlock:
 
         newb = self.fblock.copy()
 
-        with pytest.raises(IndexError, match=None):
+        with tm.external_error_raised(IndexError):
             newb.delete(3)
 
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

After #31130 got merged, I can do what I couldn't do [here](https://github.com/pandas-dev/pandas/pull/30998#discussion_r368177775)

