### PR TITLE
Update code_checks.sh to check for instances of os.remove

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -293,7 +293,7 @@ if mods:
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Check code for instances of os.remove' ; echo $MSG
-    invgrep -R --include="*.py*" --exclude "common.py" "test_writers.py" -E "os.remove" pandas/tests/
+    invgrep -R --include="*.py*" --exclude "common.py" --exclude "test_writers.py" --exclude "test_store.py" -E "os.remove" pandas/tests/
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -268,6 +268,10 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -RI --exclude=\*.{svg,c,cpp,html,js} --exclude-dir=env "\s$" *
     RET=$(($RET + $?)) ; echo $MSG "DONE"
     unset INVGREP_APPEND
+
+    MSG='Check code for instances of os.remove' ; echo $MSG
+    invgrep -R --include="*.py*" --exclude "common.py" --exclude "test_writers.py" --exclude "test_store.py" -E "os\.remove" pandas/tests/
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
 fi
 
 ### CODE ###
@@ -290,10 +294,6 @@ if mods:
     sys.stderr.write('err: pandas should not import: {}\n'.format(', '.join(mods)))
     sys.exit(len(mods))
     "
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
-    MSG='Check code for instances of os.remove' ; echo $MSG
-    invgrep -R --include="*.py*" --exclude "common.py" --exclude "test_writers.py" --exclude "test_store.py" -E "os\.remove" pandas/tests/
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -292,6 +292,10 @@ if mods:
     "
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
+    MSG='Check code for instances of os.remove' ; echo $MSG
+    invgrep -R --include="*.py*" --exclude "common.py" "test_writers.py" -E "os.remove" pandas/tests/
+    RET=$(($RET + $?)) ; echo $MSG "DONE"
+
 fi
 
 ### DOCTESTS ###

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -293,7 +293,7 @@ if mods:
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Check code for instances of os.remove' ; echo $MSG
-    invgrep -R --include="*.py*" --exclude "common.py" --exclude "test_writers.py" --exclude "test_store.py" -E "os.remove" pandas/tests/
+    invgrep -R --include="*.py*" --exclude "common.py" --exclude "test_writers.py" --exclude "test_store.py" -E "os\.remove" pandas/tests/
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
 fi


### PR DESCRIPTION
I have included a check for instances of os.remove in the tests folder. This is in line with issue #37095 whereby ensure_clean should be used rather than os.remove.

 A few outstanding questions remain:

- Should this be expanded to search for cases of os.remove elsewhere?

- ~~Cases of `os.remove ` still exist in common.py, test_writers.py, and test_store.py. For some reason, the case in test_store.py is not picked up by this check? Any idea why?~~ _(solved by passing arguments separately rather than as a list)_

- ~~Advice on how to implement this as a pre-commit hook also welcome.~~ _(to be implemented in separate PR)_



- [x] closes #37095 
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


