### PR TITLE
CI: fix lint issue

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pandas._libs import NaT, algos as libalgos, lib, writers
 import pandas._libs.internals as libinternals
-from pandas._libs.tslibs import Timedelta, conversion
+from pandas._libs.tslibs import conversion
 from pandas._libs.tslibs.timezones import tz_compare
 from pandas._typing import ArrayLike
 from pandas.util._validators import validate_bool_kwarg


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/runs/577244968

Linting .py code
##[error]./pandas/core/internals/blocks.py:11:1:F401:'pandas._libs.tslibs.Timedelta' imported but unused
Linting .py code DONE