### PR TITLE
ROADMAP: add consistent missing values for all dtypes to the roadmap

### DIFF
--- a/doc/source/development/roadmap.rst
+++ b/doc/source/development/roadmap.rst
@@ -56,25 +56,23 @@ pandas.
 Consistent missing value handling
 ---------------------------------
 
-Currently, pandas has varying missing data interfaces depending on the data
-type: pandas uses ``np.nan`` as missing value indicator in floating point data,
-``np.nan`` or ``None`` in object dtype data (eg strings, or booleans with
-missing values are cast to object), ``pd.NaT`` in datetimelike data. For
-categorical or interval data, they return ``np.nan`` on access even when the
-categories or intervals are datetime-like. Integer data cannot store missing
-data or are cast to float. In addition, ``NaN`` has different semantics as
-"nulls" in many other data tools. 
+Currently, pandas handles missing data differently for different data types. We
+use different types to indicate that a value is missing (``np.nan`` for
+floating-point data, ``np.nan`` or ``None`` for object-dtype data -- typically
+strings or booleans -- with missing values, and ``pd.NaT`` for datetimelike
+data). Integer data cannot store missing data or are cast to float. In addition,
+pandas 1.0 introduced a new missing value sentinel, ``pd.NA``, which is being
+used for the experimental nullable integer, boolean, and string data types.
 
-Long term, we want to introduce consistent missing value handling accross the
-different data types: all data types should support missing values and with the
-same behaviour.
+These different missing values have different behaviors in user-facing
+operations. Specifically, we introduced different semantics for the nullable
+data types for certain operations (e.g. propagating in comparison operations
+instead of comparing as False).
 
-To this end, a new experimental ``pd.NA`` scalar that can be used as missing
-value indicator and with a behaviour that deviates from ``np.nan`` has already
-been added in pandas 1.0 (and used in the experimental nullable dtypes). Further
-work and research is needed to integrate these new semantics with other data
-types, and to provide a path forward to make this the default in a future
-version of pandas.
+Long term, we want to introduce consistent missing data handling for all data
+types. This includes consistent behavior in all operations (indexing, arithmetic
+operations, comparisons, etc.). We want to eventually make the new semantics the
+default.
 
 This has been discussed at
 `github #28095 <https://github.com/pandas-dev/pandas/issues/28095>`__ (and

--- a/doc/source/development/roadmap.rst
+++ b/doc/source/development/roadmap.rst
@@ -53,6 +53,32 @@ need to implement certain operations expected by pandas users (for example
 the algorithm used in, ``Series.str.upper``). That work may be done outside of
 pandas.
 
+Consistent missing value handling
+---------------------------------
+
+Currently, pandas has varying missing data interfaces depending on the data
+type: pandas uses ``np.nan`` as missing value indicator in floating point data,
+``np.nan`` or ``None`` in object dtype data (eg strings, or booleans with
+missing values are cast to object), ``pd.NaT`` in datetimelike data. For
+categorical or interval data, they return ``np.nan`` on access even when the
+categories or intervals are datetime-like. Integer data cannot store missing
+data or are cast to float.
+
+Long term, we want to introduce consistent missing value handling accross the
+different data types: all data types should support missing values and with the
+same behaviour.
+
+To this end, a new experimental ``pd.NA`` scalar to be used as missing value
+indicator has already been added in pandas 1.0 (and used in the experimental
+nullable dtypes). Further work is needed to integrate this with other data
+types, and to provide a path forward to make this the default in a future
+version of pandas.
+
+This has been discussed at
+`github #28095 <https://github.com/pandas-dev/pandas/issues/28095>`__ (and
+linked issues), and described in more detail in this
+`design doc <https://hackmd.io/@jorisvandenbossche/Sk0wMeAmB>`__.
+
 Apache Arrow interoperability
 -----------------------------
 

--- a/doc/source/development/roadmap.rst
+++ b/doc/source/development/roadmap.rst
@@ -62,15 +62,17 @@ type: pandas uses ``np.nan`` as missing value indicator in floating point data,
 missing values are cast to object), ``pd.NaT`` in datetimelike data. For
 categorical or interval data, they return ``np.nan`` on access even when the
 categories or intervals are datetime-like. Integer data cannot store missing
-data or are cast to float.
+data or are cast to float. In addition, ``NaN`` has different semantics as
+"nulls" in many other data tools. 
 
 Long term, we want to introduce consistent missing value handling accross the
 different data types: all data types should support missing values and with the
 same behaviour.
 
-To this end, a new experimental ``pd.NA`` scalar to be used as missing value
-indicator has already been added in pandas 1.0 (and used in the experimental
-nullable dtypes). Further work is needed to integrate this with other data
+To this end, a new experimental ``pd.NA`` scalar that can be used as missing
+value indicator and with a behaviour that deviates from ``np.nan`` has already
+been added in pandas 1.0 (and used in the experimental nullable dtypes). Further
+work and research is needed to integrate these new semantics with other data
 types, and to provide a path forward to make this the default in a future
 version of pandas.
 


### PR DESCRIPTION
The more detailed motivation is described in https://hackmd.io/@jorisvandenbossche/Sk0wMeAmB, and many aspects have already been discussed in https://github.com/pandas-dev/pandas/issues/28095 and linked issues.  
(and there are probably still other details / practical aspects that can be further discussed in dedicated issues)

Last year when I made the `pd.NA` proposal (and which resulted in using that for the nullable integer, boolean and string dtypes), which described it as "can be used consistently across all data types", the implicit / aspirational end goal of this proposal for me always was to *actually* have this for all dtypes (and as the default, at some point). 
I tried to discuss this goal more explicitly on the mailing list earlier this year (in the thread about pandas 2.0: https://mail.python.org/pipermail/pandas-dev/2020-February/001180.html). But we never really "officially" adopted this as a goal / roadmap item, or discussed about doing that. 
Proposing to add a section about it to the roadmap is an attempt to do this (as that is actually how it's described to do it in our [roadmap](https://pandas.pydata.org/docs/dev/development/roadmap.html#roadmap-evolution)).

The aforementioned mailing list thread mostly resulted in a discussion about how to integrate the new semantics in the datetime-like dtypes (pd.NaT vs pd.NA, keep pd.NaT but change its behaviour, etc). This is still a technical discussion we further need to resolve, but note that I kept the text on that in the PR somewhat vague on purpose for this reason: *"..: all data types should support missing values and with the same behaviour"*

And the general disclaimer that is also in our roadmap: *An item being on the roadmap does not mean that it will* necessarily *happen, even with unlimited funding. During the implementation period we may discover issues preventing the adoption of the feature.*

cc @pandas-dev/pandas-core @pandas-dev/pandas-triage 