### PR TITLE
 EHN: fix unsigned int type problem of the result diff()

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1869,6 +1869,7 @@ def diff(arr, n: int, axis: int = 0, stacklevel=3):
 
     is_timedelta = False
     is_bool = False
+    original_dtype = np.dtype(dtype)
     if needs_i8_conversion(arr):
         dtype = np.float64
         arr = arr.view("i8")
@@ -1928,6 +1929,7 @@ def diff(arr, n: int, axis: int = 0, stacklevel=3):
     if is_timedelta:
         out_arr = out_arr.astype("int64").view("timedelta64[ns]")
 
+    out_arr = out_arr.astype(original_dtype)
     return out_arr
 
 


### PR DESCRIPTION
An unexpected output type(float64) occurs to diff() when using uint
type. So fix it by restoring original dtype after storing it

Fixes #28909

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


What do you think about this problem with the code? @jreback 