### PR TITLE
BUG: RollingGroupby respects __getitem__

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -44,6 +44,10 @@ Bug fixes
 
 -
 
+**Groupby/resample/rolling**
+
+- Bug in :class:`pandas.core.groupby.RollingGroupby` where ``__getitem__`` would not select the specified column (:issue:`35486`)
+
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_111.contributors:

--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
-- Bug in :class:`pandas.core.groupby.RollingGroupby` where ``__getitem__`` would not select the specified column (:issue:`35486`)
+- Bug in :class:`pandas.core.groupby.RollingGroupby` where column selection was ignored (:issue:`35486`)
 -
 -
 

--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
--
+- Bug in :class:`pandas.core.groupby.RollingGroupby` where ``__getitem__`` would not select the specified column (:issue:`35486`)
 -
 -
 
@@ -43,10 +43,6 @@ Bug fixes
 **Indexing**
 
 -
-
-**Groupby/resample/rolling**
-
-- Bug in :class:`pandas.core.groupby.RollingGroupby` where ``__getitem__`` would not select the specified column (:issue:`35486`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2220,6 +2220,10 @@ class RollingGroupby(WindowGroupByMixin, Rolling):
     def _constructor(self):
         return Rolling
 
+    @cache_readonly
+    def _selected_obj(self):
+        return self._groupby._selected_obj
+
     def _create_blocks(self, obj: FrameOrSeries):
         """
         Split data into blocks & return conformed data.

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -214,3 +214,18 @@ class TestGrouperGrouping:
             name="value",
         )
         tm.assert_series_equal(result, expected)
+
+    def test_groupby_subselect_rolling(self):
+        # GH 35486
+        df = DataFrame(
+            {"a": [1, 2, 3, 2], "b": [4.0, 2.0, 3.0, 1.0], "c": [10, 20, 30, 20]}
+        )
+        result = df.groupby("a")[["b"]].rolling(2).max()
+        expected = DataFrame(
+            [np.nan, np.nan, 2.0, np.nan],
+            columns=["b"],
+            index=pd.MultiIndex.from_tuples(
+                ((1, 0), (2, 1), (2, 3), (3, 2)), names=["a", None]
+            ),
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -229,3 +229,13 @@ class TestGrouperGrouping:
             ),
         )
         tm.assert_frame_equal(result, expected)
+
+        result = df.groupby("a")["b"].rolling(2).max()
+        expected = Series(
+            [np.nan, np.nan, 2.0, np.nan],
+            index=pd.MultiIndex.from_tuples(
+                ((1, 0), (2, 1), (2, 3), (3, 2)), names=["a", None]
+            ),
+            name="b",
+        )
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35486
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
