### PR TITLE
CLN: address FIXME/TODO/XXX comments

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -128,7 +128,7 @@ conda list pandas
 echo "[Build extensions]"
 python setup.py build_ext -q -i -j2
 
-# XXX: Some of our environments end up with old versions of pip (10.x)
+# TODO: Some of our environments end up with old versions of pip (10.x)
 # Adding a new enough version of pip to the requirements explodes the
 # solve time. Just using pip to update itself.
 # - py35_macos

--- a/pandas/_libs/src/parser/tokenizer.h
+++ b/pandas/_libs/src/parser/tokenizer.h
@@ -52,8 +52,8 @@ See LICENSE for the license
 #define PARSER_OUT_OF_MEMORY -1
 
 /*
- *  XXX Might want to couple count_rows() with read_rows() to avoid duplication
- *      of some file I/O.
+ *  TODO: Might want to couple count_rows() with read_rows() to avoid
+ *        duplication of some file I/O.
  */
 
 typedef enum {

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -544,7 +544,7 @@ class TimeRE(dict):
             'w': r"(?P<w>[0-6])",
             # W is set below by using 'U'
             'y': r"(?P<y>\d\d)",
-            # XXX: Does 'Y' need to worry about having less or more than
+            # TODO: Does 'Y' need to worry about having less or more than
             #     4 digits?
             'Y': r"(?P<Y>\d\d\d\d)",
             'z': r"(?P<z>[+-]\d\d:?[0-5]\d(:?[0-5]\d(\.\d{1,6})?)?|Z)",

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -142,6 +142,7 @@ def _ensure_data(values, dtype=None):
             if values.ndim > 1 and is_datetime64_ns_dtype(values):
                 # Avoid calling the DatetimeIndex constructor as it is 1D only
                 # Note: this is reached by DataFrame.rank calls GH#27027
+                # TODO(EA2D): special case not needed with 2D EAs
                 asi8 = values.view("i8")
                 dtype = values.dtype
                 return asi8, dtype

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -335,7 +335,7 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
         # TODO: disentangle the fill_value dtype inference from
         # dtype inference
         if data is None:
-            # XXX: What should the empty dtype be? Object or float?
+            # TODO: What should the empty dtype be? Object or float?
             data = np.array([], dtype=dtype)
 
         if not is_array_like(data):

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -178,6 +178,7 @@ def concat_categorical(to_concat, axis: int = 0):
     ]
     result = concat_compat(to_concat)
     if axis == 1:
+        # TODO(EA2D): not necessary with 2D EAs
         result = result.reshape(1, len(result))
     return result
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1129,6 +1129,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     # e.g. block.values was an IntegerArray
                     # (1, N) case can occur if block.values was Categorical
                     #  and result is ndarray[object]
+                    # TODO(EA2D): special casing not needed with 2D EAs
                     assert result.ndim == 1 or result.shape[0] == 1
                     try:
                         # Cast back if feasible

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -476,8 +476,8 @@ class BaseGrouper:
 
         if is_datetime64tz_dtype(values.dtype):
             # Cast to naive; we'll cast back at the end of the function
-            # TODO: possible need to reshape?  kludge can be avoided when
-            #  2D EA is allowed.
+            # TODO: possible need to reshape?
+            # TODO(EA2D):kludge can be avoided when 2D EA is allowed.
             values = values.view("M8[ns]")
 
         is_datetimelike = needs_i8_conversion(values.dtype)
@@ -717,7 +717,7 @@ class BaseGrouper:
                 if isinstance(res, (Series, Index, np.ndarray)):
                     if len(res) == 1:
                         # e.g. test_agg_lambda_with_timezone lambda e: e.head(1)
-                        # FIXME: are we potentially losing import res.index info?
+                        # FIXME: are we potentially losing important res.index info?
                         res = res.item()
                     else:
                         raise ValueError("Function does not reduce")

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1721,7 +1721,7 @@ class ExtensionBlock(Block):
         return self.make_block_same_class(new_values, new_mgr_locs)
 
     def _can_hold_element(self, element: Any) -> bool:
