### PR TITLE
PERF: Timestamp.normalize

### DIFF
--- a/asv_bench/benchmarks/tslibs/timestamp.py
+++ b/asv_bench/benchmarks/tslibs/timestamp.py
@@ -1,8 +1,6 @@
-from datetime import datetime, timezone, timedelta
-import datetime
+from datetime import datetime, timedelta, timezone
 
 from dateutil.tz import gettz, tzlocal, tzutc
-import dateutil
 import numpy as np
 import pytz
 

--- a/asv_bench/benchmarks/tslibs/timestamp.py
+++ b/asv_bench/benchmarks/tslibs/timestamp.py
@@ -1,17 +1,31 @@
+from datetime import datetime, timezone, timedelta
 import datetime
 
+from dateutil.tz import gettz, tzlocal, tzutc
 import dateutil
 import numpy as np
 import pytz
 
 from pandas import Timestamp
 
+# One case for each type of tzinfo object that has its own code path
+#  in tzconversion code.
+_tzs = [
+    None,
+    pytz.timezone("Europe/Amsterdam"),
+    gettz("US/Central"),
+    pytz.UTC,
+    tzutc(),
+    timezone(timedelta(minutes=60)),
+    tzlocal(),
+]
+
 
 class TimestampConstruction:
     def setup(self):
         self.npdatetime64 = np.datetime64("2020-01-01 00:00:00")
-        self.dttime_unaware = datetime.datetime(2020, 1, 1, 0, 0, 0)
-        self.dttime_aware = datetime.datetime(2020, 1, 1, 0, 0, 0, 0, pytz.UTC)
+        self.dttime_unaware = datetime(2020, 1, 1, 0, 0, 0)
+        self.dttime_aware = datetime(2020, 1, 1, 0, 0, 0, 0, pytz.UTC)
         self.ts = Timestamp("2020-01-01 00:00:00")
 
     def time_parse_iso8601_no_tz(self):
@@ -49,7 +63,6 @@ class TimestampConstruction:
 
 
 class TimestampProperties:
-    _tzs = [None, pytz.timezone("Europe/Amsterdam"), pytz.UTC, dateutil.tz.tzutc()]
     _freqs = [None, "B"]
     params = [_tzs, _freqs]
     param_names = ["tz", "freq"]
@@ -110,7 +123,7 @@ class TimestampProperties:
 
 
 class TimestampOps:
-    params = [None, "US/Eastern", pytz.UTC, dateutil.tz.tzutc()]
+    params = _tzs
     param_names = ["tz"]
 
     def setup(self, tz):
@@ -148,7 +161,7 @@ class TimestampOps:
 
 class TimestampAcrossDst:
     def setup(self):
-        dt = datetime.datetime(2016, 3, 27, 1)
+        dt = datetime(2016, 3, 27, 1)
         self.tzinfo = pytz.timezone("CET").localize(dt, is_dst=False).tzinfo
         self.ts2 = Timestamp(dt)
 

--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -26,3 +26,4 @@ cpdef datetime localize_pydatetime(datetime dt, object tz)
 cdef int64_t cast_from_unit(object ts, str unit) except? -1
 
 cpdef ndarray[int64_t] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo tz)
+cdef int64_t normalize_i8_stamp(int64_t local_val) nogil

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -795,14 +795,14 @@ cpdef ndarray[int64_t] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo t
                     result[i] = NPY_NAT
                     continue
                 local_val = stamps[i]
-                result[i] = _normalize_i8_stamp(local_val)
+                result[i] = normalize_i8_stamp(local_val)
     elif is_tzlocal(tz):
         for i in range(n):
             if stamps[i] == NPY_NAT:
                 result[i] = NPY_NAT
                 continue
             local_val = tz_convert_utc_to_tzlocal(stamps[i], tz)
-            result[i] = _normalize_i8_stamp(local_val)
+            result[i] = normalize_i8_stamp(local_val)
     else:
         # Adjust datetime64 timestamp, recompute datetimestruct
         trans, deltas, typ = get_dst_info(tz)
@@ -815,7 +815,7 @@ cpdef ndarray[int64_t] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo t
                     result[i] = NPY_NAT
                     continue
                 local_val = stamps[i] + delta
-                result[i] = _normalize_i8_stamp(local_val)
+                result[i] = normalize_i8_stamp(local_val)
         else:
             pos = trans.searchsorted(stamps, side='right') - 1
             for i in range(n):
@@ -823,13 +823,13 @@ cpdef ndarray[int64_t] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo t
                     result[i] = NPY_NAT
                     continue
                 local_val = stamps[i] + deltas[pos[i]]
-                result[i] = _normalize_i8_stamp(local_val)
+                result[i] = normalize_i8_stamp(local_val)
 
     return result.base  # `.base` to access underlying ndarray
 
 
 @cython.cdivision
-cdef inline int64_t _normalize_i8_stamp(int64_t local_val) nogil:
+cdef inline int64_t normalize_i8_stamp(int64_t local_val) nogil:
     """
     Round the localized nanosecond timestamp down to the previous midnight.
 


### PR DESCRIPTION
The perf is actually a wash here, verging on slightly negative.  The really worthwhile thing is the improved asvs.

The big perf gain is being split into a separate PR that optimizes _maybe_convert_value_to_local to the tune of 40%.