### PR TITLE
CI: Checking all the examples in `pandas/core/series.py`

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -271,8 +271,7 @@ if [[ -z "$CHECK" || "$CHECK" == "doctests" ]]; then
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Doctests series.py' ; echo $MSG
-    pytest -q --doctest-modules pandas/core/series.py \
-        -k"-nonzero -reindex -searchsorted -to_dict"
+    pytest -q --doctest-modules pandas/core/series.py
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Doctests groupby.py' ; echo $MSG


### PR DESCRIPTION
Since all the examples are passing, there is no reason not to check for all the examples (IMO).
