### PR TITLE
BUG: Cannot create third-party ExtensionArrays for datetime types (xfail)

### DIFF
--- a/pandas/tests/extension/arrow/test_timestamp.py
+++ b/pandas/tests/extension/arrow/test_timestamp.py
@@ -1,0 +1,57 @@
+import datetime
+from typing import Type
+
+import pytest
+
+import pandas as pd
+from pandas.api.extensions import ExtensionDtype, register_extension_dtype
+
+pytest.importorskip("pyarrow", minversion="0.13.0")
+
+import pyarrow as pa  # isort:skip
+
+from .arrays import ArrowExtensionArray  # isort:skip
+
+
+@register_extension_dtype
+class ArrowTimestampUSDtype(ExtensionDtype):
+
+    type = datetime.datetime
+    kind = "M"
+    name = "arrow_timestamp_us"
+    na_value = pa.NULL
+
+    @classmethod
+    def construct_array_type(cls) -> Type["ArrowTimestampUSArray"]:
+        """
+        Return the array type associated with this dtype.
+
+        Returns
+        -------
+        type
+        """
+        return ArrowTimestampUSArray
+
+
+class ArrowTimestampUSArray(ArrowExtensionArray):
+    def __init__(self, values):
+        if not isinstance(values, pa.ChunkedArray):
+            raise ValueError
+
+        assert values.type == pa.timestamp("us")
+        self._data = values
+        self._dtype = ArrowTimestampUSDtype()
+
+
+@pytest.mark.xfail(
+    reason="DatetimeTZBlock is created while ExtensionBlock should be, see #34986"
+)
+def test_constructor_extensionblock():
+    # GH 34986
+    pd.DataFrame(
+        {
+            "timestamp": ArrowTimestampUSArray.from_scalars(
+                [None, datetime.datetime(2010, 9, 8, 7, 6, 5, 4)]
+            )
+        }
+    )

--- a/pandas/tests/extension/arrow/test_timestamp.py
+++ b/pandas/tests/extension/arrow/test_timestamp.py
@@ -43,9 +43,6 @@ class ArrowTimestampUSArray(ArrowExtensionArray):
         self._dtype = ArrowTimestampUSDtype()
 
 
-@pytest.mark.xfail(
-    reason="DatetimeTZBlock is created while ExtensionBlock should be, see #34986"
-)
 def test_constructor_extensionblock():
     # GH 34986
     pd.DataFrame(


### PR DESCRIPTION
- [x] closes #34986
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
