### PR TITLE
BUG: Fix issue in preserving index name on empty DataFrame

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -35,6 +35,7 @@ Fixed regressions
 - Fixed regression in :meth:`Series.__getitem__` incorrectly raising when the input was a frozenset (:issue:`35747`)
 - Fixed regression in :meth:`read_excel` with ``engine="odf"`` caused ``UnboundLocalError`` in some cases where cells had nested child nodes (:issue:`36122`,:issue:`35802`)
 - Fixed regression in :class:`DataFrame` and :class:`Series` comparisons between numeric arrays and strings (:issue:`35700`,:issue:`36377`)
+- Fixed regression when setting empty :class:`DataFrame` column to a :class:`Series` in preserving name of index in frame (:issue:`36527`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3190,7 +3190,8 @@ class DataFrame(NDFrame):
 
             # GH31368 preserve name of index
             index_copy = value.index.copy()
-            index_copy.name = self.index.name
+            if self.index.name is not None:
+                index_copy.name = self.index.name
 
             self._mgr = self._mgr.reindex_axis(index_copy, axis=1, fill_value=np.nan)
 

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -680,4 +680,3 @@ class TestPartialSetting:
         expected = pd.DataFrame(
             {"series": [1.23] * 4}, index=pd.RangeIndex(4, name="series_index")
         )
-

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -672,3 +672,12 @@ class TestPartialSetting:
         )
 
         tm.assert_frame_equal(df, expected)
+
+        # GH 36527
+        df = pd.DataFrame()
+        series = pd.Series(1.23, index=pd.RangeIndex(4, name="series_index"))
+        df["series"] = series
+        expected = pd.DataFrame(
+            {"series": [1.23] * 4}, index=pd.RangeIndex(4, name="series_index")
+        )
+


### PR DESCRIPTION
- [x] closes #36527
- [x] tests added / passed
   - `tests/indexing/test_partial.py:tesst_index_name_empty`
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
   - v1.1.3
