### PR TITLE
DOC: use new pydata-sphinx-theme name

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -195,7 +195,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
-html_theme = "pandas_sphinx_theme"
+html_theme = "pydata_sphinx_theme"
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths

--- a/environment.yml
+++ b/environment.yml
@@ -104,5 +104,5 @@ dependencies:
   - pyreadstat  # pandas.read_spss
   - tabulate>=0.8.3  # DataFrame.to_markdown
   - pip:
-    - git+https://github.com/pandas-dev/pandas-sphinx-theme.git@master
+    - git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master
     - git+https://github.com/numpy/numpydoc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -70,5 +70,5 @@ sqlalchemy
 xarray
 pyreadstat
 tabulate>=0.8.3
-git+https://github.com/pandas-dev/pandas-sphinx-theme.git@master
+git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master
 git+https://github.com/numpy/numpydoc


### PR DESCRIPTION
Following https://github.com/pandas-dev/pydata-sphinx-theme/issues/102, need to use the new package name

We could actually also start using the released version. But going to merge this soon when CI passes (as I think doc build in other PRs will start to fail)