### PR TITLE
Track times

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -234,6 +234,7 @@ Other enhancements
   compression library. Compression was also added to the low-level Stata-file writers
   :class:`~pandas.io.stata.StataWriter`, :class:`~pandas.io.stata.StataWriter117`,
   and :class:`~pandas.io.stata.StataWriterUTF8` (:issue:`26599`).
+- :meth:`HDFStore.put` now accepts `track_times` parameter. Parameter is passed to ``create_table`` method of ``PyTables`` (:issue:`32682`).
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -4144,9 +4144,9 @@ class AppendableTable(Table):
 
             if track_times is not None:
                 from tables import __version__ as tables_version
-                from packaging.version import Version
+                from distutils.version import LooseVersion
 
-                if Version(tables_version) >= Version("3.4.3"):
+                if LooseVersion(tables_version) >= LooseVersion("3.4.3"):
                     options["track_times"] = track_times
                 else:
                     raise ValueError(

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -984,7 +984,7 @@ class HDFStore:
         data_columns: Optional[List[str]] = None,
         encoding=None,
         errors: str = "strict",
-        track_times: Optional[bool] = None,
+        track_times: bool = True,
     ):
         """
         Store object in HDFStore.
@@ -1628,7 +1628,7 @@ class HDFStore:
         data_columns=None,
         encoding=None,
         errors: str = "strict",
-        track_times: Optional[bool] = None,
+        track_times: bool = True,
     ):
         group = self.get_node(key)
 
@@ -4110,7 +4110,7 @@ class AppendableTable(Table):
         dropna=False,
         nan_rep=None,
         data_columns=None,
-        track_times=None,
+        track_times=True,
     ):
 
         if not append and self.is_exists:
@@ -4148,10 +4148,6 @@ class AppendableTable(Table):
 
                 if LooseVersion(tables_version) >= LooseVersion("3.4.3"):
                     options["track_times"] = track_times
-                else:
-                    raise ValueError(
-                        "You cannot set track_times with table version < 3.4.3"
-                    )
 
             # create the table
             table._handle.create_table(table.group, **options)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -5,6 +5,7 @@ to disk
 
 import copy
 from datetime import date, tzinfo
+from distutils.version import LooseVersion
 import itertools
 import os
 import re
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 import warnings
 
 import numpy as np
+from tables import __version__ as tables_version
 
 from pandas._config import config, get_option
 
@@ -4142,12 +4144,8 @@ class AppendableTable(Table):
             # set the table attributes
             table.set_attrs()
 
-            if track_times is not None:
-                from tables import __version__ as tables_version
-                from distutils.version import LooseVersion
-
-                if LooseVersion(tables_version) >= LooseVersion("3.4.3"):
-                    options["track_times"] = track_times
+            if LooseVersion(tables_version) >= LooseVersion("3.4.3"):
+                options["track_times"] = track_times
 
             # create the table
             table._handle.create_table(table.group, **options)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -984,7 +984,7 @@ class HDFStore:
         data_columns: Optional[List[str]] = None,
         encoding=None,
         errors: str = "strict",
-        track_times: bool = True,
+        track_times: Optional[bool] = None,
     ):
         """
         Store object in HDFStore.
@@ -1628,7 +1628,7 @@ class HDFStore:
         data_columns=None,
         encoding=None,
         errors: str = "strict",
-        track_times: bool = True,
+        track_times: Optional[bool] = None,
     ):
         group = self.get_node(key)
 
@@ -4110,7 +4110,7 @@ class AppendableTable(Table):
         dropna=False,
         nan_rep=None,
         data_columns=None,
-        track_times=True,
+        track_times=None,
     ):
 
         if not append and self.is_exists:
@@ -4142,8 +4142,19 @@ class AppendableTable(Table):
             # set the table attributes
             table.set_attrs()
 
