### PR TITLE
Remove deprecated warn kwarg for matplotlib use

### DIFF
--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -94,7 +94,7 @@ xfail_non_writeable = pytest.mark.xfail(
 def _skip_if_no_mpl():
     mod = safe_import("matplotlib")
     if mod:
-        mod.use("Agg", warn=True)
+        mod.use("Agg")
     else:
         return True
 


### PR DESCRIPTION
The warn param has been deprecated in 3.2.1: https://matplotlib.org/3.2.1/api/prev_api_changes/api_changes_3.2.0.html#matplotlib-use

On the most recent matplotlib, this is failing for me with 

```
TypeError: use() got an unexpected keyword argument 'warn'
```
