### PR TITLE
BLD: Suppressing errors while compling pandas/_libs/groupby

### DIFF
--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -869,6 +869,8 @@ def group_last(rank_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
+    # TODO(cython 3.0):
+    # Instead of `labels.shape[0]` use `len(labels)`
     if not len(values) == labels.shape[0]:
         raise AssertionError("len(index) != len(labels)")
 
@@ -960,6 +962,8 @@ def group_nth(rank_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
+    # TODO(cython 3.0):
+    # Instead of `labels.shape[0]` use `len(labels)`
     if not len(values) == labels.shape[0]:
         raise AssertionError("len(index) != len(labels)")
 
@@ -1254,6 +1258,8 @@ def group_max(groupby_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
+    # TODO(cython 3.0):
+    # Instead of `labels.shape[0]` use `len(labels)`
     if not len(values) == labels.shape[0]:
         raise AssertionError("len(index) != len(labels)")
 
@@ -1327,6 +1333,8 @@ def group_min(groupby_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
+    # TODO(cython 3.0):
+    # Instead of `labels.shape[0]` use `len(labels)`
     if not len(values) == labels.shape[0]:
         raise AssertionError("len(index) != len(labels)")
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -869,9 +869,7 @@ def group_last(rank_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
-    # NOTE:
-    # Casting to avoid build warnings
-    if not len(values) == <Py_ssize_t>len(labels):
+    if not len(values) == labels.shape[0]:
         raise AssertionError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
@@ -962,9 +960,7 @@ def group_nth(rank_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
-    # NOTE:
-    # Casting to avoid build warnings
-    if not len(values) == <Py_ssize_t>len(labels):
+    if not len(values) == labels.shape[0]:
         raise AssertionError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
@@ -1258,9 +1254,7 @@ def group_max(groupby_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
-    # NOTE:
-    # Casting to avoid build warnings
-    if not len(values) == <Py_ssize_t>len(labels):
+    if not len(values) == labels.shape[0]:
         raise AssertionError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
@@ -1333,9 +1327,7 @@ def group_min(groupby_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
-    # NOTE:
-    # Casting to avoid build warnings
-    if not len(values) == <Py_ssize_t>len(labels):
+    if not len(values) == labels.shape[0]:
         raise AssertionError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -869,7 +869,9 @@ def group_last(rank_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
-    if not len(values) == len(labels):
+    # NOTE:
+    # Casting to avoid build warnings
+    if not len(values) == <Py_ssize_t>len(labels):
         raise AssertionError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
@@ -960,7 +962,9 @@ def group_nth(rank_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
-    if not len(values) == len(labels):
+    # NOTE:
+    # Casting to avoid build warnings
+    if not len(values) == <Py_ssize_t>len(labels):
         raise AssertionError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
@@ -1254,7 +1258,9 @@ def group_max(groupby_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
-    if not len(values) == len(labels):
+    # NOTE:
+    # Casting to avoid build warnings
+    if not len(values) == <Py_ssize_t>len(labels):
         raise AssertionError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)
@@ -1327,7 +1333,9 @@ def group_min(groupby_t[:, :] out,
 
     assert min_count == -1, "'min_count' only used in add and prod"
 
-    if not len(values) == len(labels):
+    # NOTE:
+    # Casting to avoid build warnings
+    if not len(values) == <Py_ssize_t>len(labels):
         raise AssertionError("len(index) != len(labels)")
 
     nobs = np.zeros((<object>out).shape, dtype=np.int64)


### PR DESCRIPTION
- [x] ref #32163
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This are the errors that this PR is getting rid of:

```
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_116group_last’:
pandas/_libs/groupby.c:37458:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
37458 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_118group_last’:
pandas/_libs/groupby.c:38233:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
38233 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_120group_last’:
pandas/_libs/groupby.c:39008:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
39008 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_122group_last’:
pandas/_libs/groupby.c:39781:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
39781 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_124group_last’:
pandas/_libs/groupby.c:40563:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
40563 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_128group_nth’:
pandas/_libs/groupby.c:41999:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
41999 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_130group_nth’:
pandas/_libs/groupby.c:42820:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
42820 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_132group_nth’:
pandas/_libs/groupby.c:43641:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
43641 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_134group_nth’:
pandas/_libs/groupby.c:44460:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
44460 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_136group_nth’:
pandas/_libs/groupby.c:45288:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
45288 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_152group_max’:
pandas/_libs/groupby.c:55168:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
55168 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_154group_max’:
pandas/_libs/groupby.c:55970:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
55970 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_156group_max’:
pandas/_libs/groupby.c:56772:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
56772 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_158group_max’:
pandas/_libs/groupby.c:57568:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
57568 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_162group_min’:
pandas/_libs/groupby.c:58985:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
58985 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_164group_min’:
pandas/_libs/groupby.c:59784:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
59784 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_166group_min’:
pandas/_libs/groupby.c:60583:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
60583 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
      |                              ^~
pandas/_libs/groupby.c: In function ‘__pyx_pf_6pandas_5_libs_7groupby_168group_min’:
pandas/_libs/groupby.c:61376:30: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
61376 |   __pyx_t_3 = ((!((__pyx_t_2 == __pyx_t_1) != 0)) != 0);
```
