### PR TITLE
BUG: fix ngroups and len(groups) inconsistency when using [Grouper(freq=)] (GH33132)

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1863,6 +1863,17 @@ def test_groupby_groups_in_BaseGrouper():
     expected = df.groupby(["beta", "alpha"])
     assert result.groups == expected.groups
 
+    # GH 33132
+    # Test if DataFrame grouped with a pandas.Grouper and freq param has correct groups
+    mi = pd.MultiIndex.from_product([date_range(datetime.today(), periods=2),
+                                    ["C", "D"]], names=["alpha", "beta"])
+    df = pd.DataFrame({"foo": [1, 2, 1, 2], "bar": [1, 2, 3, 4]}, index=mi)
+    result = df.groupby(["beta", pd.Grouper(level="alpha", freq='D')])
+    assert result.ngroups == len(result)
+
+    result = df.groupby([pd.Grouper(level="alpha", freq='D'), "beta"])
+    assert result.ngroups == len(result)
+
 
 @pytest.mark.parametrize("group_name", ["x", ["x"]])
 def test_groupby_axis_1(group_name):


### PR DESCRIPTION
- [ ] closes #33132
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
