### PR TITLE
BUG: support median function for custom BaseIndexer rolling windows

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -175,7 +175,7 @@ Other API changes
 - :meth:`Groupby.groups` now returns an abbreviated representation when called on large dataframes (:issue:`1135`)
 - ``loc`` lookups with an object-dtype :class:`Index` and an integer key will now raise ``KeyError`` instead of ``TypeError`` when key is missing (:issue:`31905`)
 - Using a :func:`pandas.api.indexers.BaseIndexer` with ``skew``, ``cov``, ``corr`` will now raise a ``NotImplementedError`` (:issue:`32865`)
-- Using a :func:`pandas.api.indexers.BaseIndexer` with ``count``, ``min``, ``max`` will now return correct results for any monotonic :func:`pandas.api.indexers.BaseIndexer` descendant (:issue:`32865`)
+- Using a :func:`pandas.api.indexers.BaseIndexer` with ``count``, ``min``, ``max``, ``median`` will now return correct results for any monotonic :func:`pandas.api.indexers.BaseIndexer` descendant (:issue:`32865`)
 - Added a :func:`pandas.api.indexers.FixedForwardWindowIndexer` class to support forward-looking windows during ``rolling`` operations.
 -
 

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -843,7 +843,8 @@ def roll_kurt_variable(ndarray[float64_t] values, ndarray[int64_t] start,
 
 
 def roll_median_c(ndarray[float64_t] values, ndarray[int64_t] start,
-                  ndarray[int64_t] end, int64_t minp, int64_t win):
+                  ndarray[int64_t] end, int64_t minp, int64_t win=0):
+    # GH 32865. win argument kept for compatibility
     cdef:
         float64_t val, res, prev
         bint err = False

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -858,7 +858,7 @@ def roll_median_c(ndarray[float64_t] values, ndarray[int64_t] start,
     # actual skiplist ops outweigh any window computation costs
     output = np.empty(N, dtype=float)
 
-    if win == 0 or (end - start).max() == 0:
+    if (end - start).max() == 0:
         output[:] = NaN
         return output
     win = (end - start).max()

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1429,22 +1429,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     def median(self, **kwargs):
         window_func = self._get_roll_func("roll_median_c")
-
-        # GH 32865. For correct median calculation we need window_size
-        # only to build a skiplist of appropriate number of levels
-        # so for custom BaseIndexer subclasses we pick max(end - start)
-        if isinstance(self.window, BaseIndexer):
-            values = getattr(self._selected_obj, "values", self._selected_obj)
-            start, end = self.window.get_window_bounds(
-                num_values=len(values),
-                min_periods=self.min_periods,
-                center=self.center,
-                closed=self.closed,
-            )
-            win = (end - start).max()
-        else:
-            win = self._get_window()
-
+        # GH 32865. For custom BaseIndexer implementations, _get_window returns
+        # 0 or min_periods, while it should return max window size
+        # We override it inside the median function implementation
+        win = self._get_window()
         window_func = partial(window_func, win=win)
         return self._apply(window_func, center=self.center, name="median", **kwargs)
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1429,11 +1429,8 @@ class _Rolling_and_Expanding(_Rolling):
 
     def median(self, **kwargs):
         window_func = self._get_roll_func("roll_median_c")
-        # GH 32865. For custom BaseIndexer implementations, _get_window returns
-        # 0 or min_periods, while it should return max window size
-        # We override it inside the median function implementation
-        win = self._get_window()
-        window_func = partial(window_func, win=win)
+        # GH 32865. Move max window size calculation to
+        # the median function implementation
         return self._apply(window_func, center=self.center, name="median", **kwargs)
 
     def std(self, ddof=1, *args, **kwargs):

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -141,6 +141,12 @@ def test_notimplemented_functions(func):
             ],
             {"ddof": 1},
         ),
+        (
+            "median",
+            np.median,
+            [1.0, 2.0, 3.0, 4.0, 6.0, 7.0, 7.0, 8.0, 8.5, np.nan],
+            {},
+        ),
     ],
 )
 def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs):
@@ -166,3 +172,8 @@ def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs)
     tm.assert_equal(result, expected)
     expected2 = constructor(rolling.apply(lambda x: np_func(x, **np_kwargs)))
     tm.assert_equal(result, expected2)
+    # Check that function works without min_periods supplied
+    rolling3 = constructor(values).rolling(window=indexer)
+    result3 = getattr(rolling3, func)()
+    expected3 = constructor(rolling3.apply(lambda x: np_func(x, **np_kwargs)))
+    tm.assert_equal(result3, expected3)

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -172,7 +172,7 @@ def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs)
     tm.assert_equal(result, expected)
     expected2 = constructor(rolling.apply(lambda x: np_func(x, **np_kwargs)))
     tm.assert_equal(result, expected2)
-    # Check that function works without min_periods supplied
+    # Check that the function works without min_periods supplied
     rolling3 = constructor(values).rolling(window=indexer)
     result3 = getattr(rolling3, func)()
     expected3 = constructor(rolling3.apply(lambda x: np_func(x, **np_kwargs)))

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -168,10 +168,16 @@ def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs)
 
     rolling = constructor(values).rolling(window=indexer, min_periods=2)
     result = getattr(rolling, func)()
