### PR TITLE
CLN: 29547 replace old string formatting 1

### DIFF
--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -99,7 +99,7 @@ class BaseDecimal:
             check_names=kwargs.get("check_names", True),
             check_exact=kwargs.get("check_exact", False),
             check_categorical=kwargs.get("check_categorical", True),
-            obj="{obj}.columns".format(obj=kwargs.get("obj", "DataFrame")),
+            obj=f"{kwargs.get('obj', 'DataFrame')}.columns",
         )
 
         decimals = (left.dtypes == "decimal").index

--- a/pandas/tests/frame/indexing/test_categorical.py
+++ b/pandas/tests/frame/indexing/test_categorical.py
@@ -14,9 +14,7 @@ class TestDataFrameIndexingCategorical:
         df = DataFrame(
             {"value": np.array(np.random.randint(0, 10000, 100), dtype="int32")}
         )
-        labels = Categorical(
-            ["{0} - {1}".format(i, i + 499) for i in range(0, 10000, 500)]
-        )
+        labels = Categorical([f"{i} - {i + 499}" for i in range(0, 10000, 500)])
 
         df = df.sort_values(by=["value"], ascending=True)
         s = pd.cut(df.value, range(0, 10500, 500), right=False, labels=labels)
@@ -348,7 +346,7 @@ class TestDataFrameIndexingCategorical:
 
     def test_functions_no_warnings(self):
         df = DataFrame({"value": np.random.randint(0, 100, 20)})
