### PR TITLE
BUG: Fix failing MacPython 32bit wheels for groupby rolling

### DIFF
--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -218,16 +218,18 @@ class GroupbyRollingIndexer(BaseIndexer):
             start, end = indexer.get_window_bounds(
                 len(indicies), min_periods, center, closed
             )
+            start = start.astype(np.int64)
+            end = end.astype(np.int64)
             # Cannot use groupby_indicies as they might not be monotonic with the object
             # we're rolling over
             window_indicies = np.arange(
-                window_indicies_start,
-                window_indicies_start + len(indicies),
-                dtype=np.int64,
+                window_indicies_start, window_indicies_start + len(indicies),
             )
             window_indicies_start += len(indicies)
             # Extend as we'll be slicing window like [start, end)
-            window_indicies = np.append(window_indicies, [window_indicies[-1] + 1])
+            window_indicies = np.append(
+                window_indicies, [window_indicies[-1] + 1]
+            ).astype(np.int64)
             start_arrays.append(window_indicies.take(start))
             end_arrays.append(window_indicies.take(end))
         start = np.concatenate(start_arrays)

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2228,7 +2228,10 @@ class RollingGroupby(WindowGroupByMixin, Rolling):
         """
         # Ensure the object we're rolling over is monotonically sorted relative
         # to the groups
-        obj = obj.take(np.concatenate(list(self._groupby.grouper.indices.values())))
+        groupby_order = np.concatenate(
+            list(self._groupby.grouper.indices.values())
+        ).astype(np.int64)
+        obj = obj.take(groupby_order)
         return super()._create_blocks(obj)
 
     def _get_cython_func_type(self, func: str) -> Callable:


### PR DESCRIPTION
- [x] closes #34410
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

What would be the best way to validate that this fixes the MacPython/pandas-wheels @TomAugspurger 