### PR TITLE
Add xarray copyright notice to comply with reuse under Apache License

### DIFF
--- a/LICENSES/XARRAY_LICENSE
+++ b/LICENSES/XARRAY_LICENSE
@@ -1,3 +1,7 @@
+Copyright 2014-2019, xarray Developers
+
+--------------------------------------------------------------------------------
+
 Apache License
 Version 2.0, January 2004
 http://www.apache.org/licenses/


### PR DESCRIPTION
In https://github.com/xarray-contrib/pint-xarray/pull/11, @keewis and I noticed that pandas's (pandas'?...possessive forms are weird) reuse with modification of xarray code added in https://github.com/pandas-dev/pandas/commit/eee83e23ba0c5b32e27db3faca931ddb4c9619aa did not include xarray's copyright notice as required by the Apache License, Version 2.0 (which is not included in the license text itself, unlike MIT or BSD). I'm not sure how big of a deal this is, but given that pint-xarray is going ahead and modeling its code citation practice after that of pandas, I wanted to see what the thoughts are here on it. This PR takes a simple fix and just adds the copyright notice to top of the `LICENSES/XARRAY_LICENSE` file.

Also, I'm not sure if this requires a whatsnew entry or not.

- ~~closes #xxxx~~
- ~~tests added / passed~~
- ~~passes `black pandas`~~
- ~~passes `git diff upstream/master -u -- "*.py" | flake8 --diff`~~
- [ ] whatsnew entry
