### PR TITLE
DOC: Fix capitalization among headings in doc/source/whatsnew (#32550)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.rst
+++ b/doc/source/whatsnew/v0.19.0.rst
@@ -377,7 +377,7 @@ For ``MultiIndex``, values are dropped if any level is missing by default. Speci
 
 .. _whatsnew_0190.gbq:
 
-Google BigQuery Enhancements
+Google BigQuery enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - The :func:`read_gbq` method has gained the ``dialect`` argument to allow users to specify whether to use BigQuery's legacy SQL or BigQuery's standard SQL. See the `docs <https://pandas-gbq.readthedocs.io/en/latest/reading.html>`__ for more details (:issue:`13615`).
@@ -385,7 +385,7 @@ Google BigQuery Enhancements
 
 .. _whatsnew_0190.errstate:
 
-Fine-grained numpy errstate
+Fine-grained NumPy errstate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Previous versions of pandas would permanently silence numpy's ufunc error handling when ``pandas`` was imported. Pandas did this in order to silence the warnings that would arise from using numpy ufuncs on missing data, which are usually represented as ``NaN`` s. Unfortunately, this silenced legitimate warnings arising in non-pandas code in the application. Starting with 0.19.0, pandas will use the ``numpy.errstate`` context manager to silence these warnings in a more fine-grained manner, only around where these operations are actually used in the pandas code base. (:issue:`13109`, :issue:`13145`)
@@ -1185,7 +1185,7 @@ the result of calling :func:`read_csv` without the ``chunksize=`` argument
 
 .. _whatsnew_0190.sparse:
 
-Sparse Changes
+Sparse changes
 ^^^^^^^^^^^^^^
 
 These changes allow pandas to handle sparse data with more dtypes, and for work to make a smoother experience with data handling.

--- a/doc/source/whatsnew/v0.20.0.rst
+++ b/doc/source/whatsnew/v0.20.0.rst
@@ -356,7 +356,7 @@ To convert a ``SparseDataFrame`` back to sparse SciPy matrix in COO format, you 
 
 .. _whatsnew_0200.enhancements.style_excel:
 
-Excel output for styled DataFrames
+Excel output for styled dataframes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Experimental support has been added to export ``DataFrame.style`` formats to Excel using the ``openpyxl`` engine. (:issue:`15530`)
@@ -813,7 +813,7 @@ New behavior:
 
 .. _whatsnew_0200.api_breaking.gbq:
 
-Pandas Google BigQuery support has moved
+pandas Google BigQuery support has moved
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 pandas has split off Google BigQuery support into a separate package ``pandas-gbq``. You can ``conda install pandas-gbq -c conda-forge`` or
@@ -1289,7 +1289,7 @@ A new public ``pandas.plotting`` module has been added that holds plotting funct
 
 .. _whatsnew_0200.privacy.development:
 
-Other Development Changes
+Other development changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Building pandas for development now requires ``cython >= 0.23`` (:issue:`14831`)

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -733,7 +733,7 @@ is the case with :attr:`Period.end_time`, for example
 
 .. _whatsnew_0240.api_breaking.datetime_unique:
 
-Series.unique for Timezone-Aware Data
+Series.unique for timezone-aware data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The return type of :meth:`Series.unique` for datetime with timezone values has changed
@@ -1131,7 +1131,7 @@ data is incompatible with a passed ``dtype=`` (:issue:`15832`)
 
 .. _whatsnew_0240.api.concat_categorical:
 
-Concatenation Changes
+Concatenation changes
 ^^^^^^^^^^^^^^^^^^^^^
 
 Calling :func:`pandas.concat` on a ``Categorical`` of ints with NA values now

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -85,7 +85,7 @@ See :ref:`groupby.aggregate.named` for more.
 
 .. _whatsnew_0250.enhancements.multiple_lambdas:
 
-Groupby Aggregation with multiple lambdas
+Groupby aggregation with multiple lambdas
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can now provide multiple lambda functions to a list-like aggregation in
@@ -1243,7 +1243,7 @@ Sparse
 - Bug in :func:`numpy.modf` on a :class:`SparseArray`. Now a tuple of :class:`SparseArray` is returned (:issue:`26946`).
 
 
-Build Changes
+Build changes
 ^^^^^^^^^^^^^
 
 - Fix install error with PyPy on macOS (:issue:`26536`)

--- a/doc/source/whatsnew/v1.0.0.rst
+++ b/doc/source/whatsnew/v1.0.0.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
     1.0.
 
 
-New Deprecation Policy
+New deprecation policy
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Starting with Pandas 1.0.0, pandas will adopt a variant of `SemVer`_ to
@@ -61,7 +61,7 @@ the :ref:`custom window rolling documentation <stats.custom_rolling_window>`
 
 .. _whatsnew_100.to_markdown:
 
-Converting to Markdown
+Converting to markdown
 ^^^^^^^^^^^^^^^^^^^^^^
 
 We've added :meth:`~DataFrame.to_markdown` for creating a markdown table (:issue:`11052`)
@@ -746,7 +746,7 @@ Optional libraries below the lowest tested version may still work, but are not c
 
 See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for more.
 
-Build Changes
+Build changes
 ^^^^^^^^^^^^^
 
 Pandas has added a `pyproject.toml <https://www.python.org/dev/peps/pep-0517/>`_ file and will no longer include
@@ -778,7 +778,7 @@ Other API changes
 
 .. _whatsnew_100.api.documentation:
 
-Documentation Improvements
+Documentation improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Added new section on :ref:`scale` (:issue:`28315`).


### PR DESCRIPTION
Updated headers for the following files:

```
- [x] doc/source/whatsnew/v0.19.0.rst
- [x] doc/source/whatsnew/v0.20.0.rst
- [x] doc/source/whatsnew/v0.24.0.rst
- [x] doc/source/whatsnew/v0.25.0.rst
- [x] doc/source/whatsnew/v1.0.0.rst
```
