### PR TITLE
Doc: Updated aggregate docstring

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -907,6 +907,7 @@ Groupby/resample/rolling
   to the input DataFrame is inconsistent. An internal heuristic to detect index mutation would behave differently for equal but not identical
   indices. In particular, the result index shape might change if a copy of the input would be returned.
   The behaviour now is consistent, independent of internal heuristics. (:issue:`31612`, :issue:`14927`, :issue:`13056`)
+- Bug in :meth:`SeriesGroupBy.agg` where any column name is accepted in named aggregation previously. The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -907,7 +907,8 @@ Groupby/resample/rolling
   to the input DataFrame is inconsistent. An internal heuristic to detect index mutation would behave differently for equal but not identical
   indices. In particular, the result index shape might change if a copy of the input would be returned.
   The behaviour now is consistent, independent of internal heuristics. (:issue:`31612`, :issue:`14927`, :issue:`13056`)
-- Bug in :meth:`SeriesGroupBy.agg` where any column name is accepted in named aggregation previously. The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
+- Bug in :meth:`SeriesGroupBy.agg` where any column name was accepted in the named aggregation of ``SeriesGroupBy`` previously.
+  The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -907,8 +907,7 @@ Groupby/resample/rolling
   to the input DataFrame is inconsistent. An internal heuristic to detect index mutation would behave differently for equal but not identical
   indices. In particular, the result index shape might change if a copy of the input would be returned.
   The behaviour now is consistent, independent of internal heuristics. (:issue:`31612`, :issue:`14927`, :issue:`13056`)
-- Bug in :meth:`SeriesGroupBy.agg` where any column name was accepted in the named aggregation of ``SeriesGroupBy`` previously.
-  The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
+- Bug in :meth:`SeriesGroupBy.agg` where any column name was accepted in the named aggregation of ``SeriesGroupBy`` previously. The behaviour now allows only ``str`` and callables else would raise ``TypeError``. (:issue:`34422`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -5,7 +5,7 @@ kwarg aggregations in groupby and DataFrame/Series aggregation
 
 from collections import defaultdict
 from functools import partial
-from typing import Any, DefaultDict, List, Sequence, Tuple
+from typing import Any, DefaultDict, List, Sequence, Tuple, Union, Callable
 
 from pandas.core.dtypes.common import is_dict_like, is_list_like
 
@@ -196,3 +196,40 @@ def maybe_mangle_lambdas(agg_spec: Any) -> Any:
         mangled_aggspec = _managle_lambda_list(agg_spec)
 
     return mangled_aggspec
+
+def validate_func_kwargs(
+    kwargs: dict,
+) -> Tuple[List[str], List[Union[str, Callable[..., Any]]]]:
+    """
+    Validates types of user-provided "named aggregation" kwargs.
+    `TypeError` is raised if aggfunc is not `str` or callable.
+
+    Parameters
+    ----------
+    kwargs : dict
+
+    Returns
+    -------
+    columns : List[str]
+        List of user-provied keys.
+    func : List[Union[str, callable[...,Any]]]
+        List of user-provided aggfuncs
+
+    Examples
+    --------
+    >>> validate_func_kwargs({'one': 'min', 'two': 'max'})
+    (['one', 'two'], ['min','max'])
+    >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min}) 
+    (['one', 'two'], [lambda x:x+1, np.min])
+    """
+    no_arg_message = "Must provide 'func' or named aggregation **kwargs."
+    tuple_given_message = "func is expected but recieved {} in **kwargs."
+    columns = list(kwargs)
+    func = []
+    for col_func in kwargs.values():
+        if not (isinstance(col_func, str) or callable(col_func)):
+            raise TypeError(tuple_given_message.format(type(col_func).__name__))
+        func.append(col_func)
+    if not columns:
+        raise TypeError(no_arg_message)
+    return columns, func

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -220,8 +220,6 @@ def validate_func_kwargs(
     --------
     >>> validate_func_kwargs({'one': 'min', 'two': 'max'})
     (['one', 'two'], ['min', 'max'])
-    >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min})
-    (['one', 'two'], [lambda x:x+1, np.min])
     """
     no_arg_message = "Must provide 'func' or named aggregation **kwargs."
     tuple_given_message = "func is expected but recieved {} in **kwargs."

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -5,7 +5,7 @@ kwarg aggregations in groupby and DataFrame/Series aggregation
 
 from collections import defaultdict
 from functools import partial
-from typing import Any, DefaultDict, List, Sequence, Tuple, Union, Callable
+from typing import Any, Callable, DefaultDict, List, Sequence, Tuple, Union
 
 from pandas.core.dtypes.common import is_dict_like, is_list_like
 
@@ -219,7 +219,7 @@ def validate_func_kwargs(
     Examples
     --------
     >>> validate_func_kwargs({'one': 'min', 'two': 'max'})
-    (['one', 'two'], ['min','max'])
+    (['one', 'two'], ['min', 'max'])
     >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min})
     (['one', 'two'], [lambda x:x+1, np.min])
     """

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -197,6 +197,7 @@ def maybe_mangle_lambdas(agg_spec: Any) -> Any:
 
     return mangled_aggspec
 
