### PR TITLE
TST: Using ABCMultiIndex in isinstance checks

### DIFF
--- a/pandas/tests/base/test_factorize.py
+++ b/pandas/tests/base/test_factorize.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.core.dtypes.generic import ABCMultiIndex
+
 import pandas as pd
 import pandas._testing as tm
 
@@ -11,7 +13,7 @@ def test_factorize(index_or_series_obj, sort):
     result_codes, result_uniques = obj.factorize(sort=sort)
 
     constructor = pd.Index
-    if isinstance(obj, pd.MultiIndex):
+    if isinstance(obj, ABCMultiIndex):
         constructor = pd.MultiIndex.from_tuples
     expected_uniques = constructor(obj.unique())
 

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -11,6 +11,7 @@ from pandas.core.dtypes.common import (
     is_datetime64tz_dtype,
     is_object_dtype,
 )
+from pandas.core.dtypes.generic import ABCMultiIndex
 
 import pandas as pd
 from pandas import DataFrame, Index, IntervalIndex, Series
@@ -161,7 +162,7 @@ def test_searchsorted(index_or_series_obj):
     # See gh-12238
     obj = index_or_series_obj
 
-    if isinstance(obj, pd.MultiIndex):
+    if isinstance(obj, ABCMultiIndex):
         # See gh-14833
         pytest.skip("np.searchsorted doesn't work on pd.MultiIndex")
 

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -4,6 +4,7 @@ import pytest
 from pandas._libs.tslib import iNaT
 
 from pandas.core.dtypes.common import is_datetime64tz_dtype, needs_i8_conversion
+from pandas.core.dtypes.generic import ABCMultiIndex
 
 import pandas as pd
 import pandas._testing as tm
@@ -17,7 +18,7 @@ def test_unique(index_or_series_obj):
 
     # dict.fromkeys preserves the order
     unique_values = list(dict.fromkeys(obj.values))
-    if isinstance(obj, pd.MultiIndex):
+    if isinstance(obj, ABCMultiIndex):
         expected = pd.MultiIndex.from_tuples(unique_values)
         expected.names = obj.names
         tm.assert_index_equal(result, expected)
@@ -39,7 +40,7 @@ def test_unique_null(null_obj, index_or_series_obj):
         pytest.skip("type doesn't allow for NA operations")
     elif len(obj) < 1:
         pytest.skip("Test doesn't make sense on empty data")
-    elif isinstance(obj, pd.MultiIndex):
+    elif isinstance(obj, ABCMultiIndex):
         pytest.skip(f"MultiIndex can't hold '{null_obj}'")
 
     values = obj.values
@@ -85,7 +86,7 @@ def test_nunique_null(null_obj, index_or_series_obj):
 
     if not allow_na_ops(obj):
         pytest.skip("type doesn't allow for NA operations")
-    elif isinstance(obj, pd.MultiIndex):
+    elif isinstance(obj, ABCMultiIndex):
         pytest.skip(f"MultiIndex can't hold '{null_obj}'")
 
     values = obj.values

--- a/pandas/tests/base/test_value_counts.py
+++ b/pandas/tests/base/test_value_counts.py
@@ -9,6 +9,7 @@ from pandas._libs.tslib import iNaT
 from pandas.compat.numpy import np_array_datetime64_compat
 
 from pandas.core.dtypes.common import needs_i8_conversion
+from pandas.core.dtypes.generic import ABCMultiIndex
 
 import pandas as pd
 from pandas import (
@@ -32,7 +33,7 @@ def test_value_counts(index_or_series_obj):
     counter = collections.Counter(obj)
     expected = pd.Series(dict(counter.most_common()), dtype=np.int64, name=obj.name)
     expected.index = expected.index.astype(obj.dtype)
-    if isinstance(obj, pd.MultiIndex):
+    if isinstance(obj, ABCMultiIndex):
         expected.index = pd.Index(expected.index)
 
     # TODO: Order of entries with the same count is inconsistent on CI (gh-32449)


### PR DESCRIPTION
A follow-up on [#32483 (comment)](https://github.com/pandas-dev/pandas/pull/32483#discussion_r388795102) by @MomIsBestFriend 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

