### PR TITLE
BUG: FooIndex.insert casting datetimelike NAs incorrectly

### DIFF
--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -608,6 +608,9 @@ def is_valid_nat_for_dtype(obj, dtype: DtypeObj) -> bool:
         return not isinstance(obj, np.timedelta64)
     if dtype.kind == "m":
         return not isinstance(obj, np.datetime64)
+    if dtype.kind in ["i", "u", "f", "c"]:
+        # Numeric
+        return obj is not NaT and not isinstance(obj, (np.datetime64, np.timedelta64))
 
     # must be PeriodDType
     return not isinstance(obj, (np.datetime64, np.timedelta64))

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -36,7 +36,7 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_scalar,
 )
-from pandas.core.dtypes.missing import isna
+from pandas.core.dtypes.missing import is_valid_nat_for_dtype, isna
 
 from pandas.core.algorithms import take_1d
 from pandas.core.arrays.interval import IntervalArray, _interval_shared_docs
@@ -934,7 +934,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
                 )
             left_insert = item.left
             right_insert = item.right
-        elif is_scalar(item) and isna(item):
+        elif is_valid_nat_for_dtype(item, self.left.dtype):
             # GH 18295
             left_insert = right_insert = item
         else:

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -28,7 +28,7 @@ from pandas.core.dtypes.generic import (
     ABCSeries,
     ABCUInt64Index,
 )
-from pandas.core.dtypes.missing import isna
+from pandas.core.dtypes.missing import is_valid_nat_for_dtype, isna
 
 from pandas.core import algorithms
 import pandas.core.common as com
@@ -164,7 +164,12 @@ class NumericIndex(Index):
     def insert(self, loc: int, item):
         # treat NA values as nans:
         if is_scalar(item) and isna(item):
-            item = self._na_value
+            if is_valid_nat_for_dtype(item, self.dtype):
+                item = self._na_value
+            else:
+                # NaT, np.datetime64("NaT"), np.timedelta64("NaT")
+                return self.astype(object).insert(loc, item)
+
         return super().insert(loc, item)
 
     def _union(self, other, sort):

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -204,9 +204,18 @@ class TestIntervalIndex:
 
         # GH 18295 (test missing)
         na_idx = IntervalIndex([np.nan], closed=data.closed)
-        for na in (np.nan, pd.NaT, None):
+        for na in [np.nan, None, pd.NA]:
             expected = data[:1].append(na_idx).append(data[1:])
             result = data.insert(1, na)
+            tm.assert_index_equal(result, expected)
+
+        if data.left.dtype.kind not in ["m", "M"]:
+            # trying to insert pd.NaT into a numeric-dtyped Index should cast/raise
+            msg = "can only insert Interval objects and NA into an IntervalIndex"
+            with pytest.raises(ValueError, match=msg):
+                result = data.insert(1, pd.NaT)
+        else:
+            result = data.insert(1, pd.NaT)
             tm.assert_index_equal(result, expected)
 
     def test_is_unique_interval(self, closed):

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -100,9 +100,13 @@ class TestRangeIndex(Numeric):
 
         # GH 18295 (test missing)
         expected = Float64Index([0, np.nan, 1, 2, 3, 4])
-        for na in (np.nan, pd.NaT, None):
+        for na in [np.nan, None, pd.NA]:
             result = RangeIndex(5).insert(1, na)
             tm.assert_index_equal(result, expected)
+
+        result = RangeIndex(5).insert(1, pd.NaT)
+        expected = pd.Index([0, pd.NaT, 1, 2, 3, 4], dtype=object)
+        tm.assert_index_equal(result, expected)
 
     def test_delete(self):
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -84,10 +84,14 @@ class Numeric(Base):
             expected = {ex_keys[0]: idx[[0, 5]], ex_keys[1]: idx[[1, 4]]}
             tm.assert_dict_equal(idx.groupby(to_groupby), expected)
 
-    def test_insert(self, nulls_fixture):
+    def test_insert_na(self, nulls_fixture):
         # GH 18295 (test missing)
         index = self.create_index()
-        expected = Float64Index([index[0], np.nan] + list(index[1:]))
+
+        if nulls_fixture is pd.NaT:
+            expected = Index([index[0], pd.NaT] + list(index[1:]), dtype=object)
+        else:
+            expected = Float64Index([index[0], np.nan] + list(index[1:]))
         result = index.insert(1, nulls_fixture)
         tm.assert_index_equal(result, expected)
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

