### PR TITLE
BUG: get_indexer returned dtype

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -290,6 +290,7 @@ Indexing
 
 - Bug in :meth:`PeriodIndex.get_loc` incorrectly raising ``ValueError`` on non-datelike strings instead of ``KeyError``, causing similar errors in :meth:`Series.__geitem__`, :meth:`Series.__contains__`, and :meth:`Series.loc.__getitem__` (:issue:`34240`)
 - Bug in :meth:`Index.sort_values` where, when empty values were passed, the method would break by trying to compare missing values instead of pushing them to the end of the sort order. (:issue:`35584`)
+- Bug in :meth:`Index.get_indexer` and :meth:`Index.get_indexer_non_unique` where int64 arrays are returned instead of intp. (:issue:`36359`)
 -
 
 Missing

--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -1,7 +1,7 @@
 from pandas._libs.khash cimport (
     kh_int64_t, kh_uint64_t, kh_float64_t, kh_pymap_t, kh_str_t, uint64_t,
     int64_t, float64_t)
-from numpy cimport ndarray
+from numpy cimport ndarray, intp_t
 
 # prototypes for sharing
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -648,8 +648,8 @@ cdef class StringHashTable(HashTable):
     def get_indexer(self, ndarray[object] values):
         cdef:
             Py_ssize_t i, n = len(values)
-            ndarray[int64_t] labels = np.empty(n, dtype=np.int64)
-            int64_t *resbuf = <int64_t*>labels.data
+            ndarray[intp_t] labels = np.empty(n, dtype=np.intp)
+            intp_t *resbuf = <intp_t*>labels.data
             khiter_t k
             kh_str_t *table = self.table
             const char *v

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -347,7 +347,7 @@ cdef class {{name}}HashTable(HashTable):
             int ret = 0
             {{dtype}}_t val
             khiter_t k
-            int64_t[:] locs = np.empty(n, dtype=np.int64)
+            intp_t[:] locs = np.empty(n, dtype=np.intp)
 
         with nogil:
             for i in range(n):
@@ -680,7 +680,7 @@ cdef class StringHashTable(HashTable):
             object val
             const char *v
             khiter_t k
-            int64_t[:] locs = np.empty(n, dtype=np.int64)
+            intp_t[:] locs = np.empty(n, dtype=np.intp)
 
         # these by-definition *must* be strings
         vecs = <const char **>malloc(n * sizeof(char *))
@@ -986,7 +986,7 @@ cdef class PyObjectHashTable(HashTable):
             int ret = 0
             object val
             khiter_t k
-            int64_t[:] locs = np.empty(n, dtype=np.int64)
+            intp_t[:] locs = np.empty(n, dtype=np.intp)
 
         for i in range(n):
             val = values[i]

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -551,7 +551,7 @@ cdef class {{name}}HashTable(HashTable):
     def get_labels_groupby(self, const {{dtype}}_t[:] values):
         cdef:
             Py_ssize_t i, n = len(values)
-            int64_t[:] labels
+            intp_t[:] labels
             Py_ssize_t idx, count = 0
             int ret = 0
             {{dtype}}_t val
@@ -559,7 +559,7 @@ cdef class {{name}}HashTable(HashTable):
             {{name}}Vector uniques = {{name}}Vector()
             {{name}}VectorData *ud
 
-        labels = np.empty(n, dtype=np.int64)
+        labels = np.empty(n, dtype=np.intp)
         ud = uniques.data
 
         with nogil:

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -255,7 +255,7 @@ cdef class IndexEngine:
 
     def get_indexer(self, values):
         self._ensure_mapping_populated()
-        return self.mapping.lookup(values)
+        return self.mapping.lookup(values).astype('intp')
 
     def get_indexer_non_unique(self, targets):
         """
@@ -266,7 +266,7 @@ cdef class IndexEngine:
         """
         cdef:
             ndarray values, x
-            ndarray[int64_t] result, missing
+            ndarray[intp_t] result, missing
             set stargets, remaining_stargets
             dict d = {}
             object val
@@ -283,8 +283,8 @@ cdef class IndexEngine:
         else:
             n_alloc = n
 
-        result = np.empty(n_alloc, dtype=np.int64)
-        missing = np.empty(n_t, dtype=np.int64)
+        result = np.empty(n_alloc, dtype=np.intp)
+        missing = np.empty(n_t, dtype=np.intp)
 
         # map each starget to its position in the index
         if stargets and len(stargets) < 5 and self.is_monotonic_increasing:

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -255,7 +255,7 @@ cdef class IndexEngine:
 
     def get_indexer(self, values):
         self._ensure_mapping_populated()
-        return self.mapping.lookup(values).astype('intp')
+        return self.mapping.lookup(values)
 
     def get_indexer_non_unique(self, targets):
         """

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -201,4 +201,4 @@ def test_get_indexer_non_unique_dtype_mismatch():
     # GH 25459
     indexes, missing = pd.Index(["A", "B"]).get_indexer_non_unique(pd.Index([0]))
     tm.assert_numpy_array_equal(np.array([-1], dtype=np.intp), indexes)
-    tm.assert_numpy_array_equal(np.array([0], dtype=np.int64), missing)
+    tm.assert_numpy_array_equal(np.array([0], dtype=np.intp), missing)


### PR DESCRIPTION
- [x] closes #36359
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Changed the return dtype of IndexEngine’s `get_indexer()` and `get_indexer_non_unique()`. I decided to not include tests because dtypes are already implicitly tested in the following:

- pandas/tests/indexes/test_base.py (TestIndex.test_get_indexer)
- pandas/tests/base/test_misc.py (test_get_indexer_non_unique_dtype_mismatch)

Also, I ran the asv benchmarks:

```
asv continuous -f 1.1 upstream/master HEAD -b ^indexing_engines
BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```
