### PR TITLE
REF: pandas/io/formats/format.py

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -758,6 +758,7 @@ class DataFrameFormatter(TableFormatter):
         return max_rows
 
     def _get_number_of_auxillary_rows(self) -> int:
+        """Get number of rows occupied by prompt, dots and dimension info."""
         dot_row = 1
         prompt_row = 1
         num_rows = dot_row + prompt_row

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -793,19 +793,16 @@ class DataFrameFormatter(TableFormatter):
         self.tr_row_num = row_num
 
     def _get_strcols_without_index(self) -> List[List[str]]:
-        # TODO check this comment validity
-        # this method is not used by to_html where self.col_space
-        # could be a string so safe to cast
-        col_space = {k: cast(int, v) for k, v in self.col_space.items()}
-
-        frame = self.tr_frame
         strcols: List[List[str]] = []
 
         if not is_list_like(self.header) and not self.header:
-            for i, c in enumerate(frame):
+            for i, c in enumerate(self.tr_frame):
                 fmt_values = self._format_col(i)
                 fmt_values = _make_fixed_width(
-                    fmt_values, self.justify, minimum=col_space.get(c, 0), adj=self.adj
+                    strings=fmt_values,
+                    justify=self.justify,
+                    minimum=int(self.col_space.get(c, 0)),
+                    adj=self.adj,
                 )
                 strcols.append(fmt_values)
             return strcols
@@ -820,16 +817,16 @@ class DataFrameFormatter(TableFormatter):
                 )
             str_columns = [[label] for label in self.header]
         else:
-            str_columns = self._get_formatted_column_labels(frame)
+            str_columns = self._get_formatted_column_labels(self.tr_frame)
 
         if self.show_row_idx_names:
             for x in str_columns:
                 x.append("")
 
-        for i, c in enumerate(frame):
+        for i, c in enumerate(self.tr_frame):
             cheader = str_columns[i]
             header_colwidth = max(
-                col_space.get(c, 0), *(self.adj.len(x) for x in cheader)
+                int(self.col_space.get(c, 0)), *(self.adj.len(x) for x in cheader)
             )
             fmt_values = self._format_col(i)
             fmt_values = _make_fixed_width(

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -694,6 +694,10 @@ class DataFrameFormatter(TableFormatter):
         try:
             return self._max_cols_adj
         except AttributeError:
+            if not self._is_in_terminal():
+                self._max_cols_adj = self.max_cols
+                return self._max_cols_adj
+
             width, _ = get_terminal_size()
             if self._is_screen_narrow(width):
                 self._max_cols_adj = width

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -741,6 +741,18 @@ class DataFrameFormatter(TableFormatter):
     def _is_screen_short(self, max_height) -> bool:
         return bool(self.max_rows == 0 and len(self.frame) > max_height)
 
+    @property
+    def truncate_h(self) -> bool:
+        return bool(self.max_cols_adj and (len(self.columns) > self.max_cols_adj))
+
+    @property
+    def truncate_v(self) -> bool:
+        return bool(self.max_rows_adj and (len(self.frame) > self.max_rows_adj))
+
+    @property
+    def is_truncated(self) -> bool:
+        return bool(self.truncate_h or self.truncate_v)
+
     def _chk_truncate(self) -> None:
         """
         Checks whether the frame should be truncated. If so, slices
@@ -755,11 +767,8 @@ class DataFrameFormatter(TableFormatter):
         max_cols_adj = self.max_cols_adj
         max_rows_adj = self.max_rows_adj
 
-        truncate_h = max_cols_adj and (len(self.columns) > max_cols_adj)
-        truncate_v = max_rows_adj and (len(self.frame) > max_rows_adj)
-
         frame = self.frame
-        if truncate_h:
+        if self.truncate_h:
             # cast here since if truncate_h is True, max_cols_adj is not None
             max_cols_adj = cast(int, max_cols_adj)
             if max_cols_adj == 0:
@@ -781,7 +790,7 @@ class DataFrameFormatter(TableFormatter):
                         *truncate_fmt[-col_num:],
                     ]
             self.tr_col_num = col_num
-        if truncate_v:
+        if self.truncate_v:
             # cast here since if truncate_v is True, max_rows_adj is not None
             max_rows_adj = cast(int, max_rows_adj)
             if max_rows_adj == 1:
@@ -795,9 +804,6 @@ class DataFrameFormatter(TableFormatter):
             self.tr_row_num = None
 
         self.tr_frame = frame
-        self.truncate_h = truncate_h
-        self.truncate_v = truncate_v
-        self.is_truncated = bool(self.truncate_h or self.truncate_v)
 
     def _to_str_columns(self) -> List[List[str]]:
         """

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -565,12 +565,7 @@ class DataFrameFormatter(TableFormatter):
     ):
         self.frame = frame
         self.show_index_names = index_names
-
-        if sparsify is None:
-            sparsify = get_option("display.multi_sparse")
-
         self.sparsify = sparsify
-
         self.float_format = float_format
         self.formatters = formatters
         self.na_rep = na_rep
@@ -592,6 +587,17 @@ class DataFrameFormatter(TableFormatter):
         self.columns = columns
         self._chk_truncate()
         self.adj = get_adjustment()
+
+    @property
+    def sparsify(self):
+        return self._sparsify
+
+    @sparsify.setter
+    def sparsify(self, sparsify):
+        if sparsify is None:
+            self._sparsify = get_option("display.multi_sparse")
+        else:
+            self._sparsify = sparsify
 
     @property
     def formatters(self):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -805,7 +805,6 @@ class DataFrameFormatter(TableFormatter):
         max_cols_adj = cast(int, self.max_cols_adj)
 
         col_num = max_cols_adj // 2
