### PR TITLE
TST: Add test for category equalness on applies (#21239)

### DIFF
--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -793,6 +793,18 @@ class TestDataFrameApply:
         result = df.apply(lambda x: x.astype("object"))
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("val", ["asd", 12, None, np.NaN])
+    def test_apply_category_equalness(self, val):
+        # Check if categorical comparisons on apply, GH 21239
+        df_values = ["asd", None, 12, "asd", "cde", np.NaN]
+        df = pd.DataFrame({"a": df_values}, dtype="category")
+
+        result = df.a.apply(lambda x: x == val)
+        expected = pd.Series(
+            [np.NaN if pd.isnull(x) else x == val for x in df_values], name="a"
+        )
+        tm.assert_series_equal(result, expected)
+
 
 class TestInferOutputShape:
     # the user has supplied an opaque UDF where


### PR DESCRIPTION
- [x] closes #21239
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The test checks if equalness comparisons through `df.apply()` works correctly for the categorical `dtype`, especially with `np.NaN` and `None` values.