### PR TITLE
update io documentation

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -3596,7 +3596,7 @@ similar to how ``read_csv`` and ``to_csv`` work.
    os.remove('store_tl.h5')
 
 
-HDFStore will by default not drop rows that are all missing. This behavior can be changed by setting ``dropna=True``.
+HDFStore will by default drop rows that are all missing. This behavior can be changed by setting ``dropna=True``.
 
 
 .. ipython:: python


### PR DESCRIPTION
The HDFS dropna=True parameter does not drop the NaN values. Perhaps this is a bug to the core Pandas, or really a typo in the documentation

- [X] closes #35719
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
