### PR TITLE
REF: push concat logic out of internals and into concat_compat

### DIFF
--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -97,6 +97,9 @@ def concat_compat(to_concat, axis: int = 0):
     # Creating an empty array directly is tempting, but the winnings would be
     # marginal given that it would still require shape & dtype calculation and
     # np.concatenate which has them both implemented is compiled.
+    non_empties = [x for x in to_concat if is_nonempty(x)]
+    if non_empties and axis == 0:
+        to_concat = non_empties
 
     typs = get_dtype_kinds(to_concat)
     _contains_datetime = any(typ.startswith("datetime") for typ in typs)
@@ -114,11 +117,7 @@ def concat_compat(to_concat, axis: int = 0):
     elif "sparse" in typs:
         return _concat_sparse(to_concat, axis=axis, typs=typs)
 
-    non_empties = [x for x in to_concat if is_nonempty(x)]
     all_empty = not len(non_empties)
-    if non_empties and axis == 0:
-        to_concat = non_empties
-
     single_dtype = len({x.dtype for x in to_concat}) == 1
     any_ea = any(is_extension_array_dtype(x.dtype) for x in to_concat)
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1653,17 +1653,16 @@ class SingleBlockManager(BlockManager):
 
         # check if all series are of the same block type:
         if len(non_empties) > 0:
+            # Note: doing this here instead of in concat_compat fixes a
+            #  test in test for concating two category-dtype Series
+            #  one of which is empty (and with no categories)
             blocks = [obj.blocks[0] for obj in non_empties]
-            if len({b.dtype for b in blocks}) == 1:
-                new_block = blocks[0].concat_same_type(blocks)
-            else:
-                values = [x.values for x in blocks]
-                values = concat_compat(values)
-                new_block = make_block(values, placement=slice(0, len(values), 1))
         else:
-            values = [x._block.values for x in to_concat]
-            values = concat_compat(values)
-            new_block = make_block(values, placement=slice(0, len(values), 1))
+            blocks = [obj.blocks[0] for obj in to_concat]
+
+        values = concat_compat([x.values for x in blocks])
+
+        new_block = make_block(values, placement=slice(0, len(values), 1))
 
         mgr = SingleBlockManager(new_block, new_axis)
         return mgr

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1649,17 +1649,8 @@ class SingleBlockManager(BlockManager):
         -------
         SingleBlockManager
         """
-        non_empties = [x for x in to_concat if len(x) > 0]
 
-        # check if all series are of the same block type:
-        if len(non_empties) > 0:
-            # Note: doing this here instead of in concat_compat fixes a
-            #  test in test for concating two category-dtype Series
-            #  one of which is empty (and with no categories)
-            blocks = [obj.blocks[0] for obj in non_empties]
-        else:
-            blocks = [obj.blocks[0] for obj in to_concat]
-
+        blocks = [obj.blocks[0] for obj in to_concat]
         values = concat_compat([x.values for x in blocks])
 
         new_block = make_block(values, placement=slice(0, len(values), 1))

--- a/pandas/tests/dtypes/test_concat.py
+++ b/pandas/tests/dtypes/test_concat.py
@@ -2,7 +2,9 @@ import pytest
 
 import pandas.core.dtypes.concat as _concat
 
+import pandas as pd
 from pandas import DatetimeIndex, Period, PeriodIndex, Series, TimedeltaIndex
+import pandas._testing as tm
 
 
 @pytest.mark.parametrize(
@@ -76,3 +78,13 @@ def test_get_dtype_kinds(index_or_series, to_concat, expected):
 def test_get_dtype_kinds_period(to_concat, expected):
     result = _concat.get_dtype_kinds(to_concat)
     assert result == set(expected)
+
+
+def test_concat_mismatched_categoricals_with_empty():
+    # concat_compat behavior on series._values should match pd.concat on series
+    ser1 = Series(["a", "b", "c"], dtype="category")
+    ser2 = Series([], dtype="category")
+
+    result = _concat.concat_compat([ser1._values, ser2._values])
+    expected = pd.concat([ser1, ser2])._values
+    tm.assert_categorical_equal(result, expected)

--- a/pandas/tests/extension/test_external_block.py
+++ b/pandas/tests/extension/test_external_block.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
-from pandas.core.internals import BlockManager, SingleBlockManager
+from pandas.core.internals import BlockManager
 from pandas.core.internals.blocks import ExtensionBlock
 
 
@@ -31,17 +31,6 @@ def df():
     blocks = blocks + (custom_block,)
     block_manager = BlockManager(blocks, [pd.Index(["a", "b"]), df1.index])
     return pd.DataFrame(block_manager)
-
-
-def test_concat_series():
-    # GH17728
-    values = np.arange(3, dtype="int64")
-    block = CustomBlock(values, placement=slice(0, 3))
-    mgr = SingleBlockManager(block, pd.RangeIndex(3))
-    s = pd.Series(mgr, pd.RangeIndex(3), fastpath=True)
-
-    res = pd.concat([s, s])
-    assert isinstance(res._data.blocks[0], CustomBlock)
 
 
 def test_concat_dataframe(df):


### PR DESCRIPTION
This changes some empty-array behavior for concat_compat to match the behavior of pd.concat(list_of_series), see new test.

The follow-up to this basically gets concat out of internals altogether.