### PR TITLE
CLN: Remove Ops Mixin from pandas/tests/base

### DIFF
--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -40,50 +40,6 @@ def allow_na_ops(obj: Any) -> bool:
     return not is_bool_index and obj._can_hold_na
 
 
-class Ops:
-    def setup_method(self, method):
-        self.bool_index = tm.makeBoolIndex(10, name="a")
-        self.int_index = tm.makeIntIndex(10, name="a")
-        self.float_index = tm.makeFloatIndex(10, name="a")
-        self.dt_index = tm.makeDateIndex(10, name="a")
-        self.dt_tz_index = tm.makeDateIndex(10, name="a").tz_localize(tz="US/Eastern")
-        self.period_index = tm.makePeriodIndex(10, name="a")
-        self.string_index = tm.makeStringIndex(10, name="a")
-        self.unicode_index = tm.makeUnicodeIndex(10, name="a")
-
-        arr = np.random.randn(10)
-        self.bool_series = Series(arr, index=self.bool_index, name="a")
-        self.int_series = Series(arr, index=self.int_index, name="a")
-        self.float_series = Series(arr, index=self.float_index, name="a")
-        self.dt_series = Series(arr, index=self.dt_index, name="a")
-        self.dt_tz_series = self.dt_tz_index.to_series()
-        self.period_series = Series(arr, index=self.period_index, name="a")
-        self.string_series = Series(arr, index=self.string_index, name="a")
-        self.unicode_series = Series(arr, index=self.unicode_index, name="a")
-
-        types = ["bool", "int", "float", "dt", "dt_tz", "period", "string", "unicode"]
-        self.indexes = [getattr(self, f"{t}_index") for t in types]
-        self.series = [getattr(self, f"{t}_series") for t in types]
-
-        # To test narrow dtypes, we use narrower *data* elements, not *index* elements
-        index = self.int_index
-        self.float32_series = Series(arr.astype(np.float32), index=index, name="a")
-
-        arr_int = np.random.choice(10, size=10, replace=False)
-        self.int8_series = Series(arr_int.astype(np.int8), index=index, name="a")
-        self.int16_series = Series(arr_int.astype(np.int16), index=index, name="a")
-        self.int32_series = Series(arr_int.astype(np.int32), index=index, name="a")
-
-        self.uint8_series = Series(arr_int.astype(np.uint8), index=index, name="a")
-        self.uint16_series = Series(arr_int.astype(np.uint16), index=index, name="a")
-        self.uint32_series = Series(arr_int.astype(np.uint32), index=index, name="a")
-
-        nrw_types = ["float32", "int8", "int16", "int32", "uint8", "uint16", "uint32"]
-        self.narrow_series = [getattr(self, f"{t}_series") for t in nrw_types]
-
-        self.objs = self.indexes + self.series + self.narrow_series
-
-
 @pytest.mark.parametrize(
     "op_name, op",
     [
@@ -132,12 +88,7 @@ class TestTranspose:
             np.transpose(obj, axes=1)
 
 
-class TestIndexOps(Ops):
-    def setup_method(self, method):
-        super().setup_method(method)
-        self.is_valid_objs = self.objs
-        self.not_valid_objs = []
-
+class TestIndexOps:
     def test_none_comparison(self, series_with_simple_index):
         series = series_with_simple_index
         if isinstance(series.index, IntervalIndex):


### PR DESCRIPTION
11 PRs later, the moment has finally come: closes #23877 🎉 

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`


