### PR TITLE
CLN: 29547 replace old string formatting 5

### DIFF
--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -158,7 +158,7 @@ def test_precise_conversion(c_parser_only):
     # test numbers between 1 and 2
     for num in np.linspace(1.0, 2.0, num=500):
         # 25 decimal digits of precision
-        text = "a\n{0:.25}".format(num)
+        text = f"a\n{num:.25}"
 
         normal_val = float(parser.read_csv(StringIO(text))["a"][0])
         precise_val = float(
@@ -170,7 +170,7 @@ def test_precise_conversion(c_parser_only):
         actual_val = Decimal(text[2:])
 
         def error(val):
-            return abs(Decimal("{0:.100}".format(val)) - actual_val)
+            return abs(Decimal(f"{val:.100}") - actual_val)
 
         normal_errors.append(error(normal_val))
         precise_errors.append(error(precise_val))
@@ -299,9 +299,7 @@ def test_grow_boundary_at_cap(c_parser_only):
 
     def test_empty_header_read(count):
         s = StringIO("," * count)
-        expected = DataFrame(
-            columns=["Unnamed: {i}".format(i=i) for i in range(count + 1)]
-        )
+        expected = DataFrame(columns=[f"Unnamed: {i}" for i in range(count + 1)])
         df = parser.read_csv(s)
         tm.assert_frame_equal(df, expected)
 
@@ -489,7 +487,7 @@ def test_comment_whitespace_delimited(c_parser_only, capsys):
     captured = capsys.readouterr()
     # skipped lines 2, 3, 4, 9
     for line_num in (2, 3, 4, 9):
-        assert "Skipping line {}".format(line_num) in captured.err
+        assert f"Skipping line {line_num}" in captured.err
     expected = DataFrame([[1, 2], [5, 2], [6, 2], [7, np.nan], [8, np.nan]])
     tm.assert_frame_equal(df, expected)
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -957,7 +957,7 @@ def test_nonexistent_path(all_parsers):
     # gh-14086: raise more helpful FileNotFoundError
     # GH#29233 "File foo" instead of "File b'foo'"
     parser = all_parsers
-    path = "{}.csv".format(tm.rands(10))
+    path = f"{tm.rands(10)}.csv"
 
     msg = f"File {path} does not exist" if parser.engine == "c" else r"\[Errno 2\]"
     with pytest.raises(FileNotFoundError, match=msg) as e:
@@ -1872,7 +1872,7 @@ def test_internal_eof_byte_to_file(all_parsers):
     parser = all_parsers
     data = b'c1,c2\r\n"test \x1a    test", test\r\n'
     expected = DataFrame([["test \x1a    test", " test"]], columns=["c1", "c2"])
-    path = "__{}__.csv".format(tm.rands(10))
+    path = f"__{tm.rands(10)}__.csv"
 
     with tm.ensure_clean(path) as path:
         with open(path, "wb") as f:

--- a/pandas/tests/io/parser/test_compression.py
+++ b/pandas/tests/io/parser/test_compression.py
@@ -145,7 +145,7 @@ def test_invalid_compression(all_parsers, invalid_compression):
     parser = all_parsers
     compress_kwargs = dict(compression=invalid_compression)
 
-    msg = f"Unrecognized compression type: {compress_kwargs['compression']}"
+    msg = f"Unrecognized compression type: {invalid_compression}"
 
     with pytest.raises(ValueError, match=msg):
         parser.read_csv("test_file.zip", **compress_kwargs)

--- a/pandas/tests/io/parser/test_compression.py
+++ b/pandas/tests/io/parser/test_compression.py
@@ -145,7 +145,7 @@ def test_invalid_compression(all_parsers, invalid_compression):
     parser = all_parsers
     compress_kwargs = dict(compression=invalid_compression)
 
-    msg = "Unrecognized compression type: {compression}".format(**compress_kwargs)
+    msg = f"Unrecognized compression type: {compress_kwargs['compression']}"
 
     with pytest.raises(ValueError, match=msg):
         parser.read_csv("test_file.zip", **compress_kwargs)

--- a/pandas/tests/io/parser/test_encoding.py
+++ b/pandas/tests/io/parser/test_encoding.py
@@ -45,7 +45,7 @@ A,B,C
 4,5,6""".replace(
         ",", sep
     )
-    path = "__{}__.csv".format(tm.rands(10))
+    path = f"__{tm.rands(10)}__.csv"
     kwargs = dict(sep=sep, skiprows=2)
     utf8 = "utf-8"
 

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -41,9 +41,7 @@ def test_multi_thread_string_io_read_csv(all_parsers):
     num_files = 100
 
     bytes_to_df = [
-        "\n".join(
-            ["{i:d},{i:d},{i:d}".format(i=i) for i in range(max_row_range)]
-        ).encode()
+        "\n".join([f"{i:d},{i:d},{i:d}" for i in range(max_row_range)]).encode()
         for _ in range(num_files)
     ]
     files = [BytesIO(b) for b in bytes_to_df]

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -111,10 +111,10 @@ def test_default_na_values(all_parsers):
         elif i > 0:
             buf = "".join([","] * i)
 
-        buf = "{0}{1}".format(buf, v)
+        buf = f"{buf}{v}"
 
         if i < nv - 1:
-            buf = "{0}{1}".format(buf, "".join([","] * (nv - i - 1)))
+            buf = f"{buf}{''.join([','] * (nv - i - 1))}"
 
         return buf
 

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -114,7 +114,8 @@ def test_default_na_values(all_parsers):
         buf = f"{buf}{v}"
 
         if i < nv - 1:
-            buf = f"{buf}{''.join([','] * (nv - i - 1))}"
+            joined = "".join([","] * (nv - i - 1))
+            buf = f"{buf}{joined}"
 
         return buf
 

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -1101,7 +1101,7 @@ def test_bad_date_parse(all_parsers, cache_dates, value):
     # if we have an invalid date make sure that we handle this with
     # and w/o the cache properly
     parser = all_parsers
-    s = StringIO(("{value},\n".format(value=value)) * 50000)
+    s = StringIO((f"{value},\n") * 50000)
 
     parser.read_csv(
         s,

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -260,7 +260,7 @@ def test_fwf_regression():
     # Turns out "T060" is parsable as a datetime slice!
     tz_list = [1, 10, 20, 30, 60, 80, 100]
     widths = [16] + [8] * len(tz_list)
-    names = ["SST"] + ["T{z:03d}".format(z=z) for z in tz_list[1:]]
+    names = ["SST"] + [f"T{z:03d}" for z in tz_list[1:]]
 
     data = """  2009164202000   9.5403  9.4105  8.6571  7.8372  6.0612  5.8843  5.5192
 2009164203000   9.5435  9.2010  8.6167  7.8176  6.0804  5.8728  5.4869

--- a/pandas/tests/io/pytables/conftest.py
+++ b/pandas/tests/io/pytables/conftest.py
@@ -6,7 +6,7 @@ import pandas._testing as tm
 @pytest.fixture
 def setup_path():
     """Fixture for setup path"""
-    return "tmp.__{}__.h5".format(tm.rands(10))
+    return f"tmp.__{tm.rands(10)}__.h5"
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -2687,12 +2687,12 @@ class TestHDFStore:
 
             expected = df[df.boolv == True].reindex(columns=["A", "boolv"])  # noqa
             for v in [True, "true", 1]:
-                result = store.select("df", f"boolv == {v!s}", columns=["A", "boolv"])
+                result = store.select("df", f"boolv == {v}", columns=["A", "boolv"])
                 tm.assert_frame_equal(expected, result)
 
             expected = df[df.boolv == False].reindex(columns=["A", "boolv"])  # noqa
             for v in [False, "false", 0]:
-                result = store.select("df", f"boolv == {v!s}", columns=["A", "boolv"])
+                result = store.select("df", f"boolv == {v}", columns=["A", "boolv"])
                 tm.assert_frame_equal(expected, result)
 
             # integer index

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -653,7 +653,7 @@ class TestHDFStore:
 
             # not stores
             for x in ["mode", "path", "handle", "complib"]:
-                getattr(store, "_{x}".format(x=x))
+                getattr(store, f"_{x}")
 
     def test_put(self, setup_path):
 
@@ -690,9 +690,7 @@ class TestHDFStore:
 
         with ensure_clean_store(setup_path) as store:
 
-            index = Index(
-                ["I am a very long string index: {i}".format(i=i) for i in range(20)]
-            )
+            index = Index([f"I am a very long string index: {i}" for i in range(20)])
             s = Series(np.arange(20), index=index)
             df = DataFrame({"A": s, "B": s})
 
@@ -705,7 +703,7 @@ class TestHDFStore:
             # mixed length
             index = Index(
                 ["abcdefghijklmnopqrstuvwxyz1234567890"]
-                + ["I am a very long string index: {i}".format(i=i) for i in range(20)]
+                + [f"I am a very long string index: {i}" for i in range(20)]
             )
             s = Series(np.arange(21), index=index)
             df = DataFrame({"A": s, "B": s})
@@ -2044,7 +2042,7 @@ class TestHDFStore:
                 df = tm.makeDataFrame()
                 df[n] = f
                 with pytest.raises(TypeError):
-                    store.append("df1_{n}".format(n=n), df)
+                    store.append(f"df1_{n}", df)
 
         # frame
         df = tm.makeDataFrame()
@@ -2689,16 +2687,12 @@ class TestHDFStore:
 
             expected = df[df.boolv == True].reindex(columns=["A", "boolv"])  # noqa
             for v in [True, "true", 1]:
-                result = store.select(
-                    "df", "boolv == {v!s}".format(v=v), columns=["A", "boolv"]
-                )
+                result = store.select("df", f"boolv == {v!s}", columns=["A", "boolv"])
                 tm.assert_frame_equal(expected, result)
 
             expected = df[df.boolv == False].reindex(columns=["A", "boolv"])  # noqa
             for v in [False, "false", 0]:
-                result = store.select(
-                    "df", "boolv == {v!s}".format(v=v), columns=["A", "boolv"]
-                )
+                result = store.select("df", f"boolv == {v!s}", columns=["A", "boolv"])
                 tm.assert_frame_equal(expected, result)
 
             # integer index
@@ -2784,7 +2778,7 @@ class TestHDFStore:
                     users=["a"] * 50
                     + ["b"] * 50
                     + ["c"] * 100
-                    + ["a{i:03d}".format(i=i) for i in range(100)],
+                    + [f"a{i:03d}" for i in range(100)],
                 )
             )
             _maybe_remove(store, "df")
