### PR TITLE
TST: add test for non UTC datetime split #14042

### DIFF
--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -427,20 +427,9 @@ class TestDatetimeIndex:
         tm.assert_index_equal(index, exp_index)
 
     def test_split_non_utc(self):
+        # GH 14042
         indices = pd.date_range("2016-01-01 00:00:00+0200", freq="S", periods=10)
-        split_indices = np.split(indices, indices_or_sections=[])
-        valid_indices = DatetimeIndex(
-            [
-                "2016-01-01 00:00:00+02:00",
-                "2016-01-01 00:00:01+02:00",
-                "2016-01-01 00:00:02+02:00",
-                "2016-01-01 00:00:03+02:00",
-                "2016-01-01 00:00:04+02:00",
-                "2016-01-01 00:00:05+02:00",
-                "2016-01-01 00:00:06+02:00",
-                "2016-01-01 00:00:07+02:00",
-                "2016-01-01 00:00:08+02:00",
-                "2016-01-01 00:00:09+02:00",
-            ]
-        )
-        tm.assert_index_equal(split_indices[0], valid_indices)
+        result = np.split(indices, indices_or_sections=[])[0]
+        expected = indices.copy()
+        expected._set_freq(None)
+        tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -425,3 +425,22 @@ class TestDatetimeIndex:
             ((2018,), range(1, 7)), names=[name, name]
         )
         tm.assert_index_equal(index, exp_index)
+
+    def test_split_non_utc(self):
+        indices = pd.date_range("2016-01-01 00:00:00+0200", freq="S", periods=10)
+        split_indices = np.split(indices, indices_or_sections=[])
+        valid_indices = DatetimeIndex(
+            [
+                "2016-01-01 00:00:00+02:00",
+                "2016-01-01 00:00:01+02:00",
+                "2016-01-01 00:00:02+02:00",
+                "2016-01-01 00:00:03+02:00",
+                "2016-01-01 00:00:04+02:00",
+                "2016-01-01 00:00:05+02:00",
+                "2016-01-01 00:00:06+02:00",
+                "2016-01-01 00:00:07+02:00",
+                "2016-01-01 00:00:08+02:00",
+                "2016-01-01 00:00:09+02:00",
+            ]
+        )
+        tm.assert_index_equal(split_indices[0], valid_indices)


### PR DESCRIPTION
- [x] closes #14042
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`