### PR TITLE
BUG: DatetimeIndex.intersection losing freq and tz

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -458,7 +458,7 @@ Datetimelike
 - Bug in :class:`Timestamp` arithmetic when adding or subtracting a ``np.ndarray`` with ``timedelta64`` dtype (:issue:`33296`)
 - Bug in :meth:`DatetimeIndex.to_period` not infering the frequency when called with no arguments (:issue:`33358`)
 - Bug in :meth:`DatetimeIndex.tz_localize` incorrectly retaining ``freq`` in some cases where the original freq is no longer valid (:issue:`30511`)
-- Bug in :meth:`DatetimeIndex.intersection` losing ``freq`` and timezone in some cases (:issue:`????`)
+- Bug in :meth:`DatetimeIndex.intersection` losing ``freq`` and timezone in some cases (:issue:`33604`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -458,6 +458,7 @@ Datetimelike
 - Bug in :class:`Timestamp` arithmetic when adding or subtracting a ``np.ndarray`` with ``timedelta64`` dtype (:issue:`33296`)
 - Bug in :meth:`DatetimeIndex.to_period` not infering the frequency when called with no arguments (:issue:`33358`)
 - Bug in :meth:`DatetimeIndex.tz_localize` incorrectly retaining ``freq`` in some cases where the original freq is no longer valid (:issue:`30511`)
+- Bug in :meth:`DatetimeIndex.intersection` losing ``freq`` and timezone in some cases (:issue:`????`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -724,10 +724,10 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
         start = right[0]
 
         if end < start:
-            return type(self)(data=[])
+            return type(self)(data=[], dtype=self.dtype, freq=self.freq)
         else:
             lslice = slice(*left.slice_locs(start, end))
-            left_chunk = left.values[lslice]
+            left_chunk = left._values[lslice]
             return self._shallow_copy(left_chunk)
 
     def _can_fast_union(self, other) -> bool:

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -75,8 +75,9 @@ class TestGetItem:
     def test_dti_business_getitem(self):
         rng = pd.bdate_range(START, END)
         smaller = rng[:5]
-        exp = DatetimeIndex(rng.view(np.ndarray)[:5])
+        exp = DatetimeIndex(rng.view(np.ndarray)[:5], freq="B")
         tm.assert_index_equal(smaller, exp)
+        assert smaller.freq == exp.freq
 
         assert smaller.freq == rng.freq
 
@@ -102,8 +103,9 @@ class TestGetItem:
     def test_dti_custom_getitem(self):
         rng = pd.bdate_range(START, END, freq="C")
         smaller = rng[:5]
-        exp = DatetimeIndex(rng.view(np.ndarray)[:5])
+        exp = DatetimeIndex(rng.view(np.ndarray)[:5], freq="C")
         tm.assert_index_equal(smaller, exp)
+        assert smaller.freq == exp.freq
         assert smaller.freq == rng.freq
 
         sliced = rng[::5]

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -284,7 +284,7 @@ class TestDatetimeIndexSetOps:
         assert len(result) == 0
         assert result.freq == rng.freq
 
-        # no overlap
+        # no overlap GH#33604
         result = rng[:3].intersection(rng[-3:])
         tm.assert_index_equal(result, rng[:0])
         if freq != "T":

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -106,6 +106,7 @@ class TestTimedeltaIndex:
         result = index_1 & index_2
         expected = timedelta_range("1 day 01:00:00", periods=3, freq="h")
         tm.assert_index_equal(result, expected)
+        assert result.freq == expected.freq
 
     def test_intersection_equal(self, sort):
         # GH 24471 Test intersection outcome given the sort keyword
@@ -182,7 +183,7 @@ class TestTimedeltaIndex:
                 TimedeltaIndex(["2 hour", "5 hour", "5 hour", "1 hour"], name="other"),
                 TimedeltaIndex(["1 hour", "2 hour"], name=None),
             ),
-            # reveresed index
+            # reversed index
             (
                 TimedeltaIndex(["1 hour", "2 hour", "4 hour", "3 hour"], name="idx")[
                     ::-1
@@ -200,7 +201,7 @@ class TestTimedeltaIndex:
         tm.assert_index_equal(result, expected)
         assert result.name == expected.name
 
-        # if reveresed order, frequency is still the same
+        # if reversed order, frequency is still the same
         if all(base == rng[::-1]) and sort is None:
             assert isinstance(result.freq, Hour)
         else:


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
