### PR TITLE
CI: xfail intermittently-failing tests

### DIFF
--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -8,7 +8,7 @@ import sys
 import numpy as np
 import pytest
 
-from pandas.compat import IS64, is_platform_windows
+from pandas.compat import IS64, PY38, is_platform_windows
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -1695,6 +1695,11 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         result = series.to_json(orient="index")
         assert result == expected
 
+    @pytest.mark.xfail(
+        is_platform_windows() and PY38,
+        reason="localhost connection rejected",
+        strict=False,
+    )
     def test_to_s3(self, s3_resource, s3so):
         import time
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -9,7 +9,7 @@ from warnings import catch_warnings
 import numpy as np
 import pytest
 
-from pandas.compat import PY38
+from pandas.compat import PY38, is_platform_windows
 import pandas.util._test_decorators as td
 
 import pandas as pd
@@ -559,6 +559,11 @@ class TestParquetPyArrow(Base):
             expected = df.astype(object)
             check_round_trip(df, pa, expected=expected)
 
+    @pytest.mark.xfail(
+        is_platform_windows() and PY38,
+        reason="localhost connection rejected",
+        strict=False,
+    )
     def test_s3_roundtrip_explicit_fs(self, df_compat, s3_resource, pa, s3so):
         s3fs = pytest.importorskip("s3fs")
         if LooseVersion(pyarrow.__version__) <= LooseVersion("0.17.0"):

--- a/pandas/tests/plotting/test_groupby.py
+++ b/pandas/tests/plotting/test_groupby.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pytest
 
+from pandas.compat import PY38, is_platform_windows
 import pandas.util._test_decorators as td
 
 from pandas import DataFrame, Index, Series
@@ -13,6 +14,11 @@ from pandas.tests.plotting.common import TestPlotBase
 
 @td.skip_if_no_mpl
 class TestDataFrameGroupByPlots(TestPlotBase):
+    @pytest.mark.xfail(
+        is_platform_windows() and not PY38,
+        reason="Looks like LinePlot._is_ts_plot is wrong",
+        strict=False,
+    )
     def test_series_groupby_plotting_nominally_works(self):
         n = 10
         weight = Series(np.random.normal(166, 20, size=n))


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Usually I avoid `strict=False` like the plague, but these are a PITA recently.