### PR TITLE
BUG: process Int64 as ints for preservable ops, not as float64

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -406,6 +406,7 @@ Other
 - :meth:`IntegerArray.astype` now supports ``datetime64`` dtype (:issue:32538`)
 - Fixed bug in :func:`pandas.testing.assert_series_equal` where dtypes were checked for ``Interval`` and ``ExtensionArray`` operands when ``check_dtype`` was ``False`` (:issue:`32747`)
 - Bug in :meth:`DataFrame.__dir__` caused a segfault when using unicode surrogates in a column name (:issue:`25509`)
+- :meth:`IntegerArray.min` and :meth:`IntegerArray.max` no longer roundtrip through ``np.float64`` values, fixing precision for large integers (:issue:`32652`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -183,11 +183,17 @@ def _get_fill_value(
         if fill_value_typ is None:
             return iNaT
         else:
-            if fill_value_typ == "+inf":
-                # need the max int here
-                return _int64_max
-            else:
-                return iNaT
+            dtype = getattr(dtype, "numpy_dtype", dtype)
+            try:
+                if fill_value_typ == "+inf":
+                    return np.iinfo(dtype).max
+                else:
+                    return np.iinfo(dtype).min
+            except ValueError:
+                if fill_value_typ == "+inf":
+                    return _int64_max
+                else:
+                    iNaT
 
 
 def _maybe_get_mask(

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -238,7 +238,11 @@ class TestNumericReduce(base.BaseNumericReduceTests):
         # overwrite to ensure pd.NA is tested instead of np.nan
         # https://github.com/pandas-dev/pandas/issues/30958
         result = getattr(s, op_name)(skipna=skipna)
-        expected = getattr(s.astype("float64"), op_name)(skipna=skipna)
+        preserved_ops = ["min", "max"]
+        if skipna and op_name in preserved_ops:
+            expected = getattr(s.dropna(), op_name)(skipna=True)
+        else:
+            expected = getattr(s.astype("float64"), op_name)(skipna=skipna)
         if np.isnan(expected):
             expected = pd.NA
         tm.assert_almost_equal(result, expected)


### PR DESCRIPTION
Calling `.min()` or `.max()` on `pd.Int64` data returns integers, but uses `float64` as an intermediate representation, leading to data corruption.

This PR attempts to whitelist them to be processed entirely as `Int64`s. Also add a test that verifies this behavior, as existing tests failed to detect the bug.

- [x] closes #32651
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
