### PR TITLE
CLN: remove _combine_series_frame

### DIFF
--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -223,7 +223,7 @@ def evaluate(op, a, b, use_numexpr: bool = True):
     use_numexpr : bool, default True
         Whether to try to use numexpr.
     """
-    op_str = _op_str_mapping.get(op, None)
+    op_str = _op_str_mapping[op]
     if op_str is not None:
         use_numexpr = use_numexpr and _bool_arith_check(op_str, a, b)
         if use_numexpr:


### PR DESCRIPTION
Following this we can consolidate some dispatch_to_series calls, saving that for a separate step for clarity of exposition.