### PR TITLE
C Functionality for Accessing DataFrame Values in Column Order

### DIFF
--- a/pandas/_libs/ndframe_iter.c
+++ b/pandas/_libs/ndframe_iter.c
@@ -1,1 +1,146 @@
-PdBlocksIter *PdFrameIter_New(PyObject *df, int axis);
+// returns -1 on error
+// performs no bounds checking, so will likely segfault if you pass
+// and inappropriate dim for the object
+static Py_ssize_t getDimLength(PyObject *df, Py_ssize_t dim) {
+  PyObject *shape;
+  shape = PyObject_GetAttrString(df, "shape");
+  if (shape == NULL) {
+    return -1;
+  }
+  
+  if (!PyTuple_Check(shape)) {
+    Py_DECREF(shape);
+    return -1;
+  }
+
+  ncols = PyTuple_GET_ITEM(shape, dim);
+  Py_DECREF(shape);
+
+  return ncols;
+}
+
+// Return the blocks object associated with a dataframe
+// Checks that the return value is a Tuple
+static PyObject *getBlocksTuple(PyObject *df) {
+  PyObject *blockManager, *blocks;
+
+  *blockManager = PyObject_GetAttrString(df, "_data");
+  if (blockManager == NULL) {
+    return NULL;
+  }
+
+  *blocks = PyObject_GetAttrString(blockManager, "blocks");
+  Py_DECREF(blockManager);
+  if (blocks == NULL) {
+    return NULL;
+  }
+
+  if (!PyTuple_Check(blocks)) {
+    // TODO: Set error message here
+    Py_DECREF(blocks);
+    return NULL;
+  }
+
+  return blocks;
+}
+
+// Return the integer placements of the blocks columns in its owning frame
+// Checks that the return value is a List
+static PyObject *getManagerLocationsAsList(PyObject *block) {
+  PyObject *managerLocs, *ndarray, *list;
+
+  managerLocs = PyObject_GetAttrString(block "mgr_locs");
+  if (managerLocs == NULL) {
+    return NULL;
+  }
+
+  // TODO: we could probably just supply managerLocs to the list()
+  // built-in instead of going from mgr_locs->as_array->tolist
+  ndarray = PyObject_GetAttrString(managerLocs, "as_array");
+  Py_DECREF(managerLocs);
+  if (ndarray == NULL) {
+    return NULL;
+  }
+
+  list = PyObject_CallMethod(ndarray, "tolist", NULL);
+  Py_DECREF(ndarray);
+  if (list == NULL) {
+    return NULL;
+  } else if (!PyList_Check(list)) {
+    Py_DECREF(list);
+    return NULL;
+  }
+  
+  return list;
+}
+
+
+PdBlocksIter *PdFrameIter_New(PyObject *df, int axis) {
+  PyObject *blocks, *block, *managerLocs, *blockValues;
+  char ***data;  // individual ndarrays; C-order should match column order
+  Py_ssize_t i, j, loc, ncols;
+  NpyIter *iter;
+  NpyIter_IterNextFunc *iternext;
+  char **dataptr;
+
+  ncols = getDimLength(df, 1);
+  blocks = getBlocksTuple(df);
+  if (blocks == NULL) {
+    return NULL;
+  }
+  
+  data = PyObject_Malloc(sizeof(char **) * ncols);
+  if (data == NULL) {
+    Py_DECREF(blocks);
+    return NULL;
+  }
+
+  for (i = 0; i < PyTuple_GET_SIZE(blocks); i++) {
+    block = PyTuple_GET_ITEM(blocks, i);
+    
+    blockValues = PyObject_CallMethod(block, "get_block_values", NULL);
+    if (blockValues == NULL) {
+      Py_DECREF(blocks);
+      PyObject_Free(data);
+      return NULL;
+    }
+
+    if (!PyArray_Check(blockValues)) {
+      Py_DECREF(blockValues);
+      Py_DECREF(blocks);
+      PyObject_Free(data);
+      return NULL;
+    }
+
+    managerLocs = getManagerLocations(block);
+    if (managerLocs == NULL) {
+      Py_DECREF(blockValues);
+      Py_DECREF(blocks);
+      PyObject_Free(data);
+      return NULL;
+    }
+
+    // Use F-ORDER to stride down the columns of the block
+    iter = NpyIter_New(blockValues, NPY_ITER_READONLY|
+                       NPY_ITER_EXTERNAL_LOOP,
+                       NPY_FORTRANORDER, NPY_NO_CASTING, NULL);
+    if (iter == NULL) {
+      Py_DECREF(blockValues);
+      Py_DECREF(blocks);
+      PyObject_Free(data);
+      return NULL;
+    }
+    
+    iternext = NpyIter_GetIterNext(iter, NULL);
+    if (iternext == NULL) {
+      Py_DECREF(iter);
+      Py_DECREF(blockValues);
+      Py_DECREF(blocks);
+      PyObject_Free(data);
+      return NULL;
+    }
+
+    // TODO: we have the array data and we know the indices
+    // of where they are located in the dataframe, so figure out how we
+    // should iterate and store that knowledge
+}

--- a/pandas/_libs/ndframe_iter.c
+++ b/pandas/_libs/ndframe_iter.c
@@ -1,0 +1,1 @@
+PdBlocksIter *PdFrameIter_New(PyObject *df, int axis);

--- a/pandas/_libs/ndframe_iter.c
+++ b/pandas/_libs/ndframe_iter.c
@@ -144,26 +144,26 @@ PdOrderedArrays *PdOrderedArrays_New(PyObject *df, int axis) {
       loc = PyLong_AsLongLong(PyList_GET_ITEM(managerLocs, j));
       key = PyLong_FromLongLong(j);
       if (key == NULL) {
-        Py_DECREF(managerLocs);
-        Py_DECREF(blockValues);
-        Py_DECREF(blocks);
-        PyObject_Free(ndarrays);
-        return NULL;
+        goto LOOP_ERROR;
       }
 
       // TODO: Need to support slicing more than axis = 0
       ndarr = PyObject_GetItem(blockValues, key);
       Py_DECREF(key);
       if (ndarr == NULL) {
-        Py_DECREF(managerLocs);
-        Py_DECREF(blockValues);
-        Py_DECREF(blocks);
-        PyObject_Free(ndarrays);
-        return NULL;
+        goto LOOP_ERROR;
       }
 
       ndarrays[loc] = ndarr;
+      continue;
+    LOOP_ERROR:
+      Py_DECREF(managerLocs);
+      Py_DECREF(blockValues);
+      Py_DECREF(blocks);
+      PyObject_Free(ndarrays);
+      return NULL;      
     }
+    
     Py_DECREF(managerLocs);
     Py_DECREF(blockValues);
   }
