### PR TITLE
improved exception message

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3270,9 +3270,13 @@ class Index(IndexOpsMixin, PandasObject):
         """
         # trying to reindex on an axis with duplicates
         if not self.is_unique and len(indexer):
-            raise ValueError("""cannot reindex from a duplicate axis
-        (this usually occurs when trying to join / assign
-        to a column when the index contains duplicate values).""")
+        msg = (
+            """cannot reindex from a duplicate axis
+            (this usually occurs when trying to join / assign
+            to a column when the index contains duplicate values)."""
+        )
+        
+            raise ValueError(msg)
 
     def reindex(self, target, method=None, level=None, limit=None, tolerance=None):
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3270,7 +3270,9 @@ class Index(IndexOpsMixin, PandasObject):
         """
         # trying to reindex on an axis with duplicates
         if not self.is_unique and len(indexer):
-            raise ValueError("cannot reindex from a duplicate axis")
+            raise ValueError("""cannot reindex from a duplicate axis
+        (this usually occurs when trying to join / assign
+        to a column when the index contains duplicate values).""")
 
     def reindex(self, target, method=None, level=None, limit=None, tolerance=None):
         """

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -281,7 +281,7 @@ class TestDataFrameSelectReindex:
         tm.assert_frame_equal(result, expected)
 
         # reindex fails
-        msg = "cannot reindex from a duplicate axis"
+        msg = "cannot reindex from a duplicate axis (this usually occurs when trying tp join / assign to a column when the index contains duplicate values)."
         with pytest.raises(ValueError, match=msg):
             df.reindex(index=list(range(len(df))))
 

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -281,8 +281,8 @@ class TestDataFrameSelectReindex:
         tm.assert_frame_equal(result, expected)
 
         # reindex fails
-        msg = """cannot reindex from a duplicate axis 
-        (this usually occurs when trying to join / assign 
+        msg = """cannot reindex from a duplicate axis
+        (this usually occurs when trying to join / assign
         to a column when the index contains duplicate values)."""
         with pytest.raises(ValueError, match=msg):
             df.reindex(index=list(range(len(df))))

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -281,9 +281,7 @@ class TestDataFrameSelectReindex:
         tm.assert_frame_equal(result, expected)
 
         # reindex fails
-        msg = """cannot reindex from a duplicate axis
-        (this usually occurs when trying to join / assign
-        to a column when the index contains duplicate values)."""
+        msg = "cannot reindex from a duplicate axis"
         with pytest.raises(ValueError, match=msg):
             df.reindex(index=list(range(len(df))))
 

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -281,7 +281,9 @@ class TestDataFrameSelectReindex:
         tm.assert_frame_equal(result, expected)
 
         # reindex fails
-        msg = "cannot reindex from a duplicate axis (this usually occurs when trying tp join / assign to a column when the index contains duplicate values)."
+        msg = """cannot reindex from a duplicate axis 
+        (this usually occurs when trying to join / assign 
+        to a column when the index contains duplicate values)."""
         with pytest.raises(ValueError, match=msg):
             df.reindex(index=list(range(len(df))))
 


### PR DESCRIPTION
for ValueError: cannot reindex from a duplicate axis

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
