### PR TITLE
BUG: Timedelta == ndarray[td64]

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -395,7 +395,7 @@ Timedelta
 - Bug in dividing ``np.nan`` or ``None`` by :class:`Timedelta`` incorrectly returning ``NaT`` (:issue:`31869`)
 - Timedeltas now understand ``µs`` as identifier for microsecond (:issue:`32899`)
 - :class:`Timedelta` string representation now includes nanoseconds, when nanoseconds are non-zero (:issue:`9309`)
-- Bug in comparing a :class:`Timedelta`` object against a ``np.ndarray`` with ``timedelta64`` dtype incorrectly viewing all entries as unequal (:issue:`????`)
+- Bug in comparing a :class:`Timedelta`` object against a ``np.ndarray`` with ``timedelta64`` dtype incorrectly viewing all entries as unequal (:issue:`33441`)
 
 Timezones
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -395,6 +395,7 @@ Timedelta
 - Bug in dividing ``np.nan`` or ``None`` by :class:`Timedelta`` incorrectly returning ``NaT`` (:issue:`31869`)
 - Timedeltas now understand ``µs`` as identifier for microsecond (:issue:`32899`)
 - :class:`Timedelta` string representation now includes nanoseconds, when nanoseconds are non-zero (:issue:`9309`)
+- Bug in comparing a :class:`Timedelta`` object against a ``np.ndarray`` with ``timedelta64`` dtype incorrectly viewing all entries as unequal (:issue:`????`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -880,6 +880,7 @@ class BlockManager(PandasObject):
         for b in self.blocks:
             bd.setdefault(str(b.dtype), []).append(b)
 
+        # TODO(EA2D): the combine will be unnecessary with 2D EAs
         return {dtype: self._combine(blocks, copy=copy) for dtype, blocks in bd.items()}
 
     def fast_xs(self, loc: int) -> ArrayLike:

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -734,7 +734,7 @@ class TestDatetimeIndexComparisons:
         result = dti == other
         expected = np.array([True] * 5 + [False] * 5)
         tm.assert_numpy_array_equal(result, expected)
-        msg = "Cannot compare type"
+        msg = ">=' not supported between instances of 'Timestamp' and 'Timedelta'"
         with pytest.raises(TypeError, match=msg):
             dti >= other
 

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -905,6 +905,7 @@ class TestTimedeltaComparison:
         tm.assert_numpy_array_equal(result, expected)
 
     def test_compare_td64_ndarray(self):
+        # GG#33441
         arr = np.arange(5).astype("timedelta64[ns]")
         td = pd.Timedelta(arr[1])
 

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -904,6 +904,24 @@ class TestTimedeltaComparison:
         expected = np.array([False, False])
         tm.assert_numpy_array_equal(result, expected)
 
+    def test_compare_td64_ndarray(self):
+        arr = np.arange(5).astype("timedelta64[ns]")
+        td = pd.Timedelta(arr[1])
+
+        expected = np.array([False, True, False, False, False], dtype=bool)
+
+        result = td == arr
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = arr == td
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = td != arr
+        tm.assert_numpy_array_equal(result, ~expected)
+
+        result = arr != td
+        tm.assert_numpy_array_equal(result, ~expected)
+
     @pytest.mark.skip(reason="GH#20829 is reverted until after 0.24.0")
     def test_compare_custom_object(self):
         """
@@ -943,7 +961,7 @@ class TestTimedeltaComparison:
     def test_compare_unknown_type(self, val):
         # GH#20829
         t = Timedelta("1s")
-        msg = "Cannot compare type Timedelta with type (int|str)"
+        msg = "not supported between instances of 'Timedelta' and '(int|str)'"
         with pytest.raises(TypeError, match=msg):
             t >= val
         with pytest.raises(TypeError, match=msg):
@@ -984,7 +1002,7 @@ def test_ops_error_str():
         with pytest.raises(TypeError, match=msg):
             left + right
 
-        msg = "Cannot compare type"
+        msg = "not supported between instances of"
         with pytest.raises(TypeError, match=msg):
             left > right
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

xref #33346

Between the two of these, we should be able to get rid of this kludge: https://github.com/pandas-dev/pandas/blob/master/pandas/core/internals/managers.py#L629

IIRC there were some test_coercion xfails related to that kludge, will be worth revisiting.