### PR TITLE
[BUG]: Groupy and Resample miscalculated aggregation

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -314,7 +314,7 @@ Groupby/resample/rolling
 - Bug when subsetting columns on a :class:`~pandas.core.groupby.DataFrameGroupBy` (e.g. ``df.groupby('a')[['b']])``) would reset the attributes ``axis``, ``dropna``, ``group_keys``, ``level``, ``mutated``, ``sort``, and ``squeeze`` to their default values. (:issue:`9959`)
 - Bug in :meth:`DataFrameGroupby.tshift` failing to raise ``ValueError`` when a frequency cannot be inferred for the index of a group (:issue:`35937`)
 - Bug in :meth:`DataFrame.groupby` does not always maintain column index name for ``any``, ``all``, ``bfill``, ``ffill``, ``shift`` (:issue:`29764`)
--
+- Bug when combining methods :meth:`DataFrame.groupby` with :meth:`DataFrame.resample` and restricting to `Series` or using `agg` did miscalculate the aggregation (:issue:`27343`, :issue:`33548`, :issue:`35275`).
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -314,7 +314,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrameGroupby.tshift` failing to raise ``ValueError`` when a frequency cannot be inferred for the index of a group (:issue:`35937`)
 - Bug in :meth:`DataFrame.groupby` does not always maintain column index name for ``any``, ``all``, ``bfill``, ``ffill``, ``shift`` (:issue:`29764`)
 - Bug in :meth:`DataFrameGroupBy.apply` raising error with ``np.nan`` group(s) when ``dropna=False`` (:issue:`35889`)
-- Bug when combining methods :meth:`DataFrame.groupby` with :meth:`DataFrame.resample` and restricting to `Series` or using `agg` did miscalculate the aggregation (:issue:`27343`, :issue:`33548`, :issue:`35275`).
+- Bug in :meth:`DataFrame.groupby(...).resample(...)` when restricting to `Series` or using `agg` did miscalculate the aggregation (:issue:`27343`, :issue:`33548`, :issue:`35275`).
 -
 
 Reshaping

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -311,7 +311,9 @@ class Grouper:
         )
         return self.binner, self.grouper, self.obj
 
-    def _set_grouper(self, obj: FrameOrSeries, sort: bool = False, group_indices: Dict = None):
+    def _set_grouper(
+        self, obj: FrameOrSeries, sort: bool = False, group_indices: Dict = None
+    ):
         """
         given an object and the specifications, setup the internal grouper
         for this particular specification

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -339,10 +339,10 @@ class Grouper:
                 obj, ABCSeries
             ):
                 # In some cases the self._grouper may be sorted differently than obj.
-                # self.obj has the right order with the old index in the first go around.
-                # We align the index from obj with the self.obj index to select the correct
-                # values. Additionally we have to sort obj.index correctly to aggregate
-                # correctly.
+                # self.obj has the right order with the old index in the first go
+                # around. We align the index from obj with the self.obj index to
+                # select the correct values. Additionally we have to sort
+                # obj.index correctly to aggregate correctly.
                 if not hasattr(self, "_index_mapping"):
                     self._index_mapping = DataFrame(
                         self.obj.index, columns=["index"]

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -312,7 +312,10 @@ class Grouper:
         return self.binner, self.grouper, self.obj
 
     def _set_grouper(
-        self, obj: FrameOrSeries, sort: bool = False, group_indices: Dict = None
+        self,
+        obj: FrameOrSeries,
+        sort: bool = False,
+        group_indices: Optional[Dict] = None,
     ):
         """
         given an object and the specifications, setup the internal grouper

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -338,6 +338,20 @@ class Grouper:
             if getattr(self.grouper, "name", None) == key and isinstance(
                 obj, ABCSeries
             ):
+                # In some cases the self._grouper may be sorted differently than obj.
+                # self.obj has the right order with the old index in the first go around.
+                # We align the index from obj with the self.obj index to select the correct
+                # values. Additionally we have to sort obj.index correctly to aggregate
+                # correctly.
+                if not hasattr(self, "_index_mapping"):
+                    self._index_mapping = DataFrame(
+                        self.obj.index, columns=["index"]
+                    ).sort_values(by="index")
+                obj.sort_index(inplace=True)
+                obj.index = self._index_mapping.loc[
+                    self._index_mapping["index"].isin(obj.index)
+                ].index
+                obj.sort_index(inplace=True)
                 ax = self._grouper.take(obj.index)
             else:
                 if key not in obj._info_axis:

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -344,11 +344,14 @@ class Grouper:
             if getattr(self.grouper, "name", None) == key and isinstance(
                 obj, ABCSeries
             ):
-                indices = group_indices.get(obj.name)
-                if self._indexer is not None:
-                    ax = self._grouper.take(self._indexer.argsort()).take(indices)
+                if group_indices is None:
+                    ax = self._grouper.take(obj.index)
                 else:
-                    ax = self._grouper.take(indices)
+                    indices = group_indices.get(obj.name)
+                    if self._indexer is not None:
+                        ax = self._grouper.take(self._indexer.argsort()).take(indices)
+                    else:
+                        ax = self._grouper.take(indices)
             else:
                 if key not in obj._info_axis:
                     raise KeyError(f"The grouper name {key} is not found")

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -91,7 +91,11 @@ class Resampler(_GroupBy, ShallowMixin):
         self.grouper = None
 
         if self.groupby is not None:
-            self.groupby._set_grouper(self._convert_obj(obj), sort=True, group_indices=kwargs.get("group_indices"))
+            self.groupby._set_grouper(
+                self._convert_obj(obj),
+                sort=True,
+                group_indices=kwargs.get("group_indices"),
+            )
 
     def __str__(self) -> str:
         """
@@ -980,7 +984,9 @@ class _GroupByMixin(GroupByMixin):
         """
 
         def func(x):
-            x = self._shallow_copy(x, groupby=self.groupby, group_indices=self._groupby.indices)
+            x = self._shallow_copy(
+                x, groupby=self.groupby, group_indices=self._groupby.indices
+            )
 
             if isinstance(f, str):
                 return getattr(x, f)(**kwargs)

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -91,7 +91,7 @@ class Resampler(_GroupBy, ShallowMixin):
         self.grouper = None
 
         if self.groupby is not None:
-            self.groupby._set_grouper(self._convert_obj(obj), sort=True)
+            self.groupby._set_grouper(self._convert_obj(obj), sort=True, _group_indices=kwargs.get("_group_indices"))
 
     def __str__(self) -> str:
         """
@@ -980,7 +980,7 @@ class _GroupByMixin(GroupByMixin):
         """
 
         def func(x):
-            x = self._shallow_copy(x, groupby=self.groupby)
+            x = self._shallow_copy(x, groupby=self.groupby, _group_indices=self._groupby.indices)
 
             if isinstance(f, str):
                 return getattr(x, f)(**kwargs)

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -91,7 +91,7 @@ class Resampler(_GroupBy, ShallowMixin):
         self.grouper = None
 
         if self.groupby is not None:
-            self.groupby._set_grouper(self._convert_obj(obj), sort=True, _group_indices=kwargs.get("_group_indices"))
+            self.groupby._set_grouper(self._convert_obj(obj), sort=True, group_indices=kwargs.get("group_indices"))
 
     def __str__(self) -> str:
         """
@@ -980,7 +980,7 @@ class _GroupByMixin(GroupByMixin):
         """
 
         def func(x):
-            x = self._shallow_copy(x, groupby=self.groupby, _group_indices=self._groupby.indices)
+            x = self._shallow_copy(x, groupby=self.groupby, group_indices=self._groupby.indices)
 
             if isinstance(f, str):
                 return getattr(x, f)(**kwargs)

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -350,6 +350,7 @@ def test_median_duplicate_columns():
 
 
 def test_resample_different_result_with_agg():
+    # GH: 35275 and 33548
     data = pd.DataFrame(
         {
             "cat": ["cat1", "cat1", "cat2", "cat1", "cat2", "cat1", "cat2", "cat1"],
@@ -391,6 +392,7 @@ def test_resample_different_result_with_agg():
 
 
 def test_resample_agg_different_results_on_keyword():
+    # GH: 27343
     df = pd.DataFrame.from_records(
         {
             "ref": ["a", "a", "a", "b", "b"],

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -129,7 +129,7 @@ def test_groupby_resample_on_api_with_getitem(index_values):
     # GH 17813
     df = pd.DataFrame(
         {"id": list("aabbb"), "date": pd.date_range("1-1-2016", periods=5), "data": 1},
-        index=pd.Index(index_values)
+        index=pd.Index(index_values),
     )
     exp = df.set_index("date").groupby("id").resample("2D")["data"].sum()
     result = df.groupby("id").resample("2D", on="date")["data"].sum()

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -124,10 +124,12 @@ def test_getitem_multiple():
     tm.assert_series_equal(result, expected)
 
 
-def test_groupby_resample_on_api_with_getitem():
+@pytest.mark.parametrize("index_values", [[0, 1, 2, 3, 4], ["a", "b", "c", "d", "e"]])
+def test_groupby_resample_on_api_with_getitem(index_values):
     # GH 17813
     df = pd.DataFrame(
-        {"id": list("aabbb"), "date": pd.date_range("1-1-2016", periods=5), "data": 1}
+        {"id": list("aabbb"), "date": pd.date_range("1-1-2016", periods=5), "data": 1},
+        index=pd.Index(index_values)
     )
     exp = df.set_index("date").groupby("id").resample("2D")["data"].sum()
     result = df.groupby("id").resample("2D", on="date")["data"].sum()


### PR DESCRIPTION
- [x] closes #27343
- [x] closes #33548
- [x] closes #35275
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I think I found a solution for this issue. We used `obj.index` to get the Index values. In case of resample `obj.index` had the original index. This index was not necessarily a RangeIndex of course -> resulted in a IndexError. In case of a RangeIndex the object `self._grouper` may have been resorted -> Wrong elements were selected. The object `self.obj` stored the original DataFrame, but already sorted in the first go around (is overwritten later). I stored the mapping from original index to a new synthetic RangeIndex (sorted after the grouping column). This allows us to replace the Index of obj in a way, that the take function works.
