### PR TITLE
ENH: GH34946 Check type of names argument to `read_csv`, `read_table`…

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1121,7 +1121,7 @@ Other
 - :class:`IntegerArray` now implements the ``sum`` operation (:issue:`33172`)
 - Bug in :class:`Tick` comparisons raising ``TypeError`` when comparing against timedelta-like objects (:issue:`34088`)
 - Bug in :class:`Tick` multiplication raising ``TypeError`` when multiplying by a float (:issue:`34486`)
-- Passing a `set` as `names` argument to :func:`pandas.read_csv`, :func:`pandas.read_table`, or :func:`pandas.read_fwf` will raise ``ValueError: Names should have consistent ordering. Consider a list instead.`` (:issue:`34946`)
+- Passing a `set` as `names` argument to :func:`pandas.read_csv`, :func:`pandas.read_table`, or :func:`pandas.read_fwf` will raise ``ValueError: Names should be an ordered collection.`` (:issue:`34946`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1121,6 +1121,7 @@ Other
 - :class:`IntegerArray` now implements the ``sum`` operation (:issue:`33172`)
 - Bug in :class:`Tick` comparisons raising ``TypeError`` when comparing against timedelta-like objects (:issue:`34088`)
 - Bug in :class:`Tick` multiplication raising ``TypeError`` when multiplying by a float (:issue:`34486`)
+- Passing a `set` as `names` argument to :func:`pandas.read_csv`, :func:`pandas.read_table`, or :func:`pandas.read_fwf` will raise ``ValueError: Names should have consistent ordering. Consider a list instead.`` (:issue:`34946`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -408,7 +408,7 @@ def _validate_names(names):
     Raises
     ------
     ValueError
-        If names are not unique or have incosistent ordering (e.g. set).
+        If names are not unique or have inconsistent ordering (e.g. set).
     """
     if names is not None:
         if len(names) != len(set(names)):

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -408,15 +408,13 @@ def _validate_names(names):
     Raises
     ------
     ValueError
-        If names are not unique or have inconsistent ordering (e.g. set).
+        If names are not unique or are not ordered (e.g. set).
     """
     if names is not None:
         if len(names) != len(set(names)):
             raise ValueError("Duplicate names are not allowed.")
         if not is_list_like(names, allow_sets=False):
-            raise ValueError(
-                "Names should have consistent ordering. Consider a list instead."
-            )
+            raise ValueError("Names should be an ordered collection.")
 
 
 def _read(filepath_or_buffer: FilePathOrBuffer, kwds):

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -397,7 +397,8 @@ def _validate_integer(name, val, min_val=0):
 
 def _validate_names(names):
     """
-    Raise ValueError if the `names` parameter contains duplicates.
+    Raise ValueError if the `names` parameter contains duplicates or has an
+    invalid data type.
 
     Parameters
     ----------
@@ -407,11 +408,15 @@ def _validate_names(names):
     Raises
     ------
     ValueError
-        If names are not unique.
+        If names are not unique or have incosistent ordering (e.g. set).
     """
     if names is not None:
         if len(names) != len(set(names)):
             raise ValueError("Duplicate names are not allowed.")
+        if not is_list_like(names, allow_sets=False):
+            raise ValueError(
+                "Names should have consistent ordering. Consider a list instead."
+            )
 
 
 def _read(filepath_or_buffer: FilePathOrBuffer, kwds):

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2135,3 +2135,22 @@ def test_no_header_two_extra_columns(all_parsers):
     parser = all_parsers
     df = parser.read_csv(stream, header=None, names=column_names, index_col=False)
     tm.assert_frame_equal(df, ref)
+
+
+def test_read_csv_names_types(all_parsers):
+    # GH 34946
+    data = """\
+    1,2,3
+    4,5,6
+    7,8,9
+    10,11,12\n"""
+    parser = all_parsers
+    msg = "Names should have consistent ordering. Consider a list instead."
+    names = "QAZ"
+    with pytest.raises(ValueError, match=msg):
+        parser.read_csv(StringIO(data), names=set(names))
+
+    ref = DataFrame(data={"Q": [1, 4, 7, 10], "A": [2, 5, 8, 11], "Z": [3, 6, 9, 12]})
+    for valid_type_converter in (list, tuple):
+        df = parser.read_csv(StringIO(data), names=valid_type_converter(names))
+        tm.assert_frame_equal(df, ref)

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2137,20 +2137,11 @@ def test_no_header_two_extra_columns(all_parsers):
     tm.assert_frame_equal(df, ref)
 
 
-def test_read_csv_names_types(all_parsers):
+def test_read_csv_names_not_accepting_sets(all_parsers):
     # GH 34946
     data = """\
     1,2,3
-    4,5,6
-    7,8,9
-    10,11,12\n"""
+    4,5,6\n"""
     parser = all_parsers
-    msg = "Names should be an ordered collection."
-    names = "QAZ"
-    with pytest.raises(ValueError, match=msg):
-        parser.read_csv(StringIO(data), names=set(names))
-
-    ref = DataFrame(data={"Q": [1, 4, 7, 10], "A": [2, 5, 8, 11], "Z": [3, 6, 9, 12]})
-    for valid_type_converter in (list, tuple):
-        df = parser.read_csv(StringIO(data), names=valid_type_converter(names))
-        tm.assert_frame_equal(df, ref)
+    with pytest.raises(ValueError, match="Names should be an ordered collection."):
+        parser.read_csv(StringIO(data), names=set("QAZ"))

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2145,7 +2145,7 @@ def test_read_csv_names_types(all_parsers):
     7,8,9
     10,11,12\n"""
     parser = all_parsers
-    msg = "Names should have consistent ordering. Consider a list instead."
+    msg = "Names should be an ordered collection."
     names = "QAZ"
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(StringIO(data), names=set(names))


### PR DESCRIPTION

- [x] closes #34946 
- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

- ~~One test failed (TestTSPlot.test_ts_plot_with_tz) but it's not related to what I changed.~~
- ~~Does it need a whatsnew entry?~~