### PR TITLE
ERR: Better error message

### DIFF
--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -112,9 +112,12 @@ def _coerce_scalar_to_timedelta_type(r, unit="ns", errors="raise"):
     """Convert string 'r' to a timedelta object."""
     try:
         result = Timedelta(r, unit)
-    except ValueError:
+    except ValueError as err:
         if errors == "raise":
-            raise
+            raise ValueError(
+                f"Unexpected value {err.args[0]}.\n"
+                "You can coerce to NaT by passing `errors='coerce'`"
+            ) from err
         elif errors == "ignore":
             return r
 

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1630,7 +1630,10 @@ class TestToDatetimeMisc:
         malformed = np.array(["1/100/2000", np.nan], dtype=object)
 
         # GH 10636, default is now 'raise'
-        msg = r"Unknown string format:|day is out of range for month"
+        msg = (
+            "Unexpected value 1/100/2000.\n"
+            "You can coerce to NaT by passing `errors='coerce'`"
+        )
         with pytest.raises(ValueError, match=msg):
             to_datetime(malformed, errors="raise", cache=cache)
 

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -121,6 +121,13 @@ class TestTimedeltas:
             invalid_data, to_timedelta(invalid_data, errors="ignore")
         )
 
+        msg = (
+            "Unexpected value unit abbreviation w/o a number.\n"
+            "You can coerce to NaT by passing `errors='coerce'`"
+        )
+        with pytest.raises(ValueError, match=msg):
+            pd.to_timedelta("foo", errors="raise")
+
     def test_to_timedelta_via_apply(self):
         # GH 5458
         expected = Series([np.timedelta64(1, "s")])


### PR DESCRIPTION
When invalid value for pd.to_datetime or pd.to_timedelta is passed

- [x] closes #10720
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

---

Resurrection of #31118
