### PR TITLE
REF: de-duplicate listlike validation in DTA._validate_foo

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -788,8 +788,8 @@ class DatetimeLikeArrayMixin(
             pass
 
         elif not type(self)._is_recognized_dtype(value):
-            raise TypeError(  # FIXME: dont be searchsorted-specific
-                "searchsorted requires compatible dtype or scalar, "
+            raise TypeError(
+                "Operation requires compatible dtype or scalar, "
                 f"not {type(value).__name__}"
             )
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 import operator
-from typing import Any, Sequence, Type, TypeVar, Union, cast
+from typing import Any, Callable, Sequence, Type, TypeVar, Union, cast
 import warnings
 
 import numpy as np
@@ -441,6 +441,8 @@ class DatetimeLikeArrayMixin(
     and that the inheriting class has methods:
         _generate_range
     """
+
+    _is_recognized_dtype: Callable[["DatetimeLikeArrayMixin"], bool]
 
     # ------------------------------------------------------------------
     # NDArrayBackedExtensionArray compat

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -10,7 +10,7 @@ from pandas._libs.tslibs.c_timestamp import integer_op_not_supported
 from pandas._libs.tslibs.period import DIFFERENT_FREQ, IncompatibleFrequency, Period
 from pandas._libs.tslibs.timedeltas import Timedelta, delta_to_nanoseconds
 from pandas._libs.tslibs.timestamps import RoundTo, round_nsint64
-from pandas._typing import DatetimeLikeScalar
+from pandas._typing import DatetimeLikeScalar, DtypeObj
 from pandas.compat import set_function_name
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError, NullFrequencyError, PerformanceWarning
@@ -442,7 +442,7 @@ class DatetimeLikeArrayMixin(
         _generate_range
     """
 
-    _is_recognized_dtype: Callable[["DatetimeLikeArrayMixin"], bool]
+    _is_recognized_dtype: Callable[[DtypeObj], bool]
 
     # ------------------------------------------------------------------
     # NDArrayBackedExtensionArray compat


### PR DESCRIPTION
Implements a helper `_validate_listlike` that is re-used across 4 of the _validate_foo methods.  We can then smooth out the remaining differences by passing the same flags in each of the four usages.