### PR TITLE
TST/CLN: Clean categorical min / max tests

### DIFF
--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1076,7 +1076,8 @@ class TestCategoricalSeriesReductions:
     def test_min_max_unordered_raises(self, function):
         # unordered cats have no min/max
         cat = Series(Categorical(["a", "b", "c", "d"], ordered=False))
-        with pytest.raises(TypeError):
+        msg = f"Categorical is not ordered for operation {function}"
+        with pytest.raises(TypeError, match=msg):
             getattr(cat, function)()
 
     @pytest.mark.parametrize(

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -1072,67 +1072,44 @@ class TestCategoricalSeriesReductions:
     #  were moved from a series-specific test file, _not_ that these tests are
     #  intended long-term to be series-specific
 
-    def test_min_max(self):
+    @pytest.mark.parametrize("function", ["min", "max"])
+    def test_min_max_unordered_raises(self, function):
         # unordered cats have no min/max
         cat = Series(Categorical(["a", "b", "c", "d"], ordered=False))
         with pytest.raises(TypeError):
-            cat.min()
-        with pytest.raises(TypeError):
-            cat.max()
+            getattr(cat, function)()
 
-        cat = Series(Categorical(["a", "b", "c", "d"], ordered=True))
-        _min = cat.min()
-        _max = cat.max()
-        assert _min == "a"
-        assert _max == "d"
-
-        cat = Series(
-            Categorical(
-                ["a", "b", "c", "d"], categories=["d", "c", "b", "a"], ordered=True
-            )
-        )
-        _min = cat.min()
-        _max = cat.max()
-        assert _min == "d"
-        assert _max == "a"
-
-        cat = Series(
-            Categorical(
-                [np.nan, "b", "c", np.nan],
-                categories=["d", "c", "b", "a"],
-                ordered=True,
-            )
-        )
-        _min = cat.min()
-        _max = cat.max()
-        assert _min == "c"
-        assert _max == "b"
-
-        cat = Series(
-            Categorical(
-                [np.nan, 1, 2, np.nan], categories=[5, 4, 3, 2, 1], ordered=True
-            )
-        )
-        _min = cat.min()
-        _max = cat.max()
-        assert _min == 2
-        assert _max == 1
-
-    @pytest.mark.parametrize("skipna", [True, False])
-    def test_min_max_skipna(self, skipna):
+    @pytest.mark.parametrize(
+        "values, categories",
+        [
+            (list("abc"), list("abc")),
+            (list("abc"), list("cba")),
+            (list("abc") + [np.nan], list("cba")),
+            ([1, 2, 3], [3, 2, 1]),
+            ([1, 2, 3, np.nan], [3, 2, 1]),
+        ],
+    )
+    @pytest.mark.parametrize("function", ["min", "max"])
+    def test_min_max_ordered(self, values, categories, function):
         # GH 25303
+        cat = Series(Categorical(values, categories=categories, ordered=True))
+        result = getattr(cat, function)(skipna=True)
+        expected = categories[0] if function == "min" else categories[2]
+        assert result == expected
+
+    @pytest.mark.parametrize("function", ["min", "max"])
+    @pytest.mark.parametrize("skipna", [True, False])
+    def test_min_max_skipna(self, function, skipna):
         cat = Series(
             Categorical(["a", "b", np.nan, "a"], categories=["b", "a"], ordered=True)
         )
-        _min = cat.min(skipna=skipna)
-        _max = cat.max(skipna=skipna)
+        result = getattr(cat, function)(skipna=skipna)
 
         if skipna is True:
-            assert _min == "b"
-            assert _max == "a"
+            expected = "b" if function == "min" else "a"
+            assert result == expected
         else:
-            assert np.isnan(_min)
-            assert np.isnan(_max)
+            assert result is np.nan
 
 
 class TestSeriesMode:


### PR DESCRIPTION
Fixes one small error in a test, and otherwise tries to remove some code duplication