### PR TITLE
PERF: make _Tick into a cdef class

### DIFF
--- a/pandas/_libs/tslibs/offsets.pxd
+++ b/pandas/_libs/tslibs/offsets.pxd
@@ -1,1 +1,3 @@
 cdef to_offset(object obj)
+cdef bint is_offset_object(object obj)
+cdef bint is_tick_object(object obj)

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -9,6 +9,8 @@ import warnings
 
 from pandas import Index
 
+from pandas.tseries.offsets import Tick
+
 if TYPE_CHECKING:
     from pandas import Series, DataFrame
 
@@ -38,6 +40,11 @@ def load_reduce(self):
                 return
             except TypeError:
                 pass
+        elif args and issubclass(args[0], Tick):
+            # TypeError: object.__new__(Day) is not safe, use Day.__new__()
+            cls = args[0]
+            stack[-1] = cls.__new__(*args)
+            return
 
         raise
 

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -173,7 +173,8 @@ def read_pickle(
     # 3) try pickle_compat with latin-1 encoding upon a UnicodeDecodeError
 
     try:
-        excs_to_catch = (AttributeError, ImportError, ModuleNotFoundError)
+        excs_to_catch = (AttributeError, ImportError, ModuleNotFoundError, TypeError)
+        # TypeError for Cython complaints about object.__new__ vs Tick.__new__
         try:
             with warnings.catch_warnings(record=True):
                 # We want to silence any warnings about, e.g. moved modules.


### PR DESCRIPTION
The actual "PERF" part is that in the follow-up we can cimport `is_tick_object` which will be appreciably faster than the `getattr(other, "_typ", None) == "dateoffset" and hasattr(other, "delta")` checks we now do