### PR TITLE
BUG: Preserve Series/DataFrame subclasses through groupby operations

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -701,7 +701,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.groupby` where a ``ValueError`` would be raised when grouping by a categorical column with read-only categories and ``sort=False`` (:issue:`33410`)
 - Bug in :meth:`GroupBy.first` and :meth:`GroupBy.last` where None is not preserved in object dtype (:issue:`32800`)
 - Bug in :meth:`Rolling.min` and :meth:`Rolling.max`: Growing memory usage after multiple calls when using a fixed window (:issue:`30726`)
-- Bug where subclasses were not preserved through groupby operations (:issue:`28330`)
+- Bug in :meth:`GroupBy.agg`, :meth:`GroupBy.transform`, and :meth:`GroupBy.resample` where subclasses are not preserved (:issue:`28330`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -700,7 +700,7 @@ Groupby/resample/rolling
 - Bug in :meth:`GroupBy.first` and :meth:`GroupBy.last` where None is not preserved in object dtype (:issue:`32800`)
 - Bug in :meth:`Rolling.min` and :meth:`Rolling.max`: Growing memory usage after multiple calls when using a fixed window (:issue:`30726`)
 - Bug where subclasses were not preserved through groupby operations (:issue:`28330`)
-  
+
 Reshaping
 ^^^^^^^^^
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -699,7 +699,8 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.groupby` where a ``ValueError`` would be raised when grouping by a categorical column with read-only categories and ``sort=False`` (:issue:`33410`)
 - Bug in :meth:`GroupBy.first` and :meth:`GroupBy.last` where None is not preserved in object dtype (:issue:`32800`)
 - Bug in :meth:`Rolling.min` and :meth:`Rolling.max`: Growing memory usage after multiple calls when using a fixed window (:issue:`30726`)
-
+- Bug where subclasses were not preserved through groupby operations (:issue:`28330`)
+  
 Reshaping
 ^^^^^^^^^
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8524,7 +8524,7 @@ Wild         185.0
         indices = nanops.nanargmin(self.values, axis=axis, skipna=skipna)
         index = self._get_axis(axis)
         result = [index[i] if i >= 0 else np.nan for i in indices]
-        return Series(result, index=self._get_agg_axis(axis))
+        return self._constructor_sliced(result, index=self._get_agg_axis(axis))
 
     def idxmax(self, axis=0, skipna=True) -> Series:
         """
@@ -8591,7 +8591,7 @@ Wild         185.0
         indices = nanops.nanargmax(self.values, axis=axis, skipna=skipna)
         index = self._get_axis(axis)
         result = [index[i] if i >= 0 else np.nan for i in indices]
-        return Series(result, index=self._get_agg_axis(axis))
+        return self._constructor_sliced(result, index=self._get_agg_axis(axis))
 
     def _get_agg_axis(self, axis_num: int) -> Index:
         """

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -23,6 +23,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 import warnings
 
@@ -1079,7 +1080,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     continue
                 else:
                     # Ensure result is DataFrame-like type
-                    assert isinstance(result, type(self.obj))
+                    if not isinstance(result, DataFrame):
+                        result = cast(DataFrame, result)
 
                     # unwrap DataFrame to get array
                     if len(result._mgr.blocks) != 1:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -23,7 +23,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    cast,
 )
 import warnings
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1507,7 +1507,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 res = maybe_cast_result(res, obj.iloc[:, i], how=func_nm)
             output.append(res)
 
-        return type(self.obj)._from_arrays(
+        return self.obj._constructor._from_arrays(
             output, columns=result.columns, index=obj.index
         )
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1296,7 +1296,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                         **kwargs, dtype_if_empty=object
                     )
                 else:
-                    backup = first_not_none._constructor(**kwargs, dtype=object)
+                    backup = first_not_none._constructor(**kwargs)
 
                 values = [x if (x is not None) else backup for x in values]
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1070,7 +1070,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         deleted_items: List[np.ndarray] = []
         # Some object-dtype blocks might be split into List[Block[T], Block[U]]
         split_items: List[np.ndarray] = []
