### PR TITLE
DOC: Update pandas.Series.between_time docstring params

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7538,21 +7538,22 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Parameters
         ----------
         start_time : datetime.time or str
-                The first time value.
+            Initial time as a time filter limit.
         end_time : datetime.time or str
-                The second time value.
+            End time as a time filter limit.
         include_start : bool, default True
-                Adding start_time value in the result.
+            Whether the start time needs to be included in the result.
         include_end : bool, default True
-                Adding end_time value in the result.
+            Whether the end time needs to be included in the result.
         axis : {0 or 'index', 1 or 'columns'}, default 0
-                Determine range time on index or columns value.
+            Determine range time on index or columns value.
+
             .. versionadded:: 0.24.0
 
         Returns
         -------
         Series or DataFrame
-            If axis set on columns, it will return DataFrame format, vice versa.
+            Data from the original object filtered to the specified dates range.
 
         Raises
         ------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7538,16 +7538,21 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Parameters
         ----------
         start_time : datetime.time or str
+                The first time value.
         end_time : datetime.time or str
+                The second time value.
         include_start : bool, default True
+                Adding start_time value in the result.
         include_end : bool, default True
+                Adding end_time value in the result.
         axis : {0 or 'index', 1 or 'columns'}, default 0
-
+                Determine range time on index or columns value.
             .. versionadded:: 0.24.0
 
         Returns
         -------
         Series or DataFrame
+            If axis set on columns, it will return DataFrame format, vice versa.
 
         Raises
         ------


### PR DESCRIPTION
- [x] closes [https://github.com/pandanistas/pandanistas_sprint_jakarta2020/issues/20](https://github.com/pandanistas/pandanistas_sprint_jakarta2020/issues/20)
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

output from python scripts/validate_docstrings.py pandas.Series.between_time:
################################################################################
#################### Docstring (pandas.Series.between_time) ####################
################################################################################

Select values between particular times of the day (e.g., 9:00-9:30 AM).

By setting ``start_time`` to be later than ``end_time``,
you can get the times that are *not* between the two times.

Parameters
----------
start_time : datetime.time or str
        The first time value.
end_time : datetime.time or str
        The second time value.
include_start : bool, default True
        Adding start_time value in the result.
include_end : bool, default True
        Adding end_time value in the result.
axis : {0 or 'index', 1 or 'columns'}, default 0
        Determine range time on index or columns value.
    .. versionadded:: 0.24.0

Returns
-------
Series or DataFrame
    If axis set on columns, it will return DataFrame format, vice versa.

Raises
------
TypeError
    If the index is not  a :class:`DatetimeIndex`

See Also
--------
at_time : Select values at a particular time of the day.
first : Select initial periods of time series based on a date offset.
last : Select final periods of time series based on a date offset.
DatetimeIndex.indexer_between_time : Get just the index locations for
    values between particular times of the day.

Examples
--------
>>> i = pd.date_range('2018-04-09', periods=4, freq='1D20min')
>>> ts = pd.DataFrame({'A': [1, 2, 3, 4]}, index=i)
>>> ts
                     A
2018-04-09 00:00:00  1
2018-04-10 00:20:00  2
2018-04-11 00:40:00  3
2018-04-12 01:00:00  4

>>> ts.between_time('0:15', '0:45')
                     A
2018-04-10 00:20:00  2
2018-04-11 00:40:00  3

You get the times that are *not* between two times by setting
``start_time`` later than ``end_time``:

>>> ts.between_time('0:45', '0:15')
                     A
2018-04-09 00:00:00  1
2018-04-12 01:00:00  4

################################################################################
################################## Validation ##################################
################################################################################