### PR TITLE
TST: Replace tm.all_index_generator with indices fixture

### DIFF
--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1683,32 +1683,6 @@ def _make_timeseries(start="2000-01-01", end="2000-12-31", freq="1D", seed=None)
     return df
 
 
-def all_index_generator(k=10):
-    """
-    Generator which can be iterated over to get instances of all the various
-    index classes.
-
-    Parameters
-    ----------
-    k: length of each of the index instances
-    """
-    all_make_index_funcs = [
-        makeIntIndex,
-        makeFloatIndex,
-        makeStringIndex,
-        makeUnicodeIndex,
-        makeDateIndex,
-        makePeriodIndex,
-        makeTimedeltaIndex,
-        makeBoolIndex,
-        makeRangeIndex,
-        makeIntervalIndex,
-        makeCategoricalIndex,
-    ]
-    for make_index_func in all_make_index_funcs:
-        yield make_index_func(k=k)
-
-
 def index_subclass_makers_generator():
     make_index_funcs = [
         makeDateIndex,

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -7,6 +7,8 @@ import pytest
 
 import pandas.util._test_decorators as td
 
+from pandas.core.dtypes.generic import ABCMultiIndex
+
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series, date_range
 import pandas._testing as tm
@@ -245,8 +247,12 @@ class TestToXArray:
         and LooseVersion(xarray.__version__) < LooseVersion("0.10.0"),
         reason="xarray >= 0.10.0 required",
     )
-    @pytest.mark.parametrize("index", tm.all_index_generator(3))
-    def test_to_xarray_index_types(self, index):
+    def test_to_xarray_index_types(self, indices):
+        if isinstance(indices, ABCMultiIndex):
+            pytest.skip("MultiIndex is tested separately")
+        if len(indices) == 0:
+            pytest.skip("Test doesn't make sense for empty index")
+
         from xarray import Dataset
 
         df = DataFrame(
@@ -262,7 +268,7 @@ class TestToXArray:
             }
         )
 
-        df.index = index
+        df.index = indices[:3]
         df.index.name = "foo"
         df.columns.name = "bar"
         result = df.to_xarray()

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -249,14 +249,13 @@ class Generic:
             self.check_metadata(v1 & v2)
             self.check_metadata(v1 | v2)
 
-    @pytest.mark.parametrize("index", tm.all_index_generator(10))
-    def test_head_tail(self, index):
+    def test_head_tail(self, indices):
         # GH5370
 
-        o = self._construct(shape=10)
+        o = self._construct(shape=len(indices))
 
         axis = o._get_axis_name(0)
-        setattr(o, axis, index)
+        setattr(o, axis, indices)
 
         o.head()
 
@@ -272,8 +271,8 @@ class Generic:
         self._compare(o.tail(len(o) + 1), o)
 
         # neg index
-        self._compare(o.head(-3), o.head(7))
-        self._compare(o.tail(-3), o.tail(7))
+        self._compare(o.head(-3), o.head(len(indices) - 3))
+        self._compare(o.tail(-3), o.tail(len(indices) - 3))
 
     def test_sample(self):
         # Fixes issue: 2419

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pandas import MultiIndex, Series, date_range
 import pandas._testing as tm
 
+from ...core.dtypes.generic import ABCMultiIndex
 from .test_generic import Generic
 
 try:
@@ -223,21 +224,38 @@ class TestToXArray:
         and LooseVersion(xarray.__version__) < LooseVersion("0.10.0"),
         reason="xarray >= 0.10.0 required",
     )
-    @pytest.mark.parametrize("index", tm.all_index_generator(6))
-    def test_to_xarray_index_types(self, index):
+    def test_to_xarray_index_types(self, indices):
+        if isinstance(indices, ABCMultiIndex):
+            pytest.skip("MultiIndex is tested separately")
+
         from xarray import DataArray
 
-        s = Series(range(6), index=index)
+        s = Series(range(len(indices)), index=indices, dtype="object")
         s.index.name = "foo"
         result = s.to_xarray()
         repr(result)
-        assert len(result) == 6
+        assert len(result) == len(indices)
         assert len(result.coords) == 1
         tm.assert_almost_equal(list(result.coords.keys()), ["foo"])
         assert isinstance(result, DataArray)
 
         # idempotency
         tm.assert_series_equal(result.to_series(), s, check_index_type=False)
