### PR TITLE
CLN: use _values_for_argsort for join_non_unique, join_monotonic

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1494,7 +1494,7 @@ class Categorical(ExtensionArray, PandasObject):
             )
 
     def _values_for_argsort(self):
-        return self._codes.copy()
+        return self._codes
 
     def argsort(self, ascending=True, kind="quicksort", **kwargs):
         """

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -454,12 +454,6 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         return DatetimeArray._from_sequence(new_data, freq="infer")
 
     # --------------------------------------------------------------------
-    # Array-like / EA-Interface Methods
-
-    def _values_for_argsort(self):
-        return self._data
-
-    # --------------------------------------------------------------------
 
     def _time_shift(self, periods, freq=None):
         """

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -454,6 +454,12 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         return DatetimeArray._from_sequence(new_data, freq="infer")
 
     # --------------------------------------------------------------------
+    # Array-like / EA-Interface Methods
+
+    def _values_for_argsort(self):
+        return self._data
+
+    # --------------------------------------------------------------------
 
     def _time_shift(self, periods, freq=None):
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3385,6 +3385,7 @@ class Index(IndexOpsMixin, PandasObject):
         -------
         join_index, (left_indexer, right_indexer)
         """
+        other = ensure_index(other)
         self_is_mi = isinstance(self, ABCMultiIndex)
         other_is_mi = isinstance(other, ABCMultiIndex)
 
@@ -3403,8 +3404,6 @@ class Index(IndexOpsMixin, PandasObject):
             return self._join_level(
                 other, level, how=how, return_indexers=return_indexers
             )
-
-        other = ensure_index(other)
 
         if len(other) == 0 and how in ("left", "outer"):
             join_index = self._shallow_copy()
@@ -3567,16 +3566,26 @@ class Index(IndexOpsMixin, PandasObject):
     def _join_non_unique(self, other, how="left", return_indexers=False):
         from pandas.core.reshape.merge import _get_join_indexers
 
+        # We only get here if dtypes match
+        assert self.dtype == other.dtype
+
+        if is_extension_array_dtype(self.dtype):
+            lvalues = self._data._values_for_argsort()
+            rvalues = other._data._values_for_argsort()
+        else:
+            lvalues = self._values
+            rvalues = other._values
+
         left_idx, right_idx = _get_join_indexers(
-            [self._ndarray_values], [other._ndarray_values], how=how, sort=True
+            [lvalues], [rvalues], how=how, sort=True
         )
 
         left_idx = ensure_platform_int(left_idx)
         right_idx = ensure_platform_int(right_idx)
 
-        join_index = np.asarray(self._ndarray_values.take(left_idx))
+        join_index = np.asarray(lvalues.take(left_idx))
         mask = left_idx == -1
-        np.putmask(join_index, mask, other._ndarray_values.take(right_idx))
+        np.putmask(join_index, mask, rvalues.take(right_idx))
 
         join_index = self._wrap_joined_index(join_index, other)
 
@@ -3727,6 +3736,9 @@ class Index(IndexOpsMixin, PandasObject):
             return join_index
 
     def _join_monotonic(self, other, how="left", return_indexers=False):
+        # We only get here with matching dtypes
+        assert other.dtype == self.dtype
+
         if self.equals(other):
             ret_index = other if how == "right" else self
             if return_indexers:
@@ -3734,8 +3746,12 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 return ret_index
 
-        sv = self._ndarray_values
-        ov = other._ndarray_values
+        if is_extension_array_dtype(self.dtype):
+            sv = self._data._values_for_argsort()
+            ov = other._data._values_for_argsort()
+        else:
+            sv = self._values
+            ov = other._values
 
         if self.is_unique and other.is_unique:
             # We can perform much better than the general case


### PR DESCRIPTION
With the `.copy()` removed from `Categorical._values_for_argsort`, `ea_backed_index._data._values_for_argsort()` matches `ea_backed_index._ndarray_values` in all extant cases.

cc @jorisvandenbossche @TomAugspurger need to confirm 

a) this is an intended-adjacent use of _values_for_argsort, and not just a coincidence that it matches extant behavior
b) the `.copy()` this removes from `Categorical._values_for_argsort` is not important for some un-tested reason

xref #32452, #32426