### PR TITLE
paste_windows() wrong arg for c_wchar_p

### DIFF
--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -468,7 +468,11 @@ def init_windows_clipboard():
                 # (Also, it may return a handle to an empty buffer,
                 # but technically that's not empty)
                 return ""
-            return c_wchar_p(handle).value
+            locked_handle = safeGlobalLock(handle)
+            text = c_wchar_p(locked_handle).value
+            safeGlobalUnlock(handle)
+            return text
+
 
     return copy_windows, paste_windows
 


### PR DESCRIPTION
paste_windows() now directly used handle return from safeGetClipboardData(CF_UNICODETEXT) as argument for c_wchar_p, which should used safeGlobalLock(handle) instead, while copy_windows(text) doing the right thing.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
