### PR TITLE
CLN: Removed class in pandas/tests/series/test_validate.py

### DIFF
--- a/pandas/tests/series/test_validate.py
+++ b/pandas/tests/series/test_validate.py
@@ -1,20 +1,18 @@
 import pytest
 
 
-class TestSeriesValidate:
+@pytest.mark.parametrize(
+    "func",
+    ["reset_index", "_set_name", "sort_values", "sort_index", "rename", "dropna"],
+)
+@pytest.mark.parametrize("inplace", [1, "True", [1, 2, 3], 5.0])
+def test_validate_bool_args(string_series, func, inplace):
     """Tests for error handling related to data types of method arguments."""
+    msg = 'For argument "inplace" expected type bool'
+    kwargs = dict(inplace=inplace)
 
-    @pytest.mark.parametrize(
-        "func",
-        ["reset_index", "_set_name", "sort_values", "sort_index", "rename", "dropna"],
-    )
-    @pytest.mark.parametrize("inplace", [1, "True", [1, 2, 3], 5.0])
-    def test_validate_bool_args(self, string_series, func, inplace):
-        msg = 'For argument "inplace" expected type bool'
-        kwargs = dict(inplace=inplace)
+    if func == "_set_name":
+        kwargs["name"] = "hello"
 
-        if func == "_set_name":
-            kwargs["name"] = "hello"
-
-        with pytest.raises(ValueError, match=msg):
-            getattr(string_series, func)(**kwargs)
+    with pytest.raises(ValueError, match=msg):
+        getattr(string_series, func)(**kwargs)


### PR DESCRIPTION
I've seen quite a few test files that only use a class for historic reasons. As functions are easier to comprehend I think it makes sense to move in this direction.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

