### PR TITLE
CLN: 29547 replace old string formatting 7

### DIFF
--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -314,7 +314,7 @@ class TestTimestampConstructors:
     def test_constructor_invalid_Z0_isostring(self, z):
         # GH 8910
         with pytest.raises(ValueError):
-            Timestamp("2014-11-02 01:00{}".format(z))
+            Timestamp(f"2014-11-02 01:00{z}")
 
     @pytest.mark.parametrize(
         "arg",
@@ -455,9 +455,7 @@ class TestTimestampConstructors:
     @pytest.mark.parametrize("offset", ["+0300", "+0200"])
     def test_construct_timestamp_near_dst(self, offset):
         # GH 20854
-        expected = Timestamp(
-            "2016-10-30 03:00:00{}".format(offset), tz="Europe/Helsinki"
-        )
+        expected = Timestamp(f"2016-10-30 03:00:00{offset}", tz="Europe/Helsinki")
         result = Timestamp(expected).tz_convert("Europe/Helsinki")
         assert result == expected
 

--- a/pandas/tests/scalar/timestamp/test_rendering.py
+++ b/pandas/tests/scalar/timestamp/test_rendering.py
@@ -17,7 +17,7 @@ class TestTimestampRendering:
     )
     def test_repr(self, date, freq, tz):
         # avoid to match with timezone name
-        freq_repr = "'{0}'".format(freq)
+        freq_repr = f"'{freq}'"
         if tz.startswith("dateutil"):
             tz_repr = tz.replace("dateutil", "")
         else:

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -232,17 +232,17 @@ class TestTimestampUnaryOps:
 
         # test floor
         result = dt.floor(freq)
-        assert result.value % unit == 0, "floor not a {} multiple".format(freq)
+        assert result.value % unit == 0, f"floor not a {freq} multiple"
         assert 0 <= dt.value - result.value < unit, "floor error"
 
         # test ceil
         result = dt.ceil(freq)
-        assert result.value % unit == 0, "ceil not a {} multiple".format(freq)
+        assert result.value % unit == 0, f"ceil not a {freq} multiple"
         assert 0 <= result.value - dt.value < unit, "ceil error"
 
         # test round
         result = dt.round(freq)
-        assert result.value % unit == 0, "round not a {} multiple".format(freq)
+        assert result.value % unit == 0, f"round not a {freq} multiple"
         assert abs(result.value - dt.value) <= unit // 2, "round error"
         if unit % 2 == 0 and abs(result.value - dt.value) == unit // 2:
             # round half to even

--- a/pandas/tests/series/methods/test_nlargest.py
+++ b/pandas/tests/series/methods/test_nlargest.py
@@ -98,7 +98,7 @@ class TestSeriesNLargestNSmallest:
     )
     def test_nlargest_error(self, r):
         dt = r.dtype
-        msg = "Cannot use method 'n(larg|small)est' with dtype {dt}".format(dt=dt)
+        msg = f"Cannot use method 'n(larg|small)est' with dtype {dt}"
         args = 2, len(r), 0, -1
         methods = r.nlargest, r.nsmallest
         for method, arg in product(methods, args):

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -169,10 +169,10 @@ class TestSeriesAnalytics:
         name = func.__name__
 
         msg = (
-            r"the '{arg}' parameter is not "
-            r"supported in the pandas "
-            r"implementation of {fname}\(\)"
-        ).format(arg=param, fname=name)
+            f"the '{param}' parameter is not "
+            "supported in the pandas "
+            fr"implementation of {name}\(\)"
+        )
         with pytest.raises(ValueError, match=msg):
             func(s, **kwargs)
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -136,9 +136,7 @@ class TestSeriesMisc:
 
     def test_constructor_ordereddict(self):
         # GH3283
-        data = OrderedDict(
-            ("col{i}".format(i=i), np.random.random()) for i in range(12)
-        )
+        data = OrderedDict((f"col{i}", np.random.random()) for i in range(12))
 
         series = Series(data)
         expected = Series(list(data.values()), list(data.keys()))
@@ -258,7 +256,7 @@ class TestSeriesMisc:
             tm.makeIntIndex(10),
             tm.makeFloatIndex(10),
             Index([True, False]),
-            Index(["a{}".format(i) for i in range(101)]),
+            Index([f"a{i}" for i in range(101)]),
             pd.MultiIndex.from_tuples(zip("ABCD", "EFGH")),
             pd.MultiIndex.from_tuples(zip([0, 1, 2, 3], "EFGH")),
         ],

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -261,7 +261,7 @@ class TestSeriesDtypes:
 
         value = np.random.RandomState(0).randint(0, 10000, 100)
         df = DataFrame({"value": value})
-        labels = ["{0} - {1}".format(i, i + 499) for i in range(0, 10000, 500)]
+        labels = [f"{i} - {i + 499}" for i in range(0, 10000, 500)]
         cat_labels = Categorical(labels, labels)
 
         df = df.sort_values(by=["value"], ascending=True)
@@ -384,9 +384,9 @@ class TestSeriesDtypes:
         s = Series(data)
 
         msg = (
-            r"The '{dtype}' dtype has no unit\. "
-            r"Please pass in '{dtype}\[ns\]' instead."
-        ).format(dtype=dtype.__name__)
+            fr"The '{dtype.__name__}' dtype has no unit\. "
+            fr"Please pass in '{dtype.__name__}\[ns\]' instead."
+        )
         with pytest.raises(ValueError, match=msg):
             s.astype(dtype)
 

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -287,7 +287,7 @@ def test_object_dtype_ok():
             return type(other) is Thing and self.value == other.value
 
         def __repr__(self) -> str:
-            return "Thing({})".format(self.value)
+            return f"Thing({self.value})"
 
     s = pd.Series([Thing(1), Thing(2)])
     result = np.add(s, Thing(1))


### PR DESCRIPTION
I splitted PR #31844 in batches, this is the seventh
For this PR I ran the command `grep -l -R -e '%s' -e '%d' -e '\.format(' --include=*.{py,pyx} pandas/` and checked all the files that were returned for `.format(` and changed the old string format for the corresponding `fstrings` to attempt a full clean of, [#29547](https://github.com/pandas-dev/pandas/issues/29547). I may have missed something so is a good idea to double check just in case

- [ x  ] tests added / passed
- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`