### PR TITLE
BUG: transform with nunique should have dtype int64

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1080,6 +1080,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.groupby` lost index, when one of the ``agg`` keys referenced an empty list (:issue:`32580`)
 - Bug in :meth:`Rolling.apply` where ``center=True`` was ignored when ``engine='numba'`` was specified (:issue:`34784`)
 - Bug in :meth:`DataFrame.ewm.cov` was throwing ``AssertionError`` for :class:`MultiIndex` inputs (:issue:`34440`)
+- Bug in :meth:`core.groupby.DataFrameGroupBy.transform` when ``func='nunique'`` and columns are of type ``datetime64``, the result would also be of type ``datetime64`` instead of ``int64`` (:issue:`35109`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -5,10 +5,11 @@ Note: pandas.core.common is *not* part of the public API.
 """
 
 from collections import abc, defaultdict
+import contextlib
 from datetime import datetime, timedelta
 from functools import partial
 import inspect
-from typing import Any, Collection, Iterable, List, Union
+from typing import Any, Collection, Iterable, Iterator, List, Union
 import warnings
 
 import numpy as np
@@ -502,3 +503,21 @@ def convert_to_list_like(
         return list(values)
 
     return [values]
+
+
+@contextlib.contextmanager
+def temp_setattr(obj, attr: str, value) -> Iterator[None]:
+    """Temporarily set attribute on an object.
+
+    Args:
+        obj: Object whose attribute will be modified.
+        attr: Attribute to modify.
+        value: Value to temporarily set attribute to.
+
+    Yields:
+        obj with modified attribute.
+    """
+    old_value = getattr(obj, attr)
+    setattr(obj, attr, value)
+    yield obj
+    setattr(obj, attr, old_value)

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -488,9 +488,11 @@ class SeriesGroupBy(GroupBy[Series]):
         # Temporarily set observed for dealing with
         # categoricals so we don't have to convert dtypes.
         observed = self.observed
-        self.observed = True
-        result = getattr(self, func)(*args, **kwargs)
-        self.observed = observed
+        try:
+            self.observed = True
+            result = getattr(self, func)(*args, **kwargs)
+        finally:
+            self.observed = observed
         return self._transform_fast(result)
 
     def _transform_general(
@@ -1472,9 +1474,11 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             # Temporarily set observed for dealing with
             # categoricals so we don't have to convert dtypes.
             observed = self.observed
-            self.observed = True
-            result = getattr(self, func)(*args, **kwargs)
-            self.observed = observed
+            try:
+                self.observed = True
+                result = getattr(self, func)(*args, **kwargs)
+            finally:
+                self.observed = observed
 
             if isinstance(result, DataFrame) and result.columns.equals(
                 self._obj_with_exclusions.columns

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -485,14 +485,9 @@ class SeriesGroupBy(GroupBy[Series]):
         # If func is a reduction, we need to broadcast the
         # result to the whole group. Compute func result
         # and deal with possible broadcasting below.
-        # Temporarily set observed for dealing with
-        # categoricals so we don't have to convert dtypes.
-        observed = self.observed
-        try:
-            self.observed = True
+        # Temporarily set observed for dealing with categoricals.
+        with com.temp_setattr(self, "observed", True):
             result = getattr(self, func)(*args, **kwargs)
-        finally:
-            self.observed = observed
         return self._transform_fast(result)
 
     def _transform_general(
@@ -1471,14 +1466,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
             # If func is a reduction, we need to broadcast the
             # result to the whole group. Compute func result
             # and deal with possible broadcasting below.
-            # Temporarily set observed for dealing with
-            # categoricals so we don't have to convert dtypes.
-            observed = self.observed
-            try:
-                self.observed = True
+            # Temporarily set observed for dealing with categoricals.
+            with com.temp_setattr(self, "observed", True):
                 result = getattr(self, func)(*args, **kwargs)
-            finally:
-                self.observed = observed
 
             if isinstance(result, DataFrame) and result.columns.equals(
                 self._obj_with_exclusions.columns

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -170,6 +170,7 @@ def test_nunique_preserves_column_level_names():
 
 
 def test_nunique_transform_with_datetime():
+    # GH 35109 - transform with nunique on datetimes results in integers
     df = pd.DataFrame(date_range("2008-12-31", "2009-01-02"), columns=["date"])
     result = df.groupby([0, 0, 1])["date"].transform("nunique")
     expected = pd.Series([2, 2, 1], name="date")

--- a/pandas/tests/groupby/test_nunique.py
+++ b/pandas/tests/groupby/test_nunique.py
@@ -167,3 +167,10 @@ def test_nunique_preserves_column_level_names():
     result = test.groupby([0, 0, 0]).nunique()
     expected = pd.DataFrame([2], columns=test.columns)
     tm.assert_frame_equal(result, expected)
+
+
+def test_nunique_transform_with_datetime():
+    df = pd.DataFrame(date_range("2008-12-31", "2009-01-02"), columns=["date"])
+    result = df.groupby([0, 0, 1])["date"].transform("nunique")
+    expected = pd.Series([2, 2, 1], name="date")
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35109
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

cc @WillAyd 

Removes casting on transformations which go through `_transform_fast`. The result is a reduction that is broadcast to the original index, so casting isn't necessary once special care is taken for categoricals when `observed=False`

If this PR is accepted, I'll close #35130 which is for the same issue.