### PR TITLE
BUG: is_categorical shouldnt recognize Dtype objects

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -19,7 +19,7 @@ from pandas.core.dtypes.dtypes import (
     PeriodDtype,
     registry,
 )
-from pandas.core.dtypes.generic import ABCCategorical, ABCIndexClass
+from pandas.core.dtypes.generic import ABCCategorical, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import (  # noqa:F401
     is_array_like,
     is_bool,
@@ -67,9 +67,6 @@ _is_scipy_sparse = None
 
 ensure_float64 = algos.ensure_float64
 ensure_float32 = algos.ensure_float32
-
-_ensure_datetime64ns = conversion.ensure_datetime64ns
-_ensure_timedelta64ns = conversion.ensure_timedelta64ns
 
 
 def ensure_float(arr):
@@ -359,8 +356,12 @@ def is_categorical(arr) -> bool:
     True
     >>> is_categorical(pd.CategoricalIndex([1, 2, 3]))
     True
+    >>> is_categorical(cat.dtype)
+    False
     """
-    return isinstance(arr, ABCCategorical) or is_categorical_dtype(arr)
+    return isinstance(arr, ABCCategorical) or (
+        isinstance(arr, (ABCIndexClass, ABCSeries)) and is_categorical_dtype(arr.dtype)
+    )
 
 
 def is_datetime64_dtype(arr_or_dtype) -> bool:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4716,7 +4716,7 @@ class Index(IndexOpsMixin, PandasObject):
         # TODO: if we are a MultiIndex, we can do better
         # that converting to tuples
         if isinstance(values, ABCMultiIndex):
-            values = values.values
+            values = values._values
         values = ensure_categorical(values)
         result = values._reverse_indexer()
 

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -208,6 +208,7 @@ def test_is_categorical():
     assert com.is_categorical(pd.CategoricalIndex([1, 2, 3]))
 
     assert not com.is_categorical([1, 2, 3])
+    assert not com.is_categorical(cat.dtype)  # Categorical obj, not dtype
 
 
 def test_is_datetime64_dtype():

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -159,7 +159,7 @@ class TestCategoricalDtype(Base):
         assert is_categorical_dtype(s)
         assert not is_categorical_dtype(np.dtype("float64"))
 
-        assert is_categorical(s.dtype)
+        assert not is_categorical(s.dtype)
         assert is_categorical(s)
         assert not is_categorical(np.dtype("float64"))
         assert not is_categorical(1.0)


### PR DESCRIPTION
is_categorical(obj) is used in a couple places where we then go on to access `obj.dtype`, so this should not return `True` if we have a `CategoricalDtype` object.