### PR TITLE
BUG: new method for join with multiindex and single index (#34292)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -770,6 +770,7 @@ MultiIndex
         left.intersection(right, sort=False)
 
 - Bug when joining 2 Multi-indexes, without specifying level with different columns. Return-indexers parameter is ignored. (:issue:`34074`)
+- Bug when joining a Multi-index with a single index, outer-joins and right-joins don't include single-index data. (:issue:`34292`)
 
 I/O
 ^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3642,7 +3642,7 @@ class Index(IndexOpsMixin, PandasObject):
             )
 
         if how == "left":
-            #TODO: if return_indexers = False, just return "self"
+            # TODO: if return_indexers = False, just return "self"
             new_level = old_level
         elif how == "right":
             new_level = right
@@ -3652,7 +3652,9 @@ class Index(IndexOpsMixin, PandasObject):
             new_level = old_level.union(right)
 
         left_index = left._get_level_values(level)
-        join, left_indexer, right_indexer = left_index.join(right, how=how, return_indexers=True)
+        join, left_indexer, right_indexer = left_index.join(
+                right, how=how, return_indexers=True
+            )
         new_code = new_level.get_indexer(join)
         new_codes = []
 
@@ -3665,8 +3667,8 @@ class Index(IndexOpsMixin, PandasObject):
         new_levels = list(left.levels)
         new_levels[level] = new_level
         join_index = MultiIndex(
-                levels=new_levels, codes=new_codes, names=left.names, verify_integrity=False
-            )
+            levels=new_levels, codes=new_codes, names=left.names, verify_integrity=False
+        )
 
         if flip_order:
             left_indexer, right_indexer = right_indexer, left_indexer

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3653,8 +3653,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         left_index = left._get_level_values(level)
         join, left_indexer, right_indexer = left_index.join(
-                right, how=how, return_indexers=True
-            )
+            right, how=how, return_indexers=True
+        )
         new_code = new_level.get_indexer(join)
         new_codes = []
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2300,7 +2300,7 @@ class MultiIndex(Index):
             else:
                 target = ensure_index(target)
             target, indexer, _ = self._join_level(
-                target, level, how="right", return_indexers=True, keep_order=False
+                target, level, how="right", return_indexers=True
             )
         else:
             target = ensure_index(target)

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -3,7 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas import Index, MultiIndex
-import pandas._testing as tm
+    import pandas._testing as tm
 
 
 @pytest.mark.parametrize(
@@ -113,3 +113,25 @@ def test_join_multi_return_indexers():
 
     result = midx1.join(midx2, return_indexers=False)
     tm.assert_index_equal(result, midx1)
+
+def test_join_multi_single():
+    midx = pd.MultiIndex.from_arrays([[1, 1, 3],[0, 1, 0]], names=["i", "ii"])
+    idx = pd.Index([1, 2], name="i")
+
+    result = midx.join(idx, how="inner")
+    expected = pd.MultiIndex.from_arrays([[1, 1],[0, 1]], names=["i", "ii"])
+    tm.assert_index_equal(result, expected)
+
+    result = midx.join(idx, how="left")
+    expected = midx
+    tm.assert_index_equal(result, midx)
+
+    result = midx.join(idx, how="right")
+    expected = pd.MultiIndex.from_arrays([[1, 1, 2],[0, 1, None]], names=["i", "ii"])
+    tm.assert_index_equal(result, expected)
+
+    result = midx.join(idx, how="outer")
+    expected = pd.MultiIndex.from_arrays(
+        [[1, 1, 2, 3],[0, 1, None, 0]], names=["i", "ii"]
+    )
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -114,6 +114,7 @@ def test_join_multi_return_indexers():
     result = midx1.join(midx2, return_indexers=False)
     tm.assert_index_equal(result, midx1)
 
+
 def test_join_multi_single():
     midx = pd.MultiIndex.from_arrays([[1, 1, 3], [0, 1, 0]], names=["i", "ii"])
     idx = pd.Index([1, 2], name="i")

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -3,7 +3,7 @@ import pytest
 
 import pandas as pd
 from pandas import Index, MultiIndex
-    import pandas._testing as tm
+import pandas._testing as tm
 
 
 @pytest.mark.parametrize(
@@ -115,11 +115,11 @@ def test_join_multi_return_indexers():
     tm.assert_index_equal(result, midx1)
 
 def test_join_multi_single():
-    midx = pd.MultiIndex.from_arrays([[1, 1, 3],[0, 1, 0]], names=["i", "ii"])
+    midx = pd.MultiIndex.from_arrays([[1, 1, 3], [0, 1, 0]], names=["i", "ii"])
     idx = pd.Index([1, 2], name="i")
 
     result = midx.join(idx, how="inner")
-    expected = pd.MultiIndex.from_arrays([[1, 1],[0, 1]], names=["i", "ii"])
+    expected = pd.MultiIndex.from_arrays([[1, 1], [0, 1]], names=["i", "ii"])
     tm.assert_index_equal(result, expected)
 
     result = midx.join(idx, how="left")
@@ -127,11 +127,11 @@ def test_join_multi_single():
     tm.assert_index_equal(result, midx)
 
     result = midx.join(idx, how="right")
-    expected = pd.MultiIndex.from_arrays([[1, 1, 2],[0, 1, None]], names=["i", "ii"])
+    expected = pd.MultiIndex.from_arrays([[1, 1, 2], [0, 1, None]], names=["i", "ii"])
     tm.assert_index_equal(result, expected)
 
     result = midx.join(idx, how="outer")
     expected = pd.MultiIndex.from_arrays(
-        [[1, 1, 2, 3],[0, 1, None, 0]], names=["i", "ii"]
+        [[1, 1, 2, 3], [0, 1, None, 0]], names=["i", "ii"]
     )
     tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [x] closes #34292
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Tests still to be added.
I replaced the method to join a multiindex & a single index because outer joins didn't include data from the single index. The new method is similar to a join between 2 multiindexes.
I'm not sure what the keep_order parameter was, but it was never used and in other _join-methods it didn't exist either. So I suggest removing it all together.