### PR TITLE
Bug fix one element series truncate

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -49,7 +49,7 @@ Categorical
 
 **Indexing**
 
-- Bug in series.truncate when trying to truncate a single-element series (:issue:`35544`)
+- Bug in :meth:`Series.truncate` when trying to truncate a single-element series (:issue:`35544`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -49,7 +49,7 @@ Categorical
 
 **Indexing**
 
--
+- Bug in series.truncate when trying to truncate a single-element series (:issue:`35544`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9397,7 +9397,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             if before > after:
                 raise ValueError(f"Truncate: {after} must be after {before}")
 
-        if ax.is_monotonic_decreasing:
+        if len(ax) > 1 and ax.is_monotonic_decreasing:
             before, after = after, before
 
         slicer = [slice(None, None)] * self._AXIS_LEN

--- a/pandas/tests/series/methods/test_truncate.py
+++ b/pandas/tests/series/methods/test_truncate.py
@@ -148,4 +148,7 @@ class TestTruncate:
         before = pd.Timestamp("2020-08-02")
         after = pd.Timestamp("2020-08-04")
 
-        assert series.truncate(before=before, after=after).equals(series)
+        result = series.truncate(before=before, after=after)
+
+        # the input Series and the expected Series are the same
+        tm.assert_series_equal(result, series)

--- a/pandas/tests/series/methods/test_truncate.py
+++ b/pandas/tests/series/methods/test_truncate.py
@@ -141,3 +141,11 @@ class TestTruncate:
         expected = df.col
 
         tm.assert_series_equal(result, expected)
+
+    def test_truncate_one_element_series(self):
+        # GH 35544
+        series = pd.Series([0.1], index=pd.DatetimeIndex(['2020-08-04']))
+        before = pd.Timestamp('2020-08-02')
+        after = pd.Timestamp('2020-08-04')
+
+        assert series.truncate(before=before, after=after).equals(series)

--- a/pandas/tests/series/methods/test_truncate.py
+++ b/pandas/tests/series/methods/test_truncate.py
@@ -144,8 +144,8 @@ class TestTruncate:
 
     def test_truncate_one_element_series(self):
         # GH 35544
-        series = pd.Series([0.1], index=pd.DatetimeIndex(['2020-08-04']))
-        before = pd.Timestamp('2020-08-02')
-        after = pd.Timestamp('2020-08-04')
+        series = pd.Series([0.1], index=pd.DatetimeIndex(["2020-08-04"]))
+        before = pd.Timestamp("2020-08-02")
+        after = pd.Timestamp("2020-08-04")
 
         assert series.truncate(before=before, after=after).equals(series)


### PR DESCRIPTION
- [Y] closes #35544 
- [Y] tests added / passed
- [Y] passes `black pandas`
- [Y] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [Y] whatsnew entry

Fix when trying to truncate a one-element series within a correct date range returned an empty series instead of the originally passed-in series. 