### PR TITLE
PERF: fix SparseArray._simple_new object initialization

### DIFF
--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -399,7 +399,7 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
     def _simple_new(
         cls, sparse_array: np.ndarray, sparse_index: SparseIndex, dtype: SparseDtype
     ) -> "SparseArray":
-        new = cls([])
+        new = object.__new__(cls)
         new._sparse_index = sparse_index
         new._sparse_values = sparse_array
         new._dtype = dtype


### PR DESCRIPTION
Apart from this being more idiomatic, it also avoids creating a SparseArray through the normal machinery (including validation of the input etc) for the empty list.

With this PR:
```
In [1]: data = np.array([1, 2, 3], dtype=float)  

In [2]: index = pd.core.arrays.sparse.IntIndex(5, np.array([0, 2, 4]))  

In [3]: dtype = pd.SparseDtype("float64", 0)      

In [4]: pd.arrays.SparseArray._simple_new(data, index, dtype)  
Out[4]: 
[1.0, 0, 2.0, 0, 3.0]
Fill: 0
IntIndex
Indices: array([0, 2, 4], dtype=int32)

In [5]: %timeit pd.arrays.SparseArray._simple_new(data, index, dtype)    
381 ns ± 4.83 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

while on released version this gives around 50µs (100x slower)

Noticed while investigating https://github.com/pandas-dev/pandas/issues/32196