### PR TITLE
ERR: Removing quotation marks in error message

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -3826,6 +3826,6 @@ def _validate_skipfooter(kwds: Dict[str, Any]) -> None:
     """
     if kwds.get("skipfooter"):
         if kwds.get("iterator") or kwds.get("chunksize"):
-            raise ValueError("'skipfooter' not supported for 'iteration'")
+            raise ValueError("'skipfooter' not supported for iteration")
         if kwds.get("nrows"):
             raise ValueError("'skipfooter' not supported with 'nrows'")

--- a/pandas/tests/io/parser/test_common.py
+++ b/pandas/tests/io/parser/test_common.py
@@ -719,7 +719,7 @@ baz,7,8,9
     "kwargs", [dict(iterator=True, chunksize=1), dict(iterator=True), dict(chunksize=1)]
 )
 def test_iterator_skipfooter_errors(all_parsers, kwargs):
-    msg = "'skipfooter' not supported for 'iteration'"
+    msg = "'skipfooter' not supported for iteration"
     parser = all_parsers
     data = "a\n1\n2"
 


### PR DESCRIPTION
Follow-up to https://github.com/pandas-dev/pandas/pull/36852

When reviewing, I got confused and thought `iteration` was somehow an argument to `read_csv` (like `nrows`).  Since it is now, the quotation marks don't make as much sense to have.

Doing this as a follow-up since the original PR was a pure refactoring.