### PR TITLE
PERF: use from __future__ import annotations more

### DIFF
--- a/pandas/_config/config.py
+++ b/pandas/_config/config.py
@@ -47,6 +47,7 @@ Implementation
   which can save developers some typing, see the docstring.
 
 """
+from __future__ import annotations
 
 from collections import namedtuple
 from contextlib import ContextDecorator, contextmanager

--- a/pandas/_config/dates.py
+++ b/pandas/_config/dates.py
@@ -1,6 +1,8 @@
 """
 config for datetime formatting
 """
+from __future__ import annotations
+
 from pandas._config import config as cf
 
 pc_date_dayfirst_doc = """

--- a/pandas/_config/display.py
+++ b/pandas/_config/display.py
@@ -2,6 +2,8 @@
 Unopinionated display configuration.
 """
 
+from __future__ import annotations
+
 import locale
 import sys
 

--- a/pandas/_config/localization.py
+++ b/pandas/_config/localization.py
@@ -3,6 +3,8 @@ Helpers for configuring locale settings.
 
 Name `localization` is chosen to avoid overlap with builtin `locale` module.
 """
+from __future__ import annotations
+
 from contextlib import contextmanager
 import locale
 import re

--- a/pandas/compat/_optional.py
+++ b/pandas/compat/_optional.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import distutils.version
 import importlib
 import types

--- a/pandas/compat/chainmap.py
+++ b/pandas/compat/chainmap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import ChainMap, MutableMapping, TypeVar, cast
 
 _KT = TypeVar("_KT")

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -1,6 +1,7 @@
 """
 Support pre-0.12 series pickle compatibility.
 """
+from __future__ import annotations
 
 import contextlib
 import copy

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -4,6 +4,8 @@ accessor.py contains base classes for implementing accessor properties
 that can be mixed into or pinned onto other pandas classes.
 
 """
+from __future__ import annotations
+
 from typing import FrozenSet, Set
 import warnings
 

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -2,6 +2,7 @@
 aggregation.py contains utility functions to handle multiple named and lambda
 kwarg aggregations in groupby and DataFrame/Series aggregation
 """
+from __future__ import annotations
 
 from collections import defaultdict
 from functools import partial

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -1,5 +1,7 @@
 # flake8: noqa
 
+from __future__ import annotations
+
 from pandas._libs import NaT, Period, Timedelta, Timestamp
 from pandas._libs.missing import NA
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import inspect
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple, Type, Union

--- a/pandas/core/array_algos/masked_reductions.py
+++ b/pandas/core/array_algos/masked_reductions.py
@@ -3,6 +3,8 @@ masked_reductions.py is for reduction algorithms using a mask-based approach
 for missing values.
 """
 
+from __future__ import annotations
+
 from typing import Callable
 
 import numpy as np

--- a/pandas/core/array_algos/transforms.py
+++ b/pandas/core/array_algos/transforms.py
@@ -2,6 +2,8 @@
 transforms.py is for shape-preserving functions.
 """
 
+from __future__ import annotations
+
 import numpy as np
 
 from pandas.core.dtypes.common import ensure_platform_int

--- a/pandas/core/arrays/_arrow_utils.py
+++ b/pandas/core/arrays/_arrow_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from distutils.version import LooseVersion
 import json
 

--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Sequence, Tuple, TypeVar
 
 import numpy as np

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -3,6 +3,8 @@ Helper functions to generate range-like data for DatetimeArray
 (and possibly TimedeltaArray/PeriodArray)
 """
 
+from __future__ import annotations
+
 from typing import Union
 
 import numpy as np

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -6,6 +6,8 @@ An interface for extending pandas with custom arrays.
    This is an experimental API and subject to breaking changes
    without warning.
 """
+from __future__ import annotations
+
 import operator
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union, cast
 

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 from typing import TYPE_CHECKING, List, Tuple, Type, Union
 import warnings

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from csv import QUOTE_NONNUMERIC
 from functools import partial
 import operator

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 import operator
 from typing import Any, Callable, Optional, Sequence, Tuple, Type, TypeVar, Union, cast

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, time, timedelta, tzinfo
 from typing import Optional, Union
 import warnings

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 import warnings

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from operator import le, lt
 import textwrap
 

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional, Tuple, Type, TypeVar
 
 import numpy as np

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 from typing import Optional, Tuple, Type, Union
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 import operator
 from typing import Any, Callable, List, Optional, Sequence, Type, Union

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -1,5 +1,7 @@
 """Sparse accessor"""
 
+from __future__ import annotations
+
 import numpy as np
 
 from pandas.compat._optional import import_optional_dependency

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1,6 +1,8 @@
 """
 SparseArray data structure
 """
+from __future__ import annotations
+
 from collections import abc
 import numbers
 import operator

