### PR TITLE
DEPS: Removing snappy from local/docs dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -94,7 +94,6 @@ dependencies:
 
   - fastparquet>=0.3.2  # pandas.read_parquet, DataFrame.to_parquet
   - pyarrow>=0.13.1  # pandas.read_parquet, DataFrame.to_parquet, pandas.read_feather, DataFrame.to_feather
-  - python-snappy  # required by pyarrow
 
   - pyqt>=5.9.2  # pandas.read_clipboard
   - pytables>=3.4.2  # pandas.read_hdf, DataFrame.to_hdf

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -62,7 +62,6 @@ xlwt
 odfpy
 fastparquet>=0.3.2
 pyarrow>=0.13.1
-python-snappy
 pyqt5>=5.9.2
 tables>=3.4.2
 s3fs


### PR DESCRIPTION
- [X] xref #32417

The docs build should fail if snappy is required to build the docs, and should point out where it's being used. If it's not failed, I think this can be merged and we can remove snappy from the local and docs dependencies.
