### PR TITLE
fix inconsistent index naming with union/intersect #35847

### DIFF
--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -154,6 +154,14 @@ functionality below.
    frames = [ process_your_file(f) for f in files ]
    result = pd.concat(frames)
 
+.. note::
+
+   When concatenating DataFrames with named axes, pandas will attempt to preserve
+   these index/column names whenever possible. In the case where all inputs share a
+   common name, this name will be assigned to the result. When the input names do
+   not all agree, the result will be unnamed. The same is true for :class:`MultiIndex`,
+   but the logic is applied separately on a level-by-level basis.
+
 
 Set logic on the other axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -157,6 +157,26 @@ Alternatively, you can also use the dtype object:
    behaviour or API may still change without warning. Expecially the behaviour
    regarding NaN (distinct from NA missing values) is subject to change.
 
+.. _whatsnew_120.index_name_preservation:
+
+Index/column name preservation when aggregating
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When aggregating using :meth:`concat` or the :class:`DataFrame` constructor, Pandas
+will attempt to preserve index (and column) names whenever possible (:issue:`35847`).
+In the case where all inputs share a common name, this name will be assigned to the
+result. When the input names do not all agree, the result will be unnamed. Here is an
+example where the index name is preserved:
+
+.. ipython:: python
+
+    idx = pd.Index(range(5), name='abc')
+    ser = pd.Series(range(5, 10), index=idx)
+    pd.concat({'x': ser[1:], 'y': ser[:-1]}, axis=1)
+
+The same is true for :class:`MultiIndex`, but the logic is applied separately on a
+level-by-level basis.
+
 .. _whatsnew_120.enhancements.other:
 
 Other enhancements

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -4,12 +4,12 @@ from typing import List, Set
 from pandas._libs import NaT, lib
 from pandas.errors import InvalidIndexError
 
-import pandas.core.common as com
 from pandas.core.indexes.base import (
     Index,
     _new_Index,
     ensure_index,
     ensure_index_from_sequences,
+    get_unanimous_names,
 )
 from pandas.core.indexes.category import CategoricalIndex
 from pandas.core.indexes.datetimes import DatetimeIndex
@@ -57,7 +57,7 @@ __all__ = [
     "ensure_index_from_sequences",
     "get_objs_combined_axis",
     "union_indexes",
-    "get_consensus_names",
+    "get_unanimous_names",
     "all_indexes_same",
 ]
 
@@ -221,9 +221,9 @@ def union_indexes(indexes, sort=True) -> Index:
         if not all(index.equals(other) for other in indexes[1:]):
             index = _unique_indices(indexes)
 
-        name = get_consensus_names(indexes)[0]
+        name = get_unanimous_names(*indexes)[0]
         if name != index.name:
-            index = index._shallow_copy(name=name)
+            index = index.rename(name)
         return index
     else:  # kind='list'
         return _unique_indices(indexes)
@@ -265,30 +265,6 @@ def _sanitize_and_check(indexes):
         return indexes, "special"
     else:
         return indexes, "array"
-
-
-def get_consensus_names(indexes):
-    """
-    Give a consensus 'names' to indexes.
-
-    If there's exactly one non-empty 'names', return this,
-    otherwise, return empty.
-
-    Parameters
-    ----------
-    indexes : list of Index objects
-
-    Returns
-    -------
-    list
-        A list representing the consensus 'names' found.
-    """
-    # find the non-none names, need to tupleify to make
-    # the set hashable, then reverse on return
-    consensus_names = {tuple(i.names) for i in indexes if com.any_not_none(*i.names)}
-    if len(consensus_names) == 1:
-        return list(list(consensus_names)[0])
-    return [None] * indexes[0].nlevels
 
 
 def all_indexes_same(indexes):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -719,15 +719,14 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
         """
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
-        res_name = get_op_result_name(self, other)
 
         if self.equals(other):
             return self._get_reconciled_name_object(other)
 
         if len(self) == 0:
-            return self.copy()
+            return self.copy()._get_reconciled_name_object(other)
         if len(other) == 0:
-            return other.copy()
+            return other.copy()._get_reconciled_name_object(self)
 
         if not isinstance(other, type(self)):
             result = Index.intersection(self, other, sort=sort)
@@ -735,7 +734,6 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
                 if result.freq is None:
                     # TODO: no tests rely on this; needed?
                     result = result._with_freq("infer")
-            result.name = res_name
             return result
 
         elif not self._can_fast_intersect(other):
@@ -743,9 +741,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
             # We need to invalidate the freq because Index.intersection
             #  uses _shallow_copy on a view of self._data, which will preserve
             #  self.freq if we're not careful.
-            result = result._with_freq(None)._with_freq("infer")
-            result.name = res_name
-            return result
+            return result._with_freq(None)._with_freq("infer")
 
         # to make our life easier, "sort" the two ranges
         if self[0] <= other[0]:
@@ -759,11 +755,13 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
         start = right[0]
 
         if end < start:
-            return type(self)(data=[], dtype=self.dtype, freq=self.freq, name=res_name)
+            result = type(self)(data=[], dtype=self.dtype, freq=self.freq)
         else:
             lslice = slice(*left.slice_locs(start, end))
             left_chunk = left._values[lslice]
-            return type(self)._simple_new(left_chunk, name=res_name)
+            result = type(self)._simple_new(left_chunk)
+
+        return self._wrap_setop_result(other, result)
 
     def _can_fast_intersect(self: _T, other: _T) -> bool:
         if self.freq is None:
@@ -858,7 +856,7 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
             # The can_fast_union check ensures that the result.freq
             #  should match self.freq
             dates = type(self._data)(dates, freq=self.freq)
-            result = type(self)._simple_new(dates, name=self.name)
+            result = type(self)._simple_new(dates)
             return result
         else:
             return left
@@ -883,8 +881,8 @@ class DatetimeTimedeltaMixin(DatetimeIndexOpsMixin, Int64Index):
                 result = result._with_freq("infer")
             return result
         else:
-            i8self = Int64Index._simple_new(self.asi8, name=self.name)
-            i8other = Int64Index._simple_new(other.asi8, name=other.name)
+            i8self = Int64Index._simple_new(self.asi8)
+            i8other = Int64Index._simple_new(other.asi8)
             i8result = i8self._union(i8other, sort=sort)
             result = type(self)(i8result, dtype=self.dtype, freq="infer")
             return result

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -25,7 +25,7 @@ from pandas.core.dtypes.missing import is_valid_nat_for_dtype
 
 from pandas.core.arrays.datetimes import DatetimeArray, tz_to_dtype
 import pandas.core.common as com
-from pandas.core.indexes.base import Index, maybe_extract_name
+from pandas.core.indexes.base import Index, get_unanimous_names, maybe_extract_name
 from pandas.core.indexes.datetimelike import DatetimeTimedeltaMixin
 from pandas.core.indexes.extension import inherit_names
 from pandas.core.tools.times import to_time
@@ -405,6 +405,10 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
                 this = this._fast_union(other)
             else:
                 this = Index.union(this, other)
+
+        res_name = get_unanimous_names(self, *others)[0]
+        if this.name != res_name:
+            return this.rename(res_name)
         return this
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1023,7 +1023,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         if sort is None:
             taken = taken.sort_values()
 
-        return taken
+        return self._wrap_setop_result(other, taken)
 
     def _intersection_unique(self, other: "IntervalIndex") -> "IntervalIndex":
         """

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -47,7 +47,12 @@ from pandas.core.arrays import Categorical
 from pandas.core.arrays.categorical import factorize_from_iterables
 import pandas.core.common as com
 import pandas.core.indexes.base as ibase
-from pandas.core.indexes.base import Index, _index_shared_docs, ensure_index
+from pandas.core.indexes.base import (
+    Index,
+    _index_shared_docs,
+    ensure_index,
+    get_unanimous_names,
+)
 from pandas.core.indexes.frozen import FrozenList
 from pandas.core.indexes.numeric import Int64Index
 import pandas.core.missing as missing
@@ -3426,7 +3431,7 @@ class MultiIndex(Index):
         other, result_names = self._convert_can_do_setop(other)
 
         if len(other) == 0 or self.equals(other):
-            return self
+            return self.rename(result_names)
 
         # TODO: Index.union returns other when `len(self)` is 0.
 
