### PR TITLE
TYP: check_untyped_defs core.tools.datetimes

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -2,7 +2,7 @@ from collections import abc
 from datetime import datetime, time
 from functools import partial
 from itertools import islice
-from typing import Optional, TypeVar, Union
+from typing import List, Optional, TypeVar, Union
 
 import numpy as np
 
@@ -296,7 +296,9 @@ def _convert_listlike_datetimes(
         if not isinstance(arg, (DatetimeArray, DatetimeIndex)):
             return DatetimeIndex(arg, tz=tz, name=name)
         if tz == "utc":
-            arg = arg.tz_convert(None).tz_localize(tz)
+            # error: Item "DatetimeIndex" of "Union[DatetimeArray, DatetimeIndex]" has
+            # no attribute "tz_convert"
+            arg = arg.tz_convert(None).tz_localize(tz)  # type: ignore
         return arg
 
     elif is_datetime64_ns_dtype(arg):
@@ -307,7 +309,9 @@ def _convert_listlike_datetimes(
                 pass
         elif tz:
             # DatetimeArray, DatetimeIndex
-            return arg.tz_localize(tz)
+            # error: Item "DatetimeIndex" of "Union[DatetimeArray, DatetimeIndex]" has
+            # no attribute "tz_localize"
+            return arg.tz_localize(tz)  # type: ignore
 
         return arg
 
@@ -826,18 +830,18 @@ def _assemble_from_unit_mappings(arg, errors, tz):
     required = ["year", "month", "day"]
     req = sorted(set(required) - set(unit_rev.keys()))
     if len(req):
-        required = ",".join(req)
+        _required = ",".join(req)
         raise ValueError(
             "to assemble mappings requires at least that "
-            f"[year, month, day] be specified: [{required}] is missing"
+            f"[year, month, day] be specified: [{_required}] is missing"
         )
 
     # keys we don't recognize
     excess = sorted(set(unit_rev.keys()) - set(_unit_map.values()))
     if len(excess):
-        excess = ",".join(excess)
+        _excess = ",".join(excess)
         raise ValueError(
-            f"extra keys have been passed to the datetime assemblage: [{excess}]"
+            f"extra keys have been passed to the datetime assemblage: [{_excess}]"
         )
 
     def coerce(values):
@@ -992,7 +996,7 @@ def to_time(arg, format=None, infer_time_format=False, errors="raise"):
         if infer_time_format and format is None:
             format = _guess_time_format_for_array(arg)
 
-        times = []
+        times: List[Optional[time]] = []
         if format is not None:
             for element in arg:
                 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -234,9 +234,6 @@ check_untyped_defs=False
 [mypy-pandas.core.strings]
 check_untyped_defs=False
 
-[mypy-pandas.core.tools.datetimes]
-check_untyped_defs=False
-
 [mypy-pandas.core.window.common]
 check_untyped_defs=False
 


### PR DESCRIPTION
pandas\core\tools\datetimes.py:299: error: Item "DatetimeIndex" of "Union[DatetimeArray, DatetimeIndex]" has no attribute "tz_convert"
pandas\core\tools\datetimes.py:310: error: Item "DatetimeIndex" of "Union[DatetimeArray, DatetimeIndex]" has no attribute "tz_localize"
pandas\core\tools\datetimes.py:829: error: Incompatible types in assignment (expression has type "str", variable has type "List[str]")
pandas\core\tools\datetimes.py:838: error: Incompatible types in assignment (expression has type "str", variable has type "List[Any]")
pandas\core\tools\datetimes.py:1010: error: Argument 1 to "append" of "list" has incompatible type "None"; expected "time"
pandas\core\tools\datetimes.py:1035: error: Argument 1 to "append" of "list" has incompatible type "None"; expected "time"