### PR TITLE
CLN: 29547 replace old string formatting 6

### DIFF
--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -53,7 +53,7 @@ class TestFloatIndexers:
             s.iloc[3.0]
 
         msg = (
-            fr"cannot do positional indexing on {type(i).__name__} with these "
+            f"cannot do positional indexing on {type(i).__name__} with these "
             r"indexers \[3\.0\] of type float"
         )
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -24,9 +24,7 @@ def _compare_with_tz(a, b):
             a_e = a.loc[i, c]
             b_e = b.loc[i, c]
             if not (a_e == b_e and a_e.tz == b_e.tz):
-                raise AssertionError(
-                    "invalid tz comparison [{a_e}] [{b_e}]".format(a_e=a_e, b_e=b_e)
-                )
+                raise AssertionError(f"invalid tz comparison [{a_e}] [{b_e}]")
 
 
 def test_append_with_timezones_dateutil(setup_path):

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -40,8 +40,8 @@ def html_encoding_file(request, datapath):
 def assert_framelist_equal(list1, list2, *args, **kwargs):
     assert len(list1) == len(list2), (
         "lists are not of equal size "
-        "len(list1) == {0}, "
-        "len(list2) == {1}".format(len(list1), len(list2))
+        f"len(list1) == {len(list1)}, "
+        f"len(list2) == {len(list2)}"
     )
     msg = "not all list elements are DataFrames"
     both_frames = all(

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1715,7 +1715,7 @@ The repeated labels are:\n-+\nwolof
                 "'ascii' codec can't decode byte 0xef in position 14: "
                 r"ordinal not in range\(128\)"
             )
-            with pytest.raises(UnicodeEncodeError, match=r"{}|{}".format(msg1, msg2)):
+            with pytest.raises(UnicodeEncodeError, match=fr"{msg1}|{msg2}"):
                 with tm.assert_produces_warning(ResourceWarning):
                     df.to_stata(path)
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1715,7 +1715,7 @@ The repeated labels are:\n-+\nwolof
                 "'ascii' codec can't decode byte 0xef in position 14: "
                 r"ordinal not in range\(128\)"
             )
-            with pytest.raises(UnicodeEncodeError, match=fr"{msg1}|{msg2}"):
+            with pytest.raises(UnicodeEncodeError, match=f"{msg1}|{msg2}"):
                 with tm.assert_produces_warning(ResourceWarning):
                     df.to_stata(path)
 

--- a/pandas/tests/resample/test_period_index.py
+++ b/pandas/tests/resample/test_period_index.py
@@ -96,9 +96,7 @@ class TestPeriodIndex:
     def test_annual_upsample_cases(
         self, targ, conv, meth, month, simple_period_range_series
     ):
-        ts = simple_period_range_series(
-            "1/1/1990", "12/31/1991", freq="A-{month}".format(month=month)
-        )
+        ts = simple_period_range_series("1/1/1990", "12/31/1991", freq=f"A-{month}")
 
         result = getattr(ts.resample(targ, convention=conv), meth)()
         expected = result.to_timestamp(targ, how=conv)
@@ -130,9 +128,9 @@ class TestPeriodIndex:
         # These are incompatible period rules for resampling
         ts = simple_period_range_series("1/1/1990", "6/30/1995", freq="w-wed")
         msg = (
-            "Frequency <Week: weekday=2> cannot be resampled to {}, as they "
-            "are not sub or super periods"
-        ).format(expected_error_msg)
+            "Frequency <Week: weekday=2> cannot be resampled to "
+            f"{expected_error_msg}, as they are not sub or super periods"
+        )
         with pytest.raises(IncompatibleFrequency, match=msg):
             ts.resample(rule).mean()
 
@@ -176,7 +174,7 @@ class TestPeriodIndex:
     def test_quarterly_upsample(
         self, month, target, convention, simple_period_range_series
     ):
-        freq = "Q-{month}".format(month=month)
+        freq = f"Q-{month}"
         ts = simple_period_range_series("1/1/1990", "12/31/1995", freq=freq)
         result = ts.resample(target, convention=convention).ffill()
         expected = result.to_timestamp(target, how=convention)
@@ -351,7 +349,7 @@ class TestPeriodIndex:
     @pytest.mark.parametrize("target", ["D", "B"])
     @pytest.mark.parametrize("convention", ["start", "end"])
     def test_weekly_upsample(self, day, target, convention, simple_period_range_series):
