### PR TITLE
TYP: check_untyped_defs core.computation.expressions

### DIFF
--- a/pandas/core/computation/expressions.py
+++ b/pandas/core/computation/expressions.py
@@ -248,6 +248,7 @@ def where(cond, a, b, use_numexpr=True):
     use_numexpr : bool, default True
         Whether to try to use numexpr.
     """
+    assert _where is not None
     return _where(cond, a, b) if use_numexpr else _where_standard(cond, a, b)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -154,9 +154,6 @@ check_untyped_defs=False
 [mypy-pandas.core.computation.expr]
 check_untyped_defs=False
 
-[mypy-pandas.core.computation.expressions]
-check_untyped_defs=False
-
 [mypy-pandas.core.computation.ops]
 check_untyped_defs=False
 


### PR DESCRIPTION
pandas\core\computation\expressions.py:251: error: "None" not callable  [misc]

