### PR TITLE
PERF: Always using panda's hashtable approach, dropping np.in1d

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -95,14 +95,14 @@ class IsInLongSeries:
         ["int64", "int32", "float64", "float32", "object"],
         [1, 2, 5, 10, 1000, 10 ** 5],
     ]
-    param_names = ["dtype", "M"]
+    param_names = ["dtype", "MaxNumber"]
 
-    def setup(self, dtype, M):
-        self.s = Series(np.random.randint(0, M, 10 ** 7)).astype(dtype)
-        self.values = np.arange(M).astype(dtype)
+    def setup(self, dtype, MaxNumber):
+        self.series = Series(np.random.randint(0, MaxNumber, 10 ** 7)).astype(dtype)
+        self.values = np.arange(MaxNumber).astype(dtype)
 
-    def time_isin(self, dtypes, M):
-        self.s.isin(self.values)
+    def time_isin(self, dtypes, MaxNumber):
+        self.series.isin(self.values)
 
 
 class NSort:

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -90,8 +90,11 @@ class IsInForObjects:
         self.s_long_floats.isin(self.vals_long_floats)
 
 
-class IsInLongSeries(object):
-    params = [["int64", "int32", "float64", "float32"], [1, 2, 5, 10, 1000, 10 ** 5]]
+class IsInLongSeries:
+    params = [
+        ["int64", "int32", "float64", "float32", "object"],
+        [1, 2, 5, 10, 1000, 10 ** 5],
+    ]
     param_names = ["dtype", "M"]
 
     def setup(self, dtype, M):

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -91,11 +91,11 @@ class IsInForObjects:
 
 
 class IsInLongSeries(object):
-    params = [['int64', 'int32', 'float64', 'float32'], [1, 2, 5, 10, 1000, 10**5]]
-    param_names = ['dtype', 'M']
+    params = [["int64", "int32", "float64", "float32"], [1, 2, 5, 10, 1000, 10 ** 5]]
+    param_names = ["dtype", "M"]
 
     def setup(self, dtype, M):
-        self.s = Series(np.arange(10**7)).astype(dtype)
+        self.s = Series(np.random.randint(0, M, 10 ** 7)).astype(dtype)
         self.values = np.arange(M).astype(dtype)
 
     def time_isin(self, dtypes, M):

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -90,6 +90,18 @@ class IsInForObjects:
         self.s_long_floats.isin(self.vals_long_floats)
 
 
+class IsInLongSeries(object):
+    params = [['int64', 'int32', 'float64', 'float32'], [1, 2, 5, 10, 1000, 10**5]]
+    param_names = ['dtype', 'M']
+
+    def setup(self, dtype, M):
+        self.s = Series(np.arange(10**7)).astype(dtype)
+        self.values = np.arange(M).astype(dtype)
+
+    def time_isin(self, dtypes, M):
+        self.s.isin(self.values)
+
+
 class NSort:
 
     params = ["first", "last", "all"]

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -93,15 +93,25 @@ class IsInForObjects:
 class IsInLongSeries:
     params = [
         ["int64", "int32", "float64", "float32", "object"],
-        [1, 2, 5, 10, 1000, 10 ** 5],
+        [1, 2, 5, 10, 50, 100, 1000, 10 ** 5],
+        ["random_hits", "random_misses", "monotone"],
     ]
-    param_names = ["dtype", "MaxNumber"]
+    param_names = ["dtype", "MaxNumber", "series_type"]
 
