### PR TITLE
CLN: Rename ordered_fixture --> ordered

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -182,7 +182,7 @@ def observed(request):
 
 
 @pytest.fixture(params=[True, False, None])
-def ordered_fixture(request):
+def ordered(request):
     """
     Boolean 'ordered' parameter for Categorical.
     """

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -140,23 +140,21 @@ class TestTake:
         with pytest.raises(IndexError, match=msg):
             cat.take([0], allow_fill=allow_fill)
 
-    def test_positional_take(self, ordered_fixture):
+    def test_positional_take(self, ordered):
         cat = pd.Categorical(
-            ["a", "a", "b", "b"], categories=["b", "a"], ordered=ordered_fixture
+            ["a", "a", "b", "b"], categories=["b", "a"], ordered=ordered
         )
         result = cat.take([0, 1, 2], allow_fill=False)
         expected = pd.Categorical(
-            ["a", "a", "b"], categories=cat.categories, ordered=ordered_fixture
+            ["a", "a", "b"], categories=cat.categories, ordered=ordered
         )
         tm.assert_categorical_equal(result, expected)
 
-    def test_positional_take_unobserved(self, ordered_fixture):
-        cat = pd.Categorical(
-            ["a", "b"], categories=["a", "b", "c"], ordered=ordered_fixture
-        )
+    def test_positional_take_unobserved(self, ordered):
+        cat = pd.Categorical(["a", "b"], categories=["a", "b", "c"], ordered=ordered)
         result = cat.take([1, 0], allow_fill=False)
         expected = pd.Categorical(
-            ["b", "a"], categories=cat.categories, ordered=ordered_fixture
+            ["b", "a"], categories=cat.categories, ordered=ordered
         )
         tm.assert_categorical_equal(result, expected)
 

--- a/pandas/tests/arrays/categorical/test_analytics.py
+++ b/pandas/tests/arrays/categorical/test_analytics.py
@@ -114,14 +114,14 @@ class TestCategoricalAnalytics:
         exp = Categorical(exp_mode, categories=categories, ordered=True)
         tm.assert_categorical_equal(res, exp)
 
-    def test_searchsorted(self, ordered_fixture):
+    def test_searchsorted(self, ordered):
         # https://github.com/pandas-dev/pandas/issues/8420
         # https://github.com/pandas-dev/pandas/issues/14522
 
         cat = Categorical(
             ["cheese", "milk", "apple", "bread", "bread"],
             categories=["cheese", "milk", "apple", "bread"],
-            ordered=ordered_fixture,
+            ordered=ordered,
         )
         ser = Series(cat)
 

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -730,10 +730,10 @@ class TestCategoricalDtypeParametrized:
             pd.date_range("2017", periods=4),
         ],
     )
-    def test_basic(self, categories, ordered_fixture):
-        c1 = CategoricalDtype(categories, ordered=ordered_fixture)
+    def test_basic(self, categories, ordered):
+        c1 = CategoricalDtype(categories, ordered=ordered)
         tm.assert_index_equal(c1.categories, pd.Index(categories))
-        assert c1.ordered is ordered_fixture
+        assert c1.ordered is ordered
 
     def test_order_matters(self):
         categories = ["a", "b"]
@@ -754,7 +754,7 @@ class TestCategoricalDtypeParametrized:
         tm.assert_index_equal(result.categories, pd.Index(["a", "b", "c"]))
         assert result.ordered is False
 
-    def test_equal_but_different(self, ordered_fixture):
+    def test_equal_but_different(self, ordered):
         c1 = CategoricalDtype([1, 2, 3])
         c2 = CategoricalDtype([1.0, 2.0, 3.0])
         assert c1 is not c2
@@ -818,8 +818,8 @@ class TestCategoricalDtypeParametrized:
 
     @pytest.mark.parametrize("categories", [list("abc"), None])
     @pytest.mark.parametrize("other", ["category", "not a category"])
-    def test_categorical_equality_strings(self, categories, ordered_fixture, other):
-        c1 = CategoricalDtype(categories, ordered_fixture)
+    def test_categorical_equality_strings(self, categories, ordered, other):
+        c1 = CategoricalDtype(categories, ordered)
         result = c1 == other
         expected = other == "category"
         assert result is expected
@@ -862,12 +862,12 @@ class TestCategoricalDtypeParametrized:
         )
         assert result == CategoricalDtype([1, 2], ordered=False)
 
