### PR TITLE
Backport PR #34718 on branch 1.0.x (Removed __div__ impls)

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -401,11 +401,6 @@ cdef class Interval(IntervalMixin):
             return Interval(y.left * self, y.right * self, closed=y.closed)
         return NotImplemented
 
-    def __div__(self, y):
-        if isinstance(y, numbers.Number):
-            return Interval(self.left / y, self.right / y, closed=self.closed)
-        return NotImplemented
-
     def __truediv__(self, y):
         if isinstance(y, numbers.Number):
             return Interval(self.left / y, self.right / y, closed=self.closed)

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -215,9 +215,6 @@ cdef class _NaT(datetime):
     def __neg__(self):
         return NaT
 
-    def __div__(self, other):
-        return _nat_divide_op(self, other)
-
     def __truediv__(self, other):
         return _nat_divide_op(self, other)
 


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/pull/34711#issuecomment-644148383


@WillAyd on 1.0.x. we have  cython>=0.29.13 and on master cython>=0.29.16. is this an issue?