-        split_frames: List[type(self.obj)] = []
+        split_frames: List[DataFrame] = []
 
         no_result = object()
         for block in data.blocks:
@@ -1109,7 +1109,8 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     deleted_items.append(locs)
                     continue
                 else:
-                    result = cast(type(self.obj), result)
+                    # Cast to DataFrame-like type
+                    result = self.obj._constructor(result)
                     # unwrap DataFrame to get array
                     if len(result._mgr.blocks) != 1:
                         # We've split an object block! Everything we've assumed

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -541,7 +541,7 @@ class SeriesGroupBy(GroupBy[Series]):
 
             result = concat(results).sort_index()
         else:
-            result = self.obj.constructor(dtype=np.float64)
+            result = self.obj._constructor(dtype=np.float64)
 
         # we will only try to coerce the result type if
         # we have a numeric dtype, as these are *always* user-defined funcs

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1078,8 +1078,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     deleted_items.append(locs)
                     continue
                 else:
-                    # Cast to DataFrame-like type
-                    result = self.obj._constructor(result)
+                    # Ensure result is DataFrame-like type
+                    assert isinstance(result, type(self.obj))
+
                     # unwrap DataFrame to get array
                     if len(result._mgr.blocks) != 1:
                         # We've split an object block! Everything we've assumed

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -376,7 +376,9 @@ class SeriesGroupBy(GroupBy[Series]):
             result = self.obj._constructor_expanddim(indexed_output, index=index)
             result.columns = columns
         else:
-            result = self.obj._constructor(indexed_output[0], index=index, name=columns[0])
+            result = self.obj._constructor(
+                indexed_output[0], index=index, name=columns[0]
+            )
 
         return result
 
@@ -435,7 +437,9 @@ class SeriesGroupBy(GroupBy[Series]):
     def _wrap_applied_output(self, keys, values, not_indexed_same=False):
         if len(keys) == 0:
             # GH #6265
-            return self.obj._constructor([], name=self._selection_name, index=keys, dtype=np.float64)
+            return self.obj._constructor(
+                [], name=self._selection_name, index=keys, dtype=np.float64
+            )
 
         def _get_index() -> Index:
             if self.grouper.nkeys > 1:
@@ -447,7 +451,9 @@ class SeriesGroupBy(GroupBy[Series]):
         if isinstance(values[0], dict):
             # GH #823 #24880
             index = _get_index()
-            result = self._reindex_output(self.obj._constructor_expanddim(values, index=index))
+            result = self._reindex_output(
+                self.obj._constructor_expanddim(values, index=index)
+            )
             # if self.observed is False,
             # keep all-NaN rows created while re-indexing
             result = result.stack(dropna=self.observed)
@@ -461,7 +467,9 @@ class SeriesGroupBy(GroupBy[Series]):
             return self._concat_objects(keys, values, not_indexed_same=not_indexed_same)
         else:
             # GH #6265 #24880
-            result = self.obj._constructor(data=values, index=_get_index(), name=self._selection_name)
+            result = self.obj._constructor(
+                data=values, index=_get_index(), name=self._selection_name
+            )
             return self._reindex_output(result)
 
     def _aggregate_named(self, func, *args, **kwargs):
@@ -1375,7 +1383,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     #  fall through to the outer else clause
                     # TODO: sure this is right?  we used to do this
                     #  after raising AttributeError above
-                    return self.obj._constructor_sliced(values, index=key_index, name=self._selection_name)
+                    return self.obj._constructor_sliced(
+                        values, index=key_index, name=self._selection_name
+                    )
 
                 # if we have date/time like in the original, then coerce dates
                 # as we are stacking can easily have object dtypes here
@@ -1426,7 +1436,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 if cache_key not in NUMBA_FUNC_CACHE:
                     NUMBA_FUNC_CACHE[cache_key] = numba_func
                 # Return the result as a DataFrame for concatenation later
