### PR TITLE
CLN: Removed unreached else block GH33478

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1373,10 +1373,6 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 # of columns
                 return self.obj._constructor_sliced(values, index=key_index)
 
-        else:
-            # Handle cases like BinGrouper
-            return self._concat_objects(keys, values, not_indexed_same=not_indexed_same)
-
     def _transform_general(
         self, func, *args, engine="cython", engine_kwargs=None, **kwargs
     ):

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1218,7 +1218,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             return self.obj._constructor()
         elif isinstance(first_not_none, DataFrame):
             return self._concat_objects(keys, values, not_indexed_same=not_indexed_same)
-        elif self.grouper.groupings is not None:
+        else:
             if len(self.grouper.groupings) > 1:
                 key_index = self.grouper.result_index
 


### PR DESCRIPTION
Unreached else block in method _wrap_applied_output was removed.

Local tests passed before and after change

- [ ] xref #33478 (Not fully closed, this addresses 1 part)
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
