### PR TITLE
Fix 25648 improve read csv stacktrace on bad argument

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -355,6 +355,7 @@ I/O
 - Bug in :meth:`read_csv` was causing a segfault when there were blank lines between the header and data rows (:issue:`28071`)
 - Bug in :meth:`read_csv` was raising a misleading exception on a permissions issue (:issue:`23784`)
 - Bug in :meth:`read_csv` was raising an ``IndexError`` when header=None and 2 extra data columns
+- `TypeError` exceptions raised by :meth:`read_csv` and :meth:`read_table` where showing as ``parser_f`` when an unexpected keyword argument was passed (:issue:`25648`)
 
 
 Plotting

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -355,7 +355,7 @@ I/O
 - Bug in :meth:`read_csv` was causing a segfault when there were blank lines between the header and data rows (:issue:`28071`)
 - Bug in :meth:`read_csv` was raising a misleading exception on a permissions issue (:issue:`23784`)
 - Bug in :meth:`read_csv` was raising an ``IndexError`` when header=None and 2 extra data columns
-- `TypeError` exceptions raised by :meth:`read_csv` and :meth:`read_table` where showing as ``parser_f`` when an unexpected keyword argument was passed (:issue:`25648`)
+- `TypeError` exceptions raised by :meth:`read_csv` and :meth:`read_table` were showing as ``parser_f`` when an unexpected keyword argument was passed (:issue:`25648`)
 
 
 Plotting

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -528,9 +528,13 @@ _deprecated_args: Set[str] = set()
 
 
 def _make_parser_function(name, default_sep=","):
-    def parser_f(
-        filepath_or_buffer: FilePathOrBuffer,
-        sep=default_sep,
+    exec(f"""
+from pandas._typing import FilePathOrBuffer
+import csv
+
+def {name}(
+        filepath_or_buffer : FilePathOrBuffer,
+        sep="{default_sep}",
         delimiter=None,
         # Column and Index Locations and Names
         header="infer",
@@ -583,7 +587,7 @@ def _make_parser_function(name, default_sep=","):
         warn_bad_lines=True,
         # Internal
         delim_whitespace=False,
-        low_memory=_c_parser_defaults["low_memory"],
+        low_memory={_c_parser_defaults["low_memory"]},
         memory_map=False,
         float_precision=None,
     ):
@@ -674,13 +678,10 @@ def _make_parser_function(name, default_sep=","):
         )
 
         return _read(filepath_or_buffer, kwds)
-
-    parser_f.__name__ = name
-
-    return parser_f
+    """, globals())
 
 
-read_csv = _make_parser_function("read_csv", default_sep=",")
+_make_parser_function("read_csv", default_sep=",")
 read_csv = Appender(
     _doc_read_csv_and_table.format(
         func_name="read_csv",
@@ -689,7 +690,7 @@ read_csv = Appender(
     )
 )(read_csv)
 
-read_table = _make_parser_function("read_table", default_sep="\t")
+_make_parser_function("read_table", default_sep="\t")
 read_table = Appender(
     _doc_read_csv_and_table.format(
         func_name="read_table",

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -528,7 +528,8 @@ _deprecated_args: Set[str] = set()
 
 
 def _make_parser_function(name, default_sep=","):
-    exec(f"""
+    exec(
+        f"""
 from pandas._typing import FilePathOrBuffer
 import csv
 
@@ -678,7 +679,9 @@ def {name}(
         )
 
         return _read(filepath_or_buffer, kwds)
-    """, globals())
+    """,
+        globals(),
+    )
 
 
 _make_parser_function("read_csv", default_sep=",")

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -691,7 +691,8 @@ read_csv = Appender(
         summary="Read a comma-separated values (csv) file into DataFrame.",
         _default_sep="','",
     )
-)(read_csv)
+)(read_csv)  # noqa F821
+
 
 _make_parser_function("read_table", default_sep="\t")
 read_table = Appender(
@@ -700,7 +701,7 @@ read_table = Appender(
         summary="Read general delimited file into DataFrame.",
         _default_sep=r"'\\t' (tab-stop)",
     )
-)(read_table)
+)(read_table)  # noqa F821
 
 
 def read_fwf(

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -605,7 +605,7 @@ def {name}(
         # the comparison to dialect values by checking if default values
         # for BOTH "delimiter" and "sep" were provided.
         if dialect is not None:
-            sep_override = delimiter is None and sep == default_sep
+            sep_override = delimiter is None and sep == "{default_sep}"
             kwds = dict(sep_override=sep_override)
         else:
             kwds = dict()
@@ -614,7 +614,7 @@ def {name}(
         if delimiter is None:
             delimiter = sep
 
-        if delim_whitespace and delimiter != default_sep:
+        if delim_whitespace and delimiter != "{default_sep}":
             raise ValueError(
                 "Specified a delimiter with both sep and "
                 "delim_whitespace=True; you can only specify one."

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2126,3 +2126,10 @@ def test_no_header_two_extra_columns(all_parsers):
     parser = all_parsers
     df = parser.read_csv(stream, header=None, names=column_names, index_col=False)
     tm.assert_frame_equal(df, ref)
+
+def test_unexpected_keyword_parameter_exception(all_parsers):
+    # GH 25648
+    parser = all_parsers
+    msg = "read_csv\\(\\) got an unexpected keyword argument 'foo'"
+    with pytest.raises(TypeError, match=msg):
+        parser.read_csv("foo.csv", foo=1)

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2127,6 +2127,7 @@ def test_no_header_two_extra_columns(all_parsers):
     df = parser.read_csv(stream, header=None, names=column_names, index_col=False)
     tm.assert_frame_equal(df, ref)
 
+
 def test_unexpected_keyword_parameter_exception(all_parsers):
     # GH 25648
     parser = all_parsers


### PR DESCRIPTION
- [x] closes #25648
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
