### PR TITLE
[BUG]: Fix regression in read_table with delim_whitespace=True

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -37,7 +37,7 @@ Fixed regressions
 - Fixed regression in :class:`DataFrame` and :class:`Series` comparisons between numeric arrays and strings (:issue:`35700`,:issue:`36377`)
 - Fixed regression when setting empty :class:`DataFrame` column to a :class:`Series` in preserving name of index in frame (:issue:`36527`)
 - Fixed regression in :class:`Period` incorrect value for ordinal over the maximum timestamp (:issue:`36430`)
-- Fixed regression in :meth:`read_table()` raised ``ValueError`` when ``delim_whitespace`` was set to ``True`` (:issue:`35958`)
+- Fixed regression in :func:`read_table` raised ``ValueError`` when ``delim_whitespace`` was set to ``True`` (:issue:`35958`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -36,6 +36,7 @@ Fixed regressions
 - Fixed regression in :meth:`read_excel` with ``engine="odf"`` caused ``UnboundLocalError`` in some cases where cells had nested child nodes (:issue:`36122`,:issue:`35802`)
 - Fixed regression in :class:`DataFrame` and :class:`Series` comparisons between numeric arrays and strings (:issue:`35700`,:issue:`36377`)
 - Fixed regression when setting empty :class:`DataFrame` column to a :class:`Series` in preserving name of index in frame (:issue:`36527`)
+- Fixed regression in :meth:`read_table()` raised ``ValueError`` when ``delim_whitespace`` was set to ``True`` (:issue:`35958`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -757,6 +757,8 @@ def read_table(
     memory_map=False,
     float_precision=None,
 ):
+    if delim_whitespace:
+        sep = ","
     return read_csv(**locals())
 
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -763,7 +763,7 @@ def read_table(
             "Specified a delimiter with both sep and "
             "delim_whitespace=True; you can only specify one."
         )
-    if delim_whitespace and sep == "\t":
+    if delim_whitespace:
         # In this case sep is not used so we set it to the read_csv
         # default to avoid a ValueError
         sep = ","

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -758,6 +758,8 @@ def read_table(
     float_precision=None,
 ):
     if delim_whitespace and sep == "\t":
+        # In this case sep is not used so we set it to the read_csv
+        # default to avoid a ValueError
         sep = ","
     return read_csv(**locals())
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -757,7 +757,7 @@ def read_table(
     memory_map=False,
     float_precision=None,
 ):
-    if delim_whitespace:
+    if delim_whitespace and sep == "\t":
         sep = ","
     return read_csv(**locals())
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -757,6 +757,12 @@ def read_table(
     memory_map=False,
     float_precision=None,
 ):
+    # TODO: validation duplicated in read_csv
+    if delim_whitespace and (delimiter is not None or sep != "\t"):
+        raise ValueError(
+            "Specified a delimiter with both sep and "
+            "delim_whitespace=True; you can only specify one."
+        )
     if delim_whitespace and sep == "\t":
         # In this case sep is not used so we set it to the read_csv
         # default to avoid a ValueError

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2215,7 +2215,9 @@ def test_read_table_delim_whitespace_non_default_sep(all_parsers):
     # GH: 35958
     f = StringIO("a  b  c\n1 -2 -3\n4  5   6")
     parser = all_parsers
-    msg = "Specified a delimiter with both sep and " \
-          "delim_whitespace=True; you can only specify one."
+    msg = (
+        "Specified a delimiter with both sep and "
+        "delim_whitespace=True; you can only specify one."
+    )
     with pytest.raises(ValueError, match=msg):
         parser.read_table(f, delim_whitespace=True, sep=",")

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2200,3 +2200,12 @@ def test_read_csv_with_use_inf_as_na(all_parsers):
         result = parser.read_csv(StringIO(data), header=None)
     expected = DataFrame([1.0, np.nan, 3.0])
     tm.assert_frame_equal(result, expected)
+
+
+def test_read_table_delim_whitespace_default_sep(all_parsers):
+    # GH: 35958
+    f = StringIO("a  b  c\n1 -2 -3\n4  5   6")
+    parser = all_parsers
+    result = parser.read_table(f, delim_whitespace=True)
+    expected = DataFrame({"a": [1, 4], "b": [-2, 5], "c": [-3, 6]})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2209,3 +2209,13 @@ def test_read_table_delim_whitespace_default_sep(all_parsers):
     result = parser.read_table(f, delim_whitespace=True)
     expected = DataFrame({"a": [1, 4], "b": [-2, 5], "c": [-3, 6]})
     tm.assert_frame_equal(result, expected)
+
+
+def test_read_table_delim_whitespace_non_default_sep(all_parsers):
+    # GH: 35958
+    f = StringIO("a  b  c\n1 -2 -3\n4  5   6")
+    parser = all_parsers
+    msg = "Specified a delimiter with both sep and " \
+          "delim_whitespace=True; you can only specify one."
+    with pytest.raises(ValueError, match=msg):
+        parser.read_table(f, delim_whitespace=True, sep=",")


### PR DESCRIPTION
- [x] closes #35958
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

We could write a private function which is called from read_csv and read_table with the appropriate default_set alternatively.

Edit: Black_pandas formats files not touched by myself. Was there an update or change of guidelines?