### PR TITLE
TST: Dtype constants into pandas._testing to avoid direct imports from conftest

### DIFF
--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -73,10 +73,10 @@ _N = 30
 _K = 4
 _RAISE_NETWORK_ERROR_DEFAULT = False
 
-UNSIGNED_INT_DTYPES = ["uint8", "uint16", "uint32", "uint64"]
-UNSIGNED_EA_INT_DTYPES = ["UInt8", "UInt16", "UInt32", "UInt64"]
+UNSIGNED_INT_DTYPES: List[Dtype] = ["uint8", "uint16", "uint32", "uint64"]
+UNSIGNED_EA_INT_DTYPES: List[Dtype] = ["UInt8", "UInt16", "UInt32", "UInt64"]
 SIGNED_INT_DTYPES: List[Dtype] = [int, "int8", "int16", "int32", "int64"]
-SIGNED_EA_INT_DTYPES = ["Int8", "Int16", "Int32", "Int64"]
+SIGNED_EA_INT_DTYPES: List[Dtype] = ["Int8", "Int16", "Int32", "Int64"]
 ALL_INT_DTYPES = UNSIGNED_INT_DTYPES + SIGNED_INT_DTYPES
 ALL_EA_INT_DTYPES = UNSIGNED_EA_INT_DTYPES + SIGNED_EA_INT_DTYPES
 
@@ -84,8 +84,8 @@ FLOAT_DTYPES: List[Dtype] = [float, "float32", "float64"]
 COMPLEX_DTYPES: List[Dtype] = [complex, "complex64", "complex128"]
 STRING_DTYPES: List[Dtype] = [str, "str", "U"]
 
-DATETIME64_DTYPES = ["datetime64[ns]", "M8[ns]"]
-TIMEDELTA64_DTYPES = ["timedelta64[ns]", "m8[ns]"]
+DATETIME64_DTYPES: List[Dtype] = ["datetime64[ns]", "M8[ns]"]
+TIMEDELTA64_DTYPES: List[Dtype] = ["timedelta64[ns]", "m8[ns]"]
 
 BOOL_DTYPES = [bool, "bool"]
 BYTES_DTYPES = [bytes, "bytes"]

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -22,7 +22,7 @@ from pandas._config.localization import (  # noqa:F401
 )
 
 import pandas._libs.testing as _testing
