### PR TITLE
REF: dont use compute_reduction

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -220,13 +220,7 @@ class FrameApply(metaclass=abc.ABCMeta):
 
     def apply_raw(self):
         """ apply to the values as a numpy array """
-        result, reduction_success = libreduction.compute_reduction(
-            self.values, self.f, axis=self.axis
-        )
-
-        # We expect np.apply_along_axis to give a two-dimensional result, or raise.
-        if not reduction_success:
-            result = np.apply_along_axis(self.f, self.axis, self.values)
+        result = np.apply_along_axis(self.f, self.axis, self.values)
 
         # TODO: mixed type case
         if result.ndim == 2:

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -745,9 +745,6 @@ class TestDataFrameApply:
             df.apply(func, axis=1)
             assert names == list(df.index)
 
-    @pytest.mark.xfail(
-        reason="The 'run once' enhancement for apply_raw not implemented yet."
-    )
     def test_apply_raw_function_runs_once(self):
         # https://github.com/pandas-dev/pandas/issues/34506
 


### PR DESCRIPTION
Full asv run shows no change.

This gets rid of one usage of libreduction.compute_reduction; #34909 gets rid of the other.