### PR TITLE
DOC: Add clarifications and link to tutorials in the getting started page

### DIFF
--- a/web/pandas/getting_started.md
+++ b/web/pandas/getting_started.md
@@ -7,9 +7,13 @@ environment to use pandas. Other installation options can be found in
 the [advanced installation page]({{ base_url}}/docs/getting_started/install.html).
 
 1. Download [Anaconda](https://www.anaconda.com/distribution/) for your operating system and
-   the latest Python version, run the installer, and follow the steps. Detailed instructions
-   on how to install Anaconda can be found in the
-   [Anaconda documentation](https://docs.anaconda.com/anaconda/install/).
+   the latest Python version, run the installer, and follow the steps.
+
+    When asked if you wish to initialize Anaconda3, answer yes.
+    Restart the terminal after completing the installation.
+
+    Detailed instructions on how to install Anaconda can be found in the
+    [Anaconda documentation](https://docs.anaconda.com/anaconda/install/).
 
 2. In the Anaconda prompt (or terminal in Linux or MacOS), start JupyterLab:
 
@@ -27,8 +31,9 @@ the [advanced installation page]({{ base_url}}/docs/getting_started/install.html
 
 ## Tutorials
 
-You can learn more about pandas in the [tutorials](#), and more about JupyterLab
-in the [JupyterLab documentation](https://jupyterlab.readthedocs.io/en/stable/user/interface.html).
+You can learn more about pandas in the [tutorials]({{ base_url }}/docs/getting_started/intro_tutorials/),
+and more about JupyterLab in the
+[JupyterLab documentation](https://jupyterlab.readthedocs.io/en/stable/user/interface.html).
 
 ## Books
 

--- a/web/pandas/getting_started.md
+++ b/web/pandas/getting_started.md
@@ -7,10 +7,11 @@ environment to use pandas. Other installation options can be found in
 the [advanced installation page]({{ base_url}}/docs/getting_started/install.html).
 
 1. Download [Anaconda](https://www.anaconda.com/distribution/) for your operating system and
-   the latest Python version, run the installer, and follow the steps.
+   the latest Python version, run the installer, and follow the steps. Please note:
 
-    When asked if you wish to initialize Anaconda3, answer yes.
-    Restart the terminal after completing the installation.
+    - It is not needed (and discouraged) to install Anaconda as root or administrator.
+    - When asked if you wish to initialize Anaconda3, answer yes.
+    - Restart the terminal after completing the installation.
 
     Detailed instructions on how to install Anaconda can be found in the
     [Anaconda documentation](https://docs.anaconda.com/anaconda/install/).

--- a/web/pandas/static/css/pandas.css
+++ b/web/pandas/static/css/pandas.css
@@ -23,6 +23,9 @@ a {
 code {
     white-space: pre;
 }
+ol ol, ol ul, ul ol, ul ul {
+    margin-bottom: 1rem;
+}
 .blue {
     color: #150458;
 }


### PR DESCRIPTION
Some people are having problems following our getting started instructions. The notes added here should help.

Also, adding missing link to the tutorials.