### PR TITLE
BUG:#29928 Fix to_json output 'table' orient for single level MultiIndex.

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -503,6 +503,7 @@ I/O
 - Bug in :class:`HDFStore` was dropping timezone information when exporting :class:`Series` with ``datetime64[ns, tz]`` dtypes with a fixed HDF5 store (:issue:`20594`)
 - :func:`read_csv` was closing user-provided binary file handles when ``engine="c"`` and an ``encoding`` was requested (:issue:`36980`)
 - Bug in :meth:`DataFrame.to_hdf` was not dropping missing rows with ``dropna=True`` (:issue:`35719`)
+- Bug in :meth:`~DataFrame.to_json` with 'table' orient was writting wrong index field name for MultiIndex Dataframe with a single level (:issue:`29928`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -435,6 +435,23 @@ class TestTableOrient:
 
         assert result == expected
 
+    @pytest.mark.parametrize("name", [None, "foo"])
+    def test_multiindex_single_level(self, name):
+        # GH29928
+        index = pd.Index([1, 2, 3, 4], name=name)
+        expected = DataFrame(
+            data=[[1, 1], [2, 2], [3, 3], [4, 4]], columns=["A", "B"], index=index
+        )
+
+        index = pd.MultiIndex.from_tuples([(1,), (2,), (3,), (4,)], names=[name])
+        df = DataFrame(
+            data=[[1, 1], [2, 2], [3, 3], [4, 4]], columns=["A", "B"], index=index
+        )
+        js = df.to_json(orient="table")
+        result = pd.read_json(js, orient="table")
+
+        tm.assert_frame_equal(result, expected)
+
     @pytest.mark.filterwarnings(
         "ignore:an integer is required (got type float)*:DeprecationWarning"
     )


### PR DESCRIPTION
`dataframe.to_json()` was writing incorrect index field name, so applying read_json resulted in NaN index values. 
`dataframe.to_json()` now converts single level MultiIndex into single Index before encoding.


- [x] closes #29928 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
