### PR TITLE
Backport PR #33761 on branch 1.0.x (REGR: fix DataFrame reduction wit…

### DIFF
--- a/doc/source/whatsnew/v1.0.4.rst
+++ b/doc/source/whatsnew/v1.0.4.rst
@@ -16,6 +16,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Bug in :meth:`GroupBy.first` and :meth:`GroupBy.last` where None is not preserved in object dtype (:issue:`32800`)
+- Bug in DataFrame reductions using ``numeric_only=True`` and ExtensionArrays (:issue:`33256`).
 - 
 
 .. _whatsnew_104.bug_fixes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7891,9 +7891,15 @@ Wild         185.0
 
             out_dtype = "bool" if filter_type == "bool" else None
 
+            def blk_func(values):
+                if isinstance(values, ExtensionArray):
+                    return values._reduce(name, skipna=skipna, **kwds)
+                else:
+                    return op(values, axis=1, skipna=skipna, **kwds)
+
             # After possibly _get_data and transposing, we are now in the
             #  simple case where we can use BlockManager._reduce
-            res = df._data.reduce(op, axis=1, skipna=skipna, **kwds)
+            res = df._data.reduce(blk_func)
             assert isinstance(res, dict)
             if len(res):
                 assert len(res) == max(list(res.keys())) + 1, res.keys()

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -891,6 +891,20 @@ class TestDataFrameAnalytics:
         )
         tm.assert_series_equal(result, expected)
 
+        # mean of period is not allowed
+        df["D"] = pd.period_range("2016", periods=3, freq="A")
+
+        with pytest.raises(TypeError, match="mean is not implemented for Period"):
+            df.mean(numeric_only=False)
+
+    def test_mean_extensionarray_numeric_only_true(self):
+        # https://github.com/pandas-dev/pandas/issues/33256
+        arr = np.random.randint(1000, size=(10, 5))
+        df = pd.DataFrame(arr, dtype="Int64")
+        result = df.mean(numeric_only=True)
+        expected = pd.DataFrame(arr).mean()
+        tm.assert_series_equal(result, expected)
+
     def test_stats_mixed_type(self, float_string_frame):
         # don't blow up
         float_string_frame.std(1)


### PR DESCRIPTION
…h EA columns and numeric_only=True)

xref #33761

fixes regression in 1.0.0 (#33256)