### PR TITLE
Clean Up Categorical Test for JSON

### DIFF
--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -15,16 +15,6 @@ import pandas as pd
 from pandas import DataFrame, DatetimeIndex, Series, Timestamp, read_json
 import pandas._testing as tm
 
-_seriesd = tm.getSeriesData()
-
-_frame = DataFrame(_seriesd)
-
-_cat_frame = _frame.copy()
-cat = ["bah"] * 5 + ["bar"] * 5 + ["baz"] * 5 + ["foo"] * (len(_cat_frame) - 15)
-_cat_frame.index = pd.CategoricalIndex(cat, name="E")
-_cat_frame["E"] = list(reversed(cat))
-_cat_frame["sort"] = np.arange(len(_cat_frame), dtype="int64")
-
 
 def assert_json_roundtrip_equal(result, expected, orient):
     if orient == "records" or orient == "values":
@@ -36,12 +26,6 @@ def assert_json_roundtrip_equal(result, expected, orient):
 
 @pytest.mark.filterwarnings("ignore:the 'numpy' keyword is deprecated:FutureWarning")
 class TestPandasContainer:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.categorical = _cat_frame.copy()
-
-        yield
-
     def test_frame_double_encoded_labels(self, orient):
         df = DataFrame(
             [["a", "b"], ["c", "d"]],
@@ -183,25 +167,21 @@ class TestPandasContainer:
     @pytest.mark.parametrize("convert_axes", [True, False])
     @pytest.mark.parametrize("numpy", [True, False])
     def test_roundtrip_categorical(self, orient, convert_axes, numpy):
-        # TODO: create a better frame to test with and improve coverage
-        if orient in ("index", "columns"):
-            pytest.xfail(f"Can't have duplicate index values for orient '{orient}')")
+        cats = ["a", "b"]
+        df = pd.DataFrame(
+            pd.Categorical(cats), index=pd.CategoricalIndex(cats), columns=["cat"]
+        )
 
-        data = self.categorical.to_json(orient=orient)
-        if numpy and orient in ("records", "values"):
+        data = df.to_json(orient=orient)
+        if numpy and orient != "split":
             pytest.xfail(f"Orient {orient} is broken with numpy=True")
 
         result = pd.read_json(
             data, orient=orient, convert_axes=convert_axes, numpy=numpy
         )
 
-        expected = self.categorical.copy()
-        expected.index = expected.index.astype(str)  # Categorical not preserved
-        expected.index.name = None  # index names aren't preserved in JSON
-
-        if not numpy and orient == "index":
-            expected = expected.sort_index()
-
+        # Categorical dtypes are not preserved on round trip
+        expected = pd.DataFrame(cats, index=cats, columns=["cat"])
         assert_json_roundtrip_equal(result, expected, orient)
 
     @pytest.mark.parametrize("convert_axes", [True, False])


### PR DESCRIPTION
This is a little wonky in its current state, bolting categoricals onto an existing object / fixture

Instead just localized this to the one test that covers it for now