### PR TITLE
Backport PR #33983 on branch 1.0.x (BUG: Use args and kwargs in Rolling.apply)

### DIFF
--- a/doc/source/whatsnew/v1.0.4.rst
+++ b/doc/source/whatsnew/v1.0.4.rst
@@ -25,6 +25,7 @@ Fixed regressions
 - Fix to preserve the ability to index with the "nearest" method with xarray's CFTimeIndex, an :class:`Index` subclass (`pydata/xarray#3751 <https://github.com/pydata/xarray/issues/3751>`_, :issue:`32905`).
 - Fix regression in :meth:`DataFrame.describe` raising ``TypeError: unhashable type: 'dict'`` (:issue:`32409`)
 - Bug in :meth:`DataFrame.replace` casts columns to ``object`` dtype if items in ``to_replace`` not in values (:issue:`32988`)
+- Bug in :meth:`GroupBy.rolling.apply` ignores args and kwargs parameters (:issue:`33433`)
 - 
 
 .. _whatsnew_104.bug_fixes:

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1304,6 +1304,8 @@ class _Rolling_and_Expanding(_Rolling):
             name=func,
             use_numba_cache=engine == "numba",
             raw=raw,
+            args=args,
+            kwargs=kwargs,
         )
 
     def _generate_cython_apply_func(self, args, kwargs, raw, offset, func):

--- a/pandas/tests/window/test_apply.py
+++ b/pandas/tests/window/test_apply.py
@@ -3,7 +3,7 @@ import pytest
 
 import pandas.util._test_decorators as td
 
-from pandas import DataFrame, Series, Timestamp, date_range
+from pandas import DataFrame, Index, MultiIndex, Series, Timestamp, date_range
 import pandas._testing as tm
 
 
@@ -138,3 +138,28 @@ def test_invalid_kwargs_nopython():
         Series(range(1)).rolling(1).apply(
             lambda x: x, kwargs={"a": 1}, engine="numba", raw=True
         )
+
+
+@pytest.mark.parametrize("args_kwargs", [[None, {"par": 10}], [(10,), None]])
+def test_rolling_apply_args_kwargs(args_kwargs):
+    # GH 33433
+    def foo(x, par):
+        return np.sum(x + par)
+
+    df = DataFrame({"gr": [1, 1], "a": [1, 2]})
+
+    idx = Index(["gr", "a"])
+    expected = DataFrame([[11.0, 11.0], [11.0, 12.0]], columns=idx)
+
+    result = df.rolling(1).apply(foo, args=args_kwargs[0], kwargs=args_kwargs[1])
+    tm.assert_frame_equal(result, expected)
+
+    result = df.rolling(1).apply(foo, args=(10,))
+
+    midx = MultiIndex.from_tuples([(1, 0), (1, 1)], names=["gr", None])
+    expected = Series([11.0, 12.0], index=midx, name="a")
+
+    gb_rolling = df.groupby("gr")["a"].rolling(1)
+
+    result = gb_rolling.apply(foo, args=args_kwargs[0], kwargs=args_kwargs[1])
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
xref #33983, #33433

fixes regression in 1.0.0 