### PR TITLE
ENH: add 'origin' and 'offset' arguments to 'resample' and 'pd.Grouper'

### DIFF
--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1572,18 +1572,15 @@ end of the interval is closed:
 
    ts.resample('5Min', closed='left').mean()
 
-Parameters like ``label`` and ``loffset`` are used to manipulate the resulting
-labels. ``label`` specifies whether the result is labeled with the beginning or
-the end of the interval. ``loffset`` performs a time adjustment on the output
-labels.
+Parameters like ``label`` are used to manipulate the resulting labels.
+``label`` specifies whether the result is labeled with the beginning or
+the end of the interval.
 
 .. ipython:: python
 
    ts.resample('5Min').mean()  # by default label='left'
 
    ts.resample('5Min', label='left').mean()
-
-   ts.resample('5Min', label='left', loffset='1s').mean()
 
 .. warning::
 

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1809,8 +1809,8 @@ Here we can see that, when using ``origin`` with its default value (``'start_day
 
 .. ipython:: python
 
-    ts.resample('17min').sum()
-    ts[middle:end].resample('17min').sum()
+    ts.resample('17min', origin='start_day').sum()
+    ts[middle:end].resample('17min', origin='start_day').sum()
 
 
 Here we can see that, when setting ``origin`` to ``'epoch'``, the result after ``'2000-10-02 00:00:00'`` are identical depending on the start of time series:

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1793,7 +1793,7 @@ Use `origin` or `offset` to adjust the start of the bins
 
 .. versionadded:: 1.1.0
 
-The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). This can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can specify a fixed timestamp with the argument ``origin``.
+The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divide a day evenly (like `90s` or `1min`). This can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can specify a fixed timestamp with the argument ``origin``.
 
 For example:
 

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1786,6 +1786,48 @@ natural and functions similarly to :py:func:`itertools.groupby`:
 
 See :ref:`groupby.iterating-label` or :class:`Resampler.__iter__` for more.
 
+.. _timeseries.adjust-the-start-of-the-bins:
+
+Use `origin` or `offset` to adjust the start of the bins
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). But it can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can specify a fixed timestamp with the argument ``origin``.
+
+For example:
+
+.. ipython:: python
+
+    start, end = "1/10/2000 02:00:00", "1/20/2000 02:00"
+    middle = "1/15/2000 02:00"
+    rng = pd.date_range(start, end, freq="1231min")
+    ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
+    ts
+
+Here we can see that, when not using ``origin``, the result after 1/15/2000 are not identical depending on the start of time series:
+
+.. ipython:: python
+
+    ts.resample("2711min").sum()
+    ts[middle:end].resample("2711min").sum()
+
+
+Here we can see that, when using ``origin``, the result after 1/15/2000 are identical depending on the start of time series:
+
+.. ipython:: python
+
+   origin = pd.Timestamp("1970-01-01")
+   ts.resample("2711min", origin=origin).sum()
+   ts[middle:end].resample("2711min", origin=origin).sum()
+
+
+If needed we can just adjust the bins with an offset that would be added to the default ``origin``.
+Those two examples are equivalent for this time series:
+
+.. ipython:: python
+
+    ts.resample("2711min", origin="1/10/2000 02:00:00").sum()
+    ts.resample("2711min", offset="2h").sum()
+
 
 .. _timeseries.periods:
 

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1820,7 +1820,7 @@ Here we can see that, when using ``origin``, the result after 1/15/2000 are iden
    ts[middle:end].resample("2711min", origin=origin).sum()
 
 
-If needed we can just adjust the bins with an offset that would be added to the default ``origin``.
+If needed you can just adjust the bins with an offset that would be added to the default ``origin``.
 Those two examples are equivalent for this time series:
 
 .. ipython:: python

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1791,7 +1791,9 @@ See :ref:`groupby.iterating-label` or :class:`Resampler.__iter__` for more.
 Use `origin` or `offset` to adjust the start of the bins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). But it can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can specify a fixed timestamp with the argument ``origin``.
+.. versionadded:: 1.1.0
+
+The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). This can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can specify a fixed timestamp with the argument ``origin``.
 
 For example:
 
@@ -1820,7 +1822,7 @@ Here we can see that, when using ``origin``, the result after 1/15/2000 are iden
    ts[middle:end].resample("2711min", origin=origin).sum()
 
 
-If needed you can just adjust the bins with an offset that would be added to the default ``origin``.
+If needed you can just adjust the bins with an ``offset`` that would be added to the default ``origin``.
 Those two examples are equivalent for this time series:
 
 .. ipython:: python

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1793,42 +1793,42 @@ Use `origin` or `offset` to adjust the start of the bins
 
 .. versionadded:: 1.1.0
 
-The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divide a day evenly (like `90s` or `1min`). This can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can specify a fixed timestamp with the argument ``origin``.
+The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divide a day evenly (like `90s` or `1min`). This can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can specify a fixed Timestamp with the argument ``origin``.
 
 For example:
 
 .. ipython:: python
 
-    start, end = "1/10/2000 02:00:00", "1/20/2000 02:00"
-    middle = "1/15/2000 02:00"
-    rng = pd.date_range(start, end, freq="1231min")
+    start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"
+    middle = "2000-10-02 00:00:00"
+    rng = pd.date_range(start, end, freq="7min")
     ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
     ts
 
-Here we can see that, when not using ``origin``, the result after 1/15/2000 are not identical depending on the start of time series:
+Here we can see that, when not using ``origin``, the result after "2000-10-02 00:00:00" are not identical depending on the start of time series:
 
 .. ipython:: python
 
-    ts.resample("2711min").sum()
-    ts[middle:end].resample("2711min").sum()
+    ts.resample("17min").sum()
+    ts[middle:end].resample("17min").sum()
 
 
-Here we can see that, when using ``origin``, the result after 1/15/2000 are identical depending on the start of time series:
+Here we can see that, when using ``origin``, the result after "2000-10-02 00:00:00" are identical depending on the start of time series:
 
 .. ipython:: python
 
    origin = pd.Timestamp("1970-01-01")
-   ts.resample("2711min", origin=origin).sum()
-   ts[middle:end].resample("2711min", origin=origin).sum()
+   ts.resample("17min", origin=origin).sum()
+   ts[middle:end].resample("17min", origin=origin).sum()
 
 
-If needed you can just adjust the bins with an ``offset`` that would be added to the default ``origin``.
+If needed you can just adjust the bins with an ``offset`` Timedelta that would be added to the default ``origin``.
 Those two examples are equivalent for this time series:
 
 .. ipython:: python
 
-    ts.resample("2711min", origin="1/10/2000 02:00:00").sum()
-    ts.resample("2711min", offset="2h").sum()
+    ts.resample("17min", origin=start).sum()
+    ts.resample("17min", offset=pd.Timedelta("23h30min")).sum()
 
 
 .. _timeseries.periods:

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1799,37 +1799,45 @@ For example:
 
 .. ipython:: python
 
-    start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"
-    middle = "2000-10-02 00:00:00"
-    rng = pd.date_range(start, end, freq="7min")
+    start, end = '2000-10-01 23:30:00', '2000-10-02 00:30:00'
+    middle = '2000-10-02 00:00:00'
+    rng = pd.date_range(start, end, freq='7min')
     ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
     ts
 
-Here we can see that, when not using ``origin``, the result after "2000-10-02 00:00:00" are not identical depending on the start of time series:
+Here we can see that, when using ``origin`` with its default value (``'start_day'``), the result after ``'2000-10-02 00:00:00'`` are not identical depending on the start of time series:
 
 .. ipython:: python
 
-    ts.resample("17min").sum()
-    ts[middle:end].resample("17min").sum()
+    ts.resample('17min').sum()
+    ts[middle:end].resample('17min').sum()
 
 
-Here we can see that, when using ``origin``, the result after "2000-10-02 00:00:00" are identical depending on the start of time series:
+Here we can see that, when setting ``origin`` to ``'epoch'``, the result after ``'2000-10-02 00:00:00'`` are identical depending on the start of time series:
 
 .. ipython:: python
 
-   origin = pd.Timestamp("1970-01-01")
-   ts.resample("17min", origin=origin).sum()
-   ts[middle:end].resample("17min", origin=origin).sum()
+   ts.resample('17min', origin='epoch').sum()
+   ts[middle:end].resample('17min', origin='epoch').sum()
 
+
+If needed you can use a custom timestamp for ``origin``:
+
+.. ipython:: python
+
+   ts.resample('17min', origin='2001-01-01').sum()
+   ts[middle:end].resample('17min', origin=pd.Timestamp('2001-01-01')).sum()
 
 If needed you can just adjust the bins with an ``offset`` Timedelta that would be added to the default ``origin``.
 Those two examples are equivalent for this time series:
 
 .. ipython:: python
 
-    ts.resample("17min", origin=start).sum()
-    ts.resample("17min", offset=pd.Timedelta("23h30min")).sum()
+    ts.resample('17min', origin='start').sum()
+    ts.resample('17min', offset='23h30min').sum()
 
+
+Note the use of ``'start'`` for ``origin`` on the last example. In that case, ``origin`` will be set to the first value of the timeseries.
 
 .. _timeseries.periods:
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -161,7 +161,12 @@ Grouper and resample now supports the arguments origin and offset
 
 The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). But it can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can now specify a fixed timestamp with the argument ``origin``.
 
-For example:
+Two arguments are now deprecated (more information in the documentation of :class:`DataFrame.resample`):
+
+- ``base`` should be replaced by ``offset``.
+- ``loffset`` should be replaced by directly adding an offset to the index DataFrame after being resampled.
+
+Small example of the use of ``origin``:
 
 .. ipython:: python
 
@@ -185,38 +190,10 @@ Resample using a fixed origin:
     ts.resample('17min', origin='epoch').sum()
     ts.resample('17min', origin='2000-01-01').sum()
 
+If needed you can adjust the bins with the argument ``offset`` (a Timedelta) that would be added to the default ``origin``.
+
 For a full example, see: :ref:`timeseries.adjust-the-start-of-the-bins`.
 
-If needed you can just adjust the bins with an offset that would be added to the default ``origin``.
-Those two examples are equivalent for this time series:
-
-.. ipython:: python
-
-    ts.resample('17min', origin='start').sum()
-    ts.resample('17min', offset='23h30min').sum()
-
-The argument ``base`` is now deprecated in favor of ``offset``. (:issue:`31809`)
-
-.. ipython:: python
-    :okwarning:
-
-    ts.resample('17min', base=2).sum()
-
-becomes:
-
-.. ipython:: python
-
-    ts.resample('17min', offset='2min').sum()
-
-The argument ``loffset`` is now deprecated. You should now add an offset to the index DataFrame after being resampled. (:issue:`31809`)
-
-.. ipython:: python
-
-    from pandas.tseries.frequencies import to_offset
-    loffset = '19min'
-    ts_out = ts.resample('17min').sum()
-    ts_out.index = ts_out.index + to_offset(loffset)
-    ts_out
 
 .. _whatsnew_110.enhancements.other:
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -157,7 +157,7 @@ For example:
 Grouper and resample now supports the arguments origin and offset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:class:`Grouper` and :class:`DataFrame.resample` now supports the argument ``origin``. The timestamp on which to adjust the grouping. (:issue:`31809`)
+:class:`Grouper` and :class:`DataFrame.resample` now supports the arguments ``origin`` and ``offset``. It let the user control the timestamp on which to adjust the grouping. (:issue:`31809`)
 
 The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). But it can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can now specify a fixed timestamp with the argument ``origin``.
 
@@ -165,23 +165,25 @@ For example:
 
 .. ipython:: python
 
-    start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"
-    middle = "2000-10-02 00:00:00"
-    rng = pd.date_range(start, end, freq="7min")
+    start, end = '2000-10-01 23:30:00', '2000-10-02 00:30:00'
+    middle = '2000-10-02 00:00:00'
+    rng = pd.date_range(start, end, freq='7min')
     ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
     ts
 
-Resample with the default behavior (origin is 2000-10-01 00:00:00):
+Resample with the default behavior 'start_day' (origin is 2000-10-01 00:00:00):
 
 .. ipython:: python
 
-    ts.resample("17min").sum()
+    ts.resample('17min').sum()
+    ts.resample('17min', origin='start_day').sum()
 
 Resample using a fixed origin:
 
 .. ipython:: python
 
-    ts.resample("17min", origin="1970-01-01").sum()
+    ts.resample('17min', origin='epoch').sum()
+    ts.resample('17min', origin='2000-01-01').sum()
 
 For a full example, see: :ref:`timeseries.adjust-the-start-of-the-bins`.
 
@@ -190,29 +192,29 @@ Those two examples are equivalent for this time series:
 
 .. ipython:: python
 
-    ts.resample("17min", origin=start).sum()
-    ts.resample("17min", offset=pd.Timedelta("23h30min")).sum()
+    ts.resample('17min', origin='start').sum()
+    ts.resample('17min', offset='23h30min').sum()
 
 The argument ``base`` is now deprecated in favor of ``offset``. (:issue:`31809`)
 
 .. ipython:: python
     :okwarning:
 
-    ts.resample("17min", base=2).sum()
+    ts.resample('17min', base=2).sum()
 
 becomes:
 
 .. ipython:: python
 
-    ts.resample("17min", offset="2min").sum()
+    ts.resample('17min', offset='2min').sum()
 
 The argument ``loffset`` is now deprecated. You should now add an offset to the index DataFrame after being resampled. (:issue:`31809`)
 
 .. ipython:: python
 
     from pandas.tseries.frequencies import to_offset
-    loffset = "19min"
-    ts_out = ts.resample("17min").sum()
+    loffset = '19min'
+    ts_out = ts.resample('17min').sum()
     ts_out.index = ts_out.index + to_offset(loffset)
     ts_out
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -176,7 +176,7 @@ Small example of the use of ``origin``:
     ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
     ts
 
-Resample with the default behavior 'start_day' (origin is 2000-10-01 00:00:00):
+Resample with the default behavior ``'start_day'`` (origin is ``2000-10-01 00:00:00``):
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -191,7 +191,7 @@ The argument ``base`` is now deprecated in favor of ``offset``. (:issue:`31809`)
     #   becomes:
     ts.resample("2711min", offset="2min").sum()
 
-The argument ``loffset`` is now deprecated. (:issue:`31809`)
+The argument ``loffset`` is now deprecated. You should now add an offset to the index DataFrame after being resampled. (:issue:`31809`)
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -157,7 +157,7 @@ For example:
 Grouper and resample now supports the arguments origin and offset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:class:`Grouper` and :class:`DataFrame.resample` now supports the argument `origin`. The timestamp on which to adjust the grouping. (:issue:`31809`)
+:class:`Grouper` and :class:`DataFrame.resample` now supports the argument ``origin``. The timestamp on which to adjust the grouping. (:issue:`31809`)
 
 The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). But it can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can now specify a fixed timestamp with the argument ``origin``.
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -152,6 +152,55 @@ For example:
     pd.to_datetime(tz_strs, format='%Y-%m-%d %H:%M:%S %z', utc=True)
     pd.to_datetime(tz_strs, format='%Y-%m-%d %H:%M:%S %z')
 
