### PR TITLE
TYP: check_untyped_defs compat.pickle_compat

### DIFF
--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -274,7 +274,7 @@ def patch_pickle():
     """
     orig_loads = pkl.loads
     try:
-        pkl.loads = loads
+        setattr(pkl, "loads", loads)
         yield
     finally:
-        pkl.loads = orig_loads
+        setattr(pkl, "loads", orig_loads)

--- a/setup.cfg
+++ b/setup.cfg
@@ -135,9 +135,6 @@ check_untyped_defs=False
 [mypy-pandas._version]
 check_untyped_defs=False
 
-[mypy-pandas.compat.pickle_compat]
-check_untyped_defs=False
-
 [mypy-pandas.core.apply]
 check_untyped_defs=False
 


### PR DESCRIPTION
pandas\compat\pickle_compat.py:277: error: Incompatible types in assignment (expression has type "Callable[[bytes, DefaultNamedArg(bool, 'fix_imports'), DefaultNamedArg(str, 'encoding'), DefaultNamedArg(str, 'errors')], Any]", variable has type "Callable[[bytes, DefaultNamedArg(bool, 'fix_imports'), DefaultNamedArg(str, 'encoding'), DefaultNamedArg(str, 'errors'), DefaultNamedArg(Optional[Iterable[Any]], 'buffers')], Any]")  [assignment]