### PR TITLE
ENH: Clear index cache after reindex

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2464,6 +2464,7 @@ class MultiIndex(Index):
         else:
             indexer = self._engine.get_indexer(target)
 
+        self._engine.clear_mapping()
         return ensure_platform_int(indexer)
 
     @Appender(_index_shared_docs["get_indexer_non_unique"] % _index_doc_kwargs)


### PR DESCRIPTION
Add flag to clear index cache after reindex.

By default, reindex causes index to cache values which potentially increases the memory consumption significantly in the case of multiindexes. 

```
In [2]: idx = pd.MultiIndex.from_product([pd.date_range('2010-01-01', '2015-01-01'), range(1000)], names=['date', 'id'])
In [3]: idx2 = pd.MultiIndex.from_product([pd.date_range('2010-01-01', '2015-01-01'), range(500)], names=['date', 'id'])
In [4]: df =  pd.DataFrame({'a': 1}, index=idx)
In [5]: df.memory_usage(deep=True, index=True) # Original Memory Usage
Out[5]:
Index     7453600
a        14616000
dtype: int64
In [6]: df.reindex(idx2)  # df is still the same as original. 
In [7]: df.memory_usage(deep=True, index=True)  # Memory usage after reindex
Out[7]:
Index    91339680
a        14616000
dtype: int64
```

With  clear_cache=True

```
In [20]: idx = pd.MultiIndex.from_product([pd.date_range('2010-01-01', '2015-01-01'), range(1000)], names=['date', 'id'])
In [21]: idx2 = pd.MultiIndex.from_product([pd.date_range('2010-01-01', '2015-01-01'), range(500)], names=['date', 'id'])
In [22]: df =  pd.DataFrame({'a': 1}, index=idx)
In [23]: df.memory_usage(deep=True, index=True) # Original Memory Usage
Out[23]:
Index     7453600
a        14616000
dtype: int64
In [24]: df.reindex(idx2)  # df is still the same as original.
In [25]: df.memory_usage(deep=True, index=True)  # Memory usage after reindex
Out[25]:
Index     7453600
a        14616000
dtype: int64

```
