### PR TITLE
TYP: typing errors in _xlsxwriter.py #35994

### DIFF
--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -653,7 +653,6 @@ class ExcelWriter(metaclass=abc.ABCMeta):
         return object.__new__(cls)
 
     # declare external properties you can count on
-    book = None
     curr_sheet = None
     path = None
 

--- a/pandas/io/excel/_odswriter.py
+++ b/pandas/io/excel/_odswriter.py
@@ -25,7 +25,7 @@ class _ODSWriter(ExcelWriter):
 
         super().__init__(path, mode=mode, **engine_kwargs)
 
-        self.book: OpenDocumentSpreadsheet = OpenDocumentSpreadsheet()
+        self.book = OpenDocumentSpreadsheet()
         self._style_dict: Dict[str, str] = {}
 
     def save(self) -> None:

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List, Tuple
 
 import pandas._libs.json as json
 
@@ -10,7 +10,7 @@ class _XlsxStyler:
     # Map from openpyxl-oriented styles to flatter xlsxwriter representation
     # Ordering necessary for both determinism and because some are keyed by
     # prefixes of others.
-    STYLE_MAPPING: Dict[str, list] = {
+    STYLE_MAPPING: Dict[str, List[Tuple[Tuple[str, ...], str]]] = {
         "font": [
             (("name",), "font_name"),
             (("sz",), "font_size"),

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -186,7 +186,7 @@ class _XlsxWriter(ExcelWriter):
             **engine_kwargs,
         )
 
-        self.book: Workbook = Workbook(path, **engine_kwargs)
+        self.book = Workbook(path, **engine_kwargs)
 
     def save(self):
         """

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pandas._libs.json as json
 
 from pandas.io.excel._base import ExcelWriter
@@ -8,7 +10,7 @@ class _XlsxStyler:
     # Map from openpyxl-oriented styles to flatter xlsxwriter representation
     # Ordering necessary for both determinism and because some are keyed by
     # prefixes of others.
-    STYLE_MAPPING = {
+    STYLE_MAPPING: Dict[str, list] = {
         "font": [
             (("name",), "font_name"),
             (("sz",), "font_size"),
@@ -170,7 +172,7 @@ class _XlsxWriter(ExcelWriter):
         **engine_kwargs,
     ):
         # Use the xlsxwriter module as the Excel writer.
-        import xlsxwriter
+        from xlsxwriter import Workbook
 
         if mode == "a":
             raise ValueError("Append mode is not supported with xlsxwriter!")
@@ -184,7 +186,7 @@ class _XlsxWriter(ExcelWriter):
             **engine_kwargs,
         )
 
-        self.book = xlsxwriter.Workbook(path, **engine_kwargs)
+        self.book: Workbook = Workbook(path, **engine_kwargs)
 
     def save(self):
         """


### PR DESCRIPTION
- [x] closes #35994
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

