### PR TITLE
CLN: remove inplace kwarg from NDFrame._consolidate

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5447,27 +5447,18 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
         self._protect_consolidate(f)
 
-    def _consolidate(self, inplace: bool_t = False):
+    def _consolidate(self):
         """
         Compute NDFrame with "consolidated" internals (data of each dtype
         grouped together in a single ndarray).
-
-        Parameters
-        ----------
-        inplace : bool, default False
-            If False return new object, otherwise modify existing object.
 
         Returns
         -------
         consolidated : same type as caller
         """
-        inplace = validate_bool_kwarg(inplace, "inplace")
-        if inplace:
-            self._consolidate_inplace()
-        else:
-            f = lambda: self._mgr.consolidate()
-            cons_data = self._protect_consolidate(f)
-            return self._constructor(cons_data).__finalize__(self)
+        f = lambda: self._mgr.consolidate()
+        cons_data = self._protect_consolidate(f)
+        return self._constructor(cons_data).__finalize__(self)
 
     @property
     def _is_mixed_type(self) -> bool_t:

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -360,7 +360,7 @@ class _Concatenator:
                 raise TypeError(msg)
 
             # consolidate
-            obj._consolidate(inplace=True)
+            obj._consolidate_inplace()
             ndims.add(obj.ndim)
 
         # get the sample

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -64,7 +64,7 @@ class TestDataFrameBlockInternals:
         float_frame["F"] = 8.0
         assert len(float_frame._mgr.blocks) == 3
 
-        return_value = float_frame._consolidate(inplace=True)
+        return_value = float_frame._consolidate_inplace()
         assert return_value is None
         assert len(float_frame._mgr.blocks) == 1
 

--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -190,9 +190,6 @@ class TestDataFrame2:
             super(DataFrame, df).drop("a", axis=1, inplace=value)
 
         with pytest.raises(ValueError, match=msg):
-            super(DataFrame, df)._consolidate(inplace=value)
-
-        with pytest.raises(ValueError, match=msg):
             super(DataFrame, df).fillna(value=0, inplace=value)
 
         with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
