### PR TITLE
CLN: remove unnecessary to_dense call

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1352,8 +1352,6 @@ class FloatArrayFormatter(GenericArrayFormatter):
             values = self.values
             is_complex = is_complex_dtype(values)
             mask = isna(values)
-            if hasattr(values, "to_dense"):  # sparse numpy ndarray
-                values = values.to_dense()
             values = np.array(values, dtype="object")
             values[mask] = na_rep
             imask = (~mask).ravel()


### PR DESCRIPTION
This call is not reached in the tests, and if it were the following line would make it superfluous anyway.

I'm pretty sure the comment there is wrong too.