### PR TITLE
BUG #34621 added nanosecond support to class Period

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -32,7 +32,6 @@ from pandas._libs.tslibs.np_datetime cimport (
     NPY_FR_D,
     NPY_FR_us,
 )
-from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 
 cdef extern from "src/datetime/np_datetime.h":
     int64_t npy_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
@@ -2408,11 +2407,12 @@ class Period(_Period):
             dt, reso = parse_time_string(value, freq)
             try:
                 ts = Timestamp(value)
+            except ValueError:
+                nanosecond = 0
+            else:
                 nanosecond = ts.nanosecond
                 if nanosecond != 0:
                     reso = 'nanosecond'
-            except ValueError:
-                nanosecond = 0
             if dt is NaT:
                 ordinal = NPY_NAT
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2498,7 +2498,7 @@ def quarter_to_myear(year: int, quarter: int, freq):
     mnum = c_MONTH_NUMBERS[get_rule_month(freq)] + 1
     month = (mnum + (quarter - 1) * 3) % 12 + 1
     if month > mnum:
-        year -= 1ough to only use ValueError, as that would already cover the OutOfBoundsDatet
+        year -= 1
 
     return year, month
     # TODO: This whole func is really similar to parsing.pyx L434-L450

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2407,11 +2407,11 @@ class Period(_Period):
             value = value.upper()
             dt, reso = parse_time_string(value, freq)
             try:
-                ts = Timestamp(value, freq=freq)
+                ts = Timestamp(value)
                 nanosecond = ts.nanosecond
                 if nanosecond != 0:
                     reso = 'nanosecond'
-            except (ValueError, OutOfBoundsDatetime):
+            except ValueError:
                 nanosecond = 0
             if dt is NaT:
                 ordinal = NPY_NAT
@@ -2498,7 +2498,7 @@ def quarter_to_myear(year: int, quarter: int, freq):
     mnum = c_MONTH_NUMBERS[get_rule_month(freq)] + 1
     month = (mnum + (quarter - 1) * 3) % 12 + 1
     if month > mnum:
-        year -= 1
+        year -= 1ough to only use ValueError, as that would already cover the OutOfBoundsDatet
 
     return year, month
     # TODO: This whole func is really similar to parsing.pyx L434-L450

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -32,6 +32,7 @@ from pandas._libs.tslibs.np_datetime cimport (
     NPY_FR_D,
     NPY_FR_us,
 )
+from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 
 cdef extern from "src/datetime/np_datetime.h":
     int64_t npy_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
@@ -2410,8 +2411,8 @@ class Period(_Period):
                 nanosecond = ts.nanosecond
                 if nanosecond != 0:
                     reso = 'nanosecond'
-            except:
-                pass
+            except OutOfBoundsDatetime:
+                nanosecond = 0
             if dt is NaT:
                 ordinal = NPY_NAT
 
@@ -2443,7 +2444,7 @@ class Period(_Period):
             base = freq_to_dtype_code(freq)
             ordinal = period_ordinal(dt.year, dt.month, dt.day,
                                      dt.hour, dt.minute, dt.second,
-                                     dt.microsecond, nanosecond, base)
+                                     dt.microsecond, 1000*nanosecond, base)
 
         return cls._from_ordinal(ordinal, freq)
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2355,6 +2355,7 @@ class Period(_Period):
 
         if freq is not None:
             freq = cls._maybe_convert_freq(freq)
+        nanosecond = 0
 
         if ordinal is not None and value is not None:
             raise ValueError("Only value or ordinal but not both should be "
@@ -2404,6 +2405,13 @@ class Period(_Period):
                 value = str(value)
             value = value.upper()
             dt, reso = parse_time_string(value, freq)
+            try:
+                ts = Timestamp(value, freq=freq)
+                nanosecond = ts.nanosecond
+                if nanosecond != 0:
+                    reso = 'nanosecond'
+            except:
+                pass
             if dt is NaT:
                 ordinal = NPY_NAT
 
@@ -2435,7 +2443,7 @@ class Period(_Period):
             base = freq_to_dtype_code(freq)
             ordinal = period_ordinal(dt.year, dt.month, dt.day,
                                      dt.hour, dt.minute, dt.second,
-                                     dt.microsecond, 0, base)
+                                     dt.microsecond, nanosecond, base)
 
         return cls._from_ordinal(ordinal, freq)
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2411,7 +2411,7 @@ class Period(_Period):
                 nanosecond = ts.nanosecond
                 if nanosecond != 0:
                     reso = 'nanosecond'
-            except OutOfBoundsDatetime:
+            except (ValueError, OutOfBoundsDatetime):
                 nanosecond = 0
             if dt is NaT:
                 ordinal = NPY_NAT

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -484,7 +484,6 @@ class TestPeriodConstruction:
         with pytest.raises(ValueError, match=msg):
             Period("2011-01", freq="1D1W")
 
-    #@pytest.mark.xfail
     @pytest.mark.parametrize("day_", ["1970/01/01 ", "2020-12-31 ", "1981/09/13 "])
     @pytest.mark.parametrize("hour_", ["00:00:00", "00:00:01", "23:59:59", "12:00:59"])
     @pytest.mark.parametrize(

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -484,6 +484,23 @@ class TestPeriodConstruction:
         with pytest.raises(ValueError, match=msg):
             Period("2011-01", freq="1D1W")
 
+    #@pytest.mark.xfail
+    @pytest.mark.parametrize("day_", ["1970/01/01 ", "2020-12-31 ", "1981/09/13 "])
+    @pytest.mark.parametrize("hour_", ["00:00:00", "00:00:01", "23:59:59", "12:00:59"])
+    @pytest.mark.parametrize(
+        "floating_sec_, expected",
+        [
+            (".000000001", 1),
+            (".000000999", 999),
+            (".123456789", 789),
+            (".999999999", 999),
+        ],
+    )
+    def test_period_constructor_nanosecond(self, day_, hour_, floating_sec_, expected):
+        # GH 34621
+        result = Period(day_ + hour_ + floating_sec_).start_time.nanosecond
+        assert result == expected
+
 
 class TestPeriodMethods:
     def test_round_trip(self):


### PR DESCRIPTION
Closes #34621
Closes #17053
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

The class Period do not support nanosecond. I've made a quick and dirty code to support nanoseconds. I have struggled to find an alternative to dateutil.parser, but I didn't found an alternative.

The PR may be a performance issue as I've add a Timestamp constructor to the dateutil.parser. There is for sure a better solution. Please let me know !