### PR TITLE
DOC: Fixed reference to `convert_dtypes` in `to_numeric` (#32295)

### DIFF
--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -70,7 +70,7 @@ def to_numeric(arg, errors="raise", downcast=None):
     to_datetime : Convert argument to datetime.
     to_timedelta : Convert argument to timedelta.
     numpy.ndarray.astype : Cast a numpy array to a specified type.
-    convert_dtypes : Convert dtypes.
+    DataFrame.convert_dtypes : Convert dtypes.
 
     Examples
     --------


### PR DESCRIPTION
- closes #32295 
- just changed the reference from convert_dtypes to DataFrame.convert_dtypes
