### PR TITLE
TST: update test_series_factorize_na_sentinel_none for 32bit

### DIFF
--- a/pandas/tests/base/test_factorize.py
+++ b/pandas/tests/base/test_factorize.py
@@ -34,7 +34,7 @@ def test_series_factorize_na_sentinel_none():
     ser = pd.Series(values)
     codes, uniques = ser.factorize(na_sentinel=None)
 
-    expected_codes = np.array([0, 1, 0, 2], dtype="int64")
+    expected_codes = np.array([0, 1, 0, 2], dtype=np.intp)
     expected_uniques = pd.Index([1.0, 2.0, np.nan])
 
     tm.assert_numpy_array_equal(codes, expected_codes)


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/35831#issuecomment-688163069

(I've not tested this locally, after backport can retrigger https://github.com/MacPython/pandas-wheels/pull/97 to check)