### PR TITLE
FIX: remove dependence on matplotlib.dates.epoch2num

### DIFF
--- a/pandas/plotting/_matplotlib/converter.py
+++ b/pandas/plotting/_matplotlib/converter.py
@@ -252,11 +252,7 @@ def _dt_to_float_ordinal(dt):
     preserving hours, minutes, seconds and microseconds.  Return value
     is a :func:`float`.
     """
-    if isinstance(dt, (np.ndarray, Index, Series)) and is_datetime64_ns_dtype(dt):
-        base = dates.epoch2num(dt.asi8 / 1.0e9)
-    else:
-        base = dates.date2num(dt)
-    return base
+    return dates.date2num(dt)
 
 
 # Datetime Conversion


### PR DESCRIPTION
- [ ] closes #34850
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

`converter._dt_to_float_ordinal(dt)` special cased `datetime64` objects, and used `matplotlib.dates.epoch2num`.  However, matplotlib has supported `datetime64` natively since Matplotlib 2.2 (https://github.com/matplotlib/matplotlib/pull/9779), so this special casing shouldn't be necessary (unless there is a subtlety I'm missing).  Matplotlib would also prefer to deprecate `epoch2num`, so this would help us streamline.  

I didn't check your support policy - if you need to support pre MPL 2.2, then I guess some try/except logic will need to go in here.  

ping @TomAugspurger @dstansby 