### PR TITLE
TST: ensure that DataFrameGroupBy.apply does not convert datetime.date to pd.Timestamp

### DIFF
--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1017,7 +1017,7 @@ def test_apply_with_timezones_aware():
 
 
 def test_apply_with_date_in_multiindex_does_not_convert_to_timestamp():
-    # GH #29617
+    # GH 29617
 
     df = pd.DataFrame(
         {

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 from io import StringIO
 
 import numpy as np
@@ -1014,3 +1014,33 @@ def test_apply_with_timezones_aware():
     result2 = df2.groupby("x", group_keys=False).apply(lambda df: df[["x", "y"]].copy())
 
     tm.assert_frame_equal(result1, result2)
+
+
+def test_apply_with_date_in_multiindex_does_not_convert_to_timestamp():
+    # GH 29617
+
+    df = pd.DataFrame(
+        {
+            "A": ["a", "a", "a", "b"],
+            "B": [
+                date(2020, 1, 10),
+                date(2020, 1, 10),
+                date(2020, 2, 10),
+                date(2020, 2, 10),
+            ],
+            "C": [1, 2, 3, 4],
+        },
+        index=pd.Index([100, 101, 102, 103], name="idx"),
+    )
+
+    grp = df.groupby(["A", "B"])
+    result = grp.apply(lambda x: x.head(1))
+
+    expected = df.iloc[[0, 2, 3]]
+    expected = expected.reset_index()
+    expected.index = pd.MultiIndex.from_frame(expected[["A", "B", "idx"]])
+    expected = expected.drop(columns="idx")
+
+    tm.assert_frame_equal(result, expected)
+    for val in result.index.levels[1]:
+        assert type(val) is date

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1017,7 +1017,7 @@ def test_apply_with_timezones_aware():
 
 
 def test_apply_with_date_in_multiindex_does_not_convert_to_timestamp():
-    # GH 29617
+    # GH #29617
 
     df = pd.DataFrame(
         {

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date
+from datetime import date, datetime
 from io import StringIO
 
 import numpy as np


### PR DESCRIPTION
- [x] closes #29617 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Previously, there was a bug in `DataFrameGroupBy.apply` where a column of `datetime.date` would raise a `ValueError` if it was included as column in a multi-column grouping. Somewhere in the grouping the values would be converted to `pd.Timestamp` and then when the `pd.Timestamp` couldn't be found in the index of `datetime.date`s it would throw an error. 

This bug persisted until 1.0.5 but was fixed in 1.1.0 (not sure which change fixed it). In 1.1.0 the `datetime.date` are not converted to `pd.Timestamp`, so they are treated like any other dtype=object and left unchanged. 

This PR adds a test to enforce this behaviour to make sure the bug does not arise again. 