### PR TITLE
base/test_unique.py: regression test for bad unicode string

### DIFF
--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -105,3 +105,19 @@ def test_nunique_null(null_obj, index_or_series_obj):
         num_unique_values = len(obj.unique())
         assert obj.nunique() == max(0, num_unique_values - 1)
         assert obj.nunique(dropna=False) == max(0, num_unique_values)
+
+
+@pytest.mark.parametrize(
+    "idx_or_series_w_bad_unicode", [pd.Index(["\ud83d"] * 2), pd.Series(["\ud83d"] * 2)]
+)
+def test_unique_bad_unicode(idx_or_series_w_bad_unicode):
+    # regression test for #34550
+    obj = idx_or_series_w_bad_unicode
+    result = obj.unique()
+
+    if isinstance(obj, pd.Index):
+        expected = pd.Index(["\ud83d"], dtype=object)
+        tm.assert_index_equal(result, expected)
+    else:
+        expected = np.array(["\ud83d"], dtype=object)
+        tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [x] closes #34550 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I ran the tests with pandas 1.0.4, where it segfaults as expected (shown below), and `master` passes the test.

    tests/test_mytest.py::test_unique2[idx_or_series_w_bad_unicode0] Fatal Python error: Segmentation fault

    Current thread 0x00007f09d2dc4740 (most recent call first):
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pandas/core/algorithms.py", line 382 in unique
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pandas/core/base.py", line 1246 in unique
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 1974 in unique
      File "/home/suvali/tmp/pandas-tests/tests/test_mytest.py", line 16 in test_unique2
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/python.py", line 182 in pytest_pyfunc_call
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/python.py", line 1477 in runtest
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 135 in pytest_runtest_call
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 217 in <lambda>
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 244 in from_call
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 216 in call_runtest_hook
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 186 in call_and_report
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 100 in runtestprotocol
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 85 in pytest_runtest_protocol
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/main.py", line 272 in pytest_runtestloop
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/main.py", line 247 in _main
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/main.py", line 191 in wrap_session
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/main.py", line 240 in pytest_cmdline_main
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/callers.py", line 187 in _multicall
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 84 in <lambda>
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/manager.py", line 93 in _hookexec
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/pluggy/hooks.py", line 286 in __call__
      File "/opt/conda/envs/py38/lib/python3.8/site-packages/_pytest/config/__init__.py", line 124 in main
      File "/opt/conda/envs/py38/bin/pytest", line 11 in <module>
    Segmentation fault (core dumped)