### PR TITLE
[WIP] Make Index.values read-only

### DIFF
--- a/ci/deps/azure-36-32bit.yaml
+++ b/ci/deps/azure-36-32bit.yaml
@@ -22,5 +22,5 @@ dependencies:
   # see comment above
   - pip
   - pip:
-    - cython>=0.29.16
+    - Cython==3.0a5
     - pytest>=5.0.1,<6.0.0rc0

--- a/ci/deps/azure-36-locale.yaml
+++ b/ci/deps/azure-36-locale.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - pytest-asyncio
@@ -36,3 +35,6 @@ dependencies:
   - xlsxwriter
   - xlwt
   - moto
+
+  - pip:
+    - Cython==3.0a5

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -29,4 +28,5 @@ dependencies:
   - xlwt=1.2.0
   - pip
   - pip:
+    - Cython==3.0a5
     - html5lib==1.0b2

--- a/ci/deps/azure-36-minimum_versions.yaml
+++ b/ci/deps/azure-36-minimum_versions.yaml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.6.1
 
   # tools
-  - cython=0.29.16
   - pytest=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -28,3 +27,6 @@ dependencies:
   - xlsxwriter=0.9.8
   - xlwt=1.2.0
   - html5lib=1.0.1
+
+  - pip:
+    - Cython==3.0a5

--- a/ci/deps/azure-36-slow.yaml
+++ b/ci/deps/azure-36-slow.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -33,3 +32,5 @@ dependencies:
   - xlsxwriter
   - xlwt
   - moto
+  - pip:
+    - Cython==3.0a5

--- a/ci/deps/azure-37-locale.yaml
+++ b/ci/deps/azure-37-locale.yaml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - pytest-asyncio
@@ -35,4 +34,5 @@ dependencies:
   - pyarrow>=0.15
   - pip
   - pip:
+    - Cython==3.0a5
     - pyxlsb

--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytz
   - pip
   - pip:
-    - cython==0.29.16 # GH#34014
+    - Cython==3.0a5
     - "git+git://github.com/dateutil/dateutil.git"
     - "--extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - "--pre"

--- a/ci/deps/azure-macos-36.yaml
+++ b/ci/deps/azure-macos-36.yaml
@@ -31,6 +31,6 @@ dependencies:
   - xlwt
   - pip
   - pip:
-    - cython>=0.29.16
+    - Cython==3.0a5
     - pyreadstat
     - pyxlsb

--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -30,3 +29,5 @@ dependencies:
   - xlrd
   - xlsxwriter
   - xlwt
+  - pip:
+    - Cython==3.0a5

--- a/ci/deps/azure-windows-37.yaml
+++ b/ci/deps/azure-windows-37.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -38,4 +37,5 @@ dependencies:
   - pyreadstat
   - pip
   - pip:
+    - Cython==3.0a5
     - pyxlsb

--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -15,7 +14,6 @@ dependencies:
   # pandas dependencies
   - beautifulsoup4
   - botocore>=1.11
-  - cython>=0.29.16
   - dask
   - fastparquet>=0.3.2
   - fsspec>=0.7.4
@@ -47,6 +45,7 @@ dependencies:
   - xlwt
   - pip
   - pip:
+    - Cython==3.0a5
     - brotlipy
     - coverage
     - pandas-datareader

--- a/ci/deps/travis-36-locale.yaml
+++ b/ci/deps/travis-36-locale.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -38,3 +37,5 @@ dependencies:
   - xlrd
   - xlsxwriter
   - xlwt
+  - pip:
+    - Cython==3.0a5

--- a/ci/deps/travis-37-arm64.yaml
+++ b/ci/deps/travis-37-arm64.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.13
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -18,4 +17,5 @@ dependencies:
   - pytz
   - pip
   - pip:
+    - Cython==3.0a5
     - moto

--- a/ci/deps/travis-37.yaml
+++ b/ci/deps/travis-37.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -24,4 +23,5 @@ dependencies:
   - pyreadstat
   - pip
   - pip:
+    - Cython==3.0a5
     - moto

--- a/ci/deps/travis-38.yaml
+++ b/ci/deps/travis-38.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.8.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1,<6.0.0rc0
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -18,3 +17,5 @@ dependencies:
   - pytz
   - pip
   - tabulate==0.8.3
+  - pip:
+    - Cython==3.0a5

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -555,13 +555,13 @@ class IntervalArray(IntervalMixin, ExtensionArray):
 
         # Need to ensure that left and right are updated atomically, so we're
         # forced to copy, update the copy, and swap in the new values.
-        left = self.left.copy(deep=True)
-        left._values[key] = value_left
-        self._left = left
+        left_data = self.left._data.copy()
+        left_data[key] = value_left
+        self._left = self.left._shallow_copy(left_data)
 
-        right = self.right.copy(deep=True)
-        right._values[key] = value_right
-        self._right = right
+        right_data = self.right._data.copy()
+        right_data[key] = value_right
+        self._right = self.right._shallow_copy(right_data)
 
     def __eq__(self, other):
         # ensure pandas array for list-like and eliminate non-interval scalars

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3849,7 +3849,9 @@ class Index(IndexOpsMixin, PandasObject):
         Index.array : Reference to the underlying data.
         Index.to_numpy : A NumPy array representing the underlying data.
         """
-        return self._data.view(np.ndarray)
+        vals = self._data.view(np.ndarray)
+        vals.setflags(write=False)
+        return vals
 
     @cache_readonly
     @doc(IndexOpsMixin.array)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3860,7 +3860,7 @@ class Index(IndexOpsMixin, PandasObject):
         if isinstance(array, np.ndarray):
             from pandas.core.arrays.numpy_ import PandasArray
 
-            array = PandasArray(array)
+            array = PandasArray(self.values)
         return array
 
     @property

--- a/pandas/tests/indexes/test_any_index.py
+++ b/pandas/tests/indexes/test_any_index.py
@@ -33,6 +33,20 @@ def test_mutability(index):
         index[0] = index[0]
 
 
+def test_values_mutability(index):
+    if not len(index):
+        return
+    with pytest.raises(ValueError):
+        index.values[0] = index[0]
+
+
+def test_array_mutability(index):
+    if not len(index):
+        return
+    with pytest.raises(ValueError):
+        index.array[0] = index[0]
+
+
 def test_wrong_number_names(index):
     names = index.nlevels * ["apple", "banana", "carrot"]
     with pytest.raises(ValueError, match="^Length"):


### PR DESCRIPTION
- [ ] closes #33001
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is a PR for looking around enforcing immutability of `pd.Index` objects. It will be a draft, but the main idea is to show what tests fail and what would need to change for this to be implemented. Because of this, I'm going to add some commits incrementally, so there is a history in the build logs.