@@ -3468,7 +3473,7 @@ class MultiIndex(Index):
         other, result_names = self._convert_can_do_setop(other)
 
         if self.equals(other):
-            return self
+            return self.rename(result_names)
 
         if not is_object_dtype(other.dtype):
             # The intersection is empty
@@ -3539,7 +3544,7 @@ class MultiIndex(Index):
         other, result_names = self._convert_can_do_setop(other)
 
         if len(other) == 0:
-            return self
+            return self.rename(result_names)
 
         if self.equals(other):
             return MultiIndex(
@@ -3587,7 +3592,8 @@ class MultiIndex(Index):
                 except TypeError as err:
                     raise TypeError(msg) from err
         else:
-            result_names = self.names if self.names == other.names else None
+            result_names = get_unanimous_names(self, other)
+
         return other, result_names
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -539,7 +539,8 @@ class RangeIndex(Int64Index):
             new_index = new_index[::-1]
         if sort is None:
             new_index = new_index.sort_values()
-        return new_index
+
+        return self._wrap_setop_result(other, new_index)
 
     def _min_fitting_element(self, lower_limit: int) -> int:
         """Returns the smallest element greater than or equal to the limit"""

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -23,8 +23,8 @@ from pandas.core.indexes.api import (
     MultiIndex,
     all_indexes_same,
     ensure_index,
-    get_consensus_names,
     get_objs_combined_axis,
+    get_unanimous_names,
 )
 import pandas.core.indexes.base as ibase
 from pandas.core.internals import concatenate_block_managers
@@ -655,7 +655,7 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None) -> MultiInde
                 )
 
             # also copies
