### PR TITLE
CLN: 35925 rm trailing commas

### DIFF
--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -14,7 +14,7 @@ class TestGetSliceBounds:
     @pytest.mark.parametrize("kind", ["getitem", "loc", None])
     @pytest.mark.parametrize("side", ["left", "right"])
     @pytest.mark.parametrize(
-        "data, bound, expected", [(list("abcdef"), "x", 6), (list("bcdefg"), "a", 0)],
+        "data, bound, expected", [(list("abcdef"), "x", 6), (list("bcdefg"), "a", 0)]
     )
     def test_get_slice_bounds_outside(self, kind, side, expected, data, bound):
         index = Index(data)

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -411,9 +411,7 @@ def test_sort_values_invalid_na_position(index_with_missing, na_position):
         pytest.xfail("missing value sorting order not defined for index type")
 
     if na_position not in ["first", "last"]:
-        with pytest.raises(
-            ValueError, match=f"invalid na_position: {na_position}",
-        ):
+        with pytest.raises(ValueError, match=f"invalid na_position: {na_position}"):
             index_with_missing.sort_values(na_position=na_position)
 
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -699,9 +699,7 @@ class TestGetSliceBounds:
 
     @pytest.mark.parametrize("kind", ["getitem", "loc", None])
     @pytest.mark.parametrize("side", ["left", "right"])
-    @pytest.mark.parametrize(
-        "bound, expected", [(-1, 0), (10, 6)],
-    )
+    @pytest.mark.parametrize("bound, expected", [(-1, 0), (10, 6)])
     def test_get_slice_bounds_outside(self, kind, side, expected, bound):
         index = Index(range(6))
         result = index.get_slice_bound(bound, kind=kind, side=side)


### PR DESCRIPTION
#35925
Checked the following files to make sure they are ready for black :

- /pandas/tests/indexes/base_class/test_indexing.py
- /pandas/tests/indexes/test_common.py
- /pandas/tests/indexes/test_numeric.py
