### PR TITLE
BUG: Fixed __join_multi always returning indexers (#34074)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -665,7 +665,7 @@ MultiIndex
         # Common elements are now guaranteed to be ordered by the left side
         left.intersection(right, sort=False)
 
--
+- Bug when joining 2 Multi-indexes, without specifying level with different columns. Return-indexers parameter is ignored. (:issue:`34074`)
 
 I/O
 ^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3529,8 +3529,11 @@ class Index(IndexOpsMixin, PandasObject):
 
             multi_join_idx = multi_join_idx.remove_unused_levels()
 
-            return multi_join_idx, lidx, ridx
-
+            if return_indexers:
+                return multi_join_idx, lidx, ridx
+            else:
+                return multi_join_idx
+                
         jl = list(overlap)[0]
 
         # Case where only one index is multi

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3533,7 +3533,7 @@ class Index(IndexOpsMixin, PandasObject):
                 return multi_join_idx, lidx, ridx
             else:
                 return multi_join_idx
-                
+
         jl = list(overlap)[0]
 
         # Case where only one index is multi

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -104,9 +104,9 @@ def test_join_multi_wrong_order():
     assert lidx is None
     tm.assert_numpy_array_equal(ridx, exp_ridx)
 
+
 def test_join_multi_return_indexers():
     # GH 34074
-
 
     midx1 = pd.MultiIndex.from_product([[1, 2], [3, 4], [5, 6]], names=["a", "b", "c"])
     midx2 = pd.MultiIndex.from_product([[1, 2], [3, 4]], names=["a", "b"])

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -111,4 +111,5 @@ def test_join_multi_return_indexers():
     midx1 = pd.MultiIndex.from_product([[1, 2], [3, 4], [5, 6]], names=["a", "b", "c"])
     midx2 = pd.MultiIndex.from_product([[1, 2], [3, 4]], names=["a", "b"])
 
-    assert type(midx1.join(midx2, return_indexers=False)) != tuple
+    result = midx1.join(midx2, return_indexers=False)
+    tm.assert_index_equal(result, midx1)

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -111,5 +111,4 @@ def test_join_multi_return_indexers():
     midx1 = pd.MultiIndex.from_product([[1, 2], [3, 4], [5, 6]], names=["a", "b", "c"])
     midx2 = pd.MultiIndex.from_product([[1, 2], [3, 4]], names=["a", "b"])
 
-    assert len(midx1.join(midx2, return_indexers=True)) == 3
-    assert len(midx1.join(midx2, return_indexers=False)) == 1
+    assert type(midx1.join(midx2, return_indexers=False)) != tuple

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -107,10 +107,9 @@ def test_join_multi_wrong_order():
 def test_join_multi_return_indexers():
     # GH 34074
 
+
     midx1 = pd.MultiIndex.from_product([[1, 2], [3, 4], [5, 6]], names=["a", "b", "c"])
     midx2 = pd.MultiIndex.from_product([[1, 2], [3, 4]], names=["a", "b"])
 
-    assert len(midx1.join(midx2,return_indexers=True)) == 3
-    assert len(midx1.join(midx2,return_indexers=False)) == 1
-    
-    
+    assert len(midx1.join(midx2, return_indexers=True)) == 3
+    assert len(midx1.join(midx2, return_indexers=False)) == 1

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -103,3 +103,14 @@ def test_join_multi_wrong_order():
     tm.assert_index_equal(midx1, join_idx)
     assert lidx is None
     tm.assert_numpy_array_equal(ridx, exp_ridx)
+
+def test_join_multi_return_indexers():
+    # GH 34074
+
+    midx1 = pd.MultiIndex.from_product([[1, 2], [3, 4], [5, 6]], names=["a", "b", "c"])
+    midx2 = pd.MultiIndex.from_product([[1, 2], [3, 4]], names=["a", "b"])
+
+    assert len(midx1.join(midx2,return_indexers=True)) == 3
+    assert len(midx1.join(midx2,return_indexers=False)) == 1
+    
+    

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -96,7 +96,7 @@ def test_join_multi_wrong_order():
     midx1 = pd.MultiIndex.from_product([[1, 2], [3, 4]], names=["a", "b"])
     midx2 = pd.MultiIndex.from_product([[1, 2], [3, 4]], names=["b", "a"])
 
-    join_idx, lidx, ridx = midx1.join(midx2, return_indexers=False)
+    join_idx, lidx, ridx = midx1.join(midx2, return_indexers=True)
 
     exp_ridx = np.array([-1, -1, -1, -1], dtype=np.intp)
 


### PR DESCRIPTION
- [x] closes #34074
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
