### PR TITLE
TST: sparse and dense concat test GH30667

### DIFF
--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -2757,6 +2757,17 @@ def test_concat_sparse():
     tm.assert_frame_equal(result, expected)
 
 
+def test_concat_dense_sparse():
+    # GH 30668
+    a = pd.Series(pd.arrays.SparseArray([1, None]), dtype=np.float)
+    b = pd.Series([1], dtype=np.float)
+    expected = pd.Series(data=[1, None, 1], index=[0, 1, 0]).astype(
+        pd.SparseDtype(np.float64, None)
+    )
+    result = pd.concat([a, b], axis=0)
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize("test_series", [True, False])
 def test_concat_copy_index(test_series, axis):
     # GH 29879


### PR DESCRIPTION
- [x] closes #30668
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] Adds testing to ensure concat between dense and sparse
