### PR TITLE
MAINT: Fix issue in StataReader due to upstream changes

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1643,8 +1643,7 @@ the string values returned are correct."""
 
         data = self._insert_strls(data)
 
-        cols_ = np.where(self.dtyplist)[0]
-
+        cols_ = np.where([dtyp is not None for dtyp in self.dtyplist])[0]
         # Convert columns (if needed) to match input type
         ix = data.index
         requires_type_conversion = False


### PR DESCRIPTION
Avoid creating an array of dtypes to workaround NumPy future change

closes #35426

- [X] closes #35426
- [ ] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
