### PR TITLE
CLN remove trailing commas

### DIFF
--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -110,7 +110,7 @@ def test_append_with_timezones_dateutil(setup_path):
         dti = dti._with_freq(None)  # freq doesnt round-trip
 
         # GH 4098 example
-        df = DataFrame(dict(A=Series(range(3), index=dti,)))
+        df = DataFrame(dict(A=Series(range(3), index=dti)))
 
         _maybe_remove(store, "df")
         store.put("df", df)
@@ -197,7 +197,7 @@ def test_append_with_timezones_pytz(setup_path):
         dti = dti._with_freq(None)  # freq doesnt round-trip
 
         # GH 4098 example
-        df = DataFrame(dict(A=Series(range(3), index=dti,)))
+        df = DataFrame(dict(A=Series(range(3), index=dti)))
 
         _maybe_remove(store, "df")
         store.put("df", df)

--- a/pandas/tests/io/test_feather.py
+++ b/pandas/tests/io/test_feather.py
@@ -76,7 +76,7 @@ class TestFeather:
                     pd.Timestamp("20130103"),
                 ],
                 "dtns": pd.DatetimeIndex(
-                    list(pd.date_range("20130101", periods=3, freq="ns")), freq=None,
+                    list(pd.date_range("20130101", periods=3, freq="ns")), freq=None
                 ),
             }
         )

--- a/pandas/tests/io/test_s3.py
+++ b/pandas/tests/io/test_s3.py
@@ -43,6 +43,6 @@ def test_read_with_creds_from_pub_bucket():
         os.environ.setdefault("AWS_ACCESS_KEY_ID", "foobar_key")
         os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "foobar_secret")
         df = read_csv(
-            "s3://gdelt-open-data/events/1981.csv", nrows=5, sep="\t", header=None,
+            "s3://gdelt-open-data/events/1981.csv", nrows=5, sep="\t", header=None
         )
         assert len(df) == 5


### PR DESCRIPTION
#35925

From this set of 10 files, only the first 3 needed changes to comply if the new version of black:
- [x] pandas/tests/io/pytables/test_timezones.py
- [x] pandas/tests/io/test_feather.py
- [x] pandas/tests/io/test_s3.py
- [ ] pandas/tests/io/test_sql.py
- [ ] pandas/tests/io/test_stata.py
- [ ] pandas/tests/plotting/test_frame.py
- [ ] pandas/tests/resample/test_datetime_index.py
- [ ] pandas/tests/reshape/merge/test_merge_index_as_string.py
- [ ] pandas/tests/reshape/test_crosstab.py
- [ ] pandas/tests/reshape/test_get_dummies.py