### PR TITLE
CI: Revert Cython Pin (take 2)

### DIFF
--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -14,8 +14,7 @@ dependencies:
   - pytz
   - pip
   - pip:
-    - cython==0.29.16
-    # GH#33507 cython 3.0a1 is causing TypeErrors 2020-04-13
+    - cython>=0.29.16
     - "git+git://github.com/dateutil/dateutil.git"
     - "-f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
     - "--pre"


### PR DESCRIPTION
- [x] closes #33507

reverts #33534 

New Cython pre release available today - https://pypi.org/project/Cython/3.0a2/

cc @WillAyd 

Update: 3.0a2 (no such luck - seems there is a regression which is being looked at)

https://mail.python.org/pipermail/cython-devel/2020-April/005340.html

https://github.com/cython/cython/issues/3544

Update now trying 3.0a3 