### PR TITLE
REF: use consistent pattern in tslibs.vectorized

### DIFF
--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -275,7 +275,7 @@ cpdef ndarray[int64_t] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo t
         int64_t[:] deltas
         str typ
         Py_ssize_t[:] pos
-        int64_t delta, local_val
+        int64_t local_val, delta = NPY_NAT
         bint use_utc = False, use_tzlocal = False, use_fixed = False
 
     if is_utc(tz) or tz is None:
@@ -380,7 +380,7 @@ def dt64arr_to_periodarr(const int64_t[:] stamps, int freq, tzinfo tz):
         int64_t[:] deltas
         Py_ssize_t[:] pos
         npy_datetimestruct dts
-        int64_t local_val
+        int64_t local_val, delta = NPY_NAT
         bint use_utc = False, use_tzlocal = False, use_fixed = False
 
     if is_utc(tz) or tz is None:

--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -333,7 +333,7 @@ def is_date_array_normalized(const int64_t[:] stamps, tzinfo tz=None):
         ndarray[int64_t] trans
         int64_t[:] deltas
         intp_t[:] pos
-        int64_t local_val, delta
+        int64_t local_val, delta = NPY_NAT
         str typ
         int64_t day_nanos = 24 * 3600 * 1_000_000_000
         bint use_utc = False, use_tzlocal = False, use_fixed = False

