### PR TITLE
Add support for gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,7 @@
 FROM gitpod/workspace-full:latest
 
+USER root
+
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-full:latest
 
 USER gitpod
 
-RUN RUN apt-get update \
+RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update \
     # Install C compilers (gcc not enough, so just went with build-essential which admittedly might be overkill),
     # needed to build pandas C extensions
     && apt-get -y install build-essential \
+    # Install python snappy.
+    && apt-get -y install libsnappy-dev \
     #
     # cleanup
     && apt-get autoremove -y \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     # Install C compilers (gcc not enough, so just went with build-essential which admittedly might be overkill),
     # needed to build pandas C extensions
     && apt-get -y install build-essential \
-    # Install python snappy.
+    # Install lib-snappy (dependency of python-snappy).
     && apt-get -y install libsnappy-dev \
     #
     # cleanup

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,5 @@
 FROM gitpod/workspace-full:latest
 
-USER gitpod
-
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
@@ -16,3 +14,5 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+
+USER gitpod

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,18 @@
+FROM gitpod/workspace-full:latest
+
+USER gitpod
+
+RUN RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git iproute2 procps iproute2 lsb-release \
+    #
+    # Install C compilers (gcc not enough, so just went with build-essential which admittedly might be overkill),
+    # needed to build pandas C extensions
+    && apt-get -y install build-essential \
+    #
+    # cleanup
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+image:
+  file: .gitpod.Dockerfile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,4 @@
 image:
   file: .gitpod.Dockerfile
+tasks:
+  - init: pip install -r requirements-dev.txt && make develop

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![Downloads](https://anaconda.org/conda-forge/pandas/badges/downloads.svg)](https://pandas.pydata.org)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pydata/pandas)
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/pandas-dev/pandas)
 
 ## What is it?
 


### PR DESCRIPTION
This PR proposes to add support for Gitpod, which can provide (new) contributors with one-click environment to use for working on the pandas code base. 

The PR includes two main additions:
- .gitpod.yml - Config file for gitpod that specifies which image/Dockerfile to use for gitpod and which init command(s) to run when booting the pod.
- .gitpod.Dockerfile - Dockerfile used to build a base image for the pod. Partially adapted from the existing Dockerfile in the repo.

Some things maybe still to consider:
- Gitpod has some options for providing pre-built workspaces (https://www.gitpod.io/docs/prebuilds/). This may be interesting to enable.
- There is some duplication between the two dockerfiles, but unfortunately the VS Code Dockerfile is not entirely compatible with the gitpod one. As such, the duplication may not be a bad thing. 

- [x] closes #xxxx (N/A)
- [x] tests added / passed (N/A)
- [x] passes `black pandas` (N/A)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff` (N/A)
- [x] whatsnew entry (N/A)