+
 def validate_func_kwargs(
     kwargs: dict,
 ) -> Tuple[List[str], List[Union[str, Callable[..., Any]]]]:
@@ -219,7 +220,7 @@ def validate_func_kwargs(
     --------
     >>> validate_func_kwargs({'one': 'min', 'two': 'max'})
     (['one', 'two'], ['min','max'])
-    >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min}) 
+    >>> validate_func_kwargs({'one': lambda x: x+1, 'two': np.min})
     (['one', 'two'], [lambda x:x+1, np.min])
     """
     no_arg_message = "Must provide 'func' or named aggregation **kwargs."

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4457,6 +4457,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             )
 
         self._consolidate_inplace()
+        print(axes,kwargs)
+        print('hello')
 
         # if all axes that are requested to reindex are equal, then only copy
         # if indicated must have index names equal here as well as values
@@ -4483,12 +4485,15 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     ) -> FrameOrSeries:
         """Perform the reindex for all the axes."""
         obj = self
+        print(self._AXIS_ORDERS)
         for a in self._AXIS_ORDERS:
             labels = axes[a]
             if labels is None:
                 continue
 
             ax = self._get_axis(a)
+            print(ax)
+            print(labels)
             new_index, indexer = ax.reindex(
                 labels, level=level, limit=limit, tolerance=tolerance, method=method
             )
@@ -5099,6 +5104,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     Notes
     -----
     `agg` is an alias for `aggregate`. Use the alias.
+    Some NumPy functions such as `np.mean`, `np.nanmean`, `np.median` etc.
+    resolve to corresponding internal cython function.
 
     A passed user-defined-function will be passed a Series for evaluation.
     %(examples)s"""

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5105,7 +5105,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     -----
     `agg` is an alias for `aggregate`. Use the alias.
     Some NumPy functions such as `np.mean`, `np.nanmean`, `np.median` etc.