@@ -2805,7 +2799,7 @@ class TestHDFStore:
             tm.assert_frame_equal(expected, result)
 
             # big selector along the columns
-            selector = ["a", "b", "c"] + ["a{i:03d}".format(i=i) for i in range(60)]
+            selector = ["a", "b", "c"] + [f"a{i:03d}" for i in range(60)]
             result = store.select(
                 "df", "ts>=Timestamp('2012-02-01') and users=selector"
             )
@@ -2914,21 +2908,19 @@ class TestHDFStore:
 
             # select w/o iterator and where clause, single term, begin
             # of range, works
-            where = "index >= '{beg_dt}'".format(beg_dt=beg_dt)
+            where = f"index >= '{beg_dt}'"
             result = store.select("df", where=where)
             tm.assert_frame_equal(expected, result)
 
             # select w/o iterator and where clause, single term, end
             # of range, works
-            where = "index <= '{end_dt}'".format(end_dt=end_dt)
+            where = f"index <= '{end_dt}'"
             result = store.select("df", where=where)
             tm.assert_frame_equal(expected, result)
 
             # select w/o iterator and where clause, inclusive range,
             # works
-            where = "index >= '{beg_dt}' & index <= '{end_dt}'".format(
-                beg_dt=beg_dt, end_dt=end_dt
-            )
+            where = f"index >= '{beg_dt}' & index <= '{end_dt}'"
             result = store.select("df", where=where)
             tm.assert_frame_equal(expected, result)
 
