### PR TITLE
DOC: compression support for file objects in to_csv

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3088,7 +3088,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
             .. versionchanged:: 1.2.0
 
-                Compression is supported for non-binary file objects.
+                Compression is supported for binary file objects.
 
         quoting : optional constant from csv module
             Defaults to csv.QUOTE_MINIMAL. If you have set a `float_format`


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I made a mistake in #35129: `to_csv` supports the compression argument for file objects in binary mode (not for file objects in text/non-binary mode).