### PR TITLE
REF: make normalize_i8_timestamps cpdef

### DIFF
--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -1,6 +1,6 @@
 from cpython.datetime cimport datetime, tzinfo
 
-from numpy cimport int64_t, int32_t
+from numpy cimport int64_t, int32_t, ndarray
 
 from pandas._libs.tslibs.np_datetime cimport npy_datetimestruct
 
@@ -25,4 +25,4 @@ cdef int64_t get_datetime64_nanos(object val) except? -1
 cpdef datetime localize_pydatetime(datetime dt, object tz)
 cdef int64_t cast_from_unit(object ts, str unit) except? -1
 
-cpdef int64_t[:] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz)
+cpdef ndarray[int64_t] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz)

--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -1,4 +1,4 @@
-from cpython.datetime cimport datetime
+from cpython.datetime cimport datetime, tzinfo
 
 from numpy cimport int64_t, int32_t
 
@@ -24,3 +24,5 @@ cdef int64_t get_datetime64_nanos(object val) except? -1
 
 cpdef datetime localize_pydatetime(datetime dt, object tz)
 cdef int64_t cast_from_unit(object ts, str unit) except? -1
+
+cpdef int64_t[:] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz)

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -763,7 +763,7 @@ cpdef inline datetime localize_pydatetime(datetime dt, object tz):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef int64_t[:] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz):
+cpdef ndarray[int64_t] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz):
     """
     Normalize each of the (nanosecond) timezone aware timestamps in the given
     array by rounding down to the beginning of the day (i.e. midnight).
@@ -771,13 +771,12 @@ cpdef int64_t[:] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz):
 
     Parameters
     ----------
-    stamps : ndarray[int64]
+    stamps : int64 ndarray
     tz : tzinfo or None
 
     Returns
     -------
-    ndarray[int64]
-        ndarray of converted of normalized nanosecond timestamps.
+    result : int64 ndarray of converted of normalized nanosecond timestamps
     """
     cdef:
         Py_ssize_t i, n = len(stamps)
@@ -789,17 +788,7 @@ cpdef int64_t[:] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz):
         npy_datetimestruct dts
         int64_t delta, local_val
 
-    if tz is None or is_utc(tz):
-        with nogil:
-            for i in range(n):
-                if stamps[i] == NPY_NAT:
-                    result[i] = NPY_NAT
-                    continue
-                local_val = stamps[i]
-                dt64_to_dtstruct(local_val, &dts)
-                result[i] = _normalized_stamp(&dts)
-
-    elif is_tzlocal(tz):
+    if is_tzlocal(tz):
         for i in range(n):
             if stamps[i] == NPY_NAT:
                 result[i] = NPY_NAT
@@ -829,7 +818,7 @@ cpdef int64_t[:] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz):
                 dt64_to_dtstruct(stamps[i] + deltas[pos[i]], &dts)
                 result[i] = _normalized_stamp(&dts)
 
-    return result
+    return result.base  # `.base` to access underlying ndarray
 
 
 cdef inline int64_t _normalized_stamp(npy_datetimestruct *dts) nogil:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -9,7 +9,6 @@ from pandas._libs import lib, tslib
 from pandas._libs.tslibs import (
     NaT,
     Timestamp,
-    ccalendar,
     conversion,
     fields,
     iNaT,
@@ -1036,14 +1035,8 @@ default 'raise'
                        '2014-08-01 00:00:00+05:30'],
                        dtype='datetime64[ns, Asia/Calcutta]', freq=None)
         """
-        if self.tz is None or timezones.is_utc(self.tz):
-            not_null = ~self.isna()
-            DAY_NS = ccalendar.DAY_SECONDS * 1_000_000_000
-            new_values = self.asi8.copy()
-            adjustment = new_values[not_null] % DAY_NS
-            new_values[not_null] = new_values[not_null] - adjustment
-        else:
-            new_values = conversion.normalize_i8_timestamps(self.asi8, self.tz)
+        new_values = conversion.normalize_i8_timestamps(self.asi8, self.tz)
+        new_values = np.asarray(new_values, dtype="i8")
         return type(self)(new_values)._with_freq("infer").tz_localize(self.tz)
 
     def to_period(self, freq=None):

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -9,6 +9,7 @@ from pandas._libs import lib, tslib
 from pandas._libs.tslibs import (
     NaT,
     Timestamp,
+    ccalendar,
     conversion,
     fields,
     iNaT,
@@ -1035,8 +1036,14 @@ default 'raise'
                        '2014-08-01 00:00:00+05:30'],
                        dtype='datetime64[ns, Asia/Calcutta]', freq=None)
         """
-        new_values = conversion.normalize_i8_timestamps(self.asi8, self.tz)
-        new_values = np.asarray(new_values, dtype="i8")
+        if self.tz is None or timezones.is_utc(self.tz):
+            not_null = ~self.isna()
+            DAY_NS = ccalendar.DAY_SECONDS * 1_000_000_000
+            new_values = self.asi8.copy()
+            adjustment = new_values[not_null] % DAY_NS
+            new_values[not_null] = new_values[not_null] - adjustment
+        else:
+            new_values = conversion.normalize_i8_timestamps(self.asi8, self.tz)
         return type(self)(new_values)._with_freq("infer").tz_localize(self.tz)
 
     def to_period(self, freq=None):


### PR DESCRIPTION
there's a tiny perf bump, but it all comes from doing `own_tz = self.tzinfo` up-front instead of accessing `self.tz` multiple times within `Timestamp.normalize`.  With just the cimport, this is actually slightly slower, which is something of a mystery.

The main upside is that we now only cimport from libconversion, which im hopeful will make some other circular-imports easier to simplify.the perf improvement 