### PR TITLE
BUG: Fix rolling.corr with time frequency

### DIFF
--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -17,7 +17,7 @@ Fixed regressions
 
 - Fixed regression in :meth:`DataFrame.to_excel` when ``columns`` kwarg is passed (:issue:`31677`)
 - Fixed regression in :meth:`Series.align` when ``other`` is a DataFrame and ``method`` is not None (:issue:`31785`)
--
+- Fixed regression in :meth:`pandas.core.window.Rolling.corr` when using a time offset (:issue:`31789`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -18,6 +18,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.to_excel` when ``columns`` kwarg is passed (:issue:`31677`)
 - Fixed regression in :meth:`Series.align` when ``other`` is a DataFrame and ``method`` is not None (:issue:`31785`)
 - Fixed regression in :meth:`pandas.core.window.Rolling.corr` when using a time offset (:issue:`31789`)
+-
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -18,7 +18,7 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.to_excel` when ``columns`` kwarg is passed (:issue:`31677`)
 - Fixed regression in :meth:`Series.align` when ``other`` is a DataFrame and ``method`` is not None (:issue:`31785`)
 - Fixed regression in :meth:`pandas.core.groupby.RollingGroupby.apply` where the ``raw`` parameter was ignored (:issue:`31754`)
-- Fixed regression in :meth:`pandas.core.window.Rolling.corr` when using a time offset (:issue:`31789`)
+- Fixed regression in :meth:`rolling(..).corr() <pandas.core.window.Rolling.corr>` when using a time offset (:issue:`31789`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1781,7 +1781,7 @@ class _Rolling_and_Expanding(_Rolling):
             # only default unset
             pairwise = True if pairwise is None else pairwise
         other = self._shallow_copy(other)
-        window = self._get_window(other)
+        window = self._get_window(other) if not self.is_freq_type else self.win_freq
 
         def _get_corr(a, b):
             a = a.rolling(

--- a/pandas/tests/window/test_pairwise.py
+++ b/pandas/tests/window/test_pairwise.py
@@ -1,8 +1,9 @@
 import warnings
 
+import numpy as np
 import pytest
 
-from pandas import DataFrame, Series
+from pandas import DataFrame, Series, date_range
 import pandas._testing as tm
 from pandas.core.algorithms import safe_sort
 
@@ -181,3 +182,10 @@ class TestPairwise:
         for i, result in enumerate(results):
             if i > 0:
                 self.compare(result, results[0])
+
+    def test_corr_freq_memory_error(self):
+        # GH 31789
+        s = Series(range(5), index=date_range("2020", periods=5))
+        result = s.rolling("12H").corr(s)
+        expected = Series([np.nan] * 5, index=date_range("2020", periods=5))
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #31789
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
