### PR TITLE
DOC: remove an extra colon

### DIFF
--- a/doc/source/user_guide/gotchas.rst
+++ b/doc/source/user_guide/gotchas.rst
@@ -321,7 +321,7 @@ Byte-ordering issues
 --------------------
 Occasionally you may have to deal with data that were created on a machine with
 a different byte order than the one on which you are running Python. A common
-symptom of this issue is an error like:::
+symptom of this issue is an error like::
 
     Traceback
         ...


### PR DESCRIPTION
fix a typo by removing an extra colon

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