+.. _whatsnew_110.grouper_resample_origin:
+
+Grouper and resample now supports the arguments origin and offset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:class:`Grouper` and :class:`DataFrame.resample` now supports the argument `origin`. The timestamp on which to adjust the grouping. (:issue:`31809`)
+
+The bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). But it can create inconsistencies with some frequencies that do not meet this criteria. To change this behavior you can now specify a fixed timestamp with the argument ``origin``.
+
+For example:
+
+.. ipython:: python
+
+    start, end = "1/10/2000 02:00:00", "1/20/2000 02:00"
+    middle = "1/15/2000 02:00"
+    rng = pd.date_range(start, end, freq="1231min")
+    ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
+    ts
+    ts.resample("2711min").sum()
+    ts.resample("2711min", origin="1970-01-01").sum()
+
+For a full example, see: :ref:`timeseries.adjust-the-start-of-the-bins`.
+
+If needed you can just adjust the bins with an offset that would be added to the default ``origin``.
+Those two examples are equivalent for this time series:
+
+.. ipython:: python
+
+    ts.resample("2711min", origin="1/10/2000 02:00:00").sum()
+    ts.resample("2711min", offset="2h").sum()
+
+The argument ``base`` is now deprecated in favor of ``offset``. (:issue:`31809`)
+
+.. ipython:: python
+
+    # ts.resample("2711min", base=2).sum()
+    #   becomes:
+    ts.resample("2711min", offset="2min").sum()
+
+The argument ``loffset`` is now deprecated. (:issue:`31809`)
+
+.. ipython:: python
+
+    from pandas.tseries.frequencies import to_offset
+    loffset = "8H"
+    ts_out = ts.resample("2711min").sum()
+    ts_out.index = ts_out.index + to_offset(loffset)
+    ts_out
+
 .. _whatsnew_110.enhancements.other:
 
 Other enhancements

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -165,13 +165,23 @@ For example:
 
 .. ipython:: python
 
-    start, end = "1/10/2000 02:00:00", "1/20/2000 02:00"
-    middle = "1/15/2000 02:00"
-    rng = pd.date_range(start, end, freq="1231min")
+    start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"
+    middle = "2000-10-02 00:00:00"
+    rng = pd.date_range(start, end, freq="7min")
     ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
     ts
-    ts.resample("2711min").sum()
-    ts.resample("2711min", origin="1970-01-01").sum()
+
+Resample with the default behavior (origin is 2000-10-01 00:00:00):
+
+.. ipython:: python
+
+    ts.resample("17min").sum()
+
+Resample using a fixed origin:
+
+.. ipython:: python
+
+    ts.resample("17min", origin="1970-01-01").sum()
 
 For a full example, see: :ref:`timeseries.adjust-the-start-of-the-bins`.
 
@@ -180,24 +190,29 @@ Those two examples are equivalent for this time series:
 
 .. ipython:: python
 
-    ts.resample("2711min", origin="1/10/2000 02:00:00").sum()
-    ts.resample("2711min", offset="2h").sum()
+    ts.resample("17min", origin=start).sum()
+    ts.resample("17min", offset=pd.Timedelta("23h30min")).sum()
 
 The argument ``base`` is now deprecated in favor of ``offset``. (:issue:`31809`)
 
 .. ipython:: python
+    :okwarning:
 
-    # ts.resample("2711min", base=2).sum()
-    #   becomes:
-    ts.resample("2711min", offset="2min").sum()
+    ts.resample("17min", base=2).sum()
+
+becomes:
+
+.. ipython:: python
+
+    ts.resample("17min", offset="2min").sum()
 
 The argument ``loffset`` is now deprecated. You should now add an offset to the index DataFrame after being resampled. (:issue:`31809`)
 
 .. ipython:: python
 
     from pandas.tseries.frequencies import to_offset
