### PR TITLE
CLN: Numba internal routines

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1071,16 +1071,15 @@ b  2""",
         sorted_labels = algorithms.take_nd(labels, sorted_index, allow_fill=False)
         sorted_data = data.take(sorted_index, axis=self.axis).to_numpy()
         starts, ends = lib.generate_slices(sorted_labels, n_groups)
-        cache_key = (func, "groupby_transform")
-        if cache_key in NUMBA_FUNC_CACHE:
-            numba_transform_func = NUMBA_FUNC_CACHE[cache_key]
-        else:
-            numba_transform_func = numba_.generate_numba_transform_func(
-                tuple(args), kwargs, func, engine_kwargs
-            )
+
+        numba_transform_func = numba_.generate_numba_transform_func(
+            tuple(args), kwargs, func, engine_kwargs
+        )
         result = numba_transform_func(
             sorted_data, sorted_index, starts, ends, len(group_keys), len(data.columns)
         )
+
+        cache_key = (func, "groupby_transform")
         if cache_key not in NUMBA_FUNC_CACHE:
             NUMBA_FUNC_CACHE[cache_key] = numba_transform_func
 
@@ -1106,16 +1105,15 @@ b  2""",
         sorted_labels = algorithms.take_nd(labels, sorted_index, allow_fill=False)
         sorted_data = data.take(sorted_index, axis=self.axis).to_numpy()
         starts, ends = lib.generate_slices(sorted_labels, n_groups)
-        cache_key = (func, "groupby_agg")
-        if cache_key in NUMBA_FUNC_CACHE:
-            numba_agg_func = NUMBA_FUNC_CACHE[cache_key]
-        else:
-            numba_agg_func = numba_.generate_numba_agg_func(
-                tuple(args), kwargs, func, engine_kwargs
-            )
+
+        numba_agg_func = numba_.generate_numba_agg_func(
+            tuple(args), kwargs, func, engine_kwargs
+        )
         result = numba_agg_func(
             sorted_data, sorted_index, starts, ends, len(group_keys), len(data.columns)
         )
+
+        cache_key = (func, "groupby_agg")
         if cache_key not in NUMBA_FUNC_CACHE:
             NUMBA_FUNC_CACHE[cache_key] = numba_agg_func
 

--- a/pandas/core/util/numba_.py
+++ b/pandas/core/util/numba_.py
@@ -24,37 +24,8 @@ def set_use_numba(enable: bool = False) -> None:
     GLOBAL_USE_NUMBA = enable
 
 
-def check_kwargs_and_nopython(
-    kwargs: Optional[Dict] = None, nopython: Optional[bool] = None
-) -> None:
-    """
-    Validate that **kwargs and nopython=True was passed
-    https://github.com/numba/numba/issues/2916
-
-    Parameters
-    ----------
-    kwargs : dict, default None
-        user passed keyword arguments to pass into the JITed function
-    nopython : bool, default None
-        nopython parameter
-
-    Returns
-    -------
-    None
-
-    Raises
-    ------
-    NumbaUtilError
-    """
-    if kwargs and nopython:
-        raise NumbaUtilError(
-            "numba does not support kwargs with nopython=True: "
-            "https://github.com/numba/numba/issues/2916"
-        )
-
-
 def get_jit_arguments(
-    engine_kwargs: Optional[Dict[str, bool]] = None
+    engine_kwargs: Optional[Dict[str, bool]] = None, kwargs: Optional[Dict] = None,
 ) -> Tuple[bool, bool, bool]:
     """
     Return arguments to pass to numba.JIT, falling back on pandas default JIT settings.
@@ -63,16 +34,27 @@ def get_jit_arguments(
     ----------
     engine_kwargs : dict, default None
         user passed keyword arguments for numba.JIT
+    kwargs : dict, default None
+        user passed keyword arguments to pass into the JITed function
 
     Returns
     -------
     (bool, bool, bool)
         nopython, nogil, parallel
+
+    Raises
+    ------
+    NumbaUtilError
     """
     if engine_kwargs is None:
         engine_kwargs = {}
 
     nopython = engine_kwargs.get("nopython", True)
+    if kwargs and nopython:
+        raise NumbaUtilError(
+            "numba does not support kwargs with nopython=True: "
+            "https://github.com/numba/numba/issues/2916"
+        )
     nogil = engine_kwargs.get("nogil", False)
     parallel = engine_kwargs.get("parallel", False)
     return nopython, nogil, parallel

--- a/pandas/core/window/numba_.py
+++ b/pandas/core/window/numba_.py
@@ -6,7 +6,7 @@ from pandas._typing import Scalar
 from pandas.compat._optional import import_optional_dependency
 
 from pandas.core.util.numba_ import (
-    check_kwargs_and_nopython,
+    NUMBA_FUNC_CACHE,
     get_jit_arguments,
     jit_user_function,
 )
@@ -42,14 +42,14 @@ def generate_numba_apply_func(
     -------
     Numba function
     """
-    nopython, nogil, parallel = get_jit_arguments(engine_kwargs)
+    nopython, nogil, parallel = get_jit_arguments(engine_kwargs, kwargs)
 
-    check_kwargs_and_nopython(kwargs, nopython)
+    cache_key = (func, "rolling_apply")
+    if cache_key in NUMBA_FUNC_CACHE:
+        return NUMBA_FUNC_CACHE[cache_key]
 
     numba_func = jit_user_function(func, nopython, nogil, parallel)
-
     numba = import_optional_dependency("numba")
-
     if parallel:
         loop_range = numba.prange
     else:

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1374,14 +1374,7 @@ class RollingAndExpandingMixin(RollingMixin):
         if maybe_use_numba(engine):
             if raw is False:
                 raise ValueError("raw must be `True` when using the numba engine")
-            cache_key = (func, "rolling_apply")
-            if cache_key in NUMBA_FUNC_CACHE:
-                # Return an already compiled version of roll_apply if available
-                apply_func = NUMBA_FUNC_CACHE[cache_key]
-            else:
-                apply_func = generate_numba_apply_func(
-                    args, kwargs, func, engine_kwargs
-                )
+            apply_func = generate_numba_apply_func(args, kwargs, func, engine_kwargs)
             center = self.center
         elif engine in ("cython", None):
             if engine_kwargs is not None:
@@ -1403,7 +1396,7 @@ class RollingAndExpandingMixin(RollingMixin):
             center=center,
             floor=0,
             name=func,
-            use_numba_cache=engine == "numba",
+            use_numba_cache=maybe_use_numba(engine),
             raw=raw,
             original_func=func,
             args=args,


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

- Remove some leftover implementation after https://github.com/pandas-dev/pandas/pull/36240
- Delegate numba func caching to methods in `numba_.py`
- Combine some helper methods