### PR TITLE
Initialize variables in pqyear, pquarter

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1281,14 +1281,16 @@ cdef int pyear(int64_t ordinal, int freq):
 @cython.cdivision
 cdef int pqyear(int64_t ordinal, int freq):
     cdef:
-        int year, quarter
+        int year = 0
+        int quarter = 0
     get_yq(ordinal, freq, &quarter, &year)
     return year
 
 
 cdef int pquarter(int64_t ordinal, int freq):
     cdef:
-        int year, quarter
+        int year = 0
+        int quarter = 0
     get_yq(ordinal, freq, &quarter, &year)
     return quarter
 


### PR DESCRIPTION
This resolves the `-Wmaybe-uninitialized` warning observed when building with the manylinux1 docker image

```
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DNPY_NO_DEPRECATED_API=0 -Ipandas/_libs/tslibs -I./pandas/_libs/tslibs -I/opt/python/cp38-cp38/lib/python3.8/site-packages/numpy/core/include -I/opt/python/cp38-cp38/include/python3.8 -c pandas/_libs/tslibs/period.c -o build/temp.linux-x86_64-3.8/pandas/_libs/tslibs/period.o
pandas/_libs/tslibs/period.c: In function ‘__pyx_f_6pandas_5_libs_6tslibs_6period_pqyear’:
pandas/_libs/tslibs/period.c:12464:3: warning: ‘__pyx_v_year’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   return __pyx_r;
   ^
pandas/_libs/tslibs/period.c: In function ‘__pyx_f_6pandas_5_libs_6tslibs_6period_pquarter’:
pandas/_libs/tslibs/period.c:12512:3: warning: ‘__pyx_v_quarter’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   return __pyx_r;
```

Hopefully this doesn't break anything. IIUC, these pointers are just used to set the result, so it shouldn't matter what the value is going in? 

Closes https://github.com/pandas-dev/pandas/issues/34114
