### PR TITLE
CI clean pre-commit: upgrade isort, use correct file types in flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
     hooks:
     -   id: isort
         name: isort (python)
-        types: [python]
     -   id: isort
         name: isort (cython)
         types: [cython]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,24 +9,24 @@ repos:
     -   id: flake8
         additional_dependencies: [flake8-comprehensions>=3.1.0]
     -   id: flake8
-        name: flake8-pyx
-        files: \.(pyx|pxd)$
-        types:
-          - file
+        name: flake8 (cython)
+        types: [cython]
         args: [--append-config=flake8/cython.cfg]
     -   id: flake8
-        name: flake8-pxd
+        name: flake8 (cython template)
         files: \.pxi\.in$
         types:
           - file
         args: [--append-config=flake8/cython-template.cfg]
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.6.0
+    rev: 5.6.3
     hooks:
     -   id: isort
-        exclude: ^pandas/__init__\.py$|^pandas/core/api\.py$
-        files: '.pxd$|.py$'
-        types: [file]
+        name: isort (python)
+        types: [python]
+    -   id: isort
+        name: isort (cython)
+        types: [cython]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
     hooks:


### PR DESCRIPTION
A few things here:

- updating isort version
- updating to use `types` instead of `files` (see https://github.com/pre-commit/pre-commit/issues/1436#issuecomment-624219819 and https://github.com/PyCQA/isort/pull/1549#issuecomment-706621474)
- removing `exclude: ^pandas/__init__\.py$|^pandas/core/api\.py$` as it's no longer necessary
- replacing `files: \.(pyx|pxd)$` with `types: [cython]`:

  ```bash
  $ identify-cli pandas/_libs/groupby.pyx
  ["cython", "file", "non-executable", "text"]
  $ identify-cli pandas/_libs/lib.pxd
  ["cython", "file", "non-executable", "text"]
  ```

- replacing the name `flake8-pxd` with `flake8 (cython template)`, as that hook wasn't actually checking `.pxd` files (the `flake8-pyx` one was)