### PR TITLE
DOC: Fix typo of `=!` to `!=` in docstring

### DIFF
--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -611,7 +611,7 @@ Get {desc} of dataframe and other, element-wise (binary operator `{op_name}`).
 Among flexible wrappers (`eq`, `ne`, `le`, `lt`, `ge`, `gt`) to comparison
 operators.
 
-Equivalent to `==`, `=!`, `<=`, `<`, `>=`, `>` with support to choose axis
+Equivalent to `==`, `!=`, `<=`, `<`, `>=`, `>` with support to choose axis
 (rows or columns) and level for comparison.
 
 Parameters


### PR DESCRIPTION
This fixes GH36075.

- [x] closes #36075 

I'm marking the following list items as not-applicable because I'm simply swapping two characters in a docstring that had been in the incorrect order.

- [NA] tests added / passed
- [NA] passes `black pandas`
- [NA] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [NA] whatsnew entry
