### PR TITLE
CLN: use IS64 instead of is_platform_32bit #36108

### DIFF
--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -18,7 +18,7 @@ from pandas._libs.tslibs.nattype cimport (
 from pandas._libs.tslibs.np_datetime cimport get_datetime64_value, get_timedelta64_value
 
 from pandas._libs.ops_dispatch import maybe_dispatch_ufunc_to_dunder_op
-from pandas.compat import is_platform_32bit
+from pandas.compat import IS64
 
 cdef:
     float64_t INF = <float64_t>np.inf
@@ -26,7 +26,7 @@ cdef:
 
     int64_t NPY_NAT = util.get_nat()
 
-    bint is_32bit = is_platform_32bit()
+    bint is_32bit = not IS64
 
 
 cpdef bint checknull(object val):

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -8,7 +8,6 @@ Other items:
 * platform checker
 """
 import platform
-import struct
 import sys
 import warnings
 
@@ -18,14 +17,6 @@ PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
 PYPY = platform.python_implementation() == "PyPy"
 IS64 = sys.maxsize > 2 ** 32
-
-
-# ----------------------------------------------------------------------------
-# functions largely based / taken from the six module
-
-# Much of the code in this module comes from Benjamin Peterson's six library.
-# The license for this library can be found in LICENSES/SIX and the code can be
-# found at https://bitbucket.org/gutworth/six
 
 
 def set_function_name(f: F, name: str, cls) -> F:
@@ -38,7 +29,6 @@ def set_function_name(f: F, name: str, cls) -> F:
     return f
 
 
-# https://github.com/pandas-dev/pandas/pull/9123
 def is_platform_little_endian() -> bool:
     """
     Checking if the running platform is little endian.
@@ -72,7 +62,7 @@ def is_platform_linux() -> bool:
     bool
         True if the running platform is linux.
     """
-    return sys.platform == "linux2"
+    return sys.platform == "linux"
 
 
 def is_platform_mac() -> bool:
@@ -85,18 +75,6 @@ def is_platform_mac() -> bool:
         True if the running platform is mac.
     """
     return sys.platform == "darwin"
-
-
-def is_platform_32bit() -> bool:
-    """
-    Checking if the running platform is 32-bit.
-
-    Returns
-    -------
-    bool
-        True if the running platform is 32-bit.
-    """
-    return struct.calcsize("P") * 8 < 64
 
 
 def _import_lzma():

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -6,11 +6,12 @@ import pydoc
 import numpy as np
 import pytest
 
+from pandas.compat import IS64, is_platform_windows
 import pandas.util._test_decorators as td
 from pandas.util._test_decorators import async_mark, skip_if_no
 
 import pandas as pd
-from pandas import Categorical, DataFrame, Series, compat, date_range, timedelta_range
+from pandas import Categorical, DataFrame, Series, date_range, timedelta_range
 import pandas._testing as tm
 
 
@@ -254,7 +255,7 @@ class TestDataFrameMisc:
         assert list(dfaa.itertuples()) == [(0, 1, 1), (1, 2, 2), (2, 3, 3)]
 
         # repr with int on 32-bit/windows
-        if not (compat.is_platform_windows() or compat.is_platform_32bit()):
+        if not (is_platform_windows() or not IS64):
             assert (
                 repr(list(df.itertuples(name=None)))
                 == "[(0, 1, 4), (1, 2, 5), (2, 3, 6)]"

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 
 from pandas._libs.interval import IntervalTree
+from pandas.compat import IS64
 
-from pandas import compat
 import pandas._testing as tm
 
 
@@ -14,9 +14,7 @@ def skipif_32bit(param):
     Skip parameters in a parametrize on 32bit systems. Specifically used
     here to skip leaf_size parameters related to GH 23440.
     """
-    marks = pytest.mark.skipif(
-        compat.is_platform_32bit(), reason="GH 23440: int type mismatch on 32bit"
-    )
+    marks = pytest.mark.skipif(not IS64, reason="GH 23440: int type mismatch on 32bit")
     return pytest.param(param, marks=marks)
 
 
@@ -181,7 +179,7 @@ class TestIntervalTree:
         tree = IntervalTree(left, right, closed=closed)
         assert tree.is_overlapping is False
 
-    @pytest.mark.skipif(compat.is_platform_32bit(), reason="GH 23440")
+    @pytest.mark.skipif(not IS64, reason="GH 23440")
     def test_construction_overflow(self):
         # GH 25485
         left, right = np.arange(101, dtype="int64"), [np.iinfo(np.int64).max] * 101

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import numpy as np
 import pytest
 
-import pandas.compat as compat
+from pandas.compat import IS64, is_platform_windows
 
 import pandas as pd
 import pandas._testing as tm
@@ -1041,7 +1041,7 @@ class TestReplaceSeriesCoercion(CoercionBase):
             from_key == "complex128" and to_key in ("int64", "float64")
         ):
 
-            if compat.is_platform_32bit() or compat.is_platform_windows():
+            if not IS64 or is_platform_windows():
                 pytest.skip(f"32-bit platform buggy: {from_key} -> {to_key}")
 
             # Expected: do not downcast by replacement

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 import pytz
 
-from pandas.compat import is_platform_32bit, is_platform_windows
+from pandas.compat import IS64, is_platform_windows
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -41,7 +41,7 @@ import pandas._testing as tm
 import pandas.io.formats.format as fmt
 import pandas.io.formats.printing as printing
 
-use_32bit_repr = is_platform_windows() or is_platform_32bit()
+use_32bit_repr = is_platform_windows() or not IS64
 
 
 @pytest.fixture(params=["string", "pathlike", "buffer"])

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -9,7 +9,7 @@ import sys
 import numpy as np
 import pytest
 
-from pandas.compat import is_platform_32bit, is_platform_windows
+from pandas.compat import IS64, is_platform_windows
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -154,7 +154,7 @@ class TestPandasContainer:
         expected = int_frame
         if (
             numpy
-            and (is_platform_32bit() or is_platform_windows())
+            and (not IS64 or is_platform_windows())
             and not dtype
             and orient != "split"
         ):
@@ -361,9 +361,7 @@ class TestPandasContainer:
         result = read_json(df.to_json(), dtype=dtype)
         assert np.isnan(result.iloc[0, 2])
 
-    @pytest.mark.skipif(
-        is_platform_32bit(), reason="not compliant on 32-bit, xref #15865"
-    )
+    @pytest.mark.skipif(not IS64, reason="not compliant on 32-bit, xref #15865")
     @pytest.mark.parametrize(
         "value,precision,expected_val",
         [

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -15,7 +15,7 @@ import pytz
 
 import pandas._libs.json as ujson
 from pandas._libs.tslib import Timestamp
-import pandas.compat as compat
+from pandas.compat import IS64, is_platform_windows
 
 from pandas import DataFrame, DatetimeIndex, Index, NaT, Series, Timedelta, date_range
 import pandas._testing as tm
@@ -53,7 +53,7 @@ def get_int32_compat_dtype(numpy, orient):
     # See GH#32527
     dtype = np.int64
     if not ((numpy is None or orient == "index") or (numpy is True and orient is None)):
-        if compat.is_platform_windows():
+        if is_platform_windows():
             dtype = np.int32
         else:
             dtype = np.intp
@@ -62,9 +62,7 @@ def get_int32_compat_dtype(numpy, orient):
 
 
 class TestUltraJSONTests:
-    @pytest.mark.skipif(
-        compat.is_platform_32bit(), reason="not compliant on 32-bit, xref #15865"
-    )
+    @pytest.mark.skipif(not IS64, reason="not compliant on 32-bit, xref #15865")
     def test_encode_decimal(self):
         sut = decimal.Decimal("1337.1337")
         encoded = ujson.encode(sut, double_precision=15)
@@ -561,7 +559,7 @@ class TestUltraJSONTests:
         assert long_input == ujson.decode(output)
 
     @pytest.mark.parametrize("bigNum", [sys.maxsize + 1, -(sys.maxsize + 2)])
-    @pytest.mark.xfail(not compat.IS64, reason="GH-35288")
+    @pytest.mark.xfail(not IS64, reason="GH-35288")
     def test_dumps_ints_larger_than_maxsize(self, bigNum):
         # GH34395
         bigNum = sys.maxsize + 1
@@ -703,7 +701,7 @@ class TestNumpyJSONTests:
         tm.assert_numpy_array_equal(arr_input, arr_output)
 
     def test_int_max(self, any_int_dtype):
-        if any_int_dtype in ("int64", "uint64") and compat.is_platform_32bit():
+        if any_int_dtype in ("int64", "uint64") and not IS64:
             pytest.skip("Cannot test 64-bit integer on 32-bit platform")
 
         klass = np.dtype(any_int_dtype).type

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -8,6 +8,7 @@ import pytest
 
 from pandas._libs import algos as libalgos, hashtable as ht
 from pandas._libs.groupby import group_var_float32, group_var_float64
+from pandas.compat import IS64
 from pandas.compat.numpy import np_array_datetime64_compat
 import pandas.util._test_decorators as td
 
@@ -29,7 +30,6 @@ from pandas import (
     IntervalIndex,
     Series,
     Timestamp,
-    compat,
 )
 import pandas._testing as tm
 import pandas.core.algorithms as algos
@@ -1137,7 +1137,7 @@ class TestValueCounts:
         )
 
         # 32-bit linux has a different ordering
-        if not compat.is_platform_32bit():
+        if IS64:
             result = Series([10.3, 5.0, 5.0, None]).value_counts(dropna=False)
             expected = Series([2, 1, 1], index=[5.0, 10.3, np.nan])
             tm.assert_series_equal(result, expected)
@@ -1170,7 +1170,7 @@ class TestValueCounts:
         result = algos.value_counts(arr)
 
         # 32-bit linux has a different ordering
-        if not compat.is_platform_32bit():
+        if IS64:
             tm.assert_series_equal(result, expected)
 
 

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -31,7 +31,7 @@ from typing import Callable, Optional
 import numpy as np
 import pytest
 
-from pandas.compat import is_platform_32bit, is_platform_windows
+from pandas.compat import IS64, is_platform_windows
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import _np_version
 
@@ -180,7 +180,7 @@ skip_if_no_mpl = pytest.mark.skipif(
     _skip_if_no_mpl(), reason="Missing matplotlib dependency"
 )
 skip_if_mpl = pytest.mark.skipif(not _skip_if_no_mpl(), reason="matplotlib is present")
-skip_if_32bit = pytest.mark.skipif(is_platform_32bit(), reason="skipping for 32 bit")
+skip_if_32bit = pytest.mark.skipif(not IS64, reason="skipping for 32 bit")
 skip_if_windows = pytest.mark.skipif(is_platform_windows(), reason="Running on Windows")
 skip_if_windows_python_3 = pytest.mark.skipif(
     is_platform_windows(), reason="not used on win32"


### PR DESCRIPTION
- [x] closes #36108
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

