### PR TITLE
BUG/REF: unstack with EA dtypes

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -595,6 +595,16 @@ class DataFrame(NDFrame):
         else:
             return not self._mgr.is_mixed_type
 
+    @property
+    def _can_fast_transpose(self) -> bool:
+        """
+        Can we transpose this DataFrame without creating any new array objects.
+        """
+        if self._data.any_extension_types:
+            # TODO(EA2D) special case would be unnecessary with 2D EAs
+            return False
+        return len(self._data.blocks) == 1
+
     # ----------------------------------------------------------------------
     # Rendering Methods
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -24,7 +24,6 @@ from pandas.core.dtypes.missing import notna
 import pandas.core.algorithms as algos
 from pandas.core.arrays import SparseArray
 from pandas.core.arrays.categorical import factorize_from_iterable
-from pandas.core.construction import extract_array
 from pandas.core.frame import DataFrame
 from pandas.core.indexes.api import Index, MultiIndex
 from pandas.core.series import Series
@@ -413,7 +412,7 @@ def unstack(obj, level, fill_value=None):
         level = obj.index._get_level_number(level)
 
     if isinstance(obj, DataFrame):
-        if isinstance(obj.index, MultiIndex):
+        if isinstance(obj.index, MultiIndex) or not obj._can_fast_transpose:
             return _unstack_frame(obj, level, fill_value=fill_value)
         else:
             return obj.T.stack(dropna=False)
@@ -429,14 +428,14 @@ def unstack(obj, level, fill_value=None):
 
 
 def _unstack_frame(obj, level, fill_value=None):
-    if obj._is_mixed_type:
+    if not obj._can_fast_transpose:
         unstacker = _Unstacker(obj.index, level=level)
-        blocks = obj._mgr.unstack(unstacker, fill_value=fill_value)
-        return obj._constructor(blocks)
+        mgr = obj._mgr.unstack(unstacker, fill_value=fill_value)
+        return obj._constructor(mgr)
     else:
         return _Unstacker(
             obj.index, level=level, constructor=obj._constructor,
-        ).get_result(obj.values, value_columns=obj.columns, fill_value=fill_value)
+        ).get_result(obj._values, value_columns=obj.columns, fill_value=fill_value)
 
 
 def _unstack_extension_series(series, level, fill_value):