-    def test_str_vs_repr(self, ordered_fixture):
-        c1 = CategoricalDtype(["a", "b"], ordered=ordered_fixture)
+    def test_str_vs_repr(self, ordered):
+        c1 = CategoricalDtype(["a", "b"], ordered=ordered)
         assert str(c1) == "category"
         # Py2 will have unicode prefixes
         pat = r"CategoricalDtype\(categories=\[.*\], ordered={ordered}\)"
-        assert re.match(pat.format(ordered=ordered_fixture), repr(c1))
+        assert re.match(pat.format(ordered=ordered), repr(c1))
 
     def test_categorical_categories(self):
         # GH17884
@@ -880,9 +880,9 @@ class TestCategoricalDtypeParametrized:
         "new_categories", [list("abc"), list("cba"), list("wxyz"), None]
     )
     @pytest.mark.parametrize("new_ordered", [True, False, None])
-    def test_update_dtype(self, ordered_fixture, new_categories, new_ordered):
+    def test_update_dtype(self, ordered, new_categories, new_ordered):
         original_categories = list("abc")
-        dtype = CategoricalDtype(original_categories, ordered_fixture)
+        dtype = CategoricalDtype(original_categories, ordered)
         new_dtype = CategoricalDtype(new_categories, new_ordered)
 
         result = dtype.update_dtype(new_dtype)
@@ -892,8 +892,8 @@ class TestCategoricalDtypeParametrized:
         tm.assert_index_equal(result.categories, expected_categories)
         assert result.ordered is expected_ordered
 
-    def test_update_dtype_string(self, ordered_fixture):
-        dtype = CategoricalDtype(list("abc"), ordered_fixture)
+    def test_update_dtype_string(self, ordered):
+        dtype = CategoricalDtype(list("abc"), ordered)
         expected_categories = dtype.categories
         expected_ordered = dtype.ordered
         result = dtype.update_dtype("category")

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1226,10 +1226,10 @@ def test_groupby_categorical_axis_1(code):
     tm.assert_frame_equal(result, expected)
 
 
-def test_groupby_cat_preserves_structure(observed, ordered_fixture):
+def test_groupby_cat_preserves_structure(observed, ordered):
     # GH 28787
     df = DataFrame(
-        {"Name": Categorical(["Bob", "Greg"], ordered=ordered_fixture), "Item": [1, 2]},
+        {"Name": Categorical(["Bob", "Greg"], ordered=ordered), "Item": [1, 2]},
         columns=["Name", "Item"],
     )
     expected = df.copy()

--- a/pandas/tests/indexes/categorical/test_map.py
+++ b/pandas/tests/indexes/categorical/test_map.py
@@ -15,12 +15,12 @@ class TestMap:
         ],
         ids=["string", "interval"],
     )
-    def test_map_str(self, data, categories, ordered_fixture):
+    def test_map_str(self, data, categories, ordered):
         # GH 31202 - override base class since we want to maintain categorical/ordered
-        index = CategoricalIndex(data, categories=categories, ordered=ordered_fixture)
+        index = CategoricalIndex(data, categories=categories, ordered=ordered)
         result = index.map(str)
         expected = CategoricalIndex(
-            map(str, data), categories=map(str, categories), ordered=ordered_fixture
+            map(str, data), categories=map(str, categories), ordered=ordered
         )
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -240,10 +240,10 @@ class TestGetIndexer:
             ["foo", "foo", "bar", "baz"],
         ],
     )
-    def test_get_indexer_categorical(self, target, ordered_fixture):
+    def test_get_indexer_categorical(self, target, ordered):
         # GH 30063: categorical and non-categorical results should be consistent
         index = IntervalIndex.from_tuples([(0, 1), (1, 2), (3, 4)])
-        categorical_target = CategoricalIndex(target, ordered=ordered_fixture)
+        categorical_target = CategoricalIndex(target, ordered=ordered)
 
         result = index.get_indexer(categorical_target)
         expected = index.get_indexer(target)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -778,9 +778,9 @@ class TestCategoricalIndex:
             pd.timedelta_range(start="1d", periods=3).array,
         ],
     )
-    def test_loc_with_non_string_categories(self, idx_values, ordered_fixture):
+    def test_loc_with_non_string_categories(self, idx_values, ordered):
         # GH-17569
