### PR TITLE
CLN: test_moments_consistency_*.py

### DIFF
--- a/pandas/tests/window/common.py
+++ b/pandas/tests/window/common.py
@@ -4,33 +4,6 @@ from pandas import Series
 import pandas._testing as tm
 
 
-def check_binary_ew(name, A, B):
-
-    result = getattr(A.ewm(com=20, min_periods=5), name)(B)
-    assert np.isnan(result.values[:14]).all()
-    assert not np.isnan(result.values[14:]).any()
-
-
-def check_binary_ew_min_periods(name, min_periods, A, B):
-    # GH 7898
-    result = getattr(A.ewm(com=20, min_periods=min_periods), name)(B)
-    # binary functions (ewmcov, ewmcorr) with bias=False require at
-    # least two values
-    assert np.isnan(result.values[:11]).all()
-    assert not np.isnan(result.values[11:]).any()
-
-    # check series of length 0
-    empty = Series([], dtype=np.float64)
-    result = getattr(empty.ewm(com=50, min_periods=min_periods), name)(empty)
-    tm.assert_series_equal(result, empty)
-
-    # check series of length 1
-    result = getattr(Series([1.0]).ewm(com=50, min_periods=min_periods), name)(
-        Series([1.0])
-    )
-    tm.assert_series_equal(result, Series([np.NaN]))
-
-
 def moments_consistency_mock_mean(x, mean, mock_mean):
     mean_x = mean(x)
     # check that correlation of a series with itself is either 1 or NaN

--- a/pandas/tests/window/common.py
+++ b/pandas/tests/window/common.py
@@ -4,20 +4,16 @@ from pandas import Series
 import pandas._testing as tm
 
 
-def ew_func(A, B, com, name, **kwargs):
-    return getattr(A.ewm(com, **kwargs), name)(B)
-
-
 def check_binary_ew(name, A, B):
 
-    result = ew_func(A=A, B=B, com=20, name=name, min_periods=5)
+    result = getattr(A.ewm(com=20, min_periods=5), name)(B)
     assert np.isnan(result.values[:14]).all()
     assert not np.isnan(result.values[14:]).any()
 
 
 def check_binary_ew_min_periods(name, min_periods, A, B):
     # GH 7898
-    result = ew_func(A, B, 20, name=name, min_periods=min_periods)
+    result = getattr(A.ewm(com=20, min_periods=min_periods), name)(B)
     # binary functions (ewmcov, ewmcorr) with bias=False require at
     # least two values
     assert np.isnan(result.values[:11]).all()
@@ -25,12 +21,12 @@ def check_binary_ew_min_periods(name, min_periods, A, B):
 
     # check series of length 0
     empty = Series([], dtype=np.float64)
-    result = ew_func(empty, empty, 50, name=name, min_periods=min_periods)
+    result = getattr(empty.ewm(com=50, min_periods=min_periods), name)(empty)
     tm.assert_series_equal(result, empty)
 
     # check series of length 1
-    result = ew_func(
-        Series([1.0]), Series([1.0]), 50, name=name, min_periods=min_periods
+    result = getattr(Series([1.0]).ewm(com=50, min_periods=min_periods), name)(
+        Series([1.0])
     )
     tm.assert_series_equal(result, Series([np.NaN]))
 

--- a/pandas/tests/window/common.py
+++ b/pandas/tests/window/common.py
@@ -4,18 +4,6 @@ from pandas import Series
 import pandas._testing as tm
 
 
-def check_pairwise_moment(frame, dispatch, name, **kwargs):
-    def get_result(obj, obj2=None):
-        return getattr(getattr(obj, dispatch)(**kwargs), name)(obj2)
-
-    result = get_result(frame)
-    result = result.loc[(slice(None), 1), 5]
-    result.index = result.index.droplevel(1)
-    expected = get_result(frame[1], frame[5])
-    expected.index = expected.index._with_freq(None)
-    tm.assert_series_equal(result, expected, check_names=False)
-
-
 def ew_func(A, B, com, name, **kwargs):
     return getattr(A.ewm(com, **kwargs), name)(B)
 

--- a/pandas/tests/window/moments/test_moments_consistency_ewm.py
+++ b/pandas/tests/window/moments/test_moments_consistency_ewm.py
@@ -7,7 +7,6 @@ import pandas._testing as tm
 from pandas.tests.window.common import (
     check_binary_ew,
     check_binary_ew_min_periods,
-    ew_func,
     moments_consistency_cov_data,
     moments_consistency_is_constant,
     moments_consistency_mock_mean,
@@ -43,7 +42,7 @@ def test_different_input_array_raise_exception(name, binary_ew_data):
     msg = "Input arrays must be of the same type!"
     # exception raised is Exception
     with pytest.raises(Exception, match=msg):
-        ew_func(A, randn(50), 20, name=name, min_periods=5)
+        getattr(A.ewm(com=20, min_periods=5), name)(randn(50))
 
 
 @pytest.mark.slow

--- a/pandas/tests/window/moments/test_moments_consistency_rolling.py
+++ b/pandas/tests/window/moments/test_moments_consistency_rolling.py
@@ -12,7 +12,6 @@ from pandas import DataFrame, DatetimeIndex, Index, Series
 import pandas._testing as tm
 from pandas.core.window.common import flex_binary_moment
 from pandas.tests.window.common import (
-    check_pairwise_moment,
     moments_consistency_cov_data,
     moments_consistency_is_constant,
     moments_consistency_mock_mean,
@@ -60,7 +59,12 @@ def test_rolling_corr(series):
 
 @pytest.mark.parametrize("func", ["cov", "corr"])
 def test_rolling_pairwise_cov_corr(func, frame):
-    check_pairwise_moment(frame, "rolling", func, window=10, min_periods=5)
+    result = getattr(frame.rolling(window=10, min_periods=5), func)()
+    result = result.loc[(slice(None), 1), 5]
+    result.index = result.index.droplevel(1)
+    expected = getattr(frame[1].rolling(window=10, min_periods=5), func)(frame[5])
+    expected.index = expected.index._with_freq(None)
+    tm.assert_series_equal(result, expected, check_names=False)
 
 
 @pytest.mark.parametrize("method", ["corr", "cov"])


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`


In-lining some common functions to make it easier to follow test failure tracebacks