### PR TITLE
PERF: 30% faster is_period_object checks

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -75,6 +75,7 @@ from pandas._libs.tslibs.nattype cimport (
 from pandas._libs.tslibs.conversion cimport convert_to_tsobject
 from pandas._libs.tslibs.timedeltas cimport convert_to_timedelta64
 from pandas._libs.tslibs.timezones cimport get_timezone, tz_compare
+from pandas._libs.tslibs.period cimport is_period_object
 
 from pandas._libs.missing cimport (
     checknull,
@@ -185,7 +186,7 @@ def is_scalar(val: object) -> bool:
 
     # Note: PyNumber_Check check includes Decimal, Fraction, numbers.Number
     return (PyNumber_Check(val)
-            or util.is_period_object(val)
+            or is_period_object(val)
             or is_interval(val)
             or util.is_offset_object(val))
 
@@ -942,7 +943,7 @@ def is_period(val: object) -> bool:
     -------
     bool
     """
-    return util.is_period_object(val)
+    return is_period_object(val)
 
 
 def is_list_like(obj: object, allow_sets: bool = True) -> bool:
@@ -1417,7 +1418,7 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
         if is_bytes_array(values, skipna=skipna):
             return "bytes"
 
-    elif util.is_period_object(val):
+    elif is_period_object(val):
         if is_period_array(values):
             return "period"
 
@@ -1849,7 +1850,7 @@ cpdef bint is_time_array(ndarray values, bint skipna=False):
 
 cdef class PeriodValidator(TemporalValidator):
     cdef inline bint is_value_typed(self, object value) except -1:
-        return util.is_period_object(value)
+        return is_period_object(value)
 
     cdef inline bint is_valid_null(self, object value) except -1:
         return checknull_with_nat(value)

--- a/pandas/_libs/tslibs/period.pxd
+++ b/pandas/_libs/tslibs/period.pxd
@@ -1,0 +1,1 @@
+cdef bint is_period_object(object obj)

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -36,7 +36,6 @@ cdef extern from "src/datetime/np_datetime.h":
                                            npy_datetimestruct *d) nogil
 
 cimport pandas._libs.tslibs.util as util
-from pandas._libs.tslibs.util cimport is_period_object
 
 from pandas._libs.tslibs.timestamps import Timestamp
 from pandas._libs.tslibs.timezones cimport is_utc, is_tzlocal, get_dst_info
@@ -2465,6 +2464,15 @@ class Period(_Period):
                                      dt.microsecond, 0, base)
 
         return cls._from_ordinal(ordinal, freq)
+
+
+cdef bint is_period_object(object obj):
+    """
+    Cython-optimized equivalent of isinstance(obj, Period)
+    """
+    # Note: this is significantly faster than the implementation in tslibs.util,
+    #  only use the util version when necessary to prevent circular imports.
+    return isinstance(obj, _Period)
 
 
 cdef int64_t _ordinal_from_fields(int year, int month, quarter, int day,


### PR DESCRIPTION
Doing an appropriate isinstance check occurs all in C-space.

```
In [1]: import pandas as pd                                                                                                                                                   
In [2]: from pandas._libs.lib import *                                                                                                                                        
In [3]: obj = pd.Period(2004, "A")                                                                                                                                            

In [4]: %timeit is_scalar(obj)                                                                                                                                                
78.4 ns ± 0.761 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR
101 ns ± 1.74 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- master

In [5]: %timeit is_period(obj)                                                                                                                                                
54.1 ns ± 0.548 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR
80.7 ns ± 1.14 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- master

In [6]: %timeit is_period([])                                                                                                                                                 
50.1 ns ± 1.02 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR
340 ns ± 26.9 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master

In [7]: %timeit is_scalar([])                                                                                                                                                 
65.6 ns ± 0.421 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR
67.1 ns ± 0.293 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- master

In [8]: obj2 = object()                                                                                                                                                       

In [9]: %timeit is_scalar(obj2)                                                                                                                                               
544 ns ± 6.97 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- PR
782 ns ± 6.3 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <-- master

```