### PR TITLE
TST: honor encoding in read_fwf for memory-mapped files

### DIFF
--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -634,3 +634,24 @@ bba bab b a"""
             df = pd.read_fwf(file)
             file.seek(0)
             tm.assert_frame_equal(df, df_reference)
+
+
+@pytest.mark.parametrize("memory_map", [True, False])
+def test_encoding_mmap(memory_map):
+    """
+    encoding should be working, even when using a memory-mapped file.
+
+    GH 23254.
+    """
+    encoding = "iso8859_1"
+    data = BytesIO(" 1 A Ä 2\n".encode(encoding))
+    df = pd.read_fwf(
+        data,
+        header=None,
+        widths=[2, 2, 2, 2],
+        encoding=encoding,
+        memory_map=memory_map,
+    )
+    data.seek(0)
+    df_reference = pd.DataFrame([[1, "A", "Ä", 2]])
+    tm.assert_frame_equal(df, df_reference)


### PR DESCRIPTION
- [x] closes #23254
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry: not needed

`encoding` was already working for memory-mapped files in `read_fwf`.
