### PR TITLE
BUG: Fixes #36918 boxplots with matplotlib

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -437,7 +437,7 @@ Plotting
 - Bug in :meth:`DataFrame.plot` was rotating xticklabels when ``subplots=True``, even if the x-axis wasn't an irregular time series (:issue:`29460`)
 - Bug in :meth:`DataFrame.plot` where a marker letter in the ``style`` keyword sometimes causes a ``ValueError`` (:issue:`21003`)
 - Twinned axes were losing their tick labels which should only happen to all but the last row or column of 'externally' shared axes (:issue:`33819`)
-- Bug in :meth:`DataFrame.boxplot` was raising ``ValueError`` when plotting with ``vert=True`` on a subplot with shared axes (:issue:`36918`)
+- Bug in :meth:`DataFrame.boxplot` was raising ``ValueError`` when plotting with ``vert=False`` on a subplot with shared axes (:issue:`36918`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -437,6 +437,7 @@ Plotting
 - Bug in :meth:`DataFrame.plot` was rotating xticklabels when ``subplots=True``, even if the x-axis wasn't an irregular time series (:issue:`29460`)
 - Bug in :meth:`DataFrame.plot` where a marker letter in the ``style`` keyword sometimes causes a ``ValueError`` (:issue:`21003`)
 - Twinned axes were losing their tick labels which should only happen to all but the last row or column of 'externally' shared axes (:issue:`33819`)
+- Bug in :meth:`DataFrame.boxplot` was raising ``ValueError`` when plotting with ``vert=True`` on a subplot with shared axes (:issue:`36918`)
 
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -246,6 +246,7 @@ def boxplot(
 ):
 
     import matplotlib.pyplot as plt
+    from matplotlib.ticker import FixedFormatter
 
     # validate return_type:
     if return_type not in BoxPlot._valid_return_types:
@@ -302,15 +303,13 @@ def boxplot(
         bp = ax.boxplot(values, **kwds)
         if fontsize is not None:
             ax.tick_params(axis="both", labelsize=fontsize)
+
         if kwds.get("vert", 1):
-            ticks = ax.get_xticks()
-            if len(ticks) != len(keys):
-                i, remainder = divmod(len(ticks), len(keys))
-                assert remainder == 0, remainder
-                keys *= i
-            ax.set_xticklabels(keys, rotation=rot)
+            axis = ax.xaxis
         else:
-            ax.set_yticklabels(keys, rotation=rot)
+            axis = ax.yaxis
+        axis.set_major_formatter(FixedFormatter(keys))
+        ax.tick_params(axis=axis.axis_name, which="major", rotation=rot)
         maybe_color_bp(bp, **kwds)
 
         # Return axes in multiplot case, maybe revisit later # 985

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -246,7 +246,7 @@ def boxplot(
 ):
 
     import matplotlib.pyplot as plt
-    from matplotlib.ticker import FixedFormatter
+    from matplotlib.ticker import FixedFormatter, FixedLocator
 
     # validate return_type:
     if return_type not in BoxPlot._valid_return_types:
@@ -308,6 +308,8 @@ def boxplot(
             axis = ax.xaxis
         else:
             axis = ax.yaxis
+        positions = kwds.get("positions", list(range(1, 1 + len(values))))
+        axis.set_major_locator(FixedLocator(positions))
         axis.set_major_formatter(FixedFormatter(keys))
         ax.tick_params(axis=axis.axis_name, which="major", rotation=rot)
         maybe_color_bp(bp, **kwds)

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -218,6 +218,40 @@ class TestDataFramePlots(TestPlotBase):
 
         assert result[expected][0].get_color() == "C1"
 
+    @pytest.mark.parametrize("vert", [(True), (False)])
+    def test_boxplot_shared_axis(self, vert):
+        # GH 37107
+        df1 = DataFrame(np.random.random((100, 5)), columns=["A", "B", "C", "D", "E"])
+        df2 = DataFrame(np.random.random((100, 5)), columns=["A", "B", "C", "D", "E"])
+
+        # Two rows if shared axis is y, two rows if shared axis is y.
+        # This is done so that the shared axes are actually separated
+        # and get_ticklabels returns a non empty list on each ax object
+        nrows, ncols, sharex, sharey = (
+            (1, 2, True, False) if vert else (2, 1, False, True)
+        )
+        fig, axes = self.plt.subplots(
+            nrows=nrows, ncols=ncols, sharex=sharex, sharey=sharey
+        )
+        df1.boxplot(ax=axes[0], vert=vert, fontsize=10, rot=10)
+        df2.boxplot(ax=axes[1], vert=vert, fontsize=10, rot=10)
+
+        # In order for the ticklabels to be placed, the plot has to be drawn
+        fig.canvas.draw()
+
+        for ax in axes:
+            axis = ax.xaxis if vert else ax.yaxis
+            labels = [x.get_text() for x in axis.get_ticklabels(which="major")]
+            if vert:
+                self._check_ticks_props(ax, xlabelsize=10, xrot=10)
+            else:
+                self._check_ticks_props(ax, ylabelsize=10, yrot=10)
+
+            # Matplotlib returns 10 ticklabels, 5 of which are empty
+            assert len(labels) % 5 == 0
+            assert len(labels) // (len(labels) // 5) == 5
+            assert labels[:5] == ["A", "B", "C", "D", "E"]
+
 
 @td.skip_if_no_mpl
 class TestDataFrameGroupByPlots(TestPlotBase):


### PR DESCRIPTION
Fixes #36918

I believe that the @TomAugspurger in #35393 found out that, when `sharex` or `sharey` are enabled, matplotlib counts the number of ticks of an axis in a subplot as the total number of ticks of the shared axis in all subplots. Since matplotlib became stricter with `set_xticks`, the proposed workaround was replicating the labels n times where n is "total number of ticks"/"number of ticks of this subplot"="number of subplots".

However, that fix was implemented only for vertical boxplots and not for horizontal boxplots, hence why the issue.
Also, that fix causes the labels of the shared axis to be drawn n times (where n is the number of subplots) in some cases, see below (matplotlib 3.3.2, code adapted from the one posted by the author of issue 36918)

```
import pandas as pd
import numpy as np
import matplotlib.pyplot as plt
import matplotlib

df1 = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list('ABCD'))
df2 = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list('ABCD'))

f, axs = plt.subplots(nrows=2, ncols=1, figsize=(10,7), sharex=True)
df1.boxplot(ax=axs[0], vert=True)
df2.boxplot(ax=axs[1], vert=True)

plt.show()
```

![before-3 3 2](https://user-images.githubusercontent.com/36233478/95907150-69242300-0d9b-11eb-9ec8-652744d9ad0e.png)

In this fix I used `set_major_formatter` with a `FixedFormatter` which fixes the issue and does not overdraw the labels:

![after-3 3 2](https://user-images.githubusercontent.com/36233478/95907331-a7214700-0d9b-11eb-960c-a566e90cc040.png)
