### PR TITLE
CLN: De-privatize names

### DIFF
--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -44,8 +44,8 @@ from pandas._libs.tslibs.tzconversion cimport (
 # ----------------------------------------------------------------------
 # Constants
 
-NS_DTYPE = np.dtype('M8[ns]')
-TD_DTYPE = np.dtype('m8[ns]')
+DT64NS_DTYPE = np.dtype('M8[ns]')
+TD64NS_DTYPE = np.dtype('m8[ns]')
 
 
 # ----------------------------------------------------------------------
@@ -105,11 +105,11 @@ def ensure_datetime64ns(arr: ndarray, copy: bool=True):
 
     ivalues = arr.view(np.int64).ravel()
 
-    result = np.empty(shape, dtype=NS_DTYPE)
+    result = np.empty(shape, dtype=DT64NS_DTYPE)
     iresult = result.ravel().view(np.int64)
 
     if len(iresult) == 0:
-        result = arr.view(NS_DTYPE)
+        result = arr.view(DT64NS_DTYPE)
         if copy:
             result = result.copy()
         return result
@@ -145,7 +145,7 @@ def ensure_timedelta64ns(arr: ndarray, copy: bool=True):
     result : ndarray with dtype timedelta64[ns]
 
     """
-    return arr.astype(TD_DTYPE, copy=copy)
+    return arr.astype(TD64NS_DTYPE, copy=copy)
     # TODO: check for overflows when going from a lower-resolution to nanos
 
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -378,7 +378,7 @@ class Categorical(ExtensionArray, PandasObject):
             old_codes = (
                 values._values.codes if isinstance(values, ABCSeries) else values.codes
             )
-            codes = _recode_for_categories(
+            codes = recode_for_categories(
                 old_codes, values.dtype.categories, dtype.categories
             )
 
@@ -572,13 +572,13 @@ class Categorical(ExtensionArray, PandasObject):
         if known_categories:
             # Recode from observation order to dtype.categories order.
             categories = dtype.categories
-            codes = _recode_for_categories(inferred_codes, cats, categories)
+            codes = recode_for_categories(inferred_codes, cats, categories)
         elif not cats.is_monotonic_increasing:
             # Sort categories and recode for unknown categories.
             unsorted = cats.copy()
             categories = cats.sort_values()
 
-            codes = _recode_for_categories(inferred_codes, unsorted, categories)
+            codes = recode_for_categories(inferred_codes, unsorted, categories)
             dtype = CategoricalDtype(categories, ordered=False)
         else:
             dtype = CategoricalDtype(cats, ordered=False)
@@ -727,7 +727,7 @@ class Categorical(ExtensionArray, PandasObject):
         We don't do any validation here. It's assumed that the dtype is
         a (valid) instance of `CategoricalDtype`.
         """
-        codes = _recode_for_categories(self.codes, self.categories, dtype.categories)
+        codes = recode_for_categories(self.codes, self.categories, dtype.categories)
         return type(self)(codes, dtype=dtype, fastpath=True)
 
     def set_ordered(self, value, inplace=False):
@@ -849,7 +849,7 @@ class Categorical(ExtensionArray, PandasObject):
                 # remove all _codes which are larger and set to -1/NaN
                 cat._codes[cat._codes >= len(new_dtype.categories)] = -1
         else:
-            codes = _recode_for_categories(
+            codes = recode_for_categories(
                 cat.codes, cat.categories, new_dtype.categories
             )
             cat._codes = codes
@@ -2034,7 +2034,7 @@ class Categorical(ExtensionArray, PandasObject):
                     "without identical categories"
                 )
             if not self.categories.equals(value.categories):
-                new_codes = _recode_for_categories(
+                new_codes = recode_for_categories(
                     value.codes, value.categories, self.categories
                 )
                 value = Categorical.from_codes(new_codes, dtype=self.dtype)
@@ -2299,7 +2299,7 @@ class Categorical(ExtensionArray, PandasObject):
                 # fastpath to avoid re-coding
                 other_codes = other._codes
             else:
-                other_codes = _recode_for_categories(
+                other_codes = recode_for_categories(
                     other.codes, other.categories, self.categories
                 )
             return np.array_equal(self._codes, other_codes)
@@ -2584,7 +2584,7 @@ def _get_codes_for_values(values, categories):
     return coerce_indexer_dtype(t.lookup(vals), cats)
 
 
-def _recode_for_categories(codes: np.ndarray, old_categories, new_categories):
+def recode_for_categories(codes: np.ndarray, old_categories, new_categories):
     """
     Convert a set of codes for to a new set of categories
 
@@ -2602,7 +2602,7 @@ def _recode_for_categories(codes: np.ndarray, old_categories, new_categories):
     >>> old_cat = pd.Index(['b', 'a', 'c'])
     >>> new_cat = pd.Index(['a', 'b'])
     >>> codes = np.array([0, 1, 1, 2])
-    >>> _recode_for_categories(codes, old_cat, new_cat)
+    >>> recode_for_categories(codes, old_cat, new_cat)
     array([ 1,  0,  0, -1])
     """
     if len(old_categories) == 0:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -22,7 +22,7 @@ from pandas.errors import PerformanceWarning
 
 from pandas.core.dtypes.common import (
     _INT64_DTYPE,
-    _NS_DTYPE,
+    DT64NS_DTYPE,
     is_bool_dtype,
     is_categorical_dtype,
     is_datetime64_any_dtype,
@@ -66,7 +66,7 @@ def tz_to_dtype(tz):
     np.dtype or Datetime64TZDType
     """
     if tz is None:
-        return _NS_DTYPE
+        return DT64NS_DTYPE
     else:
         return DatetimeTZDtype(tz=tz)
 
@@ -209,7 +209,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
     _dtype: Union[np.dtype, DatetimeTZDtype]
     _freq = None
 
-    def __init__(self, values, dtype=_NS_DTYPE, freq=None, copy=False):
+    def __init__(self, values, dtype=DT64NS_DTYPE, freq=None, copy=False):
         if isinstance(values, (ABCSeries, ABCIndexClass)):
             values = values._values
 
@@ -246,9 +246,9 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
             # for compat with datetime/timedelta/period shared methods,
             #  we can sometimes get here with int64 values.  These represent
             #  nanosecond UTC (or tz-naive) unix timestamps
-            values = values.view(_NS_DTYPE)
+            values = values.view(DT64NS_DTYPE)
 
-        if values.dtype != _NS_DTYPE:
+        if values.dtype != DT64NS_DTYPE:
             raise ValueError(
                 "The dtype of 'values' is incorrect. Must be 'datetime64[ns]'. "
                 f"Got {values.dtype} instead."
@@ -282,11 +282,11 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
             type(self)._validate_frequency(self, freq)
 
     @classmethod
-    def _simple_new(cls, values, freq=None, dtype=_NS_DTYPE):
+    def _simple_new(cls, values, freq=None, dtype=DT64NS_DTYPE):
         assert isinstance(values, np.ndarray)
-        if values.dtype != _NS_DTYPE:
+        if values.dtype != DT64NS_DTYPE:
             assert values.dtype == "i8"
-            values = values.view(_NS_DTYPE)
+            values = values.view(DT64NS_DTYPE)
 
         result = object.__new__(cls)
         result._data = values
@@ -967,7 +967,7 @@ default 'raise'
             new_dates = conversion.tz_localize_to_utc(
                 self.asi8, tz, ambiguous=ambiguous, nonexistent=nonexistent
             )
-        new_dates = new_dates.view(_NS_DTYPE)
+        new_dates = new_dates.view(DT64NS_DTYPE)
         dtype = tz_to_dtype(tz)
         return self._simple_new(new_dates, dtype=dtype, freq=self.freq)
 
@@ -1748,7 +1748,7 @@ def sequence_to_dt64ns(
     elif is_datetime64_dtype(data):
         # tz-naive DatetimeArray or ndarray[datetime64]
         data = getattr(data, "_data", data)
-        if data.dtype != _NS_DTYPE:
+        if data.dtype != DT64NS_DTYPE:
             data = conversion.ensure_datetime64ns(data)
 
         if tz is not None:
@@ -1757,9 +1757,9 @@ def sequence_to_dt64ns(
             data = conversion.tz_localize_to_utc(
                 data.view("i8"), tz, ambiguous=ambiguous
             )
-            data = data.view(_NS_DTYPE)
+            data = data.view(DT64NS_DTYPE)
 
-        assert data.dtype == _NS_DTYPE, data.dtype
+        assert data.dtype == DT64NS_DTYPE, data.dtype
         result = data
 
     else:
@@ -1770,7 +1770,7 @@ def sequence_to_dt64ns(
 
         if data.dtype != _INT64_DTYPE:
             data = data.astype(np.int64, copy=False)
-        result = data.view(_NS_DTYPE)
+        result = data.view(DT64NS_DTYPE)
 
     if copy:
         # TODO: should this be deepcopy?
@@ -1894,7 +1894,7 @@ def maybe_convert_dtype(data, copy):
     if is_float_dtype(data.dtype):
         # Note: we must cast to datetime64[ns] here in order to treat these
         #  as wall-times instead of UTC timestamps.
-        data = data.astype(_NS_DTYPE)
+        data = data.astype(DT64NS_DTYPE)
         copy = False
         # TODO: deprecate this behavior to instead treat symmetrically
         #  with integer dtypes.  See discussion in GH#23675
@@ -1991,7 +1991,7 @@ def _validate_dt64_dtype(dtype):
             )
             raise ValueError(msg)
 
-        if (isinstance(dtype, np.dtype) and dtype != _NS_DTYPE) or not isinstance(
+        if (isinstance(dtype, np.dtype) and dtype != DT64NS_DTYPE) or not isinstance(
             dtype, (np.dtype, DatetimeTZDtype)
         ):
             raise ValueError(

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -23,7 +23,7 @@ from pandas._libs.tslibs.timedeltas import Timedelta, delta_to_nanoseconds
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
-    _TD_DTYPE,
+    TD64NS_DTYPE,
     ensure_object,
     is_datetime64_dtype,
     is_float_dtype,
@@ -718,10 +718,10 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         elif isinstance(other, np.ndarray):
             # numpy timedelta64 array; all entries must be compatible
             assert other.dtype.kind == "m"
-            if other.dtype != _TD_DTYPE:
+            if other.dtype != TD64NS_DTYPE:
                 # i.e. non-nano unit
                 # TODO: disallow unit-less timedelta64
-                other = other.astype(_TD_DTYPE)
+                other = other.astype(TD64NS_DTYPE)
             nanos = other.view("i8")
         else:
             # TimedeltaArray/Index

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -14,8 +14,8 @@ from pandas._libs.tslibs.timedeltas import (
 from pandas.compat.numpy import function as nv
 
 from pandas.core.dtypes.common import (
-    _NS_DTYPE,
-    _TD_DTYPE,
+    DT64NS_DTYPE,
+    TD64NS_DTYPE,
     is_dtype_equal,
     is_float_dtype,
     is_integer_dtype,
@@ -136,12 +136,12 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         -------
         numpy.dtype
         """
-        return _TD_DTYPE
+        return TD64NS_DTYPE
 
     # ----------------------------------------------------------------
     # Constructors
 
-    def __init__(self, values, dtype=_TD_DTYPE, freq=None, copy=False):
+    def __init__(self, values, dtype=TD64NS_DTYPE, freq=None, copy=False):
         values = extract_array(values)
 
         inferred_freq = getattr(values, "_freq", None)
@@ -167,7 +167,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
             # for compat with datetime/timedelta/period shared methods,
             #  we can sometimes get here with int64 values.  These represent
             #  nanosecond UTC (or tz-naive) unix timestamps
-            values = values.view(_TD_DTYPE)
+            values = values.view(TD64NS_DTYPE)
 
         _validate_td64_dtype(values.dtype)
         dtype = _validate_td64_dtype(dtype)
@@ -192,21 +192,21 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
             type(self)._validate_frequency(self, freq)
 
     @classmethod
-    def _simple_new(cls, values, freq=None, dtype=_TD_DTYPE):
-        assert dtype == _TD_DTYPE, dtype
+    def _simple_new(cls, values, freq=None, dtype=TD64NS_DTYPE):
+        assert dtype == TD64NS_DTYPE, dtype
         assert isinstance(values, np.ndarray), type(values)
-        if values.dtype != _TD_DTYPE:
+        if values.dtype != TD64NS_DTYPE:
             assert values.dtype == "i8"
-            values = values.view(_TD_DTYPE)
+            values = values.view(TD64NS_DTYPE)
 
         result = object.__new__(cls)
         result._data = values
         result._freq = to_offset(freq)
-        result._dtype = _TD_DTYPE
+        result._dtype = TD64NS_DTYPE
         return result
 
     @classmethod
-    def _from_sequence(cls, data, dtype=_TD_DTYPE, copy=False, freq=None, unit=None):
+    def _from_sequence(cls, data, dtype=TD64NS_DTYPE, copy=False, freq=None, unit=None):
         if dtype:
             _validate_td64_dtype(dtype)
         freq, freq_infer = dtl.maybe_infer_freq(freq)
@@ -428,7 +428,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         i8 = self.asi8
         result = checked_add_with_arr(i8, other.value, arr_mask=self._isnan)
         result = self._maybe_mask_results(result)
-        dtype = DatetimeTZDtype(tz=other.tz) if other.tz else _NS_DTYPE
+        dtype = DatetimeTZDtype(tz=other.tz) if other.tz else DT64NS_DTYPE
         return DatetimeArray(result, dtype=dtype, freq=self.freq)
 
     def _addsub_object_array(self, other, op):
@@ -950,10 +950,10 @@ def sequence_to_td64ns(data, copy=False, unit="ns", errors="raise"):
         copy = False
 
     elif is_timedelta64_dtype(data.dtype):
-        if data.dtype != _TD_DTYPE:
+        if data.dtype != TD64NS_DTYPE:
             # non-nano unit
             # TODO: watch out for overflows
-            data = data.astype(_TD_DTYPE)
+            data = data.astype(TD64NS_DTYPE)
             copy = False
 
     else:
@@ -1051,7 +1051,7 @@ def _validate_td64_dtype(dtype):
         )
         raise ValueError(msg)
 
-    if not is_dtype_equal(dtype, _TD_DTYPE):
+    if not is_dtype_equal(dtype, TD64NS_DTYPE):
         raise ValueError(f"dtype {dtype} cannot be converted to timedelta64[ns]")
 
     return dtype

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -21,9 +21,9 @@ from pandas.util._validators import validate_bool_kwarg
 
 from pandas.core.dtypes.common import (
     _INT64_DTYPE,
-    _NS_DTYPE,
     _POSSIBLY_CAST_DTYPES,
-    _TD_DTYPE,
+    DT64NS_DTYPE,
+    TD64NS_DTYPE,
     ensure_int8,
     ensure_int16,
     ensure_int32,
@@ -874,9 +874,9 @@ def coerce_to_dtypes(result, dtypes):
     def conv(r, dtype):
         if np.any(isna(r)):
             pass
-        elif dtype == _NS_DTYPE:
+        elif dtype == DT64NS_DTYPE:
             r = tslibs.Timestamp(r)
-        elif dtype == _TD_DTYPE:
+        elif dtype == TD64NS_DTYPE:
             r = tslibs.Timedelta(r)
         elif dtype == np.bool_:
             # messy. non 0/1 integers do not get converted.
@@ -944,7 +944,7 @@ def astype_nansafe(arr, dtype, copy: bool = True, skipna: bool = False):
                 raise ValueError("Cannot convert NaT values to integer")
             return arr.view(dtype)
 
-        if dtype not in [_INT64_DTYPE, _TD_DTYPE]:
+        if dtype not in [_INT64_DTYPE, TD64NS_DTYPE]:
 
             # allow frequency conversions
             # we return a float here!
@@ -953,8 +953,8 @@ def astype_nansafe(arr, dtype, copy: bool = True, skipna: bool = False):
                 result = arr.astype(dtype).astype(np.float64)
                 result[mask] = np.nan
                 return result
-        elif dtype == _TD_DTYPE:
-            return arr.astype(_TD_DTYPE, copy=copy)
+        elif dtype == TD64NS_DTYPE:
+            return arr.astype(TD64NS_DTYPE, copy=copy)
 
         raise TypeError(f"cannot astype a timedelta from [{arr.dtype}] to [{dtype}]")
 
@@ -1326,14 +1326,14 @@ def maybe_cast_to_datetime(value, dtype, errors: str = "raise"):
                 f"Please pass in '{dtype.name}[ns]' instead."
             )
 
-            if is_datetime64 and not is_dtype_equal(dtype, _NS_DTYPE):
+            if is_datetime64 and not is_dtype_equal(dtype, DT64NS_DTYPE):
 
                 # pandas supports dtype whose granularity is less than [ns]
                 # e.g., [ps], [fs], [as]
                 if dtype <= np.dtype("M8[ns]"):
                     if dtype.name == "datetime64":
                         raise ValueError(msg)
-                    dtype = _NS_DTYPE
+                    dtype = DT64NS_DTYPE
                 else:
                     raise TypeError(f"cannot convert datetimelike to dtype [{dtype}]")
             elif is_datetime64tz:
@@ -1344,14 +1344,14 @@ def maybe_cast_to_datetime(value, dtype, errors: str = "raise"):
                 if is_scalar(value) and isna(value):
                     value = [value]
 
-            elif is_timedelta64 and not is_dtype_equal(dtype, _TD_DTYPE):
+            elif is_timedelta64 and not is_dtype_equal(dtype, TD64NS_DTYPE):
 
                 # pandas supports dtype whose granularity is less than [ns]
                 # e.g., [ps], [fs], [as]
                 if dtype <= np.dtype("m8[ns]"):
                     if dtype.name == "timedelta64":
                         raise ValueError(msg)
-                    dtype = _TD_DTYPE
+                    dtype = TD64NS_DTYPE
                 else:
                     raise TypeError(f"cannot convert timedeltalike to dtype [{dtype}]")
 
@@ -1399,8 +1399,8 @@ def maybe_cast_to_datetime(value, dtype, errors: str = "raise"):
         # coerce datetimelike to object
         elif is_datetime64_dtype(value) and not is_datetime64_dtype(dtype):
             if is_object_dtype(dtype):
-                if value.dtype != _NS_DTYPE:
-                    value = value.astype(_NS_DTYPE)
+                if value.dtype != DT64NS_DTYPE:
+                    value = value.astype(DT64NS_DTYPE)
                 ints = np.asarray(value).view("i8")
                 return tslib.ints_to_pydatetime(ints)
 
@@ -1416,10 +1416,10 @@ def maybe_cast_to_datetime(value, dtype, errors: str = "raise"):
         if is_array and value.dtype.kind in ["M", "m"]:
             dtype = value.dtype
 
-            if dtype.kind == "M" and dtype != _NS_DTYPE:
+            if dtype.kind == "M" and dtype != DT64NS_DTYPE:
                 value = tslibs.conversion.ensure_datetime64ns(value)
 
-            elif dtype.kind == "m" and dtype != _TD_DTYPE:
+            elif dtype.kind == "m" and dtype != TD64NS_DTYPE:
                 value = to_timedelta(value)
 
         # only do this if we have an array and the dtype of the array is not

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -58,8 +58,8 @@ _POSSIBLY_CAST_DTYPES = {
     ]
 }
 
-_NS_DTYPE = conversion.NS_DTYPE
-_TD_DTYPE = conversion.TD_DTYPE
+DT64NS_DTYPE = conversion.DT64NS_DTYPE
+TD64NS_DTYPE = conversion.TD64NS_DTYPE
 _INT64_DTYPE = np.dtype(np.int64)
 
 # oh the troubles to reduce import time
@@ -981,7 +981,7 @@ def is_datetime64_ns_dtype(arr_or_dtype) -> bool:
             tipo = _get_dtype(arr_or_dtype.dtype)
         else:
             return False
-    return tipo == _NS_DTYPE or getattr(tipo, "base", None) == _NS_DTYPE
+    return tipo == DT64NS_DTYPE or getattr(tipo, "base", None) == DT64NS_DTYPE
 
 
 def is_timedelta64_ns_dtype(arr_or_dtype) -> bool:
@@ -1012,7 +1012,7 @@ def is_timedelta64_ns_dtype(arr_or_dtype) -> bool:
     >>> is_timedelta64_ns_dtype(np.array([1, 2], dtype=np.timedelta64))
     False
     """
-    return _is_dtype(arr_or_dtype, lambda dtype: dtype == _TD_DTYPE)
+    return _is_dtype(arr_or_dtype, lambda dtype: dtype == TD64NS_DTYPE)
 
 
 def is_datetime_or_timedelta_dtype(arr_or_dtype) -> bool:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -467,7 +467,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
             _combine_hash_arrays,
             hash_tuples,
         )
-        from pandas.core.dtypes.common import is_datetime64tz_dtype, _NS_DTYPE
+        from pandas.core.dtypes.common import is_datetime64tz_dtype, DT64NS_DTYPE
 
         if len(categories) and isinstance(categories[0], tuple):
             # assumes if any individual category is a tuple, then all our. ATM
@@ -487,7 +487,7 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
 
             if is_datetime64tz_dtype(categories.dtype):
                 # Avoid future warning.
-                categories = categories.astype(_NS_DTYPE)
+                categories = categories.astype(DT64NS_DTYPE)
 
             cat_array = hash_array(np.asarray(categories), categorize=False)
         if ordered:

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -11,8 +11,8 @@ from pandas._libs.tslibs import NaT, iNaT
 from pandas._typing import DtypeObj
 
 from pandas.core.dtypes.common import (
-    _NS_DTYPE,
-    _TD_DTYPE,
+    DT64NS_DTYPE,
+    TD64NS_DTYPE,
     ensure_object,
     is_bool_dtype,
     is_complex_dtype,
@@ -482,9 +482,9 @@ def _infer_fill_value(val):
     elif is_object_dtype(val.dtype):
         dtype = lib.infer_dtype(ensure_object(val), skipna=False)
         if dtype in ["datetime", "datetime64"]:
-            return np.array("NaT", dtype=_NS_DTYPE)
+            return np.array("NaT", dtype=DT64NS_DTYPE)
         elif dtype in ["timedelta", "timedelta64"]:
-            return np.array("NaT", dtype=_TD_DTYPE)
+            return np.array("NaT", dtype=TD64NS_DTYPE)
     return np.nan
 
 

--- a/pandas/core/groupby/categorical.py
+++ b/pandas/core/groupby/categorical.py
@@ -4,7 +4,7 @@ from pandas.core.algorithms import unique1d
 from pandas.core.arrays.categorical import (
     Categorical,
     CategoricalDtype,
-    _recode_for_categories,
+    recode_for_categories,
 )
 
 
@@ -51,7 +51,7 @@ def recode_for_groupby(c: Categorical, sort: bool, observed: bool):
 
         # we recode according to the uniques
         categories = c.categories.take(take_codes)
-        codes = _recode_for_categories(c.codes, c.categories, categories)
+        codes = recode_for_categories(c.codes, c.categories, categories)
 
         # return a new categorical that maps our new codes
         # and categories

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -23,7 +23,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core import accessor
 from pandas.core.algorithms import take_1d
-from pandas.core.arrays.categorical import Categorical, _recode_for_categories, contains
+from pandas.core.arrays.categorical import Categorical, contains, recode_for_categories
 import pandas.core.common as com
 import pandas.core.indexes.base as ibase
 from pandas.core.indexes.base import Index, _index_shared_docs, maybe_extract_name
@@ -540,7 +540,7 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
                 # we have the same codes
                 codes = target.codes
             else:
-                codes = _recode_for_categories(
+                codes = recode_for_categories(
                     target.codes, target.categories, self._values.categories
                 )
         else:

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -11,7 +11,7 @@ from pandas._typing import DtypeObj, Label
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
-    _NS_DTYPE,
+    DT64NS_DTYPE,
     is_datetime64_any_dtype,
     is_datetime64_dtype,
     is_datetime64tz_dtype,
@@ -454,7 +454,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         # Superdumb, punting on any optimizing
         freq = to_offset(freq)
 
-        snapped = np.empty(len(self), dtype=_NS_DTYPE)
+        snapped = np.empty(len(self), dtype=DT64NS_DTYPE)
 
         for i, v in enumerate(self):
             s = v

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -5,7 +5,7 @@ from pandas._typing import DtypeObj, Label
 from pandas.util._decorators import doc
 
 from pandas.core.dtypes.common import (
-    _TD_DTYPE,
+    TD64NS_DTYPE,
     is_float,
     is_integer,
     is_scalar,
@@ -134,7 +134,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin, dtl.TimelikeOps):
         unit=None,
         freq=None,
         closed=None,
-        dtype=_TD_DTYPE,
+        dtype=TD64NS_DTYPE,
         copy=False,
         name=None,
     ):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -27,8 +27,8 @@ from pandas.core.dtypes.cast import (
     soft_convert_objects,
 )
 from pandas.core.dtypes.common import (
-    _NS_DTYPE,
-    _TD_DTYPE,
+    DT64NS_DTYPE,
+    TD64NS_DTYPE,
     is_bool_dtype,
     is_categorical,
     is_categorical_dtype,
@@ -2096,7 +2096,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
 
         Overridden by DatetimeTZBlock.
         """
-        if values.dtype != _NS_DTYPE:
+        if values.dtype != DT64NS_DTYPE:
             values = conversion.ensure_datetime64ns(values)
 
         if isinstance(values, DatetimeArray):
@@ -2368,7 +2368,7 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
     fill_value = np.timedelta64("NaT", "ns")
 
     def __init__(self, values, placement, ndim=None):
-        if values.dtype != _TD_DTYPE:
+        if values.dtype != TD64NS_DTYPE:
             values = conversion.ensure_timedelta64ns(values)
         if isinstance(values, TimedeltaArray):
             values = values._data

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -18,7 +18,7 @@ from pandas.core.dtypes.cast import (
     maybe_promote,
 )
 from pandas.core.dtypes.common import (
-    _NS_DTYPE,
+    DT64NS_DTYPE,
     is_datetimelike_v_numeric,
     is_extension_array_dtype,
     is_list_like,
@@ -1748,7 +1748,7 @@ def form_blocks(arrays, names, axes):
         blocks.extend(int_blocks)
 
     if len(items_dict["DatetimeBlock"]):
-        datetime_blocks = _simple_blockify(items_dict["DatetimeBlock"], _NS_DTYPE)
+        datetime_blocks = _simple_blockify(items_dict["DatetimeBlock"], DT64NS_DTYPE)
         blocks.extend(datetime_blocks)
 
     if len(items_dict["DatetimeTZBlock"]):

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -44,7 +44,7 @@ from pandas.core.dtypes.missing import isna, na_value_for_dtype
 from pandas import Categorical, Index, MultiIndex
 from pandas.core import groupby
 import pandas.core.algorithms as algos
-from pandas.core.arrays.categorical import _recode_for_categories
+from pandas.core.arrays.categorical import recode_for_categories
 import pandas.core.common as com
 from pandas.core.construction import extract_array
 from pandas.core.frame import _merge_doc
@@ -1944,7 +1944,7 @@ def _factorize_keys(
             rk = rk.codes
         else:
             # Same categories in different orders -> recode
-            rk = _recode_for_categories(rk.codes, rk.categories, lk.categories)
+            rk = recode_for_categories(rk.codes, rk.categories, lk.categories)
 
         lk = ensure_int64(lk.codes)
         rk = ensure_int64(rk)

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -7,7 +7,7 @@ from pandas._libs import Timedelta, Timestamp
 from pandas._libs.lib import infer_dtype
 
 from pandas.core.dtypes.common import (
-    _NS_DTYPE,
+    DT64NS_DTYPE,
     ensure_int64,
     is_bool_dtype,
     is_categorical_dtype,
@@ -247,7 +247,7 @@ def cut(
 
     else:
         if is_datetime64tz_dtype(bins):
-            bins = np.asarray(bins, dtype=_NS_DTYPE)
+            bins = np.asarray(bins, dtype=DT64NS_DTYPE)
         else:
             bins = np.asarray(bins)
         bins = _convert_bin_to_numeric_type(bins, dtype)

--- a/pandas/tests/arrays/categorical/test_api.py
+++ b/pandas/tests/arrays/categorical/test_api.py
@@ -5,7 +5,7 @@ import pytest
 
 from pandas import Categorical, CategoricalIndex, DataFrame, Index, Series
 import pandas._testing as tm
-from pandas.core.arrays.categorical import _recode_for_categories
+from pandas.core.arrays.categorical import recode_for_categories
 from pandas.tests.arrays.categorical.common import TestCategorical
 
 
@@ -504,7 +504,7 @@ class TestPrivateCategoricalAPI:
         expected = np.asanyarray(expected, dtype=np.int8)
         old = Index(old)
         new = Index(new)
-        result = _recode_for_categories(codes, old, new)
+        result = recode_for_categories(codes, old, new)
         tm.assert_numpy_array_equal(result, expected)
 
     def test_recode_to_categories_large(self):
@@ -513,5 +513,5 @@ class TestPrivateCategoricalAPI:
         old = Index(codes)
         expected = np.arange(N - 1, -1, -1, dtype=np.int16)
         new = Index(expected)
-        result = _recode_for_categories(codes, old, new)
+        result = recode_for_categories(codes, old, new)
         tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
xref #32942, these are some of the more common offenders.

I'd actually prefer to not have the _NS_DTYPE and _TD_DTYPE objects and just use the pertinent strings, but if we are going to use the objects, might as well de-code-smell them.