### PR TITLE
solves ci issues with #34575

### DIFF
--- a/asv_bench/benchmarks/arithmetic.py
+++ b/asv_bench/benchmarks/arithmetic.py
@@ -466,7 +466,7 @@ class ApplyIndex:
         self.rng = rng
 
     def time_apply_index(self, offset):
-        offset.apply_index(self.rng)
+        self.rng + offset
 
 
 class BinaryOpsMultiIndex:


### PR DESCRIPTION
- [x] closes #34575 
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
solved issues with benchmarks
benchmarks running fine now

Current right output
```
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_moha_venv_pandas-dev_bin_python
[ 50.00%] ··· arithmetic.ApplyIndex.time_apply_indexgit                                                                                                ok
[ 50.00%] ··· =================================== ==========
                             offset                         
              ----------------------------------- ----------
                      <YearEnd: month=12>          2.05±0ms 
                      <YearBegin: month=1>         1.56±0ms 
                 <QuarterEnd: startingMonth=3>     4.41±0ms 
                <QuarterBegin: startingMonth=3>    2.50±0ms 
                           <MonthEnd>              4.32±0ms 
                          <MonthBegin>             2.31±0ms 
                 <DateOffset: days=2, months=2>    5.67±0ms 
                         <BusinessDay>             10.4±0ms 
                <SemiMonthEnd: day_of_month=15>    14.5±0ms 
               <SemiMonthBegin: day_of_month=15>   14.2±0ms 
              =================================== ==========
```