### PR TITLE
ENH: allow for top and mid-level assignment to DataFrames with MultIndex columns #7475

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3193,9 +3193,11 @@ class DataFrame(NDFrame, OpsMixin):
                 if len(columns) == len(key):
                     for k1, k2 in zip(key, columns):
                         self[k1] = value[k2]
-                elif columns.nlevels > 1 and len(columns.levels[0]) == len(key):
-                    for k1, k2 in zip(key, columns.levels[0]):
-                        self[k1] = value[k2]
+                elif isinstance(columns, MultiIndex):
+                    levels0 = columns.levels[0]
+                    if len(levels0) == len(key):
+                        for k1, k2 in zip(key, levels0):
+                            self[k1] = value[k2]
                 else:
                     raise ValueError(
                         "Key must be same length as columns or top level of "

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1232,6 +1232,26 @@ class BlockManager(PandasObject):
                 stacklevel=5,
             )
 
+    def append_block(self, items, values):
+        base, size = len(self.items), len(items)
+
+        new_axis = self.items.append(items)
+        block = make_block(
+            values=values, ndim=self.ndim, placement=slice(base, base + size)
+        )
+
+        blk_no = len(self.blocks)
+        self._blklocs = np.append(self.blklocs, range(size))
+        self._blknos = np.append(self.blknos, size * (blk_no,))
+
+        self.axes[0] = new_axis
+        self.blocks += (block,)
+
+        self._known_consolidated = False
+
+        if len(self.blocks) > 100:
+            self._consolidate_inplace()
+
     def reindex_axis(
         self,
         new_index,

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -119,7 +119,7 @@ class TestDataFrameIndexing:
         tm.assert_series_equal(float_frame["B"], data["A"], check_names=False)
         tm.assert_series_equal(float_frame["A"], data["B"], check_names=False)
 
-        msg = "Columns must be same length as key"
+        msg = "Key must be same length as columns or top level of MultiIndex"
         with pytest.raises(ValueError, match=msg):
             data[["A"]] = float_frame[["A", "B"]]
         newcolumndata = range(len(data.index) - 1)

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -103,7 +103,7 @@ class TestMultiIndexBasic:
             idx.get_loc([])
 
     def test_multiindex_frame_assign(self):
-        df0 = pd.DataFrame({"a": [0, 1, 2, 3], "b": [3, 4, 5, 6]})
+        df0 = DataFrame({"a": [0, 1, 2, 3], "b": [3, 4, 5, 6]})
         df1 = pd.concat({"x": df0, "y": df0}, axis=1)
         df2 = pd.concat({"q": df1, "r": df1}, axis=1)
 


### PR DESCRIPTION
- [x] closes #7475 (related to #35727)
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This allows for one to assign to the top and mid-levels of DataFrame columns. To do so, it adds another fallback execution path to `__setitem__`. The logic is:
- In `__setitem__`, if the other existing paths don't apply, there is a single key, and the columns are a MultiIndex, pass to `_setitem_multilevel`. Here, assign if the key exists in the columns. Otherwise, use the new function `append_block` to assign multiple columns at once.
- In the existing `_setitem_array`, as a fallback, if the length of the assigning key equals the length of the top level of the value columns, recurse these back onto `__setitem__`. This allows for higher level list assignments.

I've also added some tests of the functionality in various cases. Any comments much appreciated.