### PR TITLE
PERF: Improve RollingGroupby.count

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -284,7 +284,7 @@ Performance improvements
 - ``Styler`` uuid method altered to compress data transmission over web whilst maintaining reasonably low table collision probability (:issue:`36345`)
 - Performance improvement in :meth:`pd.to_datetime` with non-ns time unit for ``float`` ``dtype`` columns (:issue:`20445`)
 - Performance improvement in setting values on a :class:`IntervalArray` (:issue:`36310`)
-- Performance improvement in :meth:`RollingGroupby.count` (:issue:``)
+- Performance improvement in :meth:`RollingGroupby.count` (:issue:`35625`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -284,6 +284,7 @@ Performance improvements
 - ``Styler`` uuid method altered to compress data transmission over web whilst maintaining reasonably low table collision probability (:issue:`36345`)
 - Performance improvement in :meth:`pd.to_datetime` with non-ns time unit for ``float`` ``dtype`` columns (:issue:`20445`)
 - Performance improvement in setting values on a :class:`IntervalArray` (:issue:`36310`)
+- Performance improvement in :meth:`RollingGroupby.count` (:issue:``)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/window/common.py
+++ b/pandas/core/window/common.py
@@ -58,7 +58,6 @@ class WindowGroupByMixin(GotItemMixin):
         self._groupby.grouper.mutated = True
         super().__init__(obj, *args, **kwargs)
 
-    count = _dispatch("count")
     corr = _dispatch("corr", other=None, pairwise=None)
     cov = _dispatch("cov", other=None, pairwise=None)
 


### PR DESCRIPTION
- [x] closes #35625
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

```
In [1]: import pandas as pd
   ...:
   ...: # Generate sample df
   ...: df = pd.DataFrame({'column1': range(600), 'group': 5*['l'+str(i) for i in range(120)]})
   ...:
   ...: # sort by group for easy/efficient joining of new columns to df
   ...: df=df.sort_values('group',kind='mergesort').reset_index(drop=True)

In [2]: %timeit df['mean']=df.groupby('group').rolling(3,min_periods=1)['column1'].mean().values
5.59 ms ± 310 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [3]: %timeit df['sum']=df.groupby('group').rolling(3,min_periods=1)['column1'].sum().values
   ...:
5.34 ms ± 343 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [4]: %timeit df['count']=df.groupby('group').rolling(3,min_periods=1)['column1'].count().values
   ...:
4.97 ms ± 51.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```