### PR TITLE
PERF: Using Numpy C-API arange

### DIFF
--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -108,7 +108,7 @@ cdef class BlockPlacement:
         if not self._has_array:
             start, stop, step, _ = slice_get_indices_ex(self._as_slice)
             # NOTE: this is the C-optimized equivalent of
-            # np.arange(start, stop, step, dtype=np.int64)
+            #  np.arange(start, stop, step, dtype=np.int64)
             self._as_array = cnp.PyArray_Arange(start, stop, step, NPY_INT64)
             self._has_array = True
         return self._as_array

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -7,7 +7,9 @@ cdef extern from "Python.h":
     Py_ssize_t PY_SSIZE_T_MAX
 
 import numpy as np
-from numpy cimport int64_t
+cimport numpy as cnp
+from numpy cimport NPY_INT64, int64_t
+cnp.import_array()
 
 from pandas._libs.algos import ensure_int64
 
@@ -105,7 +107,7 @@ cdef class BlockPlacement:
             Py_ssize_t start, stop, end, _
         if not self._has_array:
             start, stop, step, _ = slice_get_indices_ex(self._as_slice)
-            self._as_array = np.arange(start, stop, step, dtype=np.int64)
+            self._as_array = cnp.PyArray_Arange(start, stop, step, NPY_INT64)
             self._has_array = True
         return self._as_array
 

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -107,6 +107,8 @@ cdef class BlockPlacement:
             Py_ssize_t start, stop, end, _
         if not self._has_array:
             start, stop, step, _ = slice_get_indices_ex(self._as_slice)
+            # NOTE: this is the C-optimized equivalent of
+            # np.arange(start, stop, step, dtype=np.int64)
             self._as_array = cnp.PyArray_Arange(start, stop, step, NPY_INT64)
             self._has_array = True
         return self._as_array


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

---

This PR was opened as @jbrockmendel suggested (ref https://github.com/pandas-dev/pandas/pull/32177#discussion_r382923663)

---

### Benchmarks:

#### Master:

```
In [1]: import pandas._libs.internals as internals

In [2]: %timeit internals.BlockPlacement(slice(1_000_000)).as_array
1.55 ms ± 143 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

---

#### PR:

```
In [1]: import pandas._libs.internals as internals

In [2]: %timeit internals.BlockPlacement(slice(1_000_000)).as_array
1.46 ms ± 3.55 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
 