### PR TITLE
Turn on stale PR GitHub action

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -18,4 +18,4 @@ jobs:
         days-before-stale: 30
         days-before-close: -1
         remove-stale-when-updated: true
-        debug-only: true
+        debug-only: false


### PR DESCRIPTION
I think it makes sense to turn this on now (it's only labeling stale PRs for now, and after doing a lot of this manually it seems to have calmed down). Later can add some sort of friendly reminder to update the PR. Also rather than closing these stalled PRs I'm wondering if they could serve as starting points for new contributors who want to pick up where someone else left off.

Some recent workflows here (you can search for the string "Marking" in the logs to find PRs that would have been labeled): https://github.com/pandas-dev/pandas/actions?query=workflow%3A%22Stale+PRs%22

@simonjayhawkins You'd mentioned doing this more frequently in debug mode, would you prefer longer intervals when running live?