### PR TITLE
PERF: Allow str.split callers to skip expensive post-processing

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2184,6 +2184,7 @@ class StringMethods(NoNewAttributesMixin):
         expand=None,
         fill_value=np.nan,
         returns_string=True,
+        pad_sequences=True,
     ):
 
         from pandas import Index, Series, MultiIndex
@@ -2216,7 +2217,7 @@ class StringMethods(NoNewAttributesMixin):
             # infer from ndim if expand is not specified
             expand = result.ndim != 1
 
-        elif expand is True and not isinstance(self._orig, ABCIndexClass):
+        elif expand is True and not isinstance(self._orig, ABCIndexClass) and pad_sequences:
             # required when expand=True is explicitly specified
             # not needed when inferred
 
@@ -2679,15 +2680,15 @@ class StringMethods(NoNewAttributesMixin):
 
     @Appender(_shared_docs["str_split"] % {"side": "beginning", "method": "split"})
     @forbid_nonstring_types(["bytes"])
-    def split(self, pat=None, n=-1, expand=False):
+    def split(self, pat=None, n=-1, expand=False, pad_sequences=True):
         result = str_split(self._parent, pat, n=n)
-        return self._wrap_result(result, expand=expand, returns_string=expand)
+        return self._wrap_result(result, expand=expand, returns_string=expand, pad_sequences=pad_sequences)
 
     @Appender(_shared_docs["str_split"] % {"side": "end", "method": "rsplit"})
     @forbid_nonstring_types(["bytes"])
-    def rsplit(self, pat=None, n=-1, expand=False):
+    def rsplit(self, pat=None, n=-1, expand=False, pad_sequences=True):
         result = str_rsplit(self._parent, pat, n=n)
