### PR TITLE
BUG: Fix memory issues in rolling.min/max

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -158,14 +158,14 @@ class PeakMemFixedWindowMinMax:
     ]
 
     def setup(self, f):
-        N = int(1e5)
-        arr = 100 * np.random.random(N)
-        self.roll = pd.Series(arr).rolling(1000)
+        N = int(1e6)
+        arr = np.random.random(N)
+        self.roll = pd.Series(arr).rolling(2)
 
     def peakmem_fixed(self, f):
         # GH 33693
         # increased size of array so we see a clearer picture
-        for x in range(1000):
+        for x in range(5):
             f(self.roll)
 
 

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -151,7 +151,7 @@ class Quantile:
 
 
 class PeakMemFixedWindowMinMax:
-    
+
     params = [
         pd.core.window.rolling.Rolling.min,
         pd.core.window.rolling.Rolling.max,

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -152,21 +152,18 @@ class Quantile:
 
 class PeakMemFixedWindowMinMax:
 
-    params = [
-        pd.core.window.rolling.Rolling.min,
-        pd.core.window.rolling.Rolling.max,
-    ]
+    params = ['min', 'max']
 
     def setup(self, f):
         N = int(1e6)
         arr = np.random.random(N)
         self.roll = pd.Series(arr).rolling(2)
 
-    def peakmem_fixed(self, f):
+    def peakmem_fixed(self, operation):
         # GH 33693
         # increased size of array so we see a clearer picture
         for x in range(5):
-            f(self.roll)
+            getattr(self.roll, operation)()
 
 
 class ForwardWindowMethods:

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -151,16 +151,22 @@ class Quantile:
 
 
 class PeakMemFixedWindowMinMax:
-    def setup(self):
+    
+    params = [
+        pd.core.window.rolling.Rolling.min,
+        pd.core.window.rolling.Rolling.max,
+    ]
+
+    def setup(self, f):
         N = int(1e5)
         arr = 100 * np.random.random(N)
         self.roll = pd.Series(arr).rolling(1000)
 
-    def peakmem_fixed(self):
+    def peakmem_fixed(self, f):
         # GH 33693
         # increased size of array so we see a clearer picture
         for x in range(1000):
-            self.roll.max()
+            f(self.roll)
 
 
 class ForwardWindowMethods:

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -150,18 +150,16 @@ class Quantile:
         self.roll.quantile(percentile, interpolation=interpolation)
 
 
-class PeakMemFixed:
+class PeakMemFixedWindowMinMax:
     def setup(self):
-        N = 10
+        N = int(1e5)
         arr = 100 * np.random.random(N)
-        self.roll = pd.Series(arr).rolling(10)
+        self.roll = pd.Series(arr).rolling(1000)
 
     def peakmem_fixed(self):
-        # GH 25926
-        # This is to detect memory leaks in rolling operations.
-        # To save time this is only ran on one method.
-        # 6000 iterations is enough for most types of leaks to be detected
-        for x in range(6000):
+        # GH 33693
+        # increased size of array so we see a clearer picture
+        for x in range(1000):
             self.roll.max()
 
 

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -152,16 +152,14 @@ class Quantile:
 
 class PeakMemFixedWindowMinMax:
 
-    params = ['min', 'max']
+    params = ["min", "max"]
 
-    def setup(self, f):
+    def setup(self, operation):
         N = int(1e6)
         arr = np.random.random(N)
         self.roll = pd.Series(arr).rolling(2)
 
     def peakmem_fixed(self, operation):
-        # GH 33693
-        # increased size of array so we see a clearer picture
         for x in range(5):
             getattr(self.roll, operation)()
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -608,7 +608,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.resample` where an ``AmbiguousTimeError`` would be raised when the resulting timezone aware :class:`DatetimeIndex` had a DST transition at midnight (:issue:`25758`)
 - Bug in :meth:`DataFrame.groupby` where a ``ValueError`` would be raised when grouping by a categorical column with read-only categories and ``sort=False`` (:issue:`33410`)
 - Bug in :meth:`GroupBy.first` and :meth:`GroupBy.last` where None is not preserved in object dtype (:issue:`32800`)
-- Bug in :meth:`Rolling.min` and :meth:`Rolling.max` when using a fixed window (:issue:`30726`)
+- Bug in :meth:`Rolling.min` and :meth:`Rolling.max`: Growing memory usage after multiple calls when using a fixed window (:issue:`30726`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -608,6 +608,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.resample` where an ``AmbiguousTimeError`` would be raised when the resulting timezone aware :class:`DatetimeIndex` had a DST transition at midnight (:issue:`25758`)
 - Bug in :meth:`DataFrame.groupby` where a ``ValueError`` would be raised when grouping by a categorical column with read-only categories and ``sort=False`` (:issue:`33410`)
 - Bug in :meth:`GroupBy.first` and :meth:`GroupBy.last` where None is not preserved in object dtype (:issue:`32800`)
+- Bug in :meth:`Rolling.min` and :meth:`Rolling.max` when using a fixed window (:issue:`30726`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -971,8 +971,8 @@ cdef inline numeric calc_mm(int64_t minp, Py_ssize_t nobs,
     return result
 
 
-def roll_max_fixed(ndarray[float64_t] values, ndarray[int64_t] start,
-                   ndarray[int64_t] end, int64_t minp, int64_t win):
+def roll_max_fixed(float64_t[:] values, int64_t[:] start,
+                   int64_t[:] end, int64_t minp, int64_t win):
     """
     Moving max of 1d array of any numeric type along axis=0 ignoring NaNs.
 
@@ -988,7 +988,7 @@ def roll_max_fixed(ndarray[float64_t] values, ndarray[int64_t] start,
             make the interval closed on the right, left,
             both or neither endpoints
     """
-    return _roll_min_max_fixed(values, start, end, minp, win, is_max=1)
+    return _roll_min_max_fixed(values, minp, win, is_max=1)
 
 
 def roll_max_variable(ndarray[float64_t] values, ndarray[int64_t] start,
@@ -1011,8 +1011,8 @@ def roll_max_variable(ndarray[float64_t] values, ndarray[int64_t] start,
     return _roll_min_max_variable(values, start, end, minp, is_max=1)
 
 
-def roll_min_fixed(ndarray[float64_t] values, ndarray[int64_t] start,
-                   ndarray[int64_t] end, int64_t minp, int64_t win):
+def roll_min_fixed(float64_t[:] values, int64_t[:] start,
+                   int64_t[:] end, int64_t minp, int64_t win):
     """
     Moving min of 1d array of any numeric type along axis=0 ignoring NaNs.
 
@@ -1025,7 +1025,7 @@ def roll_min_fixed(ndarray[float64_t] values, ndarray[int64_t] start,
     index : ndarray, optional
        index for window computation
     """
-    return _roll_min_max_fixed(values, start, end, minp, win, is_max=0)
+    return _roll_min_max_fixed(values, minp, win, is_max=0)
 
 
 def roll_min_variable(ndarray[float64_t] values, ndarray[int64_t] start,
@@ -1112,9 +1112,7 @@ cdef _roll_min_max_variable(ndarray[numeric] values,
     return output
 
 
-cdef _roll_min_max_fixed(ndarray[numeric] values,
-                         ndarray[int64_t] starti,
-                         ndarray[int64_t] endi,
+cdef _roll_min_max_fixed(numeric[:] values,
                          int64_t minp,
                          int64_t win,
                          bint is_max):


### PR DESCRIPTION
This fixes at least the reproducible part of #30726. I am not
totally sure what is going on here (is this a true memory leak?), and whether this fixes all issues, but it does strongly reduce memory usage as measured by `psutil`.

My tests have shown that there are two solutions that avoid growing memory
usage:

- pass memoryviews (`float64_t[:]`) instead of `ndarray[float64_t]`
- remove `starti` and `endi` as arguments to `_roll_min_max_fixed`

This commit implements both, since `_roll_min_max_fixed` doesn't use `starti` and `endi` anyways.

- [x] fixes at least part of 
closes #30726 
closes #32466
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry


I am unsure about testing: Does this need a test? If so, what would be a good way to go about testing? The tests I performed (example code in the linked issue) are probably very system specific.