### PR TITLE
REF: make Series/DataFrame _slice always positional

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3498,13 +3498,11 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     def _box_item_values(self, key, values):
         raise AbstractMethodError(self)
 
-    def _slice(
-        self: FrameOrSeries, slobj: slice, axis=0, kind: str = "getitem"
-    ) -> FrameOrSeries:
+    def _slice(self: FrameOrSeries, slobj: slice, axis=0) -> FrameOrSeries:
         """
         Construct a slice of this container.
 
-        kind parameter is maintained for compatibility with Series slicing.
+        Slicing with this method is *always* positional.
         """
         axis = self._get_block_manager_axis(axis)
         result = self._constructor(self._data.get_slice(slobj, axis=axis))

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1627,7 +1627,7 @@ class _LocIndexer(_LocationIndexer):
         )
 
         if isinstance(indexer, slice):
-            return self.obj._slice(indexer, axis=axis, kind="iloc")
+            return self.obj._slice(indexer, axis=axis)
         else:
             # DatetimeIndex overrides Index.slice_indexer and may
             #  return a DatetimeIndex instead of a slice object.
@@ -2034,7 +2034,7 @@ class _iLocIndexer(_LocationIndexer):
 
         labels = obj._get_axis(axis)
         labels._validate_positional_slice(slice_obj)
-        return self.obj._slice(slice_obj, axis=axis, kind="iloc")
+        return self.obj._slice(slice_obj, axis=axis)
 
     def _convert_to_indexer(self, key, axis: int, is_setter: bool = False):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -840,12 +840,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         return self._values[i]
 
-    def _slice(self, slobj: slice, axis: int = 0, kind: str = "getitem") -> "Series":
-        assert kind in ["getitem", "iloc"]
-        if kind == "getitem":
-            # If called from getitem, we need to determine whether
-            #  this slice is positional or label-based.
-            slobj = self.index._convert_slice_indexer(slobj, kind="getitem")
+    def _slice(self, slobj: slice, axis: int = 0) -> "Series":
+        # axis kwarg is retained for compat with NDFrame method
+        #  _slice is *always* positional
         return self._get_values(slobj)
 
     def __getitem__(self, key):
@@ -889,7 +886,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def _get_with(self, key):
         # other: fancy integer or otherwise
         if isinstance(key, slice):
-            return self._slice(key, kind="getitem")
+            # _convert_slice_indexer to determing if this slice is positional
+            #  or label based, and if the latter, convert to positional
+            slobj = self.index._convert_slice_indexer(key, kind="getitem")
+            return self._slice(slobj)
         elif isinstance(key, ABCDataFrame):
             raise TypeError(
                 "Indexing a Series with DataFrame is not "


### PR DESCRIPTION
ATM we have a loc/iloc kwarg that NDFrame._slice (which is in effect DataFrame._slice) ignores and always slices positionally.  This makes Series._slice always slice positionally too.