### PR TITLE
DOC: Fix remaining typos in docstrings 'handler' --> 'handle'

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2298,7 +2298,7 @@ class DataFrame(NDFrame):
         path : str or file-like object
             If a string, it will be used as Root Directory path
             when writing a partitioned dataset. By file-like object,
-            we refer to objects with a write() method, such as a file handler
+            we refer to objects with a write() method, such as a file handle
             (e.g. via builtin open function) or io.BytesIO. The engine
             fastparquet does not accept file-like objects.
 

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -104,7 +104,7 @@ def read_feather(
         ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method,
-        such as a file handler (e.g. via builtin ``open`` function)
+        such as a file handle (e.g. via builtin ``open`` function)
         or ``StringIO``.
     columns : sequence, default None
         If not provided, all columns are read.

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -393,7 +393,7 @@ def read_json(
         ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method,
-        such as a file handler (e.g. via builtin ``open`` function)
+        such as a file handle (e.g. via builtin ``open`` function)
         or ``StringIO``.
     orient : str
         Indication of expected JSON string format.

--- a/pandas/io/orc.py
+++ b/pandas/io/orc.py
@@ -31,7 +31,7 @@ def read_orc(
         ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method,
-        such as a file handler (e.g. via builtin ``open`` function)
+        such as a file handle (e.g. via builtin ``open`` function)
         or ``StringIO``.
     columns : list, default None
         If not None, only these columns will be read from the file.

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -255,7 +255,7 @@ def to_parquet(
     path : str or file-like object
         If a string, it will be used as Root Directory path
         when writing a partitioned dataset. By file-like object,
-        we refer to objects with a write() method, such as a file handler
+        we refer to objects with a write() method, such as a file handle
         (e.g. via builtin open function) or io.BytesIO. The engine
         fastparquet does not accept file-like objects.
 
@@ -333,7 +333,7 @@ def read_parquet(path, engine: str = "auto", columns=None, **kwargs):
         ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method,
-        such as a file handler (e.g. via builtin ``open`` function)
+        such as a file handle (e.g. via builtin ``open`` function)
         or ``StringIO``.
     engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
         Parquet library to use. If 'auto', then the option

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -92,7 +92,7 @@ filepath_or_buffer : str, path object or file-like object
     If you want to pass in a path object, pandas accepts any ``os.PathLike``.
 
     By file-like object, we refer to objects with a ``read()`` method, such as
-    a file handler (e.g. via builtin ``open`` function) or ``StringIO``.
+    a file handle (e.g. via builtin ``open`` function) or ``StringIO``.
 sep : str, default {_default_sep}
     Delimiter to use. If sep is None, the C engine cannot automatically detect
     the separator, but the Python parsing engine can, meaning the latter will
@@ -788,7 +788,7 @@ def read_fwf(
         ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method,
-        such as a file handler (e.g. via builtin ``open`` function)
+        such as a file handle (e.g. via builtin ``open`` function)
         or ``StringIO``.
     colspecs : list of tuple (int, int) or 'infer'. optional
         A list of tuples giving the extents of the fixed-width

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -310,7 +310,7 @@ def read_hdf(
         Alternatively, pandas accepts an open :class:`pandas.HDFStore` object.
 
         By file-like object, we refer to objects with a ``read()`` method,
-        such as a file handler (e.g. via builtin ``open`` function)
+        such as a file handle (e.g. via builtin ``open`` function)
         or ``StringIO``.
     key : object, optional
         The group identifier in the store. Can be omitted if the HDF file

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -74,7 +74,7 @@ def read_sas(
         ``os.PathLike``.
 
         By file-like object, we refer to objects with a ``read()`` method,
-        such as a file handler (e.g. via builtin ``open`` function)
+        such as a file handle (e.g. via builtin ``open`` function)
         or ``StringIO``.
     format : str {'xport', 'sas7bdat'} or None
         If None, file format is inferred from file extension. If 'xport' or

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -110,7 +110,7 @@ filepath_or_buffer : str, path object or file-like object
     If you want to pass in a path object, pandas accepts any ``os.PathLike``.
 
     By file-like object, we refer to objects with a ``read()`` method,
-    such as a file handler (e.g. via builtin ``open`` function)
+    such as a file handle (e.g. via builtin ``open`` function)
     or ``StringIO``.
 {_statafile_processing_params1}
 {_statafile_processing_params2}


### PR DESCRIPTION
Follow-on to https://github.com/pandas-dev/pandas/pull/36427#issuecomment-694249512