### PR TITLE
DOC: Examples for DataFrame.from_records

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1234,7 +1234,7 @@ class DataFrame(NDFrame):
         See Also
         --------
         DataFrame.from_records : DataFrame from structured ndarray, sequence
-			of tuples or dicts, or DataFrame.
+            of tuples or dicts, or DataFrame.
         DataFrame : DataFrame object creation using constructor.
 
         Examples

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1701,7 +1701,7 @@ class DataFrame(NDFrame):
         1      2     b
         2      1     c
         3      0     d
-        """
+        """  # noqa: E501
         # Make a copy of the input columns so we can modify it
         if columns is not None:
             columns = ensure_index(columns)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1234,7 +1234,7 @@ class DataFrame(NDFrame):
         See Also
         --------
         DataFrame.from_records : DataFrame from ndarray (structured
-            dtype), list of tuples, dict, or DataFrame.
+            dtype), sequence of tuples, sequence of dicts, or DataFrame.
         DataFrame : DataFrame object creation using constructor.
 
         Examples
@@ -1633,9 +1633,13 @@ class DataFrame(NDFrame):
         """
         Convert structured or record ndarray to DataFrame.
 
+        Creates a DataFrame object from a structured ndarray, sequence of
+        tuples, sequence of dicts, or DataFrame.
+
         Parameters
         ----------
-        data : ndarray (structured dtype), list of tuples, dict, or DataFrame
+        data : ndarray (structured dtype), sequence of tuples, sequence of dicts, or DataFrame
+            Structured input data.
         index : str, list of fields, array-like
             Field of array to use as the index, alternately a specific set of
             input labels to use.
@@ -1675,7 +1679,7 @@ class DataFrame(NDFrame):
         2      1     c
         3      0     d
 
-        Data can be provided as a list of dictionaries:
+        Data can be provided as a list of dicts:
 
         >>> data = [{'col_1': 3, 'col_2': 'a'},
         ...         {'col_1': 2, 'col_2': 'b'},

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1233,8 +1233,8 @@ class DataFrame(NDFrame):
 
         See Also
         --------
-        DataFrame.from_records : DataFrame from ndarray (structured
-            dtype), sequence of tuples or dicts, or DataFrame.
+        DataFrame.from_records : DataFrame from structured ndarray, sequence
+			of tuples or dicts, or DataFrame.
         DataFrame : DataFrame object creation using constructor.
 
         Examples
@@ -1638,7 +1638,7 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        data : ndarray (structured dtype), sequence of tuples or dicts, or DataFrame
+        data : structured ndarray, sequence of tuples or dicts, or DataFrame
             Structured input data.
         index : str, list of fields, array-like
             Field of array to use as the index, alternately a specific set of

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1234,7 +1234,7 @@ class DataFrame(NDFrame):
         See Also
         --------
         DataFrame.from_records : DataFrame from ndarray (structured
-            dtype), sequence of tuples, sequence of dicts, or DataFrame.
+            dtype), sequence of tuples or dicts, or DataFrame.
         DataFrame : DataFrame object creation using constructor.
 
         Examples
@@ -1634,11 +1634,11 @@ class DataFrame(NDFrame):
         Convert structured or record ndarray to DataFrame.
 
         Creates a DataFrame object from a structured ndarray, sequence of
-        tuples, sequence of dicts, or DataFrame.
+        tuples or dicts, or DataFrame.
 
         Parameters
         ----------
-        data : ndarray (structured dtype), sequence of tuples, sequence of dicts, or DataFrame
+        data : ndarray (structured dtype), sequence of tuples or dicts, or DataFrame
             Structured input data.
         index : str, list of fields, array-like
             Field of array to use as the index, alternately a specific set of
@@ -1701,7 +1701,7 @@ class DataFrame(NDFrame):
         1      2     b
         2      1     c
         3      0     d
-        """  # noqa: E501
+        """
         # Make a copy of the input columns so we can modify it
         if columns is not None:
             columns = ensure_index(columns)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1656,6 +1656,47 @@ class DataFrame(NDFrame):
         Returns
         -------
         DataFrame
+
+        See Also
+        --------
+        DataFrame.from_dict : DataFrame from dict of array-like or dicts.
+        DataFrame : DataFrame object creation using constructor.
+
+        Examples
+        --------
+        Data can be provided as a structured ndarray:
+
+        >>> data = np.array([(3, 'a'), (2, 'b'), (1, 'c'), (0, 'd')],
+        ...                 dtype=[('col_1', 'i4'), ('col_2', 'U1')])
+        >>> pd.DataFrame.from_records(data)
+           col_1 col_2
+        0      3     a
+        1      2     b
+        2      1     c
+        3      0     d
+
+        Data can be provided as a list of dictionaries:
+
+        >>> data = [{'col_1': 3, 'col_2': 'a'},
+        ...         {'col_1': 2, 'col_2': 'b'},
+        ...         {'col_1': 1, 'col_2': 'c'},
+        ...         {'col_1': 0, 'col_2': 'd'}]
+        >>> pd.DataFrame.from_records(data)
+           col_1 col_2
+        0      3     a
+        1      2     b
+        2      1     c
+        3      0     d
+
+        Data can be provided as a list of tuples with corresponding columns:
+
+        >>> data = [(3, 'a'), (2, 'b'), (1, 'c'), (0, 'd')]
+        >>> pd.DataFrame.from_records(data, columns=['col_1', 'col_2'])
+           col_1 col_2
+        0      3     a
+        1      2     b
+        2      1     c
+        3      0     d
         """
         # Make a copy of the input columns so we can modify it
         if columns is not None:


### PR DESCRIPTION
This PR adds examples to the documentation for `pandas.DataFrame.from_records`. It also rewords a couple sentences to clarify that the input data can be a sequence of dicts or sequence of tuples (but not a sequence of DataFrames).

- [x] closes #34057
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry