### PR TITLE
BUG: Ensure rolling groupby doesn't segfault with center=True

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -16,7 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``pandas.options.mode.use_inf_as_na`` was set to ``True`` (:issue:`35493`).
-- Fixed regression in :class:`pandas.core.groupby.RollingGroupby` where a segfault would occur with ``center=True`` and an odd number of values (:issue:`35552`)
+- Fixed regression in ``.groupby(..).rolling(..)`` where a segfault would occur with ``center=True`` and an odd number of values (:issue:`35552`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -16,7 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``pandas.options.mode.use_inf_as_na`` was set to ``True`` (:issue:`35493`).
--
+- Fixed regression in :class:`pandas.core.groupby.RollingGroupby` where a segfault would occur with ``center=True`` and an odd number of values (:issue:`35552`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -319,4 +319,10 @@ class GroupbyRollingIndexer(BaseIndexer):
             end_arrays.append(window_indicies.take(end))
         start = np.concatenate(start_arrays)
         end = np.concatenate(end_arrays)
+        # GH 35552: Need to adjust start and end based on the nans appended to values
+        # when center=True
+        if num_values > len(start):
+            offset = num_values - len(start)
+            start = np.concatenate([start, np.array([end[-1]] * offset)])
+            end = np.concatenate([end, np.array([end[-1]] * offset)])
         return start, end

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -214,3 +214,68 @@ class TestGrouperGrouping:
             name="value",
         )
         tm.assert_series_equal(result, expected)
+
+    def test_groupby_rolling_center_center(self):
+        # GH 35552
+        series = Series(range(1, 6))
+        result = series.groupby(series).rolling(center=True, window=3).mean()
+        expected = Series(
+            [np.nan] * 5,
+            index=pd.MultiIndex.from_tuples(((1, 0), (2, 1), (3, 2), (4, 3), (5, 4))),
+        )
+        tm.assert_series_equal(result, expected)
+
+        series = Series(range(1, 5))
+        result = series.groupby(series).rolling(center=True, window=3).mean()
+        expected = Series(
+            [np.nan] * 4,
+            index=pd.MultiIndex.from_tuples(((1, 0), (2, 1), (3, 2), (4, 3))),
+        )
+        tm.assert_series_equal(result, expected)
+
+        df = pd.DataFrame({"a": ["a"] * 5 + ["b"] * 6, "b": range(11)})
+        result = df.groupby("a").rolling(center=True, window=3).mean()
+        expected = pd.DataFrame(
+            [np.nan, 1, 2, 3, np.nan, np.nan, 6, 7, 8, 9, np.nan],
+            index=pd.MultiIndex.from_tuples(
+                (
+                    ("a", 0),
+                    ("a", 1),
+                    ("a", 2),
+                    ("a", 3),
+                    ("a", 4),
+                    ("b", 5),
+                    ("b", 6),
+                    ("b", 7),
+                    ("b", 8),
+                    ("b", 9),
+                    ("b", 10),
+                ),
+                names=["a", None],
+            ),
+            columns=["b"],
+        )
+        tm.assert_frame_equal(result, expected)
+
+        df = pd.DataFrame({"a": ["a"] * 5 + ["b"] * 5, "b": range(10)})
+        result = df.groupby("a").rolling(center=True, window=3).mean()
+        expected = pd.DataFrame(
+            [np.nan, 1, 2, 3, np.nan, np.nan, 6, 7, 8, np.nan],
+            index=pd.MultiIndex.from_tuples(
+                (
+                    ("a", 0),
+                    ("a", 1),
+                    ("a", 2),
+                    ("a", 3),
+                    ("a", 4),
+                    ("b", 5),
+                    ("b", 6),
+                    ("b", 7),
+                    ("b", 8),
+                    ("b", 9),
+                ),
+                names=["a", None],
+            ),
+            columns=["b"],
+        )
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35552
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
