### PR TITLE
DOC: Added documentation for building using pyenv

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -1302,7 +1302,7 @@ to enable easy monitoring of the performance of critical pandas operations.
 These benchmarks are all found in the ``pandas/asv_bench`` directory.  asv
 supports both python2 and python3.
 
-To use all features of asv, you will need either ``conda``, or
+To use all features of asv, you will need either ``conda`` or
 ``virtualenv``. For more details please check the `asv installation
 webpage <https://asv.readthedocs.io/en/latest/installing.html>`_.
 

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -270,7 +270,7 @@ Creating a Python environment (pip)
 If you aren't using conda for your development environment, follow these instructions.
 You'll need to have at least Python 3.6.1 installed on your system.
 
-**Unix**/**Mac OS**
+**Unix**/**Mac OS with virtualenv**
 
 .. code-block:: bash
 
@@ -286,7 +286,31 @@ You'll need to have at least Python 3.6.1 installed on your system.
    python -m pip install -r requirements-dev.txt
 
    # Build and install pandas
-   python setup.py build_ext --inplace -j 0
+   python setup.py build_ext --inplace -j 4
+   python -m pip install -e . --no-build-isolation --no-use-pep517
+
+**Unix**/**Mac OS with pyenv**
+
+Consult the docs for setting up pyenv `here <https://github.com/pyenv/pyenv>`__.
+
+.. code-block:: bash
+
+   # Create a virtual environment
+   # Use an ENV_DIR of your choice. We'll use ~/Users/<yourname>/.pyenv/versions/pandas-dev
+
+   pyenv virtualenv <version> <name-to-give-it>
+   
+   #For instance:
+   pyenv virtualenv 3.7.6 pandas-dev
+
+   # Activate the virtualenv
+   pyenv global pandas-dev
+
+   # Now install the build dependencies in the cloned pandas repo
+   python -m pip install -r requirements-dev.txt
+
+   # Build and install pandas
+   python setup.py build_ext --inplace -j 4
    python -m pip install -e . --no-build-isolation --no-use-pep517
 
 **Windows**
@@ -312,7 +336,7 @@ should already exist.
    python -m pip install -r requirements-dev.txt
 
    # Build and install pandas
-   python setup.py build_ext --inplace -j 0
+   python setup.py build_ext --inplace -j 4
    python -m pip install -e . --no-build-isolation --no-use-pep517
 
 Creating a branch
@@ -1278,7 +1302,7 @@ to enable easy monitoring of the performance of critical pandas operations.
 These benchmarks are all found in the ``pandas/asv_bench`` directory.  asv
 supports both python2 and python3.
 
-To use all features of asv, you will need either ``conda`` or
+To use all features of asv, you will need either ``conda``, or
 ``virtualenv``. For more details please check the `asv installation
 webpage <https://asv.readthedocs.io/en/latest/installing.html>`_.
 

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -299,8 +299,8 @@ Consult the docs for setting up pyenv `here <https://github.com/pyenv/pyenv>`__.
    # Use an ENV_DIR of your choice. We'll use ~/Users/<yourname>/.pyenv/versions/pandas-dev
 
    pyenv virtualenv <version> <name-to-give-it>
-   
-   #For instance:
+
+   # For instance:
    pyenv virtualenv 3.7.6 pandas-dev
 
    # Activate the virtualenv

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -304,7 +304,7 @@ Consult the docs for setting up pyenv `here <https://github.com/pyenv/pyenv>`__.
    pyenv virtualenv 3.7.6 pandas-dev
 
    # Activate the virtualenv
-   pyenv global pandas-dev
+   pyenv activate pandas-dev
 
    # Now install the build dependencies in the cloned pandas repo
    python -m pip install -r requirements-dev.txt


### PR DESCRIPTION
Added documentation for building using pyenv. Discussed this PR with @WillAyd on gitter on May 20.

Also fixed up another line he mentioned (python setup.py build_ext --inplace -j 4
instead of:
python setup.py build_ext --inplace -j 0) for conda/venv/pyenv.

Have rebuilt the docs and ensured they build properly.
