### PR TITLE
DOC: Fix PR01, PR07 in Index.min and Index.max

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -885,6 +885,9 @@ class IndexOpsMixin:
         axis : int, optional
             For compatibility with NumPy. Only 0 or None are allowed.
         skipna : bool, default True
+            Exclude NA/null values when showing the result.
+        *args, **kwargs
+            Additional arguments and keywords for compatibility with NumPy.
 
         Returns
         -------
@@ -982,6 +985,9 @@ class IndexOpsMixin:
         axis : {None}
             Dummy argument for consistency with Series.
         skipna : bool, default True
+            Exclude NA/null values when showing the result.
+        *args, **kwargs
+            Additional arguments and keywords for compatibility with NumPy.
 
         Returns
         -------


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Related to #27977. 

Output for pandas.Index.min:
```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found:
        No extended summary found
```

and output for pandas.Index.max:
```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found:
        No extended summary found
```