### PR TITLE
DOC: Fix reference, old file was separated last year

### DIFF
--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -1,6 +1,6 @@
 """Tests formatting as writer-agnostic ExcelCells
 
-ExcelFormatter is tested implicitly in pandas/tests/io/excel tests
+ExcelFormatter is tested implicitly in pandas/tests/io/excel
 """
 
 import pytest

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -1,6 +1,6 @@
 """Tests formatting as writer-agnostic ExcelCells
 
-ExcelFormatter is tested implicitly in pandas/tests/io/test_excel.py
+ExcelFormatter is tested implicitly in pandas/tests/io/excel tests
 """
 
 import pytest


### PR DESCRIPTION
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

The comment referenced a file deleted last year after separating the tests into a few files. I referenced the correct folder again