### PR TITLE
DataFrame: Ctor from non abc.Iterable 2-d array like

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -511,6 +511,10 @@ class DataFrame(NDFrame):
                 mgr = init_ndarray(
                     values, index, columns, dtype=values.dtype, copy=False
                 )
+            elif arr.ndim == 2 and columns is not None:
+                if index is None:
+                    index = ibase.default_index(len(arr))
+                mgr = init_ndarray(arr, index, columns, dtype=dtype, copy=copy)
             else:
                 raise ValueError("DataFrame constructor not properly called!")
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2590,3 +2590,24 @@ class TestDataFrameConstructorWithDatetimeTZ:
 
         expected = pd.DataFrame(array_dim2).astype("datetime64[ns, UTC]")
         tm.assert_frame_equal(df, expected)
+
+    def test_from_noniterable_2d_array_like(self):
+        class Sample:
+            def __init__(self, length, width):
+                self.length = length
+                self.width = width
+                self.columns = ["X" + str(i) for i in range(self.width)]
+
+            def __getitem__(self, index):
+                if isinstance(index, int):
+                    i = index
+                if i >= self.length:
+                    raise IndexError("end")
+                return [3 * i + j for j in range(self.width)]
+
+            def __len__(self):
+                return self.length
+
+        sample = Sample(4, 5)
+        df = pd.DataFrame(sample, columns=sample.columns)
+        assert df.shape == (4, 5)


### PR DESCRIPTION
In case we pass a 2d array like that do not use __iter__ but the
__getitem__ interface, it falls outside the collection.abc.Iterable case
and throw.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
