### PR TITLE
REGR: exceptions not caught in _call_map_locations

### DIFF
--- a/doc/source/whatsnew/v1.0.4.rst
+++ b/doc/source/whatsnew/v1.0.4.rst
@@ -23,7 +23,7 @@ Fixed regressions
 - Bug where an ordered :class:`Categorical` containing only ``NaN`` values would raise rather than returning ``NaN`` when taking the minimum or maximum  (:issue:`33450`)
 - Bug in :meth:`DataFrameGroupBy.agg` with dictionary input losing ``ExtensionArray`` dtypes (:issue:`32194`)
 - Fix to preserve the ability to index with the "nearest" method with xarray's CFTimeIndex, an :class:`Index` subclass (`pydata/xarray#3751 <https://github.com/pydata/xarray/issues/3751>`_, :issue:`32905`).
-- 
+- Fix regression in :meth:`DataFrame.describe` raising ``TypeError: unhashable type: 'dict'`` (:issue:`32409`)
 
 .. _whatsnew_104.bug_fixes:
 

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -270,7 +270,7 @@ cdef class IndexEngine:
 
         self.need_unique_check = 0
 
-    cdef void _call_map_locations(self, values):
+    cpdef _call_map_locations(self, values):
         self.mapping.map_locations(values)
 
     def clear_mapping(self):
@@ -509,7 +509,7 @@ cdef class PeriodEngine(Int64Engine):
     cdef _get_index_values(self):
         return super(PeriodEngine, self).vgetter()
 
-    cdef void _call_map_locations(self, values):
+    cpdef _call_map_locations(self, values):
         # super(...) pattern doesn't seem to work with `cdef`
         Int64Engine._call_map_locations(self, values.view('i8'))
 

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -38,7 +38,7 @@ cdef class {{name}}Engine(IndexEngine):
             raise KeyError(val)
     {{endif}}
 
-    cdef void _call_map_locations(self, values):
+    cpdef _call_map_locations(self, values):
         # self.mapping is of type {{hashtable_name}}HashTable,
         # so convert dtype of values
         self.mapping.map_locations(algos.ensure_{{hashtable_dtype}}(values))


### PR DESCRIPTION
- [ ] xref #32409
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

# NOTE: issue 'fixed' on master. This PR against 1.0.x branch

cc @jbrockmendel Could there still be issue on master with the exceptions not being caught?