### PR TITLE
numpy version in py36_locale_slow_old_np on 1.1.x

### DIFF
--- a/ci/deps/azure-36-32bit.yaml
+++ b/ci/deps/azure-36-32bit.yaml
@@ -15,7 +15,7 @@ dependencies:
   - attrs=19.1.0
   - gcc_linux-32
   - gxx_linux-32
-  - numpy=1.14.*
+  - numpy=1.15.4
   - python-dateutil
   - pytz=2017.2
 

--- a/ci/deps/azure-36-locale_slow.yaml
+++ b/ci/deps/azure-36-locale_slow.yaml
@@ -17,7 +17,7 @@ dependencies:
   - bottleneck=1.2.*
   - lxml
   - matplotlib=2.2.2
-  - numpy=1.14.*
+  - numpy=1.15.4
   - openpyxl=2.5.7
   - python-dateutil
   - python-blosc


### PR DESCRIPTION
PR against 1.1.x

not sure if important but numpy version in https://dev.azure.com/pandas-dev/pandas/_build/results?buildId=43144&view=logs&jobId=a69e7846-138e-5465-0656-921e8964615b&j=a69e7846-138e-5465-0656-921e8964615b&t=56da51de-fd5a-5466-5244-b5f65d252624 is 1.19.2

xref #33729