### PR TITLE
CLN: index related attributes on Series/DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8575,6 +8575,13 @@ Wild         185.0
     columns: "Index" = properties.AxisProperty(
         axis=0, doc="The column labels of the DataFrame."
     )
+    _AXIS_ORDERS = ["index", "columns"]
+    _AXIS_NUMBERS = {"index": 0, "columns": 1}
+    _AXIS_NAMES = {0: "index", 1: "columns"}
+    _AXIS_REVERSED = True
+    _info_axis_number = 1
+    _info_axis_name = _AXIS_ORDERS[_info_axis_number]
+    _AXIS_LEN = len(_AXIS_ORDERS)
 
     # ----------------------------------------------------------------------
     # Add plotting methods to DataFrame
@@ -8584,13 +8591,6 @@ Wild         185.0
     sparse = CachedAccessor("sparse", SparseFrameAccessor)
 
 
-DataFrame._setup_axes(
-    ["index", "columns"],
-    docs={
-        "index": "The index (row labels) of the DataFrame.",
-        "columns": "The column labels of the DataFrame.",
-    },
-)
 DataFrame._add_numeric_operations()
 DataFrame._add_series_or_dataframe_operations()
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8569,19 +8569,20 @@ Wild         185.0
 
     # ----------------------------------------------------------------------
     # Add index and columns
+    _AXIS_ORDERS = ["index", "columns"]
+    _AXIS_NUMBERS = {"index": 0, "columns": 1}
+    _AXIS_NAMES = {0: "index", 1: "columns"}
+    _AXIS_REVERSED = True
+    _AXIS_LEN = len(_AXIS_ORDERS)
+    _info_axis_number = 1
+    _info_axis_name = "columns"
+
     index: "Index" = properties.AxisProperty(
         axis=1, doc="The index (row labels) of the DataFrame."
     )
     columns: "Index" = properties.AxisProperty(
         axis=0, doc="The column labels of the DataFrame."
     )
-    _AXIS_ORDERS = ["index", "columns"]
-    _AXIS_NUMBERS = {"index": 0, "columns": 1}
-    _AXIS_NAMES = {0: "index", 1: "columns"}
-    _AXIS_REVERSED = True
-    _info_axis_number = 1
-    _info_axis_name = _AXIS_ORDERS[_info_axis_number]
-    _AXIS_LEN = len(_AXIS_ORDERS)
 
     # ----------------------------------------------------------------------
     # Add plotting methods to DataFrame

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -315,28 +315,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     _info_axis_name: str
     _AXIS_LEN: int
 
-    @classmethod
-    def _setup_axes(cls, axes: List[str], docs: Dict[str, str]) -> None:
-        """
-        Provide axes setup for the major PandasObjects.
-
-        Parameters
-        ----------
-        axes : the names of the axes in order (lowest to highest)
-        docs : docstrings for the axis properties
-        """
-        info_axis = len(axes) - 1
-        axes_are_reversed = len(axes) > 1
-
-        cls._AXIS_ORDERS = axes
-        cls._AXIS_NUMBERS = {a: i for i, a in enumerate(axes)}
-        cls._AXIS_LEN = len(axes)
-        cls._AXIS_NAMES = dict(enumerate(axes))
-        cls._AXIS_REVERSED = axes_are_reversed
-
-        cls._info_axis_number = info_axis
-        cls._info_axis_name = axes[info_axis]
-
     def _construct_axes_dict(self, axes=None, **kwargs):
         """Return an axes dictionary for myself."""
         d = {a: self._get_axis(a) for a in (axes or self._AXIS_ORDERS)}

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4562,16 +4562,17 @@ Name: Max Speed, dtype: float64
 
     # ----------------------------------------------------------------------
     # Add index
-    index: "Index" = properties.AxisProperty(
-        axis=0, doc="The index (axis labels) of the Series."
-    )
     _AXIS_ORDERS = ["index"]
     _AXIS_NUMBERS = {"index": 0}
     _AXIS_NAMES = {0: "index"}
     _AXIS_REVERSED = False
-    _info_axis_number = 0
-    _info_axis_name = _AXIS_ORDERS[_info_axis_number]
     _AXIS_LEN = len(_AXIS_ORDERS)
+    _info_axis_number = 0
+    _info_axis_name = "index"
+
+    index: "Index" = properties.AxisProperty(
+        axis=0, doc="The index (axis labels) of the Series."
+    )
 
     # ----------------------------------------------------------------------
     # Accessor Methods

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4565,6 +4565,13 @@ Name: Max Speed, dtype: float64
     index: "Index" = properties.AxisProperty(
         axis=0, doc="The index (axis labels) of the Series."
     )
+    _AXIS_ORDERS = ["index"]
+    _AXIS_NUMBERS = {"index": 0}
+    _AXIS_NAMES = {0: "index"}
+    _AXIS_REVERSED = False
+    _info_axis_number = 0
+    _info_axis_name = _AXIS_ORDERS[_info_axis_number]
+    _AXIS_LEN = len(_AXIS_ORDERS)
 
     # ----------------------------------------------------------------------
     # Accessor Methods
@@ -4580,7 +4587,6 @@ Name: Max Speed, dtype: float64
     hist = pandas.plotting.hist_series
 
 
-Series._setup_axes(["index"], docs={"index": "The index (axis labels) of the Series."})
 Series._add_numeric_operations()
 Series._add_series_or_dataframe_operations()
 


### PR DESCRIPTION
Followup to #31126. IMO the current approach to adding the index related class attributes is too indirect and therefore unnecessary difficult to follow. Just adding the class attributes directly on the relevant class makes reading the code easier, IMO.

Notice that the types are already defined in pandas/core/generic.py:304-316.