### PR TITLE
CI: Pyarrow Min Version on Travis 3.7 Locale Build

### DIFF
--- a/ci/deps/travis-37-locale.yaml
+++ b/ci/deps/travis-37-locale.yaml
@@ -28,6 +28,7 @@ dependencies:
   - openpyxl
   - pandas-gbq=0.12.0
   - psycopg2=2.7
+  - pyarrow>=0.15.0 # GH #35813
   - pymysql=0.7.11
   - pytables
   - python-dateutil


### PR DESCRIPTION
- [x] closes #35813

Conda seems to be installing pyarrow 0.11 for this env. 

Note pyarrow tests will now run on  Travis 3.7 Locale Build