### PR TITLE
DEPR: tz kwarg in Period.to_timestamp

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -702,7 +702,7 @@ Deprecations
   raise an ``IndexError`` in the future. You can manually convert to an integer key
   instead (:issue:`34191`).
 - The ``squeeze`` keyword in the ``groupby`` function is deprecated and will be removed in a future version (:issue:`32380`)
-- The ``tz`` keyword in :meth:`Period.to_timestamp` is deprecated and will be removed in a future version; use `per.to_timestamp(...).tz_localize(tz)`` instead (:issue:`????`)
+- The ``tz`` keyword in :meth:`Period.to_timestamp` is deprecated and will be removed in a future version; use `per.to_timestamp(...).tz_localize(tz)`` instead (:issue:`34522`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -702,6 +702,7 @@ Deprecations
   raise an ``IndexError`` in the future. You can manually convert to an integer key
   instead (:issue:`34191`).
 - The ``squeeze`` keyword in the ``groupby`` function is deprecated and will be removed in a future version (:issue:`32380`)
+- The ``tz`` keyword in :meth:`Period.to_timestamp` is deprecated and will be removed in a future version; use `per.to_timestamp(...).tz_localize(tz)`` instead (:issue:`????`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1,3 +1,5 @@
+import warnings
+
 from cpython.object cimport PyObject_RichCompareBool, Py_EQ, Py_NE
 
 from numpy cimport int64_t, import_array, ndarray
@@ -1724,6 +1726,15 @@ cdef class _Period:
         -------
         Timestamp
         """
+        if tz is not None:
+            warnings.warn(
+                "Period.to_timestamp `tz` argument is deprecated and will "
+                "be removed in a future version.  Use "
+                "`per.to_timestamp(...).tz_localize(tz)` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
         how = validate_end_alias(how)
 
         end = how == 'E'

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1733,7 +1733,7 @@ cdef class _Period:
                 "be removed in a future version.  Use "
                 "`per.to_timestamp(...).tz_localize(tz)` instead.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=1,
             )
 
         how = validate_end_alias(how)

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1727,6 +1727,7 @@ cdef class _Period:
         Timestamp
         """
         if tz is not None:
+            # GH#34522
             warnings.warn(
                 "Period.to_timestamp `tz` argument is deprecated and will "
                 "be removed in a future version.  Use "

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -221,7 +221,7 @@ def _use_dynamic_x(ax, data):
         x = data.index
         if base <= FreqGroup.FR_DAY:
             return x[:1].is_normalized
-        return Period(x[0], freq).to_timestamp(tz=x.tz) == x[0]
+        return Period(x[0], freq).to_timestamp().tz_localize(x.tz) == x[0]
     return True
 
 

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -506,6 +506,7 @@ class TestPeriodMethods:
 
     @pytest.mark.parametrize("tzstr", ["Europe/Brussels", "Asia/Tokyo", "US/Pacific"])
     def test_to_timestamp_tz_arg(self, tzstr):
+        # GH#34522 tz kwarg deprecated
         with tm.assert_produces_warning(FutureWarning):
             p = Period("1/1/2005", freq="M").to_timestamp(tz=tzstr)
         exp = Timestamp("1/1/2005", tz="UTC").tz_convert(tzstr)

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -506,7 +506,8 @@ class TestPeriodMethods:
 
     @pytest.mark.parametrize("tzstr", ["Europe/Brussels", "Asia/Tokyo", "US/Pacific"])
     def test_to_timestamp_tz_arg(self, tzstr):
-        p = Period("1/1/2005", freq="M").to_timestamp(tz=tzstr)
+        with tm.assert_produces_warning(FutureWarning):
+            p = Period("1/1/2005", freq="M").to_timestamp(tz=tzstr)
         exp = Timestamp("1/1/2005", tz="UTC").tz_convert(tzstr)
         exp_zone = pytz.timezone(tzstr).normalize(p)
 
@@ -514,7 +515,8 @@ class TestPeriodMethods:
         assert p.tz == exp_zone.tzinfo
         assert p.tz == exp.tz
 
-        p = Period("1/1/2005", freq="3H").to_timestamp(tz=tzstr)
+        with tm.assert_produces_warning(FutureWarning):
+            p = Period("1/1/2005", freq="3H").to_timestamp(tz=tzstr)
         exp = Timestamp("1/1/2005", tz="UTC").tz_convert(tzstr)
         exp_zone = pytz.timezone(tzstr).normalize(p)
 
@@ -522,7 +524,8 @@ class TestPeriodMethods:
         assert p.tz == exp_zone.tzinfo
         assert p.tz == exp.tz
 
-        p = Period("1/1/2005", freq="A").to_timestamp(freq="A", tz=tzstr)
+        with tm.assert_produces_warning(FutureWarning):
+            p = Period("1/1/2005", freq="A").to_timestamp(freq="A", tz=tzstr)
         exp = Timestamp("31/12/2005", tz="UTC").tz_convert(tzstr)
         exp_zone = pytz.timezone(tzstr).normalize(p)
 
@@ -530,7 +533,8 @@ class TestPeriodMethods:
         assert p.tz == exp_zone.tzinfo
         assert p.tz == exp.tz
 
-        p = Period("1/1/2005", freq="A").to_timestamp(freq="3H", tz=tzstr)
+        with tm.assert_produces_warning(FutureWarning):
+            p = Period("1/1/2005", freq="A").to_timestamp(freq="3H", tz=tzstr)
         exp = Timestamp("1/1/2005", tz="UTC").tz_convert(tzstr)
         exp_zone = pytz.timezone(tzstr).normalize(p)
 
@@ -544,20 +548,23 @@ class TestPeriodMethods:
     )
     def test_to_timestamp_tz_arg_dateutil(self, tzstr):
         tz = maybe_get_tz(tzstr)
-        p = Period("1/1/2005", freq="M").to_timestamp(tz=tz)
+        with tm.assert_produces_warning(FutureWarning):
+            p = Period("1/1/2005", freq="M").to_timestamp(tz=tz)
         exp = Timestamp("1/1/2005", tz="UTC").tz_convert(tzstr)
         assert p == exp
         assert p.tz == dateutil_gettz(tzstr.split("/", 1)[1])
         assert p.tz == exp.tz
 
-        p = Period("1/1/2005", freq="M").to_timestamp(freq="3H", tz=tz)
+        with tm.assert_produces_warning(FutureWarning):
+            p = Period("1/1/2005", freq="M").to_timestamp(freq="3H", tz=tz)
         exp = Timestamp("1/1/2005", tz="UTC").tz_convert(tzstr)
         assert p == exp
         assert p.tz == dateutil_gettz(tzstr.split("/", 1)[1])
         assert p.tz == exp.tz
 
     def test_to_timestamp_tz_arg_dateutil_from_string(self):
-        p = Period("1/1/2005", freq="M").to_timestamp(tz="dateutil/Europe/Brussels")
+        with tm.assert_produces_warning(FutureWarning):
+            p = Period("1/1/2005", freq="M").to_timestamp(tz="dateutil/Europe/Brussels")
         assert p.tz == dateutil_gettz("Europe/Brussels")
 
     def test_to_timestamp_mult(self):


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

inconsistent with PeriodArray/PeriodIndex methods
