### PR TITLE
DOC/CLN: Clean/Fix documentation for Window module

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -322,8 +322,8 @@ fi
 ### DOCSTRINGS ###
 if [[ -z "$CHECK" || "$CHECK" == "docstrings" ]]; then
 
-    MSG='Validate docstrings (GL03, GL04, GL05, GL06, GL07, GL09, GL10, SS04, SS05, PR03, PR04, PR05, PR10, EX04, RT01, RT04, RT05, SA02, SA03, SA05)' ; echo $MSG
-    $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=GL03,GL04,GL05,GL06,GL07,GL09,GL10,SS04,SS05,PR03,PR04,PR05,PR10,EX04,RT01,RT04,RT05,SA02,SA03,SA05
+    MSG='Validate docstrings (GL03, GL04, GL05, GL06, GL07, GL09, GL10, SS04, SS05, PR03, PR04, PR05, PR10, EX04, RT01, RT04, RT05, SA02, SA03)' ; echo $MSG
+    $BASE_DIR/scripts/validate_docstrings.py --format=actions --errors=GL03,GL04,GL05,GL06,GL07,GL09,GL10,SS04,SS05,PR03,PR04,PR05,PR10,EX04,RT01,RT04,RT05,SA02,SA03
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Validate correct capitalization among titles in documentation' ; echo $MSG

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -22,8 +22,10 @@ _doc_template = """
 
         See Also
         --------
-        Series.%(name)s : Series %(name)s.
-        DataFrame.%(name)s : DataFrame %(name)s.
+        .Series.%(name)s : Calling object with Series data.
+        .DataFrame.%(name)s : Calling object with DataFrame data.
+        .Series.%(func_name)s : Similar method for Series.
+        .DataFrame.%(func_name)s : Similar method for DataFrame.
 """
 
 

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -22,10 +22,10 @@ _doc_template = """
 
         See Also
         --------
-        .Series.%(name)s : Calling object with Series data.
-        .DataFrame.%(name)s : Calling object with DataFrame data.
-        .Series.%(func_name)s : Similar method for Series.
-        .DataFrame.%(func_name)s : Similar method for DataFrame.
+        pandas.Series.%(name)s : Calling object with Series data.
+        pandas.DataFrame.%(name)s : Calling object with DataFrame data.
+        pandas.Series.%(func_name)s : Similar method for Series.
+        pandas.DataFrame.%(func_name)s : Similar method for DataFrame.
 """
 
 

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -265,7 +265,7 @@ class EWM(_Rolling):
 
         return self._wrap_results(results, block_list, obj, exclude)
 
-    @Substitution(name="ewm")
+    @Substitution(name="ewm", func_name="mean")
     @Appender(_doc_template)
     def mean(self, *args, **kwargs):
         """
@@ -279,7 +279,7 @@ class EWM(_Rolling):
         nv.validate_window_func("mean", args, kwargs)
         return self._apply("ewma", **kwargs)
 
-    @Substitution(name="ewm")
+    @Substitution(name="ewm", func_name="std")
     @Appender(_doc_template)
     @Appender(_bias_template)
     def std(self, bias=False, *args, **kwargs):
@@ -291,7 +291,7 @@ class EWM(_Rolling):
 
     vol = std
 
-    @Substitution(name="ewm")
+    @Substitution(name="ewm", func_name="var")
     @Appender(_doc_template)
     @Appender(_bias_template)
     def var(self, bias=False, *args, **kwargs):
@@ -313,7 +313,7 @@ class EWM(_Rolling):
 
         return self._apply(f, **kwargs)
 
-    @Substitution(name="ewm")
+    @Substitution(name="ewm", func_name="cov")
     @Appender(_doc_template)
     def cov(self, other=None, pairwise=None, bias=False, **kwargs):
         """
@@ -360,7 +360,7 @@ class EWM(_Rolling):
             self._selected_obj, other._selected_obj, _get_cov, pairwise=bool(pairwise)
         )
 
