### PR TITLE
TST: make expected DTI/TDI results more specific

### DIFF
--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -25,7 +25,8 @@ class TestTimeSeries:
                 "1970-01-01 00:00:00.000000002",
                 "1970-01-01 00:00:00.000000003",
                 "1970-01-01 00:00:00.000000004",
-            ]
+            ],
+            freq="N",
         )
         tm.assert_index_equal(idx, exp)
 
@@ -34,7 +35,7 @@ class TestTimeSeries:
             end=Timestamp("1970-01-01 00:00:00.000000001"),
             freq="N",
         )
-        exp = DatetimeIndex([])
+        exp = DatetimeIndex([], freq="N")
         tm.assert_index_equal(idx, exp)
 
         idx = pd.date_range(
@@ -42,7 +43,7 @@ class TestTimeSeries:
             end=Timestamp("1970-01-01 00:00:00.000000001"),
             freq="N",
         )
-        exp = DatetimeIndex(["1970-01-01 00:00:00.000000001"])
+        exp = DatetimeIndex(["1970-01-01 00:00:00.000000001"], freq="N")
         tm.assert_index_equal(idx, exp)
 
         idx = pd.date_range(
@@ -56,7 +57,8 @@ class TestTimeSeries:
                 "1970-01-01 00:00:00.000002",
                 "1970-01-01 00:00:00.000003",
                 "1970-01-01 00:00:00.000004",
-            ]
+            ],
+            freq="U",
         )
         tm.assert_index_equal(idx, exp)
 
@@ -71,7 +73,8 @@ class TestTimeSeries:
                 "1970-01-01 00:00:00.002",
                 "1970-01-01 00:00:00.003",
                 "1970-01-01 00:00:00.004",
-            ]
+            ],
+            freq="L",
         )
         tm.assert_index_equal(idx, exp)
 
@@ -86,7 +89,8 @@ class TestTimeSeries:
                 "1970-01-01 00:00:02",
                 "1970-01-01 00:00:03",
                 "1970-01-01 00:00:04",
-            ]
+            ],
+            freq="S",
         )
         tm.assert_index_equal(idx, exp)
 
@@ -101,7 +105,8 @@ class TestTimeSeries:
                 "1970-01-01 00:02",
                 "1970-01-01 00:03",
                 "1970-01-01 00:04",
-            ]
+            ],
+            freq="T",
         )
         tm.assert_index_equal(idx, exp)
 
@@ -116,14 +121,17 @@ class TestTimeSeries:
                 "1970-01-01 02:00",
                 "1970-01-01 03:00",
                 "1970-01-01 04:00",
-            ]
+            ],
+            freq="H",
         )
         tm.assert_index_equal(idx, exp)
 
         idx = pd.date_range(
             start=Timestamp("1970-01-01"), end=Timestamp("1970-01-04"), freq="D"
         )
-        exp = DatetimeIndex(["1970-01-01", "1970-01-02", "1970-01-03", "1970-01-04"])
+        exp = DatetimeIndex(
+            ["1970-01-01", "1970-01-02", "1970-01-03", "1970-01-04"], freq="D"
+        )
         tm.assert_index_equal(idx, exp)
 
 

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -26,9 +26,11 @@ class TestSlicing:
         SLC = pd.IndexSlice
 
         def assert_slices_equivalent(l_slc, i_slc):
-            tm.assert_series_equal(ts[l_slc], ts.iloc[i_slc])
-            tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
-            tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
+            expected = ts.iloc[i_slc]
+
+            tm.assert_series_equal(ts[l_slc], expected)
+            tm.assert_series_equal(ts.loc[l_slc], expected)
+            tm.assert_series_equal(ts.loc[l_slc], expected)
 
         assert_slices_equivalent(SLC[Timestamp("2014-10-01") :: -1], SLC[9::-1])
         assert_slices_equivalent(SLC["2014-10-01"::-1], SLC[9::-1])
@@ -47,7 +49,7 @@ class TestSlicing:
             SLC[Timestamp("2015-02-01") : "2014-10-01" : -1], SLC[13:8:-1]
         )
 
-        assert_slices_equivalent(SLC["2014-10-01":"2015-02-01":-1], SLC[:0])
+        assert_slices_equivalent(SLC["2014-10-01":"2015-02-01":-1], SLC[0:0:-1])
 
     def test_slice_with_zero_step_raises(self):
         ts = Series(np.arange(20), date_range("2014-01-01", periods=20, freq="MS"))
@@ -79,7 +81,9 @@ class TestSlicing:
         df = pd.DataFrame(
             {"A": [1, 2, 3]}, index=pd.date_range("20170101", periods=3)[::-1]
         )
-        expected = pd.DataFrame({"A": 1}, index=pd.date_range("20170103", periods=1))
+        expected = pd.DataFrame(
+            {"A": 1}, index=pd.date_range("20170103", periods=1)[::-1]
+        )
         tm.assert_frame_equal(df.loc["2017-01-03"], expected)
 
     def test_slice_year(self):

