### PR TITLE
asv config to use `build_ext` instead of `build`

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -125,6 +125,6 @@
     "regression_thresholds": {
     },
     "build_command":
-    ["python setup.py build -j4",
+    ["python setup.py build_ext -j4",
      "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"],
 }


### PR DESCRIPTION
Not 100% sure on this change, feel free to close at any time.

---

I have not seen a single mention in the docs of ```python setup.py build``` there was only mention of ```python setup.py build_ext```, so I thought that asv should follow that as well (I could be wrong here).