-    @Substitution(name="ewm")
+    @Substitution(name="ewm", func_name="corr")
     @Appender(_doc_template)
     def corr(self, other=None, pairwise=None, **kwargs):
         """

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -88,9 +88,8 @@ class Expanding(_Rolling_and_Expanding):
         """
     See Also
     --------
-    DataFrame.expanding.aggregate
-    DataFrame.rolling.aggregate
-    DataFrame.aggregate
+    .DataFrame.aggregate : Similar DataFrame method.
+    .Series.aggregate : Similar Series method.
     """
     )
 
@@ -172,7 +171,7 @@ class Expanding(_Rolling_and_Expanding):
         nv.validate_expanding_func("sum", args, kwargs)
         return super().sum(*args, **kwargs)
 
-    @Substitution(name="expanding")
+    @Substitution(name="expanding", func_name="max")
     @Appender(_doc_template)
     @Appender(_shared_docs["max"])
     def max(self, *args, **kwargs):
@@ -208,7 +207,7 @@ class Expanding(_Rolling_and_Expanding):
         nv.validate_expanding_func("var", args, kwargs)
         return super().var(ddof=ddof, **kwargs)
 
-    @Substitution(name="expanding")
+    @Substitution(name="expanding", func_name="skew")
     @Appender(_doc_template)
     @Appender(_shared_docs["skew"])
     def skew(self, **kwargs):
@@ -252,7 +251,7 @@ class Expanding(_Rolling_and_Expanding):
             quantile=quantile, interpolation=interpolation, **kwargs
         )
 
-    @Substitution(name="expanding")
+    @Substitution(name="expanding", func_name="cov")
     @Appender(_doc_template)
     @Appender(_shared_docs["cov"])
     def cov(self, other=None, pairwise=None, ddof=1, **kwargs):

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -88,8 +88,8 @@ class Expanding(_Rolling_and_Expanding):
         """
     See Also
     --------
-    .DataFrame.aggregate : Similar DataFrame method.
-    .Series.aggregate : Similar Series method.
+    pandas.DataFrame.aggregate : Similar DataFrame method.
+    pandas.Series.aggregate : Similar Series method.
     """
     )
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -540,8 +540,8 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
 
     See Also
     --------
-    Series.sum : Reducing sum for Series.
-    DataFrame.sum : Reducing sum for DataFrame.
+    .Series.sum : Reducing sum for Series.
+    .DataFrame.sum : Reducing sum for DataFrame.
 
     Examples
     --------
@@ -618,10 +618,10 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
 
     See Also
     --------
-    Series.%(name)s : Calling object with Series data.
-    DataFrame.%(name)s : Calling object with DataFrames.
-    Series.mean : Equivalent method for Series.
-    DataFrame.mean : Equivalent method for DataFrame.
+    .Series.%(name)s : Calling object with Series data.
+    .DataFrame.%(name)s : Calling object with DataFrames.
+    .Series.mean : Equivalent method for Series.
+    .DataFrame.mean : Equivalent method for DataFrame.
 
     Examples
     --------
@@ -667,10 +667,10 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
 
     See Also
     --------
-    Series.%(name)s : Calling object with Series data.
-    DataFrame.%(name)s : Calling object with DataFrames.
-    Series.var : Equivalent method for Series.
-    DataFrame.var : Equivalent method for DataFrame.
+    .Series.%(name)s : Calling object with Series data.
+    .DataFrame.%(name)s : Calling object with DataFrames.
+    .Series.var : Equivalent method for Series.
+    .DataFrame.var : Equivalent method for DataFrame.
     numpy.var : Equivalent method for Numpy array.
 
     Notes
@@ -727,10 +727,10 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
 
     See Also
     --------
-    Series.%(name)s : Calling object with Series data.
-    DataFrame.%(name)s : Calling object with DataFrames.
-    Series.std : Equivalent method for Series.
-    DataFrame.std : Equivalent method for DataFrame.
+    .Series.%(name)s : Calling object with Series data.
+    .DataFrame.%(name)s : Calling object with DataFrames.
+    .Series.std : Equivalent method for Series.
+    .DataFrame.std : Equivalent method for DataFrame.
     numpy.std : Equivalent method for Numpy array.
 
     Notes
@@ -1030,8 +1030,8 @@ class Window(_Window):
         """
     See Also
     --------
