### PR TITLE
CLN: Separate transform tests

### DIFF
--- a/pandas/tests/frame/apply/test_frame_transform.py
+++ b/pandas/tests/frame/apply/test_frame_transform.py
@@ -1,0 +1,72 @@
+import operator
+
+import numpy as np
+import pytest
+
+import pandas as pd
+import pandas._testing as tm
+from pandas.tests.frame.common import zip_frames
+
+
+def test_agg_transform(axis, float_frame):
+    other_axis = 1 if axis in {0, "index"} else 0
+
+    with np.errstate(all="ignore"):
+
+        f_abs = np.abs(float_frame)
+        f_sqrt = np.sqrt(float_frame)
+
+        # ufunc
+        result = float_frame.transform(np.sqrt, axis=axis)
+        expected = f_sqrt.copy()
+        tm.assert_frame_equal(result, expected)
+
+        result = float_frame.transform(np.sqrt, axis=axis)
+        tm.assert_frame_equal(result, expected)
+
+        # list-like
+        expected = f_sqrt.copy()
+        if axis in {0, "index"}:
+            expected.columns = pd.MultiIndex.from_product(
+                [float_frame.columns, ["sqrt"]]
+            )
+        else:
+            expected.index = pd.MultiIndex.from_product([float_frame.index, ["sqrt"]])
+        result = float_frame.transform([np.sqrt], axis=axis)
+        tm.assert_frame_equal(result, expected)
+
+        # multiple items in list
+        # these are in the order as if we are applying both
+        # functions per series and then concatting
+        expected = zip_frames([f_abs, f_sqrt], axis=other_axis)
+        if axis in {0, "index"}:
+            expected.columns = pd.MultiIndex.from_product(
+                [float_frame.columns, ["absolute", "sqrt"]]
+            )
+        else:
+            expected.index = pd.MultiIndex.from_product(
+                [float_frame.index, ["absolute", "sqrt"]]
+            )
+        result = float_frame.transform([np.abs, "sqrt"], axis=axis)
+        tm.assert_frame_equal(result, expected)
+
+
+def test_transform_and_agg_err(axis, float_frame):
+    # cannot both transform and agg
+    msg = "transforms cannot produce aggregated results"
+    with pytest.raises(ValueError, match=msg):
+        float_frame.transform(["max", "min"], axis=axis)
+
+    msg = "cannot combine transform and aggregation operations"
+    with pytest.raises(ValueError, match=msg):
+        with np.errstate(all="ignore"):
+            float_frame.transform(["max", "sqrt"], axis=axis)
+
+
+@pytest.mark.parametrize("method", ["abs", "shift", "pct_change", "cumsum", "rank"])
+def test_transform_method_name(method):
+    # GH 19760
+    df = pd.DataFrame({"A": [-1, 2]})
+    result = df.transform(method)
+    expected = operator.methodcaller(method)(df)
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/common.py
+++ b/pandas/tests/frame/common.py
@@ -1,7 +1,5 @@
 from typing import List
 
-from pandas._typing import Axis
-
 from pandas import DataFrame, concat
 
 

--- a/pandas/tests/frame/common.py
+++ b/pandas/tests/frame/common.py
@@ -1,3 +1,10 @@
+from typing import List
+
+from pandas._typing import Axis
+
+from pandas import DataFrame, concat
+
+
 def _check_mixed_float(df, dtype=None):
     # float16 are most likely to be upcasted to float32
     dtypes = dict(A="float32", B="float32", C="float16", D="float64")
@@ -29,3 +36,22 @@ def _check_mixed_int(df, dtype=None):
         assert df.dtypes["C"] == dtypes["C"]
     if dtypes.get("D"):
         assert df.dtypes["D"] == dtypes["D"]
+
+
+def zip_frames(frames: List[DataFrame], axis: int = 1) -> DataFrame:
+    """
+    take a list of frames, zip them together under the
+    assumption that these all have the first frames' index/columns.
+
+    Returns
+    -------
+    new_frame : DataFrame
+    """
+    if axis == 1:
+        columns = frames[0].columns
+        zipped = [f.loc[:, c] for c in columns for f in frames]
+        return concat(zipped, axis=1)
+    else:
+        index = frames[0].index
+        zipped = [f.loc[i, :] for i in index for f in frames]
+        return DataFrame(zipped)

--- a/pandas/tests/series/apply/test_series_apply.py
+++ b/pandas/tests/series/apply/test_series_apply.py
@@ -209,23 +209,14 @@ class TestSeriesAggregate:
             f_abs = np.abs(string_series)
 
             # ufunc
