### PR TITLE
CI: activate github actions on 1.1.x (PR only) - DO NOT MERGE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: master
   pull_request:
-    branches: master
+    branches:
+      - master
+      - 1.1.x
 
 env:
   ENV_FILE: environment.yml


### PR DESCRIPTION
IIUC without changes to other scripts, activating GitHub actions for merge would push the docs. so this is only for PRs

If works. will open PR against master instead. and backport.

xref https://github.com/pandas-dev/pandas/pull/34800#issuecomment-644669496