### PR TITLE
BUG: read_csv: fix wrong exception on permissions issue 

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -346,7 +346,7 @@ I/O
 - Bug in :meth:`read_excel` where a UTF-8 string with a high surrogate would cause a segmentation violation (:issue:`23809`)
 - Bug in :meth:`read_csv` was causing a file descriptor leak on an empty file (:issue:`31488`)
 - Bug in :meth:`read_csv` was causing a segfault when there were blank lines between the header and data rows (:issue:`28071`)
-- Bug in :meth:`read_csv` was raising a misleading exception on permission issue (:issue:`23784`)
+- Bug in :meth:`read_csv` was raising a misleading exception on a permissions issue (:issue:`23784`)
 
 
 Plotting

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -346,6 +346,7 @@ I/O
 - Bug in :meth:`read_excel` where a UTF-8 string with a high surrogate would cause a segmentation violation (:issue:`23809`)
 - Bug in :meth:`read_csv` was causing a file descriptor leak on an empty file (:issue:`31488`)
 - Bug in :meth:`read_csv` was causing a segfault when there were blank lines between the header and data rows (:issue:`28071`)
+- Bug in :meth:`read_csv` was raising a misleading exception on permission issue (:issue:`23784`)
 
 
 Plotting

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -236,7 +236,7 @@ cdef extern from "parser/tokenizer.h":
 
 
 cdef extern from "parser/io.h":
-    void *new_mmap(char *fname) except NULL
+    void *new_mmap(char *fname)
     int del_mmap(void *src)
     void* buffer_mmap_bytes(void *source, size_t nbytes,
                             size_t *bytes_read, int *status)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -236,14 +236,14 @@ cdef extern from "parser/tokenizer.h":
 
 
 cdef extern from "parser/io.h":
-    void *new_mmap(char *fname)
+    void *new_mmap(char *fname) except NULL
     int del_mmap(void *src)
     void* buffer_mmap_bytes(void *source, size_t nbytes,
                             size_t *bytes_read, int *status)
 
     void *new_file_source(char *fname, size_t buffer_size) except NULL
 
-    void *new_rd_source(object obj)
+    void *new_rd_source(object obj) except NULL
 
     int del_file_source(void *src)
     int del_rd_source(void *src)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -241,7 +241,7 @@ cdef extern from "parser/io.h":
     void* buffer_mmap_bytes(void *source, size_t nbytes,
                             size_t *bytes_read, int *status)
 
-    void *new_file_source(char *fname, size_t buffer_size)
+    void *new_file_source(char *fname, size_t buffer_size) except NULL
 
     void *new_rd_source(object obj)
 
@@ -667,16 +667,6 @@ cdef class TextReader:
                 ptr = new_file_source(source, self.parser.chunksize)
                 self.parser.cb_io = &buffer_file_bytes
                 self.parser.cb_cleanup = &del_file_source
-
-            if ptr == NULL:
-                if not os.path.exists(source):
-
-                    raise FileNotFoundError(
-                        ENOENT,
-                        f'File {usource} does not exist',
-                        usource)
-                raise IOError('Initializing from file failed')
-
             self.parser.source = ptr
 
         elif hasattr(source, 'read'):

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -673,10 +673,6 @@ cdef class TextReader:
             # e.g., StringIO
 
             ptr = new_rd_source(source)
-            if ptr == NULL:
-                raise IOError('Initializing parser from file-like '
-                              'object failed')
-
             self.parser.source = ptr
             self.parser.cb_io = &buffer_rd_bytes
             self.parser.cb_cleanup = &del_rd_source

