### PR TITLE
TST: add test for get_loc on tz-aware DatetimeIndex

### DIFF
--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -423,6 +423,17 @@ class TestGetLoc:
         with pytest.raises(NotImplementedError):
             idx.get_loc(time(12, 30), method="pad")
 
+    def test_get_loc_tz_aware(self):
+        # https://github.com/pandas-dev/pandas/issues/32140
+        dti = pd.date_range(
+            pd.Timestamp("2019-12-12 00:00:00", tz="US/Eastern"),
+            pd.Timestamp("2019-12-13 00:00:00", tz="US/Eastern"),
+            freq="5s",
+        )
+        key = pd.Timestamp("2019-12-12 10:19:25", tz="US/Eastern")
+        result = dti.get_loc(key, method="nearest")
+        assert result == 7433
+
     def test_get_loc_nat(self):
         # GH#20464
         index = DatetimeIndex(["1/3/2000", "NaT"])
@@ -451,17 +462,6 @@ class TestGetLoc:
         index = DatetimeIndex(["1/3/2000"])
         with pytest.raises(KeyError, match="2000"):
             index.get_loc("1/1/2000")
-
-    def test_get_loc_tz_aware(self):
-        # https://github.com/pandas-dev/pandas/issues/32140
-        dti = pd.date_range(
-            pd.Timestamp("2019-12-12 00:00:00", tz="US/Eastern"),
-            pd.Timestamp("2019-12-13 00:00:00", tz="US/Eastern"),
-            freq="5s",
-        )
-        key = pd.Timestamp("2019-12-12 10:19:25", tz="US/Eastern")
-        result = dti.get_loc(key, method="nearest")
-        assert result == 7433
 
 
 class TestDatetimeIndex:

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -452,6 +452,17 @@ class TestGetLoc:
         with pytest.raises(KeyError, match="2000"):
             index.get_loc("1/1/2000")
 
+    def test_get_loc_tz_aware(self):
+        # https://github.com/pandas-dev/pandas/issues/32140
+        dti = pd.date_range(
+            pd.Timestamp("2019-12-12 00:00:00", tz="US/Eastern"),
+            pd.Timestamp("2019-12-13 00:00:00", tz="US/Eastern"),
+            freq="5s",
+        )
+        key = pd.Timestamp("2019-12-12 10:19:25", tz="US/Eastern")
+        result = dti.get_loc(key, method="nearest")
+        assert result == 7433
+
 
 class TestDatetimeIndex:
     @pytest.mark.parametrize(


### PR DESCRIPTION
- [ ] closes #32140
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
