### PR TITLE
ERR: Cartesian product error

### DIFF
--- a/pandas/core/reshape/util.py
+++ b/pandas/core/reshape/util.py
@@ -39,6 +39,10 @@ def cartesian_product(X):
     lenX = np.fromiter((len(x) for x in X), dtype=np.intp)
     cumprodX = np.cumproduct(lenX)
 
+    msg = "Product space too large to allocate arrays!"
+    if np.any(cumprodX < 0):
+        raise ValueError(msg)
+
     a = np.roll(cumprodX, 1)
     a[0] = 1
 

--- a/pandas/core/reshape/util.py
+++ b/pandas/core/reshape/util.py
@@ -39,9 +39,8 @@ def cartesian_product(X):
     lenX = np.fromiter((len(x) for x in X), dtype=np.intp)
     cumprodX = np.cumproduct(lenX)
 
-    msg = "Product space too large to allocate arrays!"
     if np.any(cumprodX < 0):
-        raise ValueError(msg)
+        raise ValueError("Product space too large to allocate arrays!")
 
     a = np.roll(cumprodX, 1)
     a[0] = 1

--- a/pandas/tests/reshape/test_util.py
+++ b/pandas/tests/reshape/test_util.py
@@ -65,3 +65,13 @@ class TestCartesianProduct:
 
         with pytest.raises(TypeError, match=msg):
             cartesian_product(X=X)
+
+    def test_exceed_product_space(self):
+        # GH31355: raise useful error when produce space is too large
+        msg = "Product space too large to allocate arrays!"
+
+        with pytest.raises(ValueError, match=msg):
+            dims = [np.arange(0, 22, dtype=np.int16) for i in range(12)] + [
+                (np.arange(15128, dtype=np.int16)),
+            ]
+            cartesian_product(X=dims)


### PR DESCRIPTION
- [x] closes #31355
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Added a test to trigger the reported error using code from the issue. An if statement was included to return a more helpful error message - borrowing the solution from the issue.

Replacement of [this](https://github.com/pandas-dev/pandas/pull/36169) pull request.