### PR TITLE
CI: Show ipython directive errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
     # This can be removed when the ipython directive fails when there are errors,
     # including the `tee sphinx.log` in te previous step (https://github.com/ipython/ipython/issues/11547)
     - name: Check ipython directive errors
-      run: "! grep -B1 \"^<<<-------------------------------------------------------------------------$\" sphinx.log"
+      run: "! grep -B10 \"^<<<-------------------------------------------------------------------------$\" sphinx.log"
 
     - name: Install ssh key
       run: |


### PR DESCRIPTION
Current output of ipython directive errors in CI is essentially a blank line, so adding a bit more to try to show what error is happening.
```
(pandas-dev) ➜  ~ grep -B1 "^<<<-------------------------------------------------------------------------$" sphinx.log

<<<-------------------------------------------------------------------------
```
vs.
```
(pandas-dev) ➜  ~ grep -B10 "^<<<-------------------------------------------------------------------------$" sphinx.log


>>>-------------------------------------------------------------------------
Exception in /Users/danielsaxton/pandas/doc/source/user_guide/enhancingperf.rst at block ending on line 834
Specify :okexcept: as an option in the ipython:: block to suppress this message
  File "<ipython-input-66-d3ab2b9618fd>", line 1
    df.query("strings == "a" and nums == 1")
                          ^
SyntaxError: invalid syntax

<<<-------------------------------------------------------------------------
```