### PR TITLE
CLN: Remove redundant index test from tests/base/test_ops.py

### DIFF
--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -851,23 +851,6 @@ class TestIndexOps(Ops):
         with pytest.raises(IndexError, match=msg):
             series.iloc[size]
 
-    @pytest.mark.parametrize("indexer_klass", [list, pd.Index])
-    @pytest.mark.parametrize(
-        "indexer",
-        [
-            [True] * 10,
-            [False] * 10,
-            [True, False, True, True, False, False, True, True, False, True],
-        ],
-    )
-    def test_bool_indexing(self, indexer_klass, indexer):
-        # GH 22533
-        for idx in self.indexes:
-            exp_idx = [i for i in range(len(indexer)) if indexer[i]]
-            tm.assert_index_equal(idx[indexer_klass(indexer)], idx[exp_idx])
-            s = pd.Series(idx)
-            tm.assert_series_equal(s[indexer_klass(indexer)], s.iloc[exp_idx])
-
     def test_get_indexer_non_unique_dtype_mismatch(self):
         # GH 25459
         indexes, missing = pd.Index(["A", "B"]).get_indexer_non_unique(pd.Index([0]))

--- a/pandas/tests/indexing/test_na_indexing.py
+++ b/pandas/tests/indexing/test_na_indexing.py
@@ -43,7 +43,7 @@ def test_series_mask_boolean(values, dtype, mask, indexer_class, frame):
 
     msg = "iLocation based boolean indexing cannot use an indexable as a mask"
     if indexer_class is pd.Series:
-        with pytest.raises((ValueError, TypeError), match=msg):
+        with pytest.raises(ValueError, match=msg):
             result = ser.iloc[mask]
             tm.assert_equal(result, expected)
     else:
@@ -91,7 +91,7 @@ def test_series_mask_boolean_empty(dtype, indexer_class, frame):
 
     msg = "iLocation based boolean indexing cannot use an indexable as a mask"
     if indexer_class is pd.Series:
-        with pytest.raises((ValueError, TypeError), match=msg):
+        with pytest.raises(ValueError, match=msg):
             result = ser.iloc[mask]
             tm.assert_equal(result, expected)
     else:

--- a/pandas/tests/indexing/test_na_indexing.py
+++ b/pandas/tests/indexing/test_na_indexing.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext as do_not_raise
+
 import pytest
 
 import pandas as pd
@@ -52,10 +54,11 @@ def test_series_mask_boolean(values, dtype, mask, indexer_class, frame):
 
     if indexer_class is pd.Series:
         msg = "iLocation based boolean indexing cannot use an indexable as a mask"
-        with pytest.raises(ValueError, match=msg):
-            result = obj.iloc[mask]
-            tm.assert_equal(result, expected)
+        expectation = pytest.raises(ValueError, match=msg)
     else:
+        expectation = do_not_raise()
+
+    with expectation:
         result = obj.iloc[mask]
         tm.assert_equal(result, expected)
 

--- a/pandas/tests/indexing/test_na_indexing.py
+++ b/pandas/tests/indexing/test_na_indexing.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext as do_not_raise
-
 import pytest
 
 import pandas as pd
@@ -54,11 +52,10 @@ def test_series_mask_boolean(values, dtype, mask, indexer_class, frame):
 
     if indexer_class is pd.Series:
         msg = "iLocation based boolean indexing cannot use an indexable as a mask"
-        expectation = pytest.raises(ValueError, match=msg)
+        with pytest.raises(ValueError, match=msg):
+            result = obj.iloc[mask]
+            tm.assert_equal(result, expected)
     else:
-        expectation = do_not_raise()
-
-    with expectation:
         result = obj.iloc[mask]
         tm.assert_equal(result, expected)
 


### PR DESCRIPTION
part of #23877
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Boolean indexing is already thoroughly tested in `test_series_mask_boolean` in `tests/indexes/test_na_indexing.py` - [see here](https://github.com/pandas-dev/pandas/blob/master/pandas/tests/indexing/test_na_indexing.py#L7-L61)