### PR TITLE
REF: Simplify Index.copy

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1732,9 +1732,16 @@ def _validate_date_like_dtype(dtype) -> None:
         )
 
 
-def validate_all_hashable(*args, name: str = None) -> None:
+def validate_all_hashable(*args, error_name=None) -> None:
     """
     Return None if all args are hashable, else raise a TypeError.
+
+    Parameters
+    ----------
+    *args
+        Arguments to validate.
+    error_name : str, optional
+        The name to use if error
 
     Raises
     ------
@@ -1743,17 +1750,10 @@ def validate_all_hashable(*args, name: str = None) -> None:
     Returns
     -------
     None
-
-    Examples
-    --------
-    >>> validate_all_hashable(1)
-
-    >>> validate_all_hashable([1])
-    TypeError: All elements must be hashable
     """
     if not all(is_hashable(arg) for arg in args):
-        if name:
-            raise TypeError(f"{name} must be a hashable type")
+        if error_name:
+            raise TypeError(f"{error_name} must be a hashable type")
         else:
             raise TypeError("All elements must be hashable")
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1732,6 +1732,29 @@ def _validate_date_like_dtype(dtype) -> None:
         )
 
 
+def validate_all_hashable(*args) -> None:
+    """
+    Return None if all args are hashable, else raise a TypeError.
+
+    Raises
+    ------
+    TypeError : If an argument is not hashable
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    >>> validate_all_hashable(1)
+
+    >>> validate_all_hashable([1])
+    ValueError: All elements must be hashable
+    """
+    if not all(is_hashable(x) for x in args):
+        raise TypeError("All elements must be hashable")
+
+
 def pandas_dtype(dtype) -> DtypeObj:
     """
     Convert input into a pandas only dtype object or a numpy dtype object.

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from pandas._libs import Interval, Period, algos
 from pandas._libs.tslibs import conversion
-from pandas._typing import ArrayLike, DtypeObj
+from pandas._typing import ArrayLike, DtypeObj, Optional
 
 from pandas.core.dtypes.base import registry
 from pandas.core.dtypes.dtypes import (
@@ -1732,7 +1732,7 @@ def _validate_date_like_dtype(dtype) -> None:
         )
 
 
-def validate_all_hashable(*args, error_name=None) -> None:
+def validate_all_hashable(*args, error_name: Optional[str] = None) -> None:
     """
     Return None if all args are hashable, else raise a TypeError.
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1749,9 +1749,9 @@ def validate_all_hashable(*args) -> None:
     >>> validate_all_hashable(1)
 
     >>> validate_all_hashable([1])
-    ValueError: All elements must be hashable
+    TypeError: All elements must be hashable
     """
-    if not all(is_hashable(x) for x in args):
+    if not all(is_hashable(arg) for arg in args):
         raise TypeError("All elements must be hashable")
 
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1732,7 +1732,7 @@ def _validate_date_like_dtype(dtype) -> None:
         )
 
 
-def validate_all_hashable(*args) -> None:
+def validate_all_hashable(*args, name: str = None) -> None:
     """
     Return None if all args are hashable, else raise a TypeError.
 
