### PR TITLE
CLN/PERF: move RangeIndex._cached_data to RangeIndex._cache

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 import operator
 from sys import getsizeof
-from typing import Any, Optional
+from typing import Any
 import warnings
 
 import numpy as np

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -78,8 +78,6 @@ class RangeIndex(Int64Index):
     _engine_type = libindex.Int64Engine
     _range: range
 
-    # check whether self._data has been called
-    _cached_data: Optional[np.ndarray] = None
     # --------------------------------------------------------------------
     # Constructors
 
@@ -150,20 +148,14 @@ class RangeIndex(Int64Index):
         """ return the class to use for construction """
         return Int64Index
 
-    @property
+    @cache_readonly
     def _data(self):
         """
         An int array that for performance reasons is created only when needed.
 
-        The constructed array is saved in ``_cached_data``. This allows us to
-        check if the array has been created without accessing ``_data`` and
-        triggering the construction.
+        The constructed array is saved in ``_cache``.
         """
-        if self._cached_data is None:
-            self._cached_data = np.arange(
-                self.start, self.stop, self.step, dtype=np.int64
-            )
-        return self._cached_data
+        return np.arange(self.start, self.stop, self.step, dtype=np.int64)
 
     @cache_readonly
     def _int64index(self) -> Int64Index:

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -138,7 +138,7 @@ class TestRangeIndex(Numeric):
         assert index.dtype == np.int64
 
     def test_cache(self):
-        # GH 26565, GH26617
+        # GH 26565, GH26617, GH35432
         # This test checks whether _cache has been set.
         # Calling RangeIndex._cache["_data"] creates an int64 array of the same length
         # as the RangeIndex and stores it in _cache.

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -137,53 +137,58 @@ class TestRangeIndex(Numeric):
         index = self.create_index()
         assert index.dtype == np.int64
 
-    def test_cached_data(self):
+    def test_cache(self):
         # GH 26565, GH26617
-        # Calling RangeIndex._data caches an int64 array of the same length at
-        # self._cached_data. This test checks whether _cached_data has been set
+        # This test checks whether _cache has been set.
+        # Calling RangeIndex._cache["_data"] creates an int64 array of the same length
+        # as the RangeIndex and stores it in _cache.
         idx = RangeIndex(0, 100, 10)
 
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
         repr(idx)
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
         str(idx)
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
         idx.get_loc(20)
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
-        90 in idx
-        assert idx._cached_data is None
+        90 in idx  # True
+        assert idx._cache == {}
 
-        91 in idx
-        assert idx._cached_data is None
+        91 in idx  # False
+        assert idx._cache == {}
 
         idx.all()
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
         idx.any()
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
         df = pd.DataFrame({"a": range(10)}, index=idx)
 
         df.loc[50]
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
         with pytest.raises(KeyError, match="51"):
             df.loc[51]
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
         df.loc[10:50]
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
         df.iloc[5:10]
-        assert idx._cached_data is None
+        assert idx._cache == {}
 
-        # actually calling idx._data
+        # idx._cache should contain a _data entry after call to idx._data
+        idx._data
         assert isinstance(idx._data, np.ndarray)
-        assert isinstance(idx._cached_data, np.ndarray)
+        assert idx._data is idx._data  # check cached value is reused
+        assert len(idx._cache) == 4
+        expected = np.arange(0, 100, 10, dtype="int64")
+        tm.assert_numpy_array_equal(idx._cache["_data"], expected)
 
     def test_is_monotonic(self):
         index = RangeIndex(0, 20, 2)


### PR DESCRIPTION
The ``._cached_data`` attribute is not necessary. It was originally added to allow a check to see if the ``._data`` ndarray had been created, but that's also possible to do by a ``"_data" in _cache`` check in the new implemention, which IMO would be more idiomatic.

The new implementation has the benefit that the ``_data`` will be available to new copies of a RangeIndex, saving the need to create a new ndarray for each new copy of the RangeIndex.

```python
>>> idx = pd.RangeIndex(1_000_000)
>>> idx[[1, 4]]  # this accesses ._data and saves it in cached_data (master) or _cache["_data"](this PR)
>> %timeit idx._shallow_copy()[[1, 4]]
2.55 ms ± 69.3 µs per loop  # master
17.7 µs ± 405 ns per loop  # this PR
```

xref #26565.
