### PR TITLE
CLN: remove get_base_alias

### DIFF
--- a/pandas/_libs/tslibs/frequencies.pxd
+++ b/pandas/_libs/tslibs/frequencies.pxd
@@ -3,6 +3,5 @@ cdef dict attrname_to_abbrevs
 cpdef str get_rule_month(object source, str default=*)
 
 cpdef get_freq_code(freqstr)
-cpdef str get_base_alias(freqstr)
 cpdef int get_to_timestamp_base(int base)
 cpdef str get_freq_str(base, mult=*)

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -297,21 +297,6 @@ cpdef str get_freq_str(base, mult=1):
     return str(mult) + code
 
 
-cpdef str get_base_alias(freqstr):
-    """
-    Returns the base frequency alias, e.g., '5D' -> 'D'
-
-    Parameters
-    ----------
-    freqstr : str
-
-    Returns
-    -------
-    base_alias : str
-    """
-    return base_and_stride(freqstr)[0]
-
-
 cpdef int get_to_timestamp_base(int base):
     """
     Return frequency code group used for base of to_timestamp against

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -52,7 +52,6 @@ from pandas._libs.tslibs.ccalendar cimport (
 from pandas._libs.tslibs.ccalendar cimport c_MONTH_NUMBERS
 from pandas._libs.tslibs.frequencies cimport (
     attrname_to_abbrevs,
-    get_base_alias,
     get_freq_code,
     get_freq_str,
     get_rule_month,
@@ -1600,9 +1599,7 @@ cdef class _Period:
             raise IncompatibleFrequency("Input cannot be converted to "
                                         f"Period(freq={self.freqstr})")
         elif util.is_offset_object(other):
-            freqstr = other.rule_code
-            base = get_base_alias(freqstr)
-            if base == self.freq.rule_code:
+            if self.freq.base == other.base:
                 ordinal = self.ordinal + other.n
                 return Period(ordinal=ordinal, freq=self.freq)
             msg = DIFFERENT_FREQ.format(cls=type(self).__name__,

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -665,10 +665,10 @@ class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
         res_values[self._isnan] = iNaT
         return type(self)(res_values, freq=self.freq)
 
-    def _add_offset(self, other):
+    def _add_offset(self, other: DateOffset):
         assert not isinstance(other, Tick)
-        base = libfrequencies.get_base_alias(other.rule_code)
-        if base != self.freq.rule_code:
+
+        if other.base != self.freq.base:
             raise raise_on_incompatible(self, other)
 
         # Note: when calling parent class's _add_timedeltalike_scalar,

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pandas._libs.tslibs.frequencies import (
     FreqGroup,
-    get_base_alias,
+    base_and_stride,
     get_freq_code,
     is_subperiod,
     is_superperiod,
@@ -165,6 +165,21 @@ def _get_ax_freq(ax):
     return ax_freq
 
 
+def _get_base_alias(freqstr: str) -> str:
+    """
+    Returns the base frequency alias, e.g., '5D' -> 'D'
+
+    Parameters
+    ----------
+    freqstr : str
+
+    Returns
+    -------
+    str
+    """
+    return base_and_stride(freqstr)[0]
+
+
 def _get_freq(ax, series):
     # get frequency from data
     freq = getattr(series.index, "freq", None)
@@ -181,7 +196,7 @@ def _get_freq(ax, series):
     if isinstance(freq, DateOffset):
         freq = freq.rule_code
     else:
-        freq = get_base_alias(freq)
+        freq = _get_base_alias(freq)
 
     freq = frequencies.get_period_alias(freq)
     return freq, ax_freq
@@ -203,7 +218,7 @@ def _use_dynamic_x(ax, data):
     if isinstance(freq, DateOffset):
         freq = freq.rule_code
     else:
-        freq = get_base_alias(freq)
+        freq = _get_base_alias(freq)
     freq = frequencies.get_period_alias(freq)
 
     if freq is None:
@@ -247,7 +262,7 @@ def _maybe_convert_index(ax, data):
         if freq is None:
             raise ValueError("Could not get frequency alias for plotting")
 
-        freq = get_base_alias(freq)
+        freq = _get_base_alias(freq)
         freq = frequencies.get_period_alias(freq)
 
         if isinstance(data.index, ABCDatetimeIndex):

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -1,6 +1,7 @@
 # TODO: Use the fact that axis can have units to simplify the process
 
 import functools
+from typing import Optional
 
 import numpy as np
 
@@ -165,19 +166,14 @@ def _get_ax_freq(ax):
     return ax_freq
 
 
-def _get_base_alias(freqstr: str) -> str:
-    """
-    Returns the base frequency alias, e.g., '5D' -> 'D'
+def get_period_alias(freq) -> Optional[str]:
+    if isinstance(freq, DateOffset):
+        freq = freq.rule_code
+    else:
+        freq = base_and_stride(freq)[0]
 
-    Parameters
-    ----------
-    freqstr : str
-
-    Returns
-    -------
-    str
-    """
-    return base_and_stride(freqstr)[0]
+    freq = frequencies.get_period_alias(freq)
+    return freq
 
 
 def _get_freq(ax, series):
@@ -193,12 +189,7 @@ def _get_freq(ax, series):
         freq = ax_freq
 
     # get the period frequency
-    if isinstance(freq, DateOffset):
-        freq = freq.rule_code
-    else:
-        freq = _get_base_alias(freq)
-
-    freq = frequencies.get_period_alias(freq)
+    freq = get_period_alias(freq)
     return freq, ax_freq
 
 
@@ -215,11 +206,7 @@ def _use_dynamic_x(ax, data):
     if freq is None:
         return False
 
-    if isinstance(freq, DateOffset):
-        freq = freq.rule_code
-    else:
-        freq = _get_base_alias(freq)
-    freq = frequencies.get_period_alias(freq)
+    freq = get_period_alias(freq)
 
     if freq is None:
         return False
@@ -253,8 +240,6 @@ def _maybe_convert_index(ax, data):
 
         if freq is None:
             freq = getattr(data.index, "inferred_freq", None)
-        if isinstance(freq, DateOffset):
-            freq = freq.rule_code
 
         if freq is None:
             freq = _get_ax_freq(ax)
@@ -262,8 +247,7 @@ def _maybe_convert_index(ax, data):
         if freq is None:
             raise ValueError("Could not get frequency alias for plotting")
 
-        freq = _get_base_alias(freq)
-        freq = frequencies.get_period_alias(freq)
+        freq = get_period_alias(freq)
 
         if isinstance(data.index, ABCDatetimeIndex):
             data = data.tz_localize(None).to_period(freq=freq)


### PR DESCRIPTION
There are way too many really-similar functions like this.  This trims one of them and de-duplicates 4 near-identical usages in the plotting code.