### PR TITLE
replaced one occurrence of `Appender` by `doc` decorator

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1933,112 +1933,112 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         freeze_panes=None,
     ) -> None:
         """
-            Write {klass} to an Excel sheet.
+        Write {klass} to an Excel sheet.
 
-            To write a single {klass} to an Excel .xlsx file it is only necessary to
-            specify a target file name. To write to multiple sheets it is necessary to
-            create an `ExcelWriter` object with a target file name, and specify a sheet
-            in the file to write to.
+        To write a single {klass} to an Excel .xlsx file it is only necessary to
+        specify a target file name. To write to multiple sheets it is necessary to
+        create an `ExcelWriter` object with a target file name, and specify a sheet
+        in the file to write to.
 
-            Multiple sheets may be written to by specifying unique `sheet_name`.
-            With all data written to the file it is necessary to save the changes.
-            Note that creating an `ExcelWriter` object with a file name that already
-            exists will result in the contents of the existing file being erased.
+        Multiple sheets may be written to by specifying unique `sheet_name`.
+        With all data written to the file it is necessary to save the changes.
+        Note that creating an `ExcelWriter` object with a file name that already
+        exists will result in the contents of the existing file being erased.
 
-            Parameters
-            ----------
-            excel_writer : str or ExcelWriter object
-                File path or existing ExcelWriter.
-            sheet_name : str, default 'Sheet1'
-                Name of sheet which will contain DataFrame.
-            na_rep : str, default ''
-                Missing data representation.
-            float_format : str, optional
-                Format string for floating point numbers. For example
-                ``float_format="%.2f"`` will format 0.1234 to 0.12.
-            columns : sequence or list of str, optional
-                Columns to write.
-            header : bool or list of str, default True
-                Write out the column names. If a list of string is given it is
-                assumed to be aliases for the column names.
-            index : bool, default True
-                Write row names (index).
-            index_label : str or sequence, optional
-                Column label for index column(s) if desired. If not specified, and
-                `header` and `index` are True, then the index names are used. A
-                sequence should be given if the DataFrame uses MultiIndex.
-            startrow : int, default 0
-                Upper left cell row to dump data frame.
-            startcol : int, default 0
-                Upper left cell column to dump data frame.
-            engine : str, optional
-                Write engine to use, 'openpyxl' or 'xlsxwriter'. You can also set this
-                via the options ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
-                ``io.excel.xlsm.writer``.
-            merge_cells : bool, default True
-                Write MultiIndex and Hierarchical Rows as merged cells.
-            encoding : str, optional
-                Encoding of the resulting excel file. Only necessary for xlwt,
-                other writers support unicode natively.
-            inf_rep : str, default 'inf'
-                Representation for infinity (there is no native representation for
-                infinity in Excel).
-            verbose : bool, default True
-                Display more information in the error logs.
-            freeze_panes : tuple of int (length 2), optional
-                Specifies the one-based bottommost row and rightmost column that
-                is to be frozen.
+        Parameters
+        ----------
+        excel_writer : str or ExcelWriter object
+            File path or existing ExcelWriter.
+        sheet_name : str, default 'Sheet1'
+            Name of sheet which will contain DataFrame.
+        na_rep : str, default ''
+            Missing data representation.
+        float_format : str, optional
+            Format string for floating point numbers. For example
+            ``float_format="%.2f"`` will format 0.1234 to 0.12.
+        columns : sequence or list of str, optional
+            Columns to write.
+        header : bool or list of str, default True
+            Write out the column names. If a list of string is given it is
+            assumed to be aliases for the column names.
+        index : bool, default True
+            Write row names (index).
+        index_label : str or sequence, optional
+            Column label for index column(s) if desired. If not specified, and
+            `header` and `index` are True, then the index names are used. A
+            sequence should be given if the DataFrame uses MultiIndex.
+        startrow : int, default 0
+            Upper left cell row to dump data frame.
+        startcol : int, default 0
+            Upper left cell column to dump data frame.
+        engine : str, optional
+            Write engine to use, 'openpyxl' or 'xlsxwriter'. You can also set this
+            via the options ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
+            ``io.excel.xlsm.writer``.
+        merge_cells : bool, default True
+            Write MultiIndex and Hierarchical Rows as merged cells.
+        encoding : str, optional
+            Encoding of the resulting excel file. Only necessary for xlwt,
+            other writers support unicode natively.
+        inf_rep : str, default 'inf'
+            Representation for infinity (there is no native representation for
+            infinity in Excel).
+        verbose : bool, default True
+            Display more information in the error logs.
+        freeze_panes : tuple of int (length 2), optional
+            Specifies the one-based bottommost row and rightmost column that
+            is to be frozen.
 
-            See Also
-            --------
-            to_csv : Write DataFrame to a comma-separated values (csv) file.
-            ExcelWriter : Class for writing DataFrame objects into excel sheets.
-            read_excel : Read an Excel file into a pandas DataFrame.
-            read_csv : Read a comma-separated values (csv) file into DataFrame.
+        See Also
+        --------
+        to_csv : Write DataFrame to a comma-separated values (csv) file.
+        ExcelWriter : Class for writing DataFrame objects into excel sheets.
+        read_excel : Read an Excel file into a pandas DataFrame.
+        read_csv : Read a comma-separated values (csv) file into DataFrame.
 
-            Notes
-            -----
-            For compatibility with :meth:`~DataFrame.to_csv`,
-            to_excel serializes lists and dicts to strings before writing.
+        Notes
+        -----
+        For compatibility with :meth:`~DataFrame.to_csv`,
+        to_excel serializes lists and dicts to strings before writing.
 
-            Once a workbook has been saved it is not possible write further data
-            without rewriting the whole workbook.
+        Once a workbook has been saved it is not possible write further data
+        without rewriting the whole workbook.
 
-            Examples
-            --------
+        Examples
+        --------
 
-            Create, write to and save a workbook:
+        Create, write to and save a workbook:
 
-            >>> df1 = pd.DataFrame([['a', 'b'], ['c', 'd']],
-            ...                    index=['row 1', 'row 2'],
-            ...                    columns=['col 1', 'col 2'])
-            >>> df1.to_excel("output.xlsx")  # doctest: +SKIP
+        >>> df1 = pd.DataFrame([['a', 'b'], ['c', 'd']],
+        ...                    index=['row 1', 'row 2'],
+        ...                    columns=['col 1', 'col 2'])
+        >>> df1.to_excel("output.xlsx")  # doctest: +SKIP
 
-            To specify the sheet name:
+        To specify the sheet name:
 
-            >>> df1.to_excel("output.xlsx",
-            ...              sheet_name='Sheet_name_1')  # doctest: +SKIP
+        >>> df1.to_excel("output.xlsx",
+        ...              sheet_name='Sheet_name_1')  # doctest: +SKIP
 
-            If you wish to write to more than one sheet in the workbook, it is
-            necessary to specify an ExcelWriter object:
+        If you wish to write to more than one sheet in the workbook, it is
+        necessary to specify an ExcelWriter object:
 
-            >>> df2 = df1.copy()
-            >>> with pd.ExcelWriter('output.xlsx') as writer:  # doctest: +SKIP
-            ...     df1.to_excel(writer, sheet_name='Sheet_name_1')
-            ...     df2.to_excel(writer, sheet_name='Sheet_name_2')
+        >>> df2 = df1.copy()
+        >>> with pd.ExcelWriter('output.xlsx') as writer:  # doctest: +SKIP
+        ...     df1.to_excel(writer, sheet_name='Sheet_name_1')
+        ...     df2.to_excel(writer, sheet_name='Sheet_name_2')
 
-            ExcelWriter can also be used to append to an existing Excel file:
+        ExcelWriter can also be used to append to an existing Excel file:
 
-            >>> with pd.ExcelWriter('output.xlsx',
-            ...                     mode='a') as writer:  # doctest: +SKIP
-            ...     df.to_excel(writer, sheet_name='Sheet_name_3')
+        >>> with pd.ExcelWriter('output.xlsx',
+        ...                     mode='a') as writer:  # doctest: +SKIP
+        ...     df.to_excel(writer, sheet_name='Sheet_name_3')
 
-            To set the library that is used to write the Excel file,
-            you can pass the `engine` keyword (the default engine is
-            automatically chosen depending on the file extension):
+        To set the library that is used to write the Excel file,
+        you can pass the `engine` keyword (the default engine is
+        automatically chosen depending on the file extension):
 
-            >>> df1.to_excel('output1.xlsx', engine='xlsxwriter')  # doctest: +SKIP
-            """
+        >>> df1.to_excel('output1.xlsx', engine='xlsxwriter')  # doctest: +SKIP
+        """
 
         df = self if isinstance(self, ABCDataFrame) else self.to_frame()
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1912,117 +1912,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         %(klass)s in Markdown-friendly format.
     """
 
