### PR TITLE
REGR: fillna not filling NaNs after pivot without explicitly listing pivot values on 1.1.x

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -34,6 +34,7 @@ Fixed regressions
 - Fixed regression when adding a :meth:`timedelta_range` to a :class:``Timestamp`` raised an ``ValueError`` (:issue:`35897`)
 - Fixed regression in :meth:`Series.__getitem__` incorrectly raising when the input was a tuple (:issue:`35534`)
 - Fixed regression in :meth:`Series.__getitem__` incorrectly raising when the input was a frozenset (:issue:`35747`)
+- Fixed regression where :meth:`DataFrame.fillna` not filling ``NaN`` after :meth:`DataFrame.pivot` operation (:issue:`36495`)
 - Fixed regression in :meth:`read_excel` with ``engine="odf"`` caused ``UnboundLocalError`` in some cases where cells had nested child nodes (:issue:`36122`, :issue:`35802`)
 - Fixed regression in :meth:`DataFrame.replace` inconsistent replace when using a float in the replace method (:issue:`35376`)
 - Fixed regression in :class:`DataFrame` and :class:`Series` comparisons between numeric arrays and strings (:issue:`35700`, :issue:`36377`)

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -382,6 +382,8 @@ class BlockManager(PandasObject):
         result_blocks: List[Block] = []
         # fillna: Series/DataFrame is responsible for making sure value is aligned
 
+        self._consolidate_inplace()
+
         aligned_args = {k: kwargs[k] for k in align_keys}
 
         for b in self.blocks:

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -717,3 +717,31 @@ class TestDataFrameMissingData:
 
         # TODO(wesm): unused?
         result = empty_float.fillna(value=0)  # noqa
+
+    def test_fillna_after_pivot(self):
+        # https://github.com/pandas-dev/pandas/issues/36495
+        df = DataFrame(
+            [
+                [1, 1, 1, 1.0],
+                [2, 2, 2, 2.0],
+                [3, 3, 3, 3.0],
+            ],
+            columns=["i1", "i2", "i3", "f1"],
+        )
+
+        result = df.pivot("i1", "i2").fillna(0)
+
+        expected = DataFrame(
+            [
+                [1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+                [0.0, 2.0, 0.0, 0.0, 2.0, 0.0],
+                [0.0, 0.0, 3.0, 0.0, 0.0, 3.0],
+            ],
+            index=pd.Int64Index([1, 2, 3], dtype="int64", name="i1"),
+            columns=pd.MultiIndex.from_tuples(
+                [("i3", 1), ("i3", 2), ("i3", 3), ("f1", 1), ("f1", 2), ("f1", 3)],
+                names=[None, "i2"],
+            ),
+        )
+
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -721,7 +721,7 @@ class TestDataFrameMissingData:
     def test_fillna_after_pivot(self):
         # https://github.com/pandas-dev/pandas/issues/36495
         df = DataFrame(
-            [[1, 1, 1, 1.0], [2, 2, 2, 2.0], [3, 3, 3, 3.0],],
+            [[1, 1, 1, 1.0], [2, 2, 2, 2.0], [3, 3, 3, 3.0]],
             columns=["i1", "i2", "i3", "f1"],
         )
 

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -721,11 +721,7 @@ class TestDataFrameMissingData:
     def test_fillna_after_pivot(self):
         # https://github.com/pandas-dev/pandas/issues/36495
         df = DataFrame(
-            [
-                [1, 1, 1, 1.0],
-                [2, 2, 2, 2.0],
-                [3, 3, 3, 3.0],
-            ],
+            [[1, 1, 1, 1.0], [2, 2, 2, 2.0], [3, 3, 3, 3.0],],
             columns=["i1", "i2", "i3", "f1"],
         )
 


### PR DESCRIPTION
- [ ] xref #36495

yet another alternative to fix directly on 1.1.x pending further discussion in #34407 on how to resolve the issues on master.

cc @jorisvandenbossche @jbrockmendel 

This won't close issue until fix on master. could copy test to master with xfail (and would need to sync release notes if we merge this direct to 1.1.x)