### PR TITLE
PERF: copy cached attributes on index shallow_copy

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -187,7 +187,9 @@ Performance improvements
 - Performance improvement in :class:`Timedelta` constructor (:issue:`30543`)
 - Performance improvement in :class:`Timestamp` constructor (:issue:`30543`)
 - Performance improvement in flex arithmetic ops between :class:`DataFrame` and :class:`Series` with ``axis=0`` (:issue:`31296`)
--
+- The internal :meth:`Index._shallow_copy` now copies cached attributes over to the new index,
+  avoiding creating these again on the new index. This can speed up many operations
+  that depend on creating copies of existing indexes (:issue:`28584`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -500,9 +500,9 @@ class Index(IndexOpsMixin, PandasObject):
         name : Label, defaults to self.name
         """
         name = self.name if name is no_default else name
-
-        cache = self._cache if values is None else {}
-        values = self.values if values is None else values
+        cache = self._cache.copy() if values is None else {}
+        if values is None:
+            values = self.values
 
         result = self._simple_new(values, name=name)
         result._cache = cache

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import operator
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, FrozenSet, Hashable, Union
+from typing import TYPE_CHECKING, Any, Dict, FrozenSet, Hashable, Union
 import warnings
 
 import numpy as np
@@ -250,6 +250,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     _typ = "index"
     _data: Union[ExtensionArray, np.ndarray]
+    _cache: Dict[str, Any]
     _id = None
     _name: Label = None
     # MultiIndex.levels previously allowed setting the index name. We
@@ -468,6 +469,7 @@ class Index(IndexOpsMixin, PandasObject):
         # we actually set this value too.
         result._index_data = values
         result._name = name
+        result._cache = {}
 
         return result._reset_identity()
 
@@ -499,10 +501,12 @@ class Index(IndexOpsMixin, PandasObject):
         """
         name = self.name if name is no_default else name
 
-        if values is None:
-            values = self.values
+        cache = self._cache if values is None else {}
+        values = self.values if values is None else values
 
-        return self._simple_new(values, name=name)
+        result = self._simple_new(values, name=name)
+        result._cache = cache
+        return result
 
     def _shallow_copy_with_infer(self, values, **kwargs):
         """

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -104,15 +104,11 @@ class NumericIndex(Index):
 
     @Appender(Index._shallow_copy.__doc__)
     def _shallow_copy(self, values=None, name: Label = lib.no_default):
-        name = name if name is not lib.no_default else self.name
-
         if values is not None and not self._can_hold_na and values.dtype.kind == "f":
+            name = self.name if name is lib.no_default else name
             # Ensure we are not returning an Int64Index with float data:
             return Float64Index._simple_new(values, name=name)
-
-        if values is None:
-            values = self.values
-        return type(self)._simple_new(values, name=name)
+        return super()._shallow_copy(values=values, name=name)
 
     def _convert_for_op(self, value):
         """


### PR DESCRIPTION
- [x] closes #28584
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The performance of the example in #28584 is:

```python
>>> idx = pd.Index(np.arange(100_000))
>>> %timeit idx.get_loc(99_999)
1.17 µs ± 80.6 ns per loop  # master and this PR
>>> %timeit idx._shallow_copy().get_loc(99_999)
3.57 ms ± 286 ns per loop  # master
3.67 µs ± 286 ns per loop  # this PR
```

The issue is still on the extension indexes, e.g. ``CategoricalIndex._shallow_copy``. I'd like to take them afterwards.