### PR TITLE
Added two tests for issue #29697

### DIFF
--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2030,7 +2030,7 @@ def test_merge_suffix(col1, col2, kwargs, expected_cols):
         (
             "right",
             DataFrame(
-                {"A": [100, 200, 300], "B1": [60, 70, np.nan], "B2": [600, 700, 800], }
+                {"A": [100, 200, 300], "B1": [60, 70, np.nan], "B2": [600, 700, 800],}
             ),
         ),
         (

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -645,6 +645,39 @@ class TestMerge:
 
         assert isinstance(result, NotADataFrame)
 
+    def test_merge_right_duplicate_suffix(self):
+        # https://github.com/pandas-dev/pandas/issues/29697
+
+        left_df = DataFrame({"A": [100, 200, 1], "B": [60, 70, 80]})
+        right_df = DataFrame({"A": [100, 200, 300], "B": [600, 700, 800]})
+
+        result = merge(left_df, right_df, on="A", how="right", suffixes=("_x", "_x"))
+        expected = DataFrame(
+            {"A": [100, 200, 300], "B1": [60, 70, np.nan], "B2": [600, 700, 800]}
+        )
+        expected.columns = ["A", "B_x", "B_x"]
+
+        tm.assert_frame_equal(result, expected)
+
+    def test_merge_outer_duplicate_suffix(self):
+        # https://github.com/pandas-dev/pandas/issues/29697
+
+        left_df = DataFrame({"A": [100, 200, 1], "B": [60, 70, 80]})
+        right_df = DataFrame({"A": [100, 200, 300], "B": [600, 700, 800]})
+
+        result = merge(left_df, right_df, on="A", how="outer", suffixes=("_x", "_x"))
+
+        expected = DataFrame(
+            {
+                "A": [100, 200, 1, 300],
+                "B1": [60, 70, 80, np.nan],
+                "B2": [600, 700, np.nan, 800],
+            }
+        )
+        expected.columns = ["A", "B_x", "B_x"]
+
+        tm.assert_frame_equal(result, expected)
+
     def test_join_append_timedeltas(self):
         # timedelta64 issues with join/merge
         # GH 5695

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2030,7 +2030,7 @@ def test_merge_suffix(col1, col2, kwargs, expected_cols):
         (
             "right",
             DataFrame(
-                {"A": [100, 200, 300], "B1": [60, 70, np.nan], "B2": [600, 700, 800],}
+                {"A": [100, 200, 300], "B1": [60, 70, np.nan], "B2": [600, 700, 800]}
             ),
         ),
         (


### PR DESCRIPTION
I added two basic tests for `merge` as requested in #29697, one for `how="outer"` and one for  `how="right"`. 

I'm not sure if the way I'm creating duplicate columns for the `expected` dataframe is the recommended way but I could not find anything on this. Please let me know if there's a better way to do this.

- [x] closes #29697
- [x] 2 tests added / 2 passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`



