### PR TITLE
Jsonlines append mode

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2063,6 +2063,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         index: bool_t = True,
         indent: Optional[int] = None,
         storage_options: StorageOptions = None,
+        mode: str = 'w'
     ) -> Optional[str]:
         """
         Convert the object to a JSON string.
@@ -2335,6 +2336,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             index=index,
             indent=indent,
             storage_options=storage_options,
+            mode=mode
         )
 
     def to_hdf(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2164,7 +2164,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
            .. versionadded:: 1.2.0
 
-
         Returns
         -------
         None or str

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2063,7 +2063,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         index: bool_t = True,
         indent: Optional[int] = None,
         storage_options: StorageOptions = None,
-        mode: str = 'w'
+        mode: str = "w",
     ) -> Optional[str]:
         """
         Convert the object to a JSON string.
@@ -2336,7 +2336,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             index=index,
             indent=indent,
             storage_options=storage_options,
-            mode=mode
+            mode=mode,
         )
 
     def to_hdf(

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2157,6 +2157,14 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
             .. versionadded:: 1.2.0
 
+        mode : str, default 'w'
+            If 'orient' is 'records' and 'lines' is 'True' enable option to append
+            mode ('mode' is 'a') to a json file instead of overwriting.
+            Will throw ValueError if incorrect 'orient' and 'lines'.
+
+           .. versionadded:: 1.2.0
+
+
         Returns
         -------
         None or str

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -100,7 +100,14 @@ def to_json(
     ).write()
 
     if lines:
+        exists = False
+        try:
+            exists = os.path.exists(path_or_buf)
+        except (TypeError, ValueError):
+            pass
+
         s = convert_to_line_delimits(s)
+        s = "\n" + s if exists else s
 
     if isinstance(path_or_buf, str):
         fh, handles = get_handle(path_or_buf, mode, compression=compression)

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -50,6 +50,7 @@ def to_json(
     index: bool = True,
     indent: int = 0,
     storage_options: StorageOptions = None,
+    mode: str = 'w'
 ):
 
     if not index and orient not in ["split", "table"]:
@@ -67,6 +68,9 @@ def to_json(
 
     if lines and orient != "records":
         raise ValueError("'lines' keyword only valid when 'orient' is records")
+
+    if mode == "a" and (not lines or orient!='records'):
+        raise ValueError("'append mode' only valid when 'line' is True and 'orient' is records")
 
     if orient == "table" and isinstance(obj, Series):
         obj = obj.to_frame(name=obj.name or "values")
@@ -97,7 +101,7 @@ def to_json(
         s = convert_to_line_delimits(s)
 
     if isinstance(path_or_buf, str):
-        fh, handles = get_handle(path_or_buf, "w", compression=compression)
+        fh, handles = get_handle(path_or_buf, mode, compression=compression)
         try:
             fh.write(s)
         finally:

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -111,7 +111,6 @@ def to_json(
         except (TypeError, ValueError):
             pass
 
-
     if isinstance(path_or_buf, str):
         fh, handles = get_handle(path_or_buf, mode, compression=compression)
         try:

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -100,14 +100,17 @@ def to_json(
     ).write()
 
     if lines:
-        exists = False
+        s = convert_to_line_delimits(s)
         try:
-            exists = os.path.exists(path_or_buf)
+            exists = (
+                os.path.exists(path_or_buf)
+                and os.path.isfile(path_or_buf)
+                and os.path.getsize(path_or_buf)
+            )
+            s = "\n" + s if exists else s
         except (TypeError, ValueError):
             pass
 
-        s = convert_to_line_delimits(s)
-        s = "\n" + s if exists else s
 
     if isinstance(path_or_buf, str):
         fh, handles = get_handle(path_or_buf, mode, compression=compression)

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -102,12 +102,13 @@ def to_json(
     if lines:
         s = convert_to_line_delimits(s)
         try:
-            exists = (
-                os.path.exists(path_or_buf)
+            add_new_line = (
+                mode == "a"
+                and os.path.exists(path_or_buf)
                 and os.path.isfile(path_or_buf)
                 and os.path.getsize(path_or_buf)
             )
-            s = "\n" + s if exists else s
+            s = "\n" + s if add_new_line else s
         except (TypeError, ValueError):
             pass
 

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -50,7 +50,7 @@ def to_json(
     index: bool = True,
     indent: int = 0,
     storage_options: StorageOptions = None,
-    mode: str = 'w'
+    mode: str = "w",
 ):
 
     if not index and orient not in ["split", "table"]:
@@ -69,8 +69,10 @@ def to_json(
     if lines and orient != "records":
         raise ValueError("'lines' keyword only valid when 'orient' is records")
 
-    if mode == "a" and (not lines or orient!='records'):
-        raise ValueError("'append mode' only valid when 'line' is True and 'orient' is records")
+    if mode == "a" and (not lines or orient != "records"):
+        raise ValueError(
+            "'append mode' only valid when 'line' is True and 'orient' is records"
+        )
 
     if orient == "table" and isinstance(obj, Series):
         obj = obj.to_frame(name=obj.name or "values")

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -23,7 +23,7 @@ def convert_to_line_delimits(s):
     # json object, only lists can
     if not s[0] == "[" and s[-1] == "]":
         return s
-    s = s[1:-1] + "\n"
+    s = s[1:-1]
 
     return convert_json_to_lines(s)
 

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -23,7 +23,7 @@ def convert_to_line_delimits(s):
     # json object, only lists can
     if not s[0] == "[" and s[-1] == "]":
         return s
-    s = s[1:-1]
+    s = s[1:-1]+"\n"
 
     return convert_json_to_lines(s)
 

--- a/pandas/io/json/_normalize.py
+++ b/pandas/io/json/_normalize.py
@@ -23,7 +23,7 @@ def convert_to_line_delimits(s):
     # json object, only lists can
     if not s[0] == "[" and s[-1] == "]":
         return s
-    s = s[1:-1]+"\n"
+    s = s[1:-1] + "\n"
 
     return convert_json_to_lines(s)
 


### PR DESCRIPTION
**Description**: Adding support to append mode for `to_json` when 'orient' is `records` and 'lines' is `True`

**Motivation**: [jsonlines](http://jsonlines.org/) is a format that is gaining some space (e.g. [Cloud Storage](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json)). In pandas It's achieved using `to_json` with `orient='records'` and `lines=True`. But `to_json` doesn't have the option to use `mode='a'` to append to a file, this PR aims to provide a simple append mode for jsonlines using pandas.

---

- [X] closes #35849
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry