### PR TITLE
STY: Boolean values for bint variables

### DIFF
--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -78,7 +78,7 @@ def inner_join(const int64_t[:] left, const int64_t[:] right,
 
 @cython.boundscheck(False)
 def left_outer_join(const int64_t[:] left, const int64_t[:] right,
-                    Py_ssize_t max_groups, sort=True):
+                    Py_ssize_t max_groups, bint sort=True):
     cdef:
         Py_ssize_t i, j, k, count = 0
         ndarray[int64_t] left_count, right_count, left_sorter, right_sorter
@@ -670,7 +670,7 @@ def asof_join_backward_on_X_by_Y(asof_t[:] left_values,
     cdef:
         Py_ssize_t left_pos, right_pos, left_size, right_size, found_right_pos
         ndarray[int64_t] left_indexer, right_indexer
-        bint has_tolerance = 0
+        bint has_tolerance = False
         asof_t tolerance_ = 0
         asof_t diff = 0
         HashTable hash_table
@@ -678,7 +678,7 @@ def asof_join_backward_on_X_by_Y(asof_t[:] left_values,
 
     # if we are using tolerance, set our objects
     if tolerance is not None:
-        has_tolerance = 1
+        has_tolerance = True
         tolerance_ = tolerance
 
     left_size = len(left_values)
@@ -739,7 +739,7 @@ def asof_join_forward_on_X_by_Y(asof_t[:] left_values,
     cdef:
         Py_ssize_t left_pos, right_pos, left_size, right_size, found_right_pos
         ndarray[int64_t] left_indexer, right_indexer
-        bint has_tolerance = 0
+        bint has_tolerance = False
         asof_t tolerance_ = 0
         asof_t diff = 0
         HashTable hash_table
@@ -747,7 +747,7 @@ def asof_join_forward_on_X_by_Y(asof_t[:] left_values,
 
     # if we are using tolerance, set our objects
     if tolerance is not None:
-        has_tolerance = 1
+        has_tolerance = True
         tolerance_ = tolerance
 
     left_size = len(left_values)
@@ -802,7 +802,7 @@ def asof_join_nearest_on_X_by_Y(asof_t[:] left_values,
                                 asof_t[:] right_values,
                                 by_t[:] left_by_values,
                                 by_t[:] right_by_values,
-                                bint allow_exact_matches=1,
+                                bint allow_exact_matches=True,
                                 tolerance=None):
 
     cdef:
@@ -853,19 +853,19 @@ def asof_join_nearest_on_X_by_Y(asof_t[:] left_values,
 
 def asof_join_backward(asof_t[:] left_values,
                        asof_t[:] right_values,
-                       bint allow_exact_matches=1,
+                       bint allow_exact_matches=True,
                        tolerance=None):
 
     cdef:
         Py_ssize_t left_pos, right_pos, left_size, right_size
         ndarray[int64_t] left_indexer, right_indexer
-        bint has_tolerance = 0
+        bint has_tolerance = False
         asof_t tolerance_ = 0
         asof_t diff = 0
 
     # if we are using tolerance, set our objects
     if tolerance is not None:
-        has_tolerance = 1
+        has_tolerance = True
         tolerance_ = tolerance
 
     left_size = len(left_values)
@@ -906,19 +906,19 @@ def asof_join_backward(asof_t[:] left_values,
 
 def asof_join_forward(asof_t[:] left_values,
                       asof_t[:] right_values,
-                      bint allow_exact_matches=1,
+                      bint allow_exact_matches=True,
                       tolerance=None):
 
     cdef:
         Py_ssize_t left_pos, right_pos, left_size, right_size
         ndarray[int64_t] left_indexer, right_indexer
-        bint has_tolerance = 0
+        bint has_tolerance = False
         asof_t tolerance_ = 0
         asof_t diff = 0
 
     # if we are using tolerance, set our objects
     if tolerance is not None:
-        has_tolerance = 1
+        has_tolerance = True
         tolerance_ = tolerance
 
     left_size = len(left_values)
@@ -960,7 +960,7 @@ def asof_join_forward(asof_t[:] left_values,
 
 def asof_join_nearest(asof_t[:] left_values,
                       asof_t[:] right_values,
-                      bint allow_exact_matches=1,
+                      bint allow_exact_matches=True,
                       tolerance=None):
 
     cdef:


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

---

```asv``` benchmarks: to show that performance is not changed with the stylistic changes)

```
All benchmarks:

       before           after         ratio
     [28e0f18a]       [6f1fd78d]
     <master>         <STY-bint-boolean-not-int-join>
         21.4±1ms       19.8±0.4ms     0.92  join_merge.Join.time_join_dataframe_index_multi(False)
       24.9±0.3ms       23.6±0.3ms     0.95  join_merge.Join.time_join_dataframe_index_multi(True)
       14.5±0.3ms       14.0±0.3ms     0.97  join_merge.Join.time_join_dataframe_index_shuffle_key_bigger_sort(False)
       17.6±0.6ms       16.7±0.5ms     0.95  join_merge.Join.time_join_dataframe_index_shuffle_key_bigger_sort(True)
       14.4±0.3ms       13.8±0.2ms     0.95  join_merge.Join.time_join_dataframe_index_single_key_bigger(False)
       17.8±0.7ms       16.4±0.5ms     0.92  join_merge.Join.time_join_dataframe_index_single_key_bigger(True)
       13.5±0.3ms       13.1±0.3ms     0.97  join_merge.Join.time_join_dataframe_index_single_key_small(False)
       14.5±0.1ms       13.9±0.5ms     0.96  join_merge.Join.time_join_dataframe_index_single_key_small(True)
       2.86±0.08s       2.94±0.05s     1.03  join_merge.JoinIndex.time_left_outer_join_index
         433±70μs         428±50μs     0.99  join_merge.JoinNonUnique.time_join_non_unique_equal
```