### PR TITLE
BUG: ValueError on groupby with categoricals

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1091,6 +1091,7 @@ Groupby/resample/rolling
 - Bug in :meth:`Rolling.apply` where ``center=True`` was ignored when ``engine='numba'`` was specified (:issue:`34784`)
 - Bug in :meth:`DataFrame.ewm.cov` was throwing ``AssertionError`` for :class:`MultiIndex` inputs (:issue:`34440`)
 - Bug in :meth:`core.groupby.DataFrameGroupBy.transform` when ``func='nunique'`` and columns are of type ``datetime64``, the result would also be of type ``datetime64`` instead of ``int64`` (:issue:`35109`)
+- Bug in :meth:'DataFrameGroupBy.first' and :meth:'DataFrameGroupBy.last' that would raise ``ValueError`` grouping on multiple ``Categoricals`` (:issue:`34951`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -1091,7 +1091,7 @@ Groupby/resample/rolling
 - Bug in :meth:`Rolling.apply` where ``center=True`` was ignored when ``engine='numba'`` was specified (:issue:`34784`)
 - Bug in :meth:`DataFrame.ewm.cov` was throwing ``AssertionError`` for :class:`MultiIndex` inputs (:issue:`34440`)
 - Bug in :meth:`core.groupby.DataFrameGroupBy.transform` when ``func='nunique'`` and columns are of type ``datetime64``, the result would also be of type ``datetime64`` instead of ``int64`` (:issue:`35109`)
-- Bug in :meth:'DataFrameGroupBy.first' and :meth:'DataFrameGroupBy.last' that would raise ``ValueError`` grouping on multiple ``Categoricals`` (:issue:`34951`)
+- Bug in :meth:'DataFrameGroupBy.first' and :meth:'DataFrameGroupBy.last' that would raise an unnecessary ``ValueError`` when grouping on multiple ``Categoricals`` (:issue:`34951`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1058,6 +1058,10 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     #  reductions; see GH#28949
                     obj = obj.iloc[:, 0]
 
+                # Create SeriesGroupBy with observed=True so that it does
+                # not try to add missing categories if grouping over multiple
+                # Categoricals. This will done by later self._reindex_output()
+                # Doing it here creates an error. See GH#34951
                 s = get_groupby(obj, self.grouper, observed=True)
                 try:
                     result = s.aggregate(lambda x: alt(x, axis=self.axis))

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -1058,7 +1058,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                     #  reductions; see GH#28949
                     obj = obj.iloc[:, 0]
 
-                s = get_groupby(obj, self.grouper)
+                s = get_groupby(obj, self.grouper, observed=True)
                 try:
                     result = s.aggregate(lambda x: alt(x, axis=self.axis))
                 except TypeError:

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1685,7 +1685,6 @@ def test_groupby_first_on_categorical_col_grouped_on_2_categoricals(func: str):
         "first": pd.Series([0, np.NaN, np.NaN, 1], idx, name="c"),
         "last": pd.Series([1, np.NaN, np.NaN, 0], idx, name="c"),
     }
-    import pdb; pdb.set_trace()
 
     df_grp = df.groupby(["a", "b"])
     df_res = getattr(df_grp, func)()

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1673,6 +1673,7 @@ def test_categorical_transform():
 
 @pytest.mark.parametrize("func", ["first", "last"])
 def test_groupby_first_on_categorical_col_grouped_on_2_categoricals(func: str):
+    # GH 34951
 
     cat = pd.Categorical([0, 0, 1, 1])
     val = [0, 1, 1, 0]
@@ -1684,6 +1685,7 @@ def test_groupby_first_on_categorical_col_grouped_on_2_categoricals(func: str):
         "first": pd.Series([0, np.NaN, np.NaN, 1], idx, name="c"),
         "last": pd.Series([1, np.NaN, np.NaN, 0], idx, name="c"),
     }
