### PR TITLE
Make Cython in numpydev config Consistent

### DIFF
--- a/ci/deps/azure-37-numpydev.yaml
+++ b/ci/deps/azure-37-numpydev.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytz
   - pip
   - pip:
-    - cython==0.29.16 # GH#34014
+    - cython>=0.29.16
     - "git+git://github.com/dateutil/dateutil.git"
     - "--extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - "--pre"


### PR DESCRIPTION
Follow up to #34711 and just matching the other config files. Not sure generally if we should be specifying here and in higher level configs as may be ambiguous as to what Cython version gets installed, but going with the quick patch for now