### PR TITLE
ENH: raise limit for completion number of columns and warn beyond

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5179,8 +5179,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         if len(unique_entries) > 1000:
             unique_entries = unique_entries[:1000]
             warnings.warn(
-                "Completion only considers the first 1000 entries,"
-                " for performance reasons",
+                "Completion only considers the first 1000 entries "
+                "for performance reasons",
                 UserWarning,
             )
         additions = {

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5175,9 +5175,13 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         add the string-like attributes from the info_axis.
         If info_axis is a MultiIndex, it's first level values are used.
         """
+        unique_entries = self._info_axis.unique(level=0)
+        if len(unique_entries) > 1000:
+            unique_entries = unique_entries[:1000]
+            warnings.warn("Completion only considers the first 1000 entries,"
+                          " for performance reasons", UserWarning)
         additions = {
-            c
-            for c in self._info_axis.unique(level=0)[:100]
+            c for c in unique_entries
             if isinstance(c, str) and c.isidentifier()
         }
         return super()._dir_additions().union(additions)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5178,11 +5178,13 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         unique_entries = self._info_axis.unique(level=0)
         if len(unique_entries) > 1000:
             unique_entries = unique_entries[:1000]
-            warnings.warn("Completion only considers the first 1000 entries,"
-                          " for performance reasons", UserWarning)
+            warnings.warn(
+                "Completion only considers the first 1000 entries,"
+                " for performance reasons",
+                UserWarning,
+            )
         additions = {
-            c for c in unique_entries
-            if isinstance(c, str) and c.isidentifier()
+            c for c in unique_entries if isinstance(c, str) and c.isidentifier()
         }
         return super()._dir_additions().union(additions)
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -248,7 +248,7 @@ class TestSeriesMisc:
             tm.makeIntIndex(10),
             tm.makeFloatIndex(10),
             Index([True, False]),
-            Index([f"a{i}" for i in range(101)]),
+            Index([f"a{i}" for i in range(1001)]),
             pd.MultiIndex.from_tuples(zip("ABCD", "EFGH")),
             pd.MultiIndex.from_tuples(zip([0, 1, 2, 3], "EFGH")),
         ],
@@ -256,9 +256,14 @@ class TestSeriesMisc:
     def test_index_tab_completion(self, index):
         # dir contains string-like values of the Index.
         s = pd.Series(index=index, dtype=object)
-        dir_s = dir(s)
+        if len(s) < 1000:
+            dir_s = dir(s)
+        else:
+            with tm.assert_produces_warning(UserWarning):
+                dir_s = dir(s)
+
         for i, x in enumerate(s.index.unique(level=0)):
-            if i < 100:
+            if i < 1000:
                 assert not isinstance(x, str) or not x.isidentifier() or x in dir_s
             else:
                 assert x not in dir_s


### PR DESCRIPTION
Hi,

Currently the user-completion (ipython "\<tab\>") on a dataframe with more than 100 columns will silently ignore some columns, letting an unaware user confused on whether data disapeared.

This is actually documented, and due to an arbitrary limit set to workaround a performance issue ( See #18587 )

Dataframe with more than 100 columns are quite common, so this can potentially affect and suprise many users. Therefore, I suggest to increase that limit to, say, 1000. In any case, it would probably be good to warn the user hitting that limit. 

The attached quickfix raises the limit to 1000 and adds a warning beyond. 
(Note that I didn't experience any completion latency increasing with the axis size, so I'm not sure whether this limit is still relevant in the first place).

