### PR TITLE
BLD: Suppressing warnings when compiling pandas/_libs/writers

### DIFF
--- a/pandas/_libs/writers.pyx
+++ b/pandas/_libs/writers.pyx
@@ -36,7 +36,7 @@ def write_csv_rows(
     """
     # In crude testing, N>100 yields little marginal improvement
     cdef:
-        Py_ssize_t i, j, k = len(data_index), N = 100, ncols = len(cols)
+        Py_ssize_t i, j = 0, k = len(data_index), N = 100, ncols = len(cols)
         list rows
 
     # pre-allocate rows


### PR DESCRIPTION
- [x] ref #32163
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

---

This is the error that this PR is getting rid of:

```
pandas/_libs/writers.c: In function ‘__pyx_pw_6pandas_5_libs_7writers_1write_csv_rows’:
pandas/_libs/writers.c:3435:15: warning: ‘__pyx_v_j’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3435 |     __pyx_t_1 = (__pyx_v_j + 1);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~
pandas/_libs/writers.c:2911:14: note: ‘__pyx_v_j’ was declared here
 2911 |   Py_ssize_t __pyx_v_j;
      |              ^~~~~~~~~
```