### PR TITLE
Use repr of fill_value in SparseDtype repr

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -862,6 +862,7 @@ Sparse
 - Creating a :class:`SparseArray` from timezone-aware dtype will issue a warning before dropping timezone information, instead of doing so silently (:issue:`32501`)
 - Bug in :meth:`arrays.SparseArray.from_spmatrix` wrongly read scipy sparse matrix (:issue:`31991`)
 - Bug in :meth:`Series.sum` with ``SparseArray`` raises ``TypeError`` (:issue:`25777`)
+- The repr of :class:`SparseDtype` now includes the repr of its ``fill_value`` attribute. Previously it used ``fill_value``'s  string representation (:issue:`34352`)
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -166,7 +166,7 @@ class SparseDtype(ExtensionDtype):
 
     @property
     def name(self):
-        return f"Sparse[{self.subtype.name}, {self.fill_value}]"
+        return f"Sparse[{self.subtype.name}, {repr(self.fill_value)}]"
 
     def __repr__(self) -> str:
         return self.name

--- a/pandas/tests/arrays/sparse/test_dtype.py
+++ b/pandas/tests/arrays/sparse/test_dtype.py
@@ -196,3 +196,14 @@ def test_update_dtype(original, dtype, expected):
 def test_update_dtype_raises(original, dtype, expected_error_msg):
     with pytest.raises(ValueError, match=expected_error_msg):
         original.update_dtype(dtype)
+
+
+def test_repr():
+    # GH-34352
+    result = str(pd.SparseDtype("int64", fill_value=0))
+    expected = "Sparse[int64, 0]"
+    assert result == expected
+
+    result = str(pd.SparseDtype(object, fill_value="0"))
+    expected = "Sparse[object, '0']"
+    assert result == expected

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -402,16 +402,6 @@ class TestPrinting(BaseSparseTests, base.BasePrintingTests):
     def test_array_repr(self, data, size):
         super().test_array_repr(data, size)
 
-    def test_fillna_repr(self):
-        # GH-34352
-        result = str(pd.SparseDtype("int64", fill_value=0))
-        expected = "Sparse[int64, 0]"
-        assert result == expected
-
-        result = str(pd.SparseDtype(object, fill_value="0"))
-        expected = "Sparse[object, '0']"
-        assert result == expected
-
 
 class TestParsing(BaseSparseTests, base.BaseParsingTests):
     @pytest.mark.parametrize("engine", ["c", "python"])

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -402,6 +402,14 @@ class TestPrinting(BaseSparseTests, base.BasePrintingTests):
     def test_array_repr(self, data, size):
         super().test_array_repr(data, size)
 
+    def test_fillna_repr(self):
+        result = str(pd.SparseDtype("int64", fill_value=0))
+        expected = "Sparse[int64, 0]"
+        assert result == expected
+
+        result = str(pd.SparseDtype(object, fill_value="0"))
+        expected = "Sparse[object, '0']"
+        assert result == expected
 
 class TestParsing(BaseSparseTests, base.BaseParsingTests):
     @pytest.mark.parametrize("engine", ["c", "python"])

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -403,6 +403,7 @@ class TestPrinting(BaseSparseTests, base.BasePrintingTests):
         super().test_array_repr(data, size)
 
     def test_fillna_repr(self):
+        # GH-34352
         result = str(pd.SparseDtype("int64", fill_value=0))
         expected = "Sparse[int64, 0]"
         assert result == expected
@@ -410,6 +411,7 @@ class TestPrinting(BaseSparseTests, base.BasePrintingTests):
         result = str(pd.SparseDtype(object, fill_value="0"))
         expected = "Sparse[object, '0']"
         assert result == expected
+
 
 class TestParsing(BaseSparseTests, base.BaseParsingTests):
     @pytest.mark.parametrize("engine", ["c", "python"])


### PR DESCRIPTION
This proposes changing the StringDtype repr to show the fill_value's repr rather than its string representation:

```python
>>> arr = pd.arrays.SparseArray([0, 1])
>>> arr.dtype
Sparse[int64, 0]  # master & this PR, unchanged
>>> arr.astype(str).dtype
Sparse[object, 0]  # master
Sparse[object, '0']  # this PR, notice quotes
```
