### PR TITLE
Display Timedelta nanoseconds

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -310,6 +310,7 @@ Timedelta
 - Bug in constructing a :class:`Timedelta` with a high precision integer that would round the :class:`Timedelta` components (:issue:`31354`)
 - Bug in dividing ``np.nan`` or ``None`` by :class:`Timedelta`` incorrectly returning ``NaT`` (:issue:`31869`)
 - Timedeltas now understand ``µs`` as identifier for microsecond (:issue:`32899`)
+- :class:`Timedelta` string representation now includes nanoseconds, when nanoseconds are non-zero (:issue:`9309`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1072,9 +1072,11 @@ cdef class _Timedelta(timedelta):
             subs = (self._h or self._m or self._s or
                     self._ms or self._us or self._ns)
 
-            # by default not showing nano
             if self._ms or self._us or self._ns:
                 seconds_fmt = "{seconds:02}.{milliseconds:03}{microseconds:03}"
+                if self._ns:
+                    # GH#9309
+                    seconds_fmt += "{nanoseconds:03}"
             else:
                 seconds_fmt = "{seconds:02}"
 

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -63,7 +63,7 @@ def to_timedelta(arg, unit="ns", errors="raise"):
     Parsing a list or array of strings:
 
     >>> pd.to_timedelta(['1 days 06:05:01.00003', '15.5us', 'nan'])
-    TimedeltaIndex(['1 days 06:05:01.000030', '0 days 00:00:00.000015', NaT],
+    TimedeltaIndex(['1 days 06:05:01.000030', '0 days 00:00:00.000015500', NaT],
                    dtype='timedelta64[ns]', freq=None)
 
     Converting numbers by specifying the `unit` keyword argument:

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -58,7 +58,7 @@ def to_timedelta(arg, unit="ns", errors="raise"):
     >>> pd.to_timedelta('1 days 06:05:01.00003')
     Timedelta('1 days 06:05:01.000030')
     >>> pd.to_timedelta('15.5us')
-    Timedelta('0 days 00:00:00.000015')
+    Timedelta('0 days 00:00:00.000015500')
 
     Parsing a list or array of strings:
 

--- a/pandas/tests/frame/methods/test_describe.py
+++ b/pandas/tests/frame/methods/test_describe.py
@@ -230,15 +230,15 @@ class TestDataFrameDescribe:
         tm.assert_frame_equal(result, expected)
 
         exp_repr = (
-            "                           t1                      t2\n"
-            "count                       5                       5\n"
-            "mean          3 days 00:00:00         0 days 03:00:00\n"
-            "std    1 days 13:56:50.394919  0 days 01:34:52.099788\n"
-            "min           1 days 00:00:00         0 days 01:00:00\n"
-            "25%           2 days 00:00:00         0 days 02:00:00\n"
-            "50%           3 days 00:00:00         0 days 03:00:00\n"
-            "75%           4 days 00:00:00         0 days 04:00:00\n"
-            "max           5 days 00:00:00         0 days 05:00:00"
+            "                              t1                         t2\n"
+            "count                          5                          5\n"
+            "mean             3 days 00:00:00            0 days 03:00:00\n"
+            "std    1 days 13:56:50.394919273  0 days 01:34:52.099788303\n"
+            "min              1 days 00:00:00            0 days 01:00:00\n"
+            "25%              2 days 00:00:00            0 days 02:00:00\n"
+            "50%              3 days 00:00:00            0 days 03:00:00\n"
+            "75%              4 days 00:00:00            0 days 04:00:00\n"
+            "max              5 days 00:00:00            0 days 05:00:00"
         )
         assert repr(result) == exp_repr
 

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -176,10 +176,9 @@ def test_td_from_repr_roundtrip(val):
     td = Timedelta(val)
     assert Timedelta(td.value) == td
 
-    # str does not normally display nanos
-    if not td.nanoseconds:
-        assert Timedelta(str(td)) == td
+    assert Timedelta(str(td)) == td
     assert Timedelta(td._repr_base(format="all")) == td
+    assert Timedelta(td._repr_base()) == td
 
 
 def test_overflow_on_construction():


### PR DESCRIPTION
- [x] closes #9309
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This allows us to make TimedeltaBlock.to_native_types dispatch to TimedeltaArray._format_native_types.  ATM TDBlock.to_native_types has a comment

```
        # FIXME:
        # should use the formats.format.Timedelta64Formatter here
        # to figure what format to pass to the Timedelta
        # e.g. to not show the decimals say
```