### PR TITLE
DOC: Add specific Visual Studio Installer instructions

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -204,6 +204,7 @@ You will need `Build Tools for Visual Studio 2017
 	You DO NOT need to install Visual Studio 2019.
 	You only need "Build Tools for Visual Studio 2019" found by
 	scrolling down to "All downloads" -> "Tools for Visual Studio 2019".
+	In the installer, select the "C++ build tools" workload.
 
 **Mac OS**
 


### PR DESCRIPTION
- [ ] further improves #28316 - Currently the 'Contributing to pandas', 'Installing a C compiler' section advises to install Build Tools for Visual Studio 2017 but doesn't specify which components to install.

Notes:

- The first time I installed the Build Tools it didn't seem to get everything needed, and I had to search around for a while before I could figure out what I'd missed.
- The advice at [python.org](https://wiki.python.org/moin/WindowsCompilers#Microsoft_Visual_C.2B-.2B-_14.2_standalone:_Build_Tools_for_Visual_Studio_2019_.28x86.2C_x64.2C_ARM.2C_ARM64.29) is more specific, so I have added that in here. I'm fairly sure that's the minimum required, correct?
