### PR TITLE
BUG: indexing regression with datetime index

### DIFF
--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -650,3 +650,13 @@ class TestPartialSetting:
             s[labels]
         with pytest.raises(KeyError, match=msg):
             df.loc[labels]
+
+    def test_indexing_timeseries_regression(self):
+        # Issue 34860
+        arr = date_range("1/1/2008", "1/1/2009")
+        result = arr.to_series()["2008"]
+
+        rng = date_range(start="2008-01-01", end="2008-12-31")
+        expected = Series(rng, index=rng)
+
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -678,4 +678,3 @@ def test_indexing_regression():
     expected = Series(rng, index=rng)
 
     tm.assert_series_equal(ser, expected)
-    tm.assert_index_equal(ser.index, expected.index)

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -669,14 +669,13 @@ def test_setitem_tuple_with_datetimetz():
     tm.assert_series_equal(result, expected)
 
 
-"""
-BUG: indexing regression with datetime index
-"""
-
-
 def test_indexing_regression():
-    arr = date_range("1/1/2008", "1/2/2008")
+    # Issue 34860
+    arr = date_range("1/1/2008", "1/1/2009")
     ser = arr.to_series()["2008"]
-    assert type(ser) == Series
-    assert type(ser[0]) == Timestamp
-    assert type(ser.index[0]) == Timestamp
+
+    rng = date_range(start="2008-01-01", end="2008-12-31")
+    expected = Series(rng, index=rng)
+
+    tm.assert_series_equal(ser, expected)
+    tm.assert_index_equal(ser.index, expected.index)

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -667,3 +667,17 @@ def test_setitem_tuple_with_datetimetz():
     result[(0, 1)] = np.nan
     expected.iloc[0] = np.nan
     tm.assert_series_equal(result, expected)
+
+
+"""
+BUG: indexing regression with datetime index
+"""
+
+
+def test_indexing_regression():
+    arr = date_range('1/1/2008', '1/2/2008')
+    ser = arr.to_series()['2008']
+    assert type(ser) == Series
+    assert type(ser[0]) == Timestamp
+    assert type(ser.index[0]) == Timestamp
+

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -675,9 +675,8 @@ BUG: indexing regression with datetime index
 
 
 def test_indexing_regression():
-    arr = date_range('1/1/2008', '1/2/2008')
-    ser = arr.to_series()['2008']
+    arr = date_range("1/1/2008", "1/2/2008")
+    ser = arr.to_series()["2008"]
     assert type(ser) == Series
     assert type(ser[0]) == Timestamp
     assert type(ser.index[0]) == Timestamp
-

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -667,14 +667,3 @@ def test_setitem_tuple_with_datetimetz():
     result[(0, 1)] = np.nan
     expected.iloc[0] = np.nan
     tm.assert_series_equal(result, expected)
-
-
-def test_indexing_regression():
-    # Issue 34860
-    arr = date_range("1/1/2008", "1/1/2009")
-    ser = arr.to_series()["2008"]
-
-    rng = date_range(start="2008-01-01", end="2008-12-31")
-    expected = Series(rng, index=rng)
-
-    tm.assert_series_equal(ser, expected)


### PR DESCRIPTION
The bug is already fixed on master. I have just added a unit test.

- [x] closes #34860
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
