### PR TITLE
[TST]: Groupy raised ValueError for ffill with duplicate column names

### DIFF
--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -495,51 +495,6 @@ def test_idxmin_idxmax_returns_int_types(func, values):
     tm.assert_frame_equal(result, expected)
 
 
-def test_fill_consistency():
-
-    # GH9221
-    # pass thru keyword arguments to the generated wrapper
-    # are set if the passed kw is None (only)
-    df = DataFrame(
-        index=pd.MultiIndex.from_product(
-            [["value1", "value2"], date_range("2014-01-01", "2014-01-06")]
-        ),
-        columns=Index(["1", "2"], name="id"),
-    )
-    df["1"] = [
-        np.nan,
-        1,
-        np.nan,
-        np.nan,
-        11,
-        np.nan,
-        np.nan,
-        2,
-        np.nan,
-        np.nan,
-        22,
-        np.nan,
-    ]
-    df["2"] = [
-        np.nan,
-        3,
-        np.nan,
-        np.nan,
-        33,
-        np.nan,
-        np.nan,
-        4,
-        np.nan,
-        np.nan,
-        44,
-        np.nan,
-    ]
-
-    expected = df.groupby(level=0, axis=0).fillna(method="ffill")
-    result = df.T.groupby(level=0, axis=1).fillna(method="ffill").T
-    tm.assert_frame_equal(result, expected)
-
-
 def test_groupby_cumprod():
     # GH 4095
     df = pd.DataFrame({"key": ["b"] * 10, "value": 2})

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2146,3 +2146,16 @@ def test_groupby_column_index_name_lost_fill_funcs(func):
     result = getattr(df_grouped, func)().columns
     expected = pd.Index(["a", "b"], name="idx")
     tm.assert_index_equal(result, expected)
+
+
+@pytest.mark.parametrize("func", ["ffill", "bfill"])
+def test_groupby_fill_duplicate_column_names(func):
+    # GH: 25610 ValueError with duplicate column names
+    df1 = pd.DataFrame({"field1": [1, 3, 4], "field2": [1, 3, 4],})
+    df2 = pd.DataFrame({"field1": [1, np.nan, 4],})
+    df_grouped = pd.concat([df1, df2], axis=1).groupby(by=["field2"])
+    expected = pd.DataFrame(
+        [[1, 1.0], [3, np.nan], [4, 4.0]], columns=["field1", "field1"]
+    )
+    result = getattr(df_grouped, func)()
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2151,8 +2151,8 @@ def test_groupby_column_index_name_lost_fill_funcs(func):
 @pytest.mark.parametrize("func", ["ffill", "bfill"])
 def test_groupby_fill_duplicate_column_names(func):
     # GH: 25610 ValueError with duplicate column names
