### PR TITLE
DataFrame.truncate drops MultiIndex names

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -911,7 +911,7 @@ MultiIndex
         df.loc[(['b', 'a'], [2, 1]), :]
 
 - Bug in :meth:`MultiIndex.intersection` was not guaranteed to preserve order when ``sort=False``. (:issue:`31325`)
-- Bug in :meth:`DataFrame.truncate` was dropping MultiIndex names. (:issue:`34564`)
+- Bug in :meth:`DataFrame.truncate` was dropping :class:`MultiIndex` names. (:issue:`34564`)
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -911,6 +911,7 @@ MultiIndex
         df.loc[(['b', 'a'], [2, 1]), :]
 
 - Bug in :meth:`MultiIndex.intersection` was not guaranteed to preserve order when ``sort=False``. (:issue:`31325`)
+- Bug in :meth:`DataFrame.truncate` was dropping MultiIndex names. (:issue:`34564`)
 
 .. ipython:: python
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3195,7 +3195,12 @@ class MultiIndex(Index):
         new_codes = [level_codes[left:right] for level_codes in self.codes]
         new_codes[0] = new_codes[0] - i
 
-        return MultiIndex(levels=new_levels, codes=new_codes, verify_integrity=False)
+        return MultiIndex(
+            levels=new_levels,
+            codes=new_codes,
+            names=self._names,
+            verify_integrity=False,
+        )
 
     def equals(self, other) -> bool:
         """

--- a/pandas/tests/frame/methods/test_truncate.py
+++ b/pandas/tests/frame/methods/test_truncate.py
@@ -104,3 +104,15 @@ class TestDataFrameTruncate:
         result = values.truncate(before=before, after=after)
         expected = values.loc[indices]
         tm.assert_frame_equal(result, expected)
+
+    def test_truncate_multiindex(self):
+        mi = pd.MultiIndex.from_product([[1, 2, 3, 4], ["A", "B"]], names=["L1", "L2"])
+        s1 = pd.DataFrame(range(mi.shape[0]), index=mi, columns=["col"])
+        result = s1.truncate(before=2, after=3)
+
+        df = pd.DataFrame.from_dict(
+            {"L1": [2, 2, 3, 3], "L2": ["A", "B", "A", "B"], "col": [2, 3, 4, 5]}
+        )
+        expected = df.set_index(["L1", "L2"])
+
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_truncate.py
+++ b/pandas/tests/frame/methods/test_truncate.py
@@ -106,6 +106,7 @@ class TestDataFrameTruncate:
         tm.assert_frame_equal(result, expected)
 
     def test_truncate_multiindex(self):
+        # GH 34564
         mi = pd.MultiIndex.from_product([[1, 2, 3, 4], ["A", "B"]], names=["L1", "L2"])
         s1 = pd.DataFrame(range(mi.shape[0]), index=mi, columns=["col"])
         result = s1.truncate(before=2, after=3)

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -31,6 +31,7 @@ def test_groupby(idx):
 
 
 def test_truncate():
+    # GH 34564 for MultiIndex level names check
     major_axis = Index(list(range(4)))
     minor_axis = Index(list(range(2)))
 
@@ -38,19 +39,24 @@ def test_truncate():
     minor_codes = np.array([0, 1, 0, 1, 0, 1])
 
     index = MultiIndex(
-        levels=[major_axis, minor_axis], codes=[major_codes, minor_codes]
+        levels=[major_axis, minor_axis],
+        codes=[major_codes, minor_codes],
+        names=["L1", "L2"],
     )
 
     result = index.truncate(before=1)
     assert "foo" not in result.levels[0]
     assert 1 in result.levels[0]
+    assert index.names == result.names
 
     result = index.truncate(after=1)
     assert 2 not in result.levels[0]
     assert 1 in result.levels[0]
+    assert index.names == result.names
 
     result = index.truncate(before=1, after=2)
     assert len(result.levels[0]) == 2
+    assert index.names == result.names
 
     msg = "after < before"
     with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -30,7 +30,7 @@ def test_groupby(idx):
     tm.assert_dict_equal(groups, exp)
 
 
-def test_truncate():
+def test_truncate_multiindex():
     # GH 34564 for MultiIndex level names check
     major_axis = Index(list(range(4)))
     minor_axis = Index(list(range(2)))

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -744,11 +744,3 @@ class TestMultiIndexSlicers:
         result = df.loc[tslice_]
         expected = pd.DataFrame({("b", "d"): [4, 1]})
         tm.assert_frame_equal(result, expected)
-
-    def test_truncate_multiindex_names(self):
-        # GH 34564
-
-        mi = pd.MultiIndex.from_product([[1, 2, 3, 4], ["A", "B"]], names=["L1", "L2"])
-        s1 = pd.Series(range(mi.shape[0]), index=mi)
-        s2 = s1.truncate(before=2, after=3)
-        assert s1.index.names == s2.index.names

--- a/pandas/tests/indexing/multiindex/test_slice.py
+++ b/pandas/tests/indexing/multiindex/test_slice.py
@@ -744,3 +744,11 @@ class TestMultiIndexSlicers:
         result = df.loc[tslice_]
         expected = pd.DataFrame({("b", "d"): [4, 1]})
         tm.assert_frame_equal(result, expected)
+
+    def test_truncate_multiindex_names(self):
+        # GH 34564
+
+        mi = pd.MultiIndex.from_product([[1, 2, 3, 4], ["A", "B"]], names=["L1", "L2"])
+        s1 = pd.Series(range(mi.shape[0]), index=mi)
+        s2 = s1.truncate(before=2, after=3)
+        assert s1.index.names == s2.index.names

--- a/pandas/tests/series/methods/test_truncate.py
+++ b/pandas/tests/series/methods/test_truncate.py
@@ -126,3 +126,16 @@ class TestTruncate:
 
         expected_idx2 = pd.PeriodIndex([pd.Period("2017-09-02")])
         tm.assert_series_equal(result2, pd.Series([2], index=expected_idx2))
+
+    def test_truncate_multiindex(self):
+        mi = pd.MultiIndex.from_product([[1, 2, 3, 4], ["A", "B"]], names=["L1", "L2"])
+        s1 = pd.Series(range(mi.shape[0]), index=mi)
+        result = s1.truncate(before=2, after=3)
+
+        df = pd.DataFrame.from_dict(
+            {"L1": [2, 2, 3, 3], "L2": ["A", "B", "A", "B"], "col": [2, 3, 4, 5]}
+        )
+        df.set_index(["L1", "L2"], inplace=True)
+        expected = df.col
+
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_truncate.py
+++ b/pandas/tests/series/methods/test_truncate.py
@@ -129,7 +129,7 @@ class TestTruncate:
 
     def test_truncate_multiindex(self):
         mi = pd.MultiIndex.from_product([[1, 2, 3, 4], ["A", "B"]], names=["L1", "L2"])
-        s1 = pd.Series(range(mi.shape[0]), index=mi)
+        s1 = pd.Series(range(mi.shape[0]), index=mi, name="col")
         result = s1.truncate(before=2, after=3)
 
         df = pd.DataFrame.from_dict(

--- a/pandas/tests/series/methods/test_truncate.py
+++ b/pandas/tests/series/methods/test_truncate.py
@@ -128,6 +128,7 @@ class TestTruncate:
         tm.assert_series_equal(result2, pd.Series([2], index=expected_idx2))
 
     def test_truncate_multiindex(self):
+        # GH 34564
         mi = pd.MultiIndex.from_product([[1, 2, 3, 4], ["A", "B"]], names=["L1", "L2"])
         s1 = pd.Series(range(mi.shape[0]), index=mi, name="col")
         result = s1.truncate(before=2, after=3)


### PR DESCRIPTION
- [x] closes #34564
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
- [x] added tests
- [ ] passes tests (fixed for `DataFrame`, still issue for `Series`)