### PR TITLE
Added alignable boolean series and its example to `.loc` docs.

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -255,7 +255,7 @@ class IndexingMixin:
 
         - A boolean array of the same length as the axis being sliced,
           e.g. ``[True, False, True]``.
-        - An alignable boolean series. Index of the key will be aligned before
+        - An alignable boolean Series. The index of the key will be aligned before
           masking.
         - A ``callable`` function with one argument (the calling Series or
           DataFrame) and that returns valid output for indexing (one of the above)
@@ -267,7 +267,7 @@ class IndexingMixin:
         KeyError
             If any items are not found.
         IndexingError
-            If an indexed key is passed and its index is unalignable to the index.
+            If an indexed key is passed and its index is unalignable to the frame index.
 
         See Also
         --------
@@ -323,7 +323,7 @@ class IndexingMixin:
                     max_speed  shield
         sidewinder          7       8
 
-        Alignable boolean series:
+        Alignable boolean Series:
 
         >>> df.loc[pd.Series([False, True, False],
         ...        index=['viper', 'sidewinder', 'cobra'])]

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -255,6 +255,8 @@ class IndexingMixin:
 
         - A boolean array of the same length as the axis being sliced,
           e.g. ``[True, False, True]``.
+        - An alignable boolean series. Index of the key will be aligned before
+          masking.
         - A ``callable`` function with one argument (the calling Series or
           DataFrame) and that returns valid output for indexing (one of the above)
 
@@ -264,6 +266,8 @@ class IndexingMixin:
         ------
         KeyError
             If any items are not found.
+        IndexingError
+            If an indexed key is passed and its index is unalignable to the index.
 
         See Also
         --------
@@ -316,6 +320,13 @@ class IndexingMixin:
         Boolean list with the same length as the row axis
 
         >>> df.loc[[False, False, True]]
+                    max_speed  shield
+        sidewinder          7       8
+
+        Alignable boolean series:
+
+        >>> df.loc[pd.Series([False, True, False],
+        ...        index=['viper', 'sidewinder', 'cobra'])]
                     max_speed  shield
         sidewinder          7       8
 


### PR DESCRIPTION
- [x] closes #31054
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I'm just not sure if I needed to add `IndexingError` to raises section. Added it to be safe, will remove if it's unnecessary.

Also, when someone uses `df.loc[df['col'] > 0]` it really is the same under the hood, `df['col'] > 0` is a boolean series with an alignable index. So there might be some overlap?