### PR TITLE
Restrict Pandas merge suffixes param type to list/tuple to avoid interchange in right and left suffix order

### DIFF
--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -1273,7 +1273,7 @@ columns:
 
 .. ipython:: python
 
-   result = pd.merge(left, right, on='k', suffixes=['_l', '_r'])
+   result = pd.merge(left, right, on='k', suffixes=('_l', '_r'))
 
 .. ipython:: python
    :suppress:

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -401,6 +401,7 @@ Backwards incompatible API changes
 - :func: `pandas.api.dtypes.is_string_dtype` no longer incorrectly identifies categorical series as string.
 - :func:`read_excel` no longer takes ``**kwds`` arguments. This means that passing in keyword ``chunksize`` now raises a ``TypeError``
   (previously raised a ``NotImplementedError``), while passing in keyword ``encoding`` now raises a ``TypeError`` (:issue:`34464`)
+- :func: `merge` now checks ``suffixes`` parameter type to be ``tuple`` and raises ``TypeError``, whereas before a ``list`` or ``set`` were accepted and that the ``set`` could produce unexpected results (:issue:`33740`)
 
 ``MultiIndex.get_indexer`` interprets `method` argument differently
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -226,7 +226,7 @@ right_index : bool, default False
 sort : bool, default False
     Sort the join keys lexicographically in the result DataFrame. If False,
     the order of the join keys depends on the join type (how keyword).
-suffixes : list/tuple of (str, str), default ('_x', '_y')
+suffixes : tuple of (str, str), default ('_x', '_y')
     Suffix to apply to overlapping column names in the left and right
     side, respectively. To raise an exception on overlapping columns use
     (False, False).

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -226,7 +226,7 @@ right_index : bool, default False
 sort : bool, default False
     Sort the join keys lexicographically in the result DataFrame. If False,
     the order of the join keys depends on the join type (how keyword).
-suffixes : tuple of (str, str), default ('_x', '_y')
+suffixes : list/tuple of (str, str), default ('_x', '_y')
     Suffix to apply to overlapping column names in the left and right
     side, respectively. To raise an exception on overlapping columns use
     (False, False).

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2065,16 +2065,16 @@ def _validate_operand(obj: FrameOrSeries) -> "DataFrame":
 
 def _items_overlap_with_suffix(left: Index, right: Index, suffixes):
     """
-    Suffixes type validatoin.
+    Suffixes type validation.
 
     If two indices overlap, add suffixes to overlapping entries.
 
     If corresponding suffix is empty, the entry is simply converted to string.
 
     """
-    if not isinstance(suffixes, (tuple, list)):
+    if not isinstance(suffixes, tuple):
         raise TypeError(
-            f"suffixes should be of type list/tuple. But got {type(suffixes)}"
+            f"suffixes should be tuple of (str, str). But got {type(suffixes)}"
         )
 
     to_rename = left.intersection(right)

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -667,10 +667,8 @@ class _MergeOperation:
 
         join_index, left_indexer, right_indexer = self._get_join_info()
 
-        lsuf, rsuf = self.suffixes
-
         llabels, rlabels = _items_overlap_with_suffix(
-            self.left._info_axis, lsuf, self.right._info_axis, rsuf
+            self.left._info_axis, self.right._info_axis, self.suffixes
         )
 
         lindexers = {1: left_indexer} if left_indexer is not None else {}
@@ -1484,10 +1482,8 @@ class _OrderedMerge(_MergeOperation):
     def get_result(self):
         join_index, left_indexer, right_indexer = self._get_join_info()
 
-        lsuf, rsuf = self.suffixes
-
         llabels, rlabels = _items_overlap_with_suffix(
-            self.left._info_axis, lsuf, self.right._info_axis, rsuf
+            self.left._info_axis, self.right._info_axis, self.suffixes
         )
 
         if self.fill_method == "ffill":
@@ -2067,16 +2063,25 @@ def _validate_operand(obj: FrameOrSeries) -> "DataFrame":
         )
 
 
-def _items_overlap_with_suffix(left: Index, lsuffix, right: Index, rsuffix):
+def _items_overlap_with_suffix(left: Index, right: Index, suffixes):
     """
+    Suffixes type validatoin.
+
     If two indices overlap, add suffixes to overlapping entries.
 
     If corresponding suffix is empty, the entry is simply converted to string.
 
     """
+    if not isinstance(suffixes, (tuple, list)):
+        raise TypeError(
+            f"suffixes should be of type list/tuple. But got {type(suffixes)}"
+        )
+
     to_rename = left.intersection(right)
     if len(to_rename) == 0:
         return left, right
