### PR TITLE
BUG: df.shift(n, axis=1) with multiple blocks

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -51,6 +51,9 @@ Categorical
 
 -
 
+**Other**
+- Bug in :meth:`DataFrame.shift` with ``axis=1`` and heterogeneous dtypes (:issue:`35488`)
+
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_111.contributors:

--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -16,7 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
 - Fixed regression where :func:`read_csv` would raise a ``ValueError`` when ``pandas.options.mode.use_inf_as_na`` was set to ``True`` (:issue:`35493`).
--
+- Fixed regression in :meth:`DataFrame.shift` with ``axis=1`` and heterogeneous dtypes (:issue:`35488`)
 -
 
 .. ---------------------------------------------------------------------------
@@ -51,8 +51,6 @@ Categorical
 
 -
 
-**Other**
-- Bug in :meth:`DataFrame.shift` with ``axis=1`` and heterogeneous dtypes (:issue:`35488`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -157,7 +157,8 @@ ExtensionArray
 
 Other
 ^^^^^
-- Bug in :meth:`DataFrame.shift` with ``axis=1`` and heterogeneous dtypes (:issue:`35488`)
+
+-
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -157,7 +157,7 @@ ExtensionArray
 
 Other
 ^^^^^
--
+- Bug in :meth:`DataFrame.shift` with ``axis=1`` and heterogeneous dtypes (:issue:`35488`)
 -
 
 .. ---------------------------------------------------------------------------


### PR DESCRIPTION
- [x] closes #35488
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
