### PR TITLE
PERF: tz_localize(None) from dst, asvs

### DIFF
--- a/asv_bench/benchmarks/tslibs/tz_convert.py
+++ b/asv_bench/benchmarks/tslibs/tz_convert.py
@@ -9,7 +9,7 @@ from .tslib import _sizes, _tzs
 class TimeTZConvert:
     params = (
         _sizes,
-        _tzs,
+        [x for x in _tzs if x is not None],
     )
     param_names = ["size", "tz"]
 

--- a/asv_bench/benchmarks/tslibs/tz_convert.py
+++ b/asv_bench/benchmarks/tslibs/tz_convert.py
@@ -1,0 +1,30 @@
+import numpy as np
+from pytz import UTC
+
+from pandas._libs.tslibs.tzconversion import tz_convert, tz_localize_to_utc
+
+from .tslib import _sizes, _tzs
+
+
+class TimeTZConvert:
+    params = (
+        _sizes,
+        _tzs,
+    )
+    param_names = ["size", "tz"]
+
+    def setup(self, size, tz):
+        arr = np.random.randint(0, 10, size=size, dtype="i8")
+        self.i8data = arr
+
+    def time_tz_convert_from_utc(self, size, tz):
+        # effectively:
+        #  dti = DatetimeIndex(self.i8data, tz=tz)
+        #  dti.tz_localize(None)
+        tz_convert(self.i8data, UTC, tz)
+
+    def time_tz_localize_to_utc(self, size, tz):
+        # effectively:
+        #  dti = DatetimeIndex(self.i8data)
+        #  dti.tz_localize(tz, ambiguous="NaT", nonexistent="NaT")
+        tz_localize_to_utc(self.i8data, tz, ambiguous="NaT", nonexistent="NaT")

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -551,29 +551,48 @@ cdef int64_t[:] _tz_convert_dst(
         int64_t[:] result = np.empty(n, dtype=np.int64)
         ndarray[int64_t] trans
         int64_t[:] deltas
-        int64_t v
+        int64_t v, delta
+        str typ
 
     # tz is assumed _not_ to be tzlocal; that should go
     #  through _tz_convert_tzlocal_utc
 
-    trans, deltas, _ = get_dst_info(tz)
-    if not to_utc:
-        # We add `offset` below instead of subtracting it
-        deltas = -1 * np.array(deltas, dtype='i8')
+    trans, deltas, typ = get_dst_info(tz)
 
-    # Previously, this search was done pointwise to try and benefit
-    # from getting to skip searches for iNaTs. However, it seems call
-    # overhead dominates the search time so doing it once in bulk
-    # is substantially faster (GH#24603)
-    pos = trans.searchsorted(values, side='right') - 1
+    if typ not in ["pytz", "dateutil"]:
+        # FixedOffset, we know len(deltas) == 1
+        delta = deltas[0]
 
-    for i in range(n):
-        v = values[i]
-        if v == NPY_NAT:
-            result[i] = v
-        else:
-            if pos[i] < 0:
-                raise ValueError('First time before start of DST info')
-            result[i] = v - deltas[pos[i]]
+        for i in range(n):
+            v = values[i]
+            if v == NPY_NAT:
+                result[i] = v
+            else:
+                if to_utc:
+                    result[i] = v - delta
+                else:
+                    result[i] = v + delta
+
+    else:
+        # Previously, this search was done pointwise to try and benefit
+        # from getting to skip searches for iNaTs. However, it seems call
+        # overhead dominates the search time so doing it once in bulk
+        # is substantially faster (GH#24603)
+        pos = trans.searchsorted(values, side="right") - 1
+
+        for i in range(n):
+            v = values[i]
+            if v == NPY_NAT:
+                result[i] = v
+            else:
+                if pos[i] < 0:
+                    # TODO: How is this reached?  Should we be checking for
+                    #  it elsewhere?
+                    raise ValueError("First time before start of DST info")
+
+                if to_utc:
+                    result[i] = v - deltas[pos[i]]
+                else:
+                    result[i] = v + deltas[pos[i]]
 
     return result


### PR DESCRIPTION
This makes tz_convert_dst follow the same pattern we use elsewhere, and brings a perf improvement along with it.


```
In [2]: dti = pd.date_range("2016-01-01", periods=10000, freq="S", tz="US/Pacific")                                                                                                                          

In [3]: %timeit dti.tz_localize(None)                                                                                                                                                                        
89.3 µs ± 627 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <-- PR
100 µs ± 6.36 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <-- master
```

The boost comes from not doing a copy, so makes a bigger difference in the scalar case than the array case.

```
In [5]: ts = dti[0]                                                                                                                                                                                          

In [6]: %timeit ts.tz_localize(None)                                                                                                                                                                         
12.4 µs ± 188 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)   # <-- PR
16.1 µs ± 215 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)   # <-- master
```

The improvement is much bigger for fixed offsets:

```
In [9]: tz = pytz.FixedOffset(-60)                                                                                                                                                                           
In [10]: dti2 = dti.tz_convert(tz)                                                                                                                                                                           

In [11]: %timeit dti2.tz_localize(None)                                                                                                                                                                      
34.8 µs ± 1.09 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <-- PR
71.8 µs ± 2.99 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)  # <-- master
```