### PR TITLE
DOC: Add reference in keywords arguments to Line2D mathplotlib

### DIFF
--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -280,7 +280,8 @@ def bootstrap_plot(series, fig=None, size=50, samples=500, **kwds):
     samples : int, default 500
         Number of times the bootstrap procedure is performed.
     **kwds
-        Options to pass to matplotlib plotting method.
+        Optional, two dimensional properties from
+        :func:`matplotlib.lines.Line2D`.
 
     Returns
     -------
@@ -291,6 +292,7 @@ def bootstrap_plot(series, fig=None, size=50, samples=500, **kwds):
     --------
     DataFrame.plot : Basic plotting for DataFrame objects.
     Series.plot : Basic plotting for Series objects.
+    matplotlib.lines.Line2D : Matplotlib Line2D objects.
 
     Examples
     --------


### PR DESCRIPTION
Keyword arguments in `pandas.plotting.bootstrap_plot` doesn't clearly specify argument options

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
