### PR TITLE
CI: pin matplotlib for doc build

### DIFF
--- a/ci/deps/azure-37-locale.yaml
+++ b/ci/deps/azure-37-locale.yaml
@@ -18,7 +18,7 @@ dependencies:
   - ipython
   - jinja2
   - lxml
-  - matplotlib
+  - matplotlib <3.3.0
   - moto
   - nomkl
   - numexpr

--- a/environment.yml
+++ b/environment.yml
@@ -73,7 +73,7 @@ dependencies:
   - ipykernel
   - ipython>=7.11.1
   - jinja2  # pandas.Styler
-  - matplotlib>=2.2.2  # pandas.plotting, Series.plot, DataFrame.plot
+  - matplotlib>=2.2.2,<3.3.0  # pandas.plotting, Series.plot, DataFrame.plot
   - numexpr>=2.6.8
   - scipy>=1.2
   - numba>=0.46.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,7 +47,7 @@ bottleneck>=1.2.1
 ipykernel
 ipython>=7.11.1
 jinja2
-matplotlib>=2.2.2
+matplotlib>=2.2.2,<3.3.0
 numexpr>=2.6.8
 scipy>=1.2
 numba>=0.46.0


### PR DESCRIPTION
Should fix the doc build. We have https://github.com/pandas-dev/pandas/issues/34850 to fix this.