### PR TITLE
PERF: RangeIndex.format performance

### DIFF
--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -540,7 +540,7 @@ with :attr:`numpy.nan` in the case of an empty :class:`DataFrame` (:issue:`26397
 
 .. ipython:: python
 
-    df.describe()
+   df.describe()
 
 ``__str__`` methods now call ``__repr__`` rather than vice versa
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.1.2.rst
+++ b/doc/source/whatsnew/v1.1.2.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Regression in :meth:`DatetimeIndex.intersection` incorrectly raising ``AssertionError`` when intersecting against a list (:issue:`35876`)
--
+- Performance regression for :meth:`RangeIndex.format` (:issue:`35712`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.1.2.rst
+++ b/doc/source/whatsnew/v1.1.2.rst
@@ -15,7 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 
--
+- Performance regression for :meth:`RangeIndex.format` (:issue:`35712`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.1.2.rst
+++ b/doc/source/whatsnew/v1.1.2.rst
@@ -26,7 +26,7 @@ Bug fixes
 ~~~~~~~~~
 - Bug in :meth:`DataFrame.eval` with ``object`` dtype column binary operations (:issue:`35794`)
 - Bug in :meth:`DataFrame.apply` with ``result_type="reduce"`` returning with incorrect index (:issue:`35683`)
--
+- Bug in :meth:`DateTimeIndex.format` and :meth:`PeriodIndex.format` with ``name=True`` setting the first item to ``"None"`` where it should bw ``""`` (:issue:`35712`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.1.2.rst
+++ b/doc/source/whatsnew/v1.1.2.rst
@@ -14,10 +14,10 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
-- Performance regression for :meth:`RangeIndex.format` (:issue:`35712`)
 - Regression in :meth:`DatetimeIndex.intersection` incorrectly raising ``AssertionError`` when intersecting against a list (:issue:`35876`)
 - Performance regression for :meth:`RangeIndex.format` (:issue:`35712`)
 -
+
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -924,7 +924,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         return self._format_with_header(header, na_rep=na_rep)
 
-    def _format_with_header(self, header, na_rep="NaN") -> List[str_t]:
+    def _format_with_header(
+        self, header: List[str_t], na_rep: str_t = "NaN"
+    ) -> List[str_t]:
         from pandas.io.formats.format import format_array
 
         values = self._values

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -933,7 +933,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         return self._format_with_header(header, na_rep=na_rep)
 
-    def _format_with_header(self, header, na_rep="NaN") -> List[str_t]:
+    def _format_with_header(
+        self, header: List[str_t], na_rep: str_t = "NaN"
+    ) -> List[str_t]:
         from pandas.io.formats.format import format_array
 
         values = self._values

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -347,7 +347,7 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
             attrs.append(("length", len(self)))
         return attrs
 
-    def _format_with_header(self, header, na_rep="NaN") -> List[str]:
+    def _format_with_header(self, header: List[str], na_rep: str = "NaN") -> List[str]:
         from pandas.io.formats.printing import pprint_thing
 
         result = [

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -354,8 +354,11 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
         """
         header = []
         if name:
-            fmt_name = ibase.pprint_thing(self.name, escape_chars=("\t", "\r", "\n"))
-            header.append(fmt_name)
+            header.append(
+                ibase.pprint_thing(self.name, escape_chars=("\t", "\r", "\n"))
+                if self.name is not None
+                else ""
+            )
 
         if formatter is not None:
             return header + list(self.map(formatter))

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -362,7 +362,9 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
 
         return self._format_with_header(header, na_rep=na_rep, date_format=date_format)
 
-    def _format_with_header(self, header, na_rep="NaT", date_format=None) -> List[str]:
+    def _format_with_header(
+        self, header: List[str], na_rep: str = "NaT", date_format: Optional[str] = None
+    ) -> List[str]:
         return header + list(
             self._format_native_types(na_rep=na_rep, date_format=date_format)
         )

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -948,7 +948,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
     # Rendering Methods
     # __repr__ associated methods are based on MultiIndex
 
-    def _format_with_header(self, header, na_rep="NaN") -> List[str]:
+    def _format_with_header(self, header: List[str], na_rep: str = "NaN") -> List[str]:
         return header + list(self._format_native_types(na_rep=na_rep))
 
     def _format_native_types(self, na_rep="NaN", quoting=None, **kwargs):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -188,8 +188,10 @@ class RangeIndex(Int64Index):
         return None
 
     def _format_with_header(self, header, na_rep="NaN") -> List[str]:
-        start_str, stop_str = str(self._range.start), str(self._range.stop)
-        max_length = max(len(start_str), len(stop_str))
+        first_val_str = str(self._range[0])
+        last_val_str = str(self._range[-1])
+        max_length = max(len(first_val_str), len(last_val_str))
+
         return header + [f"{x:<{max_length}}" for x in self._range]
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -189,7 +189,7 @@ class RangeIndex(Int64Index):
 
     def _format_with_header(self, header: List[str], na_rep: str = "NaN") -> List[str]:
         if len(self._range) == 0:
-            return []
+            return header
         first_val_str = str(self._range[0])
         last_val_str = str(self._range[-1])
         max_length = max(len(first_val_str), len(last_val_str))

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -188,7 +188,7 @@ class RangeIndex(Int64Index):
         return None
 
     def _format_with_header(self, header: List[str], na_rep: str = "NaN") -> List[str]:
-        if len(self._range) == 0:
+        if not len(self._range):
             return header
         first_val_str = str(self._range[0])
         last_val_str = str(self._range[-1])

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -188,6 +188,8 @@ class RangeIndex(Int64Index):
         return None
 
     def _format_with_header(self, header: List[str], na_rep: str = "NaN") -> List[str]:
+        if len(self._range) == 0:
+            return []
         first_val_str = str(self._range[0])
         last_val_str = str(self._range[-1])
         max_length = max(len(first_val_str), len(last_val_str))

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 import operator
 from sys import getsizeof
-from typing import Any
+from typing import Any, List
 import warnings
 
 import numpy as np
@@ -186,6 +186,11 @@ class RangeIndex(Int64Index):
     def _format_data(self, name=None):
         # we are formatting thru the attributes
         return None
+
+    def _format_with_header(self, header, na_rep="NaN") -> List[str]:
+        start_str, stop_str = str(self._range.start), str(self._range.stop)
+        max_length = max(len(start_str), len(stop_str))
+        return header + [f"{x:<{max_length}}" for x in self._range]
 
     # --------------------------------------------------------------------
     _deprecation_message = (

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -187,7 +187,7 @@ class RangeIndex(Int64Index):
         # we are formatting thru the attributes
         return None
 
-    def _format_with_header(self, header, na_rep="NaN") -> List[str]:
+    def _format_with_header(self, header: List[str], na_rep: str = "NaN") -> List[str]:
         first_val_str = str(self._range[0])
         last_val_str = str(self._range[-1])
         max_length = max(len(first_val_str), len(last_val_str))

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -1,5 +1,5 @@
 import gc
-from typing import Optional, Type
+from typing import Type
 
 import numpy as np
 import pytest
@@ -33,7 +33,7 @@ from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 class Base:
     """ base class for index sub-class tests """
 
-    _holder: Optional[Type[Index]] = None
+    _holder: Type[Index]
     _compat_props = ["shape", "ndim", "size", "nbytes"]
 
     def create_index(self) -> Index:
@@ -685,6 +685,10 @@ class Base:
         idx = self.create_index()
         expected = [str(x) for x in idx]
         assert idx.format() == expected
+
+    def test_format_empty(self):
+        # GH35712
+        assert self._holder([]).format() == []
 
     def test_hasnans_isnans(self, index):
         # GH 11343, added tests for hasnans / isnans

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -683,7 +683,9 @@ class Base:
 
     def test_format_empty(self):
         # GH35712
-        assert self._holder([]).format() == []
+        empty_idx = self._holder([])
+        assert empty_idx.format() == []
+        assert empty_idx.format(name=True) == [""]
 
     def test_hasnans_isnans(self, index):
         # GH 11343, added tests for hasnans / isnans

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -1,5 +1,5 @@
 import gc
-from typing import Optional, Type
+from typing import Type
 
 import numpy as np
 import pytest
@@ -33,7 +33,7 @@ from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 class Base:
     """ base class for index sub-class tests """
 
-    _holder: Optional[Type[Index]] = None
+    _holder: Type[Index]
     _compat_props = ["shape", "ndim", "size", "nbytes"]
 
     def create_index(self) -> Index:
@@ -680,6 +680,10 @@ class Base:
         idx = self.create_index()
         expected = [str(x) for x in idx]
         assert idx.format() == expected
+
+    def test_format_empty(self):
+        # GH35712
+        assert self._holder([]).format() == []
 
     def test_hasnans_isnans(self, index):
         # GH 11343, added tests for hasnans / isnans

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -688,7 +688,9 @@ class Base:
 
     def test_format_empty(self):
         # GH35712
-        assert self._holder([]).format() == []
+        empty_idx = self._holder([])
+        assert empty_idx.format() == []
+        assert empty_idx.format(name=True) == [""]
 
     def test_hasnans_isnans(self, index):
         # GH 11343, added tests for hasnans / isnans

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -536,6 +536,10 @@ class TestPeriodIndex(DatetimeLike):
         with pytest.raises(KeyError, match=msg):
             df.loc[key]
 
+    def test_format_empty(self):
+        # GH35712
+        assert self._holder([], freq="A").format() == []
+
 
 def test_maybe_convert_timedelta():
     pi = PeriodIndex(["2000", "2001"], freq="D")

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -538,7 +538,9 @@ class TestPeriodIndex(DatetimeLike):
 
     def test_format_empty(self):
         # GH35712
-        assert self._holder([], freq="A").format() == []
+        empty_idx = self._holder([], freq="A")
+        assert empty_idx.format() == []
+        assert empty_idx.format(name=True) == [""]
 
 
 def test_maybe_convert_timedelta():

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -521,3 +521,7 @@ class TestRangeIndex(Numeric):
             idx.get_loc("a")
 
         assert "_engine" not in idx._cache
+
+    def test_format_empty(self):
+        # GH35712
+        assert self._holder(0).format() == []

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -171,7 +171,13 @@ class TestRangeIndex(Numeric):
             pass
         assert idx._cache == {}
 
+        idx.format()
+        assert idx._cache == {}
+
         df = pd.DataFrame({"a": range(10)}, index=idx)
+
+        str(df)
+        assert idx._cache == {}
 
         df.loc[50]
         assert idx._cache == {}

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -524,4 +524,6 @@ class TestRangeIndex(Numeric):
 
     def test_format_empty(self):
         # GH35712
-        assert self._holder(0).format() == []
+        empty_idx = self._holder(0)
+        assert empty_idx.format() == []
+        assert empty_idx.format(name=True) == [""]


### PR DESCRIPTION
#35440 dropped ``RangeIndex._format_with_header``, which was functionally not needed, but needed to avoid creating an internal ndarray.

This rectifies that + gives some perf. improvements.

```python
>>> idx = pd.RangeIndex(1_000_000)
>>> %timeit idx.format()
4.6 s ± 102 ms per loop  # pandas v1.1.0
1.67 s ± 19.6 ms per loop  # master
595 ms ± 2.35 ms per loop  # this PR
```

Also, now the ``_data`` attribute isn't called, so this PR gives a perf. & memory improvement in some use cases compared to master:

```python
>>> idx = pd.RangeIndex(1_000_000)
>>> idx.format()
>>> "_data" in idx._cache
False # pandas v.1.1.0
True  # master
False  # this PR
```
