### PR TITLE
REGR: Fix casting of None to str during astype

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -17,6 +17,7 @@ Fixed regressions
 - Fixed regression where attempting to mutate a :class:`DateOffset` object would no longer raise an ``AttributeError`` (:issue:`36940`)
 - Fixed regression where :meth:`DataFrame.agg` would fail with :exc:`TypeError` when passed positional arguments to be passed on to the aggregation function (:issue:`36948`).
 - Fixed regression in :class:`RollingGroupby` with ``sort=False`` not being respected (:issue:`36889`)
+- Fixed regression in :meth:`Series.astype` converting ``None`` to ``"nan"`` when casting to string (:issue:`36904`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -921,7 +921,9 @@ def astype_nansafe(arr, dtype, copy: bool = True, skipna: bool = False):
         dtype = pandas_dtype(dtype)
 
     if issubclass(dtype.type, str):
-        return lib.ensure_string_array(arr.ravel(), skipna=skipna).reshape(arr.shape)
+        return lib.ensure_string_array(
+            arr.ravel(), skipna=skipna, convert_na_value=False
+        ).reshape(arr.shape)
 
     elif is_datetime64_dtype(arr):
         if is_object_dtype(dtype):

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pandas import Interval, Series, Timestamp, date_range
+from pandas import NA, Interval, Series, Timestamp, date_range
 import pandas._testing as tm
 
 
@@ -54,4 +54,19 @@ class TestAstype:
         s = Series([0.1], dtype=dtype)
         result = s.astype(str)
         expected = Series(["0.1"])
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "value, string_value",
+        [
+            (None, "None"),
+            (np.nan, "nan"),
+            (NA, "<NA>"),
+        ],
+    )
+    def test_astype_to_str_preserves_na(self, value, string_value):
+        # https://github.com/pandas-dev/pandas/issues/36904
+        s = Series(["a", "b", value], dtype=object)
+        result = s.astype(str)
+        expected = Series(["a", "b", string_value], dtype=object)
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #36904
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
