### PR TITLE
BUG: Fix join on MultiIndex for mixed Datetimelike and string levels

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -324,7 +324,7 @@ MultiIndex
         # Common elements are now guaranteed to be ordered by the left side
         left.intersection(right, sort=False)
 
--
+- Bug in :meth:`Index.join` for MultiIndex when joining level between datetimelike and string(:issue:`26558`)
 
 I/O
 ^^^

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -28,6 +28,9 @@ ABCDatetimeIndex = create_pandas_abc_type(
 ABCTimedeltaIndex = create_pandas_abc_type(
     "ABCTimedeltaIndex", "_typ", ("timedeltaindex",)
 )
+ABCDatetimeTimedeltaMixin = create_pandas_abc_type(
+    "ABCDatetimeTimedeltaMixin", "_typ", ("datetimeindex", "timedeltaindex",)
+)
 ABCPeriodIndex = create_pandas_abc_type("ABCPeriodIndex", "_typ", ("periodindex",))
 ABCCategoricalIndex = create_pandas_abc_type(
     "ABCCategoricalIndex", "_typ", ("categoricalindex",)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -830,13 +830,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
         """
         See Index.join
         """
-        if self._is_convertible_to_index_for_join(other):
-            try:
-                other = type(self)(other)
-            except (TypeError, ValueError):
-                pass
-
-        this, other = self._maybe_utc_convert(other)
+        this, other = self._prepare_for_join(other)
         return Index.join(
             this,
             other,
@@ -845,6 +839,16 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
             return_indexers=return_indexers,
             sort=sort,
         )
+
+    def _prepare_for_join(self, other):
+        if self._is_convertible_to_index_for_join(other):
+            try:
+                other = type(self)(other)
+            except (TypeError, ValueError):
+                pass
+
+        this, other = self._maybe_utc_convert(other)
+        return this, other
 
     def _maybe_utc_convert(self, other):
         this = self

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -103,3 +103,21 @@ def test_join_multi_wrong_order():
     tm.assert_index_equal(midx1, join_idx)
     assert lidx is None
     tm.assert_numpy_array_equal(ridx, exp_ridx)
+
+
+@pytest.mark.parametrize(
+    ("data", "func"), [("2020-03-15", pd.to_datetime), ("1d", pd.to_timedelta)]
+)
+def test_join_mixed_index_datetime_string(data, func, join_type):
+    # GH 26558
+    # Joining multiindex with mixed datetime and string level
+    mi1 = pd.MultiIndex.from_tuples([(data,)])
+    mi2 = pd.MultiIndex.from_tuples([(func(data),)])
+
+    _, indexer_left, indexer_right = mi1.join(mi2, how=join_type, return_indexers=True)
+    assert indexer_left is None
+    assert indexer_right is None
+
+    _, indexer_left, indexer_right = mi2.join(mi1, how=join_type, return_indexers=True)
+    assert indexer_left is None
+    assert indexer_right is None


### PR DESCRIPTION
# Problem
From #26558, a minimal example is:
```python
import pandas as pd
import datetime

i1 = pd.Index(['2019-05-31'])
i2 = pd.Index([datetime.datetime(2019, 5, 31)])

mi1 = pd.MultiIndex.from_tuples([('2019-05-31',)])
mi2 = pd.MultiIndex.from_tuples([(datetime.datetime(2019, 5, 31),)])

print(i1.join(i2, return_indexers=True))
print(mi1.join(mi2, return_indexers=True))
   
# (DatetimeIndex(['2019-05-31'], dtype='datetime64[ns]', freq=None), None, None)
# (MultiIndex([('2019-05-31',)], ), None, array([-1]))
```
Here we can see that one of the indexers for multiindex is wrong.
 
# Proposed fix 🩹
The difference of handling for single index is explain by the join method for DatetimeTimedeltaMixin.
I did some refactoring in pandas/core/indexes/datetimelike.py to be able to reuse the same datetime handling method.
Then in the Index.join method, where MultiIndex are handled, I apply this method to each level of the MultiIndex that is a DatetimeTimedeltaMixin.

# PR checkboxes :ballot_box_with_check:  

- [x] closes #26558
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
