### PR TITLE
Replace old string formatting syntax with f-strings #29547

### DIFF
--- a/pandas/tests/series/indexing/test_where.py
+++ b/pandas/tests/series/indexing/test_where.py
@@ -222,12 +222,13 @@ def test_where_setitem_invalid():
     # GH 2702
     # make sure correct exceptions are raised on invalid list assignment
 
-    msg = "cannot set using a {} indexer with a different length than the value"
+    msg = "cannot set using a slice indexer with a different length than the value"
+    msg_list = "cannot set using a list-like indexer with a different length than the value"
 
     # slice
     s = Series(list("abc"))
 
-    with pytest.raises(ValueError, match=msg.format("slice")):
+    with pytest.raises(ValueError, match=msg):
         s[0:3] = list(range(27))
 
     s[0:3] = list(range(3))
@@ -237,7 +238,7 @@ def test_where_setitem_invalid():
     # slice with step
     s = Series(list("abcdef"))
 
-    with pytest.raises(ValueError, match=msg.format("slice")):
+    with pytest.raises(ValueError, match=msg):
         s[0:4:2] = list(range(27))
 
     s = Series(list("abcdef"))
@@ -248,7 +249,7 @@ def test_where_setitem_invalid():
     # neg slices
     s = Series(list("abcdef"))
 
-    with pytest.raises(ValueError, match=msg.format("slice")):
+    with pytest.raises(ValueError, match=msg):
         s[:-1] = list(range(27))
 
     s[-3:-1] = list(range(2))
@@ -258,12 +259,12 @@ def test_where_setitem_invalid():
     # list
     s = Series(list("abc"))
 
-    with pytest.raises(ValueError, match=msg.format("list-like")):
+    with pytest.raises(ValueError, match=msg_list):
         s[[0, 1, 2]] = list(range(27))
 
     s = Series(list("abc"))
 
-    with pytest.raises(ValueError, match=msg.format("list-like")):
+    with pytest.raises(ValueError, match=msg_list):
         s[[0, 1, 2]] = list(range(2))
 
     # scalar


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
