### PR TITLE
BUG: Fix HDFStore empty keys on native HDF5 file by adding keyword include

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -962,7 +962,7 @@ I/O
 - Bug in :meth:`~DataFrame.to_excel` could not handle the column name `render` and was raising an ``KeyError`` (:issue:`34331`)
 - Bug in :meth:`~SQLDatabase.execute` was raising a ``ProgrammingError`` for some DB-API drivers when the SQL statement contained the `%` character and no parameters were present (:issue:`34211`)
 - Bug in :meth:`~pandas.io.stata.StataReader` which resulted in categorical variables with difference dtypes when reading data using an iterator. (:issue:`31544`)
-- :meth:`HDFStore.keys` has now an optional `kind` parameter that allows the retrieval of all native HDF5 table names (:issue:`29916`)
+- :meth:`HDFStore.keys` has now an optional `include` parameter that allows the retrieval of all native HDF5 table names (:issue:`29916`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -962,6 +962,7 @@ I/O
 - Bug in :meth:`~DataFrame.to_excel` could not handle the column name `render` and was raising an ``KeyError`` (:issue:`34331`)
 - Bug in :meth:`~SQLDatabase.execute` was raising a ``ProgrammingError`` for some DB-API drivers when the SQL statement contained the `%` character and no parameters were present (:issue:`34211`)
 - Bug in :meth:`~pandas.io.stata.StataReader` which resulted in categorical variables with difference dtypes when reading data using an iterator. (:issue:`31544`)
+- :meth:`HDFStore.keys` has now an optional `kind` parameter that allows the retrieval of all native HDF5 table names (:issue:`29916`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -605,7 +605,8 @@ class HDFStore:
 
         if kind == 'tables':
             self._check_if_open()
-            return [n._v_pathname for n in self._handle.walk_nodes('/', classname='Table')]
+            return [n._v_pathname
+                    for n in self._handle.walk_nodes('/', classname='Table')]
         raise ValueError(f"kind should be either pandas' or 'table' but is {kind}")
 
     def __iter__(self):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -591,14 +591,14 @@ class HDFStore:
                 When kind equals 'table' return Tables
                 Otherwise fail with a ValueError
 
-        Raises
-        ------
-        raises ValueError if kind has an illegal value
-
         Returns
         -------
         list
             List of ABSOLUTE path-names (e.g. have the leading '/').
+
+        Raises
+        ------
+        raises ValueError if kind has an illegal value
         """
         if kind == "pandas":
             return [n._v_pathname for n in self.groups()]

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,7 +580,7 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self, kind='pandas') -> List[str]:
+    def keys(self, kind="pandas") -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
 
@@ -600,13 +600,14 @@ class HDFStore:
         list
             List of ABSOLUTE path-names (e.g. have the leading '/').
         """
-        if kind == 'pandas':
+        if kind == "pandas":
             return [n._v_pathname for n in self.groups()]
 
-        if kind == 'tables':
+        if kind == "tables":
             self._check_if_open()
-            return [n._v_pathname
-                    for n in self._handle.walk_nodes('/', classname='Table')]
+            return [
+                n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
+            ]
         raise ValueError(f"kind should be either pandas' or 'table' but is {kind}")
 
     def __iter__(self):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,7 +580,7 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self, kind="pandas") -> List[str]:
+    def keys(self, kind: Optional[str] = "pandas") -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
 
@@ -588,7 +588,7 @@ class HDFStore:
         ----------
         kind : str, default 'pandas'
                 When kind equals 'pandas' return pandas objects
-                When kind equals 'table' return Tables
+                When kind equals 'table' return Table objects
                 Otherwise fail with a ValueError
 
         Returns
@@ -608,7 +608,7 @@ class HDFStore:
             return [
                 n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
             ]
-        raise ValueError(f"kind should be either pandas' or 'table' but is {kind}")
+        raise ValueError(f"`kind` should be either 'pandas' or 'table' but is [{kind}]")
 
     def __iter__(self):
         return iter(self.keys())

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,16 +580,33 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self) -> List[str]:
+    def keys(self, kind='pandas') -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
+
+        Parameters
+        ----------
+        kind : str, default 'pandas'
+                When kind equals 'pandas' return pandas objects
+                When kind equals 'table' return Tables
+                Otherwise fail with a ValueError
+
+        Raises
+        ------
+        raises ValueError if kind has an illegal value
 
         Returns
         -------
         list
             List of ABSOLUTE path-names (e.g. have the leading '/').
         """
-        return [n._v_pathname for n in self.groups()]
+        if kind == 'pandas':
+            return [n._v_pathname for n in self.groups()]
+
+        if kind == 'tables':
+            self._check_if_open()
+            return [n._v_pathname for n in self._handle.walk_nodes('/', classname='Table')]
+        raise ValueError(f"kind should be either pandas' or 'table' but is {kind}")
 
     def __iter__(self):
         return iter(self.keys())

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,7 +580,7 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self, include: Optional[str] = "pandas") -> List[str]:
+    def keys(self, include: str = "pandas") -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -606,7 +606,7 @@ class HDFStore:
         if include == "pandas":
             return [n._v_pathname for n in self.groups()]
 
-        if include == "native":
+        elif include == "native":
             assert self._handle is not None  # mypy
             return [
                 n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -587,12 +587,13 @@ class HDFStore:
         Parameters
         ----------
 
-        .. versionadded:: 1.1.0
 
         include : str, default 'pandas'
                 When kind equals 'pandas' return pandas objects
                 When kind equals 'native' return native HDF5 Table objects
                 Otherwise fail with a ValueError
+
+                .. versionadded:: 1.1.0
 
         Returns
         -------

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -590,7 +590,6 @@ class HDFStore:
         include : str, default 'pandas'
                 When kind equals 'pandas' return pandas objects
                 When kind equals 'native' return native HDF5 Table objects
-                Otherwise fail with a ValueError
 
                 .. versionadded:: 1.1.0
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -609,7 +609,7 @@ class HDFStore:
                 n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
             ]
         raise ValueError(
-            f"`include` should be either 'pandas' or 'native' but is [{include}]"
+            f"`include` should be either 'pandas' or 'native' but is '{include}'"
         )
 
     def __iter__(self):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -587,7 +587,6 @@ class HDFStore:
         Parameters
         ----------
 
-
         include : str, default 'pandas'
                 When kind equals 'pandas' return pandas objects
                 When kind equals 'native' return native HDF5 Table objects

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -586,6 +586,9 @@ class HDFStore:
 
         Parameters
         ----------
+
+        .. versionadded:: 1.1.0
+
         include : str, default 'pandas'
                 When kind equals 'pandas' return pandas objects
                 When kind equals 'native' return native HDF5 Table objects

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -580,15 +580,15 @@ class HDFStore:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
-    def keys(self, kind: Optional[str] = "pandas") -> List[str]:
+    def keys(self, include: Optional[str] = "pandas") -> List[str]:
         """
         Return a list of keys corresponding to objects stored in HDFStore.
 
         Parameters
         ----------
