### PR TITLE
PERF: masked ops for reductions (min/max)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -274,7 +274,7 @@ Performance improvements
   sparse values from ``scipy.sparse`` matrices using the
   :meth:`DataFrame.sparse.from_spmatrix` constructor (:issue:`32821`,
   :issue:`32825`,  :issue:`32826`, :issue:`32856`, :issue:`32858`).
-- Performance improvement in :meth:`Series.sum` for nullable (integer and boolean) dtypes (:issue:`30982`).
+- Performance improvement in reductions (sum, min, max) for nullable (integer and boolean) dtypes (:issue:`30982`, :issue:`33261`).
 
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -47,40 +47,41 @@ def sum(
             return np.sum(values, where=~mask)
 
 
-def _minmax(func):
-    def reduction(values: np.ndarray, mask: np.ndarray, skipna: bool = True):
-        """
-        Reduction for 1D masked array.
+def _minmax(func, values: np.ndarray, mask: np.ndarray, skipna: bool = True):
+    """
+    Reduction for 1D masked array.
 
-        Parameters
-        ----------
-        values : np.ndarray
-            Numpy array with the values (can be of any dtype that support the
-            operation).
-        mask : np.ndarray
-            Boolean numpy array (True values indicate missing values).
-        skipna : bool, default True
-            Whether to skip NA.
-        """
-        if not skipna:
-            if mask.any():
-                return libmissing.NA
-            else:
-                if values.size:
-                    return func(values)
-                else:
-                    # min/max with empty array raise in numpy, pandas returns NA
-                    return libmissing.NA
+    Parameters
+    ----------
+    values : np.ndarray
+        Numpy array with the values (can be of any dtype that support the
+        operation).
+    mask : np.ndarray
+        Boolean numpy array (True values indicate missing values).
+    skipna : bool, default True
+        Whether to skip NA.
+    """
+    if not skipna:
+        if mask.any():
+            return libmissing.NA
         else:
-            subset = values[~mask]
-            if subset.size:
-                return func(values[~mask])
+            if values.size:
+                return func(values)
             else:
                 # min/max with empty array raise in numpy, pandas returns NA
                 return libmissing.NA
+    else:
+        subset = values[~mask]
+        if subset.size:
+            return func(values[~mask])
+        else:
+            # min/max with empty array raise in numpy, pandas returns NA
+            return libmissing.NA
 
-    return reduction
+
+def min(values: np.ndarray, mask: np.ndarray, skipna: bool = True):
+    return _minmax(np.min, values=values, mask=mask, skipna=skipna)
 
 
-min = _minmax(np.min)
-max = _minmax(np.max)
+def max(values: np.ndarray, mask: np.ndarray, skipna: bool = True):
+    return _minmax(np.max, values=values, mask=mask, skipna=skipna)

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -45,3 +45,42 @@ def sum(
             return np.sum(values[~mask])
         else:
             return np.sum(values, where=~mask)
+
+
+def _minmax(func):
+    def reduction(values: np.ndarray, mask: np.ndarray, skipna: bool = True):
+        """
+        Reduction for 1D masked array.
+
+        Parameters
+        ----------
+        values : np.ndarray
+            Numpy array with the values (can be of any dtype that support the
+            operation).
+        mask : np.ndarray
+            Boolean numpy array (True values indicate missing values).
+        skipna : bool, default True
+            Whether to skip NA.
+        """
+        if not skipna:
+            if mask.any():
+                return libmissing.NA
+            else:
+                if values.size:
+                    return func(values)
+                else:
+                    # min/max with empty array raise in numpy, pandas returns NA
+                    return libmissing.NA
+        else:
+            subset = values[~mask]
+            if subset.size:
+                return func(values[~mask])
+            else:
+                # min/max with empty array raise in numpy, pandas returns NA
+                return libmissing.NA
+
+    return reduction
+
+
+min = _minmax(np.min)
+max = _minmax(np.max)

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -53,6 +53,7 @@ def _minmax(func, values: np.ndarray, mask: np.ndarray, skipna: bool = True):
 
     Parameters
     ----------
+    func : np.min or np.max
     values : np.ndarray
         Numpy array with the values (can be of any dtype that support the
         operation).

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -696,8 +696,9 @@ class BooleanArray(BaseMaskedArray):
         data = self._data
         mask = self._mask
 
-        if name == "sum":
-            return masked_reductions.sum(data, mask, skipna=skipna, **kwargs)
+        if name in {"sum", "min", "max"}:
+            op = getattr(masked_reductions, name)
+            return op(data, mask, skipna=skipna, **kwargs)
 
         # coerce to a nan-aware float if needed
         if self._hasna:
@@ -714,9 +715,6 @@ class BooleanArray(BaseMaskedArray):
             int_result = np.int64(result)
             if int_result == result:
                 result = int_result
-
-        elif name in ["min", "max"] and notna(result):
-            result = np.bool_(result)
 
         return result
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -582,7 +582,7 @@ class IntegerArray(BaseMaskedArray):
 
         # if we have a preservable numeric op,
         # provide coercion back to an integer type if possible
-        elif name in ["prod"]:
+        elif name == "prod":
             # GH#31409 more performant than casting-then-checking
             result = com.cast_scalar_indexer(result)
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -561,8 +561,9 @@ class IntegerArray(BaseMaskedArray):
         data = self._data
         mask = self._mask
 
-        if name == "sum":
-            return masked_reductions.sum(data, mask, skipna=skipna, **kwargs)
+        if name in {"sum", "min", "max"}:
+            op = getattr(masked_reductions, name)
+            return op(data, mask, skipna=skipna, **kwargs)
 
         # coerce to a nan-aware float if needed
         # (we explicitly use NaN within reductions)
@@ -581,7 +582,7 @@ class IntegerArray(BaseMaskedArray):
 
         # if we have a preservable numeric op,
         # provide coercion back to an integer type if possible
-        elif name in ["min", "max", "prod"]:
+        elif name in ["prod"]:
             # GH#31409 more performant than casting-then-checking
             result = com.cast_scalar_indexer(result)
 

--- a/pandas/tests/arrays/integer/test_dtypes.py
+++ b/pandas/tests/arrays/integer/test_dtypes.py
@@ -34,7 +34,7 @@ def test_preserve_dtypes(op):
 
     # op
     result = getattr(df.C, op)()
-    if op == "sum":
+    if op in {"sum", "min", "max"}:
         assert isinstance(result, np.int64)
     else:
         assert isinstance(result, int)

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -70,15 +70,16 @@ class TestReductions:
         [
             ("object", 2.0),
             ("float64", 2.0),
-            ("Int64", 2),
             ("datetime64[ns]", datetime(2011, 11, 1)),
+            ("Int64", 2),
+            ("boolean", True),
         ],
     )
     def test_nanminmax(self, opname, dtype, val, index_or_series):
         # GH#7261
         klass = index_or_series
 
-        if dtype == "Int64" and klass == pd.Index:
+        if dtype in ["Int64", "boolean"] and klass == pd.Index:
             pytest.skip("EAs can't yet be stored in an index")
 
         def check_missing(res):

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -65,27 +65,57 @@ class TestReductions:
             assert result.value == expected
 
     @pytest.mark.parametrize("opname", ["max", "min"])
-    def test_nanops(self, opname, index_or_series):
+    @pytest.mark.parametrize(
+        "dtype, val",
+        [
+            ("object", 2.0),
+            ("float64", 2.0),
+            ("Int64", 2),
+            ("datetime64[ns]", datetime(2011, 11, 1)),
+        ],
+    )
+    def test_nanminmax(self, opname, dtype, val, index_or_series):
+        # GH#7261
+        klass = index_or_series
+
+        if dtype == "Int64" and klass == pd.Index:
+            pytest.skip("EAs can't yet be stored in an index")
+
+        def check_missing(res):
+            if dtype == "datetime64[ns]":
+                return res is pd.NaT
+            elif dtype == "Int64":
+                return res is pd.NA
+            else:
+                return pd.isna(res)
+
+        obj = klass([None], dtype=dtype)
+        assert check_missing(getattr(obj, opname)())
+        assert check_missing(getattr(obj, opname)(skipna=False))
+
+        obj = klass([], dtype=dtype)
+        assert check_missing(getattr(obj, opname)())
+        assert check_missing(getattr(obj, opname)(skipna=False))
+
+        if dtype == "object":
+            # generic test with object only works for empty / all NaN
+            return
+
+        obj = klass([None, val], dtype=dtype)
+        assert getattr(obj, opname)() == val
+        assert check_missing(getattr(obj, opname)(skipna=False))
+
+        obj = klass([None, val, None], dtype=dtype)
+        assert getattr(obj, opname)() == val
+        assert check_missing(getattr(obj, opname)(skipna=False))
+
+    @pytest.mark.parametrize("opname", ["max", "min"])
+    def test_nanargminmax(self, opname, index_or_series):
         # GH#7261
         klass = index_or_series
         arg_op = "arg" + opname if klass is Index else "idx" + opname
 
-        obj = klass([np.nan, 2.0])
-        assert getattr(obj, opname)() == 2.0
-
-        obj = klass([np.nan])
-        assert pd.isna(getattr(obj, opname)())
-        assert pd.isna(getattr(obj, opname)(skipna=False))
-
-        obj = klass([], dtype=object)
-        assert pd.isna(getattr(obj, opname)())
-        assert pd.isna(getattr(obj, opname)(skipna=False))
-
         obj = klass([pd.NaT, datetime(2011, 11, 1)])
-        # check DatetimeIndex monotonic path
-        assert getattr(obj, opname)() == datetime(2011, 11, 1)
-        assert getattr(obj, opname)(skipna=False) is pd.NaT
-
         assert getattr(obj, arg_op)() == 1
         result = getattr(obj, arg_op)(skipna=False)
         if klass is Series:
@@ -95,9 +125,6 @@ class TestReductions:
 
         obj = klass([pd.NaT, datetime(2011, 11, 1), pd.NaT])
         # check DatetimeIndex non-monotonic path
-        assert getattr(obj, opname)(), datetime(2011, 11, 1)
-        assert getattr(obj, opname)(skipna=False) is pd.NaT
-
         assert getattr(obj, arg_op)() == 1
         result = getattr(obj, arg_op)(skipna=False)
         if klass is Series:


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/30982, adding similar mask reduction but now for min/max.