### PR TITLE
CLN: avoid ndim checks in _libs

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -355,25 +355,12 @@ cdef class Interval(IntervalMixin):
                 (key < self.right if self.open_right else key <= self.right))
 
     def __richcmp__(self, other, op: int):
-        if hasattr(other, 'ndim'):
-            # let numpy (or IntervalIndex) handle vectorization
-            return NotImplemented
-
-        if _interval_like(other):
+        if isinstance(other, Interval):
             self_tuple = (self.left, self.right, self.closed)
             other_tuple = (other.left, other.right, other.closed)
             return PyObject_RichCompare(self_tuple, other_tuple, op)
 
-        # nb. could just return NotImplemented now, but handling this
-        # explicitly allows us to opt into the Python 3 behavior, even on
-        # Python 2.
-        if op == Py_EQ or op == Py_NE:
-            return NotImplemented
-        else:
-            name = type(self).__name__
-            other = type(other).__name__
-            op_str = {Py_LT: '<', Py_LE: '<=', Py_GT: '>', Py_GE: '>='}[op]
-            raise TypeError(f"unorderable types: {name}() {op_str} {other}()")
+        return NotImplemented
 
     def __reduce__(self):
         args = (self.left, self.right, self.closed)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -6,7 +6,7 @@ from cpython.object cimport Py_NE, Py_EQ, PyObject_RichCompare
 
 import numpy as np
 cimport numpy as cnp
-from numpy cimport int64_t
+from numpy cimport int64_t, ndarray
 cnp.import_array()
 
 from cpython.datetime cimport (timedelta,
@@ -1469,7 +1469,7 @@ cdef _rfloordiv(int64_t value, right):
 
 cdef _broadcast_floordiv_td64(
     int64_t value,
-    object other,
+    ndarray other,
     object (*operation)(int64_t value, object right)
 ):
     """
@@ -1487,13 +1487,11 @@ cdef _broadcast_floordiv_td64(
     result : varies based on `other`
     """
     # assumes other.dtype.kind == 'm', i.e. other is timedelta-like
-    cdef:
-        int ndim = getattr(other, 'ndim', -1)
 
     # We need to watch out for np.timedelta64('NaT').
     mask = other.view('i8') == NPY_NAT
 
-    if ndim == 0:
+    if other.ndim == 0:
         if mask:
             return np.nan
 

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -568,13 +568,17 @@ class TestIntervalIndex:
         actual = self.index == self.index.left
         tm.assert_numpy_array_equal(actual, np.array([False, False]))
 
-        with pytest.raises(TypeError, match="unorderable types"):
+        msg = (
+            "not supported between instances of 'int' and "
+            "'pandas._libs.interval.Interval'"
+        )
+        with pytest.raises(TypeError, match=msg):
             self.index > 0
-        with pytest.raises(TypeError, match="unorderable types"):
+        with pytest.raises(TypeError, match=msg):
             self.index <= 0
-        msg = r"unorderable types: Interval\(\) > int\(\)"
         with pytest.raises(TypeError, match=msg):
             self.index > np.arange(2)
+
         msg = "Lengths must match"
         with pytest.raises(ValueError, match=msg):
             self.index > np.arange(3)
@@ -894,6 +898,6 @@ def test_searchsorted_different_argument_classes(klass):
 )
 def test_searchsorted_invalid_argument(arg):
     values = IntervalIndex([Interval(0, 1), Interval(1, 2)])
-    msg = "unorderable types"
+    msg = "'<' not supported between instances of 'pandas._libs.interval.Interval' and "
     with pytest.raises(TypeError, match=msg):
         values.searchsorted(arg)

--- a/pandas/tests/scalar/interval/test_interval.py
+++ b/pandas/tests/scalar/interval/test_interval.py
@@ -49,7 +49,10 @@ class TestInterval:
         assert Interval(0, 1) != 0
 
     def test_comparison(self):
-        msg = "unorderable types"
+        msg = (
+            "'<' not supported between instances of "
+            "'pandas._libs.interval.Interval' and 'int'"
+        )
         with pytest.raises(TypeError, match=msg):
             Interval(0, 1) < 2
 


### PR DESCRIPTION
These checks go through python-space