### PR TITLE
REGR: setting column with setitem should not modify existing array inplace

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1589,7 +1589,7 @@ class ExtensionBlock(Block):
 
     def set(self, locs, values):
         assert locs.tolist() == [0]
-        self.values[:] = values
+        self.values = values
 
     def putmask(
         self, mask, new, inplace: bool = False, axis: int = 0, transpose: bool = False,

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -709,7 +709,7 @@ class TestiLoc2:
         cat = pd.Categorical(["A", "B", "C"])
         df = pd.DataFrame({1: cat, 2: [1, 2, 3]})
 
-        df["cat"] = cat[::-1]
+        df[1] = cat[::-1]
 
         expected = pd.Categorical(["A", "B", "C"])
         tm.assert_categorical_equal(cat, expected)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -705,6 +705,15 @@ class TestiLoc2:
         expected = pd.Categorical(["C", "B", "A"])
         tm.assert_categorical_equal(cat, expected)
 
+        # __setitem__ under the other hand does not work in-place
+        cat = pd.Categorical(["A", "B", "C"])
+        df = pd.DataFrame({1: cat, 2: [1, 2, 3]})
+
+        df["cat"] = cat[::-1]
+
+        expected = pd.Categorical(["A", "B", "C"])
+        tm.assert_categorical_equal(cat, expected)
+
     def test_iloc_with_boolean_operation(self):
         # GH 20627
         result = DataFrame([[0, 1], [2, 3], [4, 5], [6, np.nan]])

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1100,3 +1100,22 @@ def test_long_text_missing_labels_inside_loc_error_message_limited():
     error_message_regex = "long_missing_label_text_0.*\\\\n.*long_missing_label_text_1"
     with pytest.raises(KeyError, match=error_message_regex):
         s.loc[["a", "c"] + missing_labels]
+
+
+def test_setitem_EA_column_update():
+    # https://github.com/pandas-dev/pandas/issues/33457
+
+    df = pd.DataFrame(
+        {
+            "int": [1, 2, 3],
+            "int2": [3, 4, 5],
+            "float": [0.1, 0.2, 0.3],
+            "EA": pd.array([1, 2, None], dtype="Int64"),
+        }
+    )
+    original_arr = df.EA.array
+
+    # overwrite column with new array
+    df["EA"] = pd.array([1, 2, 3], dtype="Int64")
+    assert original_arr is not df.EA.array
+    tm.assert_extension_array_equal(original_arr, pd.array([1, 2, None], dtype="Int64"))

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1117,5 +1117,7 @@ def test_setitem_EA_column_update():
 
     # overwrite column with new array
     df["EA"] = pd.array([1, 2, 3], dtype="Int64")
+    # ensure original array was not modified
     assert original_arr is not df.EA.array
-    tm.assert_extension_array_equal(original_arr, pd.array([1, 2, None], dtype="Int64"))
+    expected = pd.array([1, 2, None], dtype="Int64")
+    tm.assert_extension_array_equal(original_arr, expected)


### PR DESCRIPTION
Closes #33457

This changes `ExtensionBlock.setitem` to how it was before #32831: updating the Block itself inplace, but not the array. 

@jbrockmendel I know you won't like that this update the Block inplace (it's also not exactly what you suggested at https://github.com/pandas-dev/pandas/issues/33457#issuecomment-654367183). But this was the smallest change I could find to fix the issue. 

The alternative is probably changing `BlockManager.iset` to not use Block.set in case of an existing ExtensionBlock, but `BlockManager.iset` is quite complex ..
