### PR TITLE
BUG: GroupBy.count() and GroupBy.sum() incorreclty return NaN instead of 0 for missing categories (Version 2)

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1091,6 +1091,9 @@ Groupby/resample/rolling
 - Bug in :meth:`Rolling.apply` where ``center=True`` was ignored when ``engine='numba'`` was specified (:issue:`34784`)
 - Bug in :meth:`DataFrame.ewm.cov` was throwing ``AssertionError`` for :class:`MultiIndex` inputs (:issue:`34440`)
 - Bug in :meth:`core.groupby.DataFrameGroupBy.transform` when ``func='nunique'`` and columns are of type ``datetime64``, the result would also be of type ``datetime64`` instead of ``int64`` (:issue:`35109`)
+- Bug in :meth:`DataFrameGroupBy.count` was returning ``NaN`` for missing categories when grouped on multiple ``Categoricals``. Now returning ``0`` (:issue:`35028`)
+- Bug in :meth:`DataFrameGroupBy.sum` and :meth:`SeriesGroupBy.sum` was reutrning ``NaN`` for missing categories when grouped on multiple ``Categorials``. Now returning ``0`` (:issue:`31422`)
+
 
 Reshaping
 ^^^^^^^^^
@@ -1124,6 +1127,8 @@ Reshaping
 - Bug in :meth:`Series.where` with an empty Series and empty ``cond`` having non-bool dtype (:issue:`34592`)
 - Fixed regression where :meth:`DataFrame.apply` would raise ``ValueError`` for elements whth ``S`` dtype (:issue:`34529`)
 - Bug in :meth:`DataFrame.append` leading to sorting columns even when ``sort=False`` is specified (:issue:`35092`)
+- Bug in :meth:`DataFrame.pivot_table` with ``aggfunc='count'``, was returning ``NaN`` for missing categories when pivoted on a ``Categorical``. Now returning ``0`` (:issue:`35028`)
+- Bug in :meth:`DataFrame.pivot_table` with ``aggfunc='sum'``, was reutrning ``NaN`` for missing categories when pivoted on a ``Categorical``. Now returning ``0`` (:issue:`31422`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1820,13 +1820,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         )
         blocks = [make_block(val, placement=loc) for val, loc in zip(counted, locs)]
 
-        # If self.observed=False then self._reindex_output will fill the missing
-        # categories (if the grouper was grouped on pd.Categorical variables) with
-        # np.NaN. For .count() we want these values filled in with zero. So we set
-        # self.observed=True for the call to self._agg_general, and then set
-        # it back to its orignal value. We then call self._reindex_output with
-        # fill_value=0. If the original self.observed is False, then we will get
-        # our result with 0 for the missing categories.
+        # GH 35028: We want .count() to return 0 for missing categories 
+        # rather than NaN. So we set self.observed=True to turn off the 
+        # reindexing within self._wrap_agged_blocks, then reindex below with 
+        # fill_value=0
         observed_orig = self.observed
         self.observed = True
         try:

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1820,9 +1820,9 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         )
         blocks = [make_block(val, placement=loc) for val, loc in zip(counted, locs)]
 
-        # GH 35028: We want .count() to return 0 for missing categories 
-        # rather than NaN. So we set self.observed=True to turn off the 
-        # reindexing within self._wrap_agged_blocks, then reindex below with 
+        # GH 35028: We want .count() to return 0 for missing categories
+        # rather than NaN. So we set self.observed=True to turn off the
+        # reindexing within self._wrap_agged_blocks, then reindex below with
         # fill_value=0
         observed_orig = self.observed
         self.observed = True

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1532,13 +1532,10 @@ class GroupBy(_GroupBy[FrameOrSeries]):
     @doc(_groupby_agg_method_template, fname="sum", no=True, mc=0)
     def sum(self, numeric_only: bool = True, min_count: int = 0):
 
-        # If self.observed=False then self._reindex_output will fill the missing
-        # categories (if the grouper was grouped on pd.Categorical variables) with
-        # np.NaN. For .sum() we want these values filled in with zero. So we set
-        # self.observed=True for the call to self._agg_general, and then set
-        # it back to its orignal value. We then call self._reindex_output with
-        # fill_value=0. If the original self.observed is False, then we will get
-        # our result with 0 for the missing categories.
+        # GH 31422: We want .sum() to return 0 for missing categories 
+        # rather than NaN. So we set self.observed=True to turn off the 
+        # reindexing within self._agg_general, then reindex below with 
+        # fill_value=0
         observed_orig = self.observed
         self.observed = True
         try:

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1532,9 +1532,9 @@ class GroupBy(_GroupBy[FrameOrSeries]):
     @doc(_groupby_agg_method_template, fname="sum", no=True, mc=0)
     def sum(self, numeric_only: bool = True, min_count: int = 0):
 