-        return self._wrap_result(result, expand=expand, returns_string=expand)
+        return self._wrap_result(result, expand=expand, returns_string=expand, pad_sequences=pad_sequences)
 
     _shared_docs[
         "str_partition"
@@ -2706,6 +2707,13 @@ class StringMethods(NoNewAttributesMixin):
     expand : bool, default True
         If True, return DataFrame/MultiIndex expanding dimensionality.
         If False, return Series/Index.
+    pad_sequences : bool, default True
+        If True and expand is True, pad the resulting sequences with nan to
+        match the length of the longest sequence (so each row has the same
+        number of columns).
+        If False, the result of each split must result in sequences of equal
+        length.
+        Has no effect when expand is False.
 
     Returns
     -------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2217,21 +2217,20 @@ class StringMethods(NoNewAttributesMixin):
             # infer from ndim if expand is not specified
             expand = result.ndim != 1
 
-        elif (
-            expand is True
-            and not isinstance(self._orig, ABCIndexClass)
-            and pad_sequences
-        ):
-            # required when expand=True is explicitly specified
-            # not needed when inferred
-
-            result = [x if is_list_like(x) else [x] for x in result]
-            if result:
-                # propagate nan values to match longest sequence (GH 18450)
-                max_len = max(len(x) for x in result)
-                result = [
-                    x * max_len if len(x) == 0 or x[0] is np.nan else x for x in result
-                ]
+        elif expand is True and not isinstance(self._orig, ABCIndexClass):
+            if pad_sequences:
+                # required when expand=True is explicitly specified
+                # not needed when inferred
+                result = [x if is_list_like(x) else [x] for x in result]
+                if result:
+                    # propagate nan values to match longest sequence (GH 18450)
+                    max_len = max(len(x) for x in result)
+                    result = [
+                        x * max_len if len(x) == 0 or x[0] is np.nan else x
+                        for x in result
+                    ]
+            else:
+                result = result.tolist()
 
         if not isinstance(expand, bool):
             raise ValueError("expand must be True or False")

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2568,6 +2568,13 @@ class StringMethods(NoNewAttributesMixin):
 
         * If ``True``, return DataFrame/MultiIndex expanding dimensionality.
         * If ``False``, return Series/Index, containing lists of strings.
+    pad_sequences : bool, default True
+        When expand is ``True``, pad the ending of resulting sequences with
+        ``nan`` to the length of the longest sequence, ensuring each row in the
+        resulting DataFrame has the same number of columns.
+        If ``False``, you must be sure pre-hoc that the split strings will have
+        uniform lengths.
+        Has no effect when expand is ``False``.
 
     Returns
     -------
@@ -2715,13 +2722,6 @@ class StringMethods(NoNewAttributesMixin):
     expand : bool, default True
         If True, return DataFrame/MultiIndex expanding dimensionality.
         If False, return Series/Index.
-    pad_sequences : bool, default True
-        If True and expand is True, pad the resulting sequences with nan to
-        match the length of the longest sequence (so each row has the same
-        number of columns).
-        If False, the result of each split must result in sequences of equal
-        length.
-        Has no effect when expand is False.
 
     Returns
     -------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2220,13 +2220,7 @@ class StringMethods(NoNewAttributesMixin):
             # required when expand=True is explicitly specified
             # not needed when inferred
 
-            def cons_row(x):
-                if is_list_like(x):
-                    return x
-                else:
-                    return [x]
-
-            result = [cons_row(x) for x in result]
+            result = [x if is_list_like(x) else [x] for x in result]
             if result:
                 # propagate nan values to match longest sequence (GH 18450)
                 max_len = max(len(x) for x in result)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2686,6 +2686,21 @@ class StringMethods(NoNewAttributesMixin):
     >>> s.str.split(r"\+|=", expand=True)
          0    1    2
     0    1    1    2
+
+    When using ``expand=True``, if you have already verified that the
+    particular split will result in sequences of uniform length, you may opt
+    out of the (sometimes expensive) length normalzation process with
+    ``pad_sequences=False``.
+
+    >>> s = pd.Series(["foo bar", "baz qaz"])
+    >>> s
+    0    foo bar
+    1    baz qaz
+    dtype: object
+    >>> s.str.split(expand=True, pad_sequences=False)
+         0    1
+    0  foo  bar
+    1  baz  qaz
     """
 
     @Appender(_shared_docs["str_split"] % {"side": "beginning", "method": "split"})

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2217,7 +2217,11 @@ class StringMethods(NoNewAttributesMixin):
             # infer from ndim if expand is not specified
             expand = result.ndim != 1
 
-        elif expand is True and not isinstance(self._orig, ABCIndexClass) and pad_sequences:
+        elif (
+            expand is True
+            and not isinstance(self._orig, ABCIndexClass)
+            and pad_sequences
+        ):
             # required when expand=True is explicitly specified
             # not needed when inferred
 
@@ -2682,13 +2686,17 @@ class StringMethods(NoNewAttributesMixin):
     @forbid_nonstring_types(["bytes"])
     def split(self, pat=None, n=-1, expand=False, pad_sequences=True):
         result = str_split(self._parent, pat, n=n)
-        return self._wrap_result(result, expand=expand, returns_string=expand, pad_sequences=pad_sequences)
+        return self._wrap_result(
+            result, expand=expand, returns_string=expand, pad_sequences=pad_sequences
+        )
 
     @Appender(_shared_docs["str_split"] % {"side": "end", "method": "rsplit"})
     @forbid_nonstring_types(["bytes"])
     def rsplit(self, pat=None, n=-1, expand=False, pad_sequences=True):
         result = str_rsplit(self._parent, pat, n=n)
-        return self._wrap_result(result, expand=expand, returns_string=expand, pad_sequences=pad_sequences)
+        return self._wrap_result(
+            result, expand=expand, returns_string=expand, pad_sequences=pad_sequences
+        )
 
     _shared_docs[
         "str_partition"


### PR DESCRIPTION
Hey team-

I've got some string processing in my pipeline and have noticed that `Series.str.split` is a pretty significant bottleneck:

<img width="806" alt="Screen Shot 2020-07-09 at 18 03 09" src="https://user-images.githubusercontent.com/8717474/87210555-cd31d980-c2ca-11ea-8c79-e247b236cc0d.png">

(For reference, the rest of the function calls from this `pyinstrument` run take 5-10 seconds.)

It seemed odd to me that it was spending more time post-processing the result (`_wrap_result`) than actually doing the work of splitting strings, so I looked into it. It turns out that when you use `expand=True`, `_wrap_result` makes three full passes over the data (in Python iteration land!). From what I gather, the procedure is to make sure that each row of the resulting data frame ends up with the same number of columns. However, for my use case, I happen to know ahead of time that this will be true; my Series is full of well-formed IPv4 addresses (and from what I gather online, this is a pretty common use of `Series.str.split`), so I know each split string list will be 4 elements long (one for each octet).

This pull request offers an escape hatch for users like me who know that this expensive post-processing step is essentially a no-op, in the form of the `pad_sequences` argument. If `True`, the default, then the original procedure will be run. If `False`, it will be skipped in favor of simply casting the result from a numpy array of lists to a list of lists, to be crammed into a DataFrame a few lines down. It's up to the caller to determine ahead of time if the split will produce uniform-length sequences. (If `expand=False`, then `pad_sequences` has no effect.)

Looking forward to hearing your thoughts!

Many thanks

---

- Related to #10090

- ~[ ] closes #xxxx~
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

---

EDIT: forgot to mention, I have some performance testing results. Here's the data:

```sh
$ wc -l test.csv
10663901 test.csv

$ du -h test.csv
928M	test.csv
```

Here's the original performance:

```python
In [1]: pd.__version__
Out[1]: '1.1.0.dev0+2067.g2c3edaaaa'

In [2]: %%timeit
   ...: df.ip.str.split(".", expand=True)
   ...:
   ...:
26.7 s ± 2.42 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

The first optimization I tried (before adding `pad_sequences`) was simply to inline `cons_row` to save the stack frame allocation (since the function wasn't being used anywhere but the comprehension body:

```python
In [1]: pd.__version__
Out[1]: '1.1.0.dev0+2068.g15623dbe7'

In [2]: %%timeit
   ...: df.ip.str.split(".", expand=True)
   ...:
   ...:
24 s ± 202 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Works out to a few hundred nanoseconds of time savings per row, or as you can see here, about 2.5 seconds for my 10 million row test set.

Finally, here are the results without those three passes over the result:

```python
In [2]: pd.__version__
Out[2]: '1.1.0.dev0+2073.g23f88eedb'

In [5]: %%timeit
   ...: df.ip.str.split(".", expand=True, pad_sequences=False)
   ...:
   ...:
15.5 s ± 78.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

(Commit hash is a little different since I rebased onto upstream after running the test.)

So this is quite a bit faster now. If I have time, I'll keep digging to see if we can eliminate that `result.tolist()` call and go straight from the numpy-ish representation to a DataFrame (for now, I found that I needed the `tolist()` in order for `expand=True` to retain its behavior).