### PR TITLE
CLN: remove kwargs in Index.format

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -902,7 +902,7 @@ class Index(IndexOpsMixin, PandasObject):
         # how to represent ourselves to matplotlib
         return self.values
 
-    def format(self, name: bool = False, formatter=None, **kwargs):
+    def format(self, name: bool = False, formatter=None, na_rep="NaN") -> List[str_t]:
         """
         Render a string representation of the Index.
         """
@@ -917,7 +917,7 @@ class Index(IndexOpsMixin, PandasObject):
         if formatter is not None:
             return header + list(self.map(formatter))
 
-        return self._format_with_header(header, **kwargs)
+        return self._format_with_header(header, na_rep=na_rep)
 
     def _format_with_header(self, header, na_rep="NaN") -> List[str_t]:
         from pandas.io.formats.format import format_array

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -902,7 +902,12 @@ class Index(IndexOpsMixin, PandasObject):
         # how to represent ourselves to matplotlib
         return self.values
 
-    def format(self, name: bool = False, formatter=None, na_rep="NaN") -> List[str_t]:
+    def format(
+        self,
+        name: bool = False,
+        formatter: Optional[Callable] = None,
+        na_rep: str_t = "NaN",
+    ) -> List[str_t]:
         """
         Render a string representation of the Index.
         """

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -338,6 +338,22 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
     # --------------------------------------------------------------------
     # Rendering Methods
 