-    pandas.DataFrame.rolling.aggregate
-    pandas.DataFrame.aggregate
+    .DataFrame.aggregate : Similar DataFrame method.
+    .Series.aggregate : Similar Series method.
     """
     )
 
@@ -1146,9 +1146,9 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    Series.%(name)s : Calling object with Series data.
-    DataFrame.%(name)s : Calling object with DataFrames.
-    DataFrame.count : Count of the full DataFrame.
+    .Series.%(name)s : Calling object with Series data.
+    .DataFrame.%(name)s : Calling object with DataFrames.
+    .DataFrame.count : Count of the full DataFrame.
 
     Examples
     --------
@@ -1243,8 +1243,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    Series.%(name)s : Series %(name)s.
-    DataFrame.%(name)s : DataFrame %(name)s.
+    .Series.%(name)s : Calling object with Series data.
+    .DataFrame.%(name)s : Calling object with DataFrame data.
+    .Series.apply : Similar method for Series.
+    .DataFrame.apply : Similar method for DataFrame.
 
     Notes
     -----
@@ -1363,10 +1365,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    Series.%(name)s : Calling object with a Series.
-    DataFrame.%(name)s : Calling object with a DataFrame.
-    Series.min : Similar method for Series.
-    DataFrame.min : Similar method for DataFrame.
+    .Series.%(name)s : Calling object with a Series.
+    .DataFrame.%(name)s : Calling object with a DataFrame.
+    .Series.min : Similar method for Series.
+    .DataFrame.min : Similar method for DataFrame.
 
     Examples
     --------
@@ -1410,10 +1412,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    Series.%(name)s : Calling object with Series data.
-    DataFrame.%(name)s : Calling object with DataFrames.
-    Series.median : Equivalent method for Series.
-    DataFrame.median : Equivalent method for DataFrame.
+    .Series.%(name)s : Calling object with Series data.
+    .DataFrame.%(name)s : Calling object with DataFrames.
+    .Series.median : Equivalent method for Series.
+    .DataFrame.median : Equivalent method for DataFrame.
 
     Examples
     --------
@@ -1508,10 +1510,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    Series.%(name)s : Calling object with Series data.
-    DataFrame.%(name)s : Calling object with DataFrames.
-    Series.kurt : Equivalent method for Series.
-    DataFrame.kurt : Equivalent method for DataFrame.
+    .Series.%(name)s : Calling object with Series data.
+    .DataFrame.%(name)s : Calling object with DataFrames.
+    .Series.kurt : Equivalent method for Series.
+    .DataFrame.kurt : Equivalent method for DataFrame.
     scipy.stats.skew : Third moment of a probability density.
     scipy.stats.kurtosis : Reference SciPy method.
 
@@ -1564,9 +1566,9 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    Series.quantile : Computes value at the given quantile over all data
+    .Series.quantile : Computes value at the given quantile over all data
         in Series.
-    DataFrame.quantile : Computes values at the given quantile over
+    .DataFrame.quantile : Computes values at the given quantile over
         requested axis in DataFrame.
 
     Examples
@@ -1690,11 +1692,11 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    Series.%(name)s : Calling object with Series data.
-    DataFrame.%(name)s : Calling object with DataFrames.
-    Series.corr : Equivalent method for Series.
-    DataFrame.corr : Equivalent method for DataFrame.
-    %(name)s.cov : Similar method to calculate covariance.
+    .Series.%(name)s : Calling object with Series data.
+    .DataFrame.%(name)s : Calling object with DataFrames.
+    .Series.corr : Equivalent method for Series.
+    .DataFrame.corr : Equivalent method for DataFrame.
+    cov : Similar method to calculate covariance.
     numpy.corrcoef : NumPy Pearson's correlation calculation.
 
     Notes
@@ -1895,8 +1897,8 @@ class Rolling(_Rolling_and_Expanding):
         """
     See Also
     --------
