### PR TITLE
Fix documentation for new float_precision on read_csv

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -343,6 +343,7 @@ float_precision : str, optional
     `round_trip` for the round-trip converter.
 
     .. versionchanged:: 1.2
+
 Returns
 -------
 DataFrame or TextParser

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -338,9 +338,9 @@ memory_map : bool, default False
     option can improve performance because there is no longer any I/O overhead.
 float_precision : str, optional
     Specifies which converter the C engine should use for floating-point
-    values. The options are `None` or `high` for the ordinary converter,
-    `legacy` for the original lower precision pandas converter, and
-    `round_trip` for the round-trip converter.
+    values. The options are ``None`` or 'high' for the ordinary converter,
+    'legacy' for the original lower precision pandas converter, and
+    'round_trip' for the round-trip converter.
 
     .. versionchanged:: 1.2
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -342,6 +342,7 @@ float_precision : str, optional
     `legacy` for the original lower precision pandas converter, and
     `round_trip` for the round-trip converter.
 
+    .. versionchanged:: 1.2
 Returns
 -------
 DataFrame or TextParser
@@ -2281,9 +2282,10 @@ def TextParser(*args, **kwds):
         can be inferred, there often will be a large parsing speed-up.
     float_precision : str, optional
         Specifies which converter the C engine should use for floating-point
-        values. The options are None for the ordinary converter,
-        'high' for the high-precision converter, and 'round_trip' for the
-        round-trip converter.
+        values. The options are `None` or `high` for the ordinary converter,
+        `legacy` for the original lower precision pandas converter, and
+        `round_trip` for the round-trip converter.
+
         .. versionchanged:: 1.2
     """
     kwds["engine"] = "python"


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/pull/36228#discussion_r487587534
- [ ] tests added / passed
     N/A
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
     N/A

A followup to PR #36228 to get the documentation string right for version changed. (was in wrong place, missing blank line)

