### PR TITLE
BLD: Init PyDateTimeAPI Warnings

### DIFF
--- a/pandas/_libs/src/ujson/python/ujson.c
+++ b/pandas/_libs/src/ujson/python/ujson.c
@@ -38,6 +38,7 @@ https://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #include "version.h"
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include "datetime.h"
 
 /* objToJSON */
 PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs);
@@ -71,8 +72,14 @@ static PyModuleDef moduledef = {
     .m_methods = ujsonMethods
 };
 
+void pydatetime_import(void)
+{
+    PyDateTime_IMPORT;
+    return;
+}
 
 PyMODINIT_FUNC PyInit_json(void) {
+  pydatetime_import();
   initObjToJSON();  // TODO: clean up, maybe via tp_free?
   return PyModuleDef_Init(&moduledef);
 


### PR DESCRIPTION
- Fixes below warning:
```
In file included from pandas/_libs/src/ujson/python/date_conversions.h:7:0,
                 from pandas/_libs/src/ujson/python/date_conversions.c:4:
/home/vsts/miniconda3/envs/pandas-dev/include/python3.7m/datetime.h:204:25: warning: ‘PyDateTimeAPI’ defined but not used [-Wunused-variable]
 static PyDateTime_CAPI *PyDateTimeAPI = NULL;
```

https://github.com/pandas-dev/pandas/pull/32163#issuecomment-590010308 (will check CI)

Still same warning coming from np_datetime and np_datetime_strings
