### PR TITLE
TST: test that the .copy method on indexes copy the cache

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -913,7 +913,7 @@ class Base:
             {} in idx._engine
 
     def test_copy_copies_cache(self):
-        # GH32883
+        # GH32898
         idx = self.create_index()
         idx.get_loc(idx[0])  # populates the _cache.
         copy = idx.copy()
@@ -926,7 +926,7 @@ class Base:
             assert copy._cache[key] is val, key
 
     def test_shallow_copy_copies_cache(self):
-        # GH32898
+        # GH32669
         idx = self.create_index()
         idx.get_loc(idx[0])  # populates the _cache.
         shallow_copy = idx._shallow_copy()

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -912,8 +912,21 @@ class Base:
         with pytest.raises(TypeError):
             {} in idx._engine
 
+    def test_copy_copies_cache(self):
+        # GH32883
+        idx = self.create_index()
+        idx.get_loc(idx[0])  # populates the _cache.
+        copy = idx.copy()
+
+        # check that the copied cache is a copy of the original
+        assert idx._cache == copy._cache
+        assert idx._cache is not copy._cache
+        # cache values should reference the same object
+        for key, val in idx._cache.items():
+            assert copy._cache[key] is val, key
+
     def test_shallow_copy_copies_cache(self):
-        # GH32669
+        # GH32898
         idx = self.create_index()
         idx.get_loc(idx[0])  # populates the _cache.
         shallow_copy = idx._shallow_copy()


### PR DESCRIPTION
In #32883 I made a PR to fix an issue that ``MultiIndex.copy`` didn't copy the ``_cache``.

This adds a test for this for all index types (there's no futher issue, but it should still be tested for).