### PR TITLE
TYP: misc fixes for numpy types 4

### DIFF
--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -17,7 +17,9 @@ class NDArrayBackedExtensionArray(ExtensionArray):
     ExtensionArray that is backed by a single NumPy ndarray.
     """
 
-    _ndarray: np.ndarray
+    @property
+    def _ndarray(self) -> np.ndarray:
+        raise AbstractMethodError(self)
 
     def _from_backing_data(self: _T, arr: np.ndarray) -> _T:
         """

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -171,12 +171,12 @@ class PandasArray(
         if copy:
             values = values.copy()
 
-        self._values = values
+        self._ndarr = values
         self._dtype = PandasDtype(values.dtype)
 
     @property
     def _ndarray(self) -> np.ndarray:
-        return self._values
+        return self._ndarr
 
     @classmethod
     def _from_sequence(cls, scalars, dtype=None, copy: bool = False) -> "PandasArray":

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -171,12 +171,12 @@ class PandasArray(
         if copy:
             values = values.copy()
 
-        self._ndarr = values
+        self._data = values
         self._dtype = PandasDtype(values.dtype)
 
     @property
     def _ndarray(self) -> np.ndarray:
-        return self._ndarr
+        return self._data
 
     @classmethod
     def _from_sequence(cls, scalars, dtype=None, copy: bool = False) -> "PandasArray":

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -153,7 +153,6 @@ class PandasArray(
     # pandas internals, which turns off things like block consolidation.
     _typ = "npy_extension"
     __array_priority__ = 1000
-    _ndarray: np.ndarray
 
     # ------------------------------------------------------------------------
     # Constructors
@@ -172,8 +171,12 @@ class PandasArray(
         if copy:
             values = values.copy()
 
-        self._ndarray = values
+        self._values = values
         self._dtype = PandasDtype(values.dtype)
+
+    @property
+    def _ndarray(self) -> np.ndarray:
+        return self._values
 
     @classmethod
     def _from_sequence(cls, scalars, dtype=None, copy: bool = False) -> "PandasArray":

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -550,7 +550,8 @@ def _adjust_to_origin(arg, origin, unit):
 
 
 @overload
-def to_datetime(
+# error: Overloaded function signatures 1 and 3 overlap with incompatible return types
+def to_datetime(  # type: ignore[misc]
     arg: DatetimeScalar,
     errors: str = ...,
     dayfirst: bool = ...,
@@ -567,7 +568,8 @@ def to_datetime(
 
 
 @overload
-def to_datetime(
+# error: Overloaded function signatures 2 and 3 overlap with incompatible return types
+def to_datetime(  # type: ignore[misc]
     arg: "Series",
     errors: str = ...,
     dayfirst: bool = ...,
@@ -585,7 +587,7 @@ def to_datetime(
 
 @overload
 def to_datetime(
-    arg: Union[List, Tuple],
+    arg: Union[List, Tuple, ArrayLike],
     errors: str = ...,
     dayfirst: bool = ...,
     yearfirst: bool = ...,

--- a/pandas/plotting/_matplotlib/tools.py
+++ b/pandas/plotting/_matplotlib/tools.py
@@ -351,7 +351,7 @@ def handle_shared_axes(
                     _remove_labels_from_axis(ax.yaxis)
 
 
-def flatten_axes(axes: Union["Axes", Sequence["Axes"]]) -> Sequence["Axes"]:
+def flatten_axes(axes: Union["Axes", Sequence["Axes"]]) -> np.ndarray:
     if not is_list_like(axes):
         return np.array([axes])
     elif isinstance(axes, (np.ndarray, ABCIndexClass)):


### PR DESCRIPTION
```
pandas\plotting\_matplotlib\tools.py:356: error: Incompatible return value type (got "ndarray", expected "Sequence[Any]")  [return-value]
pandas\plotting\_matplotlib\tools.py:358: error: Incompatible return value type (got "Union[ndarray, Any]", expected "Sequence[Any]")  [return-value]
pandas\plotting\_matplotlib\tools.py:359: error: Incompatible return value type (got "ndarray", expected "Sequence[Any]")  [return-value]
pandas\core\dtypes\cast.py:1079: error: No overload variant of "to_datetime" matches argument types "ndarray", "str"  [call-overload]
pandas\core\arrays\categorical.py:1818: error: Signature of "_ndarray" incompatible with supertype "NDArrayBackedExtensionArray"  [override]
pandas/core/arrays/datetimelike.py:465: error: Signature of "_ndarray" incompatible with supertype "NDArrayBackedExtensionArray"  [override]
```