-        cat_idx = CategoricalIndex(idx_values, ordered=ordered_fixture)
+        cat_idx = CategoricalIndex(idx_values, ordered=ordered)
         df = DataFrame({"A": ["foo", "bar", "baz"]}, index=cat_idx)
         sl = slice(idx_values[0], idx_values[1])
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1756,18 +1756,14 @@ class TestPivotTable:
         )
         tm.assert_frame_equal(result, expected)
 
-    def test_pivot_with_categorical(self, observed, ordered_fixture):
+    def test_pivot_with_categorical(self, observed, ordered):
         # gh-21370
         idx = [np.nan, "low", "high", "low", np.nan]
         col = [np.nan, "A", "B", np.nan, "A"]
         df = pd.DataFrame(
             {
-                "In": pd.Categorical(
-                    idx, categories=["low", "high"], ordered=ordered_fixture
-                ),
-                "Col": pd.Categorical(
-                    col, categories=["A", "B"], ordered=ordered_fixture
-                ),
+                "In": pd.Categorical(idx, categories=["low", "high"], ordered=ordered),
+                "Col": pd.Categorical(col, categories=["A", "B"], ordered=ordered),
                 "Val": range(1, 6),
             }
         )
@@ -1776,16 +1772,14 @@ class TestPivotTable:
             index="In", columns="Col", values="Val", observed=observed
         )
 
-        expected_cols = pd.CategoricalIndex(
-            ["A", "B"], ordered=ordered_fixture, name="Col"
-        )
+        expected_cols = pd.CategoricalIndex(["A", "B"], ordered=ordered, name="Col")
 
         expected = pd.DataFrame(
             data=[[2.0, np.nan], [np.nan, 3.0]], columns=expected_cols
         )
         expected.index = Index(
             pd.Categorical(
-                ["low", "high"], categories=["low", "high"], ordered=ordered_fixture
+                ["low", "high"], categories=["low", "high"], ordered=ordered
             ),
             name="In",
         )

--- a/pandas/tests/series/methods/test_drop_duplicates.py
+++ b/pandas/tests/series/methods/test_drop_duplicates.py
@@ -69,12 +69,12 @@ class TestSeriesDropDuplicates:
         "dtype",
         ["int_", "uint", "float_", "unicode_", "timedelta64[h]", "datetime64[D]"],
     )
-    def test_drop_duplicates_categorical_non_bool(self, dtype, ordered_fixture):
+    def test_drop_duplicates_categorical_non_bool(self, dtype, ordered):
         cat_array = np.array([1, 2, 3, 4, 5], dtype=np.dtype(dtype))
 
         # Test case 1
         input1 = np.array([1, 2, 3, 3], dtype=np.dtype(dtype))
-        tc1 = Series(Categorical(input1, categories=cat_array, ordered=ordered_fixture))
+        tc1 = Series(Categorical(input1, categories=cat_array, ordered=ordered))
         if dtype == "datetime64[D]":
             # pre-empty flaky xfail, tc1 values are seemingly-random
             if not (np.array(tc1) == input1).all():
@@ -103,7 +103,7 @@ class TestSeriesDropDuplicates:
 
         # Test case 2
         input2 = np.array([1, 2, 3, 5, 3, 2, 4], dtype=np.dtype(dtype))
-        tc2 = Series(Categorical(input2, categories=cat_array, ordered=ordered_fixture))
+        tc2 = Series(Categorical(input2, categories=cat_array, ordered=ordered))
         if dtype == "datetime64[D]":
             # pre-empty flaky xfail, tc2 values are seemingly-random
             if not (np.array(tc2) == input2).all():
@@ -130,12 +130,10 @@ class TestSeriesDropDuplicates:
         sc.drop_duplicates(keep=False, inplace=True)
         tm.assert_series_equal(sc, tc2[~expected])
 
-    def test_drop_duplicates_categorical_bool(self, ordered_fixture):
+    def test_drop_duplicates_categorical_bool(self, ordered):
         tc = Series(
             Categorical(
-                [True, False, True, False],
-                categories=[True, False],
-                ordered=ordered_fixture,
+                [True, False, True, False], categories=[True, False], ordered=ordered,
             )
         )
 


### PR DESCRIPTION
A pretty small and straightforward rename to make things more readable and consistent with our existing naming convention for fixtures.