### PR TITLE
API: More permissive conversion to StringDtype

### DIFF
--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -203,11 +203,12 @@ class StringArray(PandasArray):
         # TODO: it would be nice to do this in _validate / lib.is_string_array
         # We are already doing a scan over the values there.
         na_values = isna(result)
-        if na_values.any():
-            if result is scalars:
-                # force a copy now, if we haven't already
-                result = result.copy()
-            result[na_values] = StringDtype.na_value
+        if na_values.any() and result is scalars:
+            # force a copy now, if we haven't already
+            result = result.copy()
+        result = np.asarray(result, str)
+        result = np.asarray(result, object)
+        result[na_values] = StringDtype.na_value
 
         return cls(result)
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -565,7 +565,11 @@ class Block(PandasObject):
         # force the copy here
         if self.is_extension:
             # TODO: Should we try/except this astype?
-            values = self.values.astype(dtype)
+            if is_extension_array_dtype(dtype):
+                arr_type = dtype.construct_array_type()
+                values = arr_type._from_sequence(self.values, dtype=dtype)
+            else:
+                values = self.values.astype(dtype)
         else:
             if issubclass(dtype.type, str):
 


### PR DESCRIPTION
- [x] closes #31204
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is a proposal to make using ``StringDtype`` more permissive and be usable inplace of ``dtype=str``.

ATM converting to StringDtype will only accept arrays that are ``str`` already, meaning you will often have to use ``astype(str).astype("string")`` to be sure not to get errors, which can be tedious. For example these fail in master and work in this PR:

```python
>>> pd.Series([1,2, np.nan], dtype="string")
0       1
1       2
2    <NA>
dtype: string
>>> pd.array([1,2, np.nan], dtype="string")
<StringArray>
['1', '2', <NA>]
Length: 3, dtype: string
>>> pd.Series([1,2, np.nan]).astype("string")
0     1.0
1     2.0
2    <NA>
dtype: string
>>> pd.Series([1,2, np.nan], dtype="Int64").astype("string")
0       1
1       2
2    <NA>
dtype: string
```

etc. now work. Previously the above all gave errors.

Obviously tests and doc updates are still missing, but I would appreciate feedback if this solution looks ok.