### PR TITLE
CLN: make tm.N, tm.K private

### DIFF
--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -17,7 +17,6 @@ Reshaping by pivoting DataFrame objects
    :suppress:
 
    import pandas._testing as tm
-   tm.N = 3
 
    def unpivot(frame):
        N, K = frame.shape
@@ -27,7 +26,7 @@ Reshaping by pivoting DataFrame objects
        columns = ['date', 'variable', 'value']
        return pd.DataFrame(data, columns=columns)
 
-   df = unpivot(tm.makeTimeDataFrame())
+   df = unpivot(tm.makeTimeDataFrame(3))
 
 Data is often stored in so-called "stacked" or "record" format:
 
@@ -42,9 +41,6 @@ For the curious here is how the above ``DataFrame`` was created:
 
    import pandas._testing as tm
 
-   tm.N = 3
-
-
    def unpivot(frame):
        N, K = frame.shape
        data = {'value': frame.to_numpy().ravel('F'),
@@ -53,7 +49,7 @@ For the curious here is how the above ``DataFrame`` was created:
        return pd.DataFrame(data, columns=['date', 'variable', 'value'])
 
 
-   df = unpivot(tm.makeTimeDataFrame())
+   df = unpivot(tm.makeTimeDataFrame(3))
 
 To select out everything for variable ``A`` we could do:
 

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -69,8 +69,8 @@ from pandas.io.formats.printing import pprint_thing
 
 lzma = _import_lzma()
 
-N = 30
-K = 4
+_N = 30
+_K = 4
 _RAISE_NETWORK_ERROR_DEFAULT = False
 
 # set testing_mode
@@ -1794,45 +1794,45 @@ def all_timeseries_index_generator(k=10):
 
 # make series
 def makeFloatSeries(name=None):
-    index = makeStringIndex(N)
-    return Series(randn(N), index=index, name=name)
+    index = makeStringIndex(_N)
+    return Series(randn(_N), index=index, name=name)
 
 
 def makeStringSeries(name=None):
-    index = makeStringIndex(N)
-    return Series(randn(N), index=index, name=name)
+    index = makeStringIndex(_N)
+    return Series(randn(_N), index=index, name=name)
 
 
 def makeObjectSeries(name=None):
-    data = makeStringIndex(N)
+    data = makeStringIndex(_N)
     data = Index(data, dtype=object)
-    index = makeStringIndex(N)
+    index = makeStringIndex(_N)
     return Series(data, index=index, name=name)
 
 
 def getSeriesData():
-    index = makeStringIndex(N)
-    return {c: Series(randn(N), index=index) for c in getCols(K)}
+    index = makeStringIndex(_N)
+    return {c: Series(randn(_N), index=index) for c in getCols(_K)}
 
 
 def makeTimeSeries(nper=None, freq="B", name=None):
     if nper is None:
-        nper = N
+        nper = _N
     return Series(randn(nper), index=makeDateIndex(nper, freq=freq), name=name)
 
 
 def makePeriodSeries(nper=None, name=None):
     if nper is None:
-        nper = N
+        nper = _N
     return Series(randn(nper), index=makePeriodIndex(nper), name=name)
 
 
 def getTimeSeriesData(nper=None, freq="B"):
-    return {c: makeTimeSeries(nper, freq) for c in getCols(K)}
+    return {c: makeTimeSeries(nper, freq) for c in getCols(_K)}
 
 
 def getPeriodData(nper=None):
-    return {c: makePeriodSeries(nper) for c in getCols(K)}
+    return {c: makePeriodSeries(nper) for c in getCols(_K)}
 
 
 # make frame


### PR DESCRIPTION
AFAICT this gets rid of the last two places where we set `tm.N` externally.  With those gone, this privatizes these variables in the hopes of not falling back into that pattern.