### PR TITLE
PERF: Timestamp dont create ndarray

### DIFF
--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -91,7 +91,7 @@ def build_field_sarray(const int64_t[:] dtindex):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def get_date_name_field(const int64_t[:] dtindex, object field, object locale=None):
+def get_date_name_field(const int64_t[:] dtindex, str field, object locale=None):
     """
     Given a int64-based datetime index, return array of strings of date
     name based on requested field (e.g. day_name)
@@ -141,7 +141,7 @@ def get_date_name_field(const int64_t[:] dtindex, object field, object locale=No
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def get_start_end_field(const int64_t[:] dtindex, object field,
+def get_start_end_field(const int64_t[:] dtindex, str field,
                         object freqstr=None, int month_kw=12):
     """
     Given an int64-based datetime index return array of indicators
@@ -386,7 +386,7 @@ def get_start_end_field(const int64_t[:] dtindex, object field,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def get_date_field(const int64_t[:] dtindex, object field):
+def get_date_field(const int64_t[:] dtindex, str field):
     """
     Given a int64-based datetime index, extract the year, month, etc.,
     field and return an array of these values.
@@ -548,7 +548,7 @@ def get_date_field(const int64_t[:] dtindex, object field):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def get_timedelta_field(const int64_t[:] tdindex, object field):
+def get_timedelta_field(const int64_t[:] tdindex, str field):
     """
     Given a int64-based timedelta index, extract the days, hrs, sec.,
     field and return an array of these values.

--- a/pandas/_libs/tslibs/timestamps.pxd
+++ b/pandas/_libs/tslibs/timestamps.pxd
@@ -17,7 +17,7 @@ cdef class _Timestamp(ABCTimestamp):
         object freq
 
     cpdef bint _get_start_end_field(self, str field)
-    cpdef _get_date_name_field(self, object field, object locale)
+    cpdef _get_date_name_field(self, str field, object locale)
     cdef int64_t _maybe_convert_value_to_local(self)
     cpdef to_datetime64(self)
     cdef _assert_tzawareness_compat(_Timestamp self, datetime other)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -467,17 +467,17 @@ cdef class _Timestamp(ABCTimestamp):
             freqstr = None
 
         val = self._maybe_convert_value_to_local()
-        out = get_start_end_field(np.array([val], dtype=np.int64),
+        out = get_start_end_field(<int64_t[:1]>&val,
                                   field, freqstr, month_kw)
         return out[0]
 
-    cpdef _get_date_name_field(self, object field, object locale):
+    cpdef _get_date_name_field(self, str field, object locale):
         cdef:
             int64_t val
             object[:] out
 
         val = self._maybe_convert_value_to_local()
-        out = get_date_name_field(np.array([val], dtype=np.int64),
+        out = get_date_name_field(<int64_t[:1]>&val,
                                   field, locale=locale)
         return out[0]
 
@@ -1448,11 +1448,11 @@ default 'raise'
         Normalize Timestamp to midnight, preserving tz information.
         """
         cdef:
+            int64_t val = self.value
             ndarray[int64_t] normalized
             tzinfo own_tz = self.tzinfo  # could be None
 
-        normalized = normalize_i8_timestamps(
-            np.array([self.value], dtype="i8"), tz=own_tz)
+        normalized = normalize_i8_timestamps(<int64_t[:1]>&val, tz=own_tz)
         return Timestamp(normalized[0]).tz_localize(own_tz)
 
 


### PR DESCRIPTION
```
In [1]: import pandas as pd                                                                                                                                   
In [2]: ts = pd.Timestamp.now()                                                                                                                               

In [3]: %timeit ts.day_name()                                                                                                                                 
6.46 µs ± 158 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- PR
8.39 µs ± 107 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- master
```