### PR TITLE
REGR: Fix interpolation on empty dataframe

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -17,7 +17,7 @@ Fixed regressions
 
 - Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``pandas.options.mode.use_inf_as_na`` was set to ``True`` (:issue:`35493`).
 - Fixed regression in :class:`pandas.core.groupby.RollingGroupby` where column selection was ignored (:issue:`35486`)
-- Fixed regression where :func:`interpolate` would raise a ``TypeError`` when the dataframe was empty (:issue:`35598`).
+- Fixed regression where :meth:`DataFrame.interpolate` would raise a ``TypeError`` when the :class:`DataFrame` was empty (:issue:`35598`).
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -16,7 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``pandas.options.mode.use_inf_as_na`` was set to ``True`` (:issue:`35493`).
--
+- Fixed regression where :func:`interpolate` would raise a ``TypeError`` when the dataframe was empty (:issue:`35598`).
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6801,7 +6801,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         if obj.empty:
             return self
-        
+
         if method not in fillna_methods:
             axis = self._info_axis_number
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6799,6 +6799,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         obj = self.T if should_transpose else self
 
+        if obj.empty:
+            return self
+        
         if method not in fillna_methods:
             axis = self._info_axis_number
 

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -34,6 +34,10 @@ class TestDataFrameInterpolate:
         expected.loc[5, "B"] = 9
         tm.assert_frame_equal(result, expected)
 
+    def test_interp_empty(self):
+        df = DataFrame()
+        tm.assert_frame_equal(df, df.interpolate())
+
     def test_interp_bad_method(self):
         df = DataFrame(
             {

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -36,7 +36,9 @@ class TestDataFrameInterpolate:
 
     def test_interp_empty(self):
         df = DataFrame()
-        tm.assert_frame_equal(df, df.interpolate())
+        result = df.interpolate()
+        expected = df
+        tm.assert_frame_equal(result, expected)
 
     def test_interp_bad_method(self):
         df = DataFrame(

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -35,6 +35,7 @@ class TestDataFrameInterpolate:
         tm.assert_frame_equal(result, expected)
 
     def test_interp_empty(self):
+        # https://github.com/pandas-dev/pandas/issues/35598
         df = DataFrame()
         result = df.interpolate()
         expected = df


### PR DESCRIPTION
Interpolation on an empty dataframe broke in 1.1 due to a change in how 'all columns are objects' is checked (specifically all(empty set) is True, while before dtype count object = None was checked against size = 0).
This is a complex function and I'm not sure what the proper fix is, suggesting to keep the empty check out of the rest of the logic.

Example code that broke:

```python
import pandas as pd
df = pd.DataFrame([1,2])
df[[]].interpolate(limit_area='inside')
```

- [x] closes #35598
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
