### PR TITLE
BUG: Don't raise on value_counts for empty Int64

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -461,7 +461,7 @@ Sparse
 ExtensionArray
 ^^^^^^^^^^^^^^
 
--
+- Fixed bug where :meth:`Serires.value_counts` would raise on empty input of ``Int64`` dtype (:issue:`33317`)
 -
 
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -499,7 +499,8 @@ class IntegerArray(BaseMaskedArray):
         ExtensionArray.argsort
         """
         data = self._data.copy()
-        data[self._mask] = data.min() - 1
+        if self._mask.any():
+            data[self._mask] = data.min() - 1
         return data
 
     @classmethod

--- a/pandas/tests/arrays/integer/test_function.py
+++ b/pandas/tests/arrays/integer/test_function.py
@@ -103,6 +103,16 @@ def test_value_counts_na():
     tm.assert_series_equal(result, expected)
 
 
+def test_value_counts_empty():
+    # https://github.com/pandas-dev/pandas/issues/33317
+    s = pd.Series([], dtype="Int64")
+    result = s.value_counts()
+    # TODO: The dtype of the index seems wrong (it's int64 for non-empty)
+    idx = pd.Index([], dtype="object")
+    expected = pd.Series([], index=idx, dtype="Int64")
+    tm.assert_series_equal(result, expected)
+
+
 # TODO(jreback) - these need testing / are broken
 
 # shift


### PR DESCRIPTION
- [ ] closes #33317
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
