### PR TITLE
FIX: series.fillna doesn't shallow copy if len(series) == 0

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -231,6 +231,7 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 
+- Calling :meth:`fillna` on an empty Series now correctly returns a shallow copied object. The behaviour is now consistent with :class:`Index`, :class:`DataFrame` and a non-empty :class:`Series` (:issue:`32543`).
 
 Categorical
 ^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -231,7 +231,6 @@ Performance improvements
 Bug fixes
 ~~~~~~~~~
 
-- Calling :meth:`fillna` on an empty Series now correctly returns a shallow copied object. The behaviour is now consistent with :class:`Index`, :class:`DataFrame` and a non-empty :class:`Series` (:issue:`32543`).
 
 Categorical
 ^^^^^^^^^^^
@@ -304,8 +303,8 @@ Indexing
 Missing
 ^^^^^^^
 
--
--
+- Calling :meth:`fillna` on an empty Series now correctly returns a shallow copied object. The behaviour is now consistent with :class:`Index`, :class:`DataFrame` and a non-empty :class:`Series` (:issue:`32543`).
+
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6081,9 +6081,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 downcast=downcast,
             )
         else:
-            if len(self._get_axis(axis)) == 0:
-                return self
-
             if self.ndim == 1:
                 if isinstance(value, (dict, ABCSeries)):
                     value = create_series_with_explicit_dtype(

--- a/pandas/tests/base/test_ops.py
+++ b/pandas/tests/base/test_ops.py
@@ -611,9 +611,6 @@ class TestIndexOps(Ops):
             tm.assert_series_equal(obj, result)
 
         # check shallow_copied
-        if isinstance(obj, Series) and len(obj) == 0:
-            # TODO: GH-32543
-            pytest.xfail("Shallow copy for empty Series is bugged")
         assert obj is not result
 
     @pytest.mark.parametrize("null_obj", [np.nan, None])


### PR DESCRIPTION
- [x] closes #32543
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
