### PR TITLE
DOC: intersphinx inventory link for statsmodels

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -413,7 +413,7 @@ if pattern is None:
         "py": ("https://pylib.readthedocs.io/en/latest/", None),
         "python": ("https://docs.python.org/3/", None),
         "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
-        "statsmodels": ("http://www.statsmodels.org/devel/", None),
+        "statsmodels": ("https://www.statsmodels.org/devel/", None),
     }
 
 # extlinks alias


### PR DESCRIPTION
intersphinx inventory has moved: http://www.statsmodels.org/devel/objects.inv -> https://www.statsmodels.org/devel/objects.inv

EDIT: this is already change on master. this PR directly against 1.0.x