### PR TITLE
BUG: handle immutable arrays in tz_convert_from_utc (#35530)

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -59,7 +59,7 @@ Categorical
 
 Datetimelike
 ^^^^^^^^^^^^
--
+- Bug in :attr:`DatetimeArray.date` where a ``ValueError`` would be raised with a read-only backing array (:issue:`33530`)
 -
 
 Timedelta

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -410,7 +410,7 @@ cpdef int64_t tz_convert_from_utc_single(int64_t val, tzinfo tz):
         return val + deltas[pos]
 
 
-def tz_convert_from_utc(int64_t[:] vals, tzinfo tz):
+def tz_convert_from_utc(const int64_t[:] vals, tzinfo tz):
     """
     Convert the values (in i8) from UTC to tz
 
@@ -435,7 +435,7 @@ def tz_convert_from_utc(int64_t[:] vals, tzinfo tz):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef int64_t[:] _tz_convert_from_utc(int64_t[:] vals, tzinfo tz):
+cdef int64_t[:] _tz_convert_from_utc(const int64_t[:] vals, tzinfo tz):
     """
     Convert the given values (in i8) either to UTC or from UTC.
 
@@ -457,7 +457,7 @@ cdef int64_t[:] _tz_convert_from_utc(int64_t[:] vals, tzinfo tz):
         str typ
 
     if is_utc(tz):
-        converted = vals
+        converted = vals.copy()
     elif is_tzlocal(tz):
         converted = np.empty(n, dtype=np.int64)
         for i in range(n):

--- a/pandas/tests/tslibs/test_conversion.py
+++ b/pandas/tests/tslibs/test_conversion.py
@@ -78,6 +78,14 @@ def test_tz_convert_corner(arr):
     tm.assert_numpy_array_equal(result, arr)
 
 
+def test_tz_convert_readonly():
+    # GH#35530
+    arr = np.array([0], dtype=np.int64)
+    arr.setflags(write=False)
+    result = tzconversion.tz_convert_from_utc(arr, UTC)
+    tm.assert_numpy_array_equal(result, arr)
+
+
 @pytest.mark.parametrize("copy", [True, False])
 @pytest.mark.parametrize("dtype", ["M8[ns]", "M8[s]"])
 def test_length_zero_copy(dtype, copy):


### PR DESCRIPTION
- [x] closes #35530 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry