### PR TITLE
DOC: Add examples to Series operators (#24589)

### DIFF
--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -234,6 +234,180 @@ e    NaN
 dtype: float64
 """
 
+_ne_example_SERIES = """
+Examples
+--------
+>>> a = pd.Series([1, 1, np.nan, np.nan, 0], index=['a', 'b', 'c', 'd', 'e'])
+>>> a
+a    1.0
+b    1.0
+c    1.0
+d    NaN
+e    1.0
+dtype: float64
+>>> b = pd.Series([0, 1, np.nan, 0, 1], index=['a', 'b', 'c', 'd', 'f'])
+>>> b
+a    0.0
+b    1.0
+c    2.0
+d    NaN
+f    1.0
+dtype: float64
+>>> a.ne(b, fill_value=0)
+a     True
+b    False
+c     True
+d    False
+e    False
+f     True
+dtype: bool
+"""
+
+_eq_example_SERIES = """
+Examples
+--------
+>>> a = pd.Series([1, 1, np.nan, np.nan, 0], index=['a', 'b', 'c', 'd', 'e'])
+>>> a
+a    1.0
+b    1.0
+c    1.0
+d    NaN
+e    1.0
+dtype: float64
+>>> b = pd.Series([0, 1, np.nan, 0, 1], index=['a', 'b', 'c', 'd', 'f'])
+>>> b
+a    0.0
+b    1.0
+c    2.0
+d    NaN
+f    1.0
+dtype: float64
+>>> a.eq(b, fill_value=0)
+a    False
+b     True
+c    False
+d     True
+e     True
+f    False
+dtype: bool
+"""
+
+_lt_example_SERIES = """
+Examples
+--------
+>>> a = pd.Series([1, 1, 1, np.nan, 1], index=['a', 'b', 'c', 'd', 'e'])
+>>> a
+a    1.0
+b    1.0
+c    1.0
+d    NaN
+e    1.0
+dtype: float64
+>>> b = pd.Series([0, 1, 2, np.nan, 1], index=['a', 'b', 'c', 'd', 'f'])
+>>> b
+a    0.0
+b    1.0
+c    2.0
+d    NaN
+f    1.0
+dtype: float64
+>>> a.lt(b, fill_value=0)
+a    False
+b    False
+c     True
+d    False
+e    False
+f     True
+dtype: bool
+"""
+
+_le_example_SERIES = """
+Examples
+--------
+>>> a = pd.Series([1, 1, 1, np.nan, 1], index=['a', 'b', 'c', 'd', 'e'])
+>>> a
+a    1.0
+b    1.0
+c    1.0
+d    NaN
+e    1.0
+dtype: float64
+>>> b = pd.Series([0, 1, 2, np.nan, 1], index=['a', 'b', 'c', 'd', 'f'])
+>>> b
+a    0.0
+b    1.0
+c    2.0
+d    NaN
+f    1.0
+dtype: float64
+>>> a.le(b, fill_value=0)
+a    False
+b     True
+c     True
+d    False
+e    False
+f     True
+dtype: bool
+"""
+
+_gt_example_SERIES = """
+Examples
+--------
+>>> a = pd.Series([1, 1, 1, np.nan, 1], index=['a', 'b', 'c', 'd', 'e'])
+>>> a
+a    1.0
+b    1.0
+c    1.0
+d    NaN
+e    1.0
+dtype: float64
+>>> b = pd.Series([0, 1, 2, np.nan, 1], index=['a', 'b', 'c', 'd', 'f'])
+>>> b
+a    0.0
+b    1.0
+c    2.0
+d    NaN
+f    1.0
+dtype: float64
+>>> a.gt(b, fill_value=0)
+a     True
+b    False
+c    False
+d    False
+e     True
+f    False
+dtype: bool
+"""
+
+_ge_example_SERIES = """
+Examples
+--------
+>>> a = pd.Series([1, 1, 1, np.nan, 1], index=['a', 'b', 'c', 'd', 'e'])
+>>> a
+a    1.0
+b    1.0
+c    1.0
+d    NaN
+e    1.0
+dtype: float64
+>>> b = pd.Series([0, 1, 2, np.nan, 1], index=['a', 'b', 'c', 'd', 'f'])
+>>> b
+a    0.0
+b    1.0
+c    2.0
+d    NaN
+f    1.0
+dtype: float64
+>>> a.ge(b, fill_value=0)
+a     True
+b     True
+c    False
+d    False
+e     True
+f    False
+dtype: bool
+"""
+
 _returns_series = """Series\n    The result of the operation."""
 
 _returns_tuple = """2-Tuple of Series\n    The result of the operation."""
@@ -306,42 +480,42 @@ _op_descriptions: Dict[str, Dict[str, Optional[str]]] = {
         "op": "==",
         "desc": "Equal to",
         "reverse": None,
-        "series_examples": None,
+        "series_examples": _eq_example_SERIES,
         "series_returns": _returns_series,
     },
     "ne": {
         "op": "!=",
         "desc": "Not equal to",
         "reverse": None,
-        "series_examples": None,
+        "series_examples": _ne_example_SERIES,
         "series_returns": _returns_series,
     },
     "lt": {
         "op": "<",
         "desc": "Less than",
         "reverse": None,
-        "series_examples": None,
+        "series_examples": _lt_example_SERIES,
         "series_returns": _returns_series,
     },
     "le": {
         "op": "<=",
         "desc": "Less than or equal to",
         "reverse": None,
-        "series_examples": None,
+        "series_examples": _le_example_SERIES,
         "series_returns": _returns_series,
     },
     "gt": {
         "op": ">",
         "desc": "Greater than",
         "reverse": None,
-        "series_examples": None,
+        "series_examples": _gt_example_SERIES,
         "series_returns": _returns_series,
     },
     "ge": {
         "op": ">=",
         "desc": "Greater than or equal to",
         "reverse": None,
-        "series_examples": None,
+        "series_examples": _ge_example_SERIES,
         "series_returns": _returns_series,
     },
 }

--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -53,7 +53,7 @@ def _make_flex_doc(op_name, typ):
     return doc
 
 
-_common_examples_SERIES = """
+_common_examples_algebra_SERIES = """
 Examples
 --------
 >>> a = pd.Series([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'])
@@ -92,7 +92,7 @@ f    1.0
 dtype: float64"""
 
 _add_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.add(b, fill_value=0)
 a    2.0
@@ -105,7 +105,7 @@ dtype: float64
 )
 
 _sub_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.subtract(b, fill_value=0)
 a    0.0
@@ -118,7 +118,7 @@ dtype: float64
 )
 
 _mul_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.multiply(b, fill_value=0)
 a    1.0
@@ -131,7 +131,7 @@ dtype: float64
 )
 
 _div_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.divide(b, fill_value=0)
 a    1.0
@@ -144,7 +144,7 @@ dtype: float64
 )
 
 _floordiv_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.floordiv(b, fill_value=0)
 a    1.0
@@ -157,7 +157,7 @@ dtype: float64
 )
 
 _mod_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.mod(b, fill_value=0)
 a    0.0
@@ -169,7 +169,7 @@ dtype: float64
 """
 )
 _pow_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.pow(b, fill_value=0)
 a    1.0
@@ -182,7 +182,7 @@ dtype: float64
 )
 
 _ne_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.ne(b, fill_value=0)
 a    False
@@ -195,7 +195,7 @@ dtype: bool
 )
 
 _eq_example_SERIES = (
-    _common_examples_SERIES
+    _common_examples_algebra_SERIES
     + """
 >>> a.eq(b, fill_value=0)
 a     True

--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -53,7 +53,7 @@ def _make_flex_doc(op_name, typ):
     return doc
 
 
-_add_example_SERIES = """
+_common_examples_SERIES = """
 Examples
 --------
 >>> a = pd.Series([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'])
@@ -69,230 +69,9 @@ a    1.0
 b    NaN
 d    1.0
 e    NaN
-dtype: float64
->>> a.add(b, fill_value=0)
-a    2.0
-b    1.0
-c    1.0
-d    1.0
-e    NaN
-dtype: float64
-"""
+dtype: float64"""
 
-_sub_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-dtype: float64
->>> b = pd.Series([1, np.nan, 1, np.nan], index=['a', 'b', 'd', 'e'])
->>> b
-a    1.0
-b    NaN
-d    1.0
-e    NaN
-dtype: float64
->>> a.subtract(b, fill_value=0)
-a    0.0
-b    1.0
-c    1.0
-d   -1.0
-e    NaN
-dtype: float64
-"""
-
-_mul_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-dtype: float64
->>> b = pd.Series([1, np.nan, 1, np.nan], index=['a', 'b', 'd', 'e'])
->>> b
-a    1.0
-b    NaN
-d    1.0
-e    NaN
-dtype: float64
->>> a.multiply(b, fill_value=0)
-a    1.0
-b    0.0
-c    0.0
-d    0.0
-e    NaN
-dtype: float64
-"""
-
-_div_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-dtype: float64
->>> b = pd.Series([1, np.nan, 1, np.nan], index=['a', 'b', 'd', 'e'])
->>> b
-a    1.0
-b    NaN
-d    1.0
-e    NaN
-dtype: float64
->>> a.divide(b, fill_value=0)
-a    1.0
-b    inf
-c    inf
-d    0.0
-e    NaN
-dtype: float64
-"""
-
-_floordiv_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-dtype: float64
->>> b = pd.Series([1, np.nan, 1, np.nan], index=['a', 'b', 'd', 'e'])
->>> b
-a    1.0
-b    NaN
-d    1.0
-e    NaN
-dtype: float64
->>> a.floordiv(b, fill_value=0)
-a    1.0
-b    NaN
-c    NaN
-d    0.0
-e    NaN
-dtype: float64
-"""
-
-_mod_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-dtype: float64
->>> b = pd.Series([1, np.nan, 1, np.nan], index=['a', 'b', 'd', 'e'])
->>> b
-a    1.0
-b    NaN
-d    1.0
-e    NaN
-dtype: float64
->>> a.mod(b, fill_value=0)
-a    0.0
-b    NaN
-c    NaN
-d    0.0
-e    NaN
-dtype: float64
-"""
-_pow_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-dtype: float64
->>> b = pd.Series([1, np.nan, 1, np.nan], index=['a', 'b', 'd', 'e'])
->>> b
-a    1.0
-b    NaN
-d    1.0
-e    NaN
-dtype: float64
->>> a.pow(b, fill_value=0)
-a    1.0
-b    1.0
-c    1.0
-d    0.0
-e    NaN
-dtype: float64
-"""
-
-_ne_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, np.nan, np.nan, 0], index=['a', 'b', 'c', 'd', 'e'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-e    1.0
-dtype: float64
->>> b = pd.Series([0, 1, np.nan, 0, 1], index=['a', 'b', 'c', 'd', 'f'])
->>> b
-a    0.0
-b    1.0
-c    2.0
-d    NaN
-f    1.0
-dtype: float64
->>> a.ne(b, fill_value=0)
-a     True
-b    False
-c     True
-d    False
-e    False
-f     True
-dtype: bool
-"""
-
-_eq_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, np.nan, np.nan, 0], index=['a', 'b', 'c', 'd', 'e'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-e    1.0
-dtype: float64
->>> b = pd.Series([0, 1, np.nan, 0, 1], index=['a', 'b', 'c', 'd', 'f'])
->>> b
-a    0.0
-b    1.0
-c    2.0
-d    NaN
-f    1.0
-dtype: float64
->>> a.eq(b, fill_value=0)
-a    False
-b     True
-c    False
-d     True
-e     True
-f    False
-dtype: bool
-"""
-
-_lt_example_SERIES = """
+_common_examples_comparison_SERIES = """
 Examples
 --------
 >>> a = pd.Series([1, 1, 1, np.nan, 1], index=['a', 'b', 'c', 'd', 'e'])
@@ -310,7 +89,98 @@ b    1.0
 c    2.0
 d    NaN
 f    1.0
+dtype: float64"""
+
+_add_example_SERIES = _common_examples_SERIES + """
+>>> a.add(b, fill_value=0)
+a    2.0
+b    1.0
+c    1.0
+d    1.0
+e    NaN
 dtype: float64
+"""
+
+_sub_example_SERIES = _common_examples_SERIES + """
+>>> a.subtract(b, fill_value=0)
+a    0.0
+b    1.0
+c    1.0
+d   -1.0
+e    NaN
+dtype: float64
+"""
+
+_mul_example_SERIES = _common_examples_SERIES + """
+>>> a.multiply(b, fill_value=0)
+a    1.0
+b    0.0
+c    0.0
+d    0.0
+e    NaN
+dtype: float64
+"""
+
+_div_example_SERIES = _common_examples_SERIES + """
+>>> a.divide(b, fill_value=0)
+a    1.0
+b    inf
+c    inf
+d    0.0
+e    NaN
+dtype: float64
+"""
+
+_floordiv_example_SERIES = _common_examples_SERIES + """
+>>> a.floordiv(b, fill_value=0)
+a    1.0
+b    NaN
+c    NaN
+d    0.0
+e    NaN
+dtype: float64
+"""
+
+_mod_example_SERIES = _common_examples_SERIES + """
+>>> a.mod(b, fill_value=0)
+a    0.0
+b    NaN
+c    NaN
+d    0.0
+e    NaN
+dtype: float64
+"""
+_pow_example_SERIES = _common_examples_SERIES + """
+>>> a.pow(b, fill_value=0)
+a    1.0
+b    1.0
+c    1.0
+d    0.0
+e    NaN
+dtype: float64
+"""
+
+_ne_example_SERIES = _common_examples_SERIES + """
+>>> a.ne(b, fill_value=0)
+a    False
+b     True
+c     True
+d     True
+e     True
+dtype: bool
+"""
+
+_eq_example_SERIES = _common_examples_SERIES + """
+>>> a.eq(b, fill_value=0)
+a     True
+b    False
+c    False
+d    False
+e    False
+dtype: bool
+"""
+
+_lt_example_SERIES = _common_examples_comparison_SERIES + """
 >>> a.lt(b, fill_value=0)
 a    False
 b    False
@@ -321,25 +191,7 @@ f     True
 dtype: bool
 """
 
-_le_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan, 1], index=['a', 'b', 'c', 'd', 'e'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-e    1.0
-dtype: float64
->>> b = pd.Series([0, 1, 2, np.nan, 1], index=['a', 'b', 'c', 'd', 'f'])
->>> b
-a    0.0
-b    1.0
-c    2.0
-d    NaN
-f    1.0
-dtype: float64
+_le_example_SERIES = _common_examples_comparison_SERIES + """
 >>> a.le(b, fill_value=0)
 a    False
 b     True
@@ -350,25 +202,7 @@ f     True
 dtype: bool
 """
 
-_gt_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan, 1], index=['a', 'b', 'c', 'd', 'e'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-e    1.0
-dtype: float64
->>> b = pd.Series([0, 1, 2, np.nan, 1], index=['a', 'b', 'c', 'd', 'f'])
->>> b
-a    0.0
-b    1.0
-c    2.0
-d    NaN
-f    1.0
-dtype: float64
+_gt_example_SERIES = _common_examples_comparison_SERIES + """
 >>> a.gt(b, fill_value=0)
 a     True
 b    False
@@ -379,25 +213,7 @@ f    False
 dtype: bool
 """
 
-_ge_example_SERIES = """
-Examples
---------
->>> a = pd.Series([1, 1, 1, np.nan, 1], index=['a', 'b', 'c', 'd', 'e'])
->>> a
-a    1.0
-b    1.0
-c    1.0
-d    NaN
-e    1.0
-dtype: float64
->>> b = pd.Series([0, 1, 2, np.nan, 1], index=['a', 'b', 'c', 'd', 'f'])
->>> b
-a    0.0
-b    1.0
-c    2.0
-d    NaN
-f    1.0
-dtype: float64
+_ge_example_SERIES = _common_examples_comparison_SERIES + """
 >>> a.ge(b, fill_value=0)
 a     True
 b     True

--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -91,7 +91,9 @@ d    NaN
 f    1.0
 dtype: float64"""
 
-_add_example_SERIES = _common_examples_SERIES + """
+_add_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.add(b, fill_value=0)
 a    2.0
 b    1.0
@@ -100,8 +102,11 @@ d    1.0
 e    NaN
 dtype: float64
 """
+)
 
-_sub_example_SERIES = _common_examples_SERIES + """
+_sub_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.subtract(b, fill_value=0)
 a    0.0
 b    1.0
@@ -110,8 +115,11 @@ d   -1.0
 e    NaN
 dtype: float64
 """
+)
 
