### PR TITLE
CI: pin setuptools on 1.1.x

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -148,7 +148,7 @@ python setup.py build_ext -q -i -j2
 # - py35_compat
 # - py36_32bit
 echo "[Updating pip]"
-python -m pip install --no-deps -U pip wheel setuptools
+python -m pip install --no-deps -U pip wheel "setuptools<50.0.0"
 
 echo "[Install pandas]"
 python -m pip install --no-build-isolation -e .


### PR DESCRIPTION
top answer on stack overflow is to pin https://stackoverflow.com/questions/63663362/django-python3-on-install-i-get-parent-module-setuptools-not-loaded

also see https://github.com/MacPython/pandas-wheels/pull/97#issuecomment-684938715

Note: 50.0.1 released a hour ago but still the same. https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=41325&view=logs&j=a67b4c4c-cd2e-5e3c-a361-de73ac9c05f9&t=9a6bfc0f-544f-57f9-291f-bf4b75b05642