### PR TITLE
DOC: fix deprecated groupby squeeze example in v0.12.0 whatsnew

### DIFF
--- a/doc/source/reference/offset_frequency.rst
+++ b/doc/source/reference/offset_frequency.rst
@@ -878,6 +878,9 @@ Properties
     FY5253.normalize
     FY5253.rule_code
     FY5253.n
+    FY5253.startingMonth
+    FY5253.variation
+    FY5253.weekday
 
 Methods
 ~~~~~~~
@@ -913,6 +916,9 @@ Properties
     FY5253Quarter.normalize
     FY5253Quarter.rule_code
     FY5253Quarter.n
+    FY5253Quarter.startingMonth
+    FY5253Quarter.variation
+    FY5253Quarter.weekday
 
 Methods
 ~~~~~~~

--- a/doc/source/whatsnew/v0.12.0.rst
+++ b/doc/source/whatsnew/v0.12.0.rst
@@ -59,21 +59,32 @@ API changes
     same shaped objects whether the groups are unique or not. Revert this issue (:issue:`2893`)
     with (:issue:`3596`).
 
-    .. ipython:: python
+    .. code-block:: ipython
 
-        df2 = pd.DataFrame([{"val1": 1, "val2": 20},
-                            {"val1": 1, "val2": 19},
-                            {"val1": 1, "val2": 27},
-                            {"val1": 1, "val2": 12}])
+        In [2]: df2 = pd.DataFrame([{"val1": 1, "val2": 20},
+           ...:                     {"val1": 1, "val2": 19},
+           ...:                     {"val1": 1, "val2": 27},
+           ...:                     {"val1": 1, "val2": 12}])
 
-        def func(dataf):
-            return dataf["val2"] - dataf["val2"].mean()
+        In [3]: def func(dataf):
+           ...:     return dataf["val2"] - dataf["val2"].mean()
+           ...:
 
-        # squeezing the result frame to a series (because we have unique groups)
-        df2.groupby("val1", squeeze=True).apply(func)
+        In [4]: # squeezing the result frame to a series (because we have unique groups)
+           ...: df2.groupby("val1", squeeze=True).apply(func)
+        Out[4]:
+        0    0.5
+        1   -0.5
+        2    7.5
+        3   -7.5
+        Name: 1, dtype: float64
 
-        # no squeezing (the default, and behavior in 0.10.1)
-        df2.groupby("val1").apply(func)
+        In [5]: # no squeezing (the default, and behavior in 0.10.1)
+           ...: df2.groupby("val1").apply(func)
+        Out[5]:
+        val2    0    1    2    3
+        val1
+        1     0.5 -0.5  7.5 -7.5
 
   - Raise on ``iloc`` when boolean indexing with a label based indexer mask
     e.g. a boolean Series, even with integer labels, will raise. Since ``iloc``


### PR DESCRIPTION
This should fix failing CI, due to https://github.com/pandas-dev/pandas/pull/33218