### PR TITLE
CI: Address linting errors in flake8 >= 3.8.1

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1049,6 +1049,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         points) and is either monotonic increasing or monotonic decreasing,
         else False.
         """
+
     # https://github.com/python/mypy/issues/1362
     # Mypy does not support decorated properties
     @property  # type: ignore

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -443,7 +443,7 @@ def _is_uniform_join_units(join_units: List[JoinUnit]) -> bool:
     #  cannot necessarily join
     return (
         # all blocks need to have the same type
-        all(type(ju.block) is type(join_units[0].block) for ju in join_units)
+        all(isinstance(ju.block, type(join_units[0].block)) for ju in join_units)
         and  # noqa
         # no blocks that would get missing values (can lead to type upcasts)
         # unless we're an extension dtype.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2584,10 +2584,7 @@ Name: Max Speed, dtype: float64
         else:
             to_concat = [self, to_append]
         if any(isinstance(x, (ABCDataFrame,)) for x in to_concat[1:]):
-            msg = (
-                f"to_append should be a Series or list/tuple of Series, "
-                f"got DataFrame"
-            )
+            msg = "to_append should be a Series or list/tuple of Series, got DataFrame"
             raise TypeError(msg)
         return concat(
             to_concat, ignore_index=ignore_index, verify_integrity=verify_integrity

--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -18,10 +18,10 @@ def test_correct_function_signature():
         {"key": ["a", "a", "b", "b", "a"], "data": [1.0, 2.0, 3.0, 4.0, 5.0]},
         columns=["key", "data"],
     )
-    with pytest.raises(NumbaUtilError, match=f"The first 2"):
+    with pytest.raises(NumbaUtilError, match="The first 2"):
         data.groupby("key").agg(incorrect_function, engine="numba")
 
-    with pytest.raises(NumbaUtilError, match=f"The first 2"):
+    with pytest.raises(NumbaUtilError, match="The first 2"):
         data.groupby("key")["data"].agg(incorrect_function, engine="numba")
 
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -502,9 +502,9 @@ def test_dataframe_categorical_ordered_observed_sort(ordered, observed, sort):
         aggr[aggr.isna()] = "missing"
     if not all(label == aggr):
         msg = (
-            f"Labels and aggregation results not consistently sorted\n"
-            + "for (ordered={ordered}, observed={observed}, sort={sort})\n"
-            + "Result:\n{result}"
+            "Labels and aggregation results not consistently sorted\n"
+            f"for (ordered={ordered}, observed={observed}, sort={sort})\n"
+            f"Result:\n{result}"
         )
         assert False, msg
 

--- a/pandas/tests/groupby/transform/test_numba.py
+++ b/pandas/tests/groupby/transform/test_numba.py
@@ -17,10 +17,10 @@ def test_correct_function_signature():
         {"key": ["a", "a", "b", "b", "a"], "data": [1.0, 2.0, 3.0, 4.0, 5.0]},
         columns=["key", "data"],
     )
-    with pytest.raises(NumbaUtilError, match=f"The first 2"):
+    with pytest.raises(NumbaUtilError, match="The first 2"):
         data.groupby("key").transform(incorrect_function, engine="numba")
 
-    with pytest.raises(NumbaUtilError, match=f"The first 2"):
+    with pytest.raises(NumbaUtilError, match="The first 2"):
         data.groupby("key")["data"].transform(incorrect_function, engine="numba")
 
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1861,7 +1861,7 @@ the string values returned are correct."""
 @pytest.mark.parametrize("version", [105, 108, 111, 113, 114])
 def test_backward_compat(version, datapath):
     data_base = datapath("io", "data", "stata")
-    ref = os.path.join(data_base, f"stata-compat-118.dta")
+    ref = os.path.join(data_base, "stata-compat-118.dta")
     old = os.path.join(data_base, f"stata-compat-{version}.dta")
     expected = pd.read_stata(ref)
     old_dta = pd.read_stata(old)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ ignore =
     W504,  # line break after binary operator
     E402,  # module level import not at top of file
     E731,  # do not assign a lambda expression, use a def
+    E741,  # ambiguous variable name 'l' (GH#34150)
+    F541,  # f-string is missing placeholders *GH#34150)
     C406,  # Unnecessary list literal - rewrite as a dict literal.
     C408,  # Unnecessary dict call - rewrite as a literal.
     C409,  # Unnecessary list passed to tuple() - rewrite as a tuple literal.

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ ignore =
     E402,  # module level import not at top of file
     E731,  # do not assign a lambda expression, use a def
     E741,  # ambiguous variable name 'l' (GH#34150)
-    F541,  # f-string is missing placeholders *GH#34150)
     C406,  # Unnecessary list literal - rewrite as a dict literal.
     C408,  # Unnecessary dict call - rewrite as a literal.
     C409,  # Unnecessary list passed to tuple() - rewrite as a tuple literal.


### PR DESCRIPTION
xref #34150

This partially addresses the above issue by:

- Ignoring E741
- Fixing other linting errors

The issue with flake8-rst is handled temporarily in #34151, and the build here will fail the flake8-rst part until that is merged in.