--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -276,43 +276,37 @@ cpdef ndarray[int64_t] normalize_i8_timestamps(const int64_t[:] stamps, tzinfo t
         str typ
         Py_ssize_t[:] pos
         int64_t delta, local_val
+        bint use_utc = False, use_tzlocal = False, use_fixed = False
 
-    if tz is None or is_utc(tz):
-        with nogil:
-            for i in range(n):
-                if stamps[i] == NPY_NAT:
-                    result[i] = NPY_NAT
-                    continue
-                local_val = stamps[i]
-                result[i] = normalize_i8_stamp(local_val)
+    if is_utc(tz) or tz is None:
+        use_utc = True
     elif is_tzlocal(tz):
-        for i in range(n):
-            if stamps[i] == NPY_NAT:
-                result[i] = NPY_NAT
-                continue
-            local_val = tz_convert_utc_to_tzlocal(stamps[i], tz)
-            result[i] = normalize_i8_stamp(local_val)
+        use_tzlocal = True
     else:
-        # Adjust datetime64 timestamp, recompute datetimestruct
         trans, deltas, typ = get_dst_info(tz)
-
         if typ not in ["pytz", "dateutil"]:
             # static/fixed; in this case we know that len(delta) == 1
+            use_fixed = True
             delta = deltas[0]
-            for i in range(n):
-                if stamps[i] == NPY_NAT:
-                    result[i] = NPY_NAT
-                    continue
-                local_val = stamps[i] + delta
-                result[i] = normalize_i8_stamp(local_val)
         else:
             pos = trans.searchsorted(stamps, side="right") - 1
-            for i in range(n):
-                if stamps[i] == NPY_NAT:
-                    result[i] = NPY_NAT
-                    continue
-                local_val = stamps[i] + deltas[pos[i]]
-                result[i] = normalize_i8_stamp(local_val)
+
+    for i in range(n):
+        # TODO: reinstate nogil for use_utc case?
+        if stamps[i] == NPY_NAT:
+            result[i] = NPY_NAT
+            continue
+
+        if use_utc:
+            local_val = stamps[i]
+        elif use_tzlocal:
+            local_val = tz_convert_utc_to_tzlocal(stamps[i], tz)
+        elif use_fixed:
+            local_val = stamps[i] + delta
+        else:
+            local_val = stamps[i] + deltas[pos[i]]
+
+        result[i] = normalize_i8_stamp(local_val)
 
     return result.base  # `.base` to access underlying ndarray
 
@@ -342,37 +336,33 @@ def is_date_array_normalized(const int64_t[:] stamps, tzinfo tz=None):
         int64_t local_val, delta
         str typ
         int64_t day_nanos = 24 * 3600 * 1_000_000_000
+        bint use_utc = False, use_tzlocal = False, use_fixed = False
 
-    if tz is None or is_utc(tz):
-        for i in range(n):
-            local_val = stamps[i]
-            if local_val % day_nanos != 0:
-                return False
-
+    if is_utc(tz) or tz is None:
+        use_utc = True
     elif is_tzlocal(tz):
-        for i in range(n):
-            local_val = tz_convert_utc_to_tzlocal(stamps[i], tz)
-            if local_val % day_nanos != 0:
-                return False
+        use_tzlocal = True
     else:
         trans, deltas, typ = get_dst_info(tz)
-
         if typ not in ["pytz", "dateutil"]:
             # static/fixed; in this case we know that len(delta) == 1
+            use_fixed = True
             delta = deltas[0]
-            for i in range(n):
-                # Adjust datetime64 timestamp, recompute datetimestruct
-                local_val = stamps[i] + delta
-                if local_val % day_nanos != 0:
-                    return False
-
         else:
-            pos = trans.searchsorted(stamps) - 1
-            for i in range(n):
-                # Adjust datetime64 timestamp, recompute datetimestruct
-                local_val = stamps[i] + deltas[pos[i]]
-                if local_val % day_nanos != 0:
-                    return False
+            pos = trans.searchsorted(stamps, side="right") - 1
+
+    for i in range(n):
+        if use_utc:
+            local_val = stamps[i]
+        elif use_tzlocal:
+            local_val = tz_convert_utc_to_tzlocal(stamps[i], tz)
+        elif use_fixed:
+            local_val = stamps[i] + delta
+        else:
+            local_val = stamps[i] + deltas[pos[i]]
+
+        if local_val % day_nanos != 0:
+            return False
 
     return True
 
@@ -391,44 +381,37 @@ def dt64arr_to_periodarr(const int64_t[:] stamps, int freq, tzinfo tz):
         Py_ssize_t[:] pos
         npy_datetimestruct dts
         int64_t local_val
+        bint use_utc = False, use_tzlocal = False, use_fixed = False
 
     if is_utc(tz) or tz is None:
-        with nogil:
-            for i in range(n):
-                if stamps[i] == NPY_NAT:
-                    result[i] = NPY_NAT
-                    continue
-                dt64_to_dtstruct(stamps[i], &dts)
-                result[i] = get_period_ordinal(&dts, freq)
-
+        use_utc = True
     elif is_tzlocal(tz):
-        for i in range(n):
-            if stamps[i] == NPY_NAT:
-                result[i] = NPY_NAT
-                continue
-            local_val = tz_convert_utc_to_tzlocal(stamps[i], tz)
-            dt64_to_dtstruct(local_val, &dts)
-            result[i] = get_period_ordinal(&dts, freq)
+        use_tzlocal = True
     else:
-        # Adjust datetime64 timestamp, recompute datetimestruct
         trans, deltas, typ = get_dst_info(tz)
-
         if typ not in ["pytz", "dateutil"]:
             # static/fixed; in this case we know that len(delta) == 1
-            for i in range(n):
-                if stamps[i] == NPY_NAT:
-                    result[i] = NPY_NAT
-                    continue
-                dt64_to_dtstruct(stamps[i] + deltas[0], &dts)
-                result[i] = get_period_ordinal(&dts, freq)
+            use_fixed = True
+            delta = deltas[0]
         else:
             pos = trans.searchsorted(stamps, side="right") - 1
 
-            for i in range(n):
-                if stamps[i] == NPY_NAT:
-                    result[i] = NPY_NAT
-                    continue
-                dt64_to_dtstruct(stamps[i] + deltas[pos[i]], &dts)
-                result[i] = get_period_ordinal(&dts, freq)
+    for i in range(n):
+        # TODO: reinstate nogil for use_utc case?
+        if stamps[i] == NPY_NAT:
+            result[i] = NPY_NAT
+            continue
+
+        if use_utc:
+            local_val = stamps[i]
+        elif use_tzlocal:
+            local_val = tz_convert_utc_to_tzlocal(stamps[i], tz)
+        elif use_fixed:
+            local_val = stamps[i] + delta
+        else:
+            local_val = stamps[i] + deltas[pos[i]]
+        
+        dt64_to_dtstruct(local_val, &dts)
+        result[i] = get_period_ordinal(&dts, freq)
 
     return result.base  # .base to get underlying ndarray

--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -410,7 +410,7 @@ def dt64arr_to_periodarr(const int64_t[:] stamps, int freq, tzinfo tz):
             local_val = stamps[i] + delta
         else:
             local_val = stamps[i] + deltas[pos[i]]
-        
+
         dt64_to_dtstruct(local_val, &dts)
         result[i] = get_period_ordinal(&dts, freq)
 


### PR DESCRIPTION
DO NOT MERGE - Performance takes a hit

We have edited some of the functions in `tslibs.vectorized to do some pre-processing in order to de-duplicate some code.  This new pattern is conducive to refactoring out helper functions for further de-duplication.

So far, moving to the new pattern has been performance-neutral or better.  But for the functions which this branch moves to the new pattern, performance takes a hit, particularly for dt64arr_to_periodarray.  I am at a loss as to why this would be, hoping more eyeballs will help.  cc @WillAyd

```
asv continuous -E virtualenv -f 1.01 master HEAD -b tslibs
[...]
       before           after         ratio
     [d82e5403]       [9f5d9ef6]
     <master~4>       <ref-vectorized>
+      21.4±0.3ms         53.7±6ms     2.51  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 1011, datetime.timezone(datetime.timedelta(seconds=3600)))
+         248±4μs         613±50μs     2.48  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 3000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      21.9±0.3ms         53.8±6ms     2.46  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 1000, datetime.timezone(datetime.timedelta(seconds=3600)))
+         238±8μs         574±60μs     2.41  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 1011, datetime.timezone(datetime.timedelta(seconds=3600)))
+         268±3μs         617±70μs     2.30  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 7000, datetime.timezone(datetime.timedelta(seconds=3600)))
+         246±5μs         562±70μs     2.28  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 2011, datetime.timezone(datetime.timedelta(seconds=3600)))
+        282±10μs         636±70μs     2.26  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 12000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        274±20μs         616±70μs     2.24  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 11000, datetime.timezone(datetime.timedelta(seconds=3600)))
+         270±6μs         599±60μs     2.22  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 6000, datetime.timezone(datetime.timedelta(seconds=3600)))
+         248±4μs         544±40μs     2.20  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 2000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      23.4±0.4ms         51.3±2ms     2.19  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 2000, datetime.timezone(datetime.timedelta(seconds=3600)))
+         278±8μs         605±70μs     2.18  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 8000, datetime.timezone(datetime.timedelta(seconds=3600)))
+         290±9μs        620±100μs     2.14  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 9000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        286±40μs         611±60μs     2.14  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 10000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        259±20μs         538±60μs     2.08  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 1000, datetime.timezone(datetime.timedelta(seconds=3600)))
+       35.5±10ms        73.5±20ms     2.07  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 9000, datetime.timezone(datetime.timedelta(seconds=3600)))
+         300±5μs         610±60μs     2.03  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 4006, datetime.timezone(datetime.timedelta(seconds=3600)))
+         289±8μs         586±60μs     2.03  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 4000, datetime.timezone(datetime.timedelta(seconds=3600)))
+       38.3±10ms        77.3±20ms     2.02  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 10000, datetime.timezone(datetime.timedelta(seconds=3600)))
+       36.6±10ms        70.9±20ms     1.94  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 11000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        26.1±1ms         49.9±1ms     1.91  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 2011, datetime.timezone(datetime.timedelta(seconds=3600)))
+       38.8±10ms        72.4±20ms     1.87  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 12000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        27.0±3ms       50.2±0.5ms     1.86  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 3000, datetime.timezone(datetime.timedelta(seconds=3600)))
+       35.3±10ms        64.6±10ms     1.83  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 7000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        35.2±9ms        64.3±10ms     1.83  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 6000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        38.0±1ms        67.7±10ms     1.78  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 4006, datetime.timezone(datetime.timedelta(seconds=3600)))
+         358±7μs         637±70μs     1.78  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(10000, 5000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      9.43±0.2μs         16.7±2μs     1.77  tslibs.resolution.TimeResolution.time_get_resolution('s', 100, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+     3.10±0.04μs         5.49±1μs     1.77  tslibs.fields.TimeGetStartEndField.time_get_start_end_field(1, 'start', 'month', None, 5)
+       37.7±10ms        66.5±10ms     1.76  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 8000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        33.5±5ms         57.0±2ms     1.70  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 4000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      26.5±0.1μs        42.8±10μs     1.61  tslibs.tz_convert.TimeTZConvert.time_tz_localize_to_utc(100, datetime.timezone(datetime.timedelta(seconds=3600)))
+        45.3±8ms        70.5±10ms     1.56  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 5000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      24.7±0.2μs        38.2±10μs     1.54  tslibs.tz_convert.TimeTZConvert.time_tz_localize_to_utc(100, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
+     1.55±0.08ms       2.36±0.2ms     1.52  tslibs.normalize.Normalize.time_is_date_array_normalized(1000000, datetime.timezone(datetime.timedelta(seconds=3600)))
+         327±4ms        491±100ms     1.50  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 1000000, None)
+      24.7±0.9ms        36.6±10ms     1.48  tslibs.fields.TimeGetDateField.time_get_date_field(1000000, 'dow')
+     3.29±0.06μs         4.87±1μs     1.48  tslibs.fields.TimeGetStartEndField.time_get_start_end_field(1, 'start', 'month', None, 12)
+         338±2ms        497±100ms     1.47  tslibs.tslib.TimeIntsToPydatetime.time_ints_to_pydatetime('time', 1000000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      22.7±0.3μs         32.0±3μs     1.41  tslibs.normalize.Normalize.time_is_date_array_normalized(10000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      12.2±0.5μs         17.1±4μs     1.41  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(100, 2000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      12.0±0.4μs         16.5±4μs     1.38  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(100, 2011, datetime.timezone(datetime.timedelta(seconds=3600)))
+      12.1±0.3μs         16.8±2μs     1.38  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(100, 12000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      12.2±0.2μs         16.6±2μs     1.36  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(100, 11000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      11.7±0.3μs         15.9±1μs     1.35  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(100, 3000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      12.6±0.3μs         16.5±2μs     1.31  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(100, 4000, datetime.timezone(datetime.timedelta(seconds=3600)))
+      8.89±0.6μs         11.3±1μs     1.27  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(0, 2000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+         115±2μs         143±20μs     1.25  tslibs.normalize.Normalize.time_is_date_array_normalized(10000, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
+      12.8±0.3μs         15.9±2μs     1.24  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(100, 6000, datetime.timezone(datetime.timedelta(seconds=3600)))
+        61.7±2μs         75.0±7μs     1.22  tslibs.normalize.Normalize.time_is_date_array_normalized(10000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+     7.58±0.08ms       8.61±0.1ms     1.14  tslibs.normalize.Normalize.time_is_date_array_normalized(1000000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
+     8.80±0.07ms       9.55±0.4ms     1.09  tslibs.normalize.Normalize.time_normalize_i8_timestamps(1000000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-     3.46±0.05μs       3.06±0.1μs     0.89  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1, 3000, tzlocal())
-      25.2±0.9ms       21.2±0.5ms     0.84  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 2011, datetime.timezone.utc)
-      2.39±0.1ms       2.01±0.3ms     0.84  tslibs.normalize.Normalize.time_normalize_i8_timestamps(1000000, datetime.timezone(datetime.timedelta(seconds=3600)))
-      47.0±0.5ms       38.7±0.8ms     0.82  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 2011, <DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)
-        38.5±3ms       31.2±0.4ms     0.81  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 3000, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-        36.4±1ms       29.3±0.7ms     0.81  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 2011, tzfile('/usr/share/zoneinfo/Asia/Tokyo'))
-        25.7±3ms       20.7±0.2ms     0.80  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 3000, datetime.timezone.utc)
-        25.7±3ms       20.5±0.2ms     0.80  tslibs.period.TimeDT64ArrToPeriodArr.time_dt64arr_to_periodarr(1000000, 3000, None)
-     1.88±0.02ms        607±200μs     0.32  tslibs.tz_convert.TimeTZConvert.time_tz_convert_from_utc(1000000, datetime.timezone.utc)
```