### PR TITLE
BUG: Ensure read_spss accepts pathlib Paths (GH33666)

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -22,7 +22,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Bug in :func:`read_spss` where passing a ``pathlib.Path`` as ``path`` would raise a ``TypeError`` (:issue:`33666`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/spss.py
+++ b/pandas/io/spss.py
@@ -7,6 +7,8 @@ from pandas.core.dtypes.inference import is_list_like
 
 from pandas.core.api import DataFrame
 
+from pandas.io.common import stringify_path
+
 
 def read_spss(
     path: Union[str, Path],
@@ -40,6 +42,6 @@ def read_spss(
             usecols = list(usecols)  # pyreadstat requires a list
 
     df, _ = pyreadstat.read_sav(
-        path, usecols=usecols, apply_value_formats=convert_categoricals
+        stringify_path(path), usecols=usecols, apply_value_formats=convert_categoricals
     )
     return df

--- a/pandas/tests/io/test_spss.py
+++ b/pandas/tests/io/test_spss.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -7,9 +9,10 @@ import pandas._testing as tm
 pyreadstat = pytest.importorskip("pyreadstat")
 
 
-def test_spss_labelled_num(datapath):
+@pytest.mark.parametrize("path_klass", [lambda p: p, Path])
+def test_spss_labelled_num(path_klass, datapath):
     # test file from the Haven project (https://haven.tidyverse.org/)
-    fname = datapath("io", "data", "spss", "labelled-num.sav")
+    fname = path_klass(datapath("io", "data", "spss", "labelled-num.sav"))
 
     df = pd.read_spss(fname, convert_categoricals=True)
     expected = pd.DataFrame({"VAR00002": "This is one"}, index=[0])


### PR DESCRIPTION
- [x] closes #33666
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Wrapped the `path` passed into `pandas.io.spss.read_spss` in a `pandas.io.common.stringify_path` call prior to passing it to `pyreadstat.read_sav`. This fixes #33666. I've also included tests validating `pd.read_spss` accepts strings and `pathlib.Path`s.