### PR TITLE
ENH: Add validation checks for non-unique merge keys

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1292,7 +1292,16 @@ class _MergeOperation:
                 )
 
         elif validate in ["many_to_many", "m:m"]:
-            pass
+            if left_unique:
+                raise MergeError(
+                    "Merge keys are unique in the left dataset;"
+                    "not a many-to-many merge"
+                )
+            elif right_unique:
+                raise MergeError(
+                    "Merge keys are unique in the right dataset;"
+                    "not a many-to-many merge"
+                )
 
         else:
             raise ValueError("Not a valid argument for validate")

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1283,6 +1283,10 @@ class _MergeOperation:
                 raise MergeError(
                     "Merge keys are not unique in left dataset; not a one-to-many merge"
                 )
+            elif right_unique:
+                raise MergeError(
+                    "Merge keys are unique in right dataset; not a one-to-many merge"
+                )
 
         elif validate in ["many_to_one", "m:1"]:
             if not right_unique:
@@ -1290,17 +1294,19 @@ class _MergeOperation:
                     "Merge keys are not unique in right dataset; "
                     "not a many-to-one merge"
                 )
+            elif left_unique:
+                raise MergeError(
+                    "Merge keys are unique in left dataset; not a many-to-one merge"
+                )
 
         elif validate in ["many_to_many", "m:m"]:
             if left_unique:
                 raise MergeError(
-                    "Merge keys are unique in the left dataset;"
-                    "not a many-to-many merge"
+                    "Merge keys are unique in left dataset; not a many-to-many merge"
                 )
             elif right_unique:
                 raise MergeError(
-                    "Merge keys are unique in the right dataset;"
-                    "not a many-to-many merge"
+                    "Merge keys are unique in right dataset; not a many-to-many merge"
                 )
 
         else:


### PR DESCRIPTION
- [x] closes #27430
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

After implementing the suggestion in #27430 I realized it should also apply to `1:m` and `m:1` merges. When any type of `many` merge is specified, an error will be raised if the `many` side is actually unique.