### PR TITLE
CLN: Index._format_with_header (remove kwargs etc.)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2,7 +2,16 @@ from copy import copy as copy_func
 from datetime import datetime
 import operator
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, FrozenSet, Hashable, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    FrozenSet,
+    Hashable,
+    List,
+    Optional,
+    Union,
+)
 import warnings
 
 import numpy as np
@@ -910,15 +919,12 @@ class Index(IndexOpsMixin, PandasObject):
 
         return self._format_with_header(header, **kwargs)
 
-    def _format_with_header(self, header, na_rep="NaN", **kwargs):
-        values = self._values
-
+    def _format_with_header(self, header, na_rep="NaN") -> List[str_t]:
         from pandas.io.formats.format import format_array
 
-        if is_categorical_dtype(values.dtype):
-            values = np.array(values)
+        values = self._values
 
-        elif is_object_dtype(values.dtype):
+        if is_object_dtype(values.dtype):
             values = lib.maybe_convert_objects(values, safe=1)
 
         if is_object_dtype(values.dtype):
@@ -929,10 +935,9 @@ class Index(IndexOpsMixin, PandasObject):
             if mask.any():
                 result = np.array(result)
                 result[mask] = na_rep
-                result = result.tolist()
-
+                result = result.tolist()  # type: ignore
         else:
-            result = _trim_front(format_array(values, None, justify="left"))
+            result = trim_front(format_array(values, None, justify="left"))
         return header + result
 
     def to_native_types(self, slicer=None, **kwargs):
@@ -5611,7 +5616,7 @@ def ensure_has_len(seq):
         return seq
 
 
-def _trim_front(strings):
+def trim_front(strings: List[str]) -> List[str]:
     """
     Trims zeros and decimal points.
     """

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -347,6 +347,15 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
             attrs.append(("length", len(self)))
         return attrs
 
+    def _format_with_header(self, header, na_rep="NaN") -> List[str]:
+        from pandas.io.formats.format import format_array
+
+        formatted_values = format_array(
+            self._values, formatter=None, na_rep=na_rep, justify="left"
+        )
+        result = ibase.trim_front(formatted_values)
+        return header + result
+
     # --------------------------------------------------------------------
 
     @property

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -338,8 +338,8 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
     # --------------------------------------------------------------------
     # Rendering Methods
 
-    def _format_with_header(self, header, na_rep="NaT", **kwargs):
-        return header + list(self._format_native_types(na_rep, **kwargs))
+    def _format_with_header(self, header, na_rep="NaT") -> List[str]:
+        return header + list(self._format_native_types(na_rep=na_rep))
 
     @property
     def _formatter_func(self):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -338,8 +338,10 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
     # --------------------------------------------------------------------
     # Rendering Methods
 
-    def _format_with_header(self, header, na_rep="NaT") -> List[str]:
-        return header + list(self._format_native_types(na_rep=na_rep))
+    def _format_with_header(self, header, na_rep="NaT", date_format=None) -> List[str]:
+        return header + list(
+            self._format_native_types(na_rep=na_rep, date_format=date_format)
+        )
 
     @property
     def _formatter_func(self):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1,7 +1,7 @@
 """ define the IntervalIndex """
 from operator import le, lt
 import textwrap
-from typing import Any, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -948,8 +948,8 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
     # Rendering Methods
     # __repr__ associated methods are based on MultiIndex
 
-    def _format_with_header(self, header, **kwargs):
-        return header + list(self._format_native_types(**kwargs))
+    def _format_with_header(self, header, na_rep="NaN") -> List[str]:
+        return header + list(self._format_native_types(na_rep=na_rep))
 
     def _format_native_types(self, na_rep="NaN", quoting=None, **kwargs):
         # GH 28210: use base method but with different default na_rep

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 import operator
 from sys import getsizeof
-from typing import Any, Optional
+from typing import Any, List, Optional
 import warnings
 
 import numpy as np
@@ -197,7 +197,7 @@ class RangeIndex(Int64Index):
         # we are formatting thru the attributes
         return None
 
-    def _format_with_header(self, header, na_rep="NaN", **kwargs):
+    def _format_with_header(self, header, na_rep="NaN") -> List[str]:
         return header + list(map(pprint_thing, self._range))
 
     # --------------------------------------------------------------------

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1524,7 +1524,10 @@ def _get_level_lengths(index, hidden_elements=None):
 
     Result is a dictionary of (level, initial_position): span
     """
-    levels = index.format(sparsify=lib.no_default, adjoin=False, names=False)
+    if isinstance(index, pd.MultiIndex):
+        levels = index.format(sparsify=lib.no_default, adjoin=False)
+    else:
+        levels = index.format()
 
     if hidden_elements is None:
         hidden_elements = []


### PR DESCRIPTION
Refactor of ``Index._format_with_header`` and subclass methods:
* remove ``kwargs`` for cleaner signature.
* Add return type
* Move functionality specific to ``CategoricalIndex`` to that class.
