### PR TITLE
CLN: 29547 replace old string formatting 2

### DIFF
--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -840,8 +840,8 @@ class TestDataFrameOperators:
             df["a"] = [True, False, True]
 
         df_copy = df.copy()
-        iop = "__i{}__".format(op)
-        op = "__{}__".format(op)
+        iop = f"__i{op}__"
+        op = f"__{op}__"
 
         # no id change and value is correct
         getattr(df, iop)(operand)

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -765,7 +765,7 @@ class TestDataFrameReshape:
         tm.assert_frame_equal(result, expected)
 
     def test_unstack_nan_index(self):  # GH7466
-        cast = lambda val: "{0:1}".format("" if val != val else val)
+        cast = lambda val: f"{'' if val != val else val:1}"
 
         def verify(df):
             mk_list = lambda a: list(a) if isinstance(a, tuple) else [a]

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -765,7 +765,8 @@ class TestDataFrameReshape:
         tm.assert_frame_equal(result, expected)
 
     def test_unstack_nan_index(self):  # GH7466
-        cast = lambda val: f"{'' if val != val else val:1}"
+        val_str = lambda val: "" if val != val else val
+        cast = lambda val: f"{val_str(val):1}"
 
         def verify(df):
             mk_list = lambda a: list(a) if isinstance(a, tuple) else [a]

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -766,7 +766,9 @@ class TestDataFrameReshape:
 
     def test_unstack_nan_index(self):  # GH7466
         val_str = lambda val: "" if val != val else val
-        cast = lambda val: f"{val_str(val):1}"
+
+        def cast(val):
+            return f"{val_str(val):1}"
 
         def verify(df):
             mk_list = lambda a: list(a) if isinstance(a, tuple) else [a]

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -765,10 +765,9 @@ class TestDataFrameReshape:
         tm.assert_frame_equal(result, expected)
 
     def test_unstack_nan_index(self):  # GH7466
-        val_str = lambda val: "" if val != val else val
-
         def cast(val):
-            return f"{val_str(val):1}"
+            val_str = "" if val != val else val
+            return f"{val_str:1}"
 
         def verify(df):
             mk_list = lambda a: list(a) if isinstance(a, tuple) else [a]

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -54,7 +54,7 @@ class TestDataFrameTimeSeriesMethods:
         ns_dtype = np.dtype("M8[ns]")
 
         for unit in units:
-            dtype = np.dtype("M8[{unit}]".format(unit=unit))
+            dtype = np.dtype(f"M8[{unit}]")
             vals = np.arange(n, dtype=np.int64).view(dtype)
 
             df = DataFrame({"ints": np.arange(n)}, index=np.arange(n))
@@ -70,7 +70,7 @@ class TestDataFrameTimeSeriesMethods:
         df["dates"] = np.arange(n, dtype=np.int64).view(ns_dtype)
 
         for unit in units:
-            dtype = np.dtype("M8[{unit}]".format(unit=unit))
+            dtype = np.dtype(f"M8[{unit}]")
             vals = np.arange(n, dtype=np.int64).view(dtype)
 
             tmp = df.copy()

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -248,21 +248,21 @@ class TestDatetimeIndexOps:
         result = dt.floor(round_freq)
         diff = dt.asi8 - result.asi8
         mod = result.asi8 % unit
-        assert (mod == 0).all(), "floor not a {} multiple".format(round_freq)
+        assert (mod == 0).all(), f"floor not a {round_freq} multiple"
         assert (0 <= diff).all() and (diff < unit).all(), "floor error"
 
         # test ceil
         result = dt.ceil(round_freq)
         diff = result.asi8 - dt.asi8
         mod = result.asi8 % unit
-        assert (mod == 0).all(), "ceil not a {} multiple".format(round_freq)
+        assert (mod == 0).all(), f"ceil not a {round_freq} multiple"
         assert (0 <= diff).all() and (diff < unit).all(), "ceil error"
 
         # test round
         result = dt.round(round_freq)
         diff = abs(result.asi8 - dt.asi8)
         mod = result.asi8 % unit
-        assert (mod == 0).all(), "round not a {} multiple".format(round_freq)
+        assert (mod == 0).all(), f"round not a {round_freq} multiple"
         assert (diff <= unit // 2).all(), "round error"
         if unit % 2 == 0:
             assert (

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -199,7 +199,7 @@ class TestTimeConversionFormats:
         # these are locale dependent
         lang, _ = locale.getlocale()
         month_abbr = calendar.month_abbr[4]
-        val = "01-{}-2011 00:00:01.978".format(month_abbr)
+        val = f"01-{month_abbr}-2011 00:00:01.978"
 
         format = "%d-%b-%Y %H:%M:%S.%f"
         result = to_datetime(val, format=format, cache=cache)
@@ -551,7 +551,7 @@ class TestToDatetime:
     )
     @pytest.mark.parametrize("cache", [True, False])
     def test_to_datetime_dt64s_out_of_bounds(self, cache, dt):
-        msg = "Out of bounds nanosecond timestamp: {}".format(dt)
+        msg = f"Out of bounds nanosecond timestamp: {dt}"
         with pytest.raises(OutOfBoundsDatetime, match=msg):
             pd.to_datetime(dt, errors="raise")
         with pytest.raises(OutOfBoundsDatetime, match=msg):

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -24,11 +24,7 @@ class TestGetLoc:
         for bound in [[0, 1], [1, 2], [2, 3], [3, 4], [0, 2], [2.5, 3], [-1, 4]]:
             # if get_loc is supplied an interval, it should only search
             # for exact matches, not overlaps or covers, else KeyError.
-            msg = re.escape(
-                "Interval({bound[0]}, {bound[1]}, closed='{side}')".format(
-                    bound=bound, side=side
-                )
-            )
+            msg = re.escape(f"Interval({bound[0]}, {bound[1]}, closed='{side}')")
             if closed == side:
                 if bound == [0, 1]:
                     assert idx.get_loc(Interval(0, 1, closed=side)) == 0
@@ -86,11 +82,7 @@ class TestGetLoc:
         else:
             with pytest.raises(
                 KeyError,
-                match=re.escape(
-                    "Interval({left}, {right}, closed='{other_closed}')".format(
-                        left=left, right=right, other_closed=other_closed
-                    )
-                ),
+                match=re.escape(f"Interval({left}, {right}, closed='{other_closed}')"),
             ):
                 index.get_loc(interval)
 

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -845,7 +845,7 @@ class TestIntervalIndex:
     def test_set_closed_errors(self, bad_closed):
         # GH 21670
         index = interval_range(0, 5)
-        msg = "invalid option for 'closed': {closed}".format(closed=bad_closed)
+        msg = f"invalid option for 'closed': {bad_closed}"
         with pytest.raises(ValueError, match=msg):
             index.set_closed(bad_closed)
 


### PR DESCRIPTION
I splitted PR #31844 in batches, this is the second
For this PR I ran the command `grep -l -R -e '%s' -e '%d' -e '\.format(' --include=*.{py,pyx} pandas/` and checked all the files that were returned for `.format(` and changed the old string format for the corresponding `fstrings` to attempt a full clean of, [#29547](https://github.com/pandas-dev/pandas/issues/29547). I may have missed something so is a good idea to double check just in case

- [ x  ] tests added / passed
- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`