### PR TITLE
CLN/TYP: update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -141,9 +141,6 @@ ignore_errors=True
 [mypy-pandas.tests.tools.test_to_datetime]
 ignore_errors=True
 
-[mypy-pandas.tests.scalar.period.test_period]
-ignore_errors=True
-
 [mypy-pandas._testing]
 check_untyped_defs=False
 


### PR DESCRIPTION
```
@pytest.mark.xfail(	
    StrictVersion(dateutil.__version__.split(".dev")[0]) < StrictVersion("2.7.0"),	
    reason="Bug in dateutil < 2.7.0 when parsing old dates: Period('0001-01-07', 'D')",	
    strict=False,	
)
```
removed in #33680