### PR TITLE
REF: dont consolidate in BlockManager.equals

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -55,12 +55,7 @@ from pandas.core.dtypes.generic import (
     ABCPandasArray,
     ABCSeries,
 )
-from pandas.core.dtypes.missing import (
-    _isna_compat,
-    array_equivalent,
-    is_valid_nat_for_dtype,
-    isna,
-)
+from pandas.core.dtypes.missing import _isna_compat, is_valid_nat_for_dtype, isna
 
 import pandas.core.algorithms as algos
 from pandas.core.array_algos.transforms import shift
@@ -1367,11 +1362,6 @@ class Block(PandasObject):
 
         return result_blocks
 
-    def equals(self, other) -> bool:
-        if self.dtype != other.dtype or self.shape != other.shape:
-            return False
-        return array_equivalent(self.values, other.values)
-
     def _unstack(self, unstacker, fill_value, new_placement):
         """
         Return a list of unstacked blocks of self
@@ -1865,9 +1855,6 @@ class ExtensionBlock(Block):
 
         return [self.make_block_same_class(result, placement=self.mgr_locs)]
 
-    def equals(self, other) -> bool:
-        return self.values.equals(other.values)
-
     def _unstack(self, unstacker, fill_value, new_placement):
         # ExtensionArray-safe unstack.
         # We override ObjectBlock._unstack, which unstacks directly on the
@@ -1912,12 +1899,6 @@ class NumericBlock(Block):
 
 class FloatOrComplexBlock(NumericBlock):
     __slots__ = ()
-
-    def equals(self, other) -> bool:
-        if self.dtype != other.dtype or self.shape != other.shape:
-            return False
-        left, right = self.values, other.values
-        return ((left == right) | (np.isnan(left) & np.isnan(right))).all()
 
 
 class FloatBlock(FloatOrComplexBlock):
@@ -2281,12 +2262,6 @@ class DatetimeTZBlock(ExtensionBlock, DatetimeBlock):
             obj_vals, placement=self.mgr_locs, klass=ObjectBlock, ndim=self.ndim
         )
         return newb.setitem(indexer, value)
-
-    def equals(self, other) -> bool:
-        # override for significant performance improvement
-        if self.dtype != other.dtype or self.shape != other.shape:
-            return False
-        return (self.values.view("i8") == other.values.view("i8")).all()
 
     def quantile(self, qs, interpolation="linear", axis=0):
         naive = self.values.view("M8[ns]")

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1419,18 +1419,20 @@ class BlockManager(PandasObject):
             return False
 
         if self.ndim == 1:
+            # For SingleBlockManager (i.e.Series)
             if other.ndim != 1:
                 return False
-            blk = self.blocks[0]
-            rblk = other.blocks[0]
-            if blk.is_extension and rblk.is_extension:
-                return blk.values.equals(rblk.values)
-            elif blk.is_extension or rblk.is_extension:
+            left = self.blocks[0].values
+            right = other.blocks[0].values
+            if not is_dtype_equal(left.dtype, right.dtype):
                 return False
+            elif isinstance(left, ExtensionArray):
+                return left.equals(right)
             else:
-                return array_equivalent(blk.values, rblk.values)
+                return array_equivalent(left, right)
 
         for i in range(len(self.items)):
+            # Check column-wise, return False if any column doesnt match
             left = self.iget_values(i)
             right = other.iget_values(i)
             if not is_dtype_equal(left.dtype, right.dtype):

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -19,6 +19,7 @@ from pandas.core.dtypes.cast import (
 from pandas.core.dtypes.common import (
     DT64NS_DTYPE,
     is_datetimelike_v_numeric,
+    is_dtype_equal,
     is_extension_array_dtype,
     is_list_like,
     is_numeric_v_string_like,
@@ -1432,13 +1433,11 @@ class BlockManager(PandasObject):
         for i in range(len(self.items)):
             left = self.iget_values(i)
             right = other.iget_values(i)
-            left_ea = isinstance(left, ExtensionArray)
-            right_ea = isinstance(right, ExtensionArray)
-            if left_ea and right_ea:
+            if not is_dtype_equal(left.dtype, right.dtype):
+                return False
+            elif isinstance(left, ExtensionArray):
                 if not left.equals(right):
                     return False
-            elif left_ea or right_ea:
-                return False
             else:
                 if not array_equivalent(left, right):
                     return False

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -377,7 +377,7 @@ class TestBlockManager:
         for blk, cp_blk in zip(mgr.blocks, cp.blocks):
 
             # view assertion
-            assert cp_blk.equals(blk)
+            tm.assert_equal(cp_blk.values, blk.values)
             if isinstance(blk.values, np.ndarray):
                 assert cp_blk.values.base is blk.values.base
             else:
@@ -389,7 +389,7 @@ class TestBlockManager:
 
             # copy assertion we either have a None for a base or in case of
             # some blocks it is an array (e.g. datetimetz), but was copied
-            assert cp_blk.equals(blk)
+            tm.assert_equal(cp_blk.values, blk.values)
             if not isinstance(cp_blk.values, np.ndarray):
                 assert cp_blk.values._data.base is not blk.values._data.base
             else:


### PR DESCRIPTION
Avoid side-effects.

Side-note: with EA.equals recently added to the interface, should we update array_equivalent to use it?  ATM array_equivalent starts by casting both inputs to ndarray.