### PR TITLE
CLN: remove Resolution.get_attrname_from_abbrev

### DIFF
--- a/pandas/_libs/tslibs/resolution.pyx
+++ b/pandas/_libs/tslibs/resolution.pyx
@@ -41,18 +41,6 @@ _reso_str_map = {
 
 _str_reso_map = {v: k for k, v in _reso_str_map.items()}
 
-# factor to multiply a value by to convert it to the next finer grained
-# resolution
-_reso_mult_map = {
-    RESO_NS: None,
-    RESO_US: 1000,
-    RESO_MS: 1000,
-    RESO_SEC: 1000,
-    RESO_MIN: 60,
-    RESO_HR: 60,
-    RESO_DAY: 24,
-}
-
 # ----------------------------------------------------------------------
 
 
@@ -145,17 +133,17 @@ class Resolution(Enum):
     def __ge__(self, other):
         return self.value >= other.value
 
-    @classmethod
-    def get_str(cls, reso: "Resolution") -> str:
+    @property
+    def attrname(self) -> str:
         """
-        Return resolution str against resolution code.
+        Return datetime attribute name corresponding to this Resolution.
 
         Examples
         --------
-        >>> Resolution.get_str(Resolution.RESO_SEC)
+        >>> Resolution.RESO_SEC.attrname
         'second'
         """
-        return _reso_str_map[reso.value]
+        return _reso_str_map[self.value]
 
     @classmethod
     def from_attrname(cls, attrname: str) -> "Resolution":
@@ -173,18 +161,6 @@ class Resolution(Enum):
         return cls(_str_reso_map[attrname])
 
     @classmethod
-    def get_attrname_from_abbrev(cls, freq: str) -> str:
-        """
-        Return resolution str against frequency str.
-
-        Examples
-        --------
-        >>> Resolution.get_attrname_from_abbrev('H')
-        'hour'
-        """
-        return _abbrev_to_attrnames[freq]
-
-    @classmethod
     def get_reso_from_freq(cls, freq: str) -> "Resolution":
         """
         Return resolution code against frequency str.
@@ -199,7 +175,8 @@ class Resolution(Enum):
         >>> Resolution.get_reso_from_freq('H') == Resolution.RESO_HR
         True
         """
-        return cls.from_attrname(cls.get_attrname_from_abbrev(freq))
+        attr_name = _abbrev_to_attrnames[freq]
+        return cls.from_attrname(attr_name)
 
 
 # ----------------------------------------------------------------------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1126,7 +1126,7 @@ class DatetimeLikeArrayMixin(
                 # somewhere in the past it was decided we default to day
                 return "day"
             # otherwise we fall through and will raise
-        return Resolution.get_str(self._resolution_obj)
+        return self._resolution_obj.attrname
 
     @classmethod
     def _validate_frequency(cls, index, freq, **kwargs):

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1126,7 +1126,7 @@ class DatetimeLikeArrayMixin(
                 # somewhere in the past it was decided we default to day
                 return "day"
             # otherwise we fall through and will raise
-        return self._resolution_obj.attrname
+        return self._resolution_obj.attrname  # type: ignore
 
     @classmethod
     def _validate_frequency(cls, index, freq, **kwargs):

--- a/pandas/tests/tseries/frequencies/test_freq_code.py
+++ b/pandas/tests/tseries/frequencies/test_freq_code.py
@@ -93,9 +93,6 @@ def test_get_to_timestamp_base(freqstr, exp_freqstr):
 @pytest.mark.parametrize(
     "freqstr,expected",
     [
-        ("A", "year"),
-        ("Q", "quarter"),
-        ("M", "month"),
         ("D", "day"),
         ("H", "hour"),
         ("T", "minute"),
@@ -106,19 +103,20 @@ def test_get_to_timestamp_base(freqstr, exp_freqstr):
     ],
 )
 def test_get_attrname_from_abbrev(freqstr, expected):
-    assert _reso.get_attrname_from_abbrev(freqstr) == expected
+    assert _reso.get_reso_from_freq(freqstr).attrname == expected
 
 
-@pytest.mark.parametrize("freq", ["A", "Q", "M", "D", "H", "T", "S", "L", "U", "N"])
-def test_get_freq_roundtrip(freq):
-    result = _attrname_to_abbrevs[_reso.get_attrname_from_abbrev(freq)]
-    assert freq == result
+@pytest.mark.parametrize("freq", ["A", "Q", "M"])
+def test_get_freq_unsupported_(freq):
+    # Lowest-frequency resolution is for Day
+    with pytest.raises(KeyError, match=freq.lower()):
+        _reso.get_reso_from_freq(freq)
 
 
-@pytest.mark.parametrize("freq", ["D", "H", "T", "S", "L", "U"])
+@pytest.mark.parametrize("freq", ["D", "H", "T", "S", "L", "U", "N"])
 def test_get_freq_roundtrip2(freq):
     obj = _reso.get_reso_from_freq(freq)
-    result = _attrname_to_abbrevs[_reso.get_str(obj)]
+    result = _attrname_to_abbrevs[obj.attrname]
     assert freq == result
 
 


### PR DESCRIPTION
rename get_str -> attrname, make it a property instead of a classmethod