### PR TITLE
CLN: Improve setting of resample deprecation warnings' stacklevel

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8221,24 +8221,25 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2000-10-02 00:41:00    24
         Freq: 17T, dtype: int64
         """
-        from pandas.core.resample import get_resampler
+        from pandas.core.resample import check_deprecated_resample_kwargs, get_resampler
 
-        axis = self._get_axis_number(axis)
-        return get_resampler(
-            self,
-            freq=rule,
-            label=label,
-            closed=closed,
-            axis=axis,
-            kind=kind,
-            loffset=loffset,
-            convention=convention,
-            base=base,
-            key=on,
-            level=level,
-            origin=origin,
-            offset=offset,
-        )
+        with check_deprecated_resample_kwargs(dict(base=base, loffset=loffset)):
+            axis = self._get_axis_number(axis)
+            return get_resampler(
+                self,
+                freq=rule,
+                label=label,
+                closed=closed,
+                axis=axis,
+                kind=kind,
+                loffset=loffset,
+                convention=convention,
+                base=base,
+                key=on,
+                level=level,
+                origin=origin,
+                offset=offset,
+            )
 
     def first(self: FrameOrSeries, offset) -> FrameOrSeries:
         """

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1795,9 +1795,13 @@ class GroupBy(BaseGroupBy[FrameOrSeries]):
             2000-01-01 00:03:00  0  2
         5   2000-01-01 00:03:00  5  1
         """
-        from pandas.core.resample import get_resampler_for_grouping
+        from pandas.core.resample import (
+            check_deprecated_resample_kwargs,
+            get_resampler_for_grouping,
+        )
 
-        return get_resampler_for_grouping(self, rule, *args, **kwargs)
+        with check_deprecated_resample_kwargs(kwargs):
+            return get_resampler_for_grouping(self, rule, *args, **kwargs)
 
     @Substitution(name="groupby")
     @Appender(_common_see_also)

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -3,7 +3,6 @@ Provide user facing operators for doing the split part of the
 split-apply-combine paradigm.
 """
 from typing import Dict, Hashable, List, Optional, Set, Tuple
-import warnings
 
 import numpy as np
 
@@ -228,43 +227,8 @@ class Grouper:
         if kwargs.get("freq") is not None:
             from pandas.core.resample import TimeGrouper
 
-            # Deprecation warning of `base` and `loffset` since v1.1.0:
-            # we are raising the warning here to be able to set the `stacklevel`
-            # properly since we need to raise the `base` and `loffset` deprecation
-            # warning from three different cases:
-            #   core/generic.py::NDFrame.resample
-            #   core/groupby/groupby.py::GroupBy.resample
-            #   core/groupby/grouper.py::Grouper
-            # raising these warnings from TimeGrouper directly would fail the test:
-            #   tests/resample/test_deprecated.py::test_deprecating_on_loffset_and_base
-            # hacky way to set the stacklevel: if cls is TimeGrouper it means
-            # that the call comes from a pandas internal call of resample,
-            # otherwise it comes from pd.Grouper
-            stacklevel = 4 if cls is TimeGrouper else 2
-            if kwargs.get("base", None) is not None:
-                warnings.warn(
-                    "'base' in .resample() and in Grouper() is deprecated.\n"
-                    "The new arguments that you should use are 'offset' or 'origin'.\n"
-                    '\n>>> df.resample(freq="3s", base=2)\n'
-                    "\nbecomes:\n"
-                    '\n>>> df.resample(freq="3s", offset="2s")\n',
-                    FutureWarning,
-                    stacklevel=stacklevel,
-                )
-
-            if kwargs.get("loffset", None) is not None:
-                warnings.warn(
-                    "'loffset' in .resample() and in Grouper() is deprecated.\n"
-                    '\n>>> df.resample(freq="3s", loffset="8H")\n'
-                    "\nbecomes:\n"
-                    "\n>>> from pandas.tseries.frequencies import to_offset"
-                    '\n>>> df = df.resample(freq="3s").mean()'
-                    '\n>>> df.index = df.index.to_timestamp() + to_offset("8H")\n',
-                    FutureWarning,
-                    stacklevel=stacklevel,
-                )
-
             cls = TimeGrouper
