### PR TITLE
Add note about limited propagation of attrs

### DIFF
--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -536,6 +536,10 @@ Metadata
 
 .. warning:: ``Series.attrs`` is considered experimental and may change without warning.
 
+.. note:: ``Series.attrs`` is retained for the ``Series`` object alone. Once the series
+   is placed into a ``DataFrame`` the ``attrs`` dictionary will not be propagated through
+   or retained in the ``DataFrame``.
+
 .. autosummary::
    :toctree: api/
 

--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -536,7 +536,7 @@ Metadata
 
 .. warning:: ``Series.attrs`` is considered experimental and may change without warning.
 
-.. note:: ``Series.attrs`` is retained for the ``Series`` object alone. Once the series
+.. note:: ``Series.attrs`` is retained for the ``Series`` object alone. If the series
    is placed into a ``DataFrame`` the ``attrs`` dictionary will not be propagated through
    or retained in the ``DataFrame``.
 


### PR DESCRIPTION
Explicitly mention that `attrs` are not retained once a series is placed into a dataframe, related to issue #35425