### PR TITLE
HDFStore: Fix empty result of keys() method on non-pandas hdf5 file

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -340,7 +340,7 @@ I/O
 - Bug in :class:`HDFStore` that caused it to set to ``int64`` the dtype of a ``datetime64`` column when reading a DataFrame in Python 3 from fixed format written in Python 2 (:issue:`31750`)
 - Bug in :meth:`read_excel` where a UTF-8 string with a high surrogate would cause a segmentation violation (:issue:`23809`)
 - Bug in :meth:`read_csv` was causing a file descriptor leak on an empty file (:issue:`31488`)
-- :meth:`HDFStore.keys` has now an optional `kind` parameter that allows the retrieval of all native HDF5 table names (:issue:`29916`)
+- :meth:`HDFStore.keys` now tries to get the list of native pandas tables first, and if there are none, it gets the native HDF5 table names (:issue:`29916`)
 
 
 Plotting

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -340,6 +340,7 @@ I/O
 - Bug in :class:`HDFStore` that caused it to set to ``int64`` the dtype of a ``datetime64`` column when reading a DataFrame in Python 3 from fixed format written in Python 2 (:issue:`31750`)
 - Bug in :meth:`read_excel` where a UTF-8 string with a high surrogate would cause a segmentation violation (:issue:`23809`)
 - Bug in :meth:`read_csv` was causing a file descriptor leak on an empty file (:issue:`31488`)
+- :meth:`HDFStore.keys` has now an optional `kind` parameter that allows the retrieval of all native HDF5 table names (:issue:`29916`)
 
 
 Plotting

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -591,15 +591,12 @@ class HDFStore:
         list
             List of ABSOLUTE path-names (e.g. have the leading '/').
         """
-        #        if kind == "pandas":
         objects = [n._v_pathname for n in self.groups()]
         if objects:
             return objects
 
         self._check_if_open()
-        return [
-            n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
-        ]
+        return [n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")]
 
     def __iter__(self):
         return iter(self.keys())

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -605,7 +605,8 @@ class HDFStore:
 
         if kind == 'tables':
             self._check_if_open()
-            return [n._v_pathname for n in self._handle.walk_nodes('/', classname='Table')]
+            return [n._v_pathname
+                    for n in self._handle.walk_nodes('/', classname='Table')]
         raise ValueError(f"kind should be either pandas' or 'table' but is {kind}")
 
     def __iter__(self):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -591,14 +591,14 @@ class HDFStore:
                 When kind equals 'table' return Tables
                 Otherwise fail with a ValueError
 
-        Raises
-        ------
-        raises ValueError if kind has an illegal value
-
         Returns
         -------
         list
             List of ABSOLUTE path-names (e.g. have the leading '/').
+
+        Raises
+        ------
+        raises ValueError if kind has an illegal value
         """
         if kind == "pandas":
             return [n._v_pathname for n in self.groups()]

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -595,7 +595,7 @@ class HDFStore:
         if objects:
             return objects
 
-        self._check_if_open()
+        assert self._handle is not None  # mypy
         return [n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")]
 
     def __iter__(self):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,7 +580,7 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self, kind='pandas') -> List[str]:
+    def keys(self, kind="pandas") -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
 
@@ -600,13 +600,14 @@ class HDFStore:
         list
             List of ABSOLUTE path-names (e.g. have the leading '/').
         """
-        if kind == 'pandas':
+        if kind == "pandas":
             return [n._v_pathname for n in self.groups()]
 
-        if kind == 'tables':
+        if kind == "tables":
             self._check_if_open()
-            return [n._v_pathname
-                    for n in self._handle.walk_nodes('/', classname='Table')]
+            return [
+                n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
+            ]
         raise ValueError(f"kind should be either pandas' or 'table' but is {kind}")
 
     def __iter__(self):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,7 +580,7 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self, kind="pandas") -> List[str]:
+    def keys(self, kind: Optional[str] = "pandas") -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
 
@@ -588,7 +588,7 @@ class HDFStore:
         ----------
         kind : str, default 'pandas'
                 When kind equals 'pandas' return pandas objects
-                When kind equals 'table' return Tables
+                When kind equals 'table' return Table objects
                 Otherwise fail with a ValueError
 
         Returns
@@ -608,7 +608,7 @@ class HDFStore:
             return [
                 n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
             ]
-        raise ValueError(f"kind should be either pandas' or 'table' but is {kind}")
+        raise ValueError(f"`kind` should be either 'pandas' or 'table' but is [{kind}]")
 
     def __iter__(self):
         return iter(self.keys())

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,35 +580,26 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self, kind: Optional[str] = "pandas") -> List[str]:
+    def keys(self) -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
-
-        Parameters
-        ----------
-        kind : str, default 'pandas'
-                When kind equals 'pandas' return pandas objects
-                When kind equals 'table' return Table objects
-                Otherwise fail with a ValueError
+        If the store contains pandas native tables, it will return their names.
+        Otherwise the list of names of HDF5 Table objects will be returned.
 
         Returns
         -------
         list
             List of ABSOLUTE path-names (e.g. have the leading '/').
-
-        Raises
-        ------
-        raises ValueError if kind has an illegal value
         """
-        if kind == "pandas":
-            return [n._v_pathname for n in self.groups()]
+        #        if kind == "pandas":
+        objects = [n._v_pathname for n in self.groups()]
+        if objects:
+            return objects
 
