### PR TITLE
typo: pivot_table -> pivot

### DIFF
--- a/doc/source/getting_started/intro_tutorials/07_reshape_table_layout.rst
+++ b/doc/source/getting_started/intro_tutorials/07_reshape_table_layout.rst
@@ -196,7 +196,7 @@ I want the values for the three stations as separate columns next to each other
 
     no2_subset.pivot(columns="location", values="value")
 
-The :meth:`~pandas.pivot_table` function is purely reshaping of the data: a single value
+The :meth:`~pandas.pivot` function is purely reshaping of the data: a single value
 for each index/column combination is required.
 
 .. raw:: html


### PR DESCRIPTION
I'm new to pandas and reading the docs for the first time.

I believe that the reference in the *pivot* section should be to `pivot`, not `pivot_table`, to match the code in the example.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
