### PR TITLE
TST: Don't use deprecated version of read_html

### DIFF
--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -321,7 +321,7 @@ class TestReadHtml:
         url = self.banklist_data
         with pytest.raises(ValueError, match="No tables found"):
             self.read_html(
-                url, "First Federal Bank of Florida", attrs={"id": "tasdfable"}
+                url, match="First Federal Bank of Florida", attrs={"id": "tasdfable"}
             )
 
     def _bank_data(self, *args, **kwargs):
@@ -573,7 +573,9 @@ class TestReadHtml:
             except AttributeError:
                 return x
 
-        df = self.read_html(self.banklist_data, "Metcalf", attrs={"id": "table"})[0]
+        df = self.read_html(self.banklist_data, match="Metcalf", attrs={"id": "table"})[
+            0
+        ]
         ground_truth = read_csv(
             datapath("io", "data", "csv", "banklist.csv"),
             converters={"Updated Date": Timestamp, "Closing Date": Timestamp},
@@ -883,7 +885,7 @@ class TestReadHtml:
 
     def test_wikipedia_states_multiindex(self, datapath):
         data = datapath("io", "data", "html", "wikipedia_states.html")
-        result = self.read_html(data, "Arizona", index_col=0)[0]
+        result = self.read_html(data, match="Arizona", index_col=0)[0]
         assert result.shape == (60, 11)
         assert "Unnamed" in result.columns[-1][1]
         assert result.columns.nlevels == 2


### PR DESCRIPTION
Usage of function read_html is marked as deprecated when used with
positional arguments. In case when we do not explicitly check the
warning message with assert_produces_warning we should use non-deprecated
version.

This will resolve #33397

To identify candidates to change I modified decorator to raise an `Exception`

```diff
--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -294,6 +294,7 @@ def deprecate_nonkeyword_arguments(
                     "Starting with Pandas version {version} all arguments of {funcname}"
                     "{except_args} will be keyword-only"
                 ).format(version=version, funcname=func.__name__, except_args=arguments)
+                raise Exception("keyword argument test")
                 warnings.warn(msg, FutureWarning, stacklevel=stacklevel)
             return func(*args, **kwargs)
```

Related test build https://dev.azure.com/piotrnielacny/piotrnielacny/_build/results?buildId=2&view=ms.vss-test-web.build-test-results-tab

- [x] closes #33397
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] ~whatsnew entry~