### PR TITLE
DOC: Remove deprecated Y and M from to_timedelta

### DIFF
--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -28,8 +28,8 @@ def to_timedelta(arg, unit="ns", errors="raise"):
         The data to be converted to timedelta.
     unit : str, default 'ns'
         Denotes the unit of the arg. Possible values:
-        ('Y', 'M', 'W', 'D', 'days', 'day', 'hours', hour', 'hr',
-        'h', 'm', 'minute', 'min', 'minutes', 'T', 'S', 'seconds',
+        ('W', 'D', 'days', 'day', 'hours', hour', 'hr', 'h',
+        'm', 'minute', 'min', 'minutes', 'T', 'S', 'seconds',
         'sec', 'second', 'ms', 'milliseconds', 'millisecond',
         'milli', 'millis', 'L', 'us', 'microseconds', 'microsecond',
         'micro', 'micros', 'U', 'ns', 'nanoseconds', 'nano', 'nanos',


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

[`to_timedelta()`](https://github.com/pandas-dev/pandas/blob/master/pandas/core/tools/timedeltas.py#L84-L88) blocks those arguments anyway, so no reason to include them in the docstring.