### PR TITLE
TYP: Ignore remaining mypy errors for pandas\tests\*

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -298,7 +298,9 @@ unique_nulls_fixture2 = unique_nulls_fixture
 # ----------------------------------------------------------------
 # Classes
 # ----------------------------------------------------------------
-@pytest.fixture(params=[pd.Index, pd.Series], ids=["index", "series"])
+@pytest.fixture(
+    params=[pd.Index, pd.Series], ids=["index", "series"]  # type: ignore[list-item]
+)
 def index_or_series(request):
     """
     Fixture to parametrize over Index and Series, made necessary by a mypy

--- a/pandas/tests/window/conftest.py
+++ b/pandas/tests/window/conftest.py
@@ -76,7 +76,12 @@ def nopython(request):
 
 
 @pytest.fixture(
-    params=[pytest.param("numba", marks=td.skip_if_no("numba", "0.46.0")), "cython"]
+    params=[
+        pytest.param(
+            "numba", marks=td.skip_if_no("numba", "0.46.0")
+        ),  # type: ignore[list-item]
+        "cython",
+    ]
 )
 def engine(request):
     """engine keyword argument for rolling.apply"""
@@ -327,7 +332,7 @@ def halflife_with_times(request):
         "float64",
         "m8[ns]",
         "M8[ns]",
-        pytest.param(
+        pytest.param(  # type: ignore[list-item]
             "datetime64[ns, UTC]",
             marks=pytest.mark.skip(
                 "direct creation of extension dtype datetime64[ns, UTC] "

--- a/setup.cfg
+++ b/setup.cfg
@@ -128,9 +128,6 @@ ignore_errors=True
 [mypy-pandas.tests.*]
 check_untyped_defs=False
 
-[mypy-pandas.conftest,pandas.tests.window.conftest]
-ignore_errors=True
-
 [mypy-pandas._testing]
 check_untyped_defs=False
 


### PR DESCRIPTION
- [ ] closes #28926
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


These are the only 3 errors outstanding in pandas\tests\* that are stopping us closing #28926

```
pandas\conftest.py:301: error: List item 0 has incompatible type "Type[Index]"; expected "Type[PandasObject]"  [list-item]
pandas\tests\window\conftest.py:79: error: List item 0 has incompatible type "ParameterSet"; expected "Sequence[Collection[object]]"  [list-item]
pandas\tests\window\conftest.py:330: error: List item 15 has incompatible type "ParameterSet"; expected "Sequence[Collection[object]]"  [list-item]
```

these appear to be from a mypy inference issue. It maybe best to `# type: ignore[list-item]` just these lines and remove the `ignore_errors=True` from setup.cfg that applies to the whole file for all error codes.

if the mypy error is resolved in a future release, the `warn_unused_ignores = True` in setup.cfg means that we will be alerted and the ignores can be removed.