### PR TITLE
BUG: Python Parser skipping over items if BOM present in first element of header

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -318,6 +318,7 @@ I/O
 - :meth:`to_csv` did not support zip compression for binary file object not having a filename (:issue:`35058`)
 - :meth:`to_csv` and :meth:`read_csv` did not honor `compression` and `encoding` for path-like objects that are internally converted to file-like objects (:issue:`35677`, :issue:`26124`, and :issue:`32392`)
 - :meth:`to_picke` and :meth:`read_pickle` did not support compression for file-objects (:issue:`26237`, :issue:`29054`, and :issue:`29570`)
+- Bug in :meth:`read_csv` with `engine='python'` truncating data if multiple items present in first row and first element started with BOM (:issue:`36343`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2876,7 +2876,7 @@ class PythonParser(ParserBase):
             return [new_row] + first_row[1:]
 
         elif len(first_row_bom) > 1:
-            return [first_row_bom[1:]]
+            return [first_row_bom[1:]] + first_row[1:]
         else:
             # First row is just the BOM, so we
             # return an empty string.

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2886,14 +2886,12 @@ class PythonParser(ParserBase):
             # quotation mark.
             if len(first_row_bom) > end + 1:
                 new_row += first_row_bom[end + 1 :]
-            return [new_row] + first_row[1:]
 
-        elif len(first_row_bom) > 1:
-            return [first_row_bom[1:]] + first_row[1:]
         else:
-            # First row is just the BOM, so we
-            # return an empty string.
-            return [""]
+
+            # No quotation so just remove BOM from first element
+            new_row = first_row_bom[1:]
+        return [new_row] + first_row[1:]
 
     def _is_line_empty(self, line):
         """

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2127,10 +2127,14 @@ def test_first_row_bom(all_parsers):
     expected = DataFrame(columns=["Head1", "Head2", "Head3"])
     tm.assert_frame_equal(result, expected)
 
+
+def test_first_row_bom_unquoted(all_parsers):
     # see gh-36343
+    parser = all_parsers
     data = """\ufeffHead1	Head2	Head3"""
 
     result = parser.read_csv(StringIO(data), delimiter="\t")
+    expected = DataFrame(columns=["Head1", "Head2", "Head3"])
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2128,10 +2128,11 @@ def test_first_row_bom(all_parsers):
     tm.assert_frame_equal(result, expected)
 
     # see gh-36343
-    data = '''\ufeffHead1	Head2	Head3'''
+    data = """\ufeffHead1	Head2	Head3"""
 
     result = parser.read_csv(StringIO(data), delimiter="\t")
     tm.assert_frame_equal(result, expected)
+
 
 def test_integer_precision(all_parsers):
     # Gh 7072

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2127,6 +2127,11 @@ def test_first_row_bom(all_parsers):
     expected = DataFrame(columns=["Head1", "Head2", "Head3"])
     tm.assert_frame_equal(result, expected)
 
+    # see gh-36343
+    data = '''\ufeffHead1	Head2	Head3'''
+
+    result = parser.read_csv(StringIO(data), delimiter="\t")
+    tm.assert_frame_equal(result, expected)
 
 def test_integer_precision(all_parsers):
     # Gh 7072


### PR DESCRIPTION
- [x] closes #36343
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
