### PR TITLE
mask based multi-index assignment of column values described

### DIFF
--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1874,7 +1874,6 @@ This is the correct access method:
                              'three', 'two', 'one', 'six'],
                        'c': np.arange(7)})
    dfd = dfc.copy()
-         
    # Setting multiple items using a mask (recommended)
    mask = dfd['a'].str.startswith('o')
    dfd.loc[mask, 'c'] = 42

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1870,25 +1870,35 @@ This is the correct access method:
 
 .. ipython:: python
 
-   dfc = pd.DataFrame({'A': ['aaa', 'bbb', 'ccc'], 'B': [1, 2, 3]})
-   dfc.loc[0, 'A'] = 11
-   dfc
+   dfc = pd.DataFrame({'a': ['one', 'one', 'two',
+                             'three', 'two', 'one', 'six'],
+                       'c': np.arange(7)})
+   dfd = dfc.copy()
+         
+   # Setting multiple items using a mask (recommended)
+   mask = dfd['a'].str.startswith('o')
+   dfd.loc[mask, 'c'] = 42
+   dfd
 
-This *can* work at times, but it is not guaranteed to, and therefore should be avoided:
+   # Setting a single item (recommended)
+   dfd.loc[2, 'a'] = 11
+   dfd
+
+The following *can* work at times, but it is not guaranteed to, and therefore should be avoided:
 
 .. ipython:: python
    :okwarning:
 
-   dfc = dfc.copy()
-   dfc['A'][0] = 111
-   dfc
+   dfd = dfc.copy()
+   dfd['a'][2] = 111
+   dfd
 
-This will **not** work at all, and so should be avoided:
+Last, the subsequent example will **not** work at all, and so should be avoided:
 
 ::
 
    >>> pd.set_option('mode.chained_assignment','raise')
-   >>> dfc.loc[0]['A'] = 1111
+   >>> dfd.loc[0]['a'] = 1111
    Traceback (most recent call last)
         ...
    SettingWithCopyException:

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1866,7 +1866,7 @@ A chained assignment can also crop up in setting in a mixed dtype frame.
 
    These setting rules apply to all of ``.loc/.iloc``.
 
-This is the correct access method:
+The following is the recommended access method using ``.loc`` for multiple items (using ``mask``) and a single item using a fixed index:
 
 .. ipython:: python
 
@@ -1874,12 +1874,12 @@ This is the correct access method:
                              'three', 'two', 'one', 'six'],
                        'c': np.arange(7)})
    dfd = dfc.copy()
-   # Setting multiple items using a mask (recommended)
+   # Setting multiple items using a mask
    mask = dfd['a'].str.startswith('o')
    dfd.loc[mask, 'c'] = 42
    dfd
 
-   # Setting a single item (recommended)
+   # Setting a single item
    dfd = dfc.copy()
    dfd.loc[2, 'a'] = 11
    dfd

--- a/doc/source/user_guide/indexing.rst
+++ b/doc/source/user_guide/indexing.rst
@@ -1880,6 +1880,7 @@ This is the correct access method:
    dfd
 
    # Setting a single item (recommended)
+   dfd = dfc.copy()
    dfd.loc[2, 'a'] = 11
    dfd
 


### PR DESCRIPTION
- [x] closes #34383
- [x] passes `black pandas`
not sure what this means, will look it up.
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`


- ~~[ ] tests added / passed~~ 
this is an PR on documentation only, unit tests are not needed.
- ~~[ ] whatsnew entry~~
I think I don't need this as this is a PR related to documentation only.
