### PR TITLE
BUG: Fix MultiIndex column stacking with dupe names

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -29,7 +29,7 @@ Bug fixes
 - Bug in :func:`read_spss` where passing a ``pathlib.Path`` as ``path`` would raise a ``TypeError`` (:issue:`33666`)
 - Bug in :meth:`Series.str.startswith` and :meth:`Series.str.endswith` with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
 - Bug in :class:`Series` constructor where integer overflow would occur for sufficiently large scalar inputs when an index was provided (:issue:`36291`)
-- Bug in :meth:`DataFrame.stack` raising a ``ValueError`` when stacking a :class:`MultiIndex` column based on position when the levels had duplicate names (:issue:`36353`)
+- Bug in :meth:`DataFrame.stack` raising a ``ValueError`` when stacking :class:`MultiIndex` columns based on position when the levels had duplicate names (:issue:`36353`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -29,6 +29,7 @@ Bug fixes
 - Bug in :func:`read_spss` where passing a ``pathlib.Path`` as ``path`` would raise a ``TypeError`` (:issue:`33666`)
 - Bug in :meth:`Series.str.startswith` and :meth:`Series.str.endswith` with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
 - Bug in :class:`Series` constructor where integer overflow would occur for sufficiently large scalar inputs when an index was provided (:issue:`36291`)
+- Bug in :meth:`DataFrame.stack` raising a ``ValueError`` when stacking a :class:`MultiIndex` column based on position when the levels had duplicate names (:issue:`36353`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -586,7 +586,9 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
     def _convert_level_number(level_num, columns):
         """
         Logic for converting the level number to something we can safely pass
-        to swaplevel. If `level_num` matches a column name return the name from
+        to swaplevel.
+
+        If `level_num` matches a column name return the name from
         position `level_num`, otherwise return `level_num`.
         """
         if level_num in columns.names:

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -586,19 +586,13 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
     def _convert_level_number(level_num, columns):
         """
         Logic for converting the level number to something we can safely pass
-        to swaplevel:
-
-        We generally want to convert the level number into a level name, except
-        when columns do not have names, in which case we must leave as a level
-        number
+        to swaplevel. If `level_num` matches a column name return the name from
+        position `level_num`, otherwise return `level_num`.
         """
         if level_num in columns.names:
             return columns.names[level_num]
-        else:
-            if columns.names[level_num] is None:
-                return level_num
-            else:
-                return columns.names[level_num]
+
+        return level_num
 
     this = frame.copy()
 

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -1302,3 +1302,16 @@ def test_unstacking_multi_index_df():
         ),
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_stack_positional_level_duplicate_column_names():
+    # https://github.com/pandas-dev/pandas/issues/36353
+    columns = pd.MultiIndex.from_product([("x", "y"), ("y", "z")], names=["a", "a"])
+    df = pd.DataFrame([[1, 1, 1, 1]], columns=columns)
+    result = df.stack(0)
+
+    new_columns = pd.Index(["y", "z"], name="a")
+    new_index = pd.MultiIndex.from_tuples([(0, "x"), (0, "y")], names=[None, "a"])
+    expected = pd.DataFrame([[1, 1], [1, 1]], index=new_index, columns=new_columns)
+
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #36353
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
