### PR TITLE
Implement pd.NA checking function

### DIFF
--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -129,6 +129,33 @@ cpdef ndarray[uint8_t] isnaobj(ndarray arr):
     return result.view(np.bool_)
 
 
+cpdef ndarray[uint8_t] ispdna(ndarray arr):
+    """
+    Return boolean mask denoting which elements of a 1-D array are pd.NA.
+
+    Parameters
+    ----------
+    arr : ndarray
+
+    Returns
+    -------
+    result : ndarray (dtype=np.bool_)
+    """
+
+    cdef:
+        Py_ssize_t i, n
+        ndarray[uint8_t] result
+
+    assert arr.ndim == 1, "'arr' must be 1-D."
+
+    n = len(arr)
+    result = np.empty(n, dtype=np.uint8)
+    for i in range(n):
+        result[i] = arr[i] is C_NA
+
+    return result.view(np.bool_)
+
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def isnaobj_old(arr: ndarray) -> ndarray:

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -599,3 +599,9 @@ class TestLibMissing:
 
         for value in never_na_vals:
             assert not is_null_datetimelike(value)
+
+    def test_ispdna(self):
+        values = np.array([0, np.nan, None, pd.NaT, pd.NA])
+        result = libmissing.ispdna(values)
+        expected = np.array([False, False, False, False, True], dtype=np.bool_)
+        tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This may already exist in some form, but if not I think it could be useful to have a fast function for checking specifically for the presence of pd.NA (e.g. if we're looking at an arbitrary array and don't know if we'll have access to a _mask attribute, or if we're handling some other data type that uses pd.NA for missing values but doesn't have this attribute).