+            if track_times is not None:
+                from tables import __version__ as tables_version
+                from packaging.version import Version
+
+                if Version(tables_version) >= Version("3.4.3"):
+                    options["track_times"] = track_times
+                else:
+                    raise ValueError(
+                        "You cannot set track_times with table version < 3.4.3"
+                    )
+
             # create the table
-            table._handle.create_table(table.group, track_times=track_times, **options)
+            table._handle.create_table(table.group, **options)
 
         # update my info
         table.attrs.info = table.info

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1011,6 +1011,12 @@ class HDFStore:
             Provide an encoding for strings.
         dropna   : bool, default False, do not write an ALL nan row to
             The store settable by the option 'io.hdf.dropna_table'.
+        track_times : bool, default True
+            Parameter is propagated to 'create_table' method of 'PyTables'.
+            If set to False it enables to have the same h5 files (same hashes)
+            independent on creation time.
+
+            .. versionadded:: 1.1.0
         """
         if format is None:
             format = get_option("io.hdf.default_format") or "fixed"

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 import warnings
 
 import numpy as np
-from tables import __version__ as tables_version
 
 from pandas._config import config, get_option
 
@@ -4114,6 +4113,7 @@ class AppendableTable(Table):
         data_columns=None,
         track_times=True,
     ):
+        from tables import __version__ as tables_version
 
         if not append and self.is_exists:
             self._handle.remove_node(self.group, "table")

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -5,7 +5,6 @@ to disk
 
 import copy
 from datetime import date, tzinfo
-from distutils.version import LooseVersion
 import itertools
 import os
 import re
@@ -4113,8 +4112,6 @@ class AppendableTable(Table):
         data_columns=None,
         track_times=True,
     ):
-        from tables import __version__ as tables_version
-
         if not append and self.is_exists:
             self._handle.remove_node(self.group, "table")
 
@@ -4144,8 +4141,7 @@ class AppendableTable(Table):
             # set the table attributes
             table.set_attrs()
 
-            if LooseVersion(tables_version) >= LooseVersion("3.4.3"):
-                options["track_times"] = track_times
+            options["track_times"] = track_times
 
             # create the table
             table._handle.create_table(table.group, **options)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -984,6 +984,7 @@ class HDFStore:
         data_columns: Optional[List[str]] = None,
         encoding=None,
         errors: str = "strict",
+        track_times: bool = True,
     ):
         """
         Store object in HDFStore.
@@ -1027,6 +1028,7 @@ class HDFStore:
             data_columns=data_columns,
             encoding=encoding,
             errors=errors,
+            track_times=track_times,
         )
 
     def remove(self, key: str, where=None, start=None, stop=None):
@@ -1626,6 +1628,7 @@ class HDFStore:
         data_columns=None,
         encoding=None,
         errors: str = "strict",
+        track_times: bool = True,
     ):
         group = self.get_node(key)
 
@@ -1688,6 +1691,7 @@ class HDFStore:
             dropna=dropna,
             nan_rep=nan_rep,
             data_columns=data_columns,
+            track_times=track_times,
         )
 
         if isinstance(s, Table) and index:
@@ -4106,6 +4110,7 @@ class AppendableTable(Table):
         dropna=False,
         nan_rep=None,
         data_columns=None,
+        track_times=True,
     ):
 
         if not append and self.is_exists:
@@ -4138,7 +4143,7 @@ class AppendableTable(Table):
             table.set_attrs()
 
             # create the table
-            table._handle.create_table(table.group, **options)
+            table._handle.create_table(table.group, track_times=track_times, **options)
 
         # update my info
         table.attrs.info = table.info

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -311,7 +311,7 @@ class TestHDFStore:
                     h.update(chunk)
             return h.digest()
 
-        def create_h5_and_return_checksum():
+        def create_h5_and_return_checksum(track_times):
             with ensure_clean_path(setup_path) as path:
                 df = pd.DataFrame({"a": [1]})
 
@@ -322,16 +322,22 @@ class TestHDFStore:
                     format='table',
                     data_columns=True,
                     index=None,