+
+    lsuffix, rsuffix = suffixes
 
     if not lsuffix and not rsuffix:
         raise ValueError(f"columns overlap but no suffix specified: {to_rename}")

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2063,7 +2063,7 @@ def _validate_operand(obj: FrameOrSeries) -> "DataFrame":
         )
 
 
-def _items_overlap_with_suffix(left: Index, right: Index, suffixes):
+def _items_overlap_with_suffix(left: Index, right: Index, suffixes: Tuple[str, str]):
     """
     Suffixes type validation.
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2074,7 +2074,7 @@ def _items_overlap_with_suffix(left: Index, right: Index, suffixes: Tuple[str, s
     """
     if not isinstance(suffixes, tuple):
         raise TypeError(
-            f"suffixes should be tuple of (str, str). But got {type(suffixes)}"
+            f"suffixes should be tuple of (str, str). But got {type(suffixes).__name__}"
         )
 
     to_rename = left.intersection(right)

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -162,7 +162,7 @@ class TestJoin:
         _check_join(self.df, self.df2, joined_both, ["key1", "key2"], how="inner")
 
     def test_handle_overlap(self):
-        joined = merge(self.df, self.df2, on="key2", suffixes=[".foo", ".bar"])
+        joined = merge(self.df, self.df2, on="key2", suffixes=(".foo", ".bar"))
 
         assert "key1.foo" in joined
         assert "key1.bar" in joined
@@ -173,7 +173,7 @@ class TestJoin:
             self.df2,
             left_on="key2",
             right_on="key1",
-            suffixes=[".foo", ".bar"],
+            suffixes=(".foo", ".bar"),
         )
         assert "key1.foo" in joined
         assert "key2.bar" in joined

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2075,15 +2075,27 @@ def test_merge_suffix_error(col1, col2, suffixes):
         pd.merge(a, b, left_index=True, right_index=True, suffixes=suffixes)
 
 
-@pytest.mark.parametrize("col1, col2, suffixes", [("a", "a", None), (0, 0, None)])
-def test_merge_suffix_none_error(col1, col2, suffixes):
-    # issue: 24782
+@pytest.mark.parametrize(
+    "col1, col2, suffixes", [("a", "a", {"a", "b"}), ("a", "a", None), (0, 0, None)],
+)
+def test_merge_suffix_type_error(col1, col2, suffixes):
     a = pd.DataFrame({col1: [1, 2, 3]})
     b = pd.DataFrame({col2: [3, 4, 5]})
 
-    # TODO: might reconsider current raise behaviour, see GH24782
-    msg = "iterable"
+    msg = f"suffixes should be of type list/tuple. But got {type(suffixes)}"
     with pytest.raises(TypeError, match=msg):
+        pd.merge(a, b, left_index=True, right_index=True, suffixes=suffixes)
+
+
+@pytest.mark.parametrize(
+    "col1, col2, suffixes", [("a", "a", ("a", "b", "c"))],
+)
+def test_merge_suffix_length_error(col1, col2, suffixes):
+    a = pd.DataFrame({col1: [1, 2, 3]})
+    b = pd.DataFrame({col2: [3, 4, 5]})
+
+    msg = r"too many values to unpack \(expected 2\)"
+    with pytest.raises(ValueError, match=msg):
         pd.merge(a, b, left_index=True, right_index=True, suffixes=suffixes)
 
 

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2056,11 +2056,7 @@ def test_merge_duplicate_suffix(how, expected):
 
 @pytest.mark.parametrize(
     "col1, col2, suffixes",
-    [
-        ("a", "a", (None, None)),
-        ("a", "a", ("", None)),
-        (0, 0, (None, "")),
-    ],
+    [("a", "a", (None, None)), ("a", "a", ("", None)), (0, 0, (None, "")),],
 )
 def test_merge_suffix_error(col1, col2, suffixes):
     # issue: 24782

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2091,7 +2091,7 @@ def test_merge_suffix_type_error(col1, col2, suffixes):
     "col1, col2, suffixes, msg",
     [
         ("a", "a", ("a", "b", "c"), r"too many values to unpack \(expected 2\)"),
-        ("a", "a", ("a"), r"not enough values to unpack \(expected 2, got 1\)"),
+        ("a", "a", ["a"], r"not enough values to unpack \(expected 2, got 1\)"),
     ],
 )
 def test_merge_suffix_length_error(col1, col2, suffixes, msg):

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2056,7 +2056,7 @@ def test_merge_duplicate_suffix(how, expected):
 
 @pytest.mark.parametrize(
     "col1, col2, suffixes",
-    [("a", "a", (None, None)), ("a", "a", ("", None)), (0, 0, (None, "")),],
+    [("a", "a", (None, None)), ("a", "a", ("", None)), (0, 0, (None, ""))],
 )
 def test_merge_suffix_error(col1, col2, suffixes):
     # issue: 24782
