### PR TITLE
CI: Fix flaky test_value_counts_null

### DIFF
--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -311,10 +311,9 @@ class TestIndexOps(Ops):
         if isinstance(obj, pd.MultiIndex):
             expected.index = pd.Index(expected.index)
 
-        if obj.dtype == np.float16:
-            # TODO: Order of entries with the same count is inconsistent on CI
-            result = result.sort_index()
-            expected = expected.sort_index()
+        # TODO: Order of entries with the same count is inconsistent on CI (gh-32449)
+        result = result.sort_index()
+        expected = expected.sort_index()
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("null_obj", [np.nan, None])
@@ -346,10 +345,9 @@ class TestIndexOps(Ops):
         expected.index = expected.index.astype(obj.dtype)
 
         result = obj.value_counts()
-        if obj.dtype == np.float16:
-            # TODO: Order of entries with the same count is inconsistent on CI
-            expected = expected.sort_index()
-            result = result.sort_index()
+        # TODO: Order of entries with the same count is inconsistent on CI (gh-32449)
+        expected = expected.sort_index()
+        result = result.sort_index()
         tm.assert_series_equal(result, expected)
 
         # can't use expected[null_obj] = 3 as
@@ -358,10 +356,9 @@ class TestIndexOps(Ops):
         expected = expected.append(new_entry)
 
         result = obj.value_counts(dropna=False)
-        if obj.dtype == np.float16:
-            # TODO: Order of entries with the same count is inconsistent on CI
-            expected = expected.sort_index()
-            result = result.sort_index()
+        # TODO: Order of entries with the same count is inconsistent on CI (gh-32449)
+        expected = expected.sort_index()
+        result = result.sort_index()
         tm.assert_series_equal(result, expected)
 
     def test_value_counts_inferred(self, index_or_series):

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -312,8 +312,9 @@ class TestIndexOps(Ops):
             expected.index = pd.Index(expected.index)
 
         # TODO: Order of entries with the same count is inconsistent on CI (gh-32449)
-        result = result.sort_index()
-        expected = expected.sort_index()
+        if obj.duplicated().any():
+            result = result.sort_index()
+            expected = expected.sort_index()
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("null_obj", [np.nan, None])
@@ -345,9 +346,11 @@ class TestIndexOps(Ops):
         expected.index = expected.index.astype(obj.dtype)
 
         result = obj.value_counts()
-        # TODO: Order of entries with the same count is inconsistent on CI (gh-32449)
-        expected = expected.sort_index()
-        result = result.sort_index()
+        if obj.duplicated().any():
+            # TODO:
+            #  Order of entries with the same count is inconsistent on CI (gh-32449)
+            expected = expected.sort_index()
+            result = result.sort_index()
         tm.assert_series_equal(result, expected)
 
         # can't use expected[null_obj] = 3 as
@@ -356,9 +359,11 @@ class TestIndexOps(Ops):
         expected = expected.append(new_entry)
 
         result = obj.value_counts(dropna=False)
-        # TODO: Order of entries with the same count is inconsistent on CI (gh-32449)
-        expected = expected.sort_index()
-        result = result.sort_index()
+        if obj.duplicated().any():
+            # TODO:
+            #  Order of entries with the same count is inconsistent on CI (gh-32449)
+            expected = expected.sort_index()
+            result = result.sort_index()
         tm.assert_series_equal(result, expected)
 
     def test_value_counts_inferred(self, index_or_series):

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -311,9 +311,10 @@ class TestIndexOps(Ops):
         if isinstance(obj, pd.MultiIndex):
             expected.index = pd.Index(expected.index)
 
-        # sort_index to avoid switched order when values share the same count
-        result = result.sort_index()
-        expected = expected.sort_index()
+        if obj.dtype == np.float16:
+            # TODO: Order of entries with the same count is inconsistent on CI
+            result = result.sort_index()
+            expected = expected.sort_index()
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("null_obj", [np.nan, None])
@@ -344,9 +345,11 @@ class TestIndexOps(Ops):
         expected = pd.Series(dict(counter.most_common()), dtype=np.int64)
         expected.index = expected.index.astype(obj.dtype)
 
-        # sort_index to avoid switched order when values share the same count
-        expected = expected.sort_index()
-        result = obj.value_counts().sort_index()
+        result = obj.value_counts()
+        if obj.dtype == np.float16:
+            # TODO: Order of entries with the same count is inconsistent on CI
+            expected = expected.sort_index()
+            result = result.sort_index()
         tm.assert_series_equal(result, expected)
 
         # can't use expected[null_obj] = 3 as
@@ -354,9 +357,11 @@ class TestIndexOps(Ops):
         new_entry = pd.Series({np.nan: 3}, dtype=np.int64)
         expected = expected.append(new_entry)
 
-        # sort_index to avoid switched order when values share the same count
-        expected = expected.sort_index()
-        result = obj.value_counts(dropna=False).sort_index()
+        result = obj.value_counts(dropna=False)
+        if obj.dtype == np.float16:
+            # TODO: Order of entries with the same count is inconsistent on CI
+            expected = expected.sort_index()
+            result = result.sort_index()
         tm.assert_series_equal(result, expected)
 
     def test_value_counts_inferred(self, index_or_series):

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -344,13 +344,20 @@ class TestIndexOps(Ops):
         expected = pd.Series(dict(counter.most_common()), dtype=np.int64)
         expected.index = expected.index.astype(obj.dtype)
 
-        tm.assert_series_equal(obj.value_counts(), expected)
+        # sort_index to avoid switched order when values share the same count
+        expected = expected.sort_index()
+        result = obj.value_counts().sort_index()
+        tm.assert_series_equal(result, expected)
 
         # can't use expected[null_obj] = 3 as
         # IntervalIndex doesn't allow assignment
         new_entry = pd.Series({np.nan: 3}, dtype=np.int64)
         expected = expected.append(new_entry)
-        tm.assert_series_equal(obj.value_counts(dropna=False), expected)
+
+        # sort_index to avoid switched order when values share the same count
+        expected = expected.sort_index()
+        result = obj.value_counts(dropna=False).sort_index()
+        tm.assert_series_equal(result, expected)
 
     def test_value_counts_inferred(self, index_or_series):
         klass = index_or_series


### PR DESCRIPTION
As mentioned by @simonjayhawkins in #32438

Trace of the failing test:
https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=29965&view=logs&j=077026cf-93c0-54aa-45e0-9996ba75f6f7&t=e95cf409-86ae-5b4d-6c5f-79395ef75e8f