### PR TITLE
PERF: allow to skip validation/sanitization in DataFrame._from_arrays

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1907,9 +1907,10 @@ class DataFrame(NDFrame):
             Optional dtype to enforce for all arrays.
         verify_integrity : bool, default True
             Validate and homogenize all input. If set to False, it is assumed
-            that all elements of `arrays` are actual arrays to be stored in
-            a block, have the same length as and are aligned with the index,
-            and that `columns` and `index` are ensured to be an Index object.
+            that all elements of `arrays` are actual arrays how they will be
+            stored in a block (numpy ndarray or ExtensionArray), have the same
+            length as and are aligned with the index, and that `columns` and
+            `index` are ensured to be an Index object.
 
         Returns
         -------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1889,8 +1889,40 @@ class DataFrame(NDFrame):
         return np.rec.fromarrays(arrays, dtype={"names": names, "formats": formats})
 
     @classmethod
-    def _from_arrays(cls, arrays, columns, index, dtype=None) -> "DataFrame":
-        mgr = arrays_to_mgr(arrays, columns, index, columns, dtype=dtype)
+    def _from_arrays(
+        cls, arrays, columns, index, dtype=None, verify_integrity=True
+    ) -> "DataFrame":
+        """
+        Create DataFrame from a list of arrays corresponding to the columns.
+
+        Parameters
+        ----------
+        arrays : list-like of arrays
+            Each array in the list corresponds to one column, in order.
+        columns : list-like, Index
+            The column names for the resulting DataFrame.
+        index : list-like, Index
+            The rows labels for the resulting DataFrame.
+        dtype : dtype, optional
+            Optional dtype to enforce for all arrays.
+        verify_integrity : bool, default True
+            Validate and homogenize all input. If set to False, it is assumed
+            that all elements of `arrays` are actual arrays to be stored in
+            a block, have the same length as and are aligned with the index,
+            and that `columns` and `index` are ensured to be an Index object.
+
+        Returns
+        -------
+        DataFrame
+        """
+        mgr = arrays_to_mgr(
+            arrays,
+            columns,
+            index,
+            columns,
+            dtype=dtype,
+            verify_integrity=verify_integrity,
+        )
         return cls(mgr)
 
     @deprecate_kwarg(old_arg_name="fname", new_arg_name="path")

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -53,23 +53,26 @@ from pandas.core.internals import (
 # BlockManager Interface
 
 
-def arrays_to_mgr(arrays, arr_names, index, columns, dtype=None):
+def arrays_to_mgr(arrays, arr_names, index, columns, dtype=None, verify_integrity=True):
     """
     Segregate Series based on type and coerce into matrices.
 
     Needs to handle a lot of exceptional cases.
     """
-    # figure out the index, if necessary
-    if index is None:
-        index = extract_index(arrays)
-    else:
-        index = ensure_index(index)
+    if verify_integrity:
+        # figure out the index, if necessary
+        if index is None:
+            index = extract_index(arrays)
+        else:
+            index = ensure_index(index)
 
-    # don't force copy because getting jammed in an ndarray anyway
-    arrays = _homogenize(arrays, index, dtype)
+        # don't force copy because getting jammed in an ndarray anyway
+        arrays = _homogenize(arrays, index, dtype)
+
+        columns = ensure_index(columns)
 
     # from BlockManager perspective
-    axes = [ensure_index(columns), index]
+    axes = [columns, index]
 
     return create_block_manager_from_arrays(arrays, arr_names, axes)
 


### PR DESCRIPTION
For cases where you know to have valid data (eg you just created them yourself, or they are already validated), it can be useful to skip the validation checks when creating a DataFrame from arrays.

Use case is for example https://github.com/pandas-dev/pandas/pull/32825

From investigating https://github.com/pandas-dev/pandas/issues/32196#issuecomment-600824238

@rth this gives another 20% improvement on the dataframe creation part. Together with https://github.com/pandas-dev/pandas/pull/32856, it gives a bit more than a 2x improvement on the dataframe creation part (once the sparse arrays are created)