### PR TITLE
Backport PR #34667 on branch 1.0.x (BLD: pyproject.toml for Py38)

### DIFF
--- a/doc/source/whatsnew/v1.0.5.rst
+++ b/doc/source/whatsnew/v1.0.5.rst
@@ -22,7 +22,8 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+
+- Fixed building from source with Python 3.8 fetching the wrong version of NumPy (:issue:`34666`)
 -
 
 Contributors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ requires = [
     "wheel",
     "Cython>=0.29.13",  # Note: sync with setup.py
     "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
-    "numpy==1.14.5; python_version>='3.7' and platform_system!='AIX'",
-    "numpy==1.15.4; python_version=='3.6' and platform_system!='AIX'",
-    "numpy==1.15.4; python_version=='3.7' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
     "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
     "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,12 @@ requires = [
     "Cython>=0.29.13",  # Note: sync with setup.py
     "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
     "numpy==1.14.5; python_version>='3.7' and platform_system!='AIX'",
+    "numpy==1.15.4; python_version=='3.6' and platform_system!='AIX'",
+    "numpy==1.15.4; python_version=='3.7' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version>='3.7' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
 ]
 
 [tool.black]


### PR DESCRIPTION
xref #34667

@jorisvandenbossche another set of eyes needed as this was not a clean cherry-pick