### PR TITLE
TST: Groupby first/last/nth nan column test

### DIFF
--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -142,8 +142,7 @@ def test_first_last_nth_dtypes(df_mixed_floats):
 
 def test_first_last_nth_nan_dtype():
     # GH 33591
-    df = pd.DataFrame({"data": ["A"]})
-    df["nans"] = df["data"].where(df["data"] != "A")
+    df = pd.DataFrame({"data": ["A"], "nans": pd.Series([np.nan], dtype=object)})
 
     grouped = df.groupby("data")
 

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -140,6 +140,18 @@ def test_first_last_nth_dtypes(df_mixed_floats):
     assert f.dtype == "int64"
 
 
+def test_first_last_nth_nan_dtype():
+    # GH 33591
+    df = pd.DataFrame({"data": ["A"]})
+    df["nans"] = df["data"].where(df["data"] != "A")
+
+    grouped = df.groupby("data")
+
+    assert grouped["nans"].first().dtype == object
+    assert grouped["nans"].last().dtype == object
+    assert grouped["nans"].nth(0).dtype == object
+
+
 def test_first_strings_timestamps():
     # GH 11244
     test = pd.DataFrame(

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -145,10 +145,10 @@ def test_first_last_nth_nan_dtype():
     df = pd.DataFrame({"data": ["A"], "nans": pd.Series([np.nan], dtype=object)})
 
     grouped = df.groupby("data")
-
-    assert grouped["nans"].first().dtype == object
-    assert grouped["nans"].last().dtype == object
-    assert grouped["nans"].nth(0).dtype == object
+    expected = df.set_index("data").nans
+    tm.assert_series_equal(grouped.nans.first(), expected)
+    tm.assert_series_equal(grouped.nans.last(), expected)
+    tm.assert_series_equal(grouped.nans.nth(0), expected)
 
 
 def test_first_strings_timestamps():

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -148,6 +148,7 @@ def test_first_last_nth_nan_dtype():
     expected = df.set_index("data").nans
     tm.assert_series_equal(grouped.nans.first(), expected)
     tm.assert_series_equal(grouped.nans.last(), expected)
+    tm.assert_series_equal(grouped.nans.nth(-1), expected)
     tm.assert_series_equal(grouped.nans.nth(0), expected)
 
 


### PR DESCRIPTION
- [X] xref https://github.com/pandas-dev/pandas/issues/33591#issuecomment-615365647
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The first two asserts (`first()`/`last()`) fail on `1.0.3`, as expected.