-    Series.rolling
-    DataFrame.rolling
+    .Series.rolling : Calling object with Series data.
+    .DataFrame.rolling : Calling object with DataFrame data.
     """
     )
 
@@ -1997,7 +1999,7 @@ class Rolling(_Rolling_and_Expanding):
         nv.validate_rolling_func("sum", args, kwargs)
         return super().sum(*args, **kwargs)
 
-    @Substitution(name="rolling")
+    @Substitution(name="rolling", func_name="max")
     @Appender(_doc_template)
     @Appender(_shared_docs["max"])
     def max(self, *args, **kwargs):
@@ -2033,7 +2035,7 @@ class Rolling(_Rolling_and_Expanding):
         nv.validate_rolling_func("var", args, kwargs)
         return super().var(ddof=ddof, **kwargs)
 
-    @Substitution(name="rolling")
+    @Substitution(name="rolling", func_name="skew")
     @Appender(_doc_template)
     @Appender(_shared_docs["skew"])
     def skew(self, **kwargs):
@@ -2077,7 +2079,7 @@ class Rolling(_Rolling_and_Expanding):
             quantile=quantile, interpolation=interpolation, **kwargs
         )
 
-    @Substitution(name="rolling")
+    @Substitution(name="rolling", func_name="cov")
     @Appender(_doc_template)
     @Appender(_shared_docs["cov"])
     def cov(self, other=None, pairwise=None, ddof=1, **kwargs):

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -540,8 +540,8 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
 
     See Also
     --------
-    .Series.sum : Reducing sum for Series.
-    .DataFrame.sum : Reducing sum for DataFrame.
+    pandas.Series.sum : Reducing sum for Series.
+    pandas.DataFrame.sum : Reducing sum for DataFrame.
 
     Examples
     --------
@@ -618,10 +618,10 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with Series data.
-    .DataFrame.%(name)s : Calling object with DataFrames.
-    .Series.mean : Equivalent method for Series.
-    .DataFrame.mean : Equivalent method for DataFrame.
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrames.
+    pandas.Series.mean : Equivalent method for Series.
+    pandas.DataFrame.mean : Equivalent method for DataFrame.
 
     Examples
     --------
@@ -667,10 +667,10 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with Series data.
-    .DataFrame.%(name)s : Calling object with DataFrames.
-    .Series.var : Equivalent method for Series.
-    .DataFrame.var : Equivalent method for DataFrame.
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrames.
+    pandas.Series.var : Equivalent method for Series.
+    pandas.DataFrame.var : Equivalent method for DataFrame.
     numpy.var : Equivalent method for Numpy array.
 
     Notes
@@ -727,10 +727,10 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with Series data.
-    .DataFrame.%(name)s : Calling object with DataFrames.
-    .Series.std : Equivalent method for Series.
-    .DataFrame.std : Equivalent method for DataFrame.
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrames.
+    pandas.Series.std : Equivalent method for Series.
+    pandas.DataFrame.std : Equivalent method for DataFrame.
     numpy.std : Equivalent method for Numpy array.
 
     Notes
@@ -1030,8 +1030,8 @@ class Window(_Window):
         """
     See Also
     --------
