### PR TITLE
CLN: Remove the duplicate configuration of flake8-rst in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ bootstrap =
 ignore = E203,  # space before : (needed for how black formats slicing)
          E402,  # module level import not at top of file
          W503,  # line break before binary operator
-         E203,  # space before : (needed for how black formats slicing)
          # Classes/functions in different blocks can generate those errors
          E302,  # expected 2 blank lines, found 0
          E305,  # expected 2 blank lines after class or function definition, found 0


### PR DESCRIPTION
Remove duplicate `ignore = E203` configuration in setup.cfg[flake8-rst]
