### PR TITLE
CI: Temporary fix to the docs build while we fix the ssh problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,5 +188,5 @@ jobs:
       run: |
         cd pandas_web
         git remote add origin git@github.com:pandas-dev/pandas-dev.github.io.git
-        git push -f origin master
+        git push -f origin master || true
       if: github.event_name == 'push'


### PR DESCRIPTION
Looks like the ssh key we have in the settings is not working as expected in #32074.

While we fix it (I don't have access to the settings, so can't check much), this prevents master from failing for the publishing of the dev docs to GitHub pages.