-        # XXX: We may need to think about pushing this onto the array.
+        # TODO: We may need to think about pushing this onto the array.
         # We're doing the same as CategoricalBlock here.
         return True
 

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -218,6 +218,7 @@ class JoinUnit:
         elif is_sparse(self.block.values.dtype):
             return False
         elif self.block.is_extension:
+            # TODO(EA2D): no need for special case with 2D EAs
             values_flat = values
         else:
             values_flat = values.ravel(order="K")

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1851,7 +1851,7 @@ class ParserBase:
             )
 
             if not is_object_dtype(values) and not known_cats:
-                # XXX this is for consistency with
+                # TODO: this is for consistency with
                 # c-parser which parses all categories
                 # as strings
                 values = astype_nansafe(values, str)

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -140,12 +140,10 @@ class TestDatetime64ArrayLikeComparisons:
         ts = pd.Timestamp.now(tz)
         ser = pd.Series([ts, pd.NaT])
 
-        # FIXME: Can't transpose because that loses the tz dtype on
-        #  the NaT column
-        obj = tm.box_expected(ser, box, transpose=False)
+        obj = tm.box_expected(ser, box)
 
         expected = pd.Series([True, False], dtype=np.bool_)
-        expected = tm.box_expected(expected, xbox, transpose=False)
+        expected = tm.box_expected(expected, xbox)
 
         result = obj == ts
         tm.assert_equal(result, expected)
@@ -843,10 +841,8 @@ class TestDatetime64Arithmetic:
         other = np.timedelta64("NaT")
         expected = pd.DatetimeIndex(["NaT"] * 9, tz=tz)
 
-        # FIXME: fails with transpose=True due to tz-aware DataFrame
-        #  transpose bug
-        obj = tm.box_expected(dti, box_with_array, transpose=False)
-        expected = tm.box_expected(expected, box_with_array, transpose=False)
+        obj = tm.box_expected(dti, box_with_array)
+        expected = tm.box_expected(expected, box_with_array)
 
         result = obj + other
         tm.assert_equal(result, expected)

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -906,9 +906,8 @@ class TestPeriodIndexArithmetic:
         pi = pd.PeriodIndex(["2016-01"], freq="2M")
         expected = pd.PeriodIndex(["2016-04"], freq="2M")
 
-        # FIXME: with transposing these tests fail
-        pi = tm.box_expected(pi, box_with_array, transpose=False)
-        expected = tm.box_expected(expected, box_with_array, transpose=False)
+        pi = tm.box_expected(pi, box_with_array)
+        expected = tm.box_expected(expected, box_with_array)
 
         result = pi + to_offset("3M")
         tm.assert_equal(result, expected)

--- a/pandas/tests/arrays/boolean/test_logical.py
+++ b/pandas/tests/arrays/boolean/test_logical.py
@@ -38,6 +38,7 @@ class TestLogicalOps(BaseOpsUtil):
         result = getattr(a, op_name)(False)
         tm.assert_extension_array_equal(a, result)
 
+        # FIXME: dont leave commented-out
         # TODO: pd.NA
         # result = getattr(a, op_name)(pd.NA)
         # tm.assert_extension_array_equal(a, result)

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -48,8 +48,6 @@ class TestToIterable:
         ],
         ids=["tolist", "to_list", "list", "iter"],
     )
-    @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
-    # TODO(GH-24559): Remove the filterwarnings
     def test_iterable(self, index_or_series, method, dtype, rdtype):
         # gh-10904
         # gh-13258
@@ -104,8 +102,6 @@ class TestToIterable:
     @pytest.mark.parametrize(
         "dtype, rdtype", dtypes + [("object", int), ("category", int)]
     )
-    @pytest.mark.filterwarnings("ignore:\\n    Passing:FutureWarning")
-    # TODO(GH-24559): Remove the filterwarnings
     def test_iterable_map(self, index_or_series, dtype, rdtype):
         # gh-13236
         # coerce iteration to underlying python / pandas types

--- a/pandas/tests/extension/base/dtype.py
+++ b/pandas/tests/extension/base/dtype.py
@@ -75,7 +75,7 @@ class BaseDtypeTests(BaseExtensionTests):
         else:
             expected = pd.Series([True, True, False, False], index=list("ABCD"))
 
