### PR TITLE
Fix MultiIndex .loc "Too Many Indexers" with None as return value

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -811,6 +811,7 @@ Indexing
 - Bug in :meth:`DataFrame.truncate` and :meth:`Series.truncate` where index was assumed to be monotone increasing (:issue:`33756`)
 - Indexing with a list of strings representing datetimes failed on :class:`DatetimeIndex` or :class:`PeriodIndex`(:issue:`11278`)
 - Bug in :meth:`Series.at` when used with a :class:`MultiIndex` would raise an exception on valid inputs (:issue:`26989`)
+- Bug in :meth:`Series.loc` when used with a :class:`MultiIndex` would raise an IndexingError when accessing a None value (:issue:`34318`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -822,6 +822,7 @@ class _LocationIndexer(_NDFrameIndexerBase):
                 result = self._handle_lowerdim_multi_index_axis0(tup)
                 return result
             except Exception:
+                print("ENTREI")
                 pass
 
             # this is a series with a multi-index specified a tuple of

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -766,9 +766,11 @@ class _LocationIndexer(_NDFrameIndexerBase):
         # ...but iloc should handle the tuple as simple integer-location
         # instead of checking it as multiindex representation (GH 13797)
         if isinstance(ax0, ABCMultiIndex) and self.name != "iloc":
-            result = self._handle_lowerdim_multi_index_axis0(tup)
-            if result is not None:
+            try:
+                result = self._handle_lowerdim_multi_index_axis0(tup)
                 return result
+            except Exception:
+                pass
 
         if len(tup) > self.ndim:
             raise IndexingError("Too many indexers. handle elsewhere")
@@ -816,9 +818,11 @@ class _LocationIndexer(_NDFrameIndexerBase):
             if self.name != "loc":
                 # This should never be reached, but lets be explicit about it
                 raise ValueError("Too many indices")
-            result = self._handle_lowerdim_multi_index_axis0(tup)
-            if result is not None:
+            try:
+                result = self._handle_lowerdim_multi_index_axis0(tup)
                 return result
+            except Exception:
+                pass
 
             # this is a series with a multi-index specified a tuple of
             # selectors
@@ -1065,7 +1069,7 @@ class _LocIndexer(_LocationIndexer):
             if len(tup) <= self.obj.index.nlevels and len(tup) > self.ndim:
                 raise ek
 
-        return None
+        raise Exception("No label returned")
 
     def _getitem_axis(self, key, axis: int):
         key = item_from_zerodim(key)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -769,7 +769,7 @@ class _LocationIndexer(_NDFrameIndexerBase):
             try:
                 result = self._handle_lowerdim_multi_index_axis0(tup)
                 return result
-            except Exception:
+            except IndexingError:
                 pass
 
         if len(tup) > self.ndim:
@@ -821,8 +821,7 @@ class _LocationIndexer(_NDFrameIndexerBase):
             try:
                 result = self._handle_lowerdim_multi_index_axis0(tup)
                 return result
-            except Exception:
-                print("ENTREI")
+            except IndexingError:
                 pass
 
             # this is a series with a multi-index specified a tuple of
@@ -1070,7 +1069,7 @@ class _LocIndexer(_LocationIndexer):
             if len(tup) <= self.obj.index.nlevels and len(tup) > self.ndim:
                 raise ek
 
-        raise Exception("No label returned")
+        raise IndexingError("No label returned")
 
     def _getitem_axis(self, key, axis: int):
         key = item_from_zerodim(key)

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -860,13 +860,13 @@ def test_access_none_value_in_multiindex():
     result = s.loc[("Level1", "Level2")]
     assert result is None
 
-    midx = MultiIndex.from_product([['Level1'], ['Level2_a', 'Level2_b']])
+    midx = MultiIndex.from_product([["Level1"], ["Level2_a", "Level2_b"]])
     s = Series([None] * len(midx), dtype=object, index=midx)
-    result = s.loc[('Level1', 'Level2_a')]
+    result = s.loc[("Level1", "Level2_a")]
     assert result is None
 
     s = Series([1] * len(midx), dtype=object, index=midx)
-    result = s.loc[('Level1', 'Level2_a')]
+    result = s.loc[("Level1", "Level2_a")]
     assert result == 1
 
 

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -853,6 +853,17 @@ def test_setitem_slice_into_readonly_backing_data():
     assert not array.any()
 
 
+def test_access_none_value_in_multiindex():
+    # GH34318: test that you can access a None value using .loc through a Multiindex
+
+    expected = None
+    result = pd.Series([None], pd.MultiIndex.from_arrays([["Level1"], ["Level2"]])).loc[
+        ("Level1", "Level2")
+    ]
+
+    assert expected == result
+
+
 """
 miscellaneous methods
 """

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -853,23 +853,6 @@ def test_setitem_slice_into_readonly_backing_data():
     assert not array.any()
 
 
-def test_access_none_value_in_multiindex():
-    # GH34318: test that you can access a None value using .loc through a Multiindex
-
-    s = Series([None], pd.MultiIndex.from_arrays([["Level1"], ["Level2"]]))
-    result = s.loc[("Level1", "Level2")]
-    assert result is None
-
-    midx = MultiIndex.from_product([["Level1"], ["Level2_a", "Level2_b"]])
-    s = Series([None] * len(midx), dtype=object, index=midx)
-    result = s.loc[("Level1", "Level2_a")]
-    assert result is None
-
-    s = Series([1] * len(midx), dtype=object, index=midx)
-    result = s.loc[("Level1", "Level2_a")]
-    assert result == 1
-
-
 """
 miscellaneous methods
 """

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -856,12 +856,18 @@ def test_setitem_slice_into_readonly_backing_data():
 def test_access_none_value_in_multiindex():
     # GH34318: test that you can access a None value using .loc through a Multiindex
 
-    expected = None
-    result = pd.Series([None], pd.MultiIndex.from_arrays([["Level1"], ["Level2"]])).loc[
-        ("Level1", "Level2")
-    ]
+    s = Series([None], pd.MultiIndex.from_arrays([["Level1"], ["Level2"]]))
+    result = s.loc[("Level1", "Level2")]
+    assert result is None
 
-    assert expected == result
+    midx = MultiIndex.from_product([['Level1'], ['Level2_a', 'Level2_b']])
+    s = Series([None] * len(midx), dtype=object, index=midx)
+    result = s.loc[('Level1', 'Level2_a')]
+    assert result is None
+
+    s = Series([1] * len(midx), dtype=object, index=midx)
+    result = s.loc[('Level1', 'Level2_a')]
+    assert result == 1
 
 
 """

--- a/pandas/tests/series/indexing/test_multiindex.py
+++ b/pandas/tests/series/indexing/test_multiindex.py
@@ -1,28 +1,8 @@
 """ test get/set & misc """
 
-from datetime import timedelta
-
-import numpy as np
-import pytest
-
-from pandas.core.dtypes.common import is_scalar
 
 import pandas as pd
-from pandas import (
-    Categorical,
-    DataFrame,
-    IndexSlice,
-    MultiIndex,
-    Series,
-    Timedelta,
-    Timestamp,
-    date_range,
-    period_range,
-    timedelta_range,
-)
-import pandas._testing as tm
-
-from pandas.tseries.offsets import BDay
+from pandas import MultiIndex, Series
 
 
 def test_access_none_value_in_multiindex():

--- a/pandas/tests/series/indexing/test_multiindex.py
+++ b/pandas/tests/series/indexing/test_multiindex.py
@@ -1,0 +1,42 @@
+""" test get/set & misc """
+
+from datetime import timedelta
+
+import numpy as np
+import pytest
+
+from pandas.core.dtypes.common import is_scalar
+
+import pandas as pd
+from pandas import (
+    Categorical,
+    DataFrame,
+    IndexSlice,
+    MultiIndex,
+    Series,
+    Timedelta,
+    Timestamp,
+    date_range,
+    period_range,
+    timedelta_range,
+)
+import pandas._testing as tm
+
+from pandas.tseries.offsets import BDay
+
+
+def test_access_none_value_in_multiindex():
+    # GH34318: test that you can access a None value using .loc through a Multiindex
+
+    s = Series([None], pd.MultiIndex.from_arrays([["Level1"], ["Level2"]]))
+    result = s.loc[("Level1", "Level2")]
+    assert result is None
+
+    midx = MultiIndex.from_product([["Level1"], ["Level2_a", "Level2_b"]])
+    s = Series([None] * len(midx), dtype=object, index=midx)
+    result = s.loc[("Level1", "Level2_a")]
+    assert result is None
+
+    s = Series([1] * len(midx), dtype=object, index=midx)
+    result = s.loc[("Level1", "Level2_a")]
+    assert result == 1


### PR DESCRIPTION
- [x] closes #34318 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Three changes in indexing.py : 
- function _handle_lowerdim_multi_index_axis0 default return value was None, now it raises an Exception.
- function _getitem_lowerdim checks for a raised exception instead of a value None.
- function _getitem_nested_tuple checks for a raised exception instead of a value None(had to be changed because it also uses _handle_lowerdim_multi_index_axis0) 

