### PR TITLE
Make option_context a ContextDecorator.

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -236,6 +236,7 @@ Other enhancements
   and :class:`~pandas.io.stata.StataWriterUTF8` (:issue:`26599`).
 - :meth:`HDFStore.put` now accepts `track_times` parameter. Parameter is passed to ``create_table`` method of ``PyTables`` (:issue:`32682`).
 - Make :class:`pandas.core.window.Rolling` and :class:`pandas.core.window.Expanding` iterable（:issue:`11704`)
+- Make ``option_context`` a :class:`contextlib.ContextDecorator`, which allows it to be used as a decorator over an entire function (:issue:`34253`).
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -49,7 +49,7 @@ Implementation
 """
 
 from collections import namedtuple
-from contextlib import contextmanager
+from contextlib import ContextDecorator, contextmanager
 import re
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, cast
 import warnings
@@ -379,7 +379,7 @@ options = DictWrapper(_global_config)
 # Functions for use by pandas developers, in addition to User - api
 
 
-class option_context:
+class option_context(ContextDecorator):
     """
     Context manager to temporarily set options in the `with` statement context.
 

--- a/pandas/tests/config/test_config.py
+++ b/pandas/tests/config/test_config.py
@@ -410,6 +410,13 @@ class TestConfig:
         self.cf.set_option("a", 17)
         eq(17)
 
+        # Test that option_context can be used as a decorator too (#34253).
+        @self.cf.option_context("a", 123)
+        def f():
+            eq(123)
+
+        f()
+
     def test_attribute_access(self):
         holder = []
 


### PR DESCRIPTION
This makes it possible to use option_context as a decorator over an
entire function, saving an indent level and making it easy to comment
out (or in) the context while keeping correct indentation.

- [ ] closes #xxxx (N/A)
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
