### PR TITLE
DOC: fix doc for crosstab with Categorical data input

### DIFF
--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -472,7 +472,7 @@ If ``crosstab`` receives only two Series, it will provide a frequency table.
     pd.crosstab(df['A'], df['B'])
 
 Any input passed containing ``Categorical`` data will have **all** of its
-categories included in the cross-tabulation while setting ``dropna=False``, 
+categories included in the cross-tabulation while setting ``dropna=False``,
 even if the actual data does not contain any instances of a particular category.
 
 .. ipython:: python

--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -471,15 +471,22 @@ If ``crosstab`` receives only two Series, it will provide a frequency table.
 
     pd.crosstab(df['A'], df['B'])
 
-Any input passed containing ``Categorical`` data will have **all** of its
-categories included in the cross-tabulation while setting ``dropna=False``,
-even if the actual data does not contain any instances of a particular category.
+``crosstab`` can also be implemented
+to ``Categorical`` data.
 
 .. ipython:: python
 
     foo = pd.Categorical(['a', 'b'], categories=['a', 'b', 'c'])
     bar = pd.Categorical(['d', 'e'], categories=['d', 'e', 'f'])
     pd.crosstab(foo, bar)
+
+If you want to include **all** of data categories even if the actual data does
+not contain any instances of a particular category, you should set ``dropna=False``.
+
+For example:
+
+.. ipython:: python
+
     pd.crosstab(foo, bar, dropna=False)
 
 Normalization

--- a/doc/source/user_guide/reshaping.rst
+++ b/doc/source/user_guide/reshaping.rst
@@ -472,14 +472,15 @@ If ``crosstab`` receives only two Series, it will provide a frequency table.
     pd.crosstab(df['A'], df['B'])
 
 Any input passed containing ``Categorical`` data will have **all** of its
-categories included in the cross-tabulation, even if the actual data does
-not contain any instances of a particular category.
+categories included in the cross-tabulation while setting ``dropna=False``, 
+even if the actual data does not contain any instances of a particular category.
 
 .. ipython:: python
 
     foo = pd.Categorical(['a', 'b'], categories=['a', 'b', 'c'])
     bar = pd.Categorical(['d', 'e'], categories=['d', 'e', 'f'])
     pd.crosstab(foo, bar)
+    pd.crosstab(foo, bar, dropna=False)
 
 Normalization
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Crosstab function should set dropna=False to keep the categories which not appear in the data, but in the DOC, it seems to be inconsistent with the description. Two examples for comparison may be better for users to get this point.

https://pandas.pydata.org/docs/dev/user_guide/reshaping.html#cross-tabulations