### PR TITLE
CLN: w3 formatting

### DIFF
--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -327,7 +327,7 @@ class Styler:
                     colspan = col_lengths.get((r, c), 0)
                     if colspan > 1:
                         es["attributes"] = [
-                            format_attr({"key": "colspan", "value": colspan})
+                            format_attr({"key": "colspan", "value": f'"{colspan}"'})
                         ]
                     row_es.append(es)
                 head.append(row_es)

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1691,6 +1691,12 @@ class TestStyler:
         s = styler.render()  # render twice to ensure ctx is not updated
         assert s.find('<td  class="data row0 col0" >') != -1
 
+    def test_colspan_w3(self):
+        # GH 36223
+        df = pd.DataFrame(data=[[1, 2]], columns=[["l0", "l0"], ["l1a", "l1b"]])
+        s = Styler(df, uuid="_", cell_ids=False)
+        assert '<th class="col_heading level0 col0" colspan="2">l0</th>' in s.render()
+
 
 @td.skip_if_no_mpl
 class TestStylerMatplotlibDep:


### PR DESCRIPTION
- [x] closes #35706
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Cleans a very minor formatting error to be consistent with w3schools specification.

`colspan=2   --->  colspan="2"`

Note this generally has no effect in browsers parsing HTML.