### PR TITLE
PERF: DataFrame initialisation with dict with single key/value pair

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -223,6 +223,7 @@ Performance improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Performance improvements when creating DataFrame or Series with dtype `str` or :class:`StringDtype` from array with many string elements (:issue:`36304`, :issue:`36317`, :issue:`36325`, :issue:`36432`)
+- Performance improvements when creating a DataFrame from a dict with a single key/value pair (:issue:`xxxxx`)
 - Performance improvement in :meth:`GroupBy.agg` with the ``numba`` engine (:issue:`35759`)
 - Performance improvements when creating :meth:`pd.Series.map` from a huge dictionary (:issue:`34717`)
 - Performance improvement in :meth:`GroupBy.transform` with the ``numba`` engine (:issue:`36240`)

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1803,13 +1803,18 @@ def _stack_arrays(tuples, dtype):
             return x.shape
 
     placement, names, arrays = zip(*tuples)
-
+    arrays = [_asarray_compat(arr) for arr in arrays]
     first = arrays[0]
+
+    if len(arrays) == 1:
+        assert first.ndim == 1
+        return first[np.newaxis, ...], placement
+
     shape = (len(arrays),) + _shape_compat(first)
 
     stacked = np.empty(shape, dtype=dtype)
     for i, arr in enumerate(arrays):
-        stacked[i] = _asarray_compat(arr)
+        stacked[i] = arr
 
     return stacked, placement
 


### PR DESCRIPTION
Faster initialisation of DataFrames, when the data is a single-item dict:

```python
>>> x = np.arange(1_000_000)
>>> %timeit pd.DataFrame(dict(a=x))
2.16 ms ± 66.7 µs per loop  # master
282 µs ± 4.63 µs per loop  # this PR
>>> x = np.array([str(u) for u in range(1_000_000)], dtype=object)
>>> %timeit pd.DataFrame(dict(a=x))
29.5 ms ± 131 µs per loop  # master
12.6 ms ± 55.8 µs per loop  # this PR
```

I don't think it's possible to optimize the case with more than 1 key/value pair, as concatenation will always take some time to perform.