### PR TITLE
CI: avoid file leaks in sas_xport tests

### DIFF
--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional, Union, overload
 
 from pandas._typing import FilePathOrBuffer, Label
 
-from pandas.io.common import stringify_path
+from pandas.io.common import get_filepath_or_buffer, stringify_path
 
 if TYPE_CHECKING:
     from pandas import DataFrame  # noqa: F401
@@ -109,6 +109,10 @@ def read_sas(
         else:
             raise ValueError("unable to infer format of SAS file")
 
+    filepath_or_buffer, _, _, should_close = get_filepath_or_buffer(
+        filepath_or_buffer, encoding
+    )
+
     reader: ReaderBase
     if format.lower() == "xport":
         from pandas.io.sas.sas_xport import XportReader
@@ -129,5 +133,7 @@ def read_sas(
         return reader
 
     data = reader.read()
-    reader.close()
+
+    if should_close:
+        reader.close()
     return data

--- a/pandas/tests/io/sas/test_xport.py
+++ b/pandas/tests/io/sas/test_xport.py
@@ -28,14 +28,11 @@ class TestXport:
         self.dirpath = datapath("io", "sas", "data")
         self.file01 = os.path.join(self.dirpath, "DEMO_G.xpt")
         self.file02 = os.path.join(self.dirpath, "SSHSV1_A.xpt")
-        self.file02b = open(os.path.join(self.dirpath, "SSHSV1_A.xpt"), "rb")
         self.file03 = os.path.join(self.dirpath, "DRXFCD_G.xpt")
         self.file04 = os.path.join(self.dirpath, "paxraw_d_short.xpt")
 
         with td.file_leak_context():
             yield
-
-        self.file02b.close()
 
     def test1_basic(self):
         # Tests with DEMO_G.xpt (all numeric file)
@@ -134,7 +131,8 @@ class TestXport:
         data_csv = pd.read_csv(self.file02.replace(".xpt", ".csv"))
         numeric_as_float(data_csv)
 
-        data = read_sas(self.file02b, format="xport")
+        with open(self.file02, "rb") as fd:
+            data = read_sas(fd, format="xport")
         tm.assert_frame_equal(data, data_csv)
 
     def test_multiple_types(self):

--- a/pandas/tests/io/sas/test_xport.py
+++ b/pandas/tests/io/sas/test_xport.py
@@ -3,6 +3,8 @@ import os
 import numpy as np
 import pytest
 
+import pandas.util._test_decorators as td
+
 import pandas as pd
 import pandas._testing as tm
 
@@ -29,6 +31,11 @@ class TestXport:
         self.file02b = open(os.path.join(self.dirpath, "SSHSV1_A.xpt"), "rb")
         self.file03 = os.path.join(self.dirpath, "DRXFCD_G.xpt")
         self.file04 = os.path.join(self.dirpath, "paxraw_d_short.xpt")
+
+        with td.file_leak_context():
+            yield
+
+        self.file02b.close()
 
     def test1_basic(self):
         # Tests with DEMO_G.xpt (all numeric file)

--- a/pandas/tests/io/sas/test_xport.py
+++ b/pandas/tests/io/sas/test_xport.py
@@ -132,7 +132,11 @@ class TestXport:
         numeric_as_float(data_csv)
 
         with open(self.file02, "rb") as fd:
-            data = read_sas(fd, format="xport")
+            with td.file_leak_context():
+                # GH#35693 ensure that if we pass an open file, we
+                #  dont incorrectly close it in read_sas
+                data = read_sas(fd, format="xport")
+
         tm.assert_frame_equal(data, data_csv)
 
     def test_multiple_types(self):

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -23,6 +23,7 @@ def test_foo():
 
 For more information, refer to the ``pytest`` documentation on ``skipif``.
 """
+from contextlib import contextmanager
 from distutils.version import LooseVersion
 from functools import wraps
 import locale
@@ -237,7 +238,7 @@ def parametrize_fixture_doc(*args):
 
 def check_file_leaks(func) -> Callable:
     """
-    Decorate a test function tot check that we are not leaking file descriptors.
+    Decorate a test function to check that we are not leaking file descriptors.
     """
     psutil = safe_import("psutil")
     if not psutil:
@@ -254,6 +255,24 @@ def check_file_leaks(func) -> Callable:
         assert flist2 == flist
 
     return new_func
+
+
+@contextmanager
+def file_leak_context():
+    """
+    ContextManager analogue to check_file_leaks.
+    """
+    psutil = safe_import("psutil")
+    if not psutil:
+        yield
+    else:
+        proc = psutil.Process()
+        flist = proc.open_files()
+
+        yield
+
+        flist2 = proc.open_files()
+        assert flist2 == flist, (flist2, flist)
 
 
 def async_mark():

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -254,11 +254,15 @@ def file_leak_context():
     else:
         proc = psutil.Process()
         flist = proc.open_files()
+        conns = proc.connections()
 
         yield
 
         flist2 = proc.open_files()
         assert flist2 == flist, (flist2, flist)
+
+        conns2 = proc.connections()
+        assert conns2 == conns, (conns2, conns)
 
 
 def async_mark():

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -25,7 +25,6 @@ For more information, refer to the ``pytest`` documentation on ``skipif``.
 """
 from contextlib import contextmanager
 from distutils.version import LooseVersion
-from functools import wraps
 import locale
 from typing import Callable, Optional
 
@@ -240,21 +239,8 @@ def check_file_leaks(func) -> Callable:
     """
     Decorate a test function to check that we are not leaking file descriptors.
     """
-    psutil = safe_import("psutil")
-    if not psutil:
+    with file_leak_context():
         return func
-
-    @wraps(func)
-    def new_func(*args, **kwargs):
-        proc = psutil.Process()
-        flist = proc.open_files()
-
-        func(*args, **kwargs)
-
-        flist2 = proc.open_files()
-        assert flist2 == flist
-
-    return new_func
 
 
 @contextmanager

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -259,7 +259,11 @@ def file_leak_context():
         yield
 
         flist2 = proc.open_files()
-        assert flist2 == flist, (flist2, flist)
+        # on some builds open_files includes file position, which we _dont_
+        #  expect to remain unchanged, so we need to compare excluding that
+        flist_ex = [(x.path, x.fd) for x in flist]
+        flist2_ex = [(x.path, x.fd) for x in flist2]
+        assert flist2_ex == flist_ex, (flist2, flist)
 
         conns2 = proc.connections()
         assert conns2 == conns, (conns2, conns)


### PR DESCRIPTION
Introduces a contextmanager version of td.check_file_leaks so we can do more targeted versions of those checks for debugging