### PR TITLE
CLN: Remove util.is_offset_object

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -22,8 +22,9 @@ cnp.import_array()
 from pandas._libs cimport util
 
 from pandas._libs.tslibs.nattype cimport c_NaT as NaT
-from pandas._libs.tslibs.base cimport ABCTimestamp, ABCTimedelta
+from pandas._libs.tslibs.base cimport ABCTimedelta
 from pandas._libs.tslibs.period cimport is_period_object
+from pandas._libs.tslibs.timestamps cimport _Timestamp
 
 from pandas._libs.hashtable cimport HashTable
 
@@ -378,7 +379,7 @@ cdef class DatetimeEngine(Int64Engine):
     cdef int64_t _unbox_scalar(self, scalar) except? -1:
         # NB: caller is responsible for ensuring tzawareness compat
         #  before we get here
-        if not (isinstance(scalar, ABCTimestamp) or scalar is NaT):
+        if not (isinstance(scalar, _Timestamp) or scalar is NaT):
             raise TypeError(scalar)
         return scalar.value
 

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -42,9 +42,9 @@ from pandas._libs.tslibs.util cimport (
     is_timedelta64_object,
 )
 
-from pandas._libs.tslibs.base cimport ABCTimestamp, ABCTimedelta
+from pandas._libs.tslibs.base cimport ABCTimedelta
 from pandas._libs.tslibs.timezones cimport tz_compare
-
+from pandas._libs.tslibs.timestamps cimport _Timestamp
 
 _VALID_CLOSED = frozenset(['left', 'right', 'both', 'neither'])
 
@@ -328,7 +328,7 @@ cdef class Interval(IntervalMixin):
             raise ValueError(f"invalid option for 'closed': {closed}")
         if not left <= right:
             raise ValueError("left side of interval must be <= right side")
