### PR TITLE
CLN: GH29547 format with f-strings

### DIFF
--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -83,19 +83,19 @@ def test_setitem_float_labels():
 
 
 def test_slice_float_get_set(datetime_series):
-    msg = (
+    msg = lambda key: (
         "cannot do slice indexing on DatetimeIndex with these indexers "
-        r"\[{key}\] of type float"
+        f"{key} of type float"
     )
-    with pytest.raises(TypeError, match=msg.format(key=r"4\.0")):
+    with pytest.raises(TypeError, match=msg(key=r"4\.0")):
         datetime_series[4.0:10.0]
 
-    with pytest.raises(TypeError, match=msg.format(key=r"4\.0")):
+    with pytest.raises(TypeError, match=msg(key=r"4\.0")):
         datetime_series[4.0:10.0] = 0
 
-    with pytest.raises(TypeError, match=msg.format(key=r"4\.5")):
+    with pytest.raises(TypeError, match=msg(key=r"4\.5")):
         datetime_series[4.5:10.0]
-    with pytest.raises(TypeError, match=msg.format(key=r"4\.5")):
+    with pytest.raises(TypeError, match=msg(key=r"4\.5")):
         datetime_series[4.5:10.0] = 0
 
 


### PR DESCRIPTION
xref #29547,#34914
replace .format() for f-strings in the following:

pandas/tests/series/indexing/test_numeric.py