-            result = string_series.transform(np.sqrt)
             expected = f_sqrt.copy()
-            tm.assert_series_equal(result, expected)
-
             result = string_series.apply(np.sqrt)
             tm.assert_series_equal(result, expected)
 
             # list-like
-            result = string_series.transform([np.sqrt])
+            result = string_series.apply([np.sqrt])
             expected = f_sqrt.to_frame().copy()
             expected.columns = ["sqrt"]
-            tm.assert_frame_equal(result, expected)
-
-            result = string_series.transform([np.sqrt])
-            tm.assert_frame_equal(result, expected)
-
-            result = string_series.transform(["sqrt"])
             tm.assert_frame_equal(result, expected)
 
             # multiple items in list
@@ -234,10 +225,6 @@ class TestSeriesAggregate:
             expected = pd.concat([f_sqrt, f_abs], axis=1)
             expected.columns = ["sqrt", "absolute"]
             result = string_series.apply([np.sqrt, np.abs])
-            tm.assert_frame_equal(result, expected)
-
-            result = string_series.transform(["sqrt", "abs"])
-            expected.columns = ["sqrt", "abs"]
             tm.assert_frame_equal(result, expected)
 
             # dict, provide renaming
@@ -250,18 +237,10 @@ class TestSeriesAggregate:
 
     def test_transform_and_agg_error(self, string_series):
         # we are trying to transform with an aggregator
-        msg = "transforms cannot produce aggregated results"
-        with pytest.raises(ValueError, match=msg):
-            string_series.transform(["min", "max"])
-
         msg = "cannot combine transform and aggregation"
         with pytest.raises(ValueError, match=msg):
             with np.errstate(all="ignore"):
                 string_series.agg(["sqrt", "max"])
-
-        with pytest.raises(ValueError, match=msg):
-            with np.errstate(all="ignore"):
-                string_series.transform(["sqrt", "max"])
 
         msg = "cannot perform both aggregation and transformation"
         with pytest.raises(ValueError, match=msg):
@@ -462,14 +441,6 @@ class TestSeriesAggregate:
         with pytest.raises(expected):
             # e.g. Series('a b'.split()).cumprod() will raise
             series.agg(func)
-
-    def test_transform_none_to_type(self):
-        # GH34377
-        df = pd.DataFrame({"a": [None]})
-
-        msg = "DataFrame constructor called with incompatible data and dtype"
-        with pytest.raises(TypeError, match=msg):
-            df.transform({"a": int})
 
 
 class TestSeriesMap:

--- a/pandas/tests/series/apply/test_series_transform.py
+++ b/pandas/tests/series/apply/test_series_transform.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+import pandas as pd
+import pandas._testing as tm
+
+
+def test_transform(string_series):
+    # transforming functions
+
+    with np.errstate(all="ignore"):
+        f_sqrt = np.sqrt(string_series)
+        f_abs = np.abs(string_series)
+
+        # ufunc
+        result = string_series.transform(np.sqrt)
+        expected = f_sqrt.copy()
+        tm.assert_series_equal(result, expected)
+
+        # list-like
+        result = string_series.transform([np.sqrt])
+        expected = f_sqrt.to_frame().copy()
+        expected.columns = ["sqrt"]
+        tm.assert_frame_equal(result, expected)
+
+        result = string_series.transform([np.sqrt])
+        tm.assert_frame_equal(result, expected)
+
+        result = string_series.transform(["sqrt"])
+        tm.assert_frame_equal(result, expected)
+
+        # multiple items in list
+        # these are in the order as if we are applying both functions per
+        # series and then concatting
+        expected = pd.concat([f_sqrt, f_abs], axis=1)
+        result = string_series.transform(["sqrt", "abs"])
+        expected.columns = ["sqrt", "abs"]
+        tm.assert_frame_equal(result, expected)
+
+
+def test_transform_and_agg_error(string_series):
+    # we are trying to transform with an aggregator
+    msg = "transforms cannot produce aggregated results"
+    with pytest.raises(ValueError, match=msg):
+        string_series.transform(["min", "max"])
+
+    msg = "cannot combine transform and aggregation operations"
+    with pytest.raises(ValueError, match=msg):
+        with np.errstate(all="ignore"):
+            string_series.transform(["sqrt", "max"])
+
+
+def test_transform_none_to_type():
+    # GH34377
+    df = pd.DataFrame({"a": [None]})
+
+    msg = "DataFrame constructor called with incompatible data and dtype"
+    with pytest.raises(TypeError, match=msg):
+        df.transform({"a": int})


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Setup for #35964. There were two tests that are accidental duplicates; I've just copied them over to the transform modules. Will cleanup in #35964.