### PR TITLE
Backport PR #36911:  BUG: RollingGroupby not respecting sort=False

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -15,6 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression where attempting to mutate a :class:`DateOffset` object would no longer raise an ``AttributeError`` (:issue:`36940`)
+- Fixed regression in :class:`RollingGroupby` with ``sort=False`` not being respected (:issue:`36889`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -556,8 +556,13 @@ class Grouping:
         if isinstance(self.grouper, ops.BaseGrouper):
             return self.grouper.indices
 
-        values = Categorical(self.grouper)
-        return values._reverse_indexer()
+        # Return a dictionary of {group label: [indices belonging to the group label]}
+        # respecting whether sort was specified
+        codes, uniques = algorithms.factorize(self.grouper, sort=self.sort)
+        return {
+            category: np.flatnonzero(codes == i)
+            for i, category in enumerate(Index(uniques))
+        }
 
     @property
     def codes(self) -> np.ndarray:

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -417,3 +417,18 @@ class TestGrouperGrouping:
         result = expected.groupby(["s1", "s2"]).rolling(window=1).sum()
         expected.index = pd.MultiIndex.from_tuples([], names=["s1", "s2", None])
         tm.assert_frame_equal(result, expected)
+
+    def test_groupby_rolling_no_sort(self):
+        # GH 36889
+        result = (
+            pd.DataFrame({"foo": [2, 1], "bar": [2, 1]})
+            .groupby("foo", sort=False)
+            .rolling(1)
+            .min()
+        )
+        expected = pd.DataFrame(
+            np.array([[2.0, 2.0], [1.0, 1.0]]),
+            columns=["foo", "bar"],
+            index=pd.MultiIndex.from_tuples([(2, 0), (1, 1)], names=["foo", None]),
+        )
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Backport PR #36911