### PR TITLE
BUG: to_timedelta fails on Int64 Series with null values

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -38,6 +38,11 @@ Categorical
 -
 -
 
+**Timedelta**
+
+- Bug in :meth:`to_timedelta` fails when arg is a :class:`Series` with `Int64` dtype containing null values (:issue:`35574`)
+
+
 **Numeric**
 
 -

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -29,7 +29,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core import nanops
 from pandas.core.algorithms import checked_add_with_arr
-from pandas.core.arrays import datetimelike as dtl
+from pandas.core.arrays import datetimelike as dtl, IntegerArray
 from pandas.core.arrays._ranges import generate_regular_range
 import pandas.core.common as com
 from pandas.core.construction import extract_array
@@ -921,6 +921,8 @@ def sequence_to_td64ns(data, copy=False, unit=None, errors="raise"):
     elif isinstance(data, (ABCTimedeltaIndex, TimedeltaArray)):
         inferred_freq = data.freq
         data = data._data
+    elif isinstance(data, IntegerArray):
+        data = data.to_numpy("int64", na_value=tslibs.iNaT)
 
     # Convert whatever we have into timedelta64[ns] dtype
     if is_object_dtype(data.dtype) or is_string_dtype(data.dtype):

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -29,7 +29,7 @@ from pandas.core.dtypes.missing import isna
 
 from pandas.core import nanops
 from pandas.core.algorithms import checked_add_with_arr
-from pandas.core.arrays import datetimelike as dtl, IntegerArray
+from pandas.core.arrays import IntegerArray, datetimelike as dtl
 from pandas.core.arrays._ranges import generate_regular_range
 import pandas.core.common as com
 from pandas.core.construction import extract_array

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -24,6 +24,18 @@ class TestTimedeltas:
         result = to_timedelta(Series(["1d", "1days 00:00:01"]))
         tm.assert_series_equal(result, expected)
 
+        # IntegerArray Series
+        expected = Series([timedelta(days=1), timedelta(days=2)])
+        result = to_timedelta(Series([1, 2], dtype="Int64"), unit="days")
+
+        tm.assert_series_equal(result, expected)
+
+        # IntegerArray Series with nulls
+        expected = Series([timedelta(days=1), None])
+        result = to_timedelta(Series([1, None], dtype="Int64"), unit="days")
+
+        tm.assert_series_equal(result, expected)
+
         # with units
         result = TimedeltaIndex(
             [np.timedelta64(0, "ns"), np.timedelta64(10, "s").astype("m8[ns]")]

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -24,18 +24,6 @@ class TestTimedeltas:
         result = to_timedelta(Series(["1d", "1days 00:00:01"]))
         tm.assert_series_equal(result, expected)
 
-        # IntegerArray Series
-        expected = Series([timedelta(days=1), timedelta(days=2)])
-        result = to_timedelta(Series([1, 2], dtype="Int64"), unit="days")
-
-        tm.assert_series_equal(result, expected)
-
-        # IntegerArray Series with nulls
-        expected = Series([timedelta(days=1), None])
-        result = to_timedelta(Series([1, None], dtype="Int64"), unit="days")
-
-        tm.assert_series_equal(result, expected)
-
         # with units
         result = TimedeltaIndex(
             [np.timedelta64(0, "ns"), np.timedelta64(10, "s").astype("m8[ns]")]
@@ -178,3 +166,15 @@ class TestTimedeltas:
         arr = np.array([1, 2, "error"], dtype=object)
         result = pd.to_timedelta(arr, unit="ns", errors="ignore")
         tm.assert_numpy_array_equal(result, arr)
+
+    def test_to_timedelta_nullable_int64_dtype(self):
+        expected = Series([timedelta(days=1), timedelta(days=2)])
+        result = to_timedelta(Series([1, 2], dtype="Int64"), unit="days")
+
+        tm.assert_series_equal(result, expected)
+
+        # IntegerArray Series with nulls
+        expected = Series([timedelta(days=1), None])
+        result = to_timedelta(Series([1, None], dtype="Int64"), unit="days")
+
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -168,6 +168,7 @@ class TestTimedeltas:
         tm.assert_numpy_array_equal(result, arr)
 
     def test_to_timedelta_nullable_int64_dtype(self):
+        # GH 35574
         expected = Series([timedelta(days=1), timedelta(days=2)])
         result = to_timedelta(Series([1, 2], dtype="Int64"), unit="days")
 


### PR DESCRIPTION
- [X] closes #35574 
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
