### PR TITLE
Fix issue #36271 to disambiguate json string

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -7,6 +7,7 @@ from io import BufferedIOBase, BytesIO, RawIOBase
 import mmap
 import os
 import pathlib
+import re
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -44,8 +45,6 @@ from pandas.compat import get_lzma_file, import_lzma
 from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.dtypes.common import is_file_like
-
-from pandas._libs.json import loads
 
 lzma = import_lzma()
 
@@ -158,13 +157,12 @@ def urlopen(*args, **kwargs):
 def is_json(url: FilePathOrBuffer) -> bool:
     """
     Returns true if the given string looks like
-    something json.loads can handle
+    json
     """
-    try:
-        loads(url)
-
+    json_pattern = re.compile(r"^\s*[\[{]")
+    if json_pattern.match(url):
         return True
-    except:
+    else:
         return False
 
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -160,10 +160,8 @@ def is_json(url: FilePathOrBuffer) -> bool:
     json
     """
     json_pattern = re.compile(r"^\s*[\[{]")
-    if json_pattern.match(url):
-        return True
-    else:
-        return False
+    return json_pattern.match(url) is not None
+
 
 
 def is_fsspec_url(url: FilePathOrBuffer) -> bool:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -45,7 +45,7 @@ from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.dtypes.common import is_file_like
 
-from pandas._libs.json import loads as json_loads
+from pandas._libs.json import loads
 
 lzma = import_lzma()
 
@@ -161,7 +161,7 @@ def is_json(url: FilePathOrBuffer) -> bool:
     something json.loads can handle
     """
     try:
-        json_loads(url)
+        loads(url)
 
         return True
     except:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -161,6 +161,7 @@ def is_fsspec_url(url: FilePathOrBuffer) -> bool:
     return (
         isinstance(url, str)
         and "://" in url
+        and not " " in url
         and not url.startswith(("http://", "https://"))
     )
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -45,6 +45,8 @@ from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.dtypes.common import is_file_like
 
+from pandas._libs.json import loads as json_loads
+
 lzma = import_lzma()
 
 
@@ -153,6 +155,19 @@ def urlopen(*args, **kwargs):
     return urllib.request.urlopen(*args, **kwargs)
 
 
+def is_json(url: FilePathOrBuffer) -> bool:
+    """
+    Returns true if the given string looks like
+    something json.loads can handle
+    """
+    try:
+        json_loads(url)
+
+        return True
+    except:
+        return False
+
+
 def is_fsspec_url(url: FilePathOrBuffer) -> bool:
     """
     Returns true if the given URL looks like
@@ -161,7 +176,7 @@ def is_fsspec_url(url: FilePathOrBuffer) -> bool:
     return (
         isinstance(url, str)
         and "://" in url
-        and " " not in url
+        and not is_json(url)
         and not url.startswith(("http://", "https://"))
     )
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -161,7 +161,7 @@ def is_fsspec_url(url: FilePathOrBuffer) -> bool:
     return (
         isinstance(url, str)
         and "://" in url
-        and not " " in url
+        and " " not in url
         and not url.startswith(("http://", "https://"))
     )
 

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -52,6 +52,12 @@ foo2,12,13,14,15
 bar2,12,13,14,15
 """
 
+    def test_is_fsspec_url(self):
+        some_string = 'some :// string'
+        expected = False
+        
+        assert icom.is_fsspec_url(some_string)==expected
+
     def test_expand_user(self):
         filename = "~/sometest"
         expanded_name = icom._expand_user(filename)

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -418,4 +418,4 @@ def test_is_fsspec_url():
     assert not icom.is_fsspec_url("/local/path")
     assert not icom.is_fsspec_url("relative/local/path")
     # there are no white spaces in a URL
-    assert not icom.is_fsspec_url("gs://pandas /somethingelse.com")
+    assert not icom.is_fsspec_url('{"json": "text ://"}')

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -52,12 +52,6 @@ foo2,12,13,14,15
 bar2,12,13,14,15
 """
 
-    def test_is_fsspec_url(self):
-        some_string = 'some :// string'
-        expected = False
-        
-        assert icom.is_fsspec_url(some_string)==expected
-
     def test_expand_user(self):
         filename = "~/sometest"
         expanded_name = icom._expand_user(filename)
@@ -423,3 +417,5 @@ def test_is_fsspec_url():
     assert not icom.is_fsspec_url("random:pandas/somethingelse.com")
     assert not icom.is_fsspec_url("/local/path")
     assert not icom.is_fsspec_url("relative/local/path")
+    # there are no white spaces in a URL
+    assert not icom.is_fsspec_url("gs://pandas /somethingelse.com")

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -417,5 +417,5 @@ def test_is_fsspec_url():
     assert not icom.is_fsspec_url("random:pandas/somethingelse.com")
     assert not icom.is_fsspec_url("/local/path")
     assert not icom.is_fsspec_url("relative/local/path")
-    # there are no white spaces in a URL
+    # Ensure json string is not interpreted as URL
     assert not icom.is_fsspec_url('{"json": "text ://"}')


### PR DESCRIPTION
pd.read_json() fails currently for strings that look like fsspec_url and contain "://". adding another condition to fix this at least in most cases

- [X] closes #36271
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
