### PR TITLE
Rolling on DataFrameGroupBy duplicated index column when part of the grouping cols is from index

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -404,6 +404,7 @@ Groupby/resample/rolling
 - Bug in :meth:`DataFrame.groupby` does not always maintain column index name for ``any``, ``all``, ``bfill``, ``ffill``, ``shift`` (:issue:`29764`)
 - Bug in :meth:`DataFrameGroupBy.apply` raising error with ``np.nan`` group(s) when ``dropna=False`` (:issue:`35889`)
 - Bug in :meth:`Rolling.sum()` returned wrong values when dtypes where mixed between float and integer and axis was equal to one (:issue:`20649`, :issue:`35596`)
+- Bug in :meth:`DataFrameGroupBy.rolling` duplicates index columns when a part of the grouping columns was from the index (:issue:`36794`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -675,9 +675,7 @@ def test_iter_rolling_datetime(expected, expected_index, window):
     [
         (
             {"level": 0},
-            pd.MultiIndex.from_tuples(
-                [(0, 0), (0, 0), (1, 1), (1, 1), (1, 1)], names=[None, None]
-            ),
+            pd.Index([0, 0, 1, 1, 1]),
         ),
         (
             {"by": "X"},


### PR DESCRIPTION
…grouping cols is from index

- [x] closes #36794
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Could not find a elegant way, to avoid adding the components in the for loop, so I dropped it from the resulting MultiIndex again.

Had to change a test, which depended on the wrong behavior.

cc @mroeschke 