### PR TITLE
Comma cleanup for #35925

### DIFF
--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -86,11 +86,7 @@ def assert_stat_op_calc(
         result0 = f(axis=0, skipna=False)
         result1 = f(axis=1, skipna=False)
         tm.assert_series_equal(
-            result0,
-            frame.apply(wrapper),
-            check_dtype=check_dtype,
-            rtol=rtol,
-            atol=atol,
+            result0, frame.apply(wrapper), check_dtype=check_dtype, rtol=rtol, atol=atol
         )
         # HACK: win32
         tm.assert_series_equal(
@@ -116,7 +112,7 @@ def assert_stat_op_calc(
     if opname in ["sum", "prod"]:
         expected = frame.apply(skipna_wrapper, axis=1)
         tm.assert_series_equal(
-            result1, expected, check_dtype=False, rtol=rtol, atol=atol,
+            result1, expected, check_dtype=False, rtol=rtol, atol=atol
         )
 
     # check dtypes

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -932,7 +932,7 @@ class TestDataFrameConstructors:
         # from GH3479
 
         assert_fr_equal = functools.partial(
-            tm.assert_frame_equal, check_index_type=True, check_column_type=True,
+            tm.assert_frame_equal, check_index_type=True, check_column_type=True
         )
         arrays = [
             ("float", np.array([1.5, 2.0])),

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -417,7 +417,7 @@ class TestDataFrameReshape:
         result = df.unstack(unstack_idx)
 
         expected = pd.DataFrame(
-            expected_values, columns=expected_columns, index=expected_index,
+            expected_values, columns=expected_columns, index=expected_index
         )
         tm.assert_frame_equal(result, expected)
 
@@ -807,7 +807,7 @@ class TestDataFrameReshape:
                 [["B", "C"], ["B", "D"]], names=["c1", "c2"]
             ),
             index=pd.MultiIndex.from_tuples(
-                [[10, 20, 30], [10, 20, 40]], names=["i1", "i2", "i3"],
+                [[10, 20, 30], [10, 20, 40]], names=["i1", "i2", "i3"]
             ),
         )
         assert df.unstack(["i2", "i1"]).columns.names[-2:] == ["i2", "i1"]

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -123,7 +123,11 @@ _all_methods = [
     (pd.DataFrame, frame_data, operator.methodcaller("sort_index")),
     (pd.DataFrame, frame_data, operator.methodcaller("nlargest", 1, "A")),
     (pd.DataFrame, frame_data, operator.methodcaller("nsmallest", 1, "A")),
-    (pd.DataFrame, frame_mi_data, operator.methodcaller("swaplevel"),),
+    (
+        pd.DataFrame,
+        frame_mi_data,
+        operator.methodcaller("swaplevel"),
+    ),
     pytest.param(
         (
             pd.DataFrame,
@@ -178,7 +182,11 @@ _all_methods = [
         marks=not_implemented_mark,
     ),
     pytest.param(
-        (pd.DataFrame, frame_mi_data, operator.methodcaller("unstack"),),
+        (
+            pd.DataFrame,
+            frame_mi_data,
+            operator.methodcaller("unstack"),
+        ),
         marks=not_implemented_mark,
     ),
     pytest.param(
@@ -317,7 +325,7 @@ _all_methods = [
         marks=not_implemented_mark,
     ),
     pytest.param(
-        (pd.Series, ([1, 2],), operator.methodcaller("squeeze")),
+        (pd.Series, ([1, 2],), operator.methodcaller("squeeze"))
         # marks=not_implemented_mark,
     ),
     (pd.Series, ([1, 2],), operator.methodcaller("rename_axis", index="a")),
@@ -733,9 +741,7 @@ def test_timedelta_property(attr):
     assert result.attrs == {"a": 1}
 
 
-@pytest.mark.parametrize(
-    "method", [operator.methodcaller("total_seconds")],
-)
+@pytest.mark.parametrize("method", [operator.methodcaller("total_seconds")])
 @not_implemented_mark
 def test_timedelta_methods(method):
     s = pd.Series(pd.timedelta_range("2000", periods=4))

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -123,11 +123,7 @@ _all_methods = [
     (pd.DataFrame, frame_data, operator.methodcaller("sort_index")),
     (pd.DataFrame, frame_data, operator.methodcaller("nlargest", 1, "A")),
     (pd.DataFrame, frame_data, operator.methodcaller("nsmallest", 1, "A")),
-    (
-        pd.DataFrame,
-        frame_mi_data,
-        operator.methodcaller("swaplevel"),
-    ),
+    (pd.DataFrame, frame_mi_data, operator.methodcaller("swaplevel")),
     pytest.param(
         (
             pd.DataFrame,
@@ -182,11 +178,7 @@ _all_methods = [
         marks=not_implemented_mark,
     ),
     pytest.param(
-        (
-            pd.DataFrame,
-            frame_mi_data,
-            operator.methodcaller("unstack"),
-        ),
+        (pd.DataFrame, frame_mi_data, operator.methodcaller("unstack")),
         marks=not_implemented_mark,
     ),
     pytest.param(

--- a/pandas/tests/generic/test_to_xarray.py
+++ b/pandas/tests/generic/test_to_xarray.py
@@ -47,9 +47,7 @@ class TestDataFrameToXArray:
         expected = df.copy()
         expected["f"] = expected["f"].astype(object)
         expected.columns.name = None
-        tm.assert_frame_equal(
-            result.to_dataframe(), expected,
-        )
+        tm.assert_frame_equal(result.to_dataframe(), expected)
 
     @td.skip_if_no("xarray", min_version="0.7.0")
     def test_to_xarray(self):

--- a/pandas/tests/groupby/aggregate/test_numba.py
+++ b/pandas/tests/groupby/aggregate/test_numba.py
@@ -57,7 +57,7 @@ def test_numba_vs_cython(jit, pandas_obj, nogil, parallel, nopython):
         func_numba = numba.jit(func_numba)
 
     data = DataFrame(
-        {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1],
+        {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
     engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
     grouped = data.groupby(0)
@@ -90,7 +90,7 @@ def test_cache(jit, pandas_obj, nogil, parallel, nopython):
         func_2 = numba.jit(func_2)
 
     data = DataFrame(
-        {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1],
+        {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
     engine_kwargs = {"nogil": nogil, "parallel": parallel, "nopython": nopython}
     grouped = data.groupby(0)
@@ -121,7 +121,7 @@ def test_use_global_config():
         return np.mean(values) - 3.4
 
     data = DataFrame(
-        {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1],
+        {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
     grouped = data.groupby(0)
     expected = grouped.agg(func_1, engine="numba")
@@ -142,7 +142,7 @@ def test_use_global_config():
 )
 def test_multifunc_notimplimented(agg_func):
     data = DataFrame(
-        {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1],
+        {0: ["a", "a", "b", "b", "a"], 1: [1.0, 2.0, 3.0, 4.0, 5.0]}, columns=[0, 1]
     )
     grouped = data.groupby(0)
     with pytest.raises(NotImplementedError, match="Numba engine can"):

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -946,9 +946,7 @@ def test_apply_function_returns_numpy_array():
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "function", [lambda gr: gr.index, lambda gr: gr.index + 1 - 1],
-)
+@pytest.mark.parametrize("function", [lambda gr: gr.index, lambda gr: gr.index + 1 - 1])
 def test_apply_function_index_return(function):
     # GH: 22541
     df = pd.DataFrame([1, 2, 2, 2, 1, 2, 3, 1, 3, 1], columns=["id"])

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -17,7 +17,7 @@ import pandas._testing as tm
 
 
 def cartesian_product_for_groupers(result, args, names, fill_value=np.NaN):
-    """ Reindex to a cartesian production for the groupers,
+    """Reindex to a cartesian production for the groupers,
     preserving the nature (Categorical) of each grouper
     """
 
@@ -1449,7 +1449,7 @@ def test_groupby_agg_categorical_columns(func, expected_values):
     result = df.groupby("groups").agg(func)
 
     expected = pd.DataFrame(
-        {"value": expected_values}, index=pd.Index([0, 1, 2], name="groups"),
+        {"value": expected_values}, index=pd.Index([0, 1, 2], name="groups")
     )
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -676,7 +676,10 @@ def test_ops_not_as_index(reduction_func):
     if reduction_func in ("corrwith",):
         pytest.skip("Test not applicable")
 
-    if reduction_func in ("nth", "ngroup",):
+    if reduction_func in (
+        "nth",
+        "ngroup",
+    ):
         pytest.skip("Skip until behavior is determined (GH #5755)")
 
     df = DataFrame(np.random.randint(0, 5, size=(100, 2)), columns=["a", "b"])

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -676,10 +676,7 @@ def test_ops_not_as_index(reduction_func):
     if reduction_func in ("corrwith",):
         pytest.skip("Test not applicable")
 
-    if reduction_func in (
-        "nth",
-        "ngroup",
-    ):
+    if reduction_func in ("nth", "ngroup"):
         pytest.skip("Skip until behavior is determined (GH #5755)")
 
     df = DataFrame(np.random.randint(0, 5, size=(100, 2)), columns=["a", "b"])

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -246,16 +246,7 @@ def test_groupby_dropna_multi_index_dataframe_agg(dropna, tuples, outputs):
         (pd.Period("2020-01-01"), pd.Period("2020-02-01")),
     ],
 )
-@pytest.mark.parametrize(
-    "dropna, values",
-    [
-        (True, [12, 3]),
-        (
-            False,
-            [12, 3, 6],
-        ),
-    ],
-)
+@pytest.mark.parametrize("dropna, values", [(True, [12, 3]), (False, [12, 3, 6])])
 def test_groupby_dropna_datetime_like_data(
     dropna, values, datetime1, datetime2, unique_nulls_fixture, unique_nulls_fixture2
 ):

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -247,7 +247,14 @@ def test_groupby_dropna_multi_index_dataframe_agg(dropna, tuples, outputs):
     ],
 )
 @pytest.mark.parametrize(
-    "dropna, values", [(True, [12, 3]), (False, [12, 3, 6],)],
+    "dropna, values",
+    [
+        (True, [12, 3]),
+        (
+            False,
+            [12, 3, 6],
+        ),
+    ],
 )
 def test_groupby_dropna_datetime_like_data(
     dropna, values, datetime1, datetime2, unique_nulls_fixture, unique_nulls_fixture2

--- a/pandas/tests/groupby/test_groupby_subclass.py
+++ b/pandas/tests/groupby/test_groupby_subclass.py
@@ -51,9 +51,7 @@ def test_groupby_preserves_subclass(obj, groupby_func):
         tm.assert_series_equal(result1, result2)
 
 
-@pytest.mark.parametrize(
-    "obj", [DataFrame, tm.SubclassedDataFrame],
-)
+@pytest.mark.parametrize("obj", [DataFrame, tm.SubclassedDataFrame])
 def test_groupby_resample_preserves_subclass(obj):
     # GH28330 -- preserve subclass through groupby.resample()
 

--- a/pandas/tests/groupby/test_size.py
+++ b/pandas/tests/groupby/test_size.py
@@ -53,7 +53,7 @@ def test_size_on_categorical(as_index):
     result = df.groupby(["A", "B"], as_index=as_index).size()
 
     expected = DataFrame(
-        [[1, 1, 1], [1, 2, 0], [2, 1, 0], [2, 2, 1]], columns=["A", "B", "size"],
+        [[1, 1, 1], [1, 2, 0], [2, 1, 0], [2, 2, 1]], columns=["A", "B", "size"]
     )
     expected["A"] = expected["A"].astype("category")
     if as_index:


### PR DESCRIPTION
- [x] pandas/tests/generic/test_finalize.py
- [x] pandas/tests/generic/test_to_xarray.py
- [x] pandas/tests/groupby/aggregate/test_numba.py
- [x] pandas/tests/groupby/test_apply.py
- [x] pandas/tests/groupby/test_categorical.py
- [x] pandas/tests/groupby/test_groupby.py
- [x] pandas/tests/groupby/test_groupby_dropna.py
- [x] pandas/tests/groupby/test_groupby_subclass.py
