### PR TITLE
TST:add test for df replace GH34871

### DIFF
--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1418,8 +1418,13 @@ class TestDataFrameReplace:
         # buggy behavior is to raise:
         # TypeError: 'value' should be a 'Period', 'NaT', or array of those.
         # Got 'float' instead
-        df_after_replace = df.replace(1.0, 0.0)
+        # so for now we want to simply call this and no exception should be
+        # raised, improving upon 1.0.4 behavior
+        # df_after_replace = df.replace(1.0, 0.0)
+        df.replace(1.0, 0.0)
 
         # 'replace()' should be ignored for these inputs,
         # so new df should equal old df
-        tm.assert_frame_equal(df, df_after_replace)
+        # this is currently still buggy, Period column becomes Object instead
+        # so needs fix in future. added this info to GH ticket
+        # tm.assert_frame_equal(df, df_after_replace)

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1403,3 +1403,23 @@ class TestDataFrameReplace:
         result["B"] = result["B"].replace(7, replacement)
 
         tm.assert_frame_equal(result, expected)
+
+    def test_replace_period_ignore_float(self):
+        """
+        Regression test for GH#34871: if df.replace(1.0, 0.0) is called on a df
+        with a Period column the old, faulty behavior is to raise TypeError
+        (reported for Pandas 1.0.4). The intended behavior is to just ignore
+        that column. This has been fixed in newer versions. This is a regression
+        test that triggers for the old, broken behavior, i.e.
+        TypeError is raised
+        """
+        df = pd.DataFrame({"Per": [pd.Period("2020-01")] * 3})
+
+        # buggy behavior is to raise:
+        # TypeError: 'value' should be a 'Period', 'NaT', or array of those.
+        # Got 'float' instead
+        df_after_replace = df.replace(1.0, 0.0)
+
+        # 'replace()' should be ignored for these inputs,
+        # so new df should equal old df
+        tm.assert_frame_equal(df, df_after_replace)

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1407,24 +1407,13 @@ class TestDataFrameReplace:
     def test_replace_period_ignore_float(self):
         """
         Regression test for GH#34871: if df.replace(1.0, 0.0) is called on a df
-        with a Period column the old, faulty behavior is to raise TypeError
-        (reported for Pandas 1.0.4). The intended behavior is to just ignore
-        that column. This has been fixed in newer versions. This is a regression
-        test that triggers for the old, broken behavior, i.e.
-        TypeError is raised
+        with a Period column the old, faulty behavior is to raise TypeError.
         """
         df = pd.DataFrame({"Per": [pd.Period("2020-01")] * 3})
+        df_after_replace = df.replace(1.0, 0.0)
 
-        # buggy behavior is to raise:
-        # TypeError: 'value' should be a 'Period', 'NaT', or array of those.
-        # Got 'float' instead
-        # so for now we want to simply call this and no exception should be
-        # raised, improving upon 1.0.4 behavior
-        # df_after_replace = df.replace(1.0, 0.0)
-        df.replace(1.0, 0.0)
+        df_expected_result = pd.DataFrame({"Per": [pd.Period("2020-01")] * 3})
+        # currently replace() changes dtype from Period to object
+        df_expected_result["Per"] = df_expected_result["Per"].astype(object)
 
-        # 'replace()' should be ignored for these inputs,
-        # so new df should equal old df
-        # this is currently still buggy, Period column becomes Object instead
-        # so needs fix in future. added this info to GH ticket
-        # tm.assert_frame_equal(df, df_after_replace)
+        tm.assert_frame_equal(df_expected_result, df_after_replace)

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1404,16 +1404,15 @@ class TestDataFrameReplace:
 
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.xfail(
+        reason="replace() changes dtype from period to object, see GH34871", strict=True
+    )
     def test_replace_period_ignore_float(self):
         """
         Regression test for GH#34871: if df.replace(1.0, 0.0) is called on a df
         with a Period column the old, faulty behavior is to raise TypeError.
         """
         df = pd.DataFrame({"Per": [pd.Period("2020-01")] * 3})
-        df_after_replace = df.replace(1.0, 0.0)
-
-        df_expected_result = pd.DataFrame({"Per": [pd.Period("2020-01")] * 3})
-        # currently replace() changes dtype from Period to object
-        df_expected_result["Per"] = df_expected_result["Per"].astype(object)
-
-        tm.assert_frame_equal(df_expected_result, df_after_replace)
+        result = df.replace(1.0, 0.0)
+        expected = pd.DataFrame({"Per": [pd.Period("2020-01")] * 3})
+        tm.assert_frame_equal(expected, result)


### PR DESCRIPTION
- [x] improves upon #34871
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry <---- is that helpful for this specific regression test? happy to write this if you think this helps! :)

add tiny regression test for not failing on calling df.replace() with Period column

working on this revealed other quirks of df.replace(): it now does not raise an exception anymore, and the dataframe returned by replace() has the right values. However, the dtype of a Period column changes to Object, which is surprising. 

I've added the observations to GH34871