### PR TITLE
PERF: avoid duplicate is_single_block check

### DIFF
--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -805,17 +805,19 @@ class BlockManager(PandasObject):
         # mutating the original object
         copy = copy or na_value is not lib.no_default
 
-        if self._is_single_block and self.blocks[0].is_extension:
-            # Avoid implicit conversion of extension blocks to object
-            arr = (
-                self.blocks[0]
-                .values.to_numpy(dtype=dtype, na_value=na_value)
-                .reshape(self.blocks[0].shape)
-            )
-        elif self._is_single_block:
-            arr = np.asarray(self.blocks[0].get_values())
-            if dtype:
-                arr = arr.astype(dtype, copy=False)
+        if self._is_single_block:
+            blk = self.blocks[0]
+            if blk.is_extension:
+                # Avoid implicit conversion of extension blocks to object
+                arr = (
+                    blk
+                    .values.to_numpy(dtype=dtype, na_value=na_value)
+                    .reshape(blk.shape)
+                )
+            else:
+                arr = np.asarray(blk.get_values())
+                if dtype:
+                    arr = arr.astype(dtype, copy=False)
         else:
             arr = self._interleave(dtype=dtype, na_value=na_value)
             # The underlying data was copied within _interleave

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -809,10 +809,8 @@ class BlockManager(PandasObject):
             blk = self.blocks[0]
             if blk.is_extension:
                 # Avoid implicit conversion of extension blocks to object
-                arr = (
-                    blk
-                    .values.to_numpy(dtype=dtype, na_value=na_value)
-                    .reshape(blk.shape)
+                arr = blk.values.to_numpy(dtype=dtype, na_value=na_value).reshape(
+                    blk.shape
                 )
             else:
                 arr = np.asarray(blk.get_values())


### PR DESCRIPTION
Small bump, make up some of the ground lost in #34999.

```
In [2]: df = pd.DataFrame([1])                                                                                                                                                                                     

In [3]: %timeit df.values                                                                                                                                                                                          
3.65 µs ± 75.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- PR
3.84 µs ± 139 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- master
```
