### PR TITLE
CLN: 29547 replace old string formatting 8

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -19,7 +19,7 @@ def import_module(name):
     try:
         return importlib.import_module(name)
     except ModuleNotFoundError:  # noqa
-        pytest.skip("skipping as {} not available".format(name))
+        pytest.skip(f"skipping as {name} not available")
 
 
 @pytest.fixture

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -896,10 +896,10 @@ Thur,Lunch,Yes,51.51,17"""
         values = np.arange(5)
         data = np.vstack(
             [
-                ["b{}".format(x) for x in values],  # b0, b1, ..
-                ["a{}".format(x) for x in values],
+                [f"b{x}" for x in values],  # b0, b1, ..
+                [f"a{x}" for x in values],  # a0, a1, ..
             ]
-        )  # a0, a1, ..
+        )
         df = pd.DataFrame(data.T, columns=["b", "a"])
         df.columns.name = "first"
         second_level_dict = {"x": df}

--- a/pandas/tests/tools/test_numeric.py
+++ b/pandas/tests/tools/test_numeric.py
@@ -308,7 +308,7 @@ def test_really_large_in_arr_consistent(large_val, signed, multiple_elts, errors
 
     if errors in (None, "raise"):
         index = int(multiple_elts)
-        msg = "Integer out of range. at position {index}".format(index=index)
+        msg = f"Integer out of range. at position {index}"
 
         with pytest.raises(ValueError, match=msg):
             to_numeric(arr, **kwargs)

--- a/pandas/tests/tslibs/test_parse_iso8601.py
+++ b/pandas/tests/tslibs/test_parse_iso8601.py
@@ -51,7 +51,7 @@ def test_parsers_iso8601(date_str, exp):
     ],
 )
 def test_parsers_iso8601_invalid(date_str):
-    msg = 'Error parsing datetime string "{s}"'.format(s=date_str)
+    msg = f'Error parsing datetime string "{date_str}"'
 
     with pytest.raises(ValueError, match=msg):
         tslib._test_parse_iso8601(date_str)

--- a/pandas/tests/window/moments/test_moments_rolling.py
+++ b/pandas/tests/window/moments/test_moments_rolling.py
@@ -860,7 +860,7 @@ class TestMoments(Base):
             tm.assert_series_equal(result, expected)
 
             # shifter index
-            s = ["x{x:d}".format(x=x) for x in range(12)]
+            s = [f"x{x:d}" for x in range(12)]
 
             if has_min_periods:
                 minp = 10
@@ -1437,13 +1437,9 @@ class TestRollingMomentsConsistency(ConsistencyBase):
     def test_rolling_min_max_numeric_types(self):
 
         # GH12373
-        types_test = [np.dtype("f{}".format(width)) for width in [4, 8]]
+        types_test = [np.dtype(f"f{width}") for width in [4, 8]]
         types_test.extend(
-            [
-                np.dtype("{}{}".format(sign, width))
-                for width in [1, 2, 4, 8]
-                for sign in "ui"
-            ]
+            [np.dtype(f"{sign}{width}") for width in [1, 2, 4, 8] for sign in "ui"]
         )
         for data_type in types_test:
             # Just testing that these don't throw exceptions and that


### PR DESCRIPTION
I splitted PR #31844 in batches, this is the eighth
For this PR I ran the command `grep -l -R -e '%s' -e '%d' -e '\.format(' --include=*.{py,pyx} pandas/` and checked all the files that were returned for `.format(` and changed the old string format for the corresponding `fstrings` to attempt a full clean of, [#29547](https://github.com/pandas-dev/pandas/issues/29547). I may have missed something so is a good idea to double check just in case

- [ x  ] tests added / passed
- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`