-        # XXX: This should probably be *fixed* not ignored.
+        # FIXME: This should probably be *fixed* not ignored.
         # See libops.scalar_compare
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)

--- a/pandas/tests/extension/base/getitem.py
+++ b/pandas/tests/extension/base/getitem.py
@@ -230,7 +230,8 @@ class BaseGetitemTests(BaseExtensionTests):
         with pytest.raises(ValueError, match=msg):
             data[idx]
 
-        # TODO this raises KeyError about labels not found (it tries label-based)
+        # FIXME: dont leave commented-out
+        # TODO: this raises KeyError about labels not found (it tries label-based)
         # import pandas._testing as tm
         # s = pd.Series(data, index=[tm.rands(4) for _ in range(len(data))])
         # with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/extension/test_boolean.py
+++ b/pandas/tests/extension/test_boolean.py
@@ -346,6 +346,7 @@ class TestUnaryOps(base.BaseUnaryOpsTests):
     pass
 
 
+# FIXME: dont leave commented-out
 # TODO parsing not yet supported
 # class TestParsing(base.BaseParsingTests):
 #     pass

--- a/pandas/tests/frame/methods/test_round.py
+++ b/pandas/tests/frame/methods/test_round.py
@@ -102,11 +102,6 @@ class TestDataFrameRound:
         # nan in Series round
         nan_round_Series = Series({"col1": np.nan, "col2": 1})
 
-        # TODO(wesm): unused?
-        expected_nan_round = DataFrame(  # noqa
-            {"col1": [1.123, 2.123, 3.123], "col2": [1.2, 2.2, 3.2]}
-        )
-
         msg = "integer argument expected, got float"
         with pytest.raises(TypeError, match=msg):
             df.round(nan_round_Series)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -561,8 +561,7 @@ class Base:
         assert not indices.equals(np.array(indices))
 
         # Cannot pass in non-int64 dtype to RangeIndex
-        if not isinstance(indices, (RangeIndex, CategoricalIndex)):
-            # TODO: CategoricalIndex can be re-allowed following GH#32167
+        if not isinstance(indices, RangeIndex):
             same_values = Index(indices, dtype=object)
             assert indices.equals(same_values)
             assert same_values.equals(indices)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -846,7 +846,7 @@ class TestBusinessDateRange:
         # GH #456
         rng1 = bdate_range("12/5/2011", "12/5/2011")
         rng2 = bdate_range("12/2/2011", "12/5/2011")
-        rng2._data.freq = BDay()  # TODO: shouldn't this already be set?
+        assert rng2._data.freq == BDay()
 
         result = rng1.union(rng2)
         assert isinstance(result, DatetimeIndex)
@@ -905,7 +905,7 @@ class TestCustomDateRange:
         # GH #456
         rng1 = bdate_range("12/5/2011", "12/5/2011", freq="C")
         rng2 = bdate_range("12/2/2011", "12/5/2011", freq="C")
-        rng2._data.freq = CDay()  # TODO: shouldn't this already be set?
+        assert rng2._data.freq == CDay()
 
         result = rng1.union(rng2)
         assert isinstance(result, DatetimeIndex)

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -376,9 +376,6 @@ class TestChaining:
         df["f"] = 0
         df.f.values[3] = 1
 
-        # TODO(wesm): unused?
-        # y = df.iloc[np.arange(2, len(df))]
-
         df.f.values[3] = 2
         expected = DataFrame(
             np.zeros((5, 6), dtype="int64"),

--- a/pandas/tests/io/excel/test_style.py
+++ b/pandas/tests/io/excel/test_style.py
@@ -23,7 +23,7 @@ from pandas.io.formats.excel import ExcelFormatter
 )
 def test_styler_to_excel(engine):
     def style(df):
