### PR TITLE
Fix regression on datetime in MultiIndex

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1165,6 +1165,9 @@ class _LocIndexer(_LocationIndexer):
                     if len(key) == labels.nlevels:
                         return {"key": key}
                     raise
+            except InvalidIndexError:
+                if not isinstance(labels, ABCMultiIndex):
+                    raise
             except TypeError:
                 pass
             except ValueError:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1166,6 +1166,7 @@ class _LocIndexer(_LocationIndexer):
                         return {"key": key}
                     raise
             except InvalidIndexError:
+                # GH35015, using datetime as column indices raises exception
                 if not isinstance(labels, ABCMultiIndex):
                     raise
             except TypeError:

--- a/pandas/tests/indexing/multiindex/test_datetime.py
+++ b/pandas/tests/indexing/multiindex/test_datetime.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from pandas import (
     DataFrame,
-    DatetimeIndex,
     Index,
     MultiIndex,
     Period,

--- a/pandas/tests/indexing/multiindex/test_datetime.py
+++ b/pandas/tests/indexing/multiindex/test_datetime.py
@@ -2,7 +2,16 @@ from datetime import datetime
 
 import numpy as np
 
-from pandas import Index, Period, Series, period_range
+from pandas import (
+    DataFrame,
+    DatetimeIndex,
+    Index,
+    MultiIndex,
+    Period,
+    Series,
+    period_range,
+    to_datetime,
+)
 
 
 def test_multiindex_period_datetime():
@@ -20,3 +29,16 @@ def test_multiindex_period_datetime():
     # try datetime as index
     result = s.loc["a", datetime(2012, 1, 1)]
     assert result == expected
+
+
+def test_multiindex_datetime_columns():
+    # GH35015, using datetime as column indices raises exception
+
+    mi = MultiIndex.from_tuples(
+        [(to_datetime("02/29/2020"), to_datetime("03/01/2020"))], names=["a", "b"]
+    )
+
+    df = DataFrame([], columns=mi)
+    assert list(df.columns.names) == ["a", "b"]
+
+    assert all(isinstance(mi.get_level_values(i), DatetimeIndex) for i in range(2))

--- a/pandas/tests/indexing/multiindex/test_datetime.py
+++ b/pandas/tests/indexing/multiindex/test_datetime.py
@@ -12,6 +12,7 @@ from pandas import (
     period_range,
     to_datetime,
 )
+import pandas._testing as tm
 
 
 def test_multiindex_period_datetime():
@@ -39,6 +40,12 @@ def test_multiindex_datetime_columns():
     )
 
     df = DataFrame([], columns=mi)
-    assert list(df.columns.names) == ["a", "b"]
 
-    assert all(isinstance(mi.get_level_values(i), DatetimeIndex) for i in range(2))
+    expected_df = DataFrame(
+        [],
+        columns=MultiIndex.from_arrays(
+            [[to_datetime("02/29/2020")], [to_datetime("03/01/2020")]], names=["a", "b"]
+        ),
+    )
+
+    tm.assert_frame_equal(df, expected_df)


### PR DESCRIPTION
- [x] closes #35015
- [x] tests added / passed
  - `tests.indexing.multiindex.test_datetime:test_multiindex_datetime_columns`
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
   - Not needed - this was a regression
