### PR TITLE
DOC: pandas.Index.astype says it raises ValueError instead of TypeError

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -652,7 +652,7 @@ class Index(IndexOpsMixin, PandasObject):
         Create an Index with values cast to dtypes.
 
         The class of a new Index is determined by dtype. When conversion is
-        impossible, a ValueError exception is raised.
+        impossible, a TypeError exception is raised.
 
         Parameters
         ----------


### PR DESCRIPTION
- [X] closes #37012 
- [X] passes pytest
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
