### PR TITLE
CLN: dont consolidate in groupby

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -497,7 +497,6 @@ class _GroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
         self._selection = selection
 
         assert isinstance(obj, NDFrame), type(obj)
-        obj._consolidate_inplace()
 
         self.level = level
 


### PR DESCRIPTION
full asv run looks like pure noise

```
       before           after         ratio
     [03f5066c]       [f2cae354]
     <master~3>       <cln-consolidate-less-3>
+      38.4±0.1μs         45.7±6μs     1.19  algorithms.SortIntegerArray.time_argsort(1000)
+      11.5±0.2ms       13.3±0.4ms     1.16  groupby.Nth.time_series_nth('float64')
+     7.09±0.02ms      8.02±0.04ms     1.13  io.hdf.HDFStoreDataFrame.time_query_store_table
+      12.3±0.1μs       13.7±0.3μs     1.11  tslibs.timestamp.TimestampOps.time_replace_None('US/Eastern')
+     3.96±0.03μs      4.36±0.04μs     1.10  period.Indexing.time_get_loc
-        1.25±0ms         1.13±0ms     0.91  arithmetic.OffsetArrayArithmetic.time_add_series_offset(<DateOffset: days=2, months=2>)
-        1.22±0ms         1.10±0ms     0.90  arithmetic.OffsetArrayArithmetic.time_add_dti_offset(<DateOffset: days=2, months=2>)
-      1.54±0.1μs      1.39±0.06μs     0.90  index_cached_properties.IndexCache.time_is_all_dates('MultiIndex')
-      12.9±0.5μs       11.6±0.5μs     0.90  tslibs.timedelta.TimedeltaConstructor.time_from_components
-     3.75±0.06ms         3.35±0ms     0.89  rolling.ForwardWindowMethods.time_rolling('Series', 1000, 'float', 'min')
-     1.22±0.01ms         1.08±0ms     0.89  arithmetic.ApplyIndex.time_apply_index(<DateOffset: days=2, months=2>)
-      4.47±0.2μs      3.95±0.08μs     0.88  tslibs.timedelta.TimedeltaConstructor.time_from_datetime_timedelta
-     12.2±0.06ms      10.7±0.04ms     0.88  groupby.MultiColumn.time_col_select_numpy_sum
-      3.98±0.5μs      3.45±0.07μs     0.87  index_cached_properties.IndexCache.time_shape('DatetimeIndex')
-      30.2±0.2ms      26.1±0.08ms     0.86  frame_methods.Dropna.time_dropna_axis_mixed_dtypes('any', 0)
-        2.25±1μs      1.78±0.06μs     0.79  index_cached_properties.IndexCache.time_shape('UInt64Index')
-      5.76±0.9μs       4.51±0.3μs     0.78  index_cached_properties.IndexCache.time_shape('IntervalIndex')
-      2.56±0.5μs       1.99±0.2μs     0.77  index_cached_properties.IndexCache.time_values('IntervalIndex')
-     3.67±0.02ms       2.66±0.1ms     0.73  rolling.ForwardWindowMethods.time_rolling('Series', 1000, 'int', 'min')
-        4.34±1μs       2.95±0.2μs     0.68  index_cached_properties.IndexCache.time_shape('CategoricalIndex')
-        2.48±2μs      1.65±0.09μs     0.66  index_cached_properties.IndexCache.time_shape('Float64Index')
-        3.04±1μs       1.96±0.1μs     0.64  index_cached_properties.IndexCache.time_values('CategoricalIndex')
-      1.88±0.6μs      1.09±0.06μs     0.58  index_cached_properties.IndexCache.time_values('Float64Index')
-        3.14±1μs      1.16±0.05μs     0.37  index_cached_properties.IndexCache.time_values('UInt64Index')


```