### PR TITLE
REGR: Make DateOffset immutable

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -14,7 +14,7 @@ including other versions of pandas.
 
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
--
+- Fixed regression where attempting to mutate a :class:`DateOffset` object would no longer raise an ``AttributeError`` (:issue:`36940`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -1212,9 +1212,8 @@ class DateOffset(RelativeDeltaOffset, metaclass=OffsetMeta):
     >>> ts + DateOffset(months=2)
     Timestamp('2017-03-01 09:10:11')
     """
-
-    pass
-
+    def __setattr__(self, name, value):
+        raise AttributeError("DateOffset objects are immutable.")
 
 # --------------------------------------------------------------------
 

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -4424,3 +4424,20 @@ def test_week_add_invalid():
     other = Day()
     with pytest.raises(TypeError, match="Cannot add"):
         offset + other
+
+
+@pytest.mark.parametrize(
+    "attribute",
+    [
+        "hours",
+        "days",
+        "weeks",
+        "months",
+        "years",
+    ],
+)
+def test_dateoffset_immutable(attribute):
+    offset = DateOffset(**{attribute: 0})
+    msg = "DateOffset objects are immutable"
+    with pytest.raises(AttributeError, match=msg):
+        setattr(offset, attribute, 5)


### PR DESCRIPTION
- [x] closes #36940
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I'm assuming this is a regression and not behavior we want?