### PR TITLE
PERF: skip non-consolidatable blocks when checking consolidation

### DIFF
--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -268,7 +268,6 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
     Indices: array([2, 3], dtype=int32)
     """
 
-    _pandas_ftype = "sparse"
     _subtyp = "sparse_array"  # register ABCSparseArray
     _deprecations = PandasObject._deprecations | frozenset(["get_values"])
     _sparse_index: SparseIndex

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -110,7 +110,6 @@ class Block(PandasObject):
     _can_consolidate = True
     _verify_integrity = True
     _validate_ndim = True
-    _ftype = "dense"
     _concatenator = staticmethod(np.concatenate)
 
     def __init__(self, values, placement, ndim=None):
@@ -321,14 +320,6 @@ class Block(PandasObject):
     @property
     def dtype(self):
         return self.values.dtype
-
-    @property
-    def ftype(self) -> str:
-        if getattr(self.values, "_pandas_ftype", False):
-            dtype = self.dtype.subtype
-        else:
-            dtype = self.dtype
-        return f"{dtype}:{self._ftype}"
 
     def merge(self, other):
         return _merge_blocks([self, other])
@@ -1955,10 +1946,6 @@ class ExtensionBlock(Block):
             )
 
         return [self.make_block_same_class(result, placement=self.mgr_locs)]
-
-    @property
-    def _ftype(self):
-        return getattr(self.values, "_pandas_ftype", Block._ftype)
 
     def _unstack(self, unstacker_func, new_columns, n_rows, fill_value):
         # ExtensionArray-safe unstack.

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -676,7 +676,7 @@ class BlockManager(PandasObject):
         return self._is_consolidated
 
     def _consolidate_check(self) -> None:
-        ftypes = [blk.ftype for blk in self.blocks]
+        ftypes = [blk.ftype for blk in self.blocks if blk._can_consolidate]
         self._is_consolidated = len(ftypes) == len(set(ftypes))
         self._known_consolidated = True
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -676,8 +676,8 @@ class BlockManager(PandasObject):
         return self._is_consolidated
 
     def _consolidate_check(self) -> None:
-        ftypes = [blk.ftype for blk in self.blocks if blk._can_consolidate]
-        self._is_consolidated = len(ftypes) == len(set(ftypes))
+        dtypes = [blk.dtype for blk in self.blocks if blk._can_consolidate]
+        self._is_consolidated = len(dtypes) == len(set(dtypes))
         self._known_consolidated = True
 
     @property


### PR DESCRIPTION
This skips the non-consolidatable blocks to determine if the blocks are consolidated. So meaning that if you have multiple EA columns with the same dtype, we do not do an unnecessary consolidation.

From investigating https://github.com/pandas-dev/pandas/issues/32196#issuecomment-600824238

@rth this should give another speed-up to your benchmark