### PR TITLE
Support downcasting of nullable arrays

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -88,6 +88,7 @@ Other enhancements
 - :class:`Series.str` now has a `fullmatch` method that matches a regular expression against the entire string in each row of the series, similar to `re.fullmatch` (:issue:`32806`).
 - :meth:`DataFrame.sample` will now also allow array-like and BitGenerator objects to be passed to ``random_state`` as seeds (:issue:`32503`)
 - :meth:`MultiIndex.union` will now raise `RuntimeWarning` if the object inside are unsortable, pass `sort=False` to suppress this warning (:issue:`33015`)
+- :func:`to_numeric` will now support downcasting of nullable dtypes.
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -143,9 +143,7 @@ def maybe_downcast_to_dtype(result, dtype):
 
             else:
                 dtype = "object"
-
         dtype = np.dtype(dtype)
-
     converted = maybe_downcast_numeric(result, dtype, do_round)
     if converted is not result:
         return converted
@@ -210,9 +208,7 @@ def maybe_downcast_numeric(result, dtype, do_round: bool = False):
         # don't allow upcasts here (except if empty)
         if result.dtype.itemsize <= dtype.itemsize and result.size:
             return result
-
     if is_bool_dtype(dtype) or is_integer_dtype(dtype):
-
         if not result.size:
             # if we don't have any elements, just astype it
             return trans(result).astype(dtype)
@@ -239,7 +235,8 @@ def maybe_downcast_numeric(result, dtype, do_round: bool = False):
                 if (new_result == result).all():
                     return new_result
             else:
-                if np.allclose(new_result, result, rtol=0):
+                nd_result = np.array(result).astype(result[0].dtype)
+                if np.allclose(new_result, nd_result, rtol=0):
                     return new_result
 
     elif (

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -178,7 +178,8 @@ def maybe_downcast_to_dtype(result, dtype):
 
 def maybe_downcast_numeric(result, dtype, do_round: bool = False):
     """
-    Subset of maybe_downcast_to_dtype restricted to numeric dtypes.
+    Subset of maybe_downcast_to_dtype restricted to numeric and
+    nullable dtypes.
 
     Parameters
     ----------

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -235,6 +235,7 @@ def maybe_downcast_numeric(result, dtype, do_round: bool = False):
                 if (new_result == result).all():
                     return new_result
             else:
+                # np.allclose raises TypeError on extension arrays
                 nd_result = np.array(result).astype(result[0].dtype)
                 if np.allclose(new_result, nd_result, rtol=0):
                     return new_result

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -159,7 +159,6 @@ def to_numeric(arg, errors="raise", downcast=None):
     # to a numerical dtype and if a downcast method has been specified
     if downcast is not None and is_numeric_dtype(values):
         typecodes = None
-
         if downcast in ("integer", "signed"):
             typecodes = np.typecodes["Integer"]
         elif downcast == "unsigned" and (not len(values) or np.min(values) >= 0):

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -649,3 +649,15 @@ def test_failure_to_convert_uint64_string_to_NaN():
     ser = Series([32, 64, np.nan])
     result = to_numeric(pd.Series(["32", "64", "uint64"]), errors="coerce")
     tm.assert_series_equal(result, ser)
+
+
+def test_support_downcast_of_nullable_dtypes():
+    # GH 33013
+    try:
+        pd.to_numeric(pd.Series([1, 2, 3], dtype="Int32"), downcast="integer")
+        pd.to_numeric(pd.Series([1, 2, 3], dtype="Int64"), downcast="integer")
+        pd.to_numeric(pd.Series([1, 2], dtype="Int32"), downcast="signed")
+        pd.to_numeric(pd.Series([1, 2, 3], dtype="Int32"), downcast="float")
+        pd.to_numeric(pd.Series([1, 2, 3], dtype="Float32"), downcast="integer")
+    except TypeError:
+        pytest.fail("TypeError raised.")

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -658,6 +658,5 @@ def test_support_downcast_of_nullable_dtypes():
         pd.to_numeric(pd.Series([1, 2, 3], dtype="Int64"), downcast="integer")
         pd.to_numeric(pd.Series([1, 2], dtype="Int32"), downcast="signed")
         pd.to_numeric(pd.Series([1, 2, 3], dtype="Int32"), downcast="float")
-        pd.to_numeric(pd.Series([1, 2, 3], dtype="Float32"), downcast="integer")
     except TypeError:
         pytest.fail("TypeError raised.")


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Addressing GH #33013. Supports downcasting of nullable dtypes by transferring elements in extension array to ndarray to avoid TypeError thrown by np.allclose. Enhancement documented on v1.1.0 in the "other enhancements" section. Unit test written in test_to_numeric.
