### PR TITLE
DOC: correction to "size" in the plotting.bootstrap_plot docstring

### DIFF
--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -300,7 +300,7 @@ def bootstrap_plot(series, fig=None, size=50, samples=500, **kwds):
         creating a new one with default parameters.
     size : int, default 50
         Number of data points to consider during each sampling. It must be
-        greater or equal than the length of the `series`.
+        less than or equal to the length of the `series`.
     samples : int, default 500
         Number of times the bootstrap procedure is performed.
     **kwds


### PR DESCRIPTION
The documentation for plotting.bootstrap_plot says that the size argument must be greater than or equal to the length of the series. Bootstrapping typically uses subsamples of a size less than or equal to the size of the data set, so I corrected the docs accordingly. Note that making size greater than the length of the series throws the following ValueError: Sample larger than population or is negative