### PR TITLE
CLN: remove redundant code in IndexOpsMixin.item

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -22,7 +22,6 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_object_dtype,
     is_scalar,
-    needs_i8_conversion,
 )
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.missing import isna
@@ -656,13 +655,6 @@ class IndexOpsMixin:
         ValueError
             If the data is not length-1.
         """
-        if not (
-            is_extension_array_dtype(self.dtype) or needs_i8_conversion(self.dtype)
-        ):
-            # numpy returns ints instead of datetime64/timedelta64 objects,
-            #  which we need to wrap in Timestamp/Timedelta/Period regardless.
-            return self._values.item()
-
         if len(self) == 1:
             return next(iter(self))
         raise ValueError("can only convert an array of size 1 to a Python scalar")


### PR DESCRIPTION
the code removed in this PR was added (with tests) in #30175. 

in a latter PR, #31506, IndexOpsMixin.\_\_iter__  was modified, making the special case in IndexOpsMixin.item redundant.

cc @jbrockmendel 