### PR TITLE
BUG/API: getitem behavior with list match ndarray/index/series

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -529,6 +529,7 @@ Indexing
 - Bug in :meth:`DataFrame.iloc` when slicing a single column-:class:`DataFrame`` with ``ExtensionDtype`` (e.g. ``df.iloc[:, :1]``) returning an invalid result (:issue:`32957`)
 - Bug in :meth:`DatetimeIndex.insert` and :meth:`TimedeltaIndex.insert` causing index ``freq`` to be lost when setting an element into an empty :class:`Series` (:issue:33573`)
 - Bug in :meth:`Series.__setitem__` with an :class:`IntervalIndex` and a list-like key of integers (:issue:`33473`)
+- Bug in :meth:`Series.__getitem__` allowing missing labels with ``np.ndarray``, :class:`Index`, :class:`Series` indexers but not ``list``, these now all raise ``KeyError`` (:issue:`33646`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -949,11 +949,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             else:
                 return self.iloc[key]
 
-        if isinstance(key, list):
-            # handle the dup indexing case GH#4246
-            return self.loc[key]
-
-        return self.reindex(key)
+        # handle the dup indexing case GH#4246
+        return self.loc[key]
 
     def _get_values_tuple(self, key):
         # mpl hackaround

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -29,11 +29,6 @@ def test_getitem_boolean_empty():
     # GH5877
     # indexing with empty series
     s = Series(["A", "B"])
-    expected = Series(np.nan, index=["C"], dtype=object)
-    result = s[Series(["C"], dtype=object)]
-    tm.assert_series_equal(result, expected)
-
-    s = Series(["A", "B"])
     expected = Series(dtype=object, index=Index([], dtype="int64"))
     result = s[Series([], dtype=object)]
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -78,6 +78,18 @@ class TestSeriesGetitemSlices:
 
 
 class TestSeriesGetitemListLike:
+    @pytest.mark.parametrize("box", [list, np.array, pd.Index, pd.Series])
+    def test_getitem_no_matches(self, box):
+        # GH#???? we expect the same behavior for list/ndarray/Index/Serioes
+        ser = Series(["A", "B"])
+
+        key = Series(["C"], dtype=object)
+        key = box(key)
+
+        msg = r"None of \[Index\(\['C'\], dtype='object'\)\] are in the \[index\]"
+        with pytest.raises(KeyError, match=msg):
+            ser[key]
+
     def test_getitem_intlist_intindex_periodvalues(self):
         ser = Series(period_range("2000-01-01", periods=10, freq="D"))
 

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -80,7 +80,7 @@ class TestSeriesGetitemSlices:
 class TestSeriesGetitemListLike:
     @pytest.mark.parametrize("box", [list, np.array, pd.Index, pd.Series])
     def test_getitem_no_matches(self, box):
-        # GH#33462 we expect the same behavior for list/ndarray/Index/Serioes
+        # GH#33462 we expect the same behavior for list/ndarray/Index/Series
         ser = Series(["A", "B"])
 
         key = Series(["C"], dtype=object)

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -80,7 +80,7 @@ class TestSeriesGetitemSlices:
 class TestSeriesGetitemListLike:
     @pytest.mark.parametrize("box", [list, np.array, pd.Index, pd.Series])
     def test_getitem_no_matches(self, box):
-        # GH#???? we expect the same behavior for list/ndarray/Index/Serioes
+        # GH#33462 we expect the same behavior for list/ndarray/Index/Serioes
         ser = Series(["A", "B"])
 
         key = Series(["C"], dtype=object)


### PR DESCRIPTION
- [x] closes #33642
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
