### PR TITLE
BUILD: make tests discoverable in .devcontainer.json

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -16,7 +16,10 @@
 		"python.linting.flake8Enabled": true,
 		"python.linting.pylintEnabled": false,
 		"python.linting.mypyEnabled": true,
-		"python.testing.pytestEnabled": true
+		"python.testing.pytestEnabled": true,
+		"python.testing.pytestArgs": [
+			"pandas"
+		]
 	},
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -16,8 +16,7 @@
 		"python.linting.flake8Enabled": true,
 		"python.linting.pylintEnabled": false,
 		"python.linting.mypyEnabled": true,
-		"python.testing.pytestEnabled": true,
-		"python.testing.cwd": "pandas/tests"
+		"python.testing.pytestEnabled": true
 	},
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.


### PR DESCRIPTION
I wasn't able to discover tests using the current setup, I had to use "python.testing.pytestArgs" instead of "python.testing.cwd"