### PR TITLE
TYP: remove inappropriate use of cast

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -588,7 +588,7 @@ class DataFrameFormatter(TableFormatter):
         elif isinstance(col_space, (int, str)):
             self.col_space = {"": col_space}
             self.col_space.update({column: col_space for column in self.frame.columns})
-        elif isinstance(col_space, dict):
+        elif isinstance(col_space, Mapping):
             for column in col_space.keys():
                 if column not in self.frame.columns and column != "":
                     raise ValueError(
@@ -596,7 +596,6 @@ class DataFrameFormatter(TableFormatter):
                     )
             self.col_space = col_space
         else:
-            col_space = cast(Sequence, col_space)
             if len(frame.columns) != len(col_space):
                 raise ValueError(
                     f"Col_space length({len(col_space)}) should match "


### PR DESCRIPTION
the cast was silencing `error: Argument 2 to "zip" has incompatible type "Union[Sequence[Union[str, int]], Mapping[Optional[Hashable], Union[str, int]]]"; expected 
"Iterable[Union[str, int]]"`

This error is because col_space is defined as `Union[str, int, Sequence[Union[str, int]], Mapping[Label, Union[str, int]]]` and the `elif isinstance(col_space, dict):` would not catch non-dict mappings, which would go though the else.

so the else is non-dict mappings and sequences and the cast to sequence is not safe.

```
>>> df = pd.DataFrame(np.random.random(size=(3, 3)), columns=["a", "b", "c"])
>>>
>>> print(df.to_string(col_space={"b": 20}))
          a                    b         c
0  0.382920             0.057121  0.862742
1  0.579339             0.391014  0.907678
2  0.340584             0.889387  0.922690
>>>
>>> from collections import UserDict
>>>
>>> print(df.to_string(col_space=UserDict(b=20)))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\simon\pandas\pandas\core\frame.py", line 838, in to_string
    formatter = fmt.DataFrameFormatter(
  File "C:\Users\simon\pandas\pandas\io\formats\format.py", line 601, in __init__
    raise ValueError(
ValueError: Col_space length(1) should match DataFrame number of columns(3)
>>>
```
