### PR TITLE
TST: prepare for freq-checking in tests.io

### DIFF
--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -407,6 +407,10 @@ class TestExcelWriter:
     def test_ts_frame(self, tsframe, path):
         df = tsframe
 
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(df.index), freq=None)
+        df.index = index
+
         df.to_excel(path, "test1")
         reader = ExcelFile(path)
 
@@ -476,6 +480,11 @@ class TestExcelWriter:
         tm.assert_frame_equal(df, recons)
 
     def test_sheets(self, frame, tsframe, path):
+
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(tsframe.index), freq=None)
+        tsframe.index = index
+
         frame = frame.copy()
         frame["A"][:5] = np.nan
 
@@ -581,6 +590,11 @@ class TestExcelWriter:
 
     def test_excel_roundtrip_datetime(self, merge_cells, tsframe, path):
         # datetime.date, not sure what to test here exactly
+
+        # freq does not round-trip
+        index = pd.DatetimeIndex(np.asarray(tsframe.index), freq=None)
+        tsframe.index = index
+
         tsf = tsframe.copy()
 
         tsf.index = [x.date() for x in tsframe.index]

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -226,6 +226,11 @@ class TestPandasContainer:
     @pytest.mark.parametrize("numpy", [True, False])
     def test_roundtrip_timestamp(self, orient, convert_axes, numpy, datetime_frame):
         # TODO: improve coverage with date_format parameter
+
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(datetime_frame.index), freq=None)
+        datetime_frame.index = index
+
         data = datetime_frame.to_json(orient=orient)
         result = pd.read_json(
             data, orient=orient, convert_axes=convert_axes, numpy=numpy
@@ -416,6 +421,9 @@ class TestPandasContainer:
         tm.assert_frame_equal(left, right)
 
     def test_v12_compat(self, datapath):
+        dti = pd.date_range("2000-01-03", "2000-01-07")
+        # freq doesnt roundtrip
+        dti = pd.DatetimeIndex(np.asarray(dti), freq=None)
         df = DataFrame(
             [
                 [1.56808523, 0.65727391, 1.81021139, -0.17251653],
@@ -425,7 +433,7 @@ class TestPandasContainer:
                 [0.05951614, -2.69652057, 1.28163262, 0.34703478],
             ],
             columns=["A", "B", "C", "D"],
-            index=pd.date_range("2000-01-03", "2000-01-07"),
+            index=dti,
         )
         df["date"] = pd.Timestamp("19920106 18:21:32.12")
         df.iloc[3, df.columns.get_loc("date")] = pd.Timestamp("20130101")
@@ -444,6 +452,9 @@ class TestPandasContainer:
 
     def test_blocks_compat_GH9037(self):
         index = pd.date_range("20000101", periods=10, freq="H")
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(list(index), freq=None)
+
         df_mixed = DataFrame(
             OrderedDict(
                 float_1=[
@@ -639,6 +650,11 @@ class TestPandasContainer:
 
     @pytest.mark.parametrize("numpy", [True, False])
     def test_series_roundtrip_timeseries(self, orient, numpy, datetime_series):
+
+        # freq doesnt roundtrip
+        index = pd.DatetimeIndex(np.asarray(datetime_series.index), freq=None)
+        datetime_series.index = index
+
         data = datetime_series.to_json(orient=orient)
         result = pd.read_json(data, typ="series", orient=orient, numpy=numpy)
 
@@ -730,6 +746,12 @@ class TestPandasContainer:
 
     def test_axis_dates(self, datetime_series, datetime_frame):
 
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(datetime_frame.index), freq=None)
+        datetime_frame.index = index
+        index = pd.DatetimeIndex(np.asarray(datetime_series.index), freq=None)
+        datetime_series.index = index
+
         # frame
         json = datetime_frame.to_json()
         result = read_json(json)
@@ -745,6 +767,11 @@ class TestPandasContainer:
 
         # frame
         df = datetime_frame
+
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(df.index), freq=None)
+        df.index = index
+
         df["date"] = Timestamp("20130101")
 
         json = df.to_json()
@@ -761,6 +788,10 @@ class TestPandasContainer:
         tm.assert_frame_equal(result, expected)
 
         # series
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(datetime_series.index), freq=None)
+        datetime_series.index = index
+
         ts = Series(Timestamp("20130101"), index=datetime_series.index)
         json = ts.to_json()
         result = read_json(json, typ="series")
@@ -827,6 +858,10 @@ class TestPandasContainer:
     def test_date_format_frame(self, date, date_unit, datetime_frame):
         df = datetime_frame
 
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(df.index), freq=None)
+        df.index = index
+
         df["date"] = Timestamp(date)
         df.iloc[1, df.columns.get_loc("date")] = pd.NaT
         df.iloc[5, df.columns.get_loc("date")] = pd.NaT
