### PR TITLE
BUG: Fix raw parameter not being respected in groupby.rolling.apply

### DIFF
--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -17,7 +17,6 @@ Fixed regressions
 
 - Fixed regression in :meth:`DataFrame.to_excel` when ``columns`` kwarg is passed (:issue:`31677`)
 - Fixed regression in :meth:`Series.align` when ``other`` is a DataFrame and ``method`` is not None (:issue:`31785`)
--
 - Fixed regression in :meth:`pandas.core.groupby.RollingGroupby.apply` where the ``raw`` parameter was ignored (:issue:`31754`)
 -
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -19,6 +19,7 @@ Fixed regressions
 - Fixed regression in :meth:`Series.align` when ``other`` is a DataFrame and ``method`` is not None (:issue:`31785`)
 - Fixed regression in :meth:`pandas.core.groupby.RollingGroupby.apply` where the ``raw`` parameter was ignored (:issue:`31754`)
 -
+
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_102.bug_fixes:

--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -18,7 +18,8 @@ Fixed regressions
 - Fixed regression in :meth:`DataFrame.to_excel` when ``columns`` kwarg is passed (:issue:`31677`)
 - Fixed regression in :meth:`Series.align` when ``other`` is a DataFrame and ``method`` is not None (:issue:`31785`)
 -
-
+- Fixed regression in :meth:`pandas.core.groupby.RollingGroupby.apply` where the ``raw`` parameter was ignored (:issue:`31754`)
+-
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_102.bug_fixes:

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1296,13 +1296,14 @@ class _Rolling_and_Expanding(_Rolling):
             raise ValueError("engine must be either 'numba' or 'cython'")
 
         # TODO: Why do we always pass center=False?
-        # name=func for WindowGroupByMixin._apply
+        # name=func & raw=raw for WindowGroupByMixin._apply
         return self._apply(
             apply_func,
             center=False,
             floor=0,
             name=func,
             use_numba_cache=engine == "numba",
+            raw=raw,
         )
 
     def _generate_cython_apply_func(self, args, kwargs, raw, offset, func):

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -190,3 +190,21 @@ class TestGrouperGrouping:
         result = r.apply(lambda x: x.sum(), raw=raw)
         expected = g.apply(lambda x: x.expanding().apply(lambda y: y.sum(), raw=raw))
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("expected_value,raw_value", [[1.0, True], [0.0, False]])
+    def test_groupby_rolling(self, expected_value, raw_value):
+        # GH 31754
+
+        def foo(x):
+            return int(isinstance(x, np.ndarray))
+
+        df = pd.DataFrame({"id": [1, 1, 1], "value": [1, 2, 3]})
+        result = df.groupby("id").value.rolling(1).apply(foo, raw=raw_value)
+        expected = Series(
+            [expected_value] * 3,
+            index=pd.MultiIndex.from_tuples(
+                ((1, 0), (1, 1), (1, 2)), names=["id", None]
+            ),
+            name="value",
+        )
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #31754
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
