### PR TITLE
ENH: specificy missing labels in loc calls GH34272

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -21,11 +21,12 @@ Previously, if labels were missing for a loc call, a Key Error was raised statin
 
 Now the error message also includes a list of the missing labels. For example,
 
-.. ipython:: python
+.. code-block:: ipython
 
     s = pd.Series({"a": 1, "b": 2, "c": 3})
     s.loc[["a", "b", "missing_0", "c", "missing_1", "missing_2"]]
-
+    ...
+    KeyError: "Passing list-likes to .loc or [] with any missing labels is no longer supported. The following labels were missing: ['missing_0', 'missing_1', 'missing_2']. See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"
 .. _whatsnew_110.astype_string:
 
 All dtypes can now be converted to ``StringDtype``

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -13,6 +13,19 @@ including other versions of pandas.
 Enhancements
 ~~~~~~~~~~~~
 
+.. _whatsnew_110.specify_missing_labels:
+
+KeyErrors raised by loc specify missing labels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Previously, if labels were missing for a loc call, a Key Error was raised stating that this was no longer supported.
+
+Now the error message also includes a list of the missing labels. For example,
+
+.. ipython:: python
+
+    s = pd.Series({"a": 1, "b": 2, "c": 3})
+    s.loc[["a", "b", "missing_0", "c", "missing_1", "missing_2"]]
+
 .. _whatsnew_110.astype_string:
 
 All dtypes can now be converted to ``StringDtype``

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -19,14 +19,7 @@ KeyErrors raised by loc specify missing labels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Previously, if labels were missing for a loc call, a Key Error was raised stating that this was no longer supported.
 
-Now the error message also includes a list of the missing labels. For example,
-.. code-block:: ipython
-
-   In [1]: s = pd.Series({"a": 1, "b": 2, "c": 3})
-   In [2]: s.loc[["a", "b", "missing_0", "c", "missing_1", "missing_2"]]
-   Passing list-likes to .loc or [] with any missing labels is no longer supported.
-   The following labels were missing: ['missing_0', 'missing_1', 'missing_2']. See
-   https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike
+Now the error message also includes a list of the missing labels (max 10 items, display width 80 characters).
 
 
 .. _whatsnew_110.astype_string:

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -20,13 +20,15 @@ KeyErrors raised by loc specify missing labels
 Previously, if labels were missing for a loc call, a Key Error was raised stating that this was no longer supported.
 
 Now the error message also includes a list of the missing labels. For example,
-
 .. code-block:: ipython
 
-    s = pd.Series({"a": 1, "b": 2, "c": 3})
-    s.loc[["a", "b", "missing_0", "c", "missing_1", "missing_2"]]
-    ...
-    KeyError: "Passing list-likes to .loc or [] with any missing labels is no longer supported. The following labels were missing: ['missing_0', 'missing_1', 'missing_2']. See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"
+   In [1]: s = pd.Series({"a": 1, "b": 2, "c": 3})
+   In [2]: s.loc[["a", "b", "missing_0", "c", "missing_1", "missing_2"]]
+   Passing list-likes to .loc or [] with any missing labels is no longer supported.
+   The following labels were missing: ['missing_0', 'missing_1', 'missing_2']. See
+   https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike
+
+
 .. _whatsnew_110.astype_string:
 
 All dtypes can now be converted to ``StringDtype``

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -19,7 +19,7 @@ KeyErrors raised by loc specify missing labels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Previously, if labels were missing for a loc call, a Key Error was raised stating that this was no longer supported.
 
-Now the error message also includes a list of the missing labels (max 10 items, display width 80 characters).
+Now the error message also includes a list of the missing labels (max 10 items, display width 80 characters). See GH34272.
 
 
 .. _whatsnew_110.astype_string:

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -17,7 +17,7 @@ Enhancements
 
 KeyErrors raised by loc specify missing labels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Previously, if labels were missing for a loc call, a Key Error was raised stating that this was no longer supported.
+Previously, if labels were missing for a loc call, a KeyError was raised stating that this was no longer supported.
 
 Now the error message also includes a list of the missing labels (max 10 items, display width 80 characters). See :issue:`34272`.
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -19,7 +19,7 @@ KeyErrors raised by loc specify missing labels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Previously, if labels were missing for a loc call, a Key Error was raised stating that this was no longer supported.
 
-Now the error message also includes a list of the missing labels (max 10 items, display width 80 characters). See GH34272.
+Now the error message also includes a list of the missing labels (max 10 items, display width 80 characters). See :issue:`34272`.
 
 
 .. _whatsnew_110.astype_string:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1306,8 +1306,9 @@ class _LocIndexer(_LocationIndexer):
                 not_found = list(key[missing_mask])
                 raise KeyError(
                     "Passing list-likes to .loc or [] with any missing labels "
-                    f"is no longer supported. The following labels were missing: {not_found}. See "
-                    "https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"  # noqa:E501
+                    "is no longer supported. "
+                    f"The following labels were missing: {not_found}. "
+                    "See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"  # noqa:E501
                 )
 
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1303,13 +1303,16 @@ class _LocIndexer(_LocationIndexer):
             # code, so we want to avoid warning & then
             # just raising
             if not ax.is_categorical():
