### PR TITLE
DOC: Fix pandas.index.copy summary documentation

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -842,6 +842,7 @@ class Index(IndexOpsMixin, PandasObject):
         Returns
         -------
         Index
+            Index refer to new object which is a copy of this object
 
         Notes
         -----

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -825,9 +825,9 @@ class Index(IndexOpsMixin, PandasObject):
 
     def copy(self, name=None, deep=False, dtype=None, names=None):
         """
-        Make a copy of this object.  Name and dtype sets those attributes on
-        the new object.
+        Make a copy of this object.
 
+        Name and dtype sets those attributes on the new object.
         Parameters
         ----------
         name : Label

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -828,11 +828,14 @@ class Index(IndexOpsMixin, PandasObject):
         Make a copy of this object.
 
         Name and dtype sets those attributes on the new object.
+
         Parameters
         ----------
-        name : Label
+        name : Label, optional
+            name for new object
         deep : bool, default False
         dtype : numpy dtype or pandas type, optional
+            dtype for new object
         names : list-like, optional
             Kept for compatibility with MultiIndex. Should not be used.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -832,17 +832,17 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         name : Label, optional
-            name for new object
+            Set name for new object.
         deep : bool, default False
         dtype : numpy dtype or pandas type, optional
-            dtype for new object
+            Set dtype for new object.
         names : list-like, optional
             Kept for compatibility with MultiIndex. Should not be used.
 
         Returns
         -------
         Index
-            Index refer to new object which is a copy of this object
+            Index refer to new object which is a copy of this object.
 
         Notes
         -----


### PR DESCRIPTION
- [ ] closes https://github.com/pandanistas/pandanistas_sprint_jakarta2020/issues/8
- [ ] tests added / passed
- [ ] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
Output of `python scripts/validate_docstrings.py pandas.Index.copy`

################################################################################
######################## Docstring (pandas.Index.copy)  ########################
################################################################################

Make a copy of this object.

Name and dtype sets those attributes on the new object.

Parameters
----------
name : Label, optional
    Set name for new object.
deep : bool, default False
dtype : numpy dtype or pandas type, optional
    Set dtype for new object.
names : list-like, optional
    Kept for compatibility with MultiIndex. Should not be used.

Returns
-------
Index
    Index refer to new object which is a copy of this object.

Notes
-----
In most cases, there should be no functional difference from using
``deep``, but if ``deep`` is passed it will attempt to deepcopy.

################################################################################
################################## Validation ##################################
################################################################################

3 Errors found:
        Parameter "deep" has no description
        See Also section not found
        No examples section found