### PR TITLE
REF: avoid passing SingleBlockManager to Series

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3649,7 +3649,9 @@ class DataFrame(NDFrame):
     @property
     def _series(self):
         return {
-            item: Series(self._mgr.iget(idx), index=self.index, name=item)
+            item: Series(
+                self._mgr.iget(idx), index=self.index, name=item, fastpath=True
+            )
             for idx, item in enumerate(self.columns)
         }
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11208,9 +11208,7 @@ def _make_cum_function(
 
         result = self._mgr.apply(block_accum_func)
 
-        d = self._construct_axes_dict()
-        d["copy"] = False
-        return self._constructor(result, **d).__finalize__(self, method=name)
+        return self._constructor(result).__finalize__(self, method=name)
 
     return set_function_name(cum_func, name, cls)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -259,12 +259,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                     # astype copies
                     data = data.astype(dtype)
                 else:
-                    # need to copy to avoid aliasing issues
+                    # GH#24096 we need to ensure the index remains immutable
                     data = data._values.copy()
-                    if isinstance(data, ABCDatetimeIndex) and data.tz is not None:
-                        # GH#24096 need copy to be deep for datetime64tz case
-                        # TODO: See if we can avoid these copies
-                        data = data._values.copy(deep=True)
                 copy = False
 
             elif isinstance(data, np.ndarray):
@@ -281,6 +277,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                     index = data.index
                 else:
                     data = data.reindex(index, copy=copy)
+                    copy = False
                 data = data._mgr
             elif is_dict_like(data):
                 data, index = self._init_dict(data, index, dtype)


### PR DESCRIPTION
cc @jorisvandenbossche IIRC you didnt want to disallow SingleBlockManager because geopandas passes it.  In those cases, does it also pass `fastpath=True`?  If so, we can consider deprecating allowing SingleBlockManager in the non-fastpath case