@@ -2076,7 +2076,9 @@ def test_merge_suffix_type_error(col1, col2, suffixes):
     a = pd.DataFrame({col1: [1, 2, 3]})
     b = pd.DataFrame({col2: [3, 4, 5]})
 
-    msg = f"suffixes should be tuple of \\(str, str\\). But got {type(suffixes)}"
+    msg = (
+        f"suffixes should be tuple of \\(str, str\\). But got {type(suffixes).__name__}"
+    )
     with pytest.raises(TypeError, match=msg):
         pd.merge(a, b, left_index=True, right_index=True, suffixes=suffixes)
 

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2088,13 +2088,16 @@ def test_merge_suffix_type_error(col1, col2, suffixes):
 
 
 @pytest.mark.parametrize(
-    "col1, col2, suffixes", [("a", "a", ("a", "b", "c"))],
+    "col1, col2, suffixes, msg",
+    [
+        ("a", "a", ("a", "b", "c"), r"too many values to unpack \(expected 2\)"),
+        ("a", "a", ("a"), r"not enough values to unpack \(expected 2, got 1\)"),
+    ],
 )
-def test_merge_suffix_length_error(col1, col2, suffixes):
+def test_merge_suffix_length_error(col1, col2, suffixes, msg):
     a = pd.DataFrame({col1: [1, 2, 3]})
     b = pd.DataFrame({col2: [3, 4, 5]})
 
-    msg = r"too many values to unpack \(expected 2\)"
     with pytest.raises(ValueError, match=msg):
         pd.merge(a, b, left_index=True, right_index=True, suffixes=suffixes)
 

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -2004,8 +2004,8 @@ def test_merge_series(on, left_on, right_on, left_index, right_index, nm):
         ("b", "b", dict(suffixes=(None, "_y")), ["b", "b_y"]),
         ("a", "a", dict(suffixes=("_x", None)), ["a_x", "a"]),
         ("a", "b", dict(suffixes=("_x", None)), ["a", "b"]),
-        ("a", "a", dict(suffixes=[None, "_x"]), ["a", "a_x"]),
-        (0, 0, dict(suffixes=["_a", None]), ["0_a", 0]),
+        ("a", "a", dict(suffixes=(None, "_x")), ["a", "a_x"]),
+        (0, 0, dict(suffixes=("_a", None)), ["0_a", 0]),
         ("a", "a", dict(), ["a_x", "a_y"]),
         (0, 0, dict(), ["0_x", "0_y"]),
     ],
@@ -2057,10 +2057,8 @@ def test_merge_duplicate_suffix(how, expected):
 @pytest.mark.parametrize(
     "col1, col2, suffixes",
     [
-        ("a", "a", [None, None]),
         ("a", "a", (None, None)),
         ("a", "a", ("", None)),
-        (0, 0, [None, None]),
         (0, 0, (None, "")),
     ],
 )
@@ -2082,7 +2080,7 @@ def test_merge_suffix_type_error(col1, col2, suffixes):
     a = pd.DataFrame({col1: [1, 2, 3]})
     b = pd.DataFrame({col2: [3, 4, 5]})
 
-    msg = f"suffixes should be of type list/tuple. But got {type(suffixes)}"
+    msg = f"suffixes should be tuple of \\(str, str\\). But got {type(suffixes)}"
     with pytest.raises(TypeError, match=msg):
         pd.merge(a, b, left_index=True, right_index=True, suffixes=suffixes)
 
@@ -2091,7 +2089,7 @@ def test_merge_suffix_type_error(col1, col2, suffixes):
     "col1, col2, suffixes, msg",
     [
         ("a", "a", ("a", "b", "c"), r"too many values to unpack \(expected 2\)"),
-        ("a", "a", ["a"], r"not enough values to unpack \(expected 2, got 1\)"),
+        ("a", "a", tuple("a"), r"not enough values to unpack \(expected 2, got 1\)"),
     ],
 )
 def test_merge_suffix_length_error(col1, col2, suffixes, msg):


### PR DESCRIPTION
- [x] closes #33740
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
