### PR TITLE
BUG: Fix behavior of isocalendar with timezones

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1277,7 +1277,11 @@ default 'raise'
         """
         from pandas import DataFrame
 
-        sarray = fields.build_isocalendar_sarray(self.asi8)
+        if self.tz is not None and not timezones.is_utc(self.tz):
+            values = self._local_timestamps()
+        else:
+            values = self.asi8
+        sarray = fields.build_isocalendar_sarray(values)
         iso_calendar_df = DataFrame(
             sarray, columns=["year", "week", "day"], dtype="UInt32"
         )

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -373,3 +373,17 @@ def test_iter_readonly():
     arr.setflags(write=False)
     dti = pd.to_datetime(arr)
     list(dti)
+
+
+def test_isocalendar_returns_correct_values_close_to_new_year_with_tz():
+    # GH 6538: Check that DatetimeIndex and its TimeStamp elements
+    # return the same weekofyear accessor close to new year w/ tz
+    dates = ["2013/12/29", "2013/12/30", "2013/12/31"]
+    dates = DatetimeIndex(dates, tz="Europe/Brussels")
+    result = dates.isocalendar()
+    expected_data_frame = pd.DataFrame(
+        [[2013, 52, 7], [2014, 1, 1], [2014, 1, 2]],
+        columns=["year", "week", "day"],
+        dtype="UInt32",
+    )
+    tm.assert_frame_equal(result, expected_data_frame)


### PR DESCRIPTION
- If timezone is not UTC, then convert to UTC
- This bug was found while deprecating 'week' and 'weekofyear'