-        # GH 31422: We want .sum() to return 0 for missing categories 
-        # rather than NaN. So we set self.observed=True to turn off the 
-        # reindexing within self._agg_general, then reindex below with 
+        # GH 31422: We want .sum() to return 0 for missing categories
+        # rather than NaN. So we set self.observed=True to turn off the
+        # reindexing within self._agg_general, then reindex below with
         # fill_value=0
         observed_orig = self.observed
         self.observed = True

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1435,6 +1435,14 @@ def test_dataframe_groupby_on_2_categoricals_when_observed_is_false(
 
 @pytest.mark.parametrize("func", ["sum", "count"])
 def test_sum_and_count_exception_handling(func: str, observed: bool, monkeypatch):
+    # GH 31422
+    # GH 35028
+    # In order to return 0 instead of NaN for missing categories in 
+    # GroupBy.count() and GroupBy.sum(), both methods overwrite the value of 
+    # self.observed and then use a try-except-finally block. This test ensures 
+    # that:
+    # a) An exception from a internal method is still raised 
+    # b) self.observed is set back to its original value
     df = pd.DataFrame(
         {
             "cat_1": pd.Categorical(list("AABB"), categories=list("ABC")),

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1433,7 +1433,7 @@ def test_dataframe_groupby_on_2_categoricals_when_observed_is_false(
         assert (res.loc[unobserved_cats] == expected).all().all()
 
 
-@pytest.mark.parametrize('func', ['sum', 'count'])
+@pytest.mark.parametrize("func", ["sum", "count"])
 def test_sum_and_count_exception_handling(func: str, observed: bool, monkeypatch):
     df = pd.DataFrame(
         {
@@ -1443,17 +1443,17 @@ def test_sum_and_count_exception_handling(func: str, observed: bool, monkeypatch
         }
     )
     df_grp = df.groupby(["cat_1", "cat_2"], observed=observed)
-    
+
     def _mock_method(*args, **kwargs):
         raise ZeroDivisionError
-    
-    to_patch = {'count' : '_wrap_agged_blocks', 'sum' : '_agg_general'}
+
+    to_patch = {"count": "_wrap_agged_blocks", "sum": "_agg_general"}
     monkeypatch.setattr(df_grp, to_patch[func], _mock_method)
-    
+
     with pytest.raises(ZeroDivisionError):
         getattr(df_grp, func)()
 
-    assert df_grp.observed is observed    
+    assert df_grp.observed is observed
 
 
 def test_series_groupby_categorical_aggregation_getitem():

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1437,11 +1437,11 @@ def test_dataframe_groupby_on_2_categoricals_when_observed_is_false(
 def test_sum_and_count_exception_handling(func: str, observed: bool, monkeypatch):
     # GH 31422
     # GH 35028
-    # In order to return 0 instead of NaN for missing categories in 
-    # GroupBy.count() and GroupBy.sum(), both methods overwrite the value of 
-    # self.observed and then use a try-except-finally block. This test ensures 
+    # In order to return 0 instead of NaN for missing categories in
+    # GroupBy.count() and GroupBy.sum(), both methods overwrite the value of
+    # self.observed and then use a try-except-finally block. This test ensures
     # that:
-    # a) An exception from a internal method is still raised 
+    # a) An exception from a internal method is still raised
     # b) self.observed is set back to its original value
     df = pd.DataFrame(
         {

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -19,7 +19,7 @@ from pandas import (
 import pandas._testing as tm
 
 
-def cartesian_product_for_groupers(result, args, names):
+def cartesian_product_for_groupers(result, args, names, fill_value=np.NaN):
     """ Reindex to a cartesian production for the groupers,
     preserving the nature (Categorical) of each grouper
     """
@@ -33,7 +33,7 @@ def cartesian_product_for_groupers(result, args, names):
         return a
 
     index = MultiIndex.from_product(map(f, args), names=names)
-    return result.reindex(index).sort_index()
+    return result.reindex(index, fill_value=fill_value).sort_index()
 
 
 _results_for_groupbys_with_missing_categories = dict(
@@ -309,7 +309,7 @@ def test_observed(observed):
     result = gb.sum()
     if not observed:
         expected = cartesian_product_for_groupers(
-            expected, [cat1, cat2, ["foo", "bar"]], list("ABC")
+            expected, [cat1, cat2, ["foo", "bar"]], list("ABC"), fill_value=0
         )
 
     tm.assert_frame_equal(result, expected)
@@ -319,7 +319,9 @@ def test_observed(observed):
     expected = DataFrame({"values": [1, 2, 3, 4]}, index=exp_index)
     result = gb.sum()
     if not observed:
-        expected = cartesian_product_for_groupers(expected, [cat1, cat2], list("AB"))
+        expected = cartesian_product_for_groupers(
+            expected, [cat1, cat2], list("AB"), fill_value=0
+        )
 
     tm.assert_frame_equal(result, expected)
 
@@ -1189,8 +1191,11 @@ def test_seriesgroupby_observed_false_or_none(df_cat, observed, operation):
     ).sortlevel()
 
     expected = Series(data=[2, 4, np.nan, 1, np.nan, 3], index=index, name="C")
+    if operation == "agg":
+        expected = expected.fillna(0, downcast="infer")
     grouped = df_cat.groupby(["A", "B"], observed=observed)["C"]
     result = getattr(grouped, operation)(sum)
+
     tm.assert_series_equal(result, expected)
 
 
@@ -1340,15 +1345,6 @@ def test_series_groupby_on_2_categoricals_unobserved_zeroes_or_nans(
         )
         request.node.add_marker(mark)
 
-    if reduction_func == "sum":  # GH 31422
-        mark = pytest.mark.xfail(
-            reason=(
-                "sum should return 0 but currently returns NaN. "
-                "This is a known bug. See GH 31422."
-            )
-        )
-        request.node.add_marker(mark)
-
     df = pd.DataFrame(
         {
             "cat_1": pd.Categorical(list("AABB"), categories=list("ABC")),
@@ -1370,7 +1366,7 @@ def test_series_groupby_on_2_categoricals_unobserved_zeroes_or_nans(
         assert (pd.isna(zero_or_nan) and pd.isna(val)) or (val == zero_or_nan)
 
     # If we expect unobserved values to be zero, we also expect the dtype to be int
-    if zero_or_nan == 0:
+    if zero_or_nan == 0 and reduction_func != "sum":
         assert np.issubdtype(result.dtype, np.integer)
 
 
@@ -1411,24 +1407,6 @@ def test_dataframe_groupby_on_2_categoricals_when_observed_is_false(
 
     if reduction_func == "ngroup":
         pytest.skip("ngroup does not return the Categories on the index")
-
-    if reduction_func == "count":  # GH 35028
-        mark = pytest.mark.xfail(
-            reason=(
-                "DataFrameGroupBy.count returns np.NaN for missing "
-                "categories, when it should return 0. See GH 35028"
-            )
-        )
-        request.node.add_marker(mark)
-
-    if reduction_func == "sum":  # GH 31422
-        mark = pytest.mark.xfail(
-            reason=(
-                "sum should return 0 but currently returns NaN. "
-                "This is a known bug. See GH 31422."
-            )
-        )
-        request.node.add_marker(mark)
 
     df = pd.DataFrame(
         {

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1817,7 +1817,7 @@ class TestPivotTable:
             ["A", "B", "C"], categories=["A", "B", "C"], ordered=False, name="C1"
         )
         expected_columns = pd.Index(["a", "b"], name="C2")
-        expected_data = np.array([[1.0, np.nan], [1.0, np.nan], [np.nan, 2.0]])
+        expected_data = np.array([[1, 0], [1, 0], [0, 2]], dtype=np.int64)
         expected = pd.DataFrame(
             expected_data, index=expected_index, columns=expected_columns
         )
@@ -1851,18 +1851,19 @@ class TestPivotTable:
             values="Sales",
             index="Month",
             columns="Year",
-            dropna=observed,
+            observed=observed,
             aggfunc="sum",
         )
         expected_columns = pd.Int64Index([2013, 2014], name="Year")
         expected_index = pd.CategoricalIndex(
-            ["January"], categories=months, ordered=False, name="Month"
+            months, categories=months, ordered=False, name="Month"
         )
+        expected_data = [[320, 120]] + [[0, 0]] * 11
         expected = pd.DataFrame(
-            [[320, 120]], index=expected_index, columns=expected_columns
+            expected_data, index=expected_index, columns=expected_columns
         )
-        if not observed:
-            result = result.dropna().astype(np.int64)
+        if observed:
+            expected = expected.loc[["January"]]
 
         tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
- [x] closes #31422 
- [x] closes #35028 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

_Behavioural Changes_
Fixing two related bugs: when grouping on multiple categoricals, .sum() and .count() would return NaN for the missing categories, but they are expected to return 0 for the missing categories. Both these bugs are fixed.

_Tests_
Tests were added in PR #35022 when these bugs were discovered and the tests were marked with an xfail. For this PR the xfails are removed and the tests are passing normally. As well, a few other existing tests were expecting `sum()` to return `NaN`; these have been updated so that the tests now expect to get `0` (which is the desired behaviour).

One new test is added to ensure that the exception handling of the new `try-except-finally` block behaves as expected. 

_df.pivot_table_
The changes to `.sum()` & `.count()` also impacts the `df.pivot_table()` if it is called with `aggfunc=sum/count` and is pivoted on a Categorical column with observed=False. This is not explicitly mentioned in either of the bugs, but it does make the behaviour consistent (i.e. the sum of a missing category is zero, not NaN). Two tests on test_pivot.py was updated to reflect this change.