### PR TITLE
CLN: remove unnecessary branches in Series.__setitem__

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -194,7 +194,7 @@ cdef class IntervalMixin:
                              f"expected {repr(self.closed)}.")
 
 
-cdef _interval_like(other):
+cdef bint _interval_like(other):
     return (hasattr(other, 'left')
             and hasattr(other, 'right')
             and hasattr(other, 'closed'))

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1059,23 +1059,6 @@ def is_datetime_or_timedelta_dtype(arr_or_dtype) -> bool:
     return _is_dtype_type(arr_or_dtype, classes(np.datetime64, np.timedelta64))
 
 
-def _is_unorderable_exception(e: TypeError) -> bool:
-    """
-    Check if the exception raised is an unorderable exception.
-
-    Parameters
-    ----------
-    e : Exception or sub-class
-        The exception object to check.
-
-    Returns
-    -------
-    bool
-        Whether or not the exception raised is an unorderable exception.
-    """
-    return "'>' not supported between instances of" in str(e)
-
-
 # This exists to silence numpy deprecation warnings, see GH#29553
 def is_numeric_v_string_like(a, b):
     """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -33,7 +33,6 @@ from pandas.core.dtypes.cast import (
     validate_numeric_casting,
 )
 from pandas.core.dtypes.common import (
-    _is_unorderable_exception,
     ensure_platform_int,
     is_bool,
     is_categorical_dtype,
@@ -1012,10 +1011,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         except TypeError as e:
             if isinstance(key, tuple) and not isinstance(self.index, MultiIndex):
                 raise ValueError("Can only tuple-index with a MultiIndex") from e
-
-            # python 3 type errors should be raised
-            if _is_unorderable_exception(e):
-                raise IndexError(key) from e
 
             if com.is_bool_indexer(key):
                 key = check_bool_indexer(self.index, key)


### PR DESCRIPTION
Eventually I'd like to get the structure of `__setitem__` to parallel the structure of `__getitem__`.  Some big improvements to both will be available following #33404.