### PR TITLE
DOC: Fix EX02 and SA01 in DataFrame.select_dtypes

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3421,6 +3421,10 @@ class DataFrame(NDFrame):
             * If ``include`` and ``exclude`` have overlapping elements
             * If any kind of string dtype is passed in.
 
+        See Also
+        --------
+        DataFrame.dtypes: Return Series with the data type of each column.
+
         Notes
         -----
         * To select all *numeric* types, use ``np.number`` or ``'number'``
@@ -3468,7 +3472,7 @@ class DataFrame(NDFrame):
         4  1.0
         5  2.0
 
-        >>> df.select_dtypes(exclude=['int'])
+        >>> df.select_dtypes(exclude=['int64'])
                b    c
         0   True  1.0
         1  False  2.0


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Related to #27977. 

output of `python scripts/validate_docstrings.py pandas.DataFrame.select_dtypes`:
```
################################################################################
################################## Validation ##################################
################################################################################

1 Errors found:
        No extended summary found
```

Notes:
It seems like passing `int` to the parameter do not include/exclude all integer dtypes. But, passing `integer` would do otherwise. I think it is related to this issue https://github.com/pandas-dev/pandas/issues/29394. It would be more convenient if passing `int` as an input would match the result with passing `integer`.

