### PR TITLE
DOC: Update dependency for to_markdown documentation

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1473,7 +1473,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Notes
         -----
-        This method requires the tabulate package.
+        This method requires the `tabulate package
+                <https://pypi.org/project/tabulate>`_.
+
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1473,8 +1473,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Notes
         -----
-        This method requires the `tabulate package
-                <https://pypi.org/project/tabulate>`_.
+        Requires the `tabulate <https://pypi.org/project/tabulate>`_ package.
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1437,7 +1437,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         **kwargs,
     ) -> Optional[str]:
         """
-        Print {klass} in Markdown-friendly format.
+        Print {klass} in Markdown-friendly format (requires the tabulate package).
 
         .. versionadded:: 1.0.0
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1437,7 +1437,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         **kwargs,
     ) -> Optional[str]:
         """
-        Print {klass} in Markdown-friendly format (requires the tabulate package).
+        Print {klass} in Markdown-friendly format.
 
         .. versionadded:: 1.0.0
 
@@ -1470,6 +1470,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         -------
         str
             {klass} in Markdown-friendly format.
+
+        Notes
+        -----
+        This method requires the tabulate package.
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1476,7 +1476,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         This method requires the `tabulate package
                 <https://pypi.org/project/tabulate>`_.
 
-
         Examples
         --------
         >>> s = pd.Series(["elk", "pig", "dog", "quetzal"], name="animal")


### PR DESCRIPTION
Adding to the documentation that tabulate is required for to_markdown to be executed

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