+    def format(
+        self, name: bool = False, formatter=None, date_format=None, na_rep="NaT"
+    ) -> List[str]:
+        """
+        Render a string representation of the Index.
+        """
+        header = []
+        if name:
+            fmt_name = ibase.pprint_thing(self.name, escape_chars=("\t", "\r", "\n"))
+            header.append(fmt_name)
+
+        if formatter is not None:
+            return header + list(self.map(formatter))
+
+        return self._format_with_header(header, date_format=date_format, na_rep=na_rep)
+
     def _format_with_header(self, header, na_rep="NaT", date_format=None) -> List[str]:
         return header + list(
             self._format_native_types(na_rep=na_rep, date_format=date_format)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -339,7 +339,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
     # Rendering Methods
 
     def format(
-        self, name: bool = False, formatter=None, date_format=None, na_rep="NaT"
+        self, name: bool = False, formatter=None, na_rep="NaT", date_format=None
     ) -> List[str]:
         """
         Render a string representation of the Index.

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -9,7 +9,7 @@ import numpy as np
 from pandas._libs import NaT, Timedelta, iNaT, join as libjoin, lib
 from pandas._libs.tslibs import BaseOffset, Resolution, Tick, timezones
 from pandas._libs.tslibs.parsing import DateParseError
-from pandas._typing import Label
+from pandas._typing import Callable, Label
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
 from pandas.util._decorators import Appender, cache_readonly, doc
@@ -339,7 +339,11 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
     # Rendering Methods
 
     def format(
-        self, name: bool = False, formatter=None, na_rep="NaT", date_format=None
+        self,
+        name: bool = False,
+        formatter: Optional[Callable] = None,
+        na_rep: str = "NaT",
+        date_format: Optional[str] = None,
     ) -> List[str]:
         """
         Render a string representation of the Index.
@@ -352,7 +356,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
         if formatter is not None:
             return header + list(self.map(formatter))
 
-        return self._format_with_header(header, date_format=date_format, na_rep=na_rep)
+        return self._format_with_header(header, na_rep=na_rep, date_format=date_format)
 
     def _format_with_header(self, header, na_rep="NaT", date_format=None) -> List[str]:
         return header + list(

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2,6 +2,7 @@ from sys import getsizeof
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Hashable,
     Iterable,
     List,
@@ -1231,13 +1232,13 @@ class MultiIndex(Index):
 
     def format(
         self,
-        name=None,
-        formatter=None,
-        na_rep=None,
-        names=False,
-        space=2,
-        sparsify=None,
-        adjoin=True,
+        name: Optional[bool] = None,
+        formatter: Optional[Callable] = None,
+        na_rep: Optional[str] = None,
+        names: bool = False,
+        space: int = 2,
+        sparsify: Optional[bool] = None,
+        adjoin: bool = True,
     ) -> list:
         if name is not None:
             names = name

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1237,7 +1237,7 @@ class MultiIndex(Index):
         na_rep: Optional[str] = None,
         names: bool = False,
         space: int = 2,
-        sparsify: Optional[bool] = None,
+        sparsify = None,
         adjoin: bool = True,
     ) -> list:
         if name is not None:
@@ -1288,10 +1288,9 @@ class MultiIndex(Index):
 
         if sparsify:
             sentinel = ""
-            # GH3547
-            # use value of sparsify as sentinel,  unless it's an obvious
-            # "Truthy" value
-            if sparsify not in [True, 1]:
+            # GH3547 use value of sparsify as sentinel if it's "Falsey"
+            assert isinstance(sparsify, bool) or sparsify is lib.no_default
+            if sparsify in [False, lib.no_default]:
                 sentinel = sparsify
             # little bit of a kludge job for #1217
             result_levels = _sparsify(

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1231,13 +1231,17 @@ class MultiIndex(Index):
 
     def format(
         self,
+        name=None,
+        formatter=None,
+        na_rep=None,
+        names=False,
         space=2,
         sparsify=None,
         adjoin=True,
-        names=False,
-        na_rep=None,
-        formatter=None,
     ) -> list:
+        if name is not None:
+            names = name
+
         if len(self) == 0:
             return []
 
@@ -1265,13 +1269,13 @@ class MultiIndex(Index):
             stringified_levels.append(formatted)
 
         result_levels = []
-        for lev, name in zip(stringified_levels, self.names):
+        for lev, lev_name in zip(stringified_levels, self.names):
             level = []
 
             if names:
                 level.append(
-                    pprint_thing(name, escape_chars=("\t", "\r", "\n"))
-                    if name is not None
+                    pprint_thing(lev_name, escape_chars=("\t", "\r", "\n"))
+                    if lev_name is not None
                     else ""
                 )
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1237,7 +1237,7 @@ class MultiIndex(Index):
         na_rep: Optional[str] = None,
         names: bool = False,
         space: int = 2,
-        sparsify = None,
+        sparsify=None,
         adjoin: bool = True,
     ) -> list:
         if name is not None:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1237,7 +1237,7 @@ class MultiIndex(Index):
         names=False,
         na_rep=None,
         formatter=None,
-    ):
+    ) -> list:
         if len(self) == 0:
             return []
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1239,7 +1239,7 @@ class MultiIndex(Index):
         space: int = 2,
         sparsify=None,
         adjoin: bool = True,
-    ) -> list:
+    ) -> List:
         if name is not None:
             names = name
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -198,7 +198,7 @@ class RangeIndex(Int64Index):
         return None
 
     def _format_with_header(self, header, na_rep="NaN") -> List[str]:
-        return header + list(map(pprint_thing, self._range))
+        return header + [pprint_thing(x) for x in self._range]
 
     # --------------------------------------------------------------------
     _deprecation_message = (

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -330,9 +330,8 @@ class SeriesFormatter:
 
     def _get_formatted_index(self) -> Tuple[List[str], bool]:
         index = self.tr_series.index
-        is_multi = isinstance(index, MultiIndex)
 
-        if is_multi:
+        if isinstance(index, MultiIndex):
             have_header = any(name for name in index.names)
             fmt_index = index.format(names=True)
         else:

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -442,6 +442,7 @@ class HTMLFormatter(TableFormatter):
         frame = self.fmt.tr_frame
         nrows = len(frame)
 
+        assert isinstance(frame.index, MultiIndex)
         idx_values = frame.index.format(sparsify=False, adjoin=False, names=False)
         idx_values = list(zip(*idx_values))
 


### PR DESCRIPTION
Removes kwargs in ``Index.format`` and subclasses. Also changes ``Index._format_with_header`` to have parameter ``na_rep`` not have a default value (in order to not have default value set in two locations).

Related to #35118.