### PR TITLE
TST: Fix bare pytest raises in generic/test_frame.py

### DIFF
--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -72,8 +72,10 @@ class TestDataFrame(Generic):
         assert not df.bool()
 
         df = DataFrame([[False, False]])
-        with pytest.raises(ValueError):
+        msg = "Frame must contain a single value"
+        with pytest.raises(ValueError, match=msg):
             df.bool()
+        msg = "Can't use standard bool() on Frame"
         with pytest.raises(ValueError):
             bool(df)
 
@@ -189,30 +191,31 @@ class TestDataFrame2:
     def test_validate_bool_args(self, value):
         df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
-        with pytest.raises(ValueError):
+        msg = "Argument 'inplace' has incorrect type (expected bool, got list)"
+        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df).rename_axis(
                 mapper={"a": "x", "b": "y"}, axis=1, inplace=value
             )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df).drop("a", axis=1, inplace=value)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df)._consolidate(inplace=value)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df).fillna(value=0, inplace=value)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df).replace(to_replace=1, value=7, inplace=value)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df).interpolate(inplace=value)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df)._where(cond=df.a > 2, inplace=value)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df).mask(cond=df.a > 2, inplace=value)
 
     def test_unexpected_keyword(self):
@@ -222,16 +225,19 @@ class TestDataFrame2:
         ts = df["joe"].copy()
         ts[2] = np.nan
 
-        with pytest.raises(TypeError, match="unexpected keyword"):
+        msg = "unexpected keyword 'in_place'"
+        with pytest.raises(TypeError, match=msg):
             df.drop("joe", axis=1, in_place=True)
 
-        with pytest.raises(TypeError, match="unexpected keyword"):
+        msg = "unexpected keyword 'inplace'"
+        with pytest.raises(TypeError, match=msg):
             df.reindex([1, 0], inplace=True)
 
-        with pytest.raises(TypeError, match="unexpected keyword"):
+        with pytest.raises(TypeError, match=msg):
             ca.fillna(0, inplace=True)
 
-        with pytest.raises(TypeError, match="unexpected keyword"):
+        msg = "unexpected keyword 'in_place'"
+        with pytest.raises(TypeError, match=msg):
             ts.fillna(0, in_place=True)
 
 

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -76,7 +76,7 @@ class TestDataFrame(Generic):
         with pytest.raises(ValueError, match=msg):
             df.bool()
         msg = "Can't use standard bool() on Frame"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             bool(df)
 
     def test_get_numeric_data_preserve_dtype(self):

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -72,10 +72,9 @@ class TestDataFrame(Generic):
         assert not df.bool()
 
         df = DataFrame([[False, False]])
-        msg = "Frame must contain a single value"
+        msg = "The truth value of a DataFrame is ambiguous"
         with pytest.raises(ValueError, match=msg):
             df.bool()
-        msg = "Can't use standard bool() on Frame"
         with pytest.raises(ValueError, match=msg):
             bool(df)
 
@@ -191,7 +190,7 @@ class TestDataFrame2:
     def test_validate_bool_args(self, value):
         df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 
-        msg = "Argument 'inplace' has incorrect type (expected bool, got list)"
+        msg = 'For argument "inplace" expected type bool, received type'
         with pytest.raises(ValueError, match=msg):
             super(DataFrame, df).rename_axis(
                 mapper={"a": "x", "b": "y"}, axis=1, inplace=value
@@ -225,18 +224,16 @@ class TestDataFrame2:
         ts = df["joe"].copy()
         ts[2] = np.nan
 
-        msg = "unexpected keyword 'in_place'"
+        msg = "unexpected keyword"
         with pytest.raises(TypeError, match=msg):
             df.drop("joe", axis=1, in_place=True)
 
-        msg = "unexpected keyword 'inplace'"
         with pytest.raises(TypeError, match=msg):
             df.reindex([1, 0], inplace=True)
 
         with pytest.raises(TypeError, match=msg):
             ca.fillna(0, inplace=True)
 
-        msg = "unexpected keyword 'in_place'"
         with pytest.raises(TypeError, match=msg):
             ts.fillna(0, in_place=True)
 


### PR DESCRIPTION
- [x] refers https://github.com/pandas-dev/pandas/issues/30999
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Adds match arguments to pytest.raises calls in pandas/tests/generic/test_frame.py
