### PR TITLE
TST: read binary file objects with read_fwf

### DIFF
--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -6,6 +6,7 @@ engine is set to 'python-fwf' internally.
 
 from datetime import datetime
 from io import BytesIO, StringIO
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -614,3 +615,22 @@ def test_fwf_compression(compression_only, infer):
 
         result = read_fwf(path, **kwargs)
         tm.assert_frame_equal(result, expected)
+
+
+def test_binary_mode():
+    """
+    read_fwf supports opening files in binary mode.
+
+    GH 18035.
+    """
+    data = """aas aas aas
+bba bab b a"""
+    df_reference = pd.DataFrame(
+        [["bba", "bab", "b a"]], columns=["aas", "aas.1", "aas.2"], index=[0]
+    )
+    with tm.ensure_clean() as path:
+        Path(path).write_text(data)
+        with open(path, "rb") as file:
+            df = pd.read_fwf(file)
+            file.seek(0)
+            tm.assert_frame_equal(df, df_reference)


### PR DESCRIPTION
- [x] closes #18035
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry: not needed

`read_fwf` has already supported reading binary file objects. Added the test case from the issue.