-from pandas._typing import FilePathOrBuffer, FrameOrSeries
+from pandas._typing import Dtype, FilePathOrBuffer, FrameOrSeries
 from pandas.compat import _get_lzma_file, _import_lzma
 
 from pandas.core.dtypes.common import (
@@ -72,6 +72,37 @@ lzma = _import_lzma()
 _N = 30
 _K = 4
 _RAISE_NETWORK_ERROR_DEFAULT = False
+
+UNSIGNED_INT_DTYPES = ["uint8", "uint16", "uint32", "uint64"]
+UNSIGNED_EA_INT_DTYPES = ["UInt8", "UInt16", "UInt32", "UInt64"]
+SIGNED_INT_DTYPES: List[Dtype] = [int, "int8", "int16", "int32", "int64"]
+SIGNED_EA_INT_DTYPES = ["Int8", "Int16", "Int32", "Int64"]
+ALL_INT_DTYPES = UNSIGNED_INT_DTYPES + SIGNED_INT_DTYPES
+ALL_EA_INT_DTYPES = UNSIGNED_EA_INT_DTYPES + SIGNED_EA_INT_DTYPES
+
+FLOAT_DTYPES: List[Dtype] = [float, "float32", "float64"]
+COMPLEX_DTYPES: List[Dtype] = [complex, "complex64", "complex128"]
+STRING_DTYPES: List[Dtype] = [str, "str", "U"]
+
+DATETIME64_DTYPES = ["datetime64[ns]", "M8[ns]"]
+TIMEDELTA64_DTYPES = ["timedelta64[ns]", "m8[ns]"]
+
+BOOL_DTYPES = [bool, "bool"]
+BYTES_DTYPES = [bytes, "bytes"]
+OBJECT_DTYPES = [object, "object"]
+
+ALL_REAL_DTYPES = FLOAT_DTYPES + ALL_INT_DTYPES
+ALL_NUMPY_DTYPES = (
+    ALL_REAL_DTYPES
+    + COMPLEX_DTYPES
+    + STRING_DTYPES
+    + DATETIME64_DTYPES
+    + TIMEDELTA64_DTYPES
+    + BOOL_DTYPES
+    + OBJECT_DTYPES
+    + BYTES_DTYPES
+)
+
 
 # set testing_mode
 _testing_mode_warnings = (DeprecationWarning, ResourceWarning)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -23,7 +23,6 @@ from datetime import date, time, timedelta, timezone
 from decimal import Decimal
 import operator
 import os
-from typing import List
 
 from dateutil.tz import tzlocal, tzutc
 import hypothesis
@@ -32,7 +31,6 @@ import numpy as np
 import pytest
 from pytz import FixedOffset, utc
 
-from pandas._typing import Dtype
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -864,39 +862,7 @@ def utc_fixture(request):
 # ----------------------------------------------------------------
 # Dtypes
 # ----------------------------------------------------------------
-
-UNSIGNED_INT_DTYPES = ["uint8", "uint16", "uint32", "uint64"]
-UNSIGNED_EA_INT_DTYPES = ["UInt8", "UInt16", "UInt32", "UInt64"]
-SIGNED_INT_DTYPES: List[Dtype] = [int, "int8", "int16", "int32", "int64"]
-SIGNED_EA_INT_DTYPES = ["Int8", "Int16", "Int32", "Int64"]
-ALL_INT_DTYPES = UNSIGNED_INT_DTYPES + SIGNED_INT_DTYPES
-ALL_EA_INT_DTYPES = UNSIGNED_EA_INT_DTYPES + SIGNED_EA_INT_DTYPES
-
-FLOAT_DTYPES: List[Dtype] = [float, "float32", "float64"]
-COMPLEX_DTYPES: List[Dtype] = [complex, "complex64", "complex128"]
-STRING_DTYPES: List[Dtype] = [str, "str", "U"]
-
-DATETIME64_DTYPES = ["datetime64[ns]", "M8[ns]"]
-TIMEDELTA64_DTYPES = ["timedelta64[ns]", "m8[ns]"]
-
-BOOL_DTYPES = [bool, "bool"]
-BYTES_DTYPES = [bytes, "bytes"]
-OBJECT_DTYPES = [object, "object"]
-
-ALL_REAL_DTYPES = FLOAT_DTYPES + ALL_INT_DTYPES
-ALL_NUMPY_DTYPES = (
-    ALL_REAL_DTYPES
-    + COMPLEX_DTYPES
-    + STRING_DTYPES
-    + DATETIME64_DTYPES
-    + TIMEDELTA64_DTYPES
-    + BOOL_DTYPES
-    + OBJECT_DTYPES
-    + BYTES_DTYPES
-)
-
-
-@pytest.fixture(params=STRING_DTYPES)
+@pytest.fixture(params=tm.STRING_DTYPES)
 def string_dtype(request):
     """
     Parametrized fixture for string dtypes.
@@ -908,7 +874,7 @@ def string_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=BYTES_DTYPES)
+@pytest.fixture(params=tm.BYTES_DTYPES)
 def bytes_dtype(request):
     """
     Parametrized fixture for bytes dtypes.
@@ -919,7 +885,7 @@ def bytes_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=OBJECT_DTYPES)
+@pytest.fixture(params=tm.OBJECT_DTYPES)
 def object_dtype(request):
     """
     Parametrized fixture for object dtypes.
@@ -930,7 +896,7 @@ def object_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=DATETIME64_DTYPES)
+@pytest.fixture(params=tm.DATETIME64_DTYPES)
 def datetime64_dtype(request):
     """
     Parametrized fixture for datetime64 dtypes.
@@ -941,7 +907,7 @@ def datetime64_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=TIMEDELTA64_DTYPES)
+@pytest.fixture(params=tm.TIMEDELTA64_DTYPES)
 def timedelta64_dtype(request):
     """
     Parametrized fixture for timedelta64 dtypes.
@@ -952,7 +918,7 @@ def timedelta64_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=FLOAT_DTYPES)
+@pytest.fixture(params=tm.FLOAT_DTYPES)
 def float_dtype(request):
     """
     Parameterized fixture for float dtypes.
@@ -964,7 +930,7 @@ def float_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=COMPLEX_DTYPES)
+@pytest.fixture(params=tm.COMPLEX_DTYPES)
 def complex_dtype(request):
     """
     Parameterized fixture for complex dtypes.
@@ -976,7 +942,7 @@ def complex_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=SIGNED_INT_DTYPES)
+@pytest.fixture(params=tm.SIGNED_INT_DTYPES)
 def sint_dtype(request):
     """
     Parameterized fixture for signed integer dtypes.
