### PR TITLE
DEPR: treating bool-containing ObjectBlock as bool

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -290,7 +290,7 @@ Deprecations
 - Deprecated automatic alignment on comparison operations between :class:`DataFrame` and :class:`Series`, do ``frame, ser = frame.align(ser, axis=1, copy=False)`` before e.g. ``frame == ser`` (:issue:`28759`)
 - :meth:`Rolling.count` with ``min_periods=None`` will default to the size of the window in a future version (:issue:`31302`)
 - :meth:`Index.ravel` returning a ``np.ndarray`` is deprecated, in the future this will return a view on the same index (:issue:`19956`)
-- Treating object-dtype columns containing boolean values as if they were bool-dtype for :meth:`DataFrame.any`, :meth:`DataFrame.all` is deprecated, will be removed in a future version.  Explicitly cast to bool-dtype instead (:issue:`???`)
+- Treating object-dtype columns containing boolean values as if they were bool-dtype for :meth:`DataFrame.any`, :meth:`DataFrame.all` is deprecated, will be removed in a future version.  Explicitly cast to bool-dtype instead (:issue:`36949`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -290,6 +290,7 @@ Deprecations
 - Deprecated automatic alignment on comparison operations between :class:`DataFrame` and :class:`Series`, do ``frame, ser = frame.align(ser, axis=1, copy=False)`` before e.g. ``frame == ser`` (:issue:`28759`)
 - :meth:`Rolling.count` with ``min_periods=None`` will default to the size of the window in a future version (:issue:`31302`)
 - :meth:`Index.ravel` returning a ``np.ndarray`` is deprecated, in the future this will return a view on the same index (:issue:`19956`)
+- Treating object-dtype columns containing boolean values as if they were bool-dtype for :meth:`DataFrame.any`, :meth:`DataFrame.all` is deprecated, will be removed in a future version.  Explicitly cast to bool-dtype instead (:issue:`???`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2452,6 +2452,13 @@ class ObjectBlock(Block):
         we can be a bool if we have only bool values but are of type
         object
         """
+        warnings.warn(
+            "Treating object-dtype columns containing boolean entries as "
+            "boolean is deprecated and will be removed in a future version.  "
+            "Explicitly cast to bool dtype instead.",
+            FutureWarning,
+            stacklevel=4,
+        )
         return lib.is_bool_array(self.values.ravel("K"))
 
     def convert(

--- a/pandas/tests/series/apply/test_series_transform.py
+++ b/pandas/tests/series/apply/test_series_transform.py
@@ -153,8 +153,9 @@ def test_transform_bad_dtype(op):
 
     msg = "Transform function failed"
 
-    # tshift is deprecated
-    warn = None if op != "tshift" else FutureWarning
+    # tshift is deprecated, pct_change calls is_bool which has deprecated
+    #  behavior for object-dtype
+    warn = None if op not in ["tshift", "pct_change"] else FutureWarning
     with tm.assert_produces_warning(warn, check_stacklevel=False):
         with pytest.raises(ValueError, match=msg):
             s.transform(op)


### PR DESCRIPTION
- [] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