-    _shared_docs[
-        "to_excel"
-    ] = """
-    Write {klass} to an Excel sheet.
-
-    To write a single {klass} to an Excel .xlsx file it is only necessary to
-    specify a target file name. To write to multiple sheets it is necessary to
-    create an `ExcelWriter` object with a target file name, and specify a sheet
-    in the file to write to.
-
-    Multiple sheets may be written to by specifying unique `sheet_name`.
-    With all data written to the file it is necessary to save the changes.
-    Note that creating an `ExcelWriter` object with a file name that already
-    exists will result in the contents of the existing file being erased.
-
-    Parameters
-    ----------
-    excel_writer : str or ExcelWriter object
-        File path or existing ExcelWriter.
-    sheet_name : str, default 'Sheet1'
-        Name of sheet which will contain DataFrame.
-    na_rep : str, default ''
-        Missing data representation.
-    float_format : str, optional
-        Format string for floating point numbers. For example
-        ``float_format="%.2f"`` will format 0.1234 to 0.12.
-    columns : sequence or list of str, optional
-        Columns to write.
-    header : bool or list of str, default True
-        Write out the column names. If a list of string is given it is
-        assumed to be aliases for the column names.
-    index : bool, default True
-        Write row names (index).
-    index_label : str or sequence, optional
-        Column label for index column(s) if desired. If not specified, and
-        `header` and `index` are True, then the index names are used. A
-        sequence should be given if the DataFrame uses MultiIndex.
-    startrow : int, default 0
-        Upper left cell row to dump data frame.
-    startcol : int, default 0
-        Upper left cell column to dump data frame.
-    engine : str, optional
-        Write engine to use, 'openpyxl' or 'xlsxwriter'. You can also set this
-        via the options ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
-        ``io.excel.xlsm.writer``.
-    merge_cells : bool, default True
-        Write MultiIndex and Hierarchical Rows as merged cells.
-    encoding : str, optional
-        Encoding of the resulting excel file. Only necessary for xlwt,
-        other writers support unicode natively.
-    inf_rep : str, default 'inf'
-        Representation for infinity (there is no native representation for
-        infinity in Excel).
-    verbose : bool, default True
-        Display more information in the error logs.
-    freeze_panes : tuple of int (length 2), optional
-        Specifies the one-based bottommost row and rightmost column that
-        is to be frozen.
-
-    See Also
-    --------
-    to_csv : Write DataFrame to a comma-separated values (csv) file.
-    ExcelWriter : Class for writing DataFrame objects into excel sheets.
-    read_excel : Read an Excel file into a pandas DataFrame.
-    read_csv : Read a comma-separated values (csv) file into DataFrame.
-
-    Notes
-    -----
-    For compatibility with :meth:`~DataFrame.to_csv`,
-    to_excel serializes lists and dicts to strings before writing.
-
-    Once a workbook has been saved it is not possible write further data
-    without rewriting the whole workbook.
-
-    Examples
-    --------
-
-    Create, write to and save a workbook:
-
-    >>> df1 = pd.DataFrame([['a', 'b'], ['c', 'd']],
-    ...                    index=['row 1', 'row 2'],
-    ...                    columns=['col 1', 'col 2'])
-    >>> df1.to_excel("output.xlsx")  # doctest: +SKIP
-
-    To specify the sheet name:
-
-    >>> df1.to_excel("output.xlsx",
-    ...              sheet_name='Sheet_name_1')  # doctest: +SKIP
-
-    If you wish to write to more than one sheet in the workbook, it is
-    necessary to specify an ExcelWriter object:
-
-    >>> df2 = df1.copy()
-    >>> with pd.ExcelWriter('output.xlsx') as writer:  # doctest: +SKIP
-    ...     df1.to_excel(writer, sheet_name='Sheet_name_1')
-    ...     df2.to_excel(writer, sheet_name='Sheet_name_2')
-
-    ExcelWriter can also be used to append to an existing Excel file:
-
-    >>> with pd.ExcelWriter('output.xlsx',
-    ...                     mode='a') as writer:  # doctest: +SKIP
-    ...     df.to_excel(writer, sheet_name='Sheet_name_3')
-
-    To set the library that is used to write the Excel file,
-    you can pass the `engine` keyword (the default engine is
-    automatically chosen depending on the file extension):
-
-    >>> df1.to_excel('output1.xlsx', engine='xlsxwriter')  # doctest: +SKIP
-    """
-
-    @doc(_shared_docs["to_excel"], klass="object")
+    @doc(klass="object")
     def to_excel(
         self,
         excel_writer,
@@ -2042,6 +1932,114 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         verbose=True,
         freeze_panes=None,
     ) -> None:
