### PR TITLE
PERF: _maybe_convert_value_to_local

### DIFF
--- a/asv_bench/benchmarks/tslibs/timestamp.py
+++ b/asv_bench/benchmarks/tslibs/timestamp.py
@@ -63,9 +63,6 @@ class TimestampProperties:
     def time_dayofweek(self, tz, freq):
         self.ts.dayofweek
 
-    def time_weekday_name(self, tz, freq):
-        self.ts.day_name
-
     def time_dayofyear(self, tz, freq):
         self.ts.dayofyear
 
@@ -107,6 +104,9 @@ class TimestampProperties:
 
     def time_month_name(self, tz, freq):
         self.ts.month_name()
+
+    def time_weekday_name(self, tz, freq):
+        self.ts.day_name()
 
 
 class TimestampOps:

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -47,6 +47,7 @@ from pandas._libs.tslibs.nattype cimport NPY_NAT, c_NaT as NaT
 from pandas._libs.tslibs.np_datetime cimport (
     check_dts_bounds, npy_datetimestruct, dt64_to_dtstruct,
     cmp_scalar,
+    pydatetime_to_dt64,
 )
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime
 from pandas._libs.tslibs.offsets cimport to_offset, is_tick_object, is_offset_object
@@ -447,9 +448,13 @@ cdef class _Timestamp(ABCTimestamp):
         """Convert UTC i8 value to local i8 value if tz exists"""
         cdef:
             int64_t val
-        val = self.value
-        if self.tz is not None and not is_utc(self.tz):
-            val = tz_convert_single(self.value, UTC, self.tz)
+            tzinfo own_tz = self.tzinfo
+            npy_datetimestruct dts
+
+        if own_tz is not None and not is_utc(own_tz):
+            val = pydatetime_to_dt64(self, &dts) + self.nanosecond
+        else:
+            val = self.value
         return val
 
     cdef bint _get_start_end_field(self, str field):


### PR DESCRIPTION
Also fixes an incorrect asv.

```
In [2]: ts = pd.Timestamp.now("US/Pacific")                                                                                                                                                                        

In [3]: %timeit ts.day_name()                                                                                                                                                                                      
9.13 µs ± 309 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <-- PR
26.4 µs ± 1.23 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)   # <-- master
```