### PR TITLE
CI: test_unsupported_other fails on pyarrow 0.17

### DIFF
--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -102,8 +102,8 @@ class TestFeather:
 
     def test_unsupported_other(self):
 
-        # period
-        df = pd.DataFrame({"a": pd.period_range("2013", freq="M", periods=3)})
+        # mixed python objects
+        df = pd.DataFrame({"a": ["a", 1, 2.0]})
         # Some versions raise ValueError, others raise ArrowInvalid.
         self.check_error_on_write(df, Exception)
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/33300#issuecomment-623690451, https://github.com/pandas-dev/pandas/pull/33422#discussion_r406240082