### PR TITLE
CLN: remove not existing argument

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -278,7 +278,6 @@ def _check_object_for_strings(values) -> str:
     Parameters
     ----------
     values : ndarray
-    ndtype : str
 
     Returns
     -------


### PR DESCRIPTION
Small clean up of argument in docstrings which is not present in function.
