### PR TITLE
DEPR: deprecate dtype param in Index.copy

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -143,7 +143,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Deprecations
 ~~~~~~~~~~~~
 - Deprecated parameter ``inplace`` in :meth:`MultiIndex.set_codes` and :meth:`MultiIndex.set_levels` (:issue:`35626`)
-- Deprecated parameter ``dtype`` in :~meth:`Index.copy` on all index classes. Use :meth:`Index.astype` method (:issue:`35626`)
+- Deprecated parameter ``dtype`` in :~meth:`Index.copy` on method all index classes. Use the :meth:`Index.astype` method instead for changing dtype(:issue:`35853`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -143,7 +143,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Deprecations
 ~~~~~~~~~~~~
 - Deprecated parameter ``inplace`` in :meth:`MultiIndex.set_codes` and :meth:`MultiIndex.set_levels` (:issue:`35626`)
--
+- Deprecated parameter ``dtype`` in :~meth:`Index.copy` on all index classes. Use :meth:`Index.astype` method (:issue:`35626`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -800,6 +800,9 @@ class Index(IndexOpsMixin, PandasObject):
         deep : bool, default False
         dtype : numpy dtype or pandas type, optional
             Set dtype for new object.
+
+            .. deprecated:: 1.2.0
+                use ``astype`` method instead.
         names : list-like, optional
             Kept for compatibility with MultiIndex. Should not be used.
 
@@ -820,6 +823,12 @@ class Index(IndexOpsMixin, PandasObject):
             new_index = self._shallow_copy(name=name)
 
         if dtype:
+            warnings.warn(
+                "parameter dtype is deprecated and will be removed in a future version."
+                " Use the astype method instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
             new_index = new_index.astype(dtype)
         return new_index
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -824,8 +824,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         if dtype:
             warnings.warn(
-                "parameter dtype is deprecated and will be removed in a future version."
-                " Use the astype method instead.",
+                "parameter dtype is deprecated and will be removed in a future "
+                "version. Use the astype method instead.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1127,8 +1127,8 @@ class MultiIndex(Index):
 
         if dtype:
             warnings.warn(
-                "parameter dtype is deprecated and will be removed in a future version."
-                " Use the astype method instead.",
+                "parameter dtype is deprecated and will be removed in a future "
+                "version. Use the astype method instead.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1030,7 +1030,6 @@ class MultiIndex(Index):
         name=lib.no_default,
         levels=None,
         codes=None,
-        dtype=None,
         sortorder=None,
         names=lib.no_default,
         _set_identity: bool = True,
@@ -1041,7 +1040,7 @@ class MultiIndex(Index):
             names = name if name is not lib.no_default else self.names
 
         if values is not None:
-            assert levels is None and codes is None and dtype is None
+            assert levels is None and codes is None
             return MultiIndex.from_tuples(values, sortorder=sortorder, names=names)
 
         levels = levels if levels is not None else self.levels
@@ -1050,7 +1049,6 @@ class MultiIndex(Index):
         result = MultiIndex(
             levels=levels,
             codes=codes,
-            dtype=dtype,
             sortorder=sortorder,
             names=names,
             verify_integrity=False,
@@ -1092,6 +1090,8 @@ class MultiIndex(Index):
         ----------
         names : sequence, optional
         dtype : numpy dtype or pandas type, optional
+
+            .. deprecated:: 1.2.0
         levels : sequence, optional
         codes : sequence, optional
         deep : bool, default False
@@ -1117,14 +1117,23 @@ class MultiIndex(Index):
             if codes is None:
                 codes = deepcopy(self.codes)
 
-        return self._shallow_copy(
+        new_index = self._shallow_copy(
             levels=levels,
             codes=codes,
             names=names,
-            dtype=dtype,
             sortorder=self.sortorder,
             _set_identity=_set_identity,
         )
+
+        if dtype:
+            warnings.warn(
+                "parameter dtype is deprecated and will be removed in a future version."
+                " Use the astype method instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            new_index = new_index.astype(dtype)
+        return new_index
 
     def __array__(self, dtype=None) -> np.ndarray:
         """ the array interface, return my values """

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -390,10 +390,17 @@ class RangeIndex(Int64Index):
 
     @doc(Int64Index.copy)
     def copy(self, name=None, deep=False, dtype=None, names=None):
-        self._validate_dtype(dtype)
-
         name = self._validate_names(name=name, names=names, deep=deep)[0]
         new_index = self._shallow_copy(name=name)
+
+        if dtype:
+            warnings.warn(
+                "parameter dtype is deprecated and will be removed in a future version."
+                " Use the astype method instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            new_index = new_index.astype(dtype)
         return new_index
 
     def _minmax(self, meth: str):

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -395,8 +395,8 @@ class RangeIndex(Int64Index):
 
         if dtype:
             warnings.warn(
-                "parameter dtype is deprecated and will be removed in a future version."
-                " Use the astype method instead.",
+                "parameter dtype is deprecated and will be removed in a future "
+                "version. Use the astype method instead.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -285,6 +285,7 @@ class Base:
             index.copy(name=[["mario"]])
 
     def test_copy_dtype_deprecated(self, index):
+        # GH35853
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             index.copy(dtype=object)
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -270,7 +270,7 @@ class Base:
             s3 = s1 * s2
             assert s3.index.name == "mario"
 
-    def test_name2(self, index):
+    def test_copy_name2(self, index):
         # gh-35592
         if isinstance(index, MultiIndex):
             return
@@ -283,6 +283,10 @@ class Base:
         msg = f"{type(index).__name__}.name must be a hashable type"
         with pytest.raises(TypeError, match=msg):
             index.copy(name=[["mario"]])
+
+    def test_copy_dtype_deprecated(self, index):
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            index.copy(dtype=object)
 
     def test_ensure_copied_data(self, index):
         # Check the "copy" argument of each Index.__new__ is honoured

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -62,11 +62,6 @@ class TestIndex(Base):
         assert new_index.ndim == 2
         assert isinstance(new_index, np.ndarray)
 
-    @pytest.mark.parametrize("index", ["int", "uint", "float"], indirect=True)
-    def test_copy_and_deepcopy(self, index):
-        new_copy2 = index.copy(dtype=int)
-        assert new_copy2.dtype.kind == "i"
-
     def test_constructor_regular(self, index):
         tm.assert_contains_all(index, index)
 

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -374,8 +374,7 @@ class TestCommon:
         "dtype",
         ["int64", "uint64", "float64", "category", "datetime64[ns]", "timedelta64[ns]"],
     )
-    @pytest.mark.parametrize("copy", [True, False])
-    def test_astype_preserves_name(self, index, dtype, copy):
+    def test_astype_preserves_name(self, index, dtype):
         # https://github.com/pandas-dev/pandas/issues/32013
         if isinstance(index, MultiIndex):
             index.names = ["idx" + str(i) for i in range(index.nlevels)]
@@ -384,10 +383,7 @@ class TestCommon:
 
         try:
             # Some of these conversions cannot succeed so we use a try / except
-            if copy:
-                result = index.copy(dtype=dtype)
-            else:
-                result = index.astype(dtype)
+            result = index.astype(dtype)
         except (ValueError, TypeError, NotImplementedError, SystemError):
             return
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -394,7 +394,7 @@ class NumericInt(Numeric):
         same_values_different_type = Index(i, dtype=object)
         assert not i.identical(same_values_different_type)
 
-        i = index.copy(dtype=object)
+        i = index.astype(dtype=object)
         i = i.rename("foo")
         same_values = Index(i, dtype=object)
         assert same_values.identical(i)
@@ -402,7 +402,7 @@ class NumericInt(Numeric):
         assert not i.identical(index)
         assert Index(same_values, name="foo", dtype=object).identical(i)
 
-        assert not index.copy(dtype=object).identical(index.copy(dtype=self._dtype))
+        assert not index.astype(dtype=object).identical(index.astype(dtype=self._dtype))
 
     def test_union_noncomparable(self):
         # corner case, non-Int64Index


### PR DESCRIPTION
Deprecate ``dtype`` param in ``Index.copy`` and child methods. If users want to change dtype, they should use ``Index.astype``.