### PR TITLE
CLN remove unnecessary trailing commas in pandas/io

### DIFF
--- a/pandas/io/sas/sas_xport.py
+++ b/pandas/io/sas/sas_xport.py
@@ -244,7 +244,7 @@ class XportReader(ReaderBase, abc.Iterator):
     __doc__ = _xport_reader_doc
 
     def __init__(
-        self, filepath_or_buffer, index=None, encoding="ISO-8859-1", chunksize=None,
+        self, filepath_or_buffer, index=None, encoding="ISO-8859-1", chunksize=None
     ):
 
         self._encoding = encoding

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1980,7 +1980,7 @@ def _open_file_binary_write(
         compression_typ = infer_compression(fname, compression_typ)
         compression = dict(compression_args, method=compression_typ)
         ioargs = get_filepath_or_buffer(
-            fname, mode="wb", compression=compression, storage_options=storage_options,
+            fname, mode="wb", compression=compression, storage_options=storage_options
         )
         f, _ = get_handle(
             ioargs.filepath_or_buffer,

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1980,7 +1980,7 @@ def _open_file_binary_write(
         compression_typ = infer_compression(fname, compression_typ)
         compression = dict(compression_args, method=compression_typ)
         path_or_buf, _, compression, _ = get_filepath_or_buffer(
-            fname, mode="wb", compression=compression, storage_options=storage_options,
+            fname, mode="wb", compression=compression, storage_options=storage_options
         )
         f, _ = get_handle(path_or_buf, "wb", compression=compression, is_text=False)
         return f, True, compression


### PR DESCRIPTION
@MarcoGorelli can you review this PR this is related to issue #35925, if this looks good to you I can open another PR
- [x] pandas/io/sas/sas_xport.py
- [x] pandas/io/stata.py
  
- [x] passes `black pandas`

