### PR TITLE
DOC: Rst Formatting, make sure continuation prompt are used.

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -59,7 +59,7 @@ class _IndexSlice:
     >>> midx = pd.MultiIndex.from_product([['A0','A1'], ['B0','B1','B2','B3']])
     >>> columns = ['foo', 'bar']
     >>> dfmi = pd.DataFrame(np.arange(16).reshape((len(midx), len(columns))),
-                            index=midx, columns=columns)
+    ...                     index=midx, columns=columns)
 
     Using the default slice command:
 

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -588,8 +588,8 @@ class ExcelWriter(metaclass=abc.ABCMeta):
     You can set the date format or datetime format:
 
     >>> with ExcelWriter('path_to_file.xlsx',
-                          date_format='YYYY-MM-DD',
-                          datetime_format='YYYY-MM-DD HH:MM:SS') as writer:
+    ...                   date_format='YYYY-MM-DD',
+    ...                   datetime_format='YYYY-MM-DD HH:MM:SS') as writer:
     ...     df.to_excel(writer)
 
     You can also append to an existing Excel file:


### PR DESCRIPTION
Without the `...` for some tools it may look like
`with ExcelWriter('path_to_file.xlsx',` is an input and
`date...` is the output.

I initially thought that I could use the hanging indent to separate
code continuation from output but `pandas/core/indexing.py`
proved me wrong as the example just after the one I fixed have
the first line of the output be indented.

