### PR TITLE
Docstring fixes for PR06 errors

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1175,7 +1175,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
         Parameters
         ----------
-        na_tuple : boolean, default True
+        na_tuple : bool, default True
             Returns NA as a tuple if True, ``(nan, nan)``, or just as the NA
             value itself if False, ``nan``.
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2336,7 +2336,8 @@ class GroupBy(_GroupBy):
         ----------
         periods : int, default 1
             Number of periods to shift.
-        freq : frequency string
+        freq : str, optional
+            Frequency string
         axis : axis to shift, default 0
         fill_value : optional
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1585,7 +1585,7 @@ class MultiIndex(Index):
         index : bool, default True
             Set the index of the returned DataFrame as the original MultiIndex.
 
-        name : list / sequence of strings, optional
+        name : list / sequence of str, optional
             The passed names should substitute index level names.
 
         Returns

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1139,11 +1139,11 @@ class HDFStore:
             queries, or True to use all columns. By default only the axes
             of the object are indexed. See `here
             <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#query-via-data-columns>`__.
-        min_itemsize : dict of columns that specify minimum string sizes
-        nan_rep      : string to use as string nan representation
+        min_itemsize : dict of columns that specify minimum str sizes
+        nan_rep      : str to use as str nan representation
         chunksize    : size to chunk the writing
         expectedrows : expected TOTAL row size of this table
-        encoding     : default None, provide an encoding for strings
+        encoding     : default None, provide an encoding for str
         dropna : bool, default False
             Do not write an ALL nan row to the store settable
             by the option 'io.hdf.dropna_table'.

--- a/pandas/io/spss.py
+++ b/pandas/io/spss.py
@@ -20,7 +20,7 @@ def read_spss(
 
     Parameters
     ----------
-    path : string or Path
+    path : str or Path
         File path.
     usecols : list-like, optional
         Return a subset of the columns. If None, return all columns.

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -284,7 +284,7 @@ def read_sql_query(
         Using SQLAlchemy makes it possible to use any DB supported by that
         library.
         If a DBAPI2 object, only sqlite3 is supported.
-    index_col : str or list of strings, optional, default: None
+    index_col : str or list of str, optional, default: None
         Column(s) to set as index(MultiIndex).
     coerce_float : bool, default True
         Attempts to convert values of non-string, non-numeric objects (like
@@ -364,7 +364,7 @@ def read_sql(
         library. If a DBAPI2 object, only sqlite3 is supported. The user is responsible
         for engine disposal and connection closure for the SQLAlchemy connectable. See
         `here <https://docs.sqlalchemy.org/en/13/core/connections.html>`_
-    index_col : str or list of strings, optional, default: None
+    index_col : str or list of str, optional, default: None
         Column(s) to set as index(MultiIndex).
     coerce_float : bool, default True
         Attempts to convert values of non-string, non-numeric objects (like


### PR DESCRIPTION
This contains some small changes that resolve some of the PR06 errors from running `./scripts/validate_docstrings.py --errors=PR06`
- [x] xref #28724
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
