### PR TITLE
BUG: fix isin with nans and large arrays

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -30,6 +30,7 @@ Bug fixes
 - Bug in :meth:`Series.str.startswith` and :meth:`Series.str.endswith` with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
 - Bug in :class:`Series` constructor where integer overflow would occur for sufficiently large scalar inputs when an index was provided (:issue:`36291`)
 - Bug in :meth:`DataFrame.stack` raising a ``ValueError`` when stacking :class:`MultiIndex` columns based on position when the levels had duplicate names (:issue:`36353`)
+- Bug in :meth:`isin()` when using NaN and a row length above 1,000,000 (:issue:`22205`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -31,6 +31,7 @@ Bug fixes
 - Bug in :class:`Series` constructor where integer overflow would occur for sufficiently large scalar inputs when an index was provided (:issue:`36291`)
 - Bug in :meth:`DataFrame.stack` raising a ``ValueError`` when stacking :class:`MultiIndex` columns based on position when the levels had duplicate names (:issue:`36353`)
 - Bug in :meth:`isin()` when using NaN and a row length above 1,000,000 (:issue:`22205`)
+- Bug in :meth:`Series.isin` when using ``NaN`` and a row length above 1,000,000 (:issue:`22205`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -30,8 +30,7 @@ Bug fixes
 - Bug in :meth:`Series.str.startswith` and :meth:`Series.str.endswith` with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
 - Bug in :class:`Series` constructor where integer overflow would occur for sufficiently large scalar inputs when an index was provided (:issue:`36291`)
 - Bug in :meth:`DataFrame.stack` raising a ``ValueError`` when stacking :class:`MultiIndex` columns based on position when the levels had duplicate names (:issue:`36353`)
-- Bug in :meth:`isin()` when using NaN and a row length above 1,000,000 (:issue:`22205`)
-- Bug in :meth:`Series.isin` when using ``NaN`` and a row length above 1,000,000 (:issue:`22205`)
+- Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` when using ``NaN`` and a row length above 1,000,000 (:issue:`22205`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -440,7 +440,12 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
     # GH16012
     # Ensure np.in1d doesn't get object types or it *may* throw an exception
     if len(comps) > 1_000_000 and not is_object_dtype(comps):
-        f = np.in1d
+        # If the the values include nan we need to check for nan explicitly
+        # since np.nan it not equal to np.nan
+        if any(np.isnan(values)):
+            f = lambda c, v: np.logical_or(np.in1d(c, v), np.isnan(c))
+        else:
+            f = np.in1d
     elif is_integer_dtype(comps):
         try:
             values = values.astype("int64", copy=False)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -442,7 +442,7 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
     if len(comps) > 1_000_000 and not is_object_dtype(comps):
         # If the the values include nan we need to check for nan explicitly
         # since np.nan it not equal to np.nan
-        if any(np.isnan(values)):
+        if np.isnan(values).any():
             f = lambda c, v: np.logical_or(np.in1d(c, v), np.isnan(c))
         else:
             f = np.in1d

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -840,12 +840,22 @@ class TestIsin:
         result = algos.isin(comps, values)
         tm.assert_numpy_array_equal(expected, result)
 
+    # issue:`22205`
     def test_same_nan_is_in_large(self):
         s = np.tile(1.0, 1_000_001)
         s[0] = np.nan
         result = algos.isin(s, [np.nan, 1])
         expected = np.ones(len(s), dtype=bool)
         tm.assert_numpy_array_equal(result, expected)
+
+    # issue:`#25395`
+    def test_same_nan_is_in_large_series(self):
+        s = np.tile(1.0, 1_000_001)
+        series = pd.Series(s)
+        s[0] = np.nan
+        result = series.isin([np.nan, 1])
+        expected = pd.Series(np.ones(len(s), dtype=bool))
+        tm.assert_series_equal(result, expected)
 
     def test_same_object_is_in(self):
         # GH 22160

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -849,7 +849,7 @@ class TestIsin:
         tm.assert_numpy_array_equal(result, expected)
 
     def test_same_nan_is_in_large_series(self):
-        # issue:`#25395`
+        # https://github.com/pandas-dev/pandas/issues/22205
         s = np.tile(1.0, 1_000_001)
         series = pd.Series(s)
         s[0] = np.nan

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -841,7 +841,7 @@ class TestIsin:
         tm.assert_numpy_array_equal(expected, result)
 
     def test_same_nan_is_in_large(self):
-        # issue:`22205`
+        # https://github.com/pandas-dev/pandas/issues/22205
         s = np.tile(1.0, 1_000_001)
         s[0] = np.nan
         result = algos.isin(s, [np.nan, 1])

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -801,7 +801,6 @@ class TestIsin:
         tm.assert_numpy_array_equal(result, expected)
 
     def test_large(self):
-
         s = pd.date_range("20000101", periods=2000000, freq="s").values
         result = algos.isin(s, s[0:2])
         expected = np.zeros(len(s), dtype=bool)
@@ -840,6 +839,13 @@ class TestIsin:
         expected = np.array([True])
         result = algos.isin(comps, values)
         tm.assert_numpy_array_equal(expected, result)
+
+    def test_same_nan_is_in_large(self):
+        s = np.tile(1.0, 1_000_001)
+        s[0] = np.nan
+        result = algos.isin(s, [np.nan, 1])
+        expected = np.ones(len(s), dtype=bool)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_same_object_is_in(self):
         # GH 22160

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -840,16 +840,16 @@ class TestIsin:
         result = algos.isin(comps, values)
         tm.assert_numpy_array_equal(expected, result)
 
-    # issue:`22205`
     def test_same_nan_is_in_large(self):
+        # issue:`22205`
         s = np.tile(1.0, 1_000_001)
         s[0] = np.nan
         result = algos.isin(s, [np.nan, 1])
         expected = np.ones(len(s), dtype=bool)
         tm.assert_numpy_array_equal(result, expected)
 
-    # issue:`#25395`
     def test_same_nan_is_in_large_series(self):
+        # issue:`#25395`
         s = np.tile(1.0, 1_000_001)
         series = pd.Series(s)
         s[0] = np.nan


### PR DESCRIPTION
Does a np.isnan if nan is given to isin and we have a large enough array to trigger the `np.in1d` path
- [x] closes #22205
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
