### PR TITLE
BLD/PERF: bump cython to 0.29.19 for searchsorted

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -39,7 +39,7 @@
     // followed by the pip installed packages).
     "matrix": {
         "numpy": [],
-        "Cython": ["0.29.16"],
+        "Cython": ["0.29.19"],
         "matplotlib": [],
         "sqlalchemy": [],
         "scipy": [],

--- a/ci/deps/azure-36-32bit.yaml
+++ b/ci/deps/azure-36-32bit.yaml
@@ -22,5 +22,5 @@ dependencies:
   # see comment above
   - pip
   - pip:
-    - cython>=0.29.16
+    - cython>=0.29.19
     - pytest>=5.0.1

--- a/ci/deps/azure-36-locale.yaml
+++ b/ci/deps/azure-36-locale.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - pytest-asyncio

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/azure-36-minimum_versions.yaml
+++ b/ci/deps/azure-36-minimum_versions.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.6.1
 
   # tools
-  - cython=0.29.16
+  - cython=0.29.19
   - pytest=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/azure-37-locale.yaml
+++ b/ci/deps/azure-37-locale.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - pytest-asyncio

--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytz
   - pip
   - pip:
-    - cython==0.29.16 # GH#34014
+    - cython==0.29.19 # GH#34014
     - "git+git://github.com/dateutil/dateutil.git"
     - "--extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - "--pre"

--- a/ci/deps/azure-macos-36.yaml
+++ b/ci/deps/azure-macos-36.yaml
@@ -31,6 +31,6 @@ dependencies:
   - xlwt
   - pip
   - pip:
-    - cython>=0.29.16
+    - cython>=0.29.19
     - pyreadstat
     - pyxlsb

--- a/ci/deps/azure-windows-36.yaml
+++ b/ci/deps/azure-windows-36.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/azure-windows-37.yaml
+++ b/ci/deps/azure-windows-37.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-36-cov.yaml
+++ b/ci/deps/travis-36-cov.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0
@@ -15,7 +15,7 @@ dependencies:
   # pandas dependencies
   - beautifulsoup4
   - botocore>=1.11
-  - cython>=0.29.16
+  - cython>=0.29.19
   - dask
   - fastparquet>=0.3.2
   - gcsfs

--- a/ci/deps/travis-36-locale.yaml
+++ b/ci/deps/travis-36-locale.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-36-slow.yaml
+++ b/ci/deps/travis-36-slow.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-37-arm64.yaml
+++ b/ci/deps/travis-37-arm64.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.13
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-37.yaml
+++ b/ci/deps/travis-37.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/ci/deps/travis-38.yaml
+++ b/ci/deps/travis-38.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.8.*
 
   # tools
-  - cython>=0.29.16
+  - cython>=0.29.19
   - pytest>=5.0.1
   - pytest-xdist>=1.21
   - hypothesis>=3.58.0

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - asv
 
   # building
-  - cython>=0.29.16
+  - cython>=0.29.19
 
   # code checks
   - black=19.10b0

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -840,8 +840,7 @@ cdef int64_t[:] _normalize_local(const int64_t[:] stamps, tzinfo tz):
                 trans, stamps.base, cnp.NPY_SEARCHRIGHT, NULL
             ) - 1
             for i in range(n):
-                local_val = stamps[i]
-                if local_val == NPY_NAT:
+                if stamps[i] == NPY_NAT:
                     result[i] = NPY_NAT
                     continue
                 dt64_to_dtstruct(stamps[i] + deltas[pos[i]], &dts)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -809,7 +809,7 @@ cdef int64_t[:] _normalize_local(const int64_t[:] stamps, tzinfo tz):
         ndarray[int64_t] trans
         int64_t[:] deltas
         str typ
-        Py_ssize_t pos
+        Py_ssize_t[:] pos
         npy_datetimestruct dts
         int64_t delta, local_val
 
@@ -835,16 +835,16 @@ cdef int64_t[:] _normalize_local(const int64_t[:] stamps, tzinfo tz):
                 dt64_to_dtstruct(stamps[i] + delta, &dts)
                 result[i] = _normalized_stamp(&dts)
         else:
+            # C equivalent to `trans.searchsorted(stamps, side="right") -1
+            pos = cnp.PyArray_SearchSorted(
+                trans, stamps.base, cnp.NPY_SEARCHRIGHT, NULL
+            ) - 1
             for i in range(n):
                 local_val = stamps[i]
                 if local_val == NPY_NAT:
                     result[i] = NPY_NAT
                     continue
-                # C equivalent to `trans.searchsorted(local_val, side="right")`
-                pos = cnp.PyArray_SearchSorted(
-                    trans, local_val, cnp.NPY_SEARCHRIGHT, NULL
-                )
-                dt64_to_dtstruct(local_val + deltas[pos - 1], &dts)
+                dt64_to_dtstruct(stamps[i] + deltas[pos[i]], &dts)
                 result[i] = _normalized_stamp(&dts)
 
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.29.16",  # Note: sync with setup.py
+    "Cython>=0.29.19",  # Note: sync with setup.py
     "numpy==1.15.4; python_version=='3.6' and platform_system!='AIX'",
     "numpy==1.15.4; python_version>='3.7' and platform_system!='AIX'",
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ numpy>=1.15
 python-dateutil>=2.7.3
 pytz
 asv
-cython>=0.29.16
+cython>=0.29.19
 black==19.10b0
 cpplint
 flake8<3.8.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def is_platform_mac():
 
 
 min_numpy_ver = "1.15.4"
-min_cython_ver = "0.29.16"  # note: sync with pyproject.toml
+min_cython_ver = "0.29.19"  # note: sync with pyproject.toml
 
 try:
     import Cython


### PR DESCRIPTION
cython 0.29.19 fixed a bug that now allows us to use `cnp.PyArray_SearchSorted` to make `ndarray.searchsorted` into a C call.  As a demonstration, this PR makes that change in `normalize_i8_timestamps` and shaves about 12% off of it for the scalar case (the non-scalar case is not noticeably affected)

```
In [4]: ts2 = pd.Timestamp.now("US/Pacific")                                    
In [5]: %timeit ts2.normalize()                                                 
59.3 µs ± 197 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)   # <-- master
51.8 µs ± 362 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)   # <-- PR
```

Not a particularly big deal on its own, _but_ this makes viable passing `int64_t*` instead of `int64_t[:]`, which in turn makes it so we can skip a wrapping/unwrapping step in the scalar code _and_ ideally share code between Timestamp/DatetimeArray, Period/PeriodArray, Timedelta/TimedeltaArray.