### PR TITLE
PERF: Using Numpy C-API when calling `np.arange`

### DIFF
--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -308,7 +308,10 @@ cdef slice_getitem(slice slc, ind):
             return slice(s_start, s_stop, s_step)
 
     else:
-        return np.arange(s_start, s_stop, s_step, dtype=np.int64)[ind]
+        # NOTE:
+        # this is the C-optimized equivalent of
+        # `np.arange(s_start, s_stop, s_step, dtype=np.int64)[ind]`
+        return cnp.PyArray_Arange(s_start, s_stop, s_step, NPY_INT64)[ind]
 
 
 @cython.boundscheck(False)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

---

Somewhat of a follow up to #32681.

---

I could not benchmark this change as this function is ```cdef``` and not ```def``` or ```cpdef``` (I would also love if someone could give me a tip on how to benchmark  ```cdef``` functions from an ```Ipython``` shell for example).

What I did what I ran ```cython -a pandas/_libs/internals.pyx``` and took a screenshot of the before and after.

---

#### Master:

![orig_arange](https://user-images.githubusercontent.com/50263213/76964675-c4885280-692b-11ea-8ddf-b9eaf2ed0cd2.png)

---

#### PR:

![New_arange](https://user-images.githubusercontent.com/50263213/76964722-d7028c00-692b-11ea-970a-454cbb56adcf.png)


---

Also, is there a reason not to replace every call of ```np.arange``` with ```cnp.PyArray_Arange```? (cython files only)