### PR TITLE
ENH: Implement sem for Rolling and Expanding

### DIFF
--- a/doc/source/reference/window.rst
+++ b/doc/source/reference/window.rst
@@ -32,6 +32,7 @@ Standard moving window functions
    Rolling.apply
    Rolling.aggregate
    Rolling.quantile
+   Rolling.sem
    Window.mean
    Window.sum
    Window.var
@@ -61,6 +62,7 @@ Standard expanding window functions
    Expanding.apply
    Expanding.aggregate
    Expanding.quantile
+   Expanding.sem
 
 Exponentially-weighted moving window functions
 ----------------------------------------------

--- a/doc/source/user_guide/computation.rst
+++ b/doc/source/user_guide/computation.rst
@@ -328,6 +328,7 @@ We provide a number of common statistical functions:
     :meth:`~Rolling.apply`, Generic apply
     :meth:`~Rolling.cov`, Sample covariance (binary)
     :meth:`~Rolling.corr`, Sample correlation (binary)
+    :meth:`~Rolling.sem`, Standard error of mean
 
 .. _computation.window_variance.caveats:
 
@@ -938,6 +939,7 @@ Method summary
     :meth:`~Expanding.apply`, Generic apply
     :meth:`~Expanding.cov`, Sample covariance (binary)
     :meth:`~Expanding.corr`, Sample correlation (binary)
+    :meth:`~Expanding.sem`, Standard error of mean
 
 .. note::
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -190,6 +190,7 @@ Other enhancements
 - :meth:`DatetimeIndex.searchsorted`, :meth:`TimedeltaIndex.searchsorted`, :meth:`PeriodIndex.searchsorted`, and :meth:`Series.searchsorted` with datetimelike dtypes will now try to cast string arguments (listlike and scalar) to the matching datetimelike type (:issue:`36346`)
 - Added methods :meth:`IntegerArray.prod`, :meth:`IntegerArray.min`, and :meth:`IntegerArray.max` (:issue:`33790`)
 - Where possible :meth:`RangeIndex.difference` and :meth:`RangeIndex.symmetric_difference` will return :class:`RangeIndex` instead of :class:`Int64Index` (:issue:`36564`)
+- Added :meth:`Rolling.sem()` and :meth:`Expanding.sem()` to compute the standard error of mean (:issue:`26476`).
 
 .. _whatsnew_120.api_breaking.python:
 

--- a/pandas/core/window/expanding.py
+++ b/pandas/core/window/expanding.py
@@ -192,6 +192,11 @@ class Expanding(RollingAndExpandingMixin):
         nv.validate_expanding_func("var", args, kwargs)
         return super().var(ddof=ddof, **kwargs)
 
