### PR TITLE
ENH: GH-35611 Tests for top-level Pandas functions serializable

### DIFF
--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -160,8 +160,10 @@ def test_version_tag():
         )
 
 
-def test_serializable():
-    for name, obj in pd.__dict__.items():
-        if callable(obj):
-            unpickled = tm.round_trip_pickle(obj)
-            assert type(obj) == type(unpickled)
+@pytest.mark.parametrize(
+    "obj", [(obj,) for obj in pd.__dict__.values() if callable(obj)]
+)
+def test_serializable(obj):
+    # GH 35611
+    unpickled = tm.round_trip_pickle(obj)
+    assert type(obj) == type(unpickled)

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -10,6 +10,7 @@ from pandas.compat.numpy import _np_version_under1p17
 
 import pandas as pd
 from pandas import Series, Timestamp
+import pandas._testing as tm
 from pandas.core import ops
 import pandas.core.common as com
 
@@ -157,3 +158,10 @@ def test_version_tag():
         raise ValueError(
             "No git tags exist, please sync tags between upstream and your repo"
         )
+
+
+def test_serializable():
+    for name, obj in pd.__dict__.items():
+        if callable(obj):
+            unpickled = tm.round_trip_pickle(obj)
+            assert type(obj) == type(unpickled)


### PR DESCRIPTION
- [x] closes #35611
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
