### PR TITLE
TYP: Add type hint for DataFrame.T and certain array types

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1317,7 +1317,7 @@ class Categorical(ExtensionArray, PandasObject):
             setattr(self, k, v)
 
     @property
-    def T(self):
+    def T(self) -> "Categorical":
         """
         Return transposed numpy array.
         """

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1296,14 +1296,14 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
             nsparse = self.sp_index.ngaps
             return (sp_sum + self.fill_value * nsparse) / (ct + nsparse)
 
-    def transpose(self, *axes):
+    def transpose(self, *axes) -> "SparseArray":
         """
         Returns the SparseArray.
         """
         return self
 
     @property
-    def T(self):
+    def T(self) -> "SparseArray":
         """
         Returns the SparseArray.
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2443,7 +2443,9 @@ class DataFrame(NDFrame):
 
         return result.__finalize__(self)
 
-    T = property(transpose)
+    @property
+    def T(self) -> "DataFrame":
+        return self.transpose()
 
     # ----------------------------------------------------------------------
     # Indexing Methods


### PR DESCRIPTION
While updating a large pandas codebase with type coverage to 1.0, I noticed that `DataFrame.transpose()` is annotated to return `DataFrame` while `DataFrame.T` has no such hint. This PR also adds hints in a few places other places where they're trivial.

The definition of `pandas.core.base.IndexOpsMixIn.transpose` (and associated `.T`) currently do not have any type hints and fixing this seems more complicated, meaning `Index.T` and `Series.T` are not fixed by this PR.

Happy to amend to cover that case if anyone has suggestions, but I believe `DataFrame.T` to be the vast majority of usage.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
