### PR TITLE
REF: matching-dtype case first in concat_compat

### DIFF
--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -19,13 +19,7 @@ from pandas.core.dtypes.common import (
     is_sparse,
     is_timedelta64_dtype,
 )
-from pandas.core.dtypes.generic import (
-    ABCCategoricalIndex,
-    ABCDatetimeArray,
-    ABCIndexClass,
-    ABCRangeIndex,
-    ABCSeries,
-)
+from pandas.core.dtypes.generic import ABCCategoricalIndex, ABCRangeIndex, ABCSeries
 
 
 def get_dtype_kinds(l):
@@ -405,7 +399,7 @@ def concat_datetime(to_concat, axis=0, typs=None):
         else:
             # when to_concat has different tz, len(typs) > 1.
             # thus no need to care
-            return _concat_datetimetz(to_concat)
+            return to_concat[0]._concat_same_type(to_concat)
 
     elif "timedelta" in typs:
         return _concatenate_2d([x.view(np.int64) for x in to_concat], axis=axis).view(
@@ -437,23 +431,6 @@ def _convert_datetimelike_to_object(x):
         x = x.reshape(shape)
 
     return x
-
-
-def _concat_datetimetz(to_concat, name=None):
-    """
-    concat DatetimeIndex with the same tz
-    all inputs must be DatetimeIndex
-    it is used in DatetimeIndex.append also
-    """
-    # Right now, internals will pass a List[DatetimeArray] here
-    # for reductions like quantile. I would like to disentangle
-    # all this before we get here.
-    sample = to_concat[0]
-
-    if isinstance(sample, ABCIndexClass):
-        return sample._concat_same_dtype(to_concat, name=name)
-    elif isinstance(sample, ABCDatetimeArray):
-        return sample._concat_same_type(to_concat)
 
 
 def _concat_sparse(to_concat, axis=0, typs=None):

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -19,7 +19,13 @@ from pandas.core.dtypes.common import (
     is_sparse,
     is_timedelta64_dtype,
 )
-from pandas.core.dtypes.generic import ABCCategoricalIndex, ABCRangeIndex, ABCSeries
+from pandas.core.dtypes.generic import (
+    ABCCategoricalIndex,
+    ABCDatetimeArray,
+    ABCIndexClass,
+    ABCRangeIndex,
+    ABCSeries,
+)
 
 
 def get_dtype_kinds(l):
@@ -400,7 +406,7 @@ def concat_datetime(to_concat, axis=0, typs=None):
         else:
             # when to_concat has different tz, len(typs) > 1.
             # thus no need to care
-            return to_concat[0]._concat_same_type(to_concat)
+            return _concat_datetimetz(to_concat)
 
     elif "timedelta" in typs:
         return _concatenate_2d([x.view(np.int64) for x in to_concat], axis=axis).view(
@@ -432,6 +438,23 @@ def _convert_datetimelike_to_object(x):
         x = x.reshape(shape)
 
     return x
+
+
+def _concat_datetimetz(to_concat, name=None):
+    """
+    concat DatetimeIndex with the same tz
+    all inputs must be DatetimeIndex
+    it is used in DatetimeIndex.append also
+    """
+    # Right now, internals will pass a List[DatetimeArray] here
+    # for reductions like quantile. I would like to disentangle
+    # all this before we get here.
+    sample = to_concat[0]
+
+    if isinstance(sample, ABCIndexClass):
+        return sample._concat_same_dtype(to_concat, name=name)
+    elif isinstance(sample, ABCDatetimeArray):
+        return sample._concat_same_type(to_concat)
 
 
 def _concat_sparse(to_concat, axis=0, typs=None):

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -99,7 +99,15 @@ def concat_compat(to_concat, axis: int = 0):
     _contains_datetime = any(typ.startswith("datetime") for typ in typs)
     _contains_period = any(typ.startswith("period") for typ in typs)
 
-    if "category" in typs:
+    all_empty = not len(non_empties)
+    single_dtype = len({x.dtype for x in to_concat}) == 1
+    any_ea = any(is_extension_array_dtype(x.dtype) for x in to_concat)
+
+    if any_ea and single_dtype and axis == 0:
+        cls = type(to_concat[0])
+        return cls._concat_same_type(to_concat)
+
+    elif "category" in typs:
         # this must be prior to concat_datetime,
         # to support Categorical + datetime-like
         return concat_categorical(to_concat, axis=axis)
@@ -111,18 +119,11 @@ def concat_compat(to_concat, axis: int = 0):
     elif "sparse" in typs:
         return _concat_sparse(to_concat, axis=axis, typs=typs)
 
-    all_empty = not len(non_empties)
-    single_dtype = len({x.dtype for x in to_concat}) == 1
-    any_ea = any(is_extension_array_dtype(x.dtype) for x in to_concat)
-
-    if any_ea and axis == 1:
+    elif any_ea and axis == 1:
         to_concat = [np.atleast_2d(x.astype("object")) for x in to_concat]
+        return np.concatenate(to_concat, axis=axis)
 
-    elif any_ea and single_dtype and axis == 0:
-        cls = type(to_concat[0])
-        return cls._concat_same_type(to_concat)
-
-    if all_empty:
+    elif all_empty:
         # we have all empties, but may need to coerce the result dtype to
         # object if we have non-numeric type operands (numpy would otherwise
         # cast this to float)
@@ -286,7 +287,7 @@ def union_categoricals(
     [b, c, a, b]
     Categories (3, object): [b, c, a]
     """
-    from pandas import Index, Categorical
+    from pandas import Categorical
     from pandas.core.arrays.categorical import recode_for_categories
 
     if len(to_union) == 0:
@@ -294,7 +295,7 @@ def union_categoricals(
 
     def _maybe_unwrap(x):
         if isinstance(x, (ABCCategoricalIndex, ABCSeries)):
-            return x.values
+            return x._values
         elif isinstance(x, Categorical):
             return x
         else:
@@ -337,7 +338,7 @@ def union_categoricals(
     elif ignore_order or all(not c.ordered for c in to_union):
         # different categories - union and recode
         cats = first.categories.append([c.categories for c in to_union[1:]])
-        categories = Index(cats.unique())
+        categories = cats.unique()
         if sort_categories:
             categories = categories.sort_values()
 


### PR DESCRIPTION
Moving towards clarifying the EA._concat_same_type behavior with unique vs non-unique dtypes