### PR TITLE
BUG: Fix a bug in 'timedelta_range' that produced an extra point on a edge case (fix #30353)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -574,6 +574,7 @@ Timedelta
 - Timedeltas now understand ``µs`` as identifier for microsecond (:issue:`32899`)
 - :class:`Timedelta` string representation now includes nanoseconds, when nanoseconds are non-zero (:issue:`9309`)
 - Bug in comparing a :class:`Timedelta`` object against a ``np.ndarray`` with ``timedelta64`` dtype incorrectly viewing all entries as unequal (:issue:`33441`)
+- Bug in :meth:`timedelta_range` that produced an extra point on a edge case (:issue:`30353`, :issue:`33498`)
 
 Timezones
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -574,7 +574,9 @@ Timedelta
 - Timedeltas now understand ``µs`` as identifier for microsecond (:issue:`32899`)
 - :class:`Timedelta` string representation now includes nanoseconds, when nanoseconds are non-zero (:issue:`9309`)
 - Bug in comparing a :class:`Timedelta`` object against a ``np.ndarray`` with ``timedelta64`` dtype incorrectly viewing all entries as unequal (:issue:`33441`)
-- Bug in :meth:`timedelta_range` that produced an extra point on a edge case (:issue:`30353`, :issue:`33498`)
+- Bug in :func:`timedelta_range` that produced an extra point on a edge case (:issue:`30353`, :issue:`33498`)
+- Bug in :meth:`DataFrame.resample` that produced an extra point on a edge case (:issue:`30353`, :issue:`13022`, :issue:`33498`)
+- Bug in :meth:`DataFrame.resample` that ignored the ``loffset`` argument when dealing with timedelta (:issue:`7687`, :issue:`33498`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -42,12 +42,13 @@ def generate_regular_range(
     end = end.value if end is not None else None
     stride = freq.nanos
 
-    b = start
     if periods is None:
+        b = start
         # cannot just use e = Timestamp(end) + 1 because arange breaks when
         # stride is too large, see GH10887
         e = b + (end - b) // stride * stride + stride // 2 + 1
     elif start is not None:
+        b = start
         e = _generate_range_overflow_safe(b, periods, stride, side="start")
     elif end is not None:
         e = end + stride

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -12,7 +12,7 @@ from pandas._libs.tslibs import OutOfBoundsDatetime, Timedelta, Timestamp
 from pandas.tseries.offsets import DateOffset
 
 
-def generate_time_range(
+def generate_regular_range(
     start: Union[Timestamp, Timedelta],
     end: Union[Timestamp, Timedelta],
     periods: int,
@@ -25,18 +25,18 @@ def generate_time_range(
     Parameters
     ----------
     start : Timedelta, Timestamp or None
-        first point of produced date range
+        First point of produced date range.
     end : Timedelta, Timestamp or None
-        last point of produced date range
+        Last point of produced date range.
     periods : int
-        number of periods in produced date range
+        Number of periods in produced date range.
     freq : DateOffset
-        describes space between dates in produced date range
+        Describes space between dates in produced date range.
+        It should be an instance of Tick.
 
     Returns
     -------
-    ndarray[np.int64]
-        Representing nanosecond unix timestamps.
+    ndarray[np.int64] Representing nanoseconds.
     """
     start = start.value if start is not None else None
     end = end.value if end is not None else None

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -30,9 +30,8 @@ def generate_regular_range(
         Last point of produced date range.
     periods : int
         Number of periods in produced date range.
-    freq : DateOffset
+    freq : Tick
         Describes space between dates in produced date range.
-        It should be an instance of Tick.
 
     Returns
     -------

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -12,7 +12,7 @@ from pandas._libs.tslibs import OutOfBoundsDatetime, Timedelta, Timestamp
 from pandas.tseries.offsets import DateOffset
 
 
-def generate_regular_range(
+def generate_time_range(
     start: Union[Timestamp, Timedelta],
     end: Union[Timestamp, Timedelta],
     periods: int,

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -26,7 +26,7 @@ def generate_regular_range(
     ----------
     start : Timedelta, Timestamp or None
         first point of produced date range
-    start : Timedelta, Timestamp or None
+    end : Timedelta, Timestamp or None
         last point of produced date range
     periods : int
         number of periods in produced date range

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -44,7 +44,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core.algorithms import checked_add_with_arr
 from pandas.core.arrays import datetimelike as dtl
-from pandas.core.arrays._ranges import generate_regular_range
+from pandas.core.arrays._ranges import generate_time_range
 import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias, to_offset
@@ -398,7 +398,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
                     end = end.tz_localize(None)
 
             if isinstance(freq, Tick):
-                values = generate_regular_range(start, end, periods, freq)
+                values = generate_time_range(start, end, periods, freq)
             else:
                 xdr = generate_range(start=start, end=end, periods=periods, offset=freq)
                 values = np.array([x.value for x in xdr], dtype=np.int64)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -44,7 +44,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core.algorithms import checked_add_with_arr
 from pandas.core.arrays import datetimelike as dtl
-from pandas.core.arrays._ranges import generate_regular_range
+from pandas.core.arrays._ranges import generate_timestamps_range
 import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias, to_offset
@@ -408,7 +408,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
                 if end is not None:
                     end = end.tz_localize(None)
 
-            values, _tz = generate_regular_range(start, end, periods, freq)
+            values, _tz = generate_timestamps_range(start, end, periods, freq)
             index = cls._simple_new(values, freq=freq, dtype=tz_to_dtype(_tz))
 
             if tz is not None and index.tz is None:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -44,7 +44,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core.algorithms import checked_add_with_arr
 from pandas.core.arrays import datetimelike as dtl
-from pandas.core.arrays._ranges import generate_time_range
+from pandas.core.arrays._ranges import generate_regular_range
 import pandas.core.common as com
 
 from pandas.tseries.frequencies import get_period_alias, to_offset
@@ -398,7 +398,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
                     end = end.tz_localize(None)
 
             if isinstance(freq, Tick):
-                values = generate_time_range(start, end, periods, freq)
+                values = generate_regular_range(start, end, periods, freq)
             else:
                 xdr = generate_range(start=start, end=end, periods=periods, offset=freq)
                 values = np.array([x.value for x in xdr], dtype=np.int64)

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -33,7 +33,7 @@ from pandas.core.dtypes.missing import isna
 from pandas.core import nanops
 from pandas.core.algorithms import checked_add_with_arr
 from pandas.core.arrays import datetimelike as dtl
-from pandas.core.arrays._ranges import generate_regular_range
+from pandas.core.arrays._ranges import generate_time_range
 import pandas.core.common as com
 from pandas.core.construction import extract_array
 from pandas.core.ops.common import unpack_zerodim_and_defer
@@ -259,7 +259,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         left_closed, right_closed = dtl.validate_endpoints(closed)
 
         if freq is not None:
-            index = generate_regular_range(start, end, periods, freq)
+            index = generate_time_range(start, end, periods, freq)
         else:
             index = np.linspace(start.value, end.value, periods).astype("i8")
             if len(index) >= 2:

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -33,7 +33,7 @@ from pandas.core.dtypes.missing import isna
 from pandas.core import nanops
 from pandas.core.algorithms import checked_add_with_arr
 from pandas.core.arrays import datetimelike as dtl
-from pandas.core.arrays._ranges import generate_time_range
+from pandas.core.arrays._ranges import generate_regular_range
 import pandas.core.common as com
 from pandas.core.construction import extract_array
 from pandas.core.ops.common import unpack_zerodim_and_defer
@@ -259,7 +259,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         left_closed, right_closed = dtl.validate_endpoints(closed)
 
         if freq is not None:
-            index = generate_time_range(start, end, periods, freq)
+            index = generate_regular_range(start, end, periods, freq)
         else:
             index = np.linspace(start.value, end.value, periods).astype("i8")
             if len(index) >= 2:

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -33,7 +33,7 @@ from pandas.core.dtypes.missing import isna
 from pandas.core import nanops
 from pandas.core.algorithms import checked_add_with_arr
 from pandas.core.arrays import datetimelike as dtl
-from pandas.core.arrays._ranges import generate_timedeltas_range
+from pandas.core.arrays._ranges import generate_regular_range
 import pandas.core.common as com
 from pandas.core.construction import extract_array
 from pandas.core.ops.common import unpack_zerodim_and_defer
@@ -256,16 +256,10 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
         if end is not None:
             end = Timedelta(end)
 
-        if start is None and end is None:
-            if closed is not None:
-                raise ValueError(
-                    "Closed has to be None if not both of start and end are defined"
-                )
-
         left_closed, right_closed = dtl.validate_endpoints(closed)
 
         if freq is not None:
-            index = generate_timedeltas_range(start, end, periods, freq)
+            index = generate_regular_range(start, end, periods, freq)
         else:
             index = np.linspace(start.value, end.value, periods).astype("i8")
             if len(index) >= 2:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1502,6 +1502,8 @@ class TimeGrouper(Grouper):
         # Addresses GH #10530
         if self.base > 0:
             labels += type(self.freq)(self.base)
+        if self.loffset:
+            labels += self.loffset
 
         return binner, bins, labels
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1499,10 +1499,11 @@ class TimeGrouper(Grouper):
         end_stamps = labels + self.freq
         bins = ax.searchsorted(end_stamps, side="left")
 
-        # Addresses GH #10530
         if self.base > 0:
+            # GH #10530
             labels += type(self.freq)(self.base)
         if self.loffset:
+            # GH #33498
             labels += self.loffset
 
         return binner, bins, labels

--- a/pandas/tests/indexes/timedeltas/test_timedelta_range.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta_range.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas import Timedelta, Timestamp, date_range, timedelta_range, to_timedelta
+from pandas import Timedelta, timedelta_range, to_timedelta
 import pandas._testing as tm
 
 from pandas.tseries.offsets import Day, Second
@@ -63,31 +63,19 @@ class TestTimedeltas:
             timedelta_range(start="0 days", end="5 days", periods=10, freq="H")
 
     @pytest.mark.parametrize(
-        "start, end, freq",
+        "start, end, freq, expected_periods",
         [
-            ("1D", "10D", "2D"),
-            ("2D", "30D", "3D"),
-            ("2s", "50s", "5s"),
+            ("1D", "10D", "2D", (10 - 1) // 2 + 1),
+            ("2D", "30D", "3D", (30 - 2) // 3 + 1),
+            ("2s", "50s", "5s", (50 - 2) // 5 + 1),
             # tests that worked before GH 33498:
-            ("4D", "16D", "3D"),
-            ("8D", "16D", "40s"),
+            ("4D", "16D", "3D", (16 - 4) // 3 + 1),
+            ("8D", "16D", "40s", (16 * 3600 * 24 - 8 * 3600 * 24) // 40 + 1),
         ],
     )
-    def test_timedelta_range_freq_divide_end(self, start, end, freq):
+    def test_timedelta_range_freq_divide_end(self, start, end, freq, expected_periods):
         # GH 33498 only the cases where `(end % freq) == 0` used to fail
-
-        def mock_timedelta_range(start=None, end=None, **kwargs):
-            epoch = Timestamp(0)
-            if start is not None:
-                start = epoch + Timedelta(start)
-            if end is not None:
-                end = epoch + Timedelta(end)
-            result = date_range(start=start, end=end, **kwargs) - epoch
-            result.freq = freq
-            return result
-
         res = timedelta_range(start=start, end=end, freq=freq)
-        exp = mock_timedelta_range(start=start, end=end, freq=freq)
-
-        tm.assert_index_equal(res, exp)
-        assert res.freq == exp.freq
+        assert Timedelta(start) == res[0]
+        assert Timedelta(end) >= res[-1]
+        assert len(res) == expected_periods

--- a/pandas/tests/resample/test_base.py
+++ b/pandas/tests/resample/test_base.py
@@ -10,7 +10,7 @@ from pandas.core.groupby.groupby import DataError
 from pandas.core.groupby.grouper import Grouper
 from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.period import PeriodIndex, period_range
-from pandas.core.indexes.timedeltas import TimedeltaIndex, timedelta_range
+from pandas.core.indexes.timedeltas import timedelta_range
 from pandas.core.resample import _asfreq_compat
 
 # a fixture value can be overridden by the test parameter value. Note that the
@@ -182,7 +182,6 @@ def test_resample_size_empty_dataframe(freq, empty_frame_dti):
 @pytest.mark.parametrize("index", tm.all_timeseries_index_generator(0))
 @pytest.mark.parametrize("dtype", [np.float, np.int, np.object, "datetime64[ns]"])
 def test_resample_empty_dtypes(index, dtype, resample_method):
-
     # Empty series were sometimes causing a segfault (for the functions
     # with Cython bounds-checking disabled) or an IndexError.  We just run
     # them to ensure they no longer do.  (GH #10228)
@@ -215,13 +214,7 @@ def test_resample_loffset_arg_type(frame, create_index, arg):
     if isinstance(arg, list):
         expected.columns = pd.MultiIndex.from_tuples([("value", "mean")])
 
-    # GH 13022, 7687 - TODO: fix resample w/ TimedeltaIndex
-    if isinstance(expected.index, TimedeltaIndex):
-        msg = "DataFrame are different"
-        with pytest.raises(AssertionError, match=msg):
-            tm.assert_frame_equal(result_agg, expected)
-    else:
-        tm.assert_frame_equal(result_agg, expected)
+    tm.assert_frame_equal(result_agg, expected)
 
 
 @all_ts

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -145,3 +145,30 @@ def test_resample_timedelta_end_already_included_in_bins(
     )
     tm.assert_index_equal(result.index, expected_index)
     assert not np.isnan(result[-1])
+
+
+@pytest.mark.parametrize(
+    "freq, start, end", [("1day", "10day", "2D")],
+)
+def test_timedelta_range_large_stride(start, end, freq):
+    # GH 30353
+
+    def mock_timedelta_range(
+        start=None, end=None, periods=None, freq=None, name=None, closed=None
+    ):
+        epoch = pd.Timestamp(0)
+        if start is not None:
+            start = epoch + pd.Timedelta(start)
+        if end is not None:
+            end = epoch + pd.Timedelta(end)
+        res = pd.date_range(
+            start=start, end=end, periods=periods, freq=freq, name=name, closed=closed
+        )
+        res -= epoch
+        res.freq = freq
+        return res
+
+    res = pd.timedelta_range("1day", "10day", freq="2D")
+    exp = mock_timedelta_range("1day", "10day", freq="2D")
+
+    tm.assert_index_equal(res, exp)

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -149,34 +149,5 @@ def test_resample_timedelta_edge_case(start, end, freq, resample_freq):
     result = s.resample(resample_freq).min()
     expected_index = pd.timedelta_range(freq=resample_freq, start=start, end=end)
     tm.assert_index_equal(result.index, expected_index)
+    assert result.index.freq == expected_index.freq
     assert not np.isnan(result[-1])
-
-
-@pytest.mark.parametrize(
-    "start, end, freq",
-    [
-        ("1D", "10D", "2D"),
-        ("2D", "30D", "3D"),
-        ("2s", "50s", "5s"),
-        # tests that worked before GH 33498:
-        ("4D", "16D", "3D"),
-        ("8D", "16D", "40s"),
-    ],
-)
-def test_timedelta_range_freq_divide_end(start, end, freq):
-    # GH 33498 only the cases where `(end % freq) == 0` used to fail
-
-    def mock_timedelta_range(start=None, end=None, **kwargs):
-        epoch = pd.Timestamp(0)
-        if start is not None:
-            start = epoch + pd.Timedelta(start)
-        if end is not None:
-            end = epoch + pd.Timedelta(end)
-        result = pd.date_range(start=start, end=end, **kwargs) - epoch
-        result.freq = freq
-        return result
-
-    res = pd.timedelta_range(start=start, end=end, freq=freq)
-    exp = mock_timedelta_range(start=start, end=end, freq=freq)
-
-    tm.assert_index_equal(res, exp)

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -131,13 +131,18 @@ def test_resample_timedelta_values():
 @pytest.mark.parametrize(
     "start, end, freq, resample_freq",
     [
-        ("8H", "21h59min", "10S", "3H"),
+        ("8H", "21h59min50s", "10S", "3H"),  # GH 30353 example
         ("3H", "22H", "1H", "5H"),
         ("527D", "5006D", "3D", "10D"),
+        ("1D", "10D", "1D", "2D"),  # GH 13022 example
+        # tests that worked before GH 33498:
+        ("8H", "21h59min50s", "10S", "2H"),
+        ("0H", "21h59min50s", "10S", "3H"),
+        ("10D", "85D", "D", "2D"),
     ],
 )
 def test_resample_timedelta_edge_case(start, end, freq, resample_freq):
-    # GH 30353
+    # GH 33498
     # check that the timedelta bins does not contains an extra bin
     idx = pd.timedelta_range(start=start, end=end, freq=freq)
     s = pd.Series(np.arange(len(idx)), index=idx)
@@ -149,10 +154,17 @@ def test_resample_timedelta_edge_case(start, end, freq, resample_freq):
 
 @pytest.mark.parametrize(
     "start, end, freq",
-    [("1day", "10day", "2D"), ("2day", "30day", "3D"), ("2s", "50s", "5s")],
+    [
+        ("1D", "10D", "2D"),
+        ("2D", "30D", "3D"),
+        ("2s", "50s", "5s"),
+        # tests that worked before GH 33498:
+        ("4D", "16D", "3D"),
+        ("8D", "16D", "40s"),
+    ],
 )
 def test_timedelta_range_freq_divide_end(start, end, freq):
-    # GH 30353 only the cases where `(end % freq) == 0` used to fail
+    # GH 33498 only the cases where `(end % freq) == 0` used to fail
 
     def mock_timedelta_range(start=None, end=None, **kwargs):
         epoch = pd.Timestamp(0)

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -133,10 +133,10 @@ def test_resample_timedelta_values():
     [
         ("8H", "21h59min", "10S", "3H"),
         ("3H", "22H", "1H", "5H"),
-        ("527D", "5006D", "3D", "10D")
+        ("527D", "5006D", "3D", "10D"),
     ],
 )
-def test_resample_timedelta_edge_case(start, end, freq, resample_freq,):
+def test_resample_timedelta_edge_case(start, end, freq, resample_freq):
     # GH 30353
     # check that the timedelta bins does not contains an extra bin
     idx = pd.timedelta_range(start=start, end=end, freq=freq)
@@ -148,11 +148,8 @@ def test_resample_timedelta_edge_case(start, end, freq, resample_freq,):
 
 
 @pytest.mark.parametrize(
-    "start, end, freq", [
-        ("1day", "10day", "2D"),
-        ("2day", "30day", "3D"),
-        ("2s", "50s", "5s")
-    ],
+    "start, end, freq",
+    [("1day", "10day", "2D"), ("2day", "30day", "3D"), ("2s", "50s", "5s")],
 )
 def test_timedelta_range_freq_divide_end(start, end, freq):
     # GH 30353 only the cases where `(end % freq) == 0` used to fail


### PR DESCRIPTION
The issue from #30353 came actually from `timedelta_range`.

```python
import pandas as pd

def mock_timedelta_range(start=None, end=None, periods=None, freq=None, name=None, closed=None):
    epoch = pd.Timestamp(0)
    if start is not None:
        start = epoch + pd.Timedelta(start)
    if end is not None:
        end = epoch + pd.Timedelta(end)
    res = pd.date_range(start=start, end=end, periods=periods, freq=freq, name=name, closed=closed)
    res -= epoch
    res.freq = freq
    return res

print(mock_timedelta_range("1day", "10day", freq="2D"))
print(pd.timedelta_range("1day", "10day", freq="2D"))
```

The outputs from `mock_timedelta_range` and from `pd.timedelta_range` are supposed to equivalent, but are not on pandas v1.0.0:
Outputs without this PR:
```
TimedeltaIndex(['1 days', '3 days', '5 days', '7 days', '9 days'], dtype='timedelta64[ns]', freq='2D')
TimedeltaIndex(['1 days', '3 days', '5 days', '7 days', '9 days', '11 days'], dtype='timedelta64[ns]', freq='2D')
```

Outputs with this PR:
```
TimedeltaIndex(['1 days', '3 days', '5 days', '7 days', '9 days'], dtype='timedelta64[ns]', freq='2D')
TimedeltaIndex(['1 days', '3 days', '5 days', '7 days', '9 days'], dtype='timedelta64[ns]', freq='2D')
```

----
It also solve an issue (that fail on master) related to this comment: https://github.com/pandas-dev/pandas/issues/13022#issuecomment-238382933

```python
import pandas as pd
rng = pd.timedelta_range(start='1d', periods=10, freq='d')
df = pd.Series(range(10), index=rng)
df.resample('2D').count()
```
Outputs with this PR:
```
1 days    2
3 days    2
5 days    2
7 days    2
9 days    2
Freq: 2D, dtype: int64
```

----

On the firsts commits I just fixed the issue in `_generate_regular_range`, then I decided to do a refactor and to use the same code that generate ranges in `core/arrays/_ranges.py` for `date_range` and `timedelta_range`.

Linked with #10887.

----

- [X] closes #30353
       closes #13022
       closes #7687 (for loffset when resampling Timedelta)
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
