### PR TITLE
BLD: remove blockslider #34014

### DIFF
--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -300,7 +300,7 @@ cdef class Slider:
     """
     cdef:
         ndarray values, buf
-        Py_ssize_t stride, orig_len
+        Py_ssize_t stride
         char *orig_data
 
     def __init__(self, ndarray values, ndarray buf):
@@ -315,7 +315,6 @@ cdef class Slider:
         self.stride = values.strides[0]
 
         self.orig_data = self.buf.data
-        self.orig_len = self.buf.shape[0]
 
         self.buf.data = self.values.data
         self.buf.strides[0] = self.stride
@@ -329,7 +328,7 @@ cdef class Slider:
 
     cdef reset(self):
         self.buf.data = self.orig_data
-        self.buf.shape[0] = self.orig_len
+        self.buf.shape[0] = 0
 
 
 class InvalidApply(Exception):


### PR DESCRIPTION
Part of #34014

xref:
https://github.com/ivirshup/pandas/commit/2c17e72a9deffd8e0d8999b88a2e31c0a58c746c
#34997

Impact on groupby
```
       before           after         ratio
     [97877442]       [a82d3773]
     <master^2>       <libreduction-cython>
+     5.07±0.06ms         43.8±1ms     8.65  groupby.Apply.time_scalar_function_single_col
+      15.5±0.2ms        108±0.6ms     6.97  groupby.Apply.time_scalar_function_multi_col
+         453±3ms          508±1ms     1.12  groupby.Apply.time_copy_overhead_single_col
+      1.44±0.03s       1.61±0.01s     1.12  groupby.Apply.time_copy_function_multi_col
-      26.0±0.7ms       23.4±0.2ms     0.90  groupby.Nth.time_frame_nth_any('float64')
```

Impact on index_cached_properties
```
       before           after         ratio
     [97877442]       [a82d3773]
     <master^2>       <libreduction-cython>
+        401±10ns        862±400ns     2.15  index_cached_properties.IndexCache.time_inferred_type('Int64Index')
+        397±10ns        649±200ns     1.64  index_cached_properties.IndexCache.time_is_unique('Int64Index')
+     1.01±0.03μs       1.31±0.2μs     1.30  index_cached_properties.IndexCache.time_values('DatetimeIndex')
+      3.51±0.2μs       4.55±0.8μs     1.29  index_cached_properties.IndexCache.time_shape('CategoricalIndex')
+      1.97±0.2μs       2.30±0.2μs     1.17  index_cached_properties.IndexCache.time_inferred_type('MultiIndex')
+     1.75±0.04μs       2.02±0.2μs     1.15  index_cached_properties.IndexCache.time_shape('DatetimeIndex')
-      1.99±0.3μs       1.58±0.2μs     0.79  index_cached_properties.IndexCache.time_values('UInt64Index')
-      2.33±0.6μs       1.77±0.5μs     0.76  index_cached_properties.IndexCache.time_inferred_type('Float64Index')
```

No significant changes on frame_methods
