### PR TITLE
CLN: remove SingleBlockManager.get_values

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1596,10 +1596,6 @@ class SingleBlockManager(BlockManager):
         """The array that Series._values returns"""
         return self._block.internal_values()
 
-    def get_values(self) -> np.ndarray:
-        """ return a dense type view """
-        return np.array(self._block.to_dense(), copy=False)
-
     @property
     def _can_hold_na(self) -> bool:
         return self._block._can_hold_na

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -537,7 +537,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         numpy.ndarray
             Data of the Series.
         """
-        return self._data.get_values()
+        blk = self._data._block
+        return np.array(blk.to_dense(), copy=False)
 
     # ops
     def ravel(self, order="C"):


### PR DESCRIPTION
It is only used in one place, and its behavior doesn't match `self.blocks[0].get_values()`, which is counter-intuitive.