@@ -178,7 +178,7 @@ PdOrderedArrays *PdOrderedArrays_New(PyObject *df, int axis) {
   result->len = ncols;
   result->ndarrays = ndarrays;
 
-  return NULL;
+  return result;
 }
 
 void PdOrderedArrays_Destroy(PdOrderedArrays *orderedArrays) {

--- a/pandas/_libs/ndframe_iter.h
+++ b/pandas/_libs/ndframe_iter.h
@@ -1,0 +1,4 @@
+// Given a dataframe and axis, returns an iterator
+// to go through each
+
+PdIter *PdFrameIter_New(PyObject *df, int axis);

--- a/pandas/_libs/ndframe_iter.h
+++ b/pandas/_libs/ndframe_iter.h
@@ -15,11 +15,12 @@
 typedef struct {
   Py_ssize_t len;
   PyObject **ndarrays;  // TODO: need some kind of destructor
-} PdBlocksIter;
+} PdOrderedArrays;
 
 // Provided a DataFrame and axis deconstructs the block
 // data to match the order represented by the BlockManager
 // Returns NULL on error
-PdBlocksIter *PdFrameIter_New(PyObject *df, int axis);
+PdOrderedArrays *PdOrderedArrays_New(PyObject *df, int axis);
+void PdOrderedArrays_Destroy(PdOrderedArrays *orderedArrays);
 
 #endif

