### PR TITLE
ENH: Add headers paramater to read_json and read_csv

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -150,9 +150,9 @@ def urlopen(*args, **kwargs):
     """
     import urllib.request
 
-    # Request class is only available in Python3, which 
+    # Request class is only available in Python3, which
     # allows headers to be specified
-    if hasattr(urllib.request, 'Request'):
+    if hasattr(urllib.request, "Request"):
         r = urllib.request.urlopen(urllib.request.Request(*args, **kwargs))
     else:
         r = urllib.request.urlopen(*args, **kwargs)
@@ -183,7 +183,7 @@ def get_filepath_or_buffer(
     compression: CompressionOptions = None,
     mode: ModeVar = None,  # type: ignore[assignment]
     storage_options: StorageOptions = None,
-    headers: dict = {}
+    headers: dict = {},
 ) -> IOargs[ModeVar, EncodingVar]:
     """
     If the filepath_or_buffer is a url, translate and return the buffer.

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -176,7 +176,7 @@ def get_filepath_or_buffer(
     compression: CompressionOptions = None,
     mode: ModeVar = None,  # type: ignore[assignment]
     storage_options: StorageOptions = None,
-    headers: dict = {},
+    headers: Dict[str, Any] = {},
 ) -> IOargs[ModeVar, EncodingVar]:
     """
     If the filepath_or_buffer is a url, translate and return the buffer.

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -150,7 +150,14 @@ def urlopen(*args, **kwargs):
     """
     import urllib.request
 
-    return urllib.request.urlopen(*args, **kwargs)
+    # Request class is only available in Python3, which 
+    # allows headers to be specified
+    if hasattr(urllib.request, 'Request'):
+        r = urllib.request.urlopen(urllib.request.Request(*args, **kwargs))
+    else:
+        r = urllib.request.urlopen(*args, **kwargs)
+
+    return r
 
 
 def is_fsspec_url(url: FilePathOrBuffer) -> bool:
@@ -176,6 +183,7 @@ def get_filepath_or_buffer(
     compression: CompressionOptions = None,
     mode: ModeVar = None,  # type: ignore[assignment]
     storage_options: StorageOptions = None,
+    headers: dict = {}
 ) -> IOargs[ModeVar, EncodingVar]:
     """
     If the filepath_or_buffer is a url, translate and return the buffer.
@@ -251,7 +259,7 @@ def get_filepath_or_buffer(
             raise ValueError(
                 "storage_options passed with file object or non-fsspec file path"
             )
-        req = urlopen(filepath_or_buffer)
+        req = urlopen(filepath_or_buffer, headers=headers)
         content_encoding = req.headers.get("Content-Encoding", None)
         if content_encoding == "gzip":
             # Override compression based on Content-Encoding header

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -148,16 +148,9 @@ def urlopen(*args, **kwargs):
     Lazy-import wrapper for stdlib urlopen, as that imports a big chunk of
     the stdlib.
     """
-    import urllib.request
+    from urllib.request import Request, urlopen as _urlopen
 
-    # Request class is only available in Python3, which
-    # allows headers to be specified
-    if hasattr(urllib.request, "Request"):
-        r = urllib.request.urlopen(urllib.request.Request(*args, **kwargs))
-    else:
-        r = urllib.request.urlopen(*args, **kwargs)
-
-    return r
+    return _urlopen(Request(*args, **kwargs))
 
 
 def is_fsspec_url(url: FilePathOrBuffer) -> bool:

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -3,7 +3,7 @@ import functools
 from io import BytesIO, StringIO
 from itertools import islice
 import os
-from typing import IO, Any, Callable, List, Optional, Type
+from typing import IO, Any, Callable, Dict, List, Optional, Type
 
 import numpy as np
 
@@ -377,7 +377,7 @@ def read_json(
     compression: CompressionOptions = "infer",
     nrows: Optional[int] = None,
     storage_options: StorageOptions = None,
-    headers: dict = {},
+    headers: Dict[str, Any] = {},
 ):
     """
     Convert a JSON string to pandas object.

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -528,6 +528,10 @@ def read_json(
         a file-like buffer. See the fsspec and backend storage implementation
         docs for the set of allowed keys and values.
 
+    headers : dict, optional
+        HTTP headers that are passed to urlopen. Allows to specify the User-Agent
+        in case the urllib User-Agent is blocked for example
+
         .. versionadded:: 1.2.0
 
     Returns

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -377,7 +377,7 @@ def read_json(
     compression: CompressionOptions = "infer",
     nrows: Optional[int] = None,
     storage_options: StorageOptions = None,
-    headers: dict = {}
+    headers: dict = {},
 ):
     """
     Convert a JSON string to pandas object.
