### PR TITLE
PERF: ints_to_pydatetime

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -161,7 +161,7 @@ def ints_to_pydatetime(
         npy_datetimestruct dts
         object dt, new_tz
         str typ
-        int64_t value, delta, local_value
+        int64_t value, local_value, delta = NPY_NAT  # dummy for delta
         ndarray[object] result = np.empty(n, dtype=object)
         object (*func_create)(int64_t, npy_datetimestruct, tzinfo, object, bint)
         bint use_utc = False, use_tzlocal = False, use_fixed = False

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -15,7 +15,7 @@ PyDateTime_IMPORT
 
 
 cimport numpy as cnp
-from numpy cimport float64_t, int64_t, ndarray, uint8_t
+from numpy cimport float64_t, int64_t, ndarray, uint8_t, intp_t
 import numpy as np
 cnp.import_array()
 
@@ -157,13 +157,15 @@ def ints_to_pydatetime(
         Py_ssize_t i, n = len(arr)
         ndarray[int64_t] trans
         int64_t[:] deltas
-        Py_ssize_t pos
+        intp_t[:] pos
         npy_datetimestruct dts
         object dt, new_tz
         str typ
         int64_t value, delta, local_value
         ndarray[object] result = np.empty(n, dtype=object)
         object (*func_create)(int64_t, npy_datetimestruct, tzinfo, object, bint)
+        bint use_utc = False, use_tzlocal = False, use_fixed = False
+        bint use_pytz = False
 
     if box == "date":
         assert (tz is None), "tz should be None when converting to date"
@@ -184,66 +186,45 @@ def ints_to_pydatetime(
         )
 
     if is_utc(tz) or tz is None:
-        for i in range(n):
-            value = arr[i]
-            if value == NPY_NAT:
-                result[i] = <object>NaT
-            else:
-                dt64_to_dtstruct(value, &dts)
-                result[i] = func_create(value, dts, tz, freq, fold)
+        use_utc = True
     elif is_tzlocal(tz):
-        for i in range(n):
-            value = arr[i]
-            if value == NPY_NAT:
-                result[i] = <object>NaT
-            else:
-                # Python datetime objects do not support nanosecond
-                # resolution (yet, PEP 564). Need to compute new value
-                # using the i8 representation.
-                local_value = tz_convert_utc_to_tzlocal(value, tz)
-                dt64_to_dtstruct(local_value, &dts)
-                result[i] = func_create(value, dts, tz, freq, fold)
+        use_tzlocal = True
     else:
         trans, deltas, typ = get_dst_info(tz)
-
-        if typ not in ['pytz', 'dateutil']:
+        if typ not in ["pytz", "dateutil"]:
             # static/fixed; in this case we know that len(delta) == 1
+            use_fixed = True
             delta = deltas[0]
-            for i in range(n):
-                value = arr[i]
-                if value == NPY_NAT:
-                    result[i] = <object>NaT
-                else:
-                    # Adjust datetime64 timestamp, recompute datetimestruct
-                    dt64_to_dtstruct(value + delta, &dts)
-                    result[i] = func_create(value, dts, tz, freq, fold)
-
-        elif typ == 'dateutil':
-            # no zone-name change for dateutil tzs - dst etc
-            # represented in single object.
-            for i in range(n):
-                value = arr[i]
-                if value == NPY_NAT:
-                    result[i] = <object>NaT
-                else:
-                    # Adjust datetime64 timestamp, recompute datetimestruct
-                    pos = trans.searchsorted(value, side='right') - 1
-                    dt64_to_dtstruct(value + deltas[pos], &dts)
-                    result[i] = func_create(value, dts, tz, freq, fold)
         else:
-            # pytz
-            for i in range(n):
-                value = arr[i]
-                if value == NPY_NAT:
-                    result[i] = <object>NaT
-                else:
-                    # Adjust datetime64 timestamp, recompute datetimestruct
-                    pos = trans.searchsorted(value, side='right') - 1
-                    # find right representation of dst etc in pytz timezone
-                    new_tz = tz._tzinfos[tz._transition_info[pos]]
+            pos = trans.searchsorted(arr, side="right") - 1
+            use_pytz = typ == "pytz"
 
-                    dt64_to_dtstruct(value + deltas[pos], &dts)
-                    result[i] = func_create(value, dts, new_tz, freq, fold)
+    for i in range(n):
+        new_tz = tz
+        value = arr[i]
+
+        if value == NPY_NAT:
+            result[i] = <object>NaT
+        else:
+            if use_utc:
+                local_value = value
+            elif use_tzlocal:
+                local_value = tz_convert_utc_to_tzlocal(value, tz)
+            elif use_fixed:
+                local_value = value + delta
+            elif not use_pytz:
+                # i.e. dateutil
+                # no zone-name change for dateutil tzs - dst etc
+                # represented in single object.
+                local_value = value + deltas[pos[i]]
+            else:
+                # pytz
+                # find right representation of dst etc in pytz timezone
+                new_tz = tz._tzinfos[tz._transition_info[pos[i]]]
+                local_value = value + deltas[pos[i]]
+
+            dt64_to_dtstruct(local_value, &dts)
+            result[i] = func_create(value, dts, new_tz, freq, fold)
 
     return result
 


### PR DESCRIPTION
This refactors ints_to_pydatetime to use a much more concise pattern (similar to #35077 but without the helper function refactored out) that I intend to move all of the ~7 functions using get_dst_info to use.  In the process, we are slower on very small arrays and faster on bigger arrays, which I think is a good trade:

```
% asv continuous -E virtualenv -f 1.01 master HEAD -b time_ints_to_pydatetime
[...]
       before           after         ratio
     [a4e19fa5]       [2492aeb4]
     <master>         <ref-ints_to_pydatetime-3>
+     3.95±0.09μs       8.22±0.5μs     2.08  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 0, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
+      4.80±0.2μs       9.53±0.5μs     1.99  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 0, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+      5.45±0.3μs       9.01±0.2μs     1.65  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 0, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+      5.31±0.6μs       8.31±0.3μs     1.57  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('datetime', 0, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
+        6.08±1μs       8.84±0.2μs     1.45  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('datetime', 0, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+      7.00±0.3μs       10.0±0.3μs     1.44  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 1, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
+      7.17±0.1μs       10.3±0.3μs     1.43  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 1, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+      7.47±0.1μs       9.77±0.2μs     1.31  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 1, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+      7.08±0.2μs       8.46±0.5μs     1.20  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 1, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-      10.7±0.6μs       9.48±0.3μs     0.88  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 0, datetime.timezone(datetime.timedelta(seconds=3600)))
-     3.38±0.02μs      2.89±0.06μs     0.85  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('date', 0, None)
-        74.3±1μs         56.3±1μs     0.76  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 100, datetime.timezone.utc)
-        73.4±4μs         54.7±2μs     0.74  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 100, None)
-        20.7±3ms         9.31±2ms     0.45  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 10000, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-      15.4±0.2ms         6.23±1ms     0.40  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('datetime', 10000, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-      1.75±0.03s          699±5ms     0.40  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 1000000, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-      1.56±0.05s         614±20ms     0.39  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('datetime', 1000000, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-      1.65±0.01s         650±10ms     0.39  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 1000000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-        156±10μs         57.3±9μs     0.37  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('datetime', 100, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-        16.8±1ms       5.95±0.2ms     0.36  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 10000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-         164±7μs       58.3±0.8μs     0.36  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('datetime', 100, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-      14.8±0.1ms       5.14±0.5ms     0.35  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('datetime', 10000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-      1.42±0.02s         491±20ms     0.34  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('datetime', 1000000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-         169±6μs         56.0±3μs     0.33  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 100, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-        193±30μs       63.1±0.9μs     0.33  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 100, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-        229±30μs         73.7±3μs     0.32  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('timestamp', 100, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-      1.65±0.06s         505±20ms     0.31  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 1000000, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-         159±3μs         46.1±2μs     0.29  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 100, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-        16.0±1ms       4.64±0.1ms     0.29  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 10000, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-      15.2±0.2ms       3.78±0.2ms     0.25  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 10000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-       1.65±0.1s         408±20ms     0.25  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 1000000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
```