### PR TITLE
Comment on stale PRs

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -2,7 +2,7 @@ name: "Stale PRs"
 on:
   schedule:
   # * is a special character in YAML so you have to quote this string
-  - cron: "0 */6 * * *"
+  - cron: "0 0 * * *"
 
 jobs:
   stale:
@@ -11,8 +11,8 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity."
-        skip-stale-pr-message: true
+        stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity. Please update or response to this comment if you're still interested in working on this."
+        skip-stale-pr-message: false
         stale-pr-label: "Stale"
         exempt-pr-labels: "Needs Review,Blocked,Needs Discussion"
         days-before-stale: 30

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity. Please update or response to this comment if you're still interested in working on this."
+        stale-pr-message: "This pull request is stale because it has been open for thirty days with no activity. Please update or respond to this comment if you're still interested in working on this."
         skip-stale-pr-message: false
         stale-pr-label: "Stale"
         exempt-pr-labels: "Needs Review,Blocked,Needs Discussion"


### PR DESCRIPTION
Updating the stale PR action to comment in the PR. Should help to automate the process of pinging contributors who go quiet. Also updating to run once daily instead of every six hours.