### PR TITLE
BUG: DataFrame.diff with dt64 and NaTs

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -360,6 +360,7 @@ Numeric
 - Bug in :meth:`DataFrame.__rmatmul__` error handling reporting transposed shapes (:issue:`21581`)
 - Bug in :class:`Series` flex arithmetic methods where the result when operating with a ``list``, ``tuple`` or ``np.ndarray`` would have an incorrect name (:issue:`36760`)
 - Bug in :class:`IntegerArray` multiplication with ``timedelta`` and ``np.timedelta64`` objects (:issue:`36870`)
+- Bug in :meth:`DataFrame.diff` with ``datetime64`` dtypes including ``NaT`` values failing to fill ``NaT`` results correctly (:issue:`32441`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/tests/frame/methods/test_diff.py
+++ b/pandas/tests/frame/methods/test_diff.py
@@ -42,7 +42,7 @@ class TestDataFrameDiff:
     def test_diff_timedelta64_with_nat(self):
         # GH#32441
         arr = np.arange(6).reshape(3, 2).astype("timedelta64[ns]")
-        arr[:, 0] = "NaT"
+        arr[:, 0] = np.timedelta64("NaT", "ns")
 
         df = pd.DataFrame(arr)
         result = df.diff(1, axis=0)

--- a/pandas/tests/frame/methods/test_diff.py
+++ b/pandas/tests/frame/methods/test_diff.py
@@ -39,6 +39,28 @@ class TestDataFrameDiff:
         expected = pd.DataFrame({"x": np.nan, "y": pd.Series(1), "z": pd.Series(1)})
         tm.assert_frame_equal(result, expected)
 
+    def test_diff_timedelta64_with_nat(self):
+        # GH#32441
+        arr = np.arange(6).reshape(3, 2).astype("timedelta64[ns]")
+        arr[:, 0] = "NaT"
+
+        df = pd.DataFrame(arr)
+        result = df.diff(1, axis=0)
+
+        expected = pd.DataFrame(
+            {0: df[0], 1: [pd.NaT, pd.Timedelta(2), pd.Timedelta(2)]}
+        )
+        tm.assert_equal(result, expected)
+
+        result = df.diff(0)
+        expected = df - df
+        assert expected[0].isna().all()
+        tm.assert_equal(result, expected)
+
+        result = df.diff(-1, axis=1)
+        expected = df * np.nan
+        tm.assert_equal(result, expected)
+
     @pytest.mark.parametrize("tz", [None, "UTC"])
     def test_diff_datetime_axis0_with_nat(self, tz):
         # GH#32441


### PR DESCRIPTION
- [x] closes #32441
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

There's a related bug in algos.diff, but the elegant solution goes through the cython code, so im doing that in a separate branch.