### PR TITLE
TST: Add test for rolling window, see GH 34605

### DIFF
--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -663,3 +663,36 @@ def test_iter_rolling_datetime(expected, expected_index, window):
 
     for (expected, actual) in zip(expected, ser.rolling(window)):
         tm.assert_series_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "grouping,_index",
+    [
+        (
+            {"level": 0},
+            pd.MultiIndex.from_tuples(
+                [(0, 0), (0, 0), (1, 1), (1, 1), (1, 1)], names=[None, None]
+            ),
+        ),
+        (
+            {"by": "X"},
+            pd.MultiIndex.from_tuples(
+                [(0, 0), (1, 0), (2, 1), (3, 1), (4, 1)], names=["X", None]
+            ),
+        ),
+    ],
+)
+def test_rolling_positional_argument(grouping, _index, raw):
+    # GH 34605
+
+    def scaled_sum(*args):
+        if len(args) < 2:
+            raise ValueError("The function needs two arguments")
+        array, scale = args
+        return array.sum() / scale
+
+    df = DataFrame(data={"X": range(5)}, index=[0, 0, 1, 1, 1])
+
+    expected = DataFrame(data={"X": [0.0, 0.5, 1.0, 1.5, 2.0]}, index=_index)
+    result = df.groupby(**grouping).rolling(1).apply(scaled_sum, raw=raw, args=(2,))
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [X] closes #34605 
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Dear maintainers,

I'm opening this PR to address issue #34605.

~I've made the test conditional to Python 3.8 as I'm using the positional only syntax as strong check. If this is not desired, let me know and I will change the function to explicitly check for the length of `*args`.~

Edit: maybe the usage of `parametrize` is a bit exaggerated here.
Edit2: Using Python 3.8 only features does not pleases the tests. Updating.