### PR TITLE
REGR: revert ExtensionBlock.set to be in-place

### DIFF
--- a/doc/source/whatsnew/v1.1.0.rst
+++ b/doc/source/whatsnew/v1.1.0.rst
@@ -999,7 +999,6 @@ Indexing
 - Bug in :meth:`Series.__getitem__` indexing with non-standard scalars, e.g. ``np.dtype`` (:issue:`32684`)
 - Bug in :class:`Index` constructor where an unhelpful error message was raised for ``numpy`` scalars (:issue:`33017`)
 - Bug in :meth:`DataFrame.lookup` incorrectly raising an ``AttributeError`` when ``frame.index`` or ``frame.columns`` is not unique; this will now raise a ``ValueError`` with a helpful error message (:issue:`33041`)
-- Bug in :meth:`DataFrame.iloc.__setitem__` creating a new array instead of overwriting ``Categorical`` values in-place (:issue:`32831`)
 - Bug in :class:`Interval` where a :class:`Timedelta` could not be added or subtracted from a :class:`Timestamp` interval (:issue:`32023`)
 - Bug in :meth:`DataFrame.copy` _item_cache not invalidated after copy causes post-copy value updates to not be reflected (:issue:`31784`)
 - Fixed regression in :meth:`DataFrame.loc` and :meth:`Series.loc` throwing an error when a ``datetime64[ns, tz]`` value is provided (:issue:`32395`)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1589,7 +1589,7 @@ class ExtensionBlock(Block):
 
     def set(self, locs, values):
         assert locs.tolist() == [0]
-        self.values[:] = values
+        self.values = values
 
     def putmask(
         self, mask, new, inplace: bool = False, axis: int = 0, transpose: bool = False,

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -694,6 +694,7 @@ class TestiLoc2:
         result = s.iloc[np.array(0)]
         assert result == 1
 
+    @pytest.mark.xfail(reason="https://github.com/pandas-dev/pandas/issues/33457")
     def test_iloc_setitem_categorical_updates_inplace(self):
         # Mixed dtype ensures we go through take_split_path in setitem_with_indexer
         cat = pd.Categorical(["A", "B", "C"])

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1100,3 +1100,13 @@ def test_long_text_missing_labels_inside_loc_error_message_limited():
     error_message_regex = "long_missing_label_text_0.*\\\\n.*long_missing_label_text_1"
     with pytest.raises(KeyError, match=error_message_regex):
         s.loc[["a", "c"] + missing_labels]
+
+
+def test_setitem_categorical():
+    # https://github.com/pandas-dev/pandas/issues/35369
+    df = pd.DataFrame({"h": pd.Series(list("mn")).astype("category")})
+    df.h = df.h.cat.reorder_categories(["n", "m"])
+    expected = pd.DataFrame(
+        {"h": pd.Categorical(["m", "n"]).reorder_categories(["n", "m"])}
+    )
+    tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
Alternative for https://github.com/pandas-dev/pandas/pull/35266 and closes #35369