### PR TITLE
Update citation webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 # pandas: powerful Python data analysis toolkit
 [![PyPI Latest Release](https://img.shields.io/pypi/v/pandas.svg)](https://pypi.org/project/pandas/)
 [![Conda Latest Release](https://anaconda.org/conda-forge/pandas/badges/version.svg)](https://anaconda.org/anaconda/pandas/)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3509134.svg)](https://doi.org/10.5281/zenodo.3509134)
 [![Package Status](https://img.shields.io/pypi/status/pandas.svg)](https://pypi.org/project/pandas/)
 [![License](https://img.shields.io/pypi/l/pandas.svg)](https://github.com/pandas-dev/pandas/blob/master/LICENSE)
 [![Travis Build Status](https://travis-ci.org/pandas-dev/pandas.svg?branch=master)](https://travis-ci.org/pandas-dev/pandas)

--- a/web/pandas/about/citing.md
+++ b/web/pandas/about/citing.md
@@ -2,7 +2,22 @@
 
 ## Citing pandas
 
-If you use _pandas_ for a scientific publication, we would appreciate citations to one of the following papers:
+If you use _pandas_ for a scientific publication, we would appreciate citations to the published software, and one of
+the two papers following the software entry:
+
+- [pandas on Zenodo](https://zenodo.org/record/3715232#.XoqFyC2ZOL8),
+   Please find us on Zenodo and replace with the citation for the version you are using.
+
+        @software{reback2020pandas,
+            author       = {The pandas development team},
+            title        = {pandas-dev/pandas: Pandas 1.0.1},
+            month        = feb,
+            year         = 2020,
+            publisher    = {Zenodo},
+            version      = {v1.0.1},
+            doi          = {10.5281/zenodo.3644238},
+            url          = {https://doi.org/10.5281/zenodo.3644238}
+        }
 
 - [Data structures for statistical computing in python](https://conference.scipy.org/proceedings/scipy2010/pdfs/mckinney.pdf),
    McKinney, Proceedings of the 9th Python in Science Conference, Volume 445, 2010.

--- a/web/pandas/about/citing.md
+++ b/web/pandas/about/citing.md
@@ -6,17 +6,18 @@ If you use _pandas_ for a scientific publication, we would appreciate citations 
 following paper:
 
 - [pandas on Zenodo](https://zenodo.org/record/3715232#.XoqFyC2ZOL8),
-   Please find us on Zenodo and replace with the citation for the version you are using.
+   Please find us on Zenodo and replace with the citation for the version you are using. You cna replace the full author
+   list from there with "The pandas development team" like in the example below.
 
         @software{reback2020pandas,
             author       = {The pandas development team},
-            title        = {pandas-dev/pandas: Pandas 1.0.1},
+            title        = {pandas-dev/pandas: Pandas},
             month        = feb,
             year         = 2020,
             publisher    = {Zenodo},
-            version      = {v1.0.1},
-            doi          = {10.5281/zenodo.3644238},
-            url          = {https://doi.org/10.5281/zenodo.3644238}
+            version      = {latest},
+            doi          = {10.5281/zenodo.3509134},
+            url          = {https://doi.org/10.5281/zenodo.3509134}
         }
 
 - [Data structures for statistical computing in python](https://conference.scipy.org/proceedings/scipy2010/pdfs/mckinney.pdf),

--- a/web/pandas/about/citing.md
+++ b/web/pandas/about/citing.md
@@ -2,8 +2,8 @@
 
 ## Citing pandas
 
-If you use _pandas_ for a scientific publication, we would appreciate citations to the published software, and one of
-the two papers following the software entry:
+If you use _pandas_ for a scientific publication, we would appreciate citations to the published software and the
+following paper:
 
 - [pandas on Zenodo](https://zenodo.org/record/3715232#.XoqFyC2ZOL8),
    Please find us on Zenodo and replace with the citation for the version you are using.
@@ -22,26 +22,14 @@ the two papers following the software entry:
 - [Data structures for statistical computing in python](https://conference.scipy.org/proceedings/scipy2010/pdfs/mckinney.pdf),
    McKinney, Proceedings of the 9th Python in Science Conference, Volume 445, 2010.
 
-        @inproceedings{mckinney2010data,
-            title={Data structures for statistical computing in python},
-            author={Wes McKinney},
-            booktitle={Proceedings of the 9th Python in Science Conference},
-            volume={445},
-            pages={51--56},
-            year={2010},
-            organization={Austin, TX}
-        }
-
-
-- [pandas: a foundational Python library for data analysis and statistics](https://www.scribd.com/document/71048089/pandas-a-Foundational-Python-Library-for-Data-Analysis-and-Statistics),
-  McKinney, Python for High Performance and Scientific Computing, Volume 14, 2011.
-
-        @article{mckinney2011pandas,
-            title={pandas: a foundational Python library for data analysis and statistics},
-            author={Wes McKinney},
-            journal={Python for High Performance and Scientific Computing},
-            volume={14},
-            year={2011}
+        @InProceedings{ mckinney-proc-scipy-2010,
+          author    = { {W}es {M}c{K}inney },
+          title     = { {D}ata {S}tructures for {S}tatistical {C}omputing in {P}ython },
+          booktitle = { {P}roceedings of the 9th {P}ython in {S}cience {C}onference },
+          pages     = { 56 - 61 },
+          year      = { 2010 },
+          editor    = { {S}t\'efan van der {W}alt and {J}arrod {M}illman },
+          doi       = { 10.25080/Majora-92bf1922-00a }
         }
 
 ## Brand and logo


### PR DESCRIPTION
Follow-up of #32388, addressing #24036 

I will leave it to the pandas team to decide whether to put in there a BibTeX entry with the concept DOI or a specific version, some options of dealing with this are described [in this comment](https://github.com/sherpa/sherpa/pull/634#issuecomment-553668211).

Note how [this comment thread](https://github.com/pandas-dev/pandas/pull/32388#discussion_r386392799) on the previous PR asked to replace the author list by "The pandas development team". However, if users go to Zenodo to get the correct BibTeX entry of the version they're actually using, their citation will contain the full author list provided in Zenodo.