### PR TITLE
Backport PR #32479 on branch 1.0.x (BUG: Fix issue with datetime[ns, tz] input in Block.setitem)

### DIFF
--- a/doc/source/whatsnew/v1.0.4.rst
+++ b/doc/source/whatsnew/v1.0.4.rst
@@ -28,6 +28,7 @@ Fixed regressions
 - Bug in :meth:`Series.groupby` would raise ``ValueError`` when grouping by :class:`PeriodIndex` level (:issue:`34010`)
 - Bug in :meth:`GroupBy.rolling.apply` ignores args and kwargs parameters (:issue:`33433`)
 - More informative error message with ``np.min`` or ``np.max`` on unordered :class:`Categorical` (:issue:`33115`)
+- Fixed regression in :meth:`DataFrame.loc` and :meth:`Series.loc` throwing an error when a ``datetime64[ns, tz]`` value is provided (:issue:`32395`)
 - 
 
 .. _whatsnew_104.bug_fixes:

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -403,6 +403,13 @@ class ExtensionArray:
         return (len(self),)
 
     @property
+    def size(self) -> int:
+        """
+        The number of elements in the array.
+        """
+        return np.prod(self.shape)
+
+    @property
     def ndim(self) -> int:
         """
         Extension Arrays are only allowed to be 1-dimensional.

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -856,8 +856,10 @@ class Block(PandasObject):
         if is_extension_array_dtype(getattr(value, "dtype", None)):
             # We need to be careful not to allow through strings that
             #  can be parsed to EADtypes
+            is_ea_value = True
             arr_value = value
         else:
+            is_ea_value = False
             arr_value = np.array(value)
 
         # cast the values to a type that can hold nan (if necessary)
@@ -893,6 +895,11 @@ class Block(PandasObject):
             # we need to create a new categorical block
             values[indexer] = value
             return self.make_block(Categorical(self.values, dtype=arr_value.dtype))
+
+        elif exact_match and is_ea_value:
+            # GH#32395 if we're going to replace the values entirely, just
+            #  substitute in the new array
+            return self.make_block(arr_value)
 
         # if we are an exact match (ex-broadcasting),
         # then use the resultant dtype

--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -19,6 +19,9 @@ class BaseInterfaceTests(BaseExtensionTests):
     def test_len(self, data):
         assert len(data) == 100
 
+    def test_size(self, data):
+        assert data.size == 100
+
     def test_ndim(self, data):
         assert data.ndim == 1
 

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
+import pandas._testing as tm
 from pandas.core.arrays.numpy_ import PandasDtype
 
 from .base import BaseExtensionTests
@@ -314,3 +315,31 @@ class BaseSetitemTests(BaseExtensionTests):
             mask = pd.array([True, True, True, False, False])
             arr[mask] = data[0]
             self.assert_extension_array_equal(expected, arr)
+
+    def test_setitem_dataframe_column_with_index(self, data):
+        # https://github.com/pandas-dev/pandas/issues/32395
+        df = expected = pd.DataFrame({"data": pd.Series(data)})
+        result = pd.DataFrame(index=df.index)
+        result.loc[df.index, "data"] = df["data"]
+        self.assert_frame_equal(result, expected)
+
+    def test_setitem_dataframe_column_without_index(self, data):
+        # https://github.com/pandas-dev/pandas/issues/32395
+        df = expected = pd.DataFrame({"data": pd.Series(data)})
+        result = pd.DataFrame(index=df.index)
+        result.loc[:, "data"] = df["data"]
+        self.assert_frame_equal(result, expected)
+
+    def test_setitem_series_with_index(self, data):
+        # https://github.com/pandas-dev/pandas/issues/32395
+        ser = expected = pd.Series(data, name="data")
+        result = pd.Series(index=ser.index, dtype=np.object, name="data")
+        result.loc[ser.index] = ser
+        self.assert_series_equal(result, expected)
+
+    def test_setitem_series_without_index(self, data):
+        # https://github.com/pandas-dev/pandas/issues/32395
+        ser = expected = pd.Series(data, name="data")
+        result = pd.Series(index=ser.index, dtype=np.object, name="data")
+        result.loc[:] = ser
+        self.assert_series_equal(result, expected)


### PR DESCRIPTION
xref #32479, #32395

regression in 1.0.0