### PR TITLE
DOC: improve description of the example which dataframe has two rows

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8971,8 +8971,7 @@ NaN 12.3   33.0
         ostrich       bird     2    NaN
 
         By default, missing values are not considered, and the mode of wings
-        are both 0 and 2. The second row of species and legs contains ``NaN``,
-        because they have only one mode. Because the resulting DataFrame has two rows, 
+        are both 0 and 2. Because the resulting DataFrame has two rows, 
         the second row of ``species`` and ``legs`` contains ``NaN``.
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8971,10 +8971,8 @@ NaN 12.3   33.0
         ostrich       bird     2    NaN
 
         By default, missing values are not considered, and the mode of wings
-        are both 0 and 2. Because the resulting DataFrame has two rows, 
+        are both 0 and 2. Because the resulting DataFrame has two rows,
         the second row of ``species`` and ``legs`` contains ``NaN``.
-
-
         >>> df.mode()
           species  legs  wings
         0    bird   2.0    0.0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8972,7 +8972,9 @@ NaN 12.3   33.0
 
         By default, missing values are not considered, and the mode of wings
         are both 0 and 2. The second row of species and legs contains ``NaN``,
-        because they have only one mode, but the resulting DataFrame has two rows.
+        because they have only one mode. Because the resulting DataFrame has two rows, 
+        the second row of ``species`` and ``legs`` contains ``NaN``.
+
 
         >>> df.mode()
           species  legs  wings

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8972,7 +8972,7 @@ NaN 12.3   33.0
 
         By default, missing values are not considered, and the mode of wings
         are both 0 and 2. The second row of species and legs contains ``NaN``,
-        because they have only one mode, but the DataFrame has two rows.
+        because they have only one mode, but the resulting DataFrame has two rows.
 
         >>> df.mode()
           species  legs  wings

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8973,6 +8973,7 @@ NaN 12.3   33.0
         By default, missing values are not considered, and the mode of wings
         are both 0 and 2. Because the resulting DataFrame has two rows,
         the second row of ``species`` and ``legs`` contains ``NaN``.
+
         >>> df.mode()
           species  legs  wings
         0    bird   2.0    0.0


### PR DESCRIPTION
improve description of the example which dataframe has two rows

- [ ] closes #36970
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