-                res = self.obj._constructor(res, index=group.index, columns=group.columns)
+                res = self.obj._constructor(
+                    res, index=group.index, columns=group.columns
+                )
             else:
                 # Try slow path and fast path.
                 try:
@@ -1525,7 +1537,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 res = maybe_cast_result(res, obj.iloc[:, i], how=func_nm)
             output.append(res)
 
-        return type(self.obj)._from_arrays(output, columns=result.columns, index=obj.index)
+        return type(self.obj)._from_arrays(
+            output, columns=result.columns, index=obj.index
+        )
 
     def _define_paths(self, func, *args, **kwargs):
         if isinstance(func, str):
@@ -1702,7 +1716,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         result_index = self.grouper.levels[0]
 
         if self.axis == 0:
-            return self.obj._constructor(result, index=obj.columns, columns=result_index).T
+            return self.obj._constructor(
+                result, index=obj.columns, columns=result_index
+            ).T
         else:
             return self.obj._constructor(result, index=obj.index, columns=result_index)
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1079,10 +1079,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     deleted_items.append(locs)
                     continue
                 else:
-                    # Ensure result is DataFrame-like type
-                    if not isinstance(result, DataFrame):
-                        result = cast(DataFrame, result)
-
+                    result = cast(DataFrame, result)
                     # unwrap DataFrame to get array
                     if len(result._mgr.blocks) != 1:
                         # We've split an object block! Everything we've assumed

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1287,7 +1287,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                         **kwargs, dtype_if_empty=object
                     )
                 else:
-                    backup = first_not_none._constructor(**kwargs)
+                    backup = first_not_none._constructor(**kwargs, dtype=object)
 
                 values = [x if (x is not None) else backup for x in values]
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1291,7 +1291,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 # this is to silence a DeprecationWarning
                 # TODO: Remove when default dtype of empty Series is object
                 kwargs = first_not_none._construct_axes_dict()
-                if first_not_none._constructor is Series:
+                if isinstance(first_not_none, Series):
                     backup = create_series_with_explicit_dtype(
                         **kwargs, dtype_if_empty=object
                     )

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2115,7 +2115,6 @@ class GroupBy(_GroupBy[FrameOrSeries]):
             cumcounts = self._cumcount_array(ascending=ascending)
             return Series(cumcounts, index)
 
