### PR TITLE
BUG: to_pickle/read_pickle do not close user-provided file objects

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -234,7 +234,7 @@ I/O
 
 - Bug in :meth:`to_csv` caused a ``ValueError`` when it was called with a filename in combination with ``mode`` containing a ``b`` (:issue:`35058`)
 - In :meth:`read_csv` `float_precision='round_trip'` now handles `decimal` and `thousands` parameters (:issue:`35365`)
--
+- :meth:`to_pickle` and :meth:`read_pickle` were closing user-provided file objects (:issue:`35679`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -100,7 +100,9 @@ def to_pickle(
     try:
         f.write(pickle.dumps(obj, protocol=protocol))
     finally:
-        f.close()
+        if f != filepath_or_buffer:
+            # do not close user-provided file objects GH 35679
+            f.close()
         for _f in fh:
             _f.close()
         if should_close:
@@ -215,7 +217,9 @@ def read_pickle(
         # e.g. can occur for files written in py27; see GH#28645 and GH#31988
         return pc.load(f, encoding="latin-1")
     finally:
-        f.close()
+        if f != filepath_or_buffer:
+            # do not close user-provided file objects GH 35679
+            f.close()
         for _f in fh:
             _f.close()
         if should_close:

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -183,6 +183,15 @@ def test_round_trip_current(current_pickle_data):
                     result = python_unpickler(path)
                     compare_element(result, expected, typ)
 
+                    # and the same for file objects (GH 35679)
+                    with open(path, mode="wb") as handle:
+                        writer(expected, path)
+                        handle.seek(0)  # shouldn't close file handle
+                    with open(path, mode="rb") as handle:
+                        result = pd.read_pickle(handle)
+                        handle.seek(0)  # shouldn't close file handle
+                    compare_element(result, expected, typ)
+
 
 def test_pickle_path_pathlib():
     df = tm.makeDataFrame()


### PR DESCRIPTION
- [x] closes #35679
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Do not close user-provided file-objects in `to_pickle` and `read_pickle`.