### PR TITLE
TYP: check_untyped_defs core.arrays.interval

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1,5 +1,6 @@
 from operator import le, lt
 import textwrap
+from typing import Any, Sequence, Tuple
 
 import numpy as np
 
@@ -433,29 +434,32 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             ),
         )
     )
-    def from_tuples(cls, data, closed="right", copy=False, dtype=None):
+    def from_tuples(
+        cls, data: Sequence[Tuple[Any, Any]], closed="right", copy=False, dtype=None
+    ):
+        left: Sequence
+        right: Sequence
         if len(data):
             left, right = [], []
+            for d in data:
+                if isna(d):
+                    lhs = rhs = np.nan
+                else:
+                    name = cls.__name__
+                    try:
+                        # need list of length 2 tuples, e.g. [(0, 1), (1, 2), ...]
+                        lhs, rhs = d
+                    except ValueError:
+                        msg = f"{name}.from_tuples requires tuples of length 2, got {d}"
+                        raise ValueError(msg)
+                    except TypeError:
+                        msg = f"{name}.from_tuples received an invalid item, {d}"
+                        raise TypeError(msg)
+                left.append(lhs)
+                right.append(rhs)
         else:
             # ensure that empty data keeps input dtype
             left = right = data
-
-        for d in data:
-            if isna(d):
-                lhs = rhs = np.nan
-            else:
-                name = cls.__name__
-                try:
-                    # need list of length 2 tuples, e.g. [(0, 1), (1, 2), ...]
-                    lhs, rhs = d
-                except ValueError:
-                    msg = f"{name}.from_tuples requires tuples of length 2, got {d}"
-                    raise ValueError(msg)
-                except TypeError:
-                    msg = f"{name}.from_tuples received an invalid item, {d}"
-                    raise TypeError(msg)
-            left.append(lhs)
-            right.append(rhs)
 
         return cls.from_arrays(left, right, closed, copy=False, dtype=dtype)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,9 +150,6 @@ check_untyped_defs=False
 [mypy-pandas.core.arrays.categorical]
 check_untyped_defs=False
 
-[mypy-pandas.core.arrays.interval]
-check_untyped_defs=False
-
 [mypy-pandas.core.arrays.sparse.array]
 check_untyped_defs=False
 


### PR DESCRIPTION
pandas\core\arrays\interval.py:438: error: Need type annotation for 'left' (hint: "left: List[<type>] = ...")
pandas\core\arrays\interval.py:438: error: Need type annotation for 'right' (hint: "right: List[<type>] = ...")