### PR TITLE
TST: remove super slow cases on upsample_nearest_limit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 19.10b0
     hooks:
     -   id: black
-        language_version: python3.7
+        language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.7
     hooks:

--- a/pandas/tests/io/parser/test_multi_thread.py
+++ b/pandas/tests/io/parser/test_multi_thread.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from multiprocessing.pool import ThreadPool
 
 import numpy as np
+import pytest
 
 import pandas as pd
 from pandas import DataFrame
@@ -34,6 +35,7 @@ def _construct_dataframe(num_rows):
     return df
 
 
+@pytest.mark.slow
 def test_multi_thread_string_io_read_csv(all_parsers):
     # see gh-11786
     parser = all_parsers
@@ -126,6 +128,7 @@ def _generate_multi_thread_dataframe(parser, path, num_rows, num_tasks):
     return final_dataframe
 
 
+@pytest.mark.slow
 def test_multi_thread_path_multipart_read_csv(all_parsers):
     # see gh-11786
     num_tasks = 4

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from functools import partial
 from io import StringIO
 
-from dateutil.tz import tzlocal
 import numpy as np
 import pytest
 import pytz
@@ -477,30 +476,11 @@ def test_upsample_with_limit():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("freq", ["Y", "10M", "5D", "10H", "5Min", "10S"])
+@pytest.mark.parametrize("freq", ["5D", "10H", "5Min", "10S"])
 @pytest.mark.parametrize("rule", ["Y", "3M", "15D", "30H", "15Min", "30S"])
 def test_nearest_upsample_with_limit(tz_aware_fixture, freq, rule):
     # GH 33939
-    tz = tz_aware_fixture
-    if str(tz) == "tzlocal()" and rule == "30S" and freq in ["Y", "10M"]:
-        # GH#34413 separate these so we can mark as slow, see
-        #  test_nearest_upsample_with_limit_tzlocal
-        return
     rng = date_range("1/1/2000", periods=3, freq=freq, tz=tz_aware_fixture)
-    ts = Series(np.random.randn(len(rng)), rng)
-
-    result = ts.resample(rule).nearest(limit=2)
-    expected = ts.reindex(result.index, method="nearest", limit=2)
-    tm.assert_series_equal(result, expected)
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("freq", ["Y", "10M"])
-def test_nearest_upsample_with_limit_tzlocal(freq):
-    # GH#33939, GH#34413 split off from test_nearest_upsample_with_limit
-    rule = "30S"
-    tz = tzlocal()
-    rng = date_range("1/1/2000", periods=3, freq=freq, tz=tz)
     ts = Series(np.random.randn(len(rng)), rng)
 
     result = ts.resample(rule).nearest(limit=2)


### PR DESCRIPTION
make multi_thread csv parsing test slow