### PR TITLE
CLN: remove _igetitem_cache

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2741,7 +2741,7 @@ class DataFrame(NDFrame):
         """
         try:
             if takeable is True:
-                series = self._iget_item_cache(col)
+                series = self._ixs(col, axis=1)
                 series._set_value(index, value, takeable=True)
                 return
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3459,15 +3459,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             res._is_copy = self._is_copy
         return res
 
-    def _iget_item_cache(self, item: int):
-        """Return the cached item, item represents a positional indexer."""
-        ax = self._info_axis
-        if ax.is_unique:
-            lower = self._get_item_cache(ax[item])
-        else:
-            return self._ixs(item, axis=1)
-        return lower
-
     def _box_item_values(self, key, values):
         raise AbstractMethodError(self)
 


### PR DESCRIPTION
Only used once (recent bugfixes got rid of the user uses IIRC) and its just an extra layer that isnt needed.