@@ -857,6 +892,11 @@ class TestPandasContainer:
         ],
     )
     def test_date_format_series(self, date, date_unit, datetime_series):
+
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(datetime_series.index), freq=None)
+        datetime_series.index = index
+
         ts = Series(Timestamp(date), index=datetime_series.index)
         ts.iloc[1] = pd.NaT
         ts.iloc[5] = pd.NaT
@@ -879,6 +919,11 @@ class TestPandasContainer:
     @pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
     def test_date_unit(self, unit, datetime_frame):
         df = datetime_frame
+
+        # freq doesnt round-trip
+        index = pd.DatetimeIndex(np.asarray(df.index), freq=None)
+        df.index = index
+
         df["date"] = Timestamp("20130101 20:43:42")
         dl = df.columns.get_loc("date")
         df.iloc[1, dl] = Timestamp("19710101 20:43:42")

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -1011,8 +1011,8 @@ class TestPandasJSONTests:
     def test_datetime_index(self):
         date_unit = "ns"
 
-        rng = date_range("1/1/2000", periods=20)
-        rng._set_freq(None)  # freq doesnt round-trip
+        # freq doesnt round-trip
+        rng = DatetimeIndex(list(date_range("1/1/2000", periods=20)), freq=None)
         encoded = ujson.encode(rng, date_unit=date_unit)
 
         decoded = DatetimeIndex(np.array(ujson.decode(encoded)))

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -1012,6 +1012,7 @@ class TestPandasJSONTests:
         date_unit = "ns"
 
         rng = date_range("1/1/2000", periods=20)
+        rng._set_freq(None)  # freq doesnt round-trip
         encoded = ujson.encode(rng, date_unit=date_unit)
 
         decoded = DatetimeIndex(np.array(ujson.decode(encoded)))

--- a/pandas/tests/io/parser/test_dtypes.py
+++ b/pandas/tests/io/parser/test_dtypes.py
@@ -299,7 +299,9 @@ def test_categorical_coerces_numeric(all_parsers):
 
 def test_categorical_coerces_datetime(all_parsers):
     parser = all_parsers
-    dtype = {"b": CategoricalDtype(pd.date_range("2017", "2019", freq="AS"))}
+    dti = pd.date_range("2017", "2019", freq="AS")
+    dti._set_freq(None)  # freq doesnt round-trip
+    dtype = {"b": CategoricalDtype(dti)}
 
     data = "b\n2017-01-01\n2018-01-01\n2019-01-01"
     expected = DataFrame({"b": Categorical(dtype["b"].categories)})

--- a/pandas/tests/io/parser/test_dtypes.py
+++ b/pandas/tests/io/parser/test_dtypes.py
@@ -299,8 +299,7 @@ def test_categorical_coerces_numeric(all_parsers):
 
 def test_categorical_coerces_datetime(all_parsers):
     parser = all_parsers
-    dti = pd.date_range("2017", "2019", freq="AS")
-    dti._set_freq(None)  # freq doesnt round-trip
+    dti = pd.DatetimeIndex(["2017-01-01", "2018-01-01", "2019-01-01"], freq=None)
     dtype = {"b": CategoricalDtype(dti)}
 
     data = "b\n2017-01-01\n2018-01-01\n2019-01-01"

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -683,6 +683,7 @@ def test_parse_dates_string(all_parsers):
     result = parser.read_csv(StringIO(data), index_col="date", parse_dates=["date"])
     index = date_range("1/1/2009", periods=3)
     index.name = "date"
+    index._set_freq(None)  # freq doesnt round-trip
 
     expected = DataFrame(
         {"A": ["a", "b", "c"], "B": [1, 3, 4], "C": [2, 4, 5]}, index=index
@@ -1436,6 +1437,7 @@ def test_parse_timezone(all_parsers):
         freq="1min",
         tz=pytz.FixedOffset(540),
     )
+    dti._set_freq(None)  # freq doesnt round-trip
     expected_data = {"dt": dti, "val": [23350, 23400, 23400, 23400, 23400]}
 
     expected = DataFrame(expected_data)

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -681,9 +681,10 @@ def test_parse_dates_string(all_parsers):
 """
     parser = all_parsers
     result = parser.read_csv(StringIO(data), index_col="date", parse_dates=["date"])
-    index = date_range("1/1/2009", periods=3)
-    index.name = "date"
-    index._set_freq(None)  # freq doesnt round-trip
+    # freq doesnt round-trip
+    index = DatetimeIndex(
+        list(date_range("1/1/2009", periods=3)), name="date", freq=None
+    )
 
     expected = DataFrame(
         {"A": ["a", "b", "c"], "B": [1, 3, 4], "C": [2, 4, 5]}, index=index
@@ -1431,13 +1432,17 @@ def test_parse_timezone(all_parsers):
               2018-01-04 09:05:00+09:00,23400"""
     result = parser.read_csv(StringIO(data), parse_dates=["dt"])
 
