### PR TITLE
DOC: updating the `indicator` wording in `merge` doc

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -237,8 +237,8 @@ indicator : bool or str, default False
     information on the source of each row. The column can be given a different
     name by providing a string argument. The column will have a Categorical
     type with the value of "left_only" for observations whose merge key only
-    appears in 'left' -> the left DataFrame, "right_only" for observations
-    whose merge key only appears in 'right' -> the right DataFrame, and "both"
+    appears in the left DataFrame, "right_only" for observations
+    whose merge key only appears in the right DataFrame, and "both"
     if the observation's merge key is found in both DataFrames.
 
 validate : str, optional

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -237,8 +237,8 @@ indicator : bool or str, default False
     information on the source of each row. The column can be given a different
     name by providing a string argument. The column will have a Categorical
     type with the value of "left_only" for observations whose merge key only
-    appears in 'left' -> the left DataFrame, "right_only" for observations 
-    whose merge key only appears in 'right' -> the right DataFrame, and "both" 
+    appears in 'left' -> the left DataFrame, "right_only" for observations
+    whose merge key only appears in 'right' -> the right DataFrame, and "both"
     if the observation's merge key is found in both DataFrames.
 
 validate : str, optional

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -233,14 +233,13 @@ suffixes : tuple of (str, str), default ('_x', '_y')
 copy : bool, default True
     If False, avoid copy if possible.
 indicator : bool or str, default False
-    If True, adds a column to output DataFrame called "_merge" with
-    information on the source of each row.
-    If string, column with information on source of each row will be added to
-    output DataFrame, and column will be named value of string.
-    Information column is Categorical-type and takes on a value of "left_only"
-    for observations whose merge key only appears in 'left' DataFrame,
-    "right_only" for observations whose merge key only appears in 'right'
-    DataFrame, and "both" if the observation's merge key is found in both.
+    If True, adds a column to the output DataFrame called "_merge" with
+    information on the source of each row. The column can be given a different
+    name by providing a string argument. The column will have a Categorical
+    type with the value of "left_only" for observations whose merge key only
+    appears in 'left' DataFrame, "right_only" for observations whose merge key
+    only appears in 'right' DataFrame, and "both" if the observation's merge
+    key is found in both.
 
 validate : str, optional
     If specified, checks if merge is of specified type.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -237,9 +237,9 @@ indicator : bool or str, default False
     information on the source of each row. The column can be given a different
     name by providing a string argument. The column will have a Categorical
     type with the value of "left_only" for observations whose merge key only
-    appears in 'left' DataFrame, "right_only" for observations whose merge key
-    only appears in 'right' DataFrame, and "both" if the observation's merge
-    key is found in both.
+    appears in 'left' -> the left DataFrame, "right_only" for observations 
+    whose merge key only appears in 'right' -> the right DataFrame, and "both" 
+    if the observation's merge key is found in both DataFrames.
 
 validate : str, optional
     If specified, checks if merge is of specified type.


### PR DESCRIPTION
- [ ] closes #34480 
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
