### PR TITLE
BUG: fix styler cell_ids arg so that blank style is ignored on False

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -26,6 +26,7 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 
+- Bug in ``Styler`` whereby `cell_ids` argument had no effect due to other recent changes (:issue:`35588`).
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -390,7 +390,7 @@ class Styler:
                     "is_visible": (c not in hidden_columns),
                 }
                 # only add an id if the cell has a style
-                if self.cell_ids or not (len(ctx[r, c]) == 1 and ctx[r, c][0] == ""):
+                if self.cell_ids or (r, c) in ctx:
                     row_dict["id"] = "_".join(cs[1:])
                 row_es.append(row_dict)
                 props = []

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1685,7 +1685,7 @@ class TestStyler:
     def test_no_cell_ids(self):
         # GH 35588
         df = pd.DataFrame(data=[[0]])
-        s = Styler(df, uuid='_', cell_ids=False).render()
+        s = Styler(df, uuid="_", cell_ids=False).render()
         assert s.find('<td  class="data row0 col0" >') != -1
 
 

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1682,6 +1682,11 @@ class TestStyler:
         result = styler.pipe((f, "styler"), a=1, b=2)
         assert result == (1, 2, styler)
 
+    def test_no_cell_ids(self):
+        df = pd.DataFrame(data=[[0]])
+        s = Styler(df, uuid='_', cell_ids=False).render()
+        assert s.find('<td  class="data row0 col0" >') != -1
+
 
 @td.skip_if_no_mpl
 class TestStylerMatplotlibDep:

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1683,6 +1683,7 @@ class TestStyler:
         assert result == (1, 2, styler)
 
     def test_no_cell_ids(self):
+        # GH 35588
         df = pd.DataFrame(data=[[0]])
         s = Styler(df, uuid='_', cell_ids=False).render()
         assert s.find('<td  class="data row0 col0" >') != -1


### PR DESCRIPTION
- [x] closes #35586 
- [ ] tests added / passed
- [x] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
