### PR TITLE
CLN: remove Block.array_dtype, SingleBlockManager.array_dtype

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -11,7 +11,6 @@ from pandas._libs import NaT, Timestamp, algos as libalgos, lib, tslib, writers
 import pandas._libs.internals as libinternals
 from pandas._libs.tslibs import Timedelta, conversion
 from pandas._libs.tslibs.timezones import tz_compare
-from pandas._typing import DtypeObj
 from pandas.util._validators import validate_bool_kwarg
 
 from pandas.core.dtypes.cast import (
@@ -255,14 +254,6 @@ class Block(PandasObject):
             new_mgr_locs = libinternals.BlockPlacement(new_mgr_locs)
 
         self._mgr_locs = new_mgr_locs
-
-    @property
-    def array_dtype(self) -> DtypeObj:
-        """
-        the dtype to return if I want to construct this block as an
-        array
-        """
-        return self.dtype
 
     def make_block(self, values, placement=None) -> "Block":
         """
@@ -2921,14 +2912,6 @@ class CategoricalBlock(ExtensionBlock):
     @property
     def _holder(self):
         return Categorical
-
-    @property
-    def array_dtype(self):
-        """
-        the dtype to return if I want to construct this block as an
-        array
-        """
-        return np.object_
 
     def to_dense(self):
         # Categorical.get_values returns a DatetimeIndex for datetime

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -193,8 +193,10 @@ class BlockManager(PandasObject):
         # preserve dtype if possible
         if self.ndim == 1:
             assert isinstance(self, SingleBlockManager)  # for mypy
-            arr = np.array([], dtype=self.array_dtype)
-            blocks = [make_block(arr, placement=slice(0, 0), ndim=1)]
+            blk = self.blocks[0]
+            arr = blk.values[:0]
+            nb = blk.make_block_same_class(arr, placement=slice(0, 0), ndim=1)
+            blocks = [nb]
         else:
             blocks = []
         return type(self).from_blocks(blocks, axes)
@@ -1587,10 +1589,6 @@ class SingleBlockManager(BlockManager):
     @property
     def dtype(self) -> DtypeObj:
         return self._block.dtype
-
-    @property
-    def array_dtype(self) -> DtypeObj:
-        return self._block.array_dtype
 
     def get_dtype_counts(self):
         return {self.dtype.name: 1}


### PR DESCRIPTION
We can get a more accurately-dtyped empty array instead.