-    resolve to corresponding internal cython function.
+    resolve to their corresponding internal cython function.
 
     A passed user-defined-function will be passed a Series for evaluation.
     %(examples)s"""

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -239,10 +239,10 @@ class SeriesGroupBy(GroupBy[Series]):
             columns = list(kwargs)
             func = []
             for col in columns:
-                if isinstance(kwargs[col],(list,NamedAgg,tuple)):
-                    raise TypeError(tuple_given_message.format(type(kwargs[col]).__name__))
+                if isinstance(kwargs[col], (list, NamedAgg, tuple)):
+                    raise TypeError(tuple_given_message.\
+                        format(type(kwargs[col]).__name__))
                 func.append(kwargs[col])
-            
             kwargs = {}
             if not columns:
                 raise TypeError(no_arg_message)
@@ -290,7 +290,6 @@ class SeriesGroupBy(GroupBy[Series]):
 
             ret = concat(ret, axis=1)
         return ret
-
     agg = aggregate
 
     def _aggregate_multiple_funcs(self, arg):

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -240,8 +240,9 @@ class SeriesGroupBy(GroupBy[Series]):
             func = []
             for col in columns:
                 if isinstance(kwargs[col], (list, NamedAgg, tuple)):
-                    raise TypeError(tuple_given_message.\
-                        format(type(kwargs[col]).__name__))
+                    raise TypeError(
+                        tuple_given_message.format(type(kwargs[col]).__name__)
+                )
                 func.append(kwargs[col])
             kwargs = {}
             if not columns:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -242,7 +242,7 @@ class SeriesGroupBy(GroupBy[Series]):
                 if isinstance(kwargs[col], (list, NamedAgg, tuple)):
                     raise TypeError(
                         tuple_given_message.format(type(kwargs[col]).__name__)
-                )
+                    )
                 func.append(kwargs[col])
             kwargs = {}
             if not columns:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -234,9 +234,15 @@ class SeriesGroupBy(GroupBy[Series]):
         relabeling = func is None
         columns = None
         no_arg_message = "Must provide 'func' or named aggregation **kwargs."
+        tuple_given_message = "'func' is expected but recieved {} in **kwargs."
         if relabeling:
             columns = list(kwargs)
-            func = [kwargs[col] for col in columns]
+            func = []
+            for col in columns:
+                if isinstance(kwargs[col],(list,NamedAgg,tuple)):
+                    raise TypeError(tuple_given_message.format(type(kwargs[col])))
+                func.append(kwargs[col])
+            
             kwargs = {}
             if not columns:
                 raise TypeError(no_arg_message)
@@ -298,11 +304,7 @@ class SeriesGroupBy(GroupBy[Series]):
 
             columns = list(arg.keys())
             arg = arg.items()
-        elif any(isinstance(x, (tuple, list)) for x in arg):
-            arg = [(x, x) if not isinstance(x, (tuple, list)) else x for x in arg]
 
-            # indicated column order
-            columns = next(zip(*arg))
         else:
             # list of functions / function names
             columns = []

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -307,8 +307,6 @@ class SeriesGroupBy(GroupBy[Series]):
         elif anyisinstance(x, (tuple, list)) for x in arg):
             arg = [(x, x) if not isinstance(x, (tuple, list)) else x for x in arg]
 
-            # indicated column order
-            columns = next(zip(*arg))
         else:
             # list of functions / function names
             columns = []

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -239,7 +239,7 @@ class SeriesGroupBy(GroupBy[Series]):
             columns = list(kwargs)
             func = []
             for col in columns:
-                if isinstance(kwargs[col], (list, NamedAgg, tuple)):
+                if isinstance(kwargs[col], (list, tuple)):
                     raise TypeError(
                         tuple_given_message.format(type(kwargs[col]).__name__)
                     )
@@ -310,12 +310,12 @@ class SeriesGroupBy(GroupBy[Series]):
 
             # indicated column order
             columns = next(zip(*arg))
-
         else:
             # list of functions / function names
             columns = []
             for f in arg:
                 columns.append(com.get_callable_name(f) or f)
+
             arg = zip(columns, arg)
 
         results = {}

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -304,7 +304,11 @@ class SeriesGroupBy(GroupBy[Series]):
 
             columns = list(arg.keys())
             arg = arg.items()
+        elif anyisinstance(x, (tuple, list)) for x in arg):
+            arg = [(x, x) if not isinstance(x, (tuple, list)) else x for x in arg]
 
+            # indicated column order
+            columns = next(zip(*arg))
         else:
             # list of functions / function names
             columns = []

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -240,7 +240,7 @@ class SeriesGroupBy(GroupBy[Series]):
             func = []
             for col in columns:
                 if isinstance(kwargs[col],(list,NamedAgg,tuple)):
-                    raise TypeError(tuple_given_message.format(type(kwargs[col])))
+                    raise TypeError(tuple_given_message.format(type(kwargs[col]).__name__))
                 func.append(kwargs[col])
             
             kwargs = {}

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -291,6 +291,7 @@ class SeriesGroupBy(GroupBy[Series]):
 
             ret = concat(ret, axis=1)
         return ret
+
     agg = aggregate
 
     def _aggregate_multiple_funcs(self, arg):

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -57,6 +57,7 @@ from pandas.core.aggregation import (
     is_multi_agg_with_relabel,
     maybe_mangle_lambdas,
     normalize_keyword_aggregation,
+    validate_func_kwargs
 )
 import pandas.core.algorithms as algorithms
 from pandas.core.base import DataError, SpecificationError
@@ -233,20 +234,9 @@ class SeriesGroupBy(GroupBy[Series]):
 
         relabeling = func is None
         columns = None
-        no_arg_message = "Must provide 'func' or named aggregation **kwargs."
-        tuple_given_message = "func is expected but recieved {} in **kwargs."
         if relabeling:
-            columns = list(kwargs)
-            func = []
-            for col in columns:
-                if isinstance(kwargs[col], (list, tuple)):
-                    raise TypeError(
-                        tuple_given_message.format(type(kwargs[col]).__name__)
-                    )
-                func.append(kwargs[col])
+            columns, func = validate_func_kwargs(kwargs)
             kwargs = {}
-            if not columns:
-                raise TypeError(no_arg_message)
 
         if isinstance(func, str):
             return getattr(self, func)(*args, **kwargs)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -234,7 +234,7 @@ class SeriesGroupBy(GroupBy[Series]):
         relabeling = func is None
         columns = None
         no_arg_message = "Must provide 'func' or named aggregation **kwargs."
-        tuple_given_message = "'func' is expected but recieved {} in **kwargs."
+        tuple_given_message = "func is expected but recieved {} in **kwargs."
         if relabeling:
             columns = list(kwargs)
             func = []

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -57,7 +57,7 @@ from pandas.core.aggregation import (
     is_multi_agg_with_relabel,
     maybe_mangle_lambdas,
     normalize_keyword_aggregation,
-    validate_func_kwargs
+    validate_func_kwargs,
 )
 import pandas.core.algorithms as algorithms
 from pandas.core.base import DataError, SpecificationError

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -304,15 +304,17 @@ class SeriesGroupBy(GroupBy[Series]):
 
             columns = list(arg.keys())
             arg = arg.items()
-        elif anyisinstance(x, (tuple, list)) for x in arg):
+        elif any(isinstance(x, (tuple, list)) for x in arg):
             arg = [(x, x) if not isinstance(x, (tuple, list)) else x for x in arg]
+
+            # indicated column order
+            columns = next(zip(*arg))
 
         else:
             # list of functions / function names
             columns = []
             for f in arg:
                 columns.append(com.get_callable_name(f) or f)
-
             arg = zip(columns, arg)
 
         results = {}

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -514,7 +514,7 @@ class TestNamedAggregationSeries:
     def test_agg_namedtuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is expected but recieved NamedAgg in **kwargs."
+        msg = "'func' is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=pd.NamedAgg(column='anything', aggfunc='min')
@@ -523,7 +523,7 @@ class TestNamedAggregationSeries:
     def test_agg_with_tuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is expected but recieved tuple in **kwargs."
+        msg = "'func' is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=('anything', 'min')
@@ -532,7 +532,7 @@ class TestNamedAggregationSeries:
     def test_agg_with_list(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is expected but recieved list in **kwargs."
+        msg = "'func' is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=['anything', 'min']

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -511,26 +511,20 @@ class TestNamedAggregationSeries:
         expected = pd.DataFrame({"a": [0, 0], "b": [1, 1]})
         tm.assert_frame_equal(result, expected)
 
-    def test_agg_namedtuple(self):
+    @pytest.mark.parametrize(
+        "inp",
+        [
+            pd.NamedAgg(column="anything", aggfunc="min"),
+            ("anything", "min"),
+            ["anything", "min"],
+        ],
+    )
+    def test_named_agg_nametuple(self, inp):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "func is"
+        msg = "func is expected but recieved {}".format(type(inp).__name__)
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(a=pd.NamedAgg(column="anything", aggfunc="min"))
-
-    def test_agg_with_tuple(self):
-        # GH34422
-        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "func is"
-        with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(a=("anything", "min"))
-
-    def test_agg_with_list(self):
-        # GH34422
-        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "func is"
-        with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(a=["anything", "min"])
 
 
 class TestNamedAggregationDataFrame:

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -511,6 +511,33 @@ class TestNamedAggregationSeries:
         expected = pd.DataFrame({"a": [0, 0], "b": [1, 1]})
         tm.assert_frame_equal(result, expected)
 
+    def test_agg_namedtuple(self):
+        #GH34422
+        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
+        msg = "'func' is expected but recieved NamedAgg in **kwargs."
+        with pytest.raises(TypeError, match=msg):
+            s.groupby(s.values).agg(
+                a=pd.NamedAgg(column='anything', aggfunc='min')
+                )
+
+    def test_agg_with_tuple(self):
+        #GH34422
+        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
+        msg = "'func' is expected but recieved tuple in **kwargs."
+        with pytest.raises(TypeError, match=msg):
+            s.groupby(s.values).agg(
+                a=('anything', 'min')
+                )
+
+    def test_agg_with_list(self):
+        #GH34422
+        s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
+        msg = "'func' is expected but recieved list in **kwargs."
+        with pytest.raises(TypeError, match=msg):
+            s.groupby(s.values).agg(
+                a=['anything', 'min']
+            )
+
 
 class TestNamedAggregationDataFrame:
     def test_agg_relabel(self):

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -522,7 +522,7 @@ class TestNamedAggregationSeries:
     def test_named_agg_nametuple(self, inp):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "func is expected but recieved {}".format(type(inp).__name__)
+        msg = f"func is expected but recieved {type(inp).__name__}"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(a=inp)
 

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -512,25 +512,25 @@ class TestNamedAggregationSeries:
         tm.assert_frame_equal(result, expected)
 
     def test_agg_namedtuple(self):
-        #GH34422
+        # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "'func' is expected but recieved NamedAgg in **kwargs."
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=pd.NamedAgg(column='anything', aggfunc='min')
-                )
+            )
 
     def test_agg_with_tuple(self):
-        #GH34422
+        # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "'func' is expected but recieved tuple in **kwargs."
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=('anything', 'min')
-                )
+            )
 
     def test_agg_with_list(self):
-        #GH34422
+        # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "'func' is expected but recieved list in **kwargs."
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -516,27 +516,21 @@ class TestNamedAggregationSeries:
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "func is"
         with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(
-                a=pd.NamedAgg(column='anything', aggfunc='min')
-            )
+            s.groupby(s.values).agg(a=pd.NamedAgg(column="anything", aggfunc="min"))
 
     def test_agg_with_tuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "func is"
         with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(
-                a=('anything', 'min')
-            )
+            s.groupby(s.values).agg(a=("anything", "min"))
 
     def test_agg_with_list(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "func is"
         with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(
-                a=['anything', 'min']
-            )
+            s.groupby(s.values).agg(a=["anything", "min"])
 
 
 class TestNamedAggregationDataFrame:

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -514,7 +514,7 @@ class TestNamedAggregationSeries:
     def test_agg_namedtuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is"
+        msg = "func is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=pd.NamedAgg(column='anything', aggfunc='min')
@@ -523,7 +523,7 @@ class TestNamedAggregationSeries:
     def test_agg_with_tuple(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is"
+        msg = "func is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=('anything', 'min')
@@ -532,7 +532,7 @@ class TestNamedAggregationSeries:
     def test_agg_with_list(self):
         # GH34422
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
-        msg = "'func' is"
+        msg = "func is"
         with pytest.raises(TypeError, match=msg):
             s.groupby(s.values).agg(
                 a=['anything', 'min']

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -524,7 +524,7 @@ class TestNamedAggregationSeries:
         s = pd.Series([1, 1, 2, 2, 3, 3, 4, 5])
         msg = "func is expected but recieved {}".format(type(inp).__name__)
         with pytest.raises(TypeError, match=msg):
-            s.groupby(s.values).agg(a=pd.NamedAgg(column="anything", aggfunc="min"))
+            s.groupby(s.values).agg(a=inp)
 
 
 class TestNamedAggregationDataFrame:


### PR DESCRIPTION
Link to current `Series.agg`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.agg.html

Original question asked in gitter:
Does `pd.Series.agg` with `func` parameter set to `'median'` uses `np.nanmedian`(Not only `median` including `mean`, `mode`)?
```python
s= pd.Series([np.nan, np.nan,1,1,1])
s.agg('median') 
# 1
s.agg(np.median)
# 1
np.median(s.to_numpy())
# nan
np.nanmedian(s.to_numpy())
# 1
```
Whenever `NaN` is present does it fallback to using `np.nanmedian`?

---

Reply from @MarcoGorelli 
if you look at `pandas/core/base.py` you'll see
```
    np.median: "median",
    np.nanmedian: "median",
```
in `_cython_table`. So, both resolve to the same internal cython function.

---

IMO it's better to mention this in the docs under `Note:` section.

Under note section saying:
*Some NumPy functions such as `np.mean`, `np.nanmean`, `np.median` etc. resolve to their corresponding internal cython function.*

<details>

```
################################################################################
######################## Docstring (pandas.Series.agg)  ########################
################################################################################

Aggregate using one or more operations over the specified axis.

.. versionadded:: 0.20.0

Parameters
----------
func : function, str, list or dict
    Function to use for aggregating the data. If a function, must either
    work when passed a Series or when passed to Series.apply.

    Accepted combinations are:

    - function
    - string function name
    - list of functions and/or function names, e.g. ``[np.sum, 'mean']``
    - dict of axis labels -> functions, function names or list of such.
axis : {0 or 'index'}
        Parameter needed for compatibility with DataFrame.
*args
    Positional arguments to pass to `func`.
**kwargs
    Keyword arguments to pass to `func`.

Returns
-------
scalar, Series or DataFrame

    The return can be:

    * scalar : when Series.agg is called with single function
    * Series : when DataFrame.agg is called with a single function
    * DataFrame : when DataFrame.agg is called with several functions

    Return scalar, Series or DataFrame.

See Also
--------
Series.apply : Invoke function on a Series.
Series.transform : Transform function producing a Series with like indexes.

Notes
-----
`agg` is an alias for `aggregate`. Use the alias.
Some NumPy functions such as `np.mean`, `np.nanmean`, `np.median` etc.
resolve to their corresponding internal cython function.

A passed user-defined-function will be passed a Series for evaluation.

Examples
--------
>>> s = pd.Series([1, 2, 3, 4])
>>> s
0    1
1    2
2    3
3    4
dtype: int64

>>> s.agg('min')
1

>>> s.agg(['min', 'max'])
min   1
max   4
dtype: int64

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.agg" correct. :)
```
</details>

[Image to updated docs of `Series.agg`](https://i.stack.imgur.com/yx7N4.png)