### PR TITLE
DOC: '10 minutes to pandas' - <TAB> completion section now show a con…

### DIFF
--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -67,20 +67,20 @@ will be completed:
    @verbatim
    In [1]: df2.<TAB>  # noqa: E225, E999
    df2.A                  df2.bool
-   df2.abs                df2.boxplot
+   df2.abs()              df2.boxplot
    df2.add                df2.C
    df2.add_prefix         df2.clip
-   df2.add_suffix         df2.clip_lower
-   df2.align              df2.clip_upper
-   df2.all                df2.columns
+   df2.add_suffix         df2.columns
+   df2.align              df2.copy
+   df2.all                df2.count
    df2.any                df2.combine
-   df2.append             df2.combine_first
-   df2.apply              df2.consolidate
-   df2.applymap
-   df2.D
+   df2.append             df2.D
+   df2.apply              df2.describe
+   df2.applymap           df2.diff
+   df2.B                  df2.duplicated
 
 As you can see, the columns ``A``, ``B``, ``C``, and ``D`` are automatically
-tab completed. ``E`` is there as well; the rest of the attributes have been
+tab completed. ``E`` and ``F`` are there as well; the rest of the attributes have been
 truncated for brevity.
 
 Viewing data

--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -67,7 +67,7 @@ will be completed:
    @verbatim
    In [1]: df2.<TAB>  # noqa: E225, E999
    df2.A                  df2.bool
-   df2.abs()              df2.boxplot
+   df2.abs                df2.boxplot
    df2.add                df2.C
    df2.add_prefix         df2.clip
    df2.add_suffix         df2.columns


### PR DESCRIPTION
…sistent block of suggestions. Solve issue #31526

- [x] closes #31526
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I didn't run those listed tests above, however I doubt it will break something.

This PR only correct a *Typo* I found on documentation. I hope I'll be useful to improve this project.