### PR TITLE
BUG: Respect center=True in rolling.apply when numba engine is used

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1015,7 +1015,7 @@ Groupby/resample/rolling
   The behaviour now is consistent, independent of internal heuristics. (:issue:`31612`, :issue:`14927`, :issue:`13056`)
 - Bug in :meth:`SeriesGroupBy.agg` where any column name was accepted in the named aggregation of ``SeriesGroupBy`` previously. The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
 - Bug in :meth:`DataFrame.groupby` lost index, when one of the ``agg`` keys referenced an empty list (:issue:`32580`)
-
+- Bug in :meth:`Rolling.apply` where ``center=True`` was ignored when ``engine='numba'`` was specified (:issue:`34784`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -150,7 +150,7 @@ class _Window(PandasObject, ShallowMixin, SelectionMixin):
         obj,
         window=None,
         min_periods: Optional[int] = None,
-        center: Optional[bool] = False,
+        center: bool = False,
         win_type: Optional[str] = None,
         axis: Axis = 0,
         on: Optional[Union[str, Index]] = None,

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1353,17 +1353,20 @@ class _Rolling_and_Expanding(_Rolling):
             kwargs = {}
         kwargs.pop("_level", None)
         kwargs.pop("floor", None)
-        window = self._get_window()
-        offset = calculate_center_offset(window) if self.center else 0
         if not is_bool(raw):
             raise ValueError("raw parameter must be `True` or `False`")
 
         if engine == "cython":
             if engine_kwargs is not None:
                 raise ValueError("cython engine does not accept engine_kwargs")
+            # Cython apply functions handle center, so don't need to use
+            # _apply's center handling
+            window = self._get_window()
+            offset = calculate_center_offset(window) if self.center else 0
             apply_func = self._generate_cython_apply_func(
                 args, kwargs, raw, offset, func
             )
+            center = False
         elif engine == "numba":
             if raw is False:
                 raise ValueError("raw must be `True` when using the numba engine")
@@ -1375,14 +1378,14 @@ class _Rolling_and_Expanding(_Rolling):
                 apply_func = generate_numba_apply_func(
                     args, kwargs, func, engine_kwargs
                 )
+            center = self.center
         else:
             raise ValueError("engine must be either 'numba' or 'cython'")
 
-        # TODO: Why do we always pass center=False?
         # name=func & raw=raw for WindowGroupByMixin._apply
         return self._apply(
             apply_func,
-            center=False,
+            center=center,
             floor=0,
             name=func,
             use_numba_cache=engine == "numba",

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -13,7 +13,7 @@ from pandas.core.util.numba_ import NUMBA_FUNC_CACHE
 # Filter warnings when parallel=True and the function can't be parallelized by Numba
 class TestApply:
     @pytest.mark.parametrize("jit", [True, False])
-    def test_numba_vs_cython(self, jit, nogil, parallel, nopython):
+    def test_numba_vs_cython(self, jit, nogil, parallel, nopython, center):
         def f(x, *args):
             arg_sum = 0
             for arg in args:
@@ -29,10 +29,12 @@ class TestApply:
         args = (2,)
 
         s = Series(range(10))
-        result = s.rolling(2).apply(
+        result = s.rolling(2, center=center).apply(
             f, args=args, engine="numba", engine_kwargs=engine_kwargs, raw=True
         )
-        expected = s.rolling(2).apply(f, engine="cython", args=args, raw=True)
+        expected = s.rolling(2, center=center).apply(
+            f, engine="cython", args=args, raw=True
+        )
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("jit", [True, False])


### PR DESCRIPTION
- [x] closes #34784
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
