### PR TITLE
BUG: na parameter for str.startswith and str.endswith not propagating for Series with categorical dtype

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -22,7 +22,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
-- Bug in :meth:`str.startswith` and :meth:`str.endswith` for Series with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
+- Bug in :meth:`Series.str.startswith` and :meth:`Series.str.endswith` with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -22,7 +22,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Bug in :meth:`str.startswith` and :meth:`str.endswith` for Series with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2050,7 +2050,7 @@ def _pat_wrapper(
     @forbid_nonstring_types(forbidden_types, name=name)
     def wrapper3(self, pat, na=np.nan):
         result = f(self._parent, pat, na=na)
-        return self._wrap_result(result, returns_string=returns_string)
+        return self._wrap_result(result, returns_string=returns_string, fill_value=na)
 
     wrapper = wrapper3 if na else wrapper2 if flags else wrapper1
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -848,7 +848,8 @@ class TestStringMethods:
     def test_startswith(self, dtype, null_value, na):
         # add category dtype parametrizations for GH-36241
         values = Series(
-            ["om", null_value, "foo_nom", "nom", "bar_foo", null_value, "foo"], dtype=dtype
+            ["om", null_value, "foo_nom", "nom", "bar_foo", null_value, "foo"],
+            dtype=dtype,
         )
 
         result = values.str.startswith("foo")
@@ -883,7 +884,8 @@ class TestStringMethods:
     def test_endswith(self, dtype, null_value, na):
         # add category dtype parametrizations for GH-36241
         values = Series(
-            ["om", null_value, "foo_nom", "nom", "bar_foo", null_value, "foo"], dtype=dtype
+            ["om", null_value, "foo_nom", "nom", "bar_foo", null_value, "foo"],
+            dtype=dtype,
         )
 
         result = values.str.endswith("foo")

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -29,6 +29,8 @@ _any_string_method = [
     ("decode", ("UTF-8",), {}),
     ("encode", ("UTF-8",), {}),
     ("endswith", ("a",), {}),
+    ("endswith", ("a",), {"na": True}),
+    ("endswith", ("a",), {"na": False}),
     ("extract", ("([a-z]*)",), {"expand": False}),
     ("extract", ("([a-z]*)",), {"expand": True}),
     ("extractall", ("([a-z]*)",), {}),
@@ -58,6 +60,8 @@ _any_string_method = [
     ("split", (" ",), {"expand": False}),
     ("split", (" ",), {"expand": True}),
     ("startswith", ("a",), {}),
+    ("startswith", ("a",), {"na": True}),
+    ("startswith", ("a",), {"na": False}),
     # translating unicode points of "a" to "d"
     ("translate", ({97: 100},), {}),
     ("wrap", (2,), {}),
@@ -838,7 +842,7 @@ class TestStringMethods:
         expected = Series([True, False, False, True, False])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("dtype", [None, "category", "string"])
+    @pytest.mark.parametrize("dtype", [None, "category"])
     @pytest.mark.parametrize("null_value", [None, np.nan, pd.NA])
     @pytest.mark.parametrize("na", [True, False])
     def test_startswith(self, dtype, null_value, na):
@@ -873,7 +877,7 @@ class TestStringMethods:
         )
         tm.assert_series_equal(rs, xp)
 
-    @pytest.mark.parametrize("dtype", [None, "category", "string"])
+    @pytest.mark.parametrize("dtype", [None, "category"])
     @pytest.mark.parametrize("null_value", [None, np.nan, pd.NA])
     @pytest.mark.parametrize("na", [True, False])
     def test_endswith(self, dtype, null_value, na):
@@ -3540,7 +3544,6 @@ class TestStringMethods:
 
 
 def test_string_array(any_string_method):
-    print(any_string_method)
     method_name, args, kwargs = any_string_method
     if method_name == "decode":
         pytest.skip("decode requires bytes.")
@@ -3564,6 +3567,10 @@ def test_string_array(any_string_method):
         ):
             assert result.dtype == "boolean"
             result = result.astype(object)
+
+        elif expected.dtype == "bool":
+            assert result.dtype == "boolean"
+            result = result.astype("bool")
 
         elif expected.dtype == "float" and expected.isna().any():
             assert result.dtype == "Int64"

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -838,19 +838,21 @@ class TestStringMethods:
         expected = Series([True, False, False, True, False])
         tm.assert_series_equal(result, expected)
 
-    # add category dtype parametrizations for GH-36241
-    @pytest.mark.parametrize("dtype", [None, "category"])
-    def test_startswith(self, dtype):
+    @pytest.mark.parametrize("dtype", [None, "category", "string"])
+    @pytest.mark.parametrize("null_value", [None, np.nan, pd.NA])
+    @pytest.mark.parametrize("na", [True, False])
+    def test_startswith(self, dtype, null_value, na):
+        # add category dtype parametrizations for GH-36241
         values = Series(
-            ["om", np.nan, "foo_nom", "nom", "bar_foo", np.nan, "foo"], dtype=dtype
+            ["om", null_value, "foo_nom", "nom", "bar_foo", null_value, "foo"], dtype=dtype
         )
 
         result = values.str.startswith("foo")
         exp = Series([False, np.nan, True, False, False, np.nan, True])
         tm.assert_series_equal(result, exp)
 
-        result = values.str.startswith("foo", na=True)
-        tm.assert_series_equal(result, exp.fillna(True).astype(bool))
+        result = values.str.startswith("foo", na=na)
+        tm.assert_series_equal(result, exp.fillna(na).astype(bool))
 
         # mixed
         mixed = np.array(
@@ -871,19 +873,21 @@ class TestStringMethods:
         )
         tm.assert_series_equal(rs, xp)
 
-    # add category dtype parametrizations for GH-36241
-    @pytest.mark.parametrize("dtype", [None, "category"])
-    def test_endswith(self, dtype):
+    @pytest.mark.parametrize("dtype", [None, "category", "string"])
+    @pytest.mark.parametrize("null_value", [None, np.nan, pd.NA])
+    @pytest.mark.parametrize("na", [True, False])
+    def test_endswith(self, dtype, null_value, na):
+        # add category dtype parametrizations for GH-36241
         values = Series(
-            ["om", np.nan, "foo_nom", "nom", "bar_foo", np.nan, "foo"], dtype=dtype
+            ["om", null_value, "foo_nom", "nom", "bar_foo", null_value, "foo"], dtype=dtype
         )
 
         result = values.str.endswith("foo")
         exp = Series([False, np.nan, False, False, True, np.nan, True])
         tm.assert_series_equal(result, exp)
 
-        result = values.str.endswith("foo", na=False)
-        tm.assert_series_equal(result, exp.fillna(False).astype(bool))
+        result = values.str.endswith("foo", na=na)
+        tm.assert_series_equal(result, exp.fillna(na).astype(bool))
 
         # mixed
         mixed = np.array(
@@ -3536,6 +3540,7 @@ class TestStringMethods:
 
 
 def test_string_array(any_string_method):
+    print(any_string_method)
     method_name, args, kwargs = any_string_method
     if method_name == "decode":
         pytest.skip("decode requires bytes.")

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -857,7 +857,8 @@ class TestStringMethods:
         tm.assert_series_equal(result, exp)
 
         result = values.str.startswith("foo", na=na)
-        tm.assert_series_equal(result, exp.fillna(na).astype(bool))
+        exp = Series([False, na, True, False, False, na, True])
+        tm.assert_series_equal(result, exp)
 
         # mixed
         mixed = np.array(
@@ -893,7 +894,8 @@ class TestStringMethods:
         tm.assert_series_equal(result, exp)
 
         result = values.str.endswith("foo", na=na)
-        tm.assert_series_equal(result, exp.fillna(na).astype(bool))
+        exp = Series([False, na, False, False, True, na, True])
+        tm.assert_series_equal(result, exp)
 
         # mixed
         mixed = np.array(

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -838,8 +838,12 @@ class TestStringMethods:
         expected = Series([True, False, False, True, False])
         tm.assert_series_equal(result, expected)
 
-    def test_startswith(self):
-        values = Series(["om", np.nan, "foo_nom", "nom", "bar_foo", np.nan, "foo"])
+    # add category dtype parametrizations for GH-36241
+    @pytest.mark.parametrize("dtype", [None, "category"])
+    def test_startswith(self, dtype):
+        values = Series(
+            ["om", np.nan, "foo_nom", "nom", "bar_foo", np.nan, "foo"], dtype=dtype
+        )
 
         result = values.str.startswith("foo")
         exp = Series([False, np.nan, True, False, False, np.nan, True])
@@ -867,8 +871,12 @@ class TestStringMethods:
         )
         tm.assert_series_equal(rs, xp)
 
-    def test_endswith(self):
-        values = Series(["om", np.nan, "foo_nom", "nom", "bar_foo", np.nan, "foo"])
+    # add category dtype parametrizations for GH-36241
+    @pytest.mark.parametrize("dtype", [None, "category"])
+    def test_endswith(self, dtype):
+        values = Series(
+            ["om", np.nan, "foo_nom", "nom", "bar_foo", np.nan, "foo"], dtype=dtype
+        )
 
         result = values.str.endswith("foo")
         exp = Series([False, np.nan, False, False, True, np.nan, True])


### PR DESCRIPTION
- [x] closes #36241
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I parametrized dtype in existing tests. Should I create a separate test instead?