### PR TITLE
DOC: Add missing descriptions in See Also section

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1041,8 +1041,8 @@ class Window(_Window):
         """
     See Also
     --------
-    pandas.DataFrame.rolling.aggregate
-    pandas.DataFrame.aggregate
+    pandas.DataFrame.rolling.aggregate: Perform a rolling aggregation over DataFrame.
+    pandas.DataFrame.aggregate: Perform an aggregation over DataFrame.
     """
     )
 
@@ -1891,8 +1891,8 @@ class Rolling(_Rolling_and_Expanding):
         """
     See Also
     --------
-    Series.rolling
-    DataFrame.rolling
+    Series.rolling: Provide rolling window calculations for Series.
+    DataFrame.rolling: Provides rolling window calculations for DataFrame.
     """
     )
 

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -645,6 +645,39 @@ class TestMerge:
 
         assert isinstance(result, NotADataFrame)
 
+    def test_merge_right_duplicate_suffix(self):
+        # https://github.com/pandas-dev/pandas/issues/29697
+
+        left_df = DataFrame({"A": [100, 200, 1], "B": [60, 70, 80]})
+        right_df = DataFrame({"A": [100, 200, 300], "B": [600, 700, 800]})
+
+        result = merge(left_df, right_df, on="A", how="right", suffixes=("_x", "_x"))
+        expected = DataFrame(
+            {"A": [100, 200, 300], "B1": [60, 70, np.nan], "B2": [600, 700, 800]}
+        )
+        expected.columns = ["A", "B_x", "B_x"]
+
+        tm.assert_frame_equal(result, expected)
+
+    def test_merge_outer_duplicate_suffix(self):
+        # https://github.com/pandas-dev/pandas/issues/29697
+
+        left_df = DataFrame({"A": [100, 200, 1], "B": [60, 70, 80]})
+        right_df = DataFrame({"A": [100, 200, 300], "B": [600, 700, 800]})
+
+        result = merge(left_df, right_df, on="A", how="outer", suffixes=("_x", "_x"))
+
+        expected = DataFrame(
+            {
+                "A": [100, 200, 1, 300],
+                "B1": [60, 70, 80, np.nan],
+                "B2": [600, 700, np.nan, 800],
+            }
+        )
+        expected.columns = ["A", "B_x", "B_x"]
+
+        tm.assert_frame_equal(result, expected)
+
     def test_join_append_timedeltas(self):
         # timedelta64 issues with join/merge
         # GH 5695


### PR DESCRIPTION
Fixed SR04 for `pandas/core/window/rolling.py`
- [X] xref #28792
- [ ] 0 tests added / 0 passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
