### PR TITLE
Move mark registration

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -44,6 +44,19 @@ from pandas.core.indexes.api import Index, MultiIndex
 # Configuration / Settings
 # ----------------------------------------------------------------
 # pytest
+def pytest_configure(config):
+    # Register marks to avoid warnings in pandas.test()
+    # sync with setup.cfg
+    config.addinivalue_line("markers", "single: mark a test as single cpu only")
+    config.addinivalue_line("markers", "slow: mark a test as slow")
+    config.addinivalue_line("markers", "network: mark a test as network")
+    config.addinivalue_line(
+        "markers", "db: tests requiring a database (mysql or postgres)"
+    )
+    config.addinivalue_line("markers", "high_memory: mark a test as a high-memory only")
+    config.addinivalue_line("markers", "clipboard: mark a pd.read_clipboard test")
+
+
 def pytest_addoption(parser):
     parser.addoption("--skip-slow", action="store_true", help="skip slow tests")
     parser.addoption("--skip-network", action="store_true", help="skip network tests")

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,13 +54,6 @@ exclude =
 # sync minversion with setup.cfg & install.rst
 minversion = 4.0.2
 testpaths = pandas
-markers =
-    single: mark a test as single cpu only
-    slow: mark a test as slow
-    network: mark a test as network
-    db: tests requiring a database (mysql or postgres)
-    high_memory: mark a test as a high-memory only
-    clipboard: mark a pd.read_clipboard test
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
 addopts = --strict-data-files
 xfail_strict = True


### PR DESCRIPTION
Should avoid warnings like

```
  D:\a\1\s\test_venv\lib\site-packages\pandas\tests\plotting\test_series.py:655: PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    @pytest.mark.slow

```

in https://dev.azure.com/pandas-dev/pandas-wheels/_build/results?buildId=38672&view=logs&j=c0130b29-789d-5a3c-6978-10796a508a7f&t=e120bc6c-1f5e-5a41-8f0a-1d992cd2fbfb