### PR TITLE
CLN: remove dtype kwarg from _simple_new

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -451,7 +451,7 @@ class Index(IndexOpsMixin, PandasObject):
         return None
 
     @classmethod
-    def _simple_new(cls, values, name=None, dtype=None):
+    def _simple_new(cls, values, name: Label = None):
         """
         We require that we have a dtype compat for the values. If we are passed
         a non-dtype compat, then coerce using the constructor.
@@ -3310,7 +3310,7 @@ class Index(IndexOpsMixin, PandasObject):
                 values = range(0)
             else:
                 values = self._data[:0]  # appropriately-dtyped empty array
-            target = self._simple_new(values, dtype=self.dtype, **attrs)
+            target = self._simple_new(values, **attrs)
         else:
             target = ensure_index(target)
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -226,8 +226,7 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
         return CategoricalIndex(cat, name=name)
 
     @classmethod
-    def _simple_new(cls, values: Categorical, name=None, dtype=None):
-        # GH#32204 dtype is included for compat with Index._simple_new
+    def _simple_new(cls, values: Categorical, name: Label = None):
         assert isinstance(values, Categorical), type(values)
         result = object.__new__(cls)
 
@@ -433,7 +432,7 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
             other = self._na_value
         values = np.where(cond, self.values, other)
         cat = Categorical(values, dtype=self.dtype)
-        return self._shallow_copy(cat)
+        return type(self)._simple_new(cat, name=self.name)
 
     def reindex(self, target, method=None, level=None, limit=None, tolerance=None):
         """

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -227,7 +227,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         return cls._simple_new(array, name)
 
     @classmethod
-    def _simple_new(cls, array, name: Label = None):
+    def _simple_new(cls, array: IntervalArray, name: Label = None):
         """
         Construct from an IntervalArray
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -9,7 +9,7 @@ from pandas._config import get_option
 
 from pandas._libs import Timedelta, Timestamp, lib
 from pandas._libs.interval import Interval, IntervalMixin, IntervalTree
-from pandas._typing import AnyArrayLike
+from pandas._typing import AnyArrayLike, Label
 from pandas.util._decorators import Appender, Substitution, cache_readonly
 from pandas.util._exceptions import rewrite_exception
 
@@ -191,7 +191,7 @@ class SetopCheck:
 class IntervalIndex(IntervalMixin, ExtensionIndex):
     _typ = "intervalindex"
     _comparables = ["name"]
-    _attributes = ["name", "closed"]
+    _attributes = ["name"]
 
     # we would like our indexing holder to defer to us
     _defer_to_indexing = True
@@ -227,17 +227,15 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         return cls._simple_new(array, name)
 
     @classmethod
-    def _simple_new(cls, array, name, closed=None):
+    def _simple_new(cls, array, name: Label = None):
         """
         Construct from an IntervalArray
 
         Parameters
         ----------
         array : IntervalArray
-        name : str
+        name : Label, default None
             Attached as result.name
-        closed : Any
-            Ignored.
         """
         assert isinstance(array, IntervalArray), type(array)
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -217,7 +217,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         return cls._simple_new(data, name=name)
 
     @classmethod
-    def _simple_new(cls, values, name=None, freq=None, **kwargs):
+    def _simple_new(cls, values: PeriodArray, name: Label = None):
         """
         Create a new PeriodIndex.
 
@@ -228,7 +228,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
             or coercion.
         """
         assert isinstance(values, PeriodArray), type(values)
-        assert freq is None or freq == values.freq, (freq, values.freq)
 
         result = object.__new__(cls)
         result._data = values

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -95,7 +95,7 @@ class RangeIndex(Int64Index):
         # RangeIndex
         if isinstance(start, RangeIndex):
             start = start._range
-            return cls._simple_new(start, dtype=dtype, name=name)
+            return cls._simple_new(start, name=name)
 
         # validate the arguments
         if com.all_none(start, stop, step):
@@ -113,7 +113,7 @@ class RangeIndex(Int64Index):
             raise ValueError("Step must not be zero")
 
         rng = range(start, stop, step)
-        return cls._simple_new(rng, dtype=dtype, name=name)
+        return cls._simple_new(rng, name=name)
 
     @classmethod
     def from_range(cls, data: range, name=None, dtype=None) -> "RangeIndex":
@@ -131,10 +131,10 @@ class RangeIndex(Int64Index):
             )
 
         cls._validate_dtype(dtype)
-        return cls._simple_new(data, dtype=dtype, name=name)
+        return cls._simple_new(data, name=name)
 
     @classmethod
-    def _simple_new(cls, values: range, name=None, dtype=None) -> "RangeIndex":
+    def _simple_new(cls, values: range, name: Label = None) -> "RangeIndex":
         result = object.__new__(cls)
 
         assert isinstance(values, range)

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -322,9 +322,9 @@ class TestPeriodIndex:
         idx = period_range("2007-01", name="p", periods=2, freq="M")
 
         with pytest.raises(AssertionError, match="<class .*PeriodIndex'>"):
-            idx._simple_new(idx, name="p", freq=idx.freq)
+            idx._simple_new(idx, name="p")
 
-        result = idx._simple_new(idx._data, name="p", freq=idx.freq)
+        result = idx._simple_new(idx._data, name="p")
         tm.assert_index_equal(result, idx)
 
         with pytest.raises(AssertionError):
@@ -339,19 +339,19 @@ class TestPeriodIndex:
         # GH13079
         idx = PeriodIndex([], freq="M", name="p")
         with pytest.raises(AssertionError, match="<class .*PeriodIndex'>"):
-            idx._simple_new(idx, name="p", freq="M")
+            idx._simple_new(idx, name="p")
 
-        result = idx._simple_new(idx._data, name="p", freq="M")
+        result = idx._simple_new(idx._data, name="p")
         tm.assert_index_equal(result, idx)
 
     @pytest.mark.parametrize("floats", [[1.1, 2.1], np.array([1.1, 2.1])])
     def test_constructor_floats(self, floats):
         with pytest.raises(AssertionError, match="<class "):
-            PeriodIndex._simple_new(floats, freq="M")
+            PeriodIndex._simple_new(floats)
 
         msg = "PeriodIndex does not allow floating point in construction"
         with pytest.raises(TypeError, match=msg):
-            PeriodIndex(floats, freq="M")
+            PeriodIndex(floats)
 
     def test_constructor_nat(self):
         msg = "start and end must not be NaT"


### PR DESCRIPTION
DatetimeIndex remains an outlier, upcoming PR