-    df1 = pd.DataFrame({"field1": [1, 3, 4], "field2": [1, 3, 4],})
-    df2 = pd.DataFrame({"field1": [1, np.nan, 4],})
+    df1 = pd.DataFrame({"field1": [1, 3, 4], "field2": [1, 3, 4]})
+    df2 = pd.DataFrame({"field1": [1, np.nan, 4]})
     df_grouped = pd.concat([df1, df2], axis=1).groupby(by=["field2"])
     expected = pd.DataFrame(
         [[1, 1.0], [3, np.nan], [4, 4.0]], columns=["field1", "field1"]

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1961,13 +1961,6 @@ def test_shift_bfill_ffill_tz(tz_naive_fixture, op, expected):
     tm.assert_frame_equal(result, expected)
 
 
-def test_ffill_missing_arguments():
-    # GH 14955
-    df = pd.DataFrame({"a": [1, 2], "b": [1, 1]})
-    with pytest.raises(ValueError, match="Must specify a fill"):
-        df.groupby("b").fillna()
-
-
 def test_groupby_only_none_group():
     # see GH21624
     # this was crashing with "ValueError: Length of passed values is 1, index implies 0"
@@ -2133,29 +2126,3 @@ def test_groupby_column_index_name_lost(func):
     df_grouped = df.groupby([1])
     result = getattr(df_grouped, func)().columns
     tm.assert_index_equal(result, expected)
-
-
-@pytest.mark.parametrize("func", ["ffill", "bfill"])
-def test_groupby_column_index_name_lost_fill_funcs(func):
-    # GH: 29764 groupby loses index sometimes
-    df = pd.DataFrame(
-        [[1, 1.0, -1.0], [1, np.nan, np.nan], [1, 2.0, -2.0]],
-        columns=pd.Index(["type", "a", "b"], name="idx"),
-    )
-    df_grouped = df.groupby(["type"])[["a", "b"]]
-    result = getattr(df_grouped, func)().columns
-    expected = pd.Index(["a", "b"], name="idx")
-    tm.assert_index_equal(result, expected)
-
-
-@pytest.mark.parametrize("func", ["ffill", "bfill"])
-def test_groupby_fill_duplicate_column_names(func):
-    # GH: 25610 ValueError with duplicate column names
-    df1 = pd.DataFrame({"field1": [1, 3, 4], "field2": [1, 3, 4]})
-    df2 = pd.DataFrame({"field1": [1, np.nan, 4]})
-    df_grouped = pd.concat([df1, df2], axis=1).groupby(by=["field2"])
-    expected = pd.DataFrame(
-        [[1, 1.0], [3, np.nan], [4, 4.0]], columns=["field1", "field1"]
-    )
-    result = getattr(df_grouped, func)()
-    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_missing.py
+++ b/pandas/tests/groupby/test_missing.py
@@ -1,9 +1,9 @@
 import numpy as np
+import pytest
 
 import pandas as pd
-import pandas._testing as tm
 from pandas import DataFrame, Index, date_range
-import pytest
+import pandas._testing as tm
 
 
 @pytest.mark.parametrize("func", ["ffill", "bfill"])

--- a/pandas/tests/groupby/test_missing.py
+++ b/pandas/tests/groupby/test_missing.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+import pandas as pd
+import pandas._testing as tm
+from pandas import DataFrame, Index, date_range
+import pytest
+
+
+@pytest.mark.parametrize("func", ["ffill", "bfill"])
+def test_groupby_column_index_name_lost_fill_funcs(func):
+    # GH: 29764 groupby loses index sometimes
+    df = pd.DataFrame(
+        [[1, 1.0, -1.0], [1, np.nan, np.nan], [1, 2.0, -2.0]],
+        columns=pd.Index(["type", "a", "b"], name="idx"),
+    )
+    df_grouped = df.groupby(["type"])[["a", "b"]]
+    result = getattr(df_grouped, func)().columns
+    expected = pd.Index(["a", "b"], name="idx")
+    tm.assert_index_equal(result, expected)
+
+
+@pytest.mark.parametrize("func", ["ffill", "bfill"])
+def test_groupby_fill_duplicate_column_names(func):
+    # GH: 25610 ValueError with duplicate column names
+    df1 = pd.DataFrame({"field1": [1, 3, 4], "field2": [1, 3, 4]})
+    df2 = pd.DataFrame({"field1": [1, np.nan, 4]})
+    df_grouped = pd.concat([df1, df2], axis=1).groupby(by=["field2"])
+    expected = pd.DataFrame(
+        [[1, 1.0], [3, np.nan], [4, 4.0]], columns=["field1", "field1"]
+    )
+    result = getattr(df_grouped, func)()
+    tm.assert_frame_equal(result, expected)
+
+
+def test_ffill_missing_arguments():
+    # GH 14955
+    df = pd.DataFrame({"a": [1, 2], "b": [1, 1]})
+    with pytest.raises(ValueError, match="Must specify a fill"):
+        df.groupby("b").fillna()
+
+
+def test_fill_consistency():
+
+    # GH9221
+    # pass thru keyword arguments to the generated wrapper
+    # are set if the passed kw is None (only)
+    df = DataFrame(
+        index=pd.MultiIndex.from_product(
+            [["value1", "value2"], date_range("2014-01-01", "2014-01-06")]
+        ),
+        columns=Index(["1", "2"], name="id"),
+    )
+    df["1"] = [
+        np.nan,
+        1,
+        np.nan,
+        np.nan,
+        11,
+        np.nan,
+        np.nan,
+        2,
+        np.nan,
+        np.nan,
+        22,
+        np.nan,
+    ]
+    df["2"] = [
+        np.nan,
+        3,
+        np.nan,
+        np.nan,
+        33,
+        np.nan,
+        np.nan,
+        4,
+        np.nan,
+        np.nan,
+        44,
+        np.nan,
+    ]
+
+    expected = df.groupby(level=0, axis=0).fillna(method="ffill")
+    result = df.T.groupby(level=0, axis=1).fillna(method="ffill").T
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #25610
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`


Was fixed in the past. Added test to avoid regression
