### PR TITLE
CLN: avoid .setitem in tests

### DIFF
--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas._libs import iNaT, lib, missing as libmissing
+from pandas._libs import lib, missing as libmissing
 import pandas.util._test_decorators as td
 
 from pandas.core.dtypes import inference
@@ -50,7 +50,6 @@ from pandas import (
     Timedelta,
     TimedeltaIndex,
     Timestamp,
-    isna,
 )
 import pandas._testing as tm
 from pandas.core.arrays import IntegerArray
@@ -1480,14 +1479,12 @@ def test_nan_to_nat_conversions():
         dict({"A": np.asarray(range(10), dtype="float64"), "B": Timestamp("20010101")})
     )
     df.iloc[3:6, :] = np.nan
-    result = df.loc[4, "B"].value
-    assert result == iNaT
+    result = df.loc[4, "B"]
+    assert result is pd.NaT
 
     s = df["B"].copy()
-    s._data = s._data.setitem(indexer=tuple([slice(8, 9)]), value=np.nan)
-    assert isna(s[8])
-
-    assert s[8].value == np.datetime64("NaT").astype(np.int64)
+    s[8:9] = np.nan
+    assert s[8] is pd.NaT
 
 
 @td.skip_if_no_scipy

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -1,5 +1,3 @@
-import operator
-
 import numpy as np
 import pytest
 
@@ -60,7 +58,7 @@ class BaseSetitemTests(BaseExtensionTests):
     def test_setitem_scalar(self, data, setter):
         arr = pd.Series(data)
         setter = getattr(arr, setter)
-        operator.setitem(setter, 0, data[1])
+        setter[0] = data[1]
         assert arr[0] == data[1]
 
     def test_setitem_loc_scalar_mixed(self, data):
@@ -196,7 +194,7 @@ class BaseSetitemTests(BaseExtensionTests):
             # Series.__setitem__
             target = ser
 
-        operator.setitem(target, mask2, data[5:7])
+        target[mask2] = data[5:7]
 
         ser[mask2] = data[5:7]
         assert ser[0] == data[5]
@@ -213,7 +211,7 @@ class BaseSetitemTests(BaseExtensionTests):
         else:  # __setitem__
             target = ser
 
-        operator.setitem(target, mask, data[10])
+        target[mask] = data[10]
         assert ser[0] == data[10]
         assert ser[1] == data[10]
 


### PR DESCRIPTION
Make a few tests marginally clearer, avoid some clutter when grepping for `.getitem`