### PR TITLE
DOC : fix errors docstrings pandas.to_numeric

### DIFF
--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -45,13 +45,13 @@ def to_numeric(arg, errors="raise", downcast=None):
         - If 'raise', then invalid parsing will raise an exception.
         - If 'coerce', then invalid parsing will be set as NaN.
         - If 'ignore', then invalid parsing will return the input.
-    downcast : {'int', 'signed', 'unsigned', 'float'}, default None
+    downcast : {'integer', 'signed', 'unsigned', 'float'}, default None
         If not None, and if the data has been successfully cast to a
         numerical dtype (or if the data was numeric to begin with),
         downcast that resulting data to the smallest numerical dtype
         possible according to the following rules:
 
-        - 'int' or 'signed': smallest signed int dtype (min.: np.int8)
+        - 'integer' or 'signed': smallest signed int dtype (min.: np.int8)
         - 'unsigned': smallest unsigned int dtype (min.: np.uint8)
         - 'float': smallest float dtype (min.: np.float32)
 

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -35,17 +35,23 @@ def to_numeric(arg, errors="raise", downcast=None):
     Parameters
     ----------
     arg : scalar, list, tuple, 1-d array, or Series
+        Arg is consists of any kinds of type :
+        - scalar is any kind of numeric type data.
+        - list is any kind of '[]' dtypes.
+        - tuple is any kind of '()' dtypes.
+        - 1-d array is list dtypes that only have 1 list.
+        - Series is kind of pandas 1-d ndarray with axis labels.
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception.
         - If 'coerce', then invalid parsing will be set as NaN.
         - If 'ignore', then invalid parsing will return the input.
-    downcast : {'integer', 'signed', 'unsigned', 'float'}, default None
+    downcast : {'int', 'signed', 'unsigned', 'float'}, default None
         If not None, and if the data has been successfully cast to a
         numerical dtype (or if the data was numeric to begin with),
         downcast that resulting data to the smallest numerical dtype
         possible according to the following rules:
 
-        - 'integer' or 'signed': smallest signed int dtype (min.: np.int8)
+        - 'int' or 'signed': smallest signed int dtype (min.: np.int8)
         - 'unsigned': smallest unsigned int dtype (min.: np.uint8)
         - 'float': smallest float dtype (min.: np.float32)
 
@@ -61,7 +67,8 @@ def to_numeric(arg, errors="raise", downcast=None):
 
     Returns
     -------
-    ret : numeric if parsing succeeded.
+    ret
+        Numeric if parsing succeeded.
         Return type depends on input.  Series if Series, otherwise ndarray.
 
     See Also

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -35,12 +35,7 @@ def to_numeric(arg, errors="raise", downcast=None):
     Parameters
     ----------
     arg : scalar, list, tuple, 1-d array, or Series
-        Arg is consists of any kinds of type :
-        - scalar is any kind of numeric type data.
-        - list is any kind of '[]' dtypes.
-        - tuple is any kind of '()' dtypes.
-        - 1-d array is list dtypes that only have 1 list.
-        - Series is kind of pandas 1-d ndarray with axis labels.
+        Argument to be converted.
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception.
         - If 'coerce', then invalid parsing will be set as NaN.


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

added docstrings information about arg descriptions, downcast type 'int', and Return type
