### PR TITLE
REF: refactor/cleanup of CSSToExcelConverter

### DIFF
--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -274,8 +274,6 @@ class CSSToExcelConverter:
             "name": font_names[0] if font_names else None,
             "family": self._select_font_family(font_names),
             "size": self._get_font_size(props),
-            # Ignored mypy errors because of changed get.
-            # Link to mypy issue: https://github.com/python/mypy/issues/9430
             "bold": self._get_is_bold(props),
             "italic": self._get_is_italic(props),
             "underline": ("single" if "underline" in decoration else None),

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -225,14 +225,12 @@ class CSSToExcelConverter:
         if width_name is None:
             return None
 
-        if style in (None, "groove", "ridge", "inset", "outset"):
+        if style in (None, "groove", "ridge", "inset", "outset", "solid"):
             # not handled
-            style = "solid"
+            return width_name
 
         if style == "double":
             return "double"
-        if style == "solid":
-            return width_name
         if style == "dotted":
             if width_name in ("hair", "thin"):
                 return "dotted"

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -257,6 +257,9 @@ class CSSToExcelConverter:
         if fill_color not in (None, "transparent", "none"):
             return {"fgColor": self.color_to_excel(fill_color), "patternType": "solid"}
 
+    def build_number_format(self, props: Dict) -> Dict[str, Optional[str]]:
+        return {"format_code": props.get("number-format")}
+
     def build_font(self, props) -> Dict[str, Optional[Union[bool, int, float, str]]]:
         decoration = props.get("text-decoration")
         if decoration is not None:
@@ -342,9 +345,6 @@ class CSSToExcelConverter:
             return self.NAMED_COLORS[val]
         except KeyError:
             warnings.warn(f"Unhandled color format: {repr(val)}", CSSWarning)
-
-    def build_number_format(self, props: Dict) -> Dict[str, Optional[str]]:
-        return {"format_code": props.get("number-format")}
 
 
 class ExcelFormatter:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -198,6 +198,7 @@ class CSSToExcelConverter:
                 return "dashed"
             return "mediumDashed"
 
+
     def build_fill(self, props: Dict[str, str]):
         # TODO: perhaps allow for special properties
         #       -excel-pattern-bgcolor and -excel-pattern-type
@@ -251,19 +252,17 @@ class CSSToExcelConverter:
             if name:
                 font_names.append(name)
 
+        family_mapping = {
+            "serif": 1,  # roman
+            "sans-serif": 2,  # swiss
+            "cursive": 4,  # script
+            "fantasy": 5,  # decorative
+        }
+
         family = None
         for name in font_names:
-            if name == "serif":
-                family = 1  # roman
-                break
-            elif name == "sans-serif":
-                family = 2  # swiss
-                break
-            elif name == "cursive":
-                family = 4  # script
-                break
-            elif name == "fantasy":
-                family = 5  # decorative
+            family = family_mapping.get(name)
+            if family:
                 break
 
         decoration = props.get("text-decoration")

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -189,7 +189,7 @@ class CSSToExcelConverter:
             ),
         }
 
