### PR TITLE
TYP: untyped decorators

### DIFF
--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -98,7 +98,7 @@ class NDArrayBackedExtensionArray(ExtensionArray):
     def size(self) -> int:
         return np.prod(self.shape)
 
-    @cache_readonly
+    @property
     def nbytes(self) -> int:
         return self._ndarray.nbytes
 

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -16,7 +16,7 @@ from pandas._typing import ArrayLike
 from pandas.compat import set_function_name
 from pandas.compat.numpy import function as nv
 from pandas.errors import AbstractMethodError
-from pandas.util._decorators import Appender, Substitution
+from pandas.util._decorators import Appender, Substitution, cache_readonly
 from pandas.util._validators import validate_fillna_kwargs
 
 from pandas.core.dtypes.cast import maybe_cast_to_extension_array
@@ -395,7 +395,7 @@ class ExtensionArray:
     # Required attributes
     # ------------------------------------------------------------------------
 
-    @property
+    @cache_readonly
     def dtype(self) -> ExtensionDtype:
         """
         An instance of 'ExtensionDtype'.
@@ -409,14 +409,14 @@ class ExtensionArray:
         """
         return (len(self),)
 
-    @property
+    @cache_readonly
     def size(self) -> int:
         """
         The number of elements in the array.
         """
         return np.prod(self.shape)
 
-    @property
+    @cache_readonly
     def ndim(self) -> int:
         """
         Extension Arrays are only allowed to be 1-dimensional.

--- a/pandas/core/arrays/boolean.py
+++ b/pandas/core/arrays/boolean.py
@@ -8,6 +8,7 @@ from pandas._libs import lib, missing as libmissing
 from pandas._typing import ArrayLike
 from pandas.compat import set_function_name
 from pandas.compat.numpy import function as nv
+from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
     is_bool_dtype,
@@ -68,7 +69,7 @@ class BooleanDtype(BaseMaskedDtype):
     def kind(self) -> str:
         return "b"
 
-    @property
+    @cache_readonly
     def numpy_dtype(self) -> np.dtype:
         return np.dtype("bool")
 
@@ -269,7 +270,7 @@ class BooleanArray(OpsMixin, BaseMaskedArray):
         self._dtype = BooleanDtype()
         super().__init__(values, mask, copy=copy)
 
-    @property
+    @cache_readonly
     def dtype(self) -> BooleanDtype:
         return self._dtype
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -373,7 +373,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         self._dtype = self._dtype.update_dtype(dtype)
         self._codes = coerce_indexer_dtype(codes, dtype.categories)
 
-    @property
+    @cache_readonly
     def dtype(self) -> CategoricalDtype:
         """
         The :class:`~pandas.api.types.CategoricalDtype` for this instance.

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -23,6 +23,7 @@ from pandas._libs.tslibs import (
     tzconversion,
 )
 from pandas.errors import PerformanceWarning
+from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
     DT64NS_DTYPE,
@@ -484,7 +485,7 @@ class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps
     def _box_func(self, x) -> Union[Timestamp, NaTType]:
         return Timestamp(x, freq=self.freq, tz=self.tz)
 
-    @property
+    @cache_readonly
     def dtype(self) -> Union[np.dtype, DatetimeTZDtype]:
         """
         The dtype for the DatetimeArray.

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -12,7 +12,7 @@ from pandas._libs.interval import (
     intervals_to_interval_bounds,
 )
 from pandas.compat.numpy import function as nv
-from pandas.util._decorators import Appender
+from pandas.util._decorators import Appender, cache_readonly
 
 from pandas.core.dtypes.cast import maybe_convert_platform
 from pandas.core.dtypes.common import (
@@ -144,7 +144,6 @@ for more.
     )
 )
 class IntervalArray(IntervalMixin, ExtensionArray):
-    ndim = 1
     can_hold_na = True
     _na_value = _fill_value = np.nan
 
@@ -522,7 +521,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     # ---------------------------------------------------------------------
     # Descriptive
 
-    @property
+    @cache_readonly
     def dtype(self):
         return IntervalDtype(self.left.dtype)
 
@@ -530,7 +529,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def nbytes(self) -> int:
         return self.left.nbytes + self.right.nbytes
 
-    @property
+    @cache_readonly
     def size(self) -> int:
         # Avoid materializing self.values
         return self.left.size

--- a/pandas/core/arrays/masked.py
+++ b/pandas/core/arrays/masked.py
@@ -45,7 +45,7 @@ class BaseMaskedDtype(ExtensionDtype):
         """ Return an instance of our numpy dtype """
         return np.dtype(self.type)
 
-    @cache_readonly
+    @property
     def kind(self) -> str:
         return self.numpy_dtype.kind
 
@@ -95,7 +95,7 @@ class BaseMaskedArray(ExtensionArray, ExtensionOpsMixin):
         self._data = values
         self._mask = mask
 
-    @property
+    @cache_readonly
     def dtype(self) -> BaseMaskedDtype:
         raise AbstractMethodError(self)
 

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -7,6 +7,7 @@ from numpy.lib.mixins import NDArrayOperatorsMixin
 from pandas._libs import lib
 from pandas._typing import Scalar
 from pandas.compat.numpy import function as nv
+from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.dtypes import ExtensionDtype
 from pandas.core.dtypes.missing import isna
@@ -194,7 +195,7 @@ class PandasArray(
     # ------------------------------------------------------------------------
     # Data
 
-    @property
+    @cache_readonly
     def dtype(self) -> PandasDtype:
         return self._dtype
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -17,6 +17,7 @@ from pandas._typing import Scalar
 import pandas.compat as compat
 from pandas.compat.numpy import function as nv
 from pandas.errors import PerformanceWarning
+from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.cast import (
     astype_nansafe,
@@ -515,7 +516,7 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
         """
         return self._sparse_values
 
-    @property
+    @cache_readonly
     def dtype(self):
         return self._dtype
 

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -19,6 +19,7 @@ from pandas._libs.tslibs.conversion import precision_from_unit
 from pandas._libs.tslibs.fields import get_timedelta_field
 from pandas._libs.tslibs.timedeltas import array_to_timedelta64, parse_timedelta_unit
 from pandas.compat.numpy import function as nv
+from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
     DT64NS_DTYPE,
@@ -122,7 +123,7 @@ class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
     def _box_func(self, x) -> Union[Timedelta, NaTType]:
         return Timedelta(x, unit="ns")
 