@@ -1752,7 +1752,10 @@ def validate_all_hashable(*args) -> None:
     TypeError: All elements must be hashable
     """
     if not all(is_hashable(arg) for arg in args):
-        raise TypeError("All elements must be hashable")
+        if name:
+            raise TypeError(f"{name} must be a hashable type")
+        else:
+            raise TypeError("All elements must be hashable")
 
 
 def pandas_dtype(dtype) -> DtypeObj:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1211,7 +1211,7 @@ class Index(IndexOpsMixin, PandasObject):
             )
 
         # All items in 'new_names' need to be hashable
-        validate_all_hashable(*new_names, name=f"{type(self).__name__}.name")
+        validate_all_hashable(*new_names, error_name=f"{type(self).__name__}.name")
 
         return new_names
 
@@ -1241,7 +1241,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         # GH 20527
         # All items in 'name' need to be hashable:
-        validate_all_hashable(*values, name=f"{type(self).__name__}.name")
+        validate_all_hashable(*values, error_name=f"{type(self).__name__}.name")
 
         self._name = values[0]
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1211,7 +1211,7 @@ class Index(IndexOpsMixin, PandasObject):
             )
 
         # All items in 'new_names' need to be hashable
-        validate_all_hashable(*new_names)
+        validate_all_hashable(*new_names, name=f"{type(self).__name__}.name")
 
         return new_names
 
@@ -1241,7 +1241,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         # GH 20527
         # All items in 'name' need to be hashable:
-        validate_all_hashable(*values)
+        validate_all_hashable(*values, name=f"{type(self).__name__}.name")
 
         self._name = values[0]
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -58,6 +58,7 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype,
     is_unsigned_integer_dtype,
     pandas_dtype,
+    validate_all_hashable,
 )
 from pandas.core.dtypes.concat import concat_compat
 from pandas.core.dtypes.generic import (
@@ -1208,10 +1209,9 @@ class Index(IndexOpsMixin, PandasObject):
             raise ValueError(
                 f"Length of new names must be {len(self.names)}, got {len(new_names)}"
             )
+
         # All items in 'new_names' need to be hashable
-        for new_name in new_names:
-            if not is_hashable(new_name):
-                raise TypeError(f"{type(self).__name__}.name must be a hashable type")
+        validate_all_hashable(*new_names)
 
         return new_names
 
@@ -1241,9 +1241,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         # GH 20527
         # All items in 'name' need to be hashable:
-        for name in values:
-            if not is_hashable(name):
-                raise TypeError(f"{type(self).__name__}.name must be a hashable type")
+        validate_all_hashable(*values)
+
         self._name = values[0]
 
     names = property(fset=_set_names, fget=_get_names)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -812,13 +812,11 @@ class Index(IndexOpsMixin, PandasObject):
         In most cases, there should be no functional difference from using
         ``deep``, but if ``deep`` is passed it will attempt to deepcopy.
         """
+        name = self._validate_names(name=name, names=names, deep=deep)[0]
         if deep:
-            new_index = self._shallow_copy(self._data.copy())
+            new_index = self._shallow_copy(self._data.copy(), name=name)
         else:
-            new_index = self._shallow_copy()
-
-        names = self._validate_names(name=name, names=names, deep=deep)
-        new_index = new_index.set_names(names)
+            new_index = self._shallow_copy(name=name)
 
         if dtype:
             new_index = new_index.astype(dtype)
@@ -1186,7 +1184,7 @@ class Index(IndexOpsMixin, PandasObject):
         maybe_extract_name(value, None, type(self))
         self._name = value
 
