### PR TITLE
TST: added test for groupby/apply timezone-aware with copy

### DIFF
--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -995,3 +995,18 @@ def test_apply_function_with_indexing_return_column():
     result = df.groupby("foo1", as_index=False).apply(lambda x: x.mean())
     expected = DataFrame({"foo1": ["one", "three", "two"], "foo2": [3.0, 4.0, 4.0]})
     tm.assert_frame_equal(result, expected)
+
+
+def test_apply_with_timezones_aware():
+    # GH: 27212
+
+    dates = ["2001-01-01"] * 2 + ["2001-01-02"] * 2 + ["2001-01-03"] * 2
+    index_no_tz = pd.DatetimeIndex(dates)
+    index_tz = pd.DatetimeIndex(dates, tz="UTC")
+    df1 = pd.DataFrame({"x": list(range(2)) * 3, "y": range(6), "t": index_no_tz})
+    df2 = pd.DataFrame({"x": list(range(2)) * 3, "y": range(6), "t": index_tz})
+
+    result1 = df1.groupby("x", group_keys=False).apply(lambda df: df[["x", "y"]].copy())
+    result2 = df2.groupby("x", group_keys=False).apply(lambda df: df[["x", "y"]].copy())
+
+    tm.assert_frame_equal(result1, result2)


### PR DESCRIPTION
- [x] closes #27212
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

added test for groupby/apply timezone-aware with copy
