### PR TITLE
CI: Numpy compat

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from pandas._libs import lib, tslibs
 from pandas._typing import AnyArrayLike, Scalar, T
-from pandas.compat.numpy import _np_version_under1p17
+from pandas.compat.numpy import _np_version_under1p18
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import (
@@ -396,7 +396,7 @@ def random_state(state=None):
 
         ..versionchanged:: 1.1.0
 
-            array-like and BitGenerator (for NumPy>=1.17) object now passed to
+            array-like and BitGenerator (for NumPy>=1.18) object now passed to
             np.random.RandomState() as seed
 
         Default None.
@@ -409,7 +409,7 @@ def random_state(state=None):
     if (
         is_integer(state)
         or is_array_like(state)
-        or (not _np_version_under1p17 and isinstance(state, np.random.BitGenerator))
+        or (not _np_version_under1p18 and isinstance(state, np.random.BitGenerator))
     ):
         return np.random.RandomState(state)
     elif isinstance(state, np.random.RandomState):


### PR DESCRIPTION
- [x] closes #34306

Likely related to: https://github.com/pandas-dev/pandas/pull/32510.

Seems doc builds have started using: 
numpy                     1.17.5           py38h95a1406_0    conda-forge
https://github.com/pandas-dev/pandas/pull/34317/checks?check_run_id=700337761

(Previous pipelines where using 1.18)

In numpy 1.17.5 BitGenerator path is:
`np.random.bit_generator.BitGenerator`

In numpy 1.18.0 path is
`np.random.BitGenerator`