### PR TITLE
CLN: F-string in pandas/tests/indexes/datetimes/test_to_period.py (#29547)

### DIFF
--- a/pandas/tests/indexes/datetimes/test_to_period.py
+++ b/pandas/tests/indexes/datetimes/test_to_period.py
@@ -43,7 +43,7 @@ class TestToPeriod:
     @pytest.mark.parametrize("month", MONTHS)
     def test_to_period_quarterly(self, month):
         # make sure we can make the round trip
-        freq = "Q-{month}".format(month=month)
+        freq = f"Q-{month}"
         rng = period_range("1989Q3", "1991Q3", freq=freq)
         stamps = rng.to_timestamp()
         result = stamps.to_period(freq)


### PR DESCRIPTION
Issue #29547
- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
