### PR TITLE
BUG: Fix to GH34422 SeriesGroupBy works only with 'func' now

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -907,6 +907,7 @@ Groupby/resample/rolling
   to the input DataFrame is inconsistent. An internal heuristic to detect index mutation would behave differently for equal but not identical
   indices. In particular, the result index shape might change if a copy of the input would be returned.
   The behaviour now is consistent, independent of internal heuristics. (:issue:`31612`, :issue:`14927`, :issue:`13056`)
+- Bug in :meth:`SeriesGroupBy.agg` where any column name is accepted in named aggregation previously. The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -907,7 +907,8 @@ Groupby/resample/rolling
   to the input DataFrame is inconsistent. An internal heuristic to detect index mutation would behave differently for equal but not identical
   indices. In particular, the result index shape might change if a copy of the input would be returned.
   The behaviour now is consistent, independent of internal heuristics. (:issue:`31612`, :issue:`14927`, :issue:`13056`)
-- Bug in :meth:`SeriesGroupBy.agg` where any column name is accepted in named aggregation previously. The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
+- Bug in :meth:`SeriesGroupBy.agg` where any column name was accepted in the named aggregation of ``SeriesGroupBy`` previously.
+  The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -907,8 +907,7 @@ Groupby/resample/rolling
   to the input DataFrame is inconsistent. An internal heuristic to detect index mutation would behave differently for equal but not identical
   indices. In particular, the result index shape might change if a copy of the input would be returned.
   The behaviour now is consistent, independent of internal heuristics. (:issue:`31612`, :issue:`14927`, :issue:`13056`)
-- Bug in :meth:`SeriesGroupBy.agg` where any column name was accepted in the named aggregation of ``SeriesGroupBy`` previously.
-  The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
+- Bug in :meth:`SeriesGroupBy.agg` where any column name was accepted in the named aggregation of ``SeriesGroupBy`` previously. The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -5,7 +5,7 @@ kwarg aggregations in groupby and DataFrame/Series aggregation
 
 from collections import defaultdict
 from functools import partial
-from typing import Any, DefaultDict, List, Sequence, Tuple
+from typing import Any, DefaultDict, List, Sequence, Tuple, Union, Callable
 
 from pandas.core.dtypes.common import is_dict_like, is_list_like
 
@@ -196,3 +196,40 @@ def maybe_mangle_lambdas(agg_spec: Any) -> Any:
         mangled_aggspec = _managle_lambda_list(agg_spec)
 
     return mangled_aggspec
+
+def validate_func_kwargs(
+    kwargs: dict,
+) -> Tuple[List[str], List[Union[str, Callable[..., Any]]]]:
+    """
+    Validates types of user-provided "named aggregation" kwargs.
+    `TypeError` is raised if aggfunc is not `str` or callable.
+
+    Parameters
+    ----------
+    kwargs : dict
+
+    Returns
+    -------
+    columns : List[str]
+        List of user-provied keys.
+    func : List[Union[str, callable[...,Any]]]
+        List of user-provided aggfuncs
+
+    Examples
+    --------
+    >>> validate_func_kwargs({'one': 'min', 'two': 'max'})
+    (['one', 'two'], ['min','max'])
+    >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min}) 
+    (['one', 'two'], [lambda x:x+1, np.min])
+    """
+    no_arg_message = "Must provide 'func' or named aggregation **kwargs."
+    tuple_given_message = "func is expected but recieved {} in **kwargs."
+    columns = list(kwargs)
+    func = []
+    for col_func in kwargs.values():
+        if not (isinstance(col_func, str) or callable(col_func)):
+            raise TypeError(tuple_given_message.format(type(col_func).__name__))
+        func.append(col_func)
+    if not columns:
+        raise TypeError(no_arg_message)
+    return columns, func

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -220,8 +220,6 @@ def validate_func_kwargs(
     --------
     >>> validate_func_kwargs({'one': 'min', 'two': 'max'})
     (['one', 'two'], ['min', 'max'])
-    >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min})
-    (['one', 'two'], [lambda x:x+1, np.min])
     """
     no_arg_message = "Must provide 'func' or named aggregation **kwargs."
     tuple_given_message = "func is expected but recieved {} in **kwargs."

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -5,7 +5,7 @@ kwarg aggregations in groupby and DataFrame/Series aggregation
 
 from collections import defaultdict
 from functools import partial
-from typing import Any, DefaultDict, List, Sequence, Tuple, Union, Callable
+from typing import Any, Callable, DefaultDict, List, Sequence, Tuple, Union
 
 from pandas.core.dtypes.common import is_dict_like, is_list_like
 
@@ -219,7 +219,7 @@ def validate_func_kwargs(
     Examples
     --------
     >>> validate_func_kwargs({'one': 'min', 'two': 'max'})
-    (['one', 'two'], ['min','max'])
+    (['one', 'two'], ['min', 'max'])
     >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min})
     (['one', 'two'], [lambda x:x+1, np.min])
     """

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -197,6 +197,7 @@ def maybe_mangle_lambdas(agg_spec: Any) -> Any:
 
     return mangled_aggspec
 