-    @property
+    @cache_readonly
     def dtype(self) -> np.dtype:
         """
         The dtype for the TimedeltaArray.

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -198,7 +198,7 @@ class SelectionMixin:
         else:
             return self.obj[self._selection]
 
-    @cache_readonly
+    @property
     def ndim(self) -> int:
         return self._selected_obj.ndim
 
@@ -1314,53 +1314,6 @@ class IndexOpsMixin(OpsMixin):
         if dropna and isna(uniqs).any():
             n -= 1
         return n
-
-    @property
-    def is_unique(self) -> bool:
-        """
-        Return boolean if values in the object are unique.
-
-        Returns
-        -------
-        bool
-        """
-        return self.nunique(dropna=False) == len(self)
-
-    @property
-    def is_monotonic(self) -> bool:
-        """
-        Return boolean if values in the object are
-        monotonic_increasing.
-
-        Returns
-        -------
-        bool
-        """
-        from pandas import Index
-
-        return Index(self).is_monotonic
-
-    @property
-    def is_monotonic_increasing(self) -> bool:
-        """
-        Alias for is_monotonic.
-        """
-        # mypy complains if we alias directly
-        return self.is_monotonic
-
-    @property
-    def is_monotonic_decreasing(self) -> bool:
-        """
-        Return boolean if values in the object are
-        monotonic_decreasing.
-
-        Returns
-        -------
-        bool
-        """
-        from pandas import Index
-
-        return Index(self).is_monotonic_decreasing
 
     def memory_usage(self, deep=False):
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1643,7 +1643,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         return self.is_monotonic_increasing
 
-    @property
+    @cache_readonly
     def is_monotonic_increasing(self) -> bool:
         """
         Return if the index is monotonic increasing (only equal or
@@ -1660,7 +1660,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         return self._engine.is_monotonic_increasing
 
-    @property
+    @cache_readonly
     def is_monotonic_decreasing(self) -> bool:
         """
         Return if the index is monotonic decreasing (only equal or

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -333,7 +333,7 @@ class CategoricalIndex(ExtensionIndex, accessor.PandasDelegate):
 
     # --------------------------------------------------------------------
 
-    @property
+    @cache_readonly
     def inferred_type(self) -> str:
         return "categorical"
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -95,13 +95,13 @@ class DatetimeIndexOpsMixin(ExtensionIndex):
     _bool_ops: List[str] = []
     _field_ops: List[str] = []
 
-    # error: "Callable[[Any], Any]" has no attribute "fget"
-    hasnans = cache_readonly(
-        DatetimeLikeArrayMixin._hasnans.fget  # type: ignore[attr-defined]
-    )
+    @cache_readonly
+    def hasnans(self) -> bool:
+        return self._data._hasnans
+
     _hasnans = hasnans  # for index / array -agnostic code
 
-    @property
+    @cache_readonly
     def _is_all_dates(self) -> bool:
         return True
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -799,7 +799,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
     def is_type_compatible(self, typ) -> bool:
         return typ == self.inferred_type or typ == "datetime"
 
-    @property
+    @cache_readonly
     def inferred_type(self) -> str:
         # b/c datetime is represented as microseconds since the epoch, make
         # sure we can't have ambiguous indexing

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -385,7 +385,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
     def _multiindex(self) -> MultiIndex:
         return MultiIndex.from_arrays([self.left, self.right], names=["left", "right"])
 
-    @cache_readonly
+    @property
     def values(self) -> IntervalArray:
         """
         Return the IntervalIndex's data as an IntervalArray.
@@ -414,7 +414,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
             return self._shallow_copy(new_values)
         return Index.astype(self, dtype, copy=copy)
 
-    @property
+    @cache_readonly
     def inferred_type(self) -> str:
         """Return a string of the type inferred from the values"""
         return "interval"
@@ -1096,7 +1096,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
 
     # --------------------------------------------------------------------
 
-    @property
+    @cache_readonly
     def _is_all_dates(self) -> bool:
         """
         This is False even when left/right contain datetime-like objects,

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1228,7 +1228,7 @@ class MultiIndex(Index):
         # a tuple representation unnecessarily
         return self._nbytes(deep)
 
-    @cache_readonly
+    @property
     def nbytes(self) -> int:
         """ return the number of bytes in the underlying data """
         return self._nbytes(False)
@@ -1748,7 +1748,7 @@ class MultiIndex(Index):
         """
         return Index(self._values, tupleize_cols=False)
 
-    @property
+    @cache_readonly
     def _is_all_dates(self) -> bool:
         return False
 

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -148,7 +148,7 @@ class NumericIndex(Index):
         """
         pass
 
-    @property
+    @cache_readonly
     def _is_all_dates(self) -> bool:
         """
         Checks that all the labels are datetime objects.
@@ -240,7 +240,7 @@ class IntegerIndex(NumericIndex):
         except (OverflowError, TypeError, ValueError):
             return False
 
-    @property
+    @cache_readonly
     def inferred_type(self) -> str:
         """
         Always 'integer' for ``Int64Index`` and ``UInt64Index``
@@ -335,7 +335,7 @@ class Float64Index(NumericIndex):
     _engine_type = libindex.Float64Engine
     _default_dtype = np.float64
 
-    @property
+    @cache_readonly
     def inferred_type(self) -> str:
         """
         Always 'floating' for ``Float64Index``

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -419,7 +419,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         # TODO: should probably raise on `how` here, so we don't ignore it.
         return super().astype(dtype, copy=copy)
 
-    @property
+    @cache_readonly
     def is_full(self) -> bool:
         """
         Returns True if this PeriodIndex is range-like in that all Periods
@@ -432,7 +432,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         values = self.asi8
         return ((values[1:] - values[:-1]) < 2).all()
 
-    @property
+    @cache_readonly
     def inferred_type(self) -> str:
         # b/c data is represented as ints make sure we can't have ambiguous
         # indexing

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -274,7 +274,7 @@ class RangeIndex(Int64Index):
         )
         return self.step
 
-    @cache_readonly
+    @property
     def nbytes(self) -> int:
         """
         Return the number of bytes in the underlying data.
@@ -310,11 +310,11 @@ class RangeIndex(Int64Index):
         """
         return self.nbytes
 
-    @property
+    @cache_readonly
     def dtype(self) -> np.dtype:
         return np.dtype(np.int64)
 
-    @property
+    @cache_readonly
     def is_unique(self) -> bool:
         """ return if the index has unique values """
         return True

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -4,7 +4,7 @@ from pandas._libs import index as libindex, lib
 from pandas._libs.tslibs import Timedelta, to_offset
 from pandas._typing import DtypeObj, Label
 from pandas.errors import InvalidIndexError
-from pandas.util._decorators import doc
+from pandas.util._decorators import cache_readonly, doc
 
 from pandas.core.dtypes.common import (
     TD64NS_DTYPE,
@@ -256,7 +256,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
     def is_type_compatible(self, typ) -> bool:
         return typ == self.inferred_type or typ == "timedelta"
 
-    @property
+    @cache_readonly
     def inferred_type(self) -> str:
         return "timedelta64"
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1106,6 +1106,53 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # Unsorted
 
     @property
+    def is_unique(self) -> bool:
+        """
+        Return boolean if values in the object are unique.
+
+        Returns
+        -------
+        bool
+        """
+        return self.nunique(dropna=False) == len(self)
+
+    @property
+    def is_monotonic(self) -> bool:
+        """
+        Return boolean if values in the object are
+        monotonic_increasing.
+
+        Returns
+        -------
+        bool
+        """
+        from pandas import Index
+
+        return Index(self).is_monotonic
+
+    @property
+    def is_monotonic_increasing(self) -> bool:
+        """
+        Alias for is_monotonic.
+        """
+        # mypy complains if we alias directly
+        return self.is_monotonic
+
+    @property
+    def is_monotonic_decreasing(self) -> bool:
+        """
+        Return boolean if values in the object are
+        monotonic_decreasing.
+
+        Returns
+        -------
+        bool
+        """
+        from pandas import Index
+
+        return Index(self).is_monotonic_decreasing
+
+    @property
     def _is_mixed_type(self):
         return False
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2307,8 +2307,7 @@ class DataCol(IndexCol):
         Get an appropriately typed and shaped pytables.Col object for values.
         """
         dtype = values.dtype
-        # error: "ExtensionDtype" has no attribute "itemsize"
-        itemsize = dtype.itemsize  # type: ignore[attr-defined]
+        itemsize = dtype.itemsize
 
         shape = values.shape
         if values.ndim == 1:

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -21,6 +21,8 @@ from typing import Any, Mapping, Type
 
 import numpy as np
 
+from pandas.util._decorators import cache_readonly
+
 from pandas.core.dtypes.common import pandas_dtype
 
 import pandas as pd
@@ -45,7 +47,6 @@ class JSONDtype(ExtensionDtype):
 
 
 class JSONArray(ExtensionArray):
-    dtype = JSONDtype()
     __array_priority__ = 1000
 
     def __init__(self, values, dtype=None, copy=False):
@@ -68,6 +69,10 @@ class JSONArray(ExtensionArray):
     @classmethod
     def _from_factorized(cls, values, original):
         return cls([UserDict(x) for x in values if x != ()])
+
+    @cache_readonly
+    def dtype(self) -> JSONDtype:
+        return JSONDtype()
 
     def __getitem__(self, item):
         if isinstance(item, numbers.Integral):

--- a/pandas/tests/extension/list/array.py
+++ b/pandas/tests/extension/list/array.py
@@ -10,6 +10,8 @@ from typing import Type
 
 import numpy as np
 
+from pandas.util._decorators import cache_readonly
+
 from pandas.core.dtypes.base import ExtensionDtype
 
 import pandas as pd
@@ -34,7 +36,6 @@ class ListDtype(ExtensionDtype):
 
 
 class ListArray(ExtensionArray):
-    dtype = ListDtype()
     __array_priority__ = 1000
 
     def __init__(self, values, dtype=None, copy=False):
@@ -50,6 +51,10 @@ class ListArray(ExtensionArray):
         data = np.empty(len(scalars), dtype=object)
         data[:] = scalars
         return cls(data)
+
+    @cache_readonly
+    def dtype(self) -> ListDtype:
+        return ListDtype()
 
     def __getitem__(self, item):
         if isinstance(item, numbers.Integral):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

xref #33455, when i use the stub @simonjayhawkins suggested there and put `disallow_untyped_decorators = True` into setup.cfg, this PR gets us down to 27 errors, including

6 from pytest.mark.parametrize
3 from numba.jit
3 from AxisProperty