+
         return super().__new__(cls)
 
     def __init__(

--- a/pandas/tests/util/test_call_once.py
+++ b/pandas/tests/util/test_call_once.py
@@ -1,0 +1,97 @@
+import time
+
+from pandas.util._call_once import call_once
+
+
+class CallbackMock:
+    # Should be MagicMock but uNitTesT.mOck is not allowed in pandas :(
+    # (see #24648)
+
+    def __init__(self):
+        self.call_count = 0
+
+    def __call__(self):
+        self.call_count += 1
+
+    def reset_mock(self):
+        self.call_count = 0
+
+
+def test_basic():
+    callback1, callback2 = CallbackMock(), CallbackMock()
+    with call_once(callback1):
+        with call_once(callback1):
+            with call_once(callback2):
+                with call_once(callback1):
+                    with call_once(callback2):
+                        pass
+
+    assert callback1.call_count == 1
+    assert callback2.call_count == 1
+
+
+def test_with_key():
+    cb1, cb2 = CallbackMock(), CallbackMock()
+    with call_once(cb1, key="callback"):
+        with call_once(cb2, key="callback"):
+            pass
+
+    assert cb1.call_count == 1
+    assert cb2.call_count == 0
+
+
+def test_across_stack_frames():
+    callback = CallbackMock()
+
+    def f():
+        with call_once(callback):
+            pass
+
+    def g():
+        with call_once(callback):
+            f()
+
+    f()
+    assert callback.call_count == 1
+    callback.reset_mock()
+
+    g()
+    assert callback.call_count == 1
+
+
+def test_concurrent_threading():
+    import threading
+
+    sleep_time = 0.01
+    callback = CallbackMock()
+
+    def run(initial_sleep=0):
+        time.sleep(initial_sleep)
+        with call_once(callback):
+            with call_once(callback):
+                time.sleep(2 * sleep_time)
+
+    thread1 = threading.Thread(target=run)
+    thread2 = threading.Thread(target=run, kwargs={"initial_sleep": sleep_time})
+    thread2.start()
+    thread1.start()
+    thread1.join()
+    thread2.join()
+    assert callback.call_count == 2
+
+
+def test_concurrent_asyncio():
+    import asyncio
+
+    callback = CallbackMock()
+
+    async def task():
+        with call_once(callback):
+            with call_once(callback):
+                await asyncio.sleep(0.01)
+
+    async def main():
+        await asyncio.gather(task(), task())
+
+    asyncio.run(main())
+    assert callback.call_count == 2

--- a/pandas/util/_call_once.py
+++ b/pandas/util/_call_once.py
@@ -21,7 +21,7 @@ class _ContextMapping(MutableMapping):
     _NO_DEFAULT_VALUE = object()
 
     def __init__(self, default_value=_NO_DEFAULT_VALUE):
-        d: dict = (
+        initial_dict: dict = (
             defaultdict(lambda: default_value)
             if default_value is not self._NO_DEFAULT_VALUE
             else dict()
@@ -29,9 +29,8 @@ class _ContextMapping(MutableMapping):
         # yes, we're creating a contextvar inside a closure, but it doesn't matter
         # because objects of this class will only be created at module level
         self._dict_var: contextvars.ContextVar[dict] = contextvars.ContextVar(
-            "_ContextMapping<{}>._dict_var".format(id(self))
+            "_ContextMapping<{}>._dict_var".format(id(self)), default=initial_dict
         )
-        self._dict_var.set(d)
 
     def __setitem__(self, k, v) -> None:
         d = self._dict_var.get().copy()

--- a/pandas/util/_call_once.py
+++ b/pandas/util/_call_once.py
@@ -1,0 +1,205 @@
+"""
+This module houses a utility class that acts as an idempotent context manager,
+ensuring that, within an active context, the given callback is called exactly once.
+"""
+from collections import defaultdict
+import contextvars
+from typing import Callable, Hashable, Iterator, MutableMapping, Optional, Union
+
+
+class _ContextMapping(MutableMapping):
+    """
+    :class:`~contextvars.Context`-aware mapping.
+
+    Ensures that modifications to the mapping aren't leaked across contexts.
+    """
+
+    # We need to copy the internal dictionary when modifying it because contextvars
+    # only makes shallow copies of Context objects, so modifications to the same dict
+    # would leak across contexts.
+
+    _NO_DEFAULT_VALUE = object()
+
+    def __init__(self, default_value=_NO_DEFAULT_VALUE):
+        d: dict = (
+            defaultdict(lambda: default_value)
+            if default_value is not self._NO_DEFAULT_VALUE
+            else dict()
+        )
+        # yes, we're creating a contextvar inside a closure, but it doesn't matter
+        # because objects of this class will only be created at module level
+        self._dict_var: contextvars.ContextVar[dict] = contextvars.ContextVar(
+            "_ContextMapping<{}>._dict_var".format(id(self))
+        )
+        self._dict_var.set(d)
+
+    def __setitem__(self, k, v) -> None:
+        d = self._dict_var.get().copy()
+        d[k] = v
+        self._dict_var.set(d)
+
+    def __delitem__(self, k) -> None:
+        d = self._dict_var.get().copy()
+        del d[k]
+        self._dict_var.set(d)
+
+    def __getitem__(self, k):
+        return self._dict_var.get()[k]
+
+    def __len__(self) -> int:
+        return len(self._dict_var.get())
+
+    def __iter__(self) -> Iterator:
+        return iter(self._dict_var.get())
+
+
+class CallOnceContextManager:
+    """
+    Ensures the given callback is called exactly once within an active context.
+
+    The first (outermost) context manager, when entered, calls the given callback,
+    and any nested context managers (including those that are further down the call
+    stack) do nothing while the first one is still active. This ensures that only the
+    outermost active context in the current call stack is the one that called the
+    callback upon being entered, and thus the callback is guaranteed to (have) be(en)
+    called exactly once within any active context.
+
+
+    It is concurrency-safe (through usage of contextvars).
+
+    Notes
+    -----
+    To distinguish between context managers with different callbacks ( which
+    shouldn't interfere with each other, as they are unrelated), unless an explicit
+    ``key`` is given, the :func:`hash` of the callback is used. This is important to
+    keep in mind, as, for example, using ``lambda``s won't work as expected:
+
+    >>> with call_once(lambda: print("callback called")):
+    ...     with call_once(lambda: print("callback called")):
+    ...         pass  # "callback called" printed twice
+
+    So, to ensure it works as intended, either pass an explicit key (preferred) or
+    always use identical callback objects (i.e. with the same object ID):
+
+    >>> with call_once(lambda: print("called"), key='foo'):
+    ...     with call_once(lambda: print("called"), key='foo'):
+    ...         pass  # "callback called" printed once
+
+    The function :func:`call_once` is an alias to this class.
+
+    Examples
+    --------
+    First, let's define some callback functions:
+
+    >>> cb1, cb2 = map(lambda n: lambda: print(n, "called"), ["callback1", "callback2"])
+
+    A basic illustrative example:
+
+    >>> with call_once(cb1):
+    ...    with call_once(cb1):
+    ...       pass
+    callback1 called
+
+    Context managers for different callbacks don't interfere with each other:
+    >>> with call_once(cb1):
+    ...     with call_once(cb2):
+    ...         with call_once(cb1):
+    ...             with call_once(cb2):
+    ...                 pass
+    callback1 called
+    callback2 called
+
+    Example across stack frames:
+
+    >>> def f():
+    ...     print("f")
+    ...     with call_once(cb1):
+    ...         print("f inside with")
+    ...
+    >>> def g():
+    ...     print("g")
+    ...     with call_once(cb1):
+    ...         print("g inside with")
+    ...         f()
+    ...
+
+    If we call ``f`` directly, the callback will be called in ``f``:
+
+    >>> f()
+    f
+    callback called
+    f inside with
+
+    But if we call ``g``, the callback will only be called in ``g``, which is where
+    the outermost context manager is:
+
+    >>> g()
+    g
+    callback called
+    g inside with
+    f
+    f inside with
+
+    Concurrency-safe (the state of the class doesn't leak across asyncio tasks or
+    different threads):
+
+    >>> import asyncio
+    >>> callback = lambda: print("callback called")
+    >>> async def task(n: int):
+    ...     print("task {} started".format(n))
+    ...     with call_once(callback):
+    ...         print("task {} sleeping".format(n))
+    ...         await asyncio.sleep(1)
+    ...         print("task {} exiting with".format(n))
+    ...
+    >>> async def main():
+    ...     await asyncio.gather(task(1), task(2))
+    ...
+    >>> asyncio.run(main())
+    task 1 started
+    callback called
+    task 1 sleeping
+    task 2 started
+    callback called
+    task 2 sleeping
+    task 1 exiting with
+    task 2 exiting with
+    """
+
+    # mapping of callbacks to the corresponding outermost context manager instances
+    _outermost_instances: MutableMapping[
+        Union[Callable, Hashable], Optional["CallOnceContextManager"]
+    ] = _ContextMapping(default_value=None)
+
+    def __init__(self, callback: Callable[[], None], key: Optional[Hashable] = None):
+        """
+        Parameters
+        ----------
+        callback : callable taking no arguments and returning ``None``
+            The callback to run.
+        key : hashable object, default ``callback``
+            Key object to uniquely identify the callback and to distinguish it from
+            other callbacks. If not specified, the ``callback`` object itself is used.
+        """
+        self.key = key if key is not None else callback
+        self.callback = callback
+
+    def __enter__(self):
+        outermost = self._outermost_instances[self.key]
+        if outermost is None:
+            self._outermost_instances[self.key] = self
+            self.callback()
+            return self
+        else:
+            return outermost
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._outermost_instances[self.key] is self:
+            self._outermost_instances[self.key] = None
+
+
+def call_once(callback: Callable[[], None], key: Optional[Hashable] = None):
+    """
+    Alias for :class:`CallOnceContextManager`.
+    """
+    return CallOnceContextManager(callback, key=key)


### PR DESCRIPTION
- [N/A] closes #xxxx (see https://github.com/pandas-dev/pandas/pull/36369#issuecomment-698763910)
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [N/A] whatsnew entry

The essence of the problem is that the tests for deprecated resample kwargs require that the warning is raised exactly where the user called the resample functionality—i.e. with the appropriate `stacklevel`— (I guess so that the warning message is more user-friendly?), but there are multiple entry points that use these deprecated parameters, so this can't be easily solved by just adjusting the stacklevel by a constant amount.

The old solution was to centralize the management of these warnings in the greatest-common-denominator call site (which was `Grouper.__new__`) and "guess" the correct value of `stacklevel` by relying on the current call graph (and hoping it never changes). This of course is poorly maintainable. (For a more detailed explanation of what is wrong with this, see https://github.com/pandas-dev/pandas/pull/36369#issuecomment-694808777.)

The essence of my proposed solution (this PR) is to add a call to the deprecated-parameter-checking code to each of these entry points—this allows instead to use a constant `stacklevel` value (2) in each of these. Now since some of these public call sites appear in the call graph of others, we have to ensure this code is only called once within any call path starting at any of these entry points. This is what the `call_once` context manager takes care of.