### PR TITLE
Fix issue #31708 Series.astype(str, skipna=True) vanished in the 1.0 release

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5508,19 +5508,17 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2   2020-01-02 19:00:00-05:00
         dtype: datetime64[ns, US/Eastern]
 
-
         By default NaN values will be casted to dtype:
         >>> pd.Series([None, 1]).astype(str)
         0     nan
         1     1.0
         dtype: object
 
-
         Skip casting NaN values:
 
         >>> pd.Series([None, 1]).astype(str, skipna=True)
-        0     NaN
-        1     42.0
+        0    NaN
+        1    1.0
         dtype: object
         """
         if is_dict_like(dtype):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5511,8 +5511,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         By default NaN values will be casted to dtype:
         >>> pd.Series([None, 1]).astype(str)
-        0    nan
-        1    1.0
+        0     nan
+        1     1.0
         dtype: object
 
 
@@ -5520,9 +5520,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         >>> pd.Series([None, 1]).astype(str, skipna=True)
         0     NaN
-        1    42.0
+        1     42.0
         dtype: object
-
         """
         if is_dict_like(dtype):
             if self.ndim == 1:  # i.e. Series

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -516,7 +516,9 @@ class Block(PandasObject):
 
         return self.split_and_operate(None, f, False)
 
-    def astype(self, dtype, copy: bool = False, errors: str = "raise"):
+    def astype(
+        self, dtype, copy: bool = False, errors: str = "raise", skipna: bool = False
+    ):
         """
         Coerce to the new dtype.
 
@@ -528,6 +530,10 @@ class Block(PandasObject):
         errors : str, {'raise', 'ignore'}, default 'ignore'
             - ``raise`` : allow exceptions to be raised
             - ``ignore`` : suppress exceptions. On error return original object
+        skipna : bool, default False
+            When ``skipna=False`` (default) nan values will be casted to proper
+            dtype.
+            Skip casting nan values when ``skipna=True``.
 
         Returns
         -------
@@ -592,7 +598,7 @@ class Block(PandasObject):
             # _astype_nansafe works fine with 1-d only
             vals1d = values.ravel()
             try:
-                values = astype_nansafe(vals1d, dtype, copy=True)
+                values = astype_nansafe(vals1d, dtype, copy=True, skipna=skipna)
             except (ValueError, TypeError):
                 # e.g. astype_nansafe can fail on object-dtype of strings
                 #  trying to convert to float
@@ -2094,7 +2100,9 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
         assert isinstance(values, np.ndarray), type(values)
         return values
 
-    def astype(self, dtype, copy: bool = False, errors: str = "raise"):
+    def astype(
+        self, dtype, copy: bool = False, errors: str = "raise", skipna: bool = False
+    ):
         """
         these automatically copy, so copy=True has no effect
         raise on an except if raise == True
@@ -2113,7 +2121,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
             return self.make_block(values)
 
         # delegate
-        return super().astype(dtype=dtype, copy=copy, errors=errors)
+        return super().astype(dtype=dtype, copy=copy, errors=errors, skipna=skipna)
 
     def _can_hold_element(self, element: Any) -> bool:
         tipo = maybe_infer_dtype_type(element)

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -560,9 +560,11 @@ class BlockManager(PandasObject):
         return self.apply("downcast")
 
     def astype(
-        self, dtype, copy: bool = False, errors: str = "raise"
+        self, dtype, copy: bool = False, errors: str = "raise", skipna: bool = False
     ) -> "BlockManager":
-        return self.apply("astype", dtype=dtype, copy=copy, errors=errors)
+        return self.apply(
+            "astype", dtype=dtype, copy=copy, errors=errors, skipna=skipna
+        )
 
     def convert(
         self,

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -495,3 +495,14 @@ class TestSeriesDtypes:
         s1 = s.reindex(new_index).astype(temp_dtype).astype(new_dtype)
         s2 = s.astype(temp_dtype).reindex(new_index).astype(new_dtype)
         tm.assert_series_equal(s1, s2)
+
+    def test_astype_skipna_default(self):
+        arr = Series([1.0, np.nan, 3.0, 4.0])
+        result = arr.astype(str)
+        tm.assert_series_equal(result, Series(["1.0", "nan", "3.0", "4.0"]))
+
+    def test_astype_skipna_true(self):
+        # GH 31708
+        arr = Series([1.0, np.nan, 3.0, 4.0])
+        result = arr.astype(str, skipna=True)
+        tm.assert_series_equal(result, Series(["1.0", np.nan, "3.0", "4.0"]))


### PR DESCRIPTION
- [ ] closes #31708
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry