### PR TITLE
CI/DEP: Use numba.extending.is_jitted for numba version > 0.49.0

### DIFF
--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -1,4 +1,5 @@
 """Common utilities for Numba operations"""
+from distutils.version import LooseVersion
 import inspect
 import types
 from typing import Callable, Dict, Optional, Tuple
@@ -90,7 +91,12 @@ def jit_user_function(
     """
     numba = import_optional_dependency("numba")
 
-    if isinstance(func, numba.targets.registry.CPUDispatcher):
+    if LooseVersion(numba.__version__) >= LooseVersion("0.49.0"):
+        is_jitted = numba.extending.is_jitted(func)
+    else:
+        is_jitted = isinstance(func, numba.targets.registry.CPUDispatcher)
+
+    if is_jitted:
         # Don't jit a user passed jitted function
         numba_func = func
     else:


### PR DESCRIPTION
- [x] xref #33686
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
