### PR TITLE
BUG: #31464 Fix error when parsing JSON list of bool into Series

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -429,6 +429,7 @@ I/O
 - Bug in :meth:`read_sas` was raising an ``AttributeError`` when reading files from Google Cloud Storage (issue:`33069`)
 - Bug in :meth:`DataFrame.to_sql` where an ``AttributeError`` was raised when saving an out of bounds date (:issue:`26761`)
 - Bug in :meth:`read_excel` did not correctly handle multiple embedded spaces in OpenDocument text cells. (:issue:`32207`)
+- Bug in :meth:`read_json` was raising ``TypeError`` when reading a list of booleans into a Series. (:issue:`31464`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -978,8 +978,8 @@ class Parser:
             if not in_range.all():
                 return data, False
 
-        # ignore bool
         if new_data.dtype == "bool":
+            # GH#33373 ignore bool
             return data, False
 
         date_units = (self.date_unit,) if self.date_unit else self._STAMP_UNITS

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -978,11 +978,15 @@ class Parser:
             if not in_range.all():
                 return data, False
 
+        # ignore bool
+        if new_data.dtype == "bool":
+            return data, False
+
         date_units = (self.date_unit,) if self.date_unit else self._STAMP_UNITS
         for date_unit in date_units:
             try:
                 new_data = to_datetime(new_data, errors="raise", unit=date_unit)
-            except (ValueError, OverflowError, TypeError):
+            except (ValueError, OverflowError):
                 continue
             return new_data, True
         return data, False

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -978,15 +978,11 @@ class Parser:
             if not in_range.all():
                 return data, False
 
-        if new_data.dtype == "bool":
-            # GH#33373 ignore bool
-            return data, False
-
         date_units = (self.date_unit,) if self.date_unit else self._STAMP_UNITS
         for date_unit in date_units:
             try:
                 new_data = to_datetime(new_data, errors="raise", unit=date_unit)
-            except (ValueError, OverflowError):
+            except (ValueError, OverflowError, TypeError):
                 continue
             return new_data, True
         return data, False

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -982,7 +982,7 @@ class Parser:
         for date_unit in date_units:
             try:
                 new_data = to_datetime(new_data, errors="raise", unit=date_unit)
-            except (ValueError, OverflowError):
+            except (ValueError, OverflowError, TypeError):
                 continue
             return new_data, True
         return data, False

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1659,3 +1659,9 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         # GH 31615
         result = pd.DataFrame([[nulls_fixture]]).to_json()
         assert result == '{"0":{"0":null}}'
+
+    def test_readjson_bool_series(self):
+        # GH31464
+        result = read_json("[true, true, false]", typ="series")
+        expected = pd.Series([True, True, False])
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -179,9 +179,3 @@ def test_readjson_unicode(monkeypatch):
         result = read_json(path)
         expected = pd.DataFrame({"£©µÀÆÖÞßéöÿ": ["АБВГДабвгд가"]})
         tm.assert_frame_equal(result, expected)
-
-
-def test_readjson_bool_series():
-    result = read_json("[true, true, false]", typ="series")
-    expected = pd.Series([True, True, False])
-    tm.assert_series_equal(result, expected)

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -179,3 +179,9 @@ def test_readjson_unicode(monkeypatch):
         result = read_json(path)
         expected = pd.DataFrame({"£©µÀÆÖÞßéöÿ": ["АБВГДабвгд가"]})
         tm.assert_frame_equal(result, expected)
+
+
+def test_readjson_bool_series():
+    result = read_json("[true, true, false]", typ="series")
+    expected = pd.Series([True, True, False])
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
Add a missing exception type to the except clause, to cover
the TypeError that is thrown by Cythonized array_to_datetime
function when trying to convert bool to nonseconds.

- [x] closes #31464
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
