### PR TITLE
BUG: instantiation using a dict with a period scalar

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -273,7 +273,7 @@ Sparse
 ExtensionArray
 ^^^^^^^^^^^^^^
 
--
+- Fixed Bug where :class:`DataFrame` column set to scalar extension type via a dict instantion was considered an object type rather than the extension type (:issue:`35965`)
 -
 
 

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -468,7 +468,7 @@ def sanitize_array(
 
             # figure out the dtype from the value (upcast if necessary)
             if dtype is None:
-                dtype, value = infer_dtype_from_scalar(value)
+                dtype, value = infer_dtype_from_scalar(value, pandas_dtype=True)
             else:
                 # need to possibly convert the value here
                 value = maybe_cast_to_datetime(value, dtype)

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -472,7 +472,12 @@ def sanitize_array(
 
             # figure out the dtype from the value (upcast if necessary)
             if dtype is None:
-                dtype, value = infer_dtype_from_scalar(value, pandas_dtype=True)
+                dtype, new_value = infer_dtype_from_scalar(value, pandas_dtype=True)
+
+                # infer_dtype_from_scalar converts periods to their ordinal values
+                # which we do not want here
+                if not lib.is_period(value):
+                    value = new_value
             else:
                 # need to possibly convert the value here
                 value = maybe_cast_to_datetime(value, dtype)

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -472,12 +472,7 @@ def sanitize_array(
 
             # figure out the dtype from the value (upcast if necessary)
             if dtype is None:
-                dtype, new_value = infer_dtype_from_scalar(value, pandas_dtype=True)
-
-                # infer_dtype_from_scalar converts periods to their ordinal values
-                # which we do not want here
-                if not lib.is_period(value):
-                    value = new_value
+                dtype, value = infer_dtype_from_scalar(value, pandas_dtype=True)
             else:
                 # need to possibly convert the value here
                 value = maybe_cast_to_datetime(value, dtype)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -709,7 +709,6 @@ def infer_dtype_from_scalar(val, pandas_dtype: bool = False) -> Tuple[DtypeObj, 
     elif pandas_dtype:
         if lib.is_period(val):
             dtype = PeriodDtype(freq=val.freq)
-            val = val.ordinal
         elif lib.is_interval(val):
             subtype = infer_dtype_from_scalar(val.left, pandas_dtype=True)[0]
             dtype = IntervalDtype(subtype=subtype)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -709,6 +709,7 @@ def infer_dtype_from_scalar(val, pandas_dtype: bool = False) -> Tuple[DtypeObj, 
     elif pandas_dtype:
         if lib.is_period(val):
             dtype = PeriodDtype(freq=val.freq)
+            val = val.ordinal
         elif lib.is_interval(val):
             subtype = infer_dtype_from_scalar(val.left, pandas_dtype=True)[0]
             dtype = IntervalDtype(subtype=subtype)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -612,8 +612,6 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         if scalar:
             # Timestamp/Timedelta
             key_dtype, key_i8 = infer_dtype_from_scalar(key, pandas_dtype=True)
-            if lib.is_period(key):
-                key_i8 = key.ordinal
         else:
             # DatetimeIndex/TimedeltaIndex
             key_dtype, key_i8 = key.dtype, Index(key.asi8)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -612,6 +612,8 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         if scalar:
             # Timestamp/Timedelta
             key_dtype, key_i8 = infer_dtype_from_scalar(key, pandas_dtype=True)
+            if lib.is_period(key):
+                key_i8 = key.ordinal
         else:
             # DatetimeIndex/TimedeltaIndex
             key_dtype, key_i8 = key.dtype, Index(key.asi8)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -609,6 +609,8 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         if scalar:
             # Timestamp/Timedelta
             key_dtype, key_i8 = infer_dtype_from_scalar(key, pandas_dtype=True)
+            if lib.is_period(key):
+                key_i8 = key.ordinal
         else:
             # DatetimeIndex/TimedeltaIndex
             key_dtype, key_i8 = key.dtype, Index(key.asi8)

--- a/pandas/tests/dtypes/cast/test_infer_dtype.py
+++ b/pandas/tests/dtypes/cast/test_infer_dtype.py
@@ -84,13 +84,11 @@ def test_infer_dtype_from_period(freq, pandas_dtype):
 
     if pandas_dtype:
         exp_dtype = f"period[{freq}]"
-        exp_val = p.ordinal
     else:
         exp_dtype = np.object_
-        exp_val = p
 
     assert dtype == exp_dtype
-    assert val == exp_val
+    assert val == p
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/dtypes/cast/test_infer_dtype.py
+++ b/pandas/tests/dtypes/cast/test_infer_dtype.py
@@ -84,11 +84,13 @@ def test_infer_dtype_from_period(freq, pandas_dtype):
 
     if pandas_dtype:
         exp_dtype = f"period[{freq}]"
+        exp_val = p.ordinal
     else:
         exp_dtype = np.object_
+        exp_val = p
 
     assert dtype == exp_dtype
-    assert val == p
+    assert val == exp_val
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -726,7 +726,7 @@ class TestDataFrameConstructors:
     )
     def test_constructor_period_dict_scalar(self, data, dtype):
         # scalar periods
-        df = DataFrame({"a": data,}, index=[0])
+        df = DataFrame({"a": data}, index=[0])
         assert df["a"].dtype == dtype
 
     @pytest.mark.parametrize(

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -717,6 +717,12 @@ class TestDataFrameConstructors:
         assert df["a"].dtype == a.dtype
         assert df["b"].dtype == b.dtype
 
+        # list of periods
+        df = DataFrame({"a": pd.Period('2012-01', freq='M'),
+                        "b": pd.Period('2012-02-01', freq='D')})
+        assert df["a"].dtype == 'period[M]'
+        assert df["b"].dtype == 'period[D]'
+
     @pytest.mark.parametrize(
         "data,dtype",
         [

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -720,18 +720,13 @@ class TestDataFrameConstructors:
     @pytest.mark.parametrize(
         "data,dtype",
         [
-            (pd.Period("2012-01", freq="M"), 'period[M]'),
-            (pd.Period("2012-02-01", freq="D"), 'period[D]'),
+            (pd.Period("2012-01", freq="M"), "period[M]"),
+            (pd.Period("2012-02-01", freq="D"), "period[D]"),
         ],
     )
     def test_constructor_period_dict_scalar(self, data, dtype):
         # scalar periods
-        df = DataFrame(
-            {
-                "a": data,
-            },
-            index=[0]
-        )
+        df = DataFrame({"a": data,}, index=[0])
         assert df["a"].dtype == dtype
 
     @pytest.mark.parametrize(

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -718,10 +718,14 @@ class TestDataFrameConstructors:
         assert df["b"].dtype == b.dtype
 
         # list of periods
-        df = DataFrame({"a": pd.Period('2012-01', freq='M'),
-                        "b": pd.Period('2012-02-01', freq='D')})
-        assert df["a"].dtype == 'period[M]'
-        assert df["b"].dtype == 'period[D]'
+        df = DataFrame(
+            {
+                "a": pd.Period("2012-01", freq="M"),
+                "b": pd.Period("2012-02-01", freq="D"),
+            }
+        )
+        assert df["a"].dtype == "period[M]"
+        assert df["b"].dtype == "period[D]"
 
     @pytest.mark.parametrize(
         "data,dtype",

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -717,15 +717,22 @@ class TestDataFrameConstructors:
         assert df["a"].dtype == a.dtype
         assert df["b"].dtype == b.dtype
 
-        # list of periods
+    @pytest.mark.parametrize(
+        "data,dtype",
+        [
+            (pd.Period("2012-01", freq="M"), 'period[M]'),
+            (pd.Period("2012-02-01", freq="D"), 'period[D]'),
+        ],
+    )
+    def test_constructor_period_dict_scalar(self, data, dtype):
+        # scalar periods
         df = DataFrame(
             {
-                "a": pd.Period("2012-01", freq="M"),
-                "b": pd.Period("2012-02-01", freq="D"),
-            }
+                "a": data,
+            },
+            index=[0]
         )
-        assert df["a"].dtype == "period[M]"
-        assert df["b"].dtype == "period[D]"
+        assert df["a"].dtype == dtype
 
     @pytest.mark.parametrize(
         "data,dtype",

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -722,12 +722,18 @@ class TestDataFrameConstructors:
         [
             (pd.Period("2012-01", freq="M"), "period[M]"),
             (pd.Period("2012-02-01", freq="D"), "period[D]"),
+            (Interval(left=0, right=5), IntervalDtype("int64")),
+            (Interval(left=0.1, right=0.5), IntervalDtype("float64")),
         ],
     )
     def test_constructor_period_dict_scalar(self, data, dtype):
         # scalar periods
         df = DataFrame({"a": data}, index=[0])
         assert df["a"].dtype == dtype
+
+        expected = DataFrame(index=[0], columns=["a"], data=data)
+
+        tm.assert_frame_equal(df, expected)
 
     @pytest.mark.parametrize(
         "data,dtype",

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -8,16 +8,23 @@ import pytest
 from pandas._libs import iNaT, lib
 
 from pandas.core.dtypes.common import is_categorical_dtype, is_datetime64tz_dtype
-from pandas.core.dtypes.dtypes import CategoricalDtype
+from pandas.core.dtypes.dtypes import (
+    CategoricalDtype,
+    DatetimeTZDtype,
+    IntervalDtype,
+    PeriodDtype,
+)
 
 import pandas as pd
 from pandas import (
     Categorical,
     DataFrame,
     Index,
+    Interval,
     IntervalIndex,
     MultiIndex,
     NaT,
+    Period,
     Series,
     Timestamp,
     date_range,
@@ -1075,6 +1082,26 @@ class TestSeriesConstructors:
         expected = Series([1, 0, 2], index=list("bac"))
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "data,dtype",
+        [
+            (Period("2020-01"), PeriodDtype("M")),
+            (Interval(left=0, right=5), IntervalDtype("int64")),
+            (
+                Timestamp("2011-01-01", tz="US/Eastern"),
+                DatetimeTZDtype(tz="US/Eastern"),
+            ),
+        ],
+    )
+    def test_constructor_dict_extension(self, data, dtype):
+        d = {"a": data}
+        result = Series(d, index=["a"])
+        expected = Series(data, index=["a"], dtype=dtype)
+
+        assert result.dtype == dtype
+
+        tm.assert_series_equal(result, expected)
+
     @pytest.mark.parametrize("value", [2, np.nan, None, float("nan")])
     def test_constructor_dict_nan_key(self, value):
         # GH 18480
@@ -1463,4 +1490,14 @@ class TestSeriesConstructors:
         result = pd.Series(values, dtype=dtype)
         arr = pd.arrays.SparseArray(values, dtype=dtype)
         expected = pd.Series(arr)
+        tm.assert_series_equal(result, expected)
+
+    def test_construction_from_ordered_collection(self):
+        # https://github.com/pandas-dev/pandas/issues/36044
+        result = Series({"a": 1, "b": 2}.keys())
+        expected = Series(["a", "b"])
+        tm.assert_series_equal(result, expected)
+
+        result = Series({"a": 1, "b": 2}.values())
+        expected = Series([1, 2])
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -8,23 +8,16 @@ import pytest
 from pandas._libs import iNaT, lib
 
 from pandas.core.dtypes.common import is_categorical_dtype, is_datetime64tz_dtype
-from pandas.core.dtypes.dtypes import (
-    CategoricalDtype,
-    DatetimeTZDtype,
-    IntervalDtype,
-    PeriodDtype,
-)
+from pandas.core.dtypes.dtypes import CategoricalDtype
 
 import pandas as pd
 from pandas import (
     Categorical,
     DataFrame,
     Index,
-    Interval,
     IntervalIndex,
     MultiIndex,
     NaT,
-    Period,
     Series,
     Timestamp,
     date_range,
@@ -1082,26 +1075,6 @@ class TestSeriesConstructors:
         expected = Series([1, 0, 2], index=list("bac"))
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize(
-        "data,dtype",
-        [
-            (Period("2020-01"), PeriodDtype("M")),
-            (Interval(left=0, right=5), IntervalDtype("int64")),
-            (
-                Timestamp("2011-01-01", tz="US/Eastern"),
-                DatetimeTZDtype(tz="US/Eastern"),
-            ),
-        ],
-    )
-    def test_constructor_dict_extension(self, data, dtype):
-        d = {"a": data}
-        result = Series(d, index=["a"])
-        expected = Series(data, index=["a"], dtype=dtype)
-
-        assert result.dtype == dtype
-
-        tm.assert_series_equal(result, expected)
-
     @pytest.mark.parametrize("value", [2, np.nan, None, float("nan")])
     def test_constructor_dict_nan_key(self, value):
         # GH 18480
@@ -1490,14 +1463,4 @@ class TestSeriesConstructors:
         result = pd.Series(values, dtype=dtype)
         arr = pd.arrays.SparseArray(values, dtype=dtype)
         expected = pd.Series(arr)
-        tm.assert_series_equal(result, expected)
-
-    def test_construction_from_ordered_collection(self):
-        # https://github.com/pandas-dev/pandas/issues/36044
-        result = Series({"a": 1, "b": 2}.keys())
-        expected = Series(["a", "b"])
-        tm.assert_series_equal(result, expected)
-
-        result = Series({"a": 1, "b": 2}.values())
-        expected = Series([1, 2])
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35965
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Fixing bug discussed in [issue 35965](https://github.com/pandas-dev/pandas/issues/35965) where `pd.DataFrame({'a': pd.Period('2020-01')})` created `a` as an object column instead of a `period[m]` column.

Changing the functionality of `infer_dtype_from_scalar` isn't necessarily required here, but the fact that `infer_dtype_from_scalar` would return the `period.ordinal` value seems inconsistent with the behavior for other dtypes in this function. Additionally, that functionality was only used in a single place within the code (`interval.py`), which I fixed accordingly.