### PR TITLE
BUG: reset_index doesn't preserve dtype on empty frame with MultiIndex

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -934,6 +934,7 @@ Indexing
 - Bug in :meth:`Series.at` when used with a :class:`MultiIndex` would raise an exception on valid inputs (:issue:`26989`)
 - Bug in :meth:`DataFrame.loc` with dictionary of values changes columns with dtype of ``int`` to ``float`` (:issue:`34573`)
 - Bug in :meth:`Series.loc` when used with a :class:`MultiIndex` would raise an IndexingError when accessing a None value (:issue:`34318`)
+- Bug in :meth:`DataFrame.reset_index` and :meth:`Series.reset_index` would not preserve data types on an empty :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` (:issue:`19602`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4679,7 +4679,7 @@ class DataFrame(NDFrame):
                 # we can have situations where the whole mask is -1,
                 # meaning there is nothing found in labels, so make all nan's
                 if mask.all():
-                    values = np.empty(len(mask))
+                    values = np.empty(len(mask), dtype=index.dtype)
                     values.fill(np.nan)
                 else:
                     values = values.take(labels)

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -297,3 +297,11 @@ class TestResetIndex:
             index=RangeIndex(stop=2),
         )
         tm.assert_frame_equal(result, expected)
+
+
+def test_reset_index_dtypes_on_empty_frame_with_multiindex():
+    # GH 19602 - Preserve dtype on empty DataFrame with MultiIndex
+    idx = MultiIndex.from_product([[0, 1], [0.5, 1.0], ["a", "b"]])
+    result = DataFrame(index=idx)[:0].reset_index().dtypes
+    expected = Series({"level_0": np.int64, "level_1": np.float64, "level_2": object})
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_reset_index.py
+++ b/pandas/tests/series/methods/test_reset_index.py
@@ -108,3 +108,13 @@ class TestResetIndex:
         s = Series(range(4), index=MultiIndex.from_product([[1, 2]] * 2))
         with pytest.raises(KeyError, match="not found"):
             s.reset_index("wrong", drop=True)
+
+
+def test_reset_index_dtypes_on_empty_series_with_multiindex():
+    # GH 19602 - Preserve dtype on empty Series with MultiIndex
+    idx = MultiIndex.from_product([[0, 1], [0.5, 1.0], ["a", "b"]])
+    result = Series(dtype=object, index=idx)[:0].reset_index().dtypes
+    expected = Series(
+        {"level_0": np.int64, "level_1": np.float64, "level_2": object, 0: object}
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #19602
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
