### PR TITLE
CLN: Pass numpy args as kwargs

### DIFF
--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -251,10 +251,15 @@ STAT_FUNC_DEFAULTS: "OrderedDict[str, Optional[Any]]" = OrderedDict()
 STAT_FUNC_DEFAULTS["dtype"] = None
 STAT_FUNC_DEFAULTS["out"] = None
 
-PROD_DEFAULTS = SUM_DEFAULTS = STAT_FUNC_DEFAULTS.copy()
+SUM_DEFAULTS = STAT_FUNC_DEFAULTS.copy()
 SUM_DEFAULTS["axis"] = None
 SUM_DEFAULTS["keepdims"] = False
 SUM_DEFAULTS["initial"] = None
+
+PROD_DEFAULTS = STAT_FUNC_DEFAULTS.copy()
+PROD_DEFAULTS["axis"] = None
+PROD_DEFAULTS["keepdims"] = False
+PROD_DEFAULTS["initial"] = None
 
 MEDIAN_DEFAULTS = STAT_FUNC_DEFAULTS.copy()
 MEDIAN_DEFAULTS["overwrite_input"] = False

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -365,36 +365,14 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
         )
         return result
 
-    def sum(
-        self,
-        axis=None,
-        dtype=None,
-        out=None,
-        keepdims=False,
-        initial=None,
-        skipna=True,
-        min_count=0,
-    ):
-        nv.validate_sum(
-            (), dict(dtype=dtype, out=out, keepdims=keepdims, initial=initial)
-        )
+    def sum(self, axis=None, skipna=True, min_count=0, **kwargs) -> Scalar:
+        nv.validate_sum((), kwargs)
         return nanops.nansum(
             self._ndarray, axis=axis, skipna=skipna, min_count=min_count
         )
 
-    def prod(
-        self,
-        axis=None,
-        dtype=None,
-        out=None,
-        keepdims=False,
-        initial=None,
-        skipna=True,
-        min_count=0,
-    ):
-        nv.validate_prod(
-            (), dict(dtype=dtype, out=out, keepdims=keepdims, initial=initial)
-        )
+    def prod(self, axis=None, skipna=True, min_count=0, **kwargs) -> Scalar:
+        nv.validate_prod((), kwargs)
         return nanops.nanprod(
             self._ndarray, axis=axis, skipna=skipna, min_count=min_count
         )


### PR DESCRIPTION
This is already done in some places for PandasArray, e.g., min / max, and seems cleaner with less boilerplate