### PR TITLE
Removed xfail for issue #31883

### DIFF
--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -408,10 +408,6 @@ class TestGetLoc:
         key = ["b", "d"]
         levels[level] = np.array([0, nulls_fixture], dtype=type(nulls_fixture))
         key[level] = nulls_fixture
-
-        if nulls_fixture is pd.NA:
-            pytest.xfail("MultiIndex from pd.NA in np.array broken; see GH 31883")
-
         idx = MultiIndex.from_product(levels)
         assert idx.get_loc(tuple(key)) == 3
 


### PR DESCRIPTION
I removed the xfail in lines 412-414 as discussed in https://github.com/pandas-dev/pandas/issues/31883.

- [x] closes #31883
- [x] 0 tests added / 0 passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
