### PR TITLE
TST: Use `sort` fixture in more places

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -146,6 +146,14 @@ def ordered_fixture(request):
     return request.param
 
 
+@pytest.fixture(params=[None, False])
+def sort(request):
+    """
+    Valid values for 'sort' parameter used in a variety of methods
+    """
+    return request.param
+
+
 _all_arithmetic_operators = [
     "__add__",
     "__radd__",

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -146,14 +146,6 @@ def ordered_fixture(request):
     return request.param
 
 
-@pytest.fixture(params=[None, False])
-def sort(request):
-    """
-    Valid values for 'sort' parameter used in a variety of methods
-    """
-    return request.param
-
-
 _all_arithmetic_operators = [
     "__add__",
     "__radd__",

--- a/pandas/tests/indexes/base_class/test_setops.py
+++ b/pandas/tests/indexes/base_class/test_setops.py
@@ -91,7 +91,6 @@ class TestIndexSetOps:
         with pytest.raises(TypeError, match=".*"):
             idx.union(idx[:1], sort=True)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_base(self, sort):
         # (same results for py2 and py3 but sortedness not tested elsewhere)
         index = Index([0, "a", 1, "b", 2, "c"])
@@ -103,7 +102,6 @@ class TestIndexSetOps:
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("klass", [np.array, Series, list])
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_different_type_base(self, klass, sort):
         # GH 10149
         index = Index([0, "a", 1, "b", 2, "c"])
@@ -123,7 +121,6 @@ class TestIndexSetOps:
         tm.assert_index_equal(idx.intersection(idx, sort=False), idx)
         tm.assert_index_equal(idx.intersection(idx, sort=None), idx)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_base(self, sort):
         # (same results for py2 and py3 but sortedness not tested elsewhere)
         index = Index([0, "a", 1, "b", 2, "c"])

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -512,7 +512,6 @@ class Base:
             with pytest.raises(TypeError, match=msg):
                 first.union([1, 2, 3])
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_base(self, sort, indices):
         first = indices[2:]
         second = indices[:4]

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture(params=[None, False])
+def sort(request):
+    """
+    Valid values for 'sort' parameter used in a variety Index methods.
+
+    Caution:
+        There are also "sort" fixtures with params [True, False] or [None, True, False].
+        For instance these might be used for DataFrame.groupby.
+
+        We can't extend the params here either as sort=True is not permitted in
+        many Index methods.
+    """
+    return request.param

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -4,13 +4,15 @@ import pytest
 @pytest.fixture(params=[None, False])
 def sort(request):
     """
-    Valid values for 'sort' parameter used in a variety Index methods.
+    Valid values for the 'sort' parameter used in the Index
+    setops methods (intersection, union, etc.)
 
     Caution:
-        There are also "sort" fixtures with params [True, False] or [None, True, False].
-        For instance these might be used for DataFrame.groupby.
+        Don't confuse this one with the "sort" fixture used
+        for DataFrame.append or concat. That one has
+        parameters [True, False].
 
-        We can't extend the params here either as sort=True is not permitted in
-        many Index methods.
+        We can't combine them as sort=True is not permitted
+        in in the Index setops methods.
     """
     return request.param

--- a/pandas/tests/indexes/datetimes/test_join.py
+++ b/pandas/tests/indexes/datetimes/test_join.py
@@ -64,7 +64,6 @@ class TestJoin:
         assert isinstance(result, DatetimeIndex)
         assert result.tz.zone == "UTC"
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_datetimeindex_union_join_empty(self, sort):
         dti = date_range(start="1/1/2001", end="2/1/2001", freq="D")
         empty = Index([])

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -33,7 +33,6 @@ class TestDatetimeIndexSetOps:
     ]
 
     # TODO: moved from test_datetimelike; dedup with version below
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union2(self, sort):
         everything = tm.makeDateIndex(10)
         first = everything[:5]
@@ -42,7 +41,6 @@ class TestDatetimeIndexSetOps:
         tm.assert_index_equal(union, everything)
 
     @pytest.mark.parametrize("box", [np.array, Series, list])
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union3(self, sort, box):
         everything = tm.makeDateIndex(10)
         first = everything[:5]
@@ -57,7 +55,6 @@ class TestDatetimeIndexSetOps:
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("tz", tz)
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union(self, tz, sort):
         rng1 = pd.date_range("1/1/2000", freq="D", periods=5, tz=tz)
         other1 = pd.date_range("1/6/2000", freq="D", periods=5, tz=tz)
@@ -89,7 +86,6 @@ class TestDatetimeIndexSetOps:
             else:
                 tm.assert_index_equal(result_union, exp_notsorted)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_coverage(self, sort):
         idx = DatetimeIndex(["2000-01-03", "2000-01-01", "2000-01-02"])
         ordered = DatetimeIndex(idx.sort_values(), freq="infer")
@@ -100,7 +96,6 @@ class TestDatetimeIndexSetOps:
         tm.assert_index_equal(result, ordered)
         assert result.freq == ordered.freq
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_bug_1730(self, sort):
         rng_a = date_range("1/1/2012", periods=4, freq="3H")
         rng_b = date_range("1/1/2012", periods=4, freq="4H")
@@ -113,7 +108,6 @@ class TestDatetimeIndexSetOps:
             exp = DatetimeIndex(exp)
         tm.assert_index_equal(result, exp)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_bug_1745(self, sort):
         left = DatetimeIndex(["2012-05-11 15:19:49.695000"])
         right = DatetimeIndex(
@@ -137,7 +131,6 @@ class TestDatetimeIndexSetOps:
             exp = exp.sort_values()
         tm.assert_index_equal(result, exp)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_bug_4564(self, sort):
         from pandas import DateOffset
 
@@ -152,7 +145,6 @@ class TestDatetimeIndexSetOps:
             exp = DatetimeIndex(exp)
         tm.assert_index_equal(result, exp)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_freq_both_none(self, sort):
         # GH11086
         expected = bdate_range("20150101", periods=10)
@@ -188,7 +180,6 @@ class TestDatetimeIndexSetOps:
         exp = pd.date_range("1/1/1980", "1/1/2012", freq="MS")
         tm.assert_index_equal(df.index, exp)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_with_DatetimeIndex(self, sort):
         i1 = Int64Index(np.arange(0, 20, 2))
         i2 = date_range(start="2012-01-03 00:00:00", periods=10, freq="D")
@@ -218,7 +209,6 @@ class TestDatetimeIndexSetOps:
     @pytest.mark.parametrize(
         "tz", [None, "Asia/Tokyo", "US/Eastern", "dateutil/US/Pacific"]
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection(self, tz, sort):
         # GH 4690 (with tz)
         base = date_range("6/1/2000", "6/30/2000", freq="D", name="idx")
@@ -298,7 +288,6 @@ class TestDatetimeIndexSetOps:
         assert len(result) == 0
 
     @pytest.mark.parametrize("tz", tz)
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference(self, tz, sort):
         rng_dates = ["1/2/2000", "1/3/2000", "1/1/2000", "1/4/2000", "1/5/2000"]
 
@@ -324,7 +313,6 @@ class TestDatetimeIndexSetOps:
                 expected = expected.sort_values()
             tm.assert_index_equal(result_diff, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_freq(self, sort):
         # GH14323: difference of DatetimeIndex should not preserve frequency
 
@@ -341,7 +329,6 @@ class TestDatetimeIndexSetOps:
         tm.assert_index_equal(idx_diff, expected)
         tm.assert_attr_equal("freq", idx_diff, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_datetimeindex_diff(self, sort):
         dti1 = date_range(freq="Q-JAN", start=datetime(1997, 12, 31), periods=100)
         dti2 = date_range(freq="Q-JAN", start=datetime(1997, 12, 31), periods=98)
@@ -352,7 +339,6 @@ class TestBusinessDatetimeIndex:
     def setup_method(self, method):
         self.rng = bdate_range(START, END)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union(self, sort):
         # overlapping
         left = self.rng[:10]
@@ -388,7 +374,6 @@ class TestBusinessDatetimeIndex:
         the_union = self.rng.union(rng, sort=sort)
         assert isinstance(the_union, DatetimeIndex)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_not_cacheable(self, sort):
         rng = date_range("1/1/2000", periods=50, freq=Minute())
         rng1 = rng[10:]
@@ -431,7 +416,6 @@ class TestBusinessDatetimeIndex:
         result = a.intersection(b)
         tm.assert_index_equal(result, b)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_month_range_union_tz_pytz(self, sort):
         from pytz import timezone
 
@@ -449,7 +433,6 @@ class TestBusinessDatetimeIndex:
         early_dr.union(late_dr, sort=sort)
 
     @td.skip_if_windows_python_3
-    @pytest.mark.parametrize("sort", [None, False])
     def test_month_range_union_tz_dateutil(self, sort):
         from pandas._libs.tslibs.timezones import dateutil_gettz
 
@@ -471,7 +454,6 @@ class TestCustomDatetimeIndex:
     def setup_method(self, method):
         self.rng = bdate_range(START, END, freq="C")
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union(self, sort):
         # overlapping
         left = self.rng[:10]

--- a/pandas/tests/indexes/interval/test_setops.py
+++ b/pandas/tests/indexes/interval/test_setops.py
@@ -10,11 +10,6 @@ def name(request):
     return request.param
 
 
-@pytest.fixture(params=[None, False])
-def sort(request):
-    return request.param
-
-
 def monotonic_index(start, end, dtype="int64", closed="right"):
     return IntervalIndex.from_breaks(np.arange(start, end, dtype=dtype), closed=closed)
 
@@ -153,7 +148,6 @@ class TestIntervalIndex:
     @pytest.mark.parametrize(
         "op_name", ["union", "intersection", "difference", "symmetric_difference"]
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_set_incompatible_types(self, closed, op_name, sort):
         index = monotonic_index(0, 11, closed=closed)
         set_op = getattr(index, op_name)

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -7,7 +7,6 @@ import pandas._testing as tm
 
 
 @pytest.mark.parametrize("case", [0.5, "xxx"])
-@pytest.mark.parametrize("sort", [None, False])
 @pytest.mark.parametrize(
     "method", ["intersection", "union", "difference", "symmetric_difference"]
 )
@@ -18,7 +17,6 @@ def test_set_ops_error_cases(idx, case, sort, method):
         getattr(idx, method)(case, sort=sort)
 
 
-@pytest.mark.parametrize("sort", [None, False])
 @pytest.mark.parametrize("klass", [MultiIndex, np.array, Series, list])
 def test_intersection_base(idx, sort, klass):
     first = idx[2::-1]  # first 3 elements reversed
@@ -39,7 +37,6 @@ def test_intersection_base(idx, sort, klass):
         first.intersection([1, 2, 3], sort=sort)
 
 
-@pytest.mark.parametrize("sort", [None, False])
 @pytest.mark.parametrize("klass", [MultiIndex, np.array, Series, list])
 def test_union_base(idx, sort, klass):
     first = idx[::-1]
@@ -60,7 +57,6 @@ def test_union_base(idx, sort, klass):
         first.union([1, 2, 3], sort=sort)
 
 
-@pytest.mark.parametrize("sort", [None, False])
 def test_difference_base(idx, sort):
     second = idx[4:]
     answer = idx[:4]
@@ -83,7 +79,6 @@ def test_difference_base(idx, sort):
         idx.difference([1, 2, 3], sort=sort)
 
 
-@pytest.mark.parametrize("sort", [None, False])
 def test_symmetric_difference(idx, sort):
     first = idx[1:]
     second = idx[:-1]
@@ -123,7 +118,6 @@ def test_empty(idx):
     assert idx[:0].empty
 
 
-@pytest.mark.parametrize("sort", [None, False])
 def test_difference(idx, sort):
 
     first = idx
@@ -234,7 +228,6 @@ def test_difference_sort_incomparable_true():
         idx.difference(other, sort=True)
 
 
-@pytest.mark.parametrize("sort", [None, False])
 def test_union(idx, sort):
     piece1 = idx[:5][::-1]
     piece2 = idx[3:]
@@ -270,7 +263,6 @@ def test_union(idx, sort):
     #     assert result.equals(result2)
 
 
-@pytest.mark.parametrize("sort", [None, False])
 def test_intersection(idx, sort):
     piece1 = idx[:5][::-1]
     piece2 = idx[3:]

--- a/pandas/tests/indexes/period/test_setops.py
+++ b/pandas/tests/indexes/period/test_setops.py
@@ -13,7 +13,6 @@ def _permute(obj):
 
 
 class TestPeriodIndex:
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union(self, sort):
         # union
         other1 = period_range("1/1/2000", freq="D", periods=5)
@@ -134,7 +133,6 @@ class TestPeriodIndex:
                 expected = expected.sort_values()
             tm.assert_index_equal(result_union, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_misc(self, sort):
         index = period_range("1/1/2000", "1/20/2000", freq="D")
 
@@ -165,7 +163,6 @@ class TestPeriodIndex:
         exp = period_range("1/1/1980", "1/1/2012", freq="M")
         tm.assert_index_equal(df.index, exp)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection(self, sort):
         index = period_range("1/1/2000", "1/20/2000", freq="D")
 
@@ -190,7 +187,6 @@ class TestPeriodIndex:
         with pytest.raises(IncompatibleFrequency):
             index.intersection(index3, sort=sort)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_cases(self, sort):
         base = period_range("6/1/2000", "6/30/2000", freq="D", name="idx")
 
@@ -259,7 +255,6 @@ class TestPeriodIndex:
         result = rng.intersection(rng[0:0])
         assert len(result) == 0
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference(self, sort):
         # diff
         period_rng = ["1/3/2000", "1/2/2000", "1/1/2000", "1/5/2000", "1/4/2000"]
@@ -324,7 +319,6 @@ class TestPeriodIndex:
                 expected = expected.sort_values()
             tm.assert_index_equal(result_difference, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_freq(self, sort):
         # GH14323: difference of Period MUST preserve frequency
         # but the ability to union results must be preserved

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -8,7 +8,6 @@ import pandas._testing as tm
 
 
 class TestRangeIndexSetOps:
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection(self, sort):
         # intersect with Int64Index
         index = RangeIndex(start=0, stop=20, step=2)

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -78,7 +78,6 @@ class TestRangeIndexSetOps:
         expected = RangeIndex(0, 0, 1)
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize("sort", [False, None])
     def test_union_noncomparable(self, sort):
         # corner case, non-Int64Index
         index = RangeIndex(start=0, stop=20, step=2)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -681,7 +681,6 @@ class TestIndex(Base):
         with pytest.raises(IndexError, match=msg):
             index[empty_farr]
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection(self, index, sort):
         first = index[:20]
         second = index[:10]
@@ -702,7 +701,6 @@ class TestIndex(Base):
             (Index([3, 4, 5, 6, 7]), False),
         ],
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_name_preservation(self, index2, keeps_name, sort):
         index1 = Index([1, 2, 3, 4, 5], name="index")
         expected = Index([3, 4, 5])
@@ -718,7 +716,6 @@ class TestIndex(Base):
         "first_name,second_name,expected_name",
         [("A", "A", "A"), ("A", "B", None), (None, "B", None)],
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_name_preservation2(
         self, index, first_name, second_name, expected_name, sort
     ):
@@ -736,7 +733,6 @@ class TestIndex(Base):
             (Index([4, 7, 6, 5, 3], name="other"), False),
         ],
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_monotonic(self, index2, keeps_name, sort):
         index1 = Index([5, 3, 2, 4, 1], name="index")
         expected = Index([5, 3, 4])
@@ -753,7 +749,6 @@ class TestIndex(Base):
         "index2,expected_arr",
         [(Index(["B", "D"]), ["B"]), (Index(["B", "D", "A"]), ["A", "B", "A"])],
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_non_monotonic_non_unique(self, index2, expected_arr, sort):
         # non-monotonic non-unique
         index1 = Index(["A", "B", "A", "C"])
@@ -763,7 +758,6 @@ class TestIndex(Base):
             expected = expected.sort_values()
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersect_str_dates(self, sort):
         dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]
 
@@ -780,7 +774,6 @@ class TestIndex(Base):
         sorted_ = pd.Index(["a", "b", "c"])
         tm.assert_index_equal(idx.intersection(idx, sort=True), sorted_)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_chained_union(self, sort):
         # Chained unions handles names correctly
         i1 = Index([1, 2], name="i1")
@@ -797,7 +790,6 @@ class TestIndex(Base):
         expected = j1.union(j2, sort=sort).union(j3, sort=sort)
         tm.assert_index_equal(union, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union(self, index, sort):
         first = index[5:20]
         second = index[:10]
@@ -835,7 +827,6 @@ class TestIndex(Base):
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("klass", [np.array, Series, list])
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_from_iterables(self, index, klass, sort):
         # GH 10149
         first = index[5:20]
@@ -848,7 +839,6 @@ class TestIndex(Base):
             tm.assert_index_equal(result, everything.sort_values())
         assert tm.equalContents(result, everything)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_identity(self, index, sort):
         first = index[5:20]
 
@@ -870,7 +860,6 @@ class TestIndex(Base):
         "first_name, second_name, expected_name",
         [("A", "B", None), (None, "B", None), ("A", None, None)],
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_name_preservation(
         self, first_list, second_list, first_name, second_name, expected_name, sort
     ):
@@ -887,7 +876,6 @@ class TestIndex(Base):
             expected = Index(vals, name=expected_name)
             assert tm.equalContents(union, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_union_dt_as_obj(self, sort):
         # TODO: Replace with fixturesult
         index = self.create_index()
@@ -1022,7 +1010,6 @@ class TestIndex(Base):
         assert result.name == expected
 
     @pytest.mark.parametrize("second_name,expected", [(None, None), ("name", "name")])
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_name_preservation(self, index, second_name, expected, sort):
         first = index[5:20]
         second = index[:10]
@@ -1039,7 +1026,6 @@ class TestIndex(Base):
         else:
             assert result.name == expected
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_empty_arg(self, index, sort):
         first = index[5:20]
         first.name == "name"
@@ -1048,7 +1034,6 @@ class TestIndex(Base):
         assert tm.equalContents(result, first)
         assert result.name == first.name
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_identity(self, index, sort):
         first = index[5:20]
         first.name == "name"
@@ -1057,7 +1042,6 @@ class TestIndex(Base):
         assert len(result) == 0
         assert result.name == first.name
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_sort(self, index, sort):
         first = index[5:20]
         second = index[:10]
@@ -1070,7 +1054,6 @@ class TestIndex(Base):
 
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_symmetric_difference(self, sort):
         # smoke
         index1 = Index([5, 2, 3, 4], name="index1")
@@ -1118,7 +1101,6 @@ class TestIndex(Base):
         with pytest.raises(TypeError, match="Cannot compare"):
             op(a)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_symmetric_difference_mi(self, sort):
         index1 = MultiIndex.from_tuples(zip(["foo", "bar", "baz"], [1, 2, 3]))
         index2 = MultiIndex.from_tuples([("foo", 1), ("bar", 3)])
@@ -1136,7 +1118,6 @@ class TestIndex(Base):
             (Index([0, 1]), Index([np.nan, 2.0, 3.0, 0.0])),
         ],
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_symmetric_difference_missing(self, index2, expected, sort):
         # GH 13514 change: {nan} - {nan} == {}
         # (GH 6444, sorting of nans, is no longer an issue)
@@ -1147,7 +1128,6 @@ class TestIndex(Base):
             expected = expected.sort_values()
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_symmetric_difference_non_index(self, sort):
         index1 = Index([1, 2, 3, 4], name="index1")
         index2 = np.array([2, 3, 4, 5])
@@ -1160,7 +1140,6 @@ class TestIndex(Base):
         assert tm.equalContents(result, expected)
         assert result.name == "new_name"
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_type(self, indices, sort):
         # GH 20040
         # If taking difference of a set and itself, it
@@ -1171,7 +1150,6 @@ class TestIndex(Base):
         expected = indices.drop(indices)
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_difference(self, indices, sort):
         # GH 20040
         # Test that the intersection of an index with an

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -107,7 +107,6 @@ class TestTimedeltaIndex:
         expected = timedelta_range("1 day 01:00:00", periods=3, freq="h")
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_equal(self, sort):
         # GH 24471 Test intersection outcome given the sort keyword
         # for equal indicies intersection should return the original index
@@ -123,7 +122,6 @@ class TestTimedeltaIndex:
         assert inter is first
 
     @pytest.mark.parametrize("period_1, period_2", [(0, 4), (4, 0)])
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_zero_length(self, period_1, period_2, sort):
         # GH 24471 test for non overlap the intersection should be zero length
         index_1 = timedelta_range("1 day", periods=period_1, freq="h")
@@ -132,7 +130,6 @@ class TestTimedeltaIndex:
         result = index_1.intersection(index_2, sort=sort)
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_zero_length_input_index(self, sort):
         # GH 24966 test for 0-len intersections are copied
         index_1 = timedelta_range("1 day", periods=0, freq="h")
@@ -162,7 +159,6 @@ class TestTimedeltaIndex:
             ),
         ],
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection(self, rng, expected, sort):
         # GH 4690 (with tz)
         base = timedelta_range("1 day", periods=4, freq="h", name="idx")
@@ -195,7 +191,6 @@ class TestTimedeltaIndex:
             ),
         ],
     )
-    @pytest.mark.parametrize("sort", [None, False])
     def test_intersection_non_monotonic(self, rng, expected, sort):
         # 24471 non-monotonic
         base = TimedeltaIndex(["1 hour", "2 hour", "4 hour", "3 hour"], name="idx")
@@ -213,7 +208,6 @@ class TestTimedeltaIndex:
 
 
 class TestTimedeltaIndexDifference:
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_freq(self, sort):
         # GH14323: Difference of TimedeltaIndex should not preserve frequency
 
@@ -231,7 +225,6 @@ class TestTimedeltaIndexDifference:
         tm.assert_index_equal(idx_diff, expected)
         tm.assert_attr_equal("freq", idx_diff, expected)
 
-    @pytest.mark.parametrize("sort", [None, False])
     def test_difference_sort(self, sort):
 
         index = pd.TimedeltaIndex(


### PR DESCRIPTION
- [x] closes #32183
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

