### PR TITLE
DOC: Use use recommended library over deprecated library

### DIFF
--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -159,11 +159,10 @@ def _json_normalize(
 
     Examples
     --------
-    >>> from pandas.io.json import json_normalize
     >>> data = [{'id': 1, 'name': {'first': 'Coleen', 'last': 'Volk'}},
     ...         {'name': {'given': 'Mose', 'family': 'Regner'}},
     ...         {'id': 2, 'name': 'Faye Raker'}]
-    >>> json_normalize(data)
+    >>> pandas.json_normalize(data)
         id        name name.family name.first name.given name.last
     0  1.0         NaN         NaN     Coleen        NaN      Volk
     1  NaN         NaN      Regner        NaN       Mose       NaN


### PR DESCRIPTION
Importing `pandas.io.json.json_normalize` in pandas 1.0.1 gives the following warning

```
FutureWarning: pandas.io.json.json_normalize is deprecated, use pandas.json_normalize instead
```

This PR updates the documentation here https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.json_normalize.html to use the recommended approach.