### PR TITLE
REF: pass setitem to unbox_scalar to de-duplicate validation

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -451,11 +451,11 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
     def _rebox_native(cls, value: int) -> np.datetime64:
         return np.int64(value).view("M8[ns]")
 
-    def _unbox_scalar(self, value):
+    def _unbox_scalar(self, value, setitem: bool = False):
         if not isinstance(value, self._scalar_type) and value is not NaT:
             raise ValueError("'value' should be a Timestamp.")
         if not isna(value):
-            self._check_compatible_with(value)
+            self._check_compatible_with(value, setitem=setitem)
         return value.value
 
     def _scalar_from_string(self, value):

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -257,11 +257,13 @@ class PeriodArray(PeriodMixin, dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
     def _rebox_native(cls, value: int) -> np.int64:
         return np.int64(value)
 
-    def _unbox_scalar(self, value: Union[Period, NaTType]) -> int:
+    def _unbox_scalar(
+        self, value: Union[Period, NaTType], setitem: bool = False
+    ) -> int:
         if value is NaT:
             return value.value
         elif isinstance(value, self._scalar_type):
-            self._check_compatible_with(value)
+            self._check_compatible_with(value, setitem=setitem)
             return value.ordinal
         else:
             raise ValueError(f"'value' should be a Period. Got '{value}' instead.")

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -283,10 +283,10 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
     def _rebox_native(cls, value: int) -> np.timedelta64:
         return np.int64(value).view("m8[ns]")
 
-    def _unbox_scalar(self, value):
+    def _unbox_scalar(self, value, setitem: bool = False):
         if not isinstance(value, self._scalar_type) and value is not NaT:
             raise ValueError("'value' should be a Timedelta.")
-        self._check_compatible_with(value)
+        self._check_compatible_with(value, setitem=setitem)
         return value.value
 
     def _scalar_from_string(self, value):

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -244,7 +244,7 @@ class SharedTests:
         # GH#29884 match numpy convention on whether NaT goes
         #  at the end or the beginning
         result = arr.searchsorted(pd.NaT)
-        if _np_version_under1p18 or self.array_cls is PeriodArray:
+        if np_version_under1p18 or self.array_cls is PeriodArray:
             # Following numpy convention, NaT goes at the beginning
             #  (unlike NaN which goes at the end)
             assert result == 0


### PR DESCRIPTION
Also fixes a test that is failing on master because _np_version_under_118 is no longer defined.