### PR TITLE
TYP: check_untyped_defs core.arrays.base

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -1176,22 +1176,22 @@ class ExtensionOpsMixin:
 
     @classmethod
     def _add_arithmetic_ops(cls):
-        cls.__add__ = cls._create_arithmetic_method(operator.add)
-        cls.__radd__ = cls._create_arithmetic_method(ops.radd)
-        cls.__sub__ = cls._create_arithmetic_method(operator.sub)
-        cls.__rsub__ = cls._create_arithmetic_method(ops.rsub)
-        cls.__mul__ = cls._create_arithmetic_method(operator.mul)
-        cls.__rmul__ = cls._create_arithmetic_method(ops.rmul)
-        cls.__pow__ = cls._create_arithmetic_method(operator.pow)
-        cls.__rpow__ = cls._create_arithmetic_method(ops.rpow)
-        cls.__mod__ = cls._create_arithmetic_method(operator.mod)
-        cls.__rmod__ = cls._create_arithmetic_method(ops.rmod)
-        cls.__floordiv__ = cls._create_arithmetic_method(operator.floordiv)
-        cls.__rfloordiv__ = cls._create_arithmetic_method(ops.rfloordiv)
-        cls.__truediv__ = cls._create_arithmetic_method(operator.truediv)
-        cls.__rtruediv__ = cls._create_arithmetic_method(ops.rtruediv)
-        cls.__divmod__ = cls._create_arithmetic_method(divmod)
-        cls.__rdivmod__ = cls._create_arithmetic_method(ops.rdivmod)
+        setattr(cls, "__add__", cls._create_arithmetic_method(operator.add))
+        setattr(cls, "__radd__", cls._create_arithmetic_method(ops.radd))
+        setattr(cls, "__sub__", cls._create_arithmetic_method(operator.sub))
+        setattr(cls, "__rsub__", cls._create_arithmetic_method(ops.rsub))
+        setattr(cls, "__mul__", cls._create_arithmetic_method(operator.mul))
+        setattr(cls, "__rmul__", cls._create_arithmetic_method(ops.rmul))
+        setattr(cls, "__pow__", cls._create_arithmetic_method(operator.pow))
+        setattr(cls, "__rpow__", cls._create_arithmetic_method(ops.rpow))
+        setattr(cls, "__mod__", cls._create_arithmetic_method(operator.mod))
+        setattr(cls, "__rmod__", cls._create_arithmetic_method(ops.rmod))
+        setattr(cls, "__floordiv__", cls._create_arithmetic_method(operator.floordiv))
+        setattr(cls, "__rfloordiv__", cls._create_arithmetic_method(ops.rfloordiv))
+        setattr(cls, "__truediv__", cls._create_arithmetic_method(operator.truediv))
+        setattr(cls, "__rtruediv__", cls._create_arithmetic_method(ops.rtruediv))
+        setattr(cls, "__divmod__", cls._create_arithmetic_method(divmod))
+        setattr(cls, "__rdivmod__", cls._create_arithmetic_method(ops.rdivmod))
 
     @classmethod
     def _create_comparison_method(cls, op):
@@ -1199,12 +1199,12 @@ class ExtensionOpsMixin:
 
     @classmethod
     def _add_comparison_ops(cls):
-        cls.__eq__ = cls._create_comparison_method(operator.eq)
-        cls.__ne__ = cls._create_comparison_method(operator.ne)
-        cls.__lt__ = cls._create_comparison_method(operator.lt)
-        cls.__gt__ = cls._create_comparison_method(operator.gt)
-        cls.__le__ = cls._create_comparison_method(operator.le)
-        cls.__ge__ = cls._create_comparison_method(operator.ge)
+        setattr(cls, "__eq__", cls._create_comparison_method(operator.eq))
+        setattr(cls, "__ne__", cls._create_comparison_method(operator.ne))
+        setattr(cls, "__lt__", cls._create_comparison_method(operator.lt))
+        setattr(cls, "__gt__", cls._create_comparison_method(operator.gt))
+        setattr(cls, "__le__", cls._create_comparison_method(operator.le))
+        setattr(cls, "__ge__", cls._create_comparison_method(operator.ge))
 
     @classmethod
     def _create_logical_method(cls, op):
@@ -1212,12 +1212,12 @@ class ExtensionOpsMixin:
 
     @classmethod
     def _add_logical_ops(cls):
