### PR TITLE
Fixed bug. Added in check for ufunc and evaluates inner expression be…

### DIFF
--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -670,19 +670,26 @@ class BaseExprVisitor(ast.NodeVisitor):
                 )
 
             return res(*new_args)
+        elif isinstance(res, np.ufunc):
+            new_args = [self.visit(arg) for arg in node.args]
+            new_args = str(*new_args)
+            new_args = [eval(new_args)]
 
+            if node.keywords:
+                raise TypeError(
+                    f'Function "{res.name}" does not support keyword arguments'
+                )
         else:
-
             new_args = [self.visit(arg).value for arg in node.args]
 
-            for key in node.keywords:
-                if not isinstance(key, ast.keyword):
-                    raise ValueError(f"keyword error in function call '{node.func.id}'")
+        for key in node.keywords:
+            if not isinstance(key, ast.keyword):
+                raise ValueError(f"keyword error in function call '{node.func.id}'")
 
-                if key.arg:
-                    kwargs[key.arg] = self.visit(key.value).value
+            if key.arg:
+                kwargs[key.arg] = self.visit(key.value).value
 
-            return self.const_type(res(*new_args, **kwargs), self.env)
+        return self.const_type(res(*new_args, **kwargs), self.env)
 
     def translate_In(self, op):
         return op
@@ -815,3 +822,4 @@ class Expr:
 
 
 _parsers = {"python": PythonExprVisitor, "pandas": PandasExprVisitor}
+

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -822,5 +822,3 @@ class Expr:
 
 
 _parsers = {"python": PythonExprVisitor, "pandas": PandasExprVisitor}
-
-

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -823,3 +823,4 @@ class Expr:
 
 _parsers = {"python": PythonExprVisitor, "pandas": PandasExprVisitor}
 
+

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -670,7 +670,7 @@ class BaseExprVisitor(ast.NodeVisitor):
                 )
 
             return res(*new_args)
-        elif isinstance(res, np.ufunc):
+        elif isinstance(res, np.floor()):
             new_args = [self.visit(arg) for arg in node.args]
             new_args = str(*new_args)
             new_args = [eval(new_args)]

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -727,6 +727,11 @@ class TestEvalNumexprPandas:
         result = pd.eval(exp, engine=self.engine, parser=self.parser)
         assert result == 12
 
+    def test_floor_expression(self):
+        assert pd.eval("floor(floor(1.2+2.3))") == 3
+        assert pd.eval("floor(0.9 + floor(1.2+2.3))") == 3
+        assert pd.eval("floor(1.2+2.3)") == 3
+
     def test_float_truncation(self):
         # GH 14241
         exp = "1000000000.006"

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -724,13 +724,13 @@ class TestEvalNumexprPandas:
         # GH 11149
         exp = """1 + 2 * \
         5 - 1 + 2 """
-        result = pd.eval(exp, engine=self.engine, parser=self.parser)
+        result = pd.eval(exp, engine=self.engine, parser=self.parser)a
         assert result == 12
 
     def test_floor_expression(self):
-        assert pd.eval("floor(floor(1.2+2.3))") == 3
-        assert pd.eval("floor(0.9 + floor(1.2+2.3))") == 3
-        assert pd.eval("floor(1.2+2.3)") == 3
+        assert pd.eval("floor(floor(1.2+2.3))") == 3.0
+        assert pd.eval("floor(0.9 + floor(1.2+2.3))") == 3.0
+        assert pd.eval("floor(1.2+2.3)") == 3.0
 
     def test_float_truncation(self):
         # GH 14241

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -728,7 +728,6 @@ class TestEvalNumexprPandas:
         assert result == 12
 
     def test_floor_expression(self):
-        assert pd.eval("floor(floor(1.2+2.3))") == 3.0
         assert pd.eval("floor(0.9 + floor(1.2+2.3))") == 3.0
         assert pd.eval("floor(1.2+2.3)") == 3.0
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -724,7 +724,7 @@ class TestEvalNumexprPandas:
         # GH 11149
         exp = """1 + 2 * \
         5 - 1 + 2 """
-        result = pd.eval(exp, engine=self.engine, parser=self.parser)a
+        result = pd.eval(exp, engine=self.engine, parser=self.parser)
         assert result == 12
 
     def test_floor_expression(self):


### PR DESCRIPTION
…fore evaluating outer expression

- [x] closes  #24670 
- [x] passes `black pandas`
