### PR TITLE
Update isort version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
           - file
         args: [--append-config=flake8/cython-template.cfg]
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+    rev: v5.2.2
     hooks:
     -   id: isort
         language: python_venv


### PR DESCRIPTION
Previously, a mismatch between the isort versions specified by
pre-commit and by the files used on CI made it impossible to make a
commit which passed both pre-commit and CI lints.

See #36426 . This is not a complete solution as the flake8 version differences are intentional and hopefully temporary (see https://github.com/pandas-dev/pandas/pull/36412#issuecomment-694072443 ), but it should resolve the current breakage.