### PR TITLE
PERF: Cythonize `from_nested_dict`

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2534,11 +2534,9 @@ def from_nested_dict(dict data) -> dict:
     cdef:
         dict new_data = {}
         object index, column, value, dict_iterator
-        dict data_dct, nested_dict
+        dict nested_dict
 
-    data_dct = dict(data)
-
-    for index, dict_iterator in data_dct.items():
+    for index, dict_iterator in data.items():
         nested_dict = dict(dict_iterator)
         for column, value in nested_dict.items():
             if column in new_data:

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2534,12 +2534,12 @@ def from_nested_dict(dict data) -> dict:
     cdef:
         object index, column, value, dict_or_series
         dict new_data = {}
-        dict new_value
 
     for index, dict_or_series in data.items():
         for column, value in dict_or_series.items():
-            new_value = dict([(index, value)])
-            new_data.setdefault(column, new_value)
-            new_data[column].update(new_value)
+            if column in new_data:
+                new_data[column][index] = value
+            else:
+                new_data[column] = {index: value}
 
     return new_data

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2531,7 +2531,7 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def from_nested_dict(object data) -> dict:
+def from_nested_dict(dict data) -> dict:
     cdef:
         object new_data = collections.defaultdict(dict)
         object index, column, value, dict_iterator

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1,4 +1,3 @@
-import collections
 from collections import abc
 from decimal import Decimal
 from fractions import Fraction
@@ -2533,7 +2532,7 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
 @cython.boundscheck(False)
 def from_nested_dict(dict data) -> dict:
     cdef:
-        object new_data = collections.defaultdict(dict)
+        dict new_data = {}
         object index, column, value, dict_iterator
         dict data_dct, nested_dict
 
@@ -2542,6 +2541,9 @@ def from_nested_dict(dict data) -> dict:
     for index, dict_iterator in data_dct.items():
         nested_dict = dict(dict_iterator)
         for column, value in nested_dict.items():
-            new_data[column][index] = value
+            if column in new_data:
+                new_data[column].update(dict([(index, value)]))
+            else:
+                new_data.setdefault(column, dict([(index, value)]))
 
-    return dict(new_data)
+    return new_data

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2529,6 +2529,8 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
     return maybe_convert_objects(output)
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
 def from_nested_dict(object data) -> object:
     cdef:
         object new_data = collections.defaultdict(dict)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2539,9 +2539,7 @@ def from_nested_dict(dict data) -> dict:
     for index, dict_or_series in data.items():
         for column, value in dict_or_series.items():
             new_value = dict([(index, value)])
-            if column in new_data:
-                new_data[column].update(new_value)
-            else:
-                new_data.setdefault(column, new_value)
+            new_data.setdefault(column, new_value)
+            new_data[column].update(new_value)
 
     return new_data

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2532,14 +2532,16 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
 @cython.boundscheck(False)
 def from_nested_dict(dict data) -> dict:
     cdef:
-        dict new_data = {}
         object index, column, value, dict_or_series
+        dict new_data = {}
+        dict new_value
 
     for index, dict_or_series in data.items():
         for column, value in dict_or_series.items():
+            new_value = dict([(index, value)])
             if column in new_data:
-                new_data[column].update(dict([(index, value)]))
+                new_data[column].update(new_value)
             else:
-                new_data.setdefault(column, dict([(index, value)]))
+                new_data.setdefault(column, new_value)
 
     return new_data

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2533,12 +2533,10 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
 def from_nested_dict(dict data) -> dict:
     cdef:
         dict new_data = {}
-        object index, column, value, dict_iterator
-        dict nested_dict
+        object index, column, value, dict_or_series
 
-    for index, dict_iterator in data.items():
-        nested_dict = dict(dict_iterator)
-        for column, value in nested_dict.items():
+    for index, dict_or_series in data.items():
+        for column, value in dict_or_series.items():
             if column in new_data:
                 new_data[column].update(dict([(index, value)]))
             else:

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2528,6 +2528,7 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
 
     return maybe_convert_objects(output)
 
+
 def from_nested_dict(object data) -> object:
     cdef:
         object new_data = collections.defaultdict(dict)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2531,12 +2531,17 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def from_nested_dict(object data) -> object:
+def from_nested_dict(object data) -> dict:
     cdef:
         object new_data = collections.defaultdict(dict)
-        object index, column, value, nested_dict
+        object index, column, value, dict_iterator
+        dict data_dct, nested_dict
 
-    for index, nested_dict in data.items():
+    data_dct = dict(data)
+
+    for index, dict_iterator in data_dct.items():
+        nested_dict = dict(dict_iterator)
         for column, value in nested_dict.items():
             new_data[column][index] = value
-    return new_data
+
+    return dict(new_data)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1,3 +1,4 @@
+import collections
 from collections import abc
 from decimal import Decimal
 from fractions import Fraction
@@ -2526,3 +2527,13 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
             output[i] = default
 
     return maybe_convert_objects(output)
+
+def from_nested_dict(object data) -> object:
+    cdef:
+        object new_data = collections.defaultdict(dict)
+        object index, column, value, nested_dict
+
+    for index, nested_dict in data.items():
+        for column, value in nested_dict.items():
+            new_data[column][index] = value
+    return new_data

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1267,6 +1267,10 @@ class DataFrame(NDFrame):
                 # TODO speed up Series case
                 first_val = next(iter((data.values())), None)
                 if isinstance(first_val, (Series, dict)):
+                    # If we are dealing with not a builtin dict,
+                    #  `collections.defaultdict` for example, we need to convert it
+                    #  to a regular dict so Cython will not raise.
+                    data = dict(data) if not type(data) is dict else data
                     data = lib.from_nested_dict(data)
                 else:
                     data, index = list(data.values()), list(data.keys())

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1266,7 +1266,7 @@ class DataFrame(NDFrame):
             if len(data) > 0:
                 # TODO speed up Series case
                 if isinstance(list(data.values())[0], (Series, dict)):
-                    data = _from_nested_dict(data)
+                    data = lib.from_nested_dict(data)
                 else:
                     data, index = list(data.values()), list(data.keys())
         elif orient == "columns":
@@ -8817,12 +8817,3 @@ DataFrame._add_series_or_dataframe_operations()
 
 ops.add_flex_arithmetic_methods(DataFrame)
 ops.add_special_arithmetic_methods(DataFrame)
-
-
-def _from_nested_dict(data):
-    # TODO: this should be seriously cythonized
-    new_data = collections.defaultdict(dict)
-    for index, s in data.items():
-        for col, v in s.items():
-            new_data[col][index] = v
-    return new_data

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1265,7 +1265,8 @@ class DataFrame(NDFrame):
         if orient == "index":
             if len(data) > 0:
                 # TODO speed up Series case
-                if isinstance(list(data.values())[0], (Series, dict)):
+                first_val = next(iter((data.values())), None)
+                if isinstance(first_val, (Series, dict)):
                     data = lib.from_nested_dict(data)
                 else:
                     data, index = list(data.values()), list(data.keys())


### PR DESCRIPTION
I did try to cythonize this function, but the problem is that it also accepting a ```collections.OrderedDict```, which cannot be ```cdef``` as ```dict```, but have to ```cdef``` as ```object```.

---

I don't see much of a performance boost, I have ran the full benchmark suite and ```asv``` says that the ```BENCHMARKS NOT SIGNIFICANTLY CHANGED.```

Maybe just better to remove the ```TODO``` note, thoughts?