### PR TITLE
PERF: make RangeIndex iterate over ._range

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -78,6 +78,16 @@ class Range:
     def time_get_loc_dec(self):
         self.idx_dec.get_loc(100000)
 
+    def time_iter_inc(self):
+        for i in self.idx_inc:
+            if i >= 100_000:
+                break
+
+    def time_iter_dec(self):
+        for i in self.idx_dec:
+            if i >= 100_000:
+                break
+
 
 class IndexEquals:
     def setup(self):

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -57,8 +57,8 @@ class SetDisjoint:
 
 class Range:
     def setup(self):
-        self.idx_inc = RangeIndex(start=0, stop=10 ** 7, step=3)
-        self.idx_dec = RangeIndex(start=10 ** 7, stop=-1, step=-3)
+        self.idx_inc = RangeIndex(start=0, stop=10 ** 6, step=3)
+        self.idx_dec = RangeIndex(start=10 ** 6, stop=-1, step=-3)
 
     def time_max(self):
         self.idx_inc.max()
@@ -73,25 +73,23 @@ class Range:
         self.idx_inc.min()
 
     def time_get_loc_inc(self):
-        self.idx_inc.get_loc(900000)
+        self.idx_inc.get_loc(900_000)
 
     def time_get_loc_dec(self):
-        self.idx_dec.get_loc(100000)
+        self.idx_dec.get_loc(100_000)
 
     def time_iter_inc(self):
-        for i in self.idx_inc:
-            if i >= 100_000:
-                break
+        for _ in self.idx_inc:
+            pass
 
     def time_iter_dec(self):
-        for i in self.idx_dec:
-            if i >= 100_000:
-                break
+        for _ in self.idx_dec:
+            pass
 
 
 class IndexEquals:
     def setup(self):
-        idx_large_fast = RangeIndex(100000)
+        idx_large_fast = RangeIndex(100_000)
         idx_small_slow = date_range(start="1/1/2012", periods=1)
         self.mi_large_slow = MultiIndex.from_product([idx_large_fast, idx_small_slow])
 
@@ -104,7 +102,7 @@ class IndexEquals:
 class IndexAppend:
     def setup(self):
 
-        N = 10000
+        N = 10_000
         self.range_idx = RangeIndex(0, 100)
         self.int_idx = self.range_idx.astype(int)
         self.obj_idx = self.int_idx.astype(str)
@@ -178,7 +176,7 @@ class Indexing:
 class Float64IndexMethod:
     # GH 13166
     def setup(self):
-        N = 100000
+        N = 100_000
         a = np.arange(N)
         self.ind = Float64Index(a * 4.8000000418824129e-08)
 
@@ -222,7 +220,7 @@ class GC:
     params = [1, 2, 5]
 
     def create_use_drop(self):
-        idx = Index(list(range(1000 * 1000)))
+        idx = Index(list(range(1_000_000)))
         idx._engine
 
     def peakmem_gc_instances(self, N):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -373,6 +373,10 @@ class RangeIndex(Int64Index):
     def tolist(self):
         return list(self._range)
 
+    @doc(Int64Index.__iter__)
+    def __iter__(self):
+        yield from self._range
+
     @doc(Int64Index._shallow_copy)
     def _shallow_copy(self, values=None, name: Label = no_default):
         name = self.name if name is no_default else name

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -168,7 +168,7 @@ class TestRangeIndex(Numeric):
         assert idx._cache == {}
 
         for _ in idx:
-            ...
+            pass
         assert idx._cache == {}
 
         df = pd.DataFrame({"a": range(10)}, index=idx)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -167,6 +167,10 @@ class TestRangeIndex(Numeric):
         idx.any()
         assert idx._cache == {}
 
+        for _ in idx:
+            ...
+        assert idx._cache == {}
+
         df = pd.DataFrame({"a": range(10)}, index=idx)
 
         df.loc[50]


### PR DESCRIPTION
Minor performance issue.

By adding a custom ``__iter__`` method to ``RangeIndex``, we partly avoid needing to create/cache the expensive ``_data`` attribute and partly it's just faster to iterate over a ``range`` than a ``ndarray``:

```python
>>> idx = pd.RangeIndex(100_000)
>>> %%timeit
... for _ in idx:
...     pass
10.9 ms ± 74.7 µs per loop  # master
6.11 ms ± 48.8 µs per loop  # this PR
>>> "_data" in idx._cache
True  # master
False  # this PR
```

xref #35432, #26565.