### PR TITLE
BUG: Rolling returned nan with FixedForwardWindowIndexer for count when window contained only missing values

### DIFF
--- a/doc/source/whatsnew/v1.1.3.rst
+++ b/doc/source/whatsnew/v1.1.3.rst
@@ -58,6 +58,7 @@ Bug fixes
 - Bug in :meth:`Series.astype` showing too much precision when casting from ``np.float32`` to string dtype (:issue:`36451`)
 - Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` when using ``NaN`` and a row length above 1,000,000 (:issue:`22205`)
 - Bug in :func:`cut` raising a ``ValueError`` when passed a :class:`Series` of labels with ``ordered=False`` (:issue:`36603`)
+- Bug in :meth:`Rolling.count` returned ``np.nan`` with ``FixedForwardWindowIndexer`` as window, ``min_periods=0`` and only missing values in window (:issue:`35579`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2056,7 +2056,7 @@ class Rolling(RollingAndExpandingMixin):
         # when using a BaseIndexer subclass as a window
         if self.is_freq_type or isinstance(self.window, BaseIndexer):
             window_func = self._get_roll_func("roll_count")
-            return self._apply(window_func, center=self.center, name="count")
+            return self._apply(window_func, center=self.center, name="count", floor=0)
 
         return super().count()
 

--- a/pandas/tests/window/test_base_indexer.py
+++ b/pandas/tests/window/test_base_indexer.py
@@ -253,3 +253,12 @@ def test_non_fixed_variable_window_indexer(closed, expected_data):
     result = df.rolling(indexer, closed=closed).sum()
     expected = DataFrame(expected_data, index=index)
     tm.assert_frame_equal(result, expected)
+
+
+def test_fixed_forward_indexer_count():
+    # GH: 35579
+    df = DataFrame({"b": [None, None, None, 7]})
+    indexer = FixedForwardWindowIndexer(window_size=2)
+    result = df.rolling(window=indexer, min_periods=0).count()
+    expected = DataFrame({"b": [0.0, 0.0, 1.0, 1.0]})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #35579
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Issue still has milestone 1.1.3. If it's to late for this release, I'll move the whats new note to 1.1.4 for when the associated PR is merged.

cc @mroeschke 