### PR TITLE
REF: _AXIS_TO_AXIS_NUMBER to simplify axis access

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -1333,39 +1333,6 @@ Values can be set to NaT using np.nan, similar to datetime
    y[1] = np.nan
    y
 
-Aliasing axis names
--------------------
-
-.. versionchanged:: 1.1.0
-
-   This recipe changed in pandas 1.1 because of changes in pandas internals.
-
-To globally provide aliases for axis names, one can define these 2 functions:
-
-.. ipython:: python
-
-   def set_axis_alias(cls, axis, alias):
-       if axis not in cls._AXIS_TO_AXIS_NUMBER:
-           raise ValueError(f"invalid axis [{axis}] for alias [{alias}]")
-       if alias in cls._AXIS_TO_AXIS_NUMBER:
-           raise ValueError(f"invalid alias [{alias}] for axis [{axis}]")
-       cls._AXIS_TO_AXIS_NUMBER[alias] = cls._AXIS_TO_AXIS_NUMBER[axis]
-
-.. ipython:: python
-
-   def clear_axis_alias(cls, axis, alias):
-       if axis not in cls._AXIS_TO_AXIS_NUMBER:
-           raise ValueError(f"invalid axis [{axis}] for alias [{alias}]")
-       cls._AXIS_TO_AXIS_NUMBER.pop(alias, None)
-
-.. ipython:: python
-
-   set_axis_alias(pd.DataFrame, 'columns', 'myaxis2')
-   df2 = pd.DataFrame(np.random.randn(3, 2), columns=['c1', 'c2'],
-                      index=['i1', 'i2', 'i3'])
-   df2.sum(axis='myaxis2')
-   clear_axis_alias(pd.DataFrame, 'columns', 'myaxis2')
-
 Creating example data
 ---------------------
 

--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -1336,21 +1336,27 @@ Values can be set to NaT using np.nan, similar to datetime
 Aliasing axis names
 -------------------
 
+.. versionchanged:: 1.1.0
+
+   This recipe changed in pandas 1.1 because of changes in pandas internals.
+
 To globally provide aliases for axis names, one can define these 2 functions:
 
 .. ipython:: python
 
    def set_axis_alias(cls, axis, alias):
-       if axis not in cls._AXIS_NUMBERS:
-           raise Exception("invalid axis [%s] for alias [%s]" % (axis, alias))
-       cls._AXIS_ALIASES[alias] = axis
+       if axis not in cls._AXIS_TO_AXIS_NUMBER:
+           raise ValueError(f"invalid axis [{axis}] for alias [{alias}]")
+       if alias in cls._AXIS_TO_AXIS_NUMBER:
+           raise ValueError(f"invalid alias [{alias}] for axis [{axis}]")
+       cls._AXIS_TO_AXIS_NUMBER[alias] = cls._AXIS_TO_AXIS_NUMBER[axis]
 
 .. ipython:: python
 
    def clear_axis_alias(cls, axis, alias):
