### PR TITLE
CLN: Update Cython data pointers for rolling apply

### DIFF
--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -1377,17 +1377,11 @@ def roll_generic_fixed(object obj,
                 output[i] = NaN
 
         # remaining full-length windows
-        buf = <float64_t *>arr.data
-        bufarr = np.empty(win, dtype=float)
-        oldbuf = <float64_t *>bufarr.data
-        for i in range((win - offset), (N - offset)):
-            buf = buf + 1
-            bufarr.data = <char *>buf
+        for j, i in enumerate(range((win - offset), (N - offset)), 1):
             if counts[i] >= minp:
-                output[i] = func(bufarr, *args, **kwargs)
+                output[i] = func(arr[j : j + win], *args, **kwargs)
             else:
                 output[i] = NaN
-        bufarr.data = <char *>oldbuf
 
         # truncated windows at the end
         for i in range(int_max(N - offset, 0), N):

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -1379,7 +1379,7 @@ def roll_generic_fixed(object obj,
         # remaining full-length windows
         for j, i in enumerate(range((win - offset), (N - offset)), 1):
             if counts[i] >= minp:
-                output[i] = func(arr[j : j + win], *args, **kwargs)
+                output[i] = func(arr[j:j + win], *args, **kwargs)
             else:
                 output[i] = NaN
 


### PR DESCRIPTION
- [x] xref #34014
- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Performance looks pretty comparable between master and this PR

```
N = 10 ** 3
arr = 100 * np.random.random(N)
roll = pd.DataFrame(arr).rolling(10)
%timeit roll.apply(lambda x: np.sum(x) + 5, raw=True)

4.48 ms ± 14.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) <--PR
4.34 ms ± 29.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) <--master
```