### PR TITLE
fix bare pytest raises in indexes/datetimes

### DIFF
--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -415,7 +415,8 @@ class TestDatetimeIndex:
 
         # tz mismatch affecting to tz-aware raises TypeError/ValueError
 
-        with pytest.raises(ValueError):
+        msg = "cannot be converted to datetime64"
+        with pytest.raises(ValueError, match=msg):
             DatetimeIndex(
                 [
                     Timestamp("2011-01-01 10:00", tz="Asia/Tokyo"),
@@ -424,7 +425,6 @@ class TestDatetimeIndex:
                 name="idx",
             )
 
-        msg = "cannot be converted to datetime64"
         with pytest.raises(ValueError, match=msg):
             DatetimeIndex(
                 [
@@ -435,7 +435,7 @@ class TestDatetimeIndex:
                 name="idx",
             )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             DatetimeIndex(
                 [
                     Timestamp("2011-01-01 10:00", tz="Asia/Tokyo"),
@@ -480,7 +480,8 @@ class TestDatetimeIndex:
         # coerces to object
         tm.assert_index_equal(Index(dates), exp)
 
-        with pytest.raises(OutOfBoundsDatetime):
+        msg = "Out of bounds nanosecond timestamp"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
             # can't create DatetimeIndex
             DatetimeIndex(dates)
 
@@ -516,7 +517,8 @@ class TestDatetimeIndex:
         with pytest.raises(TypeError, match=msg):
             date_range(start="1/1/2000", periods="foo", freq="D")
 
-        with pytest.raises(TypeError):
+        msg = "DatetimeIndex\\(\\) must be called with a collection"
+        with pytest.raises(TypeError, match=msg):
             DatetimeIndex("1/1/2000")
 
         # generator expression
@@ -664,7 +666,8 @@ class TestDatetimeIndex:
     @pytest.mark.parametrize("dtype", [object, np.int32, np.int64])
     def test_constructor_invalid_dtype_raises(self, dtype):
         # GH 23986
-        with pytest.raises(ValueError):
+        msg = "Unexpected value for 'dtype'"
+        with pytest.raises(ValueError, match=msg):
             DatetimeIndex([1, 2], dtype=dtype)
 
     def test_constructor_name(self):
@@ -681,7 +684,8 @@ class TestDatetimeIndex:
     def test_disallow_setting_tz(self):
         # GH 3746
         dti = DatetimeIndex(["2010"], tz="UTC")
-        with pytest.raises(AttributeError):
+        msg = "Cannot directly set timezone"
+        with pytest.raises(AttributeError, match=msg):
             dti.tz = pytz.timezone("US/Pacific")
 
     @pytest.mark.parametrize(
@@ -770,7 +774,8 @@ class TestDatetimeIndex:
     def test_construction_with_tz_and_tz_aware_dti(self):
         # GH 23579
         dti = date_range("2016-01-01", periods=3, tz="US/Central")
-        with pytest.raises(TypeError):
+        msg = "data is already tz-aware US/Central, unable to set specified tz"
+        with pytest.raises(TypeError, match=msg):
             DatetimeIndex(dti, tz="Asia/Tokyo")
 
     def test_construction_with_nat_and_tzlocal(self):
@@ -790,7 +795,8 @@ class TestDatetimeIndex:
             pd.Index(["2000"], dtype="datetime64")
 
     def test_constructor_wrong_precision_raises(self):
-        with pytest.raises(ValueError):
+        msg = "Unexpected value for 'dtype': 'datetime64\\[us\\]'"
+        with pytest.raises(ValueError, match=msg):
             pd.DatetimeIndex(["2000"], dtype="datetime64[us]")
 
     def test_index_constructor_with_numpy_object_array_and_timestamp_tz_with_nan(self):

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -153,9 +153,10 @@ class TestDateRanges:
 
     def test_date_range_out_of_bounds(self):
         # GH#14187
-        with pytest.raises(OutOfBoundsDatetime):
+        msg = "Cannot generate range"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
             date_range("2016-01-01", periods=100000, freq="D")
-        with pytest.raises(OutOfBoundsDatetime):
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
             date_range(end="1763-10-12", periods=100000, freq="D")
 
     def test_date_range_gen_error(self):
@@ -736,9 +737,10 @@ class TestGenRangeGeneration:
     )
     def test_mismatching_tz_raises_err(self, start, end):
         # issue 18488
-        with pytest.raises(TypeError):
+        msg = "Start and end cannot both be tz-aware with different timezones"
+        with pytest.raises(TypeError, match=msg):
             pd.date_range(start, end)
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=msg):
             pd.date_range(start, end, freq=BDay())
 
 
@@ -771,16 +773,17 @@ class TestBusinessDateRange:
     def test_date_parse_failure(self):
         badly_formed_date = "2007/100/1"
 
-        with pytest.raises(ValueError):
+        msg = "could not convert string to Timestamp"
+        with pytest.raises(ValueError, match=msg):
             Timestamp(badly_formed_date)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             bdate_range(start=badly_formed_date, periods=10)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             bdate_range(end=badly_formed_date, periods=10)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             bdate_range(badly_formed_date, badly_formed_date)
 
     def test_daterange_bug_456(self):
@@ -813,8 +816,9 @@ class TestBusinessDateRange:
 
     def test_bday_overflow_error(self):
         # GH#24252 check that we get OutOfBoundsDatetime and not OverflowError
+        msg = "Out of bounds nanosecond timestamp"
         start = pd.Timestamp.max.floor("D").to_pydatetime()
-        with pytest.raises(OutOfBoundsDatetime):
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
             pd.date_range(start, periods=2, freq="B")
 
 

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -312,7 +312,8 @@ class TestTake:
         with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
-        with pytest.raises(IndexError):
+        msg = "index -5 is out of bounds for size 3"
+        with pytest.raises(IndexError, match=msg):
             idx.take(np.array([1, -5]))
 
     def test_take_fill_value_with_timezone(self):
@@ -348,7 +349,8 @@ class TestTake:
         with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
-        with pytest.raises(IndexError):
+        msg = "index -5 is out of bounds for size 3"
+        with pytest.raises(IndexError, match=msg):
             idx.take(np.array([1, -5]))
 
 
@@ -428,7 +430,8 @@ class TestGetLoc:
         tm.assert_numpy_array_equal(
             idx.get_loc(time(12, 30)), np.array([]), check_dtype=False
         )
-        with pytest.raises(NotImplementedError):
+        msg = "cannot yet lookup inexact labels when key is a time object"
+        with pytest.raises(NotImplementedError, match=msg):
             idx.get_loc(time(12, 30), method="pad")
 
     def test_get_loc_tz_aware(self):
@@ -462,7 +465,8 @@ class TestGetLoc:
     def test_get_loc_timedelta_invalid_key(self, key):
         # GH#20464
         dti = pd.date_range("1970-01-01", periods=10)
-        with pytest.raises(TypeError):
+        msg = "Cannot index DatetimeIndex with [Tt]imedelta"
+        with pytest.raises(TypeError, match=msg):
             dti.get_loc(key)
 
     def test_get_loc_reasonable_key_error(self):
@@ -571,9 +575,9 @@ class TestDatetimeIndex:
             idx.insert(3, pd.Timestamp("2000-01-04"))
         with pytest.raises(TypeError, match="Cannot compare tz-naive and tz-aware"):
             idx.insert(3, datetime(2000, 1, 4))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Timezones don't match"):
             idx.insert(3, pd.Timestamp("2000-01-04", tz="US/Eastern"))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Timezones don't match"):
             idx.insert(3, datetime(2000, 1, 4, tzinfo=pytz.timezone("US/Eastern")))
 
         for tz in ["US/Pacific", "Asia/Singapore"]:
@@ -645,7 +649,7 @@ class TestDatetimeIndex:
             assert result.name == expected.name
             assert result.freq == expected.freq
 
-        with pytest.raises((IndexError, ValueError)):
+        with pytest.raises((IndexError, ValueError), match="out of bounds"):
             # either depending on numpy version
             idx.delete(5)
 
@@ -804,5 +808,5 @@ class TestDatetimeIndex:
         ]
         with pytest.raises(ValueError, match="abbreviation w/o a number"):
             idx.get_indexer(target, "nearest", tolerance=tol_bad)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="abbreviation w/o a number"):
             idx.get_indexer(idx[[0]], method="nearest", tolerance="foo")

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -312,7 +312,7 @@ class TestTake:
         with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
-        msg = "index -5 is out of bounds for size 3"
+        msg = "out of bounds"
         with pytest.raises(IndexError, match=msg):
             idx.take(np.array([1, -5]))
 
@@ -349,7 +349,7 @@ class TestTake:
         with pytest.raises(ValueError, match=msg):
             idx.take(np.array([1, 0, -5]), fill_value=True)
 
-        msg = "index -5 is out of bounds for size 3"
+        msg = "out of bounds"
         with pytest.raises(IndexError, match=msg):
             idx.take(np.array([1, -5]))
 

--- a/pandas/tests/indexes/datetimes/test_shift.py
+++ b/pandas/tests/indexes/datetimes/test_shift.py
@@ -80,7 +80,7 @@ class TestDatetimeIndexShift:
     def test_dti_shift_no_freq(self):
         # GH#19147
         dti = pd.DatetimeIndex(["2011-01-01 10:00", "2011-01-01"], freq=None)
-        with pytest.raises(NullFrequencyError):
+        with pytest.raises(NullFrequencyError, match="Cannot shift with no freq"):
             dti.shift(2)
 
     @pytest.mark.parametrize("tzstr", ["US/Eastern", "dateutil/US/Eastern"])


### PR DESCRIPTION
- [ ] ref #30999
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
