### PR TITLE
Silence warnings when compiling pandas/_libs/parsers.pyx

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -701,7 +701,7 @@ cdef class TextReader:
             char *word
             object name, old_name
             int status
-            uint64_t hr, data_line
+            uint64_t hr, data_line = 0
             char *errors = "strict"
             StringPath path = _string_path(self.c_encoding)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is getting rid of this warning:
```
pandas/_libs/parsers.c: In function ‘__pyx_f_6pandas_5_libs_7parsers_10TextReader__get_header’:
pandas/_libs/parsers.c:9313:27: warning: ‘__pyx_v_data_line’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 9313 |   __pyx_t_5numpy_uint64_t __pyx_v_data_line;
```