--- a/pandas/core/arrays/sparse/dtype.py
+++ b/pandas/core/arrays/sparse/dtype.py
@@ -1,5 +1,7 @@
 """Sparse Dtype"""
 
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type
 import warnings

--- a/pandas/core/arrays/sparse/scipy_sparse.py
+++ b/pandas/core/arrays/sparse/scipy_sparse.py
@@ -3,6 +3,8 @@ Interaction with scipy.sparse matrices.
 
 Currently only includes to_coo helpers.
 """
+from __future__ import annotations
+
 from pandas.core.indexes.api import Index, MultiIndex
 from pandas.core.series import Series
 

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import operator
 from typing import TYPE_CHECKING, Type, Union
 

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import List
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -2,6 +2,8 @@
 Base and utility classes for pandas objects.
 """
 
+from __future__ import annotations
+
 import builtins
 import textwrap
 from typing import Any, Dict, FrozenSet, List, Optional, Union

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -4,6 +4,8 @@ Misc tools for implementing data structures
 Note: pandas.core.common is *not* part of the public API.
 """
 
+from __future__ import annotations
+
 from collections import abc, defaultdict
 import contextlib
 from datetime import datetime, timedelta

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -2,6 +2,8 @@
 Core eval alignment algorithms.
 """
 
+from __future__ import annotations
+
 from functools import partial, wraps
 from typing import Dict, Optional, Sequence, Tuple, Type, Union
 import warnings

--- a/pandas/core/computation/common.py
+++ b/pandas/core/computation/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import reduce
 
 import numpy as np

--- a/pandas/core/computation/engines.py
+++ b/pandas/core/computation/engines.py
@@ -2,6 +2,8 @@
 Engine classes for :func:`~pandas.eval`
 """
 
+from __future__ import annotations
+
 import abc
 from typing import Dict, Type
 

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -2,6 +2,8 @@
 Top level ``eval`` module.
 """
 
+from __future__ import annotations
+
 import tokenize
 from typing import Optional
 import warnings

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -2,6 +2,8 @@
 :func:`~pandas.eval` parsers.
 """
 
+from __future__ import annotations
+
 import ast
 from functools import partial, reduce
 from keyword import iskeyword

--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -5,6 +5,8 @@ Expressions
 Offer fast expression evaluation through numexpr
 
 """
+from __future__ import annotations
+
 import operator
 from typing import List, Set
 import warnings

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -2,6 +2,8 @@
 Operator classes for eval.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from distutils.version import LooseVersion
 from functools import partial

--- a/pandas/core/computation/parsing.py
+++ b/pandas/core/computation/parsing.py
@@ -2,6 +2,8 @@
 :func:`~pandas.eval` source string parsing functions
 """
 
+from __future__ import annotations
+
 from io import StringIO
 from keyword import iskeyword
 import token

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -1,5 +1,7 @@
 """ manage PyTables query interface via Expressions """
 
+from __future__ import annotations
+
 import ast
 from functools import partial
 from typing import Any, Dict, Optional, Tuple

--- a/pandas/core/computation/scope.py
+++ b/pandas/core/computation/scope.py
@@ -2,6 +2,8 @@
 Module for scope operations
 """
 
+from __future__ import annotations
+
 import datetime
 import inspect
 from io import StringIO

--- a/pandas/core/dtypes/base.py
+++ b/pandas/core/dtypes/base.py
@@ -2,6 +2,8 @@
 Extend pandas with custom array types.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, Union
 
 import numpy as np

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -2,6 +2,8 @@
 Routines for casting.
 """
 
+from __future__ import annotations
+
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type
 

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -2,6 +2,8 @@
 Common type operations.
 """
 
+from __future__ import annotations
+
 from typing import Any, Callable, Union
 import warnings
 

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -1,6 +1,8 @@
 """
 Utility functions related to concat.
 """
+from __future__ import annotations
+
 from typing import cast
 
 import numpy as np

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1,6 +1,7 @@
 """
 Define extension dtypes.
 """
