### PR TITLE
CI: activate azure pipelines on 1.1.x - DO NOT MERGE

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,11 @@
 # Adapted from https://github.com/numba/numba/blob/master/azure-pipelines.yml
 trigger:
 - master
+- 1.1.x
 
 pr:
 - master
+- 1.1.x
 
 variables:
   PYTEST_WORKERS: auto


### PR DESCRIPTION
Azure pipelines worked for 1.0.x since #32706 which specified which branches to run on was not backported

If works. will open PR against master instead. and backport.