### PR TITLE
PERF/REF: MultiIndex.copy

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -990,17 +990,21 @@ class MultiIndex(Index):
     def _shallow_copy(
         self,
         values=None,
-        name=None,
+        name=lib.no_default,
         levels=None,
         codes=None,
+        dtype=None,
         sortorder=None,
-        names=None,
+        names=lib.no_default,
         _set_identity: bool = True,
     ):
-        names = self._validate_names(name=name, names=names)
+        if names is not lib.no_default and name is not lib.no_default:
+            raise TypeError("Can only provide one of `names` and `name`")
+        elif names is lib.no_default:
+            names = name if name is not lib.no_default else self.names
 
         if values is not None:
-            assert levels is None and codes is None
+            assert levels is None and codes is None and dtype is None
             return MultiIndex.from_tuples(values, sortorder=sortorder, names=names)
 
         levels = levels if levels is not None else self.levels
@@ -1009,6 +1013,7 @@ class MultiIndex(Index):
         result = MultiIndex(
             levels=levels,
             codes=codes,
+            dtype=dtype,
             sortorder=sortorder,
             names=names,
             verify_integrity=False,
@@ -1065,6 +1070,7 @@ class MultiIndex(Index):
         ``deep``, but if ``deep`` is passed it will attempt to deepcopy.
         This could be potentially expensive on large MultiIndex objects.
         """
+        names = self._validate_names(name=name, names=names, deep=deep)
         if deep:
             from copy import deepcopy
 
@@ -1075,9 +1081,9 @@ class MultiIndex(Index):
 
         return self._shallow_copy(
             levels=levels,
-            name=name,
             codes=codes,
             names=names,
+            dtype=dtype,
             sortorder=self.sortorder,
             _set_identity=_set_identity,
         )


### PR DESCRIPTION
Makes ``MultiIndex.copy`` call ``MultiIndex._shallow_copy`` rather than the other way around. This is cleaner and let's us copy the existing  ``.cache``, so may give performance boost when operating on copied MultiIndexes:

```python
>>> n = 100_000
>>> df = pd.DataFrame({'a': range(n), 'b': range(1, n+1)})
>>> mi = pd.MultiIndex.from_frame(df)
>>> mi.get_loc(mi[0])  # also sets up the cache
>>> %timeit mi.copy().get_loc(mi[0])
8.57 ms ± 157 µs per loop  # master
57.9 µs ± 798 ns per loop  # this PR
```

Also cleans kwargs from the ``MultiIndex._shallow_copy`` signature. This PR is somewhat related to #32669.
