### PR TITLE
CLN: 29547 replace .format() with f-strings

### DIFF
--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -99,7 +99,7 @@ def get_hits(defname, files=()):
             r = sh.git(
                 "blame",
                 "-L",
-                r"/def\s*{start}/,/def/".format(start=defname),
+                rf"/def\s*{defname}/,/def/",
                 f,
                 _tty_out=False,
             )
@@ -119,8 +119,8 @@ def get_hits(defname, files=()):
 def get_commit_info(c, fmt, sep="\t"):
     r = sh.git(
         "log",
-        "--format={}".format(fmt),
-        "{}^..{}".format(c, c),
+        f"--format={fmt}",
+        f"{c}^..{c}",
         "-n",
         "1",
         _tty_out=False,
@@ -203,10 +203,9 @@ def pprint_hits(hits):
         h, s, d = get_commit_vitals(hit.commit)
         p = hit.path.split(os.path.realpath(os.curdir) + os.path.sep)[-1]
 
-        fmt = "{:%d} {:10} {:<%d} {:<%d}" % (HASH_LEN, SUBJ_LEN, PATH_LEN)
         if len(s) > SUBJ_LEN:
             s = s[: SUBJ_LEN - 5] + " ..."
-        print(fmt.format(h[:HASH_LEN], d.isoformat()[:10], s, p[-20:]))
+        print(f"{h[:HASH_LEN]:{HASH_LEN}} {d.isoformat()[:10]:10} {s:<{SUBJ_LEN}} {p[-20:]:<{PATH_LEN}}")
 
     print("\n")
 

--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -96,13 +96,7 @@ def get_hits(defname, files=()):
     cs = set()
     for f in files:
         try:
-            r = sh.git(
-                "blame",
-                "-L",
-                rf"/def\s*{defname}/,/def/",
-                f,
-                _tty_out=False,
-            )
+            r = sh.git("blame", "-L", rf"/def\s*{defname}/,/def/", f, _tty_out=False,)
         except sh.ErrorReturnCode_128:
             logger.debug("no matches in %s" % f)
             continue
@@ -117,14 +111,7 @@ def get_hits(defname, files=()):
 
 
 def get_commit_info(c, fmt, sep="\t"):
-    r = sh.git(
-        "log",
-        f"--format={fmt}",
-        f"{c}^..{c}",
-        "-n",
-        "1",
-        _tty_out=False,
-    )
+    r = sh.git("log", f"--format={fmt}", f"{c}^..{c}", "-n", "1", _tty_out=False,)
     return str(r).split(sep)
 
 
@@ -205,11 +192,12 @@ def pprint_hits(hits):
 
         if len(s) > SUBJ_LEN:
             s = s[: SUBJ_LEN - 5] + " ..."
-        print(f"{h[:HASH_LEN]:{HASH_LEN}} "
-              f"{d.isoformat()[:10]:10} "
-              f"{s:<{SUBJ_LEN}} "
-              f"{p[-20:]:<{PATH_LEN}}"
-              )
+        print(
+            f"{h[:HASH_LEN]:{HASH_LEN}} "
+            f"{d.isoformat()[:10]:10} "
+            f"{s:<{SUBJ_LEN}} "
+            f"{p[-20:]:<{PATH_LEN}}"
+        )
 
     print("\n")
 

--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -205,7 +205,11 @@ def pprint_hits(hits):
 
         if len(s) > SUBJ_LEN:
             s = s[: SUBJ_LEN - 5] + " ..."
-        print(f"{h[:HASH_LEN]:{HASH_LEN}} {d.isoformat()[:10]:10} {s:<{SUBJ_LEN}} {p[-20:]:<{PATH_LEN}}")
+        print(f"{h[:HASH_LEN]:{HASH_LEN}} "
+              f"{d.isoformat()[:10]:10} "
+              f"{s:<{SUBJ_LEN}} "
+              f"{p[-20:]:<{PATH_LEN}}"
+              )
 
     print("\n")
 


### PR DESCRIPTION
This PR replaces .format() with f-strings as requested in https://github.com/pandas-dev/pandas/issues/29547.

It did this replacement in scripts/find_commits_touching_func.py

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
