### PR TITLE
BUG: fix origin epoch when freq is Day and harmonize epoch between timezones

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1696,6 +1696,9 @@ def _get_timestamp_range_edges(
     index_tz = first.tz
     if isinstance(origin, Timestamp) and (origin.tz is None) != (index_tz is None):
         raise ValueError("The origin must have the same timezone as the index.")
+    if origin == "epoch":
+        # set the epoch based on the timezone to have similar result between timezones
+        origin = Timestamp("1970-01-01", tz=index_tz)
 
     if isinstance(freq, Tick):
         if isinstance(freq, Day):

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1693,14 +1693,15 @@ def _get_timestamp_range_edges(
     -------
     A tuple of length 2, containing the adjusted pd.Timestamp objects.
     """
-    index_tz = first.tz
-    if isinstance(origin, Timestamp) and (origin.tz is None) != (index_tz is None):
-        raise ValueError("The origin must have the same timezone as the index.")
-    if origin == "epoch":
-        # set the epoch based on the timezone to have similar result between timezones
-        origin = Timestamp("1970-01-01", tz=index_tz)
-
     if isinstance(freq, Tick):
+        index_tz = first.tz
+        if isinstance(origin, Timestamp) and (origin.tz is None) != (index_tz is None):
+            raise ValueError("The origin must have the same timezone as the index.")
+        elif origin == "epoch":
+            # set the epoch based on the timezone to have similar bins results when
+            # resampling on the same kind of indexes on different timezones
+            origin = Timestamp("1970-01-01", tz=index_tz)
+
         if isinstance(freq, Day):
             # _adjust_dates_anchored assumes 'D' means 24H, but first/last
             # might contain a DST transition (23H, 24H, or 25H).


### PR DESCRIPTION
Follow-up of #31809.

The purpose of this PR is to fix the current behavior on master:

```python
import pandas as pd
import numpy as np

start, end = "2000-08-02 23:30:00+0500", "2000-12-02 00:30:00+0500"
rng = pd.date_range(start, end, freq="7min")
ts = pd.Series(np.random.randn(len(rng)), index=rng)

result_1 = ts.resample("D", origin="epoch").count()
result_2 = ts.resample("24H", origin="epoch").count()

print(f"result_1:\n\n{result_1}\n")
print(f"result_2:\n\n{result_2}\n")
```

Outputs on master:
```
result_1:

2000-08-02 00:00:00+05:00      5
2000-08-03 00:00:00+05:00    205
2000-08-04 00:00:00+05:00    206
2000-08-05 00:00:00+05:00    206
2000-08-06 00:00:00+05:00    206
                            ... 
2000-11-28 00:00:00+05:00    206
2000-11-29 00:00:00+05:00    206
2000-11-30 00:00:00+05:00    205
2000-12-01 00:00:00+05:00    206
2000-12-02 00:00:00+05:00      5
Freq: D, Length: 123, dtype: int64

result_2:

2000-08-02 05:00:00+05:00     48
2000-08-03 05:00:00+05:00    205
2000-08-04 05:00:00+05:00    206
2000-08-05 05:00:00+05:00    206
2000-08-06 05:00:00+05:00    205
                            ... 
2000-11-27 05:00:00+05:00    206
2000-11-28 05:00:00+05:00    206
2000-11-29 05:00:00+05:00    206
2000-11-30 05:00:00+05:00    205
2000-12-01 05:00:00+05:00    168
Freq: 24H, Length: 122, dtype: int64
```

Expected Outputs (with this PR):
```
result_1:

2000-08-02 00:00:00+05:00      5
2000-08-03 00:00:00+05:00    205
2000-08-04 00:00:00+05:00    206
2000-08-05 00:00:00+05:00    206
2000-08-06 00:00:00+05:00    206
                            ... 
2000-11-28 00:00:00+05:00    206
2000-11-29 00:00:00+05:00    206
2000-11-30 00:00:00+05:00    205
2000-12-01 00:00:00+05:00    206
2000-12-02 00:00:00+05:00      5
Freq: D, Length: 123, dtype: int64

result_2:

2000-08-02 00:00:00+05:00      5
2000-08-03 00:00:00+05:00    205
2000-08-04 00:00:00+05:00    206
2000-08-05 00:00:00+05:00    206
2000-08-06 00:00:00+05:00    206
                            ... 
2000-11-28 00:00:00+05:00    206
2000-11-29 00:00:00+05:00    206
2000-11-30 00:00:00+05:00    205
2000-12-01 00:00:00+05:00    206
2000-12-02 00:00:00+05:00      5
Freq: 24H, Length: 123, dtype: int64
```

------

I thought of two possible solutions while fixing that:
1. Consider 'epoch' as a UNIX epoch: `pd.Timestamp(0, tz=index_tz)`
2. Consider that 'epoch' is just an helper to fix the origin: `pd.Timestamp("1970-01-01", tz=index_tz)`

To have similar results between timezones, I thought the solution 2 was a better choice. The solution 2 could also help us to set the behavior `origin=epoch` as the default one in a future version since the results would be quite similar with `origin=start_day` (that is not quite the case with a DST timezone, I can provide further details if needed on why this is the case).

(The solution 1 is correct in theory but is giving results that could be hard to explain to the end user.)

------

- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry (follow-up PR, not necessary I think)
