### PR TITLE
TST/CLN: relocate tests for PyTables roundtrip of timezone-aware Index

### DIFF
--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -2189,17 +2189,6 @@ class TestHDFStore:
             result = store.select("table")
             tm.assert_series_equal(result, s)
 
-    def test_roundtrip_tz_aware_index(self, setup_path):
-        # GH 17618
-        time = pd.Timestamp("2000-01-01 01:00:00", tz="US/Eastern")
-        df = pd.DataFrame(data=[0], index=[time])
-
-        with ensure_clean_store(setup_path) as store:
-            store.put("frame", df, format="fixed")
-            recons = store["frame"]
-            tm.assert_frame_equal(recons, df)
-            assert recons.index[0].value == 946706400000000000
-
     def test_append_with_timedelta(self, setup_path):
         # GH 3577
         # append timedelta
@@ -2551,18 +2540,6 @@ class TestHDFStore:
 
         with ensure_clean_store(setup_path) as store:
             store["frame"] = df
-            recons = store["frame"]
-            tm.assert_frame_equal(recons, df)
-
-    def test_store_index_name_with_tz(self, setup_path):
-        # GH 13884
-        df = pd.DataFrame({"A": [1, 2]})
-        df.index = pd.DatetimeIndex([1234567890123456787, 1234567890123456788])
-        df.index = df.index.tz_localize("UTC")
-        df.index.name = "foo"
-
-        with ensure_clean_store(setup_path) as store:
-            store.put("frame", df, format="table")
             recons = store["frame"]
             tm.assert_frame_equal(recons, df)
 

--- a/pandas/tests/io/pytables/test_timezones.py
+++ b/pandas/tests/io/pytables/test_timezones.py
@@ -210,6 +210,31 @@ def test_append_with_timezones_pytz(setup_path):
         tm.assert_frame_equal(result, df)
 
 
+def test_roundtrip_tz_aware_index(setup_path):
+    # GH 17618
+    time = pd.Timestamp("2000-01-01 01:00:00", tz="US/Eastern")
+    df = pd.DataFrame(data=[0], index=[time])
+
+    with ensure_clean_store(setup_path) as store:
+        store.put("frame", df, format="fixed")
+        recons = store["frame"]
+        tm.assert_frame_equal(recons, df)
+        assert recons.index[0].value == 946706400000000000
+
+
+def test_store_index_name_with_tz(setup_path):
+    # GH 13884
+    df = pd.DataFrame({"A": [1, 2]})
+    df.index = pd.DatetimeIndex([1234567890123456787, 1234567890123456788])
+    df.index = df.index.tz_localize("UTC")
+    df.index.name = "foo"
+
+    with ensure_clean_store(setup_path) as store:
+        store.put("frame", df, format="table")
+        recons = store["frame"]
+        tm.assert_frame_equal(recons, df)
+
+
 def test_tseries_select_index_column(setup_path):
     # GH7777
     # selecting a UTC datetimeindex column did


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
