### PR TITLE
REF/PERF: Move MultiIndex._tuples to MultiIndex._cache

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -243,7 +243,6 @@ class MultiIndex(Index):
     _comparables = ["names"]
     rename = Index.set_names
 
-    _tuples = None
     sortorder: Optional[int]
 
     # --------------------------------------------------------------------
@@ -634,16 +633,9 @@ class MultiIndex(Index):
 
     # --------------------------------------------------------------------
 
-    @property
+    @cache_readonly
     def _values(self):
         # We override here, since our parent uses _data, which we don't use.
-        return self.values
-
-    @property
-    def values(self):
-        if self._tuples is not None:
-            return self._tuples
-
         values = []
 
         for i in range(self.nlevels):
@@ -657,8 +649,12 @@ class MultiIndex(Index):
             vals = np.array(vals, copy=False)
             values.append(vals)
 
-        self._tuples = lib.fast_zip(values)
-        return self._tuples
+        arr = lib.fast_zip(values)
+        return arr
+
+    @property
+    def values(self):
+        return self._values
 
     @property
     def array(self):
@@ -737,7 +733,6 @@ class MultiIndex(Index):
         if any(names):
             self._set_names(names)
 
-        self._tuples = None
         self._reset_cache()
 
     def set_levels(self, levels, level=None, inplace=None, verify_integrity=True):
@@ -906,7 +901,6 @@ class MultiIndex(Index):
 
         self._codes = new_codes
 
