### PR TITLE
BUG: Always cast to Categorical in lexsort_indexer

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -29,6 +29,7 @@ Bug fixes
 - Bug in :func:`read_spss` where passing a ``pathlib.Path`` as ``path`` would raise a ``TypeError`` (:issue:`33666`)
 - Bug in :meth:`Series.str.startswith` and :meth:`Series.str.endswith` with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
 - Bug in :class:`Series` constructor where integer overflow would occur for sufficiently large scalar inputs when an index was provided (:issue:`36291`)
+- Bug in :meth:`DataFrame.sort_values` raising an ``AttributeError`` when sorting on a key that casts a column to categorical dtype (:issue:`36383`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -29,7 +29,7 @@ Bug fixes
 - Bug in :func:`read_spss` where passing a ``pathlib.Path`` as ``path`` would raise a ``TypeError`` (:issue:`33666`)
 - Bug in :meth:`Series.str.startswith` and :meth:`Series.str.endswith` with ``category`` dtype not propagating ``na`` parameter (:issue:`36241`)
 - Bug in :class:`Series` constructor where integer overflow would occur for sufficiently large scalar inputs when an index was provided (:issue:`36291`)
-- Bug in :meth:`DataFrame.sort_values` raising an ``AttributeError`` when sorting on a key that casts a column to categorical dtype (:issue:`36383`)
+- Bug in :meth:`DataFrame.sort_values` raising an ``AttributeError`` when sorting on a key that casts column to categorical dtype (:issue:`36383`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -20,7 +20,6 @@ from pandas._typing import IndexKeyFunc
 from pandas.core.dtypes.common import (
     ensure_int64,
     ensure_platform_int,
-    is_categorical_dtype,
     is_extension_array_dtype,
 )
 from pandas.core.dtypes.generic import ABCMultiIndex

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -294,13 +294,7 @@ def lexsort_indexer(
     keys = [ensure_key_mapped(k, key) for k in keys]
 
     for k, order in zip(keys, orders):
-        # we are already a Categorical
-        if is_categorical_dtype(k):
-            cat = k
-
-        # create the Categorical
-        else:
-            cat = Categorical(k, ordered=True)
+        cat = Categorical(k, ordered=True)
 
         if na_position not in ["last", "first"]:
             raise ValueError(f"invalid na_position: {na_position}")

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -694,8 +694,8 @@ class TestDataFrameSortKey:  # test key sorting (issue 27237)
 
     def test_sort_values_key_casts_to_categorical(self):
         # https://github.com/pandas-dev/pandas/issues/36383
-        categories = ["a", "b", "c"]
-        df = pd.DataFrame({"x": [1, 1, 1], "y": ["c", "b", "a"]})
+        categories = ["c", "b", "a"]
+        df = pd.DataFrame({"x": [1, 1, 1], "y": ["a", "b", "c"]})
 
         def sorter(key):
             if key.name == "y":
@@ -706,7 +706,7 @@ class TestDataFrameSortKey:  # test key sorting (issue 27237)
 
         result = df.sort_values(by=["x", "y"], key=sorter)
         expected = pd.DataFrame(
-            {"x": [1, 1, 1], "y": ["a", "b", "c"]}, index=pd.Index([2, 1, 0])
+            {"x": [1, 1, 1], "y": ["c", "b", "a"]}, index=pd.Index([2, 1, 0])
         )
 
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -695,7 +695,7 @@ class TestDataFrameSortKey:  # test key sorting (issue 27237)
     def test_sort_values_key_casts_to_categorical(self):
         # https://github.com/pandas-dev/pandas/issues/36383
         categories = ["a", "b", "c"]
-        df = pd.DataFrame({"x": [3, 2, 1], "y": ["c", "b", "a"]})
+        df = pd.DataFrame({"x": [1, 1, 1], "y": ["c", "b", "a"]})
 
         def sorter(key):
             if key.name == "y":
@@ -706,7 +706,7 @@ class TestDataFrameSortKey:  # test key sorting (issue 27237)
 
         result = df.sort_values(by=["x", "y"], key=sorter)
         expected = pd.DataFrame(
-            {"x": [1, 2, 3], "y": ["a", "b", "c"]}, index=pd.Index([2, 1, 0])
+            {"x": [1, 1, 1], "y": ["a", "b", "c"]}, index=pd.Index([2, 1, 0])
         )
 
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/methods/test_sort_values.py
+++ b/pandas/tests/frame/methods/test_sort_values.py
@@ -692,7 +692,8 @@ class TestDataFrameSortKey:  # test key sorting (issue 27237)
         expected = df.loc[:, ::-1]
         tm.assert_frame_equal(result, expected)
 
-    def test_sort_values_key_casts_to_categorical(self):
+    @pytest.mark.parametrize("ordered", [True, False])
+    def test_sort_values_key_casts_to_categorical(self, ordered):
         # https://github.com/pandas-dev/pandas/issues/36383
         categories = ["c", "b", "a"]
         df = pd.DataFrame({"x": [1, 1, 1], "y": ["a", "b", "c"]})
@@ -700,7 +701,7 @@ class TestDataFrameSortKey:  # test key sorting (issue 27237)
         def sorter(key):
             if key.name == "y":
                 return pd.Series(
-                    pd.Categorical(key, categories=categories, ordered=True)
+                    pd.Categorical(key, categories=categories, ordered=ordered)
                 )
             return key
 


### PR DESCRIPTION
- [x] closes #36383
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
