### PR TITLE
CLN: to_dense->np.asarray

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1728,7 +1728,8 @@ class Categorical(ExtensionArray, PandasObject):
         # pad / bfill
         if method is not None:
 
-            values = self.to_dense().reshape(-1, len(self))
+            # TODO: dispatch when self.categories is EA-dtype
+            values = np.asarray(self).reshape(-1, len(self))
             values = interpolate_2d(values, method, 0, None, value).astype(
                 self.categories.dtype
             )[0]


### PR DESCRIPTION
This is the only non-test use of Categorical.to_dense, which is slightly different from _internal_get_values (for SparseArray the two methods are identical), and so liable to cause confusion.