### PR TITLE
IO: Fix feather s3 and http paths

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -586,6 +586,7 @@ I/O
   unsupported HDF file (:issue:`9539`)
 - Bug in :meth:`~DataFrame.to_parquet` was not raising ``PermissionError`` when writing to a private s3 bucket with invalid creds. (:issue:`27679`)
 - Bug in :meth:`~DataFrame.to_csv` was silently failing when writing to an invalid s3 bucket. (:issue:`32486`)
+- Bug in :meth:`~DataFrame.read_feather` was raising an `ArrowIOError` when reading an s3 or http file path (:issue:`29055`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -102,6 +102,7 @@ def read_feather(path, columns=None, use_threads: bool = True):
 
     df = feather.read_feather(path, columns=columns, use_threads=bool(use_threads))
 
+    # s3fs only validates the credentials when the file is closed.
     if should_close:
         path.close()
 

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -4,7 +4,7 @@ from pandas.compat._optional import import_optional_dependency
 
 from pandas import DataFrame, Int64Index, RangeIndex
 
-from pandas.io.common import stringify_path
+from pandas.io.common import get_filepath_or_buffer, stringify_path
 
 
 def to_feather(df: DataFrame, path, **kwargs):
@@ -98,6 +98,11 @@ def read_feather(path, columns=None, use_threads: bool = True):
     import_optional_dependency("pyarrow")
     from pyarrow import feather
 
-    path = stringify_path(path)
+    path, _, _, should_close = get_filepath_or_buffer(path)
 
-    return feather.read_feather(path, columns=columns, use_threads=bool(use_threads))
+    df = feather.read_feather(path, columns=columns, use_threads=bool(use_threads))
+
+    if should_close:
+        path.close()
+
+    return df

--- a/pandas/tests/io/conftest.py
+++ b/pandas/tests/io/conftest.py
@@ -15,7 +15,7 @@ def tips_file(datapath):
 
 @pytest.fixture
 def jsonl_file(datapath):
-    """Path a JSONL dataset"""
+    """Path to a JSONL dataset"""
     return datapath("io", "parser", "data", "items.jsonl")
 
 
@@ -26,7 +26,12 @@ def salaries_table(datapath):
 
 
 @pytest.fixture
-def s3_resource(tips_file, jsonl_file):
+def feather_file(datapath):
+    return datapath("io", "data", "feather", "feather-0_3_1.feather")
+
+
+@pytest.fixture
+def s3_resource(tips_file, jsonl_file, feather_file):
     """
     Fixture for mocking S3 interaction.
 
@@ -58,6 +63,7 @@ def s3_resource(tips_file, jsonl_file):
             ("tips.csv.gz", tips_file + ".gz"),
             ("tips.csv.bz2", tips_file + ".bz2"),
             ("items.jsonl", jsonl_file),
+            ("simple_dataset.feather", feather_file),
         ]
 
         def add_tips_files(bucket_name):

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -228,6 +228,7 @@ class TestS3:
         result = read_csv("s3://pandas-test/tips#1.csv")
         tm.assert_frame_equal(tips_df, result)
 
+    @td.skip_if_no("pyarrow")
     def test_read_feather_s3_file_path(self, feather_file):
         # GH 29055
         expected = read_feather(feather_file)

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -13,6 +13,7 @@ import pandas.util._test_decorators as td
 from pandas import DataFrame
 import pandas._testing as tm
 
+from pandas.io.feather_format import read_feather
 from pandas.io.parsers import read_csv
 
 
@@ -203,7 +204,6 @@ class TestS3:
         import s3fs
 
         df = DataFrame(np.random.randn(100000, 4), columns=list("abcd"))
-        buf = BytesIO()
         str_buf = StringIO()
 
         df.to_csv(str_buf)
@@ -227,3 +227,9 @@ class TestS3:
         # GH 25945
         result = read_csv("s3://pandas-test/tips#1.csv")
         tm.assert_frame_equal(tips_df, result)
+
+    def test_read_feather_s3_file_path(self, feather_file):
+        # GH 29055
+        expected = read_feather(feather_file)
+        res = read_feather("s3://pandas-test/simple_dataset.feather")
+        tm.assert_frame_equal(expected, res)

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -168,5 +168,6 @@ class TestFeather:
             "https://raw.githubusercontent.com/pandas-dev/pandas/master/"
             "pandas/tests/io/data/feather/feather-0_3_1.feather"
         )
+        expected = pd.read_feather(feather_file)
         res = pd.read_feather(url)
-        tm.assert_frame_equal(feather_file, res)
+        tm.assert_frame_equal(expected, res)

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -159,3 +159,14 @@ class TestFeather:
     def test_passthrough_keywords(self):
         df = tm.makeDataFrame().reset_index()
         self.check_round_trip(df, write_kwargs=dict(version=1))
+
+    @td.skip_if_no("pyarrow")
+    @tm.network
+    def test_http_path(self, feather_file):
+        # GH 29055
+        url = (
+            "https://raw.githubusercontent.com/pandas-dev/pandas/master/"
+            "pandas/tests/io/data/feather/feather-0_3_1.feather"
+        )
+        res = pd.read_feather(url)
+        tm.assert_frame_equal(feather_file, res)


### PR DESCRIPTION
- [x] closes #29055
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
