### PR TITLE
PERF: MultiIndex._shallow_copy

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -190,7 +190,7 @@ Performance improvements
 - Performance improvement in flex arithmetic ops between :class:`DataFrame` and :class:`Series` with ``axis=0`` (:issue:`31296`)
 - The internal index method :meth:`~Index._shallow_copy` now copies cached attributes over to the new index,
   avoiding creating these again on the new index. This can speed up many operations that depend on creating copies of
-  existing indexes (:issue:`28584`, :issue:`32640`)
+  existing indexes (:issue:`28584`, :issue:`32640`, :issue:`32669`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -690,7 +690,7 @@ class MultiIndex(Index):
     # --------------------------------------------------------------------
     # Levels Methods
 
-    @property
+    @cache_readonly
     def levels(self):
         # Use cache_readonly to ensure that self.get_locs doesn't repeatedly
         # create new IndexEngine
@@ -994,7 +994,10 @@ class MultiIndex(Index):
             return MultiIndex.from_tuples(values, names=names, **kwargs)
 
         result = self.copy(**kwargs)
-        result._cache = self._cache.copy()
+        cache = self._cache.copy()
+        if "levels" in cache:
+            cache["levels"] = FrozenList(lev._shallow_copy() for lev in cache["levels"])
+        result._cache = cache
         return result
 
     def _shallow_copy_with_infer(self, values, **kwargs):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -994,10 +994,10 @@ class MultiIndex(Index):
             return MultiIndex.from_tuples(values, names=names, **kwargs)
 
         result = self.copy(**kwargs)
-        cache = self._cache.copy()
-        if "levels" in cache:
-            cache["levels"] = FrozenList(lev._shallow_copy() for lev in cache["levels"])
-        result._cache = cache
+        result._cache = self._cache.copy()
+        # GH32669
+        if "levels" in result._cache:
+            del result._cache["levels"]
         return result
 
     def _shallow_copy_with_infer(self, values, **kwargs):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -276,6 +276,7 @@ class MultiIndex(Index):
             raise ValueError("Must pass non-zero number of levels/codes")
 
         result = object.__new__(MultiIndex)
+        result._cache = {}
 
         # we've already validated levels and codes, so shortcut here
         result._set_levels(levels, copy=copy, validate=False)
@@ -689,7 +690,7 @@ class MultiIndex(Index):
     # --------------------------------------------------------------------
     # Levels Methods
 
-    @cache_readonly
+    @property
     def levels(self):
         # Use cache_readonly to ensure that self.get_locs doesn't repeatedly
         # create new IndexEngine
@@ -991,7 +992,10 @@ class MultiIndex(Index):
             # discards freq
             kwargs.pop("freq", None)
             return MultiIndex.from_tuples(values, names=names, **kwargs)
-        return self.copy(**kwargs)
+
+        result = self.copy(**kwargs)
+        result._cache = self._cache.copy()
+        return result
 
     def _shallow_copy_with_infer(self, values, **kwargs):
         # On equal MultiIndexes the difference is empty.

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -251,11 +251,13 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
 
     def _shallow_copy(self, values=None, name: Label = no_default):
         name = name if name is not no_default else self.name
-
+        cache = self._cache.copy() if values is None else {}
         if values is None:
             values = self._data
 
-        return self._simple_new(values, name=name)
+        result = self._simple_new(values, name=name)
+        result._cache = cache
+        return result
 
     def _maybe_convert_timedelta(self, other):
         """

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -141,7 +141,7 @@ class RangeIndex(Int64Index):
 
         result._range = values
         result.name = name
-
+        result._cache = {}
         result._reset_identity()
         return result
 
@@ -391,7 +391,9 @@ class RangeIndex(Int64Index):
         name = self.name if name is no_default else name
 
         if values is None:
-            return self._simple_new(self._range, name=name)
+            result = self._simple_new(self._range, name=name)
+            result._cache = self._cache.copy()
+            return result
         else:
             return Int64Index._simple_new(values, name=name)
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -923,11 +923,12 @@ class Base:
     def test_shallow_copy_copies_cache(self):
         # GH32669
         idx = self.create_index()
-        idx.get_loc(idx[0])  # initiate the _engine etc.
+        idx.get_loc(idx[0])  # populates the _cache.
         shallow_copy = idx._shallow_copy()
+
         # check that the shallow_copied cache is a copy of the original
         assert idx._cache == shallow_copy._cache
         assert idx._cache is not shallow_copy._cache
-        # the cache values should reference the same objects
+        # cache values should reference the same object
         for key, val in idx._cache.items():
-            assert shallow_copy._cache[key] is val
+            assert shallow_copy._cache[key] is val, key

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -919,3 +919,15 @@ class Base:
 
         with pytest.raises(TypeError):
             {} in idx._engine
+
+    def test_shallow_copy_copies_cache(self):
+        # GH32669
+        idx = self.create_index()
+        idx.get_loc(idx[0])  # initiate the _engine etc.
+        shallow_copy = idx._shallow_copy()
+        # check that the shallow_copied cache is a copy of the original
+        assert idx._cache == shallow_copy._cache
+        assert idx._cache is not shallow_copy._cache
+        # the cache values should reference the same objects
+        for key, val in idx._cache.items():
+            assert shallow_copy._cache[key] is val

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -7,6 +7,7 @@ import pandas._testing as tm
 
 def check_level_names(index, names):
     assert [level.name for level in index.levels] == list(names)
+    assert index.names == list(names)
 
 
 def test_slice_keep_name():

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -7,7 +7,6 @@ import pandas._testing as tm
 
 def check_level_names(index, names):
     assert [level.name for level in index.levels] == list(names)
-    assert index.names == list(names)
 
 
 def test_slice_keep_name():


### PR DESCRIPTION
- [x] xref #28584, #32568, #32640
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Improves performance of ``MultiIndex._shallow_copy``. Example:

```python
>>> n = 100_000
>>> df = pd.DataFrame({'a': range(n), 'b': range(1, n+1)})
>>> mi = pd.MultiIndex.from_frame(df)
>>> mi.is_lexsorted()
True
>>> mi.get_loc(mi[0])  # also sets up the cache
>>> %timeit mi._shallow_copy().get_loc(mi[0])
8.56 ms ± 127 µs per loop  # master
75.1 µs ± 2.3 µs per loop  # this PR, first commit
46.9 µs ± 792 ns per loop  # this PR, second commit

```

Also adds tests for ``_shallow_copy`` for all index types. This ensures that this issue has been resolved for all index types.