### PR TITLE
CLN: disallow kind=None in _convert_slice_indexer

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3152,7 +3152,7 @@ class Index(IndexOpsMixin, PandasObject):
         self._validate_indexer("positional", key.stop, "iloc")
         self._validate_indexer("positional", key.step, "iloc")
 
-    def _convert_slice_indexer(self, key: slice, kind=None):
+    def _convert_slice_indexer(self, key: slice, kind: str_t):
         """
         Convert a slice indexer.
 
@@ -3162,9 +3162,9 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         key : label of the slice bound
-        kind : {'loc', 'getitem'} or None
+        kind : {'loc', 'getitem'}
         """
-        assert kind in ["loc", "getitem", None], kind
+        assert kind in ["loc", "getitem"], kind
 
         # potentially cast the bounds to integers
         start, stop, step = key.start, key.stop, key.step

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -885,7 +885,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
             return self.get_indexer_non_unique(target)[0]
         return self.get_indexer(target, **kwargs)
 
-    def _convert_slice_indexer(self, key: slice, kind=None):
+    def _convert_slice_indexer(self, key: slice, kind: str):
         if not (key.step is None or key.step == 1):
             raise ValueError("cannot support not-default step in a slice")
         return super()._convert_slice_indexer(key, kind)

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -393,8 +393,8 @@ class Float64Index(NumericIndex):
         return key
 
     @Appender(Index._convert_slice_indexer.__doc__)
-    def _convert_slice_indexer(self, key: slice, kind=None):
-        assert kind in ["loc", "getitem", None]
+    def _convert_slice_indexer(self, key: slice, kind: str):
+        assert kind in ["loc", "getitem"]
 
         # We always treat __getitem__ slicing as label-based
         # translate to locations

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -843,9 +843,6 @@ class _LocationIndexer(_NDFrameIndexerBase):
                     value = getattr(value, "values", value).ravel()
 
                     # we can directly set the series here
-                    # as we select a slice indexer on the mi
-                    if isinstance(idx, slice):
-                        idx = index._convert_slice_indexer(idx)
                     obj._consolidate_inplace()
                     obj = obj.copy()
                     obj._data = obj._data.setitem(indexer=tuple([idx]), value=value)


### PR DESCRIPTION
The one place where _convert_slice_indexer is currently called without kind is within _setitem_with_indexer, which I've determined should be iloc-only so it is a no-op.  With that usage removed, we can be stricter about what gets passed.