### PR TITLE
34297 sub slow in first call

### DIFF
--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -490,7 +490,7 @@ class BinaryOpsMultiIndex:
             columns=column_names,
         )
 
-    def time_sub_multiindex(self, func):
+    def time_binary_op_multiindex(self, func):
         getattr(self.df, func)(self.arg_df, level=0)
 
 

--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -469,4 +469,29 @@ class ApplyIndex:
         offset.apply_index(self.rng)
 
 
+class Sub:
+    def setup(self):
+        date_range = pd.date_range("20200101 00:00", "20200102 0:00", freq="S")
+        level_0_names = [str(i) for i in range(30)]
+
+        index = pd.MultiIndex.from_product([level_0_names, date_range])
+        column_names = ["col_1", "col_2"]
+
+        self.df = pd.DataFrame(
+            np.random.rand(len(index), 2),
+            index=index,
+            columns=column_names
+        )
+
+        self.sub_df = pd.DataFrame(
+            np.random.randint(1, 10, (len(level_0_names), 2)),
+            index=level_0_names,
+            columns=column_names,
+        )
+
+    def subsequent_sub_application(self):
+        self.df.sub(self.sub_df, level=0)
+        self.df.sub(self.sub_df, level=0)
+
+
 from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -469,8 +469,11 @@ class ApplyIndex:
         offset.apply_index(self.rng)
 
 
-class SubMultiIndex:
-    def setup(self):
+class BinaryOpsMultiIndex:
+    params = ["sub", "add", "mul", "div"]
+    param_names = ["func"]
+
+    def setup(self, func):
         date_range = pd.date_range("20200101 00:00", "20200102 0:00", freq="S")
         level_0_names = [str(i) for i in range(30)]
 
@@ -481,14 +484,14 @@ class SubMultiIndex:
             np.random.rand(len(index), 2), index=index, columns=column_names
         )
 
-        self.sub_df = pd.DataFrame(
+        self.arg_df = pd.DataFrame(
             np.random.randint(1, 10, (len(level_0_names), 2)),
             index=level_0_names,
             columns=column_names,
         )
 
-    def time_sub_multiindex(self):
-        self.df.sub(self.sub_df, level=0)
+    def time_sub_multiindex(self, func):
+        getattr(self.df, func)(self.arg_df, level=0)
 
 
 from .pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -469,7 +469,7 @@ class ApplyIndex:
         offset.apply_index(self.rng)
 
 
-class Sub:
+class SubMultiIndex:
     def setup(self):
         date_range = pd.date_range("20200101 00:00", "20200102 0:00", freq="S")
         level_0_names = [str(i) for i in range(30)]
@@ -489,8 +489,7 @@ class Sub:
             columns=column_names,
         )
 
-    def subsequent_sub_application(self):
-        self.df.sub(self.sub_df, level=0)
+    def time_sub_multiindex(self):
         self.df.sub(self.sub_df, level=0)
 
 

