### PR TITLE
[BUG]: Rolling.sum() calculated wrong values when axis is one and dtypes are mixed

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -336,7 +336,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrameGroupby.tshift` failing to raise ``ValueError`` when a frequency cannot be inferred for the index of a group (:issue:`35937`)
 - Bug in :meth:`DataFrame.groupby` does not always maintain column index name for ``any``, ``all``, ``bfill``, ``ffill``, ``shift`` (:issue:`29764`)
 - Bug in :meth:`DataFrameGroupBy.apply` raising error with ``np.nan`` group(s) when ``dropna=False`` (:issue:`35889`)
-- Bug in :meth:`Rolling.sum()` returned wrong values when dtypes where mixed between float and integer and axis was equal to one (:issue:`20649`)
+- Bug in :meth:`Rolling.sum()` returned wrong values when dtypes where mixed between float and integer and axis was equal to one (:issue:`20649`, :issue:`35596`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -336,7 +336,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrameGroupby.tshift` failing to raise ``ValueError`` when a frequency cannot be inferred for the index of a group (:issue:`35937`)
 - Bug in :meth:`DataFrame.groupby` does not always maintain column index name for ``any``, ``all``, ``bfill``, ``ffill``, ``shift`` (:issue:`29764`)
 - Bug in :meth:`DataFrameGroupBy.apply` raising error with ``np.nan`` group(s) when ``dropna=False`` (:issue:`35889`)
