### PR TITLE
PERF: construct DataFrame with string array and dtype=str

### DIFF
--- a/asv_bench/benchmarks/strings.py
+++ b/asv_bench/benchmarks/strings.py
@@ -13,13 +13,20 @@ class Construction:
     param_names = ["dtype"]
 
     def setup(self, dtype):
-        self.data = tm.rands_array(nchars=10 ** 5, size=10)
+        self.series_arr = tm.rands_array(nchars=10, size=10 ** 5)
+        self.frame_arr = self.series_arr.reshape((50_000, 2)).copy()
 
-    def time_construction(self, dtype):
-        Series(self.data, dtype=dtype)
+    def time_series_construction(self, dtype):
+        Series(self.series_arr, dtype=dtype)
 
-    def peakmem_construction(self, dtype):
-        Series(self.data, dtype=dtype)
+    def peakmem_series_construction(self, dtype):
+        Series(self.series_arr, dtype=dtype)
+
+    def time_frame_construction(self, dtype):
+        DataFrame(self.frame_arr, dtype=dtype)
+
+    def peakmem_frame_construction(self, dtype):
+        DataFrame(self.frame_arr, dtype=dtype)
 
 
 class Methods:

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -222,7 +222,7 @@ Deprecations
 Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Performance improvements when creating Series with dtype `str` or :class:`StringDtype` from array with many string elements (:issue:`36304`, :issue:`36317`, :issue:`36325`)
+- Performance improvements when creating DataFrame or Series with dtype `str` or :class:`StringDtype` from array with many string elements (:issue:`36304`, :issue:`36317`, :issue:`36325`, :issue:`36432`)
 - Performance improvement in :meth:`GroupBy.agg` with the ``numba`` engine (:issue:`35759`)
 - Performance improvements when creating :meth:`pd.Series.map` from a huge dictionary (:issue:`34717`)
 - Performance improvement in :meth:`GroupBy.transform` with the ``numba`` engine (:issue:`36240`)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1618,7 +1618,7 @@ def construct_1d_ndarray_preserving_na(
     array(['1.0', '2.0', None], dtype=object)
     """
 
-    if dtype is not None and dtype.kind == "U":
+    if is_string_dtype(dtype):
         subarr = lib.ensure_string_array(values, convert_na_value=False, copy=copy)
     else:
         subarr = np.array(values, dtype=dtype, copy=copy)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1618,7 +1618,7 @@ def construct_1d_ndarray_preserving_na(
     array(['1.0', '2.0', None], dtype=object)
     """
 
-    if is_string_dtype(dtype):
+    if dtype is not None and dtype.kind == "U":
         subarr = lib.ensure_string_array(values, convert_na_value=False, copy=copy)
     else:
         subarr = np.array(values, dtype=dtype, copy=copy)

--- a/pandas/core/internals/construction.py
+++ b/pandas/core/internals/construction.py
@@ -190,7 +190,7 @@ def init_ndarray(values, index, columns, dtype: Optional[DtypeObj], copy: bool):
     # the dtypes will be coerced to a single dtype
     values = _prep_ndarray(values, copy=copy)
 
-    if not is_dtype_equal(values.dtype, dtype):
+    if dtype is not None and not is_dtype_equal(values.dtype, dtype):
         try:
             values = construct_1d_ndarray_preserving_na(
                 values.ravel(), dtype=dtype, copy=False


### PR DESCRIPTION
Avoid inefficient call to `arr.astype()` when dtype is `str`, and use ensure_string_array instead.

Performance example:

```python
>>> x = np.array([str(u) for u in range(1_000_000)], dtype=object).reshape(500_000, 2)
>>> %timeit pd.DataFrame(x, dtype=str)
391 ms ± 17.7 ms per loop  # master
11.9 ms ± 131 µs per loop  # after this PR
```

xref #35519, #36304 & #36317.
