### PR TITLE
CI/TST #34131 fixed test_floordiv_axis0_numexpr_path

### DIFF
--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -14,7 +14,6 @@ import pandas.core.common as com
 from pandas.core.computation.expressions import (
     _MIN_ELEMENTS,
     _NUMEXPR_INSTALLED,
-    _USE_NUMEXPR,
 )
 from pandas.tests.frame.common import _check_mixed_float, _check_mixed_int
 
@@ -379,6 +378,7 @@ class TestFrameFlexArithmetic:
         result2 = df.floordiv(ser.values, axis=0)
         tm.assert_frame_equal(result2, expected)
 
+    @pytest.mark.skipif(not _NUMEXPR_INSTALLED, reason="numexpr not installed")
     @pytest.mark.parametrize("opname", ["floordiv", "pow"])
     def test_floordiv_axis0_numexpr_path(self, opname):
         # case that goes through numexpr and has to fall back to masked_arith_op
@@ -386,10 +386,6 @@ class TestFrameFlexArithmetic:
 
         arr = np.arange(_MIN_ELEMENTS + 100).reshape(_MIN_ELEMENTS // 100 + 1, -1) * 100
         df = pd.DataFrame(arr)
-        if _NUMEXPR_INSTALLED:
-            assert _USE_NUMEXPR
-        else:
-            return
         df["C"] = 1.0
 
         ser = df[0]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -10,7 +10,11 @@ import pytz
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series
 import pandas._testing as tm
-from pandas.core.computation.expressions import _USE_NUMEXPR, _MIN_ELEMENTS
+from pandas.core.computation.expressions import (
+    _USE_NUMEXPR,
+    _MIN_ELEMENTS,
+    _NUMEXPR_INSTALLED,
+)
 import pandas.core.common as com
 from pandas.tests.frame.common import _check_mixed_float, _check_mixed_int
 
@@ -384,6 +388,8 @@ class TestFrameFlexArithmetic:
         df = pd.DataFrame(arr)
         if _NUMEXPR_INSTALLED:
             assert _USE_NUMEXPR
+        else:
+            return
         df["C"] = 1.0
 
         ser = df[0]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -10,6 +10,7 @@ import pytz
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series
 import pandas._testing as tm
+from pandas.core.computation.expressions import _USE_NUMEXPR, _MIN_ELEMENTS
 import pandas.core.common as com
 from pandas.tests.frame.common import _check_mixed_float, _check_mixed_int
 
@@ -379,8 +380,9 @@ class TestFrameFlexArithmetic:
         # case that goes through numexpr and has to fall back to masked_arith_op
         op = getattr(operator, opname)
 
-        arr = np.arange(10 ** 4).reshape(100, -1) * 100
+        arr = np.arange(_MIN_ELEMENTS + 100).reshape(_MIN_ELEMENTS // 100 + 1, -1) * 100
         df = pd.DataFrame(arr)
+        assert _USE_NUMEXPR
         df["C"] = 1.0
 
         ser = df[0]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -379,7 +379,7 @@ class TestFrameFlexArithmetic:
         # case that goes through numexpr and has to fall back to masked_arith_op
         op = getattr(operator, opname)
 
-        arr = np.arange(10 ** 3).reshape(100, -1) * 1000
+        arr = np.arange(10 ** 4).reshape(100, -1) * 100
         df = pd.DataFrame(arr)
         df["C"] = 1.0
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -10,12 +10,12 @@ import pytz
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series
 import pandas._testing as tm
+import pandas.core.common as com
 from pandas.core.computation.expressions import (
     _USE_NUMEXPR,
     _MIN_ELEMENTS,
     _NUMEXPR_INSTALLED,
 )
-import pandas.core.common as com
 from pandas.tests.frame.common import _check_mixed_float, _check_mixed_int
 
 # -------------------------------------------------------------------

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -382,7 +382,8 @@ class TestFrameFlexArithmetic:
 
         arr = np.arange(_MIN_ELEMENTS + 100).reshape(_MIN_ELEMENTS // 100 + 1, -1) * 100
         df = pd.DataFrame(arr)
-        assert _USE_NUMEXPR
+        if _NUMEXPR_INSTALLED:
+            assert _USE_NUMEXPR
         df["C"] = 1.0
 
         ser = df[0]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -374,13 +374,12 @@ class TestFrameFlexArithmetic:
         result2 = df.floordiv(ser.values, axis=0)
         tm.assert_frame_equal(result2, expected)
 
-    @pytest.mark.slow
     @pytest.mark.parametrize("opname", ["floordiv", "pow"])
     def test_floordiv_axis0_numexpr_path(self, opname):
         # case that goes through numexpr and has to fall back to masked_arith_op
         op = getattr(operator, opname)
 
-        arr = np.arange(10 ** 6).reshape(100, -1)
+        arr = np.arange(10 ** 3).reshape(100, -1) * 1000
         df = pd.DataFrame(arr)
         df["C"] = 1.0
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -12,9 +12,9 @@ from pandas import DataFrame, MultiIndex, Series
 import pandas._testing as tm
 import pandas.core.common as com
 from pandas.core.computation.expressions import (
-    _USE_NUMEXPR,
     _MIN_ELEMENTS,
     _NUMEXPR_INSTALLED,
+    _USE_NUMEXPR,
 )
 from pandas.tests.frame.common import _check_mixed_float, _check_mixed_int
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -11,10 +11,7 @@ import pandas as pd
 from pandas import DataFrame, MultiIndex, Series
 import pandas._testing as tm
 import pandas.core.common as com
-from pandas.core.computation.expressions import (
-    _MIN_ELEMENTS,
-    _NUMEXPR_INSTALLED,
-)
+from pandas.core.computation.expressions import _MIN_ELEMENTS, _NUMEXPR_INSTALLED
 from pandas.tests.frame.common import _check_mixed_float, _check_mixed_int
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
xref #34131 

- [ x ] passes `black pandas`
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Test `/pandas/tests/frame/test_floordiv_axis0_numexpr_path` is slow. It builds a df with 10^6 elements to tests functions `floordiv` and `pow`. The number of elements can be reduced with keeping the same min/max values inside the dataframe.

Before/after timeit comparison:
```
26.6 s ± 1.04 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
37.6 ms ± 3.45 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```