### PR TITLE
CLN: use standard method to set unhashable object

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1764,7 +1764,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     # ----------------------------------------------------------------------
     # Iteration
 
-    __hash__ = None
+    # to indicate this object is unhashable (https://lgtm.com/rules/1780095/)
+    __hash__ = None  # type: ignore
 
     def __iter__(self):
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1764,11 +1764,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     # ----------------------------------------------------------------------
     # Iteration
 
-    def __hash__(self):
-        raise TypeError(
-            f"{repr(type(self).__name__)} objects are mutable, "
-            f"thus they cannot be hashed"
-        )
+    __hash__ = None
 
     def __iter__(self):
         """

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -123,7 +123,7 @@ class TestDataFrameMisc:
         empty_frame = DataFrame()
 
         df = DataFrame([1])
-        msg = "'DataFrame' objects are mutable, thus they cannot be hashed"
+        msg = "unhashable type: 'DataFrame'"
         with pytest.raises(TypeError, match=msg):
             hash(df)
         with pytest.raises(TypeError, match=msg):

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -268,7 +268,7 @@ class TestSeriesMisc:
     def test_not_hashable(self):
         s_empty = Series(dtype=object)
         s = Series([1])
-        msg = "'Series' objects are mutable, thus they cannot be hashed"
+        msg = "unhashable type: 'Series'"
         with pytest.raises(TypeError, match=msg):
             hash(s_empty)
         with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
#20589 mentioned lgtm. So I decided to test it. And it found this potential improvement. There is even a detailed reference with code examples. https://lgtm.com/rules/1780095/ Very interesting.

Just trying to see if their suggestion works.
