### PR TITLE
CLN: Remove is_null_period

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -67,7 +67,11 @@ cimport pandas._libs.util as util
 from pandas._libs.util cimport is_nan, UINT64_MAX, INT64_MAX, INT64_MIN
 
 from pandas._libs.tslib import array_to_datetime
-from pandas._libs.tslibs.nattype cimport NPY_NAT, c_NaT as NaT
+from pandas._libs.tslibs.nattype cimport (
+    NPY_NAT,
+    c_NaT as NaT,
+    checknull_with_nat,
+)
 from pandas._libs.tslibs.conversion cimport convert_to_tsobject
 from pandas._libs.tslibs.timedeltas cimport convert_to_timedelta64
 from pandas._libs.tslibs.timezones cimport get_timezone, tz_compare
@@ -77,7 +81,6 @@ from pandas._libs.missing cimport (
     isnaobj,
     is_null_datetime64,
     is_null_timedelta64,
-    is_null_period,
     C_NA,
 )
 
@@ -1844,7 +1847,7 @@ cdef class PeriodValidator(TemporalValidator):
         return util.is_period_object(value)
 
     cdef inline bint is_valid_null(self, object value) except -1:
-        return is_null_period(value)
+        return checknull_with_nat(value)
 
 
 cpdef bint is_period_array(ndarray values):

--- a/pandas/_libs/missing.pxd
+++ b/pandas/_libs/missing.pxd
@@ -6,7 +6,6 @@ cpdef ndarray[uint8_t] isnaobj(ndarray arr)
 
 cdef bint is_null_datetime64(v)
 cdef bint is_null_timedelta64(v)
-cdef bint is_null_period(v)
 
 cdef class C_NAType:
     pass

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -40,6 +40,7 @@ cpdef bint checknull(object val):
      - NaT
      - np.datetime64 representation of NaT
      - np.timedelta64 representation of NaT
+     - NA
 
     Parameters
     ----------
@@ -276,12 +277,6 @@ cdef inline bint is_null_timedelta64(v):
     elif util.is_timedelta64_object(v):
         return get_timedelta64_value(v) == NPY_NAT
     return False
-
-
-cdef inline bint is_null_period(v):
-    # determine if we have a null for a Period (or integer versions),
-    # excluding np.datetime64('nat') and np.timedelta64('nat')
-    return checknull_with_nat(v)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
is_null_period seems only to be an alias for checknull_with_nat so I think it can be removed?