### PR TITLE
TST/API: test column indexing copy/view semantics

### DIFF
--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -706,6 +706,15 @@ class TestiLoc2:
         expected = pd.Categorical(["C", "B", "A"])
         tm.assert_categorical_equal(cat, expected)
 
+        # __setitem__ under the other hand does not work in-place
+        cat = pd.Categorical(["A", "B", "C"])
+        df = pd.DataFrame({1: cat, 2: [1, 2, 3]})
+
+        df[1] = cat[::-1]
+
+        expected = pd.Categorical(["A", "B", "C"])
+        tm.assert_categorical_equal(cat, expected)
+
     def test_iloc_with_boolean_operation(self):
         # GH 20627
         result = DataFrame([[0, 1], [2, 3], [4, 5], [6, np.nan]])


### PR DESCRIPTION
This is adding some tests for current behaviour related to the discussions in #33457 and #35417 (and also adds the tests from https://github.com/pandas-dev/pandas/pull/35266 which got never merged). I think it is good to have some more explicit tests of current behaviour, while we are considering changing things.

Note: some semantics I am testing are certainly debatable, but I was experimenting a bit with what is happening on current master.