### PR TITLE
PERF: avoid creating many Series in apply_standard

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -8,12 +8,7 @@ from pandas._libs import reduction as libreduction
 from pandas._typing import Axis
 from pandas.util._decorators import cache_readonly
 
-from pandas.core.dtypes.common import (
-    is_dict_like,
-    is_extension_array_dtype,
-    is_list_like,
-    is_sequence,
-)
+from pandas.core.dtypes.common import is_dict_like, is_list_like, is_sequence
 from pandas.core.dtypes.generic import ABCSeries
 
 from pandas.core.construction import create_series_with_explicit_dtype

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -357,7 +357,7 @@ class FrameRowApply(FrameApply):
 
     def wrap_results_for_axis(
         self, results: ResType, res_index: "Index"
-    ) -> "DataFrame":
+    ) -> Union["Series", "DataFrame"]:
         """ return the results for the rows """
 
         if self.result_type == "reduce":
@@ -376,9 +376,9 @@ class FrameRowApply(FrameApply):
             if "arrays must all be same length" in str(err):
                 # e.g. result = [[2, 3], [1.5], ['foo', 'bar']]
                 #  see test_agg_listlike_result GH#29587
-                result = self.obj._constructor_sliced(results)
-                result.index = res_index
-                return result
+                res = self.obj._constructor_sliced(results)
+                res.index = res_index
+                return res
             else:
                 raise
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -424,11 +424,19 @@ class FrameColumnApply(FrameApply):
 
     @property
     def series_generator(self):
-        constructor = self.obj._constructor_sliced
-        return (
-            constructor(arr, index=self.columns, name=name)
-            for i, (arr, name) in enumerate(zip(self.values, self.index))
-        )
+        values = self.values
+        assert len(values) > 0
+
+        # We create one Series object, and will swap out the data inside
+        #  of it.  Kids: don't do this at home.
+        ser = self.obj._ixs(0, axis=0)
+        mgr = ser._mgr
+        blk = mgr.blocks[0]
+
+        for (arr, name) in zip(values, self.index):
+            blk.values = arr
+            ser.name = name
+            yield ser
 
     @property
     def result_index(self) -> "Index":


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This avoids going through perennial-problem-causing libreduction code (xref #34014, #34080) and instead does the same trick in python-space by re-assigning block.values instead of creating new Series objects.

If we avoid libreduction but _dont_ do this optimization, the most-affected asv is `time_apply_ref_by_name` that clocks in at 6.92x slower.  This achieves parity on that asv.

<s>ATM I'm still getting 4 test failures locally, need to troubleshoot.</s> Update: passing

