### PR TITLE
BUG: RollingGroupby with closed and column selection no longer raises ValueError

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -51,6 +51,10 @@ Categorical
 -
 -
 
+**Groupby/resample/rolling**
+
+- Bug in :class:`pandas.core.groupby.RollingGroupby` where passing ``closed`` with column selection would raise a ``ValueError`` (:issue:`35549`)
+
 **Plotting**
 
 -

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -154,7 +154,7 @@ Groupby/resample/rolling
 
 - Bug in :meth:`DataFrameGroupBy.count` and :meth:`SeriesGroupBy.sum` returning ``NaN`` for missing categories when grouped on multiple ``Categoricals``. Now returning ``0`` (:issue:`35028`)
 - Bug in :meth:`DataFrameGroupBy.apply` that would some times throw an erroneous ``ValueError`` if the grouping axis had duplicate entries (:issue:`16646`)
--
+- Bug in :class:`pandas.core.groupby.RollingGroupby` where passing ``closed`` with column selection would raise a ``ValueError`` (:issue:`35549`)
 -
 - Bug in :meth:`DataFrameGroupBy.apply` where a non-nuisance grouping column would be dropped from the output columns if another groupby method was called before ``.apply()`` (:issue:`34656`)
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -154,7 +154,7 @@ Groupby/resample/rolling
 
 - Bug in :meth:`DataFrameGroupBy.count` and :meth:`SeriesGroupBy.sum` returning ``NaN`` for missing categories when grouped on multiple ``Categoricals``. Now returning ``0`` (:issue:`35028`)
 - Bug in :meth:`DataFrameGroupBy.apply` that would some times throw an erroneous ``ValueError`` if the grouping axis had duplicate entries (:issue:`16646`)
-- Bug in :class:`pandas.core.groupby.RollingGroupby` where passing ``closed`` with column selection would raise a ``ValueError`` (:issue:`35549`)
+-
 -
 - Bug in :meth:`DataFrameGroupBy.apply` where a non-nuisance grouping column would be dropped from the output columns if another groupby method was called before ``.apply()`` (:issue:`34656`)
 

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -52,7 +52,7 @@ class WindowGroupByMixin(GroupByMixin):
         kwargs.pop("parent", None)
         groupby = kwargs.pop("groupby", None)
         if groupby is None:
-            groupby, obj = obj, obj.obj
+            groupby, obj = obj, obj._selected_obj
         self._groupby = groupby
         self._groupby.mutated = True
         self._groupby.grouper.mutated = True

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2212,7 +2212,7 @@ class RollingGroupby(WindowGroupByMixin, Rolling):
         # Cannot use _wrap_outputs because we calculate the result all at once
         # Compose MultiIndex result from grouping levels then rolling level
         # Aggregate the MultiIndex data as tuples then the level names
-        grouped_object_index = self._groupby._selected_obj.index
+        grouped_object_index = self.obj.index
         grouped_index_name = [grouped_object_index.name]
         groupby_keys = [grouping.name for grouping in self._groupby.grouper._groupings]
         result_index_names = groupby_keys + grouped_index_name
@@ -2235,10 +2235,6 @@ class RollingGroupby(WindowGroupByMixin, Rolling):
     @property
     def _constructor(self):
         return Rolling
-
-    @cache_readonly
-    def _selected_obj(self):
-        return self._groupby._selected_obj
 
     def _create_blocks(self, obj: FrameOrSeries):
         """
@@ -2278,7 +2274,7 @@ class RollingGroupby(WindowGroupByMixin, Rolling):
         rolling_indexer: Union[Type[FixedWindowIndexer], Type[VariableWindowIndexer]]
         if self.is_freq_type:
             rolling_indexer = VariableWindowIndexer
-            index_array = self._groupby._selected_obj.index.asi8
+            index_array = self.obj.index.asi8
         else:
             rolling_indexer = FixedWindowIndexer
             index_array = None
@@ -2295,7 +2291,7 @@ class RollingGroupby(WindowGroupByMixin, Rolling):
         # here so our index is carried thru to the selected obj
         # when we do the splitting for the groupby
         if self.on is not None:
-            self._groupby.obj = self._groupby.obj.set_index(self._on)
+            self.obj = self.obj.set_index(self._on)
             self.on = None
         return super()._gotitem(key, ndim, subset=subset)
 

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -304,3 +304,54 @@ class TestGrouperGrouping:
             name="b",
         )
         tm.assert_series_equal(result, expected)
+
+    def test_groupby_rolling_subset_with_closed(self):
+        # GH 35549
+        df = pd.DataFrame(
+            {
+                "column1": range(6),
+                "column2": range(6),
+                "group": 3 * ["A", "B"],
+                "date": [pd.Timestamp("2019-01-01")] * 6,
+            }
+        )
+        result = (
+            df.groupby("group").rolling("1D", on="date", closed="left")["column1"].sum()
+        )
+        expected = Series(
+            [np.nan, 0.0, 2.0, np.nan, 1.0, 4.0],
+            index=pd.MultiIndex.from_tuples(
+                [("A", pd.Timestamp("2019-01-01"))] * 3
+                + [("B", pd.Timestamp("2019-01-01"))] * 3,
+                names=["group", "date"],
+            ),
+            name="column1",
+        )
+        tm.assert_series_equal(result, expected)
+
+    def test_groupby_subset_rolling_subset_with_closed(self):
+        # GH 35549
+        df = pd.DataFrame(
+            {
+                "column1": range(6),
+                "column2": range(6),
+                "group": 3 * ["A", "B"],
+                "date": [pd.Timestamp("2019-01-01")] * 6,
+            }
+        )
+
+        result = (
+            df.groupby("group")[["column1", "date"]]
+            .rolling("1D", on="date", closed="left")["column1"]
+            .sum()
+        )
+        expected = Series(
+            [np.nan, 0.0, 2.0, np.nan, 1.0, 4.0],
+            index=pd.MultiIndex.from_tuples(
+                [("A", pd.Timestamp("2019-01-01"))] * 3
+                + [("B", pd.Timestamp("2019-01-01"))] * 3,
+                names=["group", "date"],
+            ),
+            name="column1",
+        )
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35549
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry