### PR TITLE
CLN: Change old string formatting syntax into f-strings

### DIFF
--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -406,10 +406,8 @@ def ensure_key_mapped(values, key: Optional[Callable], levels=None):
             result = type_of_values(result)  # try to revert to original type otherwise
     except TypeError:
         raise TypeError(
-            "User-provided `key` function returned an invalid type {} \
-            which could not be converted to {}.".format(
-                type(result), type(values)
-            )
+            f"User-provided `key` function returned an invalid type {type(result)} \
+            which could not be converted to {type(values)}."
         )
 
     return result

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -987,8 +987,8 @@ class TestCustomDateRange:
         )
 
         bad_freq = freq + "FOO"
-        msg = "invalid custom frequency string: {freq}"
-        with pytest.raises(ValueError, match=msg.format(freq=bad_freq)):
+        msg = f"invalid custom frequency string: {bad_freq}"
+        with pytest.raises(ValueError, match=msg):
             bdate_range(START, END, freq=bad_freq)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -425,10 +425,10 @@ class TestIntervalIndex:
         key = make_key(breaks2)
 
         msg = (
-            "Cannot index an IntervalIndex of subtype {dtype1} with "
-            "values of dtype {dtype2}"
+            f"Cannot index an IntervalIndex of subtype {breaks1.dtype} with "
+            f"values of dtype {breaks2.dtype}"
         )
-        msg = re.escape(msg.format(dtype1=breaks1.dtype, dtype2=breaks2.dtype))
+        msg = re.escape(msg)
         with pytest.raises(ValueError, match=msg):
             index._maybe_convert_i8(key)
 

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -31,8 +31,7 @@ def check_comprehensiveness(request):
 
     for combo in combos:
         if not has_test(combo):
-            msg = "test method is not defined: {0}, {1}"
-            raise AssertionError(msg.format(cls.__name__, combo))
+            raise AssertionError(f"test method is not defined: {cls.__name__}, {combo}")
 
     yield
 

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1869,12 +1869,13 @@ class TestConcatenate:
 
         # trying to concat a ndframe with a non-ndframe
         df1 = tm.makeCustomDataframe(10, 2)
-        msg = (
-            "cannot concatenate object of type '{}'; "
-            "only Series and DataFrame objs are valid"
-        )
         for obj in [1, dict(), [1, 2], (1, 2)]:
-            with pytest.raises(TypeError, match=msg.format(type(obj))):
+
+            msg = (
+                f"cannot concatenate object of type '{type(obj)}'; "
+                "only Series and DataFrame objs are valid"
+            )
+            with pytest.raises(TypeError, match=msg):
                 concat([df1, obj])
 
     def test_concat_invalid_first_argument(self):

--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -289,9 +289,9 @@ def deprecate_nonkeyword_arguments(
                 num_allow_args = allow_args
             if len(args) > num_allow_args:
                 msg = (
-                    "Starting with Pandas version {version} all arguments of {funcname}"
-                    "{except_args} will be keyword-only"
-                ).format(version=version, funcname=func.__name__, except_args=arguments)
+                    f"Starting with Pandas version {version} all arguments of "
+                    f"{func.__name__}{arguments} will be keyword-only"
+                )
                 warnings.warn(msg, FutureWarning, stacklevel=stacklevel)
             return func(*args, **kwargs)
 


### PR DESCRIPTION
- [x] xref #29547
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
