### PR TITLE
PERF: creating string Series/Arrays from sequence with many strings

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -205,6 +205,7 @@ Deprecations
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Performance improvements when converting :class:`Series` with object dtype and many string elements to dtype :class:`StringDtype` (:issue:`xxxxx`)
 - Performance improvement in :meth:`GroupBy.agg` with the ``numba`` engine (:issue:`35759`)
 -
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -205,7 +205,7 @@ Deprecations
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Performance improvements when converting :class:`Series` with object dtype and many string elements to dtype :class:`StringDtype` (:issue:`xxxxx`)
+- Performance improvements when creating Series with dtype `str` or :class:`StringDtype` from array with many string elements (:issue:`36304`)
 - Performance improvement in :meth:`GroupBy.agg` with the ``numba`` engine (:issue:`35759`)
 -
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -655,6 +655,10 @@ cpdef ndarray[object] ensure_string_array(
 
     for i in range(n):
         val = result[i]
+
+        if isinstance(val, str):
+            continue
+
         if not checknull(val):
             result[i] = str(val)
         else:


### PR DESCRIPTION
Improves performance of `pandas._libs.lib.ensure_string_array` is cases with many string elements.

Examples:

```python
>>> x = np.array([str(u) for u in range(1_000_000)], dtype=object)
>>> %timeit pd.Series(x, dtype=str)
344 ms ± 59.7 ms per loop  # v1.1.0
157 ms ± 7.04 ms per loop  # v1.1.1 and master
22.6 ms ± 191 µs per loop  # this PR
>>> %timeit pd.Series(x, dtype="string")
357 ms ± 40.2 ms per loop  # v1.1.0
148 ms ± 713 µs per loop  # v1.1.1 and master
26.3 ms ± 291 µs per loop  # this PR
```

#35519 is the cause of the improvement from 1.1.0 to 1.1.1.

Together with #35519 this PR means that the overhead of working with strings in pandas has gotten considerably smaller for cases when we many times instantiate new `Series`/`PandasArrays` with dtype `str`/`StringDtype`, i.e. probably quite often.