### PR TITLE
TST: astyp via loc to int64

### DIFF
--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pandas import (
+    NA,
     Categorical,
     CategoricalDtype,
     DataFrame,
@@ -137,7 +138,7 @@ class TestAstype:
             df.astype(dtype)
 
     @pytest.mark.parametrize("dtype", ["Int64", "Int32", "Int16"])
-    @pytest.mark.parametrize("val", [np.nan])
+    @pytest.mark.parametrize("val", [np.nan, NA])
     def test_astype_cast_via_loc_nan_int(self, val, dtype):
         # see GH#31861
         expected = DataFrame({"a": ["foo"], "b": integer_array([val], dtype=dtype)})

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -140,11 +140,11 @@ class TestAstype:
     @pytest.mark.parametrize("dtype", ["Int64", "Int32", "Int16"])
     @pytest.mark.parametrize("val", [np.nan, NA])
     def test_astype_cast_via_loc_nan_int(self, val, dtype):
-        # see GH#31861
+        # GH31861
         expected = DataFrame({"a": ["foo"], "b": integer_array([val], dtype=dtype)})
-        result = DataFrame({"a": ["foo"], "b": [val]})
-        result.loc[:, "b"] = result.loc[:, "b"].astype(dtype)
-        tm.assert_frame_equal(result, expected)
+        df = DataFrame({"a": ["foo"], "b": [val]})
+        df.loc[:, "b"] = df.loc[:, "b"].astype(dtype)
+        tm.assert_frame_equal(df, expected)
 
     def test_astype_str(self):
         # see GH#9757

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -146,6 +146,25 @@ class TestAstype:
         df.loc[:, "b"] = df.loc[:, "b"].astype(dtype)
         tm.assert_frame_equal(df, expected)
 
+        expected2 = DataFrame(
+            {"a": ["foo", "foo"], "b": integer_array([val, 1.0], dtype=dtype)}
+        )
+        df2 = DataFrame({"a": ["foo", "foo"], "b": [val, 1.0]})
+        df2.loc[:, "b"] = df2.loc[:, "b"].astype(dtype)
+        tm.assert_frame_equal(df2, expected2)
+
+        expected3 = DataFrame(
+            {"a": ["foo", "foo"], "b": integer_array([val, val], dtype=dtype)}
+        )
+        df3 = DataFrame({"a": ["foo", "foo"], "b": [val, val]})
+        df3.loc[:, "b"] = df3.loc[:, "b"].astype(dtype)
+        tm.assert_frame_equal(df3, expected3)
+
+        expected4 = DataFrame({"b": integer_array([val], dtype=dtype)})
+        df4 = DataFrame({"b": [val]})
+        df4.loc[:, "b"] = df4.loc[:, "b"].astype(dtype)
+        tm.assert_frame_equal(df4, expected4)
+
     def test_astype_str(self):
         # see GH#9757
         a = Series(date_range("2010-01-04", periods=5))

--- a/pandas/tests/frame/methods/test_astype.py
+++ b/pandas/tests/frame/methods/test_astype.py
@@ -136,6 +136,15 @@ class TestAstype:
         with pytest.raises(ValueError, match=msg):
             df.astype(dtype)
 
+    @pytest.mark.parametrize("dtype", ["Int64", "Int32", "Int16"])
+    @pytest.mark.parametrize("val", [np.nan])
+    def test_astype_cast_via_loc_nan_int(self, val, dtype):
+        # see GH#31861
+        expected = DataFrame({"a": ["foo"], "b": integer_array([val], dtype=dtype)})
+        result = DataFrame({"a": ["foo"], "b": [val]})
+        result.loc[:, "b"] = result.loc[:, "b"].astype(dtype)
+        tm.assert_frame_equal(result, expected)
+
     def test_astype_str(self):
         # see GH#9757
         a = Series(date_range("2010-01-04", periods=5))


### PR DESCRIPTION
- [x] closes #31861
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Adds a test for a special case of `astype` via `loc` to extension type Int64 when data has np.nan or pd.NA. 