### PR TITLE
ASV: used integer ndarray as indexer for Series.take indexing benchmark

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -191,7 +191,7 @@ class Take:
         }
         index = indexes[index]
         self.s = Series(np.random.rand(N), index=index)
-        self.indexer = list(np.random.randint(0, N, size=N))
+        self.indexer = np.random.randint(0, N, size=N)
 
     def time_take(self, index):
         self.s.take(self.indexer)

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -191,7 +191,7 @@ class Take:
         }
         index = indexes[index]
         self.s = Series(np.random.rand(N), index=index)
-        self.indexer = [True, False, True, True, False] * 20000
+        self.indexer = list(np.random.randint(0, N, size=N))
 
     def time_take(self, index):
         self.s.take(self.indexer)


### PR DESCRIPTION
- [x] closes #18000
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Series.take was using a list of booleans as indexers. Now, It is replaced with a random list of integers.
Here are the benchmark results with `asv run --bench indexing.Take`
### Benchmarks Results:

#### Before:

```
[100.00%] ··· indexing.Take.time_take                                                                                                                                                ok
[100.00%] ··· ========== =============
                index                 
              ---------- -------------
                 int      4.13±0.08ms 
               datetime   4.13±0.01ms 
              ========== =============
```

#### After:

```
[100.00%] ··· indexing.Take.time_take                                                                                                                                                ok
[100.00%] ··· ========== =============
                index                 
              ---------- -------------
                 int      6.36±0.08ms 
               datetime   6.29±0.03ms 
              ========== =============
```