### PR TITLE
DOC: Fix error in Series.clip and DataFrame.clip

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7299,6 +7299,12 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             Same type as calling object with the values outside the
             clip boundaries replaced.
 
+        See Also
+        --------
+        Series.clip : Trim values at input threshold in series.
+        DataFrame.clip : Trim values at input threshold in dataframe.
+        numpy.clip : Clip (limit) the values in an array.
+
         Examples
         --------
         >>> data = {'col_0': [9, -3, 0, -1, 5], 'col_1': [-2, -7, 6, 8, -5]}


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Related to #27977. 

output of `python scripts/validate_docstrings.py pandas.Series.clip and pandas.DataFrame.clip`:
```
################################################################################
################################## Validation ##################################
################################################################################
```

