### PR TITLE
BUG: Fix __ne__ comparison for Categorical

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -127,7 +127,7 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 - Bug when passing categorical data to :class:`Index` constructor along with ``dtype=object`` incorrectly returning a :class:`CategoricalIndex` instead of object-dtype :class:`Index` (:issue:`32167`)
--
+- Bug where :class:`Categorical` comparison operator ``__ne__`` would incorrectly evaluate to ``False`` when either element was missing (:issue:`32276`)
 -
 
 Datetimelike

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -103,7 +103,10 @@ def _cat_compare_op(op):
             mask = (self._codes == -1) | (other_codes == -1)
             if mask.any():
                 # In other series, the leads to False, so do that here too
-                ret[mask] = False
+                if opname == "__ne__":
+                    ret[mask & (self._codes == other_codes)] = True
+                else:
+                    ret[mask] = False
             return ret
 
         if is_scalar(other):

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -104,7 +104,7 @@ def _cat_compare_op(op):
             if mask.any():
                 # In other series, the leads to False, so do that here too
                 if opname == "__ne__":
-                    ret[mask & (self._codes == other_codes)] = True
+                    ret[(self._codes == -1) & (other_codes == -1)] = True
                 else:
                     ret[mask] = False
             return ret

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -282,6 +282,15 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             with pytest.raises(TypeError, match=msg):
                 op(data, other)
 
+    def test_not_equal_with_na():
+        # https://github.com/pandas-dev/pandas/issues/32276
+        categories = ["a", "b"]
+        c1 = Categorical([None, "a"], categories=categories)
+        c2 = Categorical(["a", "b"], categories=categories)
+
+        result = c1 != c2
+
+        assert result.all()
 
 class TestParsing(base.BaseParsingTests):
     pass

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -282,7 +282,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             with pytest.raises(TypeError, match=msg):
                 op(data, other)
 
-    def test_not_equal_with_na():
+    def test_not_equal_with_na(self):
         # https://github.com/pandas-dev/pandas/issues/32276
         categories = ["a", "b"]
         c1 = Categorical([None, "a"], categories=categories)

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -282,11 +282,14 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             with pytest.raises(TypeError, match=msg):
                 op(data, other)
 
-    def test_not_equal_with_na(self):
+    @pytest.mark.parametrize(
+        "categories",
+        [["a", "b"], [0, 1], [pd.Timestamp("2019"), pd.Timestamp("2020")]],
+    )
+    def test_not_equal_with_na(self, categories):
         # https://github.com/pandas-dev/pandas/issues/32276
-        categories = ["a", "b"]
-        c1 = Categorical([None, "a"], categories=categories)
-        c2 = Categorical(["a", "b"], categories=categories)
+        c1 = Categorical.from_codes([-1, 0], categories=categories)
+        c2 = Categorical.from_codes([0, 1], categories=categories)
 
         result = c1 != c2
 

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -292,5 +292,6 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
 
         assert result.all()
 
+
 class TestParsing(base.BaseParsingTests):
     pass


### PR DESCRIPTION
- [x] closes #32276
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
