### PR TITLE
Backport PR #33089 on branch 1.0.x (BUG: Don't cast nullable Boolean to float in groupby)

### DIFF
--- a/doc/source/whatsnew/v1.0.4.rst
+++ b/doc/source/whatsnew/v1.0.4.rst
@@ -21,13 +21,14 @@ Fixed regressions
 - Fix performance regression in ``memory_usage(deep=True)`` for object dtype (:issue:`33012`)
 - Bug where :meth:`Categorical.replace` would replace with ``NaN`` whenever the new value and replacement value were equal (:issue:`33288`)
 - Bug where an ordered :class:`Categorical` containing only ``NaN`` values would raise rather than returning ``NaN`` when taking the minimum or maximum  (:issue:`33450`)
+- Bug in :meth:`DataFrameGroupBy.agg` with dictionary input losing ``ExtensionArray`` dtypes (:issue:`32194`)
 - 
 
 .. _whatsnew_104.bug_fixes:
 
 Bug fixes
 ~~~~~~~~~
-- 
+- Bug in :meth:`SeriesGroupBy.first`, :meth:`SeriesGroupBy.last`, :meth:`SeriesGroupBy.min`, and :meth:`SeriesGroupBy.max` returning floats when applied to nullable Booleans (:issue:`33071`)
 - 
 
 Contributors

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -395,6 +395,32 @@ def test_first_last_tz_multi_column(method, ts, alpha):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "values",
+    [
+        pd.array([True, False], dtype="boolean"),
+        pd.array([1, 2], dtype="Int64"),
+        pd.to_datetime(["2020-01-01", "2020-02-01"]),
+        pd.to_timedelta([1, 2], unit="D"),
+    ],
+)
+@pytest.mark.parametrize("function", ["first", "last", "min", "max"])
+def test_first_last_extension_array_keeps_dtype(values, function):
+    # https://github.com/pandas-dev/pandas/issues/33071
+    # https://github.com/pandas-dev/pandas/issues/32194
+    df = DataFrame({"a": [1, 2], "b": values})
+    grouped = df.groupby("a")
+    idx = Index([1, 2], name="a")
+    expected_series = Series(values, name="b", index=idx)
+    expected_frame = DataFrame({"b": values}, index=idx)
+
+    result_series = getattr(grouped["b"], function)()
+    tm.assert_series_equal(result_series, expected_series)
+
+    result_frame = grouped.agg({"b": function})
+    tm.assert_frame_equal(result_frame, expected_frame)
+
+
 def test_nth_multi_index_as_expected():
     # PR 9090, related to issue 8979
     # test nth on MultiIndex

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -122,9 +122,7 @@ def test_resample_integerarray():
 
     result = ts.resample("3T").mean()
     expected = Series(
-        [1, 4, 7],
-        index=pd.date_range("1/1/2000", periods=3, freq="3T"),
-        dtype="float64",
+        [1, 4, 7], index=pd.date_range("1/1/2000", periods=3, freq="3T"), dtype="Int64",
     )
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
xref #33089

regression in 1.0.0, xref https://github.com/pandas-dev/pandas/issues/32194#issuecomment-604664466

# NOTE: same code fix, different location

cc @dsaxton 