### PR TITLE
DOC: Fixed examples in `pandas/core/accessor.py`

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -268,6 +268,10 @@ if [[ -z "$CHECK" || "$CHECK" == "doctests" ]]; then
 
     # Individual files
 
+    MSG='Doctests accessor.py' ; echo $MSG
+    pytest -q --doctest-modules pandas/core/accessor.py
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
+
     MSG='Doctests base.py' ; echo $MSG
     pytest -q --doctest-modules pandas/core/base.py
     RET=$(($RET + $?)) ; echo $MSG "DONE"

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -257,12 +257,13 @@ def _register_accessor(name, cls):
 
     Back in an interactive IPython session:
 
-        >>> ds = pd.DataFrame({{'longitude': np.linspace(0, 10),
-        ...                    'latitude': np.linspace(0, 20)}})
-        >>> ds.geo.center
-        (5.0, 10.0)
-        >>> ds.geo.plot()
-        # plots data on a map
+        .. code-block:: ipython
+
+            In [1]: ds = pd.DataFrame({{"longitude": np.linspace(0, 10),
+               ...:                    "latitude": np.linspace(0, 20)}})
+            In [2]: ds.geo.center
+            Out[2]: (5.0, 10.0)
+            In [3]: ds.geo.plot()  # plots data on a map
     """
 
     def decorator(accessor):


### PR DESCRIPTION
Since this changes require an interactive Ipython shell (I think), we can't run check them from pytest.

This is what the docs looks like:

Before:

![Screenshot_20200403_170159](https://user-images.githubusercontent.com/50263213/78368644-9c0b8400-75cc-11ea-9061-24652f2bdfca.png)

After:
![register_acc](https://user-images.githubusercontent.com/50263213/78368530-71b9c680-75cc-11ea-8ab5-d2ee2eadc727.png)