+
+    # Check that the function output matches the explicitly provided array
     expected = constructor(expected)
     tm.assert_equal(result, expected)
+
+    # Check that the rolling function gives the same result
+    # as applying an alternative function to the rolling window object
     expected2 = constructor(rolling.apply(lambda x: np_func(x, **np_kwargs)))
     tm.assert_equal(result, expected2)
+
     # Check that the function works without min_periods supplied
     rolling3 = constructor(values).rolling(window=indexer)
     result3 = getattr(rolling3, func)()

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -173,8 +173,8 @@ def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs)
     expected = constructor(expected)
     tm.assert_equal(result, expected)
 
-    # Check that the rolling function gives the same result
-    # as applying an alternative function to the rolling window object
+    # Check that the rolling function output matches applying an alternative
+    # function to the rolling window object
     expected2 = constructor(rolling.apply(lambda x: np_func(x, **np_kwargs)))
     tm.assert_equal(result, expected2)
 

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -178,7 +178,8 @@ def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs)
     expected2 = constructor(rolling.apply(lambda x: np_func(x, **np_kwargs)))
     tm.assert_equal(result, expected2)
 
-    # Check that the function works without min_periods supplied
+    # Check that the function output matches applying an alternative function
+    # if min_periods isn't specified
     rolling3 = constructor(values).rolling(window=indexer)
     result3 = getattr(rolling3, func)()
     expected3 = constructor(rolling3.apply(lambda x: np_func(x, **np_kwargs)))


### PR DESCRIPTION
- [X] xref #32865 
- [X] 1 tests added / 1 passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

## Scope of PR
This PR makes sure that when we calculate the median in `roll_median_c`, we override the maximum window width with the correct value, and the function doesn't shortcut by returning all NaNs.

## Details
The `median` function eventually calls `roll_median_c` which accepts a `win` parameter (maximum window width) to correctly allocate memory and initialize the skiplist data structure which is the backbone of the rolling median algorithm. Currently, `win` is determined by the `_get_window` function which returns `min_periods or 0` for custom `BaseIndexer` subclasses: 
```python
    def _get_window(self, other=None, win_type: Optional[str] = None) -> int:
        """
        Return window length.

        Parameters
        ----------
        other :
            ignored, exists for compatibility
        win_type :
            ignored, exists for compatibility

        Returns
        -------
        window : int
        """
        if isinstance(self.window, BaseIndexer):
            return self.min_periods or 0
        return self.window
```
Thus, `roll_median_c` either shortcuts or initializes to incorrect depth:
```python
...
    if win == 0 or (end - start).max() == 0:
        output[:] = NaN
        return output
    win = (end - start).max()
    sl = skiplist_init(<int>win)
...
```

<s>I propose we determine max window length directly in the `median` function. This means that `start` and `end` arrays get calculated twice: here and in `_apply`. However, I belive this is better than injecting a median-specific crutch into `_apply` or messing with the shortcut in `roll_median_c` (we could attempt to override `win` if `(end - start).max() > 0`. This other option is explored below.</s>
After discussing with @mroeschke , we decided to implement the bugfix directly in `roll_median_c`. Details below.

Please say if you think another approach would be preferable.

## Background on the wider issue
We currently don't support several rolling window functions when building a rolling window object using a custom class descended from `pandas.api.indexers.Baseindexer`. The implementations were written with backward-looking windows in mind, and this led to these functions breaking.
Currently, using these functions returns a `NotImplemented` error thanks to #33057, but ideally we want to update the implementations, so that they will work without a performance hit. This is what I aim to do over a series of PRs.

## Perf notes
The function currently shortcuts because of the bug or initializes the main datastructure incorrectly. For this reason, benchmarks are meaningless.
Ran benchmarks vs. the shortcut anyway:
```
 asv continuous -f 1.1 master HEAD -b ^rolling.ForwardWindowMethods
...
       before           after         ratio
     [b630cdbc]       [ce82372f]
     <master>         <rolling-median>
+      3.55▒0.2ms       75.2▒0.9ms    21.19  rolling.ForwardWindowMethods.time_rolling('DataFrame', 1000, 'float', 'median')
+     4.25▒0.08ms         76.7▒2ms    18.06  rolling.ForwardWindowMethods.time_rolling('Series', 1000, 'float', 'median')
+      4.02▒0.4ms       60.3▒0.5ms    14.99  rolling.ForwardWindowMethods.time_rolling('DataFrame', 1000, 'int', 'median')
+      3.42▒0.2ms         47.4▒1ms    13.86  rolling.ForwardWindowMethods.time_rolling('DataFrame', 10, 'float', 'median')
+      4.80▒0.1ms       61.2▒0.5ms    12.74  rolling.ForwardWindowMethods.time_rolling('Series', 1000, 'int', 'median')
+     4.58▒0.06ms       49.7▒0.9ms    10.85  rolling.ForwardWindowMethods.time_rolling('Series', 10, 'float', 'median')
+      4.45▒0.5ms       45.0▒0.8ms    10.10  rolling.ForwardWindowMethods.time_rolling('DataFrame', 10, 'int', 'median')
+     5.02▒0.07ms       45.9▒0.6ms     9.14  rolling.ForwardWindowMethods.time_rolling('Series', 10, 'int', 'median')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.
```
