### PR TITLE
ENH: Add NDFrame.format for easier conversion to string dtype

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -46,6 +46,7 @@ Conversion
    DataFrame.astype
    DataFrame.convert_dtypes
    DataFrame.infer_objects
+   DataFrame.format
    DataFrame.copy
    DataFrame.bool
 

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -48,6 +48,7 @@ Conversion
    Series.astype
    Series.convert_dtypes
    Series.infer_objects
+   Series.format
    Series.copy
    Series.bool
    Series.to_numpy

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -30,6 +30,38 @@ For example, the below now works:
    ser[0]
    pd.Series([1, 2, np.nan], dtype="Int64").astype("string")
 
+.. _whatsnew_110.format:
+
+``DataFrame.format`` and ``Series.format`` for complex conversion to StringDtype
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+New methods :meth:`DataFrame.format` and :meth:`Series.format` have been added (:issue:`xxxxx`).
+These methods allow creating a ``string`` Series from arbitrary ``Series`` or ``DataFrame`` using standard python format strings:
+
+.. ipython:: python
+
+    df = pd.DataFrame({
+        'state_name': ['California', 'Texas', 'Florida'],
+        'state_abbreviation': ['CA', 'TX', 'FL'],
+        'population': [39_512_223, 28_995_881, 21_477_737],
+        }, index=[1, 2, 3])
+    df
+    ser = df["population"]
+
+    df.format("{state_name} ({state_abbreviation}): {population:,}")
+
+    ser.format("Population: {population:,}")
+
+The output Series will always have dtype :class:`StringDtype`.
+
+Formatting using positional arguments is also possible (``positional_only=True`` is not necessary, but by disallowing keyword parameters performance is improved):
+
+.. ipython:: python
+
+    df.format("{} ({}): {:,}", positional_only=True)
+
+    ser.format("Population: {:,}", positional_only=True)
+
 
 .. _whatsnew_110.period_index_partial_string_slicing:
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -44,12 +44,10 @@ These methods allow creating a ``string`` Series from arbitrary ``Series`` or ``
         'state_name': ['California', 'Texas', 'Florida'],
         'state_abbreviation': ['CA', 'TX', 'FL'],
         'population': [39_512_223, 28_995_881, 21_477_737],
-        }, index=[1, 2, 3])
+    }, index=[1, 2, 3])
     df
     ser = df["population"]
-
     df.format("{state_name} ({state_abbreviation}): {population:,}")
-
     ser.format("Population: {population:,}")
 
 The output Series will always have dtype :class:`StringDtype`.
@@ -59,7 +57,6 @@ Formatting using positional arguments is also possible (``positional_only=True``
 .. ipython:: python
 
     df.format("{} ({}): {:,}", positional_only=True)
-
     ser.format("Population: {:,}", positional_only=True)
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3749,7 +3749,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         self,
         format: str,
         name: Optional[str] = None,
-        positional_only: bool = False,
+        positional_only: bool_t = False,
         how_na: str = "any",
     ) -> "Series":
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -97,6 +97,7 @@ import pandas.core.indexing as indexing
 from pandas.core.internals import BlockManager
 from pandas.core.missing import find_valid_index
 from pandas.core.ops import _align_method_FRAME
+from pandas.core.strings import str_format
 
 from pandas.io.formats import format as fmt
 from pandas.io.formats.format import DataFrameFormatter, format_percentiles
@@ -105,6 +106,7 @@ from pandas.tseries.offsets import Tick
 
 if TYPE_CHECKING:
     from pandas.core.resample import Resampler
+    from pandas.core.series import Series
 
 # goal is to be able to define the docs close to function, while still being
 # able to share
@@ -3741,6 +3743,19 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     # ----------------------------------------------------------------------
     # Unsorted
