### PR TITLE
PERF: isinstance ABCIndexClass and ABCExtensionArray

### DIFF
--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -38,7 +38,7 @@ ABCIntervalIndex = create_pandas_abc_type(
 ABCIndexClass = create_pandas_abc_type(
     "ABCIndexClass",
     "_typ",
-    (
+    {
         "index",
         "int64index",
         "rangeindex",
@@ -50,7 +50,7 @@ ABCIndexClass = create_pandas_abc_type(
         "periodindex",
         "categoricalindex",
         "intervalindex",
-    ),
+    },
 )
 
 ABCSeries = create_pandas_abc_type("ABCSeries", "_typ", ("series",))
@@ -66,6 +66,6 @@ ABCExtensionArray = create_pandas_abc_type(
     "ABCExtensionArray",
     "_typ",
     # Note: IntervalArray and SparseArray are included bc they have _typ="extension"
-    ("extension", "categorical", "periodarray", "datetimearray", "timedeltaarray"),
+    {"extension", "categorical", "periodarray", "datetimearray", "timedeltaarray"},
 )
 ABCPandasArray = create_pandas_abc_type("ABCPandasArray", "_typ", ("npy_extension",))


### PR DESCRIPTION
```
%timeit isinstance(pd.Series, pd.core.dtypes.generic.ABCIndexClass)
# 607 ns ± 12.4 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each) - PR
# 937 ns ± 37.5 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each) - Master


%timeit isinstance(pd.Series, pd.core.dtypes.generic.ABCExtensionArray)
# 634 ns ± 26.9 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each) - PR
# 759 ns ± 40.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each) - Master


%timeit isinstance(pd.Series, pd.core.dtypes.generic.ABCSeries)
# 638 ns ± 49.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each) - PR
# 644 ns ± 20.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each) - Master
```