### PR TITLE
DOC: Fix capitalization among headings in doc/source/whatsnew (#32550)

### DIFF
--- a/doc/source/whatsnew/index.rst
+++ b/doc/source/whatsnew/index.rst
@@ -3,7 +3,7 @@
 {{ header }}
 
 *************
-Release Notes
+Release notes
 *************
 
 This is the list of changes to pandas between each release. For full details,

--- a/doc/source/whatsnew/v0.14.0.rst
+++ b/doc/source/whatsnew/v0.14.0.rst
@@ -473,7 +473,7 @@ Some other enhancements to the sql functions include:
 
 .. _whatsnew_0140.slicers:
 
-MultiIndexing using slicers
+Multiindexing using slicers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In 0.14.0 we added a new way to slice MultiIndexed objects.
@@ -904,7 +904,7 @@ There are no experimental changes in 0.14.0
 
 .. _whatsnew_0140.bug_fixes:
 
-Bug Fixes
+Bug fixes
 ~~~~~~~~~
 
 - Bug in Series ValueError when index doesn't match data (:issue:`6532`)

--- a/doc/source/whatsnew/v0.15.0.rst
+++ b/doc/source/whatsnew/v0.15.0.rst
@@ -600,7 +600,7 @@ Rolling/expanding moments improvements
 
 .. _whatsnew_0150.sql:
 
-Improvements in the sql io module
+Improvements in the SQL io module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Added support for a ``chunksize`` parameter to ``to_sql`` function. This allows DataFrame to be written in chunks and avoid packet-size overflow errors (:issue:`8062`).

--- a/doc/source/whatsnew/v0.18.0.rst
+++ b/doc/source/whatsnew/v0.18.0.rst
@@ -1197,7 +1197,7 @@ Performance improvements
 
 .. _whatsnew_0180.bug_fixes:
 
-Bug Fixes
+Bug fixes
 ~~~~~~~~~
 
 - Bug in ``GroupBy.size`` when data-frame is empty. (:issue:`11699`)

--- a/doc/source/whatsnew/v0.18.1.rst
+++ b/doc/source/whatsnew/v0.18.1.rst
@@ -380,7 +380,7 @@ New behavior:
 
 .. _whatsnew_0181.numpy_compatibility:
 
-numpy function compatibility
+NumPy function compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Compatibility between pandas array-like methods (e.g. ``sum`` and ``take``) and their ``numpy``


### PR DESCRIPTION
Updated headers for the following files:

```
- [x] doc/source/whatsnew/index.rst
- [x] doc/source/whatsnew/v0.14.0.rst
- [x] doc/source/whatsnew/v0.15.0.rst
- [x] doc/source/whatsnew/v0.18.0.rst
- [x] doc/source/whatsnew/v0.18.1.rst
```