### PR TITLE
BUG: Fix render as column name in to_excel

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -794,6 +794,7 @@ I/O
 - Bug in :meth:`~DataFrame.read_feather` was raising an `ArrowIOError` when reading an s3 or http file path (:issue:`29055`)
 - Bug in :meth:`read_parquet` was raising a ``FileNotFoundError`` when passed an s3 directory path. (:issue:`26388`)
 - Bug in :meth:`~DataFrame.to_parquet` was throwing an ``AttributeError`` when writing a partitioned parquet file to s3 (:issue:`27596`)
+- Bug in :meth:`~DataFrame.to_excel` could not handle the column name `render` and was raising an ``KeyError`` (:issue:`34331`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -16,14 +16,13 @@ from pandas.core.dtypes import missing
 from pandas.core.dtypes.common import is_float, is_scalar
 from pandas.core.dtypes.generic import ABCIndex
 
-from pandas import Index, MultiIndex, PeriodIndex
+from pandas import Index, MultiIndex, PeriodIndex, DataFrame
 import pandas.core.common as com
 
 from pandas.io.common import stringify_path
 from pandas.io.formats.css import CSSResolver, CSSWarning
 from pandas.io.formats.format import get_level_lengths
 from pandas.io.formats.printing import pprint_thing
-from pandas.io.formats.style import Styler
 
 
 class ExcelCell:
@@ -386,7 +385,7 @@ class ExcelFormatter:
     ):
         self.rowcounter = 0
         self.na_rep = na_rep
-        if hasattr(df, "render") and isinstance(df, Styler):
+        if hasattr(df, "render") and not isinstance(df, DataFrame):
             self.styler = df
             df = df.data
             if style_converter is None:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -23,6 +23,7 @@ from pandas.io.common import stringify_path
 from pandas.io.formats.css import CSSResolver, CSSWarning
 from pandas.io.formats.format import get_level_lengths
 from pandas.io.formats.printing import pprint_thing
+from pandas.io.formats.style import Styler
 
 
 class ExcelCell:
@@ -385,7 +386,7 @@ class ExcelFormatter:
     ):
         self.rowcounter = 0
         self.na_rep = na_rep
-        if hasattr(df, "render"):
+        if hasattr(df, "render") and isinstance(df, Styler):
             self.styler = df
             df = df.data
             if style_converter is None:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -385,7 +385,7 @@ class ExcelFormatter:
     ):
         self.rowcounter = 0
         self.na_rep = na_rep
-        if hasattr(df, "render") and not isinstance(df, DataFrame):
+        if not isinstance(df, DataFrame):
             self.styler = df
             df = df.data
             if style_converter is None:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -16,7 +16,7 @@ from pandas.core.dtypes import missing
 from pandas.core.dtypes.common import is_float, is_scalar
 from pandas.core.dtypes.generic import ABCIndex
 
-from pandas import Index, MultiIndex, PeriodIndex, DataFrame
+from pandas import DataFrame, Index, MultiIndex, PeriodIndex
 import pandas.core.common as com
 
 from pandas.io.common import stringify_path

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -107,11 +107,10 @@ def test_write_append_mode(ext, mode, expected):
             assert wb2.worksheets[index]["A1"].value == cell_value
 
 
-@pytest.mark.parametrize("col", ["B", "render"])
-def test_to_excel_with_openpyxl_engine(ext, tmpdir, col):
+def test_to_excel_with_openpyxl_engine(ext, tmpdir):
     # GH 29854
     df1 = DataFrame({"A": np.linspace(1, 10, 10)})
-    df2 = DataFrame({col: np.linspace(1, 20, 10)})
+    df2 = DataFrame({"B": np.linspace(1, 20, 10)})
     df = pd.concat([df1, df2], axis=1)
     styled = df.style.applymap(
         lambda val: "color: %s" % ("red" if val < 0 else "black")
@@ -119,6 +118,17 @@ def test_to_excel_with_openpyxl_engine(ext, tmpdir, col):
 
     filename = tmpdir / "styled.xlsx"
     styled.to_excel(filename, engine="openpyxl")
+
+    assert filename.exists()
+    os.remove(filename)
+
+
+def test_to_excel_with_column_render(ext, tmpdir):
+    # GH 34331
+    df = DataFrame({"render": [1], "testcolumn": [2]})
+
+    filename = tmpdir / "render.xlsx"
+    df.to_excel(filename, engine="openpyxl")
 
     assert filename.exists()
     os.remove(filename)

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -107,10 +107,11 @@ def test_write_append_mode(ext, mode, expected):
             assert wb2.worksheets[index]["A1"].value == cell_value
 
 
-def test_to_excel_with_openpyxl_engine(ext, tmpdir):
+@pytest.mark.parametrize("col", ["B", "render"])
+def test_to_excel_with_openpyxl_engine(ext, tmpdir, col):
     # GH 29854
     df1 = DataFrame({"A": np.linspace(1, 10, 10)})
-    df2 = DataFrame({"B": np.linspace(1, 20, 10)})
+    df2 = DataFrame({col: np.linspace(1, 20, 10)})
     df = pd.concat([df1, df2], axis=1)
     styled = df.style.applymap(
         lambda val: "color: %s" % ("red" if val < 0 else "black")

--- a/pandas/tests/io/excel/test_openpyxl.py
+++ b/pandas/tests/io/excel/test_openpyxl.py
@@ -121,14 +121,3 @@ def test_to_excel_with_openpyxl_engine(ext, tmpdir):
 
     assert filename.exists()
     os.remove(filename)
-
-
-def test_to_excel_with_column_render(ext, tmpdir):
-    # GH 34331
-    df = DataFrame({"render": [1], "testcolumn": [2]})
-
-    filename = tmpdir / "render.xlsx"
-    df.to_excel(filename, engine="openpyxl")
-
-    assert filename.exists()
-    os.remove(filename)

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1201,6 +1201,14 @@ class TestExcelWriter:
 
         tm.assert_frame_equal(read, expected)
 
+    def test_render_as_column_name(self, path):
+        # see gh-34331
+        df = DataFrame({"render": [1, 2], "data": [3, 4]})
+        df.to_excel(path, "Sheet1")
+        read = pd.read_excel(path, "Sheet1", index_col=0)
+        expected = df
+        tm.assert_frame_equal(read, expected)
+
     def test_true_and_false_value_options(self, path):
         # see gh-13347
         df = pd.DataFrame([["foo", "bar"]], columns=["col1", "col2"])


### PR DESCRIPTION
- [x] closes #34331
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Should I add a whats new enty? Under which section?

https://github.com/phofl/pandas/blob/34331_render_column_name_raises_error_in_to_excel/pandas/io/formats/excel.py#L389

The previous code checked if the `df` had a attribute `render`. This check was True, if there was a `DataFrame` given as input with a column `render`. I think that this check should only be True if a `Styler` object is given, so I added an `isinstace` check for `Styler`. 

Does the `Styler` object always an attribute `render`? If not, we would run into problems, if we get a `Styler` object with a column named `render` but without the `render` attribute. If a `Styler` object has always an attribute `render`, we could delete the `hasattr` check.

Edit: I changed the check to `not isinstance(df, DataFrame)` to avoid the jinja issues.