### PR TITLE
Check if NPY_NAT is NA for int64 in rank() (#32859)

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -157,7 +157,7 @@ ExtensionArray
 
 Other
 ^^^^^
--
+- Bug in :meth:`Series.rank` incorrectly treating int64 min value as NaN (:issue:`32859`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -840,7 +840,7 @@ def rank_1d(
     elif rank_t is float64_t:
         mask = np.isnan(values)
     elif rank_t is int64_t:
-        mask = values == NPY_NAT
+        mask = missing.isnaobj(values)
 
         # create copy in case of NPY_NAT
         # values are mutated inplace

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1769,6 +1769,19 @@ class TestRank:
             s = Series([1, 100], dtype=dtype)
             tm.assert_numpy_array_equal(algos.rank(s), exp)
 
+    @pytest.mark.parametrize("dtype", ["int32", "int64"])
+    def test_negative_min_rank(self, dtype):
+        # GH#32859
+        # Check that nan is respected on float64
+        s = pd.Series(np.array([np.inf, np.nan, -np.inf]))
+        expected = pd.Series(np.array([2.0, np.nan, 1.0]))
+        tm.assert_series_equal(s.rank(na_option="keep"), expected)
+
+        # Rank works if coverted to most negative value
+        s = pd.Series(np.array([np.inf, np.nan, -np.inf]).astype(dtype))
+        expected = pd.Series(np.array([2.0, 2.0, 2.0]))
+        tm.assert_series_equal(s.rank(na_option="keep"), expected)
+
     def test_uint64_overflow(self):
         exp = np.array([1, 2], dtype=np.float64)
 


### PR DESCRIPTION
- [x] closes #32859
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Used  `missing.isnaobj()` to try to handle the suggestion from @jbrockmendel. Lmk if this might cause other issues.