+
+    @td.skip_if_no("xarray", min_version="0.7.0")
+    def test_to_xarray_multiindex(self):
+        from xarray import DataArray
+
+        s = Series(range(6))
+        s.index.name = "foo"
+        s.index = pd.MultiIndex.from_product(
+            [["a", "b"], range(3)], names=["one", "two"]
+        )
+        result = s.to_xarray()
+        assert len(result) == 2
+        tm.assert_almost_equal(list(result.coords.keys()), ["one", "two"])
+        assert isinstance(result, DataArray)
+        tm.assert_series_equal(result.to_series(), s)
 
     @td.skip_if_no("xarray", min_version="0.7.0")
     def test_to_xarray(self):
@@ -250,14 +268,3 @@ class TestToXArray:
         assert len(result.coords) == 1
         tm.assert_almost_equal(list(result.coords.keys()), ["foo"])
         assert isinstance(result, DataArray)
-
-        s = Series(range(6))
-        s.index.name = "foo"
-        s.index = pd.MultiIndex.from_product(
-            [["a", "b"], range(3)], names=["one", "two"]
-        )
-        result = s.to_xarray()
-        assert len(result) == 2
-        tm.assert_almost_equal(list(result.coords.keys()), ["one", "two"])
-        assert isinstance(result, DataArray)
-        tm.assert_series_equal(result.to_series(), s)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -107,6 +107,14 @@ class TestFancy:
         ],
     )
     def test_setitem_ndarray_3d(self, indices, obj, idxr, idxr_id):
+        if (
+            (len(indices) == 0)
+            and (idxr_id == "iloc")
+            and isinstance(obj, pd.DataFrame)
+        ):
+            # gh-32896
+            pytest.skip("This is currently failing. There's an xfailed test below.")
+
         # GH 25567
         obj = obj(indices)
         idxr = idxr(obj)
@@ -128,16 +136,19 @@ class TestFancy:
             err = ValueError
             msg = r"Buffer has wrong number of dimensions \(expected 1, got 3\)|"
 
-        if (
-            (len(indices) == 0)
-            and (idxr_id == "iloc")
-            and isinstance(obj, pd.DataFrame)
-        ):
-            # TODO: Seems to be bugged
-            pytest.xfail("This doesn't raise")
-
         with pytest.raises(err, match=msg):
             idxr[nd3] = 0
+
+    @pytest.mark.xfail(reason="gh-32896")
+    def test_setitem_ndarray_3d_does_not_fail_for_iloc_empty_dataframe(self):
+        # when fixing this, please remove the pytest.skip in test_setitem_ndarray_3d
+        i = Index([])
+        obj = DataFrame(np.random.randn(len(i), len(i)), index=i, columns=i)
+        nd3 = np.random.randint(5, size=(2, 2, 2))
+
+        msg = f"Cannot set values with ndim > {obj.ndim}"
+        with pytest.raises(ValueError, match=msg):
+            obj.iloc[nd3] = 0
 
     def test_inf_upcast(self):
         # GH 16957

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -107,6 +107,11 @@ class TestFancy:
         ],
     )
     def test_setitem_ndarray_3d(self, indices, obj, idxr, idxr_id):
+        # GH 25567
+        obj = obj(indices)
+        idxr = idxr(obj)
+        nd3 = np.random.randint(5, size=(2, 2, 2))
+
         if (
             (len(indices) == 0)
             and (idxr_id == "iloc")
@@ -114,11 +119,6 @@ class TestFancy:
         ):
             # gh-32896
             pytest.skip("This is currently failing. There's an xfailed test below.")
-
-        # GH 25567
-        obj = obj(indices)
-        idxr = idxr(obj)
-        nd3 = np.random.randint(5, size=(2, 2, 2))
 
         if idxr_id == "iloc":
             err = ValueError

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -4,6 +4,8 @@ from itertools import chain
 import numpy as np
 import pytest
 
+from pandas.core.dtypes.generic import ABCMultiIndex
+
 import pandas as pd
 from pandas import DataFrame, Index, Series, isna
 import pandas._testing as tm
@@ -514,9 +516,11 @@ class TestSeriesMap:
         exp = Series([np.nan, "B", "C", "D"])
         tm.assert_series_equal(a.map(c), exp)
 
-    @pytest.mark.parametrize("index", tm.all_index_generator(10))
-    def test_map_empty(self, index):
-        s = Series(index)
+    def test_map_empty(self, indices):
+        if isinstance(indices, ABCMultiIndex):
+            pytest.skip("Initializing a Series from a MultiIndex is not supported")
+
+        s = Series(indices)
         result = s.map({})
 
         expected = pd.Series(np.nan, index=s.index)


### PR DESCRIPTION
Inspired by #30999
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

