### PR TITLE
ENH: Adds round_decimals=None to Series.value_counts() to use with normalize=True

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -97,6 +97,7 @@ Other enhancements
   This can be used to set a custom compression level, e.g.,
   ``df.to_csv(path, compression={'method': 'gzip', 'compresslevel': 1}``
   (:issue:`33196`)
+- :meth:`Series.value_counts` now accepts ``round_decimals`` argument (and applies ``largest remainder method``)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -680,6 +680,8 @@ def value_counts(
         Number of rounding decimals. Largest remainder method will be used
         to sum up to 1.
 
+    .. versionadded:: 1.1.0
+
     Returns
     -------
     Series

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1165,7 +1165,13 @@ class IndexOpsMixin:
         return new_values
 
     def value_counts(
-        self, normalize=False, sort=True, ascending=False, bins=None, dropna=True
+        self,
+        normalize=False,
+        sort=True,
+        ascending=False,
+        bins=None,
+        dropna=True,
+        round_decimals=None,
     ):
         """
         Return a Series containing counts of unique values.
@@ -1188,6 +1194,9 @@ class IndexOpsMixin:
             a convenience for ``pd.cut``, only works with numeric data.
         dropna : bool, default True
             Don't include counts of NaN.
+        round_decimals : int, default None
+            Number of rounding decimals. Largest remainder method will be used
+            to sum up to 1.
 
         Returns
         -------
@@ -1220,6 +1229,17 @@ class IndexOpsMixin:
         1.0    0.2
         dtype: float64
 
+        With `normalize` set to `True`, and `round_decimals` to an int,
+        it will round the decimals to sum up to 1.0:
+
+        >>> s = pd.Series([3, 1, 2, 3, 4, 3, 3, np.nan])
+        >>> s.value_counts(normalize=True, round_decimals=2)
+        3.0    0.58
+        1.0    0.14
+        2.0    0.14
+        4.0    0.14
+        dtype: float64
+
         **bins**
 
         Bins can be useful for going from a continuous variable to a
@@ -1227,6 +1247,7 @@ class IndexOpsMixin:
         apparitions of values, divide the index in the specified
         number of half-open bins.
 
+        >>> s = pd.Series([3, 1, 2, 3, 4, np.nan])
         >>> s.value_counts(bins=3)
         (2.0, 3.0]      2
         (0.996, 2.0]    2
@@ -1252,6 +1273,7 @@ class IndexOpsMixin:
             normalize=normalize,
             bins=bins,
             dropna=dropna,
+            round_decimals=round_decimals,
         )
         return result
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1198,6 +1198,8 @@ class IndexOpsMixin:
             Number of rounding decimals. Largest remainder method will be used
             to sum up to 1.
 
+        .. versionadded:: 1.1.0
+
         Returns
         -------
         Series


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

When using `value_counts` with `normalize=True` with a **Series,** the result contains the relative frequencies of the unique values and therefore sums up to 1.0. If then you need to round these frequencies to some decimals, it is not a so trivial task [[1]](https://stackoverflow.com/questions/13483430/how-to-make-rounded-percentages-add-up-to-100)[[2]](https://stackoverflow.com/questions/5227215/how-to-deal-with-the-sum-of-rounded-percentage-not-being-100)[[3]](https://revs.runtime-revolution.com/getting-100-with-rounded-percentages-273ffa70252b). So when this new **int** `round_decimals` argument is **not None**, the method applies the [Largest_remainder_method](https://en.wikipedia.org/wiki/Largest_remainder_method) to round the values to the number of decimals selected, but also to sum up to 1.0 in total.