### PR TITLE
ENH: Add index to output of assert_series_equal on category and datetime values

### DIFF
--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -999,7 +999,12 @@ def assert_numpy_array_equal(
 
 
 def assert_extension_array_equal(
-    left, right, check_dtype=True, check_less_precise=False, check_exact=False
+    left,
+    right,
+    check_dtype=True,
+    check_less_precise=False,
+    check_exact=False,
+    index_values=None,
 ):
     """
     Check that left and right ExtensionArrays are equal.
@@ -1016,6 +1021,8 @@ def assert_extension_array_equal(
         If int, then specify the digits to compare.
     check_exact : bool, default False
         Whether to compare number exactly.
+    index_values : numpy.ndarray, default None
+        optional index (shared by both left and right), used in output.
 
     Notes
     -----
@@ -1031,17 +1038,23 @@ def assert_extension_array_equal(
     if hasattr(left, "asi8") and type(right) == type(left):
         # Avoid slow object-dtype comparisons
         # np.asarray for case where we have a np.MaskedArray
-        assert_numpy_array_equal(np.asarray(left.asi8), np.asarray(right.asi8))
+        assert_numpy_array_equal(
+            np.asarray(left.asi8), np.asarray(right.asi8), index_values=index_values
+        )
         return
 
     left_na = np.asarray(left.isna())
     right_na = np.asarray(right.isna())
-    assert_numpy_array_equal(left_na, right_na, obj="ExtensionArray NA mask")
+    assert_numpy_array_equal(
+        left_na, right_na, obj="ExtensionArray NA mask", index_values=index_values
+    )
 
     left_valid = np.asarray(left[~left_na].astype(object))
     right_valid = np.asarray(right[~right_na].astype(object))
     if check_exact:
-        assert_numpy_array_equal(left_valid, right_valid, obj="ExtensionArray")
+        assert_numpy_array_equal(
+            left_valid, right_valid, obj="ExtensionArray", index_values=index_values
+        )
     else:
         _testing.assert_almost_equal(
             left_valid,
@@ -1049,6 +1062,7 @@ def assert_extension_array_equal(
             check_dtype=check_dtype,
             check_less_precise=check_less_precise,
             obj="ExtensionArray",
+            index_values=index_values,
         )
 
 
@@ -1181,12 +1195,17 @@ def assert_series_equal(
             check_less_precise=check_less_precise,
             check_dtype=check_dtype,
             obj=str(obj),
+            index_values=np.asarray(left.index),
         )
     elif is_extension_array_dtype(left.dtype) and is_extension_array_dtype(right.dtype):
-        assert_extension_array_equal(left._values, right._values)
+        assert_extension_array_equal(
+            left._values, right._values, index_values=np.asarray(left.index)
+        )
     elif needs_i8_conversion(left.dtype) or needs_i8_conversion(right.dtype):
         # DatetimeArray or TimedeltaArray
-        assert_extension_array_equal(left._values, right._values)
+        assert_extension_array_equal(
+            left._values, right._values, index_values=np.asarray(left.index)
+        )
     else:
         _testing.assert_almost_equal(
             left._values,

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -165,7 +165,7 @@ Series length are different
         tm.assert_series_equal(s1, s2, check_less_precise=check_less_precise)
 
 
-def test_series_equal_values_mismatch(check_less_precise):
+def test_series_equal_numeric_values_mismatch(check_less_precise):
     msg = """Series are different
 
 Series values are different \\(33\\.33333 %\\)
@@ -175,6 +175,38 @@ Series values are different \\(33\\.33333 %\\)
 
     s1 = Series([1, 2, 3])
     s2 = Series([1, 2, 4])
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_series_equal(s1, s2, check_less_precise=check_less_precise)
+
+
+def test_series_equal_categorical_values_mismatch(check_less_precise):
+    msg = """Series are different
+
+Series values are different \\(66\\.66667 %\\)
+\\[index\\]: \\[0, 1, 2\\]
+\\[left\\]:  \\[a, b, c\\]
+Categories \\(3, object\\): \\[a, b, c\\]
+\\[right\\]: \\[a, c, b\\]
+Categories \\(3, object\\): \\[a, b, c\\]"""
+
+    s1 = Series(Categorical(["a", "b", "c"]))
+    s2 = Series(Categorical(["a", "c", "b"]))
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_series_equal(s1, s2, check_less_precise=check_less_precise)
+
+
+def test_series_equal_datetime_values_mismatch(check_less_precise):
+    msg = """numpy array are different
+
+numpy array values are different \\(100.0 %\\)
+\\[index\\]: \\[0, 1, 2\\]
+\\[left\\]:  \\[1514764800000000000, 1514851200000000000, 1514937600000000000\\]
+\\[right\\]: \\[1549065600000000000, 1549152000000000000, 1549238400000000000\\]"""
+
+    s1 = Series(pd.date_range("2018-01-01", periods=3, freq="D"))
+    s2 = Series(pd.date_range("2019-02-02", periods=3, freq="D"))
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_series_equal(s1, s2, check_less_precise=check_less_precise)


### PR DESCRIPTION
- [ ] closes #xxxx
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is really an extension of #31435, which added index output to the messages produced when series (and DataFrames) are compared.  I failed to notice that categorical values and datetime values were evaluated through a different code path and didn't add the index output for these data types.  Since the original problem (index reordering) could just as easily happen for these types the functionality should be there as well.  Also, it makes the output more consistent.

I added a couple of new tests to surface and check the additional output.