### PR TITLE
Backport PR #35688 on branch 1.1.x: Fix GH-29442 DataFrame.groupby doesn't preserve _metadata

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -27,7 +27,7 @@ Fixed regressions
 
 Bug fixes
 ~~~~~~~~~
--
+- Bug causing ``groupby(...).sum()`` and similar to not preserve metadata (:issue:`29442`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -994,9 +994,10 @@ b  2""",
     ):
         self._set_group_selection()
 
+        result = None
         # try a cython aggregation if we can
         try:
-            return self._cython_agg_general(
+            result = self._cython_agg_general(
                 how=alias, alt=npfunc, numeric_only=numeric_only, min_count=min_count,
             )
         except DataError:
@@ -1012,8 +1013,9 @@ b  2""",
                 raise
 
         # apply a non-cython aggregation
-        result = self.aggregate(lambda x: npfunc(x, axis=self.axis))
-        return result
+        if result is None:
+            result = self.aggregate(lambda x: npfunc(x, axis=self.axis))
+        return result.__finalize__(self.obj, method="groupby")
 
     def _cython_agg_general(
         self, how: str, alt=None, numeric_only: bool = True, min_count: int = -1

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -778,13 +778,27 @@ def test_categorical_accessor(method):
     [
         operator.methodcaller("sum"),
         lambda x: x.agg("sum"),
+    ],
+)
+def test_groupby_finalize(obj, method):
+    obj.attrs = {"a": 1}
+    result = method(obj.groupby([0, 0]))
+    assert result.attrs == {"a": 1}
+
+
+@pytest.mark.parametrize(
+    "obj", [pd.Series([0, 0]), pd.DataFrame({"A": [0, 1], "B": [1, 2]})]
+)
+@pytest.mark.parametrize(
+    "method",
+    [
         lambda x: x.agg(["sum", "count"]),
         lambda x: x.transform(lambda y: y),
         lambda x: x.apply(lambda y: y),
     ],
 )
 @not_implemented_mark
-def test_groupby(obj, method):
+def test_groupby_finalize_not_implemented(obj, method):
     obj.attrs = {"a": 1}
     result = method(obj.groupby([0, 0]))
     assert result.attrs == {"a": 1}

--- a/pandas/tests/generic/test_finalize.py
+++ b/pandas/tests/generic/test_finalize.py
@@ -774,11 +774,7 @@ def test_categorical_accessor(method):
     "obj", [pd.Series([0, 0]), pd.DataFrame({"A": [0, 1], "B": [1, 2]})]
 )
 @pytest.mark.parametrize(
-    "method",
-    [
-        operator.methodcaller("sum"),
-        lambda x: x.agg("sum"),
-    ],
+    "method", [operator.methodcaller("sum"), lambda x: x.agg("sum")],
 )
 def test_groupby_finalize(obj, method):
     obj.attrs = {"a": 1}


### PR DESCRIPTION
Backport PR #35688
