### PR TITLE
TST: Don't use 'is' on strings to avoid SyntaxWarning

### DIFF
--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -238,9 +238,9 @@ class TestDataFrameAlterAxes:
         first_drop = (
             False
             if (
-                type(keys[0]) == str
+                isinstance(keys[0], str)
                 and keys[0] == "A"
-                and type(keys[1]) == str
+                and isinstance(keys[1], str)
                 and keys[1] == "A"
             )
             else drop

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -234,9 +234,16 @@ class TestDataFrameAlterAxes:
 
         # need to adapt first drop for case that both keys are 'A' --
         # cannot drop the same column twice;
-        # use "is" because == would give ambiguous Boolean error for containers
+        # plain == would give ambiguous Boolean error for containers
         first_drop = (
-            False if (keys[0] is "A" and keys[1] is "A") else drop  # noqa: F632
+            False
+            if (
+                type(keys[0]) == str
+                and keys[0] == "A"
+                and type(keys[1]) == str
+                and keys[1] == "A"
+            )
+            else drop
         )
         # to test against already-tested behaviour, we add sequentially,
         # hence second append always True; must wrap keys in list, otherwise


### PR DESCRIPTION
This avoids the below warning (in Python 3.8, [user-visible in Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956021) because they byte-compile everything on install), and possibly unspecified behaviour (though I haven't seen that in practice).

```
  /usr/lib/python3/dist-packages/pandas/tests/frame/test_alter_axes.py:241: SyntaxWarning: "is" with a literal. Did you mean "=="?
    False if (keys[0] is "A" and keys[1] is "A") else drop  # noqa: F632
```

