### PR TITLE
CLN: assorted indexing-related cleanups

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2938,7 +2938,7 @@ class DataFrame(NDFrame):
         #  operates on labels and we need to operate positional for
         #  backwards-compat, xref GH#31469
         self._check_setitem_copy()
-        self.iloc[key] = value
+        self.iloc._setitem_with_indexer(key, value)
 
     def _setitem_array(self, key, value):
         # also raises Exception if object array with NA values
@@ -2950,7 +2950,7 @@ class DataFrame(NDFrame):
             key = check_bool_indexer(self.index, key)
             indexer = key.nonzero()[0]
             self._check_setitem_copy()
-            self.iloc[indexer] = value
+            self.iloc._setitem_with_indexer(indexer, value)
         else:
             if isinstance(value, DataFrame):
                 if len(value.columns) != len(key):
@@ -2962,7 +2962,7 @@ class DataFrame(NDFrame):
                     key, axis=1, raise_missing=False
                 )[1]
                 self._check_setitem_copy()
-                self.iloc[:, indexer] = value
+                self.iloc._setitem_with_indexer((slice(None), indexer), value)
 
     def _setitem_frame(self, key, value):
         # support boolean setting with DataFrame input, e.g.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2933,12 +2933,12 @@ class DataFrame(NDFrame):
             # set column
             self._set_item(key, value)
 
-    def _setitem_slice(self, key, value):
+    def _setitem_slice(self, key: slice, value):
         # NB: we can't just use self.loc[key] = value because that
         #  operates on labels and we need to operate positional for
         #  backwards-compat, xref GH#31469
         self._check_setitem_copy()
-        self.loc._setitem_with_indexer(key, value)
+        self.iloc[key] = value
 
     def _setitem_array(self, key, value):
         # also raises Exception if object array with NA values
@@ -2950,7 +2950,7 @@ class DataFrame(NDFrame):
             key = check_bool_indexer(self.index, key)
             indexer = key.nonzero()[0]
             self._check_setitem_copy()
-            self.loc._setitem_with_indexer(indexer, value)
+            self.iloc[indexer] = value
         else:
             if isinstance(value, DataFrame):
                 if len(value.columns) != len(key):
@@ -2962,7 +2962,7 @@ class DataFrame(NDFrame):
                     key, axis=1, raise_missing=False
                 )[1]
                 self._check_setitem_copy()
-                self.loc._setitem_with_indexer((slice(None), indexer), value)
+                self.iloc[:, indexer] = value
 
     def _setitem_frame(self, key, value):
         # support boolean setting with DataFrame input, e.g.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3190,17 +3190,16 @@ class Index(IndexOpsMixin, PandasObject):
         # convert the slice to an indexer here
 
         # if we are mixed and have integers
-        try:
-            if is_positional and self.is_mixed():
+        if is_positional and self.is_mixed():
+            try:
                 # Validate start & stop
                 if start is not None:
                     self.get_loc(start)
                 if stop is not None:
                     self.get_loc(stop)
                 is_positional = False
-        except KeyError:
-            if self.inferred_type in ["mixed-integer-float", "integer-na"]:
-                raise
+            except KeyError:
+                pass
 
         if is_null_slicer:
             indexer = key

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -792,7 +792,7 @@ class _LocationIndexer(_NDFrameIndexerBase):
                                     "defined index and a scalar"
                                 )
                             self.obj[key] = value
-                            return self.obj
+                            return
 
                         # add a new item with the dtype setup
                         self.obj[key] = _infer_fill_value(value)
@@ -802,7 +802,7 @@ class _LocationIndexer(_NDFrameIndexerBase):
                         )
                         self._setitem_with_indexer(new_indexer, value)
 
-                        return self.obj
+                        return
 
                     # reindex the axis
                     # make sure to clear the cache because we are
@@ -825,7 +825,8 @@ class _LocationIndexer(_NDFrameIndexerBase):
             indexer, missing = convert_missing_indexer(indexer)
 
             if missing:
-                return self._setitem_with_indexer_missing(indexer, value)
+                self._setitem_with_indexer_missing(indexer, value)
+                return
 
         # set
         item_labels = self.obj._get_axis(info_axis)
@@ -1051,7 +1052,6 @@ class _LocationIndexer(_NDFrameIndexerBase):
                 new_values, index=new_index, name=self.obj.name
             )._data
             self.obj._maybe_update_cacher(clear=True)
-            return self.obj
 
         elif self.ndim == 2:
 
@@ -1075,7 +1075,6 @@ class _LocationIndexer(_NDFrameIndexerBase):
 
             self.obj._data = self.obj.append(value)._data
             self.obj._maybe_update_cacher(clear=True)
-            return self.obj
 
     def _align_series(self, indexer, ser: ABCSeries, multiindex_indexer: bool = False):
         """

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -26,8 +26,7 @@ from pandas.core.indexers import (
     is_list_like_indexer,
     length_of_indexer,
 )
-from pandas.core.indexes.api import Index
-from pandas.core.indexes.base import InvalidIndexError
+from pandas.core.indexes.api import Index, InvalidIndexError
 
 # "null slice"
 _NS = slice(None, None)
@@ -592,6 +591,9 @@ class _LocationIndexer(_NDFrameIndexerBase):
         return self.obj._xs(label, axis=axis)
 
     def _get_setitem_indexer(self, key):
+        """
+        Convert a potentially-label-based key into a positional indexer.
+        """
         if self.axis is not None:
             return self._convert_tuple(key, is_setter=True)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -862,7 +862,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
                 return result
             except InvalidIndexError:
-                pass
+                if not isinstance(self.index, MultiIndex):
+                    raise
+
             except (KeyError, ValueError):
                 if isinstance(key, tuple) and isinstance(self.index, MultiIndex):
                     # kludge


### PR DESCRIPTION
- _setitem_with_indexer isnt consistent about whether or not it returns anything, make it always-None
- avoid using private loc method from DataFrame
