### PR TITLE
CLN: 29547 replace old string formatting 3

### DIFF
--- a/pandas/tests/indexes/interval/test_setops.py
+++ b/pandas/tests/indexes/interval/test_setops.py
@@ -181,7 +181,7 @@ class TestIntervalIndex:
         other = interval_range(Timestamp("20180101"), periods=9, closed=closed)
         msg = (
             f"can only do {op_name} between two IntervalIndex objects that have "
-            f"compatible dtypes"
+            "compatible dtypes"
         )
         with pytest.raises(TypeError, match=msg):
             set_op(other, sort=sort)

--- a/pandas/tests/indexes/interval/test_setops.py
+++ b/pandas/tests/indexes/interval/test_setops.py
@@ -180,8 +180,8 @@ class TestIntervalIndex:
         # GH 19016: incompatible dtypes
         other = interval_range(Timestamp("20180101"), periods=9, closed=closed)
         msg = (
-            "can only do {op} between two IntervalIndex objects that have "
-            "compatible dtypes"
-        ).format(op=op_name)
+            f"can only do {op_name} between two IntervalIndex objects that have "
+            f"compatible dtypes"
+        )
         with pytest.raises(TypeError, match=msg):
             set_op(other, sort=sort)

--- a/pandas/tests/indexes/multi/test_compat.py
+++ b/pandas/tests/indexes/multi/test_compat.py
@@ -29,7 +29,7 @@ def test_numeric_compat(idx):
 
 @pytest.mark.parametrize("method", ["all", "any"])
 def test_logical_compat(idx, method):
-    msg = "cannot perform {method}".format(method=method)
+    msg = f"cannot perform {method}"
 
     with pytest.raises(TypeError, match=msg):
         getattr(idx, method)()

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -364,7 +364,7 @@ class TestPeriodIndex:
         year = pd.Series([2001, 2002, 2003])
         quarter = year - 2000
         idx = PeriodIndex(year=year, quarter=quarter)
-        strs = ["{t[0]:d}Q{t[1]:d}".format(t=t) for t in zip(quarter, year)]
+        strs = [f"{t[0]:d}Q{t[1]:d}" for t in zip(quarter, year)]
         lops = list(map(Period, strs))
         p = PeriodIndex(lops)
         tm.assert_index_equal(p, idx)

--- a/pandas/tests/indexes/timedeltas/test_constructors.py
+++ b/pandas/tests/indexes/timedeltas/test_constructors.py
@@ -155,7 +155,7 @@ class TestTimedeltaIndex:
     def test_constructor_iso(self):
         # GH #21877
         expected = timedelta_range("1s", periods=9, freq="s")
-        durations = ["P0DT0H0M{}S".format(i) for i in range(1, 10)]
+        durations = [f"P0DT0H0M{i}S" for i in range(1, 10)]
         result = to_timedelta(durations)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -53,8 +53,8 @@ class TestFloatIndexers:
             s.iloc[3.0]
 
         msg = (
-            "cannot do positional indexing on {klass} with these "
-            r"indexers \[3\.0\] of type float".format(klass=type(i).__name__)
+            fr"cannot do positional indexing on {type(i).__name__} with these "
+            fr"indexers \[3\.0\] of type float"
         )
         with pytest.raises(TypeError, match=msg):
             s.iloc[3.0] = 0
@@ -94,11 +94,11 @@ class TestFloatIndexers:
                 else:
                     error = TypeError
                     msg = (
-                        r"cannot do (label|positional) indexing "
-                        r"on {klass} with these indexers \[3\.0\] of "
-                        r"type float|"
-                        "Cannot index by location index with a "
-                        "non-integer key".format(klass=type(i).__name__)
+                        fr"cannot do (label|positional) indexing "
+                        fr"on {type(i).__name__} with these indexers \[3\.0\] of "
+                        fr"type float|"
+                        fr"Cannot index by location index with a "
+                        fr"non-integer key"
                     )
                 with pytest.raises(error, match=msg):
                     idxr(s)[3.0]
@@ -115,9 +115,9 @@ class TestFloatIndexers:
             else:
                 error = TypeError
                 msg = (
-                    r"cannot do (label|positional) indexing "
-                    r"on {klass} with these indexers \[3\.0\] of "
-                    r"type float".format(klass=type(i).__name__)
+                    fr"cannot do (label|positional) indexing "
+                    fr"on {type(i).__name__} with these indexers \[3\.0\] of "
+                    fr"type float"
                 )
             with pytest.raises(error, match=msg):
                 s.loc[3.0]
