### PR TITLE
TST: tighten check_categorical=False tests

### DIFF
--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -824,10 +824,14 @@ def assert_categorical_equal(
             left.codes, right.codes, check_dtype=check_dtype, obj=f"{obj}.codes",
         )
     else:
+        try:
+            lc = left.categories.sort_values()
+            rc = right.categories.sort_values()
+        except TypeError:
+            # e.g. '<' not supported between instances of 'int' and 'str'
+            lc, rc = left.categories, right.categories
         assert_index_equal(
-            left.categories.sort_values(),
-            right.categories.sort_values(),
-            obj=f"{obj}.categories",
+            lc, rc, obj=f"{obj}.categories",
         )
         assert_index_equal(
             left.categories.take(left.codes),

--- a/pandas/tests/arrays/categorical/test_replace.py
+++ b/pandas/tests/arrays/categorical/test_replace.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import pandas as pd
@@ -5,44 +6,46 @@ import pandas._testing as tm
 
 
 @pytest.mark.parametrize(
-    "to_replace,value,expected,check_types,check_categorical",
+    "to_replace,value,expected,flip_categories",
     [
         # one-to-one
-        (1, 2, [2, 2, 3], True, True),
-        (1, 4, [4, 2, 3], True, True),
-        (4, 1, [1, 2, 3], True, True),
-        (5, 6, [1, 2, 3], True, True),
+        (1, 2, [2, 2, 3], False),
+        (1, 4, [4, 2, 3], False),
+        (4, 1, [1, 2, 3], False),
+        (5, 6, [1, 2, 3], False),
         # many-to-one
-        ([1], 2, [2, 2, 3], True, True),
-        ([1, 2], 3, [3, 3, 3], True, True),
-        ([1, 2], 4, [4, 4, 3], True, True),
-        ((1, 2, 4), 5, [5, 5, 3], True, True),
-        ((5, 6), 2, [1, 2, 3], True, True),
+        ([1], 2, [2, 2, 3], False),
+        ([1, 2], 3, [3, 3, 3], False),
+        ([1, 2], 4, [4, 4, 3], False),
+        ((1, 2, 4), 5, [5, 5, 3], False),
+        ((5, 6), 2, [1, 2, 3], False),
         # many-to-many, handled outside of Categorical and results in separate dtype
-        ([1], [2], [2, 2, 3], False, False),
-        ([1, 4], [5, 2], [5, 2, 3], False, False),
+        ([1], [2], [2, 2, 3], True),
+        ([1, 4], [5, 2], [5, 2, 3], True),
         # check_categorical sorts categories, which crashes on mixed dtypes
-        (3, "4", [1, 2, "4"], True, False),
-        ([1, 2, "3"], "5", ["5", "5", 3], True, False),
+        (3, "4", [1, 2, "4"], False),
+        ([1, 2, "3"], "5", ["5", "5", 3], True),
     ],
 )
-def test_replace(to_replace, value, expected, check_types, check_categorical):
+def test_replace(to_replace, value, expected, flip_categories):
     # GH 31720
+    stays_categorical = not isinstance(value, list)
+
     s = pd.Series([1, 2, 3], dtype="category")
     result = s.replace(to_replace, value)
     expected = pd.Series(expected, dtype="category")
     s.replace(to_replace, value, inplace=True)
+
+    if flip_categories:
+        expected = expected.cat.set_categories(expected.cat.categories[::-1])
+
+    if not stays_categorical:
+        # the replace call loses categorical dtype
+        expected = pd.Series(np.asarray(expected))
+
     tm.assert_series_equal(
-        expected,
-        result,
-        check_dtype=check_types,
-        check_categorical=check_categorical,
-        check_category_order=False,
+        expected, result, check_category_order=False,
     )
     tm.assert_series_equal(
-        expected,
-        s,
-        check_dtype=check_types,
-        check_categorical=check_categorical,
-        check_category_order=False,
+        expected, s, check_category_order=False,
     )

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -273,17 +273,13 @@ class TestToXArray:
         assert isinstance(result, Dataset)
 
         # idempotency
-        # categoricals are not preserved
         # datetimes w/tz are preserved
         # column names are lost
         expected = df.copy()
         expected["f"] = expected["f"].astype(object)
         expected.columns.name = None
         tm.assert_frame_equal(
-            result.to_dataframe(),
-            expected,
-            check_index_type=False,
-            check_categorical=False,
+            result.to_dataframe(), expected,
         )
 
     @td.skip_if_no("xarray", min_version="0.7.0")

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -13,8 +13,6 @@ import pytest
 from pandas.compat import is_platform_little_endian, is_platform_windows
 import pandas.util._test_decorators as td
 
-from pandas.core.dtypes.common import is_categorical_dtype
-
 import pandas as pd
 from pandas import (
     Categorical,
@@ -1057,18 +1055,7 @@ class TestHDFStore:
 
         s_nan = ser.replace(nan_rep, np.nan)
 
-        if is_categorical_dtype(s_nan):
-            assert is_categorical_dtype(retr)
-            tm.assert_series_equal(
-                s_nan, retr, check_dtype=False, check_categorical=False
-            )
-        else:
-            tm.assert_series_equal(s_nan, retr)
-
-        # FIXME: don't leave commented-out
-        # fails:
-        # for x in examples:
-        #     roundtrip(s, nan_rep=b'\xf8\xfc')
+        tm.assert_series_equal(s_nan, retr)
 
     def test_append_some_nans(self, setup_path):
 

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2077,8 +2077,7 @@ def test_merge_equal_cat_dtypes(cat_dtype, reverse):
         }
     ).set_index("foo")
 
-    # Categorical is unordered, so don't check ordering.
-    tm.assert_frame_equal(result, expected, check_categorical=False)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_merge_equal_cat_dtypes2():
@@ -2100,8 +2099,7 @@ def test_merge_equal_cat_dtypes2():
         {"left": [1, 2], "right": [3, 2], "foo": Series(["a", "b"]).astype(cat_dtype)}
     ).set_index("foo")
 
-    # Categorical is unordered, so don't check ordering.
-    tm.assert_frame_equal(result, expected, check_categorical=False)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_merge_on_cat_and_ext_array():

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -296,18 +296,18 @@ class TestSeriesDtypes:
         # array conversion
         tm.assert_almost_equal(np.array(s), np.array(s.values))
 
-        # valid conversion
-        for valid in [
-            lambda x: x.astype("category"),
-            lambda x: x.astype(CategoricalDtype()),
-            lambda x: x.astype("object").astype("category"),
-            lambda x: x.astype("object").astype(CategoricalDtype()),
-        ]:
+        tm.assert_series_equal(s.astype("category"), s)
+        tm.assert_series_equal(s.astype(CategoricalDtype()), s)
 
-            result = valid(s)
-            # compare series values
-            # internal .categories can't be compared because it is sorted
-            tm.assert_series_equal(result, s, check_categorical=False)
+        roundtrip_expected = s.cat.set_categories(
+            s.cat.categories.sort_values()
+        ).cat.remove_unused_categories()
+        tm.assert_series_equal(
+            s.astype("object").astype("category"), roundtrip_expected
+        )
+        tm.assert_series_equal(
+            s.astype("object").astype(CategoricalDtype()), roundtrip_expected
+        )
 
         # invalid conversion (these are NOT a dtype)
         msg = (


### PR DESCRIPTION
This removes all check_categorical=False usages except for a) those in tests/util and b) a skipped json test test_latin_encoding (cc @WillAyd is that likely to be enabled in the foreseeable future?)