### PR TITLE
(wip)BUG: make sure combine doesn't alter dtype for nullable dtypes

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -245,7 +245,8 @@ Other
   instead of ``TypeError: Can only append a Series if ignore_index=True or if the Series has a name`` (:issue:`30871`)
 - Set operations on an object-dtype :class:`Index` now always return object-dtype results (:issue:`31401`)
 - Bug in :meth:`AbstractHolidayCalendar.holidays` when no rules were defined (:issue:`31415`)
--
+- Bug in :meth:`Series.combine` was changing the result's dtype for nullable integers (:issue:`31899`)
+- 
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -246,7 +246,7 @@ Other
 - Set operations on an object-dtype :class:`Index` now always return object-dtype results (:issue:`31401`)
 - Bug in :meth:`AbstractHolidayCalendar.holidays` when no rules were defined (:issue:`31415`)
 - Bug in :meth:`Series.combine` was changing the result's dtype for nullable integers (:issue:`31899`)
-- 
+-
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2691,7 +2691,7 @@ Name: Max Speed, dtype: float64
         elif is_extension_array_dtype(self.values):
             # The function can return something of any type, so check
             # if the type is compatible with the calling EA.
-            new_values = try_cast_to_ea(self._values, new_values)
+            new_values = try_cast_to_ea(self._values, new_values, dtype=self.dtype)
         return self._constructor(new_values, index=new_index, name=new_name)
 
     def combine_first(self, other) -> "Series":

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -193,14 +193,15 @@ class BaseMethodsTests(BaseExtensionTests):
             expected = pd.Series(
                 orig_data1._from_sequence(
                     [a + b for (a, b) in zip(list(orig_data1), list(orig_data2))]
-                )
+                ),
+                dtype=orig_data1.dtype,
             )
         self.assert_series_equal(result, expected)
-
         val = s1.iloc[0]
         result = s1.combine(val, lambda x1, x2: x1 + x2)
         expected = pd.Series(
-            orig_data1._from_sequence([a + val for a in list(orig_data1)])
+            orig_data1._from_sequence([a + val for a in list(orig_data1)]),
+            dtype=orig_data1.dtype,
         )
         self.assert_series_equal(result, expected)
 


### PR DESCRIPTION
- [ ] closes #31899 
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Haven't added new tests, but have changed the expected return dtype in existing ones

EDIT
----
This is the wrong fix - for, say
```
s1.combine(s2, lambda x, y: x<y)
```
the dtype _would_ be expected to change (in this case to bool)