### PR TITLE
DOC: make return type documentation of series methods consistent #35409

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -723,8 +723,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Returns
         -------
-        Categorical
-            Ordered Categorical.
+        Categorical or None
+            Ordered Categorical or None if ``inplace=True``.
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         return self.set_ordered(True, inplace=inplace)
@@ -741,8 +741,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Returns
         -------
-        Categorical
-            Unordered Categorical.
+        Categorical or None
+            Unordered Categorical or None if ``inplace=True``.
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         return self.set_ordered(False, inplace=inplace)
@@ -848,8 +848,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         Returns
         -------
         cat : Categorical or None
-           With ``inplace=False``, the new categorical is returned.
-           With ``inplace=True``, there is no return value.
+            Categorical with removed categories or None if ``inplace=True``.
 
         Raises
         ------
@@ -917,7 +916,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Returns
         -------
-        cat : Categorical with reordered categories or None if inplace.
+        cat : Categprocal or None
+            Categorical with removed categories or None if ``inplace=True``.
 
         Raises
         ------
@@ -957,7 +957,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Returns
         -------
-        cat : Categorical with new categories added or None if inplace.
+        cat : Categorical or None
+            Categorical with new categories added or None if ``inplace=True``.
 
         Raises
         ------
@@ -1007,7 +1008,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Returns
         -------
-        cat : Categorical with removed categories or None if inplace.
+        cat : Categorical or None
+            Categorical with removed categories or None if ``inplace=True``.
 
         Raises
         ------
@@ -1054,7 +1056,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Returns
         -------
-        cat : Categorical with unused categories dropped or None if inplace.
+        cat : Categorical or None
+            Categorical with unused categories dropped or None if ``inplace=True``.
 
         See Also
         --------

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -916,7 +916,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
         Returns
         -------
