### PR TITLE
DOC: Added check for standard pandas reference

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -240,7 +240,7 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
 
     MSG='Check if the pandas word reference is always used in lowercase (pandas) NOT Pandas or PANDAS'; echo $MSG
     invgrep -R '*pandas*|Pandas|PANDAS' web/* doc/
-    RET = $(($RET + $?)) ; echo $MSG "DONE"
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
     
 fi
 

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -241,7 +241,6 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     MSG='Check if the pandas word reference is always used in lowercase (pandas) NOT Pandas or PANDAS'; echo $MSG
     invgrep -R '*pandas*|Pandas|PANDAS' web/* doc/
     RET=$(($RET + $?)) ; echo $MSG "DONE"
-    
 fi
 
 ### CODE ###

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -237,6 +237,11 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -RI --exclude=\*.{svg,c,cpp,html,js} --exclude-dir=env "\s$" *
     RET=$(($RET + $?)) ; echo $MSG "DONE"
     unset INVGREP_APPEND
+
+    MSG='Check if the pandas word reference is always used in lowercase (pandas) NOT Pandas or PANDAS'; echo $MSG
+    invgrep -R '*pandas*|Pandas|PANDAS' web/* doc/
+    RET = $(($RET + $?)) ; echo $MSG "DONE"
+    
 fi
 
 ### CODE ###


### PR DESCRIPTION
- [x] xref #32316
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

As suggested by @datapythonista , I've added checks in `ci/code_checks.sh` to look if the pandas is being referenced in a standardized way i.e pandas, not *pandas* or Pandas