### PR TITLE
ENH: Implement IntegerArray reductions

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -168,6 +168,7 @@ Other enhancements
 - ``Styler`` now allows direct CSS class name addition to individual data cells (:issue:`36159`)
 - :meth:`Rolling.mean()` and :meth:`Rolling.sum()` use Kahan summation to calculate the mean to avoid numerical problems (:issue:`10319`, :issue:`11645`, :issue:`13254`, :issue:`32761`, :issue:`36031`)
 - :meth:`DatetimeIndex.searchsorted`, :meth:`TimedeltaIndex.searchsorted`, :meth:`PeriodIndex.searchsorted`, and :meth:`Series.searchsorted` with datetimelike dtypes will now try to cast string arguments (listlike and scalar) to the matching datetimelike type (:issue:`36346`)
+- Added methods :meth:`IntegerArray.prod`, :meth:`IntegerArray.min`, and :meth:`IntegerArray.max` (:issue:`33790`)
 
 .. _whatsnew_120.api_breaking.python:
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -25,7 +25,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.missing import isna
 
 from pandas.core import ops
-from pandas.core.array_algos import masked_reductions
 from pandas.core.ops import invalid_comparison
 from pandas.core.ops.common import unpack_zerodim_and_defer
 from pandas.core.tools.numeric import to_numeric
@@ -550,10 +549,19 @@ class IntegerArray(BaseMaskedArray):
 
     def sum(self, skipna=True, min_count=0, **kwargs):
         nv.validate_sum((), kwargs)
-        result = masked_reductions.sum(
-            values=self._data, mask=self._mask, skipna=skipna, min_count=min_count
-        )
-        return result
+        return super()._reduce("sum", skipna=skipna, min_count=min_count)
+
+    def prod(self, skipna=True, min_count=0, **kwargs):
+        nv.validate_sum((), kwargs)
+        return super()._reduce("prod", skipna=skipna, min_count=min_count)
+
+    def min(self, skipna=True, **kwargs):
+        nv.validate_min((), kwargs)
+        return super()._reduce("min", skipna=skipna)
+
+    def max(self, skipna=True, **kwargs):
+        nv.validate_max((), kwargs)
+        return super()._reduce("max", skipna=skipna)
 
     def _maybe_mask_result(self, result, mask, other, op_name: str):
         """

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -552,7 +552,7 @@ class IntegerArray(BaseMaskedArray):
         return super()._reduce("sum", skipna=skipna, min_count=min_count)
 
     def prod(self, skipna=True, min_count=0, **kwargs):
-        nv.validate_sum((), kwargs)
+        nv.validate_prod((), kwargs)
         return super()._reduce("prod", skipna=skipna, min_count=min_count)
 
     def min(self, skipna=True, **kwargs):

--- a/pandas/tests/arrays/integer/test_function.py
+++ b/pandas/tests/arrays/integer/test_function.py
@@ -115,11 +115,37 @@ def test_value_counts_empty():
 
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.parametrize("min_count", [0, 4])
-def test_integer_array_sum(skipna, min_count):
-    arr = pd.array([1, 2, 3, None], dtype="Int64")
+def test_integer_array_sum(skipna, min_count, any_nullable_int_dtype):
+    dtype = any_nullable_int_dtype
+    arr = pd.array([1, 2, 3, None], dtype=dtype)
     result = arr.sum(skipna=skipna, min_count=min_count)
     if skipna and min_count == 0:
         assert result == 6
+    else:
+        assert result is pd.NA
+
+
+@pytest.mark.parametrize("skipna", [True, False])
+@pytest.mark.parametrize("method", ["min", "max"])
+def test_integer_array_min_max(skipna, method, any_nullable_int_dtype):
+    dtype = any_nullable_int_dtype
+    arr = pd.array([0, 1, None], dtype=dtype)
+    func = getattr(arr, method)
+    result = func(skipna=skipna)
+    if skipna:
+        assert result == (0 if method == "min" else 1)
+    else:
+        assert result is pd.NA
+
+
+@pytest.mark.parametrize("skipna", [True, False])
+@pytest.mark.parametrize("min_count", [0, 9])
+def test_integer_array_prod(skipna, min_count, any_nullable_int_dtype):
+    dtype = any_nullable_int_dtype
+    arr = pd.array([1, 2, None], dtype=dtype)
+    result = arr.prod(skipna=skipna, min_count=min_count)
+    if skipna and min_count == 0:
+        assert result == 2
     else:
         assert result is pd.NA
 


### PR DESCRIPTION
- [x] ref #33790
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I'm not sure if this is the "best" way to implement these reductions (see linked issue), but in any case I figure this is better than nothing since we can get these reductions pretty much for free. As far as I can tell FloatingArray can use the same machinery.

(I'm not able to pass on kwargs here because the masked reductions don't take them all, e.g. `axis`, and various tests break as a result.)