### PR TITLE
REGR: np.argwhere on pd.Series raises ValueError

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -574,7 +574,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def __array_wrap__(self, result, context=None):
         """
-        Gets called after a ufunc.
+        Gets called after a ufunc and other functions.
         """
         result = lib.item_from_zerodim(result)
         if is_bool_dtype(result) or lib.is_scalar(result) or np.ndim(result) > 1:

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -112,7 +112,7 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
 
     def __array_wrap__(self, result, context=None):
         """
-        Gets called after a ufunc.
+        Gets called after a ufunc and other functions.
         """
         result = lib.item_from_zerodim(result)
         if is_bool_dtype(result) or lib.is_scalar(result):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -345,10 +345,13 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
 
     def __array_wrap__(self, result, context=None):
         """
-        Gets called after a ufunc. Needs additional handling as
-        PeriodIndex stores internal data as int dtype
+        Gets called after a ufunc and other functions.
 
-        Replace this to __numpy_ufunc__ in future version
+        Needs additional handling as PeriodIndex stores internal data as int
+        dtype
+
+        Replace this to __numpy_ufunc__ in future version and implement
+        __array_function__ for Indexes
         """
         if isinstance(context, tuple) and len(context) > 0:
             func = context[0]


### PR DESCRIPTION
- [ ] closes #35331 

not sure what behaviour we want (will add tests after discussion). We should be thinking of removing \_\_array_wrap__ in favour of \_\_array_ufunc__ and \_\_array_function__ anyhow.

from https://numpy.org/doc/stable/user/basics.subclassing.html?highlight=__array_wrap__#array-wrap-for-ufuncs-and-other-functions

> It is hoped to eventually deprecate these, but __array_wrap__ is also used by other numpy functions and methods, such as squeeze, so at the present time is still needed for full functionality.

in 0.25.3 we returned the NumPy array (albeit with a warning)

```
>>> pd.__version__
'0.25.3'
>>>
>>> s = pd.Series(np.random.randn(5), index=["a", "b", "c", "d", "e"])
>>> s
a    1.640847
b    0.316918
c   -0.193584
d    1.473205
e    0.357223
dtype: float64
>>>
>>> np.argwhere(s < 0)
C:\Users\simon\Anaconda3\lib\site-packages\numpy\core\fromnumeric.py:61: FutureWarning: Series.nonzero() is deprecated and will be removed in a
 future version.Use Series.to_numpy().nonzero() instead
  return bound(*args, **kwds)
array([[2]], dtype=int64)
>>>
```