-        if kind == "tables":
-            self._check_if_open()
-            return [
-                n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
-            ]
-        raise ValueError(f"`kind` should be either 'pandas' or 'table' but is [{kind}]")
+        self._check_if_open()
+        return [
+            n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
+        ]
 
     def __iter__(self):
         return iter(self.keys())

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,16 +580,33 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self) -> List[str]:
+    def keys(self, kind='pandas') -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
+
+        Parameters
+        ----------
+        kind : str, default 'pandas'
+                When kind equals 'pandas' return pandas objects
+                When kind equals 'table' return Tables
+                Otherwise fail with a ValueError
+
+        Raises
+        ------
+        raises ValueError if kind has an illegal value
 
         Returns
         -------
         list
             List of ABSOLUTE path-names (e.g. have the leading '/').
         """
-        return [n._v_pathname for n in self.groups()]
+        if kind == 'pandas':
+            return [n._v_pathname for n in self.groups()]
+
+        if kind == 'tables':
+            self._check_if_open()
+            return [n._v_pathname for n in self._handle.walk_nodes('/', classname='Table')]
+        raise ValueError(f"kind should be either pandas' or 'table' but is {kind}")
 
     def __iter__(self):
         return iter(self.keys())

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -316,7 +316,7 @@ class TestHDFStore:
                 assert len(store.keys(kind="tables")) == 3
                 expected = {"/group/table1", "/group/table2", "/group/table3"}
                 assert set(store.keys(kind="tables")) == expected
-                assert set(store) == set()
+                assert set(store.keys(kind="pandas")) == set()
 
     def test_keys_ignore_hdf_softlink(self, setup_path):
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -296,6 +296,26 @@ class TestHDFStore:
             assert set(store.keys()) == expected
             assert set(store) == expected
 
+    def test_non_pandas_keys(self, setup_path):
+
+        class Table1(tables.IsDescription):
+            value1 = tables.Float32Col()
+        class Table2(tables.IsDescription):
+            value2 = tables.Float32Col()
+        class Table3(tables.IsDescription):
+            value3 = tables.Float32Col()
+        with ensure_clean_path(setup_path) as path:
+            with tables.open_file(path, mode="w") as h5file:
+                group = h5file.create_group("/", "group")
+                table1 = h5file.create_table(group, "table1", Table1, "Table 1")
+                table2 = h5file.create_table(group, "table2", Table2, "Table 2")
+                table3 = h5file.create_table(group, "table3", Table3, "Table 3")
+            with HDFStore(path) as store:
+                assert len(store.keys(kind="tables")) == 3
+                expected = {"/group/table1", "/group/table2", "/group/table3"}
+                assert set(store.keys(kind="tables")) == expected
+                assert set(store) == set()
+
     def test_keys_ignore_hdf_softlink(self, setup_path):
 
         # GH 20523

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -297,7 +297,6 @@ class TestHDFStore:
             assert set(store) == expected
 
     def test_non_pandas_keys(self, setup_path):
-
         class Table1(tables.IsDescription):
             value1 = tables.Float32Col()
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -309,9 +309,9 @@ class TestHDFStore:
         with ensure_clean_path(setup_path) as path:
             with tables.open_file(path, mode="w") as h5file:
                 group = h5file.create_group("/", "group")
-                table1 = h5file.create_table(group, "table1", Table1, "Table 1")
-                table2 = h5file.create_table(group, "table2", Table2, "Table 2")
-                table3 = h5file.create_table(group, "table3", Table3, "Table 3")
+                h5file.create_table(group, "table1", Table1, "Table 1")
+                h5file.create_table(group, "table2", Table2, "Table 2")
+                h5file.create_table(group, "table3", Table3, "Table 3")
             with HDFStore(path) as store:
                 assert len(store.keys(kind="tables")) == 3
                 expected = {"/group/table1", "/group/table2", "/group/table3"}

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -297,6 +297,7 @@ class TestHDFStore:
             assert set(store) == expected
 
     def test_non_pandas_keys(self, setup_path):
+        # GH 29916
         class Table1(tables.IsDescription):
             value1 = tables.Float32Col()
 
@@ -313,10 +314,10 @@ class TestHDFStore:
                 h5file.create_table(group, "table2", Table2, "Table 2")
                 h5file.create_table(group, "table3", Table3, "Table 3")
             with HDFStore(path) as store:
-                assert len(store.keys(kind="tables")) == 3
+                assert len(store.keys()) == 3
                 expected = {"/group/table1", "/group/table2", "/group/table3"}
-                assert set(store.keys(kind="tables")) == expected
-                assert set(store.keys(kind="pandas")) == set()
+                assert set(store.keys()) == expected
+                assert set(store) == expected
 
     def test_keys_ignore_hdf_softlink(self, setup_path):
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -300,10 +300,13 @@ class TestHDFStore:
 
         class Table1(tables.IsDescription):
             value1 = tables.Float32Col()
+
         class Table2(tables.IsDescription):
             value2 = tables.Float32Col()
+
         class Table3(tables.IsDescription):
             value3 = tables.Float32Col()
+
         with ensure_clean_path(setup_path) as path:
             with tables.open_file(path, mode="w") as h5file:
                 group = h5file.create_group("/", "group")


### PR DESCRIPTION
First try to get pandas style tables, if there are none, return the list of non-pandas (hdf5 native) tables in the file (if any)

- [x] closes #29916
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