@@ -127,9 +127,9 @@ class TestFloatIndexers:
 
             # setting with a float fails with iloc
             msg = (
-                r"cannot do (label|positional) indexing "
-                r"on {klass} with these indexers \[3\.0\] of "
-                r"type float".format(klass=type(i).__name__)
+                fr"cannot do (label|positional) indexing "
+                fr"on {type(i).__name__} with these indexers \[3\.0\] of "
+                fr"type float"
             )
             with pytest.raises(TypeError, match=msg):
                 s.iloc[3.0] = 0
@@ -164,9 +164,9 @@ class TestFloatIndexers:
         s = Series(np.arange(len(i)), index=i)
         s[3]
         msg = (
-            r"cannot do (label|positional) indexing "
-            r"on {klass} with these indexers \[3\.0\] of "
-            r"type float".format(klass=type(i).__name__)
+            fr"cannot do (label|positional) indexing "
+            fr"on {type(i).__name__} with these indexers \[3\.0\] of "
+            fr"type float"
         )
         with pytest.raises(TypeError, match=msg):
             s[3.0]
@@ -181,12 +181,10 @@ class TestFloatIndexers:
         for idxr in [lambda x: x, lambda x: x.iloc]:
 
             msg = (
-                r"cannot do label indexing "
-                r"on {klass} with these indexers \[1\.0\] of "
-                r"type float|"
-                "Cannot index by location index with a non-integer key".format(
-                    klass=Index.__name__
-                )
+                fr"cannot do label indexing "
+                fr"on {Index.__name__} with these indexers \[1\.0\] of "
+                fr"type float|"
+                fr"Cannot index by location index with a non-integer key"
             )
             with pytest.raises(TypeError, match=msg):
                 idxr(s2)[1.0]
@@ -203,9 +201,9 @@ class TestFloatIndexers:
         for idxr in [lambda x: x]:
 
             msg = (
-                r"cannot do label indexing "
-                r"on {klass} with these indexers \[1\.0\] of "
-                r"type float".format(klass=Index.__name__)
+                fr"cannot do label indexing "
+                fr"on {Index.__name__} with these indexers \[1\.0\] of "
+                fr"type float"
             )
             with pytest.raises(TypeError, match=msg):
                 idxr(s3)[1.0]
@@ -321,9 +319,9 @@ class TestFloatIndexers:
                 s.iloc[3.0]
 
             msg = (
-                r"cannot do positional indexing "
-                r"on {klass} with these indexers \[3\.0\] of "
-                r"type float".format(klass=Float64Index.__name__)
+                fr"cannot do positional indexing "
+                fr"on {Float64Index.__name__} with these indexers \[3\.0\] of "
+                fr"type float"
             )
             with pytest.raises(TypeError, match=msg):
                 s2.iloc[3.0] = 0