-    def _validate_names(self, name=None, names=None, deep: bool = False):
+    def _validate_names(self, name=None, names=None, deep: bool = False) -> List[Label]:
         """
         Handles the quirks of having a singular 'name' parameter for general
         Index and plural 'names' parameter for MultiIndex.
@@ -1196,15 +1194,26 @@ class Index(IndexOpsMixin, PandasObject):
         if names is not None and name is not None:
             raise TypeError("Can only provide one of `names` and `name`")
         elif names is None and name is None:
-            return deepcopy(self.names) if deep else self.names
+            new_names = deepcopy(self.names) if deep else self.names
         elif names is not None:
             if not is_list_like(names):
                 raise TypeError("Must pass list-like as `names`.")
-            return names
+            new_names = names
+        elif not is_list_like(name):
+            new_names = [name]
         else:
-            if not is_list_like(name):
-                return [name]
-            return name
+            new_names = name
+
+        if len(new_names) != len(self.names):
+            raise ValueError(
+                f"Length of new names must be {len(self.names)}, got {len(new_names)}"
+            )
+        # All items in 'new_names' need to be hashable
+        for new_name in new_names:
+            if not is_hashable(new_name):
+                raise TypeError(f"{type(self).__name__}.name must be a hashable type")
+
+        return new_names
 
     def _get_names(self):
         return FrozenList((self.name,))

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -388,9 +388,8 @@ class RangeIndex(Int64Index):
     def copy(self, name=None, deep=False, dtype=None, names=None):
         self._validate_dtype(dtype)
 
-        new_index = self._shallow_copy()
-        names = self._validate_names(name=name, names=names, deep=deep)
-        new_index = new_index.set_names(names)
+        name = self._validate_names(name=name, names=names, deep=deep)[0]
+        new_index = self._shallow_copy(name=name)
         return new_index
 
     def _minmax(self, meth: str):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -54,6 +54,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_object_dtype,
     is_scalar,
+    validate_all_hashable,
 )
 from pandas.core.dtypes.generic import ABCDataFrame
 from pandas.core.dtypes.inference import is_hashable
@@ -491,8 +492,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     @name.setter
     def name(self, value: Label) -> None:
-        if not is_hashable(value):
-            raise TypeError("Series.name must be a hashable type")
+        validate_all_hashable(value, error_name=f"{type(self).__name__}.name")
         object.__setattr__(self, "_name", value)
 
     @property

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -746,3 +746,13 @@ def test_astype_object_preserves_datetime_na(from_type):
     result = astype_nansafe(arr, dtype="object")
 
     assert isna(result)[0]
+
+
+def test_validate_allhashable():
+    assert com.validate_all_hashable(1, "a") is None
+
+    with pytest.raises(TypeError, match="All elements must be hashable"):
+        com.validate_all_hashable([])
+
+    with pytest.raises(TypeError, match="list must be a hashable type"):
+        com.validate_all_hashable([], error_name="list")

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -270,6 +270,20 @@ class Base:
             s3 = s1 * s2
             assert s3.index.name == "mario"
 
+    def test_name2(self, index):
+        # gh-35592
+        if isinstance(index, MultiIndex):
+            return
+
+        assert index.copy(name="mario").name == "mario"
+
+        with pytest.raises(ValueError, match="Length of new names must be 1, got 2"):
+            index.copy(name=["mario", "luigi"])
+
+        msg = f"{type(index).__name__}.name must be a hashable type"
+        with pytest.raises(TypeError, match=msg):
+            index.copy(name=[["mario"]])
+
     def test_ensure_copied_data(self, index):
         # Check the "copy" argument of each Index.__new__ is honoured
         # GH12309

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -75,6 +75,12 @@ def test_copy_names():
     assert multi_idx.names == ["MyName1", "MyName2"]
     assert multi_idx3.names == ["NewName1", "NewName2"]
 
+    with pytest.raises(ValueError, match="Length of new names must be 2, got 1"):
+        multi_idx.copy(names=["mario"])
+
+    with pytest.raises(TypeError, match="MultiIndex.name must be a hashable type"):
+        multi_idx.copy(names=[["mario"], ["luigi"]])
+
 
 def test_names(idx, index_names):
 

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -75,6 +75,7 @@ def test_copy_names():
     assert multi_idx.names == ["MyName1", "MyName2"]
     assert multi_idx3.names == ["NewName1", "NewName2"]
 
+    # gh-35592
     with pytest.raises(ValueError, match="Length of new names must be 2, got 1"):
         multi_idx.copy(names=["mario"])
 

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -79,7 +79,7 @@ def test_copy_names():
     with pytest.raises(ValueError, match="Length of new names must be 2, got 1"):
         multi_idx.copy(names=["mario"])
 
-    with pytest.raises(TypeError, match="MultiIndex.name must be a hashable type"):
+    with pytest.raises(TypeError, match="All elements must be hashable"):
         multi_idx.copy(names=[["mario"], ["luigi"]])
 
 

--- a/pandas/tests/indexes/multi/test_names.py
+++ b/pandas/tests/indexes/multi/test_names.py
@@ -79,7 +79,7 @@ def test_copy_names():
     with pytest.raises(ValueError, match="Length of new names must be 2, got 1"):
         multi_idx.copy(names=["mario"])
 
-    with pytest.raises(TypeError, match="All elements must be hashable"):
+    with pytest.raises(TypeError, match="MultiIndex.name must be a hashable type"):
         multi_idx.copy(names=[["mario"], ["luigi"]])
 
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -63,8 +63,8 @@ class Base:
         ).sum()
 
         # use Int64Index, to make sure things work
-        self.ymd.index.set_levels(
-            [lev.astype("i8") for lev in self.ymd.index.levels], inplace=True
+        self.ymd.index = self.ymd.index.set_levels(
+            [lev.astype("i8") for lev in self.ymd.index.levels]
         )
         self.ymd.index.set_names(["year", "month", "day"], inplace=True)
 


### PR DESCRIPTION
Avoid the use of the ``Index.set_names`` in ``Index.copy``, which is a slightly awkward method to use here (it calls ``_shallow_copy`` + is longwinded).

This is archieved by tightening up the checks in ``_validate_names``.