### PR TITLE
DOC: Fix capitalization among headings in documentation files (#32550) part 3

### DIFF
--- a/doc/source/development/contributing_docstring.rst
+++ b/doc/source/development/contributing_docstring.rst
@@ -160,7 +160,7 @@ backticks. It is considered inline code:
 
 .. _docstring.short_summary:
 
-Section 1: Short summary
+Section 1: short summary
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The short summary is a single sentence that expresses what the function does in
@@ -228,7 +228,7 @@ infinitive verb.
 
 .. _docstring.extended_summary:
 
-Section 2: Extended summary
+Section 2: extended summary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The extended summary provides details on what the function does. It should not
@@ -259,7 +259,7 @@ their use cases, if it is not too generic.
 
 .. _docstring.parameters:
 
-Section 3: Parameters
+Section 3: parameters
 ~~~~~~~~~~~~~~~~~~~~~
 
 The details of the parameters will be added in this section. This section has
@@ -424,7 +424,7 @@ For axis, the convention is to use something like:
 
 .. _docstring.returns:
 
-Section 4: Returns or Yields
+Section 4: returns or yields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the method returns a value, it will be documented in this section. Also
@@ -505,7 +505,7 @@ If the method yields its value:
 
 .. _docstring.see_also:
 
-Section 5: See Also
+Section 5: see also
 ~~~~~~~~~~~~~~~~~~~
 
 This section is used to let users know about pandas functionality
@@ -583,7 +583,7 @@ For example:
 
 .. _docstring.notes:
 
-Section 6: Notes
+Section 6: notes
 ~~~~~~~~~~~~~~~~
 
 This is an optional section used for notes about the implementation of the
@@ -597,7 +597,7 @@ This section follows the same format as the extended summary section.
 
 .. _docstring.examples:
 
-Section 7: Examples
+Section 7: examples
 ~~~~~~~~~~~~~~~~~~~
 
 This is one of the most important sections of a docstring, even if it is

--- a/doc/source/development/developer.rst
+++ b/doc/source/development/developer.rst
@@ -62,7 +62,7 @@ for each column, *including the index columns*. This has JSON form:
 
 See below for the detailed specification for these.
 
-Index Metadata Descriptors
+Index metadata descriptors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``RangeIndex`` can be stored as metadata only, not requiring serialization. The
@@ -89,7 +89,7 @@ with other column names) a disambiguating name with pattern matching
 columns, ``name`` attribute is always stored in the column descriptors as
 above.
 
-Column Metadata
+Column metadata
 ~~~~~~~~~~~~~~~
 
 ``pandas_type`` is the logical type of the column, and is one of:

--- a/doc/source/development/extending.rst
+++ b/doc/source/development/extending.rst
@@ -210,7 +210,7 @@ will
 
 .. _extending.extension.ufunc:
 
-NumPy Universal Functions
+NumPy universal functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :class:`Series` implements ``__array_ufunc__``. As part of the implementation,

--- a/doc/source/development/maintaining.rst
+++ b/doc/source/development/maintaining.rst
@@ -1,7 +1,7 @@
 .. _maintaining:
 
 ******************
-Pandas Maintenance
+pandas maintenance
 ******************
 
 This guide is for pandas' maintainers. It may also be interesting to contributors
@@ -41,7 +41,7 @@ reading.
 
 .. _maintaining.triage:
 
-Issue Triage
+Issue triage
 ------------
 
 
@@ -123,7 +123,7 @@ Here's a typical workflow for triaging a newly opened issue.
 
 .. _maintaining.closing:
 
-Closing Issues
+Closing issues
 --------------
 
 Be delicate here: many people interpret closing an issue as us saying that the
@@ -132,7 +132,7 @@ respond or self-close their issue if it's determined that the behavior is not a 
 or the feature is out of scope. Sometimes reporters just go away though, and
 we'll close the issue after the conversation has died.
 
-Reviewing Pull Requests
+Reviewing pull requests
 -----------------------
 
 Anybody can review a pull request: regular contributors, triagers, or core-team
@@ -144,7 +144,7 @@ members. Here are some guidelines to check.
 * User-facing changes should have a whatsnew in the appropriate file.
 * Regression tests should reference the original GitHub issue number like ``# GH-1234``.
 
-Cleaning up old Issues
+Cleaning up old issues
 ----------------------
 
 Every open issue in pandas has a cost. Open issues make finding duplicates harder,
@@ -164,7 +164,7 @@ If an older issue lacks a reproducible example, label it as "Needs Info" and
 ask them to provide one (or write one yourself if possible). If one isn't
 provide reasonably soon, close it according to the policies in :ref:`maintaining.closing`.
 
-Cleaning up old Pull Requests
+Cleaning up old pull requests
 -----------------------------
 
 Occasionally, contributors are unable to finish off a pull request.

--- a/doc/source/development/meeting.rst
+++ b/doc/source/development/meeting.rst
@@ -1,7 +1,7 @@
 .. _meeting:
 
 ==================
-Developer Meetings
+Developer meetings
 ==================
 
 We hold regular developer meetings on the second Wednesday
@@ -29,4 +29,3 @@ You can subscribe to this calendar with the following links:
 
 Additionally, we'll sometimes have one-off meetings on specific topics.
 These will be published on the same calendar.
-

--- a/doc/source/development/policies.rst
+++ b/doc/source/development/policies.rst
@@ -6,7 +6,7 @@ Policies
 
 .. _policies.version:
 
