### PR TITLE
FIX: fix cleanup warnings for errorbar timeseries

### DIFF
--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -2765,35 +2765,62 @@ class TestDataFramePlots(TestPlotBase):
             self._check_has_errorbars(ax, xerr=0, yerr=1)
 
     @pytest.mark.slow
-    def test_errorbar_timeseries(self):
+    @pytest.mark.parametrize("kind", ["line", "bar", "barh"])
+    def test_errorbar_timeseries(self, kind):
+        import matplotlib.pyplot as plt
 
-        with warnings.catch_warnings():
-            d = {"x": np.arange(12), "y": np.arange(12, 0, -1)}
-            d_err = {"x": np.ones(12) * 0.2, "y": np.ones(12) * 0.4}
+        d = {"x": np.arange(12), "y": np.arange(12, 0, -1)}
+        d_err = {"x": np.ones(12) * 0.2, "y": np.ones(12) * 0.4}
 
-            # check time-series plots
-            ix = date_range("1/1/2000", "1/1/2001", freq="M")
-            tdf = DataFrame(d, index=ix)
-            tdf_err = DataFrame(d_err, index=ix)
+        # check time-series plots
+        ix = date_range("1/1/2000", "1/1/2001", freq="M")
+        tdf = DataFrame(d, index=ix)
+        tdf_err = DataFrame(d_err, index=ix)
 
-            kinds = ["line", "bar", "barh"]
-            for kind in kinds:
-                ax = _check_plot_works(tdf.plot, yerr=tdf_err, kind=kind)
-                self._check_has_errorbars(ax, xerr=0, yerr=2)
-                ax = _check_plot_works(tdf.plot, yerr=d_err, kind=kind)
-                self._check_has_errorbars(ax, xerr=0, yerr=2)
-                ax = _check_plot_works(tdf.plot, y="y", yerr=tdf_err["x"], kind=kind)
-                self._check_has_errorbars(ax, xerr=0, yerr=1)
-                ax = _check_plot_works(tdf.plot, y="y", yerr="x", kind=kind)
-                self._check_has_errorbars(ax, xerr=0, yerr=1)
-                ax = _check_plot_works(tdf.plot, yerr=tdf_err, kind=kind)
-                self._check_has_errorbars(ax, xerr=0, yerr=2)
+        ax = _check_plot_works(tdf.plot, yerr=tdf_err, kind=kind)
+        self._check_has_errorbars(ax, xerr=0, yerr=2)
 
-                # _check_plot_works adds an ax so catch warning. see GH #13188
-                axes = _check_plot_works(
-                    tdf.plot, kind=kind, yerr=tdf_err, subplots=True
-                )
-                self._check_has_errorbars(axes, xerr=0, yerr=1)
+        ax = _check_plot_works(tdf.plot, yerr=d_err, kind=kind)
+        self._check_has_errorbars(ax, xerr=0, yerr=2)
+
+        ax = _check_plot_works(tdf.plot, y="y", yerr=tdf_err["x"], kind=kind)
+        self._check_has_errorbars(ax, xerr=0, yerr=1)
+
+        ax = _check_plot_works(tdf.plot, y="y", yerr="x", kind=kind)
+        self._check_has_errorbars(ax, xerr=0, yerr=1)
+
+        ax = _check_plot_works(tdf.plot, yerr=tdf_err, kind=kind)
+        self._check_has_errorbars(ax, xerr=0, yerr=2)
+
+        # Do not use _check_plot_works as this function creates
+        # subplots inside, which led to uncaught warnings like this:
+        # UserWarning: To output multiple subplots,
+        # the figure containing the passed axes is being cleared
+        tdf.plot(kind=kind, yerr=tdf_err, subplots=True)
+        fig = plt.gcf()
+        axes = fig.get_axes()
+        for ax in axes:
+            self._check_has_errorbars(ax, xerr=0, yerr=1)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("kind", ["line", "bar", "barh"])
+    def test_errorbar_plotting_twice_on_same_axis_warns(self, kind):
+        d = {"x": np.arange(12), "y": np.arange(12, 0, -1)}
+        d_err = {"x": np.ones(12) * 0.2, "y": np.ones(12) * 0.4}
+
+        ix = date_range("1/1/2000", "1/1/2001", freq="M")
+        tdf = DataFrame(d, index=ix)
+        tdf_err = DataFrame(d_err, index=ix)
+
+        with warnings.catch_warnings(record=True) as w:
+            # _check_plot_works creates subplots inside,
+            # thus the warning about overwriting must be raised
+            axes = _check_plot_works(tdf.plot, kind=kind, yerr=tdf_err, subplots=True)
+            self._check_has_errorbars(axes, xerr=0, yerr=1)
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
+            msg = "the figure containing the passed axes is being cleared"
+            assert msg in str(w[0].message)
 
     def test_errorbar_asymmetrical(self):
 

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -2727,8 +2727,8 @@ class TestDataFramePlots(TestPlotBase):
         self._check_has_errorbars(ax, xerr=2, yerr=2)
 
         with tm.assert_produces_warning(UserWarning):
