### PR TITLE
Regression in to_timedelta with errors="coerce" and unit

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -237,7 +237,7 @@ def array_to_timedelta64(object[:] values, unit=None, errors='raise'):
 
     if unit is not None:
         for i in range(n):
-            if isinstance(values[i], str):
+            if isinstance(values[i], str) and errors != "coerce":
                 raise ValueError(
                     "unit must not be specified if the input contains a str"
                 )

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -882,9 +882,10 @@ def sequence_to_td64ns(data, copy=False, unit=None, errors="raise"):
     ----------
     data : list-like
     copy : bool, default False
-    unit : str, default "ns"
-        The timedelta unit to treat integers as multiples of.
-        Must be un-specifed if the data contains a str.
+    unit : str, optional
+        The timedelta unit to treat integers as multiples of. For numeric
+        data this defaults to ``'ns'``.
+        Must be un-specified if the data contains a str and ``errors=="raise"``.
     errors : {"raise", "coerce", "ignore"}, default "raise"
         How to handle elements that cannot be converted to timedelta64[ns].
         See ``pandas.to_timedelta`` for details.

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -26,15 +26,24 @@ def to_timedelta(arg, unit=None, errors="raise"):
     ----------
     arg : str, timedelta, list-like or Series
         The data to be converted to timedelta.
-    unit : str, default 'ns'
-        Must not be specified if the arg is/contains a str.
-        Denotes the unit of the arg. Possible values:
-        ('W', 'D', 'days', 'day', 'hours', hour', 'hr', 'h',
-        'm', 'minute', 'min', 'minutes', 'T', 'S', 'seconds',
-        'sec', 'second', 'ms', 'milliseconds', 'millisecond',
-        'milli', 'millis', 'L', 'us', 'microseconds', 'microsecond',
-        'micro', 'micros', 'U', 'ns', 'nanoseconds', 'nano', 'nanos',
-        'nanosecond', 'N').
+    unit : str, optional
+        Denotes the unit of the arg for numeric `arg`. Defaults to ``"ns"``.
+
+        Possible values:
+
+        * 'W'
+        * 'D' / 'days' / 'day'
+        * 'hours' / 'hour' / 'hr' / 'h'
+        * 'm' / 'minute' / 'min' / 'minutes' / 'T'
+        * 'S' / 'seconds' / 'sec' / 'second'
+        * 'ms' / 'milliseconds' / 'millisecond' / 'milli' / 'millis' / 'L'
+        * 'us' / 'microseconds' / 'microsecond' / 'micro' / 'micros' / 'U'
+        * 'ns' / 'nanoseconds' / 'nano' / 'nanos' / 'nanosecond' / 'N'
+
+        .. versionchanged:: 1.1.0
+
+           Must not be specified when `arg` context strings and
+           ``errors="raise"``.
 
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception.

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -155,3 +155,14 @@ class TestTimedeltas:
         result = pd.to_timedelta(arr, unit="s")
         expected_asi8 = np.arange(999990000, int(1e9), 1000, dtype="int64")
         tm.assert_numpy_array_equal(result.asi8, expected_asi8)
+
+    def test_to_timedelta_coerce_strings_unit(self):
+        arr = np.array([1, 2, "error"], dtype=object)
+        result = pd.to_timedelta(arr, unit="ns", errors="coerce")
+        expected = pd.to_timedelta([1, 2, pd.NaT], unit="ns")
+        tm.assert_index_equal(result, expected)
+
+    def test_to_timedelta_ignore_strings_unit(self):
+        arr = np.array([1, 2, "error"], dtype=object)
+        result = pd.to_timedelta(arr, unit="ns", errors="ignore")
+        tm.assert_numpy_array_equal(result, arr)


### PR DESCRIPTION
Introduced in https://github.com/pandas-dev/pandas/commit/d3f686bb50c14594087171aa0493cb07eb5a874c

In pandas 1.0.3

```python
In [2]: pd.to_timedelta([1, 2, 'error'], errors="coerce", unit="ns")
Out[2]: TimedeltaIndex(['00:00:00.000000', '00:00:00.000000', NaT], dtype='timedelta64[ns]', freq=None)
```

In master, we raise.

```pytb
In [2]: pd.to_timedelta([1, 2, 'error'], errors="coerce", unit="ns")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-a3691c044041> in <module>
----> 1 pd.to_timedelta([1, 2, 'error'], errors="coerce", unit="ns")

~/Envs/dask-dev/lib/python3.7/site-packages/pandas/core/tools/timedeltas.py in to_timedelta(arg, unit, errors)
    101         arg = arg.item()
    102     elif is_list_like(arg) and getattr(arg, "ndim", 1) == 1:
--> 103         return _convert_listlike(arg, unit=unit, errors=errors)
    104     elif getattr(arg, "ndim", 1) > 1:
    105         raise TypeError(

~/Envs/dask-dev/lib/python3.7/site-packages/pandas/core/tools/timedeltas.py in _convert_listlike(arg, unit, errors, name)
    140
    141     try:
--> 142         value = sequence_to_td64ns(arg, unit=unit, errors=errors, copy=False)[0]
    143     except ValueError:
    144         if errors == "ignore":

~/Envs/dask-dev/lib/python3.7/site-packages/pandas/core/arrays/timedeltas.py in sequence_to_td64ns(data, copy, unit, errors)
    927     if is_object_dtype(data.dtype) or is_string_dtype(data.dtype):
    928         # no need to make a copy, need to convert if string-dtyped
--> 929         data = objects_to_td64ns(data, unit=unit, errors=errors)
    930         copy = False
    931

~/Envs/dask-dev/lib/python3.7/site-packages/pandas/core/arrays/timedeltas.py in objects_to_td64ns(data, unit, errors)
   1037     values = np.array(data, dtype=np.object_, copy=False)
   1038
-> 1039     result = array_to_timedelta64(values, unit=unit, errors=errors)
   1040     return result.view("timedelta64[ns]")
   1041

pandas/_libs/tslibs/timedeltas.pyx in pandas._libs.tslibs.timedeltas.array_to_timedelta64()

ValueError: unit must not be specified if the input contains a str
```

This restores the 1.0.3 behavior, and adds an additional test for `errors="ignore"`, and cleans up the  `to_timedelta` docstring.