### PR TITLE
TST: boolean indexing using .iloc #20627

### DIFF
--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -530,6 +530,14 @@ def test_iloc_with_boolean_operation():
     expected = DataFrame([[0, 4], [8, 12], [8, 10], [12, np.nan]])
     tm.assert_frame_equal(result, expected)
 
+    result.iloc[result.index <= 2, 0] *= 2
+    expected = DataFrame([[0, 4], [16, 12], [16, 10], [12, np.nan]])
+    tm.assert_frame_equal(result, expected)
+
+    result.iloc[result.index > 2, 0] *= 2
+    expected = DataFrame([[0, 4], [16, 12], [16, 10], [24, np.nan]])
+    tm.assert_frame_equal(result, expected)
+
     result.iloc[[False, False, True, True]] /= 2
-    expected = DataFrame([[0.0, 4.0], [8.0, 12.0], [4.0, 5.0], [6.0, np.nan]])
+    expected = DataFrame([[0.0, 4.0], [16.0, 12.0], [8.0, 5.0], [12.0, np.nan]])
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -513,23 +513,3 @@ class TestDataFrameNonuniqueIndexes:
 
         df.iloc[:, 0] = 3
         tm.assert_series_equal(df.iloc[:, 1], expected)
-
-
-def test_iloc_with_boolean_operation():
-    # GH 20627
-    result = DataFrame([[0, 1], [2, 3], [4, 5], [6, np.nan]])
-    result.iloc[result.index <= 2] *= 2
-    expected = DataFrame([[0, 2], [4, 6], [8, 10], [6, np.nan]])
-    tm.assert_frame_equal(result, expected)
-
-    result.iloc[result.index > 2] *= 2
-    expected = DataFrame([[0, 2], [4, 6], [8, 10], [12, np.nan]])
-    tm.assert_frame_equal(result, expected)
-
-    result.iloc[[True, True, False, False]] *= 2
-    expected = DataFrame([[0, 4], [8, 12], [8, 10], [12, np.nan]])
-    tm.assert_frame_equal(result, expected)
-
-    result.iloc[[False, False, True, True]] /= 2
-    expected = DataFrame([[0.0, 4.0], [8.0, 12.0], [4.0, 5.0], [6.0, np.nan]])
-    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -513,3 +513,23 @@ class TestDataFrameNonuniqueIndexes:
 
         df.iloc[:, 0] = 3
         tm.assert_series_equal(df.iloc[:, 1], expected)
+
+
+def test_iloc_with_boolean_operation():
+    # GH 20627
+    result = DataFrame([[0, 1], [2, 3], [4, 5], [6, np.nan]])
+    result.iloc[result.index <= 2] *= 2
+    expected = DataFrame([[0, 2], [4, 6], [8, 10], [6, np.nan]])
+    tm.assert_frame_equal(result, expected)
+
+    result.iloc[result.index > 2] *= 2
+    expected = DataFrame([[0, 2], [4, 6], [8, 10], [12, np.nan]])
+    tm.assert_frame_equal(result, expected)
+
+    result.iloc[[True, True, False, False]] *= 2
+    expected = DataFrame([[0, 4], [8, 12], [8, 10], [12, np.nan]])
+    tm.assert_frame_equal(result, expected)
+
+    result.iloc[[False, False, True, True]] /= 2
+    expected = DataFrame([[0.0, 4.0], [8.0, 12.0], [4.0, 5.0], [6.0, np.nan]])
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -530,14 +530,6 @@ def test_iloc_with_boolean_operation():
     expected = DataFrame([[0, 4], [8, 12], [8, 10], [12, np.nan]])
     tm.assert_frame_equal(result, expected)
 
-    result.iloc[result.index <= 2, 0] *= 2
-    expected = DataFrame([[0, 4], [16, 12], [16, 10], [12, np.nan]])
-    tm.assert_frame_equal(result, expected)
-
-    result.iloc[result.index > 2, 0] *= 2
-    expected = DataFrame([[0, 4], [16, 12], [16, 10], [24, np.nan]])
-    tm.assert_frame_equal(result, expected)
-
     result.iloc[[False, False, True, True]] /= 2
-    expected = DataFrame([[0.0, 4.0], [16.0, 12.0], [8.0, 5.0], [12.0, np.nan]])
+    expected = DataFrame([[0.0, 4.0], [8.0, 12.0], [4.0, 5.0], [6.0, np.nan]])
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -705,6 +705,25 @@ class TestiLoc2:
         expected = pd.Categorical(["C", "B", "A"])
         tm.assert_categorical_equal(cat, expected)
 
+    def test_iloc_with_boolean_operation():
+        # GH 20627
+        result = DataFrame([[0, 1], [2, 3], [4, 5], [6, np.nan]])
+        result.iloc[result.index <= 2] *= 2
+        expected = DataFrame([[0, 2], [4, 6], [8, 10], [6, np.nan]])
+        tm.assert_frame_equal(result, expected)
+
+        result.iloc[result.index > 2] *= 2
+        expected = DataFrame([[0, 2], [4, 6], [8, 10], [12, np.nan]])
+        tm.assert_frame_equal(result, expected)
+
+        result.iloc[[True, True, False, False]] *= 2
+        expected = DataFrame([[0, 4], [8, 12], [8, 10], [12, np.nan]])
+        tm.assert_frame_equal(result, expected)
+
+        result.iloc[[False, False, True, True]] /= 2
+        expected = DataFrame([[0.0, 4.0], [8.0, 12.0], [4.0, 5.0], [6.0, np.nan]])
+        tm.assert_frame_equal(result, expected)
+
 
 class TestILocSetItemDuplicateColumns:
     def test_iloc_setitem_scalar_duplicate_columns(self):

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -705,7 +705,7 @@ class TestiLoc2:
         expected = pd.Categorical(["C", "B", "A"])
         tm.assert_categorical_equal(cat, expected)
 
-    def test_iloc_with_boolean_operation():
+    def test_iloc_with_boolean_operation(self):
         # GH 20627
         result = DataFrame([[0, 1], [2, 3], [4, 5], [6, np.nan]])
         result.iloc[result.index <= 2] *= 2


### PR DESCRIPTION
- [x] closes #20627
- [1] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

A simple test was added to close this issue.