--- a/pandas/tests/indexes/datetimes/test_shift.py
+++ b/pandas/tests/indexes/datetimes/test_shift.py
@@ -28,18 +28,21 @@ class TestDatetimeIndexShift:
             ["2011-01-01 10:00", "2011-01-01 11:00", "2011-01-01 12:00"],
             name="xxx",
             tz=tz,
+            freq="H",
         )
         tm.assert_index_equal(idx.shift(0, freq="H"), idx)
         exp = pd.DatetimeIndex(
             ["2011-01-01 13:00", "2011-01-01 14:00", "2011-01-01 15:00"],
             name="xxx",
             tz=tz,
+            freq="H",
         )
         tm.assert_index_equal(idx.shift(3, freq="H"), exp)
         exp = pd.DatetimeIndex(
             ["2011-01-01 07:00", "2011-01-01 08:00", "2011-01-01 09:00"],
             name="xxx",
             tz=tz,
+            freq="H",
         )
         tm.assert_index_equal(idx.shift(-3, freq="H"), exp)
 

--- a/pandas/tests/indexes/period/test_to_timestamp.py
+++ b/pandas/tests/indexes/period/test_to_timestamp.py
@@ -60,7 +60,7 @@ class TestToTimestamp:
         pindex = PeriodIndex(year=years, quarter=quarters)
 
         stamps = pindex.to_timestamp("D", "end")
-        expected = DatetimeIndex([x.to_timestamp("D", "end") for x in pindex])
+        expected = DatetimeIndex([x.to_timestamp("D", "end") for x in pindex], freq="Q")
         tm.assert_index_equal(stamps, expected)
 
     def test_to_timestamp_pi_mult(self):

--- a/pandas/tests/indexes/timedeltas/test_partial_slicing.py
+++ b/pandas/tests/indexes/timedeltas/test_partial_slicing.py
@@ -52,9 +52,11 @@ class TestSlicing:
         SLC = pd.IndexSlice
 
         def assert_slices_equivalent(l_slc, i_slc):
-            tm.assert_series_equal(ts[l_slc], ts.iloc[i_slc])
-            tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
-            tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
+            expected = ts.iloc[i_slc]
+
+            tm.assert_series_equal(ts[l_slc], expected)
+            tm.assert_series_equal(ts.loc[l_slc], expected)
+            tm.assert_series_equal(ts.loc[l_slc], expected)
 
         assert_slices_equivalent(SLC[Timedelta(hours=7) :: -1], SLC[7::-1])
         assert_slices_equivalent(SLC["7 hours"::-1], SLC[7::-1])
@@ -73,7 +75,7 @@ class TestSlicing:
             SLC[Timedelta(hours=15) : "7 hours" : -1], SLC[15:6:-1]
         )
 
-        assert_slices_equivalent(SLC["7 hours":"15 hours":-1], SLC[:0])
+        assert_slices_equivalent(SLC["7 hours":"15 hours":-1], SLC[0:0:-1])
 
     def test_slice_with_zero_step_raises(self):
         ts = Series(np.arange(20), timedelta_range("0", periods=20, freq="H"))

--- a/pandas/tests/series/methods/test_append.py
+++ b/pandas/tests/series/methods/test_append.py
@@ -175,7 +175,7 @@ class TestSeriesAppendWithDatetimeIndex:
         ts_result = ser1.append(ser2)
 
         exp_index = DatetimeIndex(
-            ["2011-01-01 01:00", "2011-01-01 02:00"], tz="US/Eastern"
+            ["2011-01-01 01:00", "2011-01-01 02:00"], tz="US/Eastern", freq="H"
         )
         exp = Series([1, 2], index=exp_index)
         tm.assert_series_equal(ts_result, exp)
@@ -187,7 +187,9 @@ class TestSeriesAppendWithDatetimeIndex:
         ser2 = Series([2], index=rng2)
         ts_result = ser1.append(ser2)
 
-        exp_index = DatetimeIndex(["2011-01-01 01:00", "2011-01-01 02:00"], tz="UTC")
+        exp_index = DatetimeIndex(
+            ["2011-01-01 01:00", "2011-01-01 02:00"], tz="UTC", freq="H"
+        )
         exp = Series([1, 2], index=exp_index)
         tm.assert_series_equal(ts_result, exp)
         utc = rng1.tz

--- a/pandas/tests/series/methods/test_asfreq.py
+++ b/pandas/tests/series/methods/test_asfreq.py
@@ -39,11 +39,14 @@ class TestAsFreq:
     def test_asfreq(self):
         ts = Series(
             [0.0, 1.0, 2.0],
-            index=[
-                datetime(2009, 10, 30),
-                datetime(2009, 11, 30),
-                datetime(2009, 12, 31),
-            ],
+            index=DatetimeIndex(
+                [
+                    datetime(2009, 10, 30),
+                    datetime(2009, 11, 30),
+                    datetime(2009, 12, 31),
+                ],
+                freq="BM",
+            ),
         )
 
         daily_ts = ts.asfreq("B")

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -3501,7 +3501,7 @@ class TestSemiMonthEnd(Base):
 
         # ensure generating a range with DatetimeIndex gives same result
         result = date_range(start=dates[0], end=dates[-1], freq="SM")
