### PR TITLE
Bump asv Python version

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -26,7 +26,7 @@
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
     // "pythons": ["2.7", "3.4"],
-    "pythons": ["3.7.1"],
+    "pythons": ["3.8"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -26,7 +26,7 @@
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
     // "pythons": ["2.7", "3.4"],
-    "pythons": ["3.6"],
+    "pythons": ["3.7.1"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty


### PR DESCRIPTION
Got this error trying to run the asvs locally and bumping the Python version in asv.conf.json fixed it:

```
   STDOUT -------->
   Processing /Users/danielsaxton/pandas/asv_bench/env/a36d556a9d1611aba4092dc48036d261/project
       Preparing wheel metadata: started
       Preparing wheel metadata: finished with status 'done'
   STDERR -------->
   ERROR: Package 'pandas' requires a different Python: 3.6.10 not in '>=3.7.1'
```

Let me know if this is needed / correct in general or if it was just a thing with my machine.

cc @TomAugspurger 

Closes https://github.com/pandas-dev/pandas/issues/34677