-        self._tuples = None
         self._reset_cache()
 
     def set_codes(self, codes, level=None, inplace=None, verify_integrity=True):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -320,6 +320,10 @@ def read_hdf(
     mode : {'r', 'r+', 'a'}, default 'r'
         Mode to use when opening the file. Ignored if path_or_buf is a
         :class:`pandas.HDFStore`. Default is 'r'.
+    errors : str, default 'strict'
+        Specifies how encoding and decoding errors are to be handled.
+        See the errors argument for :func:`open` for a full list
+        of options.
     where : list, optional
         A list of Term (or convertible) objects.
     start : int, optional
@@ -332,10 +336,6 @@ def read_hdf(
         Return an iterator object.
     chunksize : int, optional
         Number of rows to include in an iteration when using an iterator.
-    errors : str, default 'strict'
-        Specifies how encoding and decoding errors are to be handled.
-        See the errors argument for :func:`open` for a full list
-        of options.
     **kwargs
         Additional keyword arguments passed to HDFStore.
 

--- a/pandas/tests/indexes/multi/test_compat.py
+++ b/pandas/tests/indexes/multi/test_compat.py
@@ -69,12 +69,16 @@ def test_inplace_mutation_resets_values():
     mi1 = MultiIndex(levels=levels, codes=codes)
     mi2 = MultiIndex(levels=levels2, codes=codes)
 
+    # instantiating MultiIndex should not access/cache _.values
     assert "_values" not in mi1._cache
     assert "_values" not in mi2._cache
 
     vals = mi1.values.copy()
     vals2 = mi2.values.copy()
 
+    # accessing .values should cache ._values
+    assert mi1._values is mi1._cache["_values"]
+    assert mi1.values is mi1._cache["_values"]
     assert isinstance(mi1._cache["_values"], np.ndarray)
 
     # Make sure level setting works
@@ -97,6 +101,7 @@ def test_inplace_mutation_resets_values():
     codes2 = [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]
     exp_values = np.empty((6,), dtype=object)
     exp_values[:] = [(1, "a")] * 6
+
     # Must be 1d array of tuples
     assert exp_values.shape == (6,)
 

--- a/pandas/tests/indexes/multi/test_compat.py
+++ b/pandas/tests/indexes/multi/test_compat.py
@@ -117,7 +117,8 @@ def test_inplace_mutation_resets_values():
     tm.assert_almost_equal(exp_values, new_values)
 
     # ...and again setting inplace should drop _values from _cache, etc
-    mi2.set_codes(codes2, inplace=True)
+    with tm.assert_produces_warning(FutureWarning):
+        mi2.set_codes(codes2, inplace=True)
     assert "_values" not in mi2._cache
     tm.assert_almost_equal(mi2.values, new_values)
     assert "_values" in mi2._cache

--- a/pandas/tests/indexes/multi/test_compat.py
+++ b/pandas/tests/indexes/multi/test_compat.py
@@ -68,45 +68,54 @@ def test_inplace_mutation_resets_values():
 
     mi1 = MultiIndex(levels=levels, codes=codes)
     mi2 = MultiIndex(levels=levels2, codes=codes)
+
+    assert "_values" not in mi1._cache
+    assert "_values" not in mi2._cache
+
     vals = mi1.values.copy()
     vals2 = mi2.values.copy()
 
-    assert mi1._tuples is not None
+    assert isinstance(mi1._cache["_values"], np.ndarray)
 
     # Make sure level setting works
     new_vals = mi1.set_levels(levels2).values
     tm.assert_almost_equal(vals2, new_vals)
 
-    # Non-inplace doesn't kill _tuples [implementation detail]
-    tm.assert_almost_equal(mi1._tuples, vals)
+    # Non-inplace doesn't drop _values from _cache [implementation detail]
+    tm.assert_almost_equal(mi1._cache["_values"], vals)
 
     # ...and values is still same too
     tm.assert_almost_equal(mi1.values, vals)
 
-    # Inplace should kill _tuples
+    # Inplace should drop _values from _cache
     with tm.assert_produces_warning(FutureWarning):
         mi1.set_levels(levels2, inplace=True)
+    assert "_values" not in mi1._cache
     tm.assert_almost_equal(mi1.values, vals2)
 
     # Make sure label setting works too
     codes2 = [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]
     exp_values = np.empty((6,), dtype=object)
     exp_values[:] = [(1, "a")] * 6
-
     # Must be 1d array of tuples
     assert exp_values.shape == (6,)
-    new_values = mi2.set_codes(codes2).values
+
+    new_mi = mi2.set_codes(codes2)
+    assert "_values" not in new_mi._cache
+    new_values = new_mi.values
+    assert "_values" in new_mi._cache
 
     # Not inplace shouldn't change
-    tm.assert_almost_equal(mi2._tuples, vals2)
+    tm.assert_almost_equal(mi2._cache["_values"], vals2)
 
     # Should have correct values
     tm.assert_almost_equal(exp_values, new_values)
 
-    # ...and again setting inplace should kill _tuples, etc
-    with tm.assert_produces_warning(FutureWarning):
-        mi2.set_codes(codes2, inplace=True)
+    # ...and again setting inplace should drop _values from _cache, etc
+    mi2.set_codes(codes2, inplace=True)
+    assert "_values" not in mi2._cache
     tm.assert_almost_equal(mi2.values, new_values)
+    assert "_values" in mi2._cache
 
 
 def test_ndarray_compat_properties(idx, compat_props):


### PR DESCRIPTION
Currently, the heavy-to-calculate ``MultiIndex.values`` attribute is cached in ``MultiIndex._tuples``. It would be more dogmatic to store it in ``MultiIndex._cache`` IMO, which is what this PR does.

This has the added benefit of ``._values`` getting copied over to new copies of the MultiIndex, so also gives a performance boost in cases where copying is needed:

```python
>>> n = 100_000;
>>> df = pd.DataFrame({'a': ['a', 'b'] * int(n / 2), 'b': range(n), 'c': range(20, n + 20)})
>>> mi = pd.MultiIndex.from_frame(df)
>>> mi.values # also caches mi._values in mi._cache
array([('a', 0, 20), ('b', 1, 21), ('a', 2, 22), ...,
       ('b', 99997, 100017), ('a', 99998, 100018), ('b', 99999, 100019)],
      dtype=object)
>>> %timeit mi._shallow_copy().values
22.8 ms ± 3.43 ms per loop  # master
34.6 µs ± 997 ns per loop  # this PR
```