+    @Substitution(name="expanding")
+    @Appender(_shared_docs["sem"])
+    def sem(self, ddof=1, *args, **kwargs):
+        return super().sem(ddof=ddof, **kwargs)
+
     @Substitution(name="expanding", func_name="skew")
     @Appender(_doc_template)
     @Appender(_shared_docs["skew"])

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1573,6 +1573,57 @@ class RollingAndExpandingMixin(BaseWindow):
     """
     )
 
+    def sem(self, ddof=1, *args, **kwargs):
+        return self.std(*args, **kwargs) / (self.count() - ddof).pow(0.5)
+
+    _shared_docs["sem"] = dedent(
+        """
+    Compute %(name)s standard error of mean.
+
+    Parameters
+    ----------
+
+    ddof : int, default 1
+        Delta Degrees of Freedom.  The divisor used in calculations
+        is ``N - ddof``, where ``N`` represents the number of elements.
+
+    *args, **kwargs
+        For NumPy compatibility. No additional arguments are used.
+
+    Series or DataFrame
+        Returned object type is determined by the caller of the %(name)s
+        calculation.
+
+    See Also
+    --------
+    pandas.Series.%(name)s : Calling object with Series data.
+    pandas.DataFrame.%(name)s : Calling object with DataFrames.
+    pandas.Series.sem : Equivalent method for Series.
+    pandas.DataFrame.sem : Equivalent method for DataFrame.
+
+    Notes
+    -----
+    A minimum of one period is required for the rolling calculation.
+
+    Examples
+    --------
+    >>> s = pd.Series([0, 1, 2, 3])
+    >>> s.rolling(2, min_periods=1).sem()
+    0         NaN
+    1    0.707107
+    2    0.707107
+    3    0.707107
+    dtype: float64
+
+    >>> s.expanding().sem()
+    0         NaN
+    1    0.707107
+    2    0.707107
+    3    0.707107
+    dtype: float64
+    """
+    )
+
     def kurt(self, **kwargs):
         window_func = self._get_roll_func("roll_kurt")
         kwargs.pop("require_min_periods", None)
@@ -2080,6 +2131,11 @@ class Rolling(RollingAndExpandingMixin):
     @Appender(_shared_docs["skew"])
     def skew(self, **kwargs):
         return super().skew(**kwargs)
+
+    @Substitution(name="rolling")
+    @Appender(_shared_docs["sem"])
+    def sem(self, ddof=1, *args, **kwargs):
+        return self.std(*args, **kwargs) / (self.count() - ddof).pow(0.5)
 
     _agg_doc = dedent(
         """

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1621,7 +1621,7 @@ class RollingAndExpandingMixin(BaseWindow):
     0         NaN
     1    0.707107
     2    0.707107
-    3    0.707107
+    3    0.745356
     dtype: float64
     """
     )

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1590,6 +1590,8 @@ class RollingAndExpandingMixin(BaseWindow):
     *args, **kwargs
         For NumPy compatibility. No additional arguments are used.
 
+    Returns
+    -------
     Series or DataFrame
         Returned object type is determined by the caller of the %(name)s
         calculation.

--- a/pandas/tests/window/test_expanding.py
+++ b/pandas/tests/window/test_expanding.py
@@ -236,3 +236,14 @@ def test_center_deprecate_warning():
 
     with tm.assert_produces_warning(None):
         df.expanding()
+
+
+@pytest.mark.parametrize("constructor", ["DataFrame", "Series"])
+def test_expanding_sem(constructor):
+    # GH: 26476
+    obj = getattr(pd, constructor)([0, 1, 2])
+    result = obj.expanding().sem()
+    if isinstance(result, DataFrame):
+        result = pd.Series(result[0].values)
+    expected = pd.Series([np.nan] + [0.707107] * 2)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -531,3 +531,21 @@ class TestGrouperGrouping:
             ),
         )
         tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        ("func", "kwargs"),
+        [("rolling", {"window": 2, "min_periods": 1}), ("expanding", {})],
+    )
+    def test_groupby_rolling_sem(self, func, kwargs):
+        # GH: 26476
+        df = pd.DataFrame(
+            [["a", 1], ["a", 2], ["b", 1], ["b", 2], ["b", 3]], columns=["a", "b"]
+        )
+        result = getattr(df.groupby("a"), func)(**kwargs).sem()
+        expected = pd.DataFrame(
+            {"a": [np.nan] * 5, "b": [np.nan, 0.70711, np.nan, 0.70711, 0.70711]},
+            index=pd.MultiIndex.from_tuples(
+                [("a", 0), ("a", 1), ("b", 2), ("b", 3), ("b", 4)], names=["a", None]
+            ),
+        )
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -868,3 +868,14 @@ def test_rolling_period_index(index, window, func, values):
     result = getattr(ds.rolling(window, closed="left"), func)()
     expected = pd.Series(values, index=index)
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("constructor", ["DataFrame", "Series"])
+def test_rolling_sem(constructor):
+    # GH: 26476
+    obj = getattr(pd, constructor)([0, 1, 2])
+    result = obj.rolling(2, min_periods=1).sem()
+    if isinstance(result, DataFrame):
+        result = pd.Series(result[0].values)
+    expected = pd.Series([np.nan] + [0.707107] * 2)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #26476
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I added sem to the Rolling and Expanding API as mentioned in the issue linked above.