### PR TITLE
No fastcall attribute in POWER platform

### DIFF
--- a/pandas/_libs/src/ujson/lib/ultrajson.h
+++ b/pandas/_libs/src/ujson/lib/ultrajson.h
@@ -108,7 +108,7 @@ typedef uint32_t JSUINT32;
 
 #define FASTCALL_MSVC
 
-#if !defined __x86_64__ && !defined __aarch64__
+#if !defined __x86_64__ && !defined __aarch64__ && !defined __PPC__
 #define FASTCALL_ATTR __attribute__((fastcall))
 #else
 #define FASTCALL_ATTR

--- a/pandas/_libs/src/ujson/lib/ultrajson.h
+++ b/pandas/_libs/src/ujson/lib/ultrajson.h
@@ -94,7 +94,7 @@ typedef __int64 JSLONG;
 #define EXPORTFUNCTION __declspec(dllexport)
 
 #define FASTCALL_MSVC __fastcall
-#define FASTCALL_ATTR
+
 #define INLINE_PREFIX static __inline
 
 #else
@@ -107,8 +107,6 @@ typedef int32_t JSINT32;
 typedef uint32_t JSUINT32;
 
 #define FASTCALL_MSVC
-
-#define FASTCALL_ATTR
 
 #define INLINE_PREFIX static inline
 

--- a/pandas/_libs/src/ujson/lib/ultrajson.h
+++ b/pandas/_libs/src/ujson/lib/ultrajson.h
@@ -108,11 +108,7 @@ typedef uint32_t JSUINT32;
 
 #define FASTCALL_MSVC
 
-#if !defined __x86_64__ && !defined __aarch64__ && !defined __PPC__
-#define FASTCALL_ATTR __attribute__((fastcall))
-#else
 #define FASTCALL_ATTR
-#endif
 
 #define INLINE_PREFIX static inline
 

--- a/pandas/_libs/src/ujson/lib/ultrajsondec.c
+++ b/pandas/_libs/src/ujson/lib/ultrajsondec.c
@@ -68,7 +68,7 @@ struct DecoderState {
     JSONObjectDecoder *dec;
 };
 
-JSOBJ FASTCALL_MSVC decode_any(struct DecoderState *ds) FASTCALL_ATTR;
+JSOBJ FASTCALL_MSVC decode_any(struct DecoderState *ds);
 typedef JSOBJ (*PFN_DECODER)(struct DecoderState *ds);
 
 static JSOBJ SetError(struct DecoderState *ds, int offset,
@@ -99,7 +99,7 @@ double createDouble(double intNeg, double intValue, double frcValue,
     return (intValue + (frcValue * g_pow10[frcDecimalCount])) * intNeg;
 }
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decodePreciseFloat(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decodePreciseFloat(struct DecoderState *ds) {
     char *end;
     double value;
     errno = 0;
@@ -114,7 +114,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decodePreciseFloat(struct DecoderState *ds) {
     return ds->dec->newDouble(ds->prv, value);
 }
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_numeric(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decode_numeric(struct DecoderState *ds) {
     int intNeg = 1;
     int mantSize = 0;
     JSUINT64 intValue;
@@ -340,7 +340,7 @@ BREAK_EXP_LOOP:
             pow(10.0, expValue * expNeg));
 }
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_true(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decode_true(struct DecoderState *ds) {
     char *offset = ds->start;
     offset++;
 
@@ -356,7 +356,7 @@ SETERROR:
     return SetError(ds, -1, "Unexpected character found when decoding 'true'");
 }
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_false(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decode_false(struct DecoderState *ds) {
     char *offset = ds->start;
     offset++;
 
@@ -373,7 +373,7 @@ SETERROR:
     return SetError(ds, -1, "Unexpected character found when decoding 'false'");
 }
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_null(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decode_null(struct DecoderState *ds) {
     char *offset = ds->start;
     offset++;
 
@@ -389,7 +389,7 @@ SETERROR:
     return SetError(ds, -1, "Unexpected character found when decoding 'null'");
 }
 
-FASTCALL_ATTR void FASTCALL_MSVC SkipWhitespace(struct DecoderState *ds) {
+void FASTCALL_MSVC SkipWhitespace(struct DecoderState *ds) {
     char *offset;
 
     for (offset = ds->start; (ds->end - offset) > 0; offset++) {
@@ -677,7 +677,7 @@ static const JSUINT8 g_decoderLookup[256] = {
     DS_UTFLENERROR,
 };
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decode_string(struct DecoderState *ds) {
     JSUTF16 sur[2] = {0};
     int iSur = 0;
     int index;
@@ -957,7 +957,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string(struct DecoderState *ds) {
     }
 }
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_array(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decode_array(struct DecoderState *ds) {
     JSOBJ itemValue;
     JSOBJ newObj;
     int len;
@@ -1021,7 +1021,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_array(struct DecoderState *ds) {
     }
 }
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_object(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decode_object(struct DecoderState *ds) {
     JSOBJ itemName;
     JSOBJ itemValue;
     JSOBJ newObj;
@@ -1104,7 +1104,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_object(struct DecoderState *ds) {
     }
 }
 
-FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_any(struct DecoderState *ds) {
+JSOBJ FASTCALL_MSVC decode_any(struct DecoderState *ds) {
     for (;;) {
         switch (*ds->start) {
             case '\"':

--- a/pandas/_libs/src/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/ujson/lib/ultrajsonenc.c
@@ -393,7 +393,7 @@ void Buffer_Realloc(JSONObjectEncoder *enc, size_t cbNeeded) {
     enc->end = enc->start + newSize;
 }
 
-FASTCALL_ATTR INLINE_PREFIX void FASTCALL_MSVC
+INLINE_PREFIX void FASTCALL_MSVC
 Buffer_AppendShortHexUnchecked(char *outputOffset, unsigned short value) {
     *(outputOffset++) = g_hexChars[(value & 0xf000) >> 12];
     *(outputOffset++) = g_hexChars[(value & 0x0f00) >> 8];
@@ -722,7 +722,7 @@ int Buffer_EscapeStringValidated(JSOBJ obj, JSONObjectEncoder *enc,
 
 #define Buffer_AppendCharUnchecked(__enc, __chr) *((__enc)->offset++) = __chr;
 
-FASTCALL_ATTR INLINE_PREFIX void FASTCALL_MSVC strreverse(char *begin,
+INLINE_PREFIX void FASTCALL_MSVC strreverse(char *begin,
                                                           char *end) {
     char aux;
     while (end > begin) aux = *end, *end-- = *begin, *begin++ = aux;


### PR DESCRIPTION
Compiling the development branch of pandas fail in AIX. 

pandas/_libs/src/ujson/lib/ultrajsonenc.c:397:1: error: ‘fastcall’ attribute directive ignored [-Werror=attributes]
 Buffer_AppendShortHexUnchecked(char *outputOffset, unsigned short value) {
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/src/ujson/lib/ultrajsonenc.c:726:59: error: ‘fastcall’ attribute directive ignored [-Werror=attributes]
                                                           char *end) {
                                                           ^~~~
cc1: all warnings being treated as errors


The fastcall attribute is not available in POWER platform also. 