-        freq = "W-{day}".format(day=day)
+        freq = f"W-{day}"
         ts = simple_period_range_series("1/1/1990", "12/31/1995", freq=freq)
         result = ts.resample(target, convention=convention).ffill()
         expected = result.to_timestamp(target, how=convention)
@@ -367,16 +365,14 @@ class TestPeriodIndex:
 
     def test_resample_to_quarterly(self, simple_period_range_series):
         for month in MONTHS:
-            ts = simple_period_range_series(
-                "1990", "1992", freq="A-{month}".format(month=month)
-            )
-            quar_ts = ts.resample("Q-{month}".format(month=month)).ffill()
+            ts = simple_period_range_series("1990", "1992", freq=f"A-{month}")
+            quar_ts = ts.resample(f"Q-{month}").ffill()
 
             stamps = ts.to_timestamp("D", how="start")
             qdates = period_range(
                 ts.index[0].asfreq("D", "start"),
                 ts.index[-1].asfreq("D", "end"),
-                freq="Q-{month}".format(month=month),
+                freq=f"Q-{month}",
             )
 
             expected = stamps.reindex(qdates.to_timestamp("D", "s"), method="ffill")

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -264,7 +264,7 @@ class TestJoin:
         df = DataFrame({"a": [1, 1]})
         msg = (
             "Can only merge Series or DataFrame objects, "
-            f"a {str(type(wrong_type))} was passed"
+            f"a {type(wrong_type)} was passed"
         )
         with pytest.raises(TypeError, match=msg):
             merge(wrong_type, df, left_on="a", right_on="a")