-    dti = pd.date_range(
-        start="2018-01-04 09:01:00",
-        end="2018-01-04 09:05:00",
-        freq="1min",
-        tz=pytz.FixedOffset(540),
+    dti = pd.DatetimeIndex(
+        list(
+            pd.date_range(
+                start="2018-01-04 09:01:00",
+                end="2018-01-04 09:05:00",
+                freq="1min",
+                tz=pytz.FixedOffset(540),
+            ),
+        ),
+        freq=None,
     )
-    dti._set_freq(None)  # freq doesnt round-trip
     expected_data = {"dt": dti, "val": [23350, 23400, 23400, 23400, 23400]}
 
     expected = DataFrame(expected_data)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -1231,6 +1231,8 @@ class TestHDFStore:
 
             # column oriented
             df = tm.makeTimeDataFrame()
+            df.index._set_freq(None)  # freq doesnt round-trip
+
             _maybe_remove(store, "df1")
             store.append("df1", df.iloc[:, :2], axes=["columns"])
             store.append("df1", df.iloc[:, 2:])

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -1231,7 +1231,7 @@ class TestHDFStore:
 
             # column oriented
             df = tm.makeTimeDataFrame()
-            df.index._set_freq(None)  # freq doesnt round-trip
+            df.index = df.index._with_freq(None)  # freq doesnt round-trip
 
             _maybe_remove(store, "df1")
             store.append("df1", df.iloc[:, :2], axes=["columns"])

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -106,17 +106,11 @@ def test_append_with_timezones_dateutil(setup_path):
     # as index
     with ensure_clean_store(setup_path) as store:
 
+        dti = date_range("2000-1-1", periods=3, freq="H", tz=gettz("US/Eastern"))
+        dti._set_freq(None)  # freq doesnt round-trip
+
         # GH 4098 example
-        df = DataFrame(
-            dict(
-                A=Series(
-                    range(3),
-                    index=date_range(
-                        "2000-1-1", periods=3, freq="H", tz=gettz("US/Eastern")
-                    ),
-                )
-            )
-        )
+        df = DataFrame(dict(A=Series(range(3), index=dti,)))
 
         _maybe_remove(store, "df")
         store.put("df", df)
@@ -199,15 +193,11 @@ def test_append_with_timezones_pytz(setup_path):
     # as index
     with ensure_clean_store(setup_path) as store:
 
+        dti = date_range("2000-1-1", periods=3, freq="H", tz="US/Eastern")
+        dti._set_freq(None)  # freq doesnt round-trip
+
         # GH 4098 example
-        df = DataFrame(
-            dict(
-                A=Series(
-                    range(3),
-                    index=date_range("2000-1-1", periods=3, freq="H", tz="US/Eastern"),
-                )
-            )
-        )
+        df = DataFrame(dict(A=Series(range(3), index=dti,)))
 
         _maybe_remove(store, "df")
         store.put("df", df)
@@ -258,6 +248,7 @@ def test_timezones_fixed(setup_path):
 
         # index
         rng = date_range("1/1/2000", "1/30/2000", tz="US/Eastern")
+        rng._set_freq(None)  # freq doesnt round-trip
         df = DataFrame(np.random.randn(len(rng), 4), index=rng)
         store["df"] = df
         result = store["df"]
@@ -346,6 +337,7 @@ def test_dst_transitions(setup_path):
             freq="H",
             ambiguous="infer",
         )
+        times._set_freq(None)  # freq doesnt round-trip
 
         for i in [times, times + pd.Timedelta("10min")]:
             _maybe_remove(store, "df")

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -107,7 +107,7 @@ def test_append_with_timezones_dateutil(setup_path):
     with ensure_clean_store(setup_path) as store:
 
         dti = date_range("2000-1-1", periods=3, freq="H", tz=gettz("US/Eastern"))
-        dti._set_freq(None)  # freq doesnt round-trip
+        dti = dti._with_freq(None)  # freq doesnt round-trip
 
         # GH 4098 example
         df = DataFrame(dict(A=Series(range(3), index=dti,)))
@@ -194,7 +194,7 @@ def test_append_with_timezones_pytz(setup_path):
     with ensure_clean_store(setup_path) as store:
 
         dti = date_range("2000-1-1", periods=3, freq="H", tz="US/Eastern")
-        dti._set_freq(None)  # freq doesnt round-trip
+        dti = dti._with_freq(None)  # freq doesnt round-trip
 
         # GH 4098 example
         df = DataFrame(dict(A=Series(range(3), index=dti,)))