+from __future__ import annotations
 
 import re
 from typing import (

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -1,5 +1,7 @@
 """ basic inference routines """
 
+from __future__ import annotations
+
 from collections import abc
 from numbers import Number
 import re

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -1,6 +1,8 @@
 """
 missing types & inference
 """
+from __future__ import annotations
+
 from functools import partial
 
 import numpy as np

--- a/pandas/core/flags.py
+++ b/pandas/core/flags.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import weakref
 
 

--- a/pandas/core/groupby/base.py
+++ b/pandas/core/groupby/base.py
@@ -3,6 +3,8 @@ Provide basic components for groupby. These definitions
 hold the allowlist of methods that are exposed on the
 SeriesGroupBy and the DataFrameGroupBy objects.
 """
+from __future__ import annotations
+
 import collections
 from typing import List
 

--- a/pandas/core/groupby/categorical.py
+++ b/pandas/core/groupby/categorical.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -5,6 +5,8 @@ classes that hold the groupby interfaces (and some implementations).
 These are user facing as the result of the ``df.groupby(...)`` operations,
 which here returns a DataFrameGroupBy object.
 """
+from __future__ import annotations
+
 from collections import abc, namedtuple
 import copy
 from functools import partial

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -6,6 +6,7 @@ The SeriesGroupBy and DataFrameGroupBy sub-class
 (defined in pandas.core.groupby.generic)
 expose these user-facing objects to provide specific functionality.
 """
+from __future__ import annotations
 
 from contextlib import contextmanager
 import datetime

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -2,6 +2,8 @@
 Provide user facing operators for doing the split part of the
 split-apply-combine paradigm.
 """
+from __future__ import annotations
+
 from typing import Dict, Hashable, List, Optional, Tuple
 import warnings
 

--- a/pandas/core/groupby/numba_.py
+++ b/pandas/core/groupby/numba_.py
@@ -1,4 +1,6 @@
 """Common utilities for Numba operations with groupby ops"""
+from __future__ import annotations
+
 import inspect
 from typing import Any, Callable, Dict, Optional, Tuple
 

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -6,6 +6,8 @@ operations, primarily in cython. These classes (BaseGrouper and BinGrouper)
 are contained *in* the SeriesGroupBy and DataFrameGroupBy objects.
 """
 
+from __future__ import annotations
+
 import collections
 from typing import List, Optional, Sequence, Tuple, Type
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 
 from pandas.core.indexes.api import (  # noqa:F401

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -1,6 +1,8 @@
 """
 Low-dependency indexing utilities.
 """
+from __future__ import annotations
+
 import warnings
 
 import numpy as np

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -1,6 +1,8 @@
 """
 datetimelike delegation
 """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 import warnings
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 from typing import List, Set
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import copy as copy_func
 from datetime import datetime
 import operator

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, List
 import warnings
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -1,6 +1,8 @@
 """
 Base and utility classes for tseries type pandas objects.
 """
+from __future__ import annotations
+
 from datetime import datetime, tzinfo
 from typing import Any, List, Optional, TypeVar, Union, cast
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime, time, timedelta, tzinfo
 import operator
 from typing import Optional

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -1,6 +1,8 @@
 """
 Shared methods for Index subclasses backed by ExtensionArray.
 """
+from __future__ import annotations
+
 from typing import List
 
 import numpy as np

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -6,6 +6,7 @@ These are used for:
 - .names (FrozenList)
 
 """
+from __future__ import annotations
 
 from typing import Any
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1,4 +1,6 @@
 """ define the IntervalIndex """
+from __future__ import annotations
+
 from operator import le, lt
 import textwrap
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sys import getsizeof
 from typing import (
     TYPE_CHECKING,

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Any
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 import operator
 from sys import getsizeof

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -1,5 +1,7 @@
 """ implement the TimedeltaIndex """
 
+from __future__ import annotations
+
 from pandas._libs import index as libindex, lib
 from pandas._libs.tslibs import Timedelta, to_offset
 from pandas._typing import DtypeObj, Label

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Hashable, List, Tuple, Union
 
 import numpy as np

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 import inspect
 import re

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 import copy
 from typing import Dict, List

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -2,6 +2,8 @@
 Functions for preparing various inputs passed to the DataFrame or Series
 constructors before passing them to a BlockManager.
 """
+from __future__ import annotations
+
 from collections import abc
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 import itertools
 import operator

--- a/pandas/core/internals/ops.py
+++ b/pandas/core/internals/ops.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import namedtuple
 from typing import TYPE_CHECKING, Iterator, List, Tuple
 

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -2,6 +2,8 @@
 Routines for filling missing data.
 """
 
+from __future__ import annotations
+
 from typing import Any, List, Optional, Set, Union
 
 import numpy as np

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import itertools
 import operator

--- a/pandas/core/ops/array_ops.py
+++ b/pandas/core/ops/array_ops.py
@@ -2,6 +2,8 @@
 Functions for arithmetic and comparison operations on NumPy arrays and
 ExtensionArrays.
 """
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
 import operator

--- a/pandas/core/ops/common.py
+++ b/pandas/core/ops/common.py
@@ -1,6 +1,8 @@
 """
 Boilerplate functions used in defining binary operations.
 """
+from __future__ import annotations
+
 from functools import wraps
 from typing import Callable
 

--- a/pandas/core/ops/dispatch.py
+++ b/pandas/core/ops/dispatch.py
@@ -1,6 +1,8 @@
 """
 Functions for defining unary operations.
 """
+from __future__ import annotations
+
 from typing import Any
 
 from pandas._typing import ArrayLike

--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -1,6 +1,8 @@
 """
 Templating for ops docstrings
 """
+from __future__ import annotations
+
 from typing import Dict, Optional
 
 

--- a/pandas/core/ops/invalid.py
+++ b/pandas/core/ops/invalid.py
@@ -1,6 +1,8 @@
 """
 Templates for invalid operations.
 """
+from __future__ import annotations
+
 import operator
 
 import numpy as np

--- a/pandas/core/ops/mask_ops.py
+++ b/pandas/core/ops/mask_ops.py
@@ -1,6 +1,8 @@
 """
 Ops for masked arrays.
 """
+from __future__ import annotations
+
 from typing import Optional, Union
 
 import numpy as np

--- a/pandas/core/ops/methods.py
+++ b/pandas/core/ops/methods.py
@@ -1,6 +1,8 @@
 """
 Functions to generate methods and pin them to the appropriate classes.
 """
+from __future__ import annotations
+
 import operator
 
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries

--- a/pandas/core/ops/missing.py
+++ b/pandas/core/ops/missing.py
@@ -21,6 +21,8 @@ from numpy in the following ways:
 
     3) divmod behavior consistent with 1) and 2).
 """
+from __future__ import annotations
+
 import operator
 
 import numpy as np

--- a/pandas/core/ops/roperator.py
+++ b/pandas/core/ops/roperator.py
@@ -2,6 +2,8 @@
 Reversed Operations not available in the stdlib operator module.
 Defining these instead of using lambdas allows us to reference them by name.
 """
+from __future__ import annotations
+
 import operator
 
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 from datetime import timedelta
 from textwrap import dedent

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -2,6 +2,8 @@
 Concat routines.
 """
 
+from __future__ import annotations
+
 from collections import abc
 from typing import TYPE_CHECKING, Iterable, List, Mapping, Union, overload
 

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, List, cast
 import warnings

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -2,6 +2,8 @@
 SQL-style merge routines
 """
 
+from __future__ import annotations
+
 import copy
 import datetime
 from functools import partial

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Callable,

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import List, Optional, Union
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -1,6 +1,8 @@
 """
 Quantilization functions and related stuff
 """
+from __future__ import annotations
+
 import numpy as np
 
 from pandas._libs import Timedelta, Timestamp

--- a/pandas/core/reshape/util.py
+++ b/pandas/core/reshape/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from pandas.core.dtypes.common import is_list_like

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1,6 +1,8 @@
 """
 Data structure for 1-dimensional cross-sectional and time series data
 """
+from __future__ import annotations
+
 from io import StringIO
 from shutil import get_terminal_size
 from textwrap import dedent

--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 
 _shared_docs: Dict[str, str] = dict()

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -1,4 +1,6 @@
 """ miscellaneous sorting / groupby utilities """
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, DefaultDict, Iterable, List, Optional, Tuple
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import codecs
 from functools import wraps
 import re

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import abc
 from datetime import datetime
 from functools import partial

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from pandas._libs import lib

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -2,6 +2,8 @@
 timedelta support tools
 """
 
+from __future__ import annotations
+
 import numpy as np
 
 from pandas._libs.tslibs import NaT

--- a/pandas/core/tools/times.py
+++ b/pandas/core/tools/times.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, time
 from typing import List, Optional
 

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -1,6 +1,8 @@
 """
 data hash pandas / numpy objects
 """
+from __future__ import annotations
+
 import itertools
 from typing import Optional
 

--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -1,4 +1,6 @@
 """Common utilities for Numba operations"""
+from __future__ import annotations
+
 from distutils.version import LooseVersion
 import types
 from typing import Callable, Dict, Optional, Tuple

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -1,4 +1,6 @@
 """Common utility functions for rolling operations"""
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import Callable, Optional
 import warnings

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from functools import partial
 from textwrap import dedent

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from textwrap import dedent
 from typing import Dict, Optional
 

--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -1,4 +1,6 @@
 """Indexer objects for computing start/end window bounds for rolling operations"""
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import Dict, Optional, Tuple, Type
 

--- a/pandas/core/window/numba_.py
+++ b/pandas/core/window/numba_.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import numpy as np

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2,6 +2,8 @@
 Provide a generic structure to support window functions,
 similar to how we have a Groupby object.
 """
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
 import inspect


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/36034#issuecomment-684964511

@WillAyd using `python -X importtime -c "import pandas"` I don't see any different in import time after running a few times and things are cached.

so I don't think we gain anything from a performance POV and therefore only need to use it for stylistic reasons in a few modules and not across the codebase.

I've opened this PR, in case someone wants to test performance with these changes.

so feel free to close
