### PR TITLE
BUG, TST: fix-_check_ticks_props

### DIFF
--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -272,7 +272,7 @@ class TestPlotBase:
 
         axes = self._flatten_visible(axes)
         for ax in axes:
-            if xlabelsize or xrot:
+            if xlabelsize is not None or xrot is not None:
                 if isinstance(ax.xaxis.get_minor_formatter(), NullFormatter):
                     # If minor ticks has NullFormatter, rot / fontsize are not
                     # retained
@@ -286,7 +286,7 @@ class TestPlotBase:
                     if xrot is not None:
                         tm.assert_almost_equal(label.get_rotation(), xrot)
 
-            if ylabelsize or yrot:
+            if ylabelsize is not None or yrot is not None:
                 if isinstance(ax.yaxis.get_minor_formatter(), NullFormatter):
                     labels = ax.get_yticklabels()
                 else:

--- a/pandas/tests/plotting/test_common.py
+++ b/pandas/tests/plotting/test_common.py
@@ -1,0 +1,24 @@
+import pytest
+
+import pandas.util._test_decorators as td
+
+from pandas import DataFrame
+from pandas.tests.plotting.common import TestPlotBase, _check_plot_works
+
+
+@td.skip_if_no_mpl
+class TestCommon(TestPlotBase):
+    def test__check_ticks_props(self):
+        # GH 34768
+        df = DataFrame({"b": [0, 1, 0], "a": [1, 2, 3]})
+        ax = _check_plot_works(df.plot, rot=30)
+        ax.yaxis.set_tick_params(rotation=30)
+        msg = "expected 0.00000 but got "
+        with pytest.raises(AssertionError, match=msg):
+            self._check_ticks_props(ax, xrot=0)
+        with pytest.raises(AssertionError, match=msg):
+            self._check_ticks_props(ax, xlabelsize=0)
+        with pytest.raises(AssertionError, match=msg):
+            self._check_ticks_props(ax, yrot=0)
+        with pytest.raises(AssertionError, match=msg):
+            self._check_ticks_props(ax, ylabelsize=0)

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -48,6 +48,7 @@ class TestDataFramePlots(TestPlotBase):
         for ax, exp in zip(axes, expected):
             self._check_visible(ax.get_xticklabels(), visible=exp)
 
+    @pytest.mark.xfail(reason="Waiting for PR 34334")
     @pytest.mark.slow
     def test_plot(self):
         from pandas.plotting._matplotlib.compat import _mpl_ge_3_1_0
@@ -467,6 +468,7 @@ class TestDataFramePlots(TestPlotBase):
         expected = [False, False, True, True]
         self._assert_xtickslabels_visibility(axes, expected)
 
+    @pytest.mark.xfail(reason="Waiting for PR 34334")
     @pytest.mark.slow
     def test_subplots_timeseries(self):
         idx = date_range(start="2014-07-01", freq="M", periods=10)

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -3350,6 +3350,19 @@ class TestDataFramePlots(TestPlotBase):
         for legend, line in zip(result.get_legend().legendHandles, result.lines):
             assert legend.get_color() == line.get_color()
 
+    def test_plot_with_rot(self):
+        df = pd.DataFrame({"b": [0, 1, 0], "a": [1, 2, 3]})
+        ax = _check_plot_works(df.plot, rot=30)
+        ax.yaxis.set_tick_params(rotation=30)
+        with pytest.raises(AssertionError):
+            self._check_ticks_props(ax, xrot=0)
+        with pytest.raises(AssertionError):
+            self._check_ticks_props(ax, xlabelsize=0)
+        with pytest.raises(AssertionError):
+            self._check_ticks_props(ax, yrot=0)
+        with pytest.raises(AssertionError):
+            self._check_ticks_props(ax, ylabelsize=0)
+
 
 def _generate_4_axes_via_gridspec():
     import matplotlib.pyplot as plt

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -3352,21 +3352,6 @@ class TestDataFramePlots(TestPlotBase):
         for legend, line in zip(result.get_legend().legendHandles, result.lines):
             assert legend.get_color() == line.get_color()
 
-    def test__check_ticks_props(self):
-        # GH 34768
-        df = pd.DataFrame({"b": [0, 1, 0], "a": [1, 2, 3]})
-        ax = _check_plot_works(df.plot, rot=30)
-        ax.yaxis.set_tick_params(rotation=30)
-        msg = "expected 0.00000 but got "
-        with pytest.raises(AssertionError, match=msg):
-            self._check_ticks_props(ax, xrot=0)
-        with pytest.raises(AssertionError, match=msg):
-            self._check_ticks_props(ax, xlabelsize=0)
-        with pytest.raises(AssertionError, match=msg):
-            self._check_ticks_props(ax, yrot=0)
-        with pytest.raises(AssertionError, match=msg):
-            self._check_ticks_props(ax, ylabelsize=0)
-
 
 def _generate_4_axes_via_gridspec():
     import matplotlib.pyplot as plt

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -48,7 +48,7 @@ class TestDataFramePlots(TestPlotBase):
         for ax, exp in zip(axes, expected):
             self._check_visible(ax.get_xticklabels(), visible=exp)
 
