### PR TITLE
BUG: Resolve passing datetime strings of the form "1-01-01 00:00:00"

### DIFF
--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -499,6 +499,13 @@ class TestTimestampConstructors:
         expected = Timestamp(datetime(2013, 1, 1), tz=pytz.FixedOffset(540))
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "arg", ["1-01-01 00:00:00", "3-01-01 00:00:00", "100-01-01 00:00:00"]
+    )
+    def test_construct_with_different_string_format_short_year(self, arg):
+        with pytest.raises(OutOfBoundsDatetime, match=arg):
+            Timestamp(arg)
+
     def test_construct_timestamp_preserve_original_frequency(self):
         # GH 22311
         result = Timestamp(Timestamp("2010-08-08", freq="D")).freq


### PR DESCRIPTION
- [x] closes #37071 
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
