### PR TITLE
DEPR: get_value

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -487,6 +487,7 @@ Deprecations
   arguments (:issue:`27573`).
 
 - :func:`pandas.api.types.is_categorical` is deprecated and will be removed in a future version; use `:func:pandas.api.types.is_categorical_dtype` instead (:issue:`33385`)
+- :meth:`Index.get_value` is deprecated and will be removed in a future version (:issue:`19728`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4541,6 +4541,13 @@ class Index(IndexOpsMixin, PandasObject):
         -------
         scalar or Series
         """
+        warnings.warn(
+            "get_value is deprecated and will be removed in a future version. "
+            "Use Series[key] instead",
+            FutureWarning,
+            stacklevel=2,
+        )
+
         self._check_indexing_error(key)
 
         try:

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -608,13 +608,17 @@ class TestDatetimeIndex:
         key = dti[1]
 
         with pytest.raises(AttributeError, match="has no attribute '_values'"):
-            dti.get_value(arr, key)
+            with tm.assert_produces_warning(FutureWarning):
+                dti.get_value(arr, key)
 
-        result = dti.get_value(ser, key)
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti.get_value(ser, key)
         assert result == 7
 
-        result = dti.get_value(ser, key.to_pydatetime())
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti.get_value(ser, key.to_pydatetime())
         assert result == 7
 
-        result = dti.get_value(ser, key.to_datetime64())
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti.get_value(ser, key.to_datetime64())
         assert result == 7

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -673,21 +673,24 @@ class TestGetValue:
         input0 = pd.Series(np.array([1, 2, 3]), index=idx0)
         expected0 = 2
 
-        result0 = idx0.get_value(input0, p1)
+        with tm.assert_produces_warning(FutureWarning):
+            result0 = idx0.get_value(input0, p1)
         assert result0 == expected0
 
         idx1 = PeriodIndex([p1, p1, p2])
         input1 = pd.Series(np.array([1, 2, 3]), index=idx1)
         expected1 = input1.iloc[[0, 1]]
 
-        result1 = idx1.get_value(input1, p1)
+        with tm.assert_produces_warning(FutureWarning):
+            result1 = idx1.get_value(input1, p1)
         tm.assert_series_equal(result1, expected1)
 
         idx2 = PeriodIndex([p1, p2, p1])
         input2 = pd.Series(np.array([1, 2, 3]), index=idx2)
         expected2 = input2.iloc[[0, 2]]
 
-        result2 = idx2.get_value(input2, p1)
+        with tm.assert_produces_warning(FutureWarning):
+            result2 = idx2.get_value(input2, p1)
         tm.assert_series_equal(result2, expected2)
 
     @pytest.mark.parametrize("freq", ["H", "D"])
@@ -700,7 +703,8 @@ class TestGetValue:
         ts = dti[0]
 
         assert pi.get_loc(ts) == 0
-        assert pi.get_value(ser, ts) == 7
+        with tm.assert_produces_warning(FutureWarning):
+            assert pi.get_value(ser, ts) == 7
         assert ser[ts] == 7
         assert ser.loc[ts] == 7
 
@@ -709,14 +713,16 @@ class TestGetValue:
             with pytest.raises(KeyError, match="2016-01-01 03:00"):
                 pi.get_loc(ts2)
             with pytest.raises(KeyError, match="2016-01-01 03:00"):
-                pi.get_value(ser, ts2)
+                with tm.assert_produces_warning(FutureWarning):
+                    pi.get_value(ser, ts2)
             with pytest.raises(KeyError, match="2016-01-01 03:00"):
                 ser[ts2]
             with pytest.raises(KeyError, match="2016-01-01 03:00"):
                 ser.loc[ts2]
         else:
             assert pi.get_loc(ts2) == 0
-            assert pi.get_value(ser, ts2) == 7
+            with tm.assert_produces_warning(FutureWarning):
+                assert pi.get_value(ser, ts2) == 7
             assert ser[ts2] == 7
             assert ser.loc[ts2] == 7
 
@@ -726,13 +732,15 @@ class TestGetValue:
         pi = dti.to_period("D")
         ser = pd.Series(range(3), index=pi)
         with pytest.raises(IndexError, match=msg):
-            pi.get_value(ser, 16801)
+            with tm.assert_produces_warning(FutureWarning):
+                pi.get_value(ser, 16801)
 
         msg = "index 46 is out of bounds for axis 0 with size 3"
         pi2 = dti.to_period("Y")  # duplicates, ordinals are all 46
         ser2 = pd.Series(range(3), index=pi2)
         with pytest.raises(IndexError, match=msg):
-            pi2.get_value(ser2, 46)
+            with tm.assert_produces_warning(FutureWarning):
+                pi2.get_value(ser2, 46)
 
 
 class TestContains:
@@ -758,7 +766,8 @@ class TestContains:
         with pytest.raises(KeyError, match=key):
             idx0.get_loc(key)
         with pytest.raises(KeyError, match=key):
-            idx0.get_value(ser, key)
+            with tm.assert_produces_warning(FutureWarning):
+                idx0.get_value(ser, key)
 
         assert "2017-09" in idx0
 

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -113,7 +113,8 @@ class TestPeriodIndex:
 
         expected = ser[indexer_2014]
 
-        result = nidx.get_value(ser, "2014")
+        with tm.assert_produces_warning(FutureWarning):
+            result = nidx.get_value(ser, "2014")
         tm.assert_series_equal(result, expected)
 
         result = ser.loc["2014"]
@@ -131,7 +132,8 @@ class TestPeriodIndex:
 
         expected = ser[indexer_may2015]
 
-        result = nidx.get_value(ser, "May 2015")
+        with tm.assert_produces_warning(FutureWarning):
+            result = nidx.get_value(ser, "May 2015")
         tm.assert_series_equal(result, expected)
 
         result = ser.loc["May 2015"]

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1697,9 +1697,11 @@ class TestIndex(Base):
 
         with pytest.raises(AttributeError, match="has no attribute '_values'"):
             # Index.get_value requires a Series, not an ndarray
-            indices.get_value(values, value)
+            with tm.assert_produces_warning(FutureWarning):
+                indices.get_value(values, value)
 
-        result = indices.get_value(Series(values, index=values), value)
+        with tm.assert_produces_warning(FutureWarning):
+            result = indices.get_value(Series(values, index=values), value)
         tm.assert_almost_equal(result, values[67])
 
     @pytest.mark.parametrize("values", [["foo", "bar", "quux"], {"foo", "bar", "quux"}])

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -254,9 +254,11 @@ class TestFloat64Index(Numeric):
 
         expected = vals[1]
 
-        result = ser.index.get_value(ser, 4.0)
+        with tm.assert_produces_warning(FutureWarning):
+            result = ser.index.get_value(ser, 4.0)
         assert isinstance(result, type(expected)) and result == expected
-        result = ser.index.get_value(ser, 4)
+        with tm.assert_produces_warning(FutureWarning):
+            result = ser.index.get_value(ser, 4)
         assert isinstance(result, type(expected)) and result == expected
 
         result = ser[4.0]

--- a/pandas/tests/indexing/multiindex/test_partial.py
+++ b/pandas/tests/indexing/multiindex/test_partial.py
@@ -151,7 +151,8 @@ class TestMultiIndexPartial:
         with pytest.raises(KeyError, match="14"):
             ser[14]
         with pytest.raises(KeyError, match="14"):
-            mi.get_value(ser, 14)
+            with tm.assert_produces_warning(FutureWarning):
+                mi.get_value(ser, 14)
 
     # ---------------------------------------------------------------------
     # AMBIGUOUS CASES!

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -550,7 +550,8 @@ def test_getitem_categorical_str():
     tm.assert_series_equal(result, expected)
 
     # Check the intermediate steps work as expected
-    result = ser.index.get_value(ser, "a")
+    with tm.assert_produces_warning(FutureWarning):
+        result = ser.index.get_value(ser, "a")
     tm.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #19728
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

No longer used internally.