### PR TITLE
DOC: avoid StorageOptions type alias in docstrings

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -200,13 +200,13 @@ mangle_dupe_cols : bool, default True
     Duplicate columns will be specified as 'X', 'X.1', ...'X.N', rather than
     'X'...'X'. Passing in False will cause data to be overwritten if there
     are duplicate names in the columns.
-storage_options : StorageOptions
+storage_options : dict, optional
     Extra options that make sense for a particular storage connection, e.g.
     host, port, username, password, etc., if using a URL that will
     be parsed by ``fsspec``, e.g., starting "s3://", "gcs://". An error
     will be raised if providing this argument with a local path or
     a file-like buffer. See the fsspec and backend storage implementation
-    docs for the set of allowed keys and values
+    docs for the set of allowed keys and values.
 
     .. versionadded:: 1.2.0
 

--- a/pandas/io/excel/_odfreader.py
+++ b/pandas/io/excel/_odfreader.py
@@ -18,7 +18,7 @@ class _ODFReader(_BaseExcelReader):
     ----------
     filepath_or_buffer : string, path to be parsed or
         an open readable stream.
-    storage_options : StorageOptions
+    storage_options : dict, optional
         passed to fsspec for appropriate URLs (see ``get_filepath_or_buffer``)
     """
 

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -479,7 +479,7 @@ class _OpenpyxlReader(_BaseExcelReader):
         ----------
         filepath_or_buffer : string, path object or Workbook
             Object to be parsed.
-        storage_options : StorageOptions
+        storage_options : dict, optional
             passed to fsspec for appropriate URLs (see ``get_filepath_or_buffer``)
         """
         import_optional_dependency("openpyxl")

--- a/pandas/io/excel/_pyxlsb.py
+++ b/pandas/io/excel/_pyxlsb.py
@@ -19,7 +19,7 @@ class _PyxlsbReader(_BaseExcelReader):
         ----------
         filepath_or_buffer : str, path object, or Workbook
             Object to be parsed.
-        storage_options : StorageOptions
+        storage_options : dict, optional
             passed to fsspec for appropriate URLs (see ``get_filepath_or_buffer``)
         """
         import_optional_dependency("pyxlsb")

--- a/pandas/io/excel/_xlrd.py
+++ b/pandas/io/excel/_xlrd.py
@@ -17,7 +17,7 @@ class _XlrdReader(_BaseExcelReader):
         ----------
         filepath_or_buffer : string, path object or Workbook
             Object to be parsed.
-        storage_options : StorageOptions
+        storage_options : dict, optional
             passed to fsspec for appropriate URLs (see ``get_filepath_or_buffer``)
         """
         err_msg = "Install xlrd >= 1.0.0 for Excel support"

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -16,14 +16,13 @@ def to_feather(df: DataFrame, path, storage_options: StorageOptions = None, **kw
     ----------
     df : DataFrame
     path : string file path, or file-like object
-
     storage_options : dict, optional
         Extra options that make sense for a particular storage connection, e.g.
         host, port, username, password, etc., if using a URL that will
         be parsed by ``fsspec``, e.g., starting "s3://", "gcs://". An error
         will be raised if providing this argument with a local path or
         a file-like buffer. See the fsspec and backend storage implementation
-        docs for the set of allowed keys and values
+        docs for the set of allowed keys and values.
 
         .. versionadded:: 1.2.0
 
@@ -106,6 +105,15 @@ def read_feather(
         Whether to parallelize reading using multiple threads.
 
        .. versionadded:: 0.24.0
+    storage_options : dict, optional
+        Extra options that make sense for a particular storage connection, e.g.
+        host, port, username, password, etc., if using a URL that will
+        be parsed by ``fsspec``, e.g., starting "s3://", "gcs://". An error
+        will be raised if providing this argument with a local path or
+        a file-like buffer. See the fsspec and backend storage implementation
+        docs for the set of allowed keys and values.
+
+        .. versionadded:: 1.2.0
 
     Returns
     -------


### PR DESCRIPTION
Small follow-up on https://github.com/pandas-dev/pandas/pull/35655, replacing the "StorageOptions" with a plain "dict" in the docstrings ("StorageOptions" is not something known to users, in the type annotations it will expand but not in the docstrings)

(cc @martindurant)