### PR TITLE
Backport PR #31511 on branch 1.0.x (BUG: fix reindexing with a tz-awre index and method='nearest')

### DIFF
--- a/doc/source/whatsnew/v1.0.2.rst
+++ b/doc/source/whatsnew/v1.0.2.rst
@@ -29,6 +29,10 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
+**Datetimelike**
+
+- Bug in :meth:`DataFrame.reindex` and :meth:`Series.reindex` when reindexing with a tz-aware index (:issue:`26683`)
+
 **Categorical**
 
 - Fixed bug where :meth:`Categorical.from_codes` improperly raised a ``ValueError`` when passed nullable integer codes. (:issue:`31779`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2817,9 +2817,8 @@ class Index(IndexOpsMixin, PandasObject):
         left_indexer = self.get_indexer(target, "pad", limit=limit)
         right_indexer = self.get_indexer(target, "backfill", limit=limit)
 
-        target = np.asarray(target)
-        left_distances = abs(self.values[left_indexer] - target)
-        right_distances = abs(self.values[right_indexer] - target)
+        left_distances = np.abs(self[left_indexer] - target)
+        right_distances = np.abs(self[right_indexer] - target)
 
         op = operator.lt if self.is_monotonic_increasing else operator.le
         indexer = np.where(

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1608,6 +1608,16 @@ class TestDataFrameIndexing:
         actual = df.reindex(target, method="nearest", tolerance=[0.5, 0.01, 0.4, 0.1])
         tm.assert_frame_equal(expected, actual)
 
+    def test_reindex_nearest_tz(self, tz_aware_fixture):
+        # GH26683
+        tz = tz_aware_fixture
+        idx = pd.date_range("2019-01-01", periods=5, tz=tz)
+        df = pd.DataFrame({"x": list(range(5))}, index=idx)
+
+        expected = df.head(3)
+        actual = df.reindex(idx[:3], method="nearest")
+        tm.assert_frame_equal(expected, actual)
+
     def test_reindex_frame_add_nat(self):
         rng = date_range("1/1/2000 00:00:00", periods=10, freq="10s")
         df = DataFrame({"A": np.random.randn(len(rng)), "B": rng})


### PR DESCRIPTION
with whatsnew moved to doc/source/whatsnew/v1.0.2.rst