-_mul_example_SERIES = _common_examples_SERIES + """
+_mul_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.multiply(b, fill_value=0)
 a    1.0
 b    0.0
@@ -120,8 +128,11 @@ d    0.0
 e    NaN
 dtype: float64
 """
+)
 
-_div_example_SERIES = _common_examples_SERIES + """
+_div_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.divide(b, fill_value=0)
 a    1.0
 b    inf
@@ -130,8 +141,11 @@ d    0.0
 e    NaN
 dtype: float64
 """
+)
 
-_floordiv_example_SERIES = _common_examples_SERIES + """
+_floordiv_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.floordiv(b, fill_value=0)
 a    1.0
 b    NaN
@@ -140,8 +154,11 @@ d    0.0
 e    NaN
 dtype: float64
 """
+)
 
-_mod_example_SERIES = _common_examples_SERIES + """
+_mod_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.mod(b, fill_value=0)
 a    0.0
 b    NaN
@@ -150,7 +167,10 @@ d    0.0
 e    NaN
 dtype: float64
 """
-_pow_example_SERIES = _common_examples_SERIES + """
+)
+_pow_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.pow(b, fill_value=0)
 a    1.0
 b    1.0
@@ -159,8 +179,11 @@ d    0.0
 e    NaN
 dtype: float64
 """
