### PR TITLE
Fixed mypy errors in pandas/tests/extension/json/test_json.py

### DIFF
--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -79,7 +79,8 @@ class BaseJSON:
     # The default assert_series_equal eventually does a
     # Series.values, which raises. We work around it by
     # converting the UserDicts to dicts.
-    def assert_series_equal(self, left, right, **kwargs):
+    @classmethod
+    def assert_series_equal(cls, left, right, *args, **kwargs):
         if left.dtype.name == "json":
             assert left.dtype == right.dtype
             left = pd.Series(
@@ -90,9 +91,10 @@ class BaseJSON:
                 index=right.index,
                 name=right.name,
             )
-        tm.assert_series_equal(left, right, **kwargs)
+        tm.assert_series_equal(left, right, *args, **kwargs)
 
-    def assert_frame_equal(self, left, right, *args, **kwargs):
+    @classmethod
+    def assert_frame_equal(cls, left, right, *args, **kwargs):
         obj_type = kwargs.get("obj", "DataFrame")
         tm.assert_index_equal(
             left.columns,
@@ -107,7 +109,7 @@ class BaseJSON:
         jsons = (left.dtypes == "json").index
 
         for col in jsons:
-            self.assert_series_equal(left[col], right[col], *args, **kwargs)
+            cls.assert_series_equal(left[col], right[col], *args, **kwargs)
 
         left = left.drop(columns=jsons)
         right = right.drop(columns=jsons)

--- a/setup.cfg
+++ b/setup.cfg
@@ -135,9 +135,6 @@ ignore_errors=True
 [mypy-pandas.tests.arithmetic.test_datetime64]
 ignore_errors=True
 
-[mypy-pandas.tests.extension.json.test_json]
-ignore_errors=True
-
 [mypy-pandas.tests.indexes.datetimes.test_tools]
 ignore_errors=True
 


### PR DESCRIPTION
Part of #28926
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

