### PR TITLE
Timedeltas: Understand µs

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -256,7 +256,7 @@ Timedelta
 
 - Bug in constructing a :class:`Timedelta` with a high precision integer that would round the :class:`Timedelta` components (:issue:`31354`)
 - Bug in dividing ``np.nan`` or ``None`` by :class:`Timedelta`` incorrectly returning ``NaT`` (:issue:`31869`)
--
+- Timedeltas now understand ``µs`` as identifier for microsecond (:issue:`32899`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -82,6 +82,7 @@ cdef dict timedelta_abbrevs = {
     "us": "us",
     "microseconds": "us",
     "microsecond": "us",
+    "µs": "us",
     "micro": "us",
     "micros": "us",
     "u": "us",

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -51,6 +51,7 @@ def test_construction():
     assert Timedelta("1 milli") == timedelta(milliseconds=1)
     assert Timedelta("1 millisecond") == timedelta(milliseconds=1)
     assert Timedelta("1 us") == timedelta(microseconds=1)
+    assert Timedelta("1 µs") == timedelta(microseconds=1)
     assert Timedelta("1 micros") == timedelta(microseconds=1)
     assert Timedelta("1 microsecond") == timedelta(microseconds=1)
     assert Timedelta("1.5 microsecond") == Timedelta("00:00:00.000001500")


### PR DESCRIPTION
- [ ] closes #xxxx
- [X] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry


These are emitted by golangs `time.Duration` printing: https://github.com/golang/go/blob/36b815edd6cd23d5aabdb488c24db2033bbdeea2/src/time/time.go#L669