### PR TITLE
BUG: DatetimeIndex.astype matches Series.dtype with datetime tz dtype

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -400,7 +400,7 @@ Timezones
 ^^^^^^^^^
 
 - Bug in :func:`to_datetime` with ``infer_datetime_format=True`` where timezone names (e.g. ``UTC``) would not be parsed correctly (:issue:`33133`)
--
+- Bug in :func:`DatetimeIndex.astype` with a ``datetime64[ns, tz]`` dtype where the data was not localized to UTC first (:issue:`33401`)
 
 
 Numeric

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -586,7 +586,8 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
             # GH#18951: datetime64_ns dtype but not equal means different tz
             new_tz = getattr(dtype, "tz", None)
             if getattr(self.dtype, "tz", None) is None:
-                return self.tz_localize(new_tz)
+                # GH 33401: Match the behavior of Series.astype
+                return self.tz_localize(timezones.UTC).tz_convert(new_tz)
             result = self.tz_convert(new_tz)
             if copy:
                 result = result.copy()


### PR DESCRIPTION
- [x] closes #33401
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
