### PR TITLE
DOC: update code style for remaining intro tutorial docs for #36777

### DIFF
--- a/doc/source/getting_started/intro_tutorials/01_table_oriented.rst
+++ b/doc/source/getting_started/intro_tutorials/01_table_oriented.rst
@@ -41,12 +41,16 @@ I want to store passenger data of the Titanic. For a number of passengers, I kno
 
 .. ipython:: python
 
-    df = pd.DataFrame({
-        "Name": ["Braund, Mr. Owen Harris",
-                 "Allen, Mr. William Henry",
-                 "Bonnell, Miss. Elizabeth"],
-        "Age": [22, 35, 58],
-        "Sex": ["male", "male", "female"]}
+    df = pd.DataFrame(
+        {
+            "Name": [
+                "Braund, Mr. Owen Harris",
+                "Allen, Mr. William Henry",
+                "Bonnell, Miss. Elizabeth",
+            ],
+            "Age": [22, 35, 58],
+            "Sex": ["male", "male", "female"],
+        }
     )
     df
 

--- a/doc/source/getting_started/intro_tutorials/02_read_write.rst
+++ b/doc/source/getting_started/intro_tutorials/02_read_write.rst
@@ -138,7 +138,7 @@ My colleague requested the Titanic data as a spreadsheet.
 
 .. ipython:: python
 
-    titanic.to_excel('titanic.xlsx', sheet_name='passengers', index=False)
+    titanic.to_excel("titanic.xlsx", sheet_name="passengers", index=False)
 
 Whereas ``read_*`` functions are used to read data to pandas, the
 ``to_*`` methods are used to store data. The :meth:`~DataFrame.to_excel` method stores
@@ -156,7 +156,7 @@ The equivalent read function :meth:`~DataFrame.read_excel` will reload the data 
 
 .. ipython:: python
 
-    titanic = pd.read_excel('titanic.xlsx', sheet_name='passengers')
+    titanic = pd.read_excel("titanic.xlsx", sheet_name="passengers")
 
 .. ipython:: python
 
@@ -166,7 +166,8 @@ The equivalent read function :meth:`~DataFrame.read_excel` will reload the data 
    :suppress:
 
    import os
-   os.remove('titanic.xlsx')
+
+   os.remove("titanic.xlsx")
 
 .. raw:: html
 

--- a/doc/source/getting_started/intro_tutorials/04_plotting.rst
+++ b/doc/source/getting_started/intro_tutorials/04_plotting.rst
@@ -40,8 +40,7 @@ in respectively Paris, Antwerp and London.
 
 .. ipython:: python
 
-    air_quality = pd.read_csv("data/air_quality_no2.csv",
-                              index_col=0, parse_dates=True)
+    air_quality = pd.read_csv("data/air_quality_no2.csv", index_col=0, parse_dates=True)
     air_quality.head()
 
 .. note::
@@ -112,9 +111,7 @@ I want to visually compare the :math:`N0_2` values measured in London versus Par
 .. ipython:: python
 
     @savefig 04_airqual_scatter.png
-    air_quality.plot.scatter(x="station_london",
-                             y="station_paris",
-                             alpha=0.5)
+    air_quality.plot.scatter(x="station_london", y="station_paris", alpha=0.5)
 
 .. raw:: html
 
@@ -127,8 +124,11 @@ standard Python to get an overview of the available plot methods:
 
 .. ipython:: python
 
-    [method_name for method_name in dir(air_quality.plot)
-        if not method_name.startswith("_")]
+    [
+        method_name
+        for method_name in dir(air_quality.plot)
+        if not method_name.startswith("_")
+    ]
 
 .. note::
     In many development environments as well as ipython and
@@ -196,17 +196,18 @@ I want to further customize, extend or save the resulting plot.
 
 .. ipython:: python
 
-    fig, axs = plt.subplots(figsize=(12, 4));
-    air_quality.plot.area(ax=axs);
+    fig, axs = plt.subplots(figsize=(12, 4))
+    air_quality.plot.area(ax=axs)
     @savefig 04_airqual_customized.png
-    axs.set_ylabel("NO$_2$ concentration");
+    axs.set_ylabel("NO$_2$ concentration")
     fig.savefig("no2_concentrations.png")
 
 .. ipython:: python
    :suppress:
 
    import os
-   os.remove('no2_concentrations.png')
+
+   os.remove("no2_concentrations.png")
 
 .. raw:: html
 

--- a/doc/source/getting_started/intro_tutorials/05_add_columns.rst
+++ b/doc/source/getting_started/intro_tutorials/05_add_columns.rst
@@ -39,8 +39,7 @@ in respectively Paris, Antwerp and London.
 
 .. ipython:: python
 
-    air_quality = pd.read_csv("data/air_quality_no2.csv",
-                              index_col=0, parse_dates=True)
+    air_quality = pd.read_csv("data/air_quality_no2.csv", index_col=0, parse_dates=True)
     air_quality.head()
 
 .. raw:: html
@@ -95,8 +94,9 @@ I want to check the ratio of the values in Paris versus Antwerp and save the res
 
 .. ipython:: python
 
-    air_quality["ratio_paris_antwerp"] = \
+    air_quality["ratio_paris_antwerp"] = (
         air_quality["station_paris"] / air_quality["station_antwerp"]
+    )
     air_quality.head()
 
 The calculation is again element-wise, so the ``/`` is applied *for the
@@ -122,9 +122,12 @@ I want to rename the data columns to the corresponding station identifiers used 
 .. ipython:: python
 
     air_quality_renamed = air_quality.rename(
-        columns={"station_antwerp": "BETR801",
-                 "station_paris": "FR04014",
-                 "station_london": "London Westminster"})
+        columns={
+            "station_antwerp": "BETR801",
+            "station_paris": "FR04014",
+            "station_london": "London Westminster",
+        }
+    )
 
 .. ipython:: python
 


### PR DESCRIPTION
Addresses part of #36777
Ran blacken-tools and checked for warnings from flake8-rst for the remaining 5 intro tutorials. Note that tutorial 3 met the formatting requirements as is, so there is no change there.