@@ -462,31 +461,10 @@ def _unstack_extension_series(series, level, fill_value):
         Each column of the DataFrame will have the same dtype as
         the input Series.
     """
-    # Implementation note: the basic idea is to
-    # 1. Do a regular unstack on a dummy array of integers
-    # 2. Followup with a columnwise take.
-    # We use the dummy take to discover newly-created missing values
-    # introduced by the reshape.
-    from pandas.core.reshape.concat import concat
-
-    dummy_arr = np.arange(len(series))
-    # fill_value=-1, since we will do a series.values.take later
-    result = _Unstacker(series.index, level=level).get_result(
-        dummy_arr, value_columns=None, fill_value=-1
-    )
-
-    out = []
-    values = extract_array(series, extract_numpy=False)
-
-    for col, indices in result.items():
-        out.append(
-            Series(
-                values.take(indices.values, allow_fill=True, fill_value=fill_value),
-                name=col,
-                index=result.index,
-            )
-        )
-    return concat(out, axis="columns", copy=False, keys=result.columns)
+    # Defer to the logic in ExtensionBlock._unstack
+    df = series.to_frame()
+    result = df.unstack(level=level, fill_value=fill_value)
+    return result.droplevel(level=0, axis=1)
 
 
 def stack(frame, level=-1, dropna=True):

--- a/pandas/tests/extension/base/casting.py
+++ b/pandas/tests/extension/base/casting.py
@@ -10,9 +10,21 @@ class BaseCastingTests(BaseExtensionTests):
     """Casting to and from ExtensionDtypes"""
 
     def test_astype_object_series(self, all_data):
-        ser = pd.Series({"A": all_data})
+        ser = pd.Series(all_data, name="A")
         result = ser.astype(object)
         assert isinstance(result._mgr.blocks[0], ObjectBlock)
+
+    def test_astype_object_frame(self, all_data):
+        df = pd.DataFrame({"A": all_data})
+
+        result = df.astype(object)
+        blk = result._data.blocks[0]
+        assert isinstance(blk, ObjectBlock), type(blk)
+
+        # FIXME: these currently fail; dont leave commented-out
+        # check that we can compare the dtypes
+        # cmp = result.dtypes.equals(df.dtypes)
+        # assert not cmp.any()
 
     def test_tolist(self, data):
         result = pd.Series(data).tolist()

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 import pandas as pd
-import pandas._testing as tm
 from pandas.core.internals import ExtensionBlock
 
 from .base import BaseExtensionTests
@@ -302,7 +301,7 @@ class BaseReshapingTests(BaseExtensionTests):
                 df = ser.to_frame()
 
                 alt = df.unstack(level=level).droplevel(0, axis=1)
-                tm.assert_frame_equal(result, alt)
+                self.assert_frame_equal(result, alt)
 
             expected = ser.astype(object).unstack(level=level)
             result = result.astype(object)

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
+import pandas._testing as tm
 from pandas.core.internals import ExtensionBlock
 
 from .base import BaseExtensionTests
@@ -295,6 +296,14 @@ class BaseReshapingTests(BaseExtensionTests):
             assert all(
                 isinstance(result[col].array, type(data)) for col in result.columns
             )
+
+            if obj == "series":
+                # We should get the same result with to_frame+unstack+droplevel
+                df = ser.to_frame()
+
+                alt = df.unstack(level=level).droplevel(0, axis=1)
+                tm.assert_frame_equal(result, alt)
+
             expected = ser.astype(object).unstack(level=level)
             result = result.astype(object)
 

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -3,6 +3,8 @@ import pytest
 
 from pandas.errors import PerformanceWarning
 
+from pandas.core.dtypes.common import is_object_dtype
+
 import pandas as pd
 from pandas import SparseDtype
 import pandas._testing as tm
@@ -309,7 +311,25 @@ class TestMethods(BaseSparseTests, base.BaseMethodsTests):
 
 
 class TestCasting(BaseSparseTests, base.BaseCastingTests):
-    pass
+    def test_astype_object_series(self, all_data):
+        # Unlike the base class, we do not expect the resulting Block
+        #  to be ObjectBlock
+        ser = pd.Series(all_data, name="A")
+        result = ser.astype(object)
+        assert is_object_dtype(result._data.blocks[0].dtype)
+
+    def test_astype_object_frame(self, all_data):
+        # Unlike the base class, we do not expect the resulting Block
+        #  to be ObjectBlock
+        df = pd.DataFrame({"A": all_data})
+
+        result = df.astype(object)
+        assert is_object_dtype(result._data.blocks[0].dtype)
+
+        # FIXME: these currently fail; dont leave commented-out
+        # check that we can compare the dtypes
+        # comp = result.dtypes.equals(df.dtypes)
+        # assert not comp.any()
 
 
 class TestArithmeticOps(BaseSparseTests, base.BaseArithmeticOpsTests):


### PR DESCRIPTION
1) `ser.unstack(args)` should behave like `ser.to_frame().unstack(args).droplevel(level=0, axis=1)`.  This fails on master, is fixed by this PR.
2) `reshape._unstack_extension_series` currently re-implements logic that is in `ExtensionBlock._unstack`.  This de-duplicates by dispatching.
3) We currently transpose in cases where we shouldn't.  This implements `DataFrame._can_fast_transpose` to avoid that.
4) `test_astype_object_series` has what looks like a typo that is making us test not-the-intended-thing; @TomAugspurger can you confirm im reading this right?
5) The dtype comparisons in `test_astype_object_frame` currently raise, are commented out for exposition, should be fixed in a separate PR.