### PR TITLE
CLN: remove blocking return

### DIFF
--- a/pandas/tests/indexes/multi/test_copy.py
+++ b/pandas/tests/indexes/multi/test_copy.py
@@ -80,7 +80,6 @@ def test_copy_method_kwargs(deep, kwarg, value):
         codes=[[0, 0, 0, 1], [0, 0, 1, 1]],
         names=["first", "second"],
     )
-    return
     idx_copy = idx.copy(**{kwarg: value, "deep": deep})
     if kwarg == "names":
         assert getattr(idx_copy, kwarg) == value


### PR DESCRIPTION
just noticed a `return` statement in the middle of a test that prevents it from being executed. This was added in ##23752