### PR TITLE
TYP: misc fixes for numpy types

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -62,7 +62,7 @@ Timezone = Union[str, tzinfo]
 # other
 
 Dtype = Union[
-    "ExtensionDtype", str, np.dtype, Type[Union[str, float, int, complex, bool]]
+    "ExtensionDtype", str, np.dtype, Type[Union[str, float, int, complex, bool, object]]
 ]
 DtypeObj = Union[np.dtype, "ExtensionDtype"]
 FilePathOrBuffer = Union[str, Path, IO[AnyStr], IOBase]

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import operator
 from textwrap import dedent
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union, cast
 from warnings import catch_warnings, simplefilter, warn
 
 import numpy as np
@@ -60,7 +60,7 @@ from pandas.core.construction import array, extract_array
 from pandas.core.indexers import validate_indices
 
 if TYPE_CHECKING:
-    from pandas import DataFrame, Series
+    from pandas import DataFrame, Series, Categorical
 
 _shared_docs: Dict[str, str] = {}
 
@@ -429,8 +429,7 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
     if is_categorical_dtype(comps):
         # TODO(extension)
         # handle categoricals
-        # error: "ExtensionArray" has no attribute "isin"  [attr-defined]
-        return comps.isin(values)  # type: ignore[attr-defined]
+        return cast("Categorical", comps).isin(values)
 
     comps, dtype = _ensure_data(comps)
     values, _ = _ensure_data(values, dtype=dtype)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -60,7 +60,7 @@ from pandas.core.construction import array, extract_array
 from pandas.core.indexers import validate_indices
 
 if TYPE_CHECKING:
-    from pandas import DataFrame, Series, Categorical
+    from pandas import Categorical, DataFrame, Series
 
 _shared_docs: Dict[str, str] = {}
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2316,7 +2316,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject):
 
         return union_categoricals(to_concat)
 
-    def isin(self, values):
+    def isin(self, values) -> np.ndarray:
         """
         Check whether `values` are contained in Categorical.
 

--- a/pandas/core/construction.py
+++ b/pandas/core/construction.py
@@ -335,7 +335,7 @@ def array(
     return result
 
 
-def extract_array(obj, extract_numpy: bool = False):
+def extract_array(obj: AnyArrayLike, extract_numpy: bool = False) -> ArrayLike:
     """
     Extract the ndarray or ExtensionArray from a Series or Index.
 
@@ -383,7 +383,9 @@ def extract_array(obj, extract_numpy: bool = False):
     if extract_numpy and isinstance(obj, ABCPandasArray):
         obj = obj.to_numpy()
 
-    return obj
+    # error: Incompatible return value type (got "Index", expected "ExtensionArray")
+    # error: Incompatible return value type (got "Series", expected "ExtensionArray")
+    return obj  # type: ignore[return-value]
 
 
 def sanitize_array(

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1488,7 +1488,7 @@ def find_common_type(types: List[DtypeObj]) -> DtypeObj:
     if has_bools:
         for t in types:
             if is_integer_dtype(t) or is_float_dtype(t) or is_complex_dtype(t):
-                return object
+                return np.dtype("object")
 
     return np.find_common_type(types, [])
 
@@ -1550,7 +1550,7 @@ def construct_1d_arraylike_from_scalar(
         elif isinstance(dtype, np.dtype) and dtype.kind in ("U", "S"):
             # we need to coerce to object dtype to avoid
             # to allow numpy to take our string as a scalar value
-            dtype = object
+            dtype = np.dtype("object")
             if not isna(value):
                 value = ensure_str(value)
 


### PR DESCRIPTION
```
pandas/core/dtypes/cast.py:1491: error: Incompatible return value type (got "Type[object]", expected "Union[dtype, ExtensionDtype]")  [return-value]
pandas/core/dtypes/cast.py:1553: error: Incompatible types in assignment (expression has type "Type[object]", variable has type "Union[dtype, ExtensionDtype]")  [assignment]
pandas/core/construction.py:601: error: Incompatible default for argument "dtype_if_empty" (default has type "Type[object]", argument has type "Union[ExtensionDtype, str, dtype, Type[str], Type[float], Type[int], Type[complex], Type[bool]]")  [assignment]
pandas/core/generic.py:6217: error: Argument "dtype_if_empty" to "create_series_with_explicit_dtype" has incompatible type "Type[object]"; expected "Union[ExtensionDtype, str, dtype, Type[str], Type[float], Type[int], Type[complex], Type[bool]]"  [arg-type]
pandas/tests/arrays/sparse/test_dtype.py:97: error: Argument 1 to "SparseDtype" has incompatible type "Type[object]"; expected "Union[ExtensionDtype, str, dtype, Type[str], Type[float], Type[int], Type[complex], Type[bool]]"  [arg-type]
pandas/tests/arrays/sparse/test_dtype.py:172: error: Argument 1 to "SparseDtype" has incompatible type "Type[object]"; expected "Union[ExtensionDtype, str, dtype, Type[str], Type[float], Type[int], Type[complex], Type[bool]]"  [arg-type]
pandas/tests/arrays/sparse/test_combine_concat.py:44: error: Argument 1 to "SparseDtype" has incompatible type "Type[object]"; expected "Union[ExtensionDtype, str, dtype, Type[str], Type[float], Type[int], Type[complex], Type[bool]]"  [arg-type]
pandas/tests/arrays/sparse/test_array.py:561: error: Argument 1 to "SparseDtype" has incompatible type "Type[object]"; expected "Union[ExtensionDtype, str, dtype, Type[str], Type[float], Type[int], Type[complex], Type[bool]]"  [arg-type]
```