-        exp = DatetimeIndex(dates)
+        exp = DatetimeIndex(dates, freq="SM")
         tm.assert_index_equal(result, exp)
 
     offset_cases = []
@@ -3760,7 +3760,7 @@ class TestSemiMonthBegin(Base):
 
         # ensure generating a range with DatetimeIndex gives same result
         result = date_range(start=dates[0], end=dates[-1], freq="SMS")
-        exp = DatetimeIndex(dates)
+        exp = DatetimeIndex(dates, freq="SMS")
         tm.assert_index_equal(result, exp)
 
     offset_cases = []

--- a/pandas/tests/window/moments/test_moments_rolling.py
+++ b/pandas/tests/window/moments/test_moments_rolling.py
@@ -9,7 +9,7 @@ import pytest
 import pandas.util._test_decorators as td
 
 import pandas as pd
-from pandas import DataFrame, Index, Series, isna, notna
+from pandas import DataFrame, DatetimeIndex, Index, Series, isna, notna
 import pandas._testing as tm
 from pandas.core.window.common import _flex_binary_moment
 from pandas.tests.window.common import Base, ConsistencyBase
@@ -1346,7 +1346,9 @@ class TestRollingMomentsConsistency(ConsistencyBase):
 
         expected = Series(
             [1.0, 2.0, 6.0, 4.0, 5.0],
-            index=[datetime(1975, 1, i, 0) for i in range(1, 6)],
+            index=DatetimeIndex(
+                [datetime(1975, 1, i, 0) for i in range(1, 6)], freq="D"
+            ),
         )
         x = series.resample("D").max().rolling(window=1).max()
         tm.assert_series_equal(expected, x)
@@ -1366,7 +1368,9 @@ class TestRollingMomentsConsistency(ConsistencyBase):
         # Default how should be max
         expected = Series(
             [0.0, 1.0, 2.0, 3.0, 20.0],
-            index=[datetime(1975, 1, i, 0) for i in range(1, 6)],
+            index=DatetimeIndex(
+                [datetime(1975, 1, i, 0) for i in range(1, 6)], freq="D"
+            ),
         )
         x = series.resample("D").max().rolling(window=1).max()
         tm.assert_series_equal(expected, x)
@@ -1374,7 +1378,9 @@ class TestRollingMomentsConsistency(ConsistencyBase):
         # Now specify median (10.0)
         expected = Series(
             [0.0, 1.0, 2.0, 3.0, 10.0],
-            index=[datetime(1975, 1, i, 0) for i in range(1, 6)],
+            index=DatetimeIndex(
+                [datetime(1975, 1, i, 0) for i in range(1, 6)], freq="D"
+            ),
         )
         x = series.resample("D").median().rolling(window=1).max()
         tm.assert_series_equal(expected, x)
@@ -1383,7 +1389,9 @@ class TestRollingMomentsConsistency(ConsistencyBase):
         v = (4.0 + 10.0 + 20.0) / 3.0
         expected = Series(
             [0.0, 1.0, 2.0, 3.0, v],
-            index=[datetime(1975, 1, i, 0) for i in range(1, 6)],
+            index=DatetimeIndex(
+                [datetime(1975, 1, i, 0) for i in range(1, 6)], freq="D"
+            ),
         )
         x = series.resample("D").mean().rolling(window=1).max()
         tm.assert_series_equal(expected, x)
@@ -1403,7 +1411,9 @@ class TestRollingMomentsConsistency(ConsistencyBase):
         # Default how should be min
         expected = Series(
             [0.0, 1.0, 2.0, 3.0, 4.0],
-            index=[datetime(1975, 1, i, 0) for i in range(1, 6)],
+            index=DatetimeIndex(
+                [datetime(1975, 1, i, 0) for i in range(1, 6)], freq="D"
+            ),
         )
         r = series.resample("D").min().rolling(window=1)
         tm.assert_series_equal(expected, r.min())
@@ -1423,7 +1433,9 @@ class TestRollingMomentsConsistency(ConsistencyBase):
         # Default how should be median
         expected = Series(
             [0.0, 1.0, 2.0, 3.0, 10],
-            index=[datetime(1975, 1, i, 0) for i in range(1, 6)],
+            index=DatetimeIndex(
+                [datetime(1975, 1, i, 0) for i in range(1, 6)], freq="D"
+            ),
         )
         x = series.resample("D").median().rolling(window=1).median()
         tm.assert_series_equal(expected, x)


### PR DESCRIPTION
assert_index_equal doesnt check for matching freq.  I've got a branch that changes that, but the diff is massive, so i am first going through the tests and updating the `expected`s so that they will pass once that check is in place.

Also in this sequence: xref #33604