+)
 
-_ne_example_SERIES = _common_examples_SERIES + """
+_ne_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.ne(b, fill_value=0)
 a    False
 b     True
@@ -169,8 +192,11 @@ d     True
 e     True
 dtype: bool
 """
+)
 
-_eq_example_SERIES = _common_examples_SERIES + """
+_eq_example_SERIES = (
+    _common_examples_SERIES
+    + """
 >>> a.eq(b, fill_value=0)
 a     True
 b    False
@@ -179,8 +205,11 @@ d    False
 e    False
 dtype: bool
 """
+)
 
-_lt_example_SERIES = _common_examples_comparison_SERIES + """
+_lt_example_SERIES = (
+    _common_examples_comparison_SERIES
+    + """
 >>> a.lt(b, fill_value=0)
 a    False
 b    False
@@ -190,8 +219,11 @@ e    False
 f     True
 dtype: bool
 """
+)
 
-_le_example_SERIES = _common_examples_comparison_SERIES + """
+_le_example_SERIES = (
+    _common_examples_comparison_SERIES
+    + """
 >>> a.le(b, fill_value=0)
 a    False
 b     True
@@ -201,8 +233,11 @@ e    False
 f     True
 dtype: bool
 """
+)
 
-_gt_example_SERIES = _common_examples_comparison_SERIES + """
+_gt_example_SERIES = (
+    _common_examples_comparison_SERIES
+    + """
 >>> a.gt(b, fill_value=0)
 a     True
 b    False
@@ -212,8 +247,11 @@ e     True
 f    False
 dtype: bool
 """
+)
 
-_ge_example_SERIES = _common_examples_comparison_SERIES + """
+_ge_example_SERIES = (
+    _common_examples_comparison_SERIES
+    + """
 >>> a.ge(b, fill_value=0)
 a     True
 b     True
@@ -223,6 +261,7 @@ e     True
 f    False
 dtype: bool
 """
+)
 
 _returns_series = """Series\n    The result of the operation."""
 


### PR DESCRIPTION
Further work on #24589.  PR #25524 added examples for many operations but not `pandas.Series.eq`, `pandas.Series.ne`, `pandas.Series.gt`, `pandas.Series.ge`, `pandas.series.le`, and `pandas.series.lt`.  This adds examples for those.

`pandas.Series.divmod` is still missing an example as discussed in #25524.
