### PR TITLE
MAINT: Use float arange when required or intended

### DIFF
--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -140,7 +140,7 @@ def test_win_type_not_implemented():
 )
 def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs):
     # GH 32865
-    values = np.arange(10)
+    values = np.arange(10.0)
     values[5] = 100.0
 
     indexer = FixedForwardWindowIndexer(window_size=3)
@@ -177,7 +177,7 @@ def test_rolling_forward_window(constructor, func, np_func, expected, np_kwargs)
 
 @pytest.mark.parametrize("constructor", [Series, DataFrame])
 def test_rolling_forward_skewness(constructor):
-    values = np.arange(10)
+    values = np.arange(10.0)
     values[5] = 100.0
 
     indexer = FixedForwardWindowIndexer(window_size=5)

--- a/pandas/tests/window/test_ewm.py
+++ b/pandas/tests/window/test_ewm.py
@@ -108,7 +108,7 @@ def test_ewma_halflife_without_times(halflife_with_times):
 @pytest.mark.parametrize("min_periods", [0, 2])
 def test_ewma_with_times_equal_spacing(halflife_with_times, times, min_periods):
     halflife = halflife_with_times
-    data = np.arange(10)
+    data = np.arange(10.0)
     data[::2] = np.nan
     df = DataFrame({"A": data, "time_col": date_range("2000", freq="D", periods=10)})
     result = df.ewm(halflife=halflife, min_periods=min_periods, times=times).mean()


### PR DESCRIPTION
Ensure arange is float when intened or required by NumPy

- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
