### PR TITLE
Added a check for standard documentation

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -377,5 +377,14 @@ if [[ -z "$CHECK" || "$CHECK" == "typing" ]]; then
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 fi
 
+### Checking for standardized documentation ###
+echo "Checking which files in pandas/doc/source have standardized documentation"
+
+for entry in $(find ../doc/source/ -type f)
+do	
+	if grep -q Pandas "$entry" || grep -q *pandas* "$entry"  ; then
+		echo "$entry"
+	fi
+done
 
 exit $RET

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -377,6 +377,7 @@ if [[ -z "$CHECK" || "$CHECK" == "typing" ]]; then
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 fi
 
+
 ### Checking for standardized documentation ###
 echo "Checking which files in pandas/doc/source have standardized documentation"
 
@@ -386,5 +387,6 @@ do
 		echo "$entry"
 	fi
 done
+
 
 exit $RET

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -380,13 +380,11 @@ fi
 
 ### Checking for standardized documentation ###
 echo "Checking which files in pandas/doc/source have standardized documentation"
-
 for entry in $(find ../doc/source/ -type f)
 do	
 	if grep -q Pandas "$entry" || grep -q *pandas* "$entry"  ; then
 		echo "$entry"
 	fi
 done
-
 
 exit $RET

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -387,4 +387,5 @@ do
 	fi
 done
 
+
 exit $RET

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -381,7 +381,7 @@ fi
 ### Checking for standardized documentation ###
 echo "Checking which files in pandas/doc/source have standardized documentation"
 for entry in $(find ../doc/source/ -type f)
-do	
+do
 	if grep -q Pandas "$entry" || grep -q *pandas* "$entry"  ; then
 		echo "$entry"
 	fi

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -237,6 +237,14 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -RI --exclude=\*.{svg,c,cpp,html,js} --exclude-dir=env "\s$" *
     RET=$(($RET + $?)) ; echo $MSG "DONE"
     unset INVGREP_APPEND
+
+    MSG = 'Check files that in pandas/doc/source that use standardized documentation' ; echo $MSG
+    for entry in $(find ../doc/source/ -type f)
+    do
+	if grep -q Pandas "$entry" || grep -q *pandas* "$entry"  ; then
+		echo "$entry"
+	fi
+    done
 fi
 
 ### CODE ###
@@ -377,14 +385,5 @@ if [[ -z "$CHECK" || "$CHECK" == "typing" ]]; then
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 fi
 
-
-### Checking for standardized documentation ###
-echo "Checking which files in pandas/doc/source have standardized documentation"
-for entry in $(find ../doc/source/ -type f)
-do
-	if grep -q Pandas "$entry" || grep -q *pandas* "$entry"  ; then
-		echo "$entry"
-	fi
-done
 
 exit $RET

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -387,5 +387,4 @@ do
 	fi
 done
 
-
 exit $RET


### PR DESCRIPTION
- [ ] closes #33213 
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I created a check to see which files contain Pandas or *pandas* which will be of use for individuals aiming to resolve issue #32316. When the codecheck script is run, it will output the files that contain those strings.