-            # _check_plot_works as this function creates
-            # subplots inside, which leads to warnings like this:
+            # _check_plot_works creates subplots inside,
+            # which leads to warnings like this:
             # UserWarning: To output multiple subplots,
             # the figure containing the passed axes is being cleared
             # Similar warnings were observed in GH #13188
@@ -2808,8 +2808,8 @@ class TestDataFramePlots(TestPlotBase):
         self._check_has_errorbars(ax, xerr=0, yerr=2)
 
         with tm.assert_produces_warning(UserWarning):
-            # _check_plot_works as this function creates
-            # subplots inside, which leads to warnings like this:
+            # _check_plot_works creates subplots inside,
+            # which leads to warnings like this:
             # UserWarning: To output multiple subplots,
             # the figure containing the passed axes is being cleared
             # Similar warnings were observed in GH #13188

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -2706,8 +2706,6 @@ class TestDataFramePlots(TestPlotBase):
     @pytest.mark.slow
     @pytest.mark.parametrize("kind", ["line", "bar", "barh"])
     def test_errorbar_plot_different_kinds(self, kind):
-        import matplotlib.pyplot as plt
-
         d = {"x": np.arange(12), "y": np.arange(12, 0, -1)}
         df = DataFrame(d)
         d_err = {"x": np.ones(12) * 0.2, "y": np.ones(12) * 0.4}
@@ -2734,13 +2732,10 @@ class TestDataFramePlots(TestPlotBase):
             # UserWarning: To output multiple subplots,
             # the figure containing the passed axes is being cleared
             # Similar warnings were observed in GH #13188
-            _check_plot_works(
+            axes = _check_plot_works(
                 df.plot, yerr=df_err, xerr=df_err, subplots=True, kind=kind
             )
-            fig = plt.gcf()
-            axes = fig.get_axes()
-            for ax in axes:
-                self._check_has_errorbars(ax, xerr=1, yerr=1)
+            self._check_has_errorbars(axes, xerr=1, yerr=1)
 
     @pytest.mark.xfail(reason="Iterator is consumed", raises=ValueError)
     @pytest.mark.slow
@@ -2789,8 +2784,6 @@ class TestDataFramePlots(TestPlotBase):
     @pytest.mark.slow
     @pytest.mark.parametrize("kind", ["line", "bar", "barh"])
     def test_errorbar_timeseries(self, kind):
-        import matplotlib.pyplot as plt
-
         d = {"x": np.arange(12), "y": np.arange(12, 0, -1)}
         d_err = {"x": np.ones(12) * 0.2, "y": np.ones(12) * 0.4}
 
@@ -2820,11 +2813,8 @@ class TestDataFramePlots(TestPlotBase):
             # UserWarning: To output multiple subplots,
             # the figure containing the passed axes is being cleared
             # Similar warnings were observed in GH #13188
-            _check_plot_works(tdf.plot, kind=kind, yerr=tdf_err, subplots=True)
-            fig = plt.gcf()
-            axes = fig.get_axes()
-            for ax in axes:
-                self._check_has_errorbars(ax, xerr=0, yerr=1)
+            axes = _check_plot_works(tdf.plot, kind=kind, yerr=tdf_err, subplots=True)
+            self._check_has_errorbars(axes, xerr=0, yerr=1)
 
     def test_errorbar_asymmetrical(self):
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Currently in ``pandas/tests/plotting/tests_frame.py`` there are several warnings emitted.

```
pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_mpl2_color_cycle_str
  /workspaces/pandas/pandas/plotting/_matplotlib/style.py:64: MatplotlibDeprecationWarning: Support for uppercase single-letter colors is deprecated since Matplotlib 3.1 and will be removed in 3.3; please use lowercase instead.
    [conv.to_rgba(c) for c in colors]

pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_errorbar_plot
pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_errorbar_plot
pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_errorbar_plot
pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_errorbar_timeseries
pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_errorbar_timeseries
pandas/tests/plotting/test_frame.py::TestDataFramePlots::test_errorbar_timeseries
  /workspaces/pandas/pandas/plotting/_matplotlib/__init__.py:61: UserWarning: To output multiple subplots, the figure containing the passed axes is being cleared
    plot_obj.generate()

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

This PR handles warnings in ``test_errorbar_timeseries``.
If this approach is considered reasonable by the reviewers, then I will do the same for ``test_errorbar_plot`` as well as other similar warnings among the plotting-related tests.