### PR TITLE
DOC: Remove latest whatsnew from header

### DIFF
--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -119,7 +119,6 @@ programming language.
     :titlesonly:
 {% endif %}
 {% if not single_doc %}
-    What's New in 1.1.0 <whatsnew/v1.1.0>
     getting_started/index
     user_guide/index
     {% endif -%}


### PR DESCRIPTION
In favor of going via the "Release notes" which stays in the header.

Closes https://github.com/pandas-dev/pandas/issues/32748