-        kind : str, default 'pandas'
+        include : str, default 'pandas'
                 When kind equals 'pandas' return pandas objects
-                When kind equals 'table' return Table objects
+                When kind equals 'native' return native HDF5 Table objects
                 Otherwise fail with a ValueError
 
         Returns
@@ -600,15 +600,17 @@ class HDFStore:
         ------
         raises ValueError if kind has an illegal value
         """
-        if kind == "pandas":
+        if include == "pandas":
             return [n._v_pathname for n in self.groups()]
 
-        if kind == "tables":
-            self._check_if_open()
+        if include == "native":
+            assert self._handle is not None  # mypy
             return [
                 n._v_pathname for n in self._handle.walk_nodes("/", classname="Table")
             ]
-        raise ValueError(f"`kind` should be either 'pandas' or 'table' but is [{kind}]")
+        raise ValueError(
+            f"`include` should be either 'pandas' or 'native' but is [{include}]"
+        )
 
     def __iter__(self):
         return iter(self.keys())

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -341,6 +341,29 @@ class TestHDFStore:
         # checksums are NOT same if track_time = True
         assert checksum_0_tt_true != checksum_1_tt_true
 
+    def test_non_pandas_keys(self, setup_path):
+
+        class Table1(tables.IsDescription):
+            value1 = tables.Float32Col()
+
+        class Table2(tables.IsDescription):
+            value2 = tables.Float32Col()
+
+        class Table3(tables.IsDescription):
+            value3 = tables.Float32Col()
+
+        with ensure_clean_path(setup_path) as path:
+            with tables.open_file(path, mode="w") as h5file:
+                group = h5file.create_group("/", "group")
+                h5file.create_table(group, "table1", Table1, "Table 1")
+                h5file.create_table(group, "table2", Table2, "Table 2")
+                h5file.create_table(group, "table3", Table3, "Table 3")
+            with HDFStore(path) as store:
+                assert len(store.keys(kind="tables")) == 3
+                expected = {"/group/table1", "/group/table2", "/group/table3"}
+                assert set(store.keys(kind="tables")) == expected
+                assert set(store) == set()
+
     def test_keys_ignore_hdf_softlink(self, setup_path):
 
         # GH 20523

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -367,7 +367,8 @@ class TestHDFStore:
         with ensure_clean_store(setup_path) as store:
             with pytest.raises(
                 ValueError,
-                match="`include` should be either 'pandas' or 'native' but is 'illegal'",
+                match="`include` should be either 'pandas' or 'native'"
+                " but is 'illegal'",
             ):
                 store.keys(include="illegal")
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -370,8 +370,8 @@ class TestHDFStore:
         with ensure_clean_store(setup_path) as store:
             with pytest.raises(
                 ValueError,
-                match="`include` should be either 'pandas' or 'native'"
-                " but is 'illegal'",
+                match="`include` should be either 'pandas' or 'native' "
+                "but is 'illegal'",
             ):
                 store.keys(include="illegal")
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -363,6 +363,14 @@ class TestHDFStore:
                 assert set(store.keys(include="native")) == expected
                 assert set(store.keys(include="pandas")) == set()
 
+    def test_keys_illegal_include_keyword_value(self, setup_path):
+        with ensure_clean_store(setup_path) as store:
+            with pytest.raises(
+                ValueError,
+                match="`include` should be either 'pandas' or 'native' but is 'illegal'",
+            ):
+                store.keys(include="illegal")
+
     def test_keys_ignore_hdf_softlink(self, setup_path):
 
         # GH 20523

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -358,10 +358,10 @@ class TestHDFStore:
                 h5file.create_table(group, "table2", Table2, "Table 2")
                 h5file.create_table(group, "table3", Table3, "Table 3")
             with HDFStore(path) as store:
-                assert len(store.keys(kind="tables")) == 3
+                assert len(store.keys(include="native")) == 3
                 expected = {"/group/table1", "/group/table2", "/group/table3"}
-                assert set(store.keys(kind="tables")) == expected
-                assert set(store.keys(kind="pandas")) == set()
+                assert set(store.keys(include="native")) == expected
+                assert set(store.keys(include="pandas")) == set()
 
     def test_keys_ignore_hdf_softlink(self, setup_path):
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -342,7 +342,6 @@ class TestHDFStore:
         assert checksum_0_tt_true != checksum_1_tt_true
 
     def test_non_pandas_keys(self, setup_path):
-
         class Table1(tables.IsDescription):
             value1 = tables.Float32Col()
 

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -362,6 +362,9 @@ class TestHDFStore:
                 expected = {"/group/table1", "/group/table2", "/group/table3"}
                 assert set(store.keys(include="native")) == expected
                 assert set(store.keys(include="pandas")) == set()
+                for name in expected:
+                    df = store.get(name)
+                    assert len(df.columns) == 1
 
     def test_keys_illegal_include_keyword_value(self, setup_path):
         with ensure_clean_store(setup_path) as store:

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -361,7 +361,7 @@ class TestHDFStore:
                 assert len(store.keys(kind="tables")) == 3
                 expected = {"/group/table1", "/group/table2", "/group/table3"}
                 assert set(store.keys(kind="tables")) == expected
-                assert set(store) == set()
+                assert set(store.keys(kind="pandas")) == set()
 
     def test_keys_ignore_hdf_softlink(self, setup_path):
 


### PR DESCRIPTION
- [x] closes #29916
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
