### PR TITLE
Fix test_unstack

### DIFF
--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -316,7 +316,7 @@ class BaseReshapingTests(BaseExtensionTests):
                 alt = df.unstack(level=level).droplevel(0, axis=1)
                 self.assert_frame_equal(result, alt)
 
-            expected = ser.astype(object).unstack(level=level)
+            expected = ser.astype(object).unstack(level=level, fill_value=data.dtype.na_value)
             result = result.astype(object)
 
             self.assert_frame_equal(result, expected)

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -316,7 +316,8 @@ class BaseReshapingTests(BaseExtensionTests):
                 alt = df.unstack(level=level).droplevel(0, axis=1)
                 self.assert_frame_equal(result, alt)
 
-            expected = ser.astype(object).unstack(level=level, fill_value=data.dtype.na_value)
+            expected = ser.astype(object).unstack(level=level,
+                                                  fill_value=data.dtype.na_value)
             result = result.astype(object)
 
             self.assert_frame_equal(result, expected)

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -316,8 +316,9 @@ class BaseReshapingTests(BaseExtensionTests):
                 alt = df.unstack(level=level).droplevel(0, axis=1)
                 self.assert_frame_equal(result, alt)
 
-            expected = ser.astype(object).unstack(level=level,
-                                                  fill_value=data.dtype.na_value)
+            expected = ser.astype(object).unstack(
+                level=level, fill_value=data.dtype.na_value
+            )
             result = result.astype(object)
 
             self.assert_frame_equal(result, expected)


### PR DESCRIPTION
The test was failing if the ExtensionDtype had an na_value that wasn't equivalent to nan

- [x] closes #36986 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
