### PR TITLE
inspect-safety for DataFrame._constructor_expanddim

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -422,7 +422,12 @@ class DataFrame(NDFrame):
 
     @property
     def _constructor_expanddim(self):
-        raise NotImplementedError("Not supported for DataFrames!")
+        # GH#31549 raising NotImplementedError on a property causes trouble
+        #  for `inspect`
+        def constructor(*args, **kwargs):
+            raise NotImplementedError("Not supported for DataFrames!")
+
+        return constructor
 
     # ----------------------------------------------------------------------
     # Constructors

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import datetime
+import inspect
 import pydoc
 
 import numpy as np
@@ -569,3 +570,12 @@ class TestDataFrameMisc:
 
         assert df["a"].values[0] == -1
         tm.assert_frame_equal(df, DataFrame({"a": [-1], "x": [0], "y": [0]}))
+
+    def test_constructor_expanddim_lookup(self):
+        # accessing _constructor_expanddim should not raise NotImplementedError
+        df = DataFrame()
+
+        inspect.getmembers(df)
+
+        with pytest.raises(NotImplementedError, match="Not supported for DataFrames!"):
+            df._constructor_expanddim(np.arange(27).reshape(3, 3, 3))

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from pandas.compat import PY37
-from pandas.util._test_decorators import async_mark
+from pandas.util._test_decorators import async_mark, skip_if_no
 
 import pandas as pd
 from pandas import Categorical, DataFrame, Series, compat, date_range, timedelta_range
@@ -571,8 +571,10 @@ class TestDataFrameMisc:
         assert df["a"].values[0] == -1
         tm.assert_frame_equal(df, DataFrame({"a": [-1], "x": [0], "y": [0]}))
 
+    @skip_if_no("jinja2")
     def test_constructor_expanddim_lookup(self):
-        # accessing _constructor_expanddim should not raise NotImplementedError
+        # GH#33628 accessing _constructor_expanddim should not
+        #  raise NotImplementedError
         df = DataFrame()
 
         inspect.getmembers(df)


### PR DESCRIPTION
- [x] closes #31549, closes #31474
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
