### PR TITLE
REF: IntervalIndex.equals defer to IntervalArray.equals

### DIFF
--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -8,7 +8,9 @@ from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly, doc
 from pandas.util._validators import validate_fillna_kwargs
 
+from pandas.core.dtypes.common import is_dtype_equal
 from pandas.core.dtypes.inference import is_array_like
+from pandas.core.dtypes.missing import array_equivalent
 
 from pandas.core import missing
 from pandas.core.algorithms import take, unique
@@ -114,6 +116,13 @@ class NDArrayBackedExtensionArray(ExtensionArray):
         return self._from_backing_data(new_data)
 
     # ------------------------------------------------------------------------
+
+    def equals(self, other) -> bool:
+        if type(self) is not type(other):
+            return False
+        if not is_dtype_equal(self.dtype, other.dtype):
+            return False
+        return bool(array_equivalent(self._ndarray, other._ndarray))
 
     def _values_for_argsort(self):
         return self._ndarray

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -696,6 +696,16 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             msg = f"Cannot cast {type(self).__name__} to dtype {dtype}"
             raise TypeError(msg) from err
 
+    def equals(self, other) -> bool:
+        if type(self) != type(other):
+            return False
+
+        return bool(
+            self.closed == other.closed
+            and self.left.equals(other.left)
+            and self.right.equals(other.right)
+        )
+
     @classmethod
     def _concat_same_type(cls, to_concat):
         """

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -983,19 +983,10 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         if self.is_(other):
             return True
 
-        # if we can coerce to an IntervalIndex then we can compare
         if not isinstance(other, IntervalIndex):
-            if not is_interval_dtype(other):
-                return False
-            other = Index(other)
-            if not isinstance(other, IntervalIndex):
-                return False
+            return False
 
-        return (
-            self.left.equals(other.left)
-            and self.right.equals(other.right)
-            and self.closed == other.closed
-        )
+        return self._data.equals(other._data)
 
     # --------------------------------------------------------------------
     # Set Operations


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Small behavior change in that `interval_index.equals(series[interval])` will now return False, matching other Index subclasses.