### PR TITLE
TST: Adds CategoricalIndex DataFrame from_records test (GH32805)

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -18,9 +18,9 @@ from pandas.core.dtypes.common import is_integer_dtype
 import pandas as pd
 from pandas import (
     Categorical,
+    CategoricalIndex,
     DataFrame,
     Index,
-    CategoricalIndex,
     MultiIndex,
     RangeIndex,
     Series,

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -20,6 +20,7 @@ from pandas import (
     Categorical,
     DataFrame,
     Index,
+    CategoricalIndex,
     MultiIndex,
     RangeIndex,
     Series,
@@ -2482,6 +2483,16 @@ class TestDataFrameConstructors:
         data = Series([[{"a": 1, "b": 2}], [{"a": 3, "b": 4}]])
         result = DataFrame.from_records(data)
         tm.assert_frame_equal(result, expected)
+
+    def test_from_records_series_categorical_index(self):
+        # GH 32805
+        index = CategoricalIndex(
+            [pd.Interval(-20, -10), pd.Interval(-10, 0), pd.Interval(0, 10)]
+        )
+        series_of_dicts = pd.Series([{"a": 1}, {"a": 2}, {"b": 3}], index=index)
+        frame = pd.DataFrame.from_records(series_of_dicts, index=index)
+        expected = DataFrame({"a": [1, 2, np.NaN], "b": [np.NaN, np.NaN, 3],}, index=index)
+        tm.assert_frame_equal(frame, expected)
 
     def test_frame_from_records_utc(self):
         rec = {"datum": 1.5, "begin_time": datetime(2006, 4, 27, tzinfo=pytz.utc)}

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2492,7 +2492,7 @@ class TestDataFrameConstructors:
         series_of_dicts = pd.Series([{"a": 1}, {"a": 2}, {"b": 3}], index=index)
         frame = pd.DataFrame.from_records(series_of_dicts, index=index)
         expected = DataFrame(
-            {"a": [1, 2, np.NaN], "b": [np.NaN, np.NaN, 3],}, index=index
+            {"a": [1, 2, np.NaN], "b": [np.NaN, np.NaN, 3]}, index=index
         )
         tm.assert_frame_equal(frame, expected)
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2491,7 +2491,9 @@ class TestDataFrameConstructors:
         )
         series_of_dicts = pd.Series([{"a": 1}, {"a": 2}, {"b": 3}], index=index)
         frame = pd.DataFrame.from_records(series_of_dicts, index=index)
-        expected = DataFrame({"a": [1, 2, np.NaN], "b": [np.NaN, np.NaN, 3],}, index=index)
+        expected = DataFrame(
+            {"a": [1, 2, np.NaN], "b": [np.NaN, np.NaN, 3],}, index=index
+        )
         tm.assert_frame_equal(frame, expected)
 
     def test_frame_from_records_utc(self):


### PR DESCRIPTION
- [x] closes #32805
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

The test checks to make sure `from_records` loads a `DataFrame` with a `CategorigalIndex` as shown in #32805.