### PR TITLE
copy license text from: tidyverse/haven

### DIFF
--- a/LICENSES/HAVEN_LICENSE
+++ b/LICENSES/HAVEN_LICENSE
@@ -1,2 +1,21 @@
-YEAR: 2013-2016
-COPYRIGHT HOLDER: Hadley Wickham; RStudio; and Evan Miller
+# MIT License
+
+Copyright (c) 2019 Hadley Wickham; RStudio; and Evan Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The existing HAVEN_LICENSE file was lacking any form of actual license.
After checking the pandas source, it appears that the reference to HAVEN
is in relation to tidyverse/haven, copying the license from
tidyverse/haven for clarity.

Signed-off-by: Jamin Collins <jamin@amazon.com>