+
+    @doc(str_format)
+    def format(
+        self,
+        format: str,
+        name: Optional[str] = None,
+        positional_only: bool = False,
+        how_na: str = "any",
+    ) -> "Series":
+
+        return str_format(
+            self, format, name=name, positional_only=positional_only, how_na=how_na
+        )
 
     def get(self, key, default=None):
         """

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -318,7 +318,7 @@ def str_format(
     3    Population: 21,477,737
     dtype: string
 
-    >>>  df.format("{state_name} ({state_abbreviation}): {population:,}")
+    >>> df.format("{state_name} ({state_abbreviation}): {population:,}")
     1    California (CA): 39,512,223
     2         Texas (TX): 28,995,881
     3       Florida (FL): 21,477,737

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2,7 +2,17 @@ import codecs
 from functools import wraps
 import re
 import textwrap
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Pattern, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Pattern,
+    Type,
+    Union,
+)
 import warnings
 
 import numpy as np
@@ -245,7 +255,7 @@ def _map_object(f, arr, na_mask=False, na_value=np.nan, dtype=np.dtype(object)):
 def str_format(
     arr,
     format: str,
-    name: str = None,
+    name: Optional[str] = None,
     positional_only: bool = False,
     how_na: str = "any",
 ) -> "Series":
@@ -254,16 +264,16 @@ def str_format(
 
     Parameters
     ----------
-    arr: DataFrame or Series
+    arr : DataFrame or Series
         The values to format.
     format : str
         format string.
-    name: Label, optional
+    name : Label, optional
         The name of the returned Series.
-    positional_only: bool, default False
+    positional_only : bool, default False
         If True, only allow positional parameters (i.e. allow "{}", but not "{key}").
         Setting to ``True`` will improve performance.
-    how_na: str, one of {"all", "any"}, default "any"
+    how_na : str, one of {"all", "any"}, default "any"
         If "all", return ``NA`` if all values in row are nan values.
         If "any", return ``NA`` if at least one of the values in row is a nan value.
 
@@ -294,7 +304,7 @@ def str_format(
     3    Population: 21,477,737
     dtype: string
 
-    >>>  df.format("{} ({}): {:,}")
+    >>> df.format("{} ({}): {:,}")
     1    California (CA): 39,512,223
     2         Texas (TX): 28,995,881
     3       Florida (FL): 21,477,737

--- a/pandas/tests/frame/methods/test_format.py
+++ b/pandas/tests/frame/methods/test_format.py
@@ -1,0 +1,62 @@
+import pytest
+
+import pandas as pd
+import pandas._testing as tm
+
+
+class TestFormat:
+    @pytest.mark.parametrize("format_str", ["{}-{}", "{A}-{B}", "{}-{B}"])
+    @pytest.mark.parametrize("name", [None, "X"])
+    @pytest.mark.parametrize("how_na", ["all", "any"])
+    def test_basic(self, format_str, name, how_na):
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        expected = pd.Series(["1-4", "2-5", "3-6"], dtype="string", name=name)
+
+        result = df.format(format_str, name=name, how_na=how_na)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("format_str", ["{Index}-{}-{}", "{Index}-{A}-{B}"])
+    def test_with_index(self, format_str):
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        expected = pd.Series(["0-1-4", "1-2-5", "2-3-6"], dtype="string")
+
+        result = df.format(format_str)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("format_str", ["{}-{}"])
+    @pytest.mark.parametrize("positional_only", [True, False])
+    def test_positional_only(self, format_str, positional_only):
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        expected = pd.Series(["1-4", "2-5", "3-6"], dtype="string")
+
+        result = df.format(format_str, positional_only=positional_only)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("format_str", ["{A}-{B}", "{A}-{}", "{Index}-{}"])
+    def test_positional_only_raises(self, format_str):
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        with pytest.raises(KeyError):
+            df.format(format_str, positional_only=True)
+
+    @pytest.mark.parametrize(
+        "how_na, expected",
+        [("any", ["1-4", pd.NA, pd.NA]), ("all", ["1-4", "nan-5", pd.NA])],
+    )
+    def test_na_how(self, how_na, expected):
+        df = pd.DataFrame({"A": [1, None, None], "B": [4, 5, None]})
+        expected = pd.Series(expected, dtype="string")
+
+        result = df.format("{:.0f}-{:.0f}", how_na=how_na)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("format_string", ["{}-{}-{}", "{0}-{1}-{2}"])
+    def test_too_many_positional_args(self, format_string):
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        with pytest.raises(IndexError):
+            df.format(format_string)
+
+    @pytest.mark.parametrize("format_string", ["{A}-{B}-{C}", "{C}"])
+    def test_too_many_named_args(self, format_string):
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        with pytest.raises(KeyError):
+            df.format(format_string)

--- a/pandas/tests/series/methods/test_format.py
+++ b/pandas/tests/series/methods/test_format.py
@@ -1,0 +1,64 @@
+import pytest
+
+import pandas as pd
+import pandas._testing as tm
+
+
+class TestFormat:
+    @pytest.mark.parametrize("format_str", ["Value: {}", "Value: {A}"])
+    @pytest.mark.parametrize("how_na", ["all", "any"])
+    def test_basic(self, format_str, how_na):
+        ser = pd.Series([1, 2, 3], name="A")
+        expected = pd.Series(
+            ["Value: 1", "Value: 2", "Value: 3"], dtype="string", name="X"
+        )
+
+        result = ser.format(format_str, how_na=how_na, name="X")
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("format_str", ["{Index}-{}", "{Index}-{A}"])
+    def test_with_index(self, format_str):
+        ser = pd.Series([1, 2, 3], name="A")
+        expected = pd.Series(["0-1", "1-2", "2-3"], dtype="string", name="X")
+
+        result = ser.format(format_str, name="X")
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("format_str", ["Value: {}"])
+    @pytest.mark.parametrize("positional_only", [True, False])
+    def test_positional_only(self, format_str, positional_only):
+        ser = pd.Series([1, 2, 3], name="A")
+        expected = pd.Series(["Value: 1", "Value: 2", "Value: 3"], dtype="string")
+
+        result = ser.format(format_str, positional_only=positional_only)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("format_str", ["{A}-{}", "{Index}-{}"])
+    def test_positional_only_raises(self, format_str):
+        ser = pd.Series([1, 2, 3], name="A")
+        with pytest.raises(KeyError):
+            ser.format(format_str, positional_only=True)
+
+    @pytest.mark.parametrize(
+        "how_na, expected",
+        [("any", ["Value: 1", pd.NA, pd.NA]), ("all", ["Value: 1", pd.NA, pd.NA])],
+    )
+    @pytest.mark.parametrize("format_str", ["Value: {}", "Value: {A}"])
+    def test_na_how(self, how_na, expected, format_str):
+        ser = pd.Series([1, pd.NA, pd.NA], name="A")
+        expected = pd.Series(expected, dtype="string")
+
+        result = ser.format("Value: {}", how_na=how_na)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("format_string", ["{}-{}", "{0}-{1}"])
+    def test_too_many_positional_args(self, format_string):
+        ser = pd.Series([1, 2, 3], name="A")
+        with pytest.raises(IndexError):
+            ser.format(format_string)
+
+    @pytest.mark.parametrize("format_string", ["{A}-{B}", "{B}"])
+    def test_unknown_named_args(self, format_string):
+        ser = pd.Series([1, 2, 3], name="A")
+        with pytest.raises(KeyError):
+            ser.format(format_string)


### PR DESCRIPTION
- [x] closes #17211
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This adds a ``format`` method to DataFrame and Series. This is useful for data transformation.

This method allows/makes it easier to do more complex conversion from arbitrary dtypes to ``string`` series, including combining several columns in a DataFrame to make the string series. For example we can now do this conversion quite easily:

```python
>>> df = pd.DataFrame({
...     'state_name': ['California', 'Texas', 'Florida'],
...     'state_abbreviation': ['CA', 'TX', 'FL'],
...     'population': [39_512_223, 28_995_881, 21_477_737],
...     }, index=[1, 2, 3])
>>> df
   state_name state_abbreviation  population
1  California                 CA    39512223
2       Texas                 TX    28995881
3     Florida                 FL    21477737

>>>  df.format("{state_name:<10} ({state_abbreviation}): {population:,}")
1    California (CA): 39,512,223
2    Texas      (TX): 28,995,881
3    Florida    (FL): 21,477,737
dtype: string
```

I still need to update text.rst, but would like feedback on this first, as this is a bit different than discussed in #17211. In that issue we e.g. only discussed a ``format`` method for ``Series``, while this also adds it for ``DataFrame``. In #17211 I also aired the idea of allowing series methods in the format string. I think that is technically quite difficult, so is not part of this PR.