### PR TITLE
Disallow .__call__() as workaround for non-named functions

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -784,6 +784,7 @@ Reshaping
 - Bug in :func:`concat` was not allowing for concatenation of ``DataFrame`` and ``Series`` with duplicate keys (:issue:`33654`)
 - Bug in :func:`cut` raised an error when non-unique labels (:issue:`33141`)
 - Bug in :meth:`DataFrame.replace` casts columns to ``object`` dtype if items in ``to_replace`` not in values (:issue:`32988`)
+- Ensure only named functions can be used in :func:`eval()` (:issue:`32460`)
 
 
 Sparse

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -641,7 +641,7 @@ class BaseExprVisitor(ast.NodeVisitor):
 
     def visit_Call(self, node, side=None, **kwargs):
 
-        if isinstance(node.func, ast.Attribute):
+        if isinstance(node.func, ast.Attribute) and node.func.attr != "__call__":
             res = self.visit_Attribute(node.func)
         elif not isinstance(node.func, ast.Name):
             raise TypeError("Only named functions are supported")

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1181,3 +1181,17 @@ class TestDataFrameQueryBacktickQuoting:
     def test_failing_hashtag(self, df):
         with pytest.raises(SyntaxError):
             df.query("`foo#bar` > 4")
+
+    def test_call_non_named_expression(self, df):
+        def func(*_):
+            return 1
+
+        funcs = [func]
+
+        df.eval("@func()")
+
+        with pytest.raises(TypeError):
+            df.eval("@funcs[0]()")
+
+        with pytest.raises(TypeError):
+            df.eval("@funcs[0].__call__()")

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1183,6 +1183,12 @@ class TestDataFrameQueryBacktickQuoting:
             df.query("`foo#bar` > 4")
 
     def test_call_non_named_expression(self, df):
+        """
+        Only attributes and variables ('named functions') can be called.
+        .__call__() is not an allowed attribute because that would allow calling anything.
+        https://github.com/pandas-dev/pandas/pull/32460
+        """
+
         def func(*_):
             return 1
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1190,8 +1190,8 @@ class TestDataFrameQueryBacktickQuoting:
 
         df.eval("@func()")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="Only named functions are supported"):
             df.eval("@funcs[0]()")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="Only named functions are supported"):
             df.eval("@funcs[0].__call__()")

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1186,7 +1186,7 @@ class TestDataFrameQueryBacktickQuoting:
         def func(*_):
             return 1
 
-        funcs = [func]
+        funcs = [func]  # noqa
 
         df.eval("@func()")
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1185,7 +1185,8 @@ class TestDataFrameQueryBacktickQuoting:
     def test_call_non_named_expression(self, df):
         """
         Only attributes and variables ('named functions') can be called.
-        .__call__() is not an allowed attribute because that would allow calling anything.
+        .__call__() is not an allowed attribute because that would allow
+        calling anything.
         https://github.com/pandas-dev/pandas/pull/32460
         """
 


### PR DESCRIPTION
Currently this script:
```python
import pandas as pd
funcs = [lambda: 1]
pd.eval("funcs[0]()")
```

Fails with:

    TypeError: Only named functions are supported

however this can easily be worked around by adding `.__call__`:

```python
pd.eval("funcs[0].__call__()")
```

I'm assuming we don't want to allow this workaround. This PR ensures that it will fail with the same error.