### PR TITLE
BUG: Fix file descriptor leak

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -337,6 +337,7 @@ I/O
 - Bug in :meth:`read_csv` was raising `TypeError` when `sep=None` was used in combination with `comment` keyword (:issue:`31396`)
 - Bug in :class:`HDFStore` that caused it to set to ``int64`` the dtype of a ``datetime64`` column when reading a DataFrame in Python 3 from fixed format written in Python 2 (:issue:`31750`)
 - Bug in :meth:`read_excel` where a UTF-8 string with a high surrogate would cause a segmentation violation (:issue:`23809`)
+- Bug in :meth:`read_csv` was causing a file descriptor leak on an empty file (:issue:`31488`)
 
 
 Plotting

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2279,7 +2279,7 @@ class PythonParser(ParserBase):
                 self.num_original_columns,
                 self.unnamed_cols,
             ) = self._infer_columns()
-        except EmptyDataError:
+        except (TypeError, ValueError):
             self.close()
             raise
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2273,11 +2273,15 @@ class PythonParser(ParserBase):
         # Get columns in two steps: infer from data, then
         # infer column indices from self.usecols if it is specified.
         self._col_indices = None
-        (
-            self.columns,
-            self.num_original_columns,
-            self.unnamed_cols,
-        ) = self._infer_columns()
+        try:
+            (
+                self.columns,
+                self.num_original_columns,
+                self.unnamed_cols,
+            ) = self._infer_columns()
+        except EmptyDataError:
+            self.close()
+            raise
 
         # Now self.columns has the set of columns that we will process.
         # The original set is stored in self.original_columns.

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -13,10 +13,9 @@ from urllib.error import URLError
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 from pandas._libs.tslib import Timestamp
 from pandas.errors import DtypeWarning, EmptyDataError, ParserError
+import pandas.util._test_decorators as td
 
 from pandas import DataFrame, Index, MultiIndex, Series, compat, concat
 import pandas._testing as tm

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -11,8 +11,9 @@ import platform
 from urllib.error import URLError
 
 import numpy as np
-import psutil
 import pytest
+
+import pandas.util._test_decorators as td
 
 from pandas._libs.tslib import Timestamp
 from pandas.errors import DtypeWarning, EmptyDataError, ParserError
@@ -2082,8 +2083,10 @@ def test_integer_precision(all_parsers):
     tm.assert_series_equal(result, expected)
 
 
+@td.skip_if_no("psutil")
 def test_file_descriptor_leak(all_parsers):
     # GH 31488
+    import psutil
     proc = psutil.Process()
     parser = all_parsers
     with tm.ensure_clean() as path:

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2082,18 +2082,14 @@ def test_integer_precision(all_parsers):
     tm.assert_series_equal(result, expected)
 
 
-@td.skip_if_no("psutil")
 def test_file_descriptor_leak(all_parsers):
     # GH 31488
-    # Please note that using tm.ensure_clean does not work in combination
-    # with td.check_file_leaks as tm.ensure_clean closes the file
-    # thereby preventing the leak check to trigger
-    import psutil
 
-    proc = psutil.Process()
     parser = all_parsers
     with tm.ensure_clean() as path:
-        expected = proc.open_files()
-        with pytest.raises(EmptyDataError, match="No columns to parse from file"):
-            parser.read_csv(path)
-        assert proc.open_files() == expected
+
+        def test():
+            with pytest.raises(EmptyDataError, match="No columns to parse from file"):
+                parser.read_csv(path)
+
+        td.check_file_leaks(test)()

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2085,6 +2085,9 @@ def test_integer_precision(all_parsers):
 @td.skip_if_no("psutil")
 def test_file_descriptor_leak(all_parsers):
     # GH 31488
+    # Please note that using tm.ensure_clean does not work in combination
+    # with td.check_file_leaks as tm.ensure_clean closes the file
+    # thereby preventing the leak check to trigger
     import psutil
 
     proc = psutil.Process()

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2086,6 +2086,7 @@ def test_integer_precision(all_parsers):
 def test_file_descriptor_leak(all_parsers):
     # GH 31488
     import psutil
+
     proc = psutil.Process()
     parser = all_parsers
     with tm.ensure_clean() as path:

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -324,6 +324,6 @@ def test_file_descriptor_leak(python_parser_only):
     parser = python_parser_only
     with tm.ensure_clean() as path:
         expected = proc.open_files()
-        with pytest.raises(EmptyDataError):
+        with pytest.raises(EmptyDataError, match="No columns to parse from file"):
             parser.read_csv(path)
         assert proc.open_files() == expected

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -8,14 +8,13 @@ arguments when parsing.
 import csv
 from io import BytesIO, StringIO
 
+import psutil
 import pytest
 
-from pandas.errors import ParserError, EmptyDataError
+from pandas.errors import EmptyDataError, ParserError
 
 from pandas import DataFrame, Index, MultiIndex
 import pandas._testing as tm
-
-import psutil
 
 
 def test_default_separator(python_parser_only):

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -320,11 +320,10 @@ footer
 
 def test_file_descriptor_leak(python_parser_only):
     # GH 31488
-    parser = python_parser_only
-    with open("empty.csv", "w"):
-        pass
-
     proc = psutil.Process()
-    with pytest.raises(EmptyDataError):
-        parser.read_csv("empty.csv")
-    assert not proc.open_files()
+    parser = python_parser_only
+    with tm.ensure_clean() as path:
+        expected = proc.open_files()
+        with pytest.raises(EmptyDataError):
+            parser.read_csv(path)
+        assert proc.open_files() == expected

--- a/pandas/tests/io/parser/test_python_parser_only.py
+++ b/pandas/tests/io/parser/test_python_parser_only.py
@@ -8,10 +8,9 @@ arguments when parsing.
 import csv
 from io import BytesIO, StringIO
 
-import psutil
 import pytest
 
-from pandas.errors import EmptyDataError, ParserError
+from pandas.errors import ParserError
 
 from pandas import DataFrame, Index, MultiIndex
 import pandas._testing as tm
@@ -315,14 +314,3 @@ footer
     msg = "Expected 3 fields in line 4, saw 5"
     with pytest.raises(ParserError, match=msg):
         parser.read_csv(StringIO(data), header=1, comment="#", skipfooter=1)
-
-
-def test_file_descriptor_leak(python_parser_only):
-    # GH 31488
-    proc = psutil.Process()
-    parser = python_parser_only
-    with tm.ensure_clean() as path:
-        expected = proc.open_files()
-        with pytest.raises(EmptyDataError, match="No columns to parse from file"):
-            parser.read_csv(path)
-        assert proc.open_files() == expected


### PR DESCRIPTION
- [x] closes #31488 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
