### PR TITLE
REF: Make numba function cache globally accessible

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -76,7 +76,7 @@ import pandas.core.indexes.base as ibase
 from pandas.core.internals import BlockManager, make_block
 from pandas.core.series import Series
 from pandas.core.util.numba_ import (
-    _numba_func_cache,
+    NUMBA_FUNC_CACHE,
     check_kwargs_and_nopython,
     get_jit_arguments,
     jit_user_function,
@@ -504,7 +504,7 @@ class SeriesGroupBy(GroupBy[Series]):
             check_kwargs_and_nopython(kwargs, nopython)
             validate_udf(func)
             cache_key = (func, "groupby_transform")
-            numba_func = _numba_func_cache.get(
+            numba_func = NUMBA_FUNC_CACHE.get(
                 cache_key, jit_user_function(func, nopython, nogil, parallel)
             )
 
@@ -516,8 +516,8 @@ class SeriesGroupBy(GroupBy[Series]):
             if engine == "numba":
                 values, index = split_for_numba(group)
                 res = numba_func(values, index, *args)
-                if cache_key not in _numba_func_cache:
-                    _numba_func_cache[cache_key] = numba_func
+                if cache_key not in NUMBA_FUNC_CACHE:
+                    NUMBA_FUNC_CACHE[cache_key] = numba_func
             else:
                 res = func(group, *args, **kwargs)
 
@@ -1396,7 +1396,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             check_kwargs_and_nopython(kwargs, nopython)
             validate_udf(func)
             cache_key = (func, "groupby_transform")
-            numba_func = _numba_func_cache.get(
+            numba_func = NUMBA_FUNC_CACHE.get(
                 cache_key, jit_user_function(func, nopython, nogil, parallel)
             )
         else:
@@ -1408,8 +1408,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             if engine == "numba":
                 values, index = split_for_numba(group)
                 res = numba_func(values, index, *args)
-                if cache_key not in _numba_func_cache:
-                    _numba_func_cache[cache_key] = numba_func
+                if cache_key not in NUMBA_FUNC_CACHE:
+                    NUMBA_FUNC_CACHE[cache_key] = numba_func
                 # Return the result as a DataFrame for concatenation later
                 res = DataFrame(res, index=group.index, columns=group.columns)
             else:

--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -8,7 +8,7 @@ import numpy as np
 from pandas._typing import FrameOrSeries
 from pandas.compat._optional import import_optional_dependency
 
-_numba_func_cache: Dict[Tuple[Callable, str], Callable] = dict()
+NUMBA_FUNC_CACHE: Dict[Tuple[Callable, str], Callable] = dict()
 
 
 def check_kwargs_and_nopython(

--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -8,6 +8,8 @@ import numpy as np
 from pandas._typing import FrameOrSeries
 from pandas.compat._optional import import_optional_dependency
 
+_numba_func_cache: Dict[Tuple[Callable, str], Callable] = dict()
+
 
 def check_kwargs_and_nopython(
     kwargs: Optional[Dict] = None, nopython: Optional[bool] = None

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -78,6 +78,7 @@ class WindowGroupByMixin(GroupByMixin):
         performing the original function call on the grouped object.
         """
         kwargs.pop("floor", None)
+        kwargs.pop("original_func", None)
 
         # TODO: can we de-duplicate with _dispatch?
         def f(x, name=name, *args):

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -38,7 +38,7 @@ from pandas.core.dtypes.generic import (
 from pandas.core.base import DataError, PandasObject, SelectionMixin, ShallowMixin
 import pandas.core.common as com
 from pandas.core.indexes.api import Index, ensure_index
-from pandas.core.util.numba_ import _numba_func_cache
+from pandas.core.util.numba_ import NUMBA_FUNC_CACHE
 from pandas.core.window.common import (
     WindowGroupByMixin,
     _doc_template,
@@ -505,7 +505,7 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
                     result = np.asarray(result)
 
             if use_numba_cache:
-                _numba_func_cache[(name, "rolling_apply")] = func
+                NUMBA_FUNC_CACHE[(name, "rolling_apply")] = func
 
             if center:
                 result = self._center_window(result, window)
@@ -1279,9 +1279,9 @@ class _Rolling_and_Expanding(_Rolling):
             if raw is False:
                 raise ValueError("raw must be `True` when using the numba engine")
             cache_key = (func, "rolling_apply")
-            if cache_key in _numba_func_cache:
+            if cache_key in NUMBA_FUNC_CACHE:
                 # Return an already compiled version of roll_apply if available
-                apply_func = _numba_func_cache[cache_key]
+                apply_func = NUMBA_FUNC_CACHE[cache_key]
             else:
                 apply_func = generate_numba_apply_func(
                     args, kwargs, func, engine_kwargs

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -38,6 +38,7 @@ from pandas.core.dtypes.generic import (
 from pandas.core.base import DataError, PandasObject, SelectionMixin, ShallowMixin
 import pandas.core.common as com
 from pandas.core.indexes.api import Index, ensure_index
+from pandas.core.util.numba_ import _numba_func_cache
 from pandas.core.window.common import (
     WindowGroupByMixin,
     _doc_template,
@@ -93,7 +94,6 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
         self.win_freq = None
         self.axis = obj._get_axis_number(axis) if axis is not None else None
         self.validate()
-        self._numba_func_cache: Dict[Optional[str], Callable] = dict()
 
     @property
     def _constructor(self):
@@ -505,7 +505,7 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
                     result = np.asarray(result)
 
             if use_numba_cache:
-                self._numba_func_cache[name] = func
+                _numba_func_cache[(name, "rolling_apply")] = func
 
             if center:
                 result = self._center_window(result, window)
@@ -1278,9 +1278,10 @@ class _Rolling_and_Expanding(_Rolling):
         elif engine == "numba":
             if raw is False:
                 raise ValueError("raw must be `True` when using the numba engine")
-            if func in self._numba_func_cache:
+            cache_key = (func, "rolling_apply")
+            if cache_key in _numba_func_cache:
                 # Return an already compiled version of roll_apply if available
-                apply_func = self._numba_func_cache[func]
+                apply_func = _numba_func_cache[cache_key]
             else:
                 apply_func = generate_numba_apply_func(
                     args, kwargs, func, engine_kwargs

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -505,7 +505,7 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
                     result = np.asarray(result)
 
             if use_numba_cache:
-                NUMBA_FUNC_CACHE[(name, "rolling_apply")] = func
+                NUMBA_FUNC_CACHE[(kwargs["original_func"], "rolling_apply")] = func
 
             if center:
                 result = self._center_window(result, window)
@@ -1298,6 +1298,7 @@ class _Rolling_and_Expanding(_Rolling):
             name=func,
             use_numba_cache=engine == "numba",
             raw=raw,
+            original_func=func,
         )
 
     def _generate_cython_apply_func(self, args, kwargs, raw, offset, func):

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -4,7 +4,7 @@ import pandas.util._test_decorators as td
 
 from pandas import DataFrame
 import pandas._testing as tm
-from pandas.core.util.numba_ import _numba_func_cache
+from pandas.core.util.numba_ import NUMBA_FUNC_CACHE
 
 
 @td.skip_if_no("numba", "0.46.0")
@@ -99,13 +99,13 @@ def test_cache(jit, pandas_obj, nogil, parallel, nopython):
     expected = grouped.transform(lambda x: x + 1, engine="cython")
     tm.assert_equal(result, expected)
     # func_1 should be in the cache now
-    assert (func_1, "groupby_transform") in _numba_func_cache
+    assert (func_1, "groupby_transform") in NUMBA_FUNC_CACHE
 
     # Add func_2 to the cache
     result = grouped.transform(func_2, engine="numba", engine_kwargs=engine_kwargs)
     expected = grouped.transform(lambda x: x * 5, engine="cython")
     tm.assert_equal(result, expected)
-    assert (func_2, "groupby_transform") in _numba_func_cache
+    assert (func_2, "groupby_transform") in NUMBA_FUNC_CACHE
 
     # Retest func_1 which should use the cache
     result = grouped.transform(func_1, engine="numba", engine_kwargs=engine_kwargs)

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -4,6 +4,7 @@ import pandas.util._test_decorators as td
 
 from pandas import DataFrame
 import pandas._testing as tm
+from pandas.core.util.numba_ import _numba_func_cache
 
 
 @td.skip_if_no("numba", "0.46.0")
@@ -98,13 +99,13 @@ def test_cache(jit, pandas_obj, nogil, parallel, nopython):
     expected = grouped.transform(lambda x: x + 1, engine="cython")
     tm.assert_equal(result, expected)
     # func_1 should be in the cache now
-    assert func_1 in grouped._numba_func_cache
+    assert (func_1, "groupby_transform") in _numba_func_cache
 
     # Add func_2 to the cache
     result = grouped.transform(func_2, engine="numba", engine_kwargs=engine_kwargs)
     expected = grouped.transform(lambda x: x * 5, engine="cython")
     tm.assert_equal(result, expected)
-    assert func_2 in grouped._numba_func_cache
+    assert (func_2, "groupby_transform") in _numba_func_cache
 
     # Retest func_1 which should use the cache
     result = grouped.transform(func_1, engine="numba", engine_kwargs=engine_kwargs)

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -5,6 +5,7 @@ import pandas.util._test_decorators as td
 
 from pandas import Series
 import pandas._testing as tm
+from pandas.core.util.numba_ import _numba_func_cache
 
 
 @td.skip_if_no("numba", "0.46.0")
@@ -59,7 +60,7 @@ class TestApply:
         tm.assert_series_equal(result, expected)
 
         # func_1 should be in the cache now
-        assert func_1 in roll._numba_func_cache
+        assert (func_1, "rolling_apply") in _numba_func_cache
 
         result = roll.apply(
             func_2, engine="numba", engine_kwargs=engine_kwargs, raw=True

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -5,7 +5,7 @@ import pandas.util._test_decorators as td
 
 from pandas import Series
 import pandas._testing as tm
-from pandas.core.util.numba_ import _numba_func_cache
+from pandas.core.util.numba_ import NUMBA_FUNC_CACHE
 
 
 @td.skip_if_no("numba", "0.46.0")
@@ -60,7 +60,7 @@ class TestApply:
         tm.assert_series_equal(result, expected)
 
         # func_1 should be in the cache now
-        assert (func_1, "rolling_apply") in _numba_func_cache
+        assert (func_1, "rolling_apply") in NUMBA_FUNC_CACHE
 
         result = roll.apply(
             func_2, engine="numba", engine_kwargs=engine_kwargs, raw=True


### PR DESCRIPTION
- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

For all the numba accessible operations, we use a cache to store compiled JIT'd functions for performance. 

This `_numba_func_cache` used to be an attribute of `Rolling` and `Groupby` objects before, but while working on https://github.com/pandas-dev/pandas/pull/33388, I cannot easily rely on having access to those objects.

This PR moves `_numba_func_cache` to  `pandas/core/util/numba_.py`. Since this cache is now globally shared, the key has changed from `_numba_func_cache[func] = compiled_func` to `_numba_func_cache[(func, op)] = compiled_func`
