### PR TITLE
CLN: standardize fixture usage in datetimelike array tests

### DIFF
--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -17,7 +17,12 @@ from pandas.core.indexes.timedeltas import TimedeltaIndex
 
 # TODO: more freq variants
 @pytest.fixture(params=["D", "B", "W", "M", "Q", "Y"])
-def period_index(request):
+def freqstr(request):
+    return request.param
+
+
+@pytest.fixture
+def period_index(freqstr):
     """
     A fixture to provide PeriodIndex objects with different frequencies.
 
@@ -25,14 +30,13 @@ def period_index(request):
     so here we just test that the PeriodArray behavior matches
     the PeriodIndex behavior.
     """
-    freqstr = request.param
     # TODO: non-monotone indexes; NaTs, different start dates
     pi = pd.period_range(start=pd.Timestamp("2000-01-01"), periods=100, freq=freqstr)
     return pi
 
 
-@pytest.fixture(params=["D", "B", "W", "M", "Q", "Y"])
-def datetime_index(request):
+@pytest.fixture
+def datetime_index(freqstr):
     """
     A fixture to provide DatetimeIndex objects with different frequencies.
 
@@ -40,14 +44,13 @@ def datetime_index(request):
     so here we just test that the DatetimeArray behavior matches
     the DatetimeIndex behavior.
     """
-    freqstr = request.param
     # TODO: non-monotone indexes; NaTs, different start dates, timezones
     dti = pd.date_range(start=pd.Timestamp("2000-01-01"), periods=100, freq=freqstr)
     return dti
 
 
 @pytest.fixture
