### PR TITLE
Don't unlabel stale PR on update

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -17,5 +17,5 @@ jobs:
         exempt-pr-labels: "Needs Review,Blocked,Needs Discussion"
         days-before-stale: 30
         days-before-close: -1
-        remove-stale-when-updated: true
+        remove-stale-when-updated: false
         debug-only: false


### PR DESCRIPTION
Apparently the bot unlabels on any activity (not just activity from the owner), e.g., https://github.com/pandas-dev/pandas/pull/34584#issuecomment-693107104, so if you ask the person for an update and they don't respond, the PR is no longer stale. Probably better to do this manually for now.