### PR TITLE
DOC: Fix capitalization among headings in documentation files (#32550)

### DIFF
--- a/doc/source/user_guide/options.rst
+++ b/doc/source/user_guide/options.rst
@@ -140,7 +140,7 @@ More information can be found in the `ipython documentation
 
 .. _options.frequently_used:
 
-Frequently Used Options
+Frequently used options
 -----------------------
 The following is a walk-through of the more frequently used display options.
 

--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -272,7 +272,7 @@ the right thing:
 
 .. _reshaping.melt:
 
-Reshaping by Melt
+Reshaping by melt
 -----------------
 
 .. image:: ../_static/reshaping_melt.png

--- a/doc/source/user_guide/text.rst
+++ b/doc/source/user_guide/text.rst
@@ -8,7 +8,7 @@ Working with text data
 
 .. _text.types:
 
-Text Data Types
+Text data types
 ---------------
 
 .. versionadded:: 1.0.0
@@ -113,7 +113,7 @@ Everything else that follows in the rest of this document applies equally to
 
 .. _text.string_methods:
 
-String Methods
+String methods
 --------------
 
 Series and Index are equipped with a set of string processing methods
@@ -633,7 +633,7 @@ same result as a ``Series.str.extractall`` with a default index (starts from 0).
    pd.Series(["a1a2", "b1", "c1"], dtype="string").str.extractall(two_groups)
 
 
-Testing for Strings that match or contain a pattern
+Testing for strings that match or contain a pattern
 ---------------------------------------------------
 
 You can check whether elements contain a pattern:

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -122,7 +122,7 @@ as ``np.nan`` does for float data.
 
 .. _timeseries.representation:
 
-Timestamps vs. Time Spans
+Timestamps vs. time spans
 -------------------------
 
 Timestamped data is the most basic type of time series data that associates
@@ -1434,7 +1434,7 @@ or calendars with additional rules.
 
 .. _timeseries.advanced_datetime:
 
-Time Series-Related Instance Methods
+Time series-related instance methods
 ------------------------------------
 
 Shifting / lagging

--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -796,7 +796,7 @@ before plotting.
 
 .. _visualization.tools:
 
-Plotting Tools
+Plotting tools
 --------------
 
 These functions can be imported from ``pandas.plotting``
@@ -1045,7 +1045,7 @@ for more information.
 
 .. _visualization.formatting:
 
-Plot Formatting
+Plot formatting
 ---------------
 
 Setting the plot style


### PR DESCRIPTION
Headers updated for the following files:

```
- [x] doc/source/user_guide/options.rst
- [x] doc/source/user_guide/reshaping.rst
- [x] doc/source/user_guide/text.rst
- [x] doc/source/user_guide/timeseries.rst
- [x] doc/source/user_guide/visualization.rst
```

Other files updated in #32944, #32978, #32991  and #33147
