### PR TITLE
DOC: Fix capitalization among headings in documentation files (#32550)

### DIFF
--- a/doc/source/user_guide/categorical.rst
+++ b/doc/source/user_guide/categorical.rst
@@ -799,7 +799,7 @@ Assigning a ``Categorical`` to parts of a column of other types will use the val
 .. _categorical.merge:
 .. _categorical.concat:
 
-Merging / Concatenation
+Merging / concatenation
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, combining ``Series`` or ``DataFrames`` which contain the same

--- a/doc/source/user_guide/computation.rst
+++ b/doc/source/user_guide/computation.rst
@@ -210,7 +210,7 @@ parameter:
 
 .. _stats.moments:
 
-Window Functions
+Window functions
 ----------------
 
 .. currentmodule:: pandas.core.window
@@ -323,7 +323,7 @@ We provide a number of common statistical functions:
 
 .. _stats.rolling_apply:
 
-Rolling Apply
+Rolling apply
 ~~~~~~~~~~~~~
 
 The :meth:`~Rolling.apply` function takes an extra ``func`` argument and performs

--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -179,7 +179,7 @@ One could hard code:
 Selection
 ---------
 
-DataFrames
+Dataframes
 **********
 
 The :ref:`indexing <indexing>` docs.
@@ -290,7 +290,7 @@ Notice the same results, with the exception of the index.
 
 .. _cookbook.multi_index:
 
-MultiIndexing
+Multiindexing
 -------------
 
 The :ref:`multindexing <advanced.hierarchical>` docs.
@@ -913,7 +913,7 @@ The :ref:`Plotting <visualization>` docs.
    @savefig quartile_boxplot.png
    df.boxplot(column='price', by='quartiles')
 
-Data In/Out
+Data in/out
 -----------
 
 `Performance comparison of SQL vs HDF5

--- a/doc/source/user_guide/gotchas.rst
+++ b/doc/source/user_guide/gotchas.rst
@@ -317,7 +317,7 @@ See `this link <https://stackoverflow.com/questions/13592618/python-pandas-dataf
 for more information.
 
 
-Byte-Ordering issues
+Byte-ordering issues
 --------------------
 Occasionally you may have to deal with data that were created on a machine with
 a different byte order than the one on which you are running Python. A common

--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -3,7 +3,7 @@
 {{ header }}
 
 *****************************
-Group By: split-apply-combine
+Group by: split-apply-combine
 *****************************
 
 By "group by" we are referring to a process involving one or more of the following


### PR DESCRIPTION
Headers updated for the following files:

```
- [x] doc/source/user_guide/categorical.rst
- [x] doc/source/user_guide/computation.rst
- [x] doc/source/user_guide/cookbook.rst
- [x] doc/source/user_guide/gotchas.rst
- [x] doc/source/user_guide/groupby.rst
```

Other files updated in #32944, #32978 , #32991 and #33149