### PR TITLE
BUG: ensure consistent behavior of Index.is_all_dates (#19204)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -636,6 +636,7 @@ Indexing
 - Bug in :meth:`Series.__getitem__` allowing missing labels with ``np.ndarray``, :class:`Index`, :class:`Series` indexers but not ``list``, these now all raise ``KeyError`` (:issue:`33646`)
 - Bug in :meth:`DataFrame.truncate` and :meth:`Series.truncate` where index was assumed to be monotone increasing (:issue:`33756`)
 - Indexing with a list of strings representing datetimes failed on :class:`DatetimeIndex` or :class:`PeriodIndex`(:issue:`11278`)
+- Bug in :meth:`Index.is_all_dates` incorrectly returning ``False`` when inferred type of index was other dates than datetime (:issue:`19204`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1951,7 +1951,14 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Whether or not the index values only consist of dates.
         """
-        return is_datetime_array(ensure_object(self._values))
+        return self.inferred_type in [
+            "datetime64",
+            "datetime",
+            "date",
+            "timedelta64",
+            "timedelta",
+            "period",
+        ]
 
     # --------------------------------------------------------------------
     # Pickle Methods

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from pandas._libs import algos as libalgos, index as libindex, lib
 import pandas._libs.join as libjoin
-from pandas._libs.lib import is_datetime_array, no_default
+from pandas._libs.lib import no_default
 from pandas._libs.tslibs import OutOfBoundsDatetime, Timestamp
 from pandas._libs.tslibs.period import IncompatibleFrequency
 from pandas._libs.tslibs.timezones import tz_compare
@@ -25,7 +25,6 @@ from pandas.core.dtypes.cast import (
 )
 from pandas.core.dtypes.common import (
     ensure_int64,
-    ensure_object,
     ensure_platform_int,
     is_bool,
     is_bool_dtype,

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1152,8 +1152,12 @@ class TestIndex(Base):
             ("bool", False),
             ("categorical", False),
             ("int", False),
-            ("datetime", True),
             ("float", False),
+            ("datetime", True),
+            ("datetime-tz", True),
+            ("period", True),
+            ("timedelta", True),
+            ("empty", False),
         ],
         indirect=["indices"],
     )
@@ -1162,7 +1166,7 @@ class TestIndex(Base):
 
     @pytest.mark.parametrize(
         "index",
-        ["datetime", "datetime-tz", "period", "timedelta", "empty"],
+        ["datetime", "datetime-tz", "period", "timedelta"],
         indirect=["index"],
     )
     def test_is_all_dates_consistency(self, index):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1165,9 +1165,7 @@ class TestIndex(Base):
         assert indices.is_all_dates is expected
 
     @pytest.mark.parametrize(
-        "index",
-        ["datetime", "datetime-tz", "period", "timedelta"],
-        indirect=["index"],
+        "index", ["datetime", "datetime-tz", "period", "timedelta"], indirect=["index"],
     )
     def test_is_all_dates_consistency(self, index):
         # GH 19204

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1160,6 +1160,16 @@ class TestIndex(Base):
     def test_is_all_dates(self, indices, expected):
         assert indices.is_all_dates is expected
 
+    @pytest.mark.parametrize(
+        "index",
+        ["datetime", "datetime-tz", "period", "timedelta", "empty"],
+        indirect=["index"],
+    )
+    def test_is_all_dates_consistency(self, index):
+        # GH 19204
+        non_date = pd.Index(["not a date"])
+        assert index.is_all_dates == index.append(non_date)[:-1].is_all_dates
+
     def test_summary(self, indices):
         self._check_method_works(Index._summary, indices)
 


### PR DESCRIPTION
- [x] closes #19204
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry