### PR TITLE
DOC: Remove ambiguity in fill_value documentation

### DIFF
--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -399,7 +399,7 @@ _flex_doc_SERIES = """
 Return {desc} of series and other, element-wise (binary operator `{op_name}`).
 
 Equivalent to ``{equiv}``, but with support to substitute a fill_value for
-missing data in one of the inputs.
+missing data in either one of the inputs.
 
 Parameters
 ----------
@@ -408,7 +408,7 @@ fill_value : None or float value, default None (NaN)
     Fill existing missing (NaN) values, and any new element needed for
     successful Series alignment, with this value before computation.
     If data in both corresponding Series locations is missing
-    the result will be missing.
+    the result of filling (at that location) will be missing.
 level : int or name
     Broadcast across a level, matching Index values on the
     passed MultiIndex level.


### PR DESCRIPTION
- [x] closes #33380 
- [ ] tests added / passed (Not needed)
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry (Not needed)
