### PR TITLE
ERR: Raise NotImplementedError with BaseIndexer and certain rolling operations

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -86,6 +86,7 @@ Other API changes
 - :meth:`Groupby.groups` now returns an abbreviated representation when called on large dataframes (:issue:`1135`)
 - ``loc`` lookups with an object-dtype :class:`Index` and an integer key will now raise ``KeyError`` instead of ``TypeError`` when key is missing (:issue:`31905`)
 - Using a :func:`pandas.api.indexers.BaseIndexer` with `min`, `max`, `std`, `var`, `count`, `skew`, `cov", `corr` will now raise a ``NotImplementedError` (:issue:`32865`)
+-
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -85,7 +85,7 @@ Other API changes
 - Added :meth:`DataFrame.value_counts` (:issue:`5377`)
 - :meth:`Groupby.groups` now returns an abbreviated representation when called on large dataframes (:issue:`1135`)
 - ``loc`` lookups with an object-dtype :class:`Index` and an integer key will now raise ``KeyError`` instead of ``TypeError`` when key is missing (:issue:`31905`)
-- Using a :func:`pandas.api.indexers.BaseIndexer` with `min`, `max`, `std`, `var`, `count`, `skew`, `cov", `corr` will now raise a ``NotImplementedError` (:issue:`32865`)
+- Using a :func:`pandas.api.indexers.BaseIndexer` with ``min``, ``max``, ``std``, ``var``, ``count``, ``skew``, ``cov``, ``corr`` will now raise a ``NotImplementedError`` (:issue:`32865`)
 -
 
 Backwards incompatible API changes

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -85,7 +85,7 @@ Other API changes
 - Added :meth:`DataFrame.value_counts` (:issue:`5377`)
 - :meth:`Groupby.groups` now returns an abbreviated representation when called on large dataframes (:issue:`1135`)
 - ``loc`` lookups with an object-dtype :class:`Index` and an integer key will now raise ``KeyError`` instead of ``TypeError`` when key is missing (:issue:`31905`)
--
+- Using a :func:`pandas.api.indexers.BaseIndexer` with `min`, `max`, `std`, `var`, `count`, `skew`, `cov", `corr` will now raise a ``NotImplementedError` (:issue:`32865`)
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -323,3 +323,13 @@ def get_weighted_roll_func(cfunc: Callable) -> Callable:
         return cfunc(arg, window, min_periods)
 
     return func
+
+
+def validate_baseindexer_support(func_name: Optional[str]) -> None:
+    # GH 32865: These functions work correctly with a BaseIndexer subclass
+    BASEINDEXER_WHITELIST = {"mean", "sum", "median", "kurt", "quantile"}
+    if isinstance(func_name, str) and func_name not in BASEINDEXER_WHITELIST:
+        raise NotImplementedError(
+            f"{func_name} is not supported with using a BaseIndexer "
+            f"subclasses. You can use .apply() with {func_name}."
+        )

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -404,8 +404,8 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
         if isinstance(self.window, BaseIndexer):
             if isinstance(func_name, str) and func_name not in BASEINDEXER_WHITELIST:
                 raise NotImplementedError(
-                    f"{func_name} is not supported with using a BaseIndexer subclasses. "
-                    f"You can use .apply() with {func_name}."
+                    f"{func_name} is not supported with using a BaseIndexer "
+                    f"subclasses. You can use .apply() with {func_name}."
                 )
             return self.window
         if self.is_freq_type:

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -396,7 +396,7 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
         return partial(self._get_roll_func(f"{func}_fixed"), win=self._get_window())
 
     def _get_window_indexer(
-        self, window: int, func_name: Union[Callable, str]
+        self, window: int, func_name: Optional[str]
     ) -> BaseIndexer:
         """
         Return an indexer class that will compute the window start and end bounds

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -55,7 +55,6 @@ from pandas.core.window.indexers import (
 )
 from pandas.core.window.numba_ import generate_numba_apply_func
 
-
 # GH 32865: These functions work correctly with a BaseIndexer subclass
 BASEINDEXER_WHITELIST = {"mean", "sum", "median", "kurt", "quantile"}
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -395,9 +395,7 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
             return self._get_roll_func(f"{func}_variable")
         return partial(self._get_roll_func(f"{func}_fixed"), win=self._get_window())
 
-    def _get_window_indexer(
-        self, window: int, func_name: Optional[str]
-    ) -> BaseIndexer:
+    def _get_window_indexer(self, window: int, func_name: Optional[str]) -> BaseIndexer:
         """
         Return an indexer class that will compute the window start and end bounds
         """

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -80,3 +80,18 @@ def test_win_type_not_implemented():
     indexer = CustomIndexer()
     with pytest.raises(NotImplementedError, match="BaseIndexer subclasses not"):
         df.rolling(indexer, win_type="boxcar")
+
+
+@pytest.mark.parametrize(
+    "func", ["min", "max", "std", "var", "count", "skew", "cov", "corr"]
+)
+def test_notimplemented_functions(func):
+    # GH 32865
+    class CustomIndexer(BaseIndexer):
+        def get_window_bounds(self, num_values, min_periods, center, closed):
+            return np.array([0, 1]), np.array([1, 2])
+
+    df = DataFrame({"values": range(2)})
+    indexer = CustomIndexer()
+    with pytest.raises(NotImplementedError, match=f"{func} is not supported"):
+        getattr(df.rolling(indexer), func)()


### PR DESCRIPTION
- [x] xref #32865
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

As a temporary solution for returning incorrect results when using a BaseIndexer subclass with certain rolling operations, a `NotImplementedError` will now raise with instructions to use `apply` instead.