### PR TITLE
BLD: Set max version of numba to 0.48.0

### DIFF
--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -17,7 +17,7 @@ dependencies:
   - bottleneck
   - fastparquet>=0.3.2
   - matplotlib=3.0.2
-  - numba
+  - numba<0.49.0
   - numexpr
   - numpy=1.15.*
   - openpyxl

--- a/environment.yml
+++ b/environment.yml
@@ -76,7 +76,7 @@ dependencies:
   - matplotlib>=2.2.2  # pandas.plotting, Series.plot, DataFrame.plot
   - numexpr>=2.6.8
   - scipy>=1.1
-  - numba>=0.46.0
+  - numba>=0.46.0,<0.49.0
 
   # optional for io
   # ---------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -51,7 +51,7 @@ jinja2
 matplotlib>=2.2.2
 numexpr>=2.6.8
 scipy>=1.1
-numba>=0.46.0
+numba>=0.46.0,<0.49.0
 beautifulsoup4>=4.6.0
 html5lib
 lxml


### PR DESCRIPTION
This should fix the errors in the CI (Travis) builds, e.g.

```
E       AttributeError: module 'numba' has no attribute 'targets'
```