### PR TITLE
Version Number correction in to_json table

### DIFF
--- a/pandas/io/json/_table_schema.py
+++ b/pandas/io/json/_table_schema.py
@@ -23,6 +23,7 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 from pandas import DataFrame
+from pandas import __version__ as __v__
 import pandas.core.common as com
 
 if TYPE_CHECKING:
@@ -274,7 +275,7 @@ def build_table_schema(
         schema["primaryKey"] = primary_key
 
     if version:
-        schema["pandas_version"] = "0.20.0"
+        schema["pandas_version"] = __v__
     return schema
 
 


### PR DESCRIPTION
Added a line of code to obtain version of Pandas and display it in Schema of a table json when to_json(orient='table') is used.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