-                    track_times=False,
+                    track_times=track_times,
                 )
                 hdf.close()
                 return checksum(path)
 
-        checksum_0 = create_h5_and_return_checksum()
+        checksum_0_tt_false = create_h5_and_return_checksum(track_times=False)
+        checksum_0_tt_true = create_h5_and_return_checksum(track_times=True)
         time.sleep(1)
-        checksum_1 = create_h5_and_return_checksum()
+        checksum_1_tt_false = create_h5_and_return_checksum(track_times=False)
+        checksum_1_tt_true = create_h5_and_return_checksum(track_times=True)
 
-        assert checksum_0 == checksum_1
+        # checksums are the same if track_time = False
+        assert checksum_0_tt_false == checksum_1_tt_false
+
+        # checksums are NOT same if track_time = True
+        assert checksum_0_tt_true != checksum_1_tt_true
 
     def test_keys_ignore_hdf_softlink(self, setup_path):
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -1,14 +1,17 @@
 import datetime
 from datetime import timedelta
 from distutils.version import LooseVersion
+import hashlib
 from io import BytesIO
 import os
 from pathlib import Path
 import re
+import time
 from warnings import catch_warnings, simplefilter
 
 import numpy as np
 import pytest
+import tables
 
 from pandas.compat import is_platform_little_endian, is_platform_windows
 import pandas.util._test_decorators as td
@@ -300,10 +303,6 @@ class TestHDFStore:
 
         # GH 32682
         # enables to set track_times (see `pytables` `create_table` documentation)
-
-        import hashlib
-        import time
-        import tables
 
         def checksum(filename, hash_factory=hashlib.md5, chunk_num_blocks=128):
             h = hash_factory()

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -304,7 +304,6 @@ class TestHDFStore:
         import hashlib
         import time
         import tables
-        from packaging.version import Version
 
         def checksum(filename, hash_factory=hashlib.md5, chunk_num_blocks=128):
             h = hash_factory()
@@ -329,7 +328,7 @@ class TestHDFStore:
 
                 return checksum(path)
 