+
 def validate_func_kwargs(
     kwargs: dict,
 ) -> Tuple[List[str], List[Union[str, Callable[..., Any]]]]:
@@ -219,7 +220,7 @@ def validate_func_kwargs(
     --------
     >>> validate_func_kwargs({'one': 'min', 'two': 'max'})
     (['one', 'two'], ['min','max'])
-    >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min}) 
+    >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min})
     (['one', 'two'], [lambda x:x+1, np.min])
     """
     no_arg_message = "Must provide 'func' or named aggregation **kwargs."

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -239,10 +239,10 @@ class SeriesGroupBy(GroupBy[Series]):
             columns = list(kwargs)
             func = []
             for col in columns:
-                if isinstance(kwargs[col],(list,NamedAgg,tuple)):
-                    raise TypeError(tuple_given_message.format(type(kwargs[col]).__name__))
+                if isinstance(kwargs[col], (list, NamedAgg, tuple)):
+                    raise TypeError(tuple_given_message.\
+                        format(type(kwargs[col]).__name__))
                 func.append(kwargs[col])
-            
             kwargs = {}
             if not columns:
                 raise TypeError(no_arg_message)
@@ -290,7 +290,6 @@ class SeriesGroupBy(GroupBy[Series]):
 
             ret = concat(ret, axis=1)
         return ret
-
     agg = aggregate
 
     def _aggregate_multiple_funcs(self, arg):

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -240,8 +240,9 @@ class SeriesGroupBy(GroupBy[Series]):
             func = []
             for col in columns:
                 if isinstance(kwargs[col], (list, NamedAgg, tuple)):
-                    raise TypeError(tuple_given_message.\
-                        format(type(kwargs[col]).__name__))
+                    raise TypeError(
+                        tuple_given_message.format(type(kwargs[col]).__name__)
+                )
                 func.append(kwargs[col])
             kwargs = {}
             if not columns:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -242,7 +242,7 @@ class SeriesGroupBy(GroupBy[Series]):
                 if isinstance(kwargs[col], (list, NamedAgg, tuple)):
                     raise TypeError(
                         tuple_given_message.format(type(kwargs[col]).__name__)
-                )
+                    )
                 func.append(kwargs[col])
             kwargs = {}
             if not columns:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -234,9 +234,15 @@ class SeriesGroupBy(GroupBy[Series]):
         relabeling = func is None
         columns = None
         no_arg_message = "Must provide 'func' or named aggregation **kwargs."
+        tuple_given_message = "'func' is expected but recieved {} in **kwargs."
         if relabeling:
             columns = list(kwargs)
-            func = [kwargs[col] for col in columns]
+            func = []
+            for col in columns:
+                if isinstance(kwargs[col],(list,NamedAgg,tuple)):
+                    raise TypeError(tuple_given_message.format(type(kwargs[col])))
+                func.append(kwargs[col])
+            
             kwargs = {}
             if not columns:
                 raise TypeError(no_arg_message)
@@ -298,11 +304,7 @@ class SeriesGroupBy(GroupBy[Series]):
 
             columns = list(arg.keys())
             arg = arg.items()
-        elif any(isinstance(x, (tuple, list)) for x in arg):
-            arg = [(x, x) if not isinstance(x, (tuple, list)) else x for x in arg]
 
-            # indicated column order
-            columns = next(zip(*arg))
         else:
             # list of functions / function names
             columns = []

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -307,8 +307,6 @@ class SeriesGroupBy(GroupBy[Series]):
         elif anyisinstance(x, (tuple, list)) for x in arg):
             arg = [(x, x) if not isinstance(x, (tuple, list)) else x for x in arg]
 
-            # indicated column order
-            columns = next(zip(*arg))
         else:
             # list of functions / function names
             columns = []

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -239,7 +239,7 @@ class SeriesGroupBy(GroupBy[Series]):
             columns = list(kwargs)
             func = []
             for col in columns:
-                if isinstance(kwargs[col], (list, NamedAgg, tuple)):
+                if isinstance(kwargs[col], (list, tuple)):
                     raise TypeError(
                         tuple_given_message.format(type(kwargs[col]).__name__)
                     )
@@ -310,12 +310,12 @@ class SeriesGroupBy(GroupBy[Series]):
 
             # indicated column order
             columns = next(zip(*arg))
-
         else:
             # list of functions / function names
             columns = []
             for f in arg:
                 columns.append(com.get_callable_name(f) or f)
+
             arg = zip(columns, arg)
 
         results = {}

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -304,7 +304,11 @@ class SeriesGroupBy(GroupBy[Series]):
 
             columns = list(arg.keys())
             arg = arg.items()
+        elif anyisinstance(x, (tuple, list)) for x in arg):
+            arg = [(x, x) if not isinstance(x, (tuple, list)) else x for x in arg]
 
+            # indicated column order
+            columns = next(zip(*arg))
         else:
             # list of functions / function names
             columns = []

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -240,7 +240,7 @@ class SeriesGroupBy(GroupBy[Series]):
             func = []
             for col in columns:
                 if isinstance(kwargs[col],(list,NamedAgg,tuple)):
-                    raise TypeError(tuple_given_message.format(type(kwargs[col])))
+                    raise TypeError(tuple_given_message.format(type(kwargs[col]).__name__))
                 func.append(kwargs[col])
             
             kwargs = {}

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -291,6 +291,7 @@ class SeriesGroupBy(GroupBy[Series]):
 
             ret = concat(ret, axis=1)
         return ret
+
     agg = aggregate
 
     def _aggregate_multiple_funcs(self, arg):

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -57,6 +57,7 @@ from pandas.core.aggregation import (
     is_multi_agg_with_relabel,
     maybe_mangle_lambdas,
     normalize_keyword_aggregation,
+    validate_func_kwargs
 )
 import pandas.core.algorithms as algorithms
 from pandas.core.base import DataError, SpecificationError
@@ -233,20 +234,9 @@ class SeriesGroupBy(GroupBy[Series]):
 
         relabeling = func is None
         columns = None
-        no_arg_message = "Must provide 'func' or named aggregation **kwargs."
-        tuple_given_message = "func is expected but recieved {} in **kwargs."
         if relabeling:
-            columns = list(kwargs)
-            func = []
-            for col in columns:
-                if isinstance(kwargs[col], (list, tuple)):
-                    raise TypeError(
-                        tuple_given_message.format(type(kwargs[col]).__name__)
-                    )
-                func.append(kwargs[col])
+            columns, func = validate_func_kwargs(kwargs)
             kwargs = {}
-            if not columns:
-                raise TypeError(no_arg_message)
 
         if isinstance(func, str):
             return getattr(self, func)(*args, **kwargs)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -234,7 +234,7 @@ class SeriesGroupBy(GroupBy[Series]):
         relabeling = func is None
         columns = None
         no_arg_message = "Must provide 'func' or named aggregation **kwargs."
-        tuple_given_message = "'func' is expected but recieved {} in **kwargs."
+        tuple_given_message = "func is expected but recieved {} in **kwargs."
         if relabeling:
             columns = list(kwargs)
             func = []

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -57,7 +57,7 @@ from pandas.core.aggregation import (
     is_multi_agg_with_relabel,
     maybe_mangle_lambdas,
     normalize_keyword_aggregation,
-    validate_func_kwargs
+    validate_func_kwargs,
 )
 import pandas.core.algorithms as algorithms
 from pandas.core.base import DataError, SpecificationError

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -304,15 +304,17 @@ class SeriesGroupBy(GroupBy[Series]):
 
             columns = list(arg.keys())
             arg = arg.items()
-        elif anyisinstance(x, (tuple, list)) for x in arg):
+        elif any(isinstance(x, (tuple, list)) for x in arg):
             arg = [(x, x) if not isinstance(x, (tuple, list)) else x for x in arg]
+
+            # indicated column order
+            columns = next(zip(*arg))
 
         else:
             # list of functions / function names
             columns = []
             for f in arg:
                 columns.append(com.get_callable_name(f) or f)
-
             arg = zip(columns, arg)
 
         results = {}

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -514,7 +514,7 @@ class TestNamedAggregationSeries:
     def test_agg_namedtuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is expected but recieved NamedAgg in **kwargs."
+        msg = "'func' is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=pd.NamedAgg(column='anything', aggfunc='min')
@@ -523,7 +523,7 @@ class TestNamedAggregationSeries:
     def test_agg_with_tuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is expected but recieved tuple in **kwargs."
+        msg = "'func' is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=('anything', 'min')
@@ -532,7 +532,7 @@ class TestNamedAggregationSeries:
     def test_agg_with_list(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is expected but recieved list in **kwargs."
+        msg = "'func' is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=['anything', 'min']

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -511,26 +511,20 @@ class TestNamedAggregationSeries:
         expected = pd.DataFrame({"a": [0, 0], "b": [1, 1]})
         tm.assert_frame_equal(result, expected)
 
-    def test_agg_namedtuple(self):
+    @pytest.mark.parametrize(
+        "inp",
+        [
+            pd.NamedAgg(column="anything", aggfunc="min"),
+            ("anything", "min"),
+            ["anything", "min"],
+        ],
+    )
+    def test_named_agg_nametuple(self, inp):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "func is"
+        msg = "func is expected but recieved {}".format(type(inp).__name__)
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(a=pd.NamedAgg(column="anything", aggfunc="min"))
-
-    def test_agg_with_tuple(self):
-        # GH34422
-        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "func is"
-        with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(a=("anything", "min"))
-
-    def test_agg_with_list(self):
-        # GH34422
-        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "func is"
-        with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(a=["anything", "min"])
 
 
 class TestNamedAggregationDataFrame:

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -511,6 +511,33 @@ class TestNamedAggregationSeries:
         expected = pd.DataFrame({"a": [0, 0], "b": [1, 1]})
         tm.assert_frame_equal(result, expected)
 
+    def test_agg_namedtuple(self):
+        #GH34422
+        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
+        msg = "'func' is expected but recieved NamedAgg in **kwargs."
+        with pytest.raises(TypeError, match=msg):
+            s.groupby(s.values).agg(
+                a=pd.NamedAgg(column='anything', aggfunc='min')
+                )
+
+    def test_agg_with_tuple(self):
+        #GH34422
+        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
+        msg = "'func' is expected but recieved tuple in **kwargs."
+        with pytest.raises(TypeError, match=msg):
+            s.groupby(s.values).agg(
+                a=('anything', 'min')
+                )
+
+    def test_agg_with_list(self):
+        #GH34422
+        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
+        msg = "'func' is expected but recieved list in **kwargs."
+        with pytest.raises(TypeError, match=msg):
+            s.groupby(s.values).agg(
+                a=['anything', 'min']
+            )
+
 
 class TestNamedAggregationDataFrame:
     def test_agg_relabel(self):

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -522,7 +522,7 @@ class TestNamedAggregationSeries:
     def test_named_agg_nametuple(self, inp):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "func is expected but recieved {}".format(type(inp).__name__)
+        msg = f"func is expected but recieved {type(inp).__name__}"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(a=inp)
 

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -512,25 +512,25 @@ class TestNamedAggregationSeries:
         tm.assert_frame_equal(result, expected)
 
     def test_agg_namedtuple(self):
-        #GH34422
+        # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "'func' is expected but recieved NamedAgg in **kwargs."
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=pd.NamedAgg(column='anything', aggfunc='min')
-                )
+            )
 
     def test_agg_with_tuple(self):
-        #GH34422
+        # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "'func' is expected but recieved tuple in **kwargs."
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=('anything', 'min')
-                )
+            )
 
     def test_agg_with_list(self):
-        #GH34422
+        # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "'func' is expected but recieved list in **kwargs."
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -516,27 +516,21 @@ class TestNamedAggregationSeries:
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "func is"
         with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(
-                a=pd.NamedAgg(column='anything', aggfunc='min')
-            )
+            s.groupby(s.values).agg(a=pd.NamedAgg(column="anything", aggfunc="min"))
 
     def test_agg_with_tuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "func is"
         with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(
-                a=('anything', 'min')
-            )
+            s.groupby(s.values).agg(a=("anything", "min"))
 
     def test_agg_with_list(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "func is"
         with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(
-                a=['anything', 'min']
-            )
+            s.groupby(s.values).agg(a=["anything", "min"])
 
 
 class TestNamedAggregationDataFrame:

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -514,7 +514,7 @@ class TestNamedAggregationSeries:
     def test_agg_namedtuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is"
+        msg = "func is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=pd.NamedAgg(column='anything', aggfunc='min')
@@ -523,7 +523,7 @@ class TestNamedAggregationSeries:
     def test_agg_with_tuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is"
+        msg = "func is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=('anything', 'min')
@@ -532,7 +532,7 @@ class TestNamedAggregationSeries:
     def test_agg_with_list(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is"
+        msg = "func is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=['anything', 'min']

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -524,7 +524,7 @@ class TestNamedAggregationSeries:
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "func is expected but recieved {}".format(type(inp).__name__)
         with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(a=pd.NamedAgg(column="anything", aggfunc="min"))
+            s.groupby(s.values).agg(a=inp)
 
 
 class TestNamedAggregationDataFrame:


### PR DESCRIPTION
- [X] closes #34422 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] whatsnew entry

This PR tries to fix the bug pointed in #34422 where `SeriesGroupBy.agg` works with any given column name in `NamedAgg`.

After discussing with @TomAugspurger  and @MarcoGorelli  in another issue #34380 regarding this issue in the comments, We came to a solution that

> So for SeriesGroupBy.agg, if there are any tuples or NamedAgg present in kwargs then I think we should raise.
> Disallowing `NamedAgg` and tuples with `SeriesGroupBy`.

#### Before fix:
```python3
s = pd.Series([1,1,2,2,3,3,4,5])
s.groupby(s.values).agg(one = pd.NamedAgg(column='anything',aggfunc='sum'))
  one
1    2
2    4
3    6
4    4
5    5

s.groupby(s.values).agg(one=('something','sum'))
   one
1    2
2    4
3    6
4    4
5    5
```

#### After fix:
```python3
s = pd.Series([1,1,2,2,3,3,4,5])
s.groupby(s.values).agg(one = pd.NamedAgg(column='anything',aggfunc='sum'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "d:\#gh34422\pandas\pandas\core\groupby\generic.py", line 243, in aggregate
    raise TypeError(tuple_given_message.format(type(kwargs[col]).__name__))
TypeError: 'func' is expected but recieved NamedAgg in **kwargs.

s.groupby(s.values).agg(one=('something','sum'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "d:\#gh34422\pandas\pandas\core\groupby\generic.py", line 243, in aggregate
    raise TypeError(tuple_given_message.format(type(kwargs[col]).__name__))
TypeError: 'func' is expected but recieved tuple in **kwargs.
```