### PR TITLE
REF: de-curry unstack functions

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from functools import partial
 import itertools
 import operator
 import re
@@ -1459,14 +1458,13 @@ class BlockManager(PandasObject):
             block.equals(oblock) for block, oblock in zip(self_blocks, other_blocks)
         )
 
-    def unstack(self, unstacker_func, fill_value) -> "BlockManager":
+    def unstack(self, unstacker, fill_value) -> "BlockManager":
         """
         Return a BlockManager with all blocks unstacked..
 
         Parameters
         ----------
-        unstacker_func : callable
-            A (partially-applied) ``pd.core.reshape._Unstacker`` class.
+        unstacker : reshape._Unstacker
         fill_value : Any
             fill_value for newly introduced missing values.
 
@@ -1474,19 +1472,16 @@ class BlockManager(PandasObject):
         -------
         unstacked : BlockManager
         """
-        n_rows = self.shape[-1]
-        dummy = unstacker_func(np.empty((0, 0)), value_columns=self.items)
-        new_columns = dummy.get_new_columns()
-        new_index = dummy.get_new_index()
+        new_columns = unstacker.get_new_columns(self.items)
+        new_index = unstacker.new_index
+
         new_blocks: List[Block] = []
         columns_mask: List[np.ndarray] = []
 
         for blk in self.blocks:
+            blk_cols = self.items[blk.mgr_locs.indexer]
             blocks, mask = blk._unstack(
-                partial(unstacker_func, value_columns=self.items[blk.mgr_locs.indexer]),
-                new_columns,
-                n_rows,
-                fill_value,
+                unstacker, new_columns, fill_value, value_columns=blk_cols,
             )
 
             new_blocks.extend(blocks)

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -1,4 +1,3 @@
-from functools import partial
 import itertools
 from typing import List, Optional, Union
 
@@ -7,6 +6,7 @@ import numpy as np
 import pandas._libs.algos as libalgos
 import pandas._libs.reshape as libreshape
 from pandas._libs.sparse import IntIndex
