### PR TITLE
CI: Add stale PR action

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -16,4 +16,5 @@ jobs:
         exempt-pr-labels: "Needs Review"
         days-before-stale: 30
         days-before-close: -1
+        remove-stale-when-updated: true
         debug-only: true

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,4 +1,4 @@
-name: "Manage stale pull requests"
+name: "Stale PRs"
 on:
   schedule:
   # * is a special character in YAML so you have to quote this string
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: "This pull request is stale because it has been open for 30 days with no activity. Please update to prevent this from being closed."
+        stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity. Please update to prevent this from being closed (you can always reopen later). If you need help don't hesitate to contact one of the maintainers."
         days-before-stale: 30
         days-before-close: -1
         debug-only: true

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -11,7 +11,8 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity. Please update to prevent this from being closed (you can always reopen later). If you need help don't hesitate to contact one of the maintainers."
+        stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity."
+        stale-pr-label: "Stale"
         days-before-stale: 30
         days-before-close: -1
         debug-only: true

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,7 +1,8 @@
-name: "Close stale pull requests"
+name: "Manage stale pull requests"
 on:
   schedule:
-  - cron: "0 0 * * *"
+  # * is a special character in YAML so you have to quote this string
+  - cron: "0 */6 * * *"
 
 jobs:
   stale:
@@ -10,7 +11,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+        stale-pr-message: "This pull request is stale because it has been open for 30 days with no activity. Please update to prevent this from being closed."
         days-before-stale: 30
         days-before-close: -1
         debug-only: true

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,15 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+        days-before-stale: 30
+        days-before-close: 5

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,4 +12,5 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
         days-before-stale: 30
-        days-before-close: 5
+        days-before-close: -1
+        debug-only: true

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -13,7 +13,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity."
         stale-pr-label: "Stale"
-        exempt-pr-labels: "Needs Review"
+        exempt-pr-labels: "Needs Review,Blocked"
         days-before-stale: 30
         days-before-close: -1
         remove-stale-when-updated: true

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -13,6 +13,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity."
         stale-pr-label: "Stale"
+        exempt-pr-labels: "Needs Review"
         days-before-stale: 30
         days-before-close: -1
         debug-only: true

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,6 +12,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity."
+        skip-stale-pr-message: false
         stale-pr-label: "Stale"
         exempt-pr-labels: "Needs Review,Blocked"
         days-before-stale: 30


### PR DESCRIPTION
Adding a GitHub Action for ~closing stale PRs~ labeling PRs as stale which I think could help in managing the backlog

https://github.com/actions/stale