### PR TITLE
TST: GH28813 test .diff() on Sparse dtype

### DIFF
--- a/pandas/tests/frame/methods/test_diff.py
+++ b/pandas/tests/frame/methods/test_diff.py
@@ -36,13 +36,6 @@ class TestDataFrameDiff:
         ).astype("float64")
         tm.assert_frame_equal(result, expected)
 
-        # Result should be the same for sparse df, see GH28813
-        arr = [[0, 1], [1, 0]]
-        normal = pd.DataFrame(arr)
-        sparse = pd.DataFrame(arr, dtype="Sparse[int]")
-        # we don't check dtype because one is sparse and the other isn't
-        tm.assert_frame_equal(normal.diff(), sparse.diff(), check_dtype=False)
-
     @pytest.mark.parametrize("tz", [None, "UTC"])
     def test_diff_datetime_axis0(self, tz):
         # GH#18578
@@ -164,4 +157,15 @@ class TestDataFrameDiff:
         expected = pd.DataFrame({"A": -1.0 * df["A"], "B": df["B"] * np.nan})
 
         result = df.diff(axis=1, periods=-1)
+        tm.assert_frame_equal(result, expected)
+
+    def test_diff_sparse(self):
+        # GH#28813 .diff() should work for sparse dataframes as well
+        sparse_df = pd.DataFrame([[0, 1], [1, 0]], dtype="Sparse[int]")
+
+        result = sparse_df.diff()
+        expected = pd.DataFrame(
+            [[np.nan, np.nan], [1.0, -1.0]], dtype=pd.SparseDtype("float", 0.0)
+        )
+
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_diff.py
+++ b/pandas/tests/frame/methods/test_diff.py
@@ -39,10 +39,9 @@ class TestDataFrameDiff:
         # Result should be the same for sparse df, see GH28813
         arr = [[0, 1], [1, 0]]
         normal = pd.DataFrame(arr)
-        sparse = pd.DataFrame(arr, dtype='Sparse[int]')
+        sparse = pd.DataFrame(arr, dtype="Sparse[int]")
         # we don't check dtype because one is sparse and the other isn't
         tm.assert_frame_equal(normal.diff(), sparse.diff(), check_dtype=False)
-
 
     @pytest.mark.parametrize("tz", [None, "UTC"])
     def test_diff_datetime_axis0(self, tz):

--- a/pandas/tests/frame/methods/test_diff.py
+++ b/pandas/tests/frame/methods/test_diff.py
@@ -36,6 +36,14 @@ class TestDataFrameDiff:
         ).astype("float64")
         tm.assert_frame_equal(result, expected)
 
+        # Result should be the same for sparse df, see GH28813
+        arr = [[0, 1], [1, 0]]
+        normal = pd.DataFrame(arr)
+        sparse = pd.DataFrame(arr, dtype='Sparse[int]')
+        # we don't check dtype because one is sparse and the other isn't
+        tm.assert_frame_equal(normal.diff(), sparse.diff(), check_dtype=False)
+
+
     @pytest.mark.parametrize("tz", [None, "UTC"])
     def test_diff_datetime_axis0(self, tz):
         # GH#18578


### PR DESCRIPTION
- [x] closes #28813 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Add a quick test to confirm that .diff() function handles sparse dataframes the same way as regular dataframes. 

First time making a pandas PR so comments, advice, critiques are encouraged.