-    def build_border(self, props: Dict) -> Dict[str, Dict[str, str]]:
+    def build_border(self, props: Dict) -> Dict[str, Dict[str, Optional[str]]]:
         return {
             side: {
                 "style": self._border_style(
@@ -339,7 +339,7 @@ class CSSToExcelConverter:
 
         return family
 
-    def color_to_excel(self, val: Optional[str]):
+    def color_to_excel(self, val: Optional[str]) -> Optional[str]:
         if val is None:
             return None
         if val.startswith("#") and len(val) == 7:
@@ -350,6 +350,7 @@ class CSSToExcelConverter:
             return self.NAMED_COLORS[val]
         except KeyError:
             warnings.warn(f"Unhandled color format: {repr(val)}", CSSWarning)
+        return None
 
 
 class ExcelFormatter:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -226,7 +226,7 @@ class CSSToExcelConverter:
         size = props.get("font-size")
         if size is not None:
             assert size.endswith("pt")
-            size = float(size[:-2])
+            size = float(size.rstrip("pt"))
 
         font_names_tmp = re.findall(
             r"""(?x)

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -198,7 +198,6 @@ class CSSToExcelConverter:
                 return "dashed"
             return "mediumDashed"
 
-
     def build_fill(self, props: Dict[str, str]):
         # TODO: perhaps allow for special properties
         #       -excel-pattern-bgcolor and -excel-pattern-type
@@ -252,19 +251,6 @@ class CSSToExcelConverter:
             if name:
                 font_names.append(name)
 
-        family_mapping = {
-            "serif": 1,  # roman
-            "sans-serif": 2,  # swiss
-            "cursive": 4,  # script
-            "fantasy": 5,  # decorative
-        }
-
-        family = None
-        for name in font_names:
-            family = family_mapping.get(name)
-            if family:
-                break
-
         decoration = props.get("text-decoration")
         if decoration is not None:
             decoration = decoration.split()
@@ -273,7 +259,7 @@ class CSSToExcelConverter:
 
         return {
             "name": font_names[0] if font_names else None,
-            "family": family,
+            "family": self._select_font_family(font_names),
             "size": size,
             "bold": self.BOLD_MAP.get(props.get("font-weight")),
             "italic": self.ITALIC_MAP.get(props.get("font-style")),
@@ -316,6 +302,22 @@ class CSSToExcelConverter:
         "silver": "C0C0C0",
         "white": "FFFFFF",
     }
+
+    def _select_font_family(self, font_names):
+        family_mapping = {
+            "serif": 1,  # roman
+            "sans-serif": 2,  # swiss
+            "cursive": 4,  # script
+            "fantasy": 5,  # decorative
+        }
+
+        family = None
+        for name in font_names:
+            family = family_mapping.get(name)
+            if family:
+                break
+
+        return family
 
     def color_to_excel(self, val: Optional[str]):
         if val is None:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -342,15 +342,38 @@ class CSSToExcelConverter:
     def color_to_excel(self, val: Optional[str]) -> Optional[str]:
         if val is None:
             return None
-        if val.startswith("#") and len(val) == 7:
-            return val[1:].upper()
-        if val.startswith("#") and len(val) == 4:
-            return (val[1] * 2 + val[2] * 2 + val[3] * 2).upper()
+
+        if self._is_hex_color(val):
+            return self._convert_hex_to_excel(val)
+
         try:
             return self.NAMED_COLORS[val]
         except KeyError:
             warnings.warn(f"Unhandled color format: {repr(val)}", CSSWarning)
         return None
+
+    def _is_hex_color(self, color_string: str) -> bool:
+        return bool(color_string.startswith("#"))
+
+    def _convert_hex_to_excel(self, color_string: str) -> str:
+        code = color_string.lstrip("#")
+        if self._is_shorthand_color(color_string):
+            return (code[0] * 2 + code[1] * 2 + code[2] * 2).upper()
+        else:
+            return code.upper()
+
+    def _is_shorthand_color(self, color_string: str) -> bool:
+        """Check if color code is shorthand.
+
+        #FFF is a shorthand as opposed to full #FFFFFF.
+        """
+        code = color_string.lstrip("#")
+        if len(code) == 3:
+            return True
+        elif len(code) == 6:
+            return False
+        else:
+            raise ValueError(f"Unexpected color {color_string}")
 
 
 class ExcelFormatter:

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -264,8 +264,11 @@ class CSSToExcelConverter:
     def _width_to_float(self, width: Optional[str]) -> float:
         if width is None:
             width = "2pt"
-        assert width.endswith("pt")
-        return float(width.rstrip("pt"))
+        return self._pt_to_float(width)
+
+    def _pt_to_float(self, pt_string: str) -> float:
+        assert pt_string.endswith("pt")
+        return float(pt_string.rstrip("pt"))
 
     def build_fill(self, props: Mapping[str, str]):
         # TODO: perhaps allow for special properties
@@ -360,8 +363,7 @@ class CSSToExcelConverter:
         size = props.get("font-size")
         if size is None:
             return size
-        assert size.endswith("pt")
-        return float(size.rstrip("pt"))
+        return self._pt_to_float(size)
 
     def _select_font_family(self, font_names) -> Optional[int]:
         family = None

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -58,6 +58,68 @@ class CSSToExcelConverter:
         CSS processed by :meth:`__call__`.
     """
 
+    NAMED_COLORS = {
+        "maroon": "800000",
+        "brown": "A52A2A",
+        "red": "FF0000",
+        "pink": "FFC0CB",
+        "orange": "FFA500",
+        "yellow": "FFFF00",
+        "olive": "808000",
+        "green": "008000",
+        "purple": "800080",
+        "fuchsia": "FF00FF",
+        "lime": "00FF00",
+        "teal": "008080",
+        "aqua": "00FFFF",
+        "blue": "0000FF",
+        "navy": "000080",
+        "black": "000000",
+        "gray": "808080",
+        "grey": "808080",
+        "silver": "C0C0C0",
+        "white": "FFFFFF",
+    }
+
+    VERTICAL_MAP = {
+        "top": "top",
+        "text-top": "top",
+        "middle": "center",
+        "baseline": "bottom",
+        "bottom": "bottom",
+        "text-bottom": "bottom",
+        # OpenXML also has 'justify', 'distributed'
+    }
+
+    BOLD_MAP = {
+        "bold": True,
+        "bolder": True,
+        "600": True,
+        "700": True,
+        "800": True,
+        "900": True,
+        "normal": False,
+        "lighter": False,
+        "100": False,
+        "200": False,
+        "300": False,
+        "400": False,
+        "500": False,
+    }
+
+    ITALIC_MAP = {
+        "normal": False,
+        "italic": True,
+        "oblique": True,
+    }
+
+    FAMILY_MAP = {
+        "serif": 1,  # roman
+        "sans-serif": 2,  # swiss
+        "cursive": 4,  # script
+        "fantasy": 5,  # decorative
+    }
+
     # NB: Most of the methods here could be classmethods, as only __init__
     #     and __call__ make use of instance attributes.  We leave them as
     #     instancemethods so that users can easily experiment with extensions
@@ -114,16 +176,6 @@ class CSSToExcelConverter:
 
         remove_none(out)
         return out
-
-    VERTICAL_MAP = {
-        "top": "top",
-        "text-top": "top",
-        "middle": "center",
-        "baseline": "bottom",
-        "bottom": "bottom",
-        "text-bottom": "bottom",
-        # OpenXML also has 'justify', 'distributed'
-    }
 
     def build_alignment(self, props) -> Dict[str, Optional[Union[bool, str]]]:
         # TODO: text-indent, padding-left -> alignment.indent
@@ -205,23 +257,6 @@ class CSSToExcelConverter:
         if fill_color not in (None, "transparent", "none"):
             return {"fgColor": self.color_to_excel(fill_color), "patternType": "solid"}
 
-    BOLD_MAP = {
-        "bold": True,
-        "bolder": True,
-        "600": True,
-        "700": True,
-        "800": True,
-        "900": True,
-        "normal": False,
-        "lighter": False,
-        "100": False,
-        "200": False,
-        "300": False,
-        "400": False,
-        "500": False,
-    }
-    ITALIC_MAP = {"normal": False, "italic": True, "oblique": True}
-
     def build_font(self, props) -> Dict[str, Optional[Union[bool, int, float, str]]]:
         decoration = props.get("text-decoration")
         if decoration is not None:
@@ -253,29 +288,6 @@ class CSSToExcelConverter:
             # 'outline': ,
             # 'condense': ,
         }
-
-    NAMED_COLORS = {
-        "maroon": "800000",
-        "brown": "A52A2A",
-        "red": "FF0000",
-        "pink": "FFC0CB",
-        "orange": "FFA500",
-        "yellow": "FFFF00",
-        "olive": "808000",
-        "green": "008000",
-        "purple": "800080",
-        "fuchsia": "FF00FF",
-        "lime": "00FF00",
-        "teal": "008080",
-        "aqua": "00FFFF",
-        "blue": "0000FF",
-        "navy": "000080",
-        "black": "000000",
-        "gray": "808080",
-        "grey": "808080",
-        "silver": "C0C0C0",
-        "white": "FFFFFF",
-    }
 
     def _get_font_names(self, props: Mapping[str, str]) -> Sequence[str]:
         font_names_tmp = re.findall(
@@ -311,16 +323,9 @@ class CSSToExcelConverter:
         return float(size.rstrip("pt"))
 
     def _select_font_family(self, font_names) -> Optional[int]:
-        family_mapping = {
-            "serif": 1,  # roman
-            "sans-serif": 2,  # swiss
-            "cursive": 4,  # script
-            "fantasy": 5,  # decorative
-        }
-
         family = None
         for name in font_names:
-            family = family_mapping.get(name)
+            family = self.FAMILY_MAP.get(name)
             if family:
                 break
 

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -182,12 +182,13 @@ class CSSToExcelConverter:
         return {
             "horizontal": props.get("text-align"),
             "vertical": self.VERTICAL_MAP.get(props.get("vertical-align")),
-            "wrap_text": (
-                None
-                if props.get("white-space") is None
-                else props["white-space"] not in ("nowrap", "pre", "pre-line")
-            ),
+            "wrap_text": self._get_is_wrap_text(props),
         }
+
+    def _get_is_wrap_text(self, props: Mapping[str, str]) -> Optional[bool]:
+        if props.get("white-space") is None:
+            return None
+        return bool(props["white-space"] not in ("nowrap", "pre", "pre-line"))
 
     def build_border(self, props: Dict) -> Dict[str, Dict[str, Optional[str]]]:
         return {

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -201,7 +201,7 @@ class CSSToExcelConverter:
             for side in ["top", "right", "bottom", "left"]
         }
 
-    def _border_style(self, style: Optional[str], width):
+    def _border_style(self, style: Optional[str], width: Optional[str]):
         # convert styles and widths to openxml, one of:
         #       'dashDot'
         #       'dashDotDot'
@@ -221,17 +221,9 @@ class CSSToExcelConverter:
         if style == "none" or style == "hidden":
             return None
 
-        if width is None:
-            width = "2pt"
-        width = float(width[:-2])
-        if width < 1e-5:
+        width_name = self._get_width_name(width)
+        if width_name is None:
             return None
-        elif width < 1.3:
-            width_name = "thin"
-        elif width < 2.8:
-            width_name = "medium"
-        else:
-            width_name = "thick"
 
         if style in (None, "groove", "ridge", "inset", "outset"):
             # not handled
@@ -249,6 +241,21 @@ class CSSToExcelConverter:
             if width_name in ("hair", "thin"):
                 return "dashed"
             return "mediumDashed"
+
+    def _get_width_name(self, width_input: Optional[str]) -> Optional[str]:
+        width = self._width_to_float(width_input)
+        if width < 1e-5:
+            return None
+        elif width < 1.3:
+            return "thin"
+        elif width < 2.8:
+            return "medium"
+        return "thick"
+
+    def _width_to_float(self, width: Optional[str]) -> float:
+        if width is None:
+            width = "2pt"
+        return float(width[:-2])
 
     def build_fill(self, props: Dict[str, str]):
         # TODO: perhaps allow for special properties

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -264,7 +264,8 @@ class CSSToExcelConverter:
     def _width_to_float(self, width: Optional[str]) -> float:
         if width is None:
             width = "2pt"
-        return float(width[:-2])
+        assert width.endswith("pt")
+        return float(width.rstrip("pt"))
 
     def build_fill(self, props: Mapping[str, str]):
         # TODO: perhaps allow for special properties

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -266,13 +266,8 @@ class CSSToExcelConverter:
         return {"format_code": props.get("number-format")}
 
     def build_font(self, props) -> Dict[str, Optional[Union[bool, int, float, str]]]:
-        decoration = props.get("text-decoration")
-        if decoration is not None:
-            decoration = decoration.split()
-        else:
-            decoration = ()
-
         font_names = self._get_font_names(props)
+        decoration = self._get_decoration(props)
 
         return {
             "name": font_names[0] if font_names else None,
@@ -296,6 +291,13 @@ class CSSToExcelConverter:
             # 'outline': ,
             # 'condense': ,
         }
+
+    def _get_decoration(self, props: Mapping[str, str]) -> Sequence[str]:
+        decoration = props.get("text-decoration")
+        if decoration is not None:
+            return decoration.split()
+        else:
+            return ()
 
     def _get_font_names(self, props: Mapping[str, str]) -> Sequence[str]:
         font_names_tmp = re.findall(


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Refactor/clean up of ``CSSToExcelConverter`` in module ``pandas.io.formats.excel``.

- Move class variables to the top of the class
- Add font family mapping
- Extract methods
- Add missing typing
- Make color parsing cleaner