### PR TITLE
Be specific about more indexes or values

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1169,6 +1169,7 @@ Other
 - Bug in :class:`Tick` comparisons raising ``TypeError`` when comparing against timedelta-like objects (:issue:`34088`)
 - Bug in :class:`Tick` multiplication raising ``TypeError`` when multiplying by a float (:issue:`34486`)
 - Passing a `set` as `names` argument to :func:`pandas.read_csv`, :func:`pandas.read_table`, or :func:`pandas.read_fwf` will raise ``ValueError: Names should be an ordered collection.`` (:issue:`34946`)
+- Improved error message for invalid construction of list when creating a new index (:issue:`35190`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -744,7 +744,12 @@ def sanitize_index(data, index: Index):
     through a non-Index.
     """
     if len(data) != len(index):
-        raise ValueError("Length of values does not match length of index")
+        raise ValueError(
+            "Length of values "
+            f"({len(data)}) "
+            "does not match length of index "
+            f"({len(index)})"
+        )
 
     if isinstance(data, np.ndarray):
 

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -244,7 +244,10 @@ class BaseSetitemTests(BaseExtensionTests):
 
     def test_setitem_frame_invalid_length(self, data):
         df = pd.DataFrame({"A": [1] * len(data)})
-        xpr = "Length of values does not match length of index"
+        xpr = (
+            rf"Length of values \({len(data[:5])}\) "
+            rf"does not match length of index \({len(df)}\)"
+        )
         with pytest.raises(ValueError, match=xpr):
             df["B"] = data[:5]
 

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -160,10 +160,13 @@ class TestDataFrameIndexing:
         msg = "Columns must be same length as key"
         with pytest.raises(ValueError, match=msg):
             data[["A"]] = float_frame[["A", "B"]]
-
-        msg = "Length of values does not match length of index"
+        newcolumndata = range(len(data.index) - 1)
+        msg = (
+            rf"Length of values \({len(newcolumndata)}\) "
+            rf"does not match length of index \({len(data)}\)"
+        )
         with pytest.raises(ValueError, match=msg):
-            data["A"] = range(len(data.index) - 1)
+            data["A"] = newcolumndata
 
         df = DataFrame(0, index=range(3), columns=["tt1", "tt2"], dtype=np.int_)
         df.loc[1, ["tt1", "tt2"]] = [1, 2]

--- a/pandas/tests/frame/indexing/test_setitem.py
+++ b/pandas/tests/frame/indexing/test_setitem.py
@@ -117,7 +117,10 @@ class TestDataFrameSetItem:
         cat = Categorical.from_codes([0, 1, 1, 0, 1, 2], ["a", "b", "c"])
         df = DataFrame(range(10), columns=["bar"])
 
-        msg = "Length of values does not match length of index"
+        msg = (
+            rf"Length of values \({len(cat)}\) "
+            rf"does not match length of index \({len(df)}\)"
+        )
         with pytest.raises(ValueError, match=msg):
             df["foo"] = cat
 


### PR DESCRIPTION
The generic "are not equal" really frustrated me just now when someone was conveying their issue.

This specific two errors lets me know which way around, although I believe having more indexes than data shows a place in the api for a default value (possibly per-index) which would allow this to later be reduced to the case I feel I fully understand of more data than indexes, which I think probably is unsolvable generally.

I can see that both have problems, but I still think it's more important to be specific about which side is mismatched.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
