### PR TITLE
CLN: Clean NDFrame.__finalize__ signature

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5131,9 +5131,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     # ----------------------------------------------------------------------
     # Attribute access
 
-    def __finalize__(
-        self: FrameOrSeries, other, method=None, **kwargs
-    ) -> FrameOrSeries:
+    def __finalize__(self: FrameOrSeries, other) -> FrameOrSeries:
         """
         Propagate metadata from other to self.
 
@@ -5141,9 +5139,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         ----------
         other : the object from which to get the attributes that we are going
             to propagate
-        method : optional, a passed method name ; possibly to take different
-            types of propagation actions based on this
-
         """
         if isinstance(other, NDFrame):
             for name in other.attrs:

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -460,7 +460,7 @@ class _Concatenator:
                     [x._data for x in self.objs], self.new_axes
                 )
                 cons = self.objs[0]._constructor
-                return cons(mgr, name=name).__finalize__(self, method="concat")
+                return cons(mgr, name=name).__finalize__(self)
 
             # combine as columns in a frame
             else:
@@ -470,7 +470,7 @@ class _Concatenator:
                 index, columns = self.new_axes
                 df = cons(data, index=index)
                 df.columns = columns
-                return df.__finalize__(self, method="concat")
+                return df.__finalize__(self)
 
         # combine block managers
         else:
@@ -496,7 +496,7 @@ class _Concatenator:
                 new_data._consolidate_inplace()
 
             cons = self.objs[0]._constructor
-            return cons(new_data).__finalize__(self, method="concat")
+            return cons(new_data).__finalize__(self)
 
     def _get_result_dim(self) -> int:
         if self._is_series and self.axis == 1:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -635,7 +635,7 @@ class _MergeOperation:
         )
 
         typ = self.left._constructor
-        result = typ(result_data).__finalize__(self, method=self._merge_type)
+        result = typ(result_data).__finalize__(self)
 
         if self.indicator:
             result = self._indicator_post_merge(result)
@@ -1457,7 +1457,7 @@ class _OrderedMerge(_MergeOperation):
         )
 
         typ = self.left._constructor
-        result = typ(result_data).__finalize__(self, method=self._merge_type)
+        result = typ(result_data).__finalize__(self)
 
         self._maybe_add_join_keys(result, left_indexer, right_indexer)
 

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -110,15 +110,12 @@ class TestDataFrame(Generic):
         df1.filename = "fname1.csv"
         df2.filename = "fname2.csv"
 
-        def finalize(self, other, method=None, **kwargs):
+        def finalize(self, other):
 
             for name in self._metadata:
-                if method == "merge":
-                    left, right = other.left, other.right
-                    value = getattr(left, name, "") + "|" + getattr(right, name, "")
-                    object.__setattr__(self, name, value)
-                else:
-                    object.__setattr__(self, name, getattr(other, name, ""))
+                left, right = other.left, other.right
+                value = getattr(left, name, "") + "|" + getattr(right, name, "")
+                object.__setattr__(self, name, value)
 
             return self
 
@@ -132,15 +129,12 @@ class TestDataFrame(Generic):
         df1 = DataFrame(np.random.randint(0, 4, (3, 2)), columns=list("ab"))
         df1.filename = "foo"
 
-        def finalize(self, other, method=None, **kwargs):
+        def finalize(self, other):
             for name in self._metadata:
-                if method == "concat":
-                    value = "+".join(
-                        [getattr(o, name) for o in other.objs if getattr(o, name, None)]
-                    )
-                    object.__setattr__(self, name, value)
-                else:
-                    object.__setattr__(self, name, getattr(other, name, None))
+                value = "+".join(
+                    [getattr(o, name) for o in other.objs if getattr(o, name, None)]
+                )
+                object.__setattr__(self, name, value)
 
             return self
 

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -145,9 +145,9 @@ class TestSeries(Generic):
         o.filename = "foo"
         o2.filename = "bar"
 
-        def finalize(self, other, method=None, **kwargs):
+        def finalize(self, other):
             for name in self._metadata:
-                if method == "concat" and name == "filename":
+                if name == "filename":
                     value = "+".join(
                         [getattr(o, name) for o in other.objs if getattr(o, name, None)]
                     )


### PR DESCRIPTION
`NDFrame.__finalize__` doesn't do anything with `method` or `kwargs` so removing them from the signature and all calls. Had to change a few tests which overrode this method with another that also included those arguments.