### PR TITLE
Clean Up C Warnings

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -32,7 +32,6 @@ cdef float64_t NaN = <float64_t>np.NaN
 
 cdef int64_t NPY_NAT = get_nat()
 
-
 tiebreakers = {
     'average': TIEBREAK_AVERAGE,
     'min': TIEBREAK_MIN,

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1179,7 +1179,7 @@ def diff_2d(diff_t[:, :] arr,
             Py_ssize_t periods, int axis):
     cdef:
         Py_ssize_t i, j, sx, sy, start, stop
-        bint f_contig = arr.f_contiguous
+        bint f_contig = arr.is_f_contig()
 
     # Disable for unsupported dtype combinations,
     #  see https://github.com/cython/cython/issues/2646

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1,3 +1,4 @@
+from cpython.buffer import PyBuffer_IsContiguous
 import cython
 from cython import Py_ssize_t
 
@@ -1179,7 +1180,7 @@ def diff_2d(diff_t[:, :] arr,
             Py_ssize_t periods, int axis):
     cdef:
         Py_ssize_t i, j, sx, sy, start, stop
-        bint f_contig = arr.flags.f_contiguous
+        bint f_contig = PyBuffer_IsContiguous(arr, 'F')
 
     # Disable for unsupported dtype combinations,
     #  see https://github.com/cython/cython/issues/2646

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1,4 +1,3 @@
-from cpython.buffer import PyBuffer_IsContiguous
 import cython
 from cython import Py_ssize_t
 
@@ -1180,7 +1179,7 @@ def diff_2d(diff_t[:, :] arr,
             Py_ssize_t periods, int axis):
     cdef:
         Py_ssize_t i, j, sx, sy, start, stop
-        bint f_contig = PyBuffer_IsContiguous(arr, 'F')
+        bint f_contig = arr.f_contiguous
 
     # Disable for unsupported dtype combinations,
     #  see https://github.com/cython/cython/issues/2646

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -32,6 +32,7 @@ cdef float64_t NaN = <float64_t>np.NaN
 
 cdef int64_t NPY_NAT = get_nat()
 
+
 tiebreakers = {
     'average': TIEBREAK_AVERAGE,
     'min': TIEBREAK_MIN,
@@ -1173,8 +1174,8 @@ ctypedef fused out_t:
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def diff_2d(ndarray[diff_t, ndim=2] arr,
-            ndarray[out_t, ndim=2] out,
+def diff_2d(diff_t[:, :] arr,
+            out_t[:, :] out,
             Py_ssize_t periods, int axis):
     cdef:
         Py_ssize_t i, j, sx, sy, start, stop

--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -5,7 +5,7 @@ import cython
 from libc.stdlib cimport malloc, free
 
 import numpy as np
-from numpy cimport uint8_t, uint32_t, uint64_t, import_array
+from numpy cimport ndarray, uint8_t, uint32_t, uint64_t, import_array
 import_array()
 
 from pandas._libs.util cimport is_nan
@@ -15,7 +15,7 @@ DEF dROUNDS = 4
 
 
 @cython.boundscheck(False)
-def hash_object_array(object[:] arr, object key, object encoding='utf8'):
+def hash_object_array(ndarray[object] arr, object key, object encoding='utf8'):
     """
     Parameters
     ----------

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -152,7 +152,7 @@ def ensure_timedelta64ns(arr: ndarray, copy: bool=True):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def datetime_to_datetime64(object[:] values):
+def datetime_to_datetime64(ndarray[object] values):
     """
     Convert ndarray of datetime-like objects to int64 array representing
     nanosecond timestamps.

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -56,7 +56,7 @@ cdef:
 cdef inline int int_max(int a, int b): return a if a >= b else b
 cdef inline int int_min(int a, int b): return a if a <= b else b
 
-cdef inline bint is_monotonic_start_end_bounds(
+cdef bint is_monotonic_start_end_bounds(
     ndarray[int64_t, ndim=1] start, ndarray[int64_t, ndim=1] end
 ):
     return is_monotonic(start, False)[0] and is_monotonic(end, False)[0]

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -56,7 +56,9 @@ cdef:
 cdef inline int int_max(int a, int b): return a if a >= b else b
 cdef inline int int_min(int a, int b): return a if a <= b else b
 
-cdef inline bint is_monotonic_start_end_bounds(int64_t[:] start, int64_t[:] end):
+cdef bint is_monotonic_start_end_bounds(
+    ndarray[int64_t, ndim=1] start, ndarray[int64_t, ndim=1] end
+):
     return is_monotonic(start, False)[0] and is_monotonic(end, False)[0]
 
 # Cython implementations of rolling sum, mean, variance, skewness,

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -56,9 +56,7 @@ cdef:
 cdef inline int int_max(int a, int b): return a if a >= b else b
 cdef inline int int_min(int a, int b): return a if a <= b else b
 
-cdef bint is_monotonic_start_end_bounds(
-    ndarray[int64_t, ndim=1] start, ndarray[int64_t, ndim=1] end
-):
+cdef inline bint is_monotonic_start_end_bounds(int64_t[:] start, int64_t[:] end):
     return is_monotonic(start, False)[0] and is_monotonic(end, False)[0]
 
 # Cython implementations of rolling sum, mean, variance, skewness,


### PR DESCRIPTION
Getting closer to no warnings (at least with clang). Changes in this PR get rid of the following warnings:

```sh
warning: pandas/_libs/window/aggregations.pyx:60:4: Buffer unpacking not optimized away.
warning: pandas/_libs/window/aggregations.pyx:60:4: Buffer unpacking not optimized away.
warning: pandas/_libs/window/aggregations.pyx:60:36: Buffer unpacking not optimized away.
warning: pandas/_libs/window/aggregations.pyx:60:36: Buffer unpacking not optimized away.

pandas/_libs/hashing.c:25100:20: warning: unused function '__pyx_memview_get_object' [-Wunused-function]
  static PyObject *__pyx_memview_get_object(const char *itemp) {
                   ^
pandas/_libs/hashing.c:25105:12: warning: unused function '__pyx_memview_set_object' [-Wunused-function]
static int __pyx_memview_set_object(const char *itemp, PyObject *obj) {

pandas/_libs/algos.c:81410:3: warning: code will never be executed [-Wunreachable-code]
  __Pyx_SafeReleaseBuffer(&__pyx_pybuffernd_arr.rcbuffer->pybuffer);
  ^~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/algos.c:83045:3: warning: code will never be executed [-Wunreachable-code]
  __Pyx_SafeReleaseBuffer(&__pyx_pybuffernd_arr.rcbuffer->pybuffer);
  ^~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/algos.c:83951:3: warning: code will never be executed [-Wunreachable-code]
  __Pyx_SafeReleaseBuffer(&__pyx_pybuffernd_arr.rcbuffer->pybuffer);
  ^~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/algos.c:84857:3: warning: code will never be executed [-Wunreachable-code]
  __Pyx_SafeReleaseBuffer(&__pyx_pybuffernd_arr.rcbuffer->pybuffer);
  ^~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/algos.c:85034:3: warning: code will never be executed [-Wunreachable-code]
  __Pyx_SafeReleaseBuffer(&__pyx_pybuffernd_arr.rcbuffer->pybuffer);
  ^~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/algos.c:85940:3: warning: code will never be executed [-Wunreachable-code]
  __Pyx_SafeReleaseBuffer(&__pyx_pybuffernd_arr.rcbuffer->pybuffer);
  ^~~~~~~~~~~~~~~~~~~~~~~

pandas/_libs/tslibs/conversion.c:33113:20: warning: unused function '__pyx_memview_get_object' [-Wunused-function]
  static PyObject *__pyx_memview_get_object(const char *itemp) {
                   ^
pandas/_libs/tslibs/conversion.c:33118:12: warning: unused function '__pyx_memview_set_object' [-Wunused-function]
static int __pyx_memview_set_object(const char *itemp, PyObject *obj) {
```

Only a handful left after this