### PR TITLE
Ensure _group_selection_context is always reset

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -463,8 +463,10 @@ def _group_selection_context(groupby):
     Set / reset the _group_selection_context.
     """
     groupby._set_group_selection()
-    yield groupby
-    groupby._reset_group_selection()
+    try:
+        yield groupby
+    finally:
+        groupby._reset_group_selection()
 
 
 _KeysArgType = Union[


### PR DESCRIPTION
Context managers will resume with an exception if the with block calling them fails.
This happening is not an excuse to not clean up.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Found by inspecting the code, not by actually finding a failing example.
