### PR TITLE
Fix #35484 - re-allow sqlalchemy declarative system to use `%` in read_sql.

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1159,9 +1159,7 @@ class SQLDatabase(PandasSQL):
 
     def execute(self, *args, **kwargs):
         """Simple passthrough to SQLAlchemy connectable"""
-        return self.connectable.execution_options(no_parameters=True).execute(
-            *args, **kwargs
-        )
+        return self.connectable.execution_options().execute(*args, **kwargs)
 
     def read_table(
         self,
@@ -1291,6 +1289,11 @@ class SQLDatabase(PandasSQL):
         read_sql
 
         """
+        if isinstance(sql, str) and params is None:
+            from sqlalchemy.sql import text
+
+            sql = text(sql)
+
         args = _convert_params(sql, params)
 
         result = self.execute(*args)

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -463,6 +463,7 @@ class PandasSQLTest:
         tm.assert_frame_equal(frame, DataFrame({"x": [1], "y": [2]}))
 
     def _read_sql_iris_no_parameter_with_doublepercent(self):
+        # Note that this is marked xfail in the method wrapping it...
         query = SQL_STRINGS["read_no_parameters_with_doublepercent"][self.flavor]
         frame = self.pandasSQL.read_query(query)
         tm.assert_frame_equal(frame, DataFrame({"x": [1]}))


### PR DESCRIPTION
- [x] closes #35484
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

* Adds tests to cover sql cases combining parameters and `%`.
* Notably, these tests highlight two regressions in v1.1
  - `pd.read_sql("SELECT 1 %% 2", engine)` fails. See #35871.
  - `pd.read_sql(sqlalchemy.sql.text("SELECT 1 % 2"), engine)` fails. See #35484.
* Fixes second issue by modifying SqlDatabase to not use `no_parameter`, and wrapping string queries in `sql.text()` when no parameters are passed.

I was going nuts trying to keep track of all the cases, so tossed them into a table! I didn't have time to explicitly check v1.05, so would be helpful if someone could verify that column (or I may be able to loop back to it)!

| query |   v1.05 | v.1.1 | PR | issue |
| --- | --- | --- | --- | --- |
| no params, `%` | ❌ | ✅ | ✅ | #34211 (merged) |
| no params, `%%` | ✅ | ❌ | ❌ | #35871 |
| params, `%` | ❌ | ❌ | ❌ |  https://github.com/psycopg/psycopg2/issues/827 |
| params, `%%` | ✅ | ✅ | ✅ | | 
| sqla declarative, `%` | ✅ | ❌ | ✅ | #35484 |