### PR TITLE
ENH: Add max_results kwarg to read_gbq

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -291,6 +291,7 @@ Other enhancements
 - :meth:`groupby.transform` now allows ``func`` to be ``pad``, ``backfill`` and ``cumcount`` (:issue:`31269`).
 - :meth:`~pandas.io.json.read_json` now accepts `nrows` parameter. (:issue:`33916`).
 - :meth `~pandas.io.gbq.read_gbq` now allows to disable progress bar (:issue:`33360`).
+- :meth:`~pandas.io.gbq.read_gbq` now supports the ``max_results`` kwarg from ``pandas-gbq`` (:issue:`34639`).
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -30,6 +30,7 @@ def read_gbq(
     configuration: Optional[Dict[str, Any]] = None,
     credentials=None,
     use_bqstorage_api: Optional[bool] = None,
+    max_results: Optional[int] = None,
     private_key=None,
     verbose=None,
     progress_bar_type: Optional[str] = None,
@@ -125,6 +126,13 @@ def read_gbq(
         ``fastavro`` packages.
 
         .. versionadded:: 0.25.0
+    max_results : int, optional
+        If set, limit the maximum number of rows to fetch from the query
+        results.
+
+        *New in version 0.12.0 of pandas-gbq*.
+
+        .. versionadded:: 1.1.0
     progress_bar_type : Optional, str
         If set, use the `tqdm <https://tqdm.github.io/>`__ library to
         display a progress bar while the data downloads. Install the
@@ -162,11 +170,13 @@ def read_gbq(
     """
     pandas_gbq = _try_import()
 
-    kwargs: Dict[str, Union[str, bool, None]] = {}
+    kwargs: Dict[str, Union[str, bool, int, None]] = {}
 
     # START: new kwargs.  Don't populate unless explicitly set.
     if use_bqstorage_api is not None:
         kwargs["use_bqstorage_api"] = use_bqstorage_api
+    if max_results is not None:
+        kwargs["max_results"] = max_results
 
     kwargs["progress_bar_type"] = progress_bar_type
     # END: new kwargs

--- a/pandas/tests/io/test_gbq.py
+++ b/pandas/tests/io/test_gbq.py
@@ -113,9 +113,10 @@ def test_read_gbq_with_new_kwargs(monkeypatch):
         return DataFrame([[1.0]])
 
     monkeypatch.setattr("pandas_gbq.read_gbq", mock_read_gbq)
-    pd.read_gbq("SELECT 1", use_bqstorage_api=True)
+    pd.read_gbq("SELECT 1", use_bqstorage_api=True, max_results=1)
 
     assert captured_kwargs["use_bqstorage_api"]
+    assert captured_kwargs["max_results"]
 
 
 def test_read_gbq_without_new_kwargs(monkeypatch):
@@ -129,6 +130,7 @@ def test_read_gbq_without_new_kwargs(monkeypatch):
     pd.read_gbq("SELECT 1")
 
     assert "use_bqstorage_api" not in captured_kwargs
+    assert "max_results" not in captured_kwargs
 
 
 @pytest.mark.parametrize("progress_bar", [None, "foo"])


### PR DESCRIPTION
Adds support for the new `max_results` kwarg from pandas-gbq (added in [0.12.0](https://github.com/pydata/pandas-gbq/releases/tag/0.12.0)). Since `max_results` is a new kwarg, it is handled and tested in the same way as the `use_bqstorage_api` kwarg to maintain backwards compatibility.

❓ **Open question:** Setting `max_results=0` causes `pandas_gbq.read_gbq` to return `None` instead of a DataFrame. I've kept this behaviour the same in this PR, but maintainers may prefer to always return a (empty) DataFrame instead of `None`.

- [x] closes #34639
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

