### PR TITLE
ENH: Categorical.fillna allow Categorical/ndarray

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1748,6 +1748,7 @@ class Categorical(ExtensionArray, PandasObject):
 
                 values_codes = _get_codes_for_values(value, self.categories)
                 indexer = np.where(codes == -1)
+                codes = codes.copy()
                 codes[indexer] = values_codes[indexer]
 
             # If value is not a dict or Series it should be a scalar

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1738,8 +1738,12 @@ class Categorical(ExtensionArray, PandasObject):
 
             # If value is a dict or a Series (a dict value has already
             # been converted to a Series)
-            if isinstance(value, ABCSeries):
-                if not value[~value.isin(self.categories)].isna().all():
+            if isinstance(value, (np.ndarray, Categorical, ABCSeries)):
+                # We get ndarray or Categorical if called via Series.fillna,
+                #  where it will unwrap another aligned Series before getting here
+
+                mask = ~algorithms.isin(value, self.categories)
+                if not isna(value[mask]).all():
                     raise ValueError("fill value must be in categories")
 
                 values_codes = _get_codes_for_values(value, self.categories)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5988,6 +5988,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                     value = create_series_with_explicit_dtype(
                         value, dtype_if_empty=object
                     )
+                    value = value.reindex(self.index, copy=False)
+                    value = value._values
                 elif not is_list_like(value):
                     pass
                 else:

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -364,6 +364,7 @@ class BlockManager(PandasObject):
         BlockManager
         """
         result_blocks = []
+        # fillna: Series/DataFrame is responsible for making sure value is aligned
 
         # filter kwarg is used in replace-* family of methods
         if filter is not None:
@@ -388,11 +389,6 @@ class BlockManager(PandasObject):
                 align_keys = ["new", "mask"]
             else:
                 align_keys = ["mask"]
-        elif f == "fillna":
-            # fillna internally does putmask, maybe it's better to do this
-            # at mgr, not block level?
-            align_copy = False
-            align_keys = ["value"]
         else:
             align_keys = []
 

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -84,14 +84,16 @@ class TestCategoricalMissing:
         tm.assert_categorical_equal(result, expected)
 
     def test_fillna_array(self):
-        # accept Categorical or ndarray value if it holds appropriat values
-        cat = Categorical([1, 2, 3, None, None])
+        # accept Categorical or ndarray value if it holds appropriate values
+        cat = Categorical(["A", "B", "C", None, None])
 
-        other = cat.fillna(2)
+        other = cat.fillna("C")
         result = cat.fillna(other)
         tm.assert_categorical_equal(result, other)
+        assert isna(cat[-1])  # didnt modify original inplace
 
-        other = np.array([1, 2, 3, 2, 1])
+        other = np.array(["A", "B", "C", "B", "A"])
         result = cat.fillna(other)
-        expected = Categorical([1, 2, 3, 2, 1], dtype=cat.dtype)
+        expected = Categorical(["A", "B", "C", "B", "A"], dtype=cat.dtype)
         tm.assert_categorical_equal(result, expected)
+        assert isna(cat[-1])  # didnt modify original inplace

--- a/pandas/tests/arrays/categorical/test_missing.py
+++ b/pandas/tests/arrays/categorical/test_missing.py
@@ -82,3 +82,16 @@ class TestCategoricalMissing:
         expected = Categorical([Point(0, 0), Point(0, 1), Point(0, 0)])
 
         tm.assert_categorical_equal(result, expected)
+
+    def test_fillna_array(self):
+        # accept Categorical or ndarray value if it holds appropriat values
+        cat = Categorical([1, 2, 3, None, None])
+
+        other = cat.fillna(2)
+        result = cat.fillna(other)
+        tm.assert_categorical_equal(result, other)
+
+        other = np.array([1, 2, 3, 2, 1])
+        result = cat.fillna(other)
+        expected = Categorical([1, 2, 3, 2, 1], dtype=cat.dtype)
+        tm.assert_categorical_equal(result, expected)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -760,6 +760,16 @@ class TestIsin:
         result = algos.isin(Sd, St)
         tm.assert_numpy_array_equal(expected, result)
 
+    def test_categorical_isin(self):
+        vals = np.array([0, 1, 2, 0])
+        cats = ["a", "b", "c"]
+        cat = Categorical(1).from_codes(vals, cats)
+        other = Categorical(1).from_codes(np.array([0, 1]), cats)
+
+        expected = np.array([True, True, False, True])
+        result = algos.isin(cat, other)
+        tm.assert_numpy_array_equal(expected, result)
+
     def test_same_nan_is_in(self):
         # GH 22160
         # nan is special, because from " a is b" doesn't follow "a == b"


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

xref #32414.

cc @TomAugspurger ATM the new test implemented in tests.arrays.categorical.test_missing is failing on the ndarray case for reasons that I dont fully grok.  Are you familiar with this?