### PR TITLE
BUG: handle multi-dimensional grouping better

### DIFF
--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -522,10 +522,7 @@ class Grouping:
                 if getattr(self.grouper, "ndim", 1) != 1:
                     t = self.name or str(type(self.grouper))
                     raise ValueError(f"Grouper for '{t}' not 1-dimensional")
-                self.grouper = self.index.map(self.grouper)
-
-                if isinstance(self.grouper, MultiIndex):
-                    self.grouper = self.grouper._values
+                self.grouper = self.index._transform_index(self.grouper)
 
                 if not (
                     hasattr(self.grouper, "__len__")

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -523,6 +523,10 @@ class Grouping:
                     t = self.name or str(type(self.grouper))
                     raise ValueError(f"Grouper for '{t}' not 1-dimensional")
                 self.grouper = self.index.map(self.grouper)
+
+                if isinstance(grouper, MultiIndex):
+                    self.grouper = grouper._values
+
                 if not (
                     hasattr(self.grouper, "__len__")
                     and len(self.grouper) == len(self.index)

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -522,7 +522,7 @@ class Grouping:
                 if getattr(self.grouper, "ndim", 1) != 1:
                     t = self.name or str(type(self.grouper))
                     raise ValueError(f"Grouper for '{t}' not 1-dimensional")
-                self.grouper = self.index._transform_index(self.grouper)
+                self.grouper = self.index.map(self.grouper)
 
                 if not (
                     hasattr(self.grouper, "__len__")

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -524,8 +524,8 @@ class Grouping:
                     raise ValueError(f"Grouper for '{t}' not 1-dimensional")
                 self.grouper = self.index.map(self.grouper)
 
-                if isinstance(grouper, MultiIndex):
-                    self.grouper = grouper._values
+                if isinstance(self.grouper, MultiIndex):
+                    self.grouper = self.grouper._values
 
                 if not (
                     hasattr(self.grouper, "__len__")

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -523,7 +523,6 @@ class Grouping:
                     t = self.name or str(type(self.grouper))
                     raise ValueError(f"Grouper for '{t}' not 1-dimensional")
                 self.grouper = self.index.map(self.grouper)
-
                 if not (
                     hasattr(self.grouper, "__len__")
                     and len(self.grouper) == len(self.index)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -125,6 +125,7 @@ class TestSelection:
         tm.assert_series_equal(result, expected)
 
     def test_indices_grouped_by_tuple_with_lambda(self):
+        # GH 36158
         df = pd.DataFrame(
             {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
         )
@@ -785,6 +786,7 @@ class TestGetGroup:
         tm.assert_frame_equal(result, expected)
 
     def test_get_group_grouped_by_tuple_with_lambda(self):
+        # GH 36158
         df = pd.DataFrame(
             {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
         )

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -408,14 +408,8 @@ class TestGrouping:
         # when the elements are Timestamp.
         # the result is Index[0:6], very confusing.
 
-        # GH36158
-        # issue references errors for groupby
-        # created with functions (lambda or named)
-        # after changes applied under that issue this test fails with a
-        # more sensible error than the previous assertion.
-
-        msg = r"'Timestamp' object is not subscriptable"
-        with pytest.raises(TypeError, match=msg):
+        msg = r"Grouper result violates len\(labels\) == len\(data\)"
+        with pytest.raises(AssertionError, match=msg):
             ts.groupby(lambda key: key[0:6])
 
     def test_grouping_error_on_multidim_input(self, df):

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -124,6 +124,15 @@ class TestSelection:
 
         tm.assert_series_equal(result, expected)
 
+    def test_indices_grouped_by_tuple_with_lambda(self):
+        df = pd.DataFrame({'Tuples': ((x, y)
+                                      for x in [0, 1]
+                                      for y in np.random.randint(3, 5, 5))})
+        gb = df.groupby('Tuples')
+        gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
+        expected = gb.indices
+        result = gb_lambda.indices
+        tm.assert_dict_equal(result, expected)
 
 # grouping
 # --------------------------------
@@ -773,6 +782,16 @@ class TestGetGroup:
         gr = df.groupby("ids")
         result = gr.get_group(("2010-01-01",))
         expected = DataFrame({"ids": [(dt[0],), (dt[0],)]}, index=[0, 2])
+        tm.assert_frame_equal(result, expected)
+
+    def test_get_group_grouped_by_tuple_with_lambda(self):
+        df = pd.DataFrame({'Tuples': ((x, y)
+                                      for x in [0, 1]
+                                      for y in np.random.randint(3, 5, 5))})
+        gb = df.groupby('Tuples')
+        gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
+        expected = gb.get_group(list(gb.groups.keys())[0])
+        result = gb_lambda.get_group(list(gb_lambda.groups.keys())[0])
         tm.assert_frame_equal(result, expected)
 
     def test_groupby_with_empty(self):

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -129,11 +129,15 @@ class TestSelection:
         df = pd.DataFrame(
             {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
         )
+
         gb = df.groupby("Tuples")
         gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
+
         expected = gb.indices
         result = gb_lambda.indices
+
         tm.assert_dict_equal(result, expected)
+
 
 # grouping
 # --------------------------------
@@ -790,10 +794,13 @@ class TestGetGroup:
         df = pd.DataFrame(
             {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
         )
+
         gb = df.groupby("Tuples")
         gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
+
         expected = gb.get_group(list(gb.groups.keys())[0])
         result = gb_lambda.get_group(list(gb_lambda.groups.keys())[0])
+
         tm.assert_frame_equal(result, expected)
 
     def test_groupby_with_empty(self):

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -408,8 +408,14 @@ class TestGrouping:
         # when the elements are Timestamp.
         # the result is Index[0:6], very confusing.
 
-        msg = r"Grouper result violates len\(labels\) == len\(data\)"
-        with pytest.raises(AssertionError, match=msg):
+        # GH36158
+        # issue references errors for groupby
+        # created with functions (lambda or named)
+        # after changes applied under that issue this test fails with a
+        # more sensible error than the previous assertion.
+
+        msg = r"'Timestamp' object is not subscriptable"
+        with pytest.raises(TypeError, match=msg):
             ts.groupby(lambda key: key[0:6])
 
     def test_grouping_error_on_multidim_input(self, df):

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -125,9 +125,9 @@ class TestSelection:
         tm.assert_series_equal(result, expected)
 
     def test_indices_grouped_by_tuple_with_lambda(self):
-        df = pd.DataFrame({'Tuples': ((x, y)
-                                      for x in [0, 1]
-                                      for y in np.random.randint(3, 5, 5))})
+        df = pd.DataFrame(
+            {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
+        )
         gb = df.groupby('Tuples')
         gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
         expected = gb.indices
@@ -785,9 +785,9 @@ class TestGetGroup:
         tm.assert_frame_equal(result, expected)
 
     def test_get_group_grouped_by_tuple_with_lambda(self):
-        df = pd.DataFrame({'Tuples': ((x, y)
-                                      for x in [0, 1]
-                                      for y in np.random.randint(3, 5, 5))})
+        df = pd.DataFrame(
+            {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
+        )
         gb = df.groupby('Tuples')
         gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
         expected = gb.get_group(list(gb.groups.keys())[0])

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -126,7 +126,7 @@ class TestSelection:
 
     def test_indices_grouped_by_tuple_with_lambda(self):
         # GH 36158
-        df = pd.DataFrame(
+        df = DataFrame(
             {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
         )
 
@@ -791,7 +791,7 @@ class TestGetGroup:
 
     def test_get_group_grouped_by_tuple_with_lambda(self):
         # GH 36158
-        df = pd.DataFrame(
+        df = DataFrame(
             {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
         )
 

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -124,6 +124,20 @@ class TestSelection:
 
         tm.assert_series_equal(result, expected)
 
+    def test_indices_grouped_by_tuple_with_lambda(self):
+        # GH 36158
+        df = pd.DataFrame(
+            {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
+        )
+
+        gb = df.groupby("Tuples")
+        gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
+
+        expected = gb.indices
+        result = gb_lambda.indices
+
+        tm.assert_dict_equal(result, expected)
+
 
 # grouping
 # --------------------------------
@@ -773,6 +787,20 @@ class TestGetGroup:
         gr = df.groupby("ids")
         result = gr.get_group(("2010-01-01",))
         expected = DataFrame({"ids": [(dt[0],), (dt[0],)]}, index=[0, 2])
+        tm.assert_frame_equal(result, expected)
+
+    def test_get_group_grouped_by_tuple_with_lambda(self):
+        # GH 36158
+        df = pd.DataFrame(
+            {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
+        )
+
+        gb = df.groupby("Tuples")
+        gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
+
+        expected = gb.get_group(list(gb.groups.keys())[0])
+        result = gb_lambda.get_group(list(gb_lambda.groups.keys())[0])
+
         tm.assert_frame_equal(result, expected)
 
     def test_groupby_with_empty(self):

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -129,7 +129,7 @@ class TestSelection:
         df = pd.DataFrame(
             {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
         )
-        gb = df.groupby('Tuples')
+        gb = df.groupby("Tuples")
         gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
         expected = gb.indices
         result = gb_lambda.indices
@@ -790,7 +790,7 @@ class TestGetGroup:
         df = pd.DataFrame(
             {"Tuples": ((x, y) for x in [0, 1] for y in np.random.randint(3, 5, 5))}
         )
-        gb = df.groupby('Tuples')
+        gb = df.groupby("Tuples")
         gb_lambda = df.groupby(lambda x: df.iloc[x, 0])
         expected = gb.get_group(list(gb.groups.keys())[0])
         result = gb_lambda.get_group(list(gb_lambda.groups.keys())[0])


### PR DESCRIPTION
As described in issue #36158 multi-dimensional groups prepared with lambda or named function raise error on indices as isnan() is not defined for MultiIndex.

Grouping already has the check for MultiIndex on line 440, but it's not triggered on __init__ when grouper is represented by **lambda** function and gets casted to MultiIndex later where MultiIndex stays as is.

~~Tested on the code provided in #36158, yet not sure if significant testing is needed as this is a relatively small change to code.  
Grouper code has not been changed for a while, should be save to merge.~~  
Tests for this particular issue provided.

~~**Concerns**: probably it will be better to make `isinstance(grouper, MultiIndex):` a function as after this change this piece of code occurs twice in __init__.~~  
Those operate on different grouper object. First one is passed on init, second one is `self`, where grouper is changed from lambda to MultiIndex and needs further change added in PR.

- [X] closes #36158
- [X] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
