### PR TITLE
PERF: copy cached attributes on extension index shallow_copy

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -89,9 +89,9 @@ Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - :meth:`DataFrame.swaplevels` now raises a  ``TypeError`` if the axis is not a :class:`MultiIndex`.
   Previously a ``AttributeError`` was raised (:issue:`31126`)
-- :meth:`DataFrameGroupby.mean` and :meth:`SeriesGroupby.mean` (and similarly for :meth:`~DataFrameGroupby.median`, :meth:`~DataFrameGroupby.std`` and :meth:`~DataFrameGroupby.var``)
+- :meth:`DataFrameGroupby.mean` and :meth:`SeriesGroupby.mean` (and similarly for :meth:`~DataFrameGroupby.median`, :meth:`~DataFrameGroupby.std` and :meth:`~DataFrameGroupby.var`)
   now raise a  ``TypeError`` if a not-accepted keyword argument is passed into it.
-  Previously a ``UnsupportedFunctionCall`` was raised (``AssertionError`` if ``min_count`` passed into :meth:`~DataFrameGroupby.median``) (:issue:`31485`)
+  Previously a ``UnsupportedFunctionCall`` was raised (``AssertionError`` if ``min_count`` passed into :meth:`~DataFrameGroupby.median`) (:issue:`31485`)
 - :meth:`DataFrame.at` and :meth:`Series.at` will raise a ``TypeError`` instead of a ``ValueError`` if an incompatible key is passed, and ``KeyError`` if a missing key is passed, matching the behavior of ``.loc[]`` (:issue:`31722`)
 - Passing an integer dtype other than ``int64`` to ``np.array(period_index, dtype=...)`` will now raise ``TypeError`` instead of incorrectly using ``int64`` (:issue:`32255`)
 -
@@ -190,7 +190,7 @@ Performance improvements
 - Performance improvement in flex arithmetic ops between :class:`DataFrame` and :class:`Series` with ``axis=0`` (:issue:`31296`)
 - The internal index method :meth:`~Index._shallow_copy` now copies cached attributes over to the new index,
   avoiding creating these again on the new index. This can speed up many operations that depend on creating copies of
-  existing indexes (:issue:`28584`)
+  existing indexes (:issue:`28584`, :issue:`32640`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -188,9 +188,9 @@ Performance improvements
 - Performance improvement in :class:`Timedelta` constructor (:issue:`30543`)
 - Performance improvement in :class:`Timestamp` constructor (:issue:`30543`)
 - Performance improvement in flex arithmetic ops between :class:`DataFrame` and :class:`Series` with ``axis=0`` (:issue:`31296`)
-- The internal :meth:`Index._shallow_copy` now copies cached attributes over to the new index,
-  avoiding creating these again on the new index. This can speed up many operations
-  that depend on creating copies of existing indexes (:issue:`28584`)
+- The internal index method :meth:`~Index._shallow_copy` now copies cached attributes over to the new index,
+  avoiding creating these again on the new index. This can speed up many operations that depend on creating copies of
+  existing indexes (:issue:`28584`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -233,6 +233,7 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
 
         result._data = values
         result.name = name
+        result._cache = {}
 
         result._reset_identity()
         result._no_setting_name = False
@@ -242,14 +243,9 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
 
     @Appender(Index._shallow_copy.__doc__)
     def _shallow_copy(self, values=None, name: Label = no_default):
-        name = self.name if name is no_default else name
-
-        if values is None:
-            values = self.values
-
-        cat = Categorical(values, dtype=self.dtype)
-
-        return type(self)._simple_new(cat, name=name)
+        if values is not None:
+            values = Categorical(values, dtype=self.dtype)
+        return super()._shallow_copy(values=values, name=name)
 
     def _is_dtype_compat(self, other) -> bool:
         """

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -618,7 +618,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
 
     def _shallow_copy(self, values=None, name: Label = lib.no_default):
         name = self.name if name is lib.no_default else name
-        cache = self._cache if values is None else {}
+        cache = self._cache.copy() if values is None else {}
 
         if values is None:
             values = self._data

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -618,6 +618,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
 
     def _shallow_copy(self, values=None, name: Label = lib.no_default):
         name = self.name if name is lib.no_default else name
+        cache = self._cache if values is None else {}
 
         if values is None:
             values = self._data
@@ -636,7 +637,9 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
                     del attributes["freq"]
 
         attributes["name"] = name
-        return type(self)._simple_new(values, **attributes)
+        result = self._simple_new(values, **attributes)
+        result._cache = cache
+        return result
 
     # --------------------------------------------------------------------
     # Set Operation Methods

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -268,6 +268,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         result = object.__new__(cls)
         result._data = dtarr
         result.name = name
+        result._cache = {}
         result._no_setting_name = False
         # For groupby perf. See note in indexes/base about _index_data
         result._index_data = dtarr._data

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -335,7 +335,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
     @Appender(Index._shallow_copy.__doc__)
     def _shallow_copy(self, values=None, name: Label = lib.no_default):
         name = self.name if name is lib.no_default else name
-        cache = self._cache if values is None else {}
+        cache = self._cache.copy() if values is None else {}
         if values is None:
             values = self._data
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -243,6 +243,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         result = IntervalMixin.__new__(cls)
         result._data = array
         result.name = name
+        result._cache = {}
         result._no_setting_name = False
         result._reset_identity()
         return result
@@ -332,12 +333,15 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
     # --------------------------------------------------------------------
 
     @Appender(Index._shallow_copy.__doc__)
-    def _shallow_copy(self, values=None, **kwargs):
+    def _shallow_copy(self, values=None, name: Label = lib.no_default):
+        name = self.name if name is lib.no_default else name
+        cache = self._cache if values is None else {}
         if values is None:
             values = self._data
-        attributes = self._get_attributes_dict()
-        attributes.update(kwargs)
-        return self._simple_new(values, **attributes)
+
+        result = self._simple_new(values, name=name)
+        result._cache = cache
+        return result
 
     @cache_readonly
     def _isnan(self):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -233,6 +233,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         # For groupby perf. See note in indexes/base about _index_data
         result._index_data = values._data
         result.name = name
+        result._cache = {}
         result._reset_identity()
         return result
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -180,6 +180,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin, dtl.TimelikeOps):
         result = object.__new__(cls)
         result._data = values
         result._name = name
+        result._cache = {}
         # For groupby perf. See note in indexes/base about _index_data
         result._index_data = values._data
 


### PR DESCRIPTION
Follow-up to #32568. 

Copies ``._cache`` also when copying using ``.shallow_copy`` for:
* CategoricalIndex
* DatetimeIndex
* PeriodIndex
* DateTimeIndex
* IntervalIndex

After this PR, only ``MultiIndex._shallow_copy`` is missing this optimization. ``MultiIndex._shallow_copy`` is a bit special and might require a refactor so I'd like to take that in a seperate PR.

Example performance improvement:
```pythn
>>> idx = pd.CategoricalIndex(np.arange(100_000))
>>> %timeit idx.get_loc(99_999)
4.46 µs ± 62.6 ns per loop  # master and this PR
>>> %timeit idx._shallow_copy().get_loc(99_999)
4.19 ms ± 117 µs per loop  # master
8.58 µs ± 254 ns per loop  # this PR
```