-        # XXX: RGB colors not supported in xlwt
+        # TODO: RGB colors not supported in xlwt
         return DataFrame(
             [
                 ["font-weight: bold", "", ""],
@@ -47,7 +47,7 @@ def test_styler_to_excel(engine):
             pytest.xfail(
                 reason=(f"GH25351: failing on some attribute comparisons in {engine}")
             )
-        # XXX: should find a better way to check equality
+        # TODO: should find a better way to check equality
         assert cell1.alignment.__dict__ == cell2.alignment.__dict__
         assert cell1.border.__dict__ == cell2.border.__dict__
         assert cell1.fill.__dict__ == cell2.fill.__dict__
@@ -98,7 +98,7 @@ def test_styler_to_excel(engine):
 
         # (2) check styling with default converter
 
-        # XXX: openpyxl (as at 2.4) prefixes colors with 00, xlsxwriter with FF
+        # TODO: openpyxl (as at 2.4) prefixes colors with 00, xlsxwriter with FF
         alpha = "00" if engine == "openpyxl" else "FF"
 
         n_cells = 0
@@ -106,7 +106,7 @@ def test_styler_to_excel(engine):
             assert len(col1) == len(col2)
             for cell1, cell2 in zip(col1, col2):
                 ref = f"{cell2.column}{cell2.row:d}"
-                # XXX: this isn't as strong a test as ideal; we should
+                # TODO: this isn't as strong a test as ideal; we should
                 #      confirm that differences are exclusive
                 if ref == "B2":
                     assert not cell1.font.bold

--- a/pandas/tests/io/formats/test_css.py
+++ b/pandas/tests/io/formats/test_css.py
@@ -60,8 +60,6 @@ def test_css_parse_invalid(invalid_css, remainder):
     with tm.assert_produces_warning(CSSWarning):
         assert_same_resolution(invalid_css, remainder)
 
-    # TODO: we should be checking that in other cases no warnings are raised
-
 
 @pytest.mark.parametrize(
     "shorthand,expansions",

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1130,7 +1130,7 @@ class _EngineToConnMixin:
         self.conn.close()
         self.conn = self.__engine
         self.pandasSQL = sql.SQLDatabase(self.__engine)
-        # XXX:
+        # FIXME: dont leave commented-out
         # super().teardown_method(method)
 
 

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -228,7 +228,7 @@ class TestConcatAppendCommon:
                     # same dtype is tested in test_concatlike_same_dtypes
                     continue
                 elif typ1 == "category" or typ2 == "category":
-                    # ToDo: suspicious
+                    # TODO: suspicious
                     continue
 
                 # specify expected dtype

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -652,7 +652,6 @@ class TestTimedeltaMultiplicationDivision:
         msg = "Invalid dtype"
         with pytest.raises(TypeError, match=msg):
             # Deprecated GH#19761, enforced GH#29797
-            # TODO: GH-19761. Change to TypeError.
             ser // td
 
     # ----------------------------------------------------------------

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -556,8 +556,6 @@ def test_indexing_unordered():
     ts2 = pd.concat([ts[0:4], ts[-4:], ts[4:-4]])
 
     for t in ts.index:
-        # TODO: unused?
-        s = str(t)  # noqa
 
         expected = ts[t]
         result = ts2[t]

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -445,7 +445,7 @@ def test_setitem_with_tz(tz):
 
 
 def test_setitem_with_tz_dst():
-    # GH XXX
+    # GH XXX TODO: fill in GH ref
     tz = "US/Eastern"
     orig = pd.Series(pd.date_range("2016-11-06", freq="H", periods=3, tz=tz))
     assert orig.dtype == f"datetime64[ns, {tz}]"

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -435,7 +435,7 @@ class DateOffset(BaseOffset):
     def is_on_offset(self, dt):
         if self.normalize and not _is_normalized(dt):
             return False
-        # XXX, see #1395
+        # TODO, see #1395
         if type(self) == DateOffset or isinstance(self, Tick):
             return True
 


### PR DESCRIPTION
- changed XXX comments to TODO (much more grep-friendly, since we sometimes use XXX for a `name` attribute.
- Removed some now-fixed FIXME/TODO comments
  - tests.arithmetic.test_datetime64, tests.arithmetic.test_period, test_conversion, tests.indexes.common, test_date_range, test_css, scalar.timedelta.test_arithmetic
- Added some TODO(EA2D) comments
- Removed some `TODO(wesm): unused?` comments