### PR TITLE
TYP: misc typing fixes for pandas\core\frame.py

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1014,7 +1014,7 @@ class DataFrame(NDFrame):
             s = klass(v, index=columns, name=k)
             yield k, s
 
-    def itertuples(self, index=True, name="Pandas"):
+    def itertuples(self, index: bool = True, name: Optional[str] = "Pandas"):
         """
         Iterate over DataFrame rows as namedtuples.
 
@@ -1088,7 +1088,11 @@ class DataFrame(NDFrame):
         arrays.extend(self.iloc[:, k] for k in range(len(self.columns)))
 
         if name is not None:
-            itertuple = collections.namedtuple(name, fields, rename=True)
+            # https://github.com/python/mypy/issues/848
+            # error: namedtuple() expects a string literal as the first argument  [misc]
+            itertuple = collections.namedtuple(  # type: ignore
+                name, fields, rename=True
+            )
             return map(itertuple._make, zip(*arrays))
 
         # fallback to regular tuples
@@ -4591,7 +4595,7 @@ class DataFrame(NDFrame):
             frame = self.copy()
 
         arrays = []
-        names = []
+        names: List[Label] = []
         if append:
             names = list(self.index.names)
             if isinstance(self.index, MultiIndex):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1088,9 +1088,9 @@ class DataFrame(NDFrame):
         arrays.extend(self.iloc[:, k] for k in range(len(self.columns)))
 
         if name is not None:
-            # https://github.com/python/mypy/issues/848
-            # error: namedtuple() expects a string literal as the first argument  [misc]
-            itertuple = collections.namedtuple(  # type: ignore
+            # https://github.com/python/mypy/issues/9046
+            # error: namedtuple() expects a string literal as the first argument
+            itertuple = collections.namedtuple(  # type: ignore[misc]
                 name, fields, rename=True
             )
             return map(itertuple._make, zip(*arrays))


### PR DESCRIPTION
pandas\core\frame.py:1091: error: namedtuple() expects a string literal as the first argument  [misc]
pandas\core\frame.py:4594: error: Need type annotation for 'names' (hint: "names: List[<type>] = ...")  [var-annotated]