### PR TITLE
PERF: StringArray construction

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -219,7 +219,7 @@ Deprecations
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Performance improvements when creating Series with dtype `str` or :class:`StringDtype` from array with many string elements (:issue:`36304`, :issue:`36317`)
+- Performance improvements when creating Series with dtype `str` or :class:`StringDtype` from array with many string elements (:issue:`36304`, :issue:`36317`, :issue:`36325`)
 - Performance improvement in :meth:`GroupBy.agg` with the ``numba`` engine (:issue:`35759`)
 - Performance improvements when creating :meth:`pd.Series.map` from a huge dictionary (:issue:`34717`)
 - Performance improvement in :meth:`GroupBy.transform` with the ``numba`` engine (:issue:`36240`)

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -1,5 +1,5 @@
 import operator
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Type, Union
 
 import numpy as np
 
@@ -122,9 +122,6 @@ class StringArray(PandasArray):
 
     copy : bool, default False
         Whether to copy the array of data.
-    convert : bool, default False
-        If true, force conversion of non-na scalars to strings.
-        If False, raises a ValueError, if a scalar is neither a string nor na.
 
     Attributes
     ----------
@@ -165,15 +162,7 @@ class StringArray(PandasArray):
     ['1', '1']
     Length: 2, dtype: string
 
-    Instantiating StringArrays directly with non-strings arrays  will raise an error
-    unless ``convert=True``.
-
-    >>> pd.arrays.StringArray(np.array(['1', 1]))
-    ValueError: StringArray requires a sequence of strings or pandas.NA
-    >>> pd.arrays.StringArray(['1', 1], convert=True)
-    <StringArray>
-    ['1', '1']
-    Length: 2, dtype: string
+    However, instantiating StringArrays directly with non-strings will raise an error.
 
     For comparison methods, `StringArray` returns a :class:`pandas.BooleanArray`:
 
@@ -186,29 +175,22 @@ class StringArray(PandasArray):
     # undo the PandasArray hack
     _typ = "extension"
 
-    def __init__(self, values, copy=False, convert: bool = False):
+    def __init__(self, values, copy=False):
         values = extract_array(values)
-        if not isinstance(values, type(self)):
-            if convert:
-                na_val = StringDtype.na_value
-                values = lib.ensure_string_array(values, na_value=na_val, copy=copy)
-            else:
-                self._validate(values)
 
         super().__init__(values, copy=copy)
         self._dtype = StringDtype()
+        if not isinstance(values, type(self)):
+            self._validate()
 
-    def _validate(self, values: Optional[np.ndarray] = None) -> None:
+    def _validate(self):
         """Validate that we only store NA or strings."""
-        if values is None:
-            values = self._ndarray
-
-        if len(values) and not lib.is_string_array(values, skipna=True):
+        if len(self._ndarray) and not lib.is_string_array(self._ndarray, skipna=True):
             raise ValueError("StringArray requires a sequence of strings or pandas.NA")
-        if values.dtype != "object":
+        if self._ndarray.dtype != "object":
             raise ValueError(
                 "StringArray requires a sequence of strings or pandas.NA. Got "
-                f"'{values.dtype}' dtype instead."
+                f"'{self._ndarray.dtype}' dtype instead."
             )
 
     @classmethod
@@ -217,8 +199,18 @@ class StringArray(PandasArray):
             assert dtype == "string"
 
         result = np.asarray(scalars, dtype="object")
+        # convert non-na-likes to str, and nan-likes to StringDtype.na_value
+        result = lib.ensure_string_array(
+            result, na_value=StringDtype.na_value, copy=copy
+        )
 
-        return cls(result, copy=copy, convert=True)
+        # Manually creating new array avoids the validation step in the __init__, so is
+        # faster. Refactor need for validation?
+        new_string_array = object.__new__(cls)
+        new_string_array._dtype = StringDtype()
+        new_string_array._ndarray = result
+
+        return new_string_array
 
     @classmethod
     def _from_sequence_of_strings(cls, strings, dtype=None, copy=False):

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -165,11 +165,11 @@ class StringArray(PandasArray):
     ['1', '1']
     Length: 2, dtype: string
 
-    Instantiating StringArrays directly with non-strings will raise an error unless
-    ``convert=True``.
+    Instantiating StringArrays directly with non-strings arrays  will raise an error
+    unless ``convert=True``.
 
-    >>> pd.arrays.StringArray(['1', 1])
-    TypeError: Argument 'values' has incorrect type (expected numpy.ndarray, got list)
+    >>> pd.arrays.StringArray(np.array(['1', 1], dtype=object))
+    ValueError: StringArray requires a sequence of strings or pandas.NA
     >>> pd.arrays.StringArray(['1', 1], convert=True)
     <StringArray>
     ['1', '1']

--- a/pandas/core/arrays/string_.py
+++ b/pandas/core/arrays/string_.py
@@ -168,7 +168,7 @@ class StringArray(PandasArray):
     Instantiating StringArrays directly with non-strings arrays  will raise an error
     unless ``convert=True``.
 
-    >>> pd.arrays.StringArray(np.array(['1', 1], dtype=object))
+    >>> pd.arrays.StringArray(np.array(['1', 1]))
     ValueError: StringArray requires a sequence of strings or pandas.NA
     >>> pd.arrays.StringArray(['1', 1], convert=True)
     <StringArray>
@@ -190,9 +190,8 @@ class StringArray(PandasArray):
         values = extract_array(values)
         if not isinstance(values, type(self)):
             if convert:
-                values = lib.ensure_string_array(
-                    values, na_value=StringDtype.na_value, copy=copy
-                )
+                na_val = StringDtype.na_value
+                values = lib.ensure_string_array(values, na_value=na_val, copy=copy)
             else:
                 self._validate(values)
 


### PR DESCRIPTION
Currently, when constructing through `Series(data, dtype="string")`, pandas first converts to strings/NA, then does a check that all scalars are actually strings or NA. The check is not needed in cases where we explicitly already have converted.

Performance example:

```python
>>> x = np.array([str(u) for u in range(1_000_000)], dtype=object)
>>> %timeit pd.Series(x, dtype="string")
357 ms ± 40.2 ms per loop  # v1.1.0
148 ms ± 713 µs per loop  # after #35519
26.3 ms ± 291 µs per loop  # after #36304
12.6 ms ± 115 µs per loop  # this PR
```

xref #35519, #36304 & #36317.