### PR TITLE
BUG: set_levels set wrong order levels for MutiIndex

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -762,6 +762,8 @@ class MultiIndex(Index):
             If True, mutates in place.
         verify_integrity : bool, default True
             If True, checks that levels and codes are compatible.
+        change_codes : bool, default False
+            If True, resets the codes for the levels specified.
 
         Returns
         -------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -762,8 +762,6 @@ class MultiIndex(Index):
             If True, mutates in place.
         verify_integrity : bool, default True
             If True, checks that levels and codes are compatible.
-        change_codes : bool, default False
-            If True, resets the codes for the levels specified.
 
         Returns
         -------

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -341,7 +341,7 @@ def test_set_levels_with_changed_multiindex():
     ]
     ran_array = np.random.rand(8, 4)
     test_df = pd.DataFrame(ran_array, index=arrays)
-    test_df.index.set_levels([3, 4], level=2, inplace=True)
+    test_df.index.set_levels([3, 4], level=2, inplace=True, change_codes=True)
     correct_df = pd.DataFrame(ran_array, index=arrays)
     correct_df.index = pd.MultiIndex.from_arrays(
         [

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -329,3 +329,25 @@ def test_set_levels_with_iterable():
         [expected_sizes, colors], names=["size", "color"]
     )
     tm.assert_index_equal(result, expected)
+
+
+def test_set_levels_with_changed_multiindex():
+    # GH33420
+    np.random.seed(seed=0)
+    arrays = [
+        ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
+        ["one", "one", "one", "one", "one", "one", "one", "one"],
+        ["three", "four", "three", "four", "three", "four", "three", "four"],
+    ]
+    ran_array = np.random.rand(8, 4)
+    test_df = pd.DataFrame(ran_array, index=arrays)
+    test_df.index.set_levels([3, 4], level=2, inplace=True)
+    correct_df = pd.DataFrame(ran_array, index=arrays)
+    correct_df.index = pd.MultiIndex.from_arrays(
+        [
+            test_df.index.get_level_values(0),
+            test_df.index.get_level_values(1),
+            np.tile([3, 4], 4),
+        ]
+    )
+    tm.assert_equal(test_df, correct_df)

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -649,25 +649,3 @@ def test_failure_to_convert_uint64_string_to_NaN():
     ser = Series([32, 64, np.nan])
     result = to_numeric(pd.Series(["32", "64", "uint64"]), errors="coerce")
     tm.assert_series_equal(result, ser)
-
-
-def test_set_levels_with_changed_multiindex():
-    # GH33420
-    np.random.seed(seed=0)
-    arrays = [
-        ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
-        ["one", "one", "one", "one", "one", "one", "one", "one"],
-        ["three", "four", "three", "four", "three", "four", "three", "four"],
-    ]
-    ran_array = np.random.rand(8, 4)
-    test_df = pd.DataFrame(ran_array, index=arrays)
-    test_df.index.set_levels([3, 4], level=2, inplace=True)
-    correct_df = pd.DataFrame(ran_array, index=arrays)
-    correct_df.index = pd.MultiIndex.from_arrays(
-        [
-            test_df.index.get_level_values(0),
-            test_df.index.get_level_values(1),
-            np.tile([3, 4], 4),
-        ]
-    )
-    tm.assert_equal(test_df, correct_df)

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -649,3 +649,25 @@ def test_failure_to_convert_uint64_string_to_NaN():
     ser = Series([32, 64, np.nan])
     result = to_numeric(pd.Series(["32", "64", "uint64"]), errors="coerce")
     tm.assert_series_equal(result, ser)
+
+
+def test_set_levels_with_changed_multiindex():
+    # GH33420
+    np.random.seed(seed=0)
+    arrays = [
+        ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
+        ["one", "one", "one", "one", "one", "one", "one", "one"],
+        ["three", "four", "three", "four", "three", "four", "three", "four"],
+    ]
+    ran_array = np.random.rand(8, 4)
+    test_df = pd.DataFrame(ran_array, index=arrays)
+    test_df.index.set_levels([3, 4], level=2, inplace=True)
+    correct_df = pd.DataFrame(ran_array, index=arrays)
+    correct_df.index = pd.MultiIndex.from_arrays(
+        [
+            test_df.index.get_level_values(0),
+            test_df.index.get_level_values(1),
+            np.tile([3, 4], 4),
+        ]
+    )
+    tm.assert_equal(test_df, correct_df)


### PR DESCRIPTION
- [ ] closes #33420
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Added parameter that allows user to reset codes