### PR TITLE
TST #28981 comparison operation for interval dtypes

### DIFF
--- a/pandas/tests/arithmetic/test_interval.py
+++ b/pandas/tests/arithmetic/test_interval.py
@@ -284,3 +284,11 @@ class TestComparison:
         result = op(index, other)
         expected = expected_type(self.elementwise_comparison(op, index, other))
         assert_func(result, expected)
+
+    @pytest.mark.parametrize("scalars", ["a", False, 1, 1.0, None])
+    def test_comparison_operations(self, scalars):
+        # GH #28981
+        expected = Series([False, False])
+        s = pd.Series([pd.Interval(0, 1), pd.Interval(1, 2)], dtype="interval")
+        result = s == scalars
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -1525,11 +1525,8 @@ class TestPeriodIndexSeriesMethods:
 
     @pytest.mark.parametrize("scalars", ["a", False, 1, 1.0, None])
     def test_comparison_operations(self, scalars):
-        # GH #28980 and GH #28981
+        # GH #28980
         expected = Series([False, False])
         s = Series([pd.Period("2019"), pd.Period("2020")], dtype="period[A-DEC]")
-        result = s == scalars
-        tm.assert_series_equal(result, expected)
-        s = pd.Series([pd.Interval(0, 1), pd.Interval(1, 2)], dtype="interval")
         result = s == scalars
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -1525,7 +1525,7 @@ class TestPeriodIndexSeriesMethods:
 
     @pytest.mark.parametrize("scalars", ["a", False, 1, 1.0, None])
     def test_comparison_operations(self, scalars):
-        # GH #28980
+        # GH 28980
         expected = Series([False, False])
         s = Series([pd.Period("2019"), pd.Period("2020")], dtype="period[A-DEC]")
         result = s == scalars

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -1525,8 +1525,11 @@ class TestPeriodIndexSeriesMethods:
 
     @pytest.mark.parametrize("scalars", ["a", False, 1, 1.0, None])
     def test_comparison_operations(self, scalars):
-        # GH 28980
+        # GH #28980 and GH #28981
         expected = Series([False, False])
         s = Series([pd.Period("2019"), pd.Period("2020")], dtype="period[A-DEC]")
+        result = s == scalars
+        tm.assert_series_equal(result, expected)
+        s = pd.Series([pd.Interval(0, 1), pd.Interval(1, 2)], dtype="interval")
         result = s == scalars
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
As a complement of #28980, one test was modified to take into account this issue:
- [ x ] closes #28981
- [ 1 ] test modified
- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