+from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.cast import maybe_promote
 from pandas.core.dtypes.common import (
@@ -42,14 +42,10 @@ class _Unstacker:
 
     Parameters
     ----------
-    values : ndarray
-        Values of DataFrame to "Unstack"
     index : object
         Pandas ``Index``
     level : int or str, default last level
         Level to "unstack". Accepts a name for the level.
-    value_columns : Index, optional
-        Pandas ``Index`` or ``MultiIndex`` object if unstacking a DataFrame
     fill_value : scalar, optional
         Default value to fill in missing values if subgroups do not have the
         same set of labels. By default, missing values will be replaced with
@@ -88,27 +84,12 @@ class _Unstacker:
     """
 
     def __init__(
-        self,
-        values: np.ndarray,
-        index,
-        level=-1,
-        value_columns=None,
-        fill_value=None,
-        constructor=None,
+        self, index, level=-1, constructor=None,
     ):
-
-        if values.ndim == 1:
-            values = values[:, np.newaxis]
-        self.values = values
-        self.value_columns = value_columns
-        self.fill_value = fill_value
 
         if constructor is None:
             constructor = DataFrame
         self.constructor = constructor
-
-        if value_columns is None and values.shape[1] != 1:  # pragma: no cover
-            raise ValueError("must pass column labels for multi-column data")
 
         self.index = index.remove_unused_levels()
 
@@ -117,6 +98,7 @@ class _Unstacker:
         # when index includes `nan`, need to lift levels/strides by 1
         self.lift = 1 if -1 in self.index.codes[self.level] else 0
 
+        # Note: the "pop" below alters these in-place.
         self.new_index_levels = list(self.index.levels)
         self.new_index_names = list(self.index.names)
 
@@ -137,10 +119,10 @@ class _Unstacker:
         if num_rows > 0 and num_columns > 0 and num_cells <= 0:
             raise ValueError("Unstacked DataFrame is too big, causing int32 overflow")
 
-        self._make_sorted_values_labels()
         self._make_selectors()
 
-    def _make_sorted_values_labels(self):
+    @cache_readonly
+    def _indexer_and_to_sort(self):
         v = self.level
 
         codes = list(self.index.codes)
@@ -154,8 +136,18 @@ class _Unstacker:
         indexer = libalgos.groupsort_indexer(comp_index, ngroups)[0]
         indexer = ensure_platform_int(indexer)
 
-        self.sorted_values = algos.take_nd(self.values, indexer, axis=0)
-        self.sorted_labels = [l.take(indexer) for l in to_sort]
+        return indexer, to_sort
+
+    @cache_readonly
+    def sorted_labels(self):
+        indexer, to_sort = self._indexer_and_to_sort
+        return [l.take(indexer) for l in to_sort]
+
+    def _make_sorted_values(self, values):
+        indexer, _ = self._indexer_and_to_sort
+
+        sorted_values = algos.take_nd(values, indexer, axis=0)
+        return sorted_values
 
     def _make_selectors(self):
         new_levels = self.new_index_levels
@@ -183,15 +175,26 @@ class _Unstacker:
         self.unique_groups = obs_ids
         self.compressor = comp_index.searchsorted(np.arange(ngroups))
 
-    def get_result(self):
-        values, _ = self.get_new_values()
-        columns = self.get_new_columns()
-        index = self.get_new_index()
+    def get_result(self, values, value_columns, fill_value):
+
+        if values.ndim == 1:
+            values = values[:, np.newaxis]
+
+        if value_columns is None and values.shape[1] != 1:  # pragma: no cover
+            raise ValueError("must pass column labels for multi-column data")
+
+        values, _ = self.get_new_values(values, fill_value)
+        columns = self.get_new_columns(value_columns)
+        index = self.new_index
 
         return self.constructor(values, index=index, columns=columns)
 
-    def get_new_values(self):
-        values = self.values
+    def get_new_values(self, values, fill_value=None):
+
+        if values.ndim == 1:
+            values = values[:, np.newaxis]
+
+        sorted_values = self._make_sorted_values(values)
 
         # place the values
         length, width = self.full_shape
@@ -204,7 +207,7 @@ class _Unstacker:
         # we can simply reshape if we don't have a mask
         if mask_all and len(values):
             new_values = (
-                self.sorted_values.reshape(length, width, stride)
+                sorted_values.reshape(length, width, stride)
                 .swapaxes(1, 2)
                 .reshape(result_shape)
             )
@@ -216,14 +219,13 @@ class _Unstacker:
             dtype = values.dtype
             new_values = np.empty(result_shape, dtype=dtype)
         else:
-            dtype, fill_value = maybe_promote(values.dtype, self.fill_value)
+            dtype, fill_value = maybe_promote(values.dtype, fill_value)
             new_values = np.empty(result_shape, dtype=dtype)
             new_values.fill(fill_value)
 
         new_mask = np.zeros(result_shape, dtype=bool)
 
         name = np.dtype(dtype).name
-        sorted_values = self.sorted_values
 
         # we need to convert to a basic dtype
         # and possibly coerce an input to our output dtype
@@ -254,8 +256,8 @@ class _Unstacker:
 
         return new_values, new_mask
 
-    def get_new_columns(self):
-        if self.value_columns is None:
+    def get_new_columns(self, value_columns):
+        if value_columns is None:
             if self.lift == 0:
                 return self.removed_level._shallow_copy(name=self.removed_name)
 
@@ -263,16 +265,16 @@ class _Unstacker:
             return lev.rename(self.removed_name)
 
         stride = len(self.removed_level) + self.lift
-        width = len(self.value_columns)
+        width = len(value_columns)
         propagator = np.repeat(np.arange(width), stride)
-        if isinstance(self.value_columns, MultiIndex):
-            new_levels = self.value_columns.levels + (self.removed_level_full,)
-            new_names = self.value_columns.names + (self.removed_name,)
+        if isinstance(value_columns, MultiIndex):
+            new_levels = value_columns.levels + (self.removed_level_full,)
+            new_names = value_columns.names + (self.removed_name,)
 
-            new_codes = [lab.take(propagator) for lab in self.value_columns.codes]
+            new_codes = [lab.take(propagator) for lab in value_columns.codes]
         else:
-            new_levels = [self.value_columns, self.removed_level_full]
-            new_names = [self.value_columns.name, self.removed_name]
+            new_levels = [value_columns, self.removed_level_full]
+            new_names = [value_columns.name, self.removed_name]
             new_codes = [propagator]
 
         # The two indices differ only if the unstacked level had unused items:
@@ -291,7 +293,9 @@ class _Unstacker:
             levels=new_levels, codes=new_codes, names=new_names, verify_integrity=False
         )
 
-    def get_new_index(self):
+    @cache_readonly
+    def new_index(self):
+        # Does not depend on values or value_columns
         result_codes = [lab.take(self.compressor) for lab in self.sorted_labels[:-1]]
 
         # construct the new index
@@ -417,31 +421,22 @@ def unstack(obj, level, fill_value=None):
         if is_extension_array_dtype(obj.dtype):
             return _unstack_extension_series(obj, level, fill_value)
         unstacker = _Unstacker(
-            obj.values,
-            obj.index,
-            level=level,
-            fill_value=fill_value,
-            constructor=obj._constructor_expanddim,
+            obj.index, level=level, constructor=obj._constructor_expanddim,
         )
-        return unstacker.get_result()
+        return unstacker.get_result(
+            obj.values, value_columns=None, fill_value=fill_value
+        )
 
 
 def _unstack_frame(obj, level, fill_value=None):
     if obj._is_mixed_type:
-        unstacker = partial(
-            _Unstacker, index=obj.index, level=level, fill_value=fill_value
-        )
+        unstacker = _Unstacker(obj.index, level=level)
         blocks = obj._data.unstack(unstacker, fill_value=fill_value)
         return obj._constructor(blocks)
     else:
         return _Unstacker(
-            obj.values,
-            obj.index,
-            level=level,
-            value_columns=obj.columns,
-            fill_value=fill_value,
-            constructor=obj._constructor,
-        ).get_result()
+            obj.index, level=level, constructor=obj._constructor,
+        ).get_result(obj.values, value_columns=obj.columns, fill_value=fill_value)
 
 
 def _unstack_extension_series(series, level, fill_value):
@@ -476,9 +471,9 @@ def _unstack_extension_series(series, level, fill_value):
 
     dummy_arr = np.arange(len(series))
     # fill_value=-1, since we will do a series.values.take later
-    result = _Unstacker(
-        dummy_arr, series.index, level=level, fill_value=-1
-    ).get_result()
+    result = _Unstacker(series.index, level=level).get_result(
+        dummy_arr, value_columns=None, fill_value=-1
+    )
 
     out = []
     values = extract_array(series, extract_numpy=False)


### PR DESCRIPTION
I find this much easier to follow without the double-partial.  We also avoid re-doing some work, though AFAICT its pretty tiny perf-wise.