-Version Policy
+Version policy
 ~~~~~~~~~~~~~~
 
 .. versionchanged:: 1.0.0
@@ -48,7 +48,7 @@ deprecation removed in the next next major release (2.0.0).
 These policies do not apply to features marked as **experimental** in the documentation.
 Pandas may change the behavior of experimental features at any time.
 
-Python Support
+Python support
 ~~~~~~~~~~~~~~
 
 Pandas will only drop support for specific Python versions (e.g. 3.6.x, 3.7.x) in

--- a/doc/source/development/roadmap.rst
+++ b/doc/source/development/roadmap.rst
@@ -152,7 +152,7 @@ We'd like to fund improvements and maintenance of these tools to
 
 .. _roadmap.evolution:
 
-Roadmap Evolution
+Roadmap evolution
 -----------------
 
 Pandas continues to evolve. The direction is primarily determined by community

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -5,7 +5,7 @@
 {{ header }}
 
 ****************
-Pandas ecosystem
+pandas ecosystem
 ****************
 
 Increasingly, packages are being built on top of pandas to address specific needs

--- a/doc/source/getting_started/10min.rst
+++ b/doc/source/getting_started/10min.rst
@@ -428,7 +428,7 @@ See more at :ref:`Histogramming and Discretization <basics.discretization>`.
    s
    s.value_counts()
 
-String Methods
+String methods
 ~~~~~~~~~~~~~~
 
 Series is equipped with a set of string processing methods in the `str`

--- a/doc/source/getting_started/basics.rst
+++ b/doc/source/getting_started/basics.rst
@@ -1871,7 +1871,7 @@ Series has the :meth:`~Series.searchsorted` method, which works similarly to
 
 .. _basics.nsorted:
 
-smallest / largest values
+Smallest / largest values
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``Series`` has the :meth:`~Series.nsmallest` and :meth:`~Series.nlargest` methods which return the
@@ -2142,7 +2142,7 @@ Convert certain columns to a specific dtype by passing a dict to :meth:`~DataFra
 
 .. _basics.object_conversion:
 
-object conversion
+Object conversion
 ~~~~~~~~~~~~~~~~~
 
 pandas offers various functions to try to force conversion of types from the ``object`` dtype to other types.
@@ -2257,7 +2257,7 @@ as DataFrames. However, with :meth:`~pandas.DataFrame.apply`, we can "apply" the
     df
     df.apply(pd.to_timedelta)
 
-gotchas
+Gotchas
 ~~~~~~~
 
 Performing selection operations on ``integer`` type data can easily upcast the data to ``floating``.

--- a/doc/source/getting_started/comparison/comparison_with_sas.rst
+++ b/doc/source/getting_started/comparison/comparison_with_sas.rst
@@ -698,7 +698,7 @@ In pandas this would be written as:
    tips.groupby(['sex', 'smoker']).first()
 
 
-Other Considerations
+Other considerations
 --------------------
 
 Disk vs memory

--- a/doc/source/getting_started/comparison/comparison_with_sql.rst
+++ b/doc/source/getting_started/comparison/comparison_with_sql.rst
@@ -388,10 +388,10 @@ In pandas, you can use :meth:`~pandas.concat` in conjunction with
 
     pd.concat([df1, df2]).drop_duplicates()
 
-Pandas equivalents for some SQL analytic and aggregate functions
+pandas equivalents for some SQL analytic and aggregate functions
 ----------------------------------------------------------------
 
-Top N rows with offset
+Top n rows with offset
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: sql
@@ -405,7 +405,7 @@ Top N rows with offset
 
     tips.nlargest(10 + 5, columns='tip').tail(10)
 
-Top N rows per group
+Top n rows per group
 ~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: sql

--- a/doc/source/getting_started/comparison/comparison_with_stata.rst
+++ b/doc/source/getting_started/comparison/comparison_with_stata.rst
@@ -2,7 +2,7 @@
 
 {{ header }}
 
-Comparison with Stata
+Comparison with STATA
 *********************
 For potential users coming from `Stata <https://en.wikipedia.org/wiki/Stata>`__
 this page is meant to demonstrate how different Stata operations would be

--- a/doc/source/getting_started/intro_tutorials/01_table_oriented.rst
+++ b/doc/source/getting_started/intro_tutorials/01_table_oriented.rst
@@ -26,7 +26,7 @@ documentation.
         </li>
     </ul>
 
-Pandas data table representation
+pandas data table representation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. image:: ../../_static/schemas/01_table_dataframe.svg

--- a/doc/source/getting_started/tutorials.rst
+++ b/doc/source/getting_started/tutorials.rst
@@ -30,7 +30,7 @@ entails.
 For the table of contents, see the `pandas-cookbook GitHub
 repository <https://github.com/jvns/pandas-cookbook>`_.
 
-Learn Pandas by Hernan Rojas
+Learn pandas by Hernan Rojas
 ----------------------------
 
 A set of lesson for new pandas users: https://bitbucket.org/hrojas/learn-pandas


### PR DESCRIPTION
Files updated:

```
doc/source/getting_started/comparison/comparison_with_sas.rst
doc/source/getting_started/comparison/comparison_with_sql.rst
doc/source/getting_started/comparison/comparison_with_stata.rst
doc/source/getting_started/intro_tutorials/01_table_oriented.rst
doc/source/getting_started/tutorials.rst
```
