### PR TITLE
DOC: fix code snippets for generic indexing

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -219,8 +219,8 @@ There are 2 explicit slicing methods, with a third general case
    df.loc['bar':'kar']  # Label
 
    # Generic
-   df.iloc[0:3]
-   df.loc['bar':'kar']
+   df[0:3]
+   df['bar':'kar']
 
 Ambiguity arises when an index consists of integers with a non-zero start or non-unit increment.
 


### PR DESCRIPTION
The code example for generic indexing is the same as positional/label indexing above. 

I think generic indexing here intended to be referred to something like `df[0:3]`  and `df['bar':'kar']`