### PR TITLE
DOC: Clarified pandas_version in to_json

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2207,7 +2207,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
                 Describing the data, where data component is like ``orient='records'``.
 
-                Note that ``orient='table'`` contains a 'pandas_version' field under 
+                Note that ``orient='table'`` contains a 'pandas_version' field under
                 'schema'. This denotes the version of `pandas` where the schema was last
                 revised.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2207,10 +2207,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
                 Describing the data, where data component is like ``orient='records'``.
 
-                Note that ``orient='table'`` contains a 'pandas_version' field under
-                'schema'. This stores the version of `pandas` used in the latest
-                revision of the schema.
-
         date_format : {None, 'epoch', 'iso'}
             Type of date conversion. 'epoch' = epoch milliseconds,
             'iso' = ISO8601. The default depends on the `orient`. For
@@ -2277,6 +2273,10 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         indent the output but does insert newlines. Currently, ``indent=0``
         and the default ``indent=None`` are equivalent in pandas, though this
         may change in a future release.
+
+        ``orient='table'`` contains a 'pandas_version' field under 'schema'.
+        This stores the version of `pandas` used in the latest revision of the
+        schema.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2207,6 +2207,10 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
                 Describing the data, where data component is like ``orient='records'``.
 
+                Note that ``orient='table'`` contains a 'pandas_version' field under 
+                'schema'. This denotes the version of `pandas` where the schema was last
+                revised.
+
         date_format : {None, 'epoch', 'iso'}
             Type of date conversion. 'epoch' = epoch milliseconds,
             'iso' = ISO8601. The default depends on the `orient`. For

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2208,8 +2208,8 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
                 Describing the data, where data component is like ``orient='records'``.
 
                 Note that ``orient='table'`` contains a 'pandas_version' field under
-                'schema'. This denotes the version of `pandas` where the schema was last
-                revised.
+                'schema'. This stores the version of `pandas` used in the latest
+                revision of the schema.
 
         date_format : {None, 'epoch', 'iso'}
             Type of date conversion. 'epoch' = epoch milliseconds,


### PR DESCRIPTION
- [X] closes #26637
- [ ] tests added / passed
- [X] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
