### PR TITLE
CLN: Suppres compile warnings of pandas/io/sas/sas.pyx

### DIFF
--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -120,7 +120,7 @@ cdef const uint8_t[:] rdc_decompress(int result_length, const uint8_t[:] inbuff)
 
     cdef:
         uint8_t cmd
-        uint16_t ctrl_bits, ctrl_mask = 0, ofs, cnt
+        uint16_t ctrl_bits = 0, ctrl_mask = 0, ofs, cnt
         int rpos = 0, k
         uint8_t[:] outbuff = np.zeros(result_length, dtype=np.uint8)
         Py_ssize_t ipos = 0, length = len(inbuff)


### PR DESCRIPTION
- [x] ref #32163
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

---

This is the warning that get removed:

```
pandas/io/sas/sas.c: In function ‘__pyx_f_6pandas_2io_3sas_4_sas_rdc_decompress’:
pandas/io/sas/sas.c:3732:65: warning: ‘__pyx_v_ctrl_bits’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3732 |     __pyx_t_8 = (((__pyx_v_ctrl_bits & __pyx_v_ctrl_mask) == 0) != 0);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```