### PR TITLE
ENH/VIZ: Allowing `s` parameter of scatter plots to be a column name

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -452,6 +452,7 @@ Other
 - Fixed bug in :func:`pandas.testing.assert_series_equal` where dtypes were checked for ``Interval`` and ``ExtensionArray`` operands when ``check_dtype`` was ``False`` (:issue:`32747`)
 - Bug in :meth:`Series.map` not raising on invalid ``na_action`` (:issue:`32815`)
 - Bug in :meth:`DataFrame.__dir__` caused a segfault when using unicode surrogates in a column name (:issue:`25509`)
+- Bug in :meth:`DataFrame.plot.scatter` caused an error when plotting variable marker sizes (:issue:`32904`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1468,8 +1468,10 @@ class PlotAccessor(PandasObject):
         y : int or str
             The column name or column position to be used as vertical
             coordinates for each point.
-        s : scalar or array_like, optional
+        s : str, scalar or array_like, optional
             The size of each point. Possible values are:
+
+            - A string with the name of the column to use for marker's size.
 
             - A single scalar so all points have the same size.
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1471,7 +1471,9 @@ class PlotAccessor(PandasObject):
         s : str, scalar or array_like, optional
             The size of each point. Possible values are:
 
-            - A string with the name of the column to use for marker's size.
+            - A string with the name of the column to be used for marker's size.
+            .. versionchanged:: 1.1.0
+            plot.scatter acccepts a string with the name of a column.
 
             - A single scalar so all points have the same size.
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1471,9 +1471,9 @@ class PlotAccessor(PandasObject):
         s : str, scalar or array_like, optional
             The size of each point. Possible values are:
 
-            - A string with the name of the column to be used for marker's size.
             .. versionchanged:: 1.1.0
-            plot.scatter acccepts a string with the name of a column.
+
+            - A string with the name of the column to be used for marker's size.
 
             - A single scalar so all points have the same size.
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1471,8 +1471,6 @@ class PlotAccessor(PandasObject):
         s : str, scalar or array_like, optional
             The size of each point. Possible values are:
 
-            .. versionchanged:: 1.1.0
-
             - A string with the name of the column to be used for marker's size.
 
             - A single scalar so all points have the same size.
@@ -1480,6 +1478,8 @@ class PlotAccessor(PandasObject):
             - A sequence of scalars, which will be used for each point's size
               recursively. For instance, when passing [2,14] all points size
               will be either 2 or 14, alternatively.
+
+              .. versionchanged:: 1.1.0
 
         c : str, int or array_like, optional
             The color of each point. Possible values are:

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -934,6 +934,8 @@ class ScatterPlot(PlanePlot):
             # hide the matplotlib default for size, in case we want to change
             # the handling of this argument later
             s = 20
+        elif is_hashable(s) and s in data.columns:
+            s = data[s]
         super().__init__(data, x, y, s=s, **kwargs)
         if is_integer(c) and not self.data.columns.holds_integer():
             c = self.data.columns[c]

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1310,7 +1310,8 @@ class TestDataFramePlots(TestPlotBase):
         # this refers to GH 32904
         df = DataFrame(np.random.random((10, 3)) * 100, columns=["a", "b", "c"],)
 
-        _check_plot_works(df.plot.scatter, x="a", y="b", s="c")
+        ax = df.plot.scatter(x="a", y="b", s="c")
+        assert (df["c"].values == ax.collections[0].get_sizes()).all()
 
     def test_scatter_colors(self):
         df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1306,7 +1306,6 @@ class TestDataFramePlots(TestPlotBase):
         float_array = np.array([0.0, 1.0])
         df.plot.scatter(x="A", y="B", c=float_array, cmap="spring")
 
-    @pytest.mark.slow
     def test_plot_scatter_with_s(self):
         # this refers to GH 32904
         df = DataFrame(np.random.random((10, 3)) * 100, columns=["a", "b", "c"],)

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1311,7 +1311,7 @@ class TestDataFramePlots(TestPlotBase):
         df = DataFrame(np.random.random((10, 3)) * 100, columns=["a", "b", "c"],)
 
         ax = df.plot.scatter(x="a", y="b", s="c")
-        assert (df["c"].values == ax.collections[0].get_sizes()).all()
+        tm.assert_numpy_array_equal(df["c"].values, right=ax.collections[0].get_sizes())
 
     def test_scatter_colors(self):
         df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1306,6 +1306,16 @@ class TestDataFramePlots(TestPlotBase):
         float_array = np.array([0.0, 1.0])
         df.plot.scatter(x="A", y="B", c=float_array, cmap="spring")
 
+    @pytest.mark.slow
+    def test_plot_scatter_with_s(self):
+        # this refers to GH 32904
+        df = DataFrame(
+                np.random.random((10,3))*100,
+                columns=['a', 'b', 'c'],
+                )
+
+        _check_plot_works(df.plot.scatter(x='a', y='b', s='c'))
+
     def test_scatter_colors(self):
         df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
         with pytest.raises(TypeError):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1311,7 +1311,7 @@ class TestDataFramePlots(TestPlotBase):
         # this refers to GH 32904
         df = DataFrame(np.random.random((10, 3)) * 100, columns=["a", "b", "c"],)
 
-        _check_plot_works(df.plot.scatter(x="a", y="b", s="c"))
+        _check_plot_works(df.plot.scatter, x="a", y="b", s="c")
 
     def test_scatter_colors(self):
         df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1309,12 +1309,9 @@ class TestDataFramePlots(TestPlotBase):
     @pytest.mark.slow
     def test_plot_scatter_with_s(self):
         # this refers to GH 32904
-        df = DataFrame(
-                np.random.random((10,3))*100,
-                columns=['a', 'b', 'c'],
-                )
+        df = DataFrame(np.random.random((10, 3)) * 100, columns=["a", "b", "c"],)
 
-        _check_plot_works(df.plot.scatter(x='a', y='b', s='c'))
+        _check_plot_works(df.plot.scatter(x="a", y="b", s="c"))
 
     def test_scatter_colors(self):
         df = DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})


### PR DESCRIPTION
- [x] closes #32904 
- [x] tests added
- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This PR is a continuation of #32937 (made an error when pulling changes from the master).

I had a more elaborate decision tree for what to do with a passed size variable `s`, here https://github.com/pandas-dev/pandas/pull/32937, but in the end decided to go with the simpler version since the other checks are redundant (they would contain `s=s` or `pass`).