### PR TITLE
CLN: Use https for @tm.network

### DIFF
--- a/pandas/_testing.py
+++ b/pandas/_testing.py
@@ -2404,7 +2404,7 @@ def can_connect(url, error_classes=None):
 @optional_args
 def network(
     t,
-    url="http://www.google.com",
+    url="https://www.google.com",
     raise_on_error=_RAISE_NETWORK_ERROR_DEFAULT,
     check_before_test=False,
     error_classes=None,
@@ -2428,7 +2428,7 @@ def network(
         The test requiring network connectivity.
     url : path
         The url to test via ``pandas.io.common.urlopen`` to check
-        for connectivity. Defaults to 'http://www.google.com'.
+        for connectivity. Defaults to 'https://www.google.com'.
     raise_on_error : bool
         If True, never catches errors.
     check_before_test : bool
@@ -2472,7 +2472,7 @@ def network(
 
       You can specify alternative URLs::
 
-        >>> @network("http://www.yahoo.com")
+        >>> @network("https://www.yahoo.com")
         ... def test_something_with_yahoo():
         ...    raise IOError("Failure Message")
         >>> test_something_with_yahoo()


### PR DESCRIPTION
- [x] ref #36467

 AssertionError: Caused unexpected warning(s): [('ResourceWarning', ResourceWarning("unclosed <ssl.SSLSocket fd=18, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('10.20.0.43', 54722), raddr=('**172.217.204.95**', 443)>"), ), 

**This is a google address** -> which leads me to believe this resource warning is coming from our `network` function in `_testing.py` since it calls `urllib.request.urlopen("https://www.google.com")` 

Note: this doesn't solve the problem but we should use https. (Avoids a redirect)