### PR TITLE
Fix DataFrame/Series stack/unstack docs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6739,8 +6739,6 @@ NaN 12.3   33.0
             level(s) is (are) taken from the prescribed level(s) and
             the output is a DataFrame.
 
-        The new index levels are sorted.
-
         Parameters
         ----------
         level : int, str, list, default -1
@@ -6975,8 +6973,6 @@ NaN 12.3   33.0
 
         If the index is not a MultiIndex, the output will be a Series
         (the analogue of stack when the columns are not a MultiIndex).
-
-        The level involved will automatically get sorted.
 
         Parameters
         ----------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3823,8 +3823,6 @@ Keep all original rows and also all original values
         """
         Unstack, also known as pivot, Series with MultiIndex to produce DataFrame.
 
-        The level involved will automatically get sorted.
-
         Parameters
         ----------
         level : int, str, or list of these, default last level


### PR DESCRIPTION
- [x] closes #21675
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

As discussed in the issue, the sorted level is an implementation detail that does not always happen. Thus I think we should remove the misleading documentation.