@@ -990,7 +956,7 @@ def sint_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=UNSIGNED_INT_DTYPES)
+@pytest.fixture(params=tm.UNSIGNED_INT_DTYPES)
 def uint_dtype(request):
     """
     Parameterized fixture for unsigned integer dtypes.
@@ -1003,7 +969,7 @@ def uint_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=ALL_INT_DTYPES)
+@pytest.fixture(params=tm.ALL_INT_DTYPES)
 def any_int_dtype(request):
     """
     Parameterized fixture for any integer dtype.
@@ -1021,7 +987,7 @@ def any_int_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=ALL_EA_INT_DTYPES)
+@pytest.fixture(params=tm.ALL_EA_INT_DTYPES)
 def any_nullable_int_dtype(request):
     """
     Parameterized fixture for any nullable integer dtype.
@@ -1038,7 +1004,7 @@ def any_nullable_int_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=ALL_REAL_DTYPES)
+@pytest.fixture(params=tm.ALL_REAL_DTYPES)
 def any_real_dtype(request):
     """
     Parameterized fixture for any (purely) real numeric dtype.
@@ -1059,7 +1025,7 @@ def any_real_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=ALL_NUMPY_DTYPES)
+@pytest.fixture(params=tm.ALL_NUMPY_DTYPES)
 def any_numpy_dtype(request):
     """
     Parameterized fixture for all numpy dtypes.

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -20,14 +20,6 @@ from pandas.core.dtypes.missing import isna
 import pandas as pd
 import pandas._testing as tm
 from pandas.arrays import SparseArray
-from pandas.conftest import (
-    ALL_EA_INT_DTYPES,
-    ALL_INT_DTYPES,
-    SIGNED_EA_INT_DTYPES,
-    SIGNED_INT_DTYPES,
-    UNSIGNED_EA_INT_DTYPES,
-    UNSIGNED_INT_DTYPES,
-)
 
 
 # EA & Actual Dtypes
@@ -295,10 +287,10 @@ integer_dtypes: List = []
     "dtype",
     integer_dtypes
     + [pd.Series([1, 2])]
-    + ALL_INT_DTYPES
-    + to_numpy_dtypes(ALL_INT_DTYPES)
-    + ALL_EA_INT_DTYPES
-    + to_ea_dtypes(ALL_EA_INT_DTYPES),
+    + tm.ALL_INT_DTYPES
+    + to_numpy_dtypes(tm.ALL_INT_DTYPES)
+    + tm.ALL_EA_INT_DTYPES
+    + to_ea_dtypes(tm.ALL_EA_INT_DTYPES),
 )
 def test_is_integer_dtype(dtype):
     assert com.is_integer_dtype(dtype)
@@ -327,10 +319,10 @@ signed_integer_dtypes: List = []
     "dtype",
     signed_integer_dtypes
     + [pd.Series([1, 2])]
-    + SIGNED_INT_DTYPES
-    + to_numpy_dtypes(SIGNED_INT_DTYPES)
-    + SIGNED_EA_INT_DTYPES
-    + to_ea_dtypes(SIGNED_EA_INT_DTYPES),
+    + tm.SIGNED_INT_DTYPES
+    + to_numpy_dtypes(tm.SIGNED_INT_DTYPES)
+    + tm.SIGNED_EA_INT_DTYPES
+    + to_ea_dtypes(tm.SIGNED_EA_INT_DTYPES),
 )
 def test_is_signed_integer_dtype(dtype):
     assert com.is_integer_dtype(dtype)
@@ -347,10 +339,10 @@ def test_is_signed_integer_dtype(dtype):
         np.array(["a", "b"]),
         np.array([], dtype=np.timedelta64),
     ]
-    + UNSIGNED_INT_DTYPES
-    + to_numpy_dtypes(UNSIGNED_INT_DTYPES)
-    + UNSIGNED_EA_INT_DTYPES
-    + to_ea_dtypes(UNSIGNED_EA_INT_DTYPES),
+    + tm.UNSIGNED_INT_DTYPES
+    + to_numpy_dtypes(tm.UNSIGNED_INT_DTYPES)
+    + tm.UNSIGNED_EA_INT_DTYPES
+    + to_ea_dtypes(tm.UNSIGNED_EA_INT_DTYPES),
 )
 def test_is_not_signed_integer_dtype(dtype):
     assert not com.is_signed_integer_dtype(dtype)
@@ -363,10 +355,10 @@ unsigned_integer_dtypes: List = []
     "dtype",
     unsigned_integer_dtypes
     + [pd.Series([1, 2], dtype=np.uint32)]
-    + UNSIGNED_INT_DTYPES
-    + to_numpy_dtypes(UNSIGNED_INT_DTYPES)
-    + UNSIGNED_EA_INT_DTYPES
-    + to_ea_dtypes(UNSIGNED_EA_INT_DTYPES),
+    + tm.UNSIGNED_INT_DTYPES
+    + to_numpy_dtypes(tm.UNSIGNED_INT_DTYPES)
+    + tm.UNSIGNED_EA_INT_DTYPES
+    + to_ea_dtypes(tm.UNSIGNED_EA_INT_DTYPES),
 )
 def test_is_unsigned_integer_dtype(dtype):
     assert com.is_unsigned_integer_dtype(dtype)
@@ -383,10 +375,10 @@ def test_is_unsigned_integer_dtype(dtype):
         np.array(["a", "b"]),
         np.array([], dtype=np.timedelta64),
     ]
-    + SIGNED_INT_DTYPES
-    + to_numpy_dtypes(SIGNED_INT_DTYPES)
-    + SIGNED_EA_INT_DTYPES
-    + to_ea_dtypes(SIGNED_EA_INT_DTYPES),
+    + tm.SIGNED_INT_DTYPES
+    + to_numpy_dtypes(tm.SIGNED_INT_DTYPES)
+    + tm.SIGNED_EA_INT_DTYPES
+    + to_ea_dtypes(tm.SIGNED_EA_INT_DTYPES),
 )
 def test_is_not_unsigned_integer_dtype(dtype):
     assert not com.is_unsigned_integer_dtype(dtype)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -14,7 +14,6 @@ from pandas import (
     Series,
     Timedelta,
     Timestamp,
-    conftest,
 )
 import pandas._testing as tm
 from pandas.api.types import CategoricalDtype as CDT
@@ -752,9 +751,9 @@ class TestCategoricalIndex:
             [1.5, 2.5, 3.5],
             [-1.5, -2.5, -3.5],
             # numpy int/uint
-            *[np.array([1, 2, 3], dtype=dtype) for dtype in conftest.ALL_INT_DTYPES],
+            *[np.array([1, 2, 3], dtype=dtype) for dtype in tm.ALL_INT_DTYPES],
             # numpy floats
-            *[np.array([1.5, 2.5, 3.5], dtype=dtyp) for dtyp in conftest.FLOAT_DTYPES],
+            *[np.array([1.5, 2.5, 3.5], dtype=dtyp) for dtyp in tm.FLOAT_DTYPES],
             # numpy object
             np.array([1, "b", 3.5], dtype=object),
             # pandas scalars
@@ -762,7 +761,7 @@ class TestCategoricalIndex:
             [Timestamp(2019, 1, 1), Timestamp(2019, 2, 1), Timestamp(2019, 3, 1)],
             [Timedelta(1, "d"), Timedelta(2, "d"), Timedelta(3, "D")],
             # pandas Integer arrays
-            *[pd.array([1, 2, 3], dtype=dtype) for dtype in conftest.ALL_EA_INT_DTYPES],
+            *[pd.array([1, 2, 3], dtype=dtype) for dtype in tm.ALL_EA_INT_DTYPES],
             # other pandas arrays
             pd.IntervalIndex.from_breaks([1, 4, 6, 9]).array,
             pd.date_range("2019-01-01", periods=3).array,

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -31,7 +31,6 @@ from pandas import (
     compat,
 )
 import pandas._testing as tm
-from pandas.conftest import BYTES_DTYPES, STRING_DTYPES
 import pandas.core.algorithms as algos
 from pandas.core.arrays import DatetimeArray
 import pandas.core.common as com
@@ -362,7 +361,7 @@ class TestUnique:
 
     def test_dtype_preservation(self, any_numpy_dtype):
         # GH 15442
-        if any_numpy_dtype in (BYTES_DTYPES + STRING_DTYPES):
+        if any_numpy_dtype in (tm.BYTES_DTYPES + tm.STRING_DTYPES):
             pytest.skip("skip string dtype")
         elif is_integer_dtype(any_numpy_dtype):
             data = [1, 2, 2]


### PR DESCRIPTION
part of #30914

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

---------------------------------------------------------------------------------------

Took a naive approach to move these constants into `pandas._testing`. Could also move them to a separate module instead. Let me know what you think is best.