@@ -615,7 +615,7 @@ def read_json(
         encoding=encoding,
         compression=compression,
         storage_options=storage_options,
-        headers=headers
+        headers=headers,
     )
 
     json_reader = JsonReader(

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -377,6 +377,7 @@ def read_json(
     compression: CompressionOptions = "infer",
     nrows: Optional[int] = None,
     storage_options: StorageOptions = None,
+    headers: dict = {}
 ):
     """
     Convert a JSON string to pandas object.
@@ -614,6 +615,7 @@ def read_json(
         encoding=encoding,
         compression=compression,
         storage_options=storage_options,
+        headers=headers
     )
 
     json_reader = JsonReader(

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -604,7 +604,7 @@ def read_csv(
     memory_map=False,
     float_precision=None,
     storage_options: StorageOptions = None,
-    headers={},
+    headers: Dict[str, Any] = {},
 ):
     # gh-23761
     #

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -432,9 +432,10 @@ def _read(filepath_or_buffer: FilePathOrBuffer, kwds):
         encoding = re.sub("_", "-", encoding).lower()
         kwds["encoding"] = encoding
     compression = kwds.get("compression", "infer")
+    headers = kwds.get("headers", {})
 
     ioargs = get_filepath_or_buffer(
-        filepath_or_buffer, encoding, compression, storage_options=storage_options
+        filepath_or_buffer, encoding, compression, storage_options=storage_options, headers=headers
     )
     kwds["compression"] = ioargs.compression
 
@@ -599,6 +600,7 @@ def read_csv(
     memory_map=False,
     float_precision=None,
     storage_options: StorageOptions = None,
+    headers={}
 ):
     # gh-23761
     #
@@ -686,6 +688,7 @@ def read_csv(
         infer_datetime_format=infer_datetime_format,
         skip_blank_lines=skip_blank_lines,
         storage_options=storage_options,
+        headers=headers
     )
 
     return _read(filepath_or_buffer, kwds)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -352,6 +352,10 @@ storage_options : dict, optional
     a file-like buffer. See the fsspec and backend storage implementation
     docs for the set of allowed keys and values.
 
+headers : dict, optional
+    HTTP headers that are passed to urlopen. Allows to specify the User-Agent
+    in case the urllib User-Agent is blocked for example
+
     .. versionadded:: 1.2
 
 Returns

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -435,7 +435,11 @@ def _read(filepath_or_buffer: FilePathOrBuffer, kwds):
     headers = kwds.get("headers", {})
 
     ioargs = get_filepath_or_buffer(
-        filepath_or_buffer, encoding, compression, storage_options=storage_options, headers=headers
+        filepath_or_buffer,
+        encoding,
+        compression,
+        storage_options=storage_options,
+        headers=headers,
     )
     kwds["compression"] = ioargs.compression
 
@@ -600,7 +604,7 @@ def read_csv(
     memory_map=False,
     float_precision=None,
     storage_options: StorageOptions = None,
-    headers={}
+    headers={},
 ):
     # gh-23761
     #
@@ -688,7 +692,7 @@ def read_csv(
         infer_datetime_format=infer_datetime_format,
         skip_blank_lines=skip_blank_lines,
         storage_options=storage_options,
-        headers=headers
+        headers=headers,
     )
 
     return _read(filepath_or_buffer, kwds)

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -417,3 +417,11 @@ def test_is_fsspec_url():
     assert not icom.is_fsspec_url("random:pandas/somethingelse.com")
     assert not icom.is_fsspec_url("/local/path")
     assert not icom.is_fsspec_url("relative/local/path")
+
+
+def test_urlopen_headers():
+    headers = {"User-Agent": "Pandas 1.1.0"}
+    # this returns the User-Agent
+    url = "http://ifconfig.me/ua"
+    r = icom.urlopen(url, headers=headers)
+    assert r.read().decode("utf-8") == headers["User-Agent"]


### PR DESCRIPTION
- [x] closes #36688
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This adds the option to specify headers when reading a csv or a json file from an URL in Python3.
Let me know if new tests are needed.