### PR TITLE
BUG: incorrect type when indexing sparse dataframe with iterable

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1124,6 +1124,7 @@ Sparse
 - Bug where :class:`DataFrame` containing :class:`SparseArray` filled with ``NaN`` when indexed by a list-like (:issue:`27781`, :issue:`29563`)
 - The repr of :class:`SparseDtype` now includes the repr of its ``fill_value`` attribute. Previously it used ``fill_value``'s  string representation (:issue:`34352`)
 - Bug where empty :class:`DataFrame` could not be cast to :class:`SparseDtype` (:issue:`33113`)
+- Bug in :meth:`arrays.SparseArray` was returning the incorrect type when indexing a sparse dataframe with an iterable (:issue:`34526`, :issue:`34540`)
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -866,11 +866,8 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
 
         if self.sp_index.npoints == 0:
             # Avoid taking from the empty self.sp_values
-            taken = np.full(
-                sp_indexer.shape,
-                fill_value=fill_value,
-                dtype=np.result_type(type(fill_value)),
-            )
+            _dtype = np.result_type(self.dtype.subtype, type(fill_value))
+            taken = np.full(sp_indexer.shape, fill_value=fill_value, dtype=_dtype)
         else:
             taken = self.sp_values.take(sp_indexer)
 

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -20,7 +20,6 @@ from pandas import (
     isna,
     notna,
 )
-import pandas.util._test_decorators as td
 import pandas._testing as tm
 import pandas.core.common as com
 from pandas.core.indexing import IndexingError

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -22,9 +22,7 @@ from pandas import (
 )
 import pandas.util._test_decorators as td
 import pandas._testing as tm
-from pandas.arrays import SparseArray
 import pandas.core.common as com
-from pandas.core.arrays.sparse import SparseDtype
 from pandas.core.indexing import IndexingError
 
 from pandas.tseries.offsets import BDay
@@ -1908,40 +1906,6 @@ class TestDataFrameIndexing:
 
         expect = df.iloc[[1, -1], 0]
         tm.assert_series_equal(df.loc[0.2, "a"], expect)
-
-    def test_getitem_sparse_column(self):
-        # https://github.com/pandas-dev/pandas/issues/23559
-        data = SparseArray([0, 1])
-        df = pd.DataFrame({"A": data})
-        expected = pd.Series(data, name="A")
-        result = df["A"]
-        tm.assert_series_equal(result, expected)
-
-        result = df.iloc[:, 0]
-        tm.assert_series_equal(result, expected)
-
-        result = df.loc[:, "A"]
-        tm.assert_series_equal(result, expected)
-
-    @pytest.mark.parametrize("spmatrix_t", ["coo_matrix", "csc_matrix", "csr_matrix"])
-    @td.skip_if_no_scipy
-    def test_locindexer_from_spmatrix(self, spmatrix_t):
-        import scipy.sparse
-        spmatrix_t = getattr(scipy.sparse, spmatrix_t)
-
-        spmatrix = spmatrix_t([[1.0, 0.0], [0.0, 0.0]], dtype=np.float64)
-        df = pd.DataFrame.sparse.from_spmatrix(spmatrix)
-
-        # regression test for #34526
-        itr_idx = [1]
-        result = df.loc[itr_idx].values
-        expected = spmatrix.toarray()[itr_idx]
-        tm.assert_numpy_array_equal(result, expected)
-
-        # regression test for #34540
-        result_t = df.loc[itr_idx].dtypes.values
-        expected_t = np.full(2, SparseDtype(np.float64, fill_value=0))
-        tm.assert_numpy_array_equal(result_t, expected_t)
 
     def test_setitem_with_unaligned_tz_aware_datetime_column(self):
         # GH 12981

--- a/pandas/tests/frame/indexing/test_sparse.py
+++ b/pandas/tests/frame/indexing/test_sparse.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+
+import pandas.util._test_decorators as td
+import pandas._testing as tm
+
+from pandas.arrays import SparseArray
+from pandas.core.arrays.sparse import SparseDtype
+
+import pytest
+
+
+class TestSparseDataFrameIndexing:
+    def test_getitem_sparse_column(self):
+        # https://github.com/pandas-dev/pandas/issues/23559
+        data = SparseArray([0, 1])
+        df = pd.DataFrame({"A": data})
+        expected = pd.Series(data, name="A")
+        result = df["A"]
+        tm.assert_series_equal(result, expected)
+
+        result = df.iloc[:, 0]
+        tm.assert_series_equal(result, expected)
+
+        result = df.loc[:, "A"]
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("spmatrix_t", ["coo_matrix", "csc_matrix", "csr_matrix"])
+    @td.skip_if_no_scipy
+    def test_locindexer_from_spmatrix(self, spmatrix_t):
+        import scipy.sparse
+
+        spmatrix_t = getattr(scipy.sparse, spmatrix_t)
+
+        spmatrix = spmatrix_t([[1.0, 0.0], [0.0, 0.0]], dtype=np.float64)
+        df = pd.DataFrame.sparse.from_spmatrix(spmatrix)
+
+        # regression test for #34526
+        itr_idx = [1]
+        result = df.loc[itr_idx].values
+        expected = spmatrix.toarray()[itr_idx]
+        tm.assert_numpy_array_equal(result, expected)
+
+        # regression test for #34540
+        result = df.loc[itr_idx].dtypes.values
+        expected = np.full(2, SparseDtype(np.float64, fill_value=0))
+        tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/frame/indexing/test_sparse.py
+++ b/pandas/tests/frame/indexing/test_sparse.py
@@ -1,13 +1,12 @@
 import numpy as np
-import pandas as pd
+import pytest
 
 import pandas.util._test_decorators as td
-import pandas._testing as tm
 
+import pandas as pd
+import pandas._testing as tm
 from pandas.arrays import SparseArray
 from pandas.core.arrays.sparse import SparseDtype
-
-import pytest
 
 
 class TestSparseDataFrameIndexing:

--- a/pandas/tests/frame/indexing/test_sparse.py
+++ b/pandas/tests/frame/indexing/test_sparse.py
@@ -25,7 +25,7 @@ class TestSparseDataFrameIndexing:
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("spmatrix_t", ["coo_matrix", "csc_matrix", "csr_matrix"])
-    @pytest.mark.parametrize("dtype", [np.int64, np.float64, np.complex])
+    @pytest.mark.parametrize("dtype", [np.int64, np.float64, complex])
     @td.skip_if_no_scipy
     def test_locindexer_from_spmatrix(self, spmatrix_t, dtype):
         import scipy.sparse


### PR DESCRIPTION
closes #34526
closes #34540 
- [x] 2 tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The problem arose when indexing with an iterable.  If the result consisted of columns which originally only had sparse values, the `dtype` was solely inferred from the `fill_value`, which defaults to `0`.  Hence, the resulting columns have the dtype ` Sparse[int64, 0]`.   This commit changes the type inference logic to use the numpy type promotion rules between the underlying subtype of the `SparseArray.dtype` and the type of the fill value.