### PR TITLE
pd.Timestamp constructor ignores missing arguments

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -347,7 +347,6 @@ class Timestamp(_Timestamp):
         cls,
         object ts_input=_no_input,
         object freq=None,
-        tz=None,
         unit=None,
         year=None,
         month=None,
@@ -357,8 +356,9 @@ class Timestamp(_Timestamp):
         second=None,
         microsecond=None,
         nanosecond=None,
-        tzinfo=None,
         *,
+        tz=None,
+        tzinfo=None,
         fold=None
     ):
         # The parameter list folds together legacy parameter names (the first
@@ -470,10 +470,9 @@ class Timestamp(_Timestamp):
             # User passed positional arguments:
             # Timestamp(year, month, day[, hour[, minute[, second[,
             # microsecond[, nanosecond[, tzinfo]]]]]])
-            ts_input = datetime(ts_input, freq, tz, unit or 0,
-                                year or 0, month or 0, day or 0, fold=fold or 0)
-            nanosecond = hour
-            tz = minute
+            ts_input = datetime(ts_input, freq, unit,
+                                year or 0, month or 0, day or 0, hour or 0, fold=fold or 0)
+            nanosecond = minute
             freq = None
 
         if getattr(ts_input, 'tzinfo', None) is not None and tz is not None:

--- a/pandas/tests/scalar/timestamp/test_timezones.py
+++ b/pandas/tests/scalar/timestamp/test_timezones.py
@@ -416,3 +416,32 @@ class TestTimestampTZOperations:
         expected = _datetime.timetz()
 
         assert result == expected
+
+
+class TestConstructorWithTZ:
+    def test_timestamp_creating_with_tz_or_tzinfo_only_date(self):
+        stamp = Timestamp(2019, 1, 1, tzinfo=pytz.timezone("EST5EDT"))
+        stamp2 = Timestamp(2019, 1, 1, tz="EST5EDT")
+        expected = datetime(2019, 1, 1, tzinfo=pytz.timezone("EST5EDT"))
+        assert stamp == expected
+        assert stamp2 == expected
+
+    def test_timestamp_creating_with_tz_or_tzinfo_all_fields(self):
+        stamp = Timestamp(2019, 1, 1, 1, 1, 1, 1, tzinfo=pytz.timezone("EST5EDT"))
+        stamp2 = Timestamp(2019, 1, 1, 1, 1, 1, 1, tz="EST5EDT")
+        expected = datetime(2019, 1, 1, 1, 1, 1, 1, pytz.timezone("EST5EDT"))
+        assert stamp == expected
+        assert stamp2 == expected
+
+    def test_timestamp_tzinfo_has_affect(self):
+        stamp = Timestamp(2019, 1, 1, 1, tzinfo=pytz.timezone("EST5EDT"))
+        stamp2 = Timestamp(2019, 1, 1, 1, tz="UTC")
+        assert stamp != stamp2
+
+    def test_creating_with_nano(self):
+        stamp = Timestamp(2019, 1, 2, 3, 4, 5, 6, 7, tzinfo=pytz.timezone("UTC"))
+        assert str(stamp) == "2019-01-02 03:04:05.000006007+00:00"
+
+    def test_creating_with_kwargs(self):
+        stamp = Timestamp(year=2019, month=1, day=2, hour=3, minute=4, second=5, microsecond=6, nanosecond=7, tz="UTC")
+        assert str(stamp) == "2019-01-02 03:04:05.000006007+00:00"


### PR DESCRIPTION
Hello. The PR fixes https://github.com/pandas-dev/pandas/issues/31930

Please review and merge if you think it is good enough :)

Regards,
Artyom.
