### PR TITLE
DOC: Document that read_hdf can use pickle

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3441,10 +3441,11 @@ for some advanced strategies
 
 .. warning::
 
-   pandas requires ``PyTables`` >= 3.0.0.
-   There is a indexing bug in ``PyTables`` < 3.2 which may appear when querying stores using an index.
-   If you see a subset of results being returned, upgrade to ``PyTables`` >= 3.2.
-   Stores created previously will need to be rewritten using the updated version.
+   Pandas uses PyTables for reading and writing HDF5 files, which allows
+   serializing object-dtype data with pickle. Loading pickled data received from
+   untrusted sources can be unsafe.
+
+   See: https://docs.python.org/3/library/pickle.html for more.
 
 .. ipython:: python
    :suppress:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -294,8 +294,8 @@ def read_hdf(
     .. warning::
 
        Pandas uses PyTables for reading and writing HDF5 files, which allows
-       serializing object-dtype data with pickle. Loading pickled data received
-       from untrusted sources can be unsafe.
+       serializing object-dtype data with pickle when using the "fixed" format.
+       Loading pickled data received from untrusted sources can be unsafe.
 
        See: https://docs.python.org/3/library/pickle.html for more.
 
@@ -456,8 +456,8 @@ class HDFStore:
     .. warning::
 
        Pandas uses PyTables for reading and writing HDF5 files, which allows
-       serializing object-dtype data with pickle. Loading pickled data received
-       from untrusted sources can be unsafe.
+       serializing object-dtype data with pickle when using the "fixed" format.
+       Loading pickled data received from untrusted sources can be unsafe.
 
        See: https://docs.python.org/3/library/pickle.html for more.
 
@@ -808,8 +808,8 @@ class HDFStore:
         .. warning::
 
            Pandas uses PyTables for reading and writing HDF5 files, which allows
-           serializing object-dtype data with pickle. Loading pickled data received
-           from untrusted sources can be unsafe.
+           serializing object-dtype data with pickle when using the "fixed" format.
+           Loading pickled data received from untrusted sources can be unsafe.
 
            See: https://docs.python.org/3/library/pickle.html for more.
 
@@ -879,8 +879,8 @@ class HDFStore:
         .. warning::
 
            Pandas uses PyTables for reading and writing HDF5 files, which allows
-           serializing object-dtype data with pickle. Loading pickled data received
-           from untrusted sources can be unsafe.
+           serializing object-dtype data with pickle when using the "fixed" format.
+           Loading pickled data received from untrusted sources can be unsafe.
 
            See: https://docs.python.org/3/library/pickle.html for more.
 
@@ -912,8 +912,8 @@ class HDFStore:
         .. warning::
 
            Pandas uses PyTables for reading and writing HDF5 files, which allows
-           serializing object-dtype data with pickle. Loading pickled data received
-           from untrusted sources can be unsafe.
+           serializing object-dtype data with pickle when using the "fixed" format.
+           Loading pickled data received from untrusted sources can be unsafe.
 
            See: https://docs.python.org/3/library/pickle.html for more.
 
@@ -956,8 +956,8 @@ class HDFStore:
         .. warning::
 
            Pandas uses PyTables for reading and writing HDF5 files, which allows
-           serializing object-dtype data with pickle. Loading pickled data received
-           from untrusted sources can be unsafe.
+           serializing object-dtype data with pickle when using the "fixed" format.
+           Loading pickled data received from untrusted sources can be unsafe.
 
            See: https://docs.python.org/3/library/pickle.html for more.
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -289,7 +289,15 @@ def read_hdf(
     Read from the store, close it if we opened it.
 
     Retrieve pandas object stored in file, optionally based on where
-    criteria
+    criteria.
+
+    .. warning::
+
+       Pandas uses PyTables for reading and writing HDF5 files, which allows
+       serializing object-dtype data with pickle. Loading pickled data received
+       from untrusted sources can be unsafe.
+
+       See: https://docs.python.org/3/library/pickle.html for more.
 
     Parameters
     ----------
@@ -444,6 +452,14 @@ class HDFStore:
     Dict-like IO interface for storing pandas objects in PyTables.
 
     Either Fixed or Table format.
+
+    .. warning::
+
+       Pandas uses PyTables for reading and writing HDF5 files, which allows
+       serializing object-dtype data with pickle. Loading pickled data received
+       from untrusted sources can be unsafe.
+
+       See: https://docs.python.org/3/library/pickle.html for more.
 
     Parameters
     ----------
@@ -789,6 +805,14 @@ class HDFStore:
         """
         Retrieve pandas object stored in file, optionally based on where criteria.
 
+        .. warning::
+
+           Pandas uses PyTables for reading and writing HDF5 files, which allows
+           serializing object-dtype data with pickle. Loading pickled data received
+           from untrusted sources can be unsafe.
+
+           See: https://docs.python.org/3/library/pickle.html for more.
+
         Parameters
         ----------
         key : str
@@ -852,6 +876,15 @@ class HDFStore:
         """
         return the selection as an Index
 
+        .. warning::
+
+           Pandas uses PyTables for reading and writing HDF5 files, which allows
+           serializing object-dtype data with pickle. Loading pickled data received
+           from untrusted sources can be unsafe.
+
+           See: https://docs.python.org/3/library/pickle.html for more.
+
+
         Parameters
         ----------
         key : str
@@ -875,6 +908,14 @@ class HDFStore:
         """
         return a single column from the table. This is generally only useful to
         select an indexable
+
+        .. warning::
+
+           Pandas uses PyTables for reading and writing HDF5 files, which allows
+           serializing object-dtype data with pickle. Loading pickled data received
+           from untrusted sources can be unsafe.
+
+           See: https://docs.python.org/3/library/pickle.html for more.
 
         Parameters
         ----------
@@ -911,6 +952,14 @@ class HDFStore:
     ):
         """
         Retrieve pandas objects from multiple tables.
+
+        .. warning::
+
+           Pandas uses PyTables for reading and writing HDF5 files, which allows
+           serializing object-dtype data with pickle. Loading pickled data received
+           from untrusted sources can be unsafe.
+
+           See: https://docs.python.org/3/library/pickle.html for more.
 
         Parameters
         ----------


### PR DESCRIPTION
This documents that `read_hdf`, which uses PyTables, might invoke pickle to deserialize arrays that were serialize with pickle.

PyTables clearly documents this at http://www.pytables.org/usersguide/libref/declarative_classes.html#tables.ObjectAtom, but pandas users may not realize that if they aren't aware that pandas uses pytables under the hood.

I've tried to include the warning in all the methods that eventually read data, but it's a bit hard to say if I've gotten them all.

Ideally we would also like to provide an `allow_pickle=False` keyword, but that would be best implemented in PyTables, and used by us. I opened https://github.com/PyTables/PyTables/issues/813 for discussion.