### PR TITLE
DOC: data_columns can take bool

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2359,7 +2359,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         min_itemsize: Optional[Union[int, Dict[str, int]]] = None,
         nan_rep=None,
         dropna: Optional[bool_t] = None,
-        data_columns: Optional[Union[bool, List[str]]] = None,
+        data_columns: Optional[Union[bool_t, List[str]]] = None,
         errors: str = "strict",
         encoding: str = "UTF-8",
     ) -> None:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2359,7 +2359,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         min_itemsize: Optional[Union[int, Dict[str, int]]] = None,
         nan_rep=None,
         dropna: Optional[bool_t] = None,
-        data_columns: Optional[List[str]] = None,
+        data_columns: Optional[Union[bool, List[str]]] = None,
         errors: str = "strict",
         encoding: str = "UTF-8",
     ) -> None:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -230,7 +230,7 @@ def to_hdf(
     min_itemsize: Optional[Union[int, Dict[str, int]]] = None,
     nan_rep=None,
     dropna: Optional[bool] = None,
-    data_columns: Optional[List[str]] = None,
+    data_columns: Optional[Union[bool, List[str]]] = None,
     errors: str = "strict",
     encoding: str = "UTF-8",
 ):


### PR DESCRIPTION
The ``data_columns`` argument of ``df.to_hdf`` can take ``True`` as an argument, meaning "all columns", yet the type hint is ``Optional[List[str]]``, triggering warnings in e.g. pyCharm.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
