### PR TITLE
DOC: timezone conversion example added to pandas.Series.astype doc #33399

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5538,6 +5538,24 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         0    10
         1     2
         dtype: int64
+
+        Create a series of dates:
+
+        >>> ser_date = pd.Series(pd.date_range('20200101', periods=3))
+        >>> ser_date
+        0   2020-01-01
+        1   2020-01-02
+        2   2020-01-03
+        dtype: datetime64[ns]
+
+        Convert to datetime type with time zone:
+        
+        >>> # localize to UTC and convert to US/Eastern time zone
+        >>> ser_date.astype('datetime64[ns, US/Eastern]')
+        0   2019-12-31 19:00:00-05:00
+        1   2020-01-01 19:00:00-05:00
+        2   2020-01-02 19:00:00-05:00
+        dtype: datetime64[ns, US/Eastern]
         """
         if is_dict_like(dtype):
             if self.ndim == 1:  # i.e. Series

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5549,7 +5549,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         dtype: datetime64[ns]
 
         Convert to datetime type with time zone:
-        
+
         >>> # localize to UTC and convert to US/Eastern time zone
         >>> ser_date.astype('datetime64[ns, US/Eastern]')
         0   2019-12-31 19:00:00-05:00

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5548,9 +5548,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2   2020-01-03
         dtype: datetime64[ns]
 
-        Convert to datetime type with time zone:
+        Convert to datetime type with time zone
+        (Behavior - Localize to UTC and convert to US/Eastern):
 
-        >>> # localize to UTC and convert to US/Eastern time zone
         >>> ser_date.astype('datetime64[ns, US/Eastern]')
         0   2019-12-31 19:00:00-05:00
         1   2020-01-01 19:00:00-05:00

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5548,9 +5548,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2   2020-01-03
         dtype: datetime64[ns]
 
-        Convert to datetime type with time zone
-        (Behavior - Datetimes are localized to UTC first
-        before converting to the specified timezone):
+        Datetimes are localized to UTC first before
+        converting to the specified timezone:
 
         >>> ser_date.astype('datetime64[ns, US/Eastern]')
         0   2019-12-31 19:00:00-05:00

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5549,7 +5549,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         dtype: datetime64[ns]
 
         Convert to datetime type with time zone
-        (Behavior - Localize to UTC and convert to US/Eastern):
+        (Behavior - Datetimes are localized to UTC first
+        before converting to the specified timezone):
 
         >>> ser_date.astype('datetime64[ns, US/Eastern]')
         0   2019-12-31 19:00:00-05:00


### PR DESCRIPTION
…3399

- [x] closes #33399 

Have added an example in the documentation page of pandas.Series.astype for datetime type with timezone.