### PR TITLE
BUG: GH36212 DataFrame agg() raises error when DataFrame column name is `name`

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -323,6 +323,7 @@ Reshaping
 - Bug in :meth:`DataFrame.pivot_table` with ``aggfunc='count'`` or ``aggfunc='sum'`` returning ``NaN`` for missing categories when pivoted on a ``Categorical``. Now returning ``0`` (:issue:`31422`)
 - Bug in :func:`union_indexes` where input index names are not preserved in some cases. Affects :func:`concat` and :class:`DataFrame` constructor (:issue:`13475`)
 - Bug in func :meth:`crosstab` when using multiple columns with ``margins=True`` and ``normalize=True`` (:issue:`35144`)
+- Bug in :meth:`DataFrame.agg` with ``func={'name':<FUNC>}`` incorrectly raising ``TypeError`` when ``DataFrame.columns==['Name']`` (:issue:`36212`)
 -
 
 Sparse

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -473,7 +473,7 @@ class SelectionMixin:
                 # we have a dict of scalars
 
                 # GH 36212 use name only if self is a series
-                name = getattr(self, "name", None) if (self.ndim == 1) else None
+                name = self.name if (self.ndim == 1) else None
 
                 result = Series(result, name=name)
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -19,6 +19,7 @@ from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_dict_like,
     is_extension_array_dtype,
+    is_hashable,
     is_list_like,
     is_object_dtype,
     is_scalar,
@@ -472,7 +473,7 @@ class SelectionMixin:
             except ValueError:
 
                 # we have a dict of scalars
-                
+
                 name = getattr(self, "name", None)
                 name = name if is_hashable(name) else None
                 # GH#36212

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -472,7 +472,7 @@ class SelectionMixin:
             except ValueError:
 
                 # we have a dict of scalars
-                result = Series(result, name=getattr(self, "name", None))
+                result = Series(result)
 
             return result, True
         elif is_list_like(arg):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -472,7 +472,7 @@ class SelectionMixin:
             except ValueError:
 
                 # we have a dict of scalars
-                result = Series(result)
+                result = Series(result, name=getattr(self, "name", None))
 
             return result, True
         elif is_list_like(arg):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -472,7 +472,11 @@ class SelectionMixin:
             except ValueError:
 
                 # we have a dict of scalars
-                result = Series(result, name=getattr(self, "name", None))
+                
+                name = getattr(self, "name", None)
+                name = name if is_hashable(name) else None
+                # GH#36212
+                result = Series(result, name=name)
 
             return result, True
         elif is_list_like(arg):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -471,12 +471,11 @@ class SelectionMixin:
             try:
                 result = DataFrame(result)
             except ValueError:
-
                 # we have a dict of scalars
 
-                name = getattr(self, "name", None)
-                name = name if is_hashable(name) else None
-                # GH 36212
+                # GH 36212 use name only if self is a series
+                name = getattr(self, "name", None) if (self.ndim == 1) else None
+
                 result = Series(result, name=name)
 
             return result, True

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -19,7 +19,6 @@ from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_dict_like,
     is_extension_array_dtype,
-    is_hashable,
     is_list_like,
     is_object_dtype,
     is_scalar,

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -476,7 +476,7 @@ class SelectionMixin:
 
                 name = getattr(self, "name", None)
                 name = name if is_hashable(name) else None
-                # GH#36212
+                # GH 36212
                 result = Series(result, name=name)
 
             return result, True

--- a/pandas/tests/frame/apply/test_frame_apply.py
+++ b/pandas/tests/frame/apply/test_frame_apply.py
@@ -1147,6 +1147,22 @@ class TestDataFrameAggregate:
         )
         tm.assert_frame_equal(result.reindex_like(expected), expected)
 
+    def test_agg_with_unhashable_name_column_value(self):
+        #GH 36212 - Column name is "name"
+        data = {'name': ['foo', 'bar']}
+        df = pd.DataFrame(data)
+
+        #result's name should be None
+        result = df.agg({'name': 'count'})
+        expected = pd.Series({'name':2})
+        tm.assert_series_equal(result, expected)
+
+        #Check if name is preserved when aggregating series instead
+        result = df['name'].agg({'name':'count'})
+        expected = pd.Series({'name':2}, name='name')
+        tm.assert_series_equal(result, expected)
+
+
     def test_agg_multiple_mixed_no_warning(self):
         # GH 20909
         mdf = pd.DataFrame(

--- a/pandas/tests/frame/apply/test_frame_apply.py
+++ b/pandas/tests/frame/apply/test_frame_apply.py
@@ -1147,7 +1147,7 @@ class TestDataFrameAggregate:
         )
         tm.assert_frame_equal(result.reindex_like(expected), expected)
 
-    def test_agg_with_unhashable_name_column_value(self):
+    def test_agg_with_name_as_column_name(self):
         # GH 36212 - Column name is "name"
         data = {"name": ["foo", "bar"]}
         df = pd.DataFrame(data)
@@ -1157,7 +1157,7 @@ class TestDataFrameAggregate:
         expected = pd.Series({"name": 2})
         tm.assert_series_equal(result, expected)
 
-        # Check if name is preserved when aggregating series instead
+        # Check if name is still preserved when aggregating series instead
         result = df["name"].agg({"name": "count"})
         expected = pd.Series({"name": 2}, name="name")
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/frame/apply/test_frame_apply.py
+++ b/pandas/tests/frame/apply/test_frame_apply.py
@@ -1148,20 +1148,19 @@ class TestDataFrameAggregate:
         tm.assert_frame_equal(result.reindex_like(expected), expected)
 
     def test_agg_with_unhashable_name_column_value(self):
-        #GH 36212 - Column name is "name"
-        data = {'name': ['foo', 'bar']}
+        # GH 36212 - Column name is "name"
+        data = {"name": ["foo", "bar"]}
         df = pd.DataFrame(data)
 
-        #result's name should be None
-        result = df.agg({'name': 'count'})
-        expected = pd.Series({'name':2})
+        # result's name should be None
+        result = df.agg({"name": "count"})
+        expected = pd.Series({"name": 2})
         tm.assert_series_equal(result, expected)
 
-        #Check if name is preserved when aggregating series instead
-        result = df['name'].agg({'name':'count'})
-        expected = pd.Series({'name':2}, name='name')
+        # Check if name is preserved when aggregating series instead
+        result = df["name"].agg({"name": "count"})
+        expected = pd.Series({"name": 2}, name="name")
         tm.assert_series_equal(result, expected)
-
 
     def test_agg_multiple_mixed_no_warning(self):
         # GH 20909


### PR DESCRIPTION
- [x] closes #36212 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry