### PR TITLE
PERF: put some Timetamp methods in _Timestamp

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pxd
+++ b/pandas/_libs/tslibs/timestamps.pxd
@@ -16,8 +16,8 @@ cdef class _Timestamp(ABCTimestamp):
         int64_t value, nanosecond
         object freq
 
-    cpdef bint _get_start_end_field(self, str field)
-    cpdef _get_date_name_field(self, object field, object locale)
+    cdef bint _get_start_end_field(self, str field)
+    cdef _get_date_name_field(self, str field, object locale)
     cdef int64_t _maybe_convert_value_to_local(self)
     cpdef to_datetime64(self)
     cdef _assert_tzawareness_compat(_Timestamp self, datetime other)


### PR DESCRIPTION
```
In [2]: ts = pd.Timestamp.now()                                                                                                                                                                                    

In [3]: %timeit ts.is_month_start                                                                                                                                                                                  
58.3 ns ± 1.5 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- PR
82.5 ns ± 2.16 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)  # <-- master
```