### PR TITLE
(wip) BUG: itertuples was retuning empty list if frame had no columns

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -249,6 +249,7 @@ Other
   instead of ``TypeError: Can only append a Series if ignore_index=True or if the Series has a name`` (:issue:`30871`)
 - Set operations on an object-dtype :class:`Index` now always return object-dtype results (:issue:`31401`)
 - Bug in :meth:`AbstractHolidayCalendar.holidays` when no rules were defined (:issue:`31415`)
+- Bug in :meth:`DataFrame.itertuples` was returning empty list when DataFrame has no columns (:issue:`25408`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1411,7 +1411,6 @@ class DataFrame(NDFrame):
         elif orient.lower().startswith("l"):
             return into_c((k, v.tolist()) for k, v in self.items())
         elif orient.lower().startswith("sp"):
-            breakpoint()
             return into_c(
                 (
                     ("index", self.index.tolist()),

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1027,7 +1027,11 @@ class DataFrame(NDFrame):
             fields.insert(0, "Index")
 
         # use integer indexing because of possible duplicate column names
-        arrays.extend(self.iloc[:, k] for k in range(len(self.columns)))
+        if len(self.columns) > 0:
+            arrays.extend(self.iloc[:, k] for k in range(len(self.columns)))
+        else:
+            arrays.extend([() for _ in range(len(self))])
+            return iter(arrays)
 
         # Python versions before 3.7 support at most 255 arguments to constructors
         can_return_named_tuples = PY37 or len(self.columns) + index < 255
@@ -1407,6 +1411,7 @@ class DataFrame(NDFrame):
         elif orient.lower().startswith("l"):
             return into_c((k, v.tolist()) for k, v in self.items())
         elif orient.lower().startswith("sp"):
+            breakpoint()
             return into_c(
                 (
                     ("index", self.index.tolist()),

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -349,9 +349,6 @@ def timedelta_range(
                 '5 days 00:00:00'],
                dtype='timedelta64[ns]', freq=None)
     """
-    if start is not None and end is not None and freq is not None:
-        raise ValueError("ambiguous")
-
     if freq is None and com.any_none(periods, start, end):
         freq = "D"
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -349,6 +349,9 @@ def timedelta_range(
                 '5 days 00:00:00'],
                dtype='timedelta64[ns]', freq=None)
     """
+    if start is not None and end is not None and freq is not None:
+        raise ValueError("ambiguous")
+
     if freq is None and com.any_none(periods, start, end):
         freq = "D"
 

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -267,5 +267,5 @@ class TestDataFrameToDict:
         # GH 25408
         columns = ["A", "B"]
         result = DataFrame(columns=columns).transpose().to_dict(orient="split")
-        expected = {'index': ['A', 'B'], 'columns': [], 'data': [[], []]}
+        expected = {"index": ["A", "B"], "columns": [], "data": [[], []]}
         assert result == expected

--- a/pandas/tests/frame/methods/test_to_dict.py
+++ b/pandas/tests/frame/methods/test_to_dict.py
@@ -262,3 +262,10 @@ class TestDataFrameToDict:
                 "c": type(df_dict["c"]),
             }
             assert result == expected
+
+    def test_to_dict_no_rows_split(self):
+        # GH 25408
+        columns = ["A", "B"]
+        result = DataFrame(columns=columns).transpose().to_dict(orient="split")
+        expected = {'index': ['A', 'B'], 'columns': [], 'data': [[], []]}
+        assert result == expected

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -285,11 +285,11 @@ class TestDataFrameMisc:
             assert hasattr(result_255_columns, "_fields")
         else:
             assert not hasattr(result_255_columns, "_fields")
-        
+
         # GH 25408
-        df_0_columns = DataFrame(index=['A', 'B'])
+        df_0_columns = DataFrame(index=["A", "B"])
         result = list(df_0_columns.itertuples())
-        tm.assert_index_equal(result[0], pd.Index(['A', 'B']))
+        tm.assert_index_equal(result[0], pd.Index(["A", "B"]))
         assert result[1:] == [(), ()]
 
     def test_sequence_like_with_categorical(self):

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -285,6 +285,12 @@ class TestDataFrameMisc:
             assert hasattr(result_255_columns, "_fields")
         else:
             assert not hasattr(result_255_columns, "_fields")
+        
+        # GH 25408
+        df_0_columns = DataFrame(index=['A', 'B'])
+        result = list(df_0_columns.itertuples())
+        tm.assert_index_equal(result[0], pd.Index(['A', 'B']))
+        assert result[1:] == [(), ()]
 
     def test_sequence_like_with_categorical(self):
 


### PR DESCRIPTION
(currently not right)

- [ ] closes #25408 
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