@@ -813,7 +813,7 @@ def _check_join(left, right, result, join_col, how="left", lsuffix="_x", rsuffix
         except KeyError:
             if how in ("left", "inner"):
                 raise AssertionError(
-                    f"key {group_key!s} should not have been in the join"
+                    f"key {group_key} should not have been in the join"
                 )
 
             _assert_all_na(l_joined, left.columns, join_col)
@@ -825,7 +825,7 @@ def _check_join(left, right, result, join_col, how="left", lsuffix="_x", rsuffix
         except KeyError:
             if how in ("right", "inner"):
                 raise AssertionError(
-                    f"key {group_key!s} should not have been in the join"
+                    f"key {group_key} should not have been in the join"
                 )
 
             _assert_all_na(r_joined, right.columns, join_col)

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -262,8 +262,9 @@ class TestJoin:
         # Edited test to remove the Series object from test parameters
 
         df = DataFrame({"a": [1, 1]})
-        msg = "Can only merge Series or DataFrame objects, a {} was passed".format(
-            str(type(wrong_type))
+        msg = (
+            "Can only merge Series or DataFrame objects, "
+            f"a {str(type(wrong_type))} was passed"
         )
         with pytest.raises(TypeError, match=msg):
             merge(wrong_type, df, left_on="a", right_on="a")
@@ -812,9 +813,7 @@ def _check_join(left, right, result, join_col, how="left", lsuffix="_x", rsuffix
         except KeyError:
             if how in ("left", "inner"):
                 raise AssertionError(
-                    "key {group_key!s} should not have been in the join".format(
-                        group_key=group_key
-                    )
+                    f"key {group_key!s} should not have been in the join"
                 )
 
             _assert_all_na(l_joined, left.columns, join_col)
@@ -826,9 +825,7 @@ def _check_join(left, right, result, join_col, how="left", lsuffix="_x", rsuffix
         except KeyError:
             if how in ("right", "inner"):
                 raise AssertionError(
-                    "key {group_key!s} should not have been in the join".format(
-                        group_key=group_key
-                    )
+                    f"key {group_key!s} should not have been in the join"
                 )
 
             _assert_all_na(r_joined, right.columns, join_col)

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -710,7 +710,7 @@ class TestMerge:
         df1 = pd.DataFrame({"entity_id": [101, 102]})
         s = pd.Series([None, None], index=[101, 102], name="days")
 
-        dtype = "m8[{}]".format(unit)
+        dtype = f"m8[{unit}]"
         df2 = s.astype(dtype).to_frame("days")
         assert df2["days"].dtype == "m8[ns]"
 
@@ -1012,9 +1012,9 @@ class TestMerge:
 
             msg = (
                 "Cannot use `indicator=True` option when data contains a "
-                "column named {}|"
+                f"column named {i}|"
                 "Cannot use name of an existing column for indicator column"
-            ).format(i)
+            )
             with pytest.raises(ValueError, match=msg):
                 merge(df1, df_badcolumn, on="col1", how="outer", indicator=True)
             with pytest.raises(ValueError, match=msg):
@@ -1555,11 +1555,9 @@ class TestMergeDtypes:
         df2 = DataFrame({"A": df2_vals})
 
         msg = (
-            "You are trying to merge on {lk_dtype} and "
-            "{rk_dtype} columns. If you wish to proceed "
-            "you should use pd.concat".format(
-                lk_dtype=df1["A"].dtype, rk_dtype=df2["A"].dtype
-            )
+            f"You are trying to merge on {df1['A'].dtype} and "
+            f"{df2['A'].dtype} columns. If you wish to proceed "
+            "you should use pd.concat"
         )
         msg = re.escape(msg)
         with pytest.raises(ValueError, match=msg):
@@ -1567,11 +1565,9 @@ class TestMergeDtypes:
 
         # Check that error still raised when swapping order of dataframes
         msg = (
-            "You are trying to merge on {lk_dtype} and "
-            "{rk_dtype} columns. If you wish to proceed "
-            "you should use pd.concat".format(
-                lk_dtype=df2["A"].dtype, rk_dtype=df1["A"].dtype
-            )
+            f"You are trying to merge on {df2['A'].dtype} and "
+            f"{df1['A'].dtype} columns. If you wish to proceed "
+            "you should use pd.concat"
         )
         msg = re.escape(msg)
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -1196,7 +1196,7 @@ class TestAsOfMerge:
     @pytest.mark.parametrize("side", ["left", "right"])
     def test_merge_on_nans(self, func, side):
         # GH 23189
-        msg = "Merge keys contain null values on {} side".format(side)
+        msg = f"Merge keys contain null values on {side} side"
         nulls = func([1.0, 5.0, np.nan])
         non_nulls = func([1.0, 5.0, 10.0])
         df_null = pd.DataFrame({"a": nulls, "left_val": ["a", "b", "c"]})

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -364,8 +364,8 @@ class TestLreshape:
         df = DataFrame(data)
 
         spec = {
-            "visitdt": ["visitdt{i:d}".format(i=i) for i in range(1, 4)],
-            "wt": ["wt{i:d}".format(i=i) for i in range(1, 4)],
+            "visitdt": [f"visitdt{i:d}" for i in range(1, 4)],
+            "wt": [f"wt{i:d}" for i in range(1, 4)],
         }
         result = lreshape(df, spec)
 
@@ -557,8 +557,8 @@ class TestLreshape:
             result = lreshape(df, spec, dropna=False, label="foo")
 
         spec = {
-            "visitdt": ["visitdt{i:d}".format(i=i) for i in range(1, 3)],
-            "wt": ["wt{i:d}".format(i=i) for i in range(1, 4)],
+            "visitdt": [f"visitdt{i:d}" for i in range(1, 3)],
+            "wt": [f"wt{i:d}" for i in range(1, 4)],
         }
         msg = "All column lists must be same length"
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1161,9 +1161,9 @@ class TestPivotTable:
     def test_pivot_table_with_margins_set_margin_name(self, margin_name):
         # see gh-3335
         msg = (
-            r'Conflicting name "{}" in margins|'
+            fr'Conflicting name "{margin_name}" in margins|'
             "margins_name argument must be a string"
-        ).format(margin_name)
+        )
         with pytest.raises(ValueError, match=msg):
             # multi-index index
             pivot_table(

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1161,7 +1161,7 @@ class TestPivotTable:
     def test_pivot_table_with_margins_set_margin_name(self, margin_name):
         # see gh-3335
         msg = (
-            fr'Conflicting name "{margin_name}" in margins|'
+            f'Conflicting name "{margin_name}" in margins|'
             "margins_name argument must be a string"
         )
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -239,7 +239,7 @@ def test_iso_constructor(fmt, exp):
     ],
 )
 def test_iso_constructor_raises(fmt):
-    msg = "Invalid ISO 8601 Duration format - {}".format(fmt)
+    msg = f"Invalid ISO 8601 Duration format - {fmt}"
     with pytest.raises(ValueError, match=msg):
         Timedelta(fmt)
 


### PR DESCRIPTION
I splitted PR #31844 in batches, this is the sixth
For this PR I ran the command `grep -l -R -e '%s' -e '%d' -e '\.format(' --include=*.{py,pyx} pandas/` and checked all the files that were returned for `.format(` and changed the old string format for the corresponding `fstrings` to attempt a full clean of, [#29547](https://github.com/pandas-dev/pandas/issues/29547). I may have missed something so is a good idea to double check just in case

- [ x  ] tests added / passed
- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`