### PR TITLE
CLN/DOC: DataFrame.to_parquet supports file-like objects

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -19,6 +19,7 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
+    AnyStr,
     Dict,
     FrozenSet,
     Hashable,
@@ -2252,11 +2253,11 @@ class DataFrame(NDFrame):
     @deprecate_kwarg(old_arg_name="fname", new_arg_name="path")
     def to_parquet(
         self,
-        path,
-        engine="auto",
-        compression="snappy",
-        index=None,
-        partition_cols=None,
+        path: FilePathOrBuffer[AnyStr],
+        engine: str = "auto",
+        compression: Optional[str] = "snappy",
+        index: Optional[bool] = None,
+        partition_cols: Optional[List[str]] = None,
         **kwargs,
     ) -> None:
         """
@@ -2269,9 +2270,12 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        path : str
-            File path or Root Directory path. Will be used as Root Directory
-            path while writing a partitioned dataset.
+        path : str or file-like object
+            If a string, it will be used as Root Directory path
+            when writing a partitioned dataset. By file-like object,
+            we refer to objects with a write() method, such as a file handler
+            (e.g. via builtin open function) or io.BytesIO. The engine
+            fastparquet does not accept file-like objects.
 
             .. versionchanged:: 1.0.0
 
@@ -2298,6 +2302,7 @@ class DataFrame(NDFrame):
         partition_cols : list, optional, default None
             Column names by which to partition the dataset.
             Columns are partitioned in the order they are given.
+            Must be None if path is not a string.
 
             .. versionadded:: 0.24.0
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -1,8 +1,9 @@
 """ parquet compat """
 
-from typing import Any, Dict, Optional
+from typing import Any, AnyStr, Dict, List, Optional
 from warnings import catch_warnings
 
+from pandas._typing import FilePathOrBuffer
 from pandas.compat._optional import import_optional_dependency
 from pandas.errors import AbstractMethodError
 
@@ -85,10 +86,10 @@ class PyArrowImpl(BaseImpl):
     def write(
         self,
         df: DataFrame,
-        path,
-        compression="snappy",
+        path: FilePathOrBuffer[AnyStr],
+        compression: Optional[str] = "snappy",
         index: Optional[bool] = None,
-        partition_cols=None,
+        partition_cols: Optional[List[str]] = None,
         **kwargs,
     ):
         self.validate_dataframe(df)
@@ -213,11 +214,11 @@ class FastParquetImpl(BaseImpl):
 
 def to_parquet(
     df: DataFrame,
-    path,
+    path: FilePathOrBuffer[AnyStr],
     engine: str = "auto",
-    compression="snappy",
+    compression: Optional[str] = "snappy",
     index: Optional[bool] = None,
-    partition_cols=None,
+    partition_cols: Optional[List[str]] = None,
     **kwargs,
 ):
     """
@@ -226,9 +227,12 @@ def to_parquet(
     Parameters
     ----------
     df : DataFrame
-    path : str
-        File path or Root Directory path. Will be used as Root Directory path
-        while writing a partitioned dataset.
+    path : str or file-like object
+        If a string, it will be used as Root Directory path
+        when writing a partitioned dataset. By file-like object,
+        we refer to objects with a write() method, such as a file handler
+        (e.g. via builtin open function) or io.BytesIO. The engine
+        fastparquet does not accept file-like objects.
 
         .. versionchanged:: 0.24.0
 
@@ -251,8 +255,9 @@ def to_parquet(
         .. versionadded:: 0.24.0
 
     partition_cols : str or list, optional, default None
-        Column names by which to partition the dataset
-        Columns are partitioned in the order they are given
+        Column names by which to partition the dataset.
+        Columns are partitioned in the order they are given.
+        Must be None if path is not a string.
 
         .. versionadded:: 0.24.0
 


### PR DESCRIPTION
Adds documentation and type-hints for supporting file-like objects when `engine == 'pyarrow'`; relevant to #30081. Tests for this behavior currently exist in `io.test_parquet.py`:

````
@td.skip_if_no("pyarrow")
    def test_read_file_like_obj_support(self, df_compat):
        buffer = BytesIO()
        df_compat.to_parquet(buffer)
        df_from_buf = pd.read_parquet(buffer)
        tm.assert_frame_equal(df_compat, df_from_buf)
````

Perhaps the restrictions on the arguments when path is not a string:

* partition_cols must be None; and
* engine must end up being pyarrow

should be checked directly in `DataFrame.to_parquet`, but I'm leaving this out as that is an API change that could be made in a subsequent PR. The latter gives the clear error message `TypeError: expected str, bytes or os.PathLike object, not _io.BytesIO` but the former raises `AttributeError: 'NoneType' object has no attribute '_isfilestore'` which is slightly confusing.

Another API change that could be made subsequently is changing the `path` argument to `path_or_buf`, consistent with `DataFrame.to_csv`.