### PR TITLE
REF/CLN: pandas/io/pytables.py

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -710,20 +710,7 @@ class HDFStore:
             )
             raise ValueError(msg)
 
-        try:
-            self._handle = tables.open_file(self._path, self._mode, **kwargs)
-        except OSError as err:  # pragma: no cover
-            if "can not be written" in str(err):
-                print(f"Opening {self._path} in read-only mode")
-                self._handle = tables.open_file(self._path, "r", **kwargs)
-            else:
-                raise
-        except Exception as err:
-            # trying to read from a non-existent file causes an error which
-            # is not part of IOError, make it one
-            if self._mode == "r" and "Unable to open/create file" in str(err):
-                raise OSError(str(err)) from err
-            raise
+        self._handle = tables.open_file(self._path, self._mode, **kwargs)
 
     def close(self):
         """

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -8,6 +8,7 @@ from datetime import date, tzinfo
 import itertools
 import os
 import re
+from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 import warnings
 
@@ -5174,15 +5175,16 @@ class Selection:
             # raise a nice message, suggesting that the user should use
             # data_columns
             qkeys = ",".join(q.keys())
-            raise ValueError(
-                f"The passed where expression: {where}\n"
-                "            contains an invalid variable reference\n"
-                "            all of the variable references must be a "
-                "reference to\n"
-                "            an axis (e.g. 'index' or 'columns'), or a "
-                "data_column\n"
-                f"            The currently defined references are: {qkeys}\n"
-            ) from err
+            msg = dedent(
+                f"""\
+                The passed where expression: {where}
+                            contains an invalid variable reference
+                            all of the variable references must be a reference to
+                            an axis (e.g. 'index' or 'columns'), or a data_column
+                            The currently defined references are: {qkeys}
+                """
+            )
+            raise ValueError(msg) from err
 
     def select(self):
         """

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -5,6 +5,7 @@ to disk
 from contextlib import suppress
 import copy
 from datetime import date, tzinfo
+from functools import reduce
 import itertools
 import os
 import re
@@ -4297,9 +4298,8 @@ class AppendableTable(Table):
 
         # consolidate masks
         if len(masks):
-            mask = masks[0]
-            for m in masks[1:]:
-                mask = mask & m
+            combine_masks = lambda first, second: first & second
+            mask = reduce(combine_masks, masks)
             mask = mask.ravel()
         else:
             mask = None

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -807,19 +807,19 @@ class HDFStore:
         ----------
         key : str
             Object being retrieved from file.
-        where : list, default None
+        where : list or None
             List of Term (or convertible) objects, optional.
-        start : int, default None
+        start : int or None
             Row number to start selection.
         stop : int, default None
             Row number to stop selection.
-        columns : list, default None
+        columns : list or None
             A list of columns that if not None, will limit the return columns.
-        iterator : bool, default False
+        iterator : bool or False
             Returns an iterator.
-        chunksize : int, default None
+        chunksize : int or None
             Number or rows to include in iteration, return an iterator.
-        auto_close : bool, default False
+        auto_close : bool or False
             Should automatically close the store when finished.
 
         Returns
@@ -1083,11 +1083,10 @@ class HDFStore:
                 worse but allow more flexible operations like searching / selecting
                 subsets of the data.
         append : bool, default False
-            This will force Table format, append the input data to the
-            existing.
+            This will force Table format, append the input data to the existing.
         data_columns : list, default None
-            List of columns to create as data columns, or True to
-            use all columns. See `here
+            List of columns to create as data columns, or True to use all columns.
+            See `here
             <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#query-via-data-columns>`__.
         encoding : str, default None
             Provide an encoding for strings.

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -666,12 +666,10 @@ class HDFStore:
         tables = _tables()
 
         if self._mode != mode:
-
             # if we are changing a write mode to read, ok
             if self._mode in ["a", "w"] and mode in ["r", "r+"]:
                 pass
             elif mode in ["w"]:
-
                 # this would truncate, raise here
                 if self.is_open:
                     raise PossibleDataLossError(
@@ -700,7 +698,6 @@ class HDFStore:
                 raise
 
         except ValueError as err:
-
             # trap PyTables >= 3.1 FILE_OPEN_POLICY exception
             # to provide an updated message
             if "FILE_OPEN_POLICY" in str(err):
@@ -715,11 +712,9 @@ class HDFStore:
                     "which allows\n"
                     "files to be opened multiple times at once\n"
                 )
-
             raise err
 
         except Exception as err:
-
             # trying to read from a non-existent file causes an error which
             # is not part of IOError, make it one
             if self._mode == "r" and "Unable to open/create file" in str(err):
@@ -1646,7 +1641,6 @@ class HDFStore:
         # infer the pt from the passed value
         if pt is None:
             if value is None:
-
                 _tables()
                 assert _table_mod is not None  # for mypy
                 if getattr(group, "table", None) or isinstance(
@@ -1678,10 +1672,8 @@ class HDFStore:
 
         # existing node (and must be a table)
         if tt is None:
-
             # if we are a writer, determine the tt
             if value is not None:
-
                 if pt == "series_table":
                     index = getattr(value, "index", None)
                     if index is not None:
@@ -1886,11 +1878,9 @@ class TableIterator:
         self.auto_close = auto_close
 
     def __iter__(self):
-
         # iterate
         current = self.start
         while current < self.stop:
-
             stop = min(current + self.chunksize, self.stop)
             value = self.func(None, None, self.coordinates[current:stop])
             current = stop
@@ -1906,7 +1896,6 @@ class TableIterator:
             self.store.close()
 
     def get_result(self, coordinates: bool = False):
-
         #  return the actual iterator
         if self.chunksize is not None:
             if not isinstance(self.s, Table):
@@ -2105,7 +2094,6 @@ class IndexCol:
             with an integer size
         """
         if _ensure_decoded(self.kind) == "string":
-
             if isinstance(min_itemsize, dict):
                 min_itemsize = min_itemsize.get(self.name)
 
@@ -2163,7 +2151,6 @@ class IndexCol:
 
             existing_value = idx.get(key)
             if key in idx and value is not None and existing_value != value:
-
                 # frequency/name just warn
                 if key in ["freq", "index_name"]:
                     ws = attribute_conflict_doc % (key, existing_value, value)
@@ -2356,10 +2343,8 @@ class DataCol(IndexCol):
             atom = cls.get_atom_timedelta64(shape)
         elif is_complex_dtype(dtype):
             atom = _tables().ComplexCol(itemsize=itemsize, shape=shape[0])
-
         elif is_string_dtype(dtype):
             atom = cls.get_atom_string(shape, itemsize)
-
         else:
             atom = cls.get_atom_data(shape, kind=dtype.name)
 
@@ -2465,7 +2450,6 @@ class DataCol(IndexCol):
 
         # reverse converts
         if dtype == "datetime64":
-
             # recreate with tz if indicated
             converted = _set_tz(converted, tz, coerce=True)
 
@@ -2482,7 +2466,6 @@ class DataCol(IndexCol):
                 )
 
         elif meta == "category":
-
             # we have a categorical
             categories = metadata
             codes = converted.ravel()
@@ -2837,7 +2820,6 @@ class GenericFixed(Fixed):
                 ret = node[start:stop]
 
             if dtype == "datetime64":
-
                 # reconstruct a timezone if indicated
                 tz = getattr(attrs, "tz", None)
                 ret = _set_tz(ret, tz, coerce=True)
@@ -3041,7 +3023,6 @@ class GenericFixed(Fixed):
                 self.write_array_empty(key, value)
 
         elif value.dtype.type == np.object_:
-
             # infer the type, warn if we have a non-string type here (for
             # performance)
             inferred_type = lib.infer_dtype(value, skipna=False)
@@ -3725,7 +3706,6 @@ class Table(Fixed):
 
         # if min_itemsize is a dict, add the keys (exclude 'values')
         if isinstance(min_itemsize, dict):
-
             existing_data_columns = set(data_columns)
             data_columns = list(data_columns)  # ensure we do not modify
             data_columns.extend(
@@ -4161,7 +4141,6 @@ class Table(Fixed):
         # find the axes
         for a in self.axes:
             if column == a.name:
-
                 if not a.is_data_indexable:
                     raise ValueError(
                         f"column [{column}] can not be extracted individually; "
@@ -4287,9 +4266,7 @@ class AppendableTable(Table):
         # if dropna==True, then drop ALL nan rows
         masks = []
         if dropna:
-
             for a in self.values_axes:
-
                 # figure the mask: only do if we can successfully process this
                 # column, otherwise ignore the mask
                 mask = isna(a.data).all(axis=0)
@@ -4868,7 +4845,6 @@ def _unconvert_index(
 def _maybe_convert_for_string_atom(
     name: str, block, existing_col, min_itemsize, nan_rep, encoding, errors
 ):
-
     if not block.is_object:
         return block.values
 
@@ -4901,7 +4877,6 @@ def _maybe_convert_for_string_atom(
         # we cannot serialize this data, so report an exception on a column
         # by column basis
         for i in range(len(block.shape[0])):
-
             col = block.iget(i)
             inferred_type = lib.infer_dtype(col, skipna=False)
             if inferred_type != "string":

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -697,16 +697,10 @@ class HDFStore:
                 self._complevel, self._complib, fletcher32=self._fletcher32
             )
 
-        ver = tables.__version__
-        if ver >= "3.1" and _table_file_open_policy_is_strict and self.is_open:
-            msg = dedent(
-                """\
-                PyTables [{ver}] no longer supports opening multiple files
-                even in read-only mode on this HDF5 version [{hdf_version}].
-                You can accept this and not open the same file multiple times at once,
-                upgrade the HDF5 version, or downgrade to PyTables 3.0.0 which allows
-                files to be opened multiple times at once.
-                """
+        if _table_file_open_policy_is_strict and self.is_open:
+            msg = (
+                "Cannot open HDF5 file, which is already opened, "
+                "even in read-only mode."
             )
             raise ValueError(msg)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -5,7 +5,6 @@ to disk
 from contextlib import suppress
 import copy
 from datetime import date, tzinfo
-from functools import reduce
 import itertools
 import os
 import re
@@ -4282,8 +4281,9 @@ class AppendableTable(Table):
 
         # consolidate masks
         if len(masks):
-            combine_masks = lambda first, second: first & second
-            mask = reduce(combine_masks, masks)
+            mask = masks[0]
+            for m in masks[1:]:
+                mask = mask & m
             mask = mask.ravel()
         else:
             mask = None

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -814,19 +814,19 @@ class HDFStore:
         Parameters
         ----------
         key : str
-                Object being retrieved from file.
+            Object being retrieved from file.
         where : list, default None
-                List of Term (or convertible) objects, optional.
+            List of Term (or convertible) objects, optional.
         start : int, default None
-                Row number to start selection.
+            Row number to start selection.
         stop : int, default None
-                Row number to stop selection.
+            Row number to stop selection.
         columns : list, default None
-                A list of columns that if not None, will limit the return columns.
+            A list of columns that if not None, will limit the return columns.
         iterator : bool, default False
-                Returns an iterator.
+            Returns an iterator.
         chunksize : int, default None
-                Number or rows to include in iteration, return an iterator.
+            Number or rows to include in iteration, return an iterator.
         auto_close : bool, default False
             Should automatically close the store when finished.
 
@@ -1090,7 +1090,7 @@ class HDFStore:
                 Table format.  Write as a PyTables Table structure which may perform
                 worse but allow more flexible operations like searching / selecting
                 subsets of the data.
-        append   : bool, default False
+        append : bool, default False
             This will force Table format, append the input data to the
             existing.
         data_columns : list, default None
@@ -1099,7 +1099,7 @@ class HDFStore:
             <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#query-via-data-columns>`__.
         encoding : str, default None
             Provide an encoding for strings.
-        dropna   : bool, default False, do not write an ALL nan row to
+        dropna : bool, default False, do not write an ALL nan row to
             The store settable by the option 'io.hdf.dropna_table'.
         track_times : bool, default True
             Parameter is propagated to 'create_table' method of 'PyTables'.
@@ -1521,11 +1521,12 @@ class HDFStore:
 
         Parameters
         ----------
-        propindexes: bool, default True
+        propindexes : bool, default True
             Restore indexes in copied file.
-        keys       : list of keys to include in the copy (defaults to all)
-        overwrite  : overwrite (remove and replace) existing nodes in the
-            new store (default is True)
+        keys : list, optional
+            List of keys to include in the copy (defaults to all).
+        overwrite : bool, default True
+            Whether to overwrite (remove and replace) existing nodes in the new store.
         mode, complib, complevel, fletcher32 same as in HDFStore.__init__
 
         Returns

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -10,7 +10,17 @@ import itertools
 import os
 import re
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 import warnings
 
 import numpy as np
@@ -4998,7 +5008,7 @@ def _need_convert(kind: str) -> bool:
     return False
 
 
-def _maybe_adjust_name(name: str, version) -> str:
+def _maybe_adjust_name(name: str, version: Sequence[int]) -> str:
     """
     Prior to 0.10.1, we named values blocks like: values_block_0 an the
     name values_0, adjust the given name if necessary.
@@ -5012,12 +5022,14 @@ def _maybe_adjust_name(name: str, version) -> str:
     -------
     str
     """
-    with suppress(IndexError):
-        if version[0] == 0 and version[1] <= 10 and version[2] == 0:
-            m = re.search(r"values_block_(\d+)", name)
-            if m:
-                grp = m.groups()[0]
-                name = f"values_{grp}"
+    if isinstance(version, str) or len(version) < 3:
+        raise ValueError("Version is incorrect, expected sequence of 3 integers.")
+
+    if version[0] == 0 and version[1] <= 10 and version[2] == 0:
+        m = re.search(r"values_block_(\d+)", name)
+        if m:
+            grp = m.groups()[0]
+            name = f"values_{grp}"
     return name
 
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1091,8 +1091,6 @@ class HDFStore:
             <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#query-via-data-columns>`__.
         encoding : str, default None
             Provide an encoding for strings.
-        dropna : bool, default False, do not write an ALL nan row to
-            The store settable by the option 'io.hdf.dropna_table'.
         track_times : bool, default True
             Parameter is propagated to 'create_table' method of 'PyTables'.
             If set to False it enables to have the same h5 files (same hashes)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -45,6 +45,7 @@ from pandas.tests.io.pytables.common import (
 )
 
 from pandas.io.pytables import (
+    _maybe_adjust_name,
     ClosedFileError,
     HDFStore,
     PossibleDataLossError,
@@ -4921,3 +4922,10 @@ class TestHDFStore:
 
         with pytest.raises(ValueError, match=message):
             pd.read_hdf(data_path)
+
+
+@pytest.mark.parametrize("bad_version", [(1, 2), (1,), [], '12', '123'])
+def test_maybe_adjust_name_bad_version_raises(bad_version):
+    msg = "Version is incorrect, expected sequence of 3 integers"
+    with pytest.raises(ValueError, match=msg):
+        _maybe_adjust_name("values_block_0", version=bad_version)

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -45,11 +45,11 @@ from pandas.tests.io.pytables.common import (
 )
 
 from pandas.io.pytables import (
-    _maybe_adjust_name,
     ClosedFileError,
     HDFStore,
     PossibleDataLossError,
     Term,
+    _maybe_adjust_name,
     read_hdf,
 )
 
@@ -4924,7 +4924,7 @@ class TestHDFStore:
             pd.read_hdf(data_path)
 
 
-@pytest.mark.parametrize("bad_version", [(1, 2), (1,), [], '12', '123'])
+@pytest.mark.parametrize("bad_version", [(1, 2), (1,), [], "12", "123"])
 def test_maybe_adjust_name_bad_version_raises(bad_version):
     msg = "Version is incorrect, expected sequence of 3 integers"
     with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Clean-up and minor refactor of ``pandas/io/pytables.py``.
- Extract method ``_identify_group``
- Clean-up some docstrings (spacing)
- Use suppress instead of try/except/pass
- Format error message using dedent
- Remove unnecessary empty lines as they compromise readability of some blocks