### PR TITLE
DOC: add mention of recommended dependencies in users guide

### DIFF
--- a/doc/source/user_guide/enhancingperf.rst
+++ b/doc/source/user_guide/enhancingperf.rst
@@ -13,6 +13,14 @@ when we use Cython and Numba on a test function operating row-wise on the
 ``DataFrame``. Using :func:`pandas.eval` we will speed up a sum by an order of
 ~2.
 
+.. note::
+
+   In addition to following the steps in this tutorial, users interested in enhancing
+   performance are highly encouraged to install the
+   :ref:`recommended dependencies<install.recommended_dependencies>` for pandas.
+   These dependencies are often not installed by default, but will offer speed
+   improvements if present.
+
 .. _enhancingperf.cython:
 
 Cython (writing C extensions for pandas)


### PR DESCRIPTION
First-time contributor here!

Ian Ozsvald mentioned installing the optional dependencies for pandas in his talk at PyData Amsterdam 2020. Although these are mentioned in the Getting Started section, I though they should be mentioned in the Users Guide, which is where I typically go for pandas information. It seems like many users aren't aware that these dependencies are available to increase performance.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
