### PR TITLE
PKG: Set max pin for Cython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.29.16",  # Note: sync with setup.py
+    "Cython>=0.29.16,<3",  # Note: sync with setup.py
     "numpy==1.15.4; python_version=='3.6' and platform_system!='AIX'",
     "numpy==1.15.4; python_version=='3.7' and platform_system!='AIX'",
     "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",


### PR DESCRIPTION
We know that pandas doesn't work with Cython 3.0
(https://github.com/pandas-dev/pandas/issues/34213,
https://github.com/pandas-dev/pandas/issues/34014)

This sets the maximum supported version of Cython in our pyproject.toml
to ensure that pandas 1.1.0 can continue to be built from source without
Cython pre-installed after Cython 3.0 is released.