### PR TITLE
TYP: add type annotation to `_xlwt.py` #36024

### DIFF
--- a/pandas/io/excel/_xlwt.py
+++ b/pandas/io/excel/_xlwt.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pandas._libs.json as json
 
 from pandas.io.excel._base import ExcelWriter
@@ -29,12 +31,12 @@ class _XlwtWriter(ExcelWriter):
         """
         Save workbook to disk.
         """
-        return self.book.save(self.path)
+        self.book.save(self.path)
 
     def write_cells(
         self, cells, sheet_name=None, startrow=0, startcol=0, freeze_panes=None
     ):
-        # Write the frame cells using xlwt.
+        from xlwt import XFStyle
 
         sheet_name = self._get_sheet_name(sheet_name)
 
@@ -49,7 +51,7 @@ class _XlwtWriter(ExcelWriter):
             wks.set_horz_split_pos(freeze_panes[0])
             wks.set_vert_split_pos(freeze_panes[1])
 
-        style_dict = {}
+        style_dict: Dict[str, XFStyle] = {}
 
         for cell in cells:
             val, fmt = self._value_with_fmt(cell.val)
@@ -101,14 +103,14 @@ class _XlwtWriter(ExcelWriter):
                     f"{key}: {cls._style_to_xlwt(value, False)}"
                     for key, value in item.items()
                 ]
-                out = f"{(line_sep).join(it)} "
+                out = f"{line_sep.join(it)} "
                 return out
             else:
                 it = [
                     f"{key} {cls._style_to_xlwt(value, False)}"
                     for key, value in item.items()
                 ]
-                out = f"{(field_sep).join(it)} "
+                out = f"{field_sep.join(it)} "
                 return out
         else:
             item = f"{item}"

--- a/pandas/io/excel/_xlwt.py
+++ b/pandas/io/excel/_xlwt.py
@@ -1,9 +1,12 @@
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
 import pandas._libs.json as json
 
 from pandas.io.excel._base import ExcelWriter
 from pandas.io.excel._util import _validate_freeze_panes
+
+if TYPE_CHECKING:
+    from xlwt import XFStyle
 
 
 class _XlwtWriter(ExcelWriter):
@@ -36,7 +39,6 @@ class _XlwtWriter(ExcelWriter):
     def write_cells(
         self, cells, sheet_name=None, startrow=0, startcol=0, freeze_panes=None
     ):
-        from xlwt import XFStyle
 
         sheet_name = self._get_sheet_name(sheet_name)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -223,9 +223,6 @@ check_untyped_defs=False
 [mypy-pandas.io.excel._util]
 check_untyped_defs=False
 
-[mypy-pandas.io.excel._xlwt]
-check_untyped_defs=False
-
 [mypy-pandas.io.formats.console]
 check_untyped_defs=False
 


### PR DESCRIPTION
- [x] closes #36024
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

pandas\io\excel\_xlwt.py:52: error: Need type annotation for 'style_dict' (hint: "style_dict: Dict[<type>, <type>] = ...")  [var-annotated]
