### PR TITLE
use a try block in _expand_user instead of a typing condition

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -319,9 +319,9 @@ def get_filepath_or_buffer(
             compression,
             False,
         )
-    except TypeError:
+    except TypeError as e:
         msg = f"Invalid file path or buffer object type: {type(filepath_or_buffer)}"
-        raise ValueError(msg)
+        raise ValueError(msg) from e
 
     return IOargs(
         filepath_or_buffer=filepath_or_buffer,

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -92,7 +92,7 @@ def _expand_user(
                                   input if not expandable
     """
     try:
-        return os.path.expanduser(filepath_or_buffer)
+        return os.path.expanduser(filepath_or_buffer)  # type: ignore
     except TypeError:
         if fallback:
             return filepath_or_buffer

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -85,6 +85,7 @@ def _expand_user(
     filepath_or_buffer : object to be converted if possible
 
     fallback : safely return the unchanged input object if expansion fails
+
     Returns
     -------
     expanded_filepath_or_buffer : an expanded filepath or the
@@ -126,7 +127,7 @@ def stringify_path(
     Anything that is not path-like is returned unchanged.
     This function is an alias for _expand_user
     """
-    return _expand_user(filepath_or_buffer)
+    return _expand_user(filepath_or_buffer, True)
 
 
 def urlopen(*args, **kwargs):

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -319,9 +319,9 @@ def get_filepath_or_buffer(
             compression,
             False,
         )
-    except TypeError as e:
+    except TypeError as err:
         msg = f"Invalid file path or buffer object type: {type(filepath_or_buffer)}"
-        raise ValueError(msg) from e
+        raise ValueError(msg) from err
 
     return IOargs(
         filepath_or_buffer=filepath_or_buffer,

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -54,11 +54,15 @@ bar2,12,13,14,15
 
     def test_expand_user(self):
         filename = "~/sometest"
-        expanded_name = icom._expand_user(filename)
+        expanded_name1 = icom._expand_user(filename)
+        expanded_name2 = icom._expand_user(Path(filename))
+        expanded_name3 = icom._expand_user(bytes(filename, "utf-8"))
 
-        assert expanded_name != filename
-        assert os.path.isabs(expanded_name)
-        assert os.path.expanduser(filename) == expanded_name
+        assert expanded_name1 != filename
+        assert os.path.isabs(expanded_name1)
+        assert os.path.expanduser(filename) == expanded_name1
+        assert expanded_name2 == expanded_name1
+        assert expanded_name3 == bytes(expanded_name1, "utf-8")
 
     def test_expand_user_normal_path(self):
         filename = "/somefolder/sometest"
@@ -72,6 +76,13 @@ bar2,12,13,14,15
         assert rel_path == "."
         redundant_path = icom.stringify_path(Path("foo//bar"))
         assert redundant_path == os.path.join("foo", "bar")
+
+    def test_stringify_path_bytes(self):
+        filename = "~/sometest"
+        expanded_name1 = icom.stringify_path(filename)
+        expanded_name2 = icom.stringify_path(bytes(filename, "utf-8"))
+        assert type(expanded_name2) is bytes
+        assert expanded_name2.decode() == expanded_name1
 
     @td.skip_if_no("py.path")
     def test_stringify_path_localpath(self):

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -192,7 +192,11 @@ bar2,12,13,14,15
         pytest.importorskip(module)
 
         path = os.path.join("~", "does_not_exist." + fn_ext)
-        monkeypatch.setattr(icom, "_expand_user", lambda x: os.path.join("foo", x))
+
+        def _fake_expand_user(filename, fallback=True):
+            return os.path.join("foo", filename)
+
+        monkeypatch.setattr(icom, "_expand_user", _fake_expand_user)
 
         msg1 = fr"File (b')?.+does_not_exist\.{fn_ext}'? does not exist"
         msg2 = fr"\[Errno 2\] No such file or directory: '.+does_not_exist\.{fn_ext}'"


### PR DESCRIPTION
Noticed that `_expand_user`'s docstrings stated that expansion was performed "if possible", while the actual implementation was only applying expansion to str objects.
With a try block it should work with str, os.Pathlike and bytes objects (and everything else supported by `os.path.expanduser` in the future).
I except this change may be undesirable since it will force the output type to `str`. In this case I can replace this with a docstring update.
I'll complete the checklist with tests and whatsnew entry if the change is deemed desirable.

- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