-                not_found = list(key[missing_mask])
-                raise KeyError(
-                    "Passing list-likes to .loc or [] with any missing labels "
-                    "is no longer supported. "
-                    f"The following labels were missing: {not_found}. "
-                    "See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"  # noqa:E501
-                )
+                not_found = key[missing_mask]
+                from pandas import option_context
+
+                with option_context("display.max_seq_items", 10, "display.width", 80):
+                    raise KeyError(
+                        "Passing list-likes to .loc or [] with any missing labels "
+                        "is no longer supported. "
+                        f"The following labels were missing: {not_found}. "
+                        "See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"  # noqa:E501
+                    )
 
 
 @doc(IndexingMixin.iloc)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1283,7 +1283,8 @@ class _LocIndexer(_LocationIndexer):
             return
 
         # Count missing values:
-        missing = (indexer < 0).sum()
+        missing_mask = indexer < 0
+        missing = (missing_mask).sum()
 
         if missing:
             if missing == len(indexer):
@@ -1302,9 +1303,10 @@ class _LocIndexer(_LocationIndexer):
             # code, so we want to avoid warning & then
             # just raising
             if not ax.is_categorical():
+                not_found = list(key[missing_mask])
                 raise KeyError(
                     "Passing list-likes to .loc or [] with any missing labels "
-                    "is no longer supported, see "
+                    f"is no longer supported. The following labels were missing: {not_found}. See "
                     "https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"  # noqa:E501
                 )
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Hashable, List, Tuple, Union
 import numpy as np
 
 from pandas._config.config import option_context
+
 from pandas._libs.indexing import _NDFrameIndexerBase
 from pandas._libs.lib import item_from_zerodim
 from pandas.errors import AbstractMethodError, InvalidIndexError

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Hashable, List, Tuple, Union
 
 import numpy as np
 
+from pandas._config.config import option_context
 from pandas._libs.indexing import _NDFrameIndexerBase
 from pandas._libs.lib import item_from_zerodim
 from pandas.errors import AbstractMethodError, InvalidIndexError
@@ -1304,7 +1305,6 @@ class _LocIndexer(_LocationIndexer):
             # just raising
             if not ax.is_categorical():
                 not_found = key[missing_mask]
-                from pandas import option_context
 
                 with option_context("display.max_seq_items", 10, "display.width", 80):
                     raise KeyError(

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1075,3 +1075,12 @@ def test_setitem_with_bool_mask_and_values_matching_n_trues_in_length():
     result = ser
     expected = pd.Series([None] * 3 + list(range(5)) + [None] * 2).astype("object")
     tm.assert_series_equal(result, expected)
+
+
+def test_missing_labels_inside_loc():
+    # GH34272
+    s = pd.Series({"a": 1, "b": 2, "c": 3})
+    with pytest.raises(KeyError) as e:
+        s.loc[["a", "b", "missing_0", "c", "missing_1", "missing_2"]]
+    missing_labels = ["missing_0", "missing_1", "missing_2"]
+    assert all(missing_label in str(e.value) for missing_label in missing_labels)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1077,10 +1077,30 @@ def test_setitem_with_bool_mask_and_values_matching_n_trues_in_length():
     tm.assert_series_equal(result, expected)
 
 
-def test_missing_labels_inside_loc():
+def test_missing_labels_inside_loc_matched_in_error_message():
     # GH34272
     s = pd.Series({"a": 1, "b": 2, "c": 3})
-    with pytest.raises(KeyError) as e:
+    error_message_regex = "missing_0.*missing_1.*missing_2"
+    with pytest.raises(KeyError, match=error_message_regex):
         s.loc[["a", "b", "missing_0", "c", "missing_1", "missing_2"]]
-    missing_labels = ["missing_0", "missing_1", "missing_2"]
-    assert all(missing_label in str(e.value) for missing_label in missing_labels)
+
+
+def test_many_missing_labels_inside_loc_error_message_limited():
+    # GH34272
+    n = 10000
+    missing_labels = [f"missing_{label}" for label in range(n)]
+    s = pd.Series({"a": 1, "b": 2, "c": 3})
+    # regex checks labels between 4 and 9995 are replaced with ellipses
+    error_message_regex = "missing_4.*\\.\\.\\..*missing_9995"
+    with pytest.raises(KeyError, match=error_message_regex):
+        s.loc[["a", "c"] + missing_labels]
+
+
+def test_long_text_missing_labels_inside_loc_error_message_limited():
+    # GH34272
+    s = pd.Series({"a": 1, "b": 2, "c": 3})
+    missing_labels = [f"long_missing_label_text_{i}" * 5 for i in range(3)]
+    # regex checks for very long labels there are new lines between each
+    error_message_regex = "long_missing_label_text_0.*\\\\n.*long_missing_label_text_1"
+    with pytest.raises(KeyError, match=error_message_regex):
+        s.loc[["a", "c"] + missing_labels]


### PR DESCRIPTION
- [ ] closes #34272
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
