### PR TITLE
TYP: misc fixes for numpy types 2

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -651,7 +651,7 @@ def infer_dtype_from_scalar(val, pandas_dtype: bool = False) -> Tuple[DtypeObj, 
         If False, scalar belongs to pandas extension types is inferred as
         object
     """
-    dtype = np.dtype(object)
+    dtype: DtypeObj = np.dtype(object)
 
     # a 1-element ndarray
     if isinstance(val, np.ndarray):

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -108,7 +108,7 @@ def ensure_str(value: Union[bytes, Any]) -> str:
     return value
 
 
-def ensure_int_or_float(arr: ArrayLike, copy: bool = False) -> np.array:
+def ensure_int_or_float(arr: ArrayLike, copy: bool = False) -> np.ndarray:
     """
     Ensure that an dtype array of some integer dtype
     has an int64 dtype if possible.
@@ -1388,8 +1388,7 @@ def is_bool_dtype(arr_or_dtype) -> bool:
         # guess this
         return arr_or_dtype.is_object and arr_or_dtype.inferred_type == "boolean"
     elif is_extension_array_dtype(arr_or_dtype):
-        dtype = getattr(arr_or_dtype, "dtype", arr_or_dtype)
-        return dtype._is_boolean
+        return getattr(arr_or_dtype, "dtype", arr_or_dtype)._is_boolean
 
     return issubclass(dtype.type, np.bool_)
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1870,7 +1870,7 @@ def _right_outer_join(x, y, max_groups):
 
 def _factorize_keys(
     lk: ArrayLike, rk: ArrayLike, sort: bool = True, how: str = "inner"
-) -> Tuple[np.array, np.array, int]:
+) -> Tuple[np.ndarray, np.ndarray, int]:
     """
     Encode left and right keys as enumerated types.
 


### PR DESCRIPTION
```
pandas\core\dtypes\cast.py:681: error: Incompatible types in assignment (expression has type "DatetimeTZDtype", variable has type "dtype")  [assignment]
pandas\core\dtypes\cast.py:715: error: Incompatible types in assignment (expression has type "IntervalDtype", variable has type "dtype")  [assignment]
pandas\core\dtypes\common.py:1392: error: Item "dtype" of "Union[dtype, ExtensionDtype]" has no attribute "_is_boolean"  [union-attr]
pandas\core\dtypes\common.py:111: error: Function "numpy.array" is not valid as a type  [valid-type]
pandas\core\reshape\merge.py:1873: error: Function "numpy.array" is not valid as a type  [valid-type]
```