### PR TITLE
REGR: ensure closed attribute of IntervalIndex is preserved in pickle roundtrip

### DIFF
--- a/doc/source/whatsnew/v1.1.2.rst
+++ b/doc/source/whatsnew/v1.1.2.rst
@@ -18,6 +18,7 @@ Fixed regressions
 - Fix regression in updating a column inplace (e.g. using ``df['col'].fillna(.., inplace=True)``) (:issue:`35731`)
 - Performance regression for :meth:`RangeIndex.format` (:issue:`35712`)
 - Regression in :meth:`DataFrame.replace` where a ``TypeError`` would be raised when attempting to replace elements of type :class:`Interval` (:issue:`35931`)
+- Fix regression in pickle roundtrip of the ``closed`` attribute of :class:`IntervalIndex` (:issue:`35658`)
 -
 
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -193,7 +193,7 @@ class SetopCheck:
 class IntervalIndex(IntervalMixin, ExtensionIndex):
     _typ = "intervalindex"
     _comparables = ["name"]
-    _attributes = ["name"]
+    _attributes = ["name", "closed"]
 
     # we would like our indexing holder to defer to us
     _defer_to_indexing = True

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -874,6 +874,13 @@ class TestIntervalIndex:
             with tm.assert_produces_warning(FutureWarning):
                 idx.get_value(s, key)
 
+    @pytest.mark.parametrize("closed", ["left", "right", "both"])
+    def test_pickle_round_trip_closed(self, closed):
+        # https://github.com/pandas-dev/pandas/issues/35658
+        idx = IntervalIndex.from_tuples([(1, 2), (2, 3)], closed=closed)
+        result = tm.round_trip_pickle(idx)
+        tm.assert_index_equal(result, idx)
+
 
 def test_dir():
     # GH#27571 dir(interval_index) should not raise


### PR DESCRIPTION
Closes #35658

cc @jbrockmendel 

(I suppose the long term way would rather to properly pickle the IntervalArray itself and restore from that, instead of restoring from the left/right arrays, but would rather leave such a change for 1.2)