-    loffset = "8H"
-    ts_out = ts.resample("2711min").sum()
+    loffset = "19min"
+    ts_out = ts.resample("17min").sum()
     ts_out.index = ts_out.index + to_offset(loffset)
     ts_out
 

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import (
     IO,
@@ -42,6 +43,15 @@ PythonScalar = Union[str, int, float, bool]
 DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", "Period", "Timestamp", "Timedelta")
 PandasScalar = Union["Period", "Timestamp", "Timedelta", "Interval"]
 Scalar = Union[PythonScalar, PandasScalar]
+
+# timestamp and timedelta compatible types
+
+TimestampCompatibleTypes = Union[
+    "Timestamp", datetime, np.datetime64, int, np.int64, float, str
+]
+TimedeltaCompatibleTypes = Union[
+    "Timedelta", timedelta, np.timedelta64, int, np.int64, float, str
+]
 
 # other
 

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -44,12 +44,12 @@ DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", "Period", "Timestamp", "Timed
 PandasScalar = Union["Period", "Timestamp", "Timedelta", "Interval"]
 Scalar = Union[PythonScalar, PandasScalar]
 
-# timestamp and timedelta compatible types
+# timestamp and timedelta convertible types
 
-TimestampCompatibleTypes = Union[
+TimestampConvertibleTypes = Union[
     "Timestamp", datetime, np.datetime64, int, np.int64, float, str
 ]
-TimedeltaCompatibleTypes = Union[
+TimedeltaConvertibleTypes = Union[
     "Timedelta", timedelta, np.timedelta64, int, np.int64, float, str
 ]
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7820,10 +7820,14 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         level : str or int, optional
             For a MultiIndex, level (name or number) to use for
             resampling. `level` must be datetime-like.
-        origin : Timestamp, str or datetime-like, default None
-            The timestamp on which to adjust the grouping. It must be timezone
-            aware if the index of the resampled data is. If None is passed, the
-            first day of the time series at midnight is used.
+        origin : {'epoch', 'start', 'start_day'}, Timestamp or str, default 'start_day'
+            The timestamp on which to adjust the grouping. It must be timezone aware if
+            the index of the resampled data is.
+            If a timestamp is not used, these values are also supported:
+
+            - 'epoch': `origin` is 1970-01-01
+            - 'start': `origin` is the first value of the timeseries
+            - 'start_day': `origin` is the first day at midnight of the timeseries
 
             .. versionadded:: 1.1.0
 
@@ -8051,8 +8055,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         If you want to adjust the start of the bins based on a fixed timestamp:
 
-        >>> start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"
-        >>> rng = pd.date_range(start, end, freq="7min")
+        >>> start, end = '2000-10-01 23:30:00', '2000-10-02 00:30:00'
+        >>> rng = pd.date_range(start, end, freq='7min')
         >>> ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
         >>> ts
         2000-10-01 23:30:00     0
@@ -8066,7 +8070,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-10-02 00:26:00    24
         Freq: 7T, dtype: int64
 
-        >>> ts.resample("17min").sum()
+        >>> ts.resample('17min').sum()
         2000-10-01 23:14:00     0
         2000-10-01 23:31:00     9
         2000-10-01 23:48:00    21
@@ -8074,7 +8078,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-10-02 00:22:00    24
         Freq: 17T, dtype: int64
 
-        >>> ts.resample("17min", origin=pd.Timestamp("1970-01-01")).sum()
+        >>> ts.resample('17min', origin='epoch').sum()
         2000-10-01 23:18:00     0
         2000-10-01 23:35:00    18
         2000-10-01 23:52:00    27
@@ -8082,17 +8086,24 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-10-02 00:26:00    24
         Freq: 17T, dtype: int64
 
+        >>> ts.resample('17min', origin='2000-01-01').sum()
+        2000-10-01 23:24:00     3
+        2000-10-01 23:41:00    15
+        2000-10-01 23:58:00    45
+        2000-10-02 00:15:00    45
+        Freq: 17T, dtype: int64
+
         If you want to adjust the start of the bins with an `offset` Timedelta, the two
         following lines are equivalent:
 
-        >>> ts.resample("17min", origin=start).sum()
+        >>> ts.resample('17min', origin='start').sum()
         2000-10-01 23:30:00     9
         2000-10-01 23:47:00    21
         2000-10-02 00:04:00    54
         2000-10-02 00:21:00    24
         Freq: 17T, dtype: int64
 
-        >>> ts.resample("17min", offset=pd.Timedelta("23h30min")).sum()
+        >>> ts.resample('17min', offset='23h30min').sum()
         2000-10-01 23:30:00     9
         2000-10-01 23:47:00    21
         2000-10-02 00:04:00    54
@@ -8101,7 +8112,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         To replace the use of the deprecated `base` argument, you can now use `offset`,
         in this example it is equivalent to have `base=2`:
-        >>> ts.resample("17min", offset="2min").sum()
+
+        >>> ts.resample('17min', offset='2min').sum()
         2000-10-01 23:16:00     0
         2000-10-01 23:33:00     9
         2000-10-01 23:50:00    36
@@ -8112,8 +8124,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         To replace the use of the deprecated `loffset` argument:
 
         >>> from pandas.tseries.frequencies import to_offset
-        >>> loffset = "19min"
-        >>> ts_out = ts.resample("17min").sum()
+        >>> loffset = '19min'
+        >>> ts_out = ts.resample('17min').sum()
         >>> ts_out.index = ts_out.index + to_offset(loffset)
         >>> ts_out
         2000-10-01 23:33:00     0

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7821,8 +7821,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             For a MultiIndex, level (name or number) to use for
             resampling. `level` must be datetime-like.
         origin : {'epoch', 'start', 'start_day'}, Timestamp or str, default 'start_day'
-            The timestamp on which to adjust the grouping. It must be timezone aware if
-            the index of the resampled data is.
+            The timestamp on which to adjust the grouping. The timezone of origin
+            must match the timezone of the index.
             If a timestamp is not used, these values are also supported:
 
             - 'epoch': `origin` is 1970-01-01

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8122,9 +8122,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Freq: 17T, dtype: int64
         """
         from pandas.core.resample import get_resampler
-        from pandas.core.resample import _validate_resample_deprecated_args
-
-        _validate_resample_deprecated_args(offset=offset, base=base, loffset=loffset)
 
         axis = self._get_axis_number(axis)
         return get_resampler(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -39,8 +39,8 @@ from pandas._typing import (
     Label,
     Level,
     Renamer,
-    TimedeltaCompatibleTypes,
-    TimestampCompatibleTypes,
+    TimedeltaConvertibleTypes,
+    TimestampConvertibleTypes,
     ValueKeyFunc,
 )
 from pandas.compat import set_function_name
@@ -7765,8 +7765,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         base: Optional[int] = None,
         on=None,
         level=None,
-        origin: Union[str, TimestampCompatibleTypes] = "start_day",
-        offset: Optional[TimedeltaCompatibleTypes] = None,
+        origin: Union[str, TimestampConvertibleTypes] = "start_day",
+        offset: Optional[TimedeltaConvertibleTypes] = None,
     ) -> "Resampler":
         """
         Resample time-series data.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7802,9 +7802,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
             .. deprecated:: 1.1.0
                 You should add the loffset to the `df.index` after the resample.
-                like this:
-                ``df.index = df.index.to_timestamp() + to_offset(loffset)``
-                (a more complete example is present below)
+                See below.
 
         base : int, default 0
             For frequencies that evenly subdivide 1 day, the "origin" of the
@@ -7813,9 +7811,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
             .. deprecated:: 1.1.0
                 The new arguments that you should use are 'offset' or 'origin'.
-                ``df.resample(freq="3s", base=2)``
-                becomes
-                ``df.resample(freq="3s", offset="2s")``
 
         on : str, optional
             For a DataFrame, column to use instead of index for resampling.
@@ -8052,12 +8047,87 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-01-03     32     150
         2000-01-04     36      90
 
-        To replace the use of the deprecated loffset argument:
+        If you want to adjust the start of the bins based on a fixed timestamp:
+
+        >>> start, end = "1/10/2000 02:00:00", "1/20/2000 02:00"
+        >>> rng = pd.date_range(start, end, freq="1231min")
+        >>> ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
+        >>> ts
+        2000-01-10 02:00:00     0
+        2000-01-10 22:31:00     3
+        2000-01-11 19:02:00     6
+        2000-01-12 15:33:00     9
+        2000-01-13 12:04:00    12
+        2000-01-14 08:35:00    15
+        2000-01-15 05:06:00    18
+        2000-01-16 01:37:00    21
+        2000-01-16 22:08:00    24
+        2000-01-17 18:39:00    27
+        2000-01-18 15:10:00    30
+        2000-01-19 11:41:00    33
+        Freq: 1231T, dtype: int64
+        >>> ts.resample("2711min").sum()
+        2000-01-10 00:00:00     9
+        2000-01-11 21:11:00    21
+        2000-01-13 18:22:00    33
+        2000-01-15 15:33:00    45
+        2000-01-17 12:44:00    57
+        2000-01-19 09:55:00    33
+        Freq: 2711T, dtype: int64
+        >>> ts.resample("2711min", origin=pd.Timestamp("1970-01-01")).sum()
+        2000-01-08 11:44:00     0
+        2000-01-10 08:55:00     9
+        2000-01-12 06:06:00    21
+        2000-01-14 03:17:00    33
+        2000-01-16 00:28:00    72
+        2000-01-17 21:39:00    63
+        Freq: 2711T, dtype: int64
+
+        If you want to adjust the start of the bins with an offset, the two following
+        lines are equivalent:
+
+        >>> ts.resample("2711min", origin="1/10/2000 02:00:00").sum()
+        2000-01-10 02:00:00     9
+        2000-01-11 23:11:00    21
+        2000-01-13 20:22:00    33
+        2000-01-15 17:33:00    45
+        2000-01-17 14:44:00    90
+        Freq: 2711T, dtype: int64
+        >>> ts.resample("2711min", offset="2h").sum()
+        2000-01-10 02:00:00     9
+        2000-01-11 23:11:00    21
+        2000-01-13 20:22:00    33
+        2000-01-15 17:33:00    45
+        2000-01-17 14:44:00    90
+        Freq: 2711T, dtype: int64
+
+        To replace the use of the deprecated `base` argument:
+
+        >>> # ts.resample("2711min", base=2).sum()
+        >>> #   becomes:
+        >>> ts.resample("2711min", offset="2min").sum()
+        2000-01-10 00:02:00     9
+        2000-01-11 21:13:00    21
+        2000-01-13 18:24:00    33
+        2000-01-15 15:35:00    45
+        2000-01-17 12:46:00    57
+        2000-01-19 09:57:00    33
+        Freq: 2711T, dtype: int64
+
+        To replace the use of the deprecated `loffset` argument:
+
         >>> from pandas.tseries.frequencies import to_offset
-        >>> rng = pd.date_range("2000-01-01", "2000-01-01", freq="1s")
-        >>> ts = pd.Series(np.arange(len(rng)), index=rng)
-        >>> s = s.resample("3s").mean()
-        >>> s.index = s.index.to_timestamp() + to_offset("8H")
+        >>> loffset = "8H"
+        >>> ts_out = ts.resample("2711min").sum()
+        >>> ts_out.index = ts_out.index + to_offset(loffset)
+        >>> ts_out
+        2000-01-10 08:00:00     9
+        2000-01-12 05:11:00    21
+        2000-01-14 02:22:00    33
+        2000-01-15 23:33:00    45
+        2000-01-17 20:44:00    57
+        2000-01-19 17:55:00    33
+        Freq: 2711T, dtype: int64
         """
         from pandas.core.resample import get_resampler
         from pandas.core.resample import _validate_resample_deprecated_args

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7824,10 +7824,16 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             For a MultiIndex, level (name or number) to use for
             resampling. `level` must be datetime-like.
         origin : pd.Timestamp, default None
-            The timestamp on which to adjust the grouping. If None is passed,
-            the first day of the time series at midnight is used.
+            The timestamp on which to adjust the grouping. It must be timezone
+            aware if the index of the resampled data is. If None is passed, the
+            first day of the time series at midnight is used.
+
+            .. versionadded:: 1.1.0
+
         offset : pd.Timedelta, default is None
             An offset timedelta added to the origin.
+
+            .. versionadded:: 1.1.0
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7765,7 +7765,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         base: Optional[int] = None,
         on=None,
         level=None,
-        origin: Optional[TimestampCompatibleTypes] = None,
+        origin: Union[str, TimestampCompatibleTypes] = "start_day",
         offset: Optional[TimedeltaCompatibleTypes] = None,
     ) -> "Resampler":
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8066,6 +8066,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-01-18 15:10:00    30
         2000-01-19 11:41:00    33
         Freq: 1231T, dtype: int64
+
         >>> ts.resample("2711min").sum()
         2000-01-10 00:00:00     9
         2000-01-11 21:11:00    21
@@ -8074,6 +8075,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-01-17 12:44:00    57
         2000-01-19 09:55:00    33
         Freq: 2711T, dtype: int64
+
         >>> ts.resample("2711min", origin=pd.Timestamp("1970-01-01")).sum()
         2000-01-08 11:44:00     0
         2000-01-10 08:55:00     9
@@ -8093,6 +8095,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-01-15 17:33:00    45
         2000-01-17 14:44:00    90
         Freq: 2711T, dtype: int64
+
         >>> ts.resample("2711min", offset="2h").sum()
         2000-01-10 02:00:00     9
         2000-01-11 23:11:00    21

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8054,6 +8054,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         >>> s.index = s.index.to_timestamp() + to_offset("8H")
         """
         from pandas.core.resample import get_resampler
+        from pandas.core.resample import _validate_resample_deprecated_args
+
+        _validate_resample_deprecated_args(offset=offset, base=base, loffset=loffset)
 
         axis = self._get_axis_number(axis)
         return get_resampler(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8049,88 +8049,77 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         If you want to adjust the start of the bins based on a fixed timestamp:
 
-        >>> start, end = "1/10/2000 02:00:00", "1/20/2000 02:00"
-        >>> rng = pd.date_range(start, end, freq="1231min")
+        >>> start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"
+        >>> rng = pd.date_range(start, end, freq="7min")
         >>> ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
         >>> ts
-        2000-01-10 02:00:00     0
-        2000-01-10 22:31:00     3
-        2000-01-11 19:02:00     6
-        2000-01-12 15:33:00     9
-        2000-01-13 12:04:00    12
-        2000-01-14 08:35:00    15
-        2000-01-15 05:06:00    18
-        2000-01-16 01:37:00    21
-        2000-01-16 22:08:00    24
-        2000-01-17 18:39:00    27
-        2000-01-18 15:10:00    30
-        2000-01-19 11:41:00    33
-        Freq: 1231T, dtype: int64
+        2000-10-01 23:30:00     0
+        2000-10-01 23:37:00     3
+        2000-10-01 23:44:00     6
+        2000-10-01 23:51:00     9
+        2000-10-01 23:58:00    12
+        2000-10-02 00:05:00    15
+        2000-10-02 00:12:00    18
+        2000-10-02 00:19:00    21
+        2000-10-02 00:26:00    24
+        Freq: 7T, dtype: int64
 
-        >>> ts.resample("2711min").sum()
-        2000-01-10 00:00:00     9
-        2000-01-11 21:11:00    21
-        2000-01-13 18:22:00    33
-        2000-01-15 15:33:00    45
-        2000-01-17 12:44:00    57
-        2000-01-19 09:55:00    33
-        Freq: 2711T, dtype: int64
+        >>> ts.resample("17min").sum()
+        2000-10-01 23:14:00     0
+        2000-10-01 23:31:00     9
+        2000-10-01 23:48:00    21
+        2000-10-02 00:05:00    54
+        2000-10-02 00:22:00    24
+        Freq: 17T, dtype: int64
 
-        >>> ts.resample("2711min", origin=pd.Timestamp("1970-01-01")).sum()
-        2000-01-08 11:44:00     0
-        2000-01-10 08:55:00     9
-        2000-01-12 06:06:00    21
-        2000-01-14 03:17:00    33
-        2000-01-16 00:28:00    72
-        2000-01-17 21:39:00    63
-        Freq: 2711T, dtype: int64
+        >>> ts.resample("17min", origin=pd.Timestamp("1970-01-01")).sum()
+        2000-10-01 23:18:00     0
+        2000-10-01 23:35:00    18
+        2000-10-01 23:52:00    27
+        2000-10-02 00:09:00    39
+        2000-10-02 00:26:00    24
+        Freq: 17T, dtype: int64
 
-        If you want to adjust the start of the bins with an offset, the two following
-        lines are equivalent:
+        If you want to adjust the start of the bins with an `offset` Timedelta, the two
+        following lines are equivalent:
 
-        >>> ts.resample("2711min", origin="1/10/2000 02:00:00").sum()
-        2000-01-10 02:00:00     9
-        2000-01-11 23:11:00    21
-        2000-01-13 20:22:00    33
-        2000-01-15 17:33:00    45
-        2000-01-17 14:44:00    90
-        Freq: 2711T, dtype: int64
+        >>> ts.resample("17min", origin=start).sum()
+        2000-10-01 23:30:00     9
+        2000-10-01 23:47:00    21
+        2000-10-02 00:04:00    54
+        2000-10-02 00:21:00    24
+        Freq: 17T, dtype: int64
 
-        >>> ts.resample("2711min", offset="2h").sum()
-        2000-01-10 02:00:00     9
-        2000-01-11 23:11:00    21
-        2000-01-13 20:22:00    33
-        2000-01-15 17:33:00    45
-        2000-01-17 14:44:00    90
-        Freq: 2711T, dtype: int64
+        >>> ts.resample("17min", offset=pd.Timedelta("23h30min")).sum()
+        2000-10-01 23:30:00     9
+        2000-10-01 23:47:00    21
+        2000-10-02 00:04:00    54
+        2000-10-02 00:21:00    24
+        Freq: 17T, dtype: int64
 
-        To replace the use of the deprecated `base` argument:
-
-        >>> # ts.resample("2711min", base=2).sum()
-        >>> #   becomes:
-        >>> ts.resample("2711min", offset="2min").sum()
-        2000-01-10 00:02:00     9
-        2000-01-11 21:13:00    21
-        2000-01-13 18:24:00    33
-        2000-01-15 15:35:00    45
-        2000-01-17 12:46:00    57
-        2000-01-19 09:57:00    33
-        Freq: 2711T, dtype: int64
+        To replace the use of the deprecated `base` argument, you can now use `offset`,
+        in this example it is equivalent to have `base=2`:
+        >>> ts.resample("17min", offset="2min").sum()
+        2000-10-01 23:16:00     0
+        2000-10-01 23:33:00     9
+        2000-10-01 23:50:00    36
+        2000-10-02 00:07:00    39
+        2000-10-02 00:24:00    24
+        Freq: 17T, dtype: int64
 
         To replace the use of the deprecated `loffset` argument:
 
         >>> from pandas.tseries.frequencies import to_offset
-        >>> loffset = "8H"
-        >>> ts_out = ts.resample("2711min").sum()
+        >>> loffset = "19min"
+        >>> ts_out = ts.resample("17min").sum()
         >>> ts_out.index = ts_out.index + to_offset(loffset)
         >>> ts_out
-        2000-01-10 08:00:00     9
-        2000-01-12 05:11:00    21
-        2000-01-14 02:22:00    33
-        2000-01-15 23:33:00    45
-        2000-01-17 20:44:00    57
-        2000-01-19 17:55:00    33
-        Freq: 2711T, dtype: int64
+        2000-10-01 23:33:00     0
+        2000-10-01 23:50:00     9
+        2000-10-02 00:07:00    21
+        2000-10-02 00:24:00    54
+        2000-10-02 00:41:00    24
+        Freq: 17T, dtype: int64
         """
         from pandas.core.resample import get_resampler
         from pandas.core.resample import _validate_resample_deprecated_args

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -39,6 +39,8 @@ from pandas._typing import (
     Label,
     Level,
     Renamer,
+    TimedeltaCompatibleTypes,
+    TimestampCompatibleTypes,
     ValueKeyFunc,
 )
 from pandas.compat import set_function_name
@@ -7763,8 +7765,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         base: Optional[int] = None,
         on=None,
         level=None,
-        origin: pd.Timestamp = None,
-        offset=None,
+        origin: Optional[TimestampCompatibleTypes] = None,
+        offset: Optional[TimedeltaCompatibleTypes] = None,
     ) -> "Resampler":
         """
         Resample time-series data.
@@ -7818,14 +7820,14 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         level : str or int, optional
             For a MultiIndex, level (name or number) to use for
             resampling. `level` must be datetime-like.
-        origin : pd.Timestamp, default None
+        origin : Timestamp, str or datetime-like, default None
             The timestamp on which to adjust the grouping. It must be timezone
             aware if the index of the resampled data is. If None is passed, the
             first day of the time series at midnight is used.
 
             .. versionadded:: 1.1.0
 
-        offset : pd.Timedelta, default is None
+        offset : Timedelta or str, default is None
             An offset timedelta added to the origin.
 
             .. versionadded:: 1.1.0

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7763,7 +7763,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         base: Optional[int] = None,
         on=None,
         level=None,
-        origin=None,
+        origin: pd.Timestamp = None,
         offset=None,
     ) -> "Resampler":
         """

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1648,9 +1648,6 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         5   2000-01-01 00:03:00  5  1
         """
         from pandas.core.resample import get_resampler_for_grouping
-        from pandas.core.resample import _validate_resample_deprecated_args
-
-        _validate_resample_deprecated_args(**kwargs)
 
         return get_resampler_for_grouping(self, rule, *args, **kwargs)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1657,6 +1657,9 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         5   2000-01-01 00:00:20  5  1
         """
         from pandas.core.resample import get_resampler_for_grouping
+        from pandas.core.resample import _validate_resample_deprecated_args
+
+        _validate_resample_deprecated_args(**kwargs)
 
         return get_resampler_for_grouping(self, rule, *args, **kwargs)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1646,15 +1646,6 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         0   2000-01-01 00:00:00  0  1
             2000-01-01 00:03:00  0  2
         5   2000-01-01 00:03:00  5  1
-
-        Add an offset of twenty seconds.
-
-        >>> df.groupby('a').resample('3T', loffset='20s').sum()
-                               a  b
-        a
-        0   2000-01-01 00:00:20  0  2
-            2000-01-01 00:03:20  0  1
-        5   2000-01-01 00:00:20  5  1
         """
         from pandas.core.resample import get_resampler_for_grouping
         from pandas.core.resample import _validate_resample_deprecated_args

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -84,8 +84,8 @@ class Grouper:
             See: :class:`DataFrame.resample`
 
     origin : pd.Timestamp, default None
-        The timestamp on which to adjust the grouping. It must be timezone
-        aware if the index of the resampled data is. If None is passed, the
+        The timestamp on which to adjust the grouping. The timezone of the
+        timestamp must match the timezone of the index. If None is passed, the
         first day of the time series at midnight is used.
 
         .. versionadded:: 1.1.0

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -67,8 +67,31 @@ class Grouper:
         If grouper is PeriodIndex and `freq` parameter is passed.
     base : int, default 0
         Only when `freq` parameter is passed.
+        For frequencies that evenly subdivide 1 day, the "origin" of the
+        aggregated intervals. For example, for '5min' frequency, base could
+        range from 0 through 4. Defaults to 0.
+
+        .. deprecated:: 1.1.0
+            The new arguments that you should use are 'offset' or 'origin'.
+            ``df.resample(freq="3s", base=2)``
+            becomes
+            ``df.resample(freq="3s", offset="2s")``
+
     loffset : str, DateOffset, timedelta object
         Only when `freq` parameter is passed.
+
+        .. deprecated:: 1.1.0
+            loffset is only working for ``.resample(...)`` and not for
+            Grouper (:issue:`28302`).
+            However, loffset is also deprecated for ``.resample(...)``
+            See: :class:`DataFrame.resample`
+
+    origin : Timestamp, default None
+        Only when `freq` parameter is passed.
+        The timestamp on which to adjust the grouping. If None is passed, the
+        first day of the time series at midnight is used.
+    offset : pd.Timedelta, default is None
+        An offset timedelta added to the origin.
 
     Returns
     -------

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -84,8 +84,8 @@ class Grouper:
             See: :class:`DataFrame.resample`
 
     origin : {'epoch', 'start', 'start_day'}, Timestamp or str, default 'start_day'
-        The timestamp on which to adjust the grouping. It must be timezone aware if
-        the index of the resampled data is.
+        The timestamp on which to adjust the grouping. The timezone of origin must
+        match the timezone of the index.
         If a timestamp is not used, these values are also supported:
 
         - 'epoch': `origin` is 1970-01-01

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -168,6 +168,7 @@ class Grouper:
     2000-01-18 15:10:00    30
     2000-01-19 11:41:00    33
     Freq: 1231T, dtype: int64
+
     >>> ts.groupby(pd.Grouper(freq="2711min")).sum()
     2000-01-10 00:00:00     9
     2000-01-11 21:11:00    21
@@ -176,6 +177,7 @@ class Grouper:
     2000-01-17 12:44:00    57
     2000-01-19 09:55:00    33
     Freq: 2711T, dtype: int64
+
     >>> ts.groupby(pd.Grouper(freq="2711min", origin=pd.Timestamp("1970-01-01"))).sum()
     2000-01-08 11:44:00     0
     2000-01-10 08:55:00     9
@@ -195,6 +197,7 @@ class Grouper:
     2000-01-15 17:33:00    45
     2000-01-17 14:44:00    90
     Freq: 2711T, dtype: int64
+
     >>> ts.groupby(pd.Grouper(freq="2711min", offset="2h")).sum()
     2000-01-10 02:00:00     9
     2000-01-11 23:11:00    21

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -151,72 +151,63 @@ class Grouper:
 
     If you want to adjust the start of the bins based on a fixed timestamp:
 
-    >>> start, end = "1/10/2000 02:00:00", "1/20/2000 02:00"
-    >>> rng = pd.date_range(start, end, freq="1231min")
+    >>> start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"
+    >>> rng = pd.date_range(start, end, freq="7min")
     >>> ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
     >>> ts
-    2000-01-10 02:00:00     0
-    2000-01-10 22:31:00     3
-    2000-01-11 19:02:00     6
-    2000-01-12 15:33:00     9
-    2000-01-13 12:04:00    12
-    2000-01-14 08:35:00    15
-    2000-01-15 05:06:00    18
-    2000-01-16 01:37:00    21
-    2000-01-16 22:08:00    24
-    2000-01-17 18:39:00    27
-    2000-01-18 15:10:00    30
-    2000-01-19 11:41:00    33
-    Freq: 1231T, dtype: int64
+    2000-10-01 23:30:00     0
+    2000-10-01 23:37:00     3
+    2000-10-01 23:44:00     6
+    2000-10-01 23:51:00     9
+    2000-10-01 23:58:00    12
+    2000-10-02 00:05:00    15
+    2000-10-02 00:12:00    18
+    2000-10-02 00:19:00    21
+    2000-10-02 00:26:00    24
+    Freq: 7T, dtype: int64
 
-    >>> ts.groupby(pd.Grouper(freq="2711min")).sum()
-    2000-01-10 00:00:00     9
-    2000-01-11 21:11:00    21
-    2000-01-13 18:22:00    33
-    2000-01-15 15:33:00    45
-    2000-01-17 12:44:00    57
-    2000-01-19 09:55:00    33
-    Freq: 2711T, dtype: int64
+    >>> ts.groupby(pd.Grouper(freq="17min")).sum()
+    2000-10-01 23:14:00     0
+    2000-10-01 23:31:00     9
+    2000-10-01 23:48:00    21
+    2000-10-02 00:05:00    54
+    2000-10-02 00:22:00    24
+    Freq: 17T, dtype: int64
 
-    >>> ts.groupby(pd.Grouper(freq="2711min", origin=pd.Timestamp("1970-01-01"))).sum()
-    2000-01-08 11:44:00     0
-    2000-01-10 08:55:00     9
-    2000-01-12 06:06:00    21
-    2000-01-14 03:17:00    33
-    2000-01-16 00:28:00    72
-    2000-01-17 21:39:00    63
-    Freq: 2711T, dtype: int64
+    >>> ts.groupby(pd.Grouper(freq="17min", origin=pd.Timestamp("1970-01-01"))).sum()
+    2000-10-01 23:18:00     0
+    2000-10-01 23:35:00    18
+    2000-10-01 23:52:00    27
+    2000-10-02 00:09:00    39
+    2000-10-02 00:26:00    24
+    Freq: 17T, dtype: int64
 
-    If you want to adjust the start of the bins with an offset, the two following
-    lines are equivalent:
+    If you want to adjust the start of the bins with an `offset` Timedelta, the two
+    following lines are equivalent:
 
-    >>> ts.groupby(pd.Grouper(freq="2711min", origin="1/10/2000 02:00:00")).sum()
-    2000-01-10 02:00:00     9
-    2000-01-11 23:11:00    21
-    2000-01-13 20:22:00    33
-    2000-01-15 17:33:00    45
-    2000-01-17 14:44:00    90
-    Freq: 2711T, dtype: int64
+    >>> ts.groupby(pd.Grouper(freq="17min", origin=start)).sum()
+    2000-10-01 23:30:00     9
+    2000-10-01 23:47:00    21
+    2000-10-02 00:04:00    54
+    2000-10-02 00:21:00    24
+    Freq: 17T, dtype: int64
 
-    >>> ts.groupby(pd.Grouper(freq="2711min", offset="2h")).sum()
-    2000-01-10 02:00:00     9
-    2000-01-11 23:11:00    21
-    2000-01-13 20:22:00    33
-    2000-01-15 17:33:00    45
-    2000-01-17 14:44:00    90
-    Freq: 2711T, dtype: int64
+    >>> ts.groupby(pd.Grouper(freq="17min", offset=pd.Timedelta("23h30min"))).sum()
+    2000-10-01 23:30:00     9
+    2000-10-01 23:47:00    21
+    2000-10-02 00:04:00    54
+    2000-10-02 00:21:00    24
+    Freq: 17T, dtype: int64
 
-    To replace the use of the deprecated `base` argument:
-    >>> # ts.groupby(pd.Grouper(freq="2711min", base=2)).sum()
-    >>> #   becomes:
-    >>> ts.groupby(pd.Grouper(freq="2711min", offset="2min")).sum()
-    2000-01-10 00:02:00     9
-    2000-01-11 21:13:00    21
-    2000-01-13 18:24:00    33
-    2000-01-15 15:35:00    45
-    2000-01-17 12:46:00    57
-    2000-01-19 09:57:00    33
-    Freq: 2711T, dtype: int64
+    To replace the use of the deprecated `base` argument, you can now use `offset`,
+    in this example it is equivalent to have `base=2`:
+    >>> ts.groupby(pd.Grouper(freq="17min", offset="2min")).sum()
+    2000-10-01 23:16:00     0
+    2000-10-01 23:33:00     9
+    2000-10-01 23:50:00    36
+    2000-10-02 00:07:00    39
+    2000-10-02 00:24:00    24
+    Freq: 17T, dtype: int64
     """
 
     _attributes: Tuple[str, ...] = ("key", "level", "freq", "axis", "sort")

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -2,8 +2,8 @@
 Provide user facing operators for doing the split part of the
 split-apply-combine paradigm.
 """
-import warnings
 from typing import Dict, Hashable, List, Optional, Tuple
+import warnings
 
 import numpy as np
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -83,14 +83,14 @@ class Grouper:
             However, loffset is also deprecated for ``.resample(...)``
             See: :class:`DataFrame.resample`
 
-    origin : pd.Timestamp, default None
+    origin : Timestamp, str or datetime-like, default None
         The timestamp on which to adjust the grouping. The timezone of the
         timestamp must match the timezone of the index. If None is passed, the
         first day of the time series at midnight is used.
 
         .. versionadded:: 1.1.0
 
-    offset : pd.Timedelta, default is None
+    offset : Timedelta or str, default is None
         An offset timedelta added to the origin.
 
         .. versionadded:: 1.1.0

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -83,10 +83,14 @@ class Grouper:
             However, loffset is also deprecated for ``.resample(...)``
             See: :class:`DataFrame.resample`
 
-    origin : Timestamp, str or datetime-like, default None
-        The timestamp on which to adjust the grouping. The timezone of the
-        timestamp must match the timezone of the index. If None is passed, the
-        first day of the time series at midnight is used.
+    origin : {'epoch', 'start', 'start_day'}, Timestamp or str, default 'start_day'
+        The timestamp on which to adjust the grouping. It must be timezone aware if
+        the index of the resampled data is.
+        If a timestamp is not used, these values are also supported:
+
+        - 'epoch': `origin` is 1970-01-01
+        - 'start': `origin` is the first value of the timeseries
+        - 'start_day': `origin` is the first day at midnight of the timeseries
 
         .. versionadded:: 1.1.0
 
@@ -151,8 +155,8 @@ class Grouper:
 
     If you want to adjust the start of the bins based on a fixed timestamp:
 
-    >>> start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"
-    >>> rng = pd.date_range(start, end, freq="7min")
+    >>> start, end = '2000-10-01 23:30:00', '2000-10-02 00:30:00'
+    >>> rng = pd.date_range(start, end, freq='7min')
     >>> ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
     >>> ts
     2000-10-01 23:30:00     0
@@ -166,7 +170,7 @@ class Grouper:
     2000-10-02 00:26:00    24
     Freq: 7T, dtype: int64
 
-    >>> ts.groupby(pd.Grouper(freq="17min")).sum()
+    >>> ts.groupby(pd.Grouper(freq='17min')).sum()
     2000-10-01 23:14:00     0
     2000-10-01 23:31:00     9
     2000-10-01 23:48:00    21
@@ -174,7 +178,7 @@ class Grouper:
     2000-10-02 00:22:00    24
     Freq: 17T, dtype: int64
 
-    >>> ts.groupby(pd.Grouper(freq="17min", origin=pd.Timestamp("1970-01-01"))).sum()
+    >>> ts.groupby(pd.Grouper(freq='17min', origin='epoch')).sum()
     2000-10-01 23:18:00     0
     2000-10-01 23:35:00    18
     2000-10-01 23:52:00    27
@@ -182,17 +186,24 @@ class Grouper:
     2000-10-02 00:26:00    24
     Freq: 17T, dtype: int64
 
+    >>> ts.groupby(pd.Grouper(freq='17min', origin='2000-01-01')).sum()
+    2000-10-01 23:24:00     3
+    2000-10-01 23:41:00    15
+    2000-10-01 23:58:00    45
+    2000-10-02 00:15:00    45
+    Freq: 17T, dtype: int64
+
     If you want to adjust the start of the bins with an `offset` Timedelta, the two
     following lines are equivalent:
 
-    >>> ts.groupby(pd.Grouper(freq="17min", origin=start)).sum()
+    >>> ts.groupby(pd.Grouper(freq='17min', origin='start')).sum()
     2000-10-01 23:30:00     9
     2000-10-01 23:47:00    21
     2000-10-02 00:04:00    54
     2000-10-02 00:21:00    24
     Freq: 17T, dtype: int64
 
-    >>> ts.groupby(pd.Grouper(freq="17min", offset=pd.Timedelta("23h30min"))).sum()
+    >>> ts.groupby(pd.Grouper(freq='17min', offset='23h30min')).sum()
     2000-10-01 23:30:00     9
     2000-10-01 23:47:00    21
     2000-10-02 00:04:00    54
@@ -201,7 +212,8 @@ class Grouper:
 
     To replace the use of the deprecated `base` argument, you can now use `offset`,
     in this example it is equivalent to have `base=2`:
-    >>> ts.groupby(pd.Grouper(freq="17min", offset="2min")).sum()
+
+    >>> ts.groupby(pd.Grouper(freq='17min', offset='2min')).sum()
     2000-10-01 23:16:00     0
     2000-10-01 23:33:00     9
     2000-10-01 23:50:00    36

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -153,6 +153,12 @@ class Grouper:
     def __new__(cls, *args, **kwargs):
         if kwargs.get("freq") is not None:
             from pandas.core.resample import TimeGrouper
+            from pandas.core.resample import _validate_resample_deprecated_args
+
+            if cls is not TimeGrouper:
+                # validate only when pd.Grouper is called, otherwise
+                # the warning is handled by the resample function
+                _validate_resample_deprecated_args(**kwargs)
 
             cls = TimeGrouper
         return super().__new__(cls)

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -73,9 +73,6 @@ class Grouper:
 
         .. deprecated:: 1.1.0
             The new arguments that you should use are 'offset' or 'origin'.
-            ``df.resample(freq="3s", base=2)``
-            becomes
-            ``df.resample(freq="3s", offset="2s")``
 
     loffset : str, DateOffset, timedelta object
         Only when `freq` parameter is passed.
@@ -151,6 +148,72 @@ class Grouper:
     2000-01-02    0.5   15.0
     2000-01-09    2.0   30.0
     2000-01-16    3.0   40.0
+
+    If you want to adjust the start of the bins based on a fixed timestamp:
+
+    >>> start, end = "1/10/2000 02:00:00", "1/20/2000 02:00"
+    >>> rng = pd.date_range(start, end, freq="1231min")
+    >>> ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
+    >>> ts
+    2000-01-10 02:00:00     0
+    2000-01-10 22:31:00     3
+    2000-01-11 19:02:00     6
+    2000-01-12 15:33:00     9
+    2000-01-13 12:04:00    12
+    2000-01-14 08:35:00    15
+    2000-01-15 05:06:00    18
+    2000-01-16 01:37:00    21
+    2000-01-16 22:08:00    24
+    2000-01-17 18:39:00    27
+    2000-01-18 15:10:00    30
+    2000-01-19 11:41:00    33
+    Freq: 1231T, dtype: int64
+    >>> ts.groupby(pd.Grouper(freq="2711min")).sum()
+    2000-01-10 00:00:00     9
+    2000-01-11 21:11:00    21
+    2000-01-13 18:22:00    33
+    2000-01-15 15:33:00    45
+    2000-01-17 12:44:00    57
+    2000-01-19 09:55:00    33
+    Freq: 2711T, dtype: int64
+    >>> ts.groupby(pd.Grouper(freq="2711min", origin=pd.Timestamp("1970-01-01"))).sum()
+    2000-01-08 11:44:00     0
+    2000-01-10 08:55:00     9
+    2000-01-12 06:06:00    21
+    2000-01-14 03:17:00    33
+    2000-01-16 00:28:00    72
+    2000-01-17 21:39:00    63
+    Freq: 2711T, dtype: int64
+
+    If you want to adjust the start of the bins with an offset, the two following
+    lines are equivalent:
+
+    >>> ts.groupby(pd.Grouper(freq="2711min", origin="1/10/2000 02:00:00")).sum()
+    2000-01-10 02:00:00     9
+    2000-01-11 23:11:00    21
+    2000-01-13 20:22:00    33
+    2000-01-15 17:33:00    45
+    2000-01-17 14:44:00    90
+    Freq: 2711T, dtype: int64
+    >>> ts.groupby(pd.Grouper(freq="2711min", offset="2h")).sum()
+    2000-01-10 02:00:00     9
+    2000-01-11 23:11:00    21
+    2000-01-13 20:22:00    33
+    2000-01-15 17:33:00    45
+    2000-01-17 14:44:00    90
+    Freq: 2711T, dtype: int64
+
+    To replace the use of the deprecated `base` argument:
+    >>> # ts.groupby(pd.Grouper(freq="2711min", base=2)).sum()
+    >>> #   becomes:
+    >>> ts.groupby(pd.Grouper(freq="2711min", offset="2min")).sum()
+    2000-01-10 00:02:00     9
+    2000-01-11 21:13:00    21
+    2000-01-13 18:24:00    33
+    2000-01-15 15:35:00    45
+    2000-01-17 12:46:00    57
+    2000-01-19 09:57:00    33
+    Freq: 2711T, dtype: int64
     """
 
     _attributes: Tuple[str, ...] = ("key", "level", "freq", "axis", "sort")

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -2,7 +2,7 @@
 Provide user facing operators for doing the split part of the
 split-apply-combine paradigm.
 """
-
+import warnings
 from typing import Dict, Hashable, List, Optional, Tuple
 
 import numpy as np
@@ -215,12 +215,43 @@ class Grouper:
     def __new__(cls, *args, **kwargs):
         if kwargs.get("freq") is not None:
             from pandas.core.resample import TimeGrouper
-            from pandas.core.resample import _validate_resample_deprecated_args
 
-            if cls is not TimeGrouper:
-                # validate only when pd.Grouper is called, otherwise
-                # the warning is handled by the resample function
-                _validate_resample_deprecated_args(**kwargs)
+            # Deprecation warning of `base` and `loffset` since v1.1.0:
+            # we are raising the warning here to be able to set the `stacklevel`
+            # properly since we need to raise the `base` and `loffset` deprecation
+            # warning from three different cases:
+            #   core/generic.py::NDFrame.resample
+            #   core/groupby/groupby.py::GroupBy.resample
+            #   core/groupby/grouper.py::Grouper
+            # raising these warnings from TimeGrouper directly would fail the test:
+            #   tests/resample/test_deprecated.py::test_deprecating_on_loffset_and_base
+
+            # hacky way to set the stacklevel: if cls is TimeGrouper it means
+            # that the call comes from a pandas internal call of resample,
+            # otherwise it comes from pd.Grouper
+            stacklevel = 4 if cls is TimeGrouper else 2
+            if kwargs.get("base", None) is not None:
+                warnings.warn(
+                    "'base' in .resample() and in Grouper() is deprecated.\n"
+                    "The new arguments that you should use are 'offset' or 'origin'.\n"
+                    '\n>>> df.resample(freq="3s", base=2)\n'
+                    "\nbecomes:\n"
+                    '\n>>> df.resample(freq="3s", offset="2s")\n',
+                    FutureWarning,
+                    stacklevel=stacklevel,
+                )
+
+            if kwargs.get("loffset", None) is not None:
+                warnings.warn(
+                    "'loffset' in .resample() and in Grouper() is deprecated.\n"
+                    '\n>>> df.resample(freq="3s", loffset="8H")\n'
+                    "\nbecomes:\n"
+                    "\n>>> from pandas.tseries.frequencies import to_offset"
+                    '\n>>> df = df.resample(freq="3s").mean()'
+                    '\n>>> df.index = df.index.to_timestamp() + to_offset("8H")\n',
+                    FutureWarning,
+                    stacklevel=stacklevel,
+                )
 
             cls = TimeGrouper
         return super().__new__(cls)

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -86,12 +86,17 @@ class Grouper:
             However, loffset is also deprecated for ``.resample(...)``
             See: :class:`DataFrame.resample`
 
-    origin : Timestamp, default None
-        Only when `freq` parameter is passed.
-        The timestamp on which to adjust the grouping. If None is passed, the
+    origin : pd.Timestamp, default None
+        The timestamp on which to adjust the grouping. It must be timezone
+        aware if the index of the resampled data is. If None is passed, the
         first day of the time series at midnight is used.
+
+        .. versionadded:: 1.1.0
+
     offset : pd.Timedelta, default is None
         An offset timedelta added to the origin.
+
+        .. versionadded:: 1.1.0
 
     Returns
     -------

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1356,7 +1356,7 @@ class TimeGrouper(Grouper):
         self.fill_method = fill_method
         self.limit = limit
 
-        if origin in {"epoch", "start", "start_day"}:
+        if origin in ("epoch", "start", "start_day"):
             self.origin = origin
         else:
             try:
@@ -1705,6 +1705,8 @@ def _get_timestamp_range_edges(
             # So "pretend" the dates are naive when adjusting the endpoints
             first = first.tz_localize(None)
             last = last.tz_localize(None)
+            if isinstance(origin, Timestamp):
+                origin = origin.tz_localize(None)
 
         first, last = _adjust_dates_anchored(
             first, last, freq, closed=closed, origin=origin, offset=offset,

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -9,7 +9,7 @@ from pandas._libs import lib
 from pandas._libs.tslibs import NaT, Period, Timedelta, Timestamp
 from pandas._libs.tslibs.frequencies import is_subperiod, is_superperiod
 from pandas._libs.tslibs.period import IncompatibleFrequency
-from pandas._typing import TimedeltaCompatibleTypes, TimestampCompatibleTypes
+from pandas._typing import TimedeltaConvertibleTypes, TimestampConvertibleTypes
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, doc
@@ -1317,8 +1317,8 @@ class TimeGrouper(Grouper):
         kind: Optional[str] = None,
         convention: Optional[str] = None,
         base: Optional[int] = None,
-        origin: Union[str, TimestampCompatibleTypes] = "start_day",
-        offset: Optional[TimedeltaCompatibleTypes] = None,
+        origin: Union[str, TimestampConvertibleTypes] = "start_day",
+        offset: Optional[TimedeltaConvertibleTypes] = None,
         **kwargs,
     ):
         # Check for correctness of the keyword arguments which would

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,7 +1,7 @@
 import copy
 from datetime import timedelta
 from textwrap import dedent
-from typing import Dict, no_type_check
+from typing import Dict, no_type_check, Optional
 
 import numpy as np
 
@@ -9,6 +9,8 @@ from pandas._libs import lib
 from pandas._libs.tslibs import NaT, Period, Timedelta, Timestamp
 from pandas._libs.tslibs.frequencies import is_subperiod, is_superperiod
 from pandas._libs.tslibs.period import IncompatibleFrequency
+
+from pandas._typing import TimestampCompatibleTypes, TimedeltaCompatibleTypes
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, doc
@@ -1306,18 +1308,18 @@ class TimeGrouper(Grouper):
     def __init__(
         self,
         freq="Min",
-        closed=None,
-        label=None,
+        closed: Optional[str] = None,
+        label: Optional[str] = None,
         how="mean",
         axis=0,
         fill_method=None,
         limit=None,
         loffset=None,
-        kind=None,
-        convention=None,
-        base=None,
-        origin=None,
-        offset=None,
+        kind: Optional[str] = None,
+        convention: Optional[str] = None,
+        base: Optional[int] = None,
+        origin: Optional[TimestampCompatibleTypes] = None,
+        offset: Optional[TimedeltaCompatibleTypes] = None,
         **kwargs,
     ):
         # Check for correctness of the keyword arguments which would
@@ -1722,8 +1724,8 @@ def _get_period_range_edges(first, last, freq, closed="left", origin=None, offse
     closed : {'right', 'left'}, default None
         Which side of bin interval is closed.
     origin : pd.Timestamp, default None
-        The timestamp on which to adjust the grouping. The timezone of the
-        timestamp must match the timezone of the index. If None is passed, the
+        The timestamp on which to adjust the grouping. It must be timezone
+        aware if the index of the resampled data is. If None is passed, the
         first day of the time series at midnight is used.
     offset : pd.Timedelta, default is None
         An offset timedelta added to the origin.

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1638,8 +1638,7 @@ def _validate_resample_deprecated_args(offset=None, base=None, loffset=None, **k
 
     if loffset is not None:
         warnings.warn(
-            "'loffset' in .resample() and in Grouper() is deprecated.\n"
-            "Here an example to have the same behavior than loffset:\n\n"
+            "'loffset' in .resample() and in Grouper() is deprecated.\n\n"
             '>>> df.resample(freq="3s", loffset="8H")\n'
             "\nbecomes:\n\n"
             ">>> from pandas.tseries.frequencies import to_offset\n"
@@ -1699,10 +1698,7 @@ def _get_timestamp_range_edges(
     if isinstance(freq, Tick):
         is_idx_tz_aware = first.tz is not None or last.tz is not None
         if origin is not None and origin.tz is None and is_idx_tz_aware:
-            raise ValueError(
-                "The origin must be timezone aware when the index "
-                "of the resampled data is."
-            )
+            raise ValueError("The origin must have the same timezone as the index.")
 
         if isinstance(freq, Day):
             # _adjust_dates_anchored assumes 'D' means 24H, but first/last
@@ -1750,8 +1746,8 @@ def _get_period_range_edges(first, last, freq, closed="left", origin=None, offse
     closed : {'right', 'left'}, default None
         Which side of bin interval is closed.
     origin : pd.Timestamp, default None
-        The timestamp on which to adjust the grouping. It must be timezone
-        aware if the index of the resampled data is. If None is passed, the
+        The timestamp on which to adjust the grouping. The timezone of the
+        timestamp must match the timezone of the index. If None is passed, the
         first day of the time series at midnight is used.
     offset : pd.Timedelta, default is None
         An offset timedelta added to the origin.

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1682,7 +1682,8 @@ def _get_timestamp_range_edges(
     closed : {'right', 'left'}, default None
         Which side of bin interval is closed.
     origin : pd.Timestamp, default None
-        The timestamp on which to adjust the grouping. If None is passed, the
+        The timestamp on which to adjust the grouping. It must be timezone
+        aware if the index of the resampled data is. If None is passed, the
         first day of the time series at midnight is used.
     offset : pd.Timedelta, default is None
         An offset timedelta added to the origin.
@@ -1692,6 +1693,13 @@ def _get_timestamp_range_edges(
     A tuple of length 2, containing the adjusted pd.Timestamp objects.
     """
     if isinstance(freq, Tick):
+        is_idx_tz_aware = first.tzinfo is not None or last.tzinfo is not None
+        if origin is not None and origin.tzinfo is None and is_idx_tz_aware:
+            raise ValueError(
+                "The origin must be timezone aware when the index "
+                "of the resampled data is."
+            )
+
         if isinstance(freq, Day):
             # _adjust_dates_anchored assumes 'D' means 24H, but first/last
             # might contain a DST transition (23H, 24H, or 25H).
@@ -1738,7 +1746,8 @@ def _get_period_range_edges(first, last, freq, closed="left", origin=None, offse
     closed : {'right', 'left'}, default None
         Which side of bin interval is closed.
     origin : pd.Timestamp, default None
-        The timestamp on which to adjust the grouping. If None is passed, the
+        The timestamp on which to adjust the grouping. It must be timezone
+        aware if the index of the resampled data is. If None is passed, the
         first day of the time series at midnight is used.
     offset : pd.Timedelta, default is None
         An offset timedelta added to the origin.

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,7 +1,7 @@
 import copy
 from datetime import timedelta
 from textwrap import dedent
-from typing import Dict, no_type_check, Optional
+from typing import Dict, Optional, no_type_check
 
 import numpy as np
 
@@ -9,8 +9,7 @@ from pandas._libs import lib
 from pandas._libs.tslibs import NaT, Period, Timedelta, Timestamp
 from pandas._libs.tslibs.frequencies import is_subperiod, is_superperiod
 from pandas._libs.tslibs.period import IncompatibleFrequency
-
-from pandas._typing import TimestampCompatibleTypes, TimedeltaCompatibleTypes
+from pandas._typing import TimedeltaCompatibleTypes, TimestampCompatibleTypes
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, Substitution, doc

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -209,7 +209,8 @@ def test_resample_loffset_arg_type(frame, create_index, arg):
     expected_index += timedelta(hours=2)
     expected = DataFrame({"value": expected_means}, index=expected_index)
 
-    result_agg = df.resample("2D", loffset="2H").agg(arg)
+    with tm.assert_produces_warning(FutureWarning):
+        result_agg = df.resample("2D", loffset="2H").agg(arg)
 
     if isinstance(arg, list):
         expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -9,7 +9,7 @@ import pandas._testing as tm
 from pandas.core.groupby.groupby import DataError
 from pandas.core.groupby.grouper import Grouper
 from pandas.core.indexes.datetimes import date_range
-from pandas.core.indexes.period import PeriodIndex, period_range
+from pandas.core.indexes.period import period_range
 from pandas.core.indexes.timedeltas import timedelta_range
 from pandas.core.resample import _asfreq_compat
 

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -195,30 +195,6 @@ def test_resample_empty_dtypes(index, dtype, resample_method):
 
 
 @all_ts
-@pytest.mark.parametrize("arg", ["mean", {"value": "mean"}, ["mean"]])
-def test_resample_loffset_arg_type(frame, create_index, arg):
-    # GH 13218, 15002
-    df = frame
-    expected_means = [df.values[i : i + 2].mean() for i in range(0, len(df.values), 2)]
-    expected_index = create_index(df.index[0], periods=len(df.index) / 2, freq="2D")
-
-    # loffset coerces PeriodIndex to DateTimeIndex
-    if isinstance(expected_index, PeriodIndex):
-        expected_index = expected_index.to_timestamp()
-
-    expected_index += timedelta(hours=2)
-    expected = DataFrame({"value": expected_means}, index=expected_index)
-
-    with tm.assert_produces_warning(FutureWarning):
-        result_agg = df.resample("2D", loffset="2H").agg(arg)
-
-    if isinstance(arg, list):
-        expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
-
-    tm.assert_frame_equal(result_agg, expected)
-
-
-@all_ts
 def test_apply_to_empty_series(empty_series_dti):
     # GH 14313
     s = empty_series_dti

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -763,6 +763,31 @@ def test_resample_origin():
     tm.assert_index_equal(resampled.index, exp_rng)
 
 
+@pytest.mark.parametrize(
+    "origin",
+    ["invalid_value", "epch", "startday", "startt", "2000-30-30", object()],
+)
+def test_resample_bad_origin(origin):
+    rng = date_range("2000-01-01 00:00:00", "2000-01-01 02:00", freq="s")
+    ts = Series(np.random.randn(len(rng)), index=rng)
+    msg = ("'origin' should be equal to 'epoch', 'start', 'start_day' or "
+           f"should be a Timestamp convertible type. Got '{origin}' instead.")
+    with pytest.raises(ValueError, match=msg):
+        ts.resample("5min", origin=origin)
+
+
+@pytest.mark.parametrize(
+    "offset",
+    ["invalid_value", "12dayys", "2000-30-30", object()],
+)
+def test_resample_bad_offset(offset):
+    rng = date_range("2000-01-01 00:00:00", "2000-01-01 02:00", freq="s")
+    ts = Series(np.random.randn(len(rng)), index=rng)
+    msg = f"'offset' should be a Timedelta convertible type. Got '{offset}' instead."
+    with pytest.raises(ValueError, match=msg):
+        ts.resample("5min", offset=offset)
+
+
 def test_resample_origin_prime_freq():
     # GH 31809
     start, end = "2000-10-01 23:30:00", "2000-10-02 00:30:00"

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -754,6 +754,23 @@ def test_resample_origin():
     tm.assert_index_equal(resampled.index, exp_rng)
 
 
+def test_resample_origin_with_tz():
+    # GH 31809
+    msg = "The origin must be timezone aware when the index of the resampled data is."
+
+    tz = "Europe/Paris"
+    rng = date_range("1/1/2000 00:00:00", "1/1/2000 02:00", freq="s", tz=tz)
+    ts = Series(np.random.randn(len(rng)), index=rng)
+
+    exp_rng = date_range("12/31/1999 23:57:00", "1/1/2000 01:57", freq="5min", tz=tz)
+
+    resampled = ts.resample("5min", origin="12/31/1999 23:57:00+00:00").mean()
+    tm.assert_index_equal(resampled.index, exp_rng)
+
+    with pytest.raises(ValueError, match=msg):
+        ts.resample("5min", origin="12/31/1999 23:57:00").mean()
+
+
 def test_resample_daily_anchored():
     rng = date_range("1/1/2000 0:00:00", periods=10000, freq="T")
     ts = Series(np.random.randn(len(rng)), index=rng)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -764,21 +764,21 @@ def test_resample_origin():
 
 
 @pytest.mark.parametrize(
-    "origin",
-    ["invalid_value", "epch", "startday", "startt", "2000-30-30", object()],
+    "origin", ["invalid_value", "epch", "startday", "startt", "2000-30-30", object()],
 )
 def test_resample_bad_origin(origin):
     rng = date_range("2000-01-01 00:00:00", "2000-01-01 02:00", freq="s")
     ts = Series(np.random.randn(len(rng)), index=rng)
-    msg = ("'origin' should be equal to 'epoch', 'start', 'start_day' or "
-           f"should be a Timestamp convertible type. Got '{origin}' instead.")
+    msg = (
+        "'origin' should be equal to 'epoch', 'start', 'start_day' or "
+        f"should be a Timestamp convertible type. Got '{origin}' instead."
+    )
     with pytest.raises(ValueError, match=msg):
         ts.resample("5min", origin=origin)
 
 
 @pytest.mark.parametrize(
-    "offset",
-    ["invalid_value", "12dayys", "2000-30-30", object()],
+    "offset", ["invalid_value", "12dayys", "2000-30-30", object()],
 )
 def test_resample_bad_offset(offset):
     rng = date_range("2000-01-01 00:00:00", "2000-01-01 02:00", freq="s")
@@ -844,6 +844,61 @@ def test_resample_origin_with_tz():
     ts = Series(np.random.randn(len(rng)), index=rng)
     with pytest.raises(ValueError, match=msg):
         ts.resample("5min", origin="12/31/1999 23:57:00+03:00").mean()
+
+
+def test_resample_origin_with_day_freq_on_dst():
+    # GH 31809
+    tz = "dateutil//usr/share/zoneinfo/America/Chicago"
+
+    def _create_series(values, timestamps, freq="D"):
+        return pd.Series(
+            values,
+            index=pd.DatetimeIndex(
+                [Timestamp(t, tz=tz) for t in timestamps], freq=freq, ambiguous=True
+            ),
+        )
+
+    # test classical behavior of origin in a DST context
+    start = pd.Timestamp("2013-11-02", tz=tz)
+    end = pd.Timestamp("2013-11-03 23:59", tz=tz)
+    rng = pd.date_range(start, end, freq="1h")
+    ts = pd.Series(np.ones(len(rng)), index=rng)
+
+    expected = _create_series([24.0, 25.0], ["2013-11-02", "2013-11-03"])
+    for origin in ["epoch", "start", "start_day", start, None]:
+        result = ts.resample("D", origin=origin).sum()
+        tm.assert_series_equal(result, expected)
+
+    # test complex behavior of origin/offset in a DST context
+    start = pd.Timestamp("2013-11-03", tz=tz)
+    end = pd.Timestamp("2013-11-03 23:59", tz=tz)
+    rng = pd.date_range(start, end, freq="1h")
+    ts = pd.Series(np.ones(len(rng)), index=rng)
+
+    expected_ts = ["2013-11-02 22:00-05:00", "2013-11-03 22:00-06:00"]
+    expected = _create_series([23.0, 2.0], expected_ts)
+    result = ts.resample("D", origin="start", offset="-2H").sum()
+    tm.assert_series_equal(result, expected)
+
+    expected_ts = ["2013-11-02 22:00-05:00", "2013-11-03 21:00-06:00"]
+    expected = _create_series([22.0, 3.0], expected_ts, freq="24H")
+    result = ts.resample("24H", origin="start", offset="-2H").sum()
+    tm.assert_series_equal(result, expected)
+
+    expected_ts = ["2013-11-02 02:00-05:00", "2013-11-03 02:00-06:00"]
+    expected = _create_series([3.0, 22.0], expected_ts)
+    result = ts.resample("D", origin="start", offset="2H").sum()
+    tm.assert_series_equal(result, expected)
+
+    expected_ts = ["2013-11-02 23:00-05:00", "2013-11-03 23:00-06:00"]
+    expected = _create_series([24.0, 1.0], expected_ts)
+    result = ts.resample("D", origin="start", offset="-1H").sum()
+    tm.assert_series_equal(result, expected)
+
+    expected_ts = ["2013-11-02 01:00-05:00", "2013-11-03 01:00:00-0500"]
+    expected = _create_series([1.0, 24.0], expected_ts)
+    result = ts.resample("D", origin="start", offset="1H").sum()
+    tm.assert_series_equal(result, expected)
 
 
 def test_resample_daily_anchored():

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -756,7 +756,7 @@ def test_resample_origin():
 
 def test_resample_origin_with_tz():
     # GH 31809
-    msg = "The origin must be timezone aware when the index of the resampled data is."
+    msg = "The origin must have the same timezone as the index."
 
     tz = "Europe/Paris"
     rng = date_range("1/1/2000 00:00:00", "1/1/2000 02:00", freq="s", tz=tz)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -814,6 +814,12 @@ def test_resample_origin_with_tz():
     with pytest.raises(ValueError, match=msg):
         ts.resample("5min", origin="12/31/1999 23:57:00").mean()
 
+    # if the series is not tz aware, origin should not be tz aware
+    rng = date_range("2000-01-01 00:00:00", "2000-01-01 02:00", freq="s")
+    ts = Series(np.random.randn(len(rng)), index=rng)
+    with pytest.raises(ValueError, match=msg):
+        ts.resample("5min", origin="12/31/1999 23:57:00+03:00").mean()
+
 
 def test_resample_daily_anchored():
     rng = date_range("1/1/2000 0:00:00", periods=10000, freq="T")

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -848,7 +848,7 @@ def test_resample_origin_with_tz():
 
 def test_resample_origin_with_day_freq_on_dst():
     # GH 31809
-    tz = "dateutil//usr/share/zoneinfo/America/Chicago"
+    tz = "America/Chicago"
 
     def _create_series(values, timestamps, freq="D"):
         return pd.Series(

--- a/pandas/tests/resample/test_deprecated.py
+++ b/pandas/tests/resample/test_deprecated.py
@@ -56,8 +56,9 @@ def test_deprecating_on_loffset_and_base():
     with tm.assert_produces_warning(FutureWarning):
         df.resample("3T", loffset="0s").sum()
     msg = "'offset' and 'base' cannot be present at the same time"
-    with pytest.raises(ValueError, match=msg):
-        df.groupby("a").resample("3T", base=0, offset=0).sum()
+    with tm.assert_produces_warning(FutureWarning):
+        with pytest.raises(ValueError, match=msg):
+            df.groupby("a").resample("3T", base=0, offset=0).sum()
 
 
 @all_ts

--- a/pandas/tests/resample/test_deprecated.py
+++ b/pandas/tests/resample/test_deprecated.py
@@ -9,8 +9,8 @@ import pandas._testing as tm
 from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.period import PeriodIndex, period_range
 from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
-from pandas.tseries.offsets import BDay, Minute
 
+from pandas.tseries.offsets import BDay, Minute
 
 DATE_RANGE = (date_range, "dti", datetime(2005, 1, 1), datetime(2005, 1, 10))
 PERIOD_RANGE = (period_range, "pi", datetime(2005, 1, 1), datetime(2005, 1, 10))

--- a/pandas/tests/resample/test_deprecated.py
+++ b/pandas/tests/resample/test_deprecated.py
@@ -40,13 +40,13 @@ def create_index(_index_factory):
 def test_deprecating_on_loffset_and_base():
     # GH 31809
 
-    idx = pd.date_range("1/1/2000", periods=4, freq="T")
+    idx = pd.date_range("2001-01-01", periods=4, freq="T")
     df = pd.DataFrame(data=4 * [range(2)], index=idx, columns=["a", "b"])
 
     with tm.assert_produces_warning(FutureWarning):
-        pd.Grouper(freq="10s", base=2)
+        pd.Grouper(freq="10s", base=0)
     with tm.assert_produces_warning(FutureWarning):
-        pd.Grouper(freq="10s", loffset="2s")
+        pd.Grouper(freq="10s", loffset="0s")
     with tm.assert_produces_warning(FutureWarning):
         df.groupby("a").resample("3T", base=0).sum()
     with tm.assert_produces_warning(FutureWarning):

--- a/pandas/tests/resample/test_deprecated.py
+++ b/pandas/tests/resample/test_deprecated.py
@@ -1,0 +1,263 @@
+from datetime import datetime, timedelta
+
+import numpy as np
+import pytest
+
+import pandas as pd
+from pandas import DataFrame, Series
+import pandas._testing as tm
+from pandas.core.indexes.datetimes import date_range
+from pandas.core.indexes.period import PeriodIndex, period_range
+from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
+from pandas.tseries.offsets import BDay, Minute
+
+
+DATE_RANGE = (date_range, "dti", datetime(2005, 1, 1), datetime(2005, 1, 10))
+PERIOD_RANGE = (period_range, "pi", datetime(2005, 1, 1), datetime(2005, 1, 10))
+TIMEDELTA_RANGE = (timedelta_range, "tdi", "1 day", "10 day")
+
+all_ts = pytest.mark.parametrize(
+    "_index_factory,_series_name,_index_start,_index_end",
+    [DATE_RANGE, PERIOD_RANGE, TIMEDELTA_RANGE],
+)
+
+
+@pytest.fixture()
+def _index_factory():
+    return period_range
+
+
+@pytest.fixture
+def create_index(_index_factory):
+    def _create_index(*args, **kwargs):
+        """ return the _index_factory created using the args, kwargs """
+        return _index_factory(*args, **kwargs)
+
+    return _create_index
+
+
+# new test to check that all FutureWarning are triggered
+def test_deprecating_on_loffset_and_base():
+    # GH 31809
+
+    idx = pd.date_range("1/1/2000", periods=4, freq="T")
+    df = pd.DataFrame(data=4 * [range(2)], index=idx, columns=["a", "b"])
+
+    with tm.assert_produces_warning(FutureWarning):
+        pd.Grouper(freq="10s", base=2)
+    with tm.assert_produces_warning(FutureWarning):
+        pd.Grouper(freq="10s", loffset="2s")
+    with tm.assert_produces_warning(FutureWarning):
+        df.groupby("a").resample("3T", base=0).sum()
+    with tm.assert_produces_warning(FutureWarning):
+        df.groupby("a").resample("3T", loffset="0s").sum()
+    with tm.assert_produces_warning(FutureWarning):
+        df.resample("3T", base=0).sum()
+    with tm.assert_produces_warning(FutureWarning):
+        df.resample("3T", loffset="0s").sum()
+
+
+# old tests from test_base.py:
+@all_ts
+@pytest.mark.parametrize("arg", ["mean", {"value": "mean"}, ["mean"]])
+def test_resample_loffset_arg_type(frame, create_index, arg):
+    # GH 13218, 15002
+    df = frame
+    expected_means = [df.values[i : i + 2].mean() for i in range(0, len(df.values), 2)]
+    expected_index = create_index(df.index[0], periods=len(df.index) / 2, freq="2D")
+
+    # loffset coerces PeriodIndex to DateTimeIndex
+    if isinstance(expected_index, PeriodIndex):
+        expected_index = expected_index.to_timestamp()
+
+    expected_index += timedelta(hours=2)
+    expected = DataFrame({"value": expected_means}, index=expected_index)
+
+    with tm.assert_produces_warning(FutureWarning):
+        result_agg = df.resample("2D", loffset="2H").agg(arg)
+
+    if isinstance(arg, list):
+        expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
+
+    tm.assert_frame_equal(result_agg, expected)
+
+
+# old tests from test_datetime_index.py
+@pytest.mark.parametrize(
+    "loffset", [timedelta(minutes=1), "1min", Minute(1), np.timedelta64(1, "m")]
+)
+def test_resample_loffset(loffset):
+    # GH 7687
+    rng = date_range("1/1/2000 00:00:00", "1/1/2000 00:13:00", freq="min")
+    s = Series(np.random.randn(14), index=rng)
+
+    with tm.assert_produces_warning(FutureWarning):
+        result = s.resample(
+            "5min", closed="right", label="right", loffset=loffset
+        ).mean()
+    idx = date_range("1/1/2000", periods=4, freq="5min")
+    expected = Series(
+        [s[0], s[1:6].mean(), s[6:11].mean(), s[11:].mean()],
+        index=idx + timedelta(minutes=1),
+    )
+    tm.assert_series_equal(result, expected)
+    assert result.index.freq == Minute(5)
+
+    # from daily
+    dti = date_range(start=datetime(2005, 1, 1), end=datetime(2005, 1, 10), freq="D")
+    ser = Series(np.random.rand(len(dti)), dti)
+
+    # to weekly
+    result = ser.resample("w-sun").last()
+    business_day_offset = BDay()
+    with tm.assert_produces_warning(FutureWarning):
+        expected = ser.resample("w-sun", loffset=-business_day_offset).last()
+    assert result.index[0] - business_day_offset == expected.index[0]
+
+
+def test_resample_loffset_upsample():
+    # GH 20744
+    rng = date_range("1/1/2000 00:00:00", "1/1/2000 00:13:00", freq="min")
+    s = Series(np.random.randn(14), index=rng)
+
+    with tm.assert_produces_warning(FutureWarning):
+        result = s.resample(
+            "5min", closed="right", label="right", loffset=timedelta(minutes=1)
+        ).ffill()
+    idx = date_range("1/1/2000", periods=4, freq="5min")
+    expected = Series([s[0], s[5], s[10], s[-1]], index=idx + timedelta(minutes=1))
+
+    tm.assert_series_equal(result, expected)
+
+
+def test_resample_loffset_count():
+    # GH 12725
+    start_time = "1/1/2000 00:00:00"
+    rng = date_range(start_time, periods=100, freq="S")
+    ts = Series(np.random.randn(len(rng)), index=rng)
+
+    with tm.assert_produces_warning(FutureWarning):
+        result = ts.resample("10S", loffset="1s").count()
+
+    expected_index = date_range(start_time, periods=10, freq="10S") + timedelta(
+        seconds=1
+    )
+    expected = Series(10, index=expected_index)
+
+    tm.assert_series_equal(result, expected)
+
+    # Same issue should apply to .size() since it goes through
+    #   same code path
+    with tm.assert_produces_warning(FutureWarning):
+        result = ts.resample("10S", loffset="1s").size()
+
+    tm.assert_series_equal(result, expected)
+
+
+def test_resample_base():
+    rng = date_range("1/1/2000 00:00:00", "1/1/2000 02:00", freq="s")
+    ts = Series(np.random.randn(len(rng)), index=rng)
+
+    with tm.assert_produces_warning(FutureWarning):
+        resampled = ts.resample("5min", base=2).mean()
+    exp_rng = date_range("12/31/1999 23:57:00", "1/1/2000 01:57", freq="5min")
+    tm.assert_index_equal(resampled.index, exp_rng)
+
+
+def test_resample_float_base():
+    # GH25161
+    dt = pd.to_datetime(
+        ["2018-11-26 16:17:43.51", "2018-11-26 16:17:44.51", "2018-11-26 16:17:45.51"]
+    )
+    s = Series(np.arange(3), index=dt)
+
+    base = 17 + 43.51 / 60
+    with tm.assert_produces_warning(FutureWarning):
+        result = s.resample("3min", base=base).size()
+    expected = Series(
+        3, index=pd.DatetimeIndex(["2018-11-26 16:17:43.51"], freq="3min")
+    )
+    tm.assert_series_equal(result, expected)
+
+
+# old tests from test_period_index.py
+@pytest.mark.parametrize("kind", ["period", None, "timestamp"])
+@pytest.mark.parametrize("agg_arg", ["mean", {"value": "mean"}, ["mean"]])
+def test_loffset_returns_datetimeindex(frame, kind, agg_arg):
+    # make sure passing loffset returns DatetimeIndex in all cases
+    # basic method taken from Base.test_resample_loffset_arg_type()
+    df = frame
+    expected_means = [df.values[i : i + 2].mean() for i in range(0, len(df.values), 2)]
+    expected_index = period_range(df.index[0], periods=len(df.index) / 2, freq="2D")
+
+    # loffset coerces PeriodIndex to DateTimeIndex
+    expected_index = expected_index.to_timestamp()
+    expected_index += timedelta(hours=2)
+    expected = DataFrame({"value": expected_means}, index=expected_index)
+
+    with tm.assert_produces_warning(FutureWarning):
+        result_agg = df.resample("2D", loffset="2H", kind=kind).agg(agg_arg)
+    if isinstance(agg_arg, list):
+        expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
+    tm.assert_frame_equal(result_agg, expected)
+
+
+@pytest.mark.parametrize(
+    "start,end,start_freq,end_freq,base,offset",
+    [
+        ("19910905", "19910909 03:00", "H", "24H", 10, "10H"),
+        ("19910905", "19910909 12:00", "H", "24H", 10, "10H"),
+        ("19910905", "19910909 23:00", "H", "24H", 10, "10H"),
+        ("19910905 10:00", "19910909", "H", "24H", 10, "10H"),
+        ("19910905 10:00", "19910909 10:00", "H", "24H", 10, "10H"),
+        ("19910905", "19910909 10:00", "H", "24H", 10, "10H"),
+        ("19910905 12:00", "19910909", "H", "24H", 10, "10H"),
+        ("19910905 12:00", "19910909 03:00", "H", "24H", 10, "10H"),
+        ("19910905 12:00", "19910909 12:00", "H", "24H", 10, "10H"),
+        ("19910905 12:00", "19910909 12:00", "H", "24H", 34, "34H"),
+        ("19910905 12:00", "19910909 12:00", "H", "17H", 10, "10H"),
+        ("19910905 12:00", "19910909 12:00", "H", "17H", 3, "3H"),
+        ("19910905 12:00", "19910909 1:00", "H", "M", 3, "3H"),
+        ("19910905", "19910913 06:00", "2H", "24H", 10, "10H"),
+        ("19910905", "19910905 01:39", "Min", "5Min", 3, "3Min"),
+        ("19910905", "19910905 03:18", "2Min", "5Min", 3, "3Min"),
+    ],
+)
+def test_resample_with_non_zero_base(start, end, start_freq, end_freq, base, offset):
+    # GH 23882
+    s = pd.Series(0, index=pd.period_range(start, end, freq=start_freq))
+    s = s + np.arange(len(s))
+    with tm.assert_produces_warning(FutureWarning):
+        result = s.resample(end_freq, base=base).mean()
+    result = result.to_timestamp(end_freq)
+
+    # test that the replacement argument `offset` works
+    result_offset = s.resample(end_freq, offset=offset).mean()
+    result_offset = result_offset.to_timestamp(end_freq)
+    tm.assert_series_equal(result, result_offset)
+
+    # to_timestamp casts 24H -> D
+    result = result.asfreq(end_freq) if end_freq == "24H" else result
+    with tm.assert_produces_warning(FutureWarning):
+        expected = s.to_timestamp().resample(end_freq, base=base).mean()
+    if end_freq == "M":
+        # TODO: is non-tick the relevant characteristic? (GH 33815)
+        expected.index = expected.index._with_freq(None)
+    tm.assert_series_equal(result, expected)
+
+
+# tests from test_timedelta.py
+def test_resample_base_with_timedeltaindex():
+    # GH 10530
+    rng = timedelta_range(start="0s", periods=25, freq="s")
+    ts = Series(np.random.randn(len(rng)), index=rng)
+
+    with tm.assert_produces_warning(FutureWarning):
+        with_base = ts.resample("2s", base=5).mean()
+    without_base = ts.resample("2s").mean()
+
+    exp_without_base = timedelta_range(start="0s", end="25s", freq="2s")
+    exp_with_base = timedelta_range(start="5s", end="29s", freq="2s")
+
+    tm.assert_index_equal(without_base.index, exp_without_base)
+    tm.assert_index_equal(with_base.index, exp_with_base)

--- a/pandas/tests/resample/test_deprecated.py
+++ b/pandas/tests/resample/test_deprecated.py
@@ -55,6 +55,9 @@ def test_deprecating_on_loffset_and_base():
         df.resample("3T", base=0).sum()
     with tm.assert_produces_warning(FutureWarning):
         df.resample("3T", loffset="0s").sum()
+    msg = "'offset' and 'base' cannot be present at the same time"
+    with pytest.raises(ValueError, match=msg):
+        df.groupby("a").resample("3T", base=0, offset=0).sum()
 
 
 @all_ts
@@ -228,7 +231,7 @@ def test_resample_with_non_zero_base(start, end, start_freq, end_freq, base, off
         result = s.resample(end_freq, base=base).mean()
     result = result.to_timestamp(end_freq)
 
-    # test that the replacement argument `offset` works
+    # test that the replacement argument 'offset' works
     result_offset = s.resample(end_freq, offset=offset).mean()
     result_offset = result_offset.to_timestamp(end_freq)
     tm.assert_series_equal(result, result_offset)

--- a/pandas/tests/resample/test_deprecated.py
+++ b/pandas/tests/resample/test_deprecated.py
@@ -8,7 +8,7 @@ from pandas import DataFrame, Series
 import pandas._testing as tm
 from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.period import PeriodIndex, period_range
-from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
+from pandas.core.indexes.timedeltas import timedelta_range
 
 from pandas.tseries.offsets import BDay, Minute
 

--- a/pandas/tests/resample/test_deprecated.py
+++ b/pandas/tests/resample/test_deprecated.py
@@ -57,7 +57,6 @@ def test_deprecating_on_loffset_and_base():
         df.resample("3T", loffset="0s").sum()
 
 
-# old tests from test_base.py:
 @all_ts
 @pytest.mark.parametrize("arg", ["mean", {"value": "mean"}, ["mean"]])
 def test_resample_loffset_arg_type(frame, create_index, arg):
@@ -82,7 +81,6 @@ def test_resample_loffset_arg_type(frame, create_index, arg):
     tm.assert_frame_equal(result_agg, expected)
 
 
-# old tests from test_datetime_index.py
 @pytest.mark.parametrize(
     "loffset", [timedelta(minutes=1), "1min", Minute(1), np.timedelta64(1, "m")]
 )
@@ -180,7 +178,6 @@ def test_resample_float_base():
     tm.assert_series_equal(result, expected)
 
 
-# old tests from test_period_index.py
 @pytest.mark.parametrize("kind", ["period", None, "timestamp"])
 @pytest.mark.parametrize("agg_arg", ["mean", {"value": "mean"}, ["mean"]])
 def test_loffset_returns_datetimeindex(frame, kind, agg_arg):
@@ -246,7 +243,6 @@ def test_resample_with_non_zero_base(start, end, start_freq, end_freq, base, off
     tm.assert_series_equal(result, expected)
 
 
-# tests from test_timedelta.py
 def test_resample_base_with_timedeltaindex():
     # GH 10530
     rng = timedelta_range(start="0s", periods=25, freq="s")

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -735,7 +735,8 @@ class TestPeriodIndex:
         expected_index += timedelta(hours=2)
         expected = DataFrame({"value": expected_means}, index=expected_index)
 
-        result_agg = df.resample("2D", loffset="2H", kind=kind).agg(agg_arg)
+        with tm.assert_produces_warning(FutureWarning):
+            result_agg = df.resample("2D", loffset="2H", kind=kind).agg(agg_arg)
         if isinstance(agg_arg, list):
             expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
         tm.assert_frame_equal(result_agg, expected)
@@ -815,42 +816,86 @@ class TestPeriodIndex:
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "start,end,start_freq,end_freq,base",
+        "start,end,start_freq,end_freq,base,offset",
         [
-            ("19910905", "19910909 03:00", "H", "24H", 10),
-            ("19910905", "19910909 12:00", "H", "24H", 10),
-            ("19910905", "19910909 23:00", "H", "24H", 10),
-            ("19910905 10:00", "19910909", "H", "24H", 10),
-            ("19910905 10:00", "19910909 10:00", "H", "24H", 10),
-            ("19910905", "19910909 10:00", "H", "24H", 10),
-            ("19910905 12:00", "19910909", "H", "24H", 10),
-            ("19910905 12:00", "19910909 03:00", "H", "24H", 10),
-            ("19910905 12:00", "19910909 12:00", "H", "24H", 10),
-            ("19910905 12:00", "19910909 12:00", "H", "24H", 34),
-            ("19910905 12:00", "19910909 12:00", "H", "17H", 10),
-            ("19910905 12:00", "19910909 12:00", "H", "17H", 3),
-            ("19910905 12:00", "19910909 1:00", "H", "M", 3),
-            ("19910905", "19910913 06:00", "2H", "24H", 10),
-            ("19910905", "19910905 01:39", "Min", "5Min", 3),
-            ("19910905", "19910905 03:18", "2Min", "5Min", 3),
+            ("19910905", "19910909 03:00", "H", "24H", 10, "10H"),
+            ("19910905", "19910909 12:00", "H", "24H", 10, "10H"),
+            ("19910905", "19910909 23:00", "H", "24H", 10, "10H"),
+            ("19910905 10:00", "19910909", "H", "24H", 10, "10H"),
+            ("19910905 10:00", "19910909 10:00", "H", "24H", 10, "10H"),
+            ("19910905", "19910909 10:00", "H", "24H", 10, "10H"),
+            ("19910905 12:00", "19910909", "H", "24H", 10, "10H"),
+            ("19910905 12:00", "19910909 03:00", "H", "24H", 10, "10H"),
+            ("19910905 12:00", "19910909 12:00", "H", "24H", 10, "10H"),
+            ("19910905 12:00", "19910909 12:00", "H", "24H", 34, "34H"),
+            ("19910905 12:00", "19910909 12:00", "H", "17H", 10, "10H"),
+            ("19910905 12:00", "19910909 12:00", "H", "17H", 3, "3H"),
+            ("19910905 12:00", "19910909 1:00", "H", "M", 3, "3H"),
+            ("19910905", "19910913 06:00", "2H", "24H", 10, "10H"),
+            ("19910905", "19910905 01:39", "Min", "5Min", 3, "3Min"),
+            ("19910905", "19910905 03:18", "2Min", "5Min", 3, "3Min"),
         ],
     )
-    def test_resample_with_non_zero_base(self, start, end, start_freq, end_freq, base):
+    def test_resample_with_non_zero_base(
+        self, start, end, start_freq, end_freq, base, offset
+    ):
         # GH 23882
         s = pd.Series(0, index=pd.period_range(start, end, freq=start_freq))
         s = s + np.arange(len(s))
-        result = s.resample(end_freq, base=base).mean()
+        with tm.assert_produces_warning(FutureWarning):
+            result = s.resample(end_freq, base=base).mean()
         result = result.to_timestamp(end_freq)
+
+        # test that the replacement argument `offset` works
+        result_offset = s.resample(end_freq, offset=offset).mean()
+        result_offset = result_offset.to_timestamp(end_freq)
+        tm.assert_series_equal(result, result_offset)
+
         # to_timestamp casts 24H -> D
         result = result.asfreq(end_freq) if end_freq == "24H" else result
-        expected = s.to_timestamp().resample(end_freq, base=base).mean()
+        with tm.assert_produces_warning(FutureWarning):
+            expected = s.to_timestamp().resample(end_freq, base=base).mean()
         if end_freq == "M":
-            # TODO: is non-tick the relevant characteristic?
+            # TODO: is non-tick the relevant characteristic? (GH 33815)
             expected.index = expected.index._with_freq(None)
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
-        "first,last,offset,exp_first,exp_last",
+        "start,end,start_freq,end_freq,offset",
+        [
+            ("19910905", "19910909 03:00", "H", "24H", "10H"),
+            ("19910905", "19910909 12:00", "H", "24H", "10H"),
+            ("19910905", "19910909 23:00", "H", "24H", "10H"),
+            ("19910905 10:00", "19910909", "H", "24H", "10H"),
+            ("19910905 10:00", "19910909 10:00", "H", "24H", "10H"),
+            ("19910905", "19910909 10:00", "H", "24H", "10H"),
+            ("19910905 12:00", "19910909", "H", "24H", "10H"),
+            ("19910905 12:00", "19910909 03:00", "H", "24H", "10H"),
+            ("19910905 12:00", "19910909 12:00", "H", "24H", "10H"),
+            ("19910905 12:00", "19910909 12:00", "H", "24H", "34H"),
+            ("19910905 12:00", "19910909 12:00", "H", "17H", "10H"),
+            ("19910905 12:00", "19910909 12:00", "H", "17H", "3H"),
+            ("19910905 12:00", "19910909 1:00", "H", "M", "3H"),
+            ("19910905", "19910913 06:00", "2H", "24H", "10H"),
+            ("19910905", "19910905 01:39", "Min", "5Min", "3Min"),
+            ("19910905", "19910905 03:18", "2Min", "5Min", "3Min"),
+        ],
+    )
+    def test_resample_with_offset(self, start, end, start_freq, end_freq, offset):
+        # GH 23882 & 31809
+        s = pd.Series(0, index=pd.period_range(start, end, freq=start_freq))
+        s = s + np.arange(len(s))
+        result = s.resample(end_freq, offset=offset).mean()
+        result = result.to_timestamp(end_freq)
+
+        expected = s.to_timestamp().resample(end_freq, offset=offset).mean()
+        if end_freq == "M":
+            # TODO: is non-tick the relevant characteristic? (GH 33815)
+            expected.index = expected.index._with_freq(None)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "first,last,freq,exp_first,exp_last",
         [
             ("19910905", "19920406", "D", "19910905", "19920406"),
             ("19910905 00:00", "19920406 06:00", "D", "19910905", "19920406"),
@@ -866,15 +911,15 @@ class TestPeriodIndex:
             ("1991-08", "1992-04", "M", "1991-08", "1992-04"),
         ],
     )
-    def test_get_period_range_edges(self, first, last, offset, exp_first, exp_last):
+    def test_get_period_range_edges(self, first, last, freq, exp_first, exp_last):
         first = pd.Period(first)
         last = pd.Period(last)
 
-        exp_first = pd.Period(exp_first, freq=offset)
-        exp_last = pd.Period(exp_last, freq=offset)
+        exp_first = pd.Period(exp_first, freq=freq)
+        exp_last = pd.Period(exp_last, freq=freq)
 
-        offset = pd.tseries.frequencies.to_offset(offset)
-        result = _get_period_range_edges(first, last, offset)
+        freq = pd.tseries.frequencies.to_offset(freq)
+        result = _get_period_range_edges(first, last, freq)
         expected = (exp_first, exp_last)
         assert result == expected
 

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -25,14 +25,13 @@ def test_str():
     r = test_series.resample("H")
     assert (
         "DatetimeIndexResampler [freq=<Hour>, axis=0, closed=left, "
-        "label=left, convention=start, base=0]" in str(r)
+        "label=left, convention=start]" in str(r)
     )
 
     r = test_series.resample("H", origin="1970-01-01")
     assert (
         "DatetimeIndexResampler [freq=<Hour>, axis=0, closed=left, "
-        "label=left, convention=start, base=0, "
-        "origin=1970-01-01 00:00:00]" in str(r)
+        "label=left, convention=start, origin=1970-01-01 00:00:00]" in str(r)
     )
 
 

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -25,13 +25,13 @@ def test_str():
     r = test_series.resample("H")
     assert (
         "DatetimeIndexResampler [freq=<Hour>, axis=0, closed=left, "
-        "label=left, convention=start]" in str(r)
+        "label=left, convention=start, origin=start_day]" in str(r)
     )
 
-    r = test_series.resample("H", origin="1970-01-01")
+    r = test_series.resample("H", origin="2000-01-01")
     assert (
         "DatetimeIndexResampler [freq=<Hour>, axis=0, closed=left, "
-        "label=left, convention=start, origin=1970-01-01 00:00:00]" in str(r)
+        "label=left, convention=start, origin=2000-01-01 00:00:00]" in str(r)
     )
 
 

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -28,6 +28,13 @@ def test_str():
         "label=left, convention=start, base=0]" in str(r)
     )
 
+    r = test_series.resample("H", origin="1970-01-01")
+    assert (
+        "DatetimeIndexResampler [freq=<Hour>, axis=0, closed=left, "
+        "label=left, convention=start, base=0, "
+        "origin=1970-01-01 00:00:00]" in str(r)
+    )
+
 
 def test_api():
 

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -133,6 +133,8 @@ def test_groupby_resample_on_api_with_getitem():
 
 
 def test_groupby_with_origin():
+    # GH 31809
+
     freq = "1399min"  # prime number that is smaller than 24h
     start, end = "1/1/2000 00:00:00", "1/31/2000 00:00"
     middle = "1/15/2000 00:00:00"

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -1,6 +1,7 @@
 from textwrap import dedent
 
 import numpy as np
+import pytest
 
 from pandas.util._test_decorators import async_mark
 
@@ -129,6 +130,45 @@ def test_groupby_resample_on_api_with_getitem():
     exp = df.set_index("date").groupby("id").resample("2D")["data"].sum()
     result = df.groupby("id").resample("2D", on="date")["data"].sum()
     tm.assert_series_equal(result, exp)
+
+
+def test_groupby_with_origin():
+    freq = "1399min"  # prime number that is smaller than 24h
+    start, end = "1/1/2000 00:00:00", "1/31/2000 00:00"
+    middle = "1/15/2000 00:00:00"
+
+    rng = pd.date_range(start, end, freq="1231min")  # prime number
+    ts = pd.Series(np.random.randn(len(rng)), index=rng)
+    ts2 = ts[middle:end]
+
+    # proves that grouper without a fixed origin does not work
+    # when dealing with unusual frequencies
+    simple_grouper = pd.Grouper(freq=freq)
+    count_ts = ts.groupby(simple_grouper).agg("count")
+    count_ts = count_ts[middle:end]
+    count_ts2 = ts2.groupby(simple_grouper).agg("count")
+    with pytest.raises(AssertionError):
+        tm.assert_index_equal(count_ts.index, count_ts2.index)
+
+    # test origin on 1970-01-01 00:00:00
+    origin = pd.Timestamp(0)
+    adjusted_grouper = pd.Grouper(freq=freq, origin=origin)
+    adjusted_count_ts = ts.groupby(adjusted_grouper).agg("count")
+    adjusted_count_ts = adjusted_count_ts[middle:end]
+    adjusted_count_ts2 = ts2.groupby(adjusted_grouper).agg("count")
+    tm.assert_series_equal(adjusted_count_ts, adjusted_count_ts2)
+
+    # test origin on 2049-10-18 20:00:00
+    origin_future = pd.Timestamp(0) + pd.Timedelta("1399min") * 30_000
+    adjusted_grouper2 = pd.Grouper(freq=freq, origin=origin_future)
+    adjusted2_count_ts = ts.groupby(adjusted_grouper2).agg("count")
+    adjusted2_count_ts = adjusted2_count_ts[middle:end]
+    adjusted2_count_ts2 = ts2.groupby(adjusted_grouper2).agg("count")
+    tm.assert_series_equal(adjusted2_count_ts, adjusted2_count_ts2)
+
+    # both grouper use an adjusted timestamp that is a multiple of 1399 min
+    # they should be equals even if the adjusted_timestamp is in the future
+    tm.assert_series_equal(adjusted_count_ts, adjusted2_count_ts2)
 
 
 def test_nearest():

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -287,11 +287,3 @@ def test_upsample_sum(method, method_args, expected_values):
     result = methodcaller(method, **method_args)(resampled)
     expected = pd.Series(expected_values, index=index)
     tm.assert_series_equal(result, expected)
-
-
-def test_deprecating_on_loffset_and_base():
-    with tm.assert_produces_warning(FutureWarning):
-        pd.Grouper(freq="10s", loffset="2s")
-
-    with tm.assert_produces_warning(FutureWarning):
-        pd.Grouper(freq="10s", base=2)

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -251,15 +251,15 @@ def test_repr():
     expected = (
         "TimeGrouper(key='A', freq=<Hour>, axis=0, sort=True, "
         "closed='left', label='left', how='mean', "
-        "convention='e')"
+        "convention='e', origin='start_day')"
     )
     assert result == expected
 
-    result = repr(Grouper(key="A", freq="H", origin="1970-01-01"))
+    result = repr(Grouper(key="A", freq="H", origin="2000-01-01"))
     expected = (
         "TimeGrouper(key='A', freq=<Hour>, axis=0, sort=True, "
         "closed='left', label='left', how='mean', "
-        "convention='e', origin=Timestamp('1970-01-01 00:00:00'))"
+        "convention='e', origin=Timestamp('2000-01-01 00:00:00'))"
     )
     assert result == expected
 

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -166,7 +166,7 @@ def test_aggregate_normal(resample_method):
         ("prod", dict(min_count=1), np.nan),
     ],
 )
-def test_resample_entirly_nat_window(method, method_args, unit):
+def test_resample_entirely_nat_window(method, method_args, unit):
     s = pd.Series([0] * 2 + [np.nan] * 2, index=pd.date_range("2017", periods=4))
     result = methodcaller(method, **method_args)(s.resample("2d"))
     expected = pd.Series(
@@ -255,6 +255,14 @@ def test_repr():
     )
     assert result == expected
 
+    result = repr(Grouper(key="A", freq="H", origin="1970-01-01"))
+    expected = (
+        "TimeGrouper(key='A', freq=<Hour>, axis=0, sort=True, "
+        "closed='left', label='left', how='mean', "
+        "convention='e', base=0, origin=Timestamp('1970-01-01 00:00:00'))"
+    )
+    assert result == expected
+
 
 @pytest.mark.parametrize(
     "method, method_args, expected_values",
@@ -279,3 +287,11 @@ def test_upsample_sum(method, method_args, expected_values):
     result = methodcaller(method, **method_args)(resampled)
     expected = pd.Series(expected_values, index=index)
     tm.assert_series_equal(result, expected)
+
+
+def test_deprecating_on_loffset_and_base():
+    with tm.assert_produces_warning(FutureWarning):
+        pd.Grouper(freq="10s", loffset="2s")
+
+    with tm.assert_produces_warning(FutureWarning):
+        pd.Grouper(freq="10s", base=2)

--- a/pandas/tests/resample/test_time_grouper.py
+++ b/pandas/tests/resample/test_time_grouper.py
@@ -251,7 +251,7 @@ def test_repr():
     expected = (
         "TimeGrouper(key='A', freq=<Hour>, axis=0, sort=True, "
         "closed='left', label='left', how='mean', "
-        "convention='e', base=0)"
+        "convention='e')"
     )
     assert result == expected
 
@@ -259,7 +259,7 @@ def test_repr():
     expected = (
         "TimeGrouper(key='A', freq=<Hour>, axis=0, sort=True, "
         "closed='left', label='left', how='mean', "
-        "convention='e', base=0, origin=Timestamp('1970-01-01 00:00:00'))"
+        "convention='e', origin=Timestamp('1970-01-01 00:00:00'))"
     )
     assert result == expected
 

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -80,24 +80,8 @@ def test_resample_timedelta_idempotency():
     tm.assert_series_equal(result, expected)
 
 
-def test_resample_base_with_timedeltaindex():
-
-    # GH 10530
-    rng = timedelta_range(start="0s", periods=25, freq="s")
-    ts = Series(np.random.randn(len(rng)), index=rng)
-
-    with tm.assert_produces_warning(FutureWarning):
-        with_base = ts.resample("2s", base=5).mean()
-    without_base = ts.resample("2s").mean()
-
-    exp_without_base = timedelta_range(start="0s", end="25s", freq="2s")
-    exp_with_base = timedelta_range(start="5s", end="29s", freq="2s")
-
-    tm.assert_index_equal(without_base.index, exp_without_base)
-    tm.assert_index_equal(with_base.index, exp_with_base)
-
-
 def test_resample_offset_with_timedeltaindex():
+    # GH 10530 & 31809
     rng = timedelta_range(start="0s", periods=25, freq="s")
     ts = Series(np.random.randn(len(rng)), index=rng)
 

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -86,7 +86,22 @@ def test_resample_base_with_timedeltaindex():
     rng = timedelta_range(start="0s", periods=25, freq="s")
     ts = Series(np.random.randn(len(rng)), index=rng)
 
-    with_base = ts.resample("2s", base=5).mean()
+    with tm.assert_produces_warning(FutureWarning):
+        with_base = ts.resample("2s", base=5).mean()
+    without_base = ts.resample("2s").mean()
+
+    exp_without_base = timedelta_range(start="0s", end="25s", freq="2s")
+    exp_with_base = timedelta_range(start="5s", end="29s", freq="2s")
+
+    tm.assert_index_equal(without_base.index, exp_without_base)
+    tm.assert_index_equal(with_base.index, exp_with_base)
+
+
+def test_resample_offset_with_timedeltaindex():
+    rng = timedelta_range(start="0s", periods=25, freq="s")
+    ts = Series(np.random.randn(len(rng)), index=rng)
+
+    with_base = ts.resample("2s", offset="5s").mean()
     without_base = ts.resample("2s").mean()
 
     exp_without_base = timedelta_range(start="0s", end="25s", freq="2s")


### PR DESCRIPTION
**EDIT:** this PR has changed, now instead of adding `adjust_timestamp` we are adding `origin` and `offset` arguments to `resample` and `pd.Grouper` (see https://github.com/pandas-dev/pandas/pull/31809#issuecomment-583884772)

----

Hello,

This enhancement is an alternative to the `base` argument present in `pd.Grouper` or in the method `resample`. It adds the `adjust_timestamp` argument to change the current behavior of: https://github.com/pandas-dev/pandas/blob/master/pandas/core/resample.py#L1728

-  `adjust_timestamp` is the timestamp on which to adjust the grouping. If None is passed, the first day of the time series at midnight is used.

Currently the bins of the grouping are adjusted based on the beginning of the day of the time series starting point. This works well with frequencies that are multiples of a day (like `30D`) or that divides a day (like `90s` or `1min`). But it can create inconsistencies with some frequencies that do not meet this criteria.

Here is a simple snippet from a test that I added that proves that the current behavior can lead to some inconsistencies. Inconsistencies that can be fixed if we use `adjust_timestamp`:

```python
import pandas as pd
import numpy as np
import pandas._testing as tm
import pytest


freq = "1399min"  # prime number that is smaller than 24h
start, end = "1/1/2000 00:00:00", "1/31/2000 00:00"
middle = "1/15/2000 00:00:00"

rng = pd.date_range(start, end, freq="1231min")  # prime number
ts = pd.Series(np.random.randn(len(rng)), index=rng)
ts2 = ts[middle:end]

# proves that grouper without a fixed adjust_timestamp does not work
# when dealing with unusual frequencies
simple_grouper = pd.Grouper(freq=freq)
count_ts = ts.groupby(simple_grouper).agg("count")
count_ts = count_ts[middle:end]
count_ts2 = ts2.groupby(simple_grouper).agg("count")
with pytest.raises(AssertionError):
    tm.assert_index_equal(count_ts.index, count_ts2.index)

# test adjusted_timestamp on 1970-01-01 00:00:00
adjust_timestamp = pd.Timestamp(0)
adjusted_grouper = pd.Grouper(freq=freq, adjust_timestamp=adjust_timestamp)
adjusted_count_ts = ts.groupby(adjusted_grouper).agg("count")
adjusted_count_ts = adjusted_count_ts[middle:end]
adjusted_count_ts2 = ts2.groupby(adjusted_grouper).agg("count")
tm.assert_series_equal(adjusted_count_ts, adjusted_count_ts2)
```

I think this PR is ready to be merged, but I am of course open to any suggestions or criticism. :wink: 
For instance, I am not sure if the naming of `adjust_timestamp` is correct. An alternative could be `base_timestamp` or `ref_timestamp` :thinking:?

Cheers,

----

- [X] closes #25226
closes #28302
closes #28675
closes #4197
closes #8521
- [X] Add 'origin' and 'offset' arguments to 'resample' and 'pd.Grouper'
- [X] tests added / passed
- [X] Add deprecation warning for `loffset` and `base` in the code
- [X] Add deprecation warning for `loffset` and `base` in the doc
- [x] Add examples in the doc for `origin` and `offset`
- [x] whatsnew entry (add deprecation notice with `offset` example)
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
