### PR TITLE
DTA/TDA/PA use self._data instead of self.asi8 for self._ndarray

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -27,7 +27,7 @@ from pandas._typing import DatetimeLikeScalar, DtypeObj
 from pandas.compat import set_function_name
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError, NullFrequencyError, PerformanceWarning
-from pandas.util._decorators import Appender, Substitution
+from pandas.util._decorators import Appender, Substitution, cache_readonly
 from pandas.util._validators import validate_fillna_kwargs
 
 from pandas.core.dtypes.common import (
@@ -458,9 +458,7 @@ class DatetimeLikeArrayMixin(
     # ------------------------------------------------------------------
     # NDArrayBackedExtensionArray compat
 
-    # TODO: make this a cache_readonly; need to get around _index_data
-    #  kludge in libreduction
-    @property
+    @cache_readonly
     def _ndarray(self) -> np.ndarray:
         return self._data
 
@@ -523,7 +521,7 @@ class DatetimeLikeArrayMixin(
         # used for Timedelta/DatetimeArray, overwritten by PeriodArray
         if is_object_dtype(dtype):
             return np.array(list(self), dtype=object)
-        return self._data
+        return self._ndarray
 
     def __getitem__(self, key):
         """
@@ -533,7 +531,7 @@ class DatetimeLikeArrayMixin(
 
         if lib.is_integer(key):
             # fast-path
-            result = self._data[key]
+            result = self._ndarray[key]
             if self.ndim == 1:
                 return self._box_func(result)
             return self._simple_new(result, dtype=self.dtype)
@@ -554,7 +552,7 @@ class DatetimeLikeArrayMixin(
             key = check_array_indexer(self, key)
 
         freq = self._get_getitem_freq(key)
-        result = self._data[key]
+        result = self._ndarray[key]
         if lib.is_scalar(result):
             return self._box_func(result)
         return self._simple_new(result, dtype=self.dtype, freq=freq)
@@ -609,7 +607,7 @@ class DatetimeLikeArrayMixin(
 
         value = self._validate_setitem_value(value)
         key = check_array_indexer(self, key)
-        self._data[key] = value
+        self._ndarray[key] = value
         self._maybe_clear_freq()
 
     def _maybe_clear_freq(self):
@@ -660,8 +658,8 @@ class DatetimeLikeArrayMixin(
 
     def view(self, dtype=None):
         if dtype is None or dtype is self.dtype:
-            return type(self)(self._data, dtype=self.dtype)
-        return self._data.view(dtype=dtype)
+            return type(self)(self._ndarray, dtype=self.dtype)
+        return self._ndarray.view(dtype=dtype)
 
     # ------------------------------------------------------------------
     # ExtensionArray Interface
@@ -702,7 +700,7 @@ class DatetimeLikeArrayMixin(
         return cls(values, dtype=original.dtype)
 
     def _values_for_argsort(self):
-        return self._data
+        return self._ndarray
 
     # ------------------------------------------------------------------
     # Validation Methods
@@ -954,9 +952,9 @@ class DatetimeLikeArrayMixin(
         from pandas import Index, Series
 
         if dropna:
-            values = self[~self.isna()]._data
+            values = self[~self.isna()]._ndarray
         else:
-            values = self._data
+            values = self._ndarray
 
         cls = type(self)
 
@@ -1047,9 +1045,9 @@ class DatetimeLikeArrayMixin(
                 else:
                     func = missing.backfill_1d
 
-                values = self._data
+                values = self._ndarray
                 if not is_period_dtype(self.dtype):
-                    # For PeriodArray self._data is i8, which gets copied
+                    # For PeriodArray self._ndarray is i8, which gets copied
                     #  by `func`.  Otherwise we need to make a copy manually
                     # to avoid modifying `self` in-place.
                     values = values.copy()

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -462,7 +462,6 @@ class DatetimeLikeArrayMixin(
     #  kludge in libreduction
     @property
     def _ndarray(self) -> np.ndarray:
-        # NB: A bunch of Interval tests fail if we use ._data
         return self._data
 
     def _from_backing_data(self: _T, arr: np.ndarray) -> _T:

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -446,6 +446,10 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
     # -----------------------------------------------------------------
     # DatetimeLike Interface
 
+    @classmethod
+    def _rebox_native(cls, value: int) -> np.datetime64:
+        return np.int64(value).view("M8[ns]")
+
     def _unbox_scalar(self, value):
         if not isinstance(value, self._scalar_type) and value is not NaT:
             raise ValueError("'value' should be a Timestamp.")

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -253,6 +253,10 @@ class PeriodArray(PeriodMixin, dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
     # -----------------------------------------------------------------
     # DatetimeLike Interface
 
+    @classmethod
+    def _rebox_native(cls, value: int) -> np.int64:
+        return np.int64(value)
+
     def _unbox_scalar(self, value: Union[Period, NaTType]) -> int:
         if value is NaT:
             return value.value

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -271,6 +271,10 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
     # ----------------------------------------------------------------
     # DatetimeLike Interface
 
+    @classmethod
+    def _rebox_native(cls, value: int) -> np.timedelta64:
+        return np.int64(value).view("m8[ns]")
+
     def _unbox_scalar(self, value):
         if not isinstance(value, self._scalar_type) and value is not NaT:
             raise ValueError("'value' should be a Timedelta.")

--- a/pandas/tests/frame/indexing/test_datetime.py
+++ b/pandas/tests/frame/indexing/test_datetime.py
@@ -23,7 +23,9 @@ class TestDataFrameIndexingDatetimeWithTZ:
         b1 = df._mgr.blocks[1]
         b2 = df._mgr.blocks[2]
         tm.assert_extension_array_equal(b1.values, b2.values)
-        assert id(b1.values._data.base) != id(b2.values._data.base)
+        b1base = b1.values._data.base
+        b2base = b2.values._data.base
+        assert b1base is None or (id(b1base) != id(b2base))
 
         # with nan
         df2 = df.copy()


### PR DESCRIPTION
This in turn will let us share more methods with the parent class, at the cost of re-shuffling where we do some of the view-casting.