### PR TITLE
DOC: Improve Index docstrings

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -195,7 +195,7 @@ _IndexT = TypeVar("_IndexT", bound="Index")
 
 class Index(IndexOpsMixin, PandasObject):
     """
-    Immutable ndarray implementing an ordered, sliceable list. The basic object
+    Immutable sequence used for indexing and alignment. The basic object
     storing axis labels for all pandas objects.
 
     Parameters

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -195,7 +195,7 @@ _IndexT = TypeVar("_IndexT", bound="Index")
 
 class Index(IndexOpsMixin, PandasObject):
     """
-    Immutable ndarray implementing an ordered, sliceable set. The basic object
+    Immutable ndarray implementing an ordered, sliceable list. The basic object
     storing axis labels for all pandas objects.
 
     Parameters

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -189,7 +189,7 @@ class NumericIndex(Index):
 _num_index_shared_docs[
     "class_descr"
 ] = """
-    Immutable ndarray implementing an ordered, sliceable set. The basic object
+    Immutable sequence used for indexing and alignment. The basic object
     storing axis labels for all pandas objects. %(klass)s is a special case
     of `Index` with purely %(ltype)s labels. %(extra)s.
 


### PR DESCRIPTION
Index is now described as List instead of Set

- [x] closes #36170
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
