### PR TITLE
Align cython and python reduction code paths

### DIFF
--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -29,7 +29,7 @@ import warnings
 
 import numpy as np
 
-from pandas._libs import lib
+from pandas._libs import lib, reduction as libreduction
 from pandas._typing import ArrayLike, FrameOrSeries, FrameOrSeriesUnion
 from pandas.util._decorators import Appender, Substitution, doc
 
@@ -471,12 +471,16 @@ class SeriesGroupBy(GroupBy[Series]):
 
     def _aggregate_named(self, func, *args, **kwargs):
         result = {}
+        initialized = False
 
         for name, group in self:
             group.name = name
             output = func(group, *args, **kwargs)
-            if isinstance(output, (Series, Index, np.ndarray)):
-                raise ValueError("Must produce aggregated value")
+            output = libreduction.extract_result(output)
+            if not initialized:
+                # We only do this validation on the first iteration
+                libreduction.check_result_array(output, 0)
+                initialized = True
             result[name] = output
 
         return result

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -474,7 +474,10 @@ class SeriesGroupBy(GroupBy[Series]):
         initialized = False
 
         for name, group in self:
-            group.name = name
+            # Each step of this loop corresponds to
+            #  libreduction._BaseGrouper._apply_to_group
+            group.name = name  # NB: libreduction does not pin name
+
             output = func(group, *args, **kwargs)
             output = libreduction.extract_result(output)
             if not initialized:

--- a/pandas/core/groupby/ops.py
+++ b/pandas/core/groupby/ops.py
@@ -653,23 +653,26 @@ class BaseGrouper:
         group_index, _, ngroups = self.group_info
 
         counts = np.zeros(ngroups, dtype=int)
-        result = None
+        result = np.empty(ngroups, dtype="O")
+        initialized = False
 
         splitter = get_splitter(obj, group_index, ngroups, axis=0)
 
         for label, group in splitter:
+
+            # Each step of this loop corresponds to
+            #  libreduction._BaseGrouper._apply_to_group
             res = func(group)
             res = libreduction.extract_result(res)
 
-            if result is None:
+            if not initialized:
                 # We only do this validation on the first iteration
                 libreduction.check_result_array(res, 0)
-                result = np.empty(ngroups, dtype="O")
+                initialized = True
 
             counts[label] = group.shape[0]
             result[label] = res
 
-        assert result is not None
         result = lib.maybe_convert_objects(result, try_float=0)
         # TODO: maybe_cast_to_extension_array?
 


### PR DESCRIPTION
Get rid of a few of the small behavior differences between these

(entirely disabling the cython path leads to 4 currently-xfailed tests passing, so there is still some subtle difference after this)