### PR TITLE
BUG: pd.NA in format strings with formatting parameters

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -908,6 +908,8 @@ Missing
 - Clarified documentation on interpolate with method =akima. The ``der`` parameter must be scalar or None (:issue:`33426`)
 - :meth:`DataFrame.interpolate` uses the correct axis convention now. Previously interpolating along columns lead to interpolation along indices and vice versa. Furthermore interpolating with methods ``pad``, ``ffill``, ``bfill`` and ``backfill`` are identical to using these methods with :meth:`fillna` (:issue:`12918`, :issue:`29146`)
 - Bug in :meth:`DataFrame.interpolate` when called on a DataFrame with column names of string type was throwing a ValueError. The method is no independing of the type of column names (:issue:`33956`)
+- :class:`NA` will now always work when passed into a format string. Previously a ``ValueError`` was raised if any format parameters were supplied to the format string.
+  For example ``"{:.1f}".format(pd.NA)`` would previously raise a ``ValueError``, but will now return the string ``"<NA>"`` (:issue:`xxxxx`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -349,6 +349,12 @@ class NAType(C_NAType):
     def __repr__(self) -> str:
         return "<NA>"
 
+    def __format__(self, format_spec) -> str:
+        try:
+            return self.__repr__().__format__(format_spec)
+        except ValueError:
+            return self.__repr__()
+
     def __bool__(self):
         raise TypeError("boolean value of NA is ambiguous")
 

--- a/pandas/tests/scalar/test_na_scalar.py
+++ b/pandas/tests/scalar/test_na_scalar.py
@@ -22,6 +22,16 @@ def test_repr():
     assert str(NA) == "<NA>"
 
 
+def test_format():
+    assert format(NA) == "<NA>"
+    assert format(NA, ">10") == "      <NA>"
+    assert format(NA, "xxx") == "<NA>"   # accept arbitrary format strings
+
+    assert "{}".format(NA) == "<NA>"
+    assert "{:>10}".format(NA) == "      <NA>"
+    assert "{:xxx}".format(NA) == "<NA>"  # accept arbitrary format strings
+
+
 def test_truthiness():
     msg = "boolean value of NA is ambiguous"
 


### PR DESCRIPTION
``pd.NA`` raises if passed to a format string and format parameters are supplied. This is different behaviour than ``np.nan`` and makes converting arrays containing ``pd.NA`` to strings very brittle and annoying.

Examples:

```python
>>> format(pd.NA)
'<NA>'  # master and PR, ok
>>> format(pd.NA, ".1f")
TypeError  # master
'<NA>'  # this PR
>>> format(pd.NA, ">5")
TypeError  # master
' <NA>'  # this PR, tries to behave like a string, then falls back to '<NA>', like np.na
```

The new behaviour mirrors the behaviour of ``np.nan``.