-def timedelta_index(request):
+def timedelta_index():
     """
     A fixture to provide TimedeltaIndex objects with different frequencies.
      Most TimedeltaArray behavior is already tested in TimedeltaIndex tests,
@@ -438,16 +441,15 @@ class TestDatetimeArray(SharedTests):
     dtype = pd.Timestamp
 
     @pytest.fixture
-    def arr1d(self, tz_naive_fixture):
+    def arr1d(self, tz_naive_fixture, freqstr):
         tz = tz_naive_fixture
-        dti = pd.date_range("2016-01-01 01:01:00", periods=3, freq="H", tz=tz)
+        dti = pd.date_range("2016-01-01 01:01:00", periods=3, freq=freqstr, tz=tz)
         dta = dti._data
         return dta
 
-    def test_round(self, tz_naive_fixture):
+    def test_round(self, arr1d):
         # GH#24064
-        tz = tz_naive_fixture
-        dti = pd.date_range("2016-01-01 01:01:00", periods=3, freq="H", tz=tz)
+        dti = self.index_cls(arr1d)
 
         result = dti.round(freq="2T")
         expected = dti - pd.Timedelta(minutes=1)

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -503,11 +503,10 @@ class TestDatetimeArray(SharedTests):
             expected = np.asarray(arr).astype(dtype)
             tm.assert_numpy_array_equal(result, expected)
 
-    def test_array_object_dtype(self, tz_naive_fixture):
+    def test_array_object_dtype(self, arr1d):
         # GH#23524
-        tz = tz_naive_fixture
-        dti = pd.date_range("2016-01-01", periods=3, tz=tz)
-        arr = DatetimeArray(dti)
+        arr = arr1d
+        dti = self.index_cls(arr1d)
 
         expected = np.array(list(dti))
 
@@ -518,11 +517,10 @@ class TestDatetimeArray(SharedTests):
         result = np.array(dti, dtype=object)
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_array_tz(self, tz_naive_fixture):
+    def test_array_tz(self, arr1d):
         # GH#23524
-        tz = tz_naive_fixture
-        dti = pd.date_range("2016-01-01", periods=3, tz=tz)
-        arr = DatetimeArray(dti)
+        arr = arr1d
+        dti = self.index_cls(arr1d)
 
         expected = dti.asi8.view("M8[ns]")
         result = np.array(arr, dtype="M8[ns]")
@@ -539,10 +537,9 @@ class TestDatetimeArray(SharedTests):
         assert result.base is expected.base
         assert result.base is not None
 
-    def test_array_i8_dtype(self, tz_naive_fixture):
-        tz = tz_naive_fixture
-        dti = pd.date_range("2016-01-01", periods=3, tz=tz)
-        arr = DatetimeArray(dti)
+    def test_array_i8_dtype(self, arr1d):
+        arr = arr1d
+        dti = self.index_cls(arr1d)
 
         expected = dti.asi8
         result = np.array(arr, dtype="i8")
@@ -565,10 +562,9 @@ class TestDatetimeArray(SharedTests):
         dta = DatetimeArray(arr[:0])
         assert dta._data.base is arr
 
-    def test_from_dti(self, tz_naive_fixture):
-        tz = tz_naive_fixture
-        dti = pd.date_range("2016-01-01", periods=3, tz=tz)
-        arr = DatetimeArray(dti)
+    def test_from_dti(self, arr1d):
+        arr = arr1d
+        dti = self.index_cls(arr1d)
         assert list(dti) == list(arr)
 
         # Check that Index.__new__ knows what to do with DatetimeArray
@@ -576,10 +572,10 @@ class TestDatetimeArray(SharedTests):
         assert isinstance(dti2, pd.DatetimeIndex)
         assert list(dti2) == list(arr)
 
-    def test_astype_object(self, tz_naive_fixture):
-        tz = tz_naive_fixture
-        dti = pd.date_range("2016-01-01", periods=3, tz=tz)
-        arr = DatetimeArray(dti)
+    def test_astype_object(self, arr1d):
+        arr = arr1d
+        dti = self.index_cls(arr1d)
+
         asobj = arr.astype("O")
         assert isinstance(asobj, np.ndarray)
         assert asobj.dtype == "O"

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -61,6 +61,7 @@ class TestTimedeltaArrayConstructor:
 
 
 class TestTimedeltaArray:
+    # TODO: de-duplicate with test_npsum below
     def test_np_sum(self):
         # GH#25282
         vals = np.arange(5, dtype=np.int64).view("m8[h]").astype("m8[ns]")

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -77,35 +77,6 @@ class TestTimedeltaArray:
         with pytest.raises(ValueError, match=msg):
             TimedeltaArray._from_sequence([], dtype=object)
 
-    def test_abs(self):
-        vals = np.array([-3600 * 10 ** 9, "NaT", 7200 * 10 ** 9], dtype="m8[ns]")
-        arr = TimedeltaArray(vals)
-
-        evals = np.array([3600 * 10 ** 9, "NaT", 7200 * 10 ** 9], dtype="m8[ns]")
-        expected = TimedeltaArray(evals)
-
-        result = abs(arr)
-        tm.assert_timedelta_array_equal(result, expected)
-
-    def test_neg(self):
-        vals = np.array([-3600 * 10 ** 9, "NaT", 7200 * 10 ** 9], dtype="m8[ns]")
-        arr = TimedeltaArray(vals)
-
-        evals = np.array([3600 * 10 ** 9, "NaT", -7200 * 10 ** 9], dtype="m8[ns]")
-        expected = TimedeltaArray(evals)
-
-        result = -arr
-        tm.assert_timedelta_array_equal(result, expected)
-
-    def test_neg_freq(self):
-        tdi = pd.timedelta_range("2 Days", periods=4, freq="H")
-        arr = TimedeltaArray(tdi, freq=tdi.freq)
-
-        expected = TimedeltaArray(-tdi._data, freq=-tdi.freq)
-
-        result = -arr
-        tm.assert_timedelta_array_equal(result, expected)
-
     @pytest.mark.parametrize("dtype", [int, np.int32, np.int64, "uint32", "uint64"])
     def test_astype_int(self, dtype):
         arr = TimedeltaArray._from_sequence([pd.Timedelta("1H"), pd.Timedelta("2H")])
@@ -170,6 +141,37 @@ class TestTimedeltaArray:
         )
         with pytest.raises(TypeError, match=msg):
             arr.searchsorted(other)
+
+
+class TestUnaryOps:
+    def test_abs(self):
+        vals = np.array([-3600 * 10 ** 9, "NaT", 7200 * 10 ** 9], dtype="m8[ns]")
+        arr = TimedeltaArray(vals)
+
+        evals = np.array([3600 * 10 ** 9, "NaT", 7200 * 10 ** 9], dtype="m8[ns]")
+        expected = TimedeltaArray(evals)
+
+        result = abs(arr)
+        tm.assert_timedelta_array_equal(result, expected)
+
+    def test_neg(self):
+        vals = np.array([-3600 * 10 ** 9, "NaT", 7200 * 10 ** 9], dtype="m8[ns]")
+        arr = TimedeltaArray(vals)
+
+        evals = np.array([3600 * 10 ** 9, "NaT", -7200 * 10 ** 9], dtype="m8[ns]")
+        expected = TimedeltaArray(evals)
+
+        result = -arr
+        tm.assert_timedelta_array_equal(result, expected)
+
+    def test_neg_freq(self):
+        tdi = pd.timedelta_range("2 Days", periods=4, freq="H")
+        arr = TimedeltaArray(tdi, freq=tdi.freq)
+
+        expected = TimedeltaArray(-tdi._data, freq=-tdi.freq)
+
+        result = -arr
+        tm.assert_timedelta_array_equal(result, expected)
 
 
 class TestReductions:


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
