### PR TITLE
TST: add message matches to pytest.raises in test_duplicate_labels.py GH30999

### DIFF
--- a/pandas/tests/generic/test_duplicate_labels.py
+++ b/pandas/tests/generic/test_duplicate_labels.py
@@ -275,7 +275,8 @@ class TestRaises:
         result = cls(**axes)
         assert result.flags.allows_duplicate_labels is True
 
-        with pytest.raises(pd.errors.DuplicateLabelError):
+        msg = "Index has duplicates."
+        with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
             cls(**axes).set_flags(allows_duplicate_labels=False)
 
     @pytest.mark.parametrize(
@@ -287,7 +288,8 @@ class TestRaises:
         ],
     )
     def test_setting_allows_duplicate_labels_raises(self, data):
-        with pytest.raises(pd.errors.DuplicateLabelError):
+        msg = "Index has duplicates."
+        with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
             data.flags.allows_duplicate_labels = False
 
         assert data.flags.allows_duplicate_labels is True
@@ -297,7 +299,8 @@ class TestRaises:
     )
     def test_series_raises(self, func):
         s = pd.Series([0, 1], index=["a", "b"]).set_flags(allows_duplicate_labels=False)
-        with pytest.raises(pd.errors.DuplicateLabelError):
+        msg = "Index has duplicates."
+        with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
             func(s)
 
     @pytest.mark.parametrize(
@@ -332,7 +335,8 @@ class TestRaises:
         else:
             target = df
 
-        with pytest.raises(pd.errors.DuplicateLabelError):
+        msg = "Index has duplicates."
+        with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
             getter(target)
 
     @pytest.mark.parametrize(
@@ -352,7 +356,8 @@ class TestRaises:
         ],
     )
     def test_concat_raises(self, objs, kwargs):
-        with pytest.raises(pd.errors.DuplicateLabelError):
+        msg = "Index has duplicates."
+        with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
             pd.concat(objs, **kwargs)
 
     @not_implemented
@@ -361,7 +366,8 @@ class TestRaises:
             allows_duplicate_labels=False
         )
         b = pd.DataFrame({"B": [0, 1, 2]}, index=["a", "b", "b"])
-        with pytest.raises(pd.errors.DuplicateLabelError):
+        msg = "Index has duplicates."
+        with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
             pd.merge(a, b, left_index=True, right_index=True)
 
 
@@ -381,13 +387,14 @@ class TestRaises:
     ids=lambda x: type(x).__name__,
 )
 def test_raises_basic(idx):
-    with pytest.raises(pd.errors.DuplicateLabelError):
+    msg = "Index has duplicates."
+    with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
         pd.Series(1, index=idx).set_flags(allows_duplicate_labels=False)
 
-    with pytest.raises(pd.errors.DuplicateLabelError):
+    with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
         pd.DataFrame({"A": [1, 1]}, index=idx).set_flags(allows_duplicate_labels=False)
 
-    with pytest.raises(pd.errors.DuplicateLabelError):
+    with pytest.raises(pd.errors.DuplicateLabelError, match=msg):
         pd.DataFrame([[1, 2]], columns=idx).set_flags(allows_duplicate_labels=False)
 
 
@@ -412,7 +419,8 @@ def test_format_duplicate_labels_message_multi():
 
 def test_dataframe_insert_raises():
     df = pd.DataFrame({"A": [1, 2]}).set_flags(allows_duplicate_labels=False)
-    with pytest.raises(ValueError, match="Cannot specify"):
+    msg = "Cannot specify"
+    with pytest.raises(ValueError, match=msg):
         df.insert(0, "A", [3, 4], allow_duplicates=True)
 
 


### PR DESCRIPTION
Reference https://github.com/pandas-dev/pandas/issues/30999

- [x] tests added / passed
- [x] passes `black pandas`
- [ ]  passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Hello! This is my first PR here. I followed the steps in the contributing guidelines [here](https://github.com/pandas-dev/pandas/blob/master/doc/source/development/contributing.rst#contributing-your-changes-to-pandas), but I didn't see anything about `git diff upstream/master -u -- "*.py" | flake8 --diff`. 

When I run the command locally, with `origin/master`, it returns no output. I get fatal with `upstream/master`. Is that expected, and if it isn't, could anyone advise on how to resolve the issue please? 

Thank you!