-
         if col_num >= 1:
             cols_to_keep = [
                 x for x in range(self.frame.shape[1])
@@ -819,8 +818,8 @@ class DataFrameFormatter(TableFormatter):
                 self._formatters = slicer(self.formatters)
         else:
             max_cols = cast(int, self.max_cols)
-            self.tr_frame = self.tr_frame.iloc[:, :max_cols]
             col_num = max_cols
+            self.tr_frame = self.tr_frame.iloc[:, :col_num]
 
         self.tr_col_num = col_num
 
@@ -828,14 +827,14 @@ class DataFrameFormatter(TableFormatter):
         # cast here since if is_truncated_vertically is True
         # max_rows_adj is not None
         max_rows_adj = cast(int, self.max_rows_adj)
-        if max_rows_adj == 1:
-            row_num = self.max_rows
-            self.tr_frame = self.tr_frame.iloc[:row_num, :]
-        else:
-            row_num = max_rows_adj // 2
+        row_num = max_rows_adj // 2
+        if row_num >= 1:
             self.tr_frame = concat(
                 (self.tr_frame.iloc[:row_num, :], self.tr_frame.iloc[-row_num:, :])
             )
+        else:
+            row_num = self.max_rows
+            self.tr_frame = self.tr_frame.iloc[:row_num, :]
         self.tr_row_num = row_num
 
     def _get_strcols_without_index(self):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -913,38 +913,44 @@ class DataFrameFormatter(TableFormatter):
 
     def _truncate_strcols(self, strcols):
         str_index = self._get_formatted_index(self.tr_frame)
+        index_length = len(str_index)
 
         if self.is_truncated_horizontally:
             strcols.insert(self.tr_col_num + 1, [" ..."] * (len(str_index)))
 
         if self.is_truncated_vertically:
-            n_header_rows = len(str_index) - len(self.tr_frame)
-            row_num = self.tr_row_num
-            for ix, col in enumerate(strcols):
-                # infer from above row
-                cwidth = self.adj.len(col[row_num])
+            strcols = self._insert_dot_separator_vertical(strcols, index_length)
 
-                if self.is_truncated_horizontally:
-                    is_dot_col = ix == self.tr_col_num + 1
-                else:
-                    is_dot_col = False
+        return strcols
 
-                if cwidth > 3 or is_dot_col:
-                    dots = "..."
-                else:
-                    dots = ".."
+    def _insert_dot_separator_vertical(
+        self, strcols: List[List[str]], index_length: int
+    ) -> List[List[str]]:
+        n_header_rows = index_length - len(self.tr_frame)
+        row_num = self.tr_row_num
+        for ix, col in enumerate(strcols):
+            cwidth = self.adj.len(col[row_num])
 
-                if ix == 0:
-                    dot_mode = "left"
-                elif is_dot_col:
-                    cwidth = 4
-                    dot_mode = "right"
-                else:
-                    dot_mode = "right"
+            if self.is_truncated_horizontally:
+                is_dot_col = ix == self.tr_col_num + 1
+            else:
+                is_dot_col = False
 
-                dot_str = self.adj.justify([dots], cwidth, mode=dot_mode)[0]
-                col.insert(row_num + n_header_rows, dot_str)
+            if cwidth > 3 or is_dot_col:
+                dots = "..."
+            else:
+                dots = ".."
 
+            if ix == 0:
+                dot_mode = "left"
+            elif is_dot_col:
+                cwidth = 4
+                dot_mode = "right"
+            else:
+                dot_mode = "right"
+
+            dot_str = self.adj.justify([dots], cwidth, mode=dot_mode)[0]
+            col.insert(row_num + n_header_rows, dot_str)
         return strcols
 
     def write_result(self, buf: IO[str]) -> None:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -608,13 +608,7 @@ class DataFrameFormatter(TableFormatter):
         self.justify = justify
         self.bold_rows = bold_rows
         self.escape = escape
-
-        if columns is not None:
-            self.columns = ensure_index(columns)
-            self.frame = self.frame[self.columns]
-        else:
-            self.columns = frame.columns
-
+        self.columns = columns
         self._chk_truncate()
         self.adj = get_adjustment()
 
@@ -644,6 +638,18 @@ class DataFrameFormatter(TableFormatter):
             self._justify = get_option("display.colheader_justify")
         else:
             self._justify = justify
+
+    @property
+    def columns(self):
+        return self._columns
+
+    @columns.setter
+    def columns(self, columns):
+        if columns is not None:
+            self._columns = ensure_index(columns)
+            self.frame = self.frame[self._columns]
+        else:
+            self._columns = self.frame.columns
 
     def _chk_truncate(self) -> None:
         """

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -605,12 +605,7 @@ class DataFrameFormatter(TableFormatter):
         self.show_dimensions = show_dimensions
         self.table_id = table_id
         self.render_links = render_links
-
-        if justify is None:
-            self.justify = get_option("display.colheader_justify")
-        else:
-            self.justify = justify
-
+        self.justify = justify
         self.bold_rows = bold_rows
         self.escape = escape
 
@@ -638,6 +633,17 @@ class DataFrameFormatter(TableFormatter):
                 f"Formatters length({len(formatters)}) should match "
                 f"DataFrame number of columns({len(self.frame.columns)})"
             )
+
+    @property
+    def justify(self):
+        return self._justify
+
+    @justify.setter
+    def justify(self, justify):
+        if justify is None:
+            self._justify = get_option("display.colheader_justify")
+        else:
+            self._justify = justify
 
     def _chk_truncate(self) -> None:
         """

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -904,6 +904,12 @@ class DataFrameFormatter(TableFormatter):
         """
         strcols = self._get_strcols()
 
+        if self.is_truncated:
+            strcols = self._truncate_strcols(strcols)
+
+        return strcols
+
+    def _truncate_strcols(self, strcols):
         str_index = self._get_formatted_index(self.tr_frame)
 
         if self.is_truncated_horizontally:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -655,27 +655,27 @@ class DataFrameFormatter(TableFormatter):
         return min(self.max_rows or len(self.frame), len(self.frame))
 
     @property
-    def max_cols_adj(self) -> Optional[int]:
+    def max_cols_fitted(self) -> Optional[int]:
         """Number of columns fitting the screen."""
-        self._max_cols_adj: Optional[int]
+        self._max_cols_fitted: Optional[int]
 
-        if hasattr(self, "_max_cols_adj"):
-            return self._max_cols_adj
+        if hasattr(self, "_max_cols_fitted"):
+            return self._max_cols_fitted
 
         if not self._is_in_terminal():
-            self._max_cols_adj = self.max_cols
-            return self._max_cols_adj
+            self._max_cols_fitted = self.max_cols
+            return self._max_cols_fitted
 
         width, _ = get_terminal_size()
         if self._is_screen_narrow(width):
-            self._max_cols_adj = width
+            self._max_cols_fitted = width
         else:
-            self._max_cols_adj = self.max_cols
-        return self._max_cols_adj
+            self._max_cols_fitted = self.max_cols
+        return self._max_cols_fitted
 
     @property
-    def max_rows_adj(self) -> Optional[int]:
-        """Number of rows fitting the screen."""
+    def max_rows_fitted(self) -> Optional[int]:
+        """Number of rows with data fitting the screen."""
         if not self._is_in_terminal():
             return self.max_rows
 
@@ -722,11 +722,11 @@ class DataFrameFormatter(TableFormatter):
 
     @property
     def is_truncated_horizontally(self) -> bool:
-        return bool(self.max_cols_adj and (len(self.columns) > self.max_cols_adj))
+        return bool(self.max_cols_fitted and (len(self.columns) > self.max_cols_fitted))
 
     @property
     def is_truncated_vertically(self) -> bool:
-        return bool(self.max_rows_adj and (len(self.frame) > self.max_rows_adj))
+        return bool(self.max_rows_fitted and (len(self.frame) > self.max_rows_fitted))
 
     @property
     def is_truncated(self) -> bool:
@@ -752,8 +752,8 @@ class DataFrameFormatter(TableFormatter):
             - formatters
             - tr_col_num
         """
-        assert self.max_cols_adj is not None
-        col_num = self.max_cols_adj // 2
+        assert self.max_cols_fitted is not None
+        col_num = self.max_cols_fitted // 2
         if col_num >= 1:
             cols_to_keep = [
                 x
@@ -778,8 +778,8 @@ class DataFrameFormatter(TableFormatter):
             - tr_frame
             - tr_row_num
         """
-        assert self.max_rows_adj is not None
-        row_num = self.max_rows_adj // 2
+        assert self.max_rows_fitted is not None
+        row_num = self.max_rows_fitted // 2
         if row_num >= 1:
             rows_to_keep = [
                 x
@@ -967,10 +967,10 @@ class DataFrameFormatter(TableFormatter):
             n_cols = len(col_lens)
 
         # subtract index column
-        max_cols_adj = n_cols - self.index
+        max_cols_fitted = n_cols - self.index
         # GH-21180. Ensure that we print at least two.
-        max_cols_adj = max(max_cols_adj, 2)
-        self._max_cols_adj = max_cols_adj
+        max_cols_fitted = max(max_cols_fitted, 2)
+        self._max_cols_fitted = max_cols_fitted
 
         # Call again _truncate to cut frame appropriately
         # and then generate string representation
@@ -996,8 +996,8 @@ class DataFrameFormatter(TableFormatter):
         nbins = len(col_bins)
 
         if self.is_truncated_vertically:
-            assert self.max_rows_adj is not None
-            nrows = self.max_rows_adj + 1
+            assert self.max_rows_fitted is not None
+            nrows = self.max_rows_fitted + 1
         else:
             nrows = len(self.frame)
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -583,7 +583,7 @@ class DataFrameFormatter(TableFormatter):
     ):
         self.frame = frame
         self.show_index_names = index_names
-        self.sparsify = sparsify
+        self.sparsify = sparsify  # type: ignore[assignment]
         self.float_format = float_format
 
         # Ignoring error
@@ -612,7 +612,7 @@ class DataFrameFormatter(TableFormatter):
         self.show_dimensions = show_dimensions
         self.table_id = table_id
         self.render_links = render_links
-        self.justify = justify
+        self.justify = justify  # type: ignore[assignment]
         self.bold_rows = bold_rows
         self.escape = escape
 
@@ -624,11 +624,11 @@ class DataFrameFormatter(TableFormatter):
         self.adj = get_adjustment()
 
     @property
-    def sparsify(self):
+    def sparsify(self) -> bool:
         return self._sparsify
 
     @sparsify.setter
-    def sparsify(self, sparsify):
+    def sparsify(self, sparsify: Optional[bool]) -> None:
         if sparsify is None:
             self._sparsify = get_option("display.multi_sparse")
         else:
@@ -653,11 +653,11 @@ class DataFrameFormatter(TableFormatter):
         assert self._formatters is not None
 
     @property
-    def justify(self):
+    def justify(self) -> str:
         return self._justify
 
     @justify.setter
-    def justify(self, justify):
+    def justify(self, justify: Optional[str]) -> None:
         if justify is None:
             self._justify = get_option("display.colheader_justify")
         else:
@@ -853,10 +853,9 @@ class DataFrameFormatter(TableFormatter):
         col_space = {k: cast(int, v) for k, v in self.col_space.items()}
 
         frame = self.tr_frame
-        # may include levels names also
+        strcols: List[List[str]] = []
 
         if not is_list_like(self.header) and not self.header:
-            strcols = []
             for i, c in enumerate(frame):
                 fmt_values = self._format_col(i)
                 fmt_values = _make_fixed_width(
@@ -881,7 +880,6 @@ class DataFrameFormatter(TableFormatter):
             for x in str_columns:
                 x.append("")
 
-        strcols = []
         for i, c in enumerate(frame):
             cheader = str_columns[i]
             header_colwidth = max(

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -626,16 +626,17 @@ class DataFrameFormatter(TableFormatter):
             self._justify = justify
 
     @property
-    def columns(self):
+    def columns(self) -> Index:
         return self._columns
 
     @columns.setter
-    def columns(self, columns):
+    def columns(self, columns: Optional[Sequence[str]]) -> None:
         if columns is not None:
             self._columns = ensure_index(columns)
             self.frame = self.frame[self._columns]
         else:
             self._columns = self.frame.columns
+        assert self._columns is not None
 
     @property
     def col_space(self) -> ColspaceType:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -572,15 +572,7 @@ class DataFrameFormatter(TableFormatter):
         self.sparsify = sparsify
 
         self.float_format = float_format
-        if formatters is None:
-            self.formatters = {}
-        elif len(frame.columns) == len(formatters) or isinstance(formatters, dict):
-            self.formatters = formatters
-        else:
-            raise ValueError(
-                f"Formatters length({len(formatters)}) should match "
-                f"DataFrame number of columns({len(frame.columns)})"
-            )
+        self.formatters = formatters
         self.na_rep = na_rep
         self.decimal = decimal
         if col_space is None:
@@ -630,6 +622,22 @@ class DataFrameFormatter(TableFormatter):
 
         self._chk_truncate()
         self.adj = get_adjustment()
+
+    @property
+    def formatters(self):
+        return self._formatters
+
+    @formatters.setter
+    def formatters(self, formatters):
+        if formatters is None:
+            self._formatters = {}
+        elif len(self.frame.columns) == len(formatters) or isinstance(formatters, dict):
+            self._formatters = formatters
+        else:
+            raise ValueError(
+                f"Formatters length({len(formatters)}) should match "
+                f"DataFrame number of columns({len(self.frame.columns)})"
+            )
 
     def _chk_truncate(self) -> None:
         """
@@ -701,7 +709,7 @@ class DataFrameFormatter(TableFormatter):
                 # truncate formatter
                 if isinstance(self.formatters, (list, tuple)):
                     truncate_fmt = self.formatters
-                    self.formatters = [
+                    self._formatters = [
                         *truncate_fmt[:col_num],
                         *truncate_fmt[-col_num:],
                     ]

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -796,10 +796,9 @@ class DataFrameFormatter(TableFormatter):
 
         if self.is_truncated_horizontally:
             self._truncate_horizontally()
+
         if self.is_truncated_vertically:
             self._truncate_vertically()
-        else:
-            self.tr_row_num = None
 
     def _truncate_horizontally(self):
         # cast here since if is_truncated_horizontally is True

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -585,10 +585,24 @@ class DataFrameFormatter(TableFormatter):
         self.show_index_names = index_names
         self.sparsify = sparsify
         self.float_format = float_format
-        self.formatters = formatters
+
+        # Ignoring error
+        # expression has type "Union[List[Callable[..., Any]],
+        # Tuple[Callable[..., Any], ...],
+        # Mapping[Union[str, int], Callable[..., Any]], None]",
+        # variable has type "Union[List[Callable[..., Any]],
+        # Tuple[Callable[..., Any], ...], Mapping[Union[str, int],
+        # Callable[..., Any]]]")
+        self.formatters = formatters  # type: ignore[assignment]
         self.na_rep = na_rep
         self.decimal = decimal
-        self.col_space = col_space
+
+        # Ignoring error
+        # expression has type "Union[str, int, Sequence[Union[str, int]],
+        # Mapping[Optional[Hashable], Union[str, int]], None]",
+        # variable has type "Mapping[Optional[Hashable], Union[str, int]]"
+        self.col_space = col_space  # type: ignore[assignment]
+
         self.header = header
         self.index = index
         self.line_width = line_width
@@ -601,7 +615,11 @@ class DataFrameFormatter(TableFormatter):
         self.justify = justify
         self.bold_rows = bold_rows
         self.escape = escape
-        self.columns = columns
+
+        # Ignoring error:
+        # expression has type "Optional[Sequence[str]]", variable has type "Index"
+        self.columns = columns  # type: ignore[assignment]
+
         self._chk_truncate()
         self.adj = get_adjustment()
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -920,15 +920,15 @@ class DataFrameFormatter(TableFormatter):
         if self.is_truncated_vertically:
             n_header_rows = len(str_index) - len(self.tr_frame)
             row_num = self.tr_row_num
-            # cast here since if is_truncated_vertically is True
-            # self.tr_row_num is not None
-            row_num = cast(int, row_num)
             for ix, col in enumerate(strcols):
                 # infer from above row
                 cwidth = self.adj.len(col[row_num])
-                is_dot_col = False
+
                 if self.is_truncated_horizontally:
                     is_dot_col = ix == self.tr_col_num + 1
+                else:
+                    is_dot_col = False
+
                 if cwidth > 3 or is_dot_col:
                     dots = "..."
                 else:
@@ -941,6 +941,7 @@ class DataFrameFormatter(TableFormatter):
                     dot_mode = "right"
                 else:
                     dot_mode = "right"
+
                 dot_str = self.adj.justify([dots], cwidth, mode=dot_mode)[0]
                 col.insert(row_num + n_header_rows, dot_str)
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -808,7 +808,8 @@ class DataFrameFormatter(TableFormatter):
             return strcols
 
         if is_list_like(self.header):
-            assert isinstance(self.header, list)
+            # cast here since can't be bool if is_list_like
+            self.header = cast(List[str], self.header)
             if len(self.header) != len(self.columns):
                 raise ValueError(
                     f"Writing {len(self.columns)} cols "

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -799,6 +799,13 @@ class DataFrameFormatter(TableFormatter):
             self._truncate_vertically()
 
     def _truncate_horizontally(self) -> None:
+        """Remove columns, which are not to be displayed and adjust formatters.
+
+        Attributes affected:
+            - tr_frame
+            - formatters
+            - tr_col_num
+        """
         assert self.max_cols_adj is not None
         col_num = self.max_cols_adj // 2
         if col_num >= 1:
@@ -819,6 +826,12 @@ class DataFrameFormatter(TableFormatter):
         self.tr_col_num = col_num
 
     def _truncate_vertically(self) -> None:
+        """Remove rows, which are not to be displayed.
+
+        Attributes affected:
+            - tr_frame
+            - tr_row_num
+        """
         assert self.max_rows_adj is not None
         row_num = self.max_rows_adj // 2
         if row_num >= 1:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -803,13 +803,10 @@ class DataFrameFormatter(TableFormatter):
         # cast here since if is_truncated_horizontally is True
         # max_cols_adj is not None
         max_cols_adj = cast(int, self.max_cols_adj)
-        if max_cols_adj == 1:
-            max_cols = cast(int, self.max_cols)
-            self.tr_frame = self.tr_frame.iloc[:, :max_cols]
-            col_num = max_cols
-        else:
-            col_num = max_cols_adj // 2
 
+        col_num = max_cols_adj // 2
+
+        if col_num >= 1:
             cols_to_keep = [
                 x for x in range(self.frame.shape[1])
                 if x < col_num or x >= len(self.frame.columns) - col_num
@@ -820,6 +817,10 @@ class DataFrameFormatter(TableFormatter):
             if isinstance(self.formatters, (list, tuple)):
                 slicer = itemgetter(*cols_to_keep)
                 self._formatters = slicer(self.formatters)
+        else:
+            max_cols = cast(int, self.max_cols)
+            self.tr_frame = self.tr_frame.iloc[:, :max_cols]
+            col_num = max_cols
 
         self.tr_col_num = col_num
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -829,9 +829,11 @@ class DataFrameFormatter(TableFormatter):
         max_rows_adj = cast(int, self.max_rows_adj)
         row_num = max_rows_adj // 2
         if row_num >= 1:
-            self.tr_frame = concat(
-                (self.tr_frame.iloc[:row_num, :], self.tr_frame.iloc[-row_num:, :])
-            )
+            rows_to_keep = [
+                x for x in range(self.frame.shape[0])
+                if x < row_num or x >= len(self.frame) - row_num
+            ]
+            self.tr_frame = self.tr_frame.iloc[rows_to_keep, :]
         else:
             row_num = self.max_rows
             self.tr_frame = self.tr_frame.iloc[:row_num, :]

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -597,11 +597,12 @@ class DataFrameFormatter(TableFormatter):
             self._sparsify = sparsify
 
     @property
-    def formatters(self):
+    def formatters(self) -> FormattersType:
         return self._formatters
 
     @formatters.setter
-    def formatters(self, formatters):
+    def formatters(self, formatters: Optional[FormattersType]) -> None:
+        self._formatters: FormattersType
         if formatters is None:
             self._formatters = {}
         elif len(self.frame.columns) == len(formatters) or isinstance(formatters, dict):
@@ -611,6 +612,7 @@ class DataFrameFormatter(TableFormatter):
                 f"Formatters length({len(formatters)}) should match "
                 f"DataFrame number of columns({len(self.frame.columns)})"
             )
+        assert self._formatters is not None
 
     @property
     def justify(self):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -589,6 +589,9 @@ class DataFrameFormatter(TableFormatter):
         self.escape = escape
         self.columns = self._initialize_columns(columns)
 
+        self.max_cols_fitted = self._calc_max_cols_fitted()
+        self.max_rows_fitted = self._calc_max_rows_fitted()
+
         self._truncate()
         self.adj = get_adjustment()
 
@@ -654,27 +657,18 @@ class DataFrameFormatter(TableFormatter):
     def max_rows_displayed(self) -> int:
         return min(self.max_rows or len(self.frame), len(self.frame))
 
-    @property
-    def max_cols_fitted(self) -> Optional[int]:
+    def _calc_max_cols_fitted(self) -> Optional[int]:
         """Number of columns fitting the screen."""
-        self._max_cols_fitted: Optional[int]
-
-        if hasattr(self, "_max_cols_fitted"):
-            return self._max_cols_fitted
-
         if not self._is_in_terminal():
-            self._max_cols_fitted = self.max_cols
-            return self._max_cols_fitted
+            return self.max_cols
 
         width, _ = get_terminal_size()
         if self._is_screen_narrow(width):
-            self._max_cols_fitted = width
+            return width
         else:
-            self._max_cols_fitted = self.max_cols
-        return self._max_cols_fitted
+            return self.max_cols
 
-    @property
-    def max_rows_fitted(self) -> Optional[int]:
+    def _calc_max_rows_fitted(self) -> Optional[int]:
         """Number of rows with data fitting the screen."""
         if not self._is_in_terminal():
             return self.max_rows
@@ -971,7 +965,7 @@ class DataFrameFormatter(TableFormatter):
         max_cols_fitted = n_cols - self.index
         # GH-21180. Ensure that we print at least two.
         max_cols_fitted = max(max_cols_fitted, 2)
-        self._max_cols_fitted = max_cols_fitted
+        self.max_cols_fitted = max_cols_fitted
 
         # Call again _truncate to cut frame appropriately
         # and then generate string representation

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -797,11 +797,10 @@ class DataFrameFormatter(TableFormatter):
         if self.is_truncated_vertically:
             self._truncate_vertically()
 
-    def _truncate_horizontally(self):
+    def _truncate_horizontally(self) -> None:
         # cast here since if is_truncated_horizontally is True
         # max_cols_adj is not None
         max_cols_adj = cast(int, self.max_cols_adj)
-
         col_num = max_cols_adj // 2
         if col_num >= 1:
             cols_to_keep = [
@@ -816,13 +815,11 @@ class DataFrameFormatter(TableFormatter):
                 slicer = itemgetter(*cols_to_keep)
                 self._formatters = slicer(self.formatters)
         else:
-            max_cols = cast(int, self.max_cols)
-            col_num = max_cols
+            col_num = cast(int, self.max_cols)
             self.tr_frame = self.tr_frame.iloc[:, :col_num]
-
         self.tr_col_num = col_num
 
-    def _truncate_vertically(self):
+    def _truncate_vertically(self) -> None:
         # cast here since if is_truncated_vertically is True
         # max_rows_adj is not None
         max_rows_adj = cast(int, self.max_rows_adj)
@@ -835,11 +832,11 @@ class DataFrameFormatter(TableFormatter):
             ]
             self.tr_frame = self.tr_frame.iloc[rows_to_keep, :]
         else:
-            row_num = self.max_rows
+            row_num = cast(int, self.max_rows)
             self.tr_frame = self.tr_frame.iloc[:row_num, :]
         self.tr_row_num = row_num
 
-    def _get_strcols_without_index(self):
+    def _get_strcols_without_index(self) -> List[List[str]]:
         # TODO check this comment validity
         # this method is not used by to_html where self.col_space
         # could be a string so safe to cast
@@ -911,7 +908,7 @@ class DataFrameFormatter(TableFormatter):
 
         return strcols
 
-    def _insert_dot_separators(self, strcols):
+    def _insert_dot_separators(self, strcols: List[List[str]]) -> List[List[str]]:
         str_index = self._get_formatted_index(self.tr_frame)
         index_length = len(str_index)
 
@@ -971,10 +968,10 @@ class DataFrameFormatter(TableFormatter):
             buf.write(self._dimensions_info)
 
     @property
-    def _dimensions_info(self):
+    def _dimensions_info(self) -> str:
         return f"\n\n[{len(self.frame)} rows x {len(self.frame.columns)} columns]"
 
-    def _get_string_representation(self):
+    def _get_string_representation(self) -> str:
         if self.frame.empty:
             info_line = (
                 f"Empty {type(self.frame).__name__}\n"
@@ -996,7 +993,7 @@ class DataFrameFormatter(TableFormatter):
         # max_cols == 0. Try to fit frame to terminal
         return self._fit_strcols_to_terminal_width(strcols)
 
-    def _fit_strcols_to_terminal_width(self, strcols):
+    def _fit_strcols_to_terminal_width(self, strcols) -> str:
         from pandas import Series
 
         lines = self.adj.adjoin(1, *strcols).split("\n")

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -537,8 +537,6 @@ class DataFrameFormatter(TableFormatter):
     __doc__ = __doc__ if __doc__ else ""
     __doc__ += common_docstring + return_docstring
 
-    col_space: ColspaceType
-
     def __init__(
         self,
         frame: "DataFrame",
@@ -638,11 +636,12 @@ class DataFrameFormatter(TableFormatter):
             self._columns = self.frame.columns
 
     @property
-    def col_space(self):
+    def col_space(self) -> ColspaceType:
         return self._col_space
 
     @col_space.setter
-    def col_space(self, col_space):
+    def col_space(self, col_space: Optional[ColspaceArgType]) -> None:
+        self._col_space: ColspaceType
         if col_space is None:
             self._col_space = {}
         elif isinstance(col_space, (int, str)):
@@ -662,6 +661,7 @@ class DataFrameFormatter(TableFormatter):
                     f"DataFrame number of columns({len(self.frame.columns)})"
                 )
             self._col_space = dict(zip(self.frame.columns, col_space))
+        assert self._col_space is not None
 
     @property
     def max_rows_displayed(self):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -763,7 +763,7 @@ class DataFrameFormatter(TableFormatter):
         prompt_row = 1
 
         if self.show_dimensions:
-            show_dimension_rows = 3
+            show_dimension_rows = len(self._dimensions_info.splitlines())
 
         if self.header:
             header_row = 1
@@ -953,11 +953,11 @@ class DataFrameFormatter(TableFormatter):
         buf.writelines(text)
 
         if self.should_show_dimensions:
-            dim_str = (
-                f"\n\n[{len(self.frame)} rows x "
-                f"{len(self.frame.columns)} columns]"
-            )
-            buf.write(dim_str)
+            buf.write(self._dimensions_info)
+
+    @property
+    def _dimensions_info(self):
+        return f"\n\n[{len(self.frame)} rows x {len(self.frame.columns)} columns]"
 
     def _get_string_representation(self):
         if self.frame.empty:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -847,13 +847,13 @@ class DataFrameFormatter(TableFormatter):
         # may include levels names also
 
         if not is_list_like(self.header) and not self.header:
-            stringified = []
+            strcols = []
             for i, c in enumerate(frame):
                 fmt_values = self._format_col(i)
                 fmt_values = _make_fixed_width(
                     fmt_values, self.justify, minimum=col_space.get(c, 0), adj=self.adj
                 )
-                stringified.append(fmt_values)
+                strcols.append(fmt_values)
         else:
             if is_list_like(self.header):
                 # cast here since can't be bool if is_list_like
@@ -871,7 +871,7 @@ class DataFrameFormatter(TableFormatter):
                 for x in str_columns:
                     x.append("")
 
-            stringified = []
+            strcols = []
             for i, c in enumerate(frame):
                 cheader = str_columns[i]
                 header_colwidth = max(
@@ -884,10 +884,9 @@ class DataFrameFormatter(TableFormatter):
 
                 max_len = max(max(self.adj.len(x) for x in fmt_values), header_colwidth)
                 cheader = self.adj.justify(cheader, max_len, mode=self.justify)
-                stringified.append(cheader + fmt_values)
+                strcols.append(cheader + fmt_values)
 
         str_index = self._get_formatted_index(frame)
-        strcols = stringified
         if self.index:
             strcols.insert(0, str_index)
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -583,7 +583,7 @@ class DataFrameFormatter(TableFormatter):
     ):
         self.frame = frame
         self.show_index_names = index_names
-        self.sparsify = sparsify  # type: ignore[assignment]
+        self.sparsify = self._initialize_sparsify(sparsify)
         self.float_format = float_format
 
         # Ignoring error
@@ -623,16 +623,10 @@ class DataFrameFormatter(TableFormatter):
         self._truncate()
         self.adj = get_adjustment()
 
-    @property
-    def sparsify(self) -> bool:
-        return self._sparsify
-
-    @sparsify.setter
-    def sparsify(self, sparsify: Optional[bool]) -> None:
+    def _initialize_sparsify(self, sparsify: Optional[bool]) -> bool:
         if sparsify is None:
-            self._sparsify = get_option("display.multi_sparse")
-        else:
-            self._sparsify = sparsify
+            return get_option("display.multi_sparse")
+        return sparsify
 
     @property
     def formatters(self) -> FormattersType:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -453,7 +453,11 @@ def get_adjustment() -> TextAdjustment:
 class TableFormatter:
 
     show_dimensions: Union[bool, str]
-    is_truncated: bool
+
+    @property
+    def is_truncated(self) -> bool:
+        self._is_truncated: bool
+        return self._is_truncated
 
     @property
     def formatters(self) -> FormattersType:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -688,6 +688,18 @@ class DataFrameFormatter(TableFormatter):
         """Check if the output is to be shown in terminal."""
         return bool(self.max_cols == 0 or self.max_rows == 0)
 
+    @property
+    def max_cols_adj(self) -> int:
+        try:
+            return self._max_cols_adj
+        except AttributeError:
+            width, _ = get_terminal_size()
+            if self.max_cols == 0 and len(self.frame.columns) > width:
+                self._max_cols_adj = width
+            else:
+                self._max_cols_adj = self.max_cols
+            return self._max_cols_adj
+
     def _chk_truncate(self) -> None:
         """
         Checks whether the frame should be truncated. If so, slices
@@ -718,8 +730,6 @@ class DataFrameFormatter(TableFormatter):
 
             # Format only rows and columns that could potentially fit the
             # screen
-            if max_cols == 0 and len(self.frame.columns) > width:
-                max_cols = width
             if max_rows == 0 and len(self.frame) > height:
                 max_rows = height
 
@@ -729,8 +739,6 @@ class DataFrameFormatter(TableFormatter):
                     # if truncated, set max_rows showed to min_rows
                     max_rows = min(self.min_rows, max_rows)
             self.max_rows_adj = max_rows
-        if not hasattr(self, "max_cols_adj"):
-            self.max_cols_adj = max_cols
 
         max_cols_adj = self.max_cols_adj
         max_rows_adj = self.max_rows_adj
@@ -919,7 +927,7 @@ class DataFrameFormatter(TableFormatter):
                 max_cols_adj = n_cols - self.index
                 # GH-21180. Ensure that we print at least two.
                 max_cols_adj = max(max_cols_adj, 2)
-                self.max_cols_adj = max_cols_adj
+                self._max_cols_adj = max_cols_adj
 
                 # Call again _chk_truncate to cut frame appropriately
                 # and then generate string representation

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -742,7 +742,7 @@ class DataFrameFormatter(TableFormatter):
         return bool(self.max_rows == 0 and len(self.frame) > max_height)
 
     @property
-    def truncate_h(self) -> bool:
+    def is_truncated_horizontally(self) -> bool:
         return bool(self.max_cols_adj and (len(self.columns) > self.max_cols_adj))
 
     @property
@@ -751,7 +751,7 @@ class DataFrameFormatter(TableFormatter):
 
     @property
     def is_truncated(self) -> bool:
-        return bool(self.truncate_h or self.truncate_v)
+        return bool(self.is_truncated_horizontally or self.truncate_v)
 
     def _chk_truncate(self) -> None:
         """
@@ -768,8 +768,9 @@ class DataFrameFormatter(TableFormatter):
         max_rows_adj = self.max_rows_adj
 
         frame = self.frame
-        if self.truncate_h:
-            # cast here since if truncate_h is True, max_cols_adj is not None
+        if self.is_truncated_horizontally:
+            # cast here since if is_truncated_horizontally is True
+            # max_cols_adj is not None
             max_cols_adj = cast(int, max_cols_adj)
             if max_cols_adj == 0:
                 col_num = len(frame.columns)
@@ -863,10 +864,10 @@ class DataFrameFormatter(TableFormatter):
             strcols.insert(0, str_index)
 
         # Add ... to signal truncated
-        truncate_h = self.truncate_h
+        is_truncated_horizontally = self.is_truncated_horizontally
         truncate_v = self.truncate_v
 
-        if truncate_h:
+        if is_truncated_horizontally:
             col_num = self.tr_col_num
             strcols.insert(self.tr_col_num + 1, [" ..."] * (len(str_index)))
         if truncate_v:
@@ -878,7 +879,7 @@ class DataFrameFormatter(TableFormatter):
                 # infer from above row
                 cwidth = self.adj.len(strcols[ix][row_num])
                 is_dot_col = False
-                if truncate_h:
+                if is_truncated_horizontally:
                     is_dot_col = ix == col_num + 1
                 if cwidth > 3 or is_dot_col:
                     my_str = "..."

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -734,6 +734,9 @@ class DataFrameFormatter(TableFormatter):
     def _is_screen_narrow(self, max_width) -> bool:
         return bool(self.max_cols == 0 and len(self.frame.columns) > max_width)
 
+    def _is_screen_short(self, max_height) -> bool:
+        return bool(self.max_rows == 0 and len(self.frame) > max_height)
+
     @property
     def max_rows_adj(self) -> Optional[int]:
         """Number of rows fitting the screen."""
@@ -770,9 +773,6 @@ class DataFrameFormatter(TableFormatter):
             num_rows += 1
 
         return num_rows
-
-    def _is_screen_short(self, max_height) -> bool:
-        return bool(self.max_rows == 0 and len(self.frame) > max_height)
 
     @property
     def is_truncated_horizontally(self) -> bool:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -581,12 +581,7 @@ class DataFrameFormatter(TableFormatter):
         self.formatters = self._initialize_formatters(formatters)
         self.na_rep = na_rep
         self.decimal = decimal
-
-        # Ignoring error
-        # expression has type "Union[str, int, Sequence[Union[str, int]],
-        # Mapping[Optional[Hashable], Union[str, int]], None]",
-        # variable has type "Mapping[Optional[Hashable], Union[str, int]]"
-        self.col_space = col_space  # type: ignore[assignment]
+        self.col_space = self._initialize_colspace(col_space)
 
         self.header = header
         self.index = index
@@ -650,33 +645,31 @@ class DataFrameFormatter(TableFormatter):
             self._columns = self.frame.columns
         assert self._columns is not None
 
-    @property
-    def col_space(self) -> ColspaceType:
-        return self._col_space
+    def _initialize_colspace(
+        self, col_space: Optional[ColspaceArgType]
+    ) -> ColspaceType:
+        result: ColspaceType
 
-    @col_space.setter
-    def col_space(self, col_space: Optional[ColspaceArgType]) -> None:
-        self._col_space: ColspaceType
         if col_space is None:
-            self._col_space = {}
+            result = {}
         elif isinstance(col_space, (int, str)):
-            self._col_space = {"": col_space}
-            self._col_space.update({column: col_space for column in self.frame.columns})
+            result = {"": col_space}
+            result.update({column: col_space for column in self.frame.columns})
         elif isinstance(col_space, Mapping):
             for column in col_space.keys():
                 if column not in self.frame.columns and column != "":
                     raise ValueError(
                         f"Col_space is defined for an unknown column: {column}"
                     )
-            self._col_space = col_space
+            result = col_space
         else:
             if len(self.frame.columns) != len(col_space):
                 raise ValueError(
                     f"Col_space length({len(col_space)}) should match "
                     f"DataFrame number of columns({len(self.frame.columns)})"
                 )
-            self._col_space = dict(zip(self.frame.columns, col_space))
-        assert self._col_space is not None
+            result = dict(zip(self.frame.columns, col_space))
+        return result
 
     @property
     def max_rows_displayed(self) -> int:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -695,11 +695,14 @@ class DataFrameFormatter(TableFormatter):
             return self._max_cols_adj
         except AttributeError:
             width, _ = get_terminal_size()
-            if self.max_cols == 0 and len(self.frame.columns) > width:
+            if self._is_screen_narrow(width):
                 self._max_cols_adj = width
             else:
                 self._max_cols_adj = self.max_cols
             return self._max_cols_adj
+
+    def _is_screen_narrow(self, max_width) -> bool:
+        return bool(self.max_cols == 0 and len(self.frame.columns) > max_width)
 
     @property
     def max_rows_adj(self) -> Optional[int]:
@@ -720,7 +723,7 @@ class DataFrameFormatter(TableFormatter):
                 # rows available to fill with actual data
                 return height - n_add_rows
 
-            if self.max_rows == 0 and len(self.frame) > height:
+            if self._is_screen_short(height):
                 max_rows = height
 
         if max_rows:
@@ -728,6 +731,9 @@ class DataFrameFormatter(TableFormatter):
                 # if truncated, set max_rows showed to min_rows
                 max_rows = min(self.min_rows, max_rows)
         return max_rows
+
+    def _is_screen_short(self, max_height) -> bool:
+        return bool(self.max_rows == 0 and len(self.frame) > max_height)
 
     def _chk_truncate(self) -> None:
         """

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -837,10 +837,8 @@ class DataFrameFormatter(TableFormatter):
             )
         self.tr_row_num = row_num
 
-    def _to_str_columns(self) -> List[List[str]]:
-        """
-        Render a DataFrame to a list of columns (as lists of strings).
-        """
+    def _get_strcols(self) -> List[List[str]]:
+        # TODO check this comment validity
         # this method is not used by to_html where self.col_space
         # could be a string so safe to cast
         col_space = {k: cast(int, v) for k, v in self.col_space.items()}
@@ -893,11 +891,21 @@ class DataFrameFormatter(TableFormatter):
         if self.index:
             strcols.insert(0, str_index)
 
+        return strcols
+
+    def _to_str_columns(self) -> List[List[str]]:
+        """
+        Render a DataFrame to a list of columns (as lists of strings).
+        """
+        strcols = self._get_strcols()
+
+        str_index = self._get_formatted_index(self.tr_frame)
+
         if self.is_truncated_horizontally:
             strcols.insert(self.tr_col_num + 1, [" ..."] * (len(str_index)))
 
         if self.is_truncated_vertically:
-            n_header_rows = len(str_index) - len(frame)
+            n_header_rows = len(str_index) - len(self.tr_frame)
             row_num = self.tr_row_num
             # cast here since if is_truncated_vertically is True
             # self.tr_row_num is not None

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -948,6 +948,18 @@ class DataFrameFormatter(TableFormatter):
         """
         Render a DataFrame to a console-friendly tabular output.
         """
+        text = self._get_string_representation()
+
+        buf.writelines(text)
+
+        if self.should_show_dimensions:
+            dim_str = (
+                f"\n\n[{len(self.frame)} rows x "
+                f"{len(self.frame.columns)} columns]"
+            )
+            buf.write(dim_str)
+
+    def _get_string_representation(self):
         from pandas import Series
 
         frame = self.frame
@@ -1000,10 +1012,7 @@ class DataFrameFormatter(TableFormatter):
                 self._chk_truncate()
                 strcols = self._to_str_columns()
                 text = self.adj.adjoin(1, *strcols)
-        buf.writelines(text)
-
-        if self.should_show_dimensions:
-            buf.write(f"\n\n[{len(frame)} rows x {len(frame.columns)} columns]")
+        return text
 
     def _join_multiline(self, *args) -> str:
         lwidth = self.line_width

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1040,18 +1040,18 @@ class DataFrameFormatter(TableFormatter):
             nrows = len(self.frame)
 
         str_lst = []
-        st = 0
-        for i, ed in enumerate(col_bins):
-            row = strcols[st:ed]
+        start = 0
+        for i, end in enumerate(col_bins):
+            row = strcols[start:end]
             if self.index:
                 row.insert(0, idx)
             if nbins > 1:
-                if ed <= len(strcols) and i < nbins - 1:
+                if end <= len(strcols) and i < nbins - 1:
                     row.append([" \\"] + ["  "] * (nrows - 1))
                 else:
                     row.append([" "] * nrows)
             str_lst.append(self.adj.adjoin(adjoin_width, *row))
-            st = ed
+            start = end
         return "\n\n".join(str_lst)
 
     def to_string(

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -455,10 +455,10 @@ class TableFormatter:
     show_dimensions: Union[bool, str]
     formatters: FormattersType
     columns: Index
+    _is_truncated: bool
 
     @property
     def is_truncated(self) -> bool:
-        self._is_truncated: bool
         return self._is_truncated
 
     @property

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -798,10 +798,8 @@ class DataFrameFormatter(TableFormatter):
             self._truncate_vertically()
 
     def _truncate_horizontally(self) -> None:
-        # cast here since if is_truncated_horizontally is True
-        # max_cols_adj is not None
-        max_cols_adj = cast(int, self.max_cols_adj)
-        col_num = max_cols_adj // 2
+        assert self.max_cols_adj is not None
+        col_num = self.max_cols_adj // 2
         if col_num >= 1:
             cols_to_keep = [
                 x
@@ -820,10 +818,8 @@ class DataFrameFormatter(TableFormatter):
         self.tr_col_num = col_num
 
     def _truncate_vertically(self) -> None:
-        # cast here since if is_truncated_vertically is True
-        # max_rows_adj is not None
-        max_rows_adj = cast(int, self.max_rows_adj)
-        row_num = max_rows_adj // 2
+        assert self.max_rows_adj is not None
+        row_num = self.max_rows_adj // 2
         if row_num >= 1:
             rows_to_keep = [
                 x

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -263,8 +263,6 @@ class SeriesFormatter:
         self._chk_truncate()
 
     def _chk_truncate(self) -> None:
-        from pandas.core.reshape.concat import concat
-
         self.tr_row_num: Optional[int]
 
         min_rows = self.min_rows

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -681,9 +681,7 @@ class DataFrameFormatter(TableFormatter):
         max_rows_adj: Optional[int]
 
         if max_cols == 0 or max_rows == 0:  # assume we are in the terminal
-            (w, h) = get_terminal_size()
-            self.w = w
-            self.h = h
+            (width, height) = get_terminal_size()
             if self.max_rows == 0:
                 dot_row = 1
                 prompt_row = 1
@@ -694,15 +692,15 @@ class DataFrameFormatter(TableFormatter):
                 self.header = cast(bool, self.header)
                 n_add_rows = self.header + dot_row + show_dimension_rows + prompt_row
                 # rows available to fill with actual data
-                max_rows_adj = self.h - n_add_rows
+                max_rows_adj = height - n_add_rows
                 self.max_rows_adj = max_rows_adj
 
             # Format only rows and columns that could potentially fit the
             # screen
-            if max_cols == 0 and len(self.frame.columns) > w:
-                max_cols = w
-            if max_rows == 0 and len(self.frame) > h:
-                max_rows = h
+            if max_cols == 0 and len(self.frame.columns) > width:
+                max_cols = width
+            if max_rows == 0 and len(self.frame) > height:
+                max_rows = height
 
         if not hasattr(self, "max_rows_adj"):
             if max_rows:
@@ -880,7 +878,8 @@ class DataFrameFormatter(TableFormatter):
                 lines = self.adj.adjoin(1, *strcols).split("\n")
                 max_len = Series(lines).str.len().max()
                 # plus truncate dot col
-                dif = max_len - self.w
+                width, _ = get_terminal_size()
+                dif = max_len - width
                 # '+ 1' to avoid too wide repr (GH PR #17023)
                 adj_dif = dif + 1
                 col_lens = Series([Series(ele).apply(len).max() for ele in strcols])

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -461,7 +461,13 @@ class TableFormatter:
     def formatters(self, formatters: FormattersType) -> None:
         self._formatters: FormattersType = formatters
 
-    columns: Index
+    @property
+    def columns(self) -> Index:
+        return self._columns
+
+    @columns.setter
+    def columns(self, columns: Index) -> None:
+        self._columns: Index = columns
 
     @property
     def should_show_dimensions(self) -> bool:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -684,6 +684,10 @@ class DataFrameFormatter(TableFormatter):
     def max_rows_displayed(self) -> int:
         return min(self.max_rows or len(self.frame), len(self.frame))
 
+    def _is_in_terminal(self) -> bool:
+        """Check if the output is to be shown in terminal."""
+        return bool(self.max_cols == 0 or self.max_rows == 0)
+
     def _chk_truncate(self) -> None:
         """
         Checks whether the frame should be truncated. If so, slices
@@ -697,7 +701,7 @@ class DataFrameFormatter(TableFormatter):
         self.max_rows_adj: Optional[int]
         max_rows_adj: Optional[int]
 
-        if max_cols == 0 or max_rows == 0:  # assume we are in the terminal
+        if self._is_in_terminal():
             (width, height) = get_terminal_size()
             if self.max_rows == 0:
                 dot_row = 1

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -584,7 +584,7 @@ class DataFrameFormatter(TableFormatter):
         self.show_dimensions = show_dimensions
         self.table_id = table_id
         self.render_links = render_links
-        self.justify = justify  # type: ignore[assignment]
+        self.justify = self._initialize_justify(justify)
         self.bold_rows = bold_rows
         self.escape = escape
         self.columns = self._initialize_columns(columns)
@@ -610,16 +610,11 @@ class DataFrameFormatter(TableFormatter):
                 f"DataFrame number of columns({len(self.frame.columns)})"
             )
 
-    @property
-    def justify(self) -> str:
-        return self._justify
-
-    @justify.setter
-    def justify(self, justify: Optional[str]) -> None:
+    def _initialize_justify(self, justify: Optional[str]) -> str:
         if justify is None:
-            self._justify = get_option("display.colheader_justify")
+            return get_option("display.colheader_justify")
         else:
-            self._justify = justify
+            return justify
 
     def _initialize_columns(self, columns: Optional[Sequence[str]]) -> Index:
         if columns is not None:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -454,19 +454,12 @@ class TableFormatter:
 
     show_dimensions: Union[bool, str]
     formatters: FormattersType
+    columns: Index
 
     @property
     def is_truncated(self) -> bool:
         self._is_truncated: bool
         return self._is_truncated
-
-    @property
-    def columns(self) -> Index:
-        return self._columns
-
-    @columns.setter
-    def columns(self, columns: Index) -> None:
-        self._columns: Index = columns
 
     @property
     def should_show_dimensions(self) -> bool:
@@ -582,7 +575,6 @@ class DataFrameFormatter(TableFormatter):
         self.na_rep = na_rep
         self.decimal = decimal
         self.col_space = self._initialize_colspace(col_space)
-
         self.header = header
         self.index = index
         self.line_width = line_width
@@ -595,10 +587,7 @@ class DataFrameFormatter(TableFormatter):
         self.justify = justify  # type: ignore[assignment]
         self.bold_rows = bold_rows
         self.escape = escape
-
-        # Ignoring error:
-        # expression has type "Optional[Sequence[str]]", variable has type "Index"
-        self.columns = columns  # type: ignore[assignment]
+        self.columns = self._initialize_columns(columns)
 
         self._truncate()
         self.adj = get_adjustment()
@@ -632,18 +621,13 @@ class DataFrameFormatter(TableFormatter):
         else:
             self._justify = justify
 
-    @property
-    def columns(self) -> Index:
-        return self._columns
-
-    @columns.setter
-    def columns(self, columns: Optional[Sequence[str]]) -> None:
+    def _initialize_columns(self, columns: Optional[Sequence[str]]) -> Index:
         if columns is not None:
-            self._columns = ensure_index(columns)
-            self.frame = self.frame[self._columns]
+            cols = ensure_index(columns)
+            self.frame = self.frame[cols]
+            return cols
         else:
-            self._columns = self.frame.columns
-        assert self._columns is not None
+            return self.frame.columns
 
     def _initialize_colspace(
         self, col_space: Optional[ColspaceArgType]

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -452,7 +452,15 @@ class TableFormatter:
 
     show_dimensions: Union[bool, str]
     is_truncated: bool
-    formatters: FormattersType
+
+    @property
+    def formatters(self) -> FormattersType:
+        return self._formatters
+
+    @formatters.setter
+    def formatters(self, formatters: FormattersType) -> None:
+        self._formatters: FormattersType = formatters
+
     columns: Index
 
     @property

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -960,8 +960,6 @@ class DataFrameFormatter(TableFormatter):
             buf.write(dim_str)
 
     def _get_string_representation(self):
-        from pandas import Series
-
         if self.frame.empty:
             info_line = (
                 f"Empty {type(self.frame).__name__}\n"
@@ -981,6 +979,11 @@ class DataFrameFormatter(TableFormatter):
             return self._join_multiline(*strcols)
 
         # max_cols == 0. Try to fit frame to terminal
+        return self._fit_strcols_to_terminal_width(strcols)
+
+    def _fit_strcols_to_terminal_width(self, strcols):
+        from pandas import Series
+
         lines = self.adj.adjoin(1, *strcols).split("\n")
         max_len = Series(lines).str.len().max()
         # plus truncate dot col

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -575,26 +575,7 @@ class DataFrameFormatter(TableFormatter):
         self.formatters = formatters
         self.na_rep = na_rep
         self.decimal = decimal
-        if col_space is None:
-            self.col_space = {}
-        elif isinstance(col_space, (int, str)):
-            self.col_space = {"": col_space}
-            self.col_space.update({column: col_space for column in self.frame.columns})
-        elif isinstance(col_space, Mapping):
-            for column in col_space.keys():
-                if column not in self.frame.columns and column != "":
-                    raise ValueError(
-                        f"Col_space is defined for an unknown column: {column}"
-                    )
-            self.col_space = col_space
-        else:
-            if len(frame.columns) != len(col_space):
-                raise ValueError(
-                    f"Col_space length({len(col_space)}) should match "
-                    f"DataFrame number of columns({len(frame.columns)})"
-                )
-            self.col_space = dict(zip(self.frame.columns, col_space))
-
+        self.col_space = col_space
         self.header = header
         self.index = index
         self.line_width = line_width
@@ -650,6 +631,32 @@ class DataFrameFormatter(TableFormatter):
             self.frame = self.frame[self._columns]
         else:
             self._columns = self.frame.columns
+
+    @property
+    def col_space(self):
+        return self._col_space
+
+    @col_space.setter
+    def col_space(self, col_space):
+        if col_space is None:
+            self._col_space = {}
+        elif isinstance(col_space, (int, str)):
+            self._col_space = {"": col_space}
+            self._col_space.update({column: col_space for column in self.frame.columns})
+        elif isinstance(col_space, Mapping):
+            for column in col_space.keys():
+                if column not in self.frame.columns and column != "":
+                    raise ValueError(
+                        f"Col_space is defined for an unknown column: {column}"
+                    )
+            self._col_space = col_space
+        else:
+            if len(self.frame.columns) != len(col_space):
+                raise ValueError(
+                    f"Col_space length({len(col_space)}) should match "
+                    f"DataFrame number of columns({len(self.frame.columns)})"
+                )
+            self._col_space = dict(zip(self.frame.columns, col_space))
 
     def _chk_truncate(self) -> None:
         """

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -916,11 +916,17 @@ class DataFrameFormatter(TableFormatter):
         index_length = len(str_index)
 
         if self.is_truncated_horizontally:
-            strcols.insert(self.tr_col_num + 1, [" ..."] * (len(str_index)))
+            strcols = self._insert_dot_separator_horizontal(strcols, index_length)
 
         if self.is_truncated_vertically:
             strcols = self._insert_dot_separator_vertical(strcols, index_length)
 
+        return strcols
+
+    def _insert_dot_separator_horizontal(
+        self, strcols: List[List[str]], index_length: int
+    ) -> List[List[str]]:
+        strcols.insert(self.tr_col_num + 1, [" ..."] * index_length)
         return strcols
 
     def _insert_dot_separator_vertical(

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -654,10 +654,6 @@ class DataFrameFormatter(TableFormatter):
     def max_rows_displayed(self) -> int:
         return min(self.max_rows or len(self.frame), len(self.frame))
 
-    def _is_in_terminal(self) -> bool:
-        """Check if the output is to be shown in terminal."""
-        return bool(self.max_cols == 0 or self.max_rows == 0)
-
     @property
     def max_cols_adj(self) -> Optional[int]:
         """Number of columns fitting the screen."""
@@ -676,12 +672,6 @@ class DataFrameFormatter(TableFormatter):
         else:
             self._max_cols_adj = self.max_cols
         return self._max_cols_adj
-
-    def _is_screen_narrow(self, max_width) -> bool:
-        return bool(self.max_cols == 0 and len(self.frame.columns) > max_width)
-
-    def _is_screen_short(self, max_height) -> bool:
-        return bool(self.max_rows == 0 and len(self.frame) > max_height)
 
     @property
     def max_rows_adj(self) -> Optional[int]:
@@ -705,6 +695,16 @@ class DataFrameFormatter(TableFormatter):
                 # if truncated, set max_rows showed to min_rows
                 max_rows = min(self.min_rows, max_rows)
         return max_rows
+
+    def _is_in_terminal(self) -> bool:
+        """Check if the output is to be shown in terminal."""
+        return bool(self.max_cols == 0 or self.max_rows == 0)
+
+    def _is_screen_narrow(self, max_width) -> bool:
+        return bool(self.max_cols == 0 and len(self.frame.columns) > max_width)
+
+    def _is_screen_short(self, max_height) -> bool:
+        return bool(self.max_rows == 0 and len(self.frame) > max_height)
 
     def _get_number_of_auxillary_rows(self) -> int:
         """Get number of rows occupied by prompt, dots and dimension info."""

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -667,7 +667,7 @@ class DataFrameFormatter(TableFormatter):
         assert self._col_space is not None
 
     @property
-    def max_rows_displayed(self):
+    def max_rows_displayed(self) -> int:
         return min(self.max_rows or len(self.frame), len(self.frame))
 
     def _chk_truncate(self) -> None:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -621,7 +621,7 @@ class DataFrameFormatter(TableFormatter):
         # expression has type "Optional[Sequence[str]]", variable has type "Index"
         self.columns = columns  # type: ignore[assignment]
 
-        self._chk_truncate()
+        self._truncate()
         self.adj = get_adjustment()
 
     @property
@@ -786,10 +786,9 @@ class DataFrameFormatter(TableFormatter):
     def is_truncated(self) -> bool:
         return bool(self.is_truncated_horizontally or self.is_truncated_vertically)
 
-    def _chk_truncate(self) -> None:
+    def _truncate(self) -> None:
         """
-        Checks whether the frame should be truncated. If so, slices
-        the frame up.
+        Check whether the frame should be truncated. If so, slice the frame up.
         """
         self.tr_frame = self.frame.copy()
 
@@ -1009,9 +1008,9 @@ class DataFrameFormatter(TableFormatter):
         max_cols_adj = max(max_cols_adj, 2)
         self._max_cols_adj = max_cols_adj
 
-        # Call again _chk_truncate to cut frame appropriately
+        # Call again _truncate to cut frame appropriately
         # and then generate string representation
-        self._chk_truncate()
+        self._truncate()
         strcols = self._to_str_columns()
         return self.adj.adjoin(1, *strcols)
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -761,16 +761,15 @@ class DataFrameFormatter(TableFormatter):
     def _get_number_of_auxillary_rows(self) -> int:
         dot_row = 1
         prompt_row = 1
+        num_rows = dot_row + prompt_row
 
         if self.show_dimensions:
-            show_dimension_rows = len(self._dimensions_info.splitlines())
+            num_rows += len(self._dimensions_info.splitlines())
 
         if self.header:
-            header_row = 1
-        else:
-            header_row = 0
+            num_rows += 1
 
-        return header_row + dot_row + show_dimension_rows + prompt_row
+        return num_rows
 
     def _is_screen_short(self, max_height) -> bool:
         return bool(self.max_rows == 0 and len(self.frame) > max_height)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -894,7 +894,6 @@ class DataFrameFormatter(TableFormatter):
             strcols.insert(0, str_index)
 
         if self.is_truncated_horizontally:
-            col_num = self.tr_col_num
             strcols.insert(self.tr_col_num + 1, [" ..."] * (len(str_index)))
 
         if self.is_truncated_vertically:
@@ -905,14 +904,14 @@ class DataFrameFormatter(TableFormatter):
             row_num = cast(int, row_num)
             for ix, col in enumerate(strcols):
                 # infer from above row
-                cwidth = self.adj.len(strcols[ix][row_num])
+                cwidth = self.adj.len(col[row_num])
                 is_dot_col = False
                 if self.is_truncated_horizontally:
-                    is_dot_col = ix == col_num + 1
+                    is_dot_col = ix == self.tr_col_num + 1
                 if cwidth > 3 or is_dot_col:
-                    my_str = "..."
+                    dots = "..."
                 else:
-                    my_str = ".."
+                    dots = ".."
 
                 if ix == 0:
                     dot_mode = "left"
@@ -921,8 +920,8 @@ class DataFrameFormatter(TableFormatter):
                     dot_mode = "right"
                 else:
                     dot_mode = "right"
-                dot_str = self.adj.justify([my_str], cwidth, mode=dot_mode)[0]
-                strcols[ix].insert(row_num + n_header_rows, dot_str)
+                dot_str = self.adj.justify([dots], cwidth, mode=dot_mode)[0]
+                col.insert(row_num + n_header_rows, dot_str)
 
         return strcols
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -848,8 +848,6 @@ class DataFrameFormatter(TableFormatter):
         frame = self.tr_frame
         # may include levels names also
 
-        str_index = self._get_formatted_index(frame)
-
         if not is_list_like(self.header) and not self.header:
             stringified = []
             for i, c in enumerate(frame):
@@ -890,6 +888,7 @@ class DataFrameFormatter(TableFormatter):
                 cheader = self.adj.justify(cheader, max_len, mode=self.justify)
                 stringified.append(cheader + fmt_values)
 
+        str_index = self._get_formatted_index(frame)
         strcols = stringified
         if self.index:
             strcols.insert(0, str_index)
@@ -897,6 +896,7 @@ class DataFrameFormatter(TableFormatter):
         if self.is_truncated_horizontally:
             col_num = self.tr_col_num
             strcols.insert(self.tr_col_num + 1, [" ..."] * (len(str_index)))
+
         if self.is_truncated_vertically:
             n_header_rows = len(str_index) - len(frame)
             row_num = self.tr_row_num
@@ -923,6 +923,7 @@ class DataFrameFormatter(TableFormatter):
                     dot_mode = "right"
                 dot_str = self.adj.justify([my_str], cwidth, mode=dot_mode)[0]
                 strcols[ix].insert(row_num + n_header_rows, dot_str)
+
         return strcols
 
     def write_result(self, buf: IO[str]) -> None:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -805,9 +805,7 @@ class DataFrameFormatter(TableFormatter):
         # cast here since if is_truncated_horizontally is True
         # max_cols_adj is not None
         max_cols_adj = cast(int, self.max_cols_adj)
-        if max_cols_adj == 0:
-            col_num = len(self.tr_frame.columns)
-        elif max_cols_adj == 1:
+        if max_cols_adj == 1:
             max_cols = cast(int, self.max_cols)
             self.tr_frame = self.tr_frame.iloc[:, :max_cols]
             col_num = max_cols

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -807,7 +807,8 @@ class DataFrameFormatter(TableFormatter):
         col_num = max_cols_adj // 2
         if col_num >= 1:
             cols_to_keep = [
-                x for x in range(self.frame.shape[1])
+                x
+                for x in range(self.frame.shape[1])
                 if x < col_num or x >= len(self.frame.columns) - col_num
             ]
             self.tr_frame = self.tr_frame.iloc[:, cols_to_keep]
@@ -830,7 +831,8 @@ class DataFrameFormatter(TableFormatter):
         row_num = max_rows_adj // 2
         if row_num >= 1:
             rows_to_keep = [
-                x for x in range(self.frame.shape[0])
+                x
+                for x in range(self.frame.shape[0])
                 if x < row_num or x >= len(self.frame) - row_num
             ]
             self.tr_frame = self.tr_frame.iloc[rows_to_keep, :]

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -808,8 +808,7 @@ class DataFrameFormatter(TableFormatter):
             return strcols
 
         if is_list_like(self.header):
-            # cast here since can't be bool if is_list_like
-            self.header = cast(List[str], self.header)
+            assert isinstance(self.header, list)
             if len(self.header) != len(self.columns):
                 raise ValueError(
                     f"Writing {len(self.columns)} cols "

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -741,12 +741,16 @@ class DataFrameFormatter(TableFormatter):
     def _get_number_of_auxillary_rows(self) -> int:
         dot_row = 1
         prompt_row = 1
+
         if self.show_dimensions:
             show_dimension_rows = 3
-        # assume we only get here if self.header is boolean.
-        # i.e. not to_latex() where self.header may be List[str]
-        self.header = cast(bool, self.header)
-        return self.header + dot_row + show_dimension_rows + prompt_row
+
+        if self.header:
+            header_row = 1
+        else:
+            header_row = 0
+
+        return header_row + dot_row + show_dimension_rows + prompt_row
 
     def _is_screen_short(self, max_height) -> bool:
         return bool(self.max_rows == 0 and len(self.frame) > max_height)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -717,19 +717,19 @@ class DataFrameFormatter(TableFormatter):
         """Number of columns fitting the screen."""
         self._max_cols_adj: Optional[int]
 
-        try:
+        if hasattr(self, "_max_cols_adj"):
             return self._max_cols_adj
-        except AttributeError:
-            if not self._is_in_terminal():
-                self._max_cols_adj = self.max_cols
-                return self._max_cols_adj
 
-            width, _ = get_terminal_size()
-            if self._is_screen_narrow(width):
-                self._max_cols_adj = width
-            else:
-                self._max_cols_adj = self.max_cols
+        if not self._is_in_terminal():
+            self._max_cols_adj = self.max_cols
             return self._max_cols_adj
+
+        width, _ = get_terminal_size()
+        if self._is_screen_narrow(width):
+            self._max_cols_adj = width
+        else:
+            self._max_cols_adj = self.max_cols
+        return self._max_cols_adj
 
     def _is_screen_narrow(self, max_width) -> bool:
         return bool(self.max_cols == 0 and len(self.frame.columns) > max_width)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -976,7 +976,7 @@ class DataFrameFormatter(TableFormatter):
             # no need to wrap around just print the whole frame
             return self.adj.adjoin(1, *strcols)
 
-        if (not isinstance(self.max_cols, int) or self.max_cols > 0):
+        if self.max_cols is None or self.max_cols > 0:
             # need to wrap around
             return self._join_multiline(*strcols)
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -745,6 +745,7 @@ class DataFrameFormatter(TableFormatter):
             # rows available to fill with actual data
             return height - self._get_number_of_auxillary_rows()
 
+        max_rows: Optional[int]
         if self._is_screen_short(height):
             max_rows = height
         else:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -577,7 +577,6 @@ class DataFrameFormatter(TableFormatter):
         self.max_rows = max_rows
         self.min_rows = min_rows
         self.max_cols = max_cols
-        self.max_rows_displayed = min(max_rows or len(self.frame), len(self.frame))
         self.show_dimensions = show_dimensions
         self.table_id = table_id
         self.render_links = render_links
@@ -663,6 +662,10 @@ class DataFrameFormatter(TableFormatter):
                     f"DataFrame number of columns({len(self.frame.columns)})"
                 )
             self._col_space = dict(zip(self.frame.columns, col_space))
+
+    @property
+    def max_rows_displayed(self):
+        return min(self.max_rows or len(self.frame), len(self.frame))
 
     def _chk_truncate(self) -> None:
         """

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -907,11 +907,11 @@ class DataFrameFormatter(TableFormatter):
         strcols = self._get_strcols()
 
         if self.is_truncated:
-            strcols = self._truncate_strcols(strcols)
+            strcols = self._insert_dot_separators(strcols)
 
         return strcols
 
-    def _truncate_strcols(self, strcols):
+    def _insert_dot_separators(self, strcols):
         str_index = self._get_formatted_index(self.tr_frame)
         index_length = len(str_index)
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -707,24 +707,26 @@ class DataFrameFormatter(TableFormatter):
     @property
     def max_rows_adj(self) -> Optional[int]:
         """Number of rows fitting the screen."""
-        max_rows = self.max_rows
+        if not self._is_in_terminal():
+            return self.max_rows
 
-        if self._is_in_terminal():
-            (width, height) = get_terminal_size()
-            if self.max_rows == 0:
-                dot_row = 1
-                prompt_row = 1
-                if self.show_dimensions:
-                    show_dimension_rows = 3
-                # assume we only get here if self.header is boolean.
-                # i.e. not to_latex() where self.header may be List[str]
-                self.header = cast(bool, self.header)
-                n_add_rows = self.header + dot_row + show_dimension_rows + prompt_row
-                # rows available to fill with actual data
-                return height - n_add_rows
+        (width, height) = get_terminal_size()
+        if self.max_rows == 0:
+            dot_row = 1
+            prompt_row = 1
+            if self.show_dimensions:
+                show_dimension_rows = 3
+            # assume we only get here if self.header is boolean.
+            # i.e. not to_latex() where self.header may be List[str]
+            self.header = cast(bool, self.header)
+            n_add_rows = self.header + dot_row + show_dimension_rows + prompt_row
+            # rows available to fill with actual data
+            return height - n_add_rows
 
-            if self._is_screen_short(height):
-                max_rows = height
+        if self._is_screen_short(height):
+            max_rows = height
+        else:
+            max_rows = self.max_rows
 
         if max_rows:
             if (len(self.frame) > max_rows) and self.min_rows:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -722,18 +722,10 @@ class DataFrameFormatter(TableFormatter):
         if not self._is_in_terminal():
             return self.max_rows
 
-        (width, height) = get_terminal_size()
+        _, height = get_terminal_size()
         if self.max_rows == 0:
-            dot_row = 1
-            prompt_row = 1
-            if self.show_dimensions:
-                show_dimension_rows = 3
-            # assume we only get here if self.header is boolean.
-            # i.e. not to_latex() where self.header may be List[str]
-            self.header = cast(bool, self.header)
-            n_add_rows = self.header + dot_row + show_dimension_rows + prompt_row
             # rows available to fill with actual data
-            return height - n_add_rows
+            return height - self._get_number_of_auxillary_rows()
 
         if self._is_screen_short(height):
             max_rows = height
@@ -745,6 +737,16 @@ class DataFrameFormatter(TableFormatter):
                 # if truncated, set max_rows showed to min_rows
                 max_rows = min(self.min_rows, max_rows)
         return max_rows
+
+    def _get_number_of_auxillary_rows(self) -> int:
+        dot_row = 1
+        prompt_row = 1
+        if self.show_dimensions:
+            show_dimension_rows = 3
+        # assume we only get here if self.header is boolean.
+        # i.e. not to_latex() where self.header may be List[str]
+        self.header = cast(bool, self.header)
+        return self.header + dot_row + show_dimension_rows + prompt_row
 
     def _is_screen_short(self, max_height) -> bool:
         return bool(self.max_rows == 0 and len(self.frame) > max_height)

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -456,7 +456,8 @@ class HTMLFormatter(TableFormatter):
                 # Insert ... row and adjust idx_values and
                 # level_lengths to take this into account.
                 ins_row = self.fmt.tr_row_num
-                # cast here since if is_truncated_vertically is True, self.fmt.tr_row_num is not None
+                # cast here since if is_truncated_vertically is True
+                # self.fmt.tr_row_num is not None
                 ins_row = cast(int, ins_row)
                 inserted = False
                 for lnum, records in enumerate(level_lengths):

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -456,9 +456,6 @@ class HTMLFormatter(TableFormatter):
                 # Insert ... row and adjust idx_values and
                 # level_lengths to take this into account.
                 ins_row = self.fmt.tr_row_num
-                # cast here since if is_truncated_vertically is True
-                # self.fmt.tr_row_num is not None
-                ins_row = cast(int, ins_row)
                 inserted = False
                 for lnum, records in enumerate(level_lengths):
                     rec_new = {}

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -236,7 +236,7 @@ class HTMLFormatter(TableFormatter):
         self.write("</table>", indent)
 
     def _write_col_header(self, indent: int) -> None:
-        truncate_h = self.fmt.truncate_h
+        is_truncated_horizontally = self.fmt.is_truncated_horizontally
         if isinstance(self.columns, MultiIndex):
             template = 'colspan="{span:d}" halign="left"'
 
@@ -249,7 +249,7 @@ class HTMLFormatter(TableFormatter):
             level_lengths = get_level_lengths(levels, sentinel)
             inner_lvl = len(level_lengths) - 1
             for lnum, (records, values) in enumerate(zip(level_lengths, levels)):
-                if truncate_h:
+                if is_truncated_horizontally:
                     # modify the header lines
                     ins_col = self.fmt.tr_col_num
                     if self.fmt.sparsify:
@@ -346,16 +346,16 @@ class HTMLFormatter(TableFormatter):
             row.extend(self._get_columns_formatted_values())
             align = self.fmt.justify
 
-            if truncate_h:
+            if is_truncated_horizontally:
                 ins_col = self.row_levels + self.fmt.tr_col_num
                 row.insert(ins_col, "...")
 
             self.write_tr(row, indent, self.indent_delta, header=True, align=align)
 
     def _write_row_header(self, indent: int) -> None:
-        truncate_h = self.fmt.truncate_h
+        is_truncated_horizontally = self.fmt.is_truncated_horizontally
         row = [x if x is not None else "" for x in self.frame.index.names] + [""] * (
-            self.ncols + (1 if truncate_h else 0)
+            self.ncols + (1 if is_truncated_horizontally else 0)
         )
         self.write_tr(row, indent, self.indent_delta, header=True)
 
@@ -390,7 +390,7 @@ class HTMLFormatter(TableFormatter):
     def _write_regular_rows(
         self, fmt_values: Mapping[int, List[str]], indent: int
     ) -> None:
-        truncate_h = self.fmt.truncate_h
+        is_truncated_horizontally = self.fmt.is_truncated_horizontally
         truncate_v = self.fmt.truncate_v
 
         nrows = len(self.fmt.tr_frame)
@@ -426,7 +426,7 @@ class HTMLFormatter(TableFormatter):
                 row.append("")
             row.extend(fmt_values[j][i] for j in range(self.ncols))
 
-            if truncate_h:
+            if is_truncated_horizontally:
                 dot_col_ix = self.fmt.tr_col_num + self.row_levels
                 row.insert(dot_col_ix, "...")
             self.write_tr(
@@ -438,7 +438,7 @@ class HTMLFormatter(TableFormatter):
     ) -> None:
         template = 'rowspan="{span}" valign="top"'
 
-        truncate_h = self.fmt.truncate_h
+        is_truncated_horizontally = self.fmt.is_truncated_horizontally
         truncate_v = self.fmt.truncate_v
         frame = self.fmt.tr_frame
         nrows = len(frame)
@@ -520,7 +520,7 @@ class HTMLFormatter(TableFormatter):
                     row.append(v)
 
                 row.extend(fmt_values[j][i] for j in range(self.ncols))
-                if truncate_h:
+                if is_truncated_horizontally:
                     row.insert(
                         self.row_levels - sparse_offset + self.fmt.tr_col_num, "..."
                     )
@@ -550,7 +550,7 @@ class HTMLFormatter(TableFormatter):
                 row = []
                 row.extend(idx_values[i])
                 row.extend(fmt_values[j][i] for j in range(self.ncols))
-                if truncate_h:
+                if is_truncated_horizontally:
                     row.insert(self.row_levels + self.fmt.tr_col_num, "...")
                 self.write_tr(
                     row,

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -85,10 +85,8 @@ class HTMLFormatter(TableFormatter):
     def _get_columns_formatted_values(self) -> Iterable:
         return self.columns
 
-    # https://github.com/python/mypy/issues/1237
-    # error: Signature of "is_truncated" incompatible with supertype "TableFormatter"
     @property
-    def is_truncated(self) -> bool:  # type: ignore[override]
+    def is_truncated(self) -> bool:
         return self.fmt.is_truncated
 
     @property

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -391,7 +391,7 @@ class HTMLFormatter(TableFormatter):
         self, fmt_values: Mapping[int, List[str]], indent: int
     ) -> None:
         is_truncated_horizontally = self.fmt.is_truncated_horizontally
-        truncate_v = self.fmt.truncate_v
+        is_truncated_vertically = self.fmt.is_truncated_vertically
 
         nrows = len(self.fmt.tr_frame)
 
@@ -405,7 +405,7 @@ class HTMLFormatter(TableFormatter):
         row: List[str] = []
         for i in range(nrows):
 
-            if truncate_v and i == (self.fmt.tr_row_num):
+            if is_truncated_vertically and i == (self.fmt.tr_row_num):
                 str_sep_row = ["..."] * len(row)
                 self.write_tr(
                     str_sep_row,
@@ -439,7 +439,7 @@ class HTMLFormatter(TableFormatter):
         template = 'rowspan="{span}" valign="top"'
 
         is_truncated_horizontally = self.fmt.is_truncated_horizontally
-        truncate_v = self.fmt.truncate_v
+        is_truncated_vertically = self.fmt.is_truncated_vertically
         frame = self.fmt.tr_frame
         nrows = len(frame)
 
@@ -454,11 +454,11 @@ class HTMLFormatter(TableFormatter):
 
             level_lengths = get_level_lengths(levels, sentinel)
             inner_lvl = len(level_lengths) - 1
-            if truncate_v:
+            if is_truncated_vertically:
                 # Insert ... row and adjust idx_values and
                 # level_lengths to take this into account.
                 ins_row = self.fmt.tr_row_num
-                # cast here since if truncate_v is True, self.fmt.tr_row_num is not None
+                # cast here since if is_truncated_vertically is True, self.fmt.tr_row_num is not None
                 ins_row = cast(int, ins_row)
                 inserted = False
                 for lnum, records in enumerate(level_lengths):
@@ -534,7 +534,7 @@ class HTMLFormatter(TableFormatter):
         else:
             row = []
             for i in range(len(frame)):
-                if truncate_v and i == (self.fmt.tr_row_num):
+                if is_truncated_vertically and i == (self.fmt.tr_row_num):
                     str_sep_row = ["..."] * len(row)
                     self.write_tr(
                         str_sep_row,


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Partially addresses https://github.com/pandas-dev/pandas/issues/36407

Before splitting ``DataFrameFormatter`` into more dedicated classes, I decided to refactor the class itself, to make the outstanding refactoring more manageable.

As suggested by @jreback, I made this refactor small, trying to split big functions into smaller ones and find some better naming.
Yet, rather small changes are done so far, just to keep diffs readable.
Once approved, I will move on to further refactor.
