### PR TITLE
Add ecosystem link to pandas-tfrecords project

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -56,6 +56,11 @@ joining paths, replacing file extensions, and checking if files exist are also a
 Statistics and machine learning
 -------------------------------
 
+`pandas-tfrecords <https://pypi.org/project/pandas-tfrecords/>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Easy saving pandas dataframe to tensorflow tfrecords format and reading tfrecords to pandas.
+
 `Statsmodels <https://www.statsmodels.org/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
to understand tfrecords format requires quite much time and finally its details are not so needed in daily work with data. [pandas-tfrecords](https://pypi.org/project/pandas-tfrecords/) hides low-level details and provides easy human-usable api to convert pandas to tfrecords and restore back.