### PR TITLE
BUG: MonthOffset.name

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -104,6 +104,7 @@ from pandas.io.formats import format as fmt
 from pandas.io.formats.format import DataFrameFormatter, format_percentiles
 from pandas.io.formats.printing import pprint_thing
 from pandas.tseries.frequencies import to_offset
+from pandas.tseries.offsets import Tick
 
 if TYPE_CHECKING:
     from pandas.core.resample import Resampler
@@ -8068,7 +8069,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         end_date = end = self.index[0] + offset
 
         # Tick-like, e.g. 3 weeks
-        if not offset.is_anchored() and hasattr(offset, "_inc"):
+        if isinstance(offset, Tick):
             if end_date in self.index:
                 end = self.index.searchsorted(end_date, side="left")
                 return self.iloc[:end]

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -4315,6 +4315,13 @@ def test_valid_month_attributes(kwd, month_classes):
         cls(**{kwd: 3})
 
 
+def test_month_offset_name(month_classes):
+    # GH#???? off.name with n != 1 should not raise AttributeError
+    obj = month_classes(1)
+    obj2 = month_classes(2)
+    assert obj2.name == obj.name
+
+
 @pytest.mark.parametrize("kwd", sorted(liboffsets.relativedelta_kwds))
 def test_valid_relativedelta_kwargs(kwd):
     # Check that all the arguments specified in liboffsets.relativedelta_kwds

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -4316,7 +4316,7 @@ def test_valid_month_attributes(kwd, month_classes):
 
 
 def test_month_offset_name(month_classes):
-    # GH#???? off.name with n != 1 should not raise AttributeError
+    # GH#33757 off.name with n != 1 should not raise AttributeError
     obj = month_classes(1)
     obj2 = month_classes(2)
     assert obj2.name == obj.name

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -1125,14 +1125,6 @@ class MonthOffset(SingleConstructorOffset):
 
     __init__ = BaseOffset.__init__
 
-    @property
-    def name(self) -> str:
-        if self.is_anchored:
-            return self.rule_code
-        else:
-            month = ccalendar.MONTH_ALIASES[self.n]
-            return f"{self.code_rule}-{month}"
-
     def is_on_offset(self, dt: datetime) -> bool:
         if self.normalize and not _is_normalized(dt):
             return False


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

`is_anchored` is being accessed indirectly (its not a property).  As a result we never go down the other path, which would raise AttributeError since there is no `code_rule`.