### PR TITLE
REGR: Fix comparison broadcasting over array of Intervals

### DIFF
--- a/doc/source/whatsnew/v1.1.2.rst
+++ b/doc/source/whatsnew/v1.1.2.rst
@@ -16,6 +16,7 @@ Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Regression in :meth:`DatetimeIndex.intersection` incorrectly raising ``AssertionError`` when intersecting against a list (:issue:`35876`)
 - Performance regression for :meth:`RangeIndex.format` (:issue:`35712`)
+- Regression in :meth:`DataFrame.replace` where a ``TypeError`` would be raised when attempting to replace elements of type :class:`Interval` (:issue:`35931`)
 -
 
 

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -299,7 +299,6 @@ cdef class Interval(IntervalMixin):
     True
     """
     _typ = "interval"
-    __array_priority__ = 1000
 
     cdef readonly object left
     """

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -299,6 +299,7 @@ cdef class Interval(IntervalMixin):
     True
     """
     _typ = "interval"
+    __array_priority__ = 1000
 
     cdef readonly object left
     """
@@ -357,6 +358,11 @@ cdef class Interval(IntervalMixin):
             self_tuple = (self.left, self.right, self.closed)
             other_tuple = (other.left, other.right, other.closed)
             return PyObject_RichCompare(self_tuple, other_tuple, op)
+        elif util.is_array(other):
+            return np.array(
+                [PyObject_RichCompare(self, x, op) for x in other],
+                dtype=bool,
+            )
 
         return NotImplemented
 

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1581,3 +1581,10 @@ class TestDataFrameReplace:
         result = df.replace({regex: "z"}, regex=True)
         expected = pd.DataFrame(["z", "b", "c"])
         tm.assert_frame_equal(result, expected)
+
+    def test_replace_intervals(self):
+        # https://github.com/pandas-dev/pandas/issues/35931
+        df = pd.DataFrame({"a": [pd.Interval(0, 1), pd.Interval(0, 1)]})
+        result = df.replace({"a": {pd.Interval(0, 1): "x"}})
+        expected = pd.DataFrame({"a": ["x", "x"]})
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/scalar/interval/test_arithmetic.py
+++ b/pandas/tests/scalar/interval/test_arithmetic.py
@@ -45,3 +45,15 @@ def test_numeric_interval_add_timedelta_raises(interval, delta):
 
     with pytest.raises((TypeError, ValueError), match=msg):
         delta + interval
+
+
+@pytest.mark.xfail(reason="https://github.com/pandas-dev/pandas/pull/35938")
+def test_timdelta_add_timestamp_interval():
+    delta = np.timedelta64(0)
+    expected = Interval(Timestamp("2020-01-01"), Timestamp("2020-02-01"))
+
+    result = delta + expected
+    assert result == expected
+
+    result = expected + delta
+    assert result == expected

--- a/pandas/tests/scalar/interval/test_arithmetic.py
+++ b/pandas/tests/scalar/interval/test_arithmetic.py
@@ -47,7 +47,6 @@ def test_numeric_interval_add_timedelta_raises(interval, delta):
         delta + interval
 
 
-@pytest.mark.xfail(reason="https://github.com/pandas-dev/pandas/pull/35938")
 def test_timdelta_add_timestamp_interval():
     delta = np.timedelta64(0)
     expected = Interval(Timestamp("2020-01-01"), Timestamp("2020-02-01"))

--- a/pandas/tests/scalar/interval/test_arithmetic.py
+++ b/pandas/tests/scalar/interval/test_arithmetic.py
@@ -47,8 +47,9 @@ def test_numeric_interval_add_timedelta_raises(interval, delta):
         delta + interval
 
 
-def test_timdelta_add_timestamp_interval():
-    delta = np.timedelta64(0)
+@pytest.mark.parametrize("klass", [timedelta, np.timedelta64, Timedelta])
+def test_timdelta_add_timestamp_interval(klass):
+    delta = klass(0)
     expected = Interval(Timestamp("2020-01-01"), Timestamp("2020-02-01"))
 
     result = delta + expected

--- a/pandas/tests/scalar/interval/test_interval.py
+++ b/pandas/tests/scalar/interval/test_interval.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from pandas import Interval, Period, Timedelta, Timestamp
+import pandas._testing as tm
 import pandas.core.common as com
 
 
@@ -267,3 +268,11 @@ class TestInterval:
             msg = "left and right must have the same time zone"
         with pytest.raises(error, match=msg):
             Interval(left, right)
+
+    def test_equality_comparison_broadcasts_over_array(self):
+        # https://github.com/pandas-dev/pandas/issues/35931
+        interval = Interval(0, 1)
+        arr = np.array([interval, interval])
+        result = interval == arr
+        expected = np.array([True, True])
+        tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/issues/35931
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
