### PR TITLE
CLN: avoid Block.get_values in io.sql

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -705,8 +705,16 @@ class SQLTable(PandasObject):
                 else:
                     # convert to microsecond resolution for datetime.datetime
                     d = b.values.astype("M8[us]").astype(object)
+            elif b.is_timedelta:
+                # numpy converts this to an object array of integers,
+                #  whereas b.astype(object).values would convert to
+                #  object array of Timedeltas
+                d = b.values.astype(object)
             else:
-                d = np.array(b.get_values(), dtype=object)
+                # TODO(2DEA): astype-first can be avoided with 2D EAs
+                # astype on the block instead of values to ensure we
+                #  get the right shape
+                d = b.astype(object).values
 
             # replace NaN with None
             if b._can_hold_na:


### PR DESCRIPTION
This particular usage is especially non-transparent, since it is effectively `blk.get_values().astype(object)` which is apparently _not_ equivalent to `blk.get_values(object)`