### PR TITLE
TST: resample does not yield empty groups (#10603)

### DIFF
--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -152,13 +152,16 @@ def test_resample_timedelta_edge_case(start, end, freq, resample_freq):
     assert not np.isnan(result[-1])
 
 
-def test_resample_timedelta_no_empty_groups():
+def test_resample_with_timedelta_yields_no_empty_groups():
     # GH 10603
-    # check that resample does not yield empty groups
-    df = pd.DataFrame(np.random.normal(size=(10000, 4)))
-    df.index = pd.timedelta_range(start="0s", periods=10000, freq="3906250n")
+    df = pd.DataFrame(
+        np.random.normal(size=(10000, 4)),
+        index=pd.timedelta_range(start="0s", periods=10000, freq="3906250n"),
+    )
     result = df.loc["1s":, :].resample("3s").apply(lambda x: len(x))
 
-    expected = pd.DataFrame([[768.0] * 4] * 12 + [[528.0] * 4])
-    expected.index = pd.timedelta_range(start="1s", periods=13, freq="3s")
+    expected = pd.DataFrame(
+        [[768.0] * 4] * 12 + [[528.0] * 4],
+        index=pd.timedelta_range(start="1s", periods=13, freq="3s"),
+    )
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/resample/test_timedelta.py
+++ b/pandas/tests/resample/test_timedelta.py
@@ -150,3 +150,15 @@ def test_resample_timedelta_edge_case(start, end, freq, resample_freq):
     tm.assert_index_equal(result.index, expected_index)
     assert result.index.freq == expected_index.freq
     assert not np.isnan(result[-1])
+
+
+def test_resample_timedelta_no_empty_groups():
+    # GH 10603
+    # check that resample does not yield empty groups
+    df = pd.DataFrame(np.random.normal(size=(10000, 4)))
+    df.index = pd.timedelta_range(start="0s", periods=10000, freq="3906250n")
+    result = df.loc["1s":, :].resample("3s").apply(lambda x: len(x))
+
+    expected = pd.DataFrame([[768.0] * 4] * 12 + [[528.0] * 4])
+    expected.index = pd.timedelta_range(start="1s", periods=13, freq="3s")
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #10603
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This adds a test to verify that resample does not yield empty groups.

I'm new to contributing to pandas, and I'm not sure where to add this test.
Let me know if this place is inappropriate.