### PR TITLE
TST: Remove deprecated use of apply_index

### DIFF
--- a/pandas/tests/tseries/offsets/test_offsets_properties.py
+++ b/pandas/tests/tseries/offsets/test_offsets_properties.py
@@ -94,28 +94,6 @@ def test_on_offset_implementations(dt, offset):
     assert offset.is_on_offset(dt) == (compare == dt)
 
 
-@given(gen_yqm_offset, gen_date_range)
-def test_apply_index_implementations(offset, rng):
-    # offset.apply_index(dti)[i] should match dti[i] + offset
-    assume(offset.n != 0)  # TODO: test for that case separately
-
-    # rng = pd.date_range(start='1/1/2000', periods=100000, freq='T')
-    ser = pd.Series(rng)
-
-    res = rng + offset
-    res_v2 = offset + rng
-    # res_v2 = offset.apply_index(rng.tz_localize(None)).tz_localize(rng.tz)
-    assert (res == res_v2).all()
-
-    assert res[0] == rng[0] + offset
-    assert res[-1] == rng[-1] + offset
-    res2 = ser + offset
-    # apply_index is only for indexes, not series, so no res2_v2
-    assert res2.iloc[0] == ser.iloc[0] + offset
-    assert res2.iloc[-1] == ser.iloc[-1] + offset
-    # TODO: Check randomly assorted entries, not just first/last
-
-
 @given(gen_yqm_offset)
 def test_shift_across_dst(offset):
     # GH#18319 check that 1) timezone is correctly normalized and

--- a/pandas/tests/tseries/offsets/test_offsets_properties.py
+++ b/pandas/tests/tseries/offsets/test_offsets_properties.py
@@ -12,7 +12,6 @@ import warnings
 from hypothesis import assume, given, strategies as st
 from hypothesis.extra.dateutil import timezones as dateutil_timezones
 from hypothesis.extra.pytz import timezones as pytz_timezones
-import pytest
 
 import pandas as pd
 from pandas import Timestamp
@@ -95,12 +94,6 @@ def test_on_offset_implementations(dt, offset):
     assert offset.is_on_offset(dt) == (compare == dt)
 
 
-@pytest.mark.xfail(
-    reason="res_v2 below is incorrect, needs to use the "
-    "commented-out version with tz_localize.  "
-    "But with that fix in place, hypothesis then "
-    "has errors in timezone generation."
-)
 @given(gen_yqm_offset, gen_date_range)
 def test_apply_index_implementations(offset, rng):
     # offset.apply_index(dti)[i] should match dti[i] + offset
@@ -110,7 +103,7 @@ def test_apply_index_implementations(offset, rng):
     ser = pd.Series(rng)
 
     res = rng + offset
-    res_v2 = offset.apply_index(rng)
+    res_v2 = offset + rng
     # res_v2 = offset.apply_index(rng.tz_localize(None)).tz_localize(rng.tz)
     assert (res == res_v2).all()
 


### PR DESCRIPTION
Noticed this warning. apply_index is deprecated, so not likely to get attention anyway. Removing.