### PR TITLE
BUG: Timestamp+- ndarray[td64]

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -304,6 +304,7 @@ Datetimelike
 - :class:`Timestamp` raising confusing error message when year, month or day is missing (:issue:`31200`)
 - Bug in :class:`DatetimeIndex` constructor incorrectly accepting ``bool``-dtyped inputs (:issue:`32668`)
 - Bug in :meth:`DatetimeIndex.searchsorted` not accepting a ``list`` or :class:`Series` as its argument (:issue:`32762`)
+- Bug in :class:`Timestamp` arithmetic when adding or subtracting a ``np.ndarray`` with ``timedelta64`` dtype (:issue:`?????`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -304,7 +304,7 @@ Datetimelike
 - :class:`Timestamp` raising confusing error message when year, month or day is missing (:issue:`31200`)
 - Bug in :class:`DatetimeIndex` constructor incorrectly accepting ``bool``-dtyped inputs (:issue:`32668`)
 - Bug in :meth:`DatetimeIndex.searchsorted` not accepting a ``list`` or :class:`Series` as its argument (:issue:`32762`)
-- Bug in :class:`Timestamp` arithmetic when adding or subtracting a ``np.ndarray`` with ``timedelta64`` dtype (:issue:`?????`)
+- Bug in :class:`Timestamp` arithmetic when adding or subtracting a ``np.ndarray`` with ``timedelta64`` dtype (:issue:`33296`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/c_timestamp.pyx
+++ b/pandas/_libs/tslibs/c_timestamp.pyx
@@ -253,6 +253,13 @@ cdef class _Timestamp(datetime):
         elif is_array(other):
             if other.dtype.kind in ['i', 'u']:
                 raise integer_op_not_supported(self)
+            if other.dtype.kind == "m":
+                if self.tz is None:
+                    return self.asm8 + other
+                return np.asarray(
+                    [self + other[n] for n in range(len(other))],
+                    dtype=object,
+                )
 
         # index/series like
         elif hasattr(other, '_typ'):
@@ -275,6 +282,13 @@ cdef class _Timestamp(datetime):
         elif is_array(other):
             if other.dtype.kind in ['i', 'u']:
                 raise integer_op_not_supported(self)
+            if other.dtype.kind == "m":
+                if self.tz is None:
+                    return self.asm8 - other
+                return np.asarray(
+                    [self - other[n] for n in range(len(other))],
+                    dtype=object,
+                )
 
         typ = getattr(other, '_typ', None)
         if typ is not None:

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -210,6 +210,7 @@ class TestTimestampArithmetic:
 
     @pytest.mark.parametrize("shape", [(6,), (2, 3,)])
     def test_addsub_m8ndarray(self, shape):
+        # GH#33296
         ts = Timestamp("2020-04-04 15:45")
         other = np.arange(6).astype("m8[h]").reshape(shape)
 
@@ -233,6 +234,7 @@ class TestTimestampArithmetic:
 
     @pytest.mark.parametrize("shape", [(6,), (2, 3,)])
     def test_addsub_m8ndarray_tzaware(self, shape):
+        # GH#33296
         ts = Timestamp("2020-04-04 15:45", tz="US/Pacific")
 
         other = np.arange(6).astype("m8[h]").reshape(shape)

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -6,6 +6,7 @@ import pytest
 from pandas.errors import OutOfBoundsDatetime
 
 from pandas import Timedelta, Timestamp
+import pandas._testing as tm
 
 from pandas.tseries import offsets
 from pandas.tseries.frequencies import to_offset
@@ -177,29 +178,6 @@ class TestTimestampArithmetic:
         valdiff = result.value - ts.value
         assert valdiff == expected_difference
 
-    @pytest.mark.parametrize("ts", [Timestamp.now(), Timestamp.now("utc")])
-    @pytest.mark.parametrize(
-        "other",
-        [
-            1,
-            np.int64(1),
-            np.array([1, 2], dtype=np.int32),
-            np.array([3, 4], dtype=np.uint64),
-        ],
-    )
-    def test_add_int_no_freq_raises(self, ts, other):
-        msg = "Addition/subtraction of integers and integer-arrays"
-        with pytest.raises(TypeError, match=msg):
-            ts + other
-        with pytest.raises(TypeError, match=msg):
-            other + ts
-
-        with pytest.raises(TypeError, match=msg):
-            ts - other
-        msg = "unsupported operand type"
-        with pytest.raises(TypeError, match=msg):
-            other - ts
-
     @pytest.mark.parametrize(
         "ts",
         [
@@ -227,5 +205,52 @@ class TestTimestampArithmetic:
             ts - other
 
         msg = "unsupported operand type"
+        with pytest.raises(TypeError, match=msg):
+            other - ts
+
+    @pytest.mark.parametrize("shape", [(6,), (2, 3,)])
+    def test_addsub_m8ndarray(self, shape):
+        ts = Timestamp("2020-04-04 15:45")
+        other = np.arange(6).astype("m8[h]").reshape(shape)
+
+        result = ts + other
+
+        ex_stamps = [ts + Timedelta(hours=n) for n in range(6)]
+        expected = np.array([x.asm8 for x in ex_stamps], dtype="M8[ns]").reshape(shape)
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = other + ts
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = ts - other
+        ex_stamps = [ts - Timedelta(hours=n) for n in range(6)]
+        expected = np.array([x.asm8 for x in ex_stamps], dtype="M8[ns]").reshape(shape)
+        tm.assert_numpy_array_equal(result, expected)
+
+        msg = r"unsupported operand type\(s\) for -: 'numpy.ndarray' and 'Timestamp'"
+        with pytest.raises(TypeError, match=msg):
+            other - ts
+
+    @pytest.mark.parametrize("shape", [(6,), (2, 3,)])
+    def test_addsub_m8ndarray_tzaware(self, shape):
+        ts = Timestamp("2020-04-04 15:45", tz="US/Pacific")
+
+        other = np.arange(6).astype("m8[h]").reshape(shape)
+
+        result = ts + other
+
+        ex_stamps = [ts + Timedelta(hours=n) for n in range(6)]
+        expected = np.array(ex_stamps).reshape(shape)
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = other + ts
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = ts - other
+        ex_stamps = [ts - Timedelta(hours=n) for n in range(6)]
+        expected = np.array(ex_stamps).reshape(shape)
+        tm.assert_numpy_array_equal(result, expected)
+
+        msg = r"unsupported operand type\(s\) for -: 'numpy.ndarray' and 'Timestamp'"
         with pytest.raises(TypeError, match=msg):
             other - ts


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Noticed a now-duplicate test that this gets rid of