### PR TITLE
CI: Fix botocore Error

### DIFF
--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -173,11 +173,10 @@ class TestS3:
     def test_write_s3_csv_fails(self, tips_df):
         # GH 32486
         # Attempting to write to an invalid S3 path should raise
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
         import botocore
 
-        with pytest.raises(
-            botocore.errorfactory.NoSuchBucket, match="An error occurred (NoSuchBucket)"
-        ):
+        with pytest.raises(botocore.exceptions.ClientError):
             tips_df.to_csv("s3://an_s3_bucket_data_doesnt_exit/not_real.csv")
 
     @td.skip_if_no("pyarrow")

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -176,7 +176,9 @@ class TestS3:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
         import botocore
 
-        with pytest.raises(botocore.exceptions.ClientError, match="The specified bucket does not exist"):
+        with pytest.raises(
+            botocore.exceptions.ClientError, match="The specified bucket does not exist"
+        ):
             tips_df.to_csv("s3://an_s3_bucket_data_doesnt_exit/not_real.csv")
 
     @td.skip_if_no("pyarrow")

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -172,11 +172,11 @@ class TestS3:
     def test_write_s3_csv_fails(self, tips_df):
         # GH 32486
         # Attempting to write to an invalid S3 path should raise
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
-        # Catch a ClientError since AWS Service Errors are defined dynamically
         import botocore
 
         # GH 34087
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
+        # Catch a ClientError since AWS Service Errors are defined dynamically
         error = (FileNotFoundError, botocore.exceptions.ClientError)
 
         with pytest.raises(error, match="The specified bucket does not exist"):

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -185,7 +185,7 @@ class TestS3:
     @td.skip_if_no("pyarrow")
     def test_write_s3_parquet_fails(self, tips_df):
         # GH 27679
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
+        # Attempting to write to an invalid S3 path should raise
         import botocore
 
         # GH 34087

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -169,11 +169,14 @@ class TestS3:
         with pytest.raises(IOError):
             read_csv("s3://cant_get_it/file.csv")
 
+    @td.skip_if_no("botocore")
     def test_write_s3_csv_fails(self, tips_df):
         # GH 32486
         # Attempting to write to an invalid S3 path should raise
+        import botocore
+
         with pytest.raises(
-            FileNotFoundError, match="The specified bucket does not exist"
+            botocore.errorfactory.NoSuchBucket, match="An error occurred (NoSuchBucket)"
         ):
             tips_df.to_csv("s3://an_s3_bucket_data_doesnt_exit/not_real.csv")
 

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -176,7 +176,7 @@ class TestS3:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
         import botocore
 
-        with pytest.raises(botocore.exceptions.ClientError):
+        with pytest.raises(botocore.exceptions.ClientError, match="The specified bucket does not exist"):
             tips_df.to_csv("s3://an_s3_bucket_data_doesnt_exit/not_real.csv")
 
     @td.skip_if_no("pyarrow")


### PR DESCRIPTION
- [x] closes #34086

AWS Service Exceptions are not statically defined in boto3. Easiest to just catch a ClientError here.

Ref Docs:
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#parsing-error-responses-and-catching-exceptions-from-aws-services