### PR TITLE
typo: rows -> columns

### DIFF
--- a/doc/source/getting_started/intro_tutorials/01_table_oriented.rst
+++ b/doc/source/getting_started/intro_tutorials/01_table_oriented.rst
@@ -51,7 +51,7 @@ I want to store passenger data of the Titanic. For a number of passengers, I kno
     df
 
 To manually store data in a table, create a ``DataFrame``. When using a Python dictionary of lists, the dictionary keys will be used as column headers and
-the values in each list as rows of the ``DataFrame``.
+the values in each list as columns of the ``DataFrame``.
 
 .. raw:: html
 


### PR DESCRIPTION
I'm new to pandas and reading the docs for the first time.  By my reading of the first part of this paragraph, there's a dictionary of lists and the lists are `["Braund...", "Allen...", ...]`, `[22, 35, 58]`, and `["male", "male", "female"]`.

The original sentence says: "... and the values in each list as rows of the DataFrame", but the values in the first list (`["Baund...]`) are the values in the first **column** of the illustration.  Likewise the list `[22,...]` is the second column and `["male",...]` is the third.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
