### PR TITLE
BUG/ENH: compression for google cloud storage in to_csv

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -240,6 +240,8 @@ I/O
 - In :meth:`read_csv` `float_precision='round_trip'` now handles `decimal` and `thousands` parameters (:issue:`35365`)
 - :meth:`to_pickle` and :meth:`read_pickle` were closing user-provided file objects (:issue:`35679`)
 - :meth:`to_csv` passes compression arguments for `'gzip'` always to `gzip.GzipFile` (:issue:`28103`)
+- :meth:`to_csv` did not support zip compression for binary file object not having a filename (:issue: `35058`)
+- :meth:`to_csv` and :meth:`read_csv` did not honor `compression` and `encoding` for path-like objects that are internally converted to file-like objects (:issue:`35677`, :issue:`26124`, and :issue:`32392`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timedelta, tzinfo
 from pathlib import Path
 from typing import (
@@ -8,6 +9,7 @@ from typing import (
     Callable,
     Collection,
     Dict,
+    Generic,
     Hashable,
     List,
     Mapping,
@@ -117,7 +119,13 @@ CompressionDict = Mapping[str, Optional[Union[str, int, bool]]]
 CompressionOptions = Optional[Union[str, CompressionDict]]
 
 
-class IOargs(NamedTuple):
+# lets us bind types
+ModeVar = TypeVar("ModeVar", str, None)
+EncodingVar = TypeVar("EncodingVar", str, None)
+
+
+@dataclass
+class IOargs(Generic[ModeVar, EncodingVar]):
     """
     Return value of io/common.py:get_filepath_or_buffer.
 
@@ -128,7 +136,7 @@ class IOargs(NamedTuple):
     """
 
     filepath_or_buffer: FilePathOrBuffer
-    encoding: Optional[str]
-    compression: CompressionOptions = None
-    should_close: bool = False
-    mode: Optional[str] = None
+    encoding: EncodingVar
+    compression: CompressionOptions
+    should_close: bool
+    mode: Union[ModeVar, str]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -11,6 +11,7 @@ from typing import (
     Hashable,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Type,
     TypeVar,
@@ -114,3 +115,20 @@ StorageOptions = Optional[Dict[str, Any]]
 # compression keywords and compression
 CompressionDict = Mapping[str, Optional[Union[str, int, bool]]]
 CompressionOptions = Optional[Union[str, CompressionDict]]
+
+
+class IOargs(NamedTuple):
+    """
+    Return value of io/common.py:get_filepath_or_buffer.
+
+    Note (copy&past from io/parsers):
+    filepath_or_buffer can be Union[FilePathOrBuffer, s3fs.S3File, gcsfs.GCSFile]
+    though mypy handling of conditional imports is difficult.
+    See https://github.com/python/mypy/issues/1297
+    """
+
+    filepath_or_buffer: FilePathOrBuffer
+    encoding: Optional[str]
+    compression: CompressionOptions = None
+    should_close: bool = False
+    mode: Optional[str] = None

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta, tzinfo
+from io import IOBase
 from pathlib import Path
 from typing import (
     IO,
@@ -13,7 +14,6 @@ from typing import (
     Hashable,
     List,
     Mapping,
-    NamedTuple,
     Optional,
     Type,
     TypeVar,
@@ -65,7 +65,8 @@ Dtype = Union[
     "ExtensionDtype", str, np.dtype, Type[Union[str, float, int, complex, bool]]
 ]
 DtypeObj = Union[np.dtype, "ExtensionDtype"]
-FilePathOrBuffer = Union[str, Path, IO[AnyStr]]
+FilePathOrBuffer = Union[str, Path, IO[AnyStr], IOBase]
+FileOrBuffer = Union[str, IO[AnyStr], IOBase]
 
 # FrameOrSeriesUnion  means either a DataFrame or a Series. E.g.
 # `def func(a: FrameOrSeriesUnion) -> FrameOrSeriesUnion: ...` means that if a Series
@@ -119,9 +120,9 @@ CompressionDict = Mapping[str, Optional[Union[str, int, bool]]]
 CompressionOptions = Optional[Union[str, CompressionDict]]
 
 
-# lets us bind types
-ModeVar = TypeVar("ModeVar", str, None)
-EncodingVar = TypeVar("EncodingVar", str, None)
+# let's bind types
+ModeVar = TypeVar("ModeVar", str, None, Optional[str])
+EncodingVar = TypeVar("EncodingVar", str, None, Optional[str])
 
 
 @dataclass
@@ -135,7 +136,7 @@ class IOargs(Generic[ModeVar, EncodingVar]):
     See https://github.com/python/mypy/issues/1297
     """
 
-    filepath_or_buffer: FilePathOrBuffer
+    filepath_or_buffer: FileOrBuffer
     encoding: EncodingVar
     compression: CompressionOptions
     should_close: bool

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2281,13 +2281,11 @@ class DataFrame(NDFrame):
         result = tabulate.tabulate(self, **kwargs)
         if buf is None:
             return result
-        buf, _, _, should_close, _ = get_filepath_or_buffer(
-            buf, mode=mode, storage_options=storage_options
-        )
-        assert not isinstance(buf, str)
-        buf.writelines(result)
-        if should_close:
-            buf.close()
+        ioargs = get_filepath_or_buffer(buf, mode=mode, storage_options=storage_options)
+        assert not isinstance(ioargs.filepath_or_buffer, str)
+        ioargs.filepath_or_buffer.writelines(result)
+        if ioargs.should_close:
+            ioargs.filepath_or_buffer.close()
         return None
 
     @deprecate_kwarg(old_arg_name="fname", new_arg_name="path")

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2281,10 +2281,9 @@ class DataFrame(NDFrame):
         result = tabulate.tabulate(self, **kwargs)
         if buf is None:
             return result
-        buf, _, _, should_close = get_filepath_or_buffer(
+        buf, _, _, should_close, _ = get_filepath_or_buffer(  # type: ignore
             buf, mode=mode, storage_options=storage_options
         )
-        assert buf is not None  # Help mypy.
         assert not isinstance(buf, str)
         buf.writelines(result)
         if should_close:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2281,7 +2281,7 @@ class DataFrame(NDFrame):
         result = tabulate.tabulate(self, **kwargs)
         if buf is None:
             return result
-        buf, _, _, should_close, _ = get_filepath_or_buffer(  # type: ignore
+        buf, _, _, should_close, _ = get_filepath_or_buffer(
             buf, mode=mode, storage_options=storage_options
         )
         assert not isinstance(buf, str)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3249,7 +3249,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         formatter.save()
 
         if path_or_buf is None:
-            return formatter.path_or_buf.getvalue()
+            return formatter.path_or_buf.getvalue()  # type: ignore
 
         return None
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2,6 +2,7 @@ import collections
 from datetime import timedelta
 import functools
 import gc
+from io import StringIO
 import json
 import operator
 import pickle
@@ -3249,6 +3250,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         formatter.save()
 
         if path_or_buf is None:
+            assert isinstance(formatter.path_or_buf, StringIO)
             return formatter.path_or_buf.getvalue()
 
         return None

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3249,7 +3249,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         formatter.save()
 
         if path_or_buf is None:
-            return formatter.path_or_buf.getvalue()  # type: ignore
+            return formatter.path_or_buf.getvalue()
 
         return None
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -33,8 +33,11 @@ import zipfile
 from pandas._typing import (
     CompressionDict,
     CompressionOptions,
+    EncodingVar,
     FilePathOrBuffer,
+    FilePathOrBufferVar,
     IOargs,
+    ModeVar,
     StorageOptions,
 )
 from pandas.compat import _get_lzma_file, _import_lzma
@@ -166,11 +169,11 @@ def is_fsspec_url(url: FilePathOrBuffer) -> bool:
 
 def get_filepath_or_buffer(
     filepath_or_buffer: FilePathOrBuffer,
-    encoding: Optional[str] = None,
+    encoding: EncodingVar = None,  # type: ignore[assignment]
     compression: CompressionOptions = None,
-    mode: Optional[str] = None,
+    mode: ModeVar = None,  # type: ignore[assignment]
     storage_options: StorageOptions = None,
-) -> IOargs:
+) -> IOargs[ModeVar, EncodingVar]:
     """
     If the filepath_or_buffer is a url, translate and return the buffer.
     Otherwise passthrough.

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -354,7 +354,7 @@ class _BaseExcelReader(metaclass=abc.ABCMeta):
         elif not isinstance(filepath_or_buffer, (ExcelFile, self._workbook_class)):
             filepath_or_buffer = get_filepath_or_buffer(
                 filepath_or_buffer, storage_options=storage_options
-            )[0]
+            ).filepath_or_buffer
 
         if isinstance(filepath_or_buffer, self._workbook_class):
             self.book = filepath_or_buffer

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -352,9 +352,9 @@ class _BaseExcelReader(metaclass=abc.ABCMeta):
         if is_url(filepath_or_buffer):
             filepath_or_buffer = BytesIO(urlopen(filepath_or_buffer).read())
         elif not isinstance(filepath_or_buffer, (ExcelFile, self._workbook_class)):
-            filepath_or_buffer, _, _, _ = get_filepath_or_buffer(
+            filepath_or_buffer = get_filepath_or_buffer(
                 filepath_or_buffer, storage_options=storage_options
-            )
+            )[0]
 
         if isinstance(filepath_or_buffer, self._workbook_class):
             self.book = filepath_or_buffer

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -34,9 +34,7 @@ def to_feather(df: DataFrame, path, storage_options: StorageOptions = None, **kw
     import_optional_dependency("pyarrow")
     from pyarrow import feather
 
-    path, _, _, should_close, _ = get_filepath_or_buffer(
-        path, mode="wb", storage_options=storage_options
-    )
+    ioargs = get_filepath_or_buffer(path, mode="wb", storage_options=storage_options)
 
     if not isinstance(df, DataFrame):
         raise ValueError("feather only support IO with DataFrames")
@@ -74,7 +72,11 @@ def to_feather(df: DataFrame, path, storage_options: StorageOptions = None, **kw
     if df.columns.inferred_type not in valid_types:
         raise ValueError("feather must have string column names")
 
-    feather.write_feather(df, path, **kwargs)
+    feather.write_feather(df, ioargs.filepath_or_buffer, **kwargs)
+
+    if ioargs.should_close:
+        assert not isinstance(ioargs.filepath_or_buffer, str)
+        ioargs.filepath_or_buffer.close()
 
 
 def read_feather(
@@ -122,14 +124,15 @@ def read_feather(
     import_optional_dependency("pyarrow")
     from pyarrow import feather
 
-    path, _, _, should_close, _ = get_filepath_or_buffer(
-        path, storage_options=storage_options
+    ioargs = get_filepath_or_buffer(path, storage_options=storage_options)
+
+    df = feather.read_feather(
+        ioargs.filepath_or_buffer, columns=columns, use_threads=bool(use_threads)
     )
 
-    df = feather.read_feather(path, columns=columns, use_threads=bool(use_threads))
-
     # s3fs only validates the credentials when the file is closed.
-    if should_close:
-        path.close()
+    if ioargs.should_close:
+        assert not isinstance(ioargs.filepath_or_buffer, str)
+        ioargs.filepath_or_buffer.close()
 
     return df

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -34,7 +34,7 @@ def to_feather(df: DataFrame, path, storage_options: StorageOptions = None, **kw
     import_optional_dependency("pyarrow")
     from pyarrow import feather
 
-    path, _, _, should_close = get_filepath_or_buffer(
+    path, _, _, should_close, _ = get_filepath_or_buffer(
         path, mode="wb", storage_options=storage_options
     )
 
@@ -122,7 +122,7 @@ def read_feather(
     import_optional_dependency("pyarrow")
     from pyarrow import feather
 
-    path, _, _, should_close = get_filepath_or_buffer(
+    path, _, _, should_close, _ = get_filepath_or_buffer(
         path, storage_options=storage_options
     )
 

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -62,14 +62,22 @@ class CSVFormatter:
 
         # Extract compression mode as given, if dict
         compression, self.compression_args = get_compression_method(compression)
+        self.compression = infer_compression(path_or_buf, compression)
 
-        self.path_or_buf, _, _, self.should_close = get_filepath_or_buffer(
+        (
+            self.path_or_buf,
+            _,
+            _,
+            self.should_close,
+            mode,  # type: ignore
+        ) = get_filepath_or_buffer(
             path_or_buf,
             encoding=encoding,
-            compression=compression,
+            compression=self.compression,
             mode=mode,
             storage_options=storage_options,
         )
+        assert self.path_or_buf is not None
         self.sep = sep
         self.na_rep = na_rep
         self.float_format = float_format
@@ -83,7 +91,6 @@ class CSVFormatter:
             encoding = "utf-8"
         self.encoding = encoding
         self.errors = errors
-        self.compression = infer_compression(self.path_or_buf, compression)
 
         if quoting is None:
             quoting = csvlib.QUOTE_MINIMAL

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -64,14 +64,17 @@ class CSVFormatter:
         compression, self.compression_args = get_compression_method(compression)
         self.compression = infer_compression(path_or_buf, compression)
 
-        (self.path_or_buf, _, _, self.should_close, mode,) = get_filepath_or_buffer(
+        ioargs = get_filepath_or_buffer(
             path_or_buf,
             encoding=encoding,
             compression=self.compression,
             mode=mode,
             storage_options=storage_options,
         )
-        assert self.path_or_buf is not None
+        self.path_or_buf = ioargs.filepath_or_buffer
+        self.should_close = ioargs.should_close
+        self.mode = ioargs.mode
+
         self.sep = sep
         self.na_rep = na_rep
         self.float_format = float_format
@@ -80,7 +83,6 @@ class CSVFormatter:
         self.header = header
         self.index = index
         self.index_label = index_label
-        self.mode = mode
         if encoding is None:
             encoding = "utf-8"
         self.encoding = encoding

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -64,13 +64,7 @@ class CSVFormatter:
         compression, self.compression_args = get_compression_method(compression)
         self.compression = infer_compression(path_or_buf, compression)
 
-        (
-            self.path_or_buf,
-            _,
-            _,
-            self.should_close,
-            mode,  # type: ignore
-        ) = get_filepath_or_buffer(
+        (self.path_or_buf, _, _, self.should_close, mode,) = get_filepath_or_buffer(
             path_or_buf,
             encoding=encoding,
             compression=self.compression,

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -645,7 +645,7 @@ def read_json(
 
     result = json_reader.read()
     if should_close:
-        filepath_or_buffer.close()  # type: ignore
+        filepath_or_buffer.close()
 
     return result
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -58,12 +58,14 @@ def to_json(
         )
 
     if path_or_buf is not None:
-        path_or_buf, _, _, should_close, _ = get_filepath_or_buffer(
+        ioargs = get_filepath_or_buffer(
             path_or_buf,
             compression=compression,
             mode="wt",
             storage_options=storage_options,
         )
+        path_or_buf = ioargs.filepath_or_buffer
+        should_close = ioargs.should_close
 
     if lines and orient != "records":
         raise ValueError("'lines' keyword only valid when 'orient' is records")
@@ -102,6 +104,8 @@ def to_json(
             fh.write(s)
         finally:
             fh.close()
+        for handle in handles:
+            handle.close()
     elif path_or_buf is None:
         return s
     else:
@@ -615,7 +619,7 @@ def read_json(
     compression_method, compression = get_compression_method(compression)
     compression_method = infer_compression(path_or_buf, compression_method)
     compression = dict(compression, method=compression_method)
-    filepath_or_buffer, _, compression, should_close, _ = get_filepath_or_buffer(
+    ioargs = get_filepath_or_buffer(
         path_or_buf,
         encoding=encoding,
         compression=compression,
@@ -623,7 +627,7 @@ def read_json(
     )
 
     json_reader = JsonReader(
-        filepath_or_buffer,
+        ioargs.filepath_or_buffer,
         orient=orient,
         typ=typ,
         dtype=dtype,
@@ -633,10 +637,10 @@ def read_json(
         numpy=numpy,
         precise_float=precise_float,
         date_unit=date_unit,
-        encoding=encoding,
+        encoding=ioargs.encoding,
         lines=lines,
         chunksize=chunksize,
-        compression=compression,
+        compression=ioargs.compression,
         nrows=nrows,
     )
 
@@ -644,8 +648,9 @@ def read_json(
         return json_reader
 
     result = json_reader.read()
-    if should_close:
-        filepath_or_buffer.close()
+    if ioargs.should_close:
+        assert not isinstance(ioargs.filepath_or_buffer, str)
+        ioargs.filepath_or_buffer.close()
 
     return result
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -58,7 +58,7 @@ def to_json(
         )
 
     if path_or_buf is not None:
-        path_or_buf, _, _, should_close = get_filepath_or_buffer(
+        path_or_buf, _, _, should_close, _ = get_filepath_or_buffer(
             path_or_buf,
             compression=compression,
             mode="wt",
@@ -615,7 +615,7 @@ def read_json(
     compression_method, compression = get_compression_method(compression)
     compression_method = infer_compression(path_or_buf, compression_method)
     compression = dict(compression, method=compression_method)
-    filepath_or_buffer, _, compression, should_close = get_filepath_or_buffer(
+    filepath_or_buffer, _, compression, should_close, _ = get_filepath_or_buffer(
         path_or_buf,
         encoding=encoding,
         compression=compression,
@@ -645,7 +645,7 @@ def read_json(
 
     result = json_reader.read()
     if should_close:
-        filepath_or_buffer.close()
+        filepath_or_buffer.close()  # type: ignore
 
     return result
 

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -50,7 +50,7 @@ def read_orc(
 
     import pyarrow.orc
 
-    path = get_filepath_or_buffer(path)[0]
-    orc_file = pyarrow.orc.ORCFile(path)
+    ioargs = get_filepath_or_buffer(path)
+    orc_file = pyarrow.orc.ORCFile(ioargs.filepath_or_buffer)
     result = orc_file.read(columns=columns, **kwargs).to_pandas()
     return result

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -50,7 +50,7 @@ def read_orc(
 
     import pyarrow.orc
 
-    path, _, _, _ = get_filepath_or_buffer(path)
+    path = get_filepath_or_buffer(path)[0]
     orc_file = pyarrow.orc.ORCFile(path)
     result = orc_file.read(columns=columns, **kwargs).to_pandas()
     return result

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -146,7 +146,7 @@ class PyArrowImpl(BaseImpl):
             path = _expand_user(path)
 
         if not fs:
-            path, _, _, should_close = get_filepath_or_buffer(path)
+            path, _, _, should_close, _ = get_filepath_or_buffer(path)
 
         kwargs["use_pandas_metadata"] = True
         result = self.api.parquet.read_table(
@@ -205,7 +205,7 @@ class FastParquetImpl(BaseImpl):
                 raise ValueError(
                     "storage_options passed with file object or non-fsspec file path"
                 )
-            path, _, _, _ = get_filepath_or_buffer(path)
+            path = get_filepath_or_buffer(path)[0]
 
         with catch_warnings(record=True):
             self.api.write(
@@ -228,7 +228,7 @@ class FastParquetImpl(BaseImpl):
             ).open()
             parquet_file = self.api.ParquetFile(path, open_with=open_with)
         else:
-            path, _, _, _ = get_filepath_or_buffer(path)
+            path = get_filepath_or_buffer(path)[0]
             parquet_file = self.api.ParquetFile(path)
 
         return parquet_file.to_pandas(columns=columns, **kwargs)

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -9,7 +9,7 @@ from pandas.errors import AbstractMethodError
 
 from pandas import DataFrame, get_option
 
-from pandas.io.common import _expand_user, get_filepath_or_buffer, is_fsspec_url
+from pandas.io.common import get_filepath_or_buffer, is_fsspec_url, stringify_path
 
 
 def get_engine(engine: str) -> "BaseImpl":
@@ -113,7 +113,7 @@ class PyArrowImpl(BaseImpl):
                 raise ValueError(
                     "storage_options passed with file object or non-fsspec file path"
                 )
-            path = _expand_user(path)
+            path = stringify_path(path)
         if partition_cols is not None:
             # writes to multiple files under the given path
             self.api.parquet.write_to_dataset(
@@ -143,10 +143,12 @@ class PyArrowImpl(BaseImpl):
                 )
             fs = kwargs.pop("filesystem", None)
             should_close = False
-            path = _expand_user(path)
+            path = stringify_path(path)
 
         if not fs:
-            path, _, _, should_close, _ = get_filepath_or_buffer(path)
+            ioargs = get_filepath_or_buffer(path)
+            path = ioargs.filepath_or_buffer
+            should_close = ioargs.should_close
 
         kwargs["use_pandas_metadata"] = True
         result = self.api.parquet.read_table(
@@ -205,7 +207,7 @@ class FastParquetImpl(BaseImpl):
                 raise ValueError(
                     "storage_options passed with file object or non-fsspec file path"
                 )
-            path = get_filepath_or_buffer(path)[0]
+            path = get_filepath_or_buffer(path).filepath_or_buffer
 
         with catch_warnings(record=True):
             self.api.write(
@@ -228,7 +230,7 @@ class FastParquetImpl(BaseImpl):
             ).open()
             parquet_file = self.api.ParquetFile(path, open_with=open_with)
         else:
-            path = get_filepath_or_buffer(path)[0]
+            path = get_filepath_or_buffer(path).filepath_or_buffer
             parquet_file = self.api.ParquetFile(path)
 
         return parquet_file.to_pandas(columns=columns, **kwargs)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -462,7 +462,7 @@ def _read(filepath_or_buffer: FilePathOrBuffer, kwds):
 
     if should_close:
         try:
-            fp_or_buf.close()  # type: ignore
+            fp_or_buf.close()
         except ValueError:
             pass
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -432,10 +432,10 @@ def _read(filepath_or_buffer: FilePathOrBuffer, kwds):
     # Union[FilePathOrBuffer, s3fs.S3File, gcsfs.GCSFile]
     # though mypy handling of conditional imports is difficult.
     # See https://github.com/python/mypy/issues/1297
-    fp_or_buf, _, compression, should_close, _ = get_filepath_or_buffer(
+    ioargs = get_filepath_or_buffer(
         filepath_or_buffer, encoding, compression, storage_options=storage_options
     )
-    kwds["compression"] = compression
+    kwds["compression"] = ioargs.compression
 
     if kwds.get("date_parser", None) is not None:
         if isinstance(kwds["parse_dates"], bool):
@@ -450,7 +450,7 @@ def _read(filepath_or_buffer: FilePathOrBuffer, kwds):
     _validate_names(kwds.get("names", None))
 
     # Create the parser.
-    parser = TextFileReader(fp_or_buf, **kwds)
+    parser = TextFileReader(ioargs.filepath_or_buffer, **kwds)
 
     if chunksize or iterator:
         return parser
@@ -460,9 +460,10 @@ def _read(filepath_or_buffer: FilePathOrBuffer, kwds):
     finally:
         parser.close()
 
-    if should_close:
+    if ioargs.should_close:
+        assert not isinstance(ioargs.filepath_or_buffer, str)
         try:
-            fp_or_buf.close()
+            ioargs.filepath_or_buffer.close()
         except ValueError:
             pass
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -432,7 +432,7 @@ def _read(filepath_or_buffer: FilePathOrBuffer, kwds):
     # Union[FilePathOrBuffer, s3fs.S3File, gcsfs.GCSFile]
     # though mypy handling of conditional imports is difficult.
     # See https://github.com/python/mypy/issues/1297
-    fp_or_buf, _, compression, should_close = get_filepath_or_buffer(
+    fp_or_buf, _, compression, should_close, _ = get_filepath_or_buffer(
         filepath_or_buffer, encoding, compression, storage_options=storage_options
     )
     kwds["compression"] = compression
@@ -462,7 +462,7 @@ def _read(filepath_or_buffer: FilePathOrBuffer, kwds):
 
     if should_close:
         try:
-            fp_or_buf.close()
+            fp_or_buf.close()  # type: ignore
         except ValueError:
             pass
 

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -107,7 +107,7 @@ def to_pickle(
             _f.close()
         if should_close:
             try:
-                fp_or_buf.close()  # type: ignore
+                fp_or_buf.close()
             except ValueError:
                 pass
 

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -86,7 +86,7 @@ def to_pickle(
     >>> import os
     >>> os.remove("./dummy.pkl")
     """
-    fp_or_buf, _, compression, should_close = get_filepath_or_buffer(
+    fp_or_buf, _, compression, should_close, _ = get_filepath_or_buffer(
         filepath_or_buffer,
         compression=compression,
         mode="wb",
@@ -107,7 +107,7 @@ def to_pickle(
             _f.close()
         if should_close:
             try:
-                fp_or_buf.close()
+                fp_or_buf.close()  # type: ignore
             except ValueError:
                 pass
 
@@ -189,7 +189,7 @@ def read_pickle(
     >>> import os
     >>> os.remove("./dummy.pkl")
     """
-    fp_or_buf, _, compression, should_close = get_filepath_or_buffer(
+    fp_or_buf, _, compression, should_close, _ = get_filepath_or_buffer(
         filepath_or_buffer, compression=compression, storage_options=storage_options
     )
     if not isinstance(fp_or_buf, str) and compression == "infer":
@@ -224,6 +224,6 @@ def read_pickle(
             _f.close()
         if should_close:
             try:
-                fp_or_buf.close()
+                fp_or_buf.close()  # type: ignore
             except ValueError:
                 pass

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -86,15 +86,18 @@ def to_pickle(
     >>> import os
     >>> os.remove("./dummy.pkl")
     """
-    fp_or_buf, _, compression, should_close, _ = get_filepath_or_buffer(
+    ioargs = get_filepath_or_buffer(
         filepath_or_buffer,
         compression=compression,
         mode="wb",
         storage_options=storage_options,
     )
-    if not isinstance(fp_or_buf, str) and compression == "infer":
+    compression = ioargs.compression
+    if not isinstance(ioargs.filepath_or_buffer, str) and compression == "infer":
         compression = None
-    f, fh = get_handle(fp_or_buf, "wb", compression=compression, is_text=False)
+    f, fh = get_handle(
+        ioargs.filepath_or_buffer, "wb", compression=compression, is_text=False
+    )
     if protocol < 0:
         protocol = pickle.HIGHEST_PROTOCOL
     try:
@@ -105,9 +108,10 @@ def to_pickle(
             f.close()
         for _f in fh:
             _f.close()
-        if should_close:
+        if ioargs.should_close:
+            assert not isinstance(ioargs.filepath_or_buffer, str)
             try:
-                fp_or_buf.close()
+                ioargs.filepath_or_buffer.close()
             except ValueError:
                 pass
 
@@ -189,12 +193,15 @@ def read_pickle(
     >>> import os
     >>> os.remove("./dummy.pkl")
     """
-    fp_or_buf, _, compression, should_close, _ = get_filepath_or_buffer(
+    ioargs = get_filepath_or_buffer(
         filepath_or_buffer, compression=compression, storage_options=storage_options
     )
-    if not isinstance(fp_or_buf, str) and compression == "infer":
+    compression = ioargs.compression
+    if not isinstance(ioargs.filepath_or_buffer, str) and compression == "infer":
         compression = None
-    f, fh = get_handle(fp_or_buf, "rb", compression=compression, is_text=False)
+    f, fh = get_handle(
+        ioargs.filepath_or_buffer, "rb", compression=compression, is_text=False
+    )
 
     # 1) try standard library Pickle
     # 2) try pickle_compat (older pandas version) to handle subclass changes
@@ -222,8 +229,9 @@ def read_pickle(
             f.close()
         for _f in fh:
             _f.close()
-        if should_close:
+        if ioargs.should_close:
+            assert not isinstance(ioargs.filepath_or_buffer, str)
             try:
-                fp_or_buf.close()  # type: ignore
+                ioargs.filepath_or_buffer.close()
             except ValueError:
                 pass

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -137,7 +137,7 @@ class SAS7BDATReader(ReaderBase, abc.Iterator):
         self._current_row_on_page_index = 0
         self._current_row_in_file_index = 0
 
-        self._path_or_buf = get_filepath_or_buffer(path_or_buf)[0]
+        self._path_or_buf = get_filepath_or_buffer(path_or_buf).filepath_or_buffer
         if isinstance(self._path_or_buf, str):
             self._path_or_buf = open(self._path_or_buf, "rb")
             self.handle = self._path_or_buf

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -137,7 +137,7 @@ class SAS7BDATReader(ReaderBase, abc.Iterator):
         self._current_row_on_page_index = 0
         self._current_row_in_file_index = 0
 
-        self._path_or_buf, _, _, _ = get_filepath_or_buffer(path_or_buf)
+        self._path_or_buf = get_filepath_or_buffer(path_or_buf)[0]
         if isinstance(self._path_or_buf, str):
             self._path_or_buf = open(self._path_or_buf, "rb")
             self.handle = self._path_or_buf

--- a/pandas/io/sas/sas_xport.py
+++ b/pandas/io/sas/sas_xport.py
@@ -258,6 +258,7 @@ class XportReader(ReaderBase, abc.Iterator):
                 encoding,
                 compression,
                 should_close,
+                _,
             ) = get_filepath_or_buffer(filepath_or_buffer, encoding=encoding)
 
         if isinstance(filepath_or_buffer, (str, bytes)):

--- a/pandas/io/sas/sas_xport.py
+++ b/pandas/io/sas/sas_xport.py
@@ -253,13 +253,9 @@ class XportReader(ReaderBase, abc.Iterator):
         self._chunksize = chunksize
 
         if isinstance(filepath_or_buffer, str):
-            (
-                filepath_or_buffer,
-                encoding,
-                compression,
-                should_close,
-                _,
-            ) = get_filepath_or_buffer(filepath_or_buffer, encoding=encoding)
+            filepath_or_buffer = get_filepath_or_buffer(
+                filepath_or_buffer, encoding=encoding
+            ).filepath_or_buffer
 
         if isinstance(filepath_or_buffer, (str, bytes)):
             self.filepath_or_buffer = open(filepath_or_buffer, "rb")

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -109,22 +109,26 @@ def read_sas(
         else:
             raise ValueError("unable to infer format of SAS file")
 
-    filepath_or_buffer, _, _, should_close, _ = get_filepath_or_buffer(
-        filepath_or_buffer, encoding
-    )
+    ioargs = get_filepath_or_buffer(filepath_or_buffer, encoding)
 
     reader: ReaderBase
     if format.lower() == "xport":
         from pandas.io.sas.sas_xport import XportReader
 
         reader = XportReader(
-            filepath_or_buffer, index=index, encoding=encoding, chunksize=chunksize
+            ioargs.filepath_or_buffer,
+            index=index,
+            encoding=ioargs.encoding,
+            chunksize=chunksize,
         )
     elif format.lower() == "sas7bdat":
         from pandas.io.sas.sas7bdat import SAS7BDATReader
 
         reader = SAS7BDATReader(
-            filepath_or_buffer, index=index, encoding=encoding, chunksize=chunksize
+            ioargs.filepath_or_buffer,
+            index=index,
+            encoding=ioargs.encoding,
+            chunksize=chunksize,
         )
     else:
         raise ValueError("unknown SAS format")
@@ -134,6 +138,6 @@ def read_sas(
 
     data = reader.read()
 
-    if should_close:
+    if ioargs.should_close:
         reader.close()
     return data

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -109,7 +109,7 @@ def read_sas(
         else:
             raise ValueError("unable to infer format of SAS file")
 
-    filepath_or_buffer, _, _, should_close = get_filepath_or_buffer(
+    filepath_or_buffer, _, _, should_close, _ = get_filepath_or_buffer(
         filepath_or_buffer, encoding
     )
 

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1069,7 +1069,7 @@ class StataReader(StataParser, abc.Iterator):
         self._native_byteorder = _set_endianness(sys.byteorder)
         path_or_buf = stringify_path(path_or_buf)
         if isinstance(path_or_buf, str):
-            path_or_buf, encoding, _, should_close = get_filepath_or_buffer(
+            path_or_buf, encoding, _, should_close, _ = get_filepath_or_buffer(
                 path_or_buf, storage_options=storage_options
             )
 
@@ -1979,7 +1979,7 @@ def _open_file_binary_write(
         compression_typ, compression_args = get_compression_method(compression)
         compression_typ = infer_compression(fname, compression_typ)
         compression = dict(compression_args, method=compression_typ)
-        path_or_buf, _, compression, _ = get_filepath_or_buffer(
+        path_or_buf, _, compression, _, _ = get_filepath_or_buffer(
             fname, mode="wb", compression=compression, storage_options=storage_options,
         )
         f, _ = get_handle(path_or_buf, "wb", compression=compression, is_text=False)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1069,9 +1069,9 @@ class StataReader(StataParser, abc.Iterator):
         self._native_byteorder = _set_endianness(sys.byteorder)
         path_or_buf = stringify_path(path_or_buf)
         if isinstance(path_or_buf, str):
-            path_or_buf, encoding, _, should_close, _ = get_filepath_or_buffer(
+            path_or_buf = get_filepath_or_buffer(
                 path_or_buf, storage_options=storage_options
-            )
+            ).filepath_or_buffer
 
         if isinstance(path_or_buf, (str, bytes)):
             self.path_or_buf = open(path_or_buf, "rb")
@@ -1979,11 +1979,16 @@ def _open_file_binary_write(
         compression_typ, compression_args = get_compression_method(compression)
         compression_typ = infer_compression(fname, compression_typ)
         compression = dict(compression_args, method=compression_typ)
-        path_or_buf, _, compression, _, _ = get_filepath_or_buffer(
+        ioargs = get_filepath_or_buffer(
             fname, mode="wb", compression=compression, storage_options=storage_options,
         )
-        f, _ = get_handle(path_or_buf, "wb", compression=compression, is_text=False)
-        return f, True, compression
+        f, _ = get_handle(
+            ioargs.filepath_or_buffer,
+            "wb",
+            compression=ioargs.compression,
+            is_text=False,
+        )
+        return f, True, ioargs.compression
     else:
         raise TypeError("fname must be a binary file, buffer or path-like.")
 

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -105,23 +105,21 @@ bar2,12,13,14,15
         compression = icom.infer_compression(path, compression="infer")
         assert compression == expected
 
-    def test_get_filepath_or_buffer_with_path(self):
-        filename = "~/sometest"
-        filepath_or_buffer, _, _, should_close, _ = icom.get_filepath_or_buffer(
-            filename
-        )
-        assert filepath_or_buffer != filename
-        assert os.path.isabs(filepath_or_buffer)
-        assert os.path.expanduser(filename) == filepath_or_buffer
-        assert not should_close
+    @pytest.mark.parametrize("path_type", [str, CustomFSPath, Path])
+    def test_get_filepath_or_buffer_with_path(self, path_type):
+        # ignore LocalPath: it creates strange paths: /absolute/~/sometest
+        filename = path_type("~/sometest")
+        ioargs = icom.get_filepath_or_buffer(filename)
+        assert ioargs.filepath_or_buffer != filename
+        assert os.path.isabs(ioargs.filepath_or_buffer)
+        assert os.path.expanduser(filename) == ioargs.filepath_or_buffer
+        assert not ioargs.should_close
 
     def test_get_filepath_or_buffer_with_buffer(self):
         input_buffer = StringIO()
-        filepath_or_buffer, _, _, should_close, _ = icom.get_filepath_or_buffer(
-            input_buffer
-        )
-        assert filepath_or_buffer == input_buffer
-        assert not should_close
+        ioargs = icom.get_filepath_or_buffer(input_buffer)
+        assert ioargs.filepath_or_buffer == input_buffer
+        assert not ioargs.should_close
 
     def test_iterator(self):
         reader = pd.read_csv(StringIO(self.data1), chunksize=1)

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -124,6 +124,8 @@ def test_compression_binary(compression_only):
     GH22555
     """
     df = tm.makeDataFrame()
+
+    # with a file
     with tm.ensure_clean() as path:
         with open(path, mode="wb") as file:
             df.to_csv(file, mode="wb", compression=compression_only)
@@ -131,6 +133,14 @@ def test_compression_binary(compression_only):
         tm.assert_frame_equal(
             df, pd.read_csv(path, index_col=0, compression=compression_only)
         )
+
+    # with BytesIO
+    file = io.BytesIO()
+    df.to_csv(file, mode="wb", compression=compression_only)
+    file.seek(0)  # file shouldn't be closed
+    tm.assert_frame_equal(
+        df, pd.read_csv(file, index_col=0, compression=compression_only)
+    )
 
 
 def test_gzip_reproducibility_file_name():

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -9,9 +9,29 @@ import pandas._testing as tm
 from pandas.util import _test_decorators as td
 
 
-@td.skip_if_no("gcsfs")
-def test_read_csv_gcs(monkeypatch):
+@pytest.fixture
+def gcs_buffer(monkeypatch):
+    """Emulate GCS using a binary buffer."""
     from fsspec import AbstractFileSystem, registry
+
+    registry.target.clear()  # noqa  # remove state
+
+    gcs_buffer = BytesIO()
+    gcs_buffer.close = lambda: True
+
+    class MockGCSFileSystem(AbstractFileSystem):
+        def open(*args, **kwargs):
+            gcs_buffer.seek(0)
+            return gcs_buffer
+
+    monkeypatch.setattr("gcsfs.GCSFileSystem", MockGCSFileSystem)
+
+    return gcs_buffer
+
+
+@td.skip_if_no("gcsfs")
+def test_read_csv_gcs(gcs_buffer):
+    from fsspec import registry
 
     registry.target.clear()  # noqa  # remove state
 
@@ -24,21 +44,19 @@ def test_read_csv_gcs(monkeypatch):
         }
     )
 
-    class MockGCSFileSystem(AbstractFileSystem):
-        def open(*args, **kwargs):
-            return BytesIO(df1.to_csv(index=False).encode())
+    gcs_buffer.write(df1.to_csv(index=False).encode())
 
-    monkeypatch.setattr("gcsfs.GCSFileSystem", MockGCSFileSystem)
     df2 = read_csv("gs://test/test.csv", parse_dates=["dt"])
 
     tm.assert_frame_equal(df1, df2)
 
 
 @td.skip_if_no("gcsfs")
-def test_to_csv_gcs(monkeypatch):
-    from fsspec import AbstractFileSystem, registry
+def test_to_csv_gcs(gcs_buffer):
+    from fsspec import registry
 
     registry.target.clear()  # noqa  # remove state
+
     df1 = DataFrame(
         {
             "int": [1, 3],
@@ -47,27 +65,55 @@ def test_to_csv_gcs(monkeypatch):
             "dt": date_range("2018-06-18", periods=2),
         }
     )
-    s = BytesIO()
-    s.close = lambda: True
 
-    class MockGCSFileSystem(AbstractFileSystem):
-        def open(*args, **kwargs):
-            s.seek(0)
-            return s
-
-    monkeypatch.setattr("gcsfs.GCSFileSystem", MockGCSFileSystem)
     df1.to_csv("gs://test/test.csv", index=True)
-
-    def mock_get_filepath_or_buffer(*args, **kwargs):
-        return BytesIO(df1.to_csv(index=True).encode()), None, None, False
-
-    monkeypatch.setattr(
-        "pandas.io.common.get_filepath_or_buffer", mock_get_filepath_or_buffer
-    )
 
     df2 = read_csv("gs://test/test.csv", parse_dates=["dt"], index_col=0)
 
     tm.assert_frame_equal(df1, df2)
+
+
+@td.skip_if_no("gcsfs")
+@pytest.mark.parametrize("encoding", ["utf-8", "cp1251"])
+def test_to_csv_compression_encoding_gcs(gcs_buffer, compression_only, encoding):
+    """
+    Compression and encoding should with GCS.
+
+    GH 35677 (to_csv, compression), GH 26124 (to_csv, encoding), and
+    GH 32392 (read_csv, encoding)
+    """
+    from fsspec import registry
+
+    registry.target.clear()  # noqa  # remove state
+    df = tm.makeDataFrame()
+
+    # reference of compressed and encoded file
+    compression = {"method": compression_only}
+    if compression_only == "gzip":
+        compression["mtime"] = 1  # be reproducible
+    buffer = BytesIO()
+    df.to_csv(buffer, compression=compression, encoding=encoding, mode="wb")
+
+    # write compressed file with explicit compression
+    path_gcs = "gs://test/test.csv"
+    df.to_csv(path_gcs, compression=compression, encoding=encoding)
+    assert gcs_buffer.getvalue() == buffer.getvalue()
+    read_df = read_csv(
+        path_gcs, index_col=0, compression=compression_only, encoding=encoding
+    )
+    tm.assert_frame_equal(df, read_df)
+
+    # write compressed file with implicit compression
+    if compression_only == "gzip":
+        compression_only = "gz"
+    compression["method"] = "infer"
+    path_gcs += f".{compression_only}"
+    df.to_csv(
+        path_gcs, compression=compression, encoding=encoding,
+    )
+    assert gcs_buffer.getvalue() == buffer.getvalue()
+    read_df = read_csv(path_gcs, index_col=0, compression="infer", encoding=encoding)
+    tm.assert_frame_equal(df, read_df)
 
 
 @td.skip_if_no("fastparquet")


### PR DESCRIPTION
- [x] closes #35677, closes #26124, and closes #32392
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

By inferring the compression before converting the path to a file object `df.to_csv("gs://mybucket/test2.csv.gz", compression="infer", mode="wb")` works. By wrapping fsspec file-objects in a `TextIOWrapper` `df.to_csv("gs://mybucket/test2.csv", mode="wb")` works as well. Path-like objects that are internally converted to file-like objects (in `get_filepath_or_buffer`) are now always opened in binary mode (unless text mode is explicitly requested) and the potentially changed mode is returned (no need to specify `mode="wb"` for google cloud files). As long as the google file is opened in binary mode (which is now always the case), we also honor the requested `encoding`.

This PR also fixes Zip compression for file objects not having a name.