### PR TITLE
DOC: fix PR06 (parameter type) errors in Timestamp docstrings

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1053,7 +1053,7 @@ timedelta}, default 'raise'
 
         Parameters
         ----------
-        locale : string, default None (English locale)
+        locale :str, default None (English locale)
             Locale determining the language in which to return the day name.
 
         Returns
@@ -1070,7 +1070,7 @@ timedelta}, default 'raise'
 
         Parameters
         ----------
-        locale : string, default None (English locale)
+        locale : str, default None (English locale)
             Locale determining the language in which to return the month name.
 
         Returns


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