-        cls.__and__ = cls._create_logical_method(operator.and_)
-        cls.__rand__ = cls._create_logical_method(ops.rand_)
-        cls.__or__ = cls._create_logical_method(operator.or_)
-        cls.__ror__ = cls._create_logical_method(ops.ror_)
-        cls.__xor__ = cls._create_logical_method(operator.xor)
-        cls.__rxor__ = cls._create_logical_method(ops.rxor)
+        setattr(cls, "__and__", cls._create_logical_method(operator.and_))
+        setattr(cls, "__rand__", cls._create_logical_method(ops.rand_))
+        setattr(cls, "__or__", cls._create_logical_method(operator.or_))
+        setattr(cls, "__ror__", cls._create_logical_method(ops.ror_))
+        setattr(cls, "__xor__", cls._create_logical_method(operator.xor))
+        setattr(cls, "__rxor__", cls._create_logical_method(ops.rxor))
 
 
 class ExtensionScalarOpsMixin(ExtensionOpsMixin):

--- a/setup.cfg
+++ b/setup.cfg
@@ -141,9 +141,6 @@ check_untyped_defs=False
 [mypy-pandas.core.apply]
 check_untyped_defs=False
 
-[mypy-pandas.core.arrays.base]
-check_untyped_defs=False
-
 [mypy-pandas.core.arrays.datetimelike]
 check_untyped_defs=False
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/31160

from https://docs.python.org/3/library/functions.html?highlight=setattr#setattr

> For example, setattr(x, 'foobar', 123) is equivalent to x.foobar = 123.

The changes here, don't 'fix' the issue. The correct solution is to create these methods with a statically defined interface, see https://github.com/pandas-dev/pandas/issues/31160#issuecomment-699193016

In the meantime, the changes here allows untyped defs in this module to be checked. (without adding type ignores)

pandas\core\arrays\base.py:1179: error: Unsupported left operand type for + ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1180: error: "Type[ExtensionOpsMixin]" has no attribute "__radd__"  [attr-defined]
pandas\core\arrays\base.py:1181: error: Unsupported left operand type for - ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1182: error: "Type[ExtensionOpsMixin]" has no attribute "__rsub__"  [attr-defined]
pandas\core\arrays\base.py:1183: error: Unsupported left operand type for * ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1184: error: "Type[ExtensionOpsMixin]" has no attribute "__rmul__"  [attr-defined]
pandas\core\arrays\base.py:1185: error: Unsupported left operand type for ** ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1186: error: "Type[ExtensionOpsMixin]" has no attribute "__rpow__"  [attr-defined]
pandas\core\arrays\base.py:1187: error: Unsupported left operand type for % ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1188: error: "Type[ExtensionOpsMixin]" has no attribute "__rmod__"  [attr-defined]
pandas\core\arrays\base.py:1189: error: Unsupported left operand type for // ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1190: error: "Type[ExtensionOpsMixin]" has no attribute "__rfloordiv__"  [attr-defined]
pandas\core\arrays\base.py:1191: error: Unsupported left operand type for / ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1192: error: "Type[ExtensionOpsMixin]" has no attribute "__rtruediv__"  [attr-defined]
pandas\core\arrays\base.py:1193: error: Unsupported left operand type for divmod ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1194: error: "Type[ExtensionOpsMixin]" has no attribute "__rdivmod__"  [attr-defined]
pandas\core\arrays\base.py:1202: error: Cannot assign to a method  [assignment]
pandas\core\arrays\base.py:1203: error: Cannot assign to a method  [assignment]
pandas\core\arrays\base.py:1204: error: Unsupported left operand type for < ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1205: error: Unsupported left operand type for > ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1206: error: Unsupported left operand type for <= ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1207: error: Unsupported left operand type for >= ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1215: error: Unsupported left operand type for & ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1216: error: "Type[ExtensionOpsMixin]" has no attribute "__rand__"  [attr-defined]
pandas\core\arrays\base.py:1217: error: Unsupported left operand type for | ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1218: error: "Type[ExtensionOpsMixin]" has no attribute "__ror__"  [attr-defined]
pandas\core\arrays\base.py:1219: error: Unsupported left operand type for ^ ("Type[ExtensionOpsMixin]")  [operator]
pandas\core\arrays\base.py:1220: error: "Type[ExtensionOpsMixin]" has no attribute "__rxor__"  [attr-defined]