### PR TITLE
CLN: remove trailing commas for black update

### DIFF
--- a/pandas/tests/arrays/integer/test_arithmetic.py
+++ b/pandas/tests/arrays/integer/test_arithmetic.py
@@ -279,9 +279,7 @@ def test_unary_minus_nullable_int(any_signed_nullable_int_dtype, source, target)
     tm.assert_extension_array_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "source", [[1, 2, 3], [1, 2, None], [-1, 0, 1]],
-)
+@pytest.mark.parametrize("source", [[1, 2, 3], [1, 2, None], [-1, 0, 1]])
 def test_unary_plus_nullable_int(any_signed_nullable_int_dtype, source):
     dtype = any_signed_nullable_int_dtype
     expected = pd.array(source, dtype=dtype)


### PR DESCRIPTION
Working on: CLN remove unnecessary trailing commas to get ready for new version of black #35925.
Checked the following files to make sure they are ready for black :
 pandas/tests/scalar/timestamp/test_arithmetic.py
 pandas/tests/scalar/timestamp/test_constructors.py
 pandas/tests/series/methods/test_argsort.py
 pandas/tests/series/methods/test_convert_dtypes.py
 pandas/tests/series/methods/test_drop_duplicates.py
 pandas/tests/series/methods/test_interpolate.py
 pandas/tests/series/methods/test_unstack.py
 pandas/tests/series/test_cumulative.py
 pandas/tests/test_algos.py

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
