### PR TITLE
DOC: fix announce formtting

### DIFF
--- a/doc/sphinxext/announce.py
+++ b/doc/sphinxext/announce.py
@@ -122,14 +122,15 @@ def build_string(revision_range, heading="Contributors"):
     components["uline"] = "=" * len(components["heading"])
     components["authors"] = "* " + "\n* ".join(components["authors"])
 
+    # Don't change this to an fstring. It breaks the formatting.
     tpl = textwrap.dedent(
-        f"""\
-    {components['heading']}
-    {components['uline']}
+        """\
+    {heading}
+    {uline}
 
-    {components['author_message']}
-    {components['authors']}"""
-    )
+    {author_message}
+    {authors}"""
+    ).format(**components)
     return tpl
 
 


### PR DESCRIPTION
Master:

```
    Contributors
    ============

    A total of 143 people contributed patches to this release.  People with a
"+" by their names contributed a patch for the first time.

    * 3vts +
* A Brooks +
* Abbie Popa +
* Achmad Syarif Hidayatullah +
```

PR

```
Contributors
============

A total of 143 people contributed patches to this release.  People with a
"+" by their names contributed a patch for the first time.

* 3vts +
* A Brooks +
* Abbie Popa +
```

I think the offset computed by textwrap.dedent changed. With fstrings it's calculated after the values are interpolated. We want it to be computed on the templated version.