-            names = names + get_consensus_names(indexes)
+            names = list(names) + list(get_unanimous_names(*indexes))
 
         return MultiIndex(
             levels=levels, codes=codes_list, names=names, verify_integrity=False

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1637,8 +1637,8 @@ class TestDataFrameConstructors:
         "name_in1,name_in2,name_in3,name_out",
         [
             ("idx", "idx", "idx", "idx"),
-            ("idx", "idx", None, "idx"),
-            ("idx", None, None, "idx"),
+            ("idx", "idx", None, None),
+            ("idx", None, None, None),
             ("idx1", "idx2", None, None),
             ("idx1", "idx1", "idx2", None),
             ("idx1", "idx2", "idx3", None),

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -473,7 +473,7 @@ class TestBusinessDatetimeIndex:
         values = [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-02-01")]
         idx = pd.DatetimeIndex(values, name="a")
         res = idx.intersection(values)
-        tm.assert_index_equal(res, idx)
+        tm.assert_index_equal(res, idx.rename(None))
 
     def test_month_range_union_tz_pytz(self, sort):
         from pytz import timezone

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -46,7 +46,7 @@ def test_join_level_corner_case(idx):
 
 def test_join_self(idx, join_type):
     joined = idx.join(idx, how=join_type)
-    assert idx is joined
+    tm.assert_index_equal(joined, idx)
 
 
 def test_join_multi():

--- a/pandas/tests/indexes/multi/test_setops.py
+++ b/pandas/tests/indexes/multi/test_setops.py
@@ -243,10 +243,10 @@ def test_union(idx, sort):
 
     # corner case, pass self or empty thing:
     the_union = idx.union(idx, sort=sort)
-    assert the_union is idx
+    tm.assert_index_equal(the_union, idx)
 
     the_union = idx.union(idx[:0], sort=sort)
-    assert the_union is idx
+    tm.assert_index_equal(the_union, idx)
 
     # FIXME: dont leave commented-out
     # won't work in python 3
@@ -278,7 +278,7 @@ def test_intersection(idx, sort):
 
     # corner case, pass self
     the_int = idx.intersection(idx, sort=sort)
-    assert the_int is idx
+    tm.assert_index_equal(the_int, idx)
 
     # empty intersection: disjoint
     empty = idx[:2].intersection(idx[2:], sort=sort)

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -124,6 +124,93 @@ class TestCommon:
         expected = index.drop(index).set_names(expected_name)
         tm.assert_index_equal(union, expected)
 
+    @pytest.mark.parametrize(
+        "fname, sname, expected_name",
+        [
+            ("A", "A", "A"),
+            ("A", "B", None),
+            ("A", None, None),
+            (None, "B", None),
+            (None, None, None),
+        ],
+    )
+    def test_union_unequal(self, index, fname, sname, expected_name):
+        if isinstance(index, MultiIndex) or not index.is_unique:
+            pytest.skip("Not for MultiIndex or repeated indices")
+
+        # test copy.union(subset) - need sort for unicode and string
+        first = index.copy().set_names(fname)
+        second = index[1:].set_names(sname)
+        union = first.union(second).sort_values()
+        expected = index.set_names(expected_name).sort_values()
+        tm.assert_index_equal(union, expected)
+
+    @pytest.mark.parametrize(
+        "fname, sname, expected_name",
+        [
+            ("A", "A", "A"),
+            ("A", "B", None),
+            ("A", None, None),
+            (None, "B", None),
+            (None, None, None),
+        ],
+    )
+    def test_corner_intersect(self, index, fname, sname, expected_name):
+        # GH35847
+        # Test intersections with various name combinations
+
+        if isinstance(index, MultiIndex) or not index.is_unique:
+            pytest.skip("Not for MultiIndex or repeated indices")
+
+        # Test copy.intersection(copy)
+        first = index.copy().set_names(fname)
+        second = index.copy().set_names(sname)
+        intersect = first.intersection(second)
+        expected = index.copy().set_names(expected_name)
+        tm.assert_index_equal(intersect, expected)
+
+        # Test copy.intersection(empty)
+        first = index.copy().set_names(fname)
+        second = index.drop(index).set_names(sname)
+        intersect = first.intersection(second)
+        expected = index.drop(index).set_names(expected_name)
+        tm.assert_index_equal(intersect, expected)
+
+        # Test empty.intersection(copy)
+        first = index.drop(index).set_names(fname)
+        second = index.copy().set_names(sname)
+        intersect = first.intersection(second)
+        expected = index.drop(index).set_names(expected_name)
+        tm.assert_index_equal(intersect, expected)
+
+        # Test empty.intersection(empty)
+        first = index.drop(index).set_names(fname)
+        second = index.drop(index).set_names(sname)
+        intersect = first.intersection(second)
+        expected = index.drop(index).set_names(expected_name)
+        tm.assert_index_equal(intersect, expected)
+
+    @pytest.mark.parametrize(
+        "fname, sname, expected_name",
+        [
+            ("A", "A", "A"),
+            ("A", "B", None),
+            ("A", None, None),
+            (None, "B", None),
+            (None, None, None),
+        ],
+    )
+    def test_intersect_unequal(self, index, fname, sname, expected_name):
+        if isinstance(index, MultiIndex) or not index.is_unique:
+            pytest.skip("Not for MultiIndex or repeated indices")
+
+        # test copy.intersection(subset) - need sort for unicode and string
+        first = index.copy().set_names(fname)
+        second = index[1:].set_names(sname)
+        intersect = first.intersection(second).sort_values()
+        expected = index[1:].set_names(expected_name).sort_values()
+        tm.assert_index_equal(intersect, expected)
+
     def test_to_flat_index(self, index):
         # 22866
         if isinstance(index, MultiIndex):

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1300,8 +1300,8 @@ class TestConcatenate:
         "name_in1,name_in2,name_in3,name_out",
         [
             ("idx", "idx", "idx", "idx"),
-            ("idx", "idx", None, "idx"),
-            ("idx", None, None, "idx"),
+            ("idx", "idx", None, None),
+            ("idx", None, None, None),
             ("idx1", "idx2", None, None),
             ("idx1", "idx1", "idx2", None),
             ("idx1", "idx2", "idx3", None),


### PR DESCRIPTION
- [X] closes #35847
- [X] tests added / passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This takes care of some inconsistency in how names are handled by `Index` functions `union` and `intersection`, as discussed in #35847. I believe this covers all index types, either through the base class or in the subclass when necessary.

What I've implemented here actually uses the unanimous convention, wherein all input names must match to get assigned to the output. Originally, I was thinking consensus would be better (assign if there is only one non-None input name), but looking through the existing tests, it seems that unanimous was usually expected. I also had some worries about whether index names would become too "contagious" with consensus. Anyway, it's easy to change between the two if people have strong opinions on this.