-        labels = ["{0} - {1}".format(i, i + 9) for i in range(0, 100, 10)]
+        labels = [f"{i} - {i + 9}" for i in range(0, 100, 10)]
         with tm.assert_produces_warning(False):
             df["group"] = pd.cut(
                 df.value, range(0, 105, 10), right=False, labels=labels

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -86,7 +86,7 @@ class TestDataFrameDescribe:
 
     def test_describe_categorical(self):
         df = DataFrame({"value": np.random.randint(0, 10000, 100)})
-        labels = ["{0} - {1}".format(i, i + 499) for i in range(0, 10000, 500)]
+        labels = [f"{i} - {i + 499}" for i in range(0, 10000, 500)]
         cat_labels = Categorical(labels, labels)
 
         df = df.sort_values(by=["value"], ascending=True)

--- a/pandas/tests/frame/methods/test_duplicated.py
+++ b/pandas/tests/frame/methods/test_duplicated.py
@@ -22,9 +22,7 @@ def test_duplicated_do_not_fail_on_wide_dataframes():
     # gh-21524
     # Given the wide dataframe with a lot of columns
     # with different (important!) values
-    data = {
-        "col_{0:02d}".format(i): np.random.randint(0, 1000, 30000) for i in range(100)
-    }
+    data = {f"col_{i:02d}": np.random.randint(0, 1000, 30000) for i in range(100)}
     df = DataFrame(data).T
     result = df.duplicated()
 

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -236,9 +236,9 @@ class TestDataFrameToDict:
 
     def test_to_dict_wide(self):
         # GH#24939
-        df = DataFrame({("A_{:d}".format(i)): [i] for i in range(256)})
+        df = DataFrame({(f"A_{i:d}"): [i] for i in range(256)})
         result = df.to_dict("records")[0]
-        expected = {"A_{:d}".format(i): i for i in range(256)}
+        expected = {f"A_{i:d}": i for i in range(256)}
         assert result == expected
 
     def test_to_dict_orient_dtype(self):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -382,7 +382,7 @@ class TestDataFrameAlterAxes:
             # need to stabilize repr for KeyError (due to random order in sets)
             def __repr__(self) -> str:
                 tmp = sorted(self)
-                joined_reprs = ', '.join(map(repr, tmp))
+                joined_reprs = ", ".join(map(repr, tmp))
                 # double curly brace prints one brace in format string
                 return f"frozenset({{{joined_reprs}}})"
 

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -383,7 +383,7 @@ class TestDataFrameAlterAxes:
             def __repr__(self) -> str:
                 tmp = sorted(self)
                 # double curly brace prints one brace in format string
-                return "frozenset({{{}}})".format(", ".join(map(repr, tmp)))
+                return f"frozenset({{{', '.join(map(repr, tmp))}}})"
 
         thing1 = Thing(["One", "red"])
         thing2 = Thing(["Two", "blue"])

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -382,8 +382,9 @@ class TestDataFrameAlterAxes:
             # need to stabilize repr for KeyError (due to random order in sets)
             def __repr__(self) -> str:
                 tmp = sorted(self)
+                joined_reprs = ', '.join(map(repr, tmp))
                 # double curly brace prints one brace in format string
-                return f"frozenset({{{', '.join(map(repr, tmp))}}})"
+                return f"frozenset({{{joined_reprs}}})"
 
         thing1 = Thing(["One", "red"])
         thing2 = Thing(["Two", "blue"])

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -46,19 +46,19 @@ class TestDataFrameMisc:
 
     def test_add_prefix_suffix(self, float_frame):
         with_prefix = float_frame.add_prefix("foo#")
-        expected = pd.Index(["foo#{c}".format(c=c) for c in float_frame.columns])
+        expected = pd.Index([f"foo#{c}" for c in float_frame.columns])
         tm.assert_index_equal(with_prefix.columns, expected)
 
         with_suffix = float_frame.add_suffix("#foo")
-        expected = pd.Index(["{c}#foo".format(c=c) for c in float_frame.columns])
+        expected = pd.Index([f"{c}#foo" for c in float_frame.columns])
         tm.assert_index_equal(with_suffix.columns, expected)
 
         with_pct_prefix = float_frame.add_prefix("%")
-        expected = pd.Index(["%{c}".format(c=c) for c in float_frame.columns])
+        expected = pd.Index([f"%{c}" for c in float_frame.columns])
         tm.assert_index_equal(with_pct_prefix.columns, expected)
 
         with_pct_suffix = float_frame.add_suffix("%")
-        expected = pd.Index(["{c}%".format(c=c) for c in float_frame.columns])
+        expected = pd.Index([f"{c}%" for c in float_frame.columns])
         tm.assert_index_equal(with_pct_suffix.columns, expected)
 
     def test_get_axis(self, float_frame):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -278,7 +278,7 @@ class TestDataFrameConstructors:
         nitems = 100
         nums = list(range(nitems))
         random.shuffle(nums)
-        expected = ["A{i:d}".format(i=i) for i in nums]
+        expected = [f"A{i:d}" for i in nums]
         df = DataFrame(OrderedDict(zip(expected, [[0]] * nitems)))
         assert expected == list(df.columns)
 

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -702,7 +702,7 @@ class TestDataFrameDataTypes:
     @pytest.mark.parametrize("cls", [CategoricalDtype, DatetimeTZDtype, IntervalDtype])
     def test_astype_categoricaldtype_class_raises(self, cls):
         df = DataFrame({"A": ["a", "a", "b", "c"]})
-        xpr = "Expected an instance of {}".format(cls.__name__)
+        xpr = f"Expected an instance of {cls.__name__}"
         with pytest.raises(TypeError, match=xpr):
             df.astype({"A": cls})
 
@@ -827,7 +827,7 @@ class TestDataFrameDataTypes:
     def test_astype_from_datetimelike_to_objectt(self, dtype, unit):
         # tests astype to object dtype
         # gh-19223 / gh-12425
-        dtype = "{}[{}]".format(dtype, unit)
+        dtype = f"{dtype}[{unit}]"
         arr = np.array([[1, 2, 3]], dtype=dtype)
         df = DataFrame(arr)
         result = df.astype(object)
@@ -844,7 +844,7 @@ class TestDataFrameDataTypes:
     def test_astype_to_datetimelike_unit(self, arr_dtype, dtype, unit):
         # tests all units from numeric origination
         # gh-19223 / gh-12425
-        dtype = "{}[{}]".format(dtype, unit)
+        dtype = f"{dtype}[{unit}]"
         arr = np.array([[1, 2, 3]], dtype=arr_dtype)
         df = DataFrame(arr)
         result = df.astype(dtype)
@@ -856,7 +856,7 @@ class TestDataFrameDataTypes:
     def test_astype_to_datetime_unit(self, unit):
         # tests all units from datetime origination
         # gh-19223
-        dtype = "M8[{}]".format(unit)
+        dtype = f"M8[{unit}]"
         arr = np.array([[1, 2, 3]], dtype=dtype)
         df = DataFrame(arr)
         result = df.astype(dtype)
@@ -868,7 +868,7 @@ class TestDataFrameDataTypes:
     def test_astype_to_timedelta_unit_ns(self, unit):
         # preserver the timedelta conversion
         # gh-19223
-        dtype = "m8[{}]".format(unit)
+        dtype = f"m8[{unit}]"
         arr = np.array([[1, 2, 3]], dtype=dtype)
         df = DataFrame(arr)
         result = df.astype(dtype)
@@ -880,7 +880,7 @@ class TestDataFrameDataTypes:
     def test_astype_to_timedelta_unit(self, unit):
         # coerce to float
         # gh-19223
-        dtype = "m8[{}]".format(unit)
+        dtype = f"m8[{unit}]"
         arr = np.array([[1, 2, 3]], dtype=dtype)
         df = DataFrame(arr)
         result = df.astype(dtype)
@@ -892,21 +892,21 @@ class TestDataFrameDataTypes:
     def test_astype_to_incorrect_datetimelike(self, unit):
         # trying to astype a m to a M, or vice-versa
         # gh-19224
-        dtype = "M8[{}]".format(unit)
-        other = "m8[{}]".format(unit)
+        dtype = f"M8[{unit}]"
+        other = f"m8[{unit}]"
 
         df = DataFrame(np.array([[1, 2, 3]], dtype=dtype))
         msg = (
-            r"cannot astype a datetimelike from \[datetime64\[ns\]\] to "
-            r"\[timedelta64\[{}\]\]"
-        ).format(unit)
+            fr"cannot astype a datetimelike from \[datetime64\[ns\]\] to "
+            fr"\[timedelta64\[{unit}\]\]"
+        )
         with pytest.raises(TypeError, match=msg):
             df.astype(other)
 
         msg = (
-            r"cannot astype a timedelta from \[timedelta64\[ns\]\] to "
-            r"\[datetime64\[{}\]\]"
-        ).format(unit)
+            fr"cannot astype a timedelta from \[timedelta64\[ns\]\] to "
+            fr"\[datetime64\[{unit}\]\]"
+        )
         df = DataFrame(np.array([[1, 2, 3]], dtype=other))
         with pytest.raises(TypeError, match=msg):
             df.astype(dtype)

--- a/pandas/tests/frame/test_join.py
+++ b/pandas/tests/frame/test_join.py
@@ -161,7 +161,7 @@ def test_join_overlap(float_frame):
 
 
 def test_join_period_index(frame_with_period_index):
-    other = frame_with_period_index.rename(columns=lambda x: "{key}{key}".format(key=x))
+    other = frame_with_period_index.rename(columns=lambda key: f"{key}{key}")
 
     joined_values = np.concatenate([frame_with_period_index.values] * 2, axis=1)
 


### PR DESCRIPTION
I splitted PR #31844 in batches, this is the first one
For this PR I ran the command `grep -l -R -e '%s' -e '%d' -e '\.format(' --include=*.{py,pyx} pandas/` and checked all the files that were returned for `.format(` and changed the old string format for the corresponding `fstrings` to attempt a full clean of, [#29547](https://github.com/pandas-dev/pandas/issues/29547). I may have missed something so is a good idea to double check just in case

- [ x  ] tests added / passed
- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
