### PR TITLE
CI: Pin flake8 < 3.8.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   # code checks
   - black=19.10b0
   - cpplint
-  - flake8
+  - flake8<3.8.0  # temporary pin, GH#34150
   - flake8-comprehensions>=3.1.0  # used by flake8, linting of unnecessary comprehensions
   - flake8-rst>=0.6.0,<=0.7.0  # linting of code blocks in rst files
   - isort  # check that imports are in the right order

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ asv
 cython>=0.29.16
 black==19.10b0
 cpplint
-flake8
+flake8<3.8.0
 flake8-comprehensions>=3.1.0
 flake8-rst>=0.6.0,<=0.7.0
 isort


### PR DESCRIPTION
xref #34150

This handles multiple issues:
- flake8 >= 3.8.1 introduces a new version of pycodestyle which introduces
  extra checking
- flake8-rst is broken with the newest version of flake8
    - See kataev/flake8-rst#22

A follow-up PR handling the first of these is forth-coming