-    @pytest.mark.xfail(reason="Waiting for PR 34334")
+    @pytest.mark.xfail(reason="Waiting for PR 34334", strict=True)
     @pytest.mark.slow
     def test_plot(self):
         from pandas.plotting._matplotlib.compat import _mpl_ge_3_1_0
@@ -468,7 +468,7 @@ class TestDataFramePlots(TestPlotBase):
         expected = [False, False, True, True]
         self._assert_xtickslabels_visibility(axes, expected)
 
-    @pytest.mark.xfail(reason="Waiting for PR 34334")
+    @pytest.mark.xfail(reason="Waiting for PR 34334", strict=True)
     @pytest.mark.slow
     def test_subplots_timeseries(self):
         idx = date_range(start="2014-07-01", freq="M", periods=10)

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -3355,13 +3355,14 @@ class TestDataFramePlots(TestPlotBase):
         df = pd.DataFrame({"b": [0, 1, 0], "a": [1, 2, 3]})
         ax = _check_plot_works(df.plot, rot=30)
         ax.yaxis.set_tick_params(rotation=30)
-        with pytest.raises(AssertionError):
+        msg = "expected 0.00000 but got "
+        with pytest.raises(AssertionError, match=msg):
             self._check_ticks_props(ax, xrot=0)
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError, match=msg):
             self._check_ticks_props(ax, xlabelsize=0)
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError, match=msg):
             self._check_ticks_props(ax, yrot=0)
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError, match=msg):
             self._check_ticks_props(ax, ylabelsize=0)
 
 

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -3351,6 +3351,7 @@ class TestDataFramePlots(TestPlotBase):
             assert legend.get_color() == line.get_color()
 
     def test_plot_with_rot(self):
+        # GH 34768
         df = pd.DataFrame({"b": [0, 1, 0], "a": [1, 2, 3]})
         ax = _check_plot_works(df.plot, rot=30)
         ax.yaxis.set_tick_params(rotation=30)

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -3352,7 +3352,7 @@ class TestDataFramePlots(TestPlotBase):
         for legend, line in zip(result.get_legend().legendHandles, result.lines):
             assert legend.get_color() == line.get_color()
 
-    def test_plot_with_rot(self):
+    def test__check_ticks_props(self):
         # GH 34768
         df = pd.DataFrame({"b": [0, 1, 0], "a": [1, 2, 3]})
         ax = _check_plot_works(df.plot, rot=30)


### PR DESCRIPTION
Here's something I noticed while working on #34334 : `self._check_ticks_props(ax, ylabelsize=0)` always passes!

This is because of
```python
if ylabelsize
```
instead of
```python
if ylabelsize is not None
```
being used.

The test I've added fails on master:
```python-traceback
(pandas-dev) marco@marco-Predator-PH315-52:~/pandas-dev$ pytest pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_plot_with_rot
============================================================== test session starts ==============================================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/marco/pandas-dev, inifile: setup.cfg
plugins: cov-2.8.1, xdist-1.31.0, asyncio-0.10.0, hypothesis-5.8.0, forked-1.1.2
collected 1 item                                                                                                                                

pandas/tests/plotting/test_frame.py .                                                                                                     [100%]

=============================================================== 1 passed in 0.33s ===============================================================  
(pandas-dev) marco@marco-Predator-PH315-52:~/pandas-dev$ git checkout upstream/master -- pandas/tests/plotting/common.py
(pandas-dev) marco@marco-Predator-PH315-52:~/pandas-dev$ pytest pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_plot_with_rot
============================================================== test session starts ==============================================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/marco/pandas-dev, inifile: setup.cfg
plugins: cov-2.8.1, xdist-1.31.0, asyncio-0.10.0, hypothesis-5.8.0, forked-1.1.2
collected 1 item                                                                                                                                

pandas/tests/plotting/test_frame.py F                                                                                                     [100%]

=================================================================== FAILURES ====================================================================
_____________________________________________________ TestDataFramePlots.test_plot_with_rot _____________________________________________________

self = <pandas.tests.plotting.test_frame.TestDataFramePlots object at 0x7f8c7578f3a0>

    def test_plot_with_rot(self):
        # GH 34768
        df = pd.DataFrame({"b": [0, 1, 0], "a": [1, 2, 3]})
        ax = _check_plot_works(df.plot, rot=30)
        ax.yaxis.set_tick_params(rotation=30)
        msg = "expected 0.00000 but got "
        with pytest.raises(AssertionError, match=msg):
>           self._check_ticks_props(ax, xrot=0)
E           Failed: DID NOT RAISE <class 'AssertionError'>

pandas/tests/plotting/test_frame.py:3360: Failed
============================================================ short test summary info ============================================================
FAILED pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_plot_with_rot - Failed: DID NOT RAISE <class 'AssertionError'>
=============================================================== 1 failed in 0.46s ===============================================================
```