### PR TITLE
Bump cython asv

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -39,7 +39,7 @@
     // followed by the pip installed packages).
     "matrix": {
         "numpy": [],
-        "Cython": [],
+        "Cython": ["0.29.16"],
         "matplotlib": [],
         "sqlalchemy": [],
         "scipy": [],


### PR DESCRIPTION
We were pulling in an older version, possibly from defaults.

I think we should plan a major update of all these (notably python 3.6 -> 3.8) but that'll require some care to not invalidate the results at pandas.pydata.org/speed/pandas.