### PR TITLE
Fix wrong docstring in qcut

### DIFF
--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -286,7 +286,7 @@ def qcut(
     Parameters
     ----------
     x : 1d ndarray or Series
-    q : int or list-like of int
+    q : int or list-like of float
         Number of quantiles. 10 for deciles, 4 for quartiles, etc. Alternately
         array of quantiles, e.g. [0, .25, .5, .75, 1.] for quartiles.
     labels : array or False, default None


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
