### PR TITLE
fix infer_freq raises section

### DIFF
--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -254,9 +254,9 @@ def infer_freq(index, warn: bool = True) -> Optional[str]:
     Raises
     ------
     TypeError
-        If the index is not datetime-like
+        If the index is not datetime-like.
     ValueError
-        If there are less than three values.
+        If there are fewer than three values.
     """
     import pandas as pd
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -250,8 +250,13 @@ def infer_freq(index, warn: bool = True) -> Optional[str]:
     -------
     str or None
         None if no discernible frequency
-        TypeError if the index is not datetime-like
-        ValueError if there are less than three values.
+
+    Raises
+    ------
+    TypeError
+        If the index is not datetime-like
+    ValueError
+        If there are less than three values.
     """
     import pandas as pd
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -249,7 +249,7 @@ def infer_freq(index, warn: bool = True) -> Optional[str]:
     Returns
     -------
     str or None
-        None if no discernible frequency
+        None if no discernible frequency.
 
     Raises
     ------


### PR DESCRIPTION
Fixes the raises section of the `infer_freq` doc string. Seems small enough to skip a whats new entry.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

