### PR TITLE
DOC: Fix validation issues with Index.is_ docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -523,7 +523,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         See Also
         --------
-        Index.identical : Works like ``Index.is_`` but also check metadata.
+        Index.identical : Works like ``Index.is_`` but also checks metadata.
         """
         # use something other than None to be clearer
         return self._id is getattr(other, "_id", Ellipsis) and self._id is not None

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -518,7 +518,12 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        True if both have same underlying data, False otherwise : bool
+        bool
+            True if both have same underlying data, False otherwise.
+
+        See Also
+        --------
+        Index.identical : Works like ``Index.is_`` but also check metadata.
         """
         # use something other than None to be clearer
         return self._id is getattr(other, "_id", Ellipsis) and self._id is not None


### PR DESCRIPTION
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Fix validation issues with the `Index.is_ docstring` and add `Index.identical` to see also section. Trying to finish what was started in #32357 