### PR TITLE
BUG: Categorical setitem, comparison with tuple category

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -240,7 +240,7 @@ Bug fixes
 Categorical
 ^^^^^^^^^^^
 - :meth:`Categorical.fillna` will always return a copy, will validate a passed fill value regardless of whether there are any NAs to fill, and will disallow a ``NaT`` as a fill value for numeric categories (:issue:`36530`)
--
+- Bug in :meth:`Categorical.__setitem__` that incorrectly raised when trying to set a tuple value (:issue:`20439`)
 -
 
 Datetimelike

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -75,13 +75,21 @@ class TestCategoricalIndexingWithFactor(TestCategorical):
             pd.Categorical(["b", "a"], categories=["a", "b", "c"], ordered=True),
         ],
     )
-    def test_setitem_same_ordered_rasies(self, other):
+    def test_setitem_same_ordered_raises(self, other):
         # Gh-24142
         target = pd.Categorical(["a", "b"], categories=["a", "b"], ordered=True)
         mask = np.array([True, False])
         msg = "Cannot set a Categorical with another, without identical categories"
         with pytest.raises(ValueError, match=msg):
             target[mask] = other[mask]
+
+    def test_setitem_tuple(self):
+        # GH#20439
+        cat = pd.Categorical([(0, 1), (0, 2), (0, 1)])
+
+        # This should not raise
+        cat[1] = cat[0]
+        assert cat[1] == (0, 1)
 
 
 class TestCategoricalIndexing:

--- a/pandas/tests/arrays/categorical/test_operators.py
+++ b/pandas/tests/arrays/categorical/test_operators.py
@@ -179,6 +179,20 @@ class TestCategoricalOps:
         tm.assert_numpy_array_equal(cat == 4, np.array([False, False, False]))
         tm.assert_numpy_array_equal(cat != 4, np.array([True, True, True]))
 
+    def test_comparison_with_tuple(self):
+        cat = pd.Categorical(np.array(["foo", (0, 1), 3, (0, 1)], dtype=object))
+
+        result = cat == "foo"
+        expected = np.array([True, False, False, False], dtype=bool)
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = cat == (0, 1)
+        expected = np.array([False, True, False, True], dtype=bool)
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = cat != (0, 1)
+        tm.assert_numpy_array_equal(result, ~expected)
+
     def test_comparison_of_ordered_categorical_with_nan_to_scalar(
         self, compare_operators_no_eq_ne
     ):


### PR DESCRIPTION
- [x] closes #20439
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
