### PR TITLE
DOC: add a semicolon to hide long matplotlib axes return value

### DIFF
--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -821,7 +821,7 @@ You can create a scatter plot matrix using the
    df = pd.DataFrame(np.random.randn(1000, 4), columns=['a', 'b', 'c', 'd'])
 
    @savefig scatter_matrix_kde.png
-   scatter_matrix(df, alpha=0.2, figsize=(6, 6), diagonal='kde')
+   scatter_matrix(df, alpha=0.2, figsize=(6, 6), diagonal='kde');
 
 .. ipython:: python
    :suppress:

--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -1683,4 +1683,4 @@ to generate the plots. Some libraries implementing a backend for pandas are list
 on the ecosystem :ref:`ecosystem.visualization` page.
 
 Developers guide can be found at
-https://dev.pandas.io/docs/development/extending.html#plotting-backends
+https://pandas.pydata.org/docs/dev/development/extending.html#plotting-backends


### PR DESCRIPTION
add a semicolon to hide debug messages like:
Out[85]: 
array([[<matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0ad6e3d0>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0ad4a350>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0aa10250>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0a6367d0>],
       [<matplotlib.axes._subplots.AxesSubplot object at 0x7f3d088c2d50>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d089ea310>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d08d89890>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0a76ae10>],
       [<matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0a756090>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0a8dd750>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d096aaed0>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0937d490>],
       [<matplotlib.axes._subplots.AxesSubplot object at 0x7f3d09f49a10>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0a0551d0>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0a418550>,
        <matplotlib.axes._subplots.AxesSubplot object at 0x7f3d0a6f0ad0>]],
      dtype=object)
which you can see here:

https://pandas.pydata.org/docs/user_guide/visualization.html

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
