### PR TITLE
DOC: Fixed ES01, PR07, SA04 error in pandas.core.groupby.DataFrameGroupBy.shift

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2317,6 +2317,9 @@ class GroupBy(_GroupBy):
         """
         Shift each group by periods observations.
 
+        When freq is not passed, shift the index without realigning the data.
+        If freq is passed, the index will be increased using the periods and the freq.
+
         Parameters
         ----------
         periods : int, default 1
@@ -2324,7 +2327,13 @@ class GroupBy(_GroupBy):
         freq : str, optional
             Frequency string.
         axis : axis to shift, default 0
+            Shift direction.
         fill_value : optional
+            The scalar value to use for newly introduced missing values.
+            The default depends on the dtype of *self*.
+            For numeric data, `np.nan` is used.
+            For datetime, timedelta, or period data, etc. **NaT** is used.
+            For extension dtypes, `self.dtype.na_value` is used.
 
             .. versionadded:: 0.24.0
 
@@ -2332,6 +2341,14 @@ class GroupBy(_GroupBy):
         -------
         Series or DataFrame
             Object shifted within each group.
+
+        See Also
+        --------
+        Index.shift : Shift values of Index.
+        DatetimeIndex.resample : Shift values of DatetimeIndex.
+        PeriodIndex.shift : Shift values of PeriodIndex.
+        tshift : Shift the time index, using the index’s frequency
+            if available.
         """
         if freq is not None or axis != 0 or not isna(fill_value):
             return self.apply(lambda x: x.shift(periods, freq, axis, fill_value))

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2316,7 +2316,6 @@ class GroupBy(_GroupBy):
         """
         Shift each group by periods observations.
 
-        When freq is not passed, shift the index without realigning the data.
         If freq is passed, the index will be increased using the periods and the freq.
 
         Parameters
@@ -2329,10 +2328,6 @@ class GroupBy(_GroupBy):
             Shift direction.
         fill_value : optional
             The scalar value to use for newly introduced missing values.
-            The default depends on the dtype of *self*.
-            For numeric data, `np.nan` is used.
-            For datetime, timedelta, or period data, etc. **NaT** is used.
-            For extension dtypes, `self.dtype.na_value` is used.
 
             .. versionadded:: 0.24.0
 
@@ -2344,8 +2339,6 @@ class GroupBy(_GroupBy):
         See Also
         --------
         Index.shift : Shift values of Index.
-        DatetimeIndex.resample : Shift values of DatetimeIndex.
-        PeriodIndex.shift : Shift values of PeriodIndex.
         tshift : Shift the time index, using the index’s frequency
             if available.
         """

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2312,7 +2312,6 @@ class GroupBy(_GroupBy):
             return self._wrap_transformed_output(output)
 
     @Substitution(name="groupby")
-    @Appender(_common_see_also)
     def shift(self, periods=1, freq=None, axis=0, fill_value=None):
         """
         Shift each group by periods observations.


### PR DESCRIPTION
- [x] closes: https://github.com/pandanistas/pandanistas_sprint_ui2020/issues/14
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Output of python scripts/validate_docstrings.py pandas.core.groupby.DataFrameGroupBy.shift:
```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found:
        No examples section found
```