+        """
+            Write {klass} to an Excel sheet.
+
+            To write a single {klass} to an Excel .xlsx file it is only necessary to
+            specify a target file name. To write to multiple sheets it is necessary to
+            create an `ExcelWriter` object with a target file name, and specify a sheet
+            in the file to write to.
+
+            Multiple sheets may be written to by specifying unique `sheet_name`.
+            With all data written to the file it is necessary to save the changes.
+            Note that creating an `ExcelWriter` object with a file name that already
+            exists will result in the contents of the existing file being erased.
+
+            Parameters
+            ----------
+            excel_writer : str or ExcelWriter object
+                File path or existing ExcelWriter.
+            sheet_name : str, default 'Sheet1'
+                Name of sheet which will contain DataFrame.
+            na_rep : str, default ''
+                Missing data representation.
+            float_format : str, optional
+                Format string for floating point numbers. For example
+                ``float_format="%.2f"`` will format 0.1234 to 0.12.
+            columns : sequence or list of str, optional
+                Columns to write.
+            header : bool or list of str, default True
+                Write out the column names. If a list of string is given it is
+                assumed to be aliases for the column names.
+            index : bool, default True
+                Write row names (index).
+            index_label : str or sequence, optional
+                Column label for index column(s) if desired. If not specified, and
+                `header` and `index` are True, then the index names are used. A
+                sequence should be given if the DataFrame uses MultiIndex.
+            startrow : int, default 0
+                Upper left cell row to dump data frame.
+            startcol : int, default 0
+                Upper left cell column to dump data frame.
+            engine : str, optional
+                Write engine to use, 'openpyxl' or 'xlsxwriter'. You can also set this
+                via the options ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
+                ``io.excel.xlsm.writer``.
+            merge_cells : bool, default True
+                Write MultiIndex and Hierarchical Rows as merged cells.
+            encoding : str, optional
+                Encoding of the resulting excel file. Only necessary for xlwt,
+                other writers support unicode natively.
+            inf_rep : str, default 'inf'
+                Representation for infinity (there is no native representation for
+                infinity in Excel).
+            verbose : bool, default True
+                Display more information in the error logs.
+            freeze_panes : tuple of int (length 2), optional
+                Specifies the one-based bottommost row and rightmost column that
+                is to be frozen.
+
+            See Also
+            --------
+            to_csv : Write DataFrame to a comma-separated values (csv) file.
+            ExcelWriter : Class for writing DataFrame objects into excel sheets.
+            read_excel : Read an Excel file into a pandas DataFrame.
+            read_csv : Read a comma-separated values (csv) file into DataFrame.
+
+            Notes
+            -----
+            For compatibility with :meth:`~DataFrame.to_csv`,
+            to_excel serializes lists and dicts to strings before writing.
+
+            Once a workbook has been saved it is not possible write further data
+            without rewriting the whole workbook.
+
+            Examples
+            --------
+
+            Create, write to and save a workbook:
+
+            >>> df1 = pd.DataFrame([['a', 'b'], ['c', 'd']],
+            ...                    index=['row 1', 'row 2'],
+            ...                    columns=['col 1', 'col 2'])
+            >>> df1.to_excel("output.xlsx")  # doctest: +SKIP
+
+            To specify the sheet name:
+
+            >>> df1.to_excel("output.xlsx",
+            ...              sheet_name='Sheet_name_1')  # doctest: +SKIP
+
+            If you wish to write to more than one sheet in the workbook, it is
+            necessary to specify an ExcelWriter object:
+
+            >>> df2 = df1.copy()
+            >>> with pd.ExcelWriter('output.xlsx') as writer:  # doctest: +SKIP
+            ...     df1.to_excel(writer, sheet_name='Sheet_name_1')
+            ...     df2.to_excel(writer, sheet_name='Sheet_name_2')
+
+            ExcelWriter can also be used to append to an existing Excel file:
+
+            >>> with pd.ExcelWriter('output.xlsx',
+            ...                     mode='a') as writer:  # doctest: +SKIP
+            ...     df.to_excel(writer, sheet_name='Sheet_name_3')
+
+            To set the library that is used to write the Excel file,
+            you can pass the `engine` keyword (the default engine is
+            automatically chosen depending on the file extension):
+
+            >>> df1.to_excel('output1.xlsx', engine='xlsxwriter')  # doctest: +SKIP
+            """
+
         df = self if isinstance(self, ABCDataFrame) else self.to_frame()
 
         from pandas.io.formats.excel import ExcelFormatter

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1915,9 +1915,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     _shared_docs[
         "to_excel"
     ] = """
-    Write %(klass)s to an Excel sheet.
+    Write {klass} to an Excel sheet.
 
-    To write a single %(klass)s to an Excel .xlsx file it is only necessary to
+    To write a single {klass} to an Excel .xlsx file it is only necessary to
     specify a target file name. To write to multiple sheets it is necessary to
     create an `ExcelWriter` object with a target file name, and specify a sheet
     in the file to write to.
@@ -1937,7 +1937,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Missing data representation.
     float_format : str, optional
         Format string for floating point numbers. For example
-        ``float_format="%%.2f"`` will format 0.1234 to 0.12.
+        ``float_format="%.2f"`` will format 0.1234 to 0.12.
     columns : sequence or list of str, optional
         Columns to write.
     header : bool or list of str, default True
@@ -2022,7 +2022,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     >>> df1.to_excel('output1.xlsx', engine='xlsxwriter')  # doctest: +SKIP
     """
 
