### PR TITLE
BUG: is_scalar_indexer

### DIFF
--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -65,7 +65,7 @@ def is_list_like_indexer(key) -> bool:
     return is_list_like(key) and not (isinstance(key, tuple) and type(key) is not tuple)
 
 
-def is_scalar_indexer(indexer, arr_value) -> bool:
+def is_scalar_indexer(indexer, ndim: int) -> bool:
     """
     Return True if we are all scalar indexers.
 
@@ -73,10 +73,12 @@ def is_scalar_indexer(indexer, arr_value) -> bool:
     -------
     bool
     """
-    if arr_value.ndim == 1:
-        if not isinstance(indexer, tuple):
-            indexer = tuple([indexer])
-            return any(isinstance(idx, np.ndarray) and len(idx) == 0 for idx in indexer)
+    if isinstance(indexer, tuple):
+        if len(indexer) == ndim:
+            return all(
+                is_integer(x) or (isinstance(x, np.ndarray) and x.ndim == len(x) == 1)
+                for x in indexer
+            )
     return False
 
 

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -69,6 +69,12 @@ def is_scalar_indexer(indexer, ndim: int) -> bool:
     """
     Return True if we are all scalar indexers.
 
+    Parameters
+    ----------
+    indexer : object
+    ndim : int
+        Number of dimensions in the object being indexed.
+
     Returns
     -------
     bool

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -883,7 +883,7 @@ class Block(PandasObject):
             # GH#8669 empty indexers
             pass
 
-        elif is_scalar_indexer(indexer, arr_value):
+        elif is_scalar_indexer(indexer, self.ndim):
             # setting a single element for each dim and with a rhs that could
             #  be e.g. a list; see GH#6043
             values[indexer] = value
@@ -901,12 +901,10 @@ class Block(PandasObject):
         # if we are an exact match (ex-broadcasting),
         # then use the resultant dtype
         elif exact_match:
+            # We are setting _all_ of the array's values, so can cast to new dtype
             values[indexer] = value
 
-            try:
-                values = values.astype(arr_value.dtype)
-            except ValueError:
-                pass
+            values = values.astype(arr_value.dtype)
 
         # set
         else:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -895,7 +895,7 @@ class Block(PandasObject):
             # We are setting _all_ of the array's values, so can cast to new dtype
             values[indexer] = value
 
-            values = values.astype(arr_value.dtype)
+            values = values.astype(arr_value.dtype, copy=False)
 
         # set
         else:

--- a/pandas/tests/indexing/test_indexers.py
+++ b/pandas/tests/indexing/test_indexers.py
@@ -1,7 +1,7 @@
 # Tests aimed at pandas.core.indexers
 import numpy as np
 
-from pandas.core.indexers import length_of_indexer
+from pandas.core.indexers import is_scalar_indexer, length_of_indexer
 
 
 def test_length_of_indexer():
@@ -9,3 +9,20 @@ def test_length_of_indexer():
     arr[0] = 1
     result = length_of_indexer(arr)
     assert result == 1
+
+
+def test_is_scalar_indexer():
+    indexer = (0, 1)
+    assert is_scalar_indexer(indexer, 2)
+    assert not is_scalar_indexer(indexer[0], 2)
+
+    indexer = (np.array([2]), 1)
+    assert is_scalar_indexer(indexer, 2)
+
+    indexer = (np.array([2]), np.array([3]))
+    assert is_scalar_indexer(indexer, 2)
+
+    indexer = (np.array([2]), np.array([3, 4]))
+    assert not is_scalar_indexer(indexer, 2)
+
+    assert not is_scalar_indexer(slice(None), 1)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

ATM we go through the wrong path when setting a listlike entry in a single position.

The broader goal: separate out the cases where setitem is inplace vs copying.