### PR TITLE
CLN: Use keep fixture in more places

### DIFF
--- a/pandas/tests/frame/methods/test_duplicated.py
+++ b/pandas/tests/frame/methods/test_duplicated.py
@@ -64,7 +64,6 @@ def test_duplicated_nan_none(keep, expected):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("keep", ["first", "last", False])
 @pytest.mark.parametrize("subset", [None, ["A", "B"], "A"])
 def test_duplicated_subset(subset, keep):
     df = DataFrame(

--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -238,7 +238,6 @@ def test_duplicated(idx_dup, keep, expected):
     tm.assert_numpy_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("keep", ["first", "last", False])
 def test_duplicated_large(keep):
     # GH 9125
     n, k = 200, 5000


### PR DESCRIPTION
Follow up of #32487 - for [this comment of jreback](https://github.com/pandas-dev/pandas/pull/32487#issuecomment-599153289) in particular

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

