### PR TITLE
xfail failing 32-bit tests

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -18,6 +18,7 @@ PY37 = sys.version_info >= (3, 7)
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
 PYPY = platform.python_implementation() == "PyPy"
+IS64 = sys.maxsize > 2 ** 32
 
 
 # ----------------------------------------------------------------------------

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -13,7 +13,7 @@ from pandas.compat import is_platform_32bit, is_platform_windows
 import pandas.util._test_decorators as td
 
 import pandas as pd
-from pandas import DataFrame, DatetimeIndex, Series, Timestamp, read_json
+from pandas import DataFrame, DatetimeIndex, Series, Timestamp, compat, read_json
 import pandas._testing as tm
 
 _seriesd = tm.getSeriesData()
@@ -1257,7 +1257,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert json == expected
 
     @pytest.mark.parametrize("bigNum", [sys.maxsize + 1, -(sys.maxsize + 2)])
-    @pytest.mark.skipif(sys.maxsize <= 2 ** 32, reason="GH-35279")
+    @pytest.mark.skipif(not compat.IS64, reason="GH-35279")
     def test_read_json_large_numbers(self, bigNum):
         # GH20599
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -561,6 +561,7 @@ class TestUltraJSONTests:
         assert long_input == ujson.decode(output)
 
     @pytest.mark.parametrize("bigNum", [sys.maxsize + 1, -(sys.maxsize + 2)])
+    @pytest.mark.xfail(not compat.IS64, reason="GH-35288")
     def test_dumps_ints_larger_than_maxsize(self, bigNum):
         # GH34395
         bigNum = sys.maxsize + 1

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -6,7 +6,7 @@ import pytest
 from pandas.util._test_decorators import async_mark
 
 import pandas as pd
-from pandas import DataFrame, Series, Timestamp
+from pandas import DataFrame, Series, Timestamp, compat
 import pandas._testing as tm
 from pandas.core.indexes.datetimes import date_range
 
@@ -317,6 +317,7 @@ def test_resample_groupby_with_label():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.xfail(not compat.IS64, reason="GH-35148")
 def test_consistency_with_window():
 
     # consistent return values with window


### PR DESCRIPTION
We need MacPython to be passing for the wheels to be built.