### PR TITLE
CLN: Use defaultdict for minor optimization

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8446,9 +8446,8 @@ ops.add_special_arithmetic_methods(DataFrame)
 
 def _from_nested_dict(data):
     # TODO: this should be seriously cythonized
-    new_data = {}
+    new_data = collections.defaultdict(dict)
     for index, s in data.items():
         for col, v in s.items():
-            new_data[col] = new_data.get(col, {})
             new_data[col][index] = v
     return new_data


### PR DESCRIPTION
Edit `_from_nested_dict()` by using defaultdict for optimization in performance

- [ ] closes #32209 
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
