### PR TITLE
Infer filesystem from path when writing a partitioned DataFrame to remote file systems using pyarrow

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -991,6 +991,7 @@ I/O
 - Bug in :meth:`~SQLDatabase.execute` was raising a ``ProgrammingError`` for some DB-API drivers when the SQL statement contained the `%` character and no parameters were present (:issue:`34211`)
 - Bug in :meth:`~pandas.io.stata.StataReader` which resulted in categorical variables with difference dtypes when reading data using an iterator. (:issue:`31544`)
 - :meth:`HDFStore.keys` has now an optional `include` parameter that allows the retrieval of all native HDF5 table names (:issue:`29916`)
+- `pandas.io.parquet.PyArrowImpl` now infers `filesystem` using the provided `path` if `filesystem` is not provided via `kwargs`. (:issue:`34841`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -118,10 +118,10 @@ class PyArrowImpl(BaseImpl):
         else:
             self.api.parquet.write_table(
                 table,
-                file_obj_or_path, 
+                file_obj_or_path,
                 compression=compression,
                 filesystem=get_fs_for_path(path),
-                 **kwargs
+                **kwargs,
             )
         if should_close:
             file_obj_or_path.close()

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -105,7 +105,7 @@ class PyArrowImpl(BaseImpl):
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
 
-        fs = get_fs_for_path(path)
+        fs = kwargs.get('filesystem', get_fs_for_path(path))
         # write_to_dataset does not support a file-like object when
         # a directory path is used, so just pass the path string.
         if partition_cols is not None:

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -105,7 +105,7 @@ class PyArrowImpl(BaseImpl):
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
 
-        fs = kwargs.pop('filesystem', get_fs_for_path(path))
+        fs = kwargs.pop("filesystem", get_fs_for_path(path))
 
         # write_to_dataset does not support a file-like object when
         # a directory path is used, so just pass the path string.
@@ -120,10 +120,7 @@ class PyArrowImpl(BaseImpl):
             )
         else:
             self.api.parquet.write_table(
-                table,
-                file_obj_or_path,
-                compression=compression,
-                **kwargs,
+                table, file_obj_or_path, compression=compression, **kwargs,
             )
         if should_close:
             file_obj_or_path.close()

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -104,7 +104,7 @@ class PyArrowImpl(BaseImpl):
             from_pandas_kwargs["preserve_index"] = index
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
-        
+
         fs = get_fs_for_path(path)
         # write_to_dataset does not support a file-like object when
         # a directory path is used, so just pass the path string.

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -111,12 +111,17 @@ class PyArrowImpl(BaseImpl):
                 table,
                 path,
                 compression=compression,
+                filesystem=get_fs_for_path(path),
                 partition_cols=partition_cols,
                 **kwargs,
             )
         else:
             self.api.parquet.write_table(
-                table, file_obj_or_path, compression=compression, **kwargs
+                table,
+                file_obj_or_path, 
+                compression=compression,
+                filesystem=get_fs_for_path(path),
+                 **kwargs
             )
         if should_close:
             file_obj_or_path.close()

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -105,7 +105,8 @@ class PyArrowImpl(BaseImpl):
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
 
-        fs = kwargs.get('filesystem', get_fs_for_path(path))
+        fs = kwargs.pop('filesystem', get_fs_for_path(path))
+
         # write_to_dataset does not support a file-like object when
         # a directory path is used, so just pass the path string.
         if partition_cols is not None:
@@ -122,7 +123,6 @@ class PyArrowImpl(BaseImpl):
                 table,
                 file_obj_or_path,
                 compression=compression,
-                filesystem=fs,
                 **kwargs,
             )
         if should_close:

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -104,6 +104,8 @@ class PyArrowImpl(BaseImpl):
             from_pandas_kwargs["preserve_index"] = index
 
         table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
+        
+        fs = get_fs_for_path(path)
         # write_to_dataset does not support a file-like object when
         # a directory path is used, so just pass the path string.
         if partition_cols is not None:
@@ -111,7 +113,7 @@ class PyArrowImpl(BaseImpl):
                 table,
                 path,
                 compression=compression,
-                filesystem=get_fs_for_path(path),
+                filesystem=fs,
                 partition_cols=partition_cols,
                 **kwargs,
             )
@@ -120,7 +122,7 @@ class PyArrowImpl(BaseImpl):
                 table,
                 file_obj_or_path,
                 compression=compression,
-                filesystem=get_fs_for_path(path),
+                filesystem=fs,
                 **kwargs,
             )
         if should_close:

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -581,7 +581,7 @@ class TestParquetPyArrow(Base):
             pa,
             expected=expected_df,
             path="s3://pandas-test/parquet_dir",
-            write_kwargs={"partition_cols": partition_col, "compression": None,},
+            write_kwargs={"partition_cols": partition_col, "compression": None},
             check_like=True,
             repeat=1,
         )

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -587,7 +587,7 @@ class TestParquetPyArrow(Base):
             check_like=True,
             repeat=1,
         )
-   
+
     @tm.network
     @td.skip_if_no("pyarrow")
     def test_parquet_read_from_url(self, df_compat):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -568,6 +568,26 @@ class TestParquetPyArrow(Base):
             repeat=1,
         )
 
+    @td.skip_if_no("s3fs")
+    @pytest.mark.parametrize("partition_col", [["A"], []])
+    def test_s3_roundtrip_for_dir_infer_fs(self, df_compat, s3_resource, pa,
+                                           partition_col):
+        expected_df = df_compat.copy()
+        if partition_col:
+            expected_df[partition_col] = expected_df[partition_col].astype("category")
+        check_round_trip(
+            df_compat,
+            pa,
+            expected=expected_df,
+            path="s3://pandas-test/parquet_dir",
+            write_kwargs={
+                "partition_cols": partition_col,
+                "compression": None,
+            },
+            check_like=True,
+            repeat=1,
+        )
+    
     @tm.network
     @td.skip_if_no("pyarrow")
     def test_parquet_read_from_url(self, df_compat):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -587,7 +587,7 @@ class TestParquetPyArrow(Base):
             check_like=True,
             repeat=1,
         )
-    
+   
     @tm.network
     @td.skip_if_no("pyarrow")
     def test_parquet_read_from_url(self, df_compat):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -570,8 +570,9 @@ class TestParquetPyArrow(Base):
 
     @td.skip_if_no("s3fs")
     @pytest.mark.parametrize("partition_col", [["A"], []])
-    def test_s3_roundtrip_for_dir_infer_fs(self, df_compat, s3_resource, pa,
-                                           partition_col):
+    def test_s3_roundtrip_for_dir_infer_fs(
+        self, df_compat, s3_resource, pa, partition_col
+    ):
         expected_df = df_compat.copy()
         if partition_col:
             expected_df[partition_col] = expected_df[partition_col].astype("category")
@@ -580,10 +581,7 @@ class TestParquetPyArrow(Base):
             pa,
             expected=expected_df,
             path="s3://pandas-test/parquet_dir",
-            write_kwargs={
-                "partition_cols": partition_col,
-                "compression": None,
-            },
+            write_kwargs={"partition_cols": partition_col, "compression": None,},
             check_like=True,
             repeat=1,
         )


### PR DESCRIPTION
Infer the file system to be passed to pyarrow based on the path provided.

- [x] closes #34841
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
