### PR TITLE
REGR: Check for float in isnaobj_old

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
--
+- Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``use_inf_as_na`` was set to ``True`` (:issue:`35493`).
 -
 -
 

--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
-- Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``use_inf_as_na`` was set to ``True`` (:issue:`35493`).
+- Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``pandas.options.mode.use_inf_as_na`` was set to ``True`` (:issue:`35493`).
 -
 -
 

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -157,7 +157,7 @@ def isnaobj_old(arr: ndarray) -> ndarray:
         val = arr[i]
         result[i] = (
             checknull(val)
-            or isinstance(val, float) and (val == INF or val == NEGINF)
+            or util.is_float_object(val) and (val == INF or val == NEGINF)
         )
     return result.view(np.bool_)
 

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -155,7 +155,10 @@ def isnaobj_old(arr: ndarray) -> ndarray:
     result = np.zeros(n, dtype=np.uint8)
     for i in range(n):
         val = arr[i]
-        result[i] = checknull(val) or val == INF or val == NEGINF
+        result[i] = (
+            checknull(val)
+            or isinstance(val, float) and (val == INF or val == NEGINF)
+        )
     return result.view(np.bool_)
 
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -18,7 +18,7 @@ from pandas._libs.tslib import Timestamp
 from pandas.errors import DtypeWarning, EmptyDataError, ParserError
 import pandas.util._test_decorators as td
 
-from pandas import DataFrame, Index, MultiIndex, Series, compat, concat
+from pandas import DataFrame, Index, MultiIndex, Series, compat, concat, option_context
 import pandas._testing as tm
 
 from pandas.io.parsers import CParserWrapper, TextFileReader, TextParser
@@ -2179,3 +2179,13 @@ def test_read_csv_names_not_accepting_sets(all_parsers):
     parser = all_parsers
     with pytest.raises(ValueError, match="Names should be an ordered collection."):
         parser.read_csv(StringIO(data), names=set("QAZ"))
+
+
+def test_read_csv_with_use_inf_as_na(all_parsers):
+    # https://github.com/pandas-dev/pandas/issues/35493
+    parser = all_parsers
+    data = "1.0\nNaN\n3.0"
+    with option_context("use_inf_as_na", True):
+        result = parser.read_csv(StringIO(data), header=None)
+    expected = DataFrame([1.0, np.nan, 3.0])
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35493
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Looks like we lost an isinstance check that caused this regression.