### PR TITLE
BUG: Handle NA in assert_numpy_array_equal

### DIFF
--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -32,6 +32,10 @@ Bug fixes
 
 - Using ``pd.NA`` with :meth:`DataFrame.to_json` now correctly outputs a null value instead of an empty object (:issue:`31615`)
 
+**Testing**
+
+- Fixed bug where :meth:`assert_numpy_array_equal` would raise a ``TypeError`` when encountering ``pd.NA`` (:issue:`31881`)
+
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_102.contributors:

--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -32,10 +32,6 @@ Bug fixes
 
 - Using ``pd.NA`` with :meth:`DataFrame.to_json` now correctly outputs a null value instead of an empty object (:issue:`31615`)
 
-**Testing**
-
-- Fixed bug where :meth:`assert_numpy_array_equal` would raise a ``TypeError`` when encountering ``pd.NA`` (:issue:`31881`)
-
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_102.contributors:

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -571,11 +571,8 @@ def array_equivalent_object(left: object[:], right: object[:]) -> bool:
             if PyArray_Check(x) and PyArray_Check(y):
                 if not array_equivalent_object(x, y):
                     return False
-            elif x is C_NA or y is C_NA:
-                if x is C_NA and y is C_NA:
-                    return True
-                else:
-                    return False
+            elif (x is C_NA) ^ (y is C_NA):
+                return False
             elif not (PyObject_RichCompareBool(x, y, Py_EQ) or
                       (x is None or is_nan(x)) and (y is None or is_nan(y))):
                 return False

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -571,6 +571,11 @@ def array_equivalent_object(left: object[:], right: object[:]) -> bool:
             if PyArray_Check(x) and PyArray_Check(y):
                 if not array_equivalent_object(x, y):
                     return False
+            elif x is C_NA or y is C_NA:
+                if x is C_NA and y is C_NA:
+                    return True
+                else:
+                    return False
             elif not (PyObject_RichCompareBool(x, y, Py_EQ) or
                       (x is None or is_nan(x)) and (y is None or is_nan(y))):
                 return False

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -192,3 +192,9 @@ numpy array values are different \\(50.0 %\\)
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_numpy_array_equal(a, b)
+
+
+def test_numpy_array_equal_identical_na(nulls_fixture):
+    a = np.array([nulls_fixture])
+
+    tm.assert_numpy_array_equal(a, a)

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -195,6 +195,6 @@ numpy array values are different \\(50.0 %\\)
 
 
 def test_numpy_array_equal_identical_na(nulls_fixture):
-    a = np.array([nulls_fixture])
+    a = np.array([nulls_fixture], dtype=object)
 
     tm.assert_numpy_array_equal(a, a)

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas._libs.missing import NA
+
 from pandas import Timestamp
 import pandas._testing as tm
 
@@ -175,3 +177,18 @@ def test_numpy_array_equal_copy_flag(other_type, check_same):
             tm.assert_numpy_array_equal(a, other, check_same=check_same)
     else:
         tm.assert_numpy_array_equal(a, other, check_same=check_same)
+
+
+def test_numpy_array_equal_contains_na():
+    # https://github.com/pandas-dev/pandas/issues/31881
+    a = np.array([True, False])
+    b = np.array([True, NA])
+
+    msg = """numpy array are different
+
+numpy array values are different \\(50.0 %\\)
+\\[left\\]:  \\[True, False\\]
+\\[right\\]: \\[True, <NA>\\]"""
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_numpy_array_equal(a, b)

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -182,7 +182,7 @@ def test_numpy_array_equal_copy_flag(other_type, check_same):
 def test_numpy_array_equal_contains_na():
     # https://github.com/pandas-dev/pandas/issues/31881
     a = np.array([True, False])
-    b = np.array([True, NA])
+    b = np.array([True, NA], dtype=object)
 
     msg = """numpy array are different
 

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas._libs.missing import NA
-
+import pandas as pd
 from pandas import Timestamp
 import pandas._testing as tm
 
@@ -182,7 +181,7 @@ def test_numpy_array_equal_copy_flag(other_type, check_same):
 def test_numpy_array_equal_contains_na():
     # https://github.com/pandas-dev/pandas/issues/31881
     a = np.array([True, False])
-    b = np.array([True, NA], dtype=object)
+    b = np.array([True, pd.NA], dtype=object)
 
     msg = """numpy array are different
 
@@ -198,3 +197,17 @@ def test_numpy_array_equal_identical_na(nulls_fixture):
     a = np.array([nulls_fixture], dtype=object)
 
     tm.assert_numpy_array_equal(a, a)
+
+
+def test_numpy_array_equal_different_na():
+    a = np.array([np.nan], dtype=object)
+    b = np.array([pd.NA], dtype=object)
+
+    msg = """numpy array are different
+
+numpy array values are different \\(100.0 %\\)
+\\[left\\]:  \\[nan\\]
+\\[right\\]: \\[<NA>\\]"""
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_numpy_array_equal(a, b)


### PR DESCRIPTION
- [x] closes #31881
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

I think in the the case where we have NA we want to use identity rather than equality for checking when two arrays are equal.