### PR TITLE
DOC: Use consistent casing in headers

### DIFF
--- a/doc/source/user_guide/boolean.rst
+++ b/doc/source/user_guide/boolean.rst
@@ -9,7 +9,7 @@
 .. _boolean:
 
 **************************
-Nullable Boolean Data Type
+Nullable Boolean data type
 **************************
 
 .. versionadded:: 1.0.0


### PR DESCRIPTION
This is super nitty, but in the left side bar of the user guide the nullable Boolean data type section is the only one that uses all caps (other than Frequently Asked Questions, which possibly makes sense), so this might look a bit better.

https://pandas.pydata.org/pandas-docs/stable/user_guide/index.html#user-guide