### PR TITLE
BUG: Categorical.sort_values inplace breaking views

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1541,7 +1541,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject):
         sorted_idx = nargsort(self, ascending=ascending, na_position=na_position)
 
         if inplace:
-            self._codes = self._codes[sorted_idx]
+            self._codes[:] = self._codes[sorted_idx]
         else:
             codes = self._codes[sorted_idx]
             return self._from_backing_data(codes)

--- a/pandas/tests/arrays/categorical/test_sorting.py
+++ b/pandas/tests/arrays/categorical/test_sorting.py
@@ -66,7 +66,9 @@ class TestCategoricalSort:
 
         # sort (inplace order)
         cat1 = cat.copy()
+        orig_codes = cat1._codes
         cat1.sort_values(inplace=True)
+        assert cat1._codes is orig_codes
         exp = np.array(["a", "b", "c", "d"], dtype=object)
         tm.assert_numpy_array_equal(cat1.__array__(), exp)
         tm.assert_index_equal(res.categories, cat.categories)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
