### PR TITLE
DOC: Add notes about M and Y to to_timedelata documentation.  (#34968)

### DIFF
--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -25,7 +25,10 @@ def to_timedelta(arg, unit=None, errors="raise"):
     Parameters
     ----------
     arg : str, timedelta, list-like or Series
-        The data to be converted to timedelta.
+        The data to be converted to timedelta.  Note that the character M
+        is treated as minute, not month.  The characters Y and y are treated
+        as the mean length of the Gregorian calendar year - 365.2425 days or
+        365 days 5 hours 49 minutes 12 seconds
     unit : str, optional
         Denotes the unit of the arg for numeric `arg`. Defaults to ``"ns"``.
 

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -25,10 +25,10 @@ def to_timedelta(arg, unit=None, errors="raise"):
     Parameters
     ----------
     arg : str, timedelta, list-like or Series
-        The data to be converted to timedelta.  Note that the character M
-        is treated as minute, not month.  The characters Y and y are treated
-        as the mean length of the Gregorian calendar year - 365.2425 days or
-        365 days 5 hours 49 minutes 12 seconds
+        The data to be converted to timedelta.  The character M by itself, 
+        e.g. '1M', is treated as minute, not month. The characters Y and y 
+        are treated as the mean length of the Gregorian calendar year - 
+        365.2425 days or 365 days 5 hours 49 minutes 12 seconds.
     unit : str, optional
         Denotes the unit of the arg for numeric `arg`. Defaults to ``"ns"``.
 

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -25,9 +25,9 @@ def to_timedelta(arg, unit=None, errors="raise"):
     Parameters
     ----------
     arg : str, timedelta, list-like or Series
-        The data to be converted to timedelta.  The character M by itself, 
-        e.g. '1M', is treated as minute, not month. The characters Y and y 
-        are treated as the mean length of the Gregorian calendar year - 
+        The data to be converted to timedelta.  The character M by itself,
+        e.g. '1M', is treated as minute, not month. The characters Y and y
+        are treated as the mean length of the Gregorian calendar year -
         365.2425 days or 365 days 5 hours 49 minutes 12 seconds.
     unit : str, optional
         Denotes the unit of the arg for numeric `arg`. Defaults to ``"ns"``.


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Not sure it closes these issues, but using "M" in the arg argument of to_timedelta caused confusion in #34968 and #27285.  #33094 is somewhat related. I came across another issue I can't find now where there was confusion about "Y" returning a days with times delta