--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -478,9 +478,7 @@ class SubMultiIndex:
         column_names = ["col_1", "col_2"]
 
         self.df = pd.DataFrame(
-            np.random.rand(len(index), 2),
-            index=index,
-            columns=column_names
+            np.random.rand(len(index), 2), index=index, columns=column_names
         )
 
         self.sub_df = pd.DataFrame(

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -616,6 +616,7 @@ Performance improvements
 - Performance improvement in :func:`factorize` for nullable (integer and boolean) dtypes (:issue:`33064`).
 - Performance improvement in reductions (sum, prod, min, max) for nullable (integer and boolean) dtypes (:issue:`30982`, :issue:`33261`, :issue:`33442`).
 - Performance improvement in arithmetic operations between two :class:`DataFrame` objects (:issue:`32779`)
+- Performance improvement in arithmetic operations (sub, add, mul, div) for MultiIndex (:issue:`34297`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3218,6 +3218,8 @@ class MultiIndex(Index):
                 # other cannot contain tuples, so cannot match self
                 return False
 
+            if len(self) != len(other) or isinstance(self, MultiIndex):
+                return False
             return array_equivalent(self._values, other._values)
 
         if self.nlevels != other.nlevels:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3218,7 +3218,7 @@ class MultiIndex(Index):
                 # other cannot contain tuples, so cannot match self
                 return False
 
-            if len(self) != len(other) or isinstance(self, MultiIndex):
+            if len(self) != len(other):
                 return False
             return array_equivalent(self._values, other._values)
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3217,8 +3217,7 @@ class MultiIndex(Index):
             if not is_object_dtype(other.dtype):
                 # other cannot contain tuples, so cannot match self
                 return False
-
-            if len(self) != len(other):
+            elif len(self) != len(other):
                 return False
             return array_equivalent(self._values, other._values)
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1488,7 +1488,7 @@ def test_pow_nan_with_zero():
 
 def test_performance_subsequent_sub_calls():
     date_range = pd.date_range("20200101 00:00", "20200102 0:00", freq="S")
-    level_0_names = list(str(i) for i in range(30))
+    level_0_names = [str(i) for i in range(30)]
 
     index = pd.MultiIndex.from_product([level_0_names, date_range])
     column_names = ["col_1", "col_2"]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1487,17 +1487,19 @@ def test_pow_nan_with_zero():
 
 
 def test_performance_subsequent_sub_calls():
-    date_range = pd.date_range('20200101 00:00', '20200102 0:00', freq='S')
+    date_range = pd.date_range("20200101 00:00", "20200102 0:00", freq="S")
     level_0_names = list(str(i) for i in range(30))
 
     index = pd.MultiIndex.from_product([level_0_names, date_range])
-    column_names = ['col_1', 'col_2']
+    column_names = ["col_1", "col_2"]
 
     df = pd.DataFrame(np.random.rand(len(index), 2), index=index, columns=column_names)
 
-    sub_df = pd.DataFrame(np.random.randint(1, 10, (len(level_0_names), 2)),
-                          index=level_0_names,
-                          columns=column_names)
+    sub_df = pd.DataFrame(
+        np.random.randint(1, 10, (len(level_0_names), 2)),
+        index=level_0_names,
+        columns=column_names,
+    )
 
     start = datetime.now()
     df.sub(sub_df, level=0)

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1484,26 +1484,3 @@ def test_pow_nan_with_zero():
 
     result = left["A"] ** right["A"]
     tm.assert_series_equal(result, expected["A"])
-
-
-def test_performance_subsequent_sub_calls():
-    date_range = pd.date_range("20200101 00:00", "20200102 0:00", freq="S")
-    level_0_names = [str(i) for i in range(30)]
-
-    index = pd.MultiIndex.from_product([level_0_names, date_range])
-    column_names = ["col_1", "col_2"]
-
-    df = pd.DataFrame(np.random.rand(len(index), 2), index=index, columns=column_names)
-
-    sub_df = pd.DataFrame(
-        np.random.randint(1, 10, (len(level_0_names), 2)),
-        index=level_0_names,
-        columns=column_names,
-    )
-
-    start = datetime.now()
-    df.sub(sub_df, level=0)
-    middle = datetime.now()
-    df.sub(sub_df, level=0)
-    end = datetime.now()
-    assert (middle - start).microseconds < (end - middle).microseconds * 2

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1484,3 +1484,24 @@ def test_pow_nan_with_zero():
 
     result = left["A"] ** right["A"]
     tm.assert_series_equal(result, expected["A"])
+
+
+def test_performance_subsequent_sub_calls():
+    date_range = pd.date_range('20200101 00:00', '20200102 0:00', freq='S')
+    level_0_names = list(str(i) for i in range(30))
+
+    index = pd.MultiIndex.from_product([level_0_names, date_range])
+    column_names = ['col_1', 'col_2']
+
+    df = pd.DataFrame(np.random.rand(len(index), 2), index=index, columns=column_names)
+
+    sub_df = pd.DataFrame(np.random.randint(1, 10, (len(level_0_names), 2)),
+                          index=level_0_names,
+                          columns=column_names)
+
+    start = datetime.now()
+    df.sub(sub_df, level=0)
+    middle = datetime.now()
+    df.sub(sub_df, level=0)
+    end = datetime.now()
+    assert (middle - start).microseconds < (end - middle).microseconds * 2


### PR DESCRIPTION
- [x] closes #34297
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

@jbrockmendel 

I added a lenght check as suggested by you. I could not find another method to check the indices (nlevels for example does not work). I'm open to recommendations about adding additional checks before running into the values call.

I have added a test, which measures the execution time of both calls to `sub`. Is there a better way to test, if they are equally fast?