### PR TITLE
TST: Add test to verify 'dropna' behaviour on SparseArray

### DIFF
--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1295,3 +1295,14 @@ def test_map_missing():
 
     result = arr.map({0: 10, 1: 11})
     tm.assert_sp_array_equal(result, expected)
+
+
+def test_dropna_sparse_column_doesnt_drop_nonna():
+    # GH-28287
+    arr = SparseArray([np.nan, 1])
+    exp = SparseArray([1.0])
+    tm.assert_sp_array_equal(arr.dropna(), exp)
+
+    df = pd.DataFrame({"a": [0, 1], "b": arr})
+    expected_df = pd.DataFrame({"a": [1], "b": exp}, index=pd.Int64Index([1]))
+    tm.assert_equal(df.dropna(), expected_df)

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1297,10 +1297,11 @@ def test_map_missing():
     tm.assert_sp_array_equal(result, expected)
 
 
-def test_dropna_sparse_column_doesnt_drop_nonna():
+@pytest.mark.parametrize("fill_value", [np.nan, 1])
+def test_dropna_sparse_column_doesnt_drop_nonna(fill_value):
     # GH-28287
-    arr = SparseArray([np.nan, 1])
-    exp = SparseArray([1.0])
+    arr = SparseArray([np.nan, 1], fill_value=fill_value)
+    exp = SparseArray([1.0], fill_value=fill_value)
     tm.assert_sp_array_equal(arr.dropna(), exp)
 
     df = pd.DataFrame({"a": [0, 1], "b": arr})

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -1298,7 +1298,7 @@ def test_map_missing():
 
 
 @pytest.mark.parametrize("fill_value", [np.nan, 1])
-def test_dropna_sparse_column_doesnt_drop_nonna(fill_value):
+def test_dropna(fill_value):
     # GH-28287
     arr = SparseArray([np.nan, 1], fill_value=fill_value)
     exp = SparseArray([1.0], fill_value=fill_value)


### PR DESCRIPTION
verify that calling `dropna` on a pd.SparseArray does not inadvertently drop non-na records on both DataFrames and the SparseArray itself.

- [x] closes #28287
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry (not applicable?)