-    @Appender(_shared_docs["to_excel"] % dict(klass="object"))
+    @doc(_shared_docs["to_excel"], klass="object")
     def to_excel(
         self,
         excel_writer,

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -35,7 +35,7 @@ import pandas as pd
 from pandas.api.types import is_dict_like, is_list_like
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
-from pandas.core.generic import _shared_docs
+from pandas.core.generic import NDFrame
 from pandas.core.indexing import _maybe_numeric_slice, _non_reducing_slice
 
 jinja2 = import_optional_dependency("jinja2", extra="DataFrame.style requires jinja2.")
@@ -192,16 +192,7 @@ class Styler:
         """
         return self.render()
 
-    @doc(
-        _shared_docs["to_excel"],
-        axes="index, columns",
-        klass="Styler",
-        axes_single_arg="{0 or 'index', 1 or 'columns'}",
-        optional_by="""
-            by : str or list of str
-                Name or list of names which refer to the axis items.""",
-        versionadded_to_excel="\n    .. versionadded:: 0.20",
-    )
+    @doc(NDFrame.to_excel, klass="Styler")
     def to_excel(
         self,
         excel_writer,

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -27,7 +27,7 @@ from pandas._config import get_option
 from pandas._libs import lib
 from pandas._typing import Axis, FrameOrSeries, FrameOrSeriesUnion, Label
 from pandas.compat._optional import import_optional_dependency
-from pandas.util._decorators import Appender, doc
+from pandas.util._decorators import doc
 
 from pandas.core.dtypes.common import is_float
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -27,7 +27,7 @@ from pandas._config import get_option
 from pandas._libs import lib
 from pandas._typing import Axis, FrameOrSeries, FrameOrSeriesUnion, Label
 from pandas.compat._optional import import_optional_dependency
-from pandas.util._decorators import Appender
+from pandas.util._decorators import Appender, doc
 
 from pandas.core.dtypes.common import is_float
 
@@ -192,17 +192,15 @@ class Styler:
         """
         return self.render()
 
-    @Appender(
-        _shared_docs["to_excel"]
-        % dict(
-            axes="index, columns",
-            klass="Styler",
-            axes_single_arg="{0 or 'index', 1 or 'columns'}",
-            optional_by="""
+    @doc(
+        _shared_docs["to_excel"],
+        axes="index, columns",
+        klass="Styler",
+        axes_single_arg="{0 or 'index', 1 or 'columns'}",
+        optional_by="""
             by : str or list of str
                 Name or list of names which refer to the axis items.""",
-            versionadded_to_excel="\n    .. versionadded:: 0.20",
-        )
+        versionadded_to_excel="\n    .. versionadded:: 0.20",
     )
     def to_excel(
         self,


### PR DESCRIPTION
- [X] xref #31942
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] replaces one use of `Appender` in pandas/core/generic.py with `doc`