-    def setup(self, dtype, MaxNumber):
-        self.series = Series(np.random.randint(0, MaxNumber, 10 ** 7)).astype(dtype)
+    def setup(self, dtype, MaxNumber, series_type):
+        N = 10 ** 7
+        if series_type == "random_hits":
+            np.random.seed(42)
+            array = np.random.randint(0, MaxNumber, N)
+        if series_type == "random_misses":
+            np.random.seed(42)
+            array = np.random.randint(0, MaxNumber, N) + MaxNumber
+        if series_type == "monotone":
+            array = np.repeat(np.arange(MaxNumber), N // MaxNumber)
+        self.series = Series(array).astype(dtype)
         self.values = np.arange(MaxNumber).astype(dtype)
 
-    def time_isin(self, dtypes, MaxNumber):
+    def time_isin(self, dtypes, MaxNumber, series_type):
         self.series.isin(self.values)
 
 

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -94,7 +94,7 @@ class IsInLongSeries:
     params = [
         ["int64", "int32", "float64", "float32", "object"],
         [1, 2, 5, 10, 50, 100, 1000, 10 ** 5],
-        ["random_hits", "random_misses", "monotone"],
+        ["random_hits", "random_misses", "monotone_hits", "monotone_misses"],
     ]
     param_names = ["dtype", "MaxNumber", "series_type"]
 
@@ -106,8 +106,10 @@ class IsInLongSeries:
         if series_type == "random_misses":
             np.random.seed(42)
             array = np.random.randint(0, MaxNumber, N) + MaxNumber
-        if series_type == "monotone":
+        if series_type == "monotone_hits":
             array = np.repeat(np.arange(MaxNumber), N // MaxNumber)
+        if series_type == "monotone_misses":
+            array = np.arange(N) + MaxNumber
         self.series = Series(array).astype(dtype)
         self.values = np.arange(MaxNumber).astype(dtype)
 

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -90,10 +90,10 @@ class IsInForObjects:
         self.s_long_floats.isin(self.vals_long_floats)
 
 
-class IsInLongSeries:
+class IsInLongSeriesLookUpDominates:
     params = [
         ["int64", "int32", "float64", "float32", "object"],
-        [1, 2, 5, 10, 50, 100, 1000, 10 ** 5],
+        [1, 2, 5, 10, 16, 50, 100, 1000, 10 ** 5],
         ["random_hits", "random_misses", "monotone_hits", "monotone_misses"],
     ]
     param_names = ["dtype", "MaxNumber", "series_type"]
@@ -114,6 +114,28 @@ class IsInLongSeries:
         self.values = np.arange(MaxNumber).astype(dtype)
 
     def time_isin(self, dtypes, MaxNumber, series_type):
+        self.series.isin(self.values)
+
+
+class IsInLongSeriesValuesDominate:
+    params = [
+        ["int64", "int32", "float64", "float32", "object"],
+        ["random", "monotone"],
+    ]
+    param_names = ["dtype", "series_type"]
+
+    def setup(self, dtype, series_type):
+        N = 10 ** 7
+        if series_type == "random":
+            np.random.seed(42)
+            vals = np.random.randint(0, 10 * N, N)
+        if series_type == "monotone":
+            vals = np.arange(N)
+        self.values = vals.astype(dtype)
+        M = 10 ** 6 + 1
+        self.series = Series(np.arange(M)).astype(dtype)
+
+    def time_isin(self, dtypes, series_type):
         self.series.isin(self.values)
 
 

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -93,7 +93,7 @@ class IsInForObjects:
 class IsInLongSeriesLookUpDominates:
     params = [
         ["int64", "int32", "float64", "float32", "object"],
-        [1, 2, 5, 10, 16, 50, 100, 1000, 10 ** 5],
+        [5, 1000],
         ["random_hits", "random_misses", "monotone_hits", "monotone_misses"],
     ]
     param_names = ["dtype", "MaxNumber", "series_type"]

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -482,6 +482,7 @@ Performance improvements
 - faster ``dir`` calls when many index labels, e.g. ``dir(ser)`` (:issue:`37450`)
 - Performance improvement in :class:`ExpandingGroupby` (:issue:`37064`)
 - Performance improvement in :meth:`pd.DataFrame.groupby` for ``float`` ``dtype`` (:issue:`28303`), changes of the underlying hash-function can lead to changes in float based indexes sort ordering for ties (e.g. :meth:`pd.Index.value_counts`)
+- Performance improvement in :meth:`pd.isin` for inputs with more than 1e6 elements
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -439,7 +439,7 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
     # Ensure np.in1d doesn't get object types or it *may* throw an exception
     # Albeit hashmap has O(1) look-up (vs. O(logn) in sorted array),
     # in1d is faster for small sizes
-    if len(comps) > 1_000_000 and len(values) <= 16 and not is_object_dtype(comps):
+    if len(comps) > 1_000_000 and len(values) <= 26 and not is_object_dtype(comps):
         # If the the values include nan we need to check for nan explicitly
         # since np.nan it not equal to np.nan
         if isna(values).any():

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -433,19 +433,9 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
     comps, dtype = _ensure_data(comps)
     values, _ = _ensure_data(values, dtype=dtype)
 
-    # faster for larger cases to use np.in1d
     f = htable.ismember_object
 
-    # GH16012
-    # Ensure np.in1d doesn't get object types or it *may* throw an exception
-    if len(comps) > 1_000_000 and not is_object_dtype(comps):
-        # If the the values include nan we need to check for nan explicitly
-        # since np.nan it not equal to np.nan
-        if isna(values).any():
-            f = lambda c, v: np.logical_or(np.in1d(c, v), np.isnan(c))
-        else:
-            f = np.in1d
-    elif is_integer_dtype(comps):
+    if is_integer_dtype(comps):
         try:
             values = values.astype("int64", copy=False)
             comps = comps.astype("int64", copy=False)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -435,7 +435,7 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
 
     f = htable.ismember_object
 
-    if is_integer_dtype(comps):
+    if is_integer_dtype(comps.dtype):
         try:
             values = values.astype("int64", copy=False)
             comps = comps.astype("int64", copy=False)
@@ -444,7 +444,7 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
             values = values.astype(object)
             comps = comps.astype(object)
 
-    elif is_float_dtype(comps):
+    elif is_float_dtype(comps.dtype):
         try:
             values = values.astype("float64", copy=False)
             comps = comps.astype("float64", copy=False)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -435,6 +435,10 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
 
     f = htable.ismember_object
 
+    # an alternative is to use np.in1d if values has a few
+    # elements (about 10) - it is faster than a hash-table
+    # for these cases. However, one must be cautious with
+    # nans (see GH22205)
     if is_integer_dtype(comps.dtype):
         try:
             values = values.astype("int64", copy=False)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

numpy's `in1d` uses look-up in `O(log n)` in `in1d` compared to panda's `O(1)` so for a large number of unique elements in `values` pandas solution will become better.

Here is comparison in the performance benchmark:

```
       before           after         ratio
     [27aae225]       [796a7dbc]
+     11.4±0.07ms       48.8±0.3ms     4.29  series_methods.IsInLongSeries.time_isin('float64', 1)
+      19.4±0.2ms       59.5±0.6ms     3.06  series_methods.IsInLongSeries.time_isin('float64', 2)
+      13.1±0.1ms       39.2±0.5ms     2.98  series_methods.IsInLongSeries.time_isin('int64', 1)
+      26.9±0.4ms       64.0±0.7ms     2.38  series_methods.IsInLongSeries.time_isin('float32', 1)
+      34.5±0.2ms       74.9±0.9ms     2.17  series_methods.IsInLongSeries.time_isin('float32', 2)
+      23.2±0.1ms       44.5±0.3ms     1.92  series_methods.IsInLongSeries.time_isin('int64', 2)
+      28.1±0.4ms       53.8±0.4ms     1.91  series_methods.IsInLongSeries.time_isin('int32', 1)
+      42.7±0.2ms       70.3±0.3ms     1.64  series_methods.IsInLongSeries.time_isin('float64', 5)
+      38.2±0.3ms       59.1±0.5ms     1.55  series_methods.IsInLongSeries.time_isin('int32', 2)
+      57.4±0.3ms       85.3±0.5ms     1.49  series_methods.IsInLongSeries.time_isin('float32', 5)
-        83.2±1ms       76.6±0.5ms     0.92  series_methods.IsInLongSeries.time_isin('float64', 10)
-         118±6ms       69.8±0.2ms     0.59  series_methods.IsInLongSeries.time_isin('int32', 10)
-         102±1ms       54.9±0.3ms     0.54  series_methods.IsInLongSeries.time_isin('int64', 10)
-         515±3ms          216±1ms     0.42  series_methods.IsInLongSeries.time_isin('int32', 100000)
-         498±3ms          201±1ms     0.40  series_methods.IsInLongSeries.time_isin('int64', 100000)
-         529±2ms          154±7ms     0.29  series_methods.IsInLongSeries.time_isin('float32', 100000)
-         529±3ms        131±0.7ms     0.25  series_methods.IsInLongSeries.time_isin('float64', 100000)
-         519±5ms        107±0.6ms     0.21  series_methods.IsInLongSeries.time_isin('int32', 1000)
-         499±3ms       91.3±0.3ms     0.18  series_methods.IsInLongSeries.time_isin('int64', 1000)
-         534±4ms         87.6±3ms     0.16  series_methods.IsInLongSeries.time_isin('float32', 1000)
-         519±2ms       72.6±0.9ms     0.14  series_methods.IsInLongSeries.time_isin('float64', 1000)
```

It looks as if for more than 10 `values`-elements, panda's approach is faster.

See also this comment (https://github.com/pandas-dev/pandas/issues/22205#issuecomment-410519409).

The question is whether it really makes sense to keep numpy's approach for less than 10 `values`-elements.