### PR TITLE
TST: check whether printing an IntervalIndex works (GH32553)

### DIFF
--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -114,6 +114,10 @@ class TestIntervalIndex:
         with pytest.raises(KeyError, match="^$"):
             df.loc[[10, 4]]
 
+    def test_print_intervalindex(self):
+        # GH#32553
+        print(self.s)
+
 
 class TestIntervalIndexInsideMultiIndex:
     def test_mi_intervalindex_slicing_with_scalar(self):


### PR DESCRIPTION
- [x] closes #32553
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry (not applicable)

I just added a test that checks whether print succeeds, would we also want to check the exact output of the `str` function on an `IntervalIndex`?
