### PR TITLE
Bug in DataFrame.replace casts columns to ``object`` dtype if items in ``to_replace`` not in values

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -744,6 +744,7 @@ Reshaping
 - Bug in :meth:`DataFrame.unstack` when MultiIndexed columns and MultiIndexed rows were used (:issue:`32624`, :issue:`24729` and :issue:`28306`)
 - Bug in :func:`concat` was not allowing for concatenation of ``DataFrame`` and ``Series`` with duplicate keys (:issue:`33654`)
 - Bug in :func:`cut` raised an error when non-unique labels (:issue:`33141`)
+- Bug in :meth:`DataFrame.replace` casts columns to ``object`` dtype if items in ``to_replace`` not in values (:issue:`32988`)
 
 
 Sparse

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -684,8 +684,26 @@ class Block(PandasObject):
         # If we cannot replace with own dtype, convert to ObjectBlock and
         # retry
         if not self._can_hold_element(to_replace):
-            # TODO: we should be able to infer at this point that there is
-            #  nothing to replace
+            if not isinstance(to_replace, list):
+                if inplace:
+                    return [self]
+                return [self.copy()]
+
+            to_replace = [x for x in to_replace if self._can_hold_element(x)]
+            if not len(to_replace):
+                # GH#28084 avoid costly checks since we can infer
+                #  that there is nothing to replace in this block
+                if inplace:
+                    return [self]
+                return [self.copy()]
+
+            if len(to_replace) == 1:
+                # _can_hold_element checks have reduced this back to the
+                #  scalar case and we can avoid a costly object cast
+                return self.replace(
+                    to_replace[0], value, inplace=inplace, regex=regex, convert=convert,
+                )
+
             # GH 22083, TypeError or ValueError occurred within error handling
             # causes infinite loop. Cast and retry only if not objectblock.
             if is_object_dtype(self):
@@ -712,11 +730,19 @@ class Block(PandasObject):
 
         try:
             blocks = self.putmask(mask, value, inplace=inplace)
+            # Note: it is _not_ the case that self._can_hold_element(value)
+            #  is always true at this point.  In particular, that can fail
+            #  for:
+            #   "2u" with bool-dtype, float-dtype
+            #   0.5 with int64-dtype
+            #   np.nan with int64-dtype
         except (TypeError, ValueError):
             # GH 22083, TypeError or ValueError occurred within error handling
             # causes infinite loop. Cast and retry only if not objectblock.
             if is_object_dtype(self):
                 raise
+
+            assert not self._can_hold_element(value), value
 
             # try again with a compatible block
             block = self.astype(object)
@@ -874,6 +900,7 @@ class Block(PandasObject):
 
         # if we are passed a scalar None, convert it here
         if not is_list_like(new) and isna(new) and not self.is_object:
+            # FIXME: make sure we have compatible NA
             new = self.fill_value
 
         if self._can_hold_element(new):

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1381,12 +1381,8 @@ class TestDataFrameReplace:
         with pytest.raises(TypeError, match=msg):
             df.replace(lambda x: x.strip())
 
-    @pytest.mark.parametrize(
-        "dtype", ["float", "float64", "int64", "Int64", "boolean"]
-    )
-    @pytest.mark.parametrize(
-        "value", [np.nan, pd.NA]
-    )
+    @pytest.mark.parametrize("dtype", ["float", "float64", "int64", "Int64", "boolean"])
+    @pytest.mark.parametrize("value", [np.nan, pd.NA])
     def test_replace_no_replacement_dtypes(self, dtype, value):
         # https://github.com/pandas-dev/pandas/issues/32988
         df = pd.DataFrame(np.eye(2), dtype=dtype)

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1380,3 +1380,15 @@ class TestDataFrameReplace:
         )
         with pytest.raises(TypeError, match=msg):
             df.replace(lambda x: x.strip())
+
+    @pytest.mark.parametrize(
+        "dtype", ["float", "float64", "int64", "Int64", "boolean"]
+    )
+    @pytest.mark.parametrize(
+        "value", [np.nan, pd.NA]
+    )
+    def test_replace_no_replacement_dtypes(self, dtype, value):
+        # https://github.com/pandas-dev/pandas/issues/32988
+        df = pd.DataFrame(np.eye(2), dtype=dtype)
+        result = df.replace(to_replace=[None, -np.inf, np.inf], value=value)
+        tm.assert_frame_equal(result, df)


### PR DESCRIPTION
- [ ] closes #32988
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
