### PR TITLE
BUG: Fix value setting in case of merging via index on one side and column on other side.

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -936,6 +936,7 @@ Reshaping
 - Bug in :meth:`DataFrame.replace` casts columns to ``object`` dtype if items in ``to_replace`` not in values (:issue:`32988`)
 - Ensure only named functions can be used in :func:`eval()` (:issue:`32460`)
 - Fixed bug in :func:`melt` where melting MultiIndex columns with ``col_level`` > 0 would raise a ``KeyError`` on ``id_vars`` (:issue:`34129`)
+- Fixed bug setting wrong values in result when joining one side over index and other side over column in case of join type not equal to inner (:issue:`17257`, :issue`28220`, :issue:`28243`, :issue:`33232`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -936,7 +936,7 @@ Reshaping
 - Bug in :meth:`DataFrame.replace` casts columns to ``object`` dtype if items in ``to_replace`` not in values (:issue:`32988`)
 - Ensure only named functions can be used in :func:`eval()` (:issue:`32460`)
 - Fixed bug in :func:`melt` where melting MultiIndex columns with ``col_level`` > 0 would raise a ``KeyError`` on ``id_vars`` (:issue:`34129`)
-- Fixed bug setting wrong values in result when joining one side over index and other side over column in case of join type not equal to inner (:issue:`17257`, :issue`28220`, :issue:`28243`, :issue:`33232`)
+- Fixed bug setting wrong values in result when joining one side over index and other side over column in case of join type not equal to inner (:issue:`17257`, :issue:`28220`, :issue:`28243` and :issue:`33232`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -787,33 +787,49 @@ class _MergeOperation:
             take_left, take_right = None, None
 
             if name in result:
+                array_like = is_array_like(rname) or is_array_like(lname)
+                right_in, left_in = False, False
+                if not array_like:
+                    right_in = (
+                        name in self.right_on
+                        or self.right_index is True
+                        and name in self.right.index.names
+                    )
+                    left_in = (
+                        name in self.left_on
+                        or self.left_index is True
+                        and name in self.left.index.names
+                    )
+                if right_in and left_in or array_like or self.how == "asof":
 
-                if left_indexer is not None and right_indexer is not None:
-                    if name in self.left:
+                    if left_indexer is not None and right_indexer is not None:
+                        if name in self.left:
 
-                        if left_has_missing is None:
-                            left_has_missing = (left_indexer == -1).any()
+                            if left_has_missing is None:
+                                left_has_missing = (left_indexer == -1).any()
 
-                        if left_has_missing:
-                            take_right = self.right_join_keys[i]
+                            if left_has_missing:
+                                take_right = self.right_join_keys[i]
 
-                            if not is_dtype_equal(
-                                result[name].dtype, self.left[name].dtype
-                            ):
-                                take_left = self.left[name]._values
+                                if not is_dtype_equal(
+                                    result[name].dtype, self.left[name].dtype
+                                ):
+                                    take_left = self.left[name]._values
 
-                    elif name in self.right:
+                        elif name in self.right:
 
-                        if right_has_missing is None:
-                            right_has_missing = (right_indexer == -1).any()
+                            if right_has_missing is None:
+                                right_has_missing = (right_indexer == -1).any()
 
-                        if right_has_missing:
-                            take_left = self.left_join_keys[i]
+                            if right_has_missing:
+                                take_left = self.left_join_keys[i]
 
-                            if not is_dtype_equal(
-                                result[name].dtype, self.right[name].dtype
-                            ):
-                                take_right = self.right[name]._values
+                                if not is_dtype_equal(
+                                    result[name].dtype, self.right[name].dtype
+                                ):
+                                    take_right = self.right[name]._values
+                else:
+                    continue
 
             elif left_indexer is not None and is_array_like(self.left_join_keys[i]):
                 take_left = self.left_join_keys[i]

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -800,7 +800,11 @@ class _MergeOperation:
                         or self.left_index is True
                         and name in self.left.index.names
                     )
-                if (not right_in or not left_in) and not array_like and self.how != "asof":
+                if (
+                    (not right_in or not left_in)
+                    and not array_like
+                    and self.how != "asof"
+                ):
                     continue
                 if left_indexer is not None and right_indexer is not None:
                     if name in self.left:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -800,36 +800,34 @@ class _MergeOperation:
                         or self.left_index is True
                         and name in self.left.index.names
                     )
-                if right_in and left_in or array_like or self.how == "asof":
-
-                    if left_indexer is not None and right_indexer is not None:
-                        if name in self.left:
-
-                            if left_has_missing is None:
-                                left_has_missing = (left_indexer == -1).any()
-
-                            if left_has_missing:
-                                take_right = self.right_join_keys[i]
-
-                                if not is_dtype_equal(
-                                    result[name].dtype, self.left[name].dtype
-                                ):
-                                    take_left = self.left[name]._values
-
-                        elif name in self.right:
-
-                            if right_has_missing is None:
-                                right_has_missing = (right_indexer == -1).any()
-
-                            if right_has_missing:
-                                take_left = self.left_join_keys[i]
-
-                                if not is_dtype_equal(
-                                    result[name].dtype, self.right[name].dtype
-                                ):
-                                    take_right = self.right[name]._values
-                else:
+                if (not right_in or not left_in) and not array_like and self.how != "asof":
                     continue
+                if left_indexer is not None and right_indexer is not None:
+                    if name in self.left:
+
+                        if left_has_missing is None:
+                            left_has_missing = (left_indexer == -1).any()
+
+                        if left_has_missing:
+                            take_right = self.right_join_keys[i]
+
+                            if not is_dtype_equal(
+                                result[name].dtype, self.left[name].dtype
+                            ):
+                                take_left = self.left[name]._values
+
+                    elif name in self.right:
+
+                        if right_has_missing is None:
+                            right_has_missing = (right_indexer == -1).any()
+
+                        if right_has_missing:
+                            take_left = self.left_join_keys[i]
+
+                            if not is_dtype_equal(
+                                result[name].dtype, self.right[name].dtype
+                            ):
+                                take_right = self.right[name]._values
 
             elif left_indexer is not None and is_array_like(self.left_join_keys[i]):
                 take_left = self.left_join_keys[i]


### PR DESCRIPTION
- [x] xref #15692
- [x] xref #17257 
- [x] xref #28220
- [x] xref #28243
- [x] xref #33232
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Until now the `_maybe_add_join_keys` function changed the target column in the result, if the join was done over index on one side and the column on the other side. This resulted in taking values from the index and setting them for the target column, which explained the weird behavior in the issues referenced. Together with #34468 this will fix the issues. Both combined will transfer the merged index in these cases and the merged columns with the correct name. As of now this fix will only transfer the values, so the index will be wrong here.

We can not skip the method completly, because this would cause issues in case of the column is in both `DataFrames` we have to run through this steps to ensure that the target values are right. So I check if this is only contained in one side.