### PR TITLE
IO: Fix S3 Error Handling

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -582,6 +582,8 @@ I/O
 - Bug in :func:`pandas.io.json.json_normalize` where location specified by `record_path` doesn't point to an array. (:issue:`26284`)
 - :func:`pandas.read_hdf` has a more explicit error message when loading an
   unsupported HDF file (:issue:`9539`)
+- Bug in :meth:`to_parquet` was not raising ``NoCredentialsError`` when writing to s3. (:issue:`27679`)
+- Bug in :meth:`to_csv` was silently failing when writing to an invalid s3 bucket. (:issue:`32486`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -582,7 +582,7 @@ I/O
 - Bug in :func:`pandas.io.json.json_normalize` where location specified by `record_path` doesn't point to an array. (:issue:`26284`)
 - :func:`pandas.read_hdf` has a more explicit error message when loading an
   unsupported HDF file (:issue:`9539`)
-- Bug in :meth:`to_parquet` was not raising ``NoCredentialsError`` when writing to s3. (:issue:`27679`)
+- Bug in :meth:`to_parquet` was not raising ``PermissionError`` when writing to a private s3 bucket with invalid creds. (:issue:`27679`)
 - Bug in :meth:`to_csv` was silently failing when writing to an invalid s3 bucket. (:issue:`32486`)
 
 Plotting

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -582,8 +582,8 @@ I/O
 - Bug in :func:`pandas.io.json.json_normalize` where location specified by `record_path` doesn't point to an array. (:issue:`26284`)
 - :func:`pandas.read_hdf` has a more explicit error message when loading an
   unsupported HDF file (:issue:`9539`)
-- Bug in :meth:`to_parquet` was not raising ``PermissionError`` when writing to a private s3 bucket with invalid creds. (:issue:`27679`)
-- Bug in :meth:`to_csv` was silently failing when writing to an invalid s3 bucket. (:issue:`32486`)
+- Bug in :meth:`~DataFrame.to_parquet` was not raising ``PermissionError`` when writing to a private s3 bucket with invalid creds. (:issue:`27679`)
+- Bug in :meth:`~DataFrame.to_csv` was silently failing when writing to an invalid s3 bucket. (:issue:`32486`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -62,7 +62,7 @@ class CSVFormatter:
         # Extract compression mode as given, if dict
         compression, self.compression_args = get_compression_method(compression)
 
-        self.path_or_buf, _, _, _ = get_filepath_or_buffer(
+        self.path_or_buf, _, _, self.should_close = get_filepath_or_buffer(
             path_or_buf, encoding=encoding, compression=compression, mode=mode
         )
         self.sep = sep
@@ -219,7 +219,7 @@ class CSVFormatter:
                     )
                     f.write(buf)
                     close = True
-            if close:
+            if close or self.should_close:
                 f.close()
                 for _fh in handles:
                     _fh.close()

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -219,10 +219,12 @@ class CSVFormatter:
                     )
                     f.write(buf)
                     close = True
-            if close or self.should_close:
+            if close:
                 f.close()
                 for _fh in handles:
                     _fh.close()
+            elif self.should_close:
+                f.close()
 
     def _save_header(self):
         writer = self.writer

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -92,7 +92,7 @@ class PyArrowImpl(BaseImpl):
         **kwargs,
     ):
         self.validate_dataframe(df)
-        path, _, _, _ = get_filepath_or_buffer(path, mode="wb")
+        path, _, _, should_close = get_filepath_or_buffer(path, mode="wb")
 
         from_pandas_kwargs: Dict[str, Any] = {"schema": kwargs.pop("schema", None)}
         if index is not None:
@@ -109,6 +109,8 @@ class PyArrowImpl(BaseImpl):
             )
         else:
             self.api.parquet.write_table(table, path, compression=compression, **kwargs)
+        if should_close:
+            path.close()
 
     def read(self, path, columns=None, **kwargs):
         path, _, _, should_close = get_filepath_or_buffer(path)

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -159,7 +159,7 @@ class TestS3:
             assert not df.empty
             tm.assert_frame_equal(tips_df.iloc[:10], df)
 
-    def test_s3_fails(self):
+    def test_read_s3_fails(self):
         with pytest.raises(IOError):
             read_csv("s3://nyqpug/asdf.csv")
 
@@ -167,6 +167,20 @@ class TestS3:
         # It's irrelevant here that this isn't actually a table.
         with pytest.raises(IOError):
             read_csv("s3://cant_get_it/file.csv")
+
+    def test_write_s3_csv_fails(self, tips_df):
+        # GH 32486
+        with pytest.raises(
+            FileNotFoundError, match="The specified bucket does not exist"
+        ):
+            tips_df.to_csv("s3://an_s3_bucket_data_doesnt_exit/not_real.csv")
+
+    def test_write_s3_parquet_fails(self, tips_df):
+        # GH 27679
+        with pytest.raises(
+            FileNotFoundError, match="The specified bucket does not exist"
+        ):
+            tips_df.to_parquet("s3://an_s3_bucket_data_doesnt_exit/not_real.parquet")
 
     def test_read_csv_handles_boto_s3_object(self, s3_resource, tips_file):
         # see gh-16135

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -54,8 +54,8 @@ def tips_df(datapath):
 @pytest.mark.usefixtures("s3_resource")
 @td.skip_if_not_us_locale()
 class TestS3:
+    @td.skip_if_no("s3fs")
     def test_parse_public_s3_bucket(self, tips_df):
-        pytest.importorskip("s3fs")
 
         # more of an integration test due to the not-public contents portion
         # can probably mock this though.
@@ -170,13 +170,14 @@ class TestS3:
 
     def test_write_s3_csv_fails(self, tips_df):
         # GH 32486
+        # Attempting to write to an invalid S3 path should raise
         with pytest.raises(
             FileNotFoundError, match="The specified bucket does not exist"
         ):
             tips_df.to_csv("s3://an_s3_bucket_data_doesnt_exit/not_real.csv")
 
+    @td.skip_if_no("pyarrow")
     def test_write_s3_parquet_fails(self, tips_df):
-        pytest.importorskip("pyarrow")
         # GH 27679
         with pytest.raises(
             FileNotFoundError, match="The specified bucket does not exist"

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -176,6 +176,7 @@ class TestS3:
             tips_df.to_csv("s3://an_s3_bucket_data_doesnt_exit/not_real.csv")
 
     def test_write_s3_parquet_fails(self, tips_df):
+        pytest.importorskip("pyarrow")
         # GH 27679
         with pytest.raises(
             FileNotFoundError, match="The specified bucket does not exist"


### PR DESCRIPTION
closes #27679 
closes #32486 

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