@@ -248,7 +248,7 @@ def test_timezones_fixed(setup_path):
 
         # index
         rng = date_range("1/1/2000", "1/30/2000", tz="US/Eastern")
-        rng._set_freq(None)  # freq doesnt round-trip
+        rng = rng._with_freq(None)  # freq doesnt round-trip
         df = DataFrame(np.random.randn(len(rng), 4), index=rng)
         store["df"] = df
         result = store["df"]
@@ -337,7 +337,7 @@ def test_dst_transitions(setup_path):
             freq="H",
             ambiguous="infer",
         )
-        times._set_freq(None)  # freq doesnt round-trip
+        times = times._with_freq(None)  # freq doesnt round-trip
 
         for i in [times, times + pd.Timedelta("10min")]:
             _maybe_remove(store, "df")

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -63,14 +63,21 @@ class TestFeather:
                 "bool": [True, False, True],
                 "bool_with_null": [True, np.nan, False],
                 "cat": pd.Categorical(list("abc")),
-                "dt": pd.date_range("20130101", periods=3),
-                "dttz": pd.date_range("20130101", periods=3, tz="US/Eastern"),
+                "dt": pd.DatetimeIndex(
+                    list(pd.date_range("20130101", periods=3)), freq=None
+                ),
+                "dttz": pd.DatetimeIndex(
+                    list(pd.date_range("20130101", periods=3, tz="US/Eastern")),
+                    freq=None,
+                ),
                 "dt_with_null": [
                     pd.Timestamp("20130101"),
                     pd.NaT,
                     pd.Timestamp("20130103"),
                 ],
-                "dtns": pd.date_range("20130101", periods=3, freq="ns"),
+                "dtns": pd.DatetimeIndex(
+                    pd.date_range("20130101", periods=3, freq="ns"), freq=None
+                ),
             }
         )
         if pyarrow_version >= LooseVersion("0.16.1.dev"):

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -76,7 +76,7 @@ class TestFeather:
                     pd.Timestamp("20130103"),
                 ],
                 "dtns": pd.DatetimeIndex(
-                    pd.date_range("20130101", periods=3, freq="ns"), freq=None
+                    list(pd.date_range("20130101", periods=3, freq="ns")), freq=None,
                 ),
             }
         )

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -385,6 +385,8 @@ class TestBasic(Base):
         # non-default index
         for index in indexes:
             df.index = index
+            if isinstance(index, pd.DatetimeIndex):
+                index._set_freq(None)  # freq doesnt round-trip
             check_round_trip(df, engine, check_names=check_names)
 
         # index with meta-data
@@ -462,7 +464,9 @@ class TestParquetPyArrow(Base):
         df = df_full
 
         # additional supported types for pyarrow
-        df["datetime_tz"] = pd.date_range("20130101", periods=3, tz="Europe/Brussels")
+        dti = pd.date_range("20130101", periods=3, tz="Europe/Brussels")
+        dti._set_freq(None)  # freq doesnt round-trip
+        df["datetime_tz"] = dti
         df["bool_with_none"] = [True, None, True]
 
         check_round_trip(df, pa)
@@ -629,7 +633,9 @@ class TestParquetFastParquet(Base):
     def test_basic(self, fp, df_full):
         df = df_full
 
-        df["datetime_tz"] = pd.date_range("20130101", periods=3, tz="US/Eastern")
+        dti = pd.date_range("20130101", periods=3, tz="US/Eastern")
+        dti._set_freq(None)  # freq doesnt round-trip
+        df["datetime_tz"] = dti
         df["timedelta"] = pd.timedelta_range("1 day", periods=3)
         check_round_trip(df, fp)
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1492,6 +1492,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         # GH 23510
         # Ensure that a naive DatetimeIndex isn't converted to UTC
         dates = date_range("2018-01-01", periods=5, freq="6H")
+        dates._set_freq(None)  # freq doesnt round-trip
         expected = DataFrame({"nums": range(5)}, index=dates)
         expected.to_sql("foo_table", self.conn, index_label="info_date")
         result = sql.read_sql_table("foo_table", self.conn, index_col="info_date")

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1491,8 +1491,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
     def test_naive_datetimeindex_roundtrip(self):
         # GH 23510
         # Ensure that a naive DatetimeIndex isn't converted to UTC
-        dates = date_range("2018-01-01", periods=5, freq="6H")
-        dates._set_freq(None)  # freq doesnt round-trip
+        dates = date_range("2018-01-01", periods=5, freq="6H")._with_freq(None)
         expected = DataFrame({"nums": range(5)}, index=dates)
         expected.to_sql("foo_table", self.conn, index_label="info_date")
         result = sql.read_sql_table("foo_table", self.conn, index_col="info_date")


### PR DESCRIPTION
Working on making assert_index_equal check that `freq` attrs match.  This ports the necessary test changes from tests.io.