@@ -2948,21 +2940,19 @@ class TestHDFStore:
             tm.assert_frame_equal(expected, result)
 
             # select w/iterator and where clause, single term, begin of range
-            where = "index >= '{beg_dt}'".format(beg_dt=beg_dt)
+            where = f"index >= '{beg_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
             result = concat(results)
             tm.assert_frame_equal(expected, result)
 
             # select w/iterator and where clause, single term, end of range
-            where = "index <= '{end_dt}'".format(end_dt=end_dt)
+            where = f"index <= '{end_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
             result = concat(results)
             tm.assert_frame_equal(expected, result)
 
             # select w/iterator and where clause, inclusive range
-            where = "index >= '{beg_dt}' & index <= '{end_dt}'".format(
-                beg_dt=beg_dt, end_dt=end_dt
-            )
+            where = f"index >= '{beg_dt}' & index <= '{end_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
             result = concat(results)
             tm.assert_frame_equal(expected, result)
@@ -2984,23 +2974,21 @@ class TestHDFStore:
             end_dt = expected.index[-2]
 
             # select w/iterator and where clause, single term, begin of range
-            where = "index >= '{beg_dt}'".format(beg_dt=beg_dt)
+            where = f"index >= '{beg_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
             result = concat(results)
             rexpected = expected[expected.index >= beg_dt]
             tm.assert_frame_equal(rexpected, result)
 
             # select w/iterator and where clause, single term, end of range