--- a/pandas/_libs/ndframe_iter.h
+++ b/pandas/_libs/ndframe_iter.h
@@ -1,4 +1,17 @@
-// Given a dataframe and axis, returns an iterator
-// to go through each
+// TODO: could use better naming than "PdBlockIter"
+// showing that this is really "deconstructed" block data
+// in native form
 
+// Struct containing a pointer to len # of NDArrays
+// The order of each item in data should match the
+// order specified by the BlockManager
+typedef struct {
+  Py_ssize_t len;
+  PyArrayObject **data;
+} PdBlocksIter;
+
+// Provided a DataFrame and axis deconstructs the block
+// data to match the order represented by the BlockManager
+// Returns NULL on error
 PdIter *PdFrameIter_New(PyObject *df, int axis);
+

--- a/pandas/_libs/ndframe_iter.h
+++ b/pandas/_libs/ndframe_iter.h
@@ -13,5 +13,5 @@ typedef struct {
 // Provided a DataFrame and axis deconstructs the block
 // data to match the order represented by the BlockManager
 // Returns NULL on error
-PdIter *PdFrameIter_New(PyObject *df, int axis);
+PdBlocksIter *PdFrameIter_New(PyObject *df, int axis);
 

--- a/pandas/_libs/ndframe_iter.h
+++ b/pandas/_libs/ndframe_iter.h
@@ -14,7 +14,7 @@
 // order specified by the BlockManager
 typedef struct {
   Py_ssize_t len;
-  char ***data;  // each of these points to an array containing numpy data
+  PyObject **ndarrays;  // TODO: need some kind of destructor
 } PdBlocksIter;
 
 // Provided a DataFrame and axis deconstructs the block

--- a/pandas/_libs/ndframe_iter.h
+++ b/pandas/_libs/ndframe_iter.h
@@ -7,7 +7,7 @@
 // order specified by the BlockManager
 typedef struct {
   Py_ssize_t len;
-  PyArrayObject **data;
+  char ***data;  // each of these points to an array containing numpy data
 } PdBlocksIter;
 
 // Provided a DataFrame and axis deconstructs the block

--- a/pandas/_libs/ndframe_iter.h
+++ b/pandas/_libs/ndframe_iter.h
@@ -2,6 +2,13 @@
 // showing that this is really "deconstructed" block data
 // in native form
 
+#ifndef PANDAS__NDFRAME_ITER
+#define PANDAS__NDFRAME_ITER
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+
 // Struct containing a pointer to len # of NDArrays
 // The order of each item in data should match the
 // order specified by the BlockManager
@@ -15,3 +22,4 @@ typedef struct {
 // Returns NULL on error
 PdBlocksIter *PdFrameIter_New(PyObject *df, int axis);
 
+#endif

--- a/pandas/tests/frame/test_native.py
+++ b/pandas/tests/frame/test_native.py
@@ -6,4 +6,5 @@ import pandas as pd
 def test_func():
     libc = ctypes.PyDLL('pandas/_libs/ndframe_data.cpython-37m-darwin.so')
     df = pd.DataFrame([[1, "2", 3., 4., 5], [6, "7", 8., 9, 10]])
-    libc.PdOrderedArrays_New(ctypes.py_object(df), ctypes.c_int(0))
+    obj = libc.PdOrderedArrays_New(ctypes.py_object(df), ctypes.c_int(0))
+    #libc.PdOrderedArrays_Destroy(obj)

--- a/pandas/tests/frame/test_native.py
+++ b/pandas/tests/frame/test_native.py
@@ -4,7 +4,10 @@ import pandas as pd
 
 
 def test_func():
+    # TODO: this is hard coded to only work on Mac
     libc = ctypes.PyDLL('pandas/_libs/ndframe_data.cpython-37m-darwin.so')
     df = pd.DataFrame([[1, "2", 3., 4., 5], [6, "7", 8., 9, 10]])
     obj = libc.PdOrderedArrays_New(ctypes.py_object(df), ctypes.c_int(0))
+    # TODO: Improve test by accessing numpy array elements sequentially
+    # and testing for appropriate values
     #libc.PdOrderedArrays_Destroy(obj)

--- a/pandas/tests/frame/test_native.py
+++ b/pandas/tests/frame/test_native.py
@@ -6,4 +6,4 @@ import pandas as pd
 def test_func():
     libc = ctypes.PyDLL('pandas/_libs/ndframe_data.cpython-37m-darwin.so')
     df = pd.DataFrame([[1, "2", 3., 4., 5], [6, "7", 8., 9, 10]])
-    libc.PdFrameIter_New(ctypes.py_object(df), ctypes.c_int(0))
+    libc.PdOrderedArrays_New(ctypes.py_object(df), ctypes.c_int(0))

--- a/pandas/tests/frame/test_native.py
+++ b/pandas/tests/frame/test_native.py
@@ -1,0 +1,7 @@
+import ctypes
+
+
+def test_func():
+    libc = ctypes.CDLL('pandas/_libs/ndframe_data.cpython-37m-darwin.so')
+    df = pd.DataFrame([[1, "2", 3., 4., 5], [6, "7", 8., 9, 10]])
+    libc.PdFrameIter_New(ctypes.py_object(df), ctypes.c_int(0))

--- a/pandas/tests/frame/test_native.py
+++ b/pandas/tests/frame/test_native.py
@@ -1,7 +1,9 @@
 import ctypes
 
+import pandas as pd
+
 
 def test_func():
-    libc = ctypes.CDLL('pandas/_libs/ndframe_data.cpython-37m-darwin.so')
+    libc = ctypes.PyDLL('pandas/_libs/ndframe_data.cpython-37m-darwin.so')
     df = pd.DataFrame([[1, "2", 3., 4., 5], [6, "7", 8., 9, 10]])
     libc.PdFrameIter_New(ctypes.py_object(df), ctypes.c_int(0))

--- a/setup.py
+++ b/setup.py
@@ -234,6 +234,7 @@ class CleanCommand(Command):
             pjoin(ujson_lib, "ultrajsonenc.c"),
             pjoin(ujson_lib, "ultrajsondec.c"),
             pjoin(util, "move.c"),
+            pjoin("pandas", "_libs", "ndframe_iter.c"),
         ]
 
         for root, dirs, files in os.walk("pandas"):
@@ -737,6 +738,7 @@ native_frame_ext = Extension(
     sources=["pandas/_libs/ndframe_iter.c"],
     include_dirs=["pandas/_libs"],
     define_macros=macros,
+    depends=["ndframe_iter.h"],
 )
 
 extensions.append(native_frame_ext)

--- a/setup.py
+++ b/setup.py
@@ -730,8 +730,17 @@ ujson_ext = Extension(
 
 
 extensions.append(ujson_ext)
+# ----------------------------------------------------------------------w
+# native frame access functions
+native_frame_ext = Extension(
+    "pandas._libs.ndframe_data",
+    sources=["pandas/_libs/ndframe_iter.c"],
+    include_dirs=["pandas/_libs"],
+    define_macros=macros,
+)
 
-# ----------------------------------------------------------------------
+extensions.append(native_frame_ext)
+# ----------------------------------------------------------------------w
 
 
 def setup_package():


### PR DESCRIPTION
This is very rough and was a little hesitant to even push here, but figured worth opening up to feedback.

The main motivation for this PR is to get block management out of the JSON serializer, but it could potentially be extended beyond that for external uses

The gist of this is that we can hold a struct `PdOrderedArrays` which gives the length of the DataFrame and sequential access to Numpy arrays that mirror what the user sees when dealing with a DataFrame, all by deconstructing the blocks that already exist down in some C functions