### PR TITLE
Add date overflow message to tz_localize (#32967)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -897,6 +897,7 @@ Datetimelike
   resolution which converted to object dtype instead of coercing to ``datetime64[ns]``
   dtype when within the timestamp bounds (:issue:`34843`).
 - The ``freq`` keyword in :class:`Period`, :func:`date_range`, :func:`period_range`, :func:`pd.tseries.frequencies.to_offset` no longer allows tuples, pass as string instead (:issue:`34703`)
+- ``OutOfBoundsDatetime`` issues an error message when timestamp is out of implementation bounds. (:issue:`32967`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -897,7 +897,7 @@ Datetimelike
   resolution which converted to object dtype instead of coercing to ``datetime64[ns]``
   dtype when within the timestamp bounds (:issue:`34843`).
 - The ``freq`` keyword in :class:`Period`, :func:`date_range`, :func:`period_range`, :func:`pd.tseries.frequencies.to_offset` no longer allows tuples, pass as string instead (:issue:`34703`)
-- ``OutOfBoundsDatetime`` issues an error message when timestamp is out of implementation bounds. (:issue:`32967`)
+- ``OutOfBoundsDatetime`` issues an improved error message when timestamp is out of implementation bounds. (:issue:`32967`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -605,19 +605,21 @@ cdef inline check_overflows(_TSObject obj):
     OutOfBoundsDatetime
     """
     # GH#12677
-    fmt = (f'{obj.dts.year}-{obj.dts.month:02d}-{obj.dts.day:02d} '
-           f'{obj.dts.hour:02d}:{obj.dts.min:02d}:{obj.dts.sec:02d}')
     if obj.dts.year == 1677:
         if not (obj.value < 0):
             from pandas._libs.tslibs.timestamps import Timestamp
+            fmt = (f"{obj.dts.year}-{obj.dts.month:02d}-{obj.dts.day:02d} "
+                   f"{obj.dts.hour:02d}:{obj.dts.min:02d}:{obj.dts.sec:02d}")
             raise OutOfBoundsDatetime(
-                f'Converting {fmt} underflows past {Timestamp.min}'
+                f"Converting {fmt} underflows past {Timestamp.min}"
             )
     elif obj.dts.year == 2262:
         if not (obj.value > 0):
             from pandas._libs.tslibs.timestamps import Timestamp
+            fmt = (f"{obj.dts.year}-{obj.dts.month:02d}-{obj.dts.day:02d} "
+                   f"{obj.dts.hour:02d}:{obj.dts.min:02d}:{obj.dts.sec:02d}")
             raise OutOfBoundsDatetime(
-                f'Converting {fmt} overflows past {Timestamp.max}'
+                f"Converting {fmt} overflows past {Timestamp.max}"
             )
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -605,13 +605,20 @@ cdef inline check_overflows(_TSObject obj):
     OutOfBoundsDatetime
     """
     # GH#12677
+    fmt = (f'{obj.dts.year}-{obj.dts.month:02d}-{obj.dts.day:02d} '
+           f'{obj.dts.hour:02d}:{obj.dts.min:02d}:{obj.dts.sec:02d}')
     if obj.dts.year == 1677:
         if not (obj.value < 0):
-            raise OutOfBoundsDatetime
+            from pandas._libs.tslibs.timestamps import Timestamp
+            raise OutOfBoundsDatetime(
+                f'Converting {fmt} underflows past {Timestamp.min}'
+            )
     elif obj.dts.year == 2262:
         if not (obj.value > 0):
-            raise OutOfBoundsDatetime
-
+            from pandas._libs.tslibs.timestamps import Timestamp
+            raise OutOfBoundsDatetime(
+                f'Converting {fmt} overflows past {Timestamp.max}'
+            )
 
 # ----------------------------------------------------------------------
 # Localization

--- a/pandas/tests/scalar/timestamp/test_timezones.py
+++ b/pandas/tests/scalar/timestamp/test_timezones.py
@@ -21,9 +21,12 @@ class TestTimestampTZOperations:
     # Timestamp.tz_localize
 
     def test_tz_localize_pushes_out_of_bounds(self):
-        msg = "^$"
         # GH#12677
         # tz_localize that pushes away from the boundary is OK
+        msg = (
+            f"Converting {Timestamp.min.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"underflows past {Timestamp.min}"
+        )
         pac = Timestamp.min.tz_localize("US/Pacific")
         assert pac.value > Timestamp.min.value
         pac.tz_convert("Asia/Tokyo")  # tz_convert doesn't change value
@@ -31,6 +34,10 @@ class TestTimestampTZOperations:
             Timestamp.min.tz_localize("Asia/Tokyo")
 
         # tz_localize that pushes away from the boundary is OK
+        msg = (
+            f"Converting {Timestamp.max.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"overflows past {Timestamp.max}"
+        )
         tokyo = Timestamp.max.tz_localize("Asia/Tokyo")
         assert tokyo.value < Timestamp.max.value
         tokyo.tz_convert("US/Pacific")  # tz_convert doesn't change value


### PR DESCRIPTION
- [x] closes #32967
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Added an error message to tz_localize when the timestamp overflows. I got a little confused by the history in #32979 as some changes were lost on the force pushes, but I tried to handle all review comments.