### PR TITLE
Write pickle to file-like without intermediate in-memory buffer

### DIFF
--- a/asv_bench/benchmarks/io/pickle.py
+++ b/asv_bench/benchmarks/io/pickle.py
@@ -24,5 +24,11 @@ class Pickle(BaseIO):
     def time_write_pickle(self):
         self.df.to_pickle(self.fname)
 
+    def peakmem_read_pickle(self):
+        read_pickle(self.fname)
+
+    def peakmem_write_pickle(self):
+        self.df.to_pickle(self.fname)
+
 
 from ..pandas_vb_common import setup  # noqa: F401 isort:skip

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -313,6 +313,7 @@ Performance improvements
   avoiding creating these again, if created on either. This can speed up operations that depend on creating copies of existing indexes (:issue:`36840`)
 - Performance improvement in :meth:`RollingGroupby.count` (:issue:`35625`)
 - Small performance decrease to :meth:`Rolling.min` and :meth:`Rolling.max` for fixed windows (:issue:`36567`)
+- Reduced peak memory usage in DataFrame.to_pickle() when using protocol=5 in python 3.8+
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -313,7 +313,7 @@ Performance improvements
   avoiding creating these again, if created on either. This can speed up operations that depend on creating copies of existing indexes (:issue:`36840`)
 - Performance improvement in :meth:`RollingGroupby.count` (:issue:`35625`)
 - Small performance decrease to :meth:`Rolling.min` and :meth:`Rolling.max` for fixed windows (:issue:`36567`)
-- Reduced peak memory usage in DataFrame.to_pickle() when using protocol=5 in python 3.8+
+- Reduced peak memory usage in :meth:`DataFrame.to_pickle` when using ``protocol=5`` in python 3.8+ (:issue:`34244`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -98,7 +98,7 @@ def to_pickle(
     if protocol < 0:
         protocol = pickle.HIGHEST_PROTOCOL
     try:
-        f.write(pickle.dumps(obj, protocol=protocol))
+        pickle.dump(obj, f, protocol=protocol)
     finally:
         if f != filepath_or_buffer:
             # do not close user-provided file objects GH 35679

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -20,7 +20,6 @@ import os
 from pathlib import Path
 import pickle
 import shutil
-import sys
 from warnings import catch_warnings, simplefilter
 import zipfile
 
@@ -181,7 +180,7 @@ def python_unpickler(path):
         pytest.param(
             functools.partial(pd.to_pickle, protocol=5),
             id="pandas_proto_5",
-            marks=pytest.mark.skipif(not PY38, reason="pickle protocol 5 not supported"),
+            marks=pytest.mark.skipif(not PY38, reason="protocol 5 not supported"),
         ),
     ],
 )

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -25,7 +25,7 @@ import zipfile
 
 import pytest
 
-from pandas.compat import get_lzma_file, import_lzma, is_platform_little_endian, PY38
+from pandas.compat import PY38, get_lzma_file, import_lzma, is_platform_little_endian
 import pandas.util._test_decorators as td
 
 import pandas as pd


### PR DESCRIPTION
Before this change, calling `pickle.dumps()` created an in-memory byte buffer, negating the advantage
of zero-copy pickle protocol 5. After this change, `pickle.dump` writes directly to open file(-like),
cutting peak memory in half in most cases.

Profiling was done with pandas@master and python 3.8.5

Related issues:
- https://github.com/pandas-dev/pandas/issues/34244

![image](https://user-images.githubusercontent.com/25141514/95683850-9929c580-0be5-11eb-8ab1-b9e43407c5bb.png)

## Update: ASV results
`$ asv continuous -f 1.1 origin/master HEAD -b pickle` yields:
```
       before           after         ratio
     [58f74686]       [3c1ee270]
                      <zero-copy-pickle>
-           91.9M            80.1M     0.87  io.pickle.Pickle.peakmem_write_pickle

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```


- [ ] closes #34244
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