-        if (isinstance(left, ABCTimestamp) and
+        if (isinstance(left, _Timestamp) and
                 not tz_compare(left.tzinfo, right.tzinfo)):
             # GH 18538
             raise ValueError("left and right must have the same time zone, got "
@@ -340,7 +340,7 @@ cdef class Interval(IntervalMixin):
     def _validate_endpoint(self, endpoint):
         # GH 23013
         if not (is_integer_object(endpoint) or is_float_object(endpoint) or
-                isinstance(endpoint, (ABCTimestamp, ABCTimedelta))):
+                isinstance(endpoint, (_Timestamp, ABCTimedelta))):
             raise ValueError("Only numeric, Timestamp and Timedelta endpoints "
                              "are allowed when constructing an Interval.")
 
@@ -370,7 +370,7 @@ cdef class Interval(IntervalMixin):
         right = self.right
 
         # TODO: need more general formatting methodology here
-        if isinstance(left, ABCTimestamp) and isinstance(right, ABCTimestamp):
+        if isinstance(left, _Timestamp) and isinstance(right, _Timestamp):
             left = left._short_repr
             right = right._short_repr
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -75,6 +75,7 @@ from pandas._libs.tslibs.conversion cimport convert_to_tsobject
 from pandas._libs.tslibs.timedeltas cimport convert_to_timedelta64
 from pandas._libs.tslibs.timezones cimport get_timezone, tz_compare
 from pandas._libs.tslibs.period cimport is_period_object
+from pandas._libs.tslibs.offsets cimport is_offset_object
 
 from pandas._libs.missing cimport (
     checknull,
@@ -187,7 +188,7 @@ def is_scalar(val: object) -> bool:
     return (PyNumber_Check(val)
             or is_period_object(val)
             or is_interval(val)
-            or util.is_offset_object(val))
+            or is_offset_object(val))
 
 
 def is_iterator(obj: object) -> bool:

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -26,8 +26,6 @@ from pandas._libs.util cimport (
     is_integer_object,
 )
 
-from pandas._libs.tslibs.base cimport ABCTimestamp
-
 from pandas._libs.tslibs.np_datetime cimport (
     _string_to_dts,
     check_dts_bounds,
@@ -58,7 +56,7 @@ from pandas._libs.tslibs.nattype cimport (
 
 from pandas._libs.tslibs.offsets cimport to_offset
 
-from pandas._libs.tslibs.timestamps cimport create_timestamp_from_ts
+from pandas._libs.tslibs.timestamps cimport create_timestamp_from_ts, _Timestamp
 from pandas._libs.tslibs.timestamps import Timestamp
 
 from pandas._libs.tslibs.tzconversion cimport (
@@ -622,7 +620,7 @@ cpdef array_to_datetime(
                                              'datetime64 unless utc=True')
                     else:
                         iresult[i] = pydatetime_to_dt64(val, &dts)
-                        if isinstance(val, ABCTimestamp):
+                        if isinstance(val, _Timestamp):
                             iresult[i] += val.nanosecond
                         check_dts_bounds(&dts)
 

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -3,9 +3,10 @@ import re
 cimport numpy as cnp
 cnp.import_array()
 
-from pandas._libs.tslibs.util cimport is_integer_object, is_offset_object
+from pandas._libs.tslibs.util cimport is_integer_object
 
 from pandas._libs.tslibs.ccalendar cimport c_MONTH_NUMBERS
+from pandas._libs.tslibs.offsets cimport is_offset_object
 
 # ----------------------------------------------------------------------
 # Constants

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -145,8 +145,6 @@ cdef class _NaT(datetime):
             return c_NaT
         elif util.is_datetime64_object(other) or util.is_timedelta64_object(other):
             return c_NaT
-        elif util.is_offset_object(other):
-            return c_NaT
 
         elif util.is_integer_object(other):
             # For Period compat
@@ -162,7 +160,7 @@ cdef class _NaT(datetime):
                 return result
             raise TypeError(f"Cannot add NaT to ndarray with dtype {other.dtype}")
 
-        # Includes Period going through here
+        # Includes Period, DateOffset going through here
         return NotImplemented
 
     def __sub__(self, other):
@@ -181,8 +179,6 @@ cdef class _NaT(datetime):
         elif PyDelta_Check(other):
             return c_NaT
         elif util.is_datetime64_object(other) or util.is_timedelta64_object(other):
-            return c_NaT
-        elif util.is_offset_object(other):
             return c_NaT
 
         elif util.is_integer_object(other):
@@ -216,7 +212,7 @@ cdef class _NaT(datetime):
                 f"Cannot subtract NaT from ndarray with dtype {other.dtype}"
             )
 
-        # Includes Period going through here
+        # Includes Period, DateOffset going through here
         return NotImplemented
 
     def __pos__(self):

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -39,10 +39,10 @@ from pandas._libs.tslibs.nattype cimport (
 )
 from pandas._libs.tslibs.util cimport (
     is_array,
-    is_offset_object,
     get_c_string_buf_and_size,
 )
 from pandas._libs.tslibs.frequencies cimport get_rule_month
+from pandas._libs.tslibs.offsets cimport is_offset_object
 
 cdef extern from "../src/headers/portable.h":
     int getdigit_ascii(char c, int default) nogil

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -66,7 +66,9 @@ from pandas._libs.tslibs.nattype cimport (
     c_NaT as NaT,
     c_nat_strings as nat_strings,
 )
-from pandas._libs.tslibs.offsets cimport to_offset, is_tick_object
+from pandas._libs.tslibs.offsets cimport (
+    to_offset, is_tick_object, is_offset_object,
+)
 from pandas._libs.tslibs.tzconversion cimport tz_convert_utc_to_tzlocal
 
 
@@ -1599,7 +1601,7 @@ cdef class _Period:
                     return Period(ordinal=ordinal, freq=self.freq)
             raise IncompatibleFrequency("Input cannot be converted to "
                                         f"Period(freq={self.freqstr})")
-        elif util.is_offset_object(other):
+        elif is_offset_object(other):
             freqstr = other.rule_code
             base = get_base_alias(freqstr)
             if base == self.freq.rule_code:
@@ -1615,7 +1617,7 @@ cdef class _Period:
     def __add__(self, other):
         if is_period_object(self):
             if (PyDelta_Check(other) or util.is_timedelta64_object(other) or
-                    util.is_offset_object(other)):
+                    is_offset_object(other)):
                 return self._add_delta(other)
             elif other is NaT:
                 return NaT
@@ -1641,7 +1643,7 @@ cdef class _Period:
     def __sub__(self, other):
         if is_period_object(self):
             if (PyDelta_Check(other) or util.is_timedelta64_object(other) or
-                    util.is_offset_object(other)):
+                    is_offset_object(other)):
                 neg_other = -other
                 return self + neg_other
             elif util.is_integer_object(other):

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -21,7 +21,7 @@ from cpython.datetime cimport (datetime, time, PyDateTime_Check, PyDelta_Check,
 PyDateTime_IMPORT
 
 from pandas._libs.tslibs.util cimport (
-    is_datetime64_object, is_float_object, is_integer_object, is_offset_object,
+    is_datetime64_object, is_float_object, is_integer_object,
     is_timedelta64_object, is_array,
 )
 
@@ -40,7 +40,7 @@ from pandas._libs.tslibs.np_datetime cimport (
     cmp_scalar,
 )
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
-from pandas._libs.tslibs.offsets cimport to_offset, is_tick_object
+from pandas._libs.tslibs.offsets cimport to_offset, is_tick_object, is_offset_object
 from pandas._libs.tslibs.timedeltas import Timedelta
 from pandas._libs.tslibs.timezones cimport (
     is_utc, maybe_get_tz, treat_tz_as_pytz, utc_pytz as UTC,

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -168,21 +168,6 @@ cdef inline bint is_array(object val):
     return PyArray_Check(val)
 
 
-cdef inline bint is_offset_object(object val):
-    """
-    Check if an object is a DateOffset object.
-
-    Parameters
-    ----------
-    val : object
-
-    Returns
-    -------
-    is_date_offset : bool
-    """
-    return getattr(val, '_typ', None) == "dateoffset"
-
-
 cdef inline bint is_nan(object val):
     """
     Check if val is a Not-A-Number float or complex, including


### PR DESCRIPTION
Do isinstance checks on _Timestamp instead of ABCTimestamp where possible (less mro traversal)