### PR TITLE
Fix BUG: overflow on pd.Timedelta(nanoseconds=) constructor

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -234,7 +234,7 @@ Numeric
 Conversion
 ^^^^^^^^^^
 - Bug in :class:`Series` construction from NumPy array with big-endian ``datetime64`` dtype (:issue:`29684`)
--
+- Bug in :class:`Timedelta` construction with large nanoseconds keyword value (:issue:`34202`)
 -
 
 Strings

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1198,7 +1198,7 @@ class Timedelta(_Timedelta):
 
             kwargs = {key: _to_py_int_float(kwargs[key]) for key in kwargs}
 
-            nano = np.timedelta64(kwargs.pop('nanoseconds', 0), 'ns')
+            nano = convert_to_timedelta64(kwargs.pop('nanoseconds', 0), 'ns')
             try:
                 value = nano + convert_to_timedelta64(timedelta(**kwargs),
                                                       'ns')

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -16,6 +16,8 @@ from pandas import Timedelta, offsets
         (1, 1),
         (np.int64(2), 2),
         (np.int32(3), 3),
+        (Timedelta(1e10), 1e10),
+        (Timedelta(nanoseconds=1e10), 1e10),
     ],
 )
 def test_delta_to_nanoseconds(obj, expected):

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -31,5 +31,6 @@ def test_delta_to_nanoseconds_error():
 
 
 def test_huge_nanoseconds_overflow():
+    # GH 32402
     assert delta_to_nanoseconds(Timedelta(1e10)) == 1e10
     assert delta_to_nanoseconds(Timedelta(nanoseconds=1e10)) == 1e10

--- a/pandas/tests/tslibs/test_timedeltas.py
+++ b/pandas/tests/tslibs/test_timedeltas.py
@@ -16,8 +16,6 @@ from pandas import Timedelta, offsets
         (1, 1),
         (np.int64(2), 2),
         (np.int32(3), 3),
-        (Timedelta(1e10), 1e10),
-        (Timedelta(nanoseconds=1e10), 1e10),
     ],
 )
 def test_delta_to_nanoseconds(obj, expected):
@@ -30,3 +28,8 @@ def test_delta_to_nanoseconds_error():
 
     with pytest.raises(TypeError, match="<class 'numpy.ndarray'>"):
         delta_to_nanoseconds(obj)
+
+
+def test_huge_nanoseconds_overflow():
+    assert delta_to_nanoseconds(Timedelta(1e10)) == 1e10
+    assert delta_to_nanoseconds(Timedelta(nanoseconds=1e10)) == 1e10


### PR DESCRIPTION
Add regression test

- [x] closes #32402
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