-
     @Substitution(name="groupby")
     @Appender(_common_see_also)
     def rank(

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1421,9 +1421,10 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         result = self.grouper.size()
 
         # GH28330 preserve subclassed Series/DataFrames through calls
-        if isinstance(self.obj, Series):
-            result = self.obj._constructor(result)
+        if self.obj._constructor is Series:
             result.name = self.obj.name
+        elif isinstance(self.obj, Series):
+            result = self.obj._constructor(result, name=self.obj.name)
         elif isinstance(self.obj, DataFrame):
             result = self.obj._constructor_sliced(result)
         return self._reindex_output(result, fill_value=0)
@@ -2120,7 +2121,13 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         """
         with _group_selection_context(self):
             index = self._selected_obj.index
-            result = Series(self.grouper.group_info[0], index)
+
+            # GH28330 preserve subclassed Series/DataFrames
+            if isinstance(self.obj, Series):
+                result = self.obj._constructor(self.grouper.group_info[0], index)
+            elif isinstance(self.obj, DataFrame):
+                result = self.obj._constructor_sliced(self.grouper.group_info[0], index)
+
             if not ascending:
                 result = self.ngroups - 1 - result
             return result
@@ -2182,7 +2189,12 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         with _group_selection_context(self):
             index = self._selected_obj.index
             cumcounts = self._cumcount_array(ascending=ascending)
-            return Series(cumcounts, index)
+
+            # GH28330 preserve subclassed Series/DataFrames
+            if isinstance(self.obj, Series):
+                return self.obj._constructor(cumcounts, index)
+            elif isinstance(self.obj, DataFrame):
+                return self.obj._constructor_sliced(cumcounts, index)
 
     @Substitution(name="groupby")
     @Appender(_common_see_also)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1187,10 +1187,8 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         # GH28330 preserve subclassed Series/DataFrames
         if isinstance(self.obj, DataFrame):
             return self.obj._constructor_sliced
-        elif isinstance(self.obj, Series):
-            return self.obj._constructor
-        else:
-            return Series
+        assert isinstance(self.obj, Series)
+        return self.obj._constructor
 
     def _bool_agg(self, val_test, skipna):
         """

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2051,7 +2051,13 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         """
         with _group_selection_context(self):
             index = self._selected_obj.index
-            result = Series(self.grouper.group_info[0], index)
+
+            # GH28330 preserve subclassed Series/DataFrames through calls
+            if isinstance(self._selected_obj, Series):
+                result = self.obj._constructor(self.grouper.group_info[0], index)
+            elif isinstance(self._selected_obj, DataFrame):
+                result = self.obj._constructor_sliced(self.grouper.group_info[0], index)
+
             if not ascending:
                 result = self.ngroups - 1 - result
             return result

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1183,7 +1183,7 @@ class GroupBy(_GroupBy[FrameOrSeries]):
     """
 
     @property
-    def _constructor(self) -> Type["Series"]:
+    def _obj_1d_constructor(self) -> Type["Series"]:
         # GH28330 preserve subclassed Series/DataFrames
         if isinstance(self.obj, DataFrame):
             return self.obj._constructor_sliced
@@ -1430,9 +1430,9 @@ class GroupBy(_GroupBy[FrameOrSeries]):
 
         # GH28330 preserve subclassed Series/DataFrames through calls
         if issubclass(self.obj._constructor, Series):
-            result = self._constructor(result, name=self.obj.name)
+            result = self._obj_1d_constructor(result, name=self.obj.name)
         else:
-            result = self._constructor(result)
+            result = self._obj_1d_constructor(result)
         return self._reindex_output(result, fill_value=0)
 
     @classmethod
@@ -2127,7 +2127,7 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         """
         with _group_selection_context(self):
             index = self._selected_obj.index
-            result = self._constructor(self.grouper.group_info[0], index)
+            result = self._obj_1d_constructor(self.grouper.group_info[0], index)
             if not ascending:
                 result = self.ngroups - 1 - result
             return result
@@ -2189,7 +2189,7 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         with _group_selection_context(self):
             index = self._selected_obj.index
             cumcounts = self._cumcount_array(ascending=ascending)
-            return self._constructor(cumcounts, index)
+            return self._obj_1d_constructor(cumcounts, index)
 
     @Substitution(name="groupby")
     @Appender(_common_see_also)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2051,13 +2051,7 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         """
         with _group_selection_context(self):
             index = self._selected_obj.index
-
-            # GH28330 preserve subclassed Series/DataFrames through calls
-            if isinstance(self._selected_obj, Series):
-                result = self.obj._constructor(self.grouper.group_info[0], index)
-            elif isinstance(self._selected_obj, DataFrame):
-                result = self.obj._constructor_sliced(self.grouper.group_info[0], index)
-
+            result = Series(self.grouper.group_info[0], index)
             if not ascending:
                 result = self.ngroups - 1 - result
             return result
@@ -2119,12 +2113,8 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         with _group_selection_context(self):
             index = self._selected_obj.index
             cumcounts = self._cumcount_array(ascending=ascending)
+            return Series(cumcounts, index)
 
-            # GH28330 preserve subclassed Series/DataFrames through calls
-            if isinstance(self._selected_obj, Series):
-                return self.obj._constructor(cumcounts, index)
-            elif isinstance(self._selected_obj, DataFrame):
-                return self.obj._constructor_sliced(cumcounts, index)
 
     @Substitution(name="groupby")
     @Appender(_common_see_also)

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1351,8 +1351,12 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         """
         result = self.grouper.size()
 
+        # GH28330 preserve subclassed Series/DataFrames through calls
         if isinstance(self.obj, Series):
+            result = self.obj._constructor(result)
             result.name = self.obj.name
+        elif isinstance(self.obj, DataFrame):
+            result = self.obj._constructor_sliced(result)
         return self._reindex_output(result, fill_value=0)
 
     @classmethod

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2119,7 +2119,12 @@ class GroupBy(_GroupBy[FrameOrSeries]):
         with _group_selection_context(self):
             index = self._selected_obj.index
             cumcounts = self._cumcount_array(ascending=ascending)
-            return Series(cumcounts, index)
+
+            # GH28330 preserve subclassed Series/DataFrames through calls
+            if isinstance(self._selected_obj, Series):
+                return self.obj._constructor(cumcounts, index)
+            elif isinstance(self._selected_obj, DataFrame):
+                return self.obj._constructor_sliced(cumcounts, index)
 
     @Substitution(name="groupby")
     @Appender(_common_see_also)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -467,8 +467,10 @@ class _Concatenator:
                 return result.__finalize__(self, method="concat")
 
             # combine as columns in a frame
-            else:
+            else:                
                 data = dict(zip(range(len(self.objs)), self.objs))
+
+                # GH28330 Preserves subclassed objects through concat
                 cons = self.objs[0]._constructor_expanddim
 
                 index, columns = self.new_axes

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -469,7 +469,7 @@ class _Concatenator:
             # combine as columns in a frame
             else:
                 data = dict(zip(range(len(self.objs)), self.objs))
-                cons = DataFrame
+                cons = self.objs[0]._constructor_expanddim
 
                 index, columns = self.new_axes
                 df = cons(data, index=index)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -467,7 +467,7 @@ class _Concatenator:
                 return result.__finalize__(self, method="concat")
 
             # combine as columns in a frame
-            else:                
+            else:
                 data = dict(zip(range(len(self.objs)), self.objs))
 
                 # GH28330 Preserves subclassed objects through concat

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -573,3 +573,17 @@ class TestDataFrameSubclassing:
         df = tm.SubclassedDataFrame({"A": [1, 2, 3], "B": [4, 5, 6], "C": [7, 8, 9]})
         result = getattr(df, all_boolean_reductions)()
         assert isinstance(result, tm.SubclassedSeries)
+
+    def test_idxmin_preserves_subclass(self):
+        # GH 28330
+
+        df = tm.SubclassedDataFrame({"A": [1, 2, 3], "B": [4, 5, 6], "C": [7, 8, 9]})
+        result = df.idxmin()
+        assert isinstance(result, tm.SubclassedSeries)
+
+    def test_idxmax_preserves_subclass(self):
+        # GH 28330
+
+        df = tm.SubclassedDataFrame({"A": [1, 2, 3], "B": [4, 5, 6], "C": [7, 8, 9]})
+        result = df.idxmax()
+        assert isinstance(result, tm.SubclassedSeries)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -195,6 +195,45 @@ def test_inconsistent_return_type():
     tm.assert_series_equal(result, e)
 
 
+@pytest.mark.parametrize(
+    "obj",
+    [
+        tm.SubclassedDataFrame(
+            dict(A=[0, 0, 0, 1, 1, 1], B=range(6)),
+            index=["A", "B", "C", "D", "E", "F"]),
+        tm.SubclassedSeries([0, 0, 0, 1, 1, 1],
+                            index=["A", "B", "C", "D", "E", "F"]),
+    ],
+)
+def test_groupby_preserves_subclass(obj, groupby_func):
+    # GH28330 -- preserve subclass through groupby operations
+
+    if isinstance(obj, Series) and groupby_func in {"corrwith"}:
+        pytest.skip("Not applicable")
+    
+    grouped = obj.groupby(np.repeat([0, 1], 3))
+
+    # Groups should preserve subclass type
+    assert isinstance(grouped.get_group(0), type(obj))
+    
+    args = []
+    if groupby_func in {"fillna", "nth"}:
+        args.append(0)
+    elif groupby_func == "corrwith":
+        args.append(obj)
+    elif groupby_func == "tshift":
+        args.extend([0, 0])
+
+    result = getattr(grouped, groupby_func)(*args)
+
+    # Reduction or transformation kernels should preserve type
+    slices = groupby_func in {"cumcount", "ngroup", "size"}
+    if isinstance(obj, DataFrame) and slices:
+        assert isinstance(result, type(obj._constructor_sliced(dtype=object)))
+    else:
+        assert isinstance(result, type(obj))
+
+
 def test_pass_args_kwargs(ts, tsframe):
     def f(x, q=None, axis=0):
         return np.percentile(x, q, axis=axis)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -199,7 +199,7 @@ def test_inconsistent_return_type():
     "obj",
     [
         tm.SubclassedDataFrame({"A": np.arange(0, 10)}),
-        tm.SubclassedSeries(np.arange(0, 10), name="A")
+        tm.SubclassedSeries(np.arange(0, 10), name="A"),
     ],
 )
 def test_groupby_preserves_subclass(obj, groupby_func):
@@ -207,12 +207,12 @@ def test_groupby_preserves_subclass(obj, groupby_func):
 
     if isinstance(obj, Series) and groupby_func in {"corrwith"}:
         pytest.skip("Not applicable")
-    
+
     grouped = obj.groupby(np.arange(0, 10))
 
     # Groups should preserve subclass type
     assert isinstance(grouped.get_group(0), type(obj))
-    
+
     args = []
     if groupby_func in {"fillna", "nth"}:
         args.append(0)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -198,11 +198,8 @@ def test_inconsistent_return_type():
 @pytest.mark.parametrize(
     "obj",
     [
-        tm.SubclassedDataFrame(
-            dict(A=[0, 0, 0, 1, 1, 1], B=range(6)),
-            index=["A", "B", "C", "D", "E", "F"]),
-        tm.SubclassedSeries([0, 0, 0, 1, 1, 1],
-                            index=["A", "B", "C", "D", "E", "F"]),
+        tm.SubclassedDataFrame({"A": np.arange(0, 10)}),
+        tm.SubclassedSeries(np.arange(0, 10), name="A")
     ],
 )
 def test_groupby_preserves_subclass(obj, groupby_func):
@@ -211,7 +208,7 @@ def test_groupby_preserves_subclass(obj, groupby_func):
     if isinstance(obj, Series) and groupby_func in {"corrwith"}:
         pytest.skip("Not applicable")
     
-    grouped = obj.groupby(np.repeat([0, 1], 3))
+    grouped = obj.groupby(np.arange(0, 10))
 
     # Groups should preserve subclass type
     assert isinstance(grouped.get_group(0), type(obj))

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -36,10 +36,12 @@ def test_groupby_preserves_subclass(obj, groupby_func):
     result1 = getattr(grouped, groupby_func)(*args)
     result2 = grouped.agg(groupby_func, *args)
 
-    # Reduction or transformation kernels should preserve type
-    slices = groupby_func in {"cumcount", "ngroup", "size"}
-    if isinstance(obj, DataFrame) and slices:
+    # Reduction or transformation kernels should preserve type;
+    # ngroup() and cumcount() always return Series
+    if isinstance(obj, DataFrame) and groupby_func in {"size"}:
         assert isinstance(result1, type(obj._constructor_sliced(dtype=object)))
+    elif groupby_func in {"ngroup", "cumcount"}:
+        assert isinstance(result1, Series)
     else:
         assert isinstance(result1, type(obj))
 

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from pandas import DataFrame, Series
+import pandas._testing as tm
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        tm.SubclassedDataFrame({"A": np.arange(0, 10)}),
+        tm.SubclassedSeries(np.arange(0, 10), name="A"),
+    ],
+)
+def test_groupby_preserves_subclass(obj, groupby_func):
+    # GH28330 -- preserve subclass through groupby operations
+
+    if isinstance(obj, Series) and groupby_func in {"corrwith"}:
+        pytest.skip("Not applicable")
+
+    grouped = obj.groupby(np.arange(0, 10))
+
+    # Groups should preserve subclass type
+    assert isinstance(grouped.get_group(0), type(obj))
+
+    args = []
+    if groupby_func in {"fillna", "nth"}:
+        args.append(0)
+    elif groupby_func == "corrwith":
+        args.append(obj)
+    elif groupby_func == "tshift":
+        args.extend([0, 0])
+
+    result1 = getattr(grouped, groupby_func)(*args)
+    result2 = grouped.agg(groupby_func, *args)
+
+    # Reduction or transformation kernels should preserve type
+    slices = groupby_func in {"cumcount", "ngroup", "size"}
+    if isinstance(obj, DataFrame) and slices:
+        assert isinstance(result1, type(obj._constructor_sliced(dtype=object)))
+    else:
+        assert isinstance(result1, type(obj))
+
+    # Confirm .agg() groupby operations return same results
+    if isinstance(result1, DataFrame):
+        tm.assert_frame_equal(result1, result2)
+    else:
+        tm.assert_series_equal(result1, result2)
+
+
+@pytest.mark.parametrize(
+    "obj", [DataFrame, tm.SubclassedDataFrame],
+)
+def test_groupby_resample_preserves_subclass(obj):
+    # GH28330 -- preserve subclass through groupby.resample()
+
+    df = obj(
+        {
+            "Buyer": "Carl Carl Carl Carl Joe Carl".split(),
+            "Quantity": [18, 3, 5, 1, 9, 3],
+            "Date": [
+                datetime(2013, 9, 1, 13, 0),
+                datetime(2013, 9, 1, 13, 5),
+                datetime(2013, 10, 1, 20, 0),
+                datetime(2013, 10, 3, 10, 0),
+                datetime(2013, 12, 2, 12, 0),
+                datetime(2013, 9, 2, 14, 0),
+            ],
+        }
+    )
+    df = df.set_index("Date")
+
+    # Confirm groupby.resample() preserves dataframe type
+    result = df.groupby("Buyer").resample("5D").sum()
+    assert isinstance(result, obj)

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -36,12 +36,10 @@ def test_groupby_preserves_subclass(obj, groupby_func):
     result1 = getattr(grouped, groupby_func)(*args)
     result2 = grouped.agg(groupby_func, *args)
 
-    # Reduction or transformation kernels should preserve type;
-    # ngroup() and cumcount() always return Series
-    if isinstance(obj, DataFrame) and groupby_func in {"size"}:
-        assert isinstance(result1, type(obj._constructor_sliced(dtype=object)))
-    elif groupby_func in {"ngroup", "cumcount"}:
-        assert isinstance(result1, Series)
+    # Reduction or transformation kernels should preserve type
+    slices = {"ngroup", "cumcount", "size"}
+    if isinstance(obj, DataFrame) and groupby_func in slices:
+        assert isinstance(result1, obj._constructor_sliced)
     else:
         assert isinstance(result1, type(obj))
 

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -2802,3 +2802,17 @@ def test_concat_multiindex_datetime_object_index():
     )
     result = concat([s, s2], axis=1)
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        tm.SubclassedDataFrame({"A": np.arange(0, 10)}),
+        tm.SubclassedSeries(np.arange(0, 10), name="A"),
+    ],
+)
+def test_concat_preserves_subclass(obj):
+    # GH28330 -- preserve subclass
+
+    result = concat([obj, obj])
+    assert isinstance(result, type(obj))


### PR DESCRIPTION
This pull request fixes a bug that caused subclassed Series/DataFrames to revert to `pd.Series` and `pd.DataFrame` after `groupby()` operations. This is a follow-up on a previously abandoned pull request (#28573)

- [x] closes #28330
- [x] tests added / passed
- [x] passes black pandas
- [x] passes git diff upstream/master -u -- "*.py" | flake8 --diff
- [x] whatsnew entry