### PR TITLE
TST: Feather RoundTrip Column Ordering

### DIFF
--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -115,6 +115,11 @@ class TestFeather:
         columns = ["col1", "col3"]
         self.check_round_trip(df, expected=df[columns], columns=columns)
 
+    def read_columns_different_order(self):
+        # GH 33878
+        df = pd.DataFrame({"A": [1, 2], "B": ["x", "y"], "C": [True, False]})
+        self.check_round_trip(df, columns=["B", "A"])
+
     def test_unsupported_other(self):
 
         # mixed python objects

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -115,6 +115,7 @@ class TestFeather:
         columns = ["col1", "col3"]
         self.check_round_trip(df, expected=df[columns], columns=columns)
 
+    @td.skip_if_no("pyarrow", min_version="0.17.1")
     def read_columns_different_order(self):
         # GH 33878
         df = pd.DataFrame({"A": [1, 2], "B": ["x", "y"], "C": [True, False]})


### PR DESCRIPTION
Looks like this in fixed from pyarrow 0.17.1 -> Added a Test.

- [x] closes #https://github.com/pandas-dev/pandas/issues/33878
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
