### PR TITLE
CI: add pre-commit action, include pyupgrade

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,23 +3,19 @@ repos:
     rev: 19.10b0
     hooks:
     -   id: black
-        language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:
     -   id: flake8
-        language: python_venv
         additional_dependencies: [flake8-comprehensions>=3.1.0]
     -   id: flake8
         name: flake8-pyx
-        language: python_venv
         files: \.(pyx|pxd)$
         types:
           - file
         args: [--append-config=flake8/cython.cfg]
     -   id: flake8
         name: flake8-pxd
-        language: python_venv
         files: \.pxi\.in$
         types:
           - file
@@ -28,5 +24,9 @@ repos:
     rev: v5.2.2
     hooks:
     -   id: isort
-        language: python_venv
         exclude: ^pandas/__init__\.py$|^pandas/core/api\.py$
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.2
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
         types:
           - file
         args: [--append-config=flake8/cython-template.cfg]
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.2.2
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.2.2
     hooks:
     -   id: isort
         exclude: ^pandas/__init__\.py$|^pandas/core/api\.py$

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -48,38 +48,6 @@ fi
 ### LINTING ###
 if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
 
-    echo "black --version"
-    black --version
-
-    MSG='Checking black formatting' ; echo $MSG
-    black . --check
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
-    # `setup.cfg` contains the list of error codes that are being ignored in flake8
-
-    echo "flake8 --version"
-    flake8 --version
-
-    # pandas/_libs/src is C code, so no need to search there.
-    MSG='Linting .py code' ; echo $MSG
-    flake8 --format="$FLAKE8_FORMAT" .
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
-    MSG='Linting .pyx and .pxd code' ; echo $MSG
-    flake8 --format="$FLAKE8_FORMAT" pandas --append-config=flake8/cython.cfg
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
-    MSG='Linting .pxi.in' ; echo $MSG
-    flake8 --format="$FLAKE8_FORMAT" pandas/_libs --append-config=flake8/cython-template.cfg
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
-    echo "flake8-rst --version"
-    flake8-rst --version
-
-    MSG='Linting code-blocks in .rst documentation' ; echo $MSG
-    flake8-rst doc/source --filename=*.rst --format="$FLAKE8_FORMAT"
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
     # Check that cython casting is of the form `<type>obj` as opposed to `<type> obj`;
     # it doesn't make a difference, but we want to be internally consistent.
     # Note: this grep pattern is (intended to be) equivalent to the python
@@ -129,19 +97,6 @@ if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
         $BASE_DIR/scripts/validate_unwanted_patterns.py --validation-type="private_function_across_module" --included-file-extensions="py" --excluded-file-paths=pandas/tests,asv_bench/,pandas/_vendored,doc/ --format="##[error]{source_path}:{line_number}:{msg}" pandas/
     else
         $BASE_DIR/scripts/validate_unwanted_patterns.py --validation-type="private_function_across_module" --included-file-extensions="py" --excluded-file-paths=pandas/tests,asv_bench/,pandas/_vendored,doc/ pandas/
-    fi
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
-    echo "isort --version-number"
-    isort --version-number
-
-    # Imports - Check formatting using isort see setup.cfg for settings
-    MSG='Check import format using isort' ; echo $MSG
-    ISORT_CMD="isort --quiet --check-only pandas asv_bench scripts web"
-    if [[ "$GITHUB_ACTIONS" == "true" ]]; then
-        eval $ISORT_CMD | awk '{print "##[error]" $0}'; RET=$(($RET + ${PIPESTATUS[0]}))
-    else
-        eval $ISORT_CMD
     fi
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -48,6 +48,13 @@ fi
 ### LINTING ###
 if [[ -z "$CHECK" || "$CHECK" == "lint" ]]; then
 
+    echo "flake8-rst --version"
+    flake8-rst --version
+
+    MSG='Linting code-blocks in .rst documentation' ; echo $MSG
+    flake8-rst doc/source --filename=*.rst --format="$FLAKE8_FORMAT"
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
+
     # Check that cython casting is of the form `<type>obj` as opposed to `<type> obj`;
     # it doesn't make a difference, but we want to be internally consistent.
     # Note: this grep pattern is (intended to be) equivalent to the python

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -634,6 +634,10 @@ do not make sudden changes to the code that could have the potential to break
 a lot of user code as a result, that is, we need it to be as *backwards compatible*
 as possible to avoid mass breakages.
 
+In addition to `./ci/code_checks.sh`, some extra checks are run by
+``pre-commit`` - see :ref:`here <contributing.pre-commit>` for how to
+run them.
+
 Additional standards are outlined on the :ref:`pandas code style guide <code_style>`
 
 Optional dependencies
@@ -825,6 +829,13 @@ In addition, using this pre-commit hook will also allow you to more easily
 remain up-to-date with our code checks as they change.
 
 Note that if needed, you can skip these checks with ``git commit --no-verify``.
+
+If you don't want to use ``pre-commit`` as part of your workflow, you can still use it
+to run its checks by running::
+
+    pre-commit run --files <files you have modified>
+
+without having to have done ``pre-commit install`` beforehand.
 
 Backwards compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -634,7 +634,7 @@ do not make sudden changes to the code that could have the potential to break
 a lot of user code as a result, that is, we need it to be as *backwards compatible*
 as possible to avoid mass breakages.
 
-In addition to `./ci/code_checks.sh`, some extra checks are run by
+In addition to ``./ci/code_checks.sh``, some extra checks are run by
 ``pre-commit`` - see :ref:`here <contributing.pre-commit>` for how to
 run them.
 

--- a/doc/sphinxext/announce.py
+++ b/doc/sphinxext/announce.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- encoding:utf-8 -*-
 """
 Script to generate contributor and pull request lists
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - flake8-rst>=0.6.0,<=0.7.0  # linting of code blocks in rst files
   - isort>=5.2.1  # check that imports are in the right order
   - mypy=0.782
+  - pre-commit
   - pycodestyle  # used by flake8
   - pyupgrade
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - isort>=5.2.1  # check that imports are in the right order
   - mypy=0.782
   - pycodestyle  # used by flake8
+  - pyupgrade
 
   # documentation
   - gitpython  # obtain contributors from git for whatsnew

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,9 @@ flake8-comprehensions>=3.1.0
 flake8-rst>=0.6.0,<=0.7.0
 isort>=5.2.1
 mypy==0.782
+pre-commit
 pycodestyle
+pyupgrade
 gitpython
 gitdb
 sphinx


### PR DESCRIPTION
xref this comment https://github.com/pandas-dev/pandas/issues/36426#issuecomment-694238629 by @TomAugspurger 

> I would recommend running the linting commands on CI through pre-commit. That way the versions in .pre-commit-config.yaml are used everywhere.

So, this PR does that.

It also adds pyupgrade as a pre-commit hook (xref #36450 ) and removes some unnecessary configurations from the `.pre-commit-config.yaml` file (all of these hooks already specify `language: python`, see e.g. https://github.com/psf/black/blob/master/.pre-commit-hooks.yaml )

TODO
----
update https://pandas.pydata.org/docs/development/contributing.html#code-standards (thanks Ali!)