### PR TITLE
ADMIN: Update stale PR action

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,9 +12,9 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity."
-        skip-stale-pr-message: false
+        skip-stale-pr-message: true
         stale-pr-label: "Stale"
-        exempt-pr-labels: "Needs Review,Blocked"
+        exempt-pr-labels: "Needs Review,Blocked,Needs Discussion"
         days-before-stale: 30
         days-before-close: -1
         remove-stale-when-updated: true


### PR DESCRIPTION
I think also that it could be good to skip the PR message for when debugging is turned off and only label / manually review the labeled PRs to start (until we're comfortable with the tagging logic and message)