### PR TITLE
BUG: Segfault with string Index when using Rolling after Groupby

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -397,7 +397,7 @@ class BaseWindow(ShallowMixin, SelectionMixin):
 
         if self.on is not None and not self._on.equals(obj.index):
             name = self._on.name
-            extra_col = Series(self._on, index=obj.index, name=name)
+            extra_col = Series(self._on, index=self.obj.index, name=name).sort_index()
             if name in result.columns:
                 # TODO: sure we want to overwrite results?
                 result[name] = extra_col
@@ -2268,7 +2268,7 @@ class RollingGroupby(WindowGroupByMixin, Rolling):
         """
         rolling_indexer: Type[BaseIndexer]
         indexer_kwargs: Optional[Dict] = None
-        index_array = self.obj.index.asi8
+        index_array = self._on.asi8
         if isinstance(self.window, BaseIndexer):
             rolling_indexer = type(self.window)
             indexer_kwargs = self.window.__dict__

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -397,7 +397,7 @@ class BaseWindow(ShallowMixin, SelectionMixin):
 
         if self.on is not None and not self._on.equals(obj.index):
             name = self._on.name
-            extra_col = Series(self._on, index=self.obj.index, name=name).sort_index()
+            extra_col = Series(self._on, index=self.obj.index, name=name)
             if name in result.columns:
                 # TODO: sure we want to overwrite results?
                 result[name] = extra_col

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -416,3 +416,32 @@ class TestGrouperGrouping:
         result = expected.groupby(["s1", "s2"]).rolling(window=1).sum()
         expected.index = pd.MultiIndex.from_tuples([], names=["s1", "s2", None])
         tm.assert_frame_equal(result, expected)
+
+    def test_groupby_rolling_string_index(self):
+        # GH: 36727
+        df = pd.DataFrame(
+            [
+                ["A", "group_1", pd.Timestamp(2019, 1, 1, 9)],
+                ["B", "group_1", pd.Timestamp(2019, 1, 2, 9)],
+                ["C", "group_2", pd.Timestamp(2019, 1, 3, 9)],
+                ["D", "group_1", pd.Timestamp(2019, 1, 6, 9)],
+                ["E", "group_2", pd.Timestamp(2019, 1, 20, 9)],
+            ],
+            columns=["index", "group", "eventTime"],
+        ).set_index("index")
+
+        groups = df.groupby("group")
+        df["count_to_date"] = groups.cumcount()
+        rolling_groups = groups.rolling("10d", on="eventTime")
+        result = rolling_groups.apply(lambda df: df.shape[0])
+        expected = pd.DataFrame(
+            [
+                ["A", "group_1", pd.Timestamp(2019, 1, 1, 9), 1.0],
+                ["B", "group_1", pd.Timestamp(2019, 1, 2, 9), 2.0],
+                ["D", "group_1", pd.Timestamp(2019, 1, 6, 9), 3.0],
+                ["C", "group_2", pd.Timestamp(2019, 1, 3, 9), 1.0],
+                ["E", "group_2", pd.Timestamp(2019, 1, 20, 9), 1.0],
+            ],
+            columns=["index", "group", "eventTime", "count_to_date"]
+        ).set_index(["group", "index"])
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -423,8 +423,8 @@ class TestGrouperGrouping:
             [
                 ["A", "group_1", pd.Timestamp(2019, 1, 1, 9)],
                 ["B", "group_1", pd.Timestamp(2019, 1, 2, 9)],
-                ["C", "group_2", pd.Timestamp(2019, 1, 3, 9)],
-                ["D", "group_1", pd.Timestamp(2019, 1, 6, 9)],
+                ["Z", "group_2", pd.Timestamp(2019, 1, 3, 9)],
+                ["H", "group_1", pd.Timestamp(2019, 1, 6, 9)],
                 ["E", "group_2", pd.Timestamp(2019, 1, 20, 9)],
             ],
             columns=["index", "group", "eventTime"],
@@ -438,8 +438,8 @@ class TestGrouperGrouping:
             [
                 ["A", "group_1", pd.Timestamp(2019, 1, 1, 9), 1.0],
                 ["B", "group_1", pd.Timestamp(2019, 1, 2, 9), 2.0],
-                ["D", "group_1", pd.Timestamp(2019, 1, 6, 9), 3.0],
-                ["C", "group_2", pd.Timestamp(2019, 1, 3, 9), 1.0],
+                ["H", "group_1", pd.Timestamp(2019, 1, 6, 9), 3.0],
+                ["Z", "group_2", pd.Timestamp(2019, 1, 3, 9), 1.0],
                 ["E", "group_2", pd.Timestamp(2019, 1, 20, 9), 1.0],
             ],
             columns=["index", "group", "eventTime", "count_to_date"]

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -442,6 +442,6 @@ class TestGrouperGrouping:
                 ["Z", "group_2", pd.Timestamp(2019, 1, 3, 9), 1.0],
                 ["E", "group_2", pd.Timestamp(2019, 1, 20, 9), 1.0],
             ],
-            columns=["index", "group", "eventTime", "count_to_date"]
+            columns=["index", "group", "eventTime", "count_to_date"],
         ).set_index(["group", "index"])
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #36727
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The segfault was caused by ``self.obj.index.asi8=None`` when Index is a string Index. ``self._on.asi8`` solves that issue.

Additionally I noticed, that ``obj.index`` was already sorted, so the insert of ``extra_col`` mixed up the order. We should use ``self.obj.index``.

I will add a whats new after #36689 is merged.

cc @mroeschke 