### PR TITLE
TST: Mark groupby.nunique test as slow

### DIFF
--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -9,6 +9,7 @@ from pandas import DataFrame, MultiIndex, NaT, Series, Timestamp, date_range
 import pandas._testing as tm
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("n", 10 ** np.arange(2, 6))
 @pytest.mark.parametrize("m", [10, 100, 1000])
 @pytest.mark.parametrize("sort", [False, True])


### PR DESCRIPTION
This test takes about 40 seconds to run for me while shrinking the size of the data brings the runtime down to 2 seconds, presumably without changing coverage (do we even need to parametrize over n and m here?).