### PR TITLE
Backport PR #33292 on branch 1.0.x (REGR: Fix bug when replacing cate…

### DIFF
--- a/doc/source/whatsnew/v1.0.4.rst
+++ b/doc/source/whatsnew/v1.0.4.rst
@@ -17,6 +17,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Bug in :meth:`GroupBy.first` and :meth:`GroupBy.last` where None is not preserved in object dtype (:issue:`32800`)
 - Bug in DataFrame reductions using ``numeric_only=True`` and ExtensionArrays (:issue:`33256`).
+- Bug where :meth:`Categorical.replace` would replace with ``NaN`` whenever the new value and replacement value were equal (:issue:`33288`)
 - 
 
 .. _whatsnew_104.bug_fixes:

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2459,6 +2459,8 @@ class Categorical(ExtensionArray, PandasObject):
         # other cases, like if both to_replace and value are list-like or if
         # to_replace is a dict, are handled separately in NDFrame
         for replace_value, new_value in replace_dict.items():
+            if new_value == replace_value:
+                continue
             if replace_value in cat.categories:
                 if isna(new_value):
                     cat.remove_categories(replace_value, inplace=True)

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -64,6 +64,8 @@ def test_isin_cats():
     [
         ("b", "c", ["a", "c"], "Categorical.categories are different"),
         ("c", "d", ["a", "b"], None),
+        # https://github.com/pandas-dev/pandas/issues/33288
+        ("a", "a", ["a", "b"], None),
         ("b", None, ["a", None], "Categorical.categories length are different"),
     ],
 )


### PR DESCRIPTION
…gorical value with self)

xref #33292 

fixes regression in 1.0.0 #33288