### PR TITLE
BUG: DatetimeIndex.shift(1) with empty index

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -252,7 +252,8 @@ Datetimelike
 - Bug in :meth:`DatetimeIndex.slice_locs` where ``datetime.date`` objects were not accepted (:issue:`34077`)
 - Bug in :meth:`DatetimeIndex.searchsorted`, :meth:`TimedeltaIndex.searchsorted`, :meth:`PeriodIndex.searchsorted`, and :meth:`Series.searchsorted` with ``datetime64``, ``timedelta64`` or ``Period`` dtype placement of ``NaT`` values being inconsistent with ``NumPy`` (:issue:`36176`, :issue:`36254`)
 - Inconsistency in :class:`DatetimeArray`, :class:`TimedeltaArray`, and :class:`PeriodArray`  setitem casting arrays of strings to datetimelike scalars but not scalar strings (:issue:`36261`)
--
+- Bug in :class:`DatetimeIndex.shift` incorrectly raising when shifting empty indexes (:issue:`14811`)
+
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1276,8 +1276,8 @@ class DatetimeLikeArrayMixin(
             result = self + offset
             return result
 
-        if periods == 0:
-            # immutable so OK
+        if periods == 0 or len(self) == 0:
+            # GH#14811 empty case
             return self.copy()
 
         if self.freq is None:

--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -34,7 +34,7 @@ class DatetimeLike(Base):
 
     def test_shift_empty(self):
         # GH#14811
-        idx = self.create_index()
+        idx = self.create_index()[:0]
         tm.assert_index_equal(idx, idx.shift(1))
 
     def test_str(self):

--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -32,6 +32,11 @@ class DatetimeLike(Base):
         idx = self.create_index()
         tm.assert_index_equal(idx, idx.shift(0))
 
+    def test_shift_empty(self):
+        # GH#14811
+        idx = self.create_index()
+        tm.assert_index_equal(idx, idx.shift(1))
+
     def test_str(self):
 
         # test the string repr

--- a/pandas/tests/indexes/datetimes/test_shift.py
+++ b/pandas/tests/indexes/datetimes/test_shift.py
@@ -151,3 +151,9 @@ class TestDatetimeIndexShift:
         with tm.assert_produces_warning(pd.errors.PerformanceWarning):
             shifted = rng.shift(1, freq=pd.offsets.CDay())
             assert shifted[0] == rng[0] + pd.offsets.CDay()
+
+    def test_shift_empty(self):
+        # GH#14811
+        dti = date_range(start="2016-10-21", end="2016-10-21", freq="BM")
+        result = dti.shift(1)
+        tm.assert_index_equal(result, dti)


### PR DESCRIPTION
- [x] closes #14811
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
