### PR TITLE
CLN: OrderedDict->dict

### DIFF
--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -17,7 +17,6 @@ This module provides a set of commonly used default arguments for functions
 and methods that are spread throughout the codebase. This module will make it
 easier to adjust to future upstream changes in the analogous numpy signatures.
 """
-from collections import OrderedDict
 from distutils.version import LooseVersion
 from typing import Any, Dict, Optional, Union
 
@@ -117,7 +116,7 @@ def validate_argmax_with_skipna(skipna, args, kwargs):
     return skipna
 
 
-ARGSORT_DEFAULTS: "OrderedDict[str, Optional[Union[int, str]]]" = OrderedDict()
+ARGSORT_DEFAULTS: Dict[str, Optional[Union[int, str]]] = {}
 ARGSORT_DEFAULTS["axis"] = -1
 ARGSORT_DEFAULTS["kind"] = "quicksort"
 ARGSORT_DEFAULTS["order"] = None
@@ -133,7 +132,7 @@ validate_argsort = CompatValidator(
 
 # two different signatures of argsort, this second validation
 # for when the `kind` param is supported
-ARGSORT_DEFAULTS_KIND: "OrderedDict[str, Optional[int]]" = OrderedDict()
+ARGSORT_DEFAULTS_KIND: Dict[str, Optional[int]] = {}
 ARGSORT_DEFAULTS_KIND["axis"] = -1
 ARGSORT_DEFAULTS_KIND["order"] = None
 validate_argsort_kind = CompatValidator(
@@ -178,7 +177,7 @@ def validate_clip_with_axis(axis, args, kwargs):
     return axis
 
 
-CUM_FUNC_DEFAULTS: "OrderedDict[str, Any]" = OrderedDict()
+CUM_FUNC_DEFAULTS: Dict[str, Any] = {}
 CUM_FUNC_DEFAULTS["dtype"] = None
 CUM_FUNC_DEFAULTS["out"] = None
 validate_cum_func = CompatValidator(
@@ -204,7 +203,7 @@ def validate_cum_func_with_skipna(skipna, args, kwargs, name):
     return skipna
 
 
-ALLANY_DEFAULTS: "OrderedDict[str, Optional[bool]]" = OrderedDict()
+ALLANY_DEFAULTS: Dict[str, Optional[bool]] = {}
 ALLANY_DEFAULTS["dtype"] = None
 ALLANY_DEFAULTS["out"] = None
 ALLANY_DEFAULTS["keepdims"] = False
@@ -241,13 +240,13 @@ validate_round = CompatValidator(
     ROUND_DEFAULTS, fname="round", method="both", max_fname_arg_count=1
 )
 
-SORT_DEFAULTS: "OrderedDict[str, Optional[Union[int, str]]]" = OrderedDict()
+SORT_DEFAULTS: Dict[str, Optional[Union[int, str]]] = {}
 SORT_DEFAULTS["axis"] = -1
 SORT_DEFAULTS["kind"] = "quicksort"
 SORT_DEFAULTS["order"] = None
 validate_sort = CompatValidator(SORT_DEFAULTS, fname="sort", method="kwargs")
 
-STAT_FUNC_DEFAULTS: "OrderedDict[str, Optional[Any]]" = OrderedDict()
+STAT_FUNC_DEFAULTS: Dict[str, Optional[Any]] = {}
 STAT_FUNC_DEFAULTS["dtype"] = None
 STAT_FUNC_DEFAULTS["out"] = None
 
@@ -281,13 +280,13 @@ validate_median = CompatValidator(
     MEDIAN_DEFAULTS, fname="median", method="both", max_fname_arg_count=1
 )
 
-STAT_DDOF_FUNC_DEFAULTS: "OrderedDict[str, Optional[bool]]" = OrderedDict()
+STAT_DDOF_FUNC_DEFAULTS: Dict[str, Optional[bool]] = {}
 STAT_DDOF_FUNC_DEFAULTS["dtype"] = None
 STAT_DDOF_FUNC_DEFAULTS["out"] = None
 STAT_DDOF_FUNC_DEFAULTS["keepdims"] = False
 validate_stat_ddof_func = CompatValidator(STAT_DDOF_FUNC_DEFAULTS, method="kwargs")
 
-TAKE_DEFAULTS: "OrderedDict[str, Optional[str]]" = OrderedDict()
+TAKE_DEFAULTS: Dict[str, Optional[str]] = {}
 TAKE_DEFAULTS["out"] = None
 TAKE_DEFAULTS["mode"] = "raise"
 validate_take = CompatValidator(TAKE_DEFAULTS, fname="take", method="kwargs")

--- a/pandas/tests/frame/apply/test_frame_apply.py
+++ b/pandas/tests/frame/apply/test_frame_apply.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from datetime import datetime
 from itertools import chain
 import warnings
@@ -1225,7 +1224,7 @@ class TestDataFrameAggregate:
         tm.assert_frame_equal(result, expected)
 
         # dict input with scalars
-        func = OrderedDict([(name1, "mean"), (name2, "sum")])
+        func = dict([(name1, "mean"), (name2, "sum")])
         result = float_frame.agg(func, axis=axis)
         expected = Series(
             [
@@ -1237,7 +1236,7 @@ class TestDataFrameAggregate:
         tm.assert_series_equal(result, expected)
 
         # dict input with lists
-        func = OrderedDict([(name1, ["mean"]), (name2, ["sum"])])
+        func = dict([(name1, ["mean"]), (name2, ["sum"])])
         result = float_frame.agg(func, axis=axis)
         expected = DataFrame(
             {
@@ -1253,10 +1252,10 @@ class TestDataFrameAggregate:
         tm.assert_frame_equal(result, expected)
 
         # dict input with lists with multiple
-        func = OrderedDict([(name1, ["mean", "sum"]), (name2, ["sum", "max"])])
+        func = dict([(name1, ["mean", "sum"]), (name2, ["sum", "max"])])
         result = float_frame.agg(func, axis=axis)
         expected = DataFrame(
-            OrderedDict(
+            dict(
                 [
                     (
                         name1,

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import numpy as np
 import pytest
 
@@ -202,9 +200,8 @@ class TestSelectDtypes:
 
     def test_select_dtypes_duplicate_columns(self):
         # GH20839
-        odict = OrderedDict
         df = DataFrame(
-            odict(
+            dict(
                 [
                     ("a", list("abc")),
                     ("b", list(range(1, 4))),

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from datetime import timedelta
 
 import numpy as np
@@ -50,10 +49,9 @@ class TestDataFrameDataTypes:
             norows_int_df.dtypes, pd.Series(np.dtype("int32"), index=list("abc"))
         )
 
-        odict = OrderedDict
-        df = pd.DataFrame(odict([("a", 1), ("b", True), ("c", 1.0)]), index=[1, 2, 3])
+        df = pd.DataFrame(dict([("a", 1), ("b", True), ("c", 1.0)]), index=[1, 2, 3])
         ex_dtypes = pd.Series(
-            odict([("a", np.int64), ("b", np.bool_), ("c", np.float64)])
+            dict([("a", np.int64), ("b", np.bool_), ("c", np.float64)])
         )
         tm.assert_series_equal(df.dtypes, ex_dtypes)
 
@@ -85,17 +83,16 @@ class TestDataFrameDataTypes:
     def test_dtypes_are_correct_after_column_slice(self):
         # GH6525
         df = pd.DataFrame(index=range(5), columns=list("abc"), dtype=np.float_)
-        odict = OrderedDict
         tm.assert_series_equal(
             df.dtypes,
-            pd.Series(odict([("a", np.float_), ("b", np.float_), ("c", np.float_)])),
+            pd.Series(dict([("a", np.float_), ("b", np.float_), ("c", np.float_)])),
         )
         tm.assert_series_equal(
-            df.iloc[:, 2:].dtypes, pd.Series(odict([("c", np.float_)]))
+            df.iloc[:, 2:].dtypes, pd.Series(dict([("c", np.float_)]))
         )
         tm.assert_series_equal(
             df.dtypes,
-            pd.Series(odict([("a", np.float_), ("b", np.float_), ("c", np.float_)])),
+            pd.Series(dict([("a", np.float_), ("b", np.float_), ("c", np.float_)])),
         )
 
     def test_dtypes_gh8722(self, float_string_frame):

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from datetime import date, datetime
 import itertools
 import operator
@@ -165,7 +164,7 @@ def create_mgr(descr, item_shape=None):
 
     offset = 0
     mgr_items = []
-    block_placements = OrderedDict()
+    block_placements = {}
     for d in descr.split(";"):
         d = d.strip()
         if not len(d):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import datetime
 from datetime import timedelta
 from io import StringIO
@@ -470,7 +469,7 @@ class TestPandasContainer:
         index = pd.DatetimeIndex(list(index), freq=None)
 
         df_mixed = DataFrame(
-            OrderedDict(
+            dict(
                 float_1=[
                     -0.92077639,
                     0.77434435,

--- a/pandas/tests/resample/test_resample_api.py
+++ b/pandas/tests/resample/test_resample_api.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from datetime import datetime
 
 import numpy as np
@@ -428,7 +427,7 @@ def test_agg_misc():
     msg = r"Column\(s\) \['result1', 'result2'\] do not exist"
     for t in cases:
         with pytest.raises(pd.core.base.SpecificationError, match=msg):
-            t[["A", "B"]].agg(OrderedDict([("result1", np.sum), ("result2", np.mean)]))
+            t[["A", "B"]].agg(dict([("result1", np.sum), ("result2", np.mean)]))
 
     # agg with different hows
     expected = pd.concat(
@@ -438,7 +437,7 @@ def test_agg_misc():
         [("A", "sum"), ("A", "std"), ("B", "mean"), ("B", "std")]
     )
     for t in cases:
-        result = t.agg(OrderedDict([("A", ["sum", "std"]), ("B", ["mean", "std"])]))
+        result = t.agg(dict([("A", ["sum", "std"]), ("B", ["mean", "std"])]))
         tm.assert_frame_equal(result, expected, check_like=True)
 
     # equivalent of using a selection list / or not

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from datetime import date, datetime, timedelta
 import random
 import re
@@ -1931,7 +1930,7 @@ def test_merge_index_types(index):
     result = left.merge(right, on=["index_col"])
 
     expected = DataFrame(
-        OrderedDict([("left_data", [1, 2]), ("right_data", [1.0, 2.0])]), index=index
+        dict([("left_data", [1, 2]), ("right_data", [1.0, 2.0])]), index=index
     )
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, abc, deque
+from collections import abc, deque
 import datetime as dt
 from datetime import datetime
 from decimal import Decimal
@@ -2609,9 +2609,7 @@ bar2,12,13,14,15
             [pd.Series(range(3)), pd.Series(range(4))], keys=["First", "Another"]
         )
         result = pd.concat(
-            OrderedDict(
-                [("First", pd.Series(range(3))), ("Another", pd.Series(range(4)))]
-            )
+            dict([("First", pd.Series(range(3))), ("Another", pd.Series(range(4)))])
         )
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/reshape/test_get_dummies.py
+++ b/pandas/tests/reshape/test_get_dummies.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import numpy as np
 import pytest
 
@@ -569,9 +567,7 @@ class TestGetDummies:
     @pytest.mark.parametrize("sparse", [True, False])
     def test_get_dummies_dont_sparsify_all_columns(self, sparse):
         # GH18914
-        df = DataFrame.from_dict(
-            OrderedDict([("GDP", [1, 2]), ("Nation", ["AB", "CD"])])
-        )
+        df = DataFrame.from_dict(dict([("GDP", [1, 2]), ("Nation", ["AB", "CD"])]))
         df = get_dummies(df, columns=["Nation"], sparse=sparse)
         df2 = df.reindex(columns=["GDP"])
 

--- a/pandas/tests/window/test_api.py
+++ b/pandas/tests/window/test_api.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import numpy as np
 import pytest
 
@@ -335,8 +333,6 @@ def test_multiple_agg_funcs(func, window_size, expected_vals):
     )
     expected = pd.DataFrame(expected_vals, index=index, columns=columns)
 
-    result = window.agg(
-        OrderedDict((("low", ["mean", "max"]), ("high", ["mean", "min"])))
-    )
+    result = window.agg(dict((("low", ["mean", "max"]), ("high", ["mean", "min"]))))
 
     tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #30469 
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Grepping for OrderedDict in *.py files I see 84 more usages, but AFAICT these are all explicitly checking for the class, so I'm considering this as closing #30469.