### PR TITLE
TST: Add test to verify align behaviour on CategoricalIndex

### DIFF
--- a/pandas/tests/frame/methods/test_align.py
+++ b/pandas/tests/frame/methods/test_align.py
@@ -129,6 +129,26 @@ class TestDataFrameAlign:
         )
         tm.assert_index_equal(bf.index, Index([]))
 
+    def test_align_categorical(self):
+        # GH-28397
+        df_1 = DataFrame(
+            {
+                "A": np.arange(6, dtype="int64"),
+                "B": Series(list("aabbca")).astype(pd.CategoricalDtype(list("cab"))),
+            }
+        ).set_index("B")
+        df_2 = DataFrame(
+            {
+                "A": np.arange(5, dtype="int64"),
+                "B": Series(list("babca")).astype(pd.CategoricalDtype(list("cab"))),
+            }
+        ).set_index("B")
+
+        aligned_1, aligned_2 = df_1.align(df_2)
+        assert isinstance(aligned_1.index, pd.CategoricalIndex)
+        assert isinstance(aligned_2.index, pd.CategoricalIndex)
+        tm.assert_index_equal(aligned_1.index, aligned_2.index)
+
     def test_align_multiindex(self):
         # GH#10665
         # same test cases as test_align_multiindex in test_series.py

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -806,12 +806,3 @@ class TestCategoricalIndex:
         result.loc[sl, "A"] = ["qux", "qux2"]
         expected = DataFrame({"A": ["qux", "qux2", "baz"]}, index=cat_idx)
         tm.assert_frame_equal(result, expected)
-
-    def test_align(self):
-        # GH-28397
-        df_1, df_2 = self.df.copy(), self.df.copy().iloc[::-1]
-
-        aligned_1, aligned_2 = df_1.align(df_2)
-        assert isinstance(aligned_1.index, CategoricalIndex)
-        assert isinstance(aligned_2.index, CategoricalIndex)
-        tm.assert_index_equal(aligned_1.index, aligned_2.index)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -807,12 +807,11 @@ class TestCategoricalIndex:
         expected = DataFrame({"A": ["qux", "qux2", "baz"]}, index=cat_idx)
         tm.assert_frame_equal(result, expected)
 
-    def test_align_keeps_categorical_index(self):
+    def test_align(self):
         # GH-28397
-        df_1, df_2 = self.df.copy(), self.df.copy()
+        df_1, df_2 = self.df.copy(), self.df.copy().iloc[::-1]
 
         aligned_1, aligned_2 = df_1.align(df_2)
         assert isinstance(aligned_1.index, CategoricalIndex)
         assert isinstance(aligned_2.index, CategoricalIndex)
-        tm.assert_index_equal(aligned_1.index, df_1.index)
-        tm.assert_index_equal(aligned_2.index, df_2.index)
+        tm.assert_index_equal(aligned_1.index, aligned_2.index)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -806,3 +806,13 @@ class TestCategoricalIndex:
         result.loc[sl, "A"] = ["qux", "qux2"]
         expected = DataFrame({"A": ["qux", "qux2", "baz"]}, index=cat_idx)
         tm.assert_frame_equal(result, expected)
+
+    def test_align_keeps_categorical_index(self):
+        # GH-28397
+        df_1, df_2 = self.df.copy(), self.df.copy()
+
+        aligned_1, aligned_2 = df_1.align(df_2)
+        assert isinstance(aligned_1.index, CategoricalIndex)
+        assert isinstance(aligned_2.index, CategoricalIndex)
+        tm.assert_index_equal(aligned_1.index, df_1.index)
+        tm.assert_index_equal(aligned_2.index, df_2.index)


### PR DESCRIPTION
verify that aligning two dataframes with a `CategoricalIndex` does not change the type of the index.

- [x] closes #28397
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry (not applicable?)