@@ -354,9 +352,9 @@ class TestFloatIndexers:
             for l in [slice(3.0, 4), slice(3, 4.0), slice(3.0, 4.0)]:
 
                 msg = (
-                    "cannot do positional indexing "
-                    r"on {klass} with these indexers \[(3|4)\.0\] of "
-                    "type float".format(klass=type(index).__name__)
+                    fr"cannot do positional indexing "
+                    fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s.iloc[l]
@@ -364,10 +362,10 @@ class TestFloatIndexers:
                 for idxr in [lambda x: x.loc, lambda x: x.iloc, lambda x: x]:
 
                     msg = (
-                        "cannot do (slice|positional) indexing "
-                        r"on {klass} with these indexers "
-                        r"\[(3|4)(\.0)?\] "
-                        r"of type (float|int)".format(klass=type(index).__name__)
+                        fr"cannot do (slice|positional) indexing "
+                        fr"on {type(index).__name__} with these indexers "
+                        fr"\[(3|4)(\.0)?\] "
+                        fr"of type (float|int)"
                     )
                     with pytest.raises(TypeError, match=msg):
                         idxr(s)[l]
@@ -376,19 +374,19 @@ class TestFloatIndexers:
             for l in [slice(3.0, 4), slice(3, 4.0), slice(3.0, 4.0)]:
 
                 msg = (
-                    "cannot do positional indexing "
-                    r"on {klass} with these indexers \[(3|4)\.0\] of "
-                    "type float".format(klass=type(index).__name__)
+                    fr"cannot do positional indexing "
+                    fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s.iloc[l] = 0
 
                 for idxr in [lambda x: x.loc, lambda x: x.iloc, lambda x: x]:
                     msg = (
-                        "cannot do (slice|positional) indexing "
-                        r"on {klass} with these indexers "
-                        r"\[(3|4)(\.0)?\] "
-                        r"of type (float|int)".format(klass=type(index).__name__)
+                        fr"cannot do (slice|positional) indexing "
+                        fr"on {type(index).__name__} with these indexers "
+                        fr"\[(3|4)(\.0)?\] "
+                        fr"of type (float|int)"
                     )
                     with pytest.raises(TypeError, match=msg):
                         idxr(s)[l] = 0
@@ -426,9 +424,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    "cannot do slice indexing "
-                    r"on {klass} with these indexers \[(3|4)\.0\] of "
-                    "type float".format(klass=type(index).__name__)
+                    fr"cannot do slice indexing "
+                    fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -450,9 +448,9 @@ class TestFloatIndexers:
 
             # positional indexing
             msg = (
-                "cannot do slice indexing "
-                r"on {klass} with these indexers \[-6\.0\] of "
-                "type float".format(klass=type(index).__name__)
+                fr"cannot do slice indexing "
+                fr"on {type(index).__name__} with these indexers \[-6\.0\] of "
+                fr"type float"
             )
             with pytest.raises(TypeError, match=msg):
                 s[slice(-6.0, 6.0)]
@@ -476,9 +474,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    "cannot do slice indexing "
-                    r"on {klass} with these indexers \[(2|3)\.5\] of "
-                    "type float".format(klass=type(index).__name__)
+                    fr"cannot do slice indexing "
+                    fr"on {type(index).__name__} with these indexers \[(2|3)\.5\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -494,9 +492,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    "cannot do slice indexing "
-                    r"on {klass} with these indexers \[(3|4)\.0\] of "
-                    "type float".format(klass=type(index).__name__)
+                    fr"cannot do slice indexing "
+                    fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l] = 0
@@ -517,9 +515,9 @@ class TestFloatIndexers:
 
                 klass = RangeIndex
                 msg = (
-                    "cannot do (slice|positional) indexing "
-                    r"on {klass} with these indexers \[(2|4)\.0\] of "
-                    "type float".format(klass=klass.__name__)
+                    fr"cannot do (slice|positional) indexing "
+                    fr"on {klass.__name__} with these indexers \[(2|4)\.0\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     idxr(s)[l]
@@ -545,9 +543,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    "cannot do slice indexing "
-                    r"on {klass} with these indexers \[(0|1)\.0\] of "
-                    "type float".format(klass=type(index).__name__)
+                    fr"cannot do slice indexing "
+                    fr"on {type(index).__name__} with these indexers \[(0|1)\.0\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -560,9 +558,9 @@ class TestFloatIndexers:
 
             # positional indexing
             msg = (
-                "cannot do slice indexing "
-                r"on {klass} with these indexers \[-10\.0\] of "
-                "type float".format(klass=type(index).__name__)
+                fr"cannot do slice indexing "
+                fr"on {type(index).__name__} with these indexers \[-10\.0\] of "
+                fr"type float"
             )
             with pytest.raises(TypeError, match=msg):
                 s[slice(-10.0, 10.0)]
@@ -579,9 +577,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    "cannot do slice indexing "
-                    r"on {klass} with these indexers \[0\.5\] of "
-                    "type float".format(klass=type(index).__name__)
+                    fr"cannot do slice indexing "
+                    fr"on {type(index).__name__} with these indexers \[0\.5\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -596,9 +594,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    "cannot do slice indexing "
-                    r"on {klass} with these indexers \[(3|4)\.0\] of "
-                    "type float".format(klass=type(index).__name__)
+                    fr"cannot do slice indexing "
+                    fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
+                    fr"type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l] = 0

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -54,7 +54,7 @@ class TestFloatIndexers:
 
         msg = (
             fr"cannot do positional indexing on {type(i).__name__} with these "
-            "indexers \[3\.0\] of type float"
+            r"indexers \[3\.0\] of type float"
         )
         with pytest.raises(TypeError, match=msg):
             s.iloc[3.0] = 0

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -54,7 +54,7 @@ class TestFloatIndexers:
 
         msg = (
             fr"cannot do positional indexing on {type(i).__name__} with these "
-            fr"indexers \[3\.0\] of type float"
+            "indexers \[3\.0\] of type float"
         )
         with pytest.raises(TypeError, match=msg):
             s.iloc[3.0] = 0
@@ -94,11 +94,11 @@ class TestFloatIndexers:
                 else:
                     error = TypeError
                     msg = (
-                        fr"cannot do (label|positional) indexing "
+                        r"cannot do (label|positional) indexing "
                         fr"on {type(i).__name__} with these indexers \[3\.0\] of "
-                        fr"type float|"
-                        fr"Cannot index by location index with a "
-                        fr"non-integer key"
+                        r"type float|"
+                        "Cannot index by location index with a "
+                        "non-integer key"
                     )
                 with pytest.raises(error, match=msg):
                     idxr(s)[3.0]
@@ -115,9 +115,9 @@ class TestFloatIndexers:
             else:
                 error = TypeError
                 msg = (
-                    fr"cannot do (label|positional) indexing "
+                    r"cannot do (label|positional) indexing "
                     fr"on {type(i).__name__} with these indexers \[3\.0\] of "
-                    fr"type float"
+                    "type float"
                 )
             with pytest.raises(error, match=msg):
                 s.loc[3.0]
@@ -127,9 +127,9 @@ class TestFloatIndexers:
 
             # setting with a float fails with iloc
             msg = (
-                fr"cannot do (label|positional) indexing "
+                r"cannot do (label|positional) indexing "
                 fr"on {type(i).__name__} with these indexers \[3\.0\] of "
-                fr"type float"
+                "type float"
             )
             with pytest.raises(TypeError, match=msg):
                 s.iloc[3.0] = 0
@@ -164,9 +164,9 @@ class TestFloatIndexers:
         s = Series(np.arange(len(i)), index=i)
         s[3]
         msg = (
-            fr"cannot do (label|positional) indexing "
+            r"cannot do (label|positional) indexing "
             fr"on {type(i).__name__} with these indexers \[3\.0\] of "
-            fr"type float"
+            "type float"
         )
         with pytest.raises(TypeError, match=msg):
             s[3.0]
@@ -181,10 +181,10 @@ class TestFloatIndexers:
         for idxr in [lambda x: x, lambda x: x.iloc]:
 
             msg = (
-                fr"cannot do label indexing "
+                "cannot do label indexing "
                 fr"on {Index.__name__} with these indexers \[1\.0\] of "
-                fr"type float|"
-                fr"Cannot index by location index with a non-integer key"
+                r"type float|"
+                "Cannot index by location index with a non-integer key"
             )
             with pytest.raises(TypeError, match=msg):
                 idxr(s2)[1.0]
@@ -201,9 +201,9 @@ class TestFloatIndexers:
         for idxr in [lambda x: x]:
 
             msg = (
-                fr"cannot do label indexing "
+                "cannot do label indexing "
                 fr"on {Index.__name__} with these indexers \[1\.0\] of "
-                fr"type float"
+                "type float"
             )
             with pytest.raises(TypeError, match=msg):
                 idxr(s3)[1.0]
@@ -319,9 +319,9 @@ class TestFloatIndexers:
                 s.iloc[3.0]
 
             msg = (
-                fr"cannot do positional indexing "
+                "cannot do positional indexing "
                 fr"on {Float64Index.__name__} with these indexers \[3\.0\] of "
-                fr"type float"
+                "type float"
             )
             with pytest.raises(TypeError, match=msg):
                 s2.iloc[3.0] = 0
@@ -352,9 +352,9 @@ class TestFloatIndexers:
             for l in [slice(3.0, 4), slice(3, 4.0), slice(3.0, 4.0)]:
 
                 msg = (
-                    fr"cannot do positional indexing "
+                    "cannot do positional indexing "
                     fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s.iloc[l]
@@ -362,10 +362,10 @@ class TestFloatIndexers:
                 for idxr in [lambda x: x.loc, lambda x: x.iloc, lambda x: x]:
 
                     msg = (
-                        fr"cannot do (slice|positional) indexing "
+                        "cannot do (slice|positional) indexing "
                         fr"on {type(index).__name__} with these indexers "
-                        fr"\[(3|4)(\.0)?\] "
-                        fr"of type (float|int)"
+                        r"\[(3|4)(\.0)?\] "
+                        r"of type (float|int)"
                     )
                     with pytest.raises(TypeError, match=msg):
                         idxr(s)[l]
@@ -374,19 +374,19 @@ class TestFloatIndexers:
             for l in [slice(3.0, 4), slice(3, 4.0), slice(3.0, 4.0)]:
 
                 msg = (
-                    fr"cannot do positional indexing "
+                    "cannot do positional indexing "
                     fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s.iloc[l] = 0
 
                 for idxr in [lambda x: x.loc, lambda x: x.iloc, lambda x: x]:
                     msg = (
-                        fr"cannot do (slice|positional) indexing "
+                        "cannot do (slice|positional) indexing "
                         fr"on {type(index).__name__} with these indexers "
-                        fr"\[(3|4)(\.0)?\] "
-                        fr"of type (float|int)"
+                        r"\[(3|4)(\.0)?\] "
+                        r"of type (float|int)"
                     )
                     with pytest.raises(TypeError, match=msg):
                         idxr(s)[l] = 0
@@ -424,9 +424,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    fr"cannot do slice indexing "
+                    "cannot do slice indexing "
                     fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -448,9 +448,9 @@ class TestFloatIndexers:
 
             # positional indexing
             msg = (
-                fr"cannot do slice indexing "
+                "cannot do slice indexing "
                 fr"on {type(index).__name__} with these indexers \[-6\.0\] of "
-                fr"type float"
+                "type float"
             )
             with pytest.raises(TypeError, match=msg):
                 s[slice(-6.0, 6.0)]
@@ -474,9 +474,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    fr"cannot do slice indexing "
+                    "cannot do slice indexing "
                     fr"on {type(index).__name__} with these indexers \[(2|3)\.5\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -492,9 +492,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    fr"cannot do slice indexing "
+                    "cannot do slice indexing "
                     fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l] = 0
@@ -515,9 +515,9 @@ class TestFloatIndexers:
 
                 klass = RangeIndex
                 msg = (
-                    fr"cannot do (slice|positional) indexing "
+                    "cannot do (slice|positional) indexing "
                     fr"on {klass.__name__} with these indexers \[(2|4)\.0\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     idxr(s)[l]
@@ -543,9 +543,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    fr"cannot do slice indexing "
+                    "cannot do slice indexing "
                     fr"on {type(index).__name__} with these indexers \[(0|1)\.0\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -558,9 +558,9 @@ class TestFloatIndexers:
 
             # positional indexing
             msg = (
-                fr"cannot do slice indexing "
+                "cannot do slice indexing "
                 fr"on {type(index).__name__} with these indexers \[-10\.0\] of "
-                fr"type float"
+                "type float"
             )
             with pytest.raises(TypeError, match=msg):
                 s[slice(-10.0, 10.0)]
@@ -577,9 +577,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    fr"cannot do slice indexing "
+                    "cannot do slice indexing "
                     fr"on {type(index).__name__} with these indexers \[0\.5\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l]
@@ -594,9 +594,9 @@ class TestFloatIndexers:
 
                 # positional indexing
                 msg = (
-                    fr"cannot do slice indexing "
+                    "cannot do slice indexing "
                     fr"on {type(index).__name__} with these indexers \[(3|4)\.0\] of "
-                    fr"type float"
+                    "type float"
                 )
                 with pytest.raises(TypeError, match=msg):
                     s[l] = 0


### PR DESCRIPTION
I splitted PR #31844 in batches, this is the third
For this PR I ran the command `grep -l -R -e '%s' -e '%d' -e '\.format(' --include=*.{py,pyx} pandas/` and checked all the files that were returned for `.format(` and changed the old string format for the corresponding `fstrings` to attempt a full clean of, [#29547](https://github.com/pandas-dev/pandas/issues/29547). I may have missed something so is a good idea to double check just in case

- [ x  ] tests added / passed
- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`