### PR TITLE
DOC: Add GCS as supported filesystem for read_parquet

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -321,7 +321,7 @@ def read_parquet(path, engine: str = "auto", columns=None, **kwargs):
     ----------
     path : str, path object or file-like object
         Any valid string path is acceptable. The string could be a URL. Valid
-        URL schemes include http, ftp, s3, and file. For file URLs, a host is
+        URL schemes include http, ftp, s3, gs, and file. For file URLs, a host is
         expected. A local file could be:
         ``file://localhost/path/to/table.parquet``.
         A file URL can also be a path to a directory that contains multiple


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
