### PR TITLE
API: remove dropped multilevel index from levels (GH: #34097)

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2072,8 +2072,9 @@ class MultiIndex(Index):
             except KeyError:
                 if errors != "ignore":
                     raise
-
-        return self.delete(inds)
+        inds = self.delete(inds)
+        dropped = inds.remove_unused_levels()
+        return dropped
 
     def _drop_from_level(self, codes, level, errors="raise"):
         codes = com.index_labels_to_array(codes)

--- a/pandas/tests/indexes/multi/test_drop.py
+++ b/pandas/tests/indexes/multi/test_drop.py
@@ -140,16 +140,19 @@ def test_drop_not_lexsorted():
     with tm.assert_produces_warning(PerformanceWarning):
         tm.assert_index_equal(lexsorted_mi.drop("a"), not_lexsorted_mi.drop("a"))
 
+
 def test_drop_index_update_level():
     # GH 34097
 
     # create df with multiindex
-    df = pd.DataFrame(np.arange(16).reshape(4, 4),
-                      index=pd.MultiIndex.from_arrays([list("AABB"), list("XYXY")]),
-                      columns=list("abcd"))
+    df = pd.DataFrame(
+        np.arange(16).reshape(4, 4),
+        index=pd.MultiIndex.from_arrays([list("AABB"), list("XYXY")]),
+        columns=list("abcd"),
+    )
     # drop one of the level-0 indices
     result = df.drop(index="A").index
-    expected = pd.MultiIndex.from_arrays([list('BB'), list('XY')])
+    expected = pd.MultiIndex.from_arrays([list("BB"), list("XY")])
 
     # check whether dropped level-0 index is found in levels and codes
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_drop.py
+++ b/pandas/tests/indexes/multi/test_drop.py
@@ -139,3 +139,17 @@ def test_drop_not_lexsorted():
     tm.assert_index_equal(lexsorted_mi, not_lexsorted_mi)
     with tm.assert_produces_warning(PerformanceWarning):
         tm.assert_index_equal(lexsorted_mi.drop("a"), not_lexsorted_mi.drop("a"))
+
+def test_drop_index_update_level():
+    # GH 34097
+
+    # create df with multiindex
+    df = pd.DataFrame(np.arange(16).reshape(4, 4),
+                      index=pd.MultiIndex.from_arrays([list("AABB"), list("XYXY")]),
+                      columns=list("abcd"))
+    # drop one of the level-0 indices
+    result = df.drop(index="A").index
+    expected = pd.MultiIndex.from_arrays([list('BB'), list('XY')])
+
+    # check whether dropped level-0 index is found in levels and codes
+    tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] closes #34097
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