-            where = "index <= '{end_dt}'".format(end_dt=end_dt)
+            where = f"index <= '{end_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
             result = concat(results)
             rexpected = expected[expected.index <= end_dt]
             tm.assert_frame_equal(rexpected, result)
 
             # select w/iterator and where clause, inclusive range
-            where = "index >= '{beg_dt}' & index <= '{end_dt}'".format(
-                beg_dt=beg_dt, end_dt=end_dt
-            )
+            where = f"index >= '{beg_dt}' & index <= '{end_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
             result = concat(results)
             rexpected = expected[
@@ -3018,7 +3006,7 @@ class TestHDFStore:
             end_dt = expected.index[-1]
 
             # select w/iterator and where clause, single term, begin of range
-            where = "index > '{end_dt}'".format(end_dt=end_dt)
+            where = f"index > '{end_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
             assert 0 == len(results)
 
@@ -3040,14 +3028,14 @@ class TestHDFStore:
             end_dt = expected.index[chunksize - 1]
 
             # select w/iterator and where clause, single term, begin of range
-            where = "index >= '{beg_dt}'".format(beg_dt=beg_dt)
+            where = f"index >= '{beg_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
             result = concat(results)
             rexpected = expected[expected.index >= beg_dt]
             tm.assert_frame_equal(rexpected, result)
 
             # select w/iterator and where clause, single term, end of range
-            where = "index <= '{end_dt}'".format(end_dt=end_dt)
+            where = f"index <= '{end_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
 
             assert len(results) == 1
@@ -3056,9 +3044,7 @@ class TestHDFStore:
             tm.assert_frame_equal(rexpected, result)
 
             # select w/iterator and where clause, inclusive range
-            where = "index >= '{beg_dt}' & index <= '{end_dt}'".format(
-                beg_dt=beg_dt, end_dt=end_dt
-            )
+            where = f"index >= '{beg_dt}' & index <= '{end_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
 
             # should be 1, is 10
@@ -3076,9 +3062,7 @@ class TestHDFStore:
             # return [] e.g. `for e in []: print True` never prints
             # True.
 
-            where = "index <= '{beg_dt}' & index >= '{end_dt}'".format(
-                beg_dt=beg_dt, end_dt=end_dt
-            )
+            where = f"index <= '{beg_dt}' & index >= '{end_dt}'"
             results = list(store.select("df", where=where, chunksize=chunksize))
 
             # should be []
@@ -3807,8 +3791,8 @@ class TestHDFStore:
     def test_select_filter_corner(self, setup_path):
 
         df = DataFrame(np.random.randn(50, 100))
-        df.index = ["{c:3d}".format(c=c) for c in df.index]
-        df.columns = ["{c:3d}".format(c=c) for c in df.columns]
+        df.index = [f"{c:3d}" for c in df.index]
+        df.columns = [f"{c:3d}" for c in df.columns]
 
         with ensure_clean_store(setup_path) as store:
             store.put("frame", df, format="table")
@@ -4259,7 +4243,7 @@ class TestHDFStore:
         df5 = DataFrame({("1", 2, object): np.random.randn(10)})
 
         with ensure_clean_store(setup_path) as store:
-            name = "df_{}".format(tm.rands(10))
+            name = f"df_{tm.rands(10)}"
             store.append(name, df)
 
             for d in (df2, df3, df4, df5):
@@ -4543,9 +4527,7 @@ class TestHDFStore:
             with ensure_clean_path(setup_path) as path:
                 with catch_warnings(record=True):
                     df.to_hdf(path, "df", format="table", data_columns=True)
-                    result = pd.read_hdf(
-                        path, "df", where="index = [{0}]".format(df.index[0])
-                    )
+                    result = pd.read_hdf(path, "df", where=f"index = [{df.index[0]}]")
                     assert len(result)
 
     def test_read_hdf_open_store(self, setup_path):
@@ -4678,16 +4660,16 @@ class TestHDFStore:
             store.append("test", df, format="table", data_columns=True)
 
             cutoff = 1000000000.0006
-            result = store.select("test", "A < {cutoff:.4f}".format(cutoff=cutoff))
+            result = store.select("test", f"A < {cutoff:.4f}")
             assert result.empty
 
             cutoff = 1000000000.0010
-            result = store.select("test", "A > {cutoff:.4f}".format(cutoff=cutoff))
+            result = store.select("test", f"A > {cutoff:.4f}")
             expected = df.loc[[1, 2], :]
             tm.assert_frame_equal(expected, result)
 
             exact = 1000000000.0011
-            result = store.select("test", "A == {exact:.4f}".format(exact=exact))
+            result = store.select("test", f"A == {exact:.4f}")
             expected = df.loc[[1], :]
             tm.assert_frame_equal(expected, result)
 
@@ -4714,21 +4696,21 @@ class TestHDFStore:
             for op in ["<", ">", "=="]:
                 # non strings to string column always fail
                 for v in [2.1, True, pd.Timestamp("2014-01-01"), pd.Timedelta(1, "s")]:
-                    query = "date {op} v".format(op=op)
+                    query = f"date {op} v"
                     with pytest.raises(TypeError):
                         store.select("test", where=query)
 
                 # strings to other columns must be convertible to type
                 v = "a"
                 for col in ["int", "float", "real_date"]:
-                    query = "{col} {op} v".format(op=op, col=col)
+                    query = f"{col} {op} v"
                     with pytest.raises(ValueError):
                         store.select("test", where=query)
 
                 for v, col in zip(
                     ["1", "1.1", "2014-01-01"], ["int", "float", "real_date"]
                 ):
-                    query = "{col} {op} v".format(op=op, col=col)
+                    query = f"{col} {op} v"
                     result = store.select("test", where=query)
 
                     if op == "==":


### PR DESCRIPTION
I splitted PR #31844 in batches, this is the fifth
For this PR I ran the command `grep -l -R -e '%s' -e '%d' -e '\.format(' --include=*.{py,pyx} pandas/` and checked all the files that were returned for `.format(` and changed the old string format for the corresponding `fstrings` to attempt a full clean of, [#29547](https://github.com/pandas-dev/pandas/issues/29547). I may have missed something so is a good idea to double check just in case

- [ x  ] tests added / passed
- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`