### PR TITLE
BUG: Do not use string Index like Datetimelike Index

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -907,34 +907,6 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
                 other = other.tz_convert("UTC")
         return this, other
 
-    @classmethod
-    def _is_convertible_to_index_for_join(cls, other: Index) -> bool:
-        """
-        return a boolean whether I can attempt conversion to a
-        DatetimeIndex/TimedeltaIndex
-        """
-        if isinstance(other, cls):
-            return False
-        elif len(other) > 0 and other.inferred_type not in (
-            "floating",
-            "mixed-integer",
-            "integer",
-            "integer-na",
-            "mixed-integer-float",
-            "mixed",
-        ):
-            return True
-        return False
-
-    def _wrap_joined_index(self, joined: np.ndarray, other):
-        assert other.dtype == self.dtype, (other.dtype, self.dtype)
-        name = get_op_result_name(self, other)
-
-        freq = self.freq if self._can_fast_union(other) else None
-        new_data = type(self._data)._simple_new(joined, dtype=self.dtype, freq=freq)
-
-        return type(self)._simple_new(new_data, name=name)
-
     # --------------------------------------------------------------------
     # List-Like Methods
 

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -408,3 +408,20 @@ def test_isocalendar_returns_correct_values_close_to_new_year_with_tz():
         dtype="UInt32",
     )
     tm.assert_frame_equal(result, expected_data_frame)
+
+
+def test_datetimelike_string():
+    # Related to PR 32739
+    # Ensure we do not compare strings and datetimelike type.
+    date_string = "2020-04-13"
+    i1 = pd.Index([date_string])
+    i2 = pd.Index([pd.to_datetime(date_string)])
+
+    assert i1.equals(i2) is False
+    assert i2.equals(i1) is False
+
+    assert len(i1.intersection(i2)) == 0
+    assert len(i2.intersection(i1)) == 0
+
+    assert len(i1.union(i2)) == 2
+    assert len(i2.union(i1)) == 2


### PR DESCRIPTION
Follow up of conversation in https://github.com/pandas-dev/pandas/pull/32739#issuecomment-602271577.

The goal is to prevent index of string that look like datetimelike to be used as datetimelike.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
