### PR TITLE
TST: add test.indexes.common.Base.create_index and annotate .create_index

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -35,6 +35,9 @@ class Base:
     _holder: Optional[Type[Index]] = None
     _compat_props = ["shape", "ndim", "size", "nbytes"]
 
+    def create_index(self) -> Index:
+        raise NotImplementedError("Method not implemented")
+
     def test_pickle_compat_construction(self):
         # need an object to create with
         msg = (

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -17,7 +17,7 @@ class TestDatetimeIndex(DatetimeLike):
     def indices(self, request):
         return request.param
 
-    def create_index(self):
+    def create_index(self) -> DatetimeIndex:
         return date_range("20130101", periods=5)
 
     def test_shift(self):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -35,7 +35,7 @@ class TestPeriodIndex(DatetimeLike):
     def indices(self, request):
         return request.param
 
-    def create_index(self):
+    def create_index(self) -> PeriodIndex:
         return period_range("20130101", periods=5, freq="D")
 
     def test_pickle_compat_construction(self):

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -30,7 +30,7 @@ class TestRangeIndex(Numeric):
     def indices(self, request):
         return request.param
 
-    def create_index(self):
+    def create_index(self) -> RangeIndex:
         return RangeIndex(start=0, stop=20, step=2)
 
     def test_can_hold_identifiers(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -59,7 +59,7 @@ class TestIndex(Base):
         # copy to avoid mutation, e.g. setting .name
         return indices_dict[key].copy()
 
-    def create_index(self):
+    def create_index(self) -> Index:
         return Index(list("abcde"))
 
     def test_can_hold_identifiers(self):
@@ -2277,7 +2277,7 @@ class TestMixedIntIndex(Base):
     def indices(self, request):
         return Index(request.param)
 
-    def create_index(self):
+    def create_index(self) -> Index:
         return Index([0, "a", 1, "b", 2, "c"])
 
     def test_argsort(self):

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -118,7 +118,7 @@ class TestFloat64Index(Numeric):
     def float_index(self):
         return Float64Index([0.0, 2.5, 5.0, 7.5, 10.0])
 
-    def create_index(self):
+    def create_index(self) -> Float64Index:
         return Float64Index(np.arange(5, dtype="float64"))
 
     def test_repr_roundtrip(self, indices):
@@ -663,7 +663,7 @@ class TestInt64Index(NumericInt):
     def indices(self, request):
         return Int64Index(request.param)
 
-    def create_index(self):
+    def create_index(self) -> Int64Index:
         # return Int64Index(np.arange(5, dtype="int64"))
         return Int64Index(range(0, 20, 2))
 
@@ -801,7 +801,7 @@ class TestUInt64Index(NumericInt):
         large = [2 ** 63, 2 ** 63 + 10, 2 ** 63 + 15, 2 ** 63 + 20, 2 ** 63 + 25]
         return UInt64Index(large)
 
-    def create_index(self):
+    def create_index(self) -> UInt64Index:
         # compat with shared Int64/Float64 tests; use index_large for UInt64 only tests
         return UInt64Index(np.arange(5, dtype="uint64"))
 

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -28,7 +28,7 @@ class TestTimedeltaIndex(DatetimeLike):
     def indices(self):
         return tm.makeTimedeltaIndex(10)
 
-    def create_index(self):
+    def create_index(self) -> TimedeltaIndex:
         return pd.to_timedelta(range(5), unit="d") + pd.offsets.Hour(1)
 
     def test_numeric_compat(self):


### PR DESCRIPTION
Makes ``test.indexes.common.Base`` and ``create_index`` a bit easier to work with.