### PR TITLE
BUG: fix union_indexes not supporting sort=False for Index subclasses

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -974,7 +974,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` with dictionary of values changes columns with dtype of ``int`` to ``float`` (:issue:`34573`)
 - Bug in :meth:`Series.loc` when used with a :class:`MultiIndex` would raise an IndexingError when accessing a None value (:issue:`34318`)
 - Bug in :meth:`DataFrame.reset_index` and :meth:`Series.reset_index` would not preserve data types on an empty :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` (:issue:`19602`)
-- Bug in :func:`pandas.core.indexes.api.union_indexes` would lead to :meth:`DataFrame.append` sorting columns even when ``sort=False`` is specified (:issue`35092`)
+- Bug in :func:`pandas.core.indexes.api.union_indexes` would lead to :meth:`DataFrame.append` sorting columns even when ``sort=False`` is specified (:issue:`35092`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -974,7 +974,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` with dictionary of values changes columns with dtype of ``int`` to ``float`` (:issue:`34573`)
 - Bug in :meth:`Series.loc` when used with a :class:`MultiIndex` would raise an IndexingError when accessing a None value (:issue:`34318`)
 - Bug in :meth:`DataFrame.reset_index` and :meth:`Series.reset_index` would not preserve data types on an empty :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` (:issue:`19602`)
-- Bug in :func:``pandas.core.indexes.api.union_indexes`` would lead to :meth:`DataFrame.append` sorting columns even when ``sort=False`` is specified (:issue`35092`)
+- Bug in :func:`pandas.core.indexes.api.union_indexes` would lead to :meth:`DataFrame.append` sorting columns even when ``sort=False`` is specified (:issue`35092`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -976,7 +976,6 @@ Indexing
 - Bug in :meth:`DataFrame.loc` with dictionary of values changes columns with dtype of ``int`` to ``float`` (:issue:`34573`)
 - Bug in :meth:`Series.loc` when used with a :class:`MultiIndex` would raise an IndexingError when accessing a None value (:issue:`34318`)
 - Bug in :meth:`DataFrame.reset_index` and :meth:`Series.reset_index` would not preserve data types on an empty :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` (:issue:`19602`)
-- Bug in :func:`pandas.core.indexes.api.union_indexes` would lead to :meth:`DataFrame.append` sorting columns even when ``sort=False`` is specified (:issue:`35092`)
 
 Missing
 ^^^^^^^
@@ -1113,6 +1112,7 @@ Reshaping
 - Fixed bug in :func:`melt` where melting MultiIndex columns with ``col_level`` > 0 would raise a ``KeyError`` on ``id_vars`` (:issue:`34129`)
 - Bug in :meth:`Series.where` with an empty Series and empty ``cond`` having non-bool dtype (:issue:`34592`)
 - Fixed regression where :meth:`DataFrame.apply` would raise ``ValueError`` for elements whth ``S`` dtype (:issue:`34529`)
+- Bug in :meth:`DataFrame.append` leading to sorting columns even when ``sort=False`` is specified (:issue:`35092`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -974,6 +974,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` with dictionary of values changes columns with dtype of ``int`` to ``float`` (:issue:`34573`)
 - Bug in :meth:`Series.loc` when used with a :class:`MultiIndex` would raise an IndexingError when accessing a None value (:issue:`34318`)
 - Bug in :meth:`DataFrame.reset_index` and :meth:`Series.reset_index` would not preserve data types on an empty :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` (:issue:`19602`)
+- Bug in :func:``pandas.core.indexes.api.union_indexes`` would lead to :meth:`DataFrame.append` sorting columns even when ``sort=False`` is specified (:issue`35092`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -210,7 +210,8 @@ def union_indexes(indexes, sort=True) -> Index:
     # setting doesn't make sense
     ind_types = [type(index) for index in indexes]
     if any(
-        ind_type in [MultiIndex, RangeIndex, CategoricalIndex] for ind_type in ind_types
+        ind_type in [MultiIndex, RangeIndex, DatetimeIndex, CategoricalIndex]
+        for ind_type in ind_types
     ):
         ignore_sort = True
     else:

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -210,8 +210,7 @@ def union_indexes(indexes, sort=True) -> Index:
     # setting doesn't make sense
     ind_types = [type(index) for index in indexes]
     if any(
-        ind_type in [MultiIndex, RangeIndex, CategoricalIndex]
-        for ind_type in ind_types
+        ind_type in [MultiIndex, RangeIndex, CategoricalIndex] for ind_type in ind_types
     ):
         ignore_sort = True
     else:

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -214,10 +214,6 @@ def union_indexes(indexes, sort=True) -> Index:
             return result.union_many(indexes[1:])
         else:
             for other in indexes[1:]:
-                # GH 35092. Pass sort to Index.union
-                # Index.union expects sort=None instead of sort=True
-                if sort:
-                    sort = None
                 result = result.union(other, sort=sort)
             return result
     elif kind == "array":

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -214,6 +214,10 @@ def union_indexes(indexes, sort=True) -> Index:
             return result.union_many(indexes[1:])
         else:
             for other in indexes[1:]:
+                # GH 35092. Pass sort to Index.union
+                # Index.union expects sort=None instead of sort=True
+                if sort:
+                    sort = None
                 result = result.union(other, sort=sort)
             return result
     elif kind == "array":

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -275,7 +275,8 @@ def _sanitize_and_check(indexes):
     # exclude MultiIndex, RangeIndex as sorting for them doesn't make much sense
     # exclude DatetimeIndex as it's explicitly processed through union_many
     if len(kinds) > 1 or not any(
-        issubclass(kind, Index) and kind not in [MultiIndex, RangeIndex, DatetimeIndex]
+        issubclass(kind, Index)
+        and kind not in [MultiIndex, RangeIndex, DatetimeIndex, CategoricalIndex]
         for kind in kinds
     ):
         return indexes, "special"

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -210,7 +210,7 @@ def union_indexes(indexes, sort=True) -> Index:
     # setting doesn't make sense
     ind_types = [type(index) for index in indexes]
     if any(
-        ind_type in [MultiIndex, RangeIndex, DatetimeIndex, CategoricalIndex]
+        ind_type in [MultiIndex, RangeIndex]
         for ind_type in ind_types
     ):
         ignore_sort = True

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -227,9 +227,12 @@ def union_indexes(indexes, sort=True) -> Index:
             for other in indexes[1:]:
                 # GH 35092. Pass sort to Index.union
                 # Index.union expects sort=None instead of sort=True
-                if sort:
-                    sort = None
-                result = result.union(other, sort=sort)
+                if not ignore_sort:
+                    if sort:
+                        sort = None
+                    result = result.union(other, sort=sort)
+                else:
+                    result = result.union(other)
             return result
     elif kind == "array":
         index = indexes[0]

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -206,6 +206,17 @@ def union_indexes(indexes, sort=True) -> Index:
 
         return Index(lib.fast_unique_multiple_list([conv(i) for i in inds], sort=sort))
 
+    # GH 35092. Detect if we have an Index type, for which the sort
+    # setting doesn't make sense
+    ind_types = list({type(index) for index in indexes})
+    if any(
+        ind_type in [MultiIndex, RangeIndex, DatetimeIndex, CategoricalIndex]
+        for ind_type in ind_types
+    ):
+        ignore_sort = True
+    else:
+        ignore_sort = False
+
     if kind == "special":
         result = indexes[0]
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -263,7 +263,7 @@ def _sanitize_and_check(indexes):
             return indexes, "list"
 
     # GH 35092. Check for Index subclass to avoid setting special type by error
-    if len(kinds) > 1 or all([not isinstance(index, Index) for index in indexes]):
+    if len(kinds) > 1 or not any([issubclass(kind, Index) for kind in kinds]):
         return indexes, "special"
     else:
         return indexes, "array"

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -217,7 +217,7 @@ def union_indexes(indexes, sort=True) -> Index:
                 # GH 35092. Pass sort to Index.union
                 # Index.union expects sort=None instead of sort=True
                 # to signify that sometimes it might not sort (see GH 24959)
-                # to mirror legacy behavior. In this case, it does.
+                # to mirror legacy behavior.
                 if sort:
                     sort = None
                 result = result.union(other, sort=sort)

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -216,6 +216,8 @@ def union_indexes(indexes, sort=True) -> Index:
             for other in indexes[1:]:
                 # GH 35092. Pass sort to Index.union
                 # Index.union expects sort=None instead of sort=True
+                # to signify that sometimes it might not sort (see GH 24959)
+                # to mirror legacy behavior. In this case, it does.
                 if sort:
                     sort = None
                 result = result.union(other, sort=sort)

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -211,7 +211,6 @@ def union_indexes(indexes, sort=True) -> Index:
         else:
             ind_class = Index
 
-        print(inds)
         return ind_class(
             lib.fast_unique_multiple_list([conv(i) for i in inds], sort=sort)
         )
@@ -273,9 +272,10 @@ def _sanitize_and_check(indexes):
             return indexes, "list"
 
     # GH 35092. Check for Index subclass to avoid setting special type by error
-    # exclude MultiIndex
+    # exclude MultiIndex, RangeIndex as sorting for them doesn't make much sense
+    # exclude DatetimeIndex as it's explicitly processed through union_many
     if len(kinds) > 1 or not any(
-        issubclass(kind, Index) and kind != MultiIndex and kind != RangeIndex
+        issubclass(kind, Index) and kind not in [MultiIndex, RangeIndex, DatetimeIndex]
         for kind in kinds
     ):
         return indexes, "special"

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -206,17 +206,6 @@ def union_indexes(indexes, sort=True) -> Index:
 
         return Index(lib.fast_unique_multiple_list([conv(i) for i in inds], sort=sort))
 
-    # GH 35092. Detect if we have an Index type for which the sort
-    # setting doesn't make sense
-    ind_types = [type(index) for index in indexes]
-    if any(
-        ind_type in [MultiIndex, RangeIndex, DatetimeIndex, CategoricalIndex]
-        for ind_type in ind_types
-    ):
-        ignore_sort = True
-    else:
-        ignore_sort = False
-
     if kind == "special":
         result = indexes[0]
 
@@ -227,12 +216,9 @@ def union_indexes(indexes, sort=True) -> Index:
             for other in indexes[1:]:
                 # GH 35092. Pass sort to Index.union
                 # Index.union expects sort=None instead of sort=True
-                if not ignore_sort:
-                    if sort:
-                        sort = None
-                    result = result.union(other, sort=sort)
-                else:
-                    result = result.union(other)
+                if sort:
+                    sort = None
+                result = result.union(other, sort=sort)
             return result
     elif kind == "array":
         index = indexes[0]

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -214,10 +214,10 @@ def union_indexes(indexes, sort=True) -> Index:
             return result.union_many(indexes[1:])
         else:
             for other in indexes[1:]:
-                # GH 35092. Pass sort to Index.union
-                # Index.union expects sort=None instead of sort=True
-                # to signify that sometimes it might not sort (see GH 24959)
-                # to mirror legacy behavior.
+                # GH 35092. Index.union expects sort=None instead of sort=True
+                # to signify that sort=True isn't fully implemented and
+                # legacy implementation sometimes might not sort (see GH 24959)
+                # In this case we currently sort in _get_combined_index
                 if sort:
                     sort = None
                 result = result.union(other, sort=sort)

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -206,7 +206,7 @@ def union_indexes(indexes, sort=True) -> Index:
 
         return Index(lib.fast_unique_multiple_list([conv(i) for i in inds], sort=sort))
 
-    # GH 35092. Detect if we have an Index type, for which the sort
+    # GH 35092. Detect if we have an Index type for which the sort
     # setting doesn't make sense
     ind_types = list({type(index) for index in indexes})
     if any(

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -210,7 +210,7 @@ def union_indexes(indexes, sort=True) -> Index:
     # setting doesn't make sense
     ind_types = [type(index) for index in indexes]
     if any(
-        ind_type in [CategoricalIndex]
+        ind_type in [MultiIndex, RangeIndex, CategoricalIndex]
         for ind_type in ind_types
     ):
         ignore_sort = True

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -210,7 +210,7 @@ def union_indexes(indexes, sort=True) -> Index:
     # setting doesn't make sense
     ind_types = [type(index) for index in indexes]
     if any(
-        ind_type in [MultiIndex, RangeIndex]
+        ind_type in [CategoricalIndex]
         for ind_type in ind_types
     ):
         ignore_sort = True

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -211,6 +211,7 @@ def union_indexes(indexes, sort=True) -> Index:
         else:
             ind_class = Index
 
+        print(inds)
         return ind_class(
             lib.fast_unique_multiple_list([conv(i) for i in inds], sort=sort)
         )
@@ -274,7 +275,8 @@ def _sanitize_and_check(indexes):
     # GH 35092. Check for Index subclass to avoid setting special type by error
     # exclude MultiIndex
     if len(kinds) > 1 or not any(
-        issubclass(kind, Index) and kind != MultiIndex for kind in kinds
+        issubclass(kind, Index) and kind != MultiIndex and kind != RangeIndex
+        for kind in kinds
     ):
         return indexes, "special"
     else:

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -262,7 +262,7 @@ def _sanitize_and_check(indexes):
         else:
             return indexes, "list"
 
-    if len(kinds) > 1 or Index not in kinds:
+    if len(kinds) > 1 or all([not isinstance(index, Index) for index in indexes]):
         return indexes, "special"
     else:
         return indexes, "array"

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -262,6 +262,7 @@ def _sanitize_and_check(indexes):
         else:
             return indexes, "list"
 
+    # GH 35092. Check for Index subclass to avoid setting special type by error
     if len(kinds) > 1 or all([not isinstance(index, Index) for index in indexes]):
         return indexes, "special"
     else:

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -208,7 +208,7 @@ def union_indexes(indexes, sort=True) -> Index:
 
     # GH 35092. Detect if we have an Index type for which the sort
     # setting doesn't make sense
-    ind_types = list({type(index) for index in indexes})
+    ind_types = [type(index) for index in indexes]
     if any(
         ind_type in [MultiIndex, RangeIndex, DatetimeIndex, CategoricalIndex]
         for ind_type in ind_types

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -263,7 +263,7 @@ def _sanitize_and_check(indexes):
             return indexes, "list"
 
     # GH 35092. Check for Index subclass to avoid setting special type by error
-    if len(kinds) > 1 or not any([issubclass(kind, Index) for kind in kinds]):
+    if len(kinds) > 1 or not any(issubclass(kind, Index) for kind in kinds):
         return indexes, "special"
     else:
         return indexes, "array"

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2542,11 +2542,13 @@ class TestDataFrameConstructors:
             index=pd.CategoricalIndex(["f", "female", "m", "male", "unknown"]),
         )
         result = DataFrame([s1, s2])
+        # GH 35092. Extra s2 columns are now appended to s1 columns
+        # in original order
         expected = DataFrame(
             np.array(
-                [[np.nan, 39.0, np.nan, 6.0, 4.0], [2.0, 152.0, 2.0, 242.0, 150.0]]
+                [[39.0, 6.0, 4.0, np.nan, np.nan], [152.0, 242.0, 150.0, 2.0, 2.0]]
             ),
-            columns=["f", "female", "m", "male", "unknown"],
+            columns=["female", "male", "unknown", "f", "m"],
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -11,11 +11,11 @@ import pytest
 from pandas._libs.tslibs import iNaT
 
 from pandas.core.dtypes.common import is_period_dtype, needs_i8_conversion
-from pandas.core.indexes.api import union_indexes
 
 import pandas as pd
 from pandas import CategoricalIndex, Index, MultiIndex, RangeIndex
 import pandas._testing as tm
+from pandas.core.indexes.api import union_indexes
 
 
 class TestCommon:

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -398,13 +398,13 @@ class TestCommon:
             assert result.name == index.name
 
 
+@pytest.mark.parametrize("exp_arr, sort", [([0, 1, 4, 3], False), ([0, 1, 3, 4], True)])
 @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64"])
-def test_union_index_no_sort(dtype):
+def test_union_index_no_sort(exp_arr, sort, dtype):
     # GH 35092. Check that we don't sort with sort=False
     ind1 = Index([0, 1], dtype=dtype)
     ind2 = Index([4, 3], dtype=dtype)
 
-    expected = Index([0, 1, 4, 3], dtype=dtype)
-    result = union_indexes([ind1, ind2], sort=False)
-
+    expected = Index(exp_arr, dtype=dtype)
+    result = union_indexes([ind1, ind2], sort=sort)
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -11,9 +11,10 @@ import pytest
 from pandas._libs.tslibs import iNaT
 
 from pandas.core.dtypes.common import is_period_dtype, needs_i8_conversion
+from pandas.core.indexes.api import union_indexes
 
 import pandas as pd
-from pandas import CategoricalIndex, MultiIndex, RangeIndex
+from pandas import CategoricalIndex, Index, MultiIndex, RangeIndex
 import pandas._testing as tm
 
 
@@ -395,3 +396,15 @@ class TestCommon:
             assert result.names == index.names
         else:
             assert result.name == index.name
+
+
+@pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64"])
+def test_union_index_no_sort(dtype):
+    # GH 35092. Check that we don't sort with sort=False
+    ind1 = Index([0, 1], dtype=dtype)
+    ind2 = Index([4, 3], dtype=dtype)
+
+    expected = Index([0, 1, 4, 3], dtype=dtype)
+    result = union_indexes([ind1, ind2], sort=False)
+
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -398,13 +398,16 @@ class TestCommon:
             assert result.name == index.name
 
 
-@pytest.mark.parametrize("exp_arr, sort", [([0, 1, 4, 3], False), ([0, 1, 3, 4], True)])
+@pytest.mark.parametrize("arr", [[0, 1, 4, 3]])
 @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64"])
-def test_union_index_no_sort(exp_arr, sort, dtype):
+def test_union_index_no_sort(arr, sort, dtype):
     # GH 35092. Check that we don't sort with sort=False
-    ind1 = Index([0, 1], dtype=dtype)
-    ind2 = Index([4, 3], dtype=dtype)
+    ind1 = Index(arr[:2], dtype=dtype)
+    ind2 = Index(arr[2:], dtype=dtype)
 
-    expected = Index(exp_arr, dtype=dtype)
+    # sort is None indicates that we sort the combined index
+    if sort is None:
+        arr.sort()
+    expected = Index(arr, dtype=dtype)
     result = union_indexes([ind1, ind2], sort=sort)
     tm.assert_index_equal(result, expected)

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -2862,8 +2862,8 @@ def test_concat_frame_axis0_extension_dtypes():
 @pytest.mark.parametrize("sort", [True, False])
 def test_append_sort(sort):
     # GH 35092. Check that DataFrame.append respects the sort argument.
-    df1 = pd.DataFrame(data={0: [1,2], 1: [3,4]})
-    df2 = pd.DataFrame(data={3: [1,2], 2: [3,4]})
+    df1 = pd.DataFrame(data={0: [1, 2], 1: [3, 4]})
+    df2 = pd.DataFrame(data={3: [1, 2], 2: [3, 4]})
     cols = list(df1.columns) + list(df2.columns)
     if sort:
         cols.sort()

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -2857,3 +2857,17 @@ def test_concat_frame_axis0_extension_dtypes():
     result = pd.concat([df2, df1], ignore_index=True)
     expected = pd.DataFrame({"a": [4, 5, 6, 1, 2, 3]}, dtype="Int64")
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("sort", [True, False])
+def test_append_sort(sort):
+    # GH 35092. Check that DataFrame.append respects the sort argument.
+    df1 = pd.DataFrame(data={0: [1,2], 1: [3,4]})
+    df2 = pd.DataFrame(data={3: [1,2], 2: [3,4]})
+    cols = list(df1.columns) + list(df2.columns)
+    if sort:
+        cols.sort()
+
+    result = df1.append(df2, sort=sort).columns
+    expected = type(result)(cols)
+    tm.assert_index_equal(result, expected)

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -938,10 +938,10 @@ class TestWideToLong:
         )
         expected = pd.DataFrame(
             {
-                "A": ["X1", "X1", "X2", "X2"],
-                "colname": ["placebo", "test", "placebo", "test"],
-                "result": [5.0, np.nan, 6.0, np.nan],
-                "treatment": [1.0, 3.0, 2.0, 4.0],
+                "A": ["X1", "X2", "X1", "X2"],
+                "colname": ["placebo", "placebo", "test", "test"],
+                "result": [5.0, 6.0, np.nan, np.nan],
+                "treatment": [1.0, 2.0, 3.0, 4.0],
             }
         )
         expected = expected.set_index(["A", "colname"])
@@ -985,10 +985,10 @@ class TestWideToLong:
         )
         expected = pd.DataFrame(
             {
-                "A": ["X1", "X1", "X1", "X1", "X2", "X2", "X2", "X2"],
-                "colname": [1, 1.1, 1.2, 2.1, 1, 1.1, 1.2, 2.1],
-                "result": [0.0, np.nan, 5.0, np.nan, 9.0, np.nan, 6.0, np.nan],
-                "treatment": [np.nan, 1.0, np.nan, 3.0, np.nan, 2.0, np.nan, 4.0],
+                "A": ['X1', 'X2', 'X1', 'X2', 'X1', 'X2', 'X1', 'X2'],
+                "colname": [1.2, 1.2, 1.0, 1.0, 1.1, 1.1, 2.1, 2.1],
+                "result": [5.0, 6.0, 0.0, 9.0, np.nan, np.nan, np.nan, np.nan],
+                "treatment": [np.nan, np.nan, np.nan, np.nan, 1.0, 2.0, 3.0, 4.0],
             }
         )
         expected = expected.set_index(["A", "colname"])

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -691,11 +691,11 @@ class TestWideToLong:
         )
         df["id"] = df.index
         exp_data = {
-            "X": ["X1", "X1", "X2", "X2"],
-            "A": [1.0, 3.0, 2.0, 4.0],
-            "B": [5.0, np.nan, 6.0, np.nan],
-            "id": [0, 0, 1, 1],
-            "year": [2010, 2011, 2010, 2011],
+            "X": ["X1", "X2", "X1", "X2"],
+            "A": [1.0, 2.0, 3.0, 4.0],
+            "B": [5.0, 6.0, np.nan, np.nan],
+            "id": [0, 1, 0, 1],
+            "year": [2010, 2010, 2011, 2011],
         }
         expected = pd.DataFrame(exp_data)
         expected = expected.set_index(["id", "year"])[["X", "A", "B"]]

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -985,7 +985,7 @@ class TestWideToLong:
         )
         expected = pd.DataFrame(
             {
-                "A": ['X1', 'X2', 'X1', 'X2', 'X1', 'X2', 'X1', 'X2'],
+                "A": ["X1", "X2", "X1", "X2", "X1", "X2", "X1", "X2"],
                 "colname": [1.2, 1.2, 1.0, 1.0, 1.1, 1.1, 2.1, 2.1],
                 "result": [5.0, 6.0, 0.0, 9.0, np.nan, np.nan, np.nan, np.nan],
                 "treatment": [np.nan, np.nan, np.nan, np.nan, 1.0, 2.0, 3.0, 4.0],

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -636,8 +636,15 @@ class TestStringMethods:
         # mixed list of indexed/unindexed
         u = np.array(["A", "B", "C", "D"])
         expected_outer = Series(["aaA", "bbB", "c-C", "ddD", "-e-"])
+
         # joint index of rhs [t, u]; u will be forced have index of s
-        rhs_idx = t.index & s.index if join == "inner" else t.index | s.index
+        # GH 35092. If right join, maintain order of t.index
+        if join == "inner":
+            rhs_idx = t.index & s.index
+        elif join == "right":
+            rhs_idx = t.index.union(s.index, sort=False)
+        else:
+            rhs_idx = t.index | s.index
 
         expected = expected_outer.loc[s.index.join(rhs_idx, how=join)]
         result = s.str.cat([t, u], join=join, na_rep="-")


### PR DESCRIPTION
- [X] closes #35092
- [X] 1 tests added / 1 passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

# Scope of PR
The reason for `DataFrame.append` unnecessarily sorting columns turned out to be that when merging indexes we were not passing the `sort` argument for an `Index` subclass. This PR fixes this bug.

# Details
At some point down the call stack, `DataFrame.append` calls `union_indexes` in `core.indexes.api`. In it we detect the type of our indexes: 
```python
indexes, kind = _sanitize_and_check(indexes)
```
We don't pass `sort` for `kind == 'special'` in `union_indexes`.

I had some other ideas, but what I ended up doing is to simply pass the `sort` argument to `Index.union` for `kind == 'special'`. We do have to ignore the `sort` argument for `[MultiIndex, RangeIndex, DatetimeIndex, CategoricalIndex]` to avoid breaking tests and backward compatibility, but it doesn't make sense for these ones to not be sorted when joined anyway, in my opinion.

# Performance
There are no changes to algorithms called. I still did some benchmarking to compare with my previous approach. The current solution didn't have any negative performance impact.
