### PR TITLE
Backport PR #35777: BUG: DataFrame.apply with result_type=reduce incorrect index

### DIFF
--- a/doc/source/whatsnew/v1.1.2.rst
+++ b/doc/source/whatsnew/v1.1.2.rst
@@ -24,7 +24,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
-
+- Bug in :meth:`DataFrame.apply` with ``result_type="reduce"`` returning with incorrect index (:issue:`35683`)
 -
 -
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -340,7 +340,10 @@ class FrameRowApply(FrameApply):
 
         if self.result_type == "reduce":
             # e.g. test_apply_dict GH#8735
-            return self.obj._constructor_sliced(results)
+            res = self.obj._constructor_sliced(results)
+            res.index = res_index
+            return res
+
         elif self.result_type is None and all(
             isinstance(x, dict) for x in results.values()
         ):

--- a/pandas/tests/frame/apply/test_frame_apply.py
+++ b/pandas/tests/frame/apply/test_frame_apply.py
@@ -1541,3 +1541,12 @@ def test_apply_mutating():
 
     tm.assert_frame_equal(result, expected)
     tm.assert_frame_equal(df, result)
+
+
+def test_apply_empty_list_reduce():
+    # GH#35683 get columns correct
+    df = pd.DataFrame([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]], columns=["a", "b"])
+
+    result = df.apply(lambda x: [], result_type="reduce")
+    expected = pd.Series({"a": [], "b": []}, dtype=object)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
#35777