### PR TITLE
BUG: support count function for custom BaseIndexer rolling windows

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -174,8 +174,8 @@ Other API changes
 - Added :meth:`DataFrame.value_counts` (:issue:`5377`)
 - :meth:`Groupby.groups` now returns an abbreviated representation when called on large dataframes (:issue:`1135`)
 - ``loc`` lookups with an object-dtype :class:`Index` and an integer key will now raise ``KeyError`` instead of ``TypeError`` when key is missing (:issue:`31905`)
-- Using a :func:`pandas.api.indexers.BaseIndexer` with ``count``, ``skew``, ``cov``, ``corr`` will now raise a ``NotImplementedError`` (:issue:`32865`)
-- Using a :func:`pandas.api.indexers.BaseIndexer` with ``min``, ``max`` will now return correct results for any monotonic :func:`pandas.api.indexers.BaseIndexer` descendant (:issue:`32865`)
+- Using a :func:`pandas.api.indexers.BaseIndexer` with ``skew``, ``cov``, ``corr`` will now raise a ``NotImplementedError`` (:issue:`32865`)
+- Using a :func:`pandas.api.indexers.BaseIndexer` with ``count``, ``min``, ``max`` will now return correct results for any monotonic :func:`pandas.api.indexers.BaseIndexer` descendant (:issue:`32865`)
 - Added a :func:`pandas.api.indexers.FixedForwardWindowIndexer` class to support forward-looking windows during ``rolling`` operations.
 -
 

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -328,6 +328,7 @@ def get_weighted_roll_func(cfunc: Callable) -> Callable:
 def validate_baseindexer_support(func_name: Optional[str]) -> None:
     # GH 32865: These functions work correctly with a BaseIndexer subclass
     BASEINDEXER_WHITELIST = {
+        "count",
         "min",
         "max",
         "mean",

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1937,8 +1937,8 @@ class Rolling(_Rolling_and_Expanding):
     def count(self):
 
         # different impl for freq counting
-        # GH 32865. Also use custom rolling windows calculation
-        # when using a BaseIndexer subclass
+        # GH 32865. Use a custom count function implementation
+        # when using a BaseIndexer subclass as a window
         if self.is_freq_type or isinstance(self.window, BaseIndexer):
             window_func = self._get_roll_func("roll_count")
             return self._apply(window_func, center=self.center, name="count")

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1171,6 +1171,8 @@ class _Rolling_and_Expanding(_Rolling):
     )
 
     def count(self):
+        # GH 32865. Using count with custom BaseIndexer subclass
+        # implementations shouldn't end up here
         assert not isinstance(self.window, BaseIndexer)
 
         blocks, obj = self._create_blocks()

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1171,8 +1171,6 @@ class _Rolling_and_Expanding(_Rolling):
     )
 
     def count(self):
-        if isinstance(self.window, BaseIndexer):
-            validate_baseindexer_support("count")
 
         blocks, obj = self._create_blocks()
         results = []

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1171,6 +1171,7 @@ class _Rolling_and_Expanding(_Rolling):
     )
 
     def count(self):
+        assert not isinstance(self.window, BaseIndexer)
 
         blocks, obj = self._create_blocks()
         results = []

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1939,7 +1939,9 @@ class Rolling(_Rolling_and_Expanding):
     def count(self):
 
         # different impl for freq counting
-        if self.is_freq_type:
+        # GH 32865. Also use custom rolling windows calculation
+        # when using a BaseIndexer subclass
+        if self.is_freq_type or isinstance(self.window, BaseIndexer):
             window_func = self._get_roll_func("roll_count")
             return self._apply(window_func, center=self.center, name="count")
 

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -82,7 +82,7 @@ def test_win_type_not_implemented():
         df.rolling(indexer, win_type="boxcar")
 
 
-@pytest.mark.parametrize("func", ["count", "skew", "cov", "corr"])
+@pytest.mark.parametrize("func", ["skew", "cov", "corr"])
 def test_notimplemented_functions(func):
     # GH 32865
     class CustomIndexer(BaseIndexer):

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -99,6 +99,7 @@ def test_notimplemented_functions(func):
 @pytest.mark.parametrize(
     "func,np_func,expected,np_kwargs",
     [
+        ("count", len, [3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 2.0, np.nan], {},),
         ("min", np.min, [0.0, 1.0, 2.0, 3.0, 4.0, 6.0, 6.0, 7.0, 8.0, np.nan], {},),
         (
             "max",


### PR DESCRIPTION
- [X] xref #32865 
- [X] 1 tests added / 1 passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

## Scope of PR
This PR makes sure that when we call `count` with a `BaseIndexer` subclass, custom `start` and `end` arrays get calculated, and the algorithm in the `aggregations.pyx` gets called instead of the `_Window.create_blocks`.

Turns out that we were sending the calculation into `aggregations.pyx` only for frequency-based windows, and custom `BaseIndexer` subclasses got ignored. Fixed it and cleaned the code up a bit.

## Background on the wider issue
We currently don't support several rolling window functions when building a rolling window object using a custom class descended from `pandas.api.indexers.Baseindexer`. The implementations were written with backward-looking windows in mind, and this led to these functions breaking.
Currently, using these functions returns a `NotImplemented` error thanks to #33057, but ideally we want to update the implementations, so that they will work without a performance hit. This is what I aim to do over a series of PRs.

## Perf notes
No changes to the algorithms necessary.
