### PR TITLE
TST: GH23452 test reorder_categories() on categorical index

### DIFF
--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -807,3 +807,31 @@ class TestCategoricalIndex:
         result.loc[sl, "A"] = ["qux", "qux2"]
         expected = DataFrame({"A": ["qux", "qux2", "baz"]}, index=cat_idx)
         tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "categories",
+        [
+            pytest.param(["a", "b", "c"], id="str"),
+            pytest.param(
+                [pd.Interval(0, 1), pd.Interval(1, 2), pd.Interval(2, 3)],
+                id="pd.Interval",
+            ),
+        ],
+    )
+    def test_categorical_index_reorder_categories(self, categories):
+        # GH23452
+        df = DataFrame(
+            {"foo": [1, 2, 3]},
+            index=CategoricalIndex(
+                data=categories, categories=categories, ordered=True
+            ),
+        )
+        df.index = df.index.reorder_categories(df.index.categories[::-1])
+        actual = df.sort_index()
+        expected = DataFrame(
+            {"foo": [3, 2, 1]},
+            index=CategoricalIndex(
+                data=categories[::-1], categories=categories[::-1], ordered=True
+            ),
+        )
+        tm.assert_frame_equal(actual, expected)

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -821,7 +821,7 @@ class TestCategoricalIndex:
     def test_categorical_index_reorder_categories(self, categories):
         # GH23452
         df = DataFrame(
-            {"foo": [1, 2, 3]},
+            {"foo": range(len(categories))},
             index=CategoricalIndex(
                 data=categories, categories=categories, ordered=True
             ),
@@ -829,7 +829,7 @@ class TestCategoricalIndex:
         df.index = df.index.reorder_categories(df.index.categories[::-1])
         actual = df.sort_index()
         expected = DataFrame(
-            {"foo": [3, 2, 1]},
+            {"foo": reversed(range(len(categories)))},
             index=CategoricalIndex(
                 data=categories[::-1], categories=categories[::-1], ordered=True
             ),

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -818,7 +818,7 @@ class TestCategoricalIndex:
             ),
         ],
     )
-    def test_categorical_index_reorder_categories(self, categories):
+    def test_reorder_index_with_categories(self, categories):
         # GH23452
         df = DataFrame(
             {"foo": range(len(categories))},
@@ -827,11 +827,11 @@ class TestCategoricalIndex:
             ),
         )
         df.index = df.index.reorder_categories(df.index.categories[::-1])
-        actual = df.sort_index()
+        result = df.sort_index()
         expected = DataFrame(
             {"foo": reversed(range(len(categories)))},
             index=CategoricalIndex(
                 data=categories[::-1], categories=categories[::-1], ordered=True
             ),
         )
-        tm.assert_frame_equal(actual, expected)
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #23452
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Couldn't see entries for tests in whatsnew files so I assume it's not needed if only a test case is added This is my first Pandas contribution, looking forward to your feedback.