-        cat : Categprocal or None
+        cat : Categorical or None
             Categorical with removed categories or None if ``inplace=True``.
 
         Raises

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -242,7 +242,8 @@ def eval(
 
     Returns
     -------
-    ndarray, numeric scalar, DataFrame, Series
+    ndarray, numeric scalar, DataFrame, Series, or None
+        The completion value of evaluating the given code or None if ``inplace=True``.
 
     Raises
     ------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3251,8 +3251,9 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        DataFrame
-            DataFrame resulting from the provided query expression.
+        DataFrame or None
+            DataFrame resulting from the provided query expression or
+            None if ``inplace=True``.
 
         See Also
         --------
@@ -3399,8 +3400,8 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        ndarray, scalar, or pandas object
-            The result of the evaluation.
+        ndarray, scalar, pandas object, or None
+            The result of the evaluation or None if ``inplace=True``.
 
         See Also
         --------
@@ -4117,8 +4118,9 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        DataFrame
-            DataFrame without the removed index or column labels.
+        DataFrame or None
+            DataFrame without the removed index or column labels or
+            None if ``inplace=True``.
 
         Raises
         ------
@@ -4272,8 +4274,8 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        DataFrame
-            DataFrame with the renamed axis labels.
+        DataFrame or None
+            DataFrame with the renamed axis labels or None if ``inplace=True``.
 
         Raises
         ------
@@ -4501,8 +4503,8 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        DataFrame
-            Changed row labels.
+        DataFrame or None
+            Changed row labels or None if ``inplace=True``.
 
         See Also
         --------
@@ -4964,8 +4966,8 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        DataFrame
-            DataFrame with NA entries dropped from it.
+        DataFrame or None
+            DataFrame with NA entries dropped from it or None if ``inplace=True``.
 
         See Also
         --------
@@ -5100,7 +5102,7 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        DataFrame
+        DataFrame or None
             DataFrame with duplicates removed or None if ``inplace=True``.
 
         See Also
@@ -5423,8 +5425,8 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        DataFrame
-            The original DataFrame sorted by the labels.
+        DataFrame or None
+            The original DataFrame sorted by the labels or None if ``inplace=True``.
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9048,7 +9048,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         try_cast : bool, default False
             Try to cast the result back to the input type (if possible).
 
-        Returns or None
+        Returns
         -------
         Same type as caller or None if ``inplace=True``.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4326,7 +4326,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Returns
         -------
         DataFrame or None
-            DataFrame with sorted values if inplace=False, None otherwise.
+            DataFrame with sorted values or None if ``inplace=True``.
 
         See Also
         --------
@@ -6898,7 +6898,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         -------
         Series or DataFrame or None
             Returns the same object type as the caller, interpolated at
-            some or all ``NaN`` values
+            some or all ``NaN`` values or None if ``inplace=True``.
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -649,7 +649,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Returns
         -------
         renamed : %(klass)s or None
-            An object of type %(klass)s if inplace=False, None otherwise.
+            An object of type %(klass)s or None if ``inplace=True``.
 
         See Also
         --------
@@ -1096,7 +1096,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         Returns
         -------
         Series, DataFrame, or None
-            The same type as the caller or None if `inplace` is True.
+            The same type as the caller or None if ``inplace=True``.
 
         See Also
         --------
@@ -6461,8 +6461,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         Returns
         -------
-        {klass}
-            Object after replacement.
+        {klass} or None
+            Object after replacement or None if ``inplace=True``.
 
         Raises
         ------
@@ -6896,9 +6896,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         Returns
         -------
-        Series or DataFrame
+        Series or DataFrame or None
             Returns the same object type as the caller, interpolated at
-            some or all ``NaN`` values.
+            some or all ``NaN`` values
 
         See Also
         --------
@@ -7494,9 +7494,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         Returns
         -------
-        Series or DataFrame
+        Series or DataFrame or None
             Same type as calling object with the values outside the
-            clip boundaries replaced.
+            clip boundaries replaced or None if ``inplace=True``.
 
         See Also
         --------
@@ -9048,9 +9048,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         try_cast : bool, default False
             Try to cast the result back to the input type (if possible).
 
-        Returns
+        Returns or None
         -------
-        Same type as caller
+        Same type as caller or None if ``inplace=True``.
 
         See Also
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1345,8 +1345,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        Index
-            The same type as the caller or None if inplace is True.
+        Index or None
+            The same type as the caller or None if ``inplace=True``.
 
         See Also
         --------
@@ -1421,8 +1421,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        Index
-            The same type as the caller or None if inplace is True.
+        Index or None
+            The same type as the caller or None if ``inplace=True``.
 
         See Also
         --------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -782,7 +782,8 @@ class MultiIndex(Index):
 
         Returns
         -------
-        new index (of same type and class...etc)
+        new index (of same type and class...etc) or None
+            The same type as the caller or None if ``inplace=True``.
 
         Examples
         --------
@@ -961,7 +962,8 @@ class MultiIndex(Index):
 
         Returns
         -------
-        new index (of same type and class...etc)
+        new index (of same type and class...etc) or None
+            The same type as the caller or None if ``inplace=True``.
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1192,7 +1192,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        Series or DataFrame
+        Series or DataFrame or None
             When `drop` is False (the default), a DataFrame is returned.
             The newly created columns will come first in the DataFrame,
             followed by the original Series values.
@@ -1911,8 +1911,8 @@ Name: Max Speed, dtype: float64
 
         Returns
         -------
-        Series
-            Series with duplicates dropped.
+        Series or None
+            Series with duplicates dropped or None if ``inplace=True``.
 
         See Also
         --------
@@ -3129,8 +3129,8 @@ Keep all original rows and also all original values
 
         Returns
         -------
-        Series
-            Series ordered by values.
+        Series or None
+            Series ordered by values or None if ``inplace=True``.
 
         See Also
         --------
@@ -3375,8 +3375,8 @@ Keep all original rows and also all original values
 
         Returns
         -------
-        Series
-            The original Series sorted by the labels.
+        Series or None
+            The original Series sorted by the labels or None if ``inplace=True``.
 
         See Also
         --------
@@ -4304,8 +4304,8 @@ Keep all original rows and also all original values
 
         Returns
         -------
-        Series
-            Series with index labels or name altered.
+        Series or None
+            Series with index labels or name altered
 
         See Also
         --------
@@ -4418,8 +4418,8 @@ Keep all original rows and also all original values
 
         Returns
         -------
-        Series
-            Series with specified index labels removed.
+        Series or None
+            Series with specified index labels removed or None if ``inplace=True``.
 
         Raises
         ------
@@ -4807,8 +4807,8 @@ Keep all original rows and also all original values
 
         Returns
         -------
-        Series
-            Series with NA entries dropped from it.
+        Series or None
+            Series with NA entries dropped from it or None if ``inplace=True``.
 
         See Also
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4305,7 +4305,7 @@ Keep all original rows and also all original values
         Returns
         -------
         Series or None
-            Series with index labels or name altered
+            Series with index labels or name altered or None if ``inplace=True``.
 
         See Also
         --------


### PR DESCRIPTION
- [x] closes #35409 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`