### PR TITLE
BUG: create new MI from MultiIndex._get_level_values

### DIFF
--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -323,8 +323,8 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
 
     @cache_readonly
     def _engine(self):
-        # To avoid a reference cycle, pass a weakref of self to _engine_type.
-        period = weakref.ref(self)
+        # To avoid a reference cycle, pass a weakref of self._values to _engine_type.
+        period = weakref.ref(self._values)
         return self._engine_type(period, len(self))
 
     @doc(Index.__contains__)

--- a/pandas/tests/indexes/multi/test_get_level_values.py
+++ b/pandas/tests/indexes/multi/test_get_level_values.py
@@ -89,3 +89,17 @@ def test_get_level_values_na():
     result = index.get_level_values(0)
     expected = pd.Index([], dtype=object)
     tm.assert_index_equal(result, expected)
+
+
+def test_get_level_values_when_periods():
+    # GH33131. See also discussion in GH32669.
+    # This test can probably be removed when PeriodIndex._engine is removed.
+    from pandas import Period, PeriodIndex
+
+    idx = MultiIndex.from_arrays(
+        [PeriodIndex([Period("2019Q1"), Period("2019Q2")], name="b")]
+    )
+    idx2 = MultiIndex.from_arrays(
+        [idx._get_level_values(level) for level in range(idx.nlevels)]
+    )
+    assert all(x.is_monotonic for x in idx2.levels) is True

--- a/pandas/tests/indexes/multi/test_get_level_values.py
+++ b/pandas/tests/indexes/multi/test_get_level_values.py
@@ -102,4 +102,4 @@ def test_get_level_values_when_periods():
     idx2 = MultiIndex.from_arrays(
         [idx._get_level_values(level) for level in range(idx.nlevels)]
     )
-    assert all(x.is_monotonic for x in idx2.levels) is True
+    assert all(x.is_monotonic for x in idx2.levels)


### PR DESCRIPTION
- [x] closes #33131
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Closes #33131, a weakref was released too early.