### PR TITLE
CLN: require td64 in TimeDeltaBlock

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2377,7 +2377,11 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
 
     def _maybe_coerce_values(self, values):
         if values.dtype != TD64NS_DTYPE:
-            # e.g. non-nano or int64
+            # non-nano we will convert to nano
+            if values.dtype.kind != "m":
+                # caller is responsible for ensuring timedelta64 dtype
+                raise TypeError(values.dtype)  # pragma: no cover
+
             values = TimedeltaArray._from_sequence(values)._data
         if isinstance(values, TimedeltaArray):
             values = values._data

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -573,9 +573,9 @@ def interpolate_2d(
     if ndim == 1:
         result = result[0]
 
-    if orig_values.dtype.kind == "M":
-        # convert float back to datetime64
-        result = result.astype(orig_values.dtype)
+    if orig_values.dtype.kind in ["m", "M"]:
+        # convert float back to datetime64/timedelta64
+        result = result.view(orig_values.dtype)
 
     return result
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

only one place where the check currently fails, fixed in core.missing