-    .DataFrame.aggregate : Similar DataFrame method.
-    .Series.aggregate : Similar Series method.
+    pandas.DataFrame.aggregate : Similar DataFrame method.
+    pandas.Series.aggregate : Similar Series method.
     """
     )
 
@@ -1146,9 +1146,9 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with Series data.
-    .DataFrame.%(name)s : Calling object with DataFrames.
-    .DataFrame.count : Count of the full DataFrame.
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrames.
+    pandas.DataFrame.count : Count of the full DataFrame.
 
     Examples
     --------
@@ -1243,10 +1243,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with Series data.
-    .DataFrame.%(name)s : Calling object with DataFrame data.
-    .Series.apply : Similar method for Series.
-    .DataFrame.apply : Similar method for DataFrame.
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrame data.
+    pandas.Series.apply : Similar method for Series.
+    pandas.DataFrame.apply : Similar method for DataFrame.
 
     Notes
     -----
@@ -1365,10 +1365,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with a Series.
-    .DataFrame.%(name)s : Calling object with a DataFrame.
-    .Series.min : Similar method for Series.
-    .DataFrame.min : Similar method for DataFrame.
+    pandas.Series.%(name)s : Calling object with a Series.
+    pandas.DataFrame.%(name)s : Calling object with a DataFrame.
+    pandas.Series.min : Similar method for Series.
+    pandas.DataFrame.min : Similar method for DataFrame.
 
     Examples
     --------
@@ -1412,10 +1412,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with Series data.
-    .DataFrame.%(name)s : Calling object with DataFrames.
-    .Series.median : Equivalent method for Series.
-    .DataFrame.median : Equivalent method for DataFrame.
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrames.
+    pandas.Series.median : Equivalent method for Series.
+    pandas.DataFrame.median : Equivalent method for DataFrame.
 
     Examples
     --------
@@ -1510,10 +1510,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with Series data.
-    .DataFrame.%(name)s : Calling object with DataFrames.
-    .Series.kurt : Equivalent method for Series.
-    .DataFrame.kurt : Equivalent method for DataFrame.
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrames.
+    pandas.Series.kurt : Equivalent method for Series.
+    pandas.DataFrame.kurt : Equivalent method for DataFrame.
     scipy.stats.skew : Third moment of a probability density.
     scipy.stats.kurtosis : Reference SciPy method.
 
@@ -1566,9 +1566,9 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    .Series.quantile : Computes value at the given quantile over all data
+    pandas.Series.quantile : Computes value at the given quantile over all data
         in Series.
-    .DataFrame.quantile : Computes values at the given quantile over
+    pandas.DataFrame.quantile : Computes values at the given quantile over
         requested axis in DataFrame.
 
     Examples
@@ -1692,10 +1692,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    .Series.%(name)s : Calling object with Series data.
-    .DataFrame.%(name)s : Calling object with DataFrames.
-    .Series.corr : Equivalent method for Series.
-    .DataFrame.corr : Equivalent method for DataFrame.
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrames.
+    pandas.Series.corr : Equivalent method for Series.
+    pandas.DataFrame.corr : Equivalent method for DataFrame.
     cov : Similar method to calculate covariance.
     numpy.corrcoef : NumPy Pearson's correlation calculation.
 
@@ -1897,8 +1897,8 @@ class Rolling(_Rolling_and_Expanding):
         """
     See Also
     --------
-    .Series.rolling : Calling object with Series data.
-    .DataFrame.rolling : Calling object with DataFrame data.
+    pandas.Series.rolling : Calling object with Series data.
+    pandas.DataFrame.rolling : Calling object with DataFrame data.
     """
     )
 


### PR DESCRIPTION
- xref #31661
- xref #28792

- Added '.' before dataframe/series reference to fix missing link problem. Don't know if it's the best approach.
- Changed base template that is used by some functions to return better See Also section. Hope it's ok.


- Also question about Window class. It doesn't has its counterpart from Series/DF modules, its doc containing examples from Rolling part and there're only 4 functions. Is it internal base class for all windows and maybe shoul be excluded from docs or is it used somewhere maybe for creating custom windows?