### PR TITLE
DOC: Fix broken link in cookbook.rst

### DIFF
--- a/doc/source/user_guide/cookbook.rst
+++ b/doc/source/user_guide/cookbook.rst
@@ -765,7 +765,7 @@ Timeseries
 <https://stackoverflow.com/questions/13893227/vectorized-look-up-of-values-in-pandas-dataframe>`__
 
 `Aggregation and plotting time series
-<http://nipunbatra.github.io/2015/06/timeseries/>`__
+<https://nipunbatra.github.io/blog/visualisation/2013/05/01/aggregation-timeseries.html>`__
 
 Turn a matrix with hours in columns and days in rows into a continuous row sequence in the form of a time series.
 `How to rearrange a Python pandas DataFrame?


### PR DESCRIPTION
The original link [Aggregation and plotting time series](http://nipunbatra.github.io/2015/06/timeseries/) found in the [Pandas Cookbook](https://pandas.pydata.org/pandas-docs/stable/user_guide/cookbook.html?highlight=get_group#timeseries) is broken.

This appears to have been moved to the authors [Blog](https://nipunbatra.github.io/blog/visualisation/2013/05/01/aggregation-timeseries.html)

While the date does not match ( 2013/05 vs 2015/06 ) the contents appear identical. I was able to determine this after viewing the archive at [WayBack Machine](https://web.archive.org/web/20161202094122/http://nipunbatra.github.io/2015/06/timeseries/)


- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


