### PR TITLE
Bump flake8 version in pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: black
         language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.8.3
     hooks:
     -   id: flake8
         language: python_venv


### PR DESCRIPTION
The flake8 version used in pre-commit-config.yaml seems to emit spurious errors when there are mypy comments for ignoring specific kinds of type errors. Bumping to the latest version of flake8 seems to fix this.

```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

pandas/core/generic.py:701:36: F821 undefined name 'ignore'
pandas/core/generic.py:701:36: F821 undefined name 'arg'
pandas/core/generic.py:4220:39: F723 syntax error in type comment 'ignore[return-value, arg-type]'
pandas/core/generic.py:4283:39: F723 syntax error in type comment 'ignore[return-value, arg-type]'
```

For reference this is line 701 that it's complaining about:
```python
            new_values, *new_axes  # type: ignore[arg-type]
```

ref https://github.com/PyCQA/pyflakes/pull/455