### PR TITLE
REF: use check_setitem_lengths in DTA.__setitem__

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 import operator
-from typing import Any, Callable, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Callable, Optional, Sequence, Tuple, Type, TypeVar, Union
 import warnings
 
 import numpy as np
@@ -58,7 +58,7 @@ from pandas.core.arrays._mixins import _T, NDArrayBackedExtensionArray
 from pandas.core.arrays.base import ExtensionOpsMixin
 import pandas.core.common as com
 from pandas.core.construction import array, extract_array
-from pandas.core.indexers import check_array_indexer
+from pandas.core.indexers import check_array_indexer, check_setitem_lengths
 from pandas.core.ops.common import unpack_zerodim_and_defer
 from pandas.core.ops.invalid import invalid_comparison, make_invalid_op
 
@@ -605,23 +605,9 @@ class DatetimeLikeArrayMixin(
         # to a period in from_sequence). For DatetimeArray, it's Timestamp...
         # I don't know if mypy can do that, possibly with Generics.
         # https://mypy.readthedocs.io/en/latest/generics.html
-        if is_list_like(value):
-            is_slice = isinstance(key, slice)
-
-            if lib.is_scalar(key):
-                raise ValueError("setting an array element with a sequence.")
-
-            if not is_slice:
-                key = cast(Sequence, key)
-                if len(key) != len(value) and not com.is_bool_indexer(key):
-                    msg = (
-                        f"shape mismatch: value array of length '{len(key)}' "
-                        "does not match indexing result of length "
-                        f"'{len(value)}'."
-                    )
-                    raise ValueError(msg)
-                elif not len(key):
-                    return
+        no_op = check_setitem_lengths(key, value, self)
+        if no_op:
+            return
 
         value = self._validate_setitem_value(value)
         key = check_array_indexer(self, key)

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -149,12 +149,12 @@ def check_setitem_lengths(indexer, value, values) -> bool:
         #  b) boolean indexers e.g. BoolArray
         if is_list_like(value):
             if len(indexer) != len(value):
+                # boolean with truth values == len of the value is ok too
                 if not (
                     isinstance(indexer, np.ndarray)
                     and indexer.dtype == np.bool_
                     and len(indexer[indexer]) == len(value)
                 ):
-                    # boolean with truth values == len of the value is ok too
                     raise ValueError(
                         "cannot set using a list-like indexer "
                         "with a different length than the value"
@@ -163,17 +163,15 @@ def check_setitem_lengths(indexer, value, values) -> bool:
                 no_op = True
 
     elif isinstance(indexer, slice):
-        # slice
         if is_list_like(value):
-            if len(values):
-                if len(value) != length_of_indexer(indexer, values):
-                    raise ValueError(
-                        "cannot set using a slice indexer with a "
-                        "different length than the value"
-                    )
-            else:
-                # TODO: dont we still need lengths to match?
+            if len(value) != length_of_indexer(indexer, values):
+                raise ValueError(
+                    "cannot set using a slice indexer with a "
+                    "different length than the value"
+                )
+            if len(value) == 0:
                 no_op = True
+
     return no_op
 
 

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -159,7 +159,7 @@ def check_setitem_lengths(indexer, value, values) -> bool:
                         "cannot set using a list-like indexer "
                         "with a different length than the value"
                     )
-            if len(indexer) == 0:
+            if not len(indexer):
                 no_op = True
 
     elif isinstance(indexer, slice):
@@ -169,7 +169,7 @@ def check_setitem_lengths(indexer, value, values) -> bool:
                     "cannot set using a slice indexer with a "
                     "different length than the value"
                 )
-            if len(value) == 0:
+            if not len(value):
                 no_op = True
 
     return no_op

--- a/pandas/core/indexers.py
+++ b/pandas/core/indexers.py
@@ -14,8 +14,11 @@ from pandas.core.dtypes.common import (
     is_integer,
     is_integer_dtype,
     is_list_like,
+    is_scalar,
 )
 from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
+
+import pandas.core.common as com
 
 # -----------------------------------------------------------
 # Indexer Identification
@@ -141,7 +144,7 @@ def check_setitem_lengths(indexer, value, values) -> None:
         When the indexer is an ndarray or list and the lengths don't match.
     """
     # boolean with truth values == len of the value is ok too
-    if isinstance(indexer, (np.ndarray, list)):
+    if isinstance(indexer, (np.ndarray, list)):  # TODO: why not other listlike?
         if is_list_like(value) and len(indexer) != len(value):
             if not (
                 isinstance(indexer, np.ndarray)
@@ -482,3 +485,34 @@ def check_array_indexer(array: AnyArrayLike, indexer: Any) -> Any:
         raise IndexError("arrays used as indices must be of integer or boolean type")
 
     return indexer
+
+
+def check_empty_setitem(key, value, array) -> bool:
+    """
+    If the value being set is listlike, check that its length matches array[key].
+
+    If the value is empty, notify the caller that this is a no-op.
+    NB: we skip some dtype validation on these no-ops.
+    """
+    no_op = False
+    if is_list_like(value):  # TODO: what about object dtype holding listlike?
+        if is_scalar(key):
+            raise ValueError("Setting an array element with a sequence.")
+
+        key_len = length_of_indexer(key, array)
+        if key_len != len(value):
+            if com.is_bool_indexer(key):
+                # We will fall through to let numpy raise with an accurate message
+                pass
+            else:
+                msg = (
+                    f"shape mismatch: value array of length '{len(key)}' "
+                    "does not match indexing result of length "
+                    f"'{len(value)}'."
+                )
+                raise ValueError(msg)
+        else:
+            if len(value) == 0:
+                no_op = True
+
+    return no_op

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -338,6 +338,16 @@ class SharedTests:
         with pytest.raises(TypeError, match="'value' should be a.* 'object'"):
             arr[0] = object()
 
+        msg = "cannot set using a list-like indexer with a different length"
+        with pytest.raises(ValueError, match=msg):
+            # GH#36339
+            arr[[]] = [arr[1]]
+
+        msg = "cannot set using a slice indexer with a different length than"
+        with pytest.raises(ValueError, match=msg):
+            # GH#36339
+            arr[1:1] = arr[:3]
+
     @pytest.mark.parametrize("box", [list, np.array, pd.Index, pd.Series])
     def test_setitem_numeric_raises(self, arr1d, box):
         # We dont case e.g. int64 to our own dtype for setitem


### PR DESCRIPTION
Turning this into a two-line check will make it easy to add to `PandasArray.__setitem__` and `Categorical.__setitem__`, at which point we'll be able to move these methods up to `NDArrayBackedExtensionArray.__setitem__`