### PR TITLE
Backport PR #34049 on branch 1.0.x (Bug in Series.groupby would raise ValueError when grouping by PeriodIndex level)

### DIFF
--- a/doc/source/whatsnew/v1.0.4.rst
+++ b/doc/source/whatsnew/v1.0.4.rst
@@ -25,6 +25,7 @@ Fixed regressions
 - Fix to preserve the ability to index with the "nearest" method with xarray's CFTimeIndex, an :class:`Index` subclass (`pydata/xarray#3751 <https://github.com/pydata/xarray/issues/3751>`_, :issue:`32905`).
 - Fix regression in :meth:`DataFrame.describe` raising ``TypeError: unhashable type: 'dict'`` (:issue:`32409`)
 - Bug in :meth:`DataFrame.replace` casts columns to ``object`` dtype if items in ``to_replace`` not in values (:issue:`32988`)
+- Bug in :meth:`Series.groupby` would raise ``ValueError`` when grouping by :class:`PeriodIndex` level (:issue:`34010`)
 - Bug in :meth:`GroupBy.rolling.apply` ignores args and kwargs parameters (:issue:`33433`)
 - 
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -577,7 +577,9 @@ def get_grouper(
             return False
         try:
             return gpr is obj[gpr.name]
-        except (KeyError, IndexError):
+        except (KeyError, IndexError, ValueError):
+            # TODO: ValueError: Given date string not likely a datetime.
+            # should be KeyError?
             return False
 
     for i, (gpr, level) in enumerate(zip(keys, levels)):

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -1288,6 +1288,14 @@ def test_size_groupby_all_null():
     tm.assert_series_equal(result, expected)
 
 
+def test_size_period_index():
+    # https://github.com/pandas-dev/pandas/issues/34010
+    ser = Series([1], index=pd.PeriodIndex(["2000"], name="A", freq="D"))
+    grp = ser.groupby(level="A")
+    result = grp.size()
+    tm.assert_series_equal(result, ser)
+
+
 # quantile
 # --------------------------------
 @pytest.mark.parametrize(


### PR DESCRIPTION
xref #34049, #34010

regression in 1.0.0