### PR TITLE
BUG: Avoids b' prefix for bytes in to_csv() (#9712)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1030,6 +1030,7 @@ I/O
 - Bug in :meth:`read_excel` for ODS files removes 0.0 values (:issue:`27222`)
 - Bug in :meth:`ujson.encode` was raising an `OverflowError` with numbers larger than sys.maxsize (:issue: `34395`)
 - Bug in :meth:`HDFStore.append_to_multiple` was raising a ``ValueError`` when the min_itemsize parameter is set (:issue:`11238`)
+- Bug in :meth:`to_csv` which emitted b'' around bytes (:issue:`9712`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -77,7 +77,7 @@ import pandas.core.missing as missing
 from pandas.core.ops import get_op_result_name
 from pandas.core.ops.invalid import make_invalid_op
 from pandas.core.sorting import ensure_key_mapped
-from pandas.core.strings import StringMethods
+from pandas.core.strings import StringMethods, str_decode
 
 from pandas.io.formats.printing import (
     PrettyDict,
@@ -954,6 +954,8 @@ class Index(IndexOpsMixin, PandasObject):
                 Whether or not there are quoted values in `self`
             3) date_format : str
                 The format used to represent date-like values.
+            4) bytes_encoding : str
+                The encoding scheme to use to decode the bytes.
 
         Returns
         -------
@@ -965,7 +967,9 @@ class Index(IndexOpsMixin, PandasObject):
             values = values[slicer]
         return values._format_native_types(**kwargs)
 
-    def _format_native_types(self, na_rep="", quoting=None, **kwargs):
+    def _format_native_types(
+        self, na_rep="", quoting=None, bytes_encoding=None, **kwargs
+    ):
         """
         Actually format specific types of the index.
         """
@@ -976,6 +980,8 @@ class Index(IndexOpsMixin, PandasObject):
             values = np.array(self, dtype=object, copy=True)
 
         values[mask] = na_rep
+        if lib.is_bytes_array(values, skipna=True, mixing_allowed=False):
+            values = str_decode(values, bytes_encoding)
         return values
 
     def _summary(self, name=None) -> str_t:


### PR DESCRIPTION
Avoids b' prefix written for bytes in the `to_csv()` method (in accordance with this [proposal](https://github.com/pandas-dev/pandas/issues/9712#issuecomment-635803657))

The `encoding` parameter passing in `to_csv()` method is used as the encoding scheme to decode the bytes.

Example:
```python
import pandas as pd
import sys
df = pd.DataFrame({
    b'hello': [b'abc', b'def'],
    b'world': ['pqr', 'xyz']
})
df.to_csv(sys.stdout, encoding='utf-8')
```

After the bug fix will print:
```
,hello,world
0,abc,pqr
1,def,xyz
```

Currently the `to_csv()` method prints:
```
,b'hello',b'world'
0,b'abc',pqr
1,b'def',xyz
```

- [x] closes #9712
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry