### PR TITLE
DOC: Group relevant df.mask/df.where examples together

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9088,7 +9088,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         3    3.0
         4    4.0
         dtype: float64
-
         >>> s.mask(s > 0)
         0    0.0
         1    NaN
@@ -9103,6 +9102,13 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         2    2
         3    3
         4    4
+        dtype: int64
+        >>> s.mask(s > 1, 10)
+        0     0
+        1     1
+        2    10
+        3    10
+        4    10
         dtype: int64
 
         >>> df = pd.DataFrame(np.arange(10).reshape(-1, 2), columns=['A', 'B'])


### PR DESCRIPTION
df.mask() and df.where() are complementary and so they share docs, see [here](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.mask.html). I grouped related examples together.

- [x] Close #25187
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`