### PR TITLE
Allow merge_asof on first column of like-levelled MultiIndexes

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -544,7 +544,7 @@ def merge_asof(
     4 2016-05-25 13:30:00.048   AAPL   98.00       100     NaN     NaN
     """
 
-    def _merge(x, y, by):
+    def _merge(x, y, _by):
         op = _AsOfMerge(
             x,
             y,
@@ -553,7 +553,7 @@ def merge_asof(
             right_on=right_on,
             left_index=left_index,
             right_index=right_index,
-            by=by,
+            by=_by,
             left_by=left_by,
             right_by=right_by,
             suffixes=suffixes,

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -592,7 +592,7 @@ def merge_asof(
     res = _merge(
         left.reset_index(level=subsequent_levels),
         right.reset_index(level=subsequent_levels),
-        by
+        by,
     )
 
     # Send subsequent levels back to the index

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -218,18 +218,20 @@ class TestAsOfMerge:
         )
         tm.assert_frame_equal(result, expected)
 
-    def test_multi_index(self):
+    def test_multi_index_on(self):
+        def index_by_time_then_arbitrary_new_level(df):
+            df = df.set_index("time")
+            df = pd.concat([df, df], keys=['f1', 'f2'], names=['f', 'time'])
+            return df.reorder_levels([1, 0]).sort_index()
 
-        # MultiIndex is prohibited
-        trades = self.trades.set_index(["time", "price"])
-        quotes = self.quotes.set_index("time")
-        with pytest.raises(MergeError):
-            merge_asof(trades, quotes, left_index=True, right_index=True)
+        trades = index_by_time_then_arbitrary_new_level(self.trades)
+        quotes = index_by_time_then_arbitrary_new_level(self.quotes)
+        expected = index_by_time_then_arbitrary_new_level(self.asof)
 
-        trades = self.trades.set_index("time")
-        quotes = self.quotes.set_index(["time", "bid"])
-        with pytest.raises(MergeError):
-            merge_asof(trades, quotes, left_index=True, right_index=True)
+        result = merge_asof(
+            trades, quotes, on="time", by=["ticker"],
+        )
+        tm.assert_frame_equal(result, expected)
 
     def test_on_and_index(self):
 

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -221,16 +221,14 @@ class TestAsOfMerge:
     def test_multi_index_on(self):
         def index_by_time_then_arbitrary_new_level(df):
             df = df.set_index("time")
-            df = pd.concat([df, df], keys=['f1', 'f2'], names=['f', 'time'])
+            df = pd.concat([df, df], keys=["f1", "f2"], names=["f", "time"])
             return df.reorder_levels([1, 0]).sort_index()
 
         trades = index_by_time_then_arbitrary_new_level(self.trades)
         quotes = index_by_time_then_arbitrary_new_level(self.quotes)
         expected = index_by_time_then_arbitrary_new_level(self.asof)
 
-        result = merge_asof(
-            trades, quotes, on="time", by=["ticker"],
-        )
+        result = merge_asof(trades, quotes, on="time", by=["ticker"])
         tm.assert_frame_equal(result, expected)
 
     def test_on_and_index(self):


### PR DESCRIPTION
This change essentially allows you to merge_asof on the first level of a MultiIndex, treating the levels after the first as additional 'by' columns. It is possible to do the reset_index/set_index oneself but I think this is a nice syntax and a fairly natural thing to do. Would you be interested in incorporating something like this into pandas?

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
