### PR TITLE
BUG: Fix Series.update ExtensionArray issue

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -757,6 +757,7 @@ ExtensionArray
 - Fixed bug where :meth:`Series.value_counts` would raise on empty input of ``Int64`` dtype (:issue:`33317`)
 - Fixed bug in :class:`Series` construction with EA dtype and index but no data or scalar data fails (:issue:`26469`)
 - Fixed bug that caused :meth:`Series.__repr__()` to crash for extension types whose elements are multidimensional arrays (:issue:`33770`).
+- Fixed bug where :meth:`Series.update` would raise a ``ValueError`` for ``ExtensionArray`` dtypes with missing values (:issue:`33980`)
 
 
 Other

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1599,7 +1599,7 @@ class ExtensionBlock(Block):
 
         new_values = self.values if inplace else self.values.copy()
 
-        if isinstance(new, np.ndarray) and len(new) == len(mask):
+        if isinstance(new, (np.ndarray, ExtensionArray)) and len(new) == len(mask):
             new = new[mask]
 
         mask = _safe_reshape(mask, new_values.shape)

--- a/pandas/tests/series/methods/test_update.py
+++ b/pandas/tests/series/methods/test_update.py
@@ -74,3 +74,27 @@ class TestUpdate:
         # GH 33215
         series.update(other)
         tm.assert_series_equal(series, expected)
+
+    @pytest.mark.parametrize(
+        "result, target, expected",
+        [
+            (
+                Series(["a", None], dtype="string"),
+                Series([None, "b"], dtype="string"),
+                Series(["a", "b"], dtype="string"),
+            ),
+            (
+                Series([1, None], dtype="Int64"),
+                Series([None, 2], dtype="Int64"),
+                Series([1, 2], dtype="Int64"),
+            ),
+            (
+                Series([True, None], dtype="boolean"),
+                Series([None, False], dtype="boolean"),
+                Series([True, False], dtype="boolean"),
+            ),
+        ],
+    )
+    def test_update_extension_array_series(self, result, target, expected):
+        result.update(target)
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #33980
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
