### PR TITLE
WEB: Add new Maintainers to Team Page

### DIFF
--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -79,6 +79,13 @@ maintainers:
   - datapythonista
   - simonjayhawkins
   - topper-123
+  - alimcmaster1
+  - bashtage
+  - charlesdong1991
+  - Dr-Irv
+  - dsaxton
+  - MarcoGorelli
+  - rhshadrach
   emeritus:
   - Wouter Overmeire
   - Skipper Seabold


### PR DESCRIPTION
Add new maintainers.

cc:
@bashtage
@charlesdong1991
@Dr-Irv
@dsaxton
@MarcoGorelli
@rhshadrach

In case anyone doesn't want to appear here: https://pandas.pydata.org/about/team.html