### PR TITLE
BUG: taking slices in _slice_take_blocks_ax0

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1337,7 +1337,8 @@ class BlockManager(PandasObject):
         # When filling blknos, make sure blknos is updated before appending to
         # blocks list, that way new blkno is exactly len(blocks).
         blocks = []
-        for blkno, mgr_locs in libinternals.get_blkno_placements(blknos, group=True):
+        group = not only_slice
+        for blkno, mgr_locs in libinternals.get_blkno_placements(blknos, group=group):
             if blkno == -1:
                 # If we've got here, fill_value was not lib.no_default
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1514,3 +1514,16 @@ def test_dataframe_series_extension_dtypes():
     tm.assert_frame_equal(result, expected)
     result = df_ea + ser.astype("Int64")
     tm.assert_frame_equal(result, expected)
+
+
+def test_dataframe_blockwise_slicelike():
+    # GH#34367
+    arr = np.random.randint(0, 1000, (100, 10))
+    df1 = pd.DataFrame(arr)
+    df2 = df1.copy()
+    df2.iloc[0, [1, 3, 7]] = np.nan
+
+    res = df1 + df2
+
+    expected = pd.DataFrame({i: df1[i] + df2[i] for i in df1.columns})
+    tm.assert_frame_equal(res, expected)


### PR DESCRIPTION
- [x] closes #34367
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