-       if axis not in cls._AXIS_NUMBERS:
-           raise Exception("invalid axis [%s] for alias [%s]" % (axis, alias))
-       cls._AXIS_ALIASES.pop(alias, None)
+       if axis not in cls._AXIS_TO_AXIS_NUMBER:
+           raise ValueError(f"invalid axis [{axis}] for alias [{alias}]")
+       cls._AXIS_TO_AXIS_NUMBER.pop(alias, None)
 
 .. ipython:: python
 

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -38,7 +38,7 @@ def _align_core_single_unary_op(
 def _zip_axes_from_type(
     typ: Type[FrameOrSeries], new_axes: Sequence[int]
 ) -> Dict[str, int]:
-    axes = {name: new_axes[i] for i, name in typ._AXIS_NAMES.items()}
+    axes = {name: new_axes[i] for i, name in enumerate(typ._AXIS_ORDERS)}
     return axes
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8787,8 +8787,11 @@ Wild         185.0
     # ----------------------------------------------------------------------
     # Add index and columns
     _AXIS_ORDERS = ["index", "columns"]
-    _AXIS_NUMBERS = {"index": 0, "columns": 1}
-    _AXIS_NAMES = {0: "index", 1: "columns"}
+    _AXIS_TO_AXIS_NUMBER: Dict[Axis, int] = {
+        **NDFrame._AXIS_TO_AXIS_NUMBER,
+        1: 1,
+        "columns": 1,
+    }
     _AXIS_REVERSED = True
     _AXIS_LEN = len(_AXIS_ORDERS)
     _info_axis_number = 1
@@ -8800,6 +8803,18 @@ Wild         185.0
     columns: "Index" = properties.AxisProperty(
         axis=0, doc="The column labels of the DataFrame."
     )
+
+    @property
+    def _AXIS_NUMBERS(self) -> Dict[str, int]:
+        """.. deprecated:: 1.1.0"""
+        super()._AXIS_NUMBERS
+        return {"index": 0, "columns": 1}
+
+    @property
+    def _AXIS_NAMES(self) -> Dict[int, str]:
+        """.. deprecated:: 1.1.0"""
+        super()._AXIS_NAMES
+        return {0: "index", 1: "columns"}
 
     # ----------------------------------------------------------------------
     # Add plotting methods to DataFrame

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -67,7 +67,6 @@ from pandas.core.dtypes.common import (
     is_dict_like,
     is_extension_array_dtype,
     is_float,
-    is_integer,
     is_list_like,
     is_number,
     is_numeric_dtype,
@@ -302,18 +301,35 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     # ----------------------------------------------------------------------
     # Axis
-    _AXIS_ALIASES = {"rows": 0}
-    _AXIS_IALIASES = {0: "rows"}
     _stat_axis_number = 0
     _stat_axis_name = "index"
     _ix = None
     _AXIS_ORDERS: List[str]
-    _AXIS_NUMBERS: Dict[str, int]
-    _AXIS_NAMES: Dict[int, str]
+    _AXIS_TO_AXIS_NUMBER: Dict[Axis, int] = {0: 0, "index": 0, "rows": 0}
     _AXIS_REVERSED: bool
     _info_axis_number: int
     _info_axis_name: str
     _AXIS_LEN: int
+
+    @property
+    def _AXIS_NUMBERS(self) -> Dict[str, int]:
+        """.. deprecated:: 1.1.0"""
+        warnings.warn(
+            "_AXIS_NUMBERS has been deprecated. Call ._get_axis_number instead",
+            FutureWarning,
+            stacklevel=3,
+        )
+        return {"index": 0}
+
+    @property
+    def _AXIS_NAMES(self) -> Dict[int, str]:
+        """.. deprecated:: 1.1.0"""
+        warnings.warn(
+            "_AXIS_NAMES has been deprecated. Call ._get_axis_name instead",
+            FutureWarning,
+            stacklevel=3,
+        )
+        return {0: "index"}
 
     def _construct_axes_dict(self, axes=None, **kwargs):
         """Return an axes dictionary for myself."""
@@ -353,37 +369,24 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         return axes, kwargs
 
     @classmethod
-    def _get_axis_number(cls, axis) -> int:
-        axis = cls._AXIS_ALIASES.get(axis, axis)
-        if is_integer(axis):
-            if axis in cls._AXIS_NAMES:
-                return axis
-        else:
-            try:
-                return cls._AXIS_NUMBERS[axis]
-            except KeyError:
-                pass
-        raise ValueError(f"No axis named {axis} for object type {cls.__name__}")
+    def _get_axis_number(cls, axis: Axis) -> int:
+        try:
+            return cls._AXIS_TO_AXIS_NUMBER[axis]
+        except KeyError:
+            raise ValueError(f"No axis named {axis} for object type {cls.__name__}")
 
     @classmethod
-    def _get_axis_name(cls, axis) -> str:
-        axis = cls._AXIS_ALIASES.get(axis, axis)
-        if isinstance(axis, str):
-            if axis in cls._AXIS_NUMBERS:
-                return axis
-        else:
-            try:
-                return cls._AXIS_NAMES[axis]
-            except KeyError:
-                pass
-        raise ValueError(f"No axis named {axis} for object type {cls.__name__}")
+    def _get_axis_name(cls, axis: Axis) -> str:
+        axis_number = cls._get_axis_number(axis)
+        return cls._AXIS_ORDERS[axis_number]
 
-    def _get_axis(self, axis) -> Index:
-        name = self._get_axis_name(axis)
-        return getattr(self, name)
+    def _get_axis(self, axis: Axis) -> Index:
+        axis_number = self._get_axis_number(axis)
+        assert axis_number in {0, 1}
+        return self.index if axis_number == 0 else self.columns
 
     @classmethod
-    def _get_block_manager_axis(cls, axis) -> int:
+    def _get_block_manager_axis(cls, axis: Axis) -> int:
         """Map the axis to the block_manager axis."""
         axis = cls._get_axis_number(axis)
         if cls._AXIS_REVERSED:
@@ -448,11 +451,11 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         }
 
     @property
-    def _info_axis(self):
+    def _info_axis(self) -> Index:
         return getattr(self, self._info_axis_name)
 
     @property
-    def _stat_axis(self):
+    def _stat_axis(self) -> Index:
         return getattr(self, self._stat_axis_name)
 
     @property
@@ -813,7 +816,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         >>> df_0a.squeeze()
         1
         """
-        axis = self._AXIS_NAMES if axis is None else (self._get_axis_number(axis),)
+        axis = range(self._AXIS_LEN) if axis is None else (self._get_axis_number(axis),)
         return self.iloc[
             tuple(
                 0 if i in axis and len(a) == 1 else slice(None)
@@ -1156,7 +1159,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             result = self if inplace else self.copy(deep=copy)
 
             for axis in range(self._AXIS_LEN):
-                v = axes.get(self._AXIS_NAMES[axis])
+                v = axes.get(self._get_axis_name(axis))
                 if v is lib.no_default:
                     continue
                 non_mapper = is_scalar(v) or (is_list_like(v) and not is_dict_like(v))

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -315,9 +315,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     def _AXIS_NUMBERS(self) -> Dict[str, int]:
         """.. deprecated:: 1.1.0"""
         warnings.warn(
-            "_AXIS_NUMBERS has been deprecated. Call ._get_axis_number instead",
-            FutureWarning,
-            stacklevel=3,
+            "_AXIS_NUMBERS has been deprecated.", FutureWarning, stacklevel=3,
         )
         return {"index": 0}
 
@@ -325,9 +323,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     def _AXIS_NAMES(self) -> Dict[int, str]:
         """.. deprecated:: 1.1.0"""
         warnings.warn(
-            "_AXIS_NAMES has been deprecated. Call ._get_axis_name instead",
-            FutureWarning,
-            stacklevel=3,
+            "_AXIS_NAMES has been deprecated.", FutureWarning, stacklevel=3,
         )
         return {0: "index"}
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4599,8 +4599,6 @@ Name: Max Speed, dtype: float64
     # ----------------------------------------------------------------------
     # Add index
     _AXIS_ORDERS = ["index"]
-    _AXIS_NUMBERS = {"index": 0}
-    _AXIS_NAMES = {0: "index"}
     _AXIS_REVERSED = False
     _AXIS_LEN = len(_AXIS_ORDERS)
     _info_axis_number = 0

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -867,12 +867,15 @@ class Parser:
         """
         Try to convert axes.
         """
-        for axis in self.obj._AXIS_NUMBERS.keys():
+        for axis_name in self.obj._AXIS_ORDERS:
             new_axis, result = self._try_convert_data(
-                axis, self.obj._get_axis(axis), use_dtypes=False, convert_dates=True
+                name=axis_name,
+                data=self.obj._get_axis(axis_name),
+                use_dtypes=False,
+                convert_dates=True,
             )
             if result:
-                setattr(self.obj, axis, new_axis)
+                setattr(self.obj, axis_name, new_axis)
 
     def _try_convert_types(self):
         raise AbstractMethodError(self)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3712,7 +3712,7 @@ class Table(Fixed):
         # Now we can construct our new index axis
         idx = axes[0]
         a = obj.axes[idx]
-        axis_name = obj._AXIS_NAMES[idx]
+        axis_name = obj._get_axis_name(idx)
         new_index = _convert_index(axis_name, a, self.encoding, self.errors)
         new_index.axis = idx
 
@@ -3919,7 +3919,7 @@ class Table(Fixed):
 
                 def process_filter(field, filt):
 
-                    for axis_name in obj._AXIS_NAMES.values():
+                    for axis_name in obj._AXIS_ORDERS:
                         axis_number = obj._get_axis_number(axis_name)
                         axis_values = obj._get_axis(axis_name)
                         assert axis_number is not None

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -86,7 +86,9 @@ class Generic:
     def test_get_numeric_data(self):
 
         n = 4
-        kwargs = {self._typ._AXIS_NAMES[i]: list(range(n)) for i in range(self._ndim)}
+        kwargs = {
+            self._typ._get_axis_name(i): list(range(n)) for i in range(self._ndim)
+        }
 
         # get the numeric data
         o = self._construct(n, **kwargs)

--- a/pandas/tests/generic/test_generic.py
+++ b/pandas/tests/generic/test_generic.py
@@ -901,12 +901,22 @@ class TestNDFrame:
     @pytest.mark.parametrize("box", [pd.Series, pd.DataFrame])
     def test_axis_classmethods(self, box):
         obj = box(dtype=object)
-        values = (
-            list(box._AXIS_NAMES.keys())
-            + list(box._AXIS_NUMBERS.keys())
-            + list(box._AXIS_ALIASES.keys())
-        )
+        values = box._AXIS_TO_AXIS_NUMBER.keys()
         for v in values:
             assert obj._get_axis_number(v) == box._get_axis_number(v)
             assert obj._get_axis_name(v) == box._get_axis_name(v)
             assert obj._get_block_manager_axis(v) == box._get_block_manager_axis(v)
+
+    @pytest.mark.parametrize("box", [pd.Series, pd.DataFrame])
+    def test_axis_names_deprecated(self, box):
+        # GH33637
+        obj = box(dtype=object)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            obj._AXIS_NAMES
+
+    @pytest.mark.parametrize("box", [pd.Series, pd.DataFrame])
+    def test_axis_numbers_deprecated(self, box):
+        # GH33637
+        obj = box(dtype=object)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            obj._AXIS_NUMBERS

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -257,7 +257,7 @@ def validate_axis_style_args(data, args, kwargs, arg_name, method_name):
     # like out = {'index': foo, 'columns': bar}
 
     # Start by validating for consistency
-    if "axis" in kwargs and any(x in kwargs for x in data._AXIS_NUMBERS):
+    if "axis" in kwargs and any(x in kwargs for x in data._AXIS_TO_AXIS_NUMBER):
         msg = "Cannot specify both 'axis' and any of 'index' or 'columns'."
         raise TypeError(msg)
 
@@ -302,8 +302,8 @@ def validate_axis_style_args(data, args, kwargs, arg_name, method_name):
             "a 'TypeError'."
         )
         warnings.warn(msg.format(method_name=method_name), FutureWarning, stacklevel=4)
-        out[data._AXIS_NAMES[0]] = args[0]
-        out[data._AXIS_NAMES[1]] = args[1]
+        out[data._get_axis_name(0)] = args[0]
+        out[data._get_axis_name(1)] = args[1]
     else:
         msg = f"Cannot specify all of '{arg_name}', 'index', 'columns'."
         raise TypeError(msg)


### PR DESCRIPTION
This adds a dict called ``_AXIS_TO_AXIS_NUMBER `` to NDFrame/DataFrame where the keys are the allowed parameter values for the ``axis`` parameter in various ndframe methods and the dict values are the related axis number. This makes getting to the correct axis more straight forward, see for example the new ``_get_axis_number``, and makes adding type hints to the ``axis`` parameter easier.