### PR TITLE
REF: de-duplicate methods calling get_dst_info

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -12,6 +12,7 @@ import cython
 
 from cpython.datetime cimport (
     datetime,
+    tzinfo,
     PyDate_Check,
     PyDateTime_Check,
     PyDateTime_IMPORT,
@@ -962,23 +963,8 @@ def dt64arr_to_periodarr(const int64_t[:] dtarr, int freq, tz=None):
     """
     cdef:
         int64_t[:] out
-        Py_ssize_t i, l
-        npy_datetimestruct dts
 
-    l = len(dtarr)
-
-    out = np.empty(l, dtype='i8')
-
-    if tz is None:
-        with nogil:
-            for i in range(l):
-                if dtarr[i] == NPY_NAT:
-                    out[i] = NPY_NAT
-                    continue
-                dt64_to_dtstruct(dtarr[i], &dts)
-                out[i] = get_period_ordinal(&dts, freq)
-    else:
-        out = localize_dt64arr_to_period(dtarr, freq, tz)
+    out = localize_dt64arr_to_period(dtarr, freq, tz)
     return out.base  # .base to access underlying np.ndarray
 
 
@@ -1470,7 +1456,8 @@ def extract_freq(ndarray[object] values):
 @cython.wraparound(False)
 @cython.boundscheck(False)
 cdef int64_t[:] localize_dt64arr_to_period(const int64_t[:] stamps,
-                                           int freq, object tz):
+                                           int freq, tzinfo tz):
+    # Note: the tzinfo type for tz does not preclude None
     cdef:
         Py_ssize_t n = len(stamps)
         int64_t[:] result = np.empty(n, dtype=np.int64)

--- a/pandas/_libs/tslibs/tzconversion.pxd
+++ b/pandas/_libs/tslibs/tzconversion.pxd
@@ -3,6 +3,15 @@ from numpy cimport int64_t
 
 
 cdef int64_t tz_convert_utc_to_tzlocal(int64_t utc_val, tzinfo tz)
-cdef int64_t _tz_convert_tzlocal_utc(int64_t val, tzinfo tz, bint to_utc=*)
 cdef int64_t _tz_convert_tzlocal_fromutc(int64_t val, tzinfo tz, bint *fold)
 cpdef int64_t tz_convert_single(int64_t val, object tz1, object tz2)
+
+
+cdef class Localizer:
+    cdef readonly:
+        tzinfo tz
+
+    cdef int64_t localize(self, int64_t value, Py_ssize_t i)
+    cdef initialize(self, const int64_t[:] values)
+
+cdef Localizer get_localizer(tz)


### PR DESCRIPTION
We have a 8ish functions that all do something like:

```
def do_thing_vectorized(values, tz):
    if is_utc(tz):
        for i in range(n):
             local_val = values[n]
             do_thing(local_val)
    elif is_tzlocal(tz);
        for i in range(n):
             local_val = get_local_val_for_tzlocal(values[n])
             do_thing(local_val)
    elif is_fixed_offset(tz):
        for i in range(n):
             local_val = get_local_val_for_fixed_offset(values[n])
             do_thing(local_val)
[...]
```

with each of these functions using a different "do_thing".  If this were happening in python-space, we would use a generator and it would look like:

```
def do_thing_vectorized(values, tz):
    for local_val in hypothetical_generator(tz):
         do_thing(local_val)
```

But we can't do that in cython-space.  Until now, we've just made do with having this repeated code.  This PR de-duplicates this code by implementing a Localizer class, so do_thing_vectorized becomes:

```
def do_thing_vectorized(values, tz):
    localizer = get_localizer(tz)
    
     for i in range(N):
          local_val = localizer.localize(value)
          do_thing(local_val)
```

I still need to run asvs, but based on ipython results, i am not seeing any performance degradation so far.

cc @jorisvandenbossche pretty good exposition huh?