-        if Version(tables.__version__) < Version("3.4.3"):
+        if LooseVersion(tables.__version__) < LooseVersion("3.4.3"):
             with pytest.raises(
                 ValueError,
                 match="You cannot set track_times with table version < 3.4.3",

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -306,7 +306,7 @@ class TestHDFStore:
 
         def checksum(filename, hash_factory=hashlib.md5, chunk_num_blocks=128):
             h = hash_factory()
-            with open(filename, 'rb') as f:
+            with open(filename, "rb") as f:
                 for chunk in iter(lambda: f.read(chunk_num_blocks * h.block_size), b''):
                     h.update(chunk)
             return h.digest()
@@ -319,7 +319,7 @@ class TestHDFStore:
                 hdf.put(
                     "table",
                     df,
-                    format='table',
+                    format="table",
                     data_columns=True,
                     index=None,
                     track_times=track_times,

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -299,6 +299,13 @@ class TestHDFStore:
             assert set(store.keys()) == expected
             assert set(store) == expected
 
+    @pytest.mark.skipif(
+        LooseVersion(tables.__version__) < LooseVersion("3.4.3"),
+        reason=(
+            "Skipping  pytables test when tables version is "
+            "lower than 3.4.3"
+        ),
+    )
     def test_no_track_times(self, setup_path):
 
         # GH 32682
@@ -327,21 +334,20 @@ class TestHDFStore:
 
                 return checksum(path)
 
-        if LooseVersion(tables.__version__) >= LooseVersion("3.4.3"):
-            checksum_0_tt_false = create_h5_and_return_checksum(track_times=False)
-            checksum_0_tt_true = create_h5_and_return_checksum(track_times=True)
+        checksum_0_tt_false = create_h5_and_return_checksum(track_times=False)
+        checksum_0_tt_true = create_h5_and_return_checksum(track_times=True)
 
-            # sleep is necessary to create h5 with different creation time
-            time.sleep(1)
+        # sleep is necessary to create h5 with different creation time
+        time.sleep(1)
 
-            checksum_1_tt_false = create_h5_and_return_checksum(track_times=False)
-            checksum_1_tt_true = create_h5_and_return_checksum(track_times=True)
+        checksum_1_tt_false = create_h5_and_return_checksum(track_times=False)
+        checksum_1_tt_true = create_h5_and_return_checksum(track_times=True)
 
-            # checksums are the same if track_time = False
-            assert checksum_0_tt_false == checksum_1_tt_false
+        # checksums are the same if track_time = False
+        assert checksum_0_tt_false == checksum_1_tt_false
 
-            # checksums are NOT same if track_time = True
-            assert checksum_0_tt_true != checksum_1_tt_true
+        # checksums are NOT same if track_time = True
+        assert checksum_0_tt_true != checksum_1_tt_true
 
     def test_keys_ignore_hdf_softlink(self, setup_path):
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -328,13 +328,7 @@ class TestHDFStore:
 
                 return checksum(path)
 
-        if LooseVersion(tables.__version__) < LooseVersion("3.4.3"):
-            with pytest.raises(
-                ValueError,
-                match="You cannot set track_times with table version < 3.4.3",
-            ):
-                create_h5_and_return_checksum(track_times=False)
-        else:
+        if LooseVersion(tables.__version__) >= LooseVersion("3.4.3"):
             checksum_0_tt_false = create_h5_and_return_checksum(track_times=False)
             checksum_0_tt_true = create_h5_and_return_checksum(track_times=True)
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -307,7 +307,7 @@ class TestHDFStore:
         def checksum(filename, hash_factory=hashlib.md5, chunk_num_blocks=128):
             h = hash_factory()
             with open(filename, "rb") as f:
-                for chunk in iter(lambda: f.read(chunk_num_blocks * h.block_size), b''):
+                for chunk in iter(lambda: f.read(chunk_num_blocks * h.block_size), b""):
                     h.update(chunk)
             return h.digest()
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -298,10 +298,6 @@ class TestHDFStore:
             assert set(store.keys()) == expected
             assert set(store) == expected
 
-    @pytest.mark.skipif(
-        LooseVersion(tables.__version__) < LooseVersion("3.4.3"),
-        reason=("Skipping  pytables test when tables version is lower than 3.4.3"),
-    )
     def test_no_track_times(self, setup_path):
 
         # GH 32682

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -329,7 +329,10 @@ class TestHDFStore:
 
         checksum_0_tt_false = create_h5_and_return_checksum(track_times=False)
         checksum_0_tt_true = create_h5_and_return_checksum(track_times=True)
+
+        # sleep is necessary to create h5 with different creation time
         time.sleep(1)
+
         checksum_1_tt_false = create_h5_and_return_checksum(track_times=False)
         checksum_1_tt_true = create_h5_and_return_checksum(track_times=True)
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -11,7 +11,6 @@ from warnings import catch_warnings, simplefilter
 
 import numpy as np
 import pytest
-import tables
 
 from pandas.compat import is_platform_little_endian, is_platform_windows
 import pandas.util._test_decorators as td

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -300,10 +300,7 @@ class TestHDFStore:
 
     @pytest.mark.skipif(
         LooseVersion(tables.__version__) < LooseVersion("3.4.3"),
-        reason=(
-            "Skipping  pytables test when tables version is "
-            "lower than 3.4.3"
-        ),
+        reason=("Skipping  pytables test when tables version is lower than 3.4.3"),
     )
     def test_no_track_times(self, setup_path):
 


### PR DESCRIPTION
I implement feature request https://github.com/pandas-dev/pandas/issues/32682 but if someone has more experience with pytables consider these changes.

The h5 files generated with track_times=False has the same md5 hashes, that is covered in the unit test as well as the fact that the hashes are not the same with track_times=True

- [x] closes #32682
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