--
+- Bug in :meth:`Rolling.sum()` returned wrong values when dtypes where mixed between float and integer and axis was equal to one (:issue:`20649`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -245,7 +245,9 @@ class _Window(ShallowMixin, SelectionMixin):
                 obj = obj.reindex(columns=obj.columns.difference([self.on]), copy=False)
         if self.axis == 1:
             # GH: 20649 in case of mixed dtype and axis=1 we have to convert everything
-            # to float to calculate the complete row at once
+            # to float to calculate the complete row at once. We exclude all non-numeric
+            # dtypes.
+            obj = obj.select_dtypes(include=["integer", "float"], exclude=["timedelta"])
             obj = obj.astype("float64", copy=False)
             obj._mgr = obj._mgr.consolidate()
         return obj

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -25,7 +25,6 @@ import pandas._libs.window.aggregations as window_aggregations
 from pandas._typing import ArrayLike, Axis, FrameOrSeries, FrameOrSeriesUnion
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
-from pandas.core.dtypes.cast import infer_dtype_from
 from pandas.util._decorators import Appender, Substitution, cache_readonly, doc
 
 from pandas.core.dtypes.common import (

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -244,6 +244,8 @@ class _Window(ShallowMixin, SelectionMixin):
             if obj.ndim == 2:
                 obj = obj.reindex(columns=obj.columns.difference([self.on]), copy=False)
         if self.axis == 1:
+            # GH: 20649 in case of mixed dtype and axis=1 we have to convert everything
+            # to float to calculate the complete row at once
             obj = obj.astype("float64", copy=False)
             obj._mgr = obj._mgr.consolidate()
         return obj

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -244,7 +244,7 @@ class _Window(ShallowMixin, SelectionMixin):
             if obj.ndim == 2:
                 obj = obj.reindex(columns=obj.columns.difference([self.on]), copy=False)
         if self.axis == 1:
-            obj = obj.astype("float", copy=False)
+            obj = obj.astype("float64", copy=False)
             obj._mgr = obj._mgr.consolidate()
         return obj
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -244,7 +244,9 @@ class _Window(ShallowMixin, SelectionMixin):
         if self.on is not None and not isinstance(self.on, Index):
             if obj.ndim == 2:
                 obj = obj.reindex(columns=obj.columns.difference([self.on]), copy=False)
-
+        if self.axis == 1:
+            obj = obj.astype("float", copy=False)
+            obj._mgr = obj._mgr.consolidate()
         return obj
 
     def _gotitem(self, key, ndim, subset=None):
@@ -491,9 +493,6 @@ class _Window(ShallowMixin, SelectionMixin):
             return self._apply_series(homogeneous_func)
 
         obj = self._create_data(self._selected_obj)
-        if self.axis == 1:
-            obj = obj.astype(infer_dtype_from(obj.values)[0], copy=False)
-            obj._mgr = obj._mgr.consolidate()
         mgr = obj._mgr
 
         def hfunc(bvalues: ArrayLike) -> ArrayLike:

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -25,6 +25,7 @@ import pandas._libs.window.aggregations as window_aggregations
 from pandas._typing import ArrayLike, Axis, FrameOrSeries, FrameOrSeriesUnion
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
+from pandas.core.dtypes.cast import infer_dtype_from
 from pandas.util._decorators import Appender, Substitution, cache_readonly, doc
 
 from pandas.core.dtypes.common import (
@@ -490,6 +491,9 @@ class _Window(ShallowMixin, SelectionMixin):
             return self._apply_series(homogeneous_func)
 
         obj = self._create_data(self._selected_obj)
+        if self.axis == 1:
+            obj = obj.astype(infer_dtype_from(obj.values)[0], copy=False)
+            obj._mgr = obj._mgr.consolidate()
         mgr = obj._mgr
 
         def hfunc(bvalues: ArrayLike) -> ArrayLike:

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -786,3 +786,15 @@ def test_rolling_mixed_dtypes_axis_1(func, value):
         {"a": [1.0, 1.0], "b": [value, value], "c": [value, value]}, index=[1, 2]
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_rolling_axis_one_with_nan():
+    # GH: 35596
+    df = pd.DataFrame([[0, 1, 2, 4, np.nan, np.nan, np.nan],
+                       [0, 1, 2, np.nan, np.nan, np.nan, np.nan],
+                       [0, 2, 2, np.nan, 2, np.nan, 1]])
+    result = df.rolling(window=7, min_periods=1, axis='columns').sum()
+    expected = pd.DataFrame([[0.0, 1.0, 3.0, 7.0, 7.0, 7.0, 7.0],
+                             [0.0, 1.0, 3.0, 3.0, 3.0, 3.0, 3.0],
+                             [0.0, 2.0, 4.0, 4.0, 6.0, 6.0, 7.0]])
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -790,11 +790,19 @@ def test_rolling_mixed_dtypes_axis_1(func, value):
 
 def test_rolling_axis_one_with_nan():
     # GH: 35596
-    df = pd.DataFrame([[0, 1, 2, 4, np.nan, np.nan, np.nan],
-                       [0, 1, 2, np.nan, np.nan, np.nan, np.nan],
-                       [0, 2, 2, np.nan, 2, np.nan, 1]])
-    result = df.rolling(window=7, min_periods=1, axis='columns').sum()
-    expected = pd.DataFrame([[0.0, 1.0, 3.0, 7.0, 7.0, 7.0, 7.0],
-                             [0.0, 1.0, 3.0, 3.0, 3.0, 3.0, 3.0],
-                             [0.0, 2.0, 4.0, 4.0, 6.0, 6.0, 7.0]])
+    df = pd.DataFrame(
+        [
+            [0, 1, 2, 4, np.nan, np.nan, np.nan],
+            [0, 1, 2, np.nan, np.nan, np.nan, np.nan],
+            [0, 2, 2, np.nan, 2, np.nan, 1],
+        ]
+    )
+    result = df.rolling(window=7, min_periods=1, axis="columns").sum()
+    expected = pd.DataFrame(
+        [
+            [0.0, 1.0, 3.0, 7.0, 7.0, 7.0, 7.0],
+            [0.0, 1.0, 3.0, 3.0, 3.0, 3.0, 3.0],
+            [0.0, 2.0, 4.0, 4.0, 6.0, 6.0, 7.0],
+        ]
+    )
     tm.assert_frame_equal(result, expected)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -806,3 +806,16 @@ def test_rolling_axis_one_with_nan():
         ]
     )
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["test", pd.to_datetime("2019-12-31"), pd.to_timedelta("1 days 06:05:01.00003")],
+)
+def test_rolling_axis_1_non_numeric_dtypes(value):
+    # GH: 20649
+    df = pd.DataFrame({"a": [1, 2]})
+    df["b"] = value
+    result = df.rolling(window=2, min_periods=1, axis=1).sum()
+    expected = pd.DataFrame({"a": [1.0, 2.0]})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -771,3 +771,18 @@ def test_rolling_numerical_too_large_numbers():
         index=dates,
     )
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("func", "value"),
+    [("sum", 2.0), ("max", 1.0), ("min", 1.0), ("mean", 1.0), ("median", 1.0)],
+)
+def test_rolling_mixed_dtypes_axis_1(func, value):
+    # GH: 20649
+    df = pd.DataFrame(1, index=[1, 2], columns=["a", "b", "c"])
+    df["c"] = 1.0
+    result = getattr(df.rolling(window=2, min_periods=1, axis=1), func)()
+    expected = pd.DataFrame(
+        {"a": [1.0, 1.0], "b": [value, value], "c": [value, value]}, index=[1, 2]
+    )
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #20649
- [x] closes #35596
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

In case of ``axis=1`` and mixed dtypes, the ``_apply_blockwise`` did not calculate the sum for a complete row. Through converting the obj and consolidating the blocks we can avoid this.