### PR TITLE
ENH: fix arrow roundtrip for ExtensionDtypes in absence of pandas metadata

### DIFF
--- a/pandas/core/arrays/_arrow_utils.py
+++ b/pandas/core/arrays/_arrow_utils.py
@@ -70,6 +70,11 @@ if _pyarrow_version_ge_015:
         def __hash__(self):
             return hash((str(self), self.freq))
 
+        def to_pandas_dtype(self):
+            import pandas as pd
+
+            return pd.PeriodDtype(freq=self.freq)
+
     # register the type with a dummy instance
     _period_type = ArrowPeriodType("D")
     pyarrow.register_extension_type(_period_type)
@@ -118,6 +123,11 @@ if _pyarrow_version_ge_015:
 
         def __hash__(self):
             return hash((str(self), str(self.subtype), self.closed))
+
+        def to_pandas_dtype(self):
+            import pandas as pd
+
+            return pd.IntervalDtype(self.subtype.to_pandas_dtype())
 
     # register the type with a dummy instance
     _interval_type = ArrowIntervalType(pyarrow.int64(), "left")

--- a/pandas/tests/arrays/test_period.py
+++ b/pandas/tests/arrays/test_period.py
@@ -414,3 +414,21 @@ def test_arrow_table_roundtrip():
     result = table2.to_pandas()
     expected = pd.concat([df, df], ignore_index=True)
     tm.assert_frame_equal(result, expected)
+
+
+@pyarrow_skip
+def test_arrow_table_roundtrip_without_metadata():
+    import pyarrow as pa
+
+    arr = PeriodArray([1, 2, 3], freq="H")
+    arr[1] = pd.NaT
+    df = pd.DataFrame({"a": arr})
+
+    table = pa.table(df)
+    # remove the metadata
+    table = table.replace_schema_metadata()
+    assert table.schema.metadata is None
+
+    result = table.to_pandas()
+    assert isinstance(result["a"].dtype, PeriodDtype)
+    tm.assert_frame_equal(result, df)


### PR DESCRIPTION
An oversight in our Arrow Extension Types for period and interval to also define the conversion to the equivalent pandas dtype. This ensures that the arrow->pandas conversion also works if there is no "pandas_metadata" in the schema's metadata, eg when this metadata was lost during some operations (up to now, the pandas ExtensionDtype was reconstructed based on the string name in the stored metadata).

See https://arrow.apache.org/docs/python/extending_types.html#conversion-to-pandas