### PR TITLE
CLN: Change isocalendar to be a method

### DIFF
--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -772,7 +772,6 @@ There are several time/date properties that one can access from ``Timestamp`` or
     week,"The week ordinal of the year"
     dayofweek,"The number of the day of the week with Monday=0, Sunday=6"
     weekday,"The number of the day of the week with Monday=0, Sunday=6"
-    isocalendar,"The ISO 8601 year, week and day of the date"
     quarter,"Quarter of the date: Jan-Mar = 1, Apr-Jun = 2, etc."
     days_in_month,"The number of days in the month of the datetime"
     is_month_start,"Logical indicating if first day of month (defined by frequency)"
@@ -794,7 +793,7 @@ You may obtain the year, week and day components of the ISO year from the ISO 86
 .. ipython:: python
 
    idx = pd.date_range(start='2019-12-29', freq='D', periods=4)
-   idx.to_series().dt.isocalendar
+   idx.to_series().dt.isocalendar()
 
 .. _timeseries.offsets:
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -88,7 +88,7 @@ Other enhancements
 - :class:`Series.str` now has a `fullmatch` method that matches a regular expression against the entire string in each row of the series, similar to `re.fullmatch` (:issue:`32806`).
 - :meth:`DataFrame.sample` will now also allow array-like and BitGenerator objects to be passed to ``random_state`` as seeds (:issue:`32503`)
 - :meth:`MultiIndex.union` will now raise `RuntimeWarning` if the object inside are unsortable, pass `sort=False` to suppress this warning (:issue:`33015`)
-- :class:`Series.dt` and :class:`DatatimeIndex` now have an `isocalendar` accessor that returns a :class:`DataFrame` with year, week, and day calculated according to the ISO 8601 calendar (:issue:`33206`).
+- :class:`Series.dt` and :class:`DatatimeIndex` now have an `isocalendar` method that returns a :class:`DataFrame` with year, week, and day calculated according to the ISO 8601 calendar (:issue:`33206`).
 - The :meth:`DataFrame.to_feather` method now supports additional keyword
   arguments (e.g. to set the compression) that are added in pyarrow 0.17
   (:issue:`33422`).

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -183,7 +183,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
         "microsecond",
         "nanosecond",
     ]
-    _other_ops = ["date", "time", "timetz", "isocalendar"]
+    _other_ops = ["date", "time", "timetz"]
     _datetimelike_ops = _field_ops + _object_ops + _bool_ops + _other_ops
     _datetimelike_methods = [
         "to_period",
@@ -1242,7 +1242,6 @@ default 'raise'
 
         return tslib.ints_to_pydatetime(timestamps, box="date")
 
-    @property
     def isocalendar(self):
         """
         Returns a DataFrame with the year, week, and day calculated according to
@@ -1263,13 +1262,13 @@ default 'raise'
         Examples
         --------
         >>> idx = pd.date_range(start='2019-12-29', freq='D', periods=4)
-        >>> idx.isocalendar
+        >>> idx.isocalendar()
            year  week  day
         0  2019    52    7
         1  2020     1    1
         2  2020     1    2
         3  2020     1    3
-        >>> idx.isocalendar.week
+        >>> idx.isocalendar().week
         0    52
         1     1
         2     1

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -219,7 +219,6 @@ class DatetimeProperties(Properties):
     def freq(self):
         return self._get_values().inferred_freq
 
-    @property
     def isocalendar(self):
         """
         Returns a DataFrame with the year, week, and day calculated according to
@@ -240,16 +239,16 @@ class DatetimeProperties(Properties):
         Examples
         --------
         >>> ser = pd.to_datetime(pd.Series(["2010-01-01", pd.NaT]))
-        >>> ser.dt.isocalendar
+        >>> ser.dt.isocalendar()
            year  week  day
         0  2009    53     5
         1  <NA>  <NA>  <NA>
-        >>> ser.dt.isocalendar.week
+        >>> ser.dt.isocalendar().week
         0      53
         1    <NA>
         Name: week, dtype: UInt32
         """
-        return self._get_values().isocalendar.set_index(self._parent.index)
+        return self._get_values().isocalendar().set_index(self._parent.index)
 
 
 @delegate_names(

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -49,6 +49,7 @@ class TestSeriesDatetimeValues:
             "ceil",
             "day_name",
             "month_name",
+            "isocalendar",
         ]
         ok_for_td = TimedeltaIndex._datetimelike_ops
         ok_for_td_methods = [
@@ -678,7 +679,7 @@ class TestSeriesDatetimeValues:
         ],
     )
     def test_isocalendar(self, input_series, expected_output):
-        result = pd.to_datetime(pd.Series(input_series)).dt.isocalendar
+        result = pd.to_datetime(pd.Series(input_series)).dt.isocalendar()
         expected_frame = pd.DataFrame(
             expected_output, columns=["year", "week", "day"], dtype="UInt32"
         )


### PR DESCRIPTION
For consistency with `Timestamp.isocalendar`, `Series.dt.isocalendar` and
`DatetimeIndex.isocalendar` should rather be methods and not attributes.

Followup of #33220, see the discussions following the merge of that PR