### PR TITLE
BUG: Concat typing

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -31,6 +31,7 @@ from pandas.core.internals import concatenate_block_managers
 
 if TYPE_CHECKING:
     from pandas import DataFrame
+    from pandas.core.generic import NDFrame
 
 # ---------------------------------------------------------------------
 # Concatenate DataFrame objects
@@ -54,7 +55,7 @@ def concat(
 
 @overload
 def concat(
-    objs: Union[Iterable[FrameOrSeriesUnion], Mapping[Label, FrameOrSeriesUnion]],
+    objs: Union[Iterable["NDFrame"], Mapping[Label, "NDFrame"]],
     axis=0,
     join: str = "outer",
     ignore_index: bool = False,
@@ -69,7 +70,7 @@ def concat(
 
 
 def concat(
-    objs: Union[Iterable[FrameOrSeriesUnion], Mapping[Label, FrameOrSeriesUnion]],
+    objs: Union[Iterable["NDFrame"], Mapping[Label, "NDFrame"]],
     axis=0,
     join="outer",
     ignore_index: bool = False,

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -69,7 +69,7 @@ def concat(
 
 
 def concat(
-    objs: Union[Iterable[FrameOrSeries], Mapping[Label, FrameOrSeries]],
+    objs: Union[Iterable[FrameOrSeriesUnion], Mapping[Label, FrameOrSeriesUnion]],
     axis=0,
     join="outer",
     ignore_index: bool = False,

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -54,7 +54,7 @@ def concat(
 
 @overload
 def concat(
-    objs: Union[Iterable[FrameOrSeries], Mapping[Label, FrameOrSeries]],
+    objs: Union[Iterable[FrameOrSeriesUnion], Mapping[Label, FrameOrSeriesUnion]],
     axis=0,
     join: str = "outer",
     ignore_index: bool = False,


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

cc @simonjayhawkins 

Attempting to add typing to results in aggregation.transform. Here, the obj can be a Series but the list passed into concat contain frames. mypy correctly identifies this as an issue, I think concat needs to be typed as FrameOrSeriesUnion for this purpose.

When I try just typing the function definition and not the overload, mypy complains:

    error: Overloaded function implementation does not accept all possible arguments of signature 2  [misc]

so I've changed the type of the overload to FrameOrSeriesUnion as well. I don't believe this is any weaker than the current state because it is an overload.