### PR TITLE
BUG: Multiple unstack using row index level labels and multi level columns DataFrame

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -387,6 +387,7 @@ Reshaping
 - Bug in :meth:`DataFrame.apply` where callback was called with :class:`Series` parameter even though ``raw=True`` requested. (:issue:`32423`)
 - Bug in :meth:`DataFrame.pivot_table` losing timezone information when creating a :class:`MultiIndex` level from a column with timezone-aware dtype (:issue:`32558`)
 - :meth:`DataFrame.agg` now provides more descriptive ``SpecificationError`` message when attempting to aggregating non-existant column (:issue:`32755`)
+- Bug in :meth:`DataFrame.unstack` when MultiIndexed columns and MultiIndexed rows were used (:issue:`32624`, :issue:`24729` and :issue:`28306`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -338,7 +338,7 @@ def _unstack_multiple(data, clocs, fill_value=None):
     comp_ids, obs_ids = compress_group_index(group_index, sort=False)
     recons_codes = decons_obs_group_ids(comp_ids, obs_ids, shape, ccodes, xnull=False)
 
-    if rlocs == []:
+    if not rlocs:
         # Everything is in clocs, so the dummy df has a regular index
         dummy_index = Index(obs_ids, name="__placeholder__")
     else:

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -363,7 +363,7 @@ def _unstack_multiple(data, clocs, fill_value=None):
             for i in range(len(clocs)):
                 val = clocs[i]
                 result = result.unstack(val, fill_value=fill_value)
-                clocs = [v if i > v else v - 1 for v in clocs]
+                clocs = [v if v < val else v - 1 for v in clocs]
 
             return result
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -260,7 +260,7 @@ def _convert_listlike_datetimes(
     Parameters
     ----------
     arg : list, tuple, ndarray, Series, Index
-        date to be parsed
+        date to be parced
     name : object
         None or string for the Index name
     tz : object

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -260,7 +260,7 @@ def _convert_listlike_datetimes(
     Parameters
     ----------
     arg : list, tuple, ndarray, Series, Index
-        date to be parced
+        date to be parsed
     name : object
         None or string for the Index name
     tz : object

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -785,7 +785,6 @@ class TestDataFrameReshape:
             ),
             index=pd.Index([0], name="i1"),
         )
-        print(expected)
         tm.assert_frame_equal(result, expected)
 
     def test_unstack_multi_level_cols(self):

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -785,6 +785,39 @@ class TestDataFrameReshape:
             ),
             index=pd.Index([0], name="i1"),
         )
+        print(expected)
+        tm.assert_frame_equal(result, expected)
+
+    def test_unstack_multi_level_cols(self):
+        # PH 24729: Unstack a df with multi level columns
+        df = pd.DataFrame(
+            [[0.0, 0.0], [0.0, 0.0]],
+            columns=pd.MultiIndex.from_tuples(
+                [["B", "C"], ["B", "D"]], names=["c1", "c2"]
+            ),
+            index=pd.MultiIndex.from_tuples(
+                [[10, 20, 30], [10, 20, 40]], names=["i1", "i2", "i3"],
+            ),
+        )
+        assert df.unstack(["i2", "i1"]).columns.names[-2:] == ["i2", "i1"]
+
+    def test_unstack_multi_level_rows_and_cols(self):
+        # PH 28306: Unstack df with multi level cols and rows
+        df = pd.DataFrame(
+            [[1, 2], [3, 4], [-1, -2], [-3, -4]],
+            columns=pd.MultiIndex.from_tuples([["a", "b", "c"], ["d", "e", "f"]]),
+            index=pd.MultiIndex.from_tuples(
+                [
+                    ["m1", "P3", 222],
+                    ["m1", "A5", 111],
+                    ["m2", "P3", 222],
+                    ["m2", "A5", 111],
+                ],
+                names=["i1", "i2", "i3"],
+            ),
+        )
+        result = df.unstack(["i3", "i2"])
+        expected = df.unstack(["i3"]).unstack(["i2"])
         tm.assert_frame_equal(result, expected)
 
     def test_unstack_nan_index(self):  # GH7466

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -765,6 +765,19 @@ class TestDataFrameReshape:
         expected.index = expected.index.droplevel("C")
         tm.assert_frame_equal(result, expected)
 
+    def test_unstack_long_index(self):
+        # PH 32624: Error when using a lot of indices to unstack. The error occurred only, if a lot of indices are used.
+        df = pd.DataFrame([[1]],
+                          columns=pd.MultiIndex.from_tuples([[0]], names=['c1']),
+                          index=pd.MultiIndex.from_tuples([[0, 0, 1, 0, 0, 0, 1]],
+                                                          names=['i1', 'i2', 'i3', 'i4', 'i5', 'i6', 'i7']))
+        result = df.unstack(["i2", "i3", "i4", "i5", "i6", "i7"])
+        expected = pd.DataFrame([[1]],
+                                columns=pd.MultiIndex.from_tuples([[0, 0, 1, 0, 0, 0, 1]],
+                                                                  names=['c1', 'i2', 'i3', 'i4', 'i5', 'i6', 'i7']),
+                                index=pd.Index([0], name='i1'))
+        tm.assert_frame_equal(result, expected)
+
     def test_unstack_nan_index(self):  # GH7466
         def cast(val):
             val_str = "" if val != val else val

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -766,16 +766,25 @@ class TestDataFrameReshape:
         tm.assert_frame_equal(result, expected)
 
     def test_unstack_long_index(self):
-        # PH 32624: Error when using a lot of indices to unstack. The error occurred only, if a lot of indices are used.
-        df = pd.DataFrame([[1]],
-                          columns=pd.MultiIndex.from_tuples([[0]], names=['c1']),
-                          index=pd.MultiIndex.from_tuples([[0, 0, 1, 0, 0, 0, 1]],
-                                                          names=['i1', 'i2', 'i3', 'i4', 'i5', 'i6', 'i7']))
+        # PH 32624: Error when using a lot of indices to unstack.
+        # The error occurred only, if a lot of indices are used.
+        df = pd.DataFrame(
+            [[1]],
+            columns=pd.MultiIndex.from_tuples([[0]], names=["c1"]),
+            index=pd.MultiIndex.from_tuples(
+                [[0, 0, 1, 0, 0, 0, 1]],
+                names=["i1", "i2", "i3", "i4", "i5", "i6", "i7"],
+            ),
+        )
         result = df.unstack(["i2", "i3", "i4", "i5", "i6", "i7"])
-        expected = pd.DataFrame([[1]],
-                                columns=pd.MultiIndex.from_tuples([[0, 0, 1, 0, 0, 0, 1]],
-                                                                  names=['c1', 'i2', 'i3', 'i4', 'i5', 'i6', 'i7']),
-                                index=pd.Index([0], name='i1'))
+        expected = pd.DataFrame(
+            [[1]],
+            columns=pd.MultiIndex.from_tuples(
+                [[0, 0, 1, 0, 0, 0, 1]],
+                names=["c1", "i2", "i3", "i4", "i5", "i6", "i7"],
+            ),
+            index=pd.Index([0], name="i1"),
+        )
         tm.assert_frame_equal(result, expected)
 
     def test_unstack_nan_index(self):  # GH7466


### PR DESCRIPTION
- [x] closes #24729
- [x] closes #28306
- [x] closes #32624
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This should fix the issue with a long list of indices and unstack. The issue appeared with 6 indices for the first time.
