### PR TITLE
CLN: disallow passing tuples for Period freq

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -403,6 +403,7 @@ Backwards incompatible API changes
 - :func:`read_excel` no longer takes ``**kwds`` arguments. This means that passing in keyword ``chunksize`` now raises a ``TypeError``
   (previously raised a ``NotImplementedError``), while passing in keyword ``encoding`` now raises a ``TypeError`` (:issue:`34464`)
 - :func: `merge` now checks ``suffixes`` parameter type to be ``tuple`` and raises ``TypeError``, whereas before a ``list`` or ``set`` were accepted and that the ``set`` could produce unexpected results (:issue:`33740`)
+- :class:`Period` no longer accepts tuples for the ``freq`` argument (:issue:`34658`)
 
 ``MultiIndex.get_indexer`` interprets `method` argument differently
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1536,9 +1536,10 @@ cdef class _Period:
         -------
         DateOffset
         """
-        if isinstance(freq, (int, tuple)):
-            code, stride = get_freq_code(freq)
-            freq = get_freq_str(code, stride)
+        if isinstance(freq, int):
+            # We already have a dtype code
+            dtype = PeriodDtypeBase(freq)
+            freq = dtype.date_offset
 
         freq = to_offset(freq)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -501,7 +501,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             raise KeyError
 
         grp = get_freq_group(reso)
-        per = Period(parsed, freq=(grp, 1))
+        per = Period(parsed, freq=grp)
         start, end = per.start_time, per.end_time
 
         # GH 24076

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -574,7 +574,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
             raise KeyError(reso)
 
         grp = get_freq_group(reso)
-        iv = Period(parsed, freq=(grp, 1))
+        iv = Period(parsed, freq=grp)
         return (iv.asfreq(self.freq, how="start"), iv.asfreq(self.freq, how="end"))
 
     def _validate_partial_date_slice(self, reso: str):


### PR DESCRIPTION
Really looking forward to killing off `get_freq_code`