### PR TITLE
BUG: Fix assert_equal when check_exact=True for non-numeric dtypes #3…

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -16,6 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``pandas.options.mode.use_inf_as_na`` was set to ``True`` (:issue:`35493`).
+- Fixed regression where :func:`pandas.testing.assert_series_equal` would raise an error when non-numeric dtypes were passed with ``check_exact=True`` (:issue:`35446`)
 -
 -
 

--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -1339,10 +1339,8 @@ def assert_series_equal(
         else:
             assert_attr_equal("dtype", left, right, obj=f"Attributes of {obj}")
 
-    if check_exact:
-        if not is_numeric_dtype(left.dtype):
-            raise AssertionError("check_exact may only be used with numeric Series")
-
+    if check_exact and is_numeric_dtype(left.dtype) and is_numeric_dtype(right.dtype):
+        # Only check exact if dtype is numeric
         assert_numpy_array_equal(
             left._values,
             right._values,

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -281,3 +281,13 @@ def test_series_equal_series_type():
 
     with pytest.raises(AssertionError, match="Series classes are different"):
         tm.assert_series_equal(s3, s1, check_series_type=True)
+
+
+def test_series_equal_exact_for_nonnumeric():
+    # https://github.com/pandas-dev/pandas/issues/35446
+    s1 = Series(["a", "b"])
+    s2 = Series(["a", "b"])
+    s3 = Series(["b", "a"])
+
+    _assert_series_equal_both(s1, s2, check_exact=True)
+    _assert_not_series_equal_both(s1, s3, check_exact=True)

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -289,5 +289,10 @@ def test_series_equal_exact_for_nonnumeric():
     s2 = Series(["a", "b"])
     s3 = Series(["b", "a"])
 
-    _assert_series_equal_both(s1, s2, check_exact=True)
-    _assert_not_series_equal_both(s1, s3, check_exact=True)
+    tm.assert_series_equal(s1, s2, check_exact=True)
+    tm.assert_series_equal(s2, s1, check_exact=True)
+
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(s1, s3, check_exact=True)
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(s3, s1, check_exact=True)


### PR DESCRIPTION
`assert_series_equal(..., check_exact=True)` no longer raises an error when series has a non-numeric dtype. This fixes a bug/ regression introduced in `1.1.0`.

- [x] closes #35446
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I've added a very simple test, but could add more. For instance, there could be a check on `assert_frame_equal`, but I'm not sure what the desired strategy is for that.

I've left off the `whatsnew` entry for now since I figure that's the most likely to generate conflicts while this gets reviewed.