### PR TITLE
BUG: Support custom BaseIndexers in groupby.rolling

### DIFF
--- a/doc/source/whatsnew/v1.1.1.rst
+++ b/doc/source/whatsnew/v1.1.1.rst
@@ -20,6 +20,7 @@ Fixed regressions
 - Fixed regression in :class:`pandas.core.groupby.RollingGroupby` where column selection was ignored (:issue:`35486`)
 - Fixed regression in :meth:`DataFrame.shift` with ``axis=1`` and heterogeneous dtypes (:issue:`35488`)
 - Fixed regression in ``.groupby(..).rolling(..)`` where a segfault would occur with ``center=True`` and an odd number of values (:issue:`35552`)
+- Fixed regression in ``.groupby(..).rolling(..)`` where a custom ``BaseIndexer`` would be ignored (:issue:`35557`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -1,6 +1,6 @@
 """Indexer objects for computing start/end window bounds for rolling operations"""
 from datetime import timedelta
-from typing import Dict, Optional, Tuple, Type, Union
+from typing import Dict, Optional, Tuple, Type
 
 import numpy as np
 

--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -265,7 +265,8 @@ class GroupbyRollingIndexer(BaseIndexer):
         index_array: Optional[np.ndarray],
         window_size: int,
         groupby_indicies: Dict,
-        rolling_indexer: Union[Type[FixedWindowIndexer], Type[VariableWindowIndexer]],
+        rolling_indexer: Type[BaseIndexer],
+        indexer_kwargs: Optional[Dict],
         **kwargs,
     ):
         """
@@ -276,7 +277,10 @@ class GroupbyRollingIndexer(BaseIndexer):
         """
         self.groupby_indicies = groupby_indicies
         self.rolling_indexer = rolling_indexer
-        super().__init__(index_array, window_size, **kwargs)
+        self.indexer_kwargs = indexer_kwargs or {}
+        super().__init__(
+            index_array, self.indexer_kwargs.pop("window_size", window_size), **kwargs
+        )
 
     @Appender(get_window_bounds_doc)
     def get_window_bounds(
@@ -298,7 +302,9 @@ class GroupbyRollingIndexer(BaseIndexer):
             else:
                 index_array = self.index_array
             indexer = self.rolling_indexer(
-                index_array=index_array, window_size=self.window_size,
+                index_array=index_array,
+                window_size=self.window_size,
+                **self.indexer_kwargs,
             )
             start, end = indexer.get_window_bounds(
                 len(indicies), min_periods, center, closed

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2272,20 +2272,17 @@ class RollingGroupby(WindowGroupByMixin, Rolling):
         GroupbyRollingIndexer
         """
         rolling_indexer: Type[BaseIndexer]
-        indexer_kwargs: Optional[Dict]
+        indexer_kwargs: Optional[Dict] = None
+        index_array = self.obj.index.asi8
         if isinstance(self.window, BaseIndexer):
             rolling_indexer = type(self.window)
             indexer_kwargs = self.window.__dict__
             # We'll be using the index of each group later
             indexer_kwargs.pop("index_array", None)
-            index_array = self.obj.index.asi8
         elif self.is_freq_type:
             rolling_indexer = VariableWindowIndexer
-            indexer_kwargs = None
-            index_array = self.obj.index.asi8
         else:
             rolling_indexer = FixedWindowIndexer
-            indexer_kwargs = None
             index_array = None
         window_indexer = GroupbyRollingIndexer(
             index_array=index_array,

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -304,3 +304,26 @@ class TestGrouperGrouping:
             name="b",
         )
         tm.assert_series_equal(result, expected)
+
+    def test_groupby_rolling_custom_indexer(self):
+        # GH 35557
+        class SimpleIndexer(pd.api.indexers.BaseIndexer):
+            def get_window_bounds(
+                self, num_values=0, min_periods=None, center=None, closed=None
+            ):
+                min_periods = self.window_size if min_periods is None else 0
+                end = np.arange(num_values, dtype=np.int64) + 1
+                start = end.copy() - self.window_size
+                start[start < 0] = min_periods
+                return start, end
+
+        df = pd.DataFrame(
+            {"a": [1.0, 2.0, 3.0, 4.0, 5.0] * 3}, index=[0] * 5 + [1] * 5 + [2] * 5
+        )
+        result = (
+            df.groupby(df.index)
+            .rolling(SimpleIndexer(window_size=3), min_periods=1)
+            .sum()
+        )
+        expected = df.groupby(df.index).rolling(window=3, min_periods=1).sum()
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35557
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
