### PR TITLE
ENH: Use Kahan summation and Welfords method to calculate rolling var and std

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -191,6 +191,7 @@ Other enhancements
 - :meth:`DatetimeIndex.searchsorted`, :meth:`TimedeltaIndex.searchsorted`, :meth:`PeriodIndex.searchsorted`, and :meth:`Series.searchsorted` with datetimelike dtypes will now try to cast string arguments (listlike and scalar) to the matching datetimelike type (:issue:`36346`)
 - Added methods :meth:`IntegerArray.prod`, :meth:`IntegerArray.min`, and :meth:`IntegerArray.max` (:issue:`33790`)
 - Where possible :meth:`RangeIndex.difference` and :meth:`RangeIndex.symmetric_difference` will return :class:`RangeIndex` instead of :class:`Int64Index` (:issue:`36564`)
+- :meth:`Rolling.var()` and :meth:`Rolling.std()` use Kahan summation and Welfords Method to avoid numerical issues (:issue:`37051`)
 
 .. _whatsnew_120.api_breaking.python:
 

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -321,7 +321,7 @@ cdef inline void add_var(float64_t val, float64_t *nobs, float64_t *mean_x,
         return
 
     nobs[0] = nobs[0] + 1
-    # a part of Welford's method for the online variance-calculation
+    # Welford's method for the online variance-calculation using Kahan summation
     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
     y = val - compensation[0]
     t = y - mean_x[0]
@@ -341,7 +341,7 @@ cdef inline void remove_var(float64_t val, float64_t *nobs, float64_t *mean_x,
     if notnan(val):
         nobs[0] = nobs[0] - 1
         if nobs[0]:
-            # a part of Welford's method for the online variance-calculation
+            # Welford's method for the online variance-calculation using Kahan summation
             # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
             y = val - compensation[0]
             t = y - mean_x[0]

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -300,9 +300,7 @@ cdef inline float64_t calc_var(int64_t minp, int ddof, float64_t nobs,
             result = 0
         else:
             result = ssqdm_x / (nobs - <float64_t>ddof)
-            # Fix for numerical imprecision.
-            # Can be result < 0 once Kahan Summation is implemented
-            if result < 0: #1e-15:
+            if result < 0:
                 result = 0
     else:
         result = NaN

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -311,10 +311,10 @@ cdef inline float64_t calc_var(int64_t minp, int ddof, float64_t nobs,
 
 
 cdef inline void add_var(float64_t val, float64_t *nobs, float64_t *mean_x,
-                         float64_t *ssqdm_x, float64_t *m_x) nogil:
+                         float64_t *ssqdm_x, float64_t *compensation) nogil:
     """ add a value from the var calc """
     cdef:
-        float64_t delta, prev_mean
+        float64_t delta, prev_mean, y, t
 
     # `isnan` instead of equality as fix for GH-21813, msvc 2017 bug
     if isnan(val):
@@ -323,35 +323,36 @@ cdef inline void add_var(float64_t val, float64_t *nobs, float64_t *mean_x,
     nobs[0] = nobs[0] + 1
     # a part of Welford's method for the online variance-calculation
     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
-    delta = val - mean_x[0]
+    y = val - compensation[0]
+    t = y - mean_x[0]
+    compensation[0] = t + mean_x[0] - y
+    delta = t
     prev_mean = mean_x[0]
     mean_x[0] = mean_x[0] + delta / nobs[0]
-    m_x[0] = m_x[0] + (val - prev_mean) * (val - mean_x[0])
-    ssqdm_x[0] = m_x[0]
-    # ssqdm_x[0] = ssqdm_x[0] + ((nobs[0] - 1) * delta ** 2) / nobs[0]
+    ssqdm_x[0] = ssqdm_x[0] + (val - prev_mean) * (val - mean_x[0])
 
 
 cdef inline void remove_var(float64_t val, float64_t *nobs, float64_t *mean_x,
-                            float64_t *ssqdm_x, float64_t *m_x) nogil:
+                            float64_t *ssqdm_x, float64_t *compensation) nogil:
     """ remove a value from the var calc """
     cdef:
-        float64_t delta, prev_mean
+        float64_t delta, prev_mean, y, t
 
     if notnan(val):
         nobs[0] = nobs[0] - 1
         if nobs[0]:
             # a part of Welford's method for the online variance-calculation
             # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
-            delta = val - mean_x[0]
+            y = val - compensation[0]
+            t = y - mean_x[0]
+            compensation[0] = t + mean_x[0] - y
+            delta = t
             prev_mean = mean_x[0]
             mean_x[0] = mean_x[0] - delta / nobs[0]
-            m_x[0] = m_x[0] - (val - prev_mean) * (val - mean_x[0])
-            # ssqdm_x[0] = ssqdm_x[0] - ((nobs[0] + 1) * delta ** 2) / nobs[0]
-            ssqdm_x[0] = m_x[0]
+            ssqdm_x[0] = ssqdm_x[0] - (val - prev_mean) * (val - mean_x[0])
         else:
             mean_x[0] = 0
             ssqdm_x[0] = 0
-            m_x[0] = 0
 
 
 def roll_var(ndarray[float64_t] values, ndarray[int64_t] start,
@@ -360,7 +361,7 @@ def roll_var(ndarray[float64_t] values, ndarray[int64_t] start,
     Numerically stable implementation using Welford's method.
     """
     cdef:
-        float64_t mean_x = 0, ssqdm_x = 0, nobs = 0, m_x = 0,
+        float64_t mean_x = 0, ssqdm_x = 0, nobs = 0, compensation_add = 0, compensation_remove = 0,
         float64_t val, prev, delta, mean_x_old
         int64_t s, e
         Py_ssize_t i, j, N = len(values)
@@ -382,26 +383,26 @@ def roll_var(ndarray[float64_t] values, ndarray[int64_t] start,
             if i == 0 or not is_monotonic_bounds:
 
                 for j in range(s, e):
-                    add_var(values[j], &nobs, &mean_x, &ssqdm_x, &m_x)
+                    add_var(values[j], &nobs, &mean_x, &ssqdm_x, &compensation_add)
 
             else:
 
                 # After the first window, observations can both be added
                 # and removed
 
-                # calculate adds
-                for j in range(end[i - 1], e):
-                    add_var(values[j], &nobs, &mean_x, &ssqdm_x, &m_x)
-
                 # calculate deletes
                 for j in range(start[i - 1], s):
-                    remove_var(values[j], &nobs, &mean_x, &ssqdm_x, &m_x)
+                    remove_var(values[j], &nobs, &mean_x, &ssqdm_x, &compensation_remove)
+
+                # calculate adds
+                for j in range(end[i - 1], e):
+                    add_var(values[j], &nobs, &mean_x, &ssqdm_x, &compensation_add)
 
             output[i] = calc_var(minp, ddof, nobs, ssqdm_x)
 
             if not is_monotonic_bounds:
                 for j in range(s, e):
-                    remove_var(values[j], &nobs, &mean_x, &ssqdm_x, &m_x)
+                    remove_var(values[j], &nobs, &mean_x, &ssqdm_x, &compensation_remove)
 
     return output
 

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -300,7 +300,9 @@ cdef inline float64_t calc_var(int64_t minp, int ddof, float64_t nobs,
             result = 0
         else:
             result = ssqdm_x / (nobs - <float64_t>ddof)
-            if result < 0:
+            # Fix for numerical imprecision.
+            # Can be result < 0 once Kahan Summation is implemented
+            if result < 1e-15:
                 result = 0
     else:
         result = NaN

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -319,7 +319,8 @@ cdef inline void add_var(float64_t val, float64_t *nobs, float64_t *mean_x,
         return
 
     nobs[0] = nobs[0] + 1
-    # Welford's method for the online variance-calculation using Kahan summation
+    # Welford's method for the online variance-calculation
+    # using Kahan summation
     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
     y = val - compensation[0]
     t = y - mean_x[0]
@@ -339,7 +340,8 @@ cdef inline void remove_var(float64_t val, float64_t *nobs, float64_t *mean_x,
     if notnan(val):
         nobs[0] = nobs[0] - 1
         if nobs[0]:
-            # Welford's method for the online variance-calculation using Kahan summation
+            # Welford's method for the online variance-calculation
+            # using Kahan summation
             # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
             y = val - compensation[0]
             t = y - mean_x[0]
@@ -359,7 +361,8 @@ def roll_var(ndarray[float64_t] values, ndarray[int64_t] start,
     Numerically stable implementation using Welford's method.
     """
     cdef:
-        float64_t mean_x = 0, ssqdm_x = 0, nobs = 0, compensation_add = 0, compensation_remove = 0,
+        float64_t mean_x = 0, ssqdm_x = 0, nobs = 0, compensation_add = 0,
+        float64_t compensation_remove = 0,
         float64_t val, prev, delta, mean_x_old
         int64_t s, e
         Py_ssize_t i, j, N = len(values)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -876,7 +876,7 @@ def test_rolling_period_index(index, window, func, values):
         ("var", 1, [5e33, 0, 0.5, 0.5, 2, 0]),
         ("std", 1, [7.071068e16, 0, 0.7071068, 0.7071068, 1.414214, 0]),
         ("var", 2, [5e33, 0.5, 0, 0.5, 2, 0]),
-        ("std", 2, [7.071068e16, 0.7071068, 0,  0.7071068, 1.414214, 0]),
+        ("std", 2, [7.071068e16, 0.7071068, 0, 0.7071068, 1.414214, 0]),
     ],
 )
 def test_rolling_var_numerical_issues(func, third_value, values):

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -871,15 +871,17 @@ def test_rolling_period_index(index, window, func, values):
 
 
 @pytest.mark.parametrize(
-    ("func", "values"),
+    ("func", "third_value", "values"),
     [
-        ("var", [5e33, 0, 0.5, 0.5, 2, 0]),
-        ("std", [7.071068e16, 0, 0.7071068, 0.7071068, 1.414214, 0]),
+        ("var", 1, [5e33, 0, 0.5, 0.5, 2, 0]),
+        ("std", 1, [7.071068e16, 0, 0.7071068, 0.7071068, 1.414214, 0]),
+        ("var", 2, [5e33, 0.5, 0, 0.5, 2, 0]),
+        ("std", 2, [7.071068e16, 0.7071068, 0,  0.7071068, 1.414214, 0]),
     ],
 )
-def test_rolling_var_numerical_issues(func, values):
+def test_rolling_var_numerical_issues(func, third_value, values):
     # GH: 37051
-    ds = pd.Series([99999999999999999, 1, 1, 2, 3, 1, 1])
+    ds = pd.Series([99999999999999999, 1, third_value, 2, 3, 1, 1])
     result = getattr(ds.rolling(2), func)()
     expected = pd.Series([np.nan] + values)
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -868,3 +868,18 @@ def test_rolling_period_index(index, window, func, values):
     result = getattr(ds.rolling(window, closed="left"), func)()
     expected = pd.Series(values, index=index)
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("func", "values"),
+    [
+        ("var", [5e33, 0, 0.5, 0.5, 2, 0]),
+        ("std", [7.071068e16, 0, 0.7071068, 0.7071068, 1.414214, 0]),
+    ],
+)
+def test_rolling_var_numerical_issues(func, values):
+    # GH: 37051
+    ds = pd.Series([99999999999999999, 1, 1, 2, 3, 1, 1])
+    result = getattr(ds.rolling(2), func)()
+    expected = pd.Series([np.nan] + values)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] xref #37051
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

As suggested by @mroeschke Kahan summation fixes the numerical problems. Additionally I used Welfords Method to calculate ``ssqdm``, because previously the tests I have added would return

```
0             NaN
1    3.500000e+34
2    3.000000e+34
3    3.000000e+34
4    3.000000e+34
5    3.000000e+34
6    3.000000e+34
7    3.000000e+34
8    3.000000e+34
9    3.000000e+34
dtype: float64
```

for ``var()``. I am running the asv and will post the results when available