### PR TITLE
TYP: check_untyped_defs core.computation.pytables

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -160,9 +160,6 @@ check_untyped_defs=False
 [mypy-pandas.core.computation.ops]
 check_untyped_defs=False
 
-[mypy-pandas.core.computation.pytables]
-check_untyped_defs=False
-
 [mypy-pandas.core.computation.scope]
 check_untyped_defs=False
 


### PR DESCRIPTION
pandas\core\computation\pytables.py:46: error: Argument 1 to "__new__" of "object" has incompatible type "object"; expected "Type[object]"  [arg-type]
pandas\core\computation\pytables.py:189: error: Incompatible types in assignment (expression has type "Callable[[Any, int, Union[Mapping[str, str], Iterable[str], None], bool, bool, Optional[int]], str]", variable has type "partial[bytes]")  [assignment]
pandas\core\computation\pytables.py:262: error: Incompatible types in assignment (expression has type "Tuple[Any, ...]", variable has type "Optional[Tuple[Any, Any, Index]]")  [assignment]
pandas\core\computation\pytables.py:351: error: Incompatible types in assignment (expression has type "str", variable has type "None")  [assignment]
pandas\core\computation\pytables.py:357: error: Incompatible types in assignment (expression has type "str", variable has type "None")  [assignment]
pandas\core\computation\pytables.py:364: error: Incompatible types in assignment (expression has type "str", variable has type "None")  [assignment]