### PR TITLE
BLD: Increase minimum version of Cython to 0.29.16

### DIFF
--- a/ci/deps/azure-36-32bit.yaml
+++ b/ci/deps/azure-36-32bit.yaml
@@ -22,5 +22,5 @@ dependencies:
   # see comment above
   - pip
   - pip:
-    - cython>=0.29.13
+    - cython>=0.29.16
     - pytest>=5.0.1

--- a/ci/deps/azure-36-locale.yaml
+++ b/ci/deps/azure-36-locale.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - pytest-asyncio

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/azure-36-minimum_versions.yaml
+++ b/ci/deps/azure-36-minimum_versions.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.1
 
   # tools
-  - cython=0.29.13
+  - cython=0.29.16
   - pytest=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/azure-37-locale.yaml
+++ b/ci/deps/azure-37-locale.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - pytest-asyncio

--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -15,6 +14,7 @@ dependencies:
   - pytz
   - pip
   - pip:
+    - cython>=0.29.16
     - "git+git://github.com/dateutil/dateutil.git"
     - "-f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
     - "--pre"

--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/azure-macos-36.yaml
+++ b/ci/deps/azure-macos-36.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/azure-macos-36.yaml
+++ b/ci/deps/azure-macos-36.yaml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -32,5 +31,6 @@ dependencies:
   - xlwt
   - pip
   - pip:
+    - cython>=0.29.16
     - pyreadstat
     - pyxlsb

--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/azure-windows-37.yaml
+++ b/ci/deps/azure-windows-37.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -15,7 +15,7 @@ dependencies:
   # pandas dependencies
   - beautifulsoup4
   - botocore>=1.11
-  - cython>=0.29.13
+  - cython>=0.29.16
   - dask
   - fastparquet>=0.3.2
   - gcsfs

--- a/ci/deps/travis-36-locale.yaml
+++ b/ci/deps/travis-36-locale.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-36-slow.yaml
+++ b/ci/deps/travis-36-slow.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-37.yaml
+++ b/ci/deps/travis-37.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-38.yaml
+++ b/ci/deps/travis-38.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.8.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.16
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -92,8 +92,8 @@ Other enhancements
 
 .. ---------------------------------------------------------------------------
 
-Build Changes
-^^^^^^^^^^^^^
+Development Changes
+^^^^^^^^^^^^^^^^^^^
 
 - The minimum version of Cython is now the most recent bug-fix version (0.29.16).
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -92,6 +92,11 @@ Other enhancements
 
 .. ---------------------------------------------------------------------------
 
+Build Changes
+^^^^^^^^^^^^^
+
+- The minimum version of Cython is now the most recent bug-fix version (0.29.16).
+
 .. _whatsnew_110.api.other:
 
 Other API changes

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -95,7 +95,7 @@ Other enhancements
 Development Changes
 ^^^^^^^^^^^^^^^^^^^
 
-- The minimum version of Cython is now the most recent bug-fix version (0.29.16).
+- The minimum version of Cython is now the most recent bug-fix version (0.29.16) (:issue:`33334`).
 
 .. _whatsnew_110.api.other:
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - asv
 
   # building
-  - cython>=0.29.13
+  - cython>=0.29.16
 
   # code checks
   - black=19.10b0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.29.13",  # Note: sync with setup.py
+    "Cython>=0.29.16",  # Note: sync with setup.py
     "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
     "numpy==1.14.5; python_version>='3.7' and platform_system!='AIX'",
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ numpy>=1.15
 python-dateutil>=2.6.1
 pytz
 asv
-cython>=0.29.13
+cython>=0.29.16
 black==19.10b0
 cpplint
 flake8

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def is_platform_mac():
 
 
 min_numpy_ver = "1.13.3"
-min_cython_ver = "0.29.13"  # note: sync with pyproject.toml
+min_cython_ver = "0.29.16"  # note: sync with pyproject.toml
 
 try:
     import Cython


### PR DESCRIPTION
- In particular, this fixes a bug in code returning ctuples
    - cython/cython#2745 
    - cython/cython#1427
- This is a prereq for #33220

- [x] whatsnew entry