### PR TITLE
REF: standardize tz_convert_single usage

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1379,7 +1379,7 @@ default 'raise'
 
         cdef:
             npy_datetimestruct dts
-            int64_t value, value_tz
+            int64_t value
             object k, v
             datetime ts_input
             tzinfo_type tzobj
@@ -1388,8 +1388,7 @@ default 'raise'
         tzobj = self.tzinfo
         value = self.value
         if tzobj is not None:
-            value_tz = tz_convert_single(value, tzobj, UTC)
-            value += value - value_tz
+            value = tz_convert_single(value, UTC, tzobj)
 
         # setup components
         dt64_to_dtstruct(value, &dts)


### PR DESCRIPTION
I'm increasingly convinced that we can get all tz_convert/tz_convert_single usages to have tz1=UTC, and everything else should go through tz_localize_to_utc.