### PR TITLE
Fix ambiguous reference to "previous" section

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -7,8 +7,8 @@
 ==============================
 
 Here we discuss a lot of the essential functionality common to the pandas data
-structures. Here's how to create some of the objects used in the examples from
-the previous section:
+structures. To begin, let's create some example objects like we did in
+the :ref:`10 minutes to pandas <10min>` section:
 
 .. ipython:: python
 


### PR DESCRIPTION
This section originally came just after "10 minutes to pandas",
but now it's after the "Getting started tutorials".
Also, the examples have diverged a bit, so let's not pretend
that we are creating the same objects.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
