### PR TITLE
CLN: let Index use general concat machinery - remove Index._concat_same_dtype

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4101,37 +4101,13 @@ class Index(IndexOpsMixin, PandasObject):
         return self._concat(to_concat, name)
 
     def _concat(self, to_concat, name):
-
-        typs = _concat.get_dtype_kinds(to_concat)
-
-        if len(typs) == 1:
-            return self._concat_same_dtype(to_concat, name=name)
-        return Index._concat_same_dtype(self, to_concat, name=name)
-
-    def _concat_same_dtype(self, to_concat, name):
         """
-        Concatenate to_concat which has the same class.
+        Concatenate multiple Index objects.
         """
-        # must be overridden in specific classes
-        klasses = (
-            ABCDatetimeIndex,
-            ABCTimedeltaIndex,
-            ABCPeriodIndex,
-            ExtensionArray,
-            ABCIntervalIndex,
-        )
-        to_concat = [
-            x.astype(object) if isinstance(x, klasses) else x for x in to_concat
-        ]
-
-        self = to_concat[0]
-        attribs = self._get_attributes_dict()
-        attribs["name"] = name
-
         to_concat = [x._values if isinstance(x, Index) else x for x in to_concat]
 
-        res_values = np.concatenate(to_concat)
-        return Index(res_values, name=name)
+        result = _concat.concat_compat(to_concat)
+        return Index(result, name=name)
 
     def putmask(self, mask, value):
         """

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -738,13 +738,6 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
 
     def _concat(self, to_concat, name):
         # if calling index is category, don't check dtype of others
-        return CategoricalIndex._concat_same_dtype(self, to_concat, name)
-
-    def _concat_same_dtype(self, to_concat, name):
-        """
-        Concatenate to_concat which has the same class
-        ValueError if other is not in the categories
-        """
         codes = np.concatenate([self._is_dtype_compat(c).codes for c in to_concat])
         result = self._create_from_codes(codes, name=name)
         # if name is None, _create_from_codes sets self.name

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -236,10 +236,6 @@ class ExtensionIndex(Index):
         # ExtensionIndex subclasses must override Index.insert
         raise AbstractMethodError(self)
 
-    def _concat_same_dtype(self, to_concat, name):
-        arr = type(self._data)._concat_same_type(to_concat)
-        return type(self)._simple_new(arr, name=name)
-
     def _get_unique_index(self, dropna=False):
         if self.is_unique and not dropna:
             return self

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -147,10 +147,6 @@ class NumericIndex(Index):
         """
         pass
 
-    def _concat_same_dtype(self, indexes, name):
-        result = type(indexes[0])(np.concatenate([x._values for x in indexes]))
-        return result.rename(name)
-
     @property
     def is_all_dates(self) -> bool:
         """

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -627,14 +627,18 @@ class RangeIndex(Int64Index):
 
         return super().join(other, how, level, return_indexers, sort)
 
-    def _concat_same_dtype(self, indexes, name):
+    def _concat(self, indexes, name):
         """
-        Concatenates multiple RangeIndex instances. All members of "indexes" must
-        be of type RangeIndex; result will be RangeIndex if possible, Int64Index
-        otherwise. E.g.:
+        Overriding parent method for the case of all RangeIndex instances.
+
+        When all members of "indexes" are of type RangeIndex: result will be
+        RangeIndex if possible, Int64Index otherwise. E.g.:
         indexes = [RangeIndex(3), RangeIndex(3, 6)] -> RangeIndex(6)
         indexes = [RangeIndex(3), RangeIndex(4, 6)] -> Int64Index([0,1,2,4,5])
         """
+        if not all(isinstance(x, RangeIndex) for x in indexes):
+            return super()._concat(indexes, name)
+
         start = step = next_ = None
 
         # Filter the empty indexes

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -168,7 +168,8 @@ class SharedTests:
         arr = self.array_cls(idx)
 
         result = arr._concat_same_type([arr[:-1], arr[1:], arr])
-        expected = idx._concat_same_dtype([idx[:-1], idx[1:], idx], None)
+        arr2 = arr.astype(object)
+        expected = self.index_cls(np.concatenate([arr2[:-1], arr2[1:], arr2]), None)
 
         tm.assert_index_equal(self.index_cls(result), expected)
 

--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -136,7 +136,7 @@ class TestCategoricalIndex(Base):
         tm.assert_index_equal(result, expected, exact=True)
 
     def test_append_to_another(self):
-        # hits Index._concat_same_dtype
+        # hits Index._concat
         fst = Index(["a", "b"])
         snd = CategoricalIndex(["d", "e"])
         result = fst.append(snd)


### PR DESCRIPTION
Following up on the recent changes in the `concat_compat` machinery (to use the `_get_common_dtype` protocol for EAs), we can also use this in the Index class. 

Doing this also makes the `_concat_same_dtype` method unnecessary (as this is handled in `concat_compat` to use `EA._concat_same_type` when appropriate)

cc @jbrockmendel 