### PR TITLE
DOC: Clarify pivot_table fill_value description

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5903,7 +5903,8 @@ Wild         185.0
             If dict is passed, the key is column to aggregate and value
             is function or list of functions.
         fill_value : scalar, default None
-            Value to replace missing values with.
+            Value to replace missing values with (in the resulting pivot table,
+            after aggregation).
         margins : bool, default False
             Add all row / columns (e.g. for subtotal / grand totals).
         dropna : bool, default True


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

---

Clarify that `fill_value` gets used after performing the aggregation (i.e. it fills values in the resulting pivot table).
(Depending on the aggfunc and df, the result will be different if performing the filling before/after aggregation).

---

### Actually, why not remove it, requiring the user to more explicitly do `df.pivot_table(...).fillna(...)`?