### PR TITLE
TYP: remove #type:ignore from core.arrays.datetimelike

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1532,7 +1532,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
 
         return -(self - other)
 
-    def __iadd__(self, other):  # type: ignore
+    def __iadd__(self, other):
         result = self + other
         self[:] = result[:]
 
@@ -1541,7 +1541,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin, ExtensionArray)
             self._freq = result._freq
         return self
 
-    def __isub__(self, other):  # type: ignore
+    def __isub__(self, other):
         result = self - other
         self[:] = result[:]
 

--- a/pandas/core/ops/common.py
+++ b/pandas/core/ops/common.py
@@ -2,13 +2,15 @@
 Boilerplate functions used in defining binary operations.
 """
 from functools import wraps
+from typing import Callable
 
 from pandas._libs.lib import item_from_zerodim
+from pandas._typing import F
 
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 
 
-def unpack_zerodim_and_defer(name: str):
+def unpack_zerodim_and_defer(name: str) -> Callable[[F], F]:
     """
     Boilerplate for pandas conventions in arithmetic and comparison methods.
 
@@ -21,7 +23,7 @@ def unpack_zerodim_and_defer(name: str):
     decorator
     """
 
-    def wrapper(method):
+    def wrapper(method: F) -> F:
         return _unpack_zerodim_and_defer(method, name)
 
     return wrapper


### PR DESCRIPTION
pandas\core\arrays\datetimelike.py:1535: error: Signatures of "__iadd__" and "__add__" are incompatible
pandas\core\arrays\datetimelike.py:1544: error: Signatures of "__isub__" and "__sub__" are incompatible