### PR TITLE
Fixing a confused method name in 02_read_write.rst

### DIFF
--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -151,7 +151,7 @@ named *passengers* instead of the default *Sheet1*. By setting
         </li>
     </ul>
 
-The equivalent read function :meth:`~DataFrame.to_excel` will reload the data to a
+The equivalent read function :meth:`~DataFrame.read_excel` will reload the data to a
 ``DataFrame``:
 
 .. ipython:: python


### PR DESCRIPTION
Fixed the confused method name. It should be `read_excel` based on the context, but `to_excel` was provided instead.
Very simple PR for a simple fix to the documentation.