### PR TITLE
Fix MPL dt conversion (epoch2num deprecation) #34850

### DIFF
--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -253,7 +253,7 @@ def _dt_to_float_ordinal(dt):
     is a :func:`float`.
     """
     if isinstance(dt, (np.ndarray, Index, Series)) and is_datetime64_ns_dtype(dt):
-        base = dates.epoch2num(dt.asi8 / 1.0e9)
+        base = np.asarray(dt.asi8 / 1.0e9) / 86400
     else:
         base = dates.date2num(dt)
     return base


### PR DESCRIPTION
Fix datetime conversion after matplotlib (3.3.0 update) deprecating epoch2num.

- [ ] closes #34850
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
