### PR TITLE
DOC, ENH: Clarify ExcelFile's available engine compatibility with file types in...

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -236,6 +236,7 @@ Other enhancements
   and :class:`~pandas.io.stata.StataWriterUTF8` (:issue:`26599`).
 - :meth:`HDFStore.put` now accepts `track_times` parameter. Parameter is passed to ``create_table`` method of ``PyTables`` (:issue:`32682`).
 - Make :class:`pandas.core.window.Rolling` and :class:`pandas.core.window.Expanding` iterable（:issue:`11704`)
+- :meth:`read_excel` now checks if the engine passed as an argument can process the file provided and outputs a suggestion if it cannot (:issue:`34237`).
 
 .. ---------------------------------------------------------------------------
 


### PR DESCRIPTION
the docstring. Add check to the ExcelFile class that verifies it. GH34237.

DOC: I edited the available ExcelFile's docstring to add information about the recent pyxlsb engine. I also added some compatibility information between the available engines and file types.

ENH: Passing an incompatible filetype-engine combo to the read_excel method would result in an error at line 824/845 (`self._reader = self._engines[engine](self._io)`), which would be engine-dependent and provide little information to the user about what went wrong. The changes proposed check for compatibility in-class and provide some feedback in case of error.

- [x] closes #34237 
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
