### PR TITLE
Improve document for **kwargs argument of pandas.Series.to_markdown

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1422,6 +1422,21 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         |  1 | pig      |
         |  2 | dog      |
         |  3 | quetzal  |
+
+        Output markdown with a tabulate option.
+
+        >>> print(s.to_markdown(tablefmt="grid"))
+        +----+----------+
+        |    | animal   |
+        +====+==========+
+        |  0 | elk      |
+        +----+----------+
+        |  1 | pig      |
+        +----+----------+
+        |  2 | dog      |
+        +----+----------+
+        |  3 | quetzal  |
+        +----+----------+
         """
     )
     @Substitution(klass="Series")


### PR DESCRIPTION
This is a follow-up PR of #34594 .  
`pandas.Series.to_markdown` has also same argument.

This PR adds example for `pandas.Series.to_markdown` with tabulate option.

Related Issue: #34568 