### PR TITLE
BUG: Fix unordered cut with Series labels

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -51,6 +51,7 @@ Bug fixes
 - Bug in :meth:`DataFrame.stack` raising a ``ValueError`` when stacking :class:`MultiIndex` columns based on position when the levels had duplicate names (:issue:`36353`)
 - Bug in :meth:`Series.astype` showing too much precision when casting from ``np.float32`` to string dtype (:issue:`36451`)
 - Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` when using ``NaN`` and a row length above 1,000,000 (:issue:`22205`)
+- Bug in :func:`cut` raising a ``ValueError`` when passed a :class:`Series` of labels with ``ordered=False`` (:issue:`36603`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -379,7 +379,7 @@ def _bins_to_cuts(
     duplicates: str = "raise",
     ordered: bool = True,
 ):
-    if not ordered and not labels:
+    if not ordered and labels is None:
         raise ValueError("'labels' must be provided if 'ordered = False'")
 
     if duplicates not in ["raise", "drop"]:

--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -667,6 +667,7 @@ def test_cut_unordered_with_missing_labels_raises_error():
 
 
 def test_cut_unordered_with_series_labels():
+    # https://github.com/pandas-dev/pandas/issues/36603
     s = pd.Series([1, 2, 3, 4, 5])
     bins = pd.Series([0, 2, 4, 6])
     labels = pd.Series(["a", "b", "c"])

--- a/pandas/tests/reshape/test_cut.py
+++ b/pandas/tests/reshape/test_cut.py
@@ -664,3 +664,12 @@ def test_cut_unordered_with_missing_labels_raises_error():
     msg = "'labels' must be provided if 'ordered = False'"
     with pytest.raises(ValueError, match=msg):
         cut([0.5, 3], bins=[0, 1, 2], ordered=False)
+
+
+def test_cut_unordered_with_series_labels():
+    s = pd.Series([1, 2, 3, 4, 5])
+    bins = pd.Series([0, 2, 4, 6])
+    labels = pd.Series(["a", "b", "c"])
+    result = pd.cut(s, bins=bins, labels=labels, ordered=False)
+    expected = pd.Series(["a", "a", "b", "b", "c"], dtype="category")
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #36603
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
