### PR TITLE
BUG: GH36928 Allow dict_keys to be used as column names by read_csv

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
-- `dict_keys` not being accepted as valid column names by `pandas.io.parsers._validate_names`
+- ``dict_keys`` not being accepted as valid column names by ``pandas.io.parsers._validate_names``
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
-- ``dict_keys`` not being accepted as valid column names by ``pandas.io.parsers._validate_names``
+- Fixed regression in :func:`read_csv` raised ``ValueError`` when ``names`` was ``dict_keys`` (:issue:`36928`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
-- Fixed regression in :func:`read_csv` raised ``ValueError`` when ``names`` was ``dict_keys`` (:issue:`36928`)
+- Fixed regression in :func:`read_csv` raising a ``ValueError`` when ``names`` was of type ``dict_keys`` (:issue:`36928`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- `dict_keys` not being accepted as valid column names by `pandas.io.parsers._validate_names`
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1019,8 +1019,6 @@ cdef inline bint c_is_list_like(object obj, bint allow_sets) except -1:
         and not (util.is_array(obj) and obj.ndim == 0)
         # exclude sets if allow_sets is False
         and not (allow_sets is False and isinstance(obj, abc.Set))
-        # allow dict_keys objects
-        or isinstance(obj, abc.KeysView)
     )
 
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1019,6 +1019,8 @@ cdef inline bint c_is_list_like(object obj, bint allow_sets) except -1:
         and not (util.is_array(obj) and obj.ndim == 0)
         # exclude sets if allow_sets is False
         and not (allow_sets is False and isinstance(obj, abc.Set))
+        # allow dict_keys objects
+        or isinstance(obj, abc.KeysView)
     )
 
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -420,8 +420,8 @@ def _validate_names(names):
     if names is not None:
         if len(names) != len(set(names)):
             raise ValueError("Duplicate names are not allowed.")
-        if not is_list_like(names, allow_sets=False) and not isinstance(
-            names, abc.KeysView
+        if not (
+            is_list_like(names, allow_sets=False) or isinstance(names, abc.KeysView)
         ):
             raise ValueError("Names should be an ordered collection.")
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -420,7 +420,9 @@ def _validate_names(names):
     if names is not None:
         if len(names) != len(set(names)):
             raise ValueError("Duplicate names are not allowed.")
-        if not is_list_like(names, allow_sets=False):
+        if not is_list_like(names, allow_sets=False) and not isinstance(
+            names, abc.KeysView
+        ):
             raise ValueError("Names should be an ordered collection.")
 
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2222,7 +2222,7 @@ def test_read_csv_delim_whitespace_non_default_sep(all_parsers, delimiter):
     )
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(f, delim_whitespace=True, sep=delimiter)
-        
+
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(f, delim_whitespace=True, delimiter=delimiter)
 

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2221,3 +2221,12 @@ def test_read_table_delim_whitespace_non_default_sep(all_parsers):
     )
     with pytest.raises(ValueError, match=msg):
         parser.read_table(f, delim_whitespace=True, sep=",")
+
+
+def test_dict_keys_as_names(all_parsers):
+    data = "a,b\n1,2"
+
+    keys = {"a": int, "b": int}.keys()
+    parser = all_parsers
+
+    parser.read_csv(StringIO(data), names=keys)

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2222,6 +2222,9 @@ def test_read_csv_delim_whitespace_non_default_sep(all_parsers, delimiter):
     )
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(f, delim_whitespace=True, sep=delimiter)
+        
+    with pytest.raises(ValueError, match=msg):
+        parser.read_csv(f, delim_whitespace=True, delimiter=delimiter)
 
 
 @pytest.mark.parametrize("delimiter", [",", "\t"])
@@ -2250,7 +2253,3 @@ def test_dict_keys_as_names(all_parsers):
     result = parser.read_csv(StringIO(data), names=keys)
     expected = DataFrame({"a": [1], "b": [2]})
     tm.assert_frame_equal(result, expected)
-        parser.read_csv(f, delim_whitespace=True, sep=delimiter)
-
-    with pytest.raises(ValueError, match=msg):
-        parser.read_csv(f, delim_whitespace=True, delimiter=delimiter)

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2221,7 +2221,10 @@ def test_read_csv_delim_whitespace_non_default_sep(all_parsers, delimiter):
         "delim_whitespace=True; you can only specify one."
     )
     with pytest.raises(ValueError, match=msg):
-        parser.read_table(f, delim_whitespace=True, sep=",")
+        parser.read_csv(f, delim_whitespace=True, sep=delimiter)
+
+    with pytest.raises(ValueError, match=msg):
+        parser.read_csv(f, delim_whitespace=True, delimiter=delimiter)
 
 
 @pytest.mark.parametrize("delimiter", [",", "\t"])

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2223,9 +2223,6 @@ def test_read_csv_delim_whitespace_non_default_sep(all_parsers, delimiter):
     with pytest.raises(ValueError, match=msg):
         parser.read_csv(f, delim_whitespace=True, sep=delimiter)
 
-    with pytest.raises(ValueError, match=msg):
-        parser.read_csv(f, delim_whitespace=True, delimiter=delimiter)
-
 
 @pytest.mark.parametrize("delimiter", [",", "\t"])
 def test_read_table_delim_whitespace_non_default_sep(all_parsers, delimiter):

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -2224,9 +2224,12 @@ def test_read_table_delim_whitespace_non_default_sep(all_parsers):
 
 
 def test_dict_keys_as_names(all_parsers):
-    data = "a,b\n1,2"
+    # GH: 36928
+    data = "1,2"
 
     keys = {"a": int, "b": int}.keys()
     parser = all_parsers
 
-    parser.read_csv(StringIO(data), names=keys)
+    result = parser.read_csv(StringIO(data), names=keys)
+    expected = DataFrame({"a": [1], "b": [2]})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #36928 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry