### PR TITLE
CLN: freq inference in DTI/TDI set ops

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -762,6 +762,8 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
             loc = right.searchsorted(left_end, side="right")
             right_chunk = right._values[loc:]
             dates = concat_compat([left._values, right_chunk])
+            # The can_fast_union check ensures that the result.freq
+            #  should match self.freq
             dates = type(self._data)(dates, freq=self.freq)
             result = type(self)._simple_new(dates, name=self.name)
             return result
@@ -830,7 +832,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
             return this, other
 
         if isinstance(other, type(self)):
-            if self.tz is not None:  # TODO: use an existing validation func
+            if self.tz is not None:
                 if other.tz is None:
                     raise TypeError("Cannot join tz-naive with tz-aware DatetimeIndex")
             elif other.tz is not None:
@@ -856,7 +858,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
             "integer-na",
             "mixed-integer-float",
             "mixed",
-        ):  # TOOD: can we use a positive check instead of a negative check?
+        ):
             return True
         return False
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -770,7 +770,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
         else:
             return left
 
-    def _union(self: _T, other: _T, sort) -> _T:
+    def _union(self, other, sort):
         if not len(other) or self.equals(other) or not len(self):
             return super()._union(other, sort=sort)
 


### PR DESCRIPTION
These ops are a PITA for getting the freq check into assert_index_equal.  I'm leaning towards ripping out the freq="infer" behavior in all the cases where we can't fast-infer it.