### PR TITLE
TST: skip test_groupby_rolling_index_changed on 32bit

### DIFF
--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -384,6 +384,7 @@ class TestGrouperGrouping:
         )
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.xfail(not compat.IS64, reason="GH-35294")
     @pytest.mark.parametrize("func", ["max", "min"])
     def test_groupby_rolling_index_changed(self, func):
         # GH: #36018 nlevels of MultiIndex changed


### PR DESCRIPTION
this is against 1.1.x directly. see https://github.com/pandas-dev/pandas/issues/35831#issuecomment-688862692