### PR TITLE
REF: do slicing before calling Block.to_native_types

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -651,12 +651,10 @@ class Block(PandasObject):
         """
         return is_dtype_equal(value.dtype, self.dtype)
 
-    def to_native_types(self, slicer=None, na_rep="nan", quoting=None, **kwargs):
-        """ convert to our native types format, slicing if desired """
+    def to_native_types(self, na_rep="nan", quoting=None, **kwargs):
+        """ convert to our native types format """
         values = self.values
 
-        if slicer is not None:
-            values = values[:, slicer]
         mask = isna(values)
         itemsize = writers.word_len(na_rep)
 
@@ -1715,11 +1713,9 @@ class ExtensionBlock(Block):
     def array_values(self) -> ExtensionArray:
         return self.values
 
-    def to_native_types(self, slicer=None, na_rep="nan", quoting=None, **kwargs):
+    def to_native_types(self, na_rep="nan", quoting=None, **kwargs):
         """override to use ExtensionArray astype for the conversion"""
         values = self.values
-        if slicer is not None:
-            values = values[slicer]
         mask = isna(values)
 
         values = np.asarray(values.astype(object))
@@ -1937,18 +1933,10 @@ class FloatBlock(FloatOrComplexBlock):
         )
 
     def to_native_types(
-        self,
-        slicer=None,
-        na_rep="",
-        float_format=None,
-        decimal=".",
-        quoting=None,
-        **kwargs,
+        self, na_rep="", float_format=None, decimal=".", quoting=None, **kwargs,
     ):
-        """ convert to our native types format, slicing if desired """
+        """ convert to our native types format """
         values = self.values
-        if slicer is not None:
-            values = values[:, slicer]
 
         # see gh-13418: no special formatting is desired at the
         # output (important for appropriate 'quoting' behaviour),
@@ -2131,16 +2119,10 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
 
         return is_valid_nat_for_dtype(element, self.dtype)
 
-    def to_native_types(
-        self, slicer=None, na_rep=None, date_format=None, quoting=None, **kwargs
-    ):
+    def to_native_types(self, na_rep=None, date_format=None, quoting=None, **kwargs):
         """ convert to our native types format, slicing if desired """
         values = self.values
         i8values = self.values.view("i8")
-
-        if slicer is not None:
-            values = values[..., slicer]
-            i8values = i8values[..., slicer]
 
         from pandas.io.formats.format import _get_format_datetime64_from_values
 
@@ -2387,11 +2369,9 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
             )
         return super().fillna(value, **kwargs)
 
-    def to_native_types(self, slicer=None, na_rep=None, quoting=None, **kwargs):
-        """ convert to our native types format, slicing if desired """
+    def to_native_types(self, na_rep=None, quoting=None, **kwargs):
+        """ convert to our native types format """
         values = self.values
-        if slicer is not None:
-            values = values[:, slicer]
         mask = isna(values)
 
         rvalues = np.empty(values.shape, dtype=object)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -132,7 +132,7 @@ class CSVFormatter:
 
         # preallocate data 2d list
         self.blocks = self.obj._data.blocks
-        ncols = sum(b.shape[0] for b in self.blocks)
+        ncols = self.obj.shape[-1]
         self.data = [None] * ncols
 
         if chunksize is None:
@@ -327,10 +327,13 @@ class CSVFormatter:
 
         # create the data for a chunk
         slicer = slice(start_i, end_i)
-        for i in range(len(self.blocks)):
-            b = self.blocks[i]
+
+        df = self.obj.iloc[slicer]
+        blocks = df._data.blocks
+
+        for i in range(len(blocks)):
+            b = blocks[i]
             d = b.to_native_types(
-                slicer=slicer,
                 na_rep=self.na_rep,
                 float_format=self.float_format,
                 decimal=self.decimal,


### PR DESCRIPTION
Related upcoming steps:

- Dispatch DatetimeBlock.to_native_types to DatetimeArray._format_native_types (identical behavior
- Dispatch TimeDeltaBlock.to_native_types to TimedeltaArray._format_native_types (behavior changing, but there is a FIXME in the Block version)
- Dispatch FloatBlock.to_native_types to Float64Index._format_native_types
- Possibly rename to_native_types to something more informative?  (i think there's an issue about deprecating/renaming the Index method)
- in io.csvs use `df._data.apply` instead of iterating over blocks.  Still touches internals, but its a lighter touch.