### PR TITLE
`_ensure_type` should use `issubclass`

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -93,7 +93,7 @@ class PandasObject(DirNamesMixin):
 
         Used by type checkers.
         """
-        assert isinstance(obj, type(self)), type(obj)
+        assert issubclass(type(obj), type(self)), type(obj)
         return obj
 
 

--- a/pandas/tests/base/test_base.py
+++ b/pandas/tests/base/test_base.py
@@ -1,0 +1,38 @@
+import pytest
+
+from pandas.core.base import PandasObject
+
+pandas_object = PandasObject()
+
+
+class SubclassPandasObject(PandasObject):
+    pass
+
+
+subclass_pandas_object = SubclassPandasObject()
+
+
+@pytest.mark.parametrize("other_object", [pandas_object, subclass_pandas_object])
+def test_pandas_object_ensure_type(other_object):
+    pandas_object = PandasObject()
+    assert pandas_object._ensure_type(other_object)
+
+
+def test_pandas_object_ensure_type_for_same_object():
+    pandas_object_a = PandasObject()
+    pandas_object_b = pandas_object_a
+    assert pandas_object_a._ensure_type(pandas_object_b)
+
+
+class OtherClass:
+    pass
+
+
+other_class = OtherClass()
+
+
+@pytest.mark.parametrize("other_object", [other_class])
+def test_pandas_object_ensure_type_for_false(other_object):
+    pandas_object = PandasObject()
+    with pytest.raises(AssertionError):
+        assert pandas_object._ensure_type(other_object)


### PR DESCRIPTION
Commit pandas-dev/pandas@6fd326d5a249967f9b6be60fc3c5f7366d914684 in pull request pandas-dev/pandas#30613 added `_ensure_type`, which utilizes `isinstance`. However, it is reasonable to assume that someone may want to create a DataFrame subclass. Therefore, `_ensure_type` should use `issubclass`.

- [x] closes #31925 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

whatsnew entry isn't necessary?
