### PR TITLE
Fix mixup between mean and median

### DIFF
--- a/doc/source/getting_started/intro_tutorials/09_timeseries.rst
+++ b/doc/source/getting_started/intro_tutorials/09_timeseries.rst
@@ -335,7 +335,7 @@ When defined, the frequency of the time series is provided by the
     <ul class="task-bullet">
         <li>
 
-Make a plot of the daily median :math:`NO_2` value in each of the stations.
+Make a plot of the daily mean :math:`NO_2` value in each of the stations.
 
 .. ipython:: python
     :okwarning:


### PR DESCRIPTION
Text said "median", but code uses "mean". Make text match the code

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
