### PR TITLE
REF: de-duplicate Categorical validators

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1177,13 +1177,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject):
         return self._validate_listlike(value)
 
     def _validate_insert_value(self, value) -> int:
-        code = self.categories.get_indexer([value])
-        if (code == -1) and not (is_scalar(value) and isna(value)):
-            raise TypeError(
-                "cannot insert an item into a CategoricalIndex "
-                "that is not already an existing category"
-            )
-        return code[0]
+        return self._validate_fill_value(value)
 
     def _validate_searchsorted_value(self, value):
         # searchsorted is very performance sensitive. By converting codes
@@ -1213,7 +1207,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject):
         ValueError
         """
 
-        if isna(fill_value):
+        if is_valid_nat_for_dtype(fill_value, self.categories.dtype):
             fill_value = -1
         elif fill_value in self.categories:
             fill_value = self._unbox_scalar(fill_value)

--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -171,11 +171,8 @@ class TestCategoricalIndex(Base):
         tm.assert_index_equal(result, expected, exact=True)
 
         # invalid
-        msg = (
-            "cannot insert an item into a CategoricalIndex that is not "
-            "already an existing category"
-        )
-        with pytest.raises(TypeError, match=msg):
+        msg = "'fill_value=d' is not present in this Categorical's categories"
+        with pytest.raises(ValueError, match=msg):
             ci.insert(0, "d")
 
         # GH 18295 (test missing)
@@ -183,6 +180,12 @@ class TestCategoricalIndex(Base):
         for na in (np.nan, pd.NaT, None):
             result = CategoricalIndex(list("aabcb")).insert(1, na)
             tm.assert_index_equal(result, expected)
+
+    def test_insert_na_mismatched_dtype(self):
+        ci = pd.CategoricalIndex([0, 1, 1])
+        msg = "'fill_value=NaT' is not present in this Categorical's categories"
+        with pytest.raises(ValueError, match=msg):
+            ci.insert(0, pd.NaT)
 
     def test_delete(self):
 

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -76,9 +76,10 @@ class TestCategoricalIndex:
             "cannot insert an item into a CategoricalIndex that is not "
             "already an existing category"
         )
-        with pytest.raises(TypeError, match=msg):
+        msg = "'fill_value=d' is not present in this Categorical's categories"
+        with pytest.raises(ValueError, match=msg):
             df.loc["d", "A"] = 10
-        with pytest.raises(TypeError, match=msg):
+        with pytest.raises(ValueError, match=msg):
             df.loc["d", "C"] = 10
 
         with pytest.raises(KeyError, match="^1$"):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
