### PR TITLE
CLN: consolidate arrow roundtrip tests for nullable dtypes in base masked tests

### DIFF
--- a/pandas/tests/arrays/boolean/test_construction.py
+++ b/pandas/tests/arrays/boolean/test_construction.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 import pandas._testing as tm
 from pandas.arrays import BooleanArray
@@ -346,31 +344,3 @@ def test_to_numpy_copy():
 #     mask = pd.array([True, False, True, None], dtype="boolean")
 #     with pytest.raises(IndexError):
 #         result = arr[mask]
-
-
-@td.skip_if_no("pyarrow", min_version="0.15.0")
-def test_arrow_array(data):
-    # protocol added in 0.15.0
-    import pyarrow as pa
-
-    arr = pa.array(data)
-
-    # TODO use to_numpy(na_value=None) here
-    data_object = np.array(data, dtype=object)
-    data_object[data.isna()] = None
-    expected = pa.array(data_object, type=pa.bool_(), from_pandas=True)
-    assert arr.equals(expected)
-
-
-@td.skip_if_no("pyarrow", min_version="0.15.1.dev")
-def test_arrow_roundtrip():
-    # roundtrip possible from arrow 1.0.0
-    import pyarrow as pa
-
-    data = pd.array([True, False, None], dtype="boolean")
-    df = pd.DataFrame({"a": data})
-    table = pa.table(df)
-    assert table.field("a").type == "bool"
-    result = table.to_pandas()
-    assert isinstance(result["a"].dtype, pd.BooleanDtype)
-    tm.assert_frame_equal(result, df)

--- a/pandas/tests/arrays/integer/test_construction.py
+++ b/pandas/tests/arrays/integer/test_construction.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 
-import pandas.util._test_decorators as td
-
 import pandas as pd
 import pandas._testing as tm
 from pandas.api.types import is_integer
@@ -198,41 +196,4 @@ def test_to_integer_array(values, to_dtype, result_dtype):
     result = integer_array(values, dtype=to_dtype)
     assert result.dtype == result_dtype()
     expected = integer_array(values, dtype=result_dtype())
-    tm.assert_extension_array_equal(result, expected)
-
-
-@td.skip_if_no("pyarrow", min_version="0.15.0")
-def test_arrow_array(data):
-    # protocol added in 0.15.0
-    import pyarrow as pa
-
-    arr = pa.array(data)
-    expected = np.array(data, dtype=object)
-    expected[data.isna()] = None
-    expected = pa.array(expected, type=data.dtype.name.lower(), from_pandas=True)
-    assert arr.equals(expected)
-
-
-@td.skip_if_no("pyarrow", min_version="0.16.0")
-def test_arrow_roundtrip(data):
-    # roundtrip possible from arrow 0.16.0
-    import pyarrow as pa
-
-    df = pd.DataFrame({"a": data})
-    table = pa.table(df)
-    assert table.field("a").type == str(data.dtype.numpy_dtype)
-    result = table.to_pandas()
-    tm.assert_frame_equal(result, df)
-
-
-@td.skip_if_no("pyarrow", min_version="0.16.0")
-def test_arrow_from_arrow_uint():
-    # https://github.com/pandas-dev/pandas/issues/31896
-    # possible mismatch in types
-    import pyarrow as pa
-
-    dtype = pd.UInt32Dtype()
-    result = dtype.__from_arrow__(pa.array([1, 2, 3, 4, None], type="int64"))
-    expected = pd.array([1, 2, 3, 4, None], dtype="UInt32")
-
     tm.assert_extension_array_equal(result, expected)

--- a/pandas/tests/arrays/masked/test_arrow_compat.py
+++ b/pandas/tests/arrays/masked/test_arrow_compat.py
@@ -1,0 +1,53 @@
+import pytest
+
+import pandas.util._test_decorators as td
+
+import pandas as pd
+import pandas._testing as tm
+
+arrays = [pd.array([1, 2, 3, None], dtype=dtype) for dtype in tm.ALL_EA_INT_DTYPES]
+arrays += [pd.array([True, False, True, None], dtype="boolean")]
+
+
+@pytest.fixture(params=arrays, ids=[a.dtype.name for a in arrays])
+def data(request):
+    return request.param
+
+
+@td.skip_if_no("pyarrow", min_version="0.15.0")
+def test_arrow_array(data):
+    # protocol added in 0.15.0
+    import pyarrow as pa
+
+    arr = pa.array(data)
+    expected = pa.array(
+        data.to_numpy(object, na_value=None),
+        type=pa.from_numpy_dtype(data.dtype.numpy_dtype),
+    )
+    assert arr.equals(expected)
+
+
+@td.skip_if_no("pyarrow", min_version="0.16.0")
+def test_arrow_roundtrip(data):
+    # roundtrip possible from arrow 0.16.0
+    import pyarrow as pa
+
+    df = pd.DataFrame({"a": data})
+    table = pa.table(df)
+    assert table.field("a").type == str(data.dtype.numpy_dtype)
+    result = table.to_pandas()
+    assert result["a"].dtype == data.dtype
+    tm.assert_frame_equal(result, df)
+
+
+@td.skip_if_no("pyarrow", min_version="0.16.0")
+def test_arrow_from_arrow_uint():
+    # https://github.com/pandas-dev/pandas/issues/31896
+    # possible mismatch in types
+    import pyarrow as pa
+
+    dtype = pd.UInt32Dtype()
+    result = dtype.__from_arrow__(pa.array([1, 2, 3, 4, None], type="int64"))
+    expected = pd.array([1, 2, 3, 4, None], dtype="UInt32")
+
+    tm.assert_extension_array_equal(result, expected)


### PR DESCRIPTION
We recently splitted the test_boolean and test_integer in multiple files in each a directory, but I think a next step can be to deduplicate some of the common tests for the different nullable/masked dtypes. 
Certainly given that we are going to add float tests as well (cfr https://github.com/pandas-dev/pandas/pull/34307)

Starting here with the arrow-compat/roundtrip tests for both integer/boolean.

I didn't yet write a full blown conftest.py and just defined a `data` fixture inline, since here it's just a single file. But if adding more later, we probably want to move this to a `conftest.py` (or a base test class), although this duplicates a bit the `tests/arrays/integer/conftest.py` and `tests/arrays/boolean/conftest.py`

cc @dsaxton @jbrockmendel 