### PR TITLE
TYP: misc fixes for numpy types 3

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -40,7 +40,9 @@ if TYPE_CHECKING:
 # array-like
 
 AnyArrayLike = TypeVar("AnyArrayLike", "ExtensionArray", "Index", "Series", np.ndarray)
+AnyArrayLikeUnion = Union["ExtensionArray", "Index", "Series", np.ndarray]
 ArrayLike = TypeVar("ArrayLike", "ExtensionArray", np.ndarray)
+ArrayLikeUnion = Union["ExtensionArray", np.ndarray]
 
 # scalars
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from pandas._libs import Timedelta, hashtable as libhashtable, lib
 import pandas._libs.join as libjoin
-from pandas._typing import ArrayLike, FrameOrSeries
+from pandas._typing import ArrayLikeUnion, FrameOrSeries
 from pandas.errors import MergeError
 from pandas.util._decorators import Appender, Substitution
 
@@ -1869,7 +1869,7 @@ def _right_outer_join(x, y, max_groups):
 
 
 def _factorize_keys(
-    lk: ArrayLike, rk: ArrayLike, sort: bool = True, how: str = "inner"
+    lk: ArrayLikeUnion, rk: ArrayLikeUnion, sort: bool = True, how: str = "inner"
 ) -> Tuple[np.array, np.array, int]:
     """
     Encode left and right keys as enumerated types.

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -16,7 +16,7 @@ from pandas._config import config, get_option
 
 from pandas._libs import lib, writers as libwriters
 from pandas._libs.tslibs import timezones
-from pandas._typing import ArrayLike, FrameOrSeries, Label
+from pandas._typing import AnyArrayLikeUnion, ArrayLike, FrameOrSeries, Label
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.pickle_compat import patch_pickle
 from pandas.errors import PerformanceWarning
@@ -5076,7 +5076,7 @@ def _dtype_to_kind(dtype_str: str) -> str:
     return kind
 
 
-def _get_data_and_dtype_name(data: ArrayLike):
+def _get_data_and_dtype_name(data: AnyArrayLikeUnion):
     """
     Convert the passed data into a storable form and a dtype string.
     """


### PR DESCRIPTION
```
pandas\core\reshape\merge.py:1931: error: Incompatible types in assignment (expression has type "ndarray", variable has type "ExtensionArray")  [assignment]
pandas\core\reshape\merge.py:1932: error: Incompatible types in assignment (expression has type "ndarray", variable has type "ExtensionArray")  [assignment]
pandas\core\reshape\merge.py:1941: error: Incompatible types in assignment (expression has type "ndarray", variable has type "ExtensionArray")  [assignment]
pandas\core\reshape\merge.py:1950: error: Incompatible types in assignment (expression has type "ndarray", variable has type "ExtensionArray")  [assignment]
pandas\core\reshape\merge.py:1951: error: Incompatible types in assignment (expression has type "ndarray", variable has type "ExtensionArray")  [assignment]
pandas\io\pytables.py:5084: error: Incompatible types in assignment (expression has type "ndarray", variable has type "ExtensionArray")  [assignment]
```