--- a/pandas/_libs/src/parser/io.c
+++ b/pandas/_libs/src/parser/io.c
@@ -42,7 +42,7 @@ void *new_file_source(char *fname, size_t buffer_size) {
         int required = MultiByteToWideChar(CP_UTF8, 0, fname, -1, NULL, 0);
         if (required == 0) {
             free(fs);
-            PyErr_SetFromWindowsErr(GetLastError());
+            PyErr_SetFromWindowsErr(0);
             return NULL;
         }
         wname = (wchar_t*)malloc(required * sizeof(wchar_t));
@@ -55,7 +55,7 @@ void *new_file_source(char *fname, size_t buffer_size) {
                                                                 required) {
             free(wname);
             free(fs);
-            PyErr_SetFromWindowsErr(GetLastError());
+            PyErr_SetFromWindowsErr(0);
             return NULL;
         }
         fs->fd = _wopen(wname, O_RDONLY | O_BINARY);

--- a/pandas/_libs/src/parser/io.c
+++ b/pandas/_libs/src/parser/io.c
@@ -28,6 +28,7 @@ The full license is in the LICENSE file, distributed with this software.
 void *new_file_source(char *fname, size_t buffer_size) {
     file_source *fs = (file_source *)malloc(sizeof(file_source));
     if (fs == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
 
@@ -41,17 +42,20 @@ void *new_file_source(char *fname, size_t buffer_size) {
         int required = MultiByteToWideChar(CP_UTF8, 0, fname, -1, NULL, 0);
         if (required == 0) {
             free(fs);
+            PyErr_SetFromWindowsErr(GetLastError())
             return NULL;
         }
         wname = (wchar_t*)malloc(required * sizeof(wchar_t));
         if (wname == NULL) {
             free(fs);
+            PyErr_NoMemory();
             return NULL;
         }
         if (MultiByteToWideChar(CP_UTF8, 0, fname, -1, wname, required) <
                                                                 required) {
             free(wname);
             free(fs);
+            PyErr_SetFromWindowsErr(GetLastError())
             return NULL;
         }
         fs->fd = _wopen(wname, O_RDONLY | O_BINARY);
@@ -62,6 +66,11 @@ void *new_file_source(char *fname, size_t buffer_size) {
 #endif
     if (fs->fd == -1) {
         free(fs);
+#ifdef USE_WIN_UTF16
+        PyErr_SetFromWindowsErr(GetLastError())
+#else
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
+#endif
         return NULL;
     }
 
@@ -71,6 +80,7 @@ void *new_file_source(char *fname, size_t buffer_size) {
     if (fs->buffer == NULL) {
         close(fs->fd);
         free(fs);
+        PyErr_NoMemory();
         return NULL;
     }
 
@@ -83,6 +93,10 @@ void *new_file_source(char *fname, size_t buffer_size) {
 void *new_rd_source(PyObject *obj) {
     rd_source *rds = (rd_source *)malloc(sizeof(rd_source));
 
+    if (rds == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
     /* hold on to this object */
     Py_INCREF(obj);
     rds->obj = obj;
@@ -220,20 +234,18 @@ void *new_mmap(char *fname) {
 
     mm = (memory_map *)malloc(sizeof(memory_map));
     if (mm == NULL) {
-        fprintf(stderr, "new_file_buffer: malloc() failed.\n");
-        return (NULL);
+        PyErr_NoMemory();
+        return NULL;
     }
     mm->fd = open(fname, O_RDONLY | O_BINARY);
     if (mm->fd == -1) {
-        fprintf(stderr, "new_file_buffer: open(%s) failed. errno =%d\n",
-          fname, errno);
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
         free(mm);
         return NULL;
     }
 
     if (fstat(mm->fd, &stat) == -1) {
-        fprintf(stderr, "new_file_buffer: fstat() failed. errno =%d\n",
-          errno);
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
         close(mm->fd);
         free(mm);
         return NULL;
@@ -242,8 +254,7 @@ void *new_mmap(char *fname) {
 
     mm->memmap = mmap(NULL, filesize, PROT_READ, MAP_SHARED, mm->fd, 0);
     if (mm->memmap == MAP_FAILED) {
-        /* XXX Eventually remove this print statement. */
-        fprintf(stderr, "new_file_buffer: mmap() failed.\n");
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
         close(mm->fd);
         free(mm);
         return NULL;

--- a/pandas/_libs/src/parser/io.c
+++ b/pandas/_libs/src/parser/io.c
@@ -66,11 +66,7 @@ void *new_file_source(char *fname, size_t buffer_size) {
 #endif
     if (fs->fd == -1) {
         free(fs);
-#ifdef USE_WIN_UTF16
-        PyErr_SetFromWindowsErr(GetLastError());
-#else
         PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
-#endif
         return NULL;
     }
 

--- a/pandas/_libs/src/parser/io.c
+++ b/pandas/_libs/src/parser/io.c
@@ -230,18 +230,15 @@ void *new_mmap(char *fname) {
 
     mm = (memory_map *)malloc(sizeof(memory_map));
     if (mm == NULL) {
-        PyErr_NoMemory();
         return NULL;
     }
     mm->fd = open(fname, O_RDONLY | O_BINARY);
     if (mm->fd == -1) {
-        PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
         free(mm);
         return NULL;
     }
 
     if (fstat(mm->fd, &stat) == -1) {
-        PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
         close(mm->fd);
         free(mm);
         return NULL;
@@ -250,7 +247,6 @@ void *new_mmap(char *fname) {
 
     mm->memmap = mmap(NULL, filesize, PROT_READ, MAP_SHARED, mm->fd, 0);
     if (mm->memmap == MAP_FAILED) {
-        PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
         close(mm->fd);
         free(mm);
         return NULL;

--- a/pandas/_libs/src/parser/io.c
+++ b/pandas/_libs/src/parser/io.c
@@ -42,7 +42,7 @@ void *new_file_source(char *fname, size_t buffer_size) {
         int required = MultiByteToWideChar(CP_UTF8, 0, fname, -1, NULL, 0);
         if (required == 0) {
             free(fs);
-            PyErr_SetFromWindowsErr(GetLastError())
+            PyErr_SetFromWindowsErr(GetLastError());
             return NULL;
         }
         wname = (wchar_t*)malloc(required * sizeof(wchar_t));
@@ -55,7 +55,7 @@ void *new_file_source(char *fname, size_t buffer_size) {
                                                                 required) {
             free(wname);
             free(fs);
-            PyErr_SetFromWindowsErr(GetLastError())
+            PyErr_SetFromWindowsErr(GetLastError());
             return NULL;
         }
         fs->fd = _wopen(wname, O_RDONLY | O_BINARY);
@@ -67,7 +67,7 @@ void *new_file_source(char *fname, size_t buffer_size) {
     if (fs->fd == -1) {
         free(fs);
 #ifdef USE_WIN_UTF16
-        PyErr_SetFromWindowsErr(GetLastError())
+        PyErr_SetFromWindowsErr(GetLastError());
 #else
         PyErr_SetFromErrnoWithFilename(PyExc_OSError, fname);
 #endif

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -960,7 +960,7 @@ def test_nonexistent_path(all_parsers):
     parser = all_parsers
     path = f"{tm.rands(10)}.csv"
 
-    msg = f"File {path} does not exist" if parser.engine == "c" else r"\[Errno 2\]"
+    msg = r"\[Errno 2\]"
     with pytest.raises(FileNotFoundError, match=msg) as e:
         parser.read_csv(path)
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -975,7 +975,7 @@ def test_no_permission(all_parsers):
 
     msg = r"\[Errno 13\]"
     with tm.ensure_clean() as path:
-        os.chmod(path, 0)       # make file unreadable
+        os.chmod(path, 0)  # make file unreadable
         with pytest.raises(PermissionError, match=msg) as e:
             parser.read_csv(path)
             assert path == e.value.filename

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -963,10 +963,7 @@ def test_nonexistent_path(all_parsers):
     msg = r"\[Errno 2\]"
     with pytest.raises(FileNotFoundError, match=msg) as e:
         parser.read_csv(path)
-
-        filename = e.value.filename
-
-        assert path == filename
+    assert path == e.value.filename
 
 
 def test_no_permission(all_parsers):
@@ -978,7 +975,7 @@ def test_no_permission(all_parsers):
         os.chmod(path, 0)  # make file unreadable
         with pytest.raises(PermissionError, match=msg) as e:
             parser.read_csv(path)
-            assert path == e.value.filename
+        assert path == e.value.filename
 
 
 def test_missing_trailing_delimiters(all_parsers):

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -969,6 +969,18 @@ def test_nonexistent_path(all_parsers):
         assert path == filename
 
 
+def test_no_permission(all_parsers):
+    # GH 23784
+    parser = all_parsers
+
+    msg = r"\[Errno 13\]"
+    with tm.ensure_clean() as path:
+        os.chmod(path, 0)       # make file unreadable
+        with pytest.raises(PermissionError, match=msg) as e:
+            parser.read_csv(path)
+            assert path == e.value.filename
+
+
 def test_missing_trailing_delimiters(all_parsers):
     parser = all_parsers
     data = """A,B,C,D

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -966,7 +966,7 @@ def test_nonexistent_path(all_parsers):
     assert path == e.value.filename
 
 
-@td.skip_if_windows             # os.chmod does not work in windows
+@td.skip_if_windows  # os.chmod does not work in windows
 def test_no_permission(all_parsers):
     # GH 23784
     parser = all_parsers

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -966,6 +966,7 @@ def test_nonexistent_path(all_parsers):
     assert path == e.value.filename
 
 
+@td.skip_if_windows             # os.chmod does not work in windows
 def test_no_permission(all_parsers):
     # GH 23784
     parser = all_parsers


### PR DESCRIPTION
Get rid of all error printf's and produce proper Python exceptions

- [x] closes #23784
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
