### PR TITLE
CI: Not deleting docs symlink in prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       if: github.event_name == 'push'
 
     - name: Upload web
-      run: rsync -az --delete --exclude='pandas-docs' --exclude='Pandas_Cheat_Sheet*' web/build/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas
+      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='Pandas_Cheat_Sheet*' web/build/ docs@${{ secrets.server_ip }}:/usr/share/nginx/pandas
       if: github.event_name == 'push'
 
     - name: Upload dev docs


### PR DESCRIPTION
In #33341 I forgot to exclude the `docs` symlink for deletion, meaning that it'll be deleted when a PR is merged. And the docs will be unavailable. Fixing it here. 

@pandas-dev/pandas-core can we prioritize this please.