### PR TITLE
pin numpy<1.19 in doc build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
 dependencies:
   # required
-  - numpy>=1.15
+  # Pin numpy<1.19 until MPL 3.3.0 is released.
+  - numpy>=1.15,<1.19.0
   - python=3
   - python-dateutil>=2.7.3
   - pytz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # This file is auto-generated from environment.yml, do not modify.
 # See that file for comments about the need/usage of each dependency.
 
-numpy>=1.15
+numpy>=1.15,<1.19.0
 python-dateutil>=2.7.3
 pytz
 asv


### PR DESCRIPTION
Doc build is failing on master with a warning from NumPy via matplotlib. Waiting on a release with https://github.com/matplotlib/matplotlib/pull/17289 (3.3.0), so pinning numpy<1.19 for now.