+    import pdb; pdb.set_trace()
 
     df_grp = df.groupby(["a", "b"])
     df_res = getattr(df_grp, func)()

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1672,11 +1672,10 @@ def test_categorical_transform():
 
 
 @pytest.mark.parametrize("func", ["first", "last"])
-def test_groupby_first_on_categorical_col_grouped_on_2_categoricals(
+def test_series_groupby_first_on_categorical_col_grouped_on_2_categoricals(
     func: str, observed: bool
 ):
     # GH 34951
-
     cat = pd.Categorical([0, 0, 1, 1])
     val = [0, 1, 1, 0]
     df = pd.DataFrame({"a": cat, "b": cat, "c": val})
@@ -1692,13 +1691,31 @@ def test_groupby_first_on_categorical_col_grouped_on_2_categoricals(
     if observed:
         expected = expected.dropna().astype(np.int64)
 
-    # Check SeriesGroupBy
     srs_grp = df.groupby(["a", "b"], observed=observed)["c"]
     result = getattr(srs_grp, func)()
     tm.assert_series_equal(result, expected)
 
-    # Check DataFrameGroupBy
+
+@pytest.mark.parametrize("func", ["first", "last"])
+def test_df_groupby_first_on_categorical_col_grouped_on_2_categoricals(
+    func: str, observed: bool
+):
+    # GH 34951
+    cat = pd.Categorical([0, 0, 1, 1])
+    val = [0, 1, 1, 0]
+    df = pd.DataFrame({"a": cat, "b": cat, "c": val})
+
+    idx = pd.Categorical([0, 1])
+    idx = pd.MultiIndex.from_product([idx, idx], names=["a", "b"])
+    expected_dict = {
+        "first": pd.Series([0, np.NaN, np.NaN, 1], idx, name="c"),
+        "last": pd.Series([1, np.NaN, np.NaN, 0], idx, name="c"),
+    }
+
+    expected = expected_dict[func].to_frame()
+    if observed:
+        expected = expected.dropna().astype(np.int64)
+
     df_grp = df.groupby(["a", "b"], observed=observed)
     result = getattr(df_grp, func)()
-    expected = expected.to_frame()
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1669,3 +1669,26 @@ def test_categorical_transform():
     expected["status"] = expected["status"].astype(delivery_status_type)
 
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("func", ["first", "last"])
+def test_groupby_first_on_categorical_col_grouped_on_2_categoricals(func: str):
+
+    cat = pd.Categorical([0, 0, 1, 1])
+    val = [0, 1, 1, 0]
+    df = pd.DataFrame({"a": cat, "b": cat, "c": val})
+
+    idx = pd.Categorical([0, 1])
+    idx = pd.MultiIndex.from_product([idx, idx], names=["a", "b"])
+    expected = {
+        "first": pd.Series([0, np.NaN, np.NaN, 1], idx, name="c"),
+        "last": pd.Series([1, np.NaN, np.NaN, 0], idx, name="c"),
+    }
+
+    df_grp = df.groupby(["a", "b"])
+    df_res = getattr(df_grp, func)()
+    tm.assert_frame_equal(df_res, expected[func].to_frame())
+
+    srs_grp = df_grp["c"]
+    srs_res = getattr(srs_grp, func)()
+    tm.assert_series_equal(srs_res, expected[func])


### PR DESCRIPTION
- [x] closes #34951 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Within `DataFrameGroupBy._cython_agg_blocks`, if it is aggregating a one-column DataFrame, it creates a `SeriresGroupBy`, calls the function on that and takes the returned values. But the `SeriesGroupBy` also does the missing-categories reindexing. The `DataFrameGroupBy` ends up with values that contain the missing categories, and an index that does not. When they are passed into a BlockManager it raises a `ValueError` stating that their lengths don't match. 

Solutions is to have `_cython_agg_blocks` create a `SeriesGroupBy` with `observed=True` so it doesn't do any reindexing. The reindexing is left to the calling `DataFrameGroupBy`

This also explains why error only occurred in `DataFrameGroupBy` but not `SeriesGroupBy`.