### PR TITLE
ENH: DataFrame.to_parquet() returns bytes if path_or_buf not provided

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -220,7 +220,11 @@ Other enhancements
 - Added :meth:`Rolling.sem()` and :meth:`Expanding.sem()` to compute the standard error of mean (:issue:`26476`).
 - :meth:`Rolling.var()` and :meth:`Rolling.std()` use Kahan summation and Welfords Method to avoid numerical issues (:issue:`37051`)
 - :meth:`DataFrame.plot` now recognizes ``xlabel`` and ``ylabel`` arguments for plots of type ``scatter`` and ``hexbin`` (:issue:`37001`)
+<<<<<<< HEAD
 - :class:`DataFrame` now supports ``divmod`` operation (:issue:`37165`)
+=======
+- :meth:`DataFrame.to_parquet` now writes to ``io.Bytes`` when no ``path`` argument is passed (:issue:`37105`)
+>>>>>>> feedback: move whatsnew to enhancements
 
 .. _whatsnew_120.api_breaking.python:
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -464,6 +464,7 @@ I/O
 - Bug in :meth:`read_parquet` with fixed offset timezones. String representation of timezones was not recognized (:issue:`35997`, :issue:`36004`)
 - Bug in output rendering of complex numbers showing too many trailing zeros (:issue:`36799`)
 - Bug in :class:`HDFStore` threw a ``TypeError`` when exporting an empty :class:`DataFrame` with ``datetime64[ns, tz]`` dtypes with a fixed HDF5 store (:issue:`20594`)
+- Bug in :meth:`DataFrame.to_parquet` now returns bytes when no ``path`` argument is passed (:issue:`37105`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -220,11 +220,8 @@ Other enhancements
 - Added :meth:`Rolling.sem()` and :meth:`Expanding.sem()` to compute the standard error of mean (:issue:`26476`).
 - :meth:`Rolling.var()` and :meth:`Rolling.std()` use Kahan summation and Welfords Method to avoid numerical issues (:issue:`37051`)
 - :meth:`DataFrame.plot` now recognizes ``xlabel`` and ``ylabel`` arguments for plots of type ``scatter`` and ``hexbin`` (:issue:`37001`)
-<<<<<<< HEAD
 - :class:`DataFrame` now supports ``divmod`` operation (:issue:`37165`)
-=======
-- :meth:`DataFrame.to_parquet` now writes to ``io.Bytes`` when no ``path`` argument is passed (:issue:`37105`)
->>>>>>> feedback: move whatsnew to enhancements
+- :meth:`DataFrame.to_parquet` now returns a ``bytes`` object when no ``path`` argument is passed (:issue:`37105`)
 
 .. _whatsnew_120.api_breaking.python:
 
@@ -468,7 +465,6 @@ I/O
 - Bug in :meth:`read_parquet` with fixed offset timezones. String representation of timezones was not recognized (:issue:`35997`, :issue:`36004`)
 - Bug in output rendering of complex numbers showing too many trailing zeros (:issue:`36799`)
 - Bug in :class:`HDFStore` threw a ``TypeError`` when exporting an empty :class:`DataFrame` with ``datetime64[ns, tz]`` dtypes with a fixed HDF5 store (:issue:`20594`)
-- Bug in :meth:`DataFrame.to_parquet` now returns bytes when no ``path`` argument is passed (:issue:`37105`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2289,7 +2289,7 @@ class DataFrame(NDFrame, OpsMixin):
     @deprecate_kwarg(old_arg_name="fname", new_arg_name="path")
     def to_parquet(
         self,
-        path: Optional[FilePathOrBuffer[AnyStr]] = None,
+        path: Optional[FilePathOrBuffer] = None,
         engine: str = "auto",
         compression: Optional[str] = "snappy",
         index: Optional[bool] = None,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2392,7 +2392,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         from pandas.io.parquet import to_parquet
 
-        to_parquet(
+        return to_parquet(
             self,
             path,
             engine,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2289,7 +2289,7 @@ class DataFrame(NDFrame, OpsMixin):
     @deprecate_kwarg(old_arg_name="fname", new_arg_name="path")
     def to_parquet(
         self,
-        path: FilePathOrBuffer[AnyStr],
+        path: Optional[FilePathOrBuffer[AnyStr]] = None,
         engine: str = "auto",
         compression: Optional[str] = "snappy",
         index: Optional[bool] = None,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2296,7 +2296,7 @@ class DataFrame(NDFrame, OpsMixin):
         partition_cols: Optional[List[str]] = None,
         storage_options: StorageOptions = None,
         **kwargs,
-    ) -> None:
+    ) -> Optional[bytes]:
         """
         Write a DataFrame to the binary parquet format.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2307,14 +2307,15 @@ class DataFrame(NDFrame, OpsMixin):
 
         Parameters
         ----------
-        path : str or file-like object
+        path : str or file-like object, default None
             If a string, it will be used as Root Directory path
             when writing a partitioned dataset. By file-like object,
             we refer to objects with a write() method, such as a file handle
             (e.g. via builtin open function) or io.BytesIO. The engine
-            fastparquet does not accept file-like objects.
+            fastparquet does not accept file-like objects. If path is None,
+            a bytes object is returned.
 
-            .. versionchanged:: 1.0.0
+            .. versionchanged:: 1.2.0
 
             Previously this was "fname"
 
@@ -2356,6 +2357,10 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs
             Additional arguments passed to the parquet library. See
             :ref:`pandas io <io.parquet>` for more details.
+
+        Returns
+        -------
+        bytes if no path argument is provided else None
 
         See Also
         --------

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -304,18 +304,20 @@ def to_parquet(
         partition_cols = [partition_cols]
     impl = get_engine(engine)
 
-    if path is None:
-        path = io.BytesIO()
+    path_or_buf = io.BytesIO() if path is None else path
 
-    return impl.write(
+    impl.write(
         df,
-        path,
+        path_or_buf,
         compression=compression,
         index=index,
         partition_cols=partition_cols,
         storage_options=storage_options,
         **kwargs,
     )
+
+    if path is None:
+        return path_or_buf.getvalue()
 
 
 def read_parquet(path, engine: str = "auto", columns=None, **kwargs):

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -309,10 +309,7 @@ def to_parquet(
         partition_cols = [partition_cols]
     impl = get_engine(engine)
 
-    if path is None:
-        path_or_buf = io.BytesIO()
-    else:
-        path_or_buf = path
+    path_or_buf: FilePathOrBuffer = io.BytesIO() if path is None else path
 
     impl.write(
         df,
@@ -325,6 +322,7 @@ def to_parquet(
     )
 
     if path is None:
+        assert isinstance(path_or_buf, io.BytesIO)
         return path_or_buf.getvalue()
     else:
         return None

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -1,5 +1,6 @@
 """ parquet compat """
 
+import io
 from typing import Any, AnyStr, Dict, List, Optional
 from warnings import catch_warnings
 
@@ -238,7 +239,7 @@ class FastParquetImpl(BaseImpl):
 
 def to_parquet(
     df: DataFrame,
-    path: FilePathOrBuffer[AnyStr],
+    path: Optional[FilePathOrBuffer[AnyStr]] = None,
     engine: str = "auto",
     compression: Optional[str] = "snappy",
     index: Optional[bool] = None,
@@ -302,6 +303,10 @@ def to_parquet(
     if isinstance(partition_cols, str):
         partition_cols = [partition_cols]
     impl = get_engine(engine)
+
+    if path is None:
+        path = io.BytesIO()
+
     return impl.write(
         df,
         path,

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -246,19 +246,21 @@ def to_parquet(
     storage_options: StorageOptions = None,
     partition_cols: Optional[List[str]] = None,
     **kwargs,
-):
+) -> Optional[bytes]:
     """
     Write a DataFrame to the parquet format.
 
     Parameters
     ----------
     df : DataFrame
-    path : str or file-like object
+    path : str or file-like object, default None
         If a string, it will be used as Root Directory path
         when writing a partitioned dataset. By file-like object,
         we refer to objects with a write() method, such as a file handle
         (e.g. via builtin open function) or io.BytesIO. The engine
-        fastparquet does not accept file-like objects.
+        fastparquet does not accept file-like objects. If path is None,
+        frame is written to an io.BytesIO object and a bytes object with
+        the contents of the buffer is returned.
 
         .. versionchanged:: 0.24.0
 
@@ -304,7 +306,10 @@ def to_parquet(
         partition_cols = [partition_cols]
     impl = get_engine(engine)
 
-    path_or_buf = io.BytesIO() if path is None else path
+    if path is None:
+        path_or_buf = io.BytesIO()
+    else:
+        path_or_buf = path
 
     impl.write(
         df,
@@ -318,6 +323,8 @@ def to_parquet(
 
     if path is None:
         return path_or_buf.getvalue()
+    else:
+        return None
 
 
 def read_parquet(path, engine: str = "auto", columns=None, **kwargs):

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -239,7 +239,7 @@ class FastParquetImpl(BaseImpl):
 
 def to_parquet(
     df: DataFrame,
-    path: Optional[FilePathOrBuffer[AnyStr]] = None,
+    path: Optional[FilePathOrBuffer] = None,
     engine: str = "auto",
     compression: Optional[str] = "snappy",
     index: Optional[bool] = None,

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -259,10 +259,9 @@ def to_parquet(
         we refer to objects with a write() method, such as a file handle
         (e.g. via builtin open function) or io.BytesIO. The engine
         fastparquet does not accept file-like objects. If path is None,
-        frame is written to an io.BytesIO object and a bytes object with
-        the contents of the buffer is returned.
+        a bytes object is returned.
 
-        .. versionchanged:: 0.24.0
+        .. versionchanged:: 1.2.0
 
     engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
         Parquet library to use. If 'auto', then the option
@@ -301,6 +300,10 @@ def to_parquet(
 
     kwargs
         Additional keyword arguments passed to the engine
+
+    Returns
+    -------
+    bytes if no path argument is provided else None
     """
     if isinstance(partition_cols, str):
         partition_cols = [partition_cols]

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -376,19 +376,6 @@ class TestBasic(Base):
         ]
         self.check_error_on_write(df, engine, ValueError)
 
-    def test_to_bytes_without_path_or_buf_provided(self, engine, df_full):
-        # GH 37105
-
-        buf = df_full.to_parquet(engine=engine)
-        assert isinstance(buf, bytes)
-
-        with tm.ensure_clean() as path:
-            with open(path, "wb") as f:
-                f.write(buf)
-            res = pd.read_parquet(path)
-
-        tm.assert_frame_equal(df_full, res)
-
     @pytest.mark.parametrize("compression", [None, "gzip", "snappy", "brotli"])
     def test_compression(self, engine, compression):
 
@@ -524,6 +511,19 @@ class TestParquetPyArrow(Base):
             expected=df[["string", "int"]],
             read_kwargs={"columns": ["string", "int"]},
         )
+
+    def test_to_bytes_without_path_or_buf_provided(self, pa, df_full):
+        # GH 37105
+
+        buf = df_full.to_parquet(engine=pa)
+        assert isinstance(buf, bytes)
+
+        with tm.ensure_clean() as path:
+            with open(path, "wb") as f:
+                f.write(buf)
+            res = pd.read_parquet(path)
+
+        tm.assert_frame_equal(df_full, res)
 
     def test_duplicate_columns(self, pa):
         # not currently able to handle duplicate columns

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -515,13 +515,11 @@ class TestParquetPyArrow(Base):
     def test_to_bytes_without_path_or_buf_provided(self, pa, df_full):
         # GH 37105
 
-        buf = df_full.to_parquet(engine=pa)
-        assert isinstance(buf, bytes)
+        buf_bytes = df_full.to_parquet(engine=pa)
+        assert isinstance(buf_bytes, bytes)
 
-        with tm.ensure_clean() as path:
-            with open(path, "wb") as f:
-                f.write(buf)
-            res = pd.read_parquet(path)
+        buf_stream = BytesIO(buf_bytes)
+        res = pd.read_parquet(buf_stream)
 
         tm.assert_frame_equal(df_full, res)
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -380,6 +380,7 @@ class TestBasic(Base):
         # GH 37105
 
         buf = df_full.to_parquet()
+        assert isinstance(buf, bytes)
 
         with tm.ensure_clean() as path:
             with open(path, "wb") as f:

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -376,6 +376,11 @@ class TestBasic(Base):
         ]
         self.check_error_on_write(df, engine, ValueError)
 
+    def test_to_bytes_without_path_or_buf_provided(self):
+        # GH 37105
+        df = pd.DataFrame()
+        df.to_parquet()
+
     @pytest.mark.parametrize("compression", [None, "gzip", "snappy", "brotli"])
     def test_compression(self, engine, compression):
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -376,10 +376,17 @@ class TestBasic(Base):
         ]
         self.check_error_on_write(df, engine, ValueError)
 
-    def test_to_bytes_without_path_or_buf_provided(self):
+    def test_to_bytes_without_path_or_buf_provided(self, df_full):
         # GH 37105
-        df = pd.DataFrame()
-        df.to_parquet()
+
+        buf = df_full.to_parquet()
+
+        with tm.ensure_clean() as path:
+            with open(path, "wb") as f:
+                f.write(buf)
+            res = pd.read_parquet(path)
+
+        tm.assert_frame_equal(df_full, res)
 
     @pytest.mark.parametrize("compression", [None, "gzip", "snappy", "brotli"])
     def test_compression(self, engine, compression):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -376,10 +376,10 @@ class TestBasic(Base):
         ]
         self.check_error_on_write(df, engine, ValueError)
 
-    def test_to_bytes_without_path_or_buf_provided(self, df_full):
+    def test_to_bytes_without_path_or_buf_provided(self, engine, df_full):
         # GH 37105
 
-        buf = df_full.to_parquet()
+        buf = df_full.to_parquet(engine=engine)
         assert isinstance(buf, bytes)
 
         with tm.ensure_clean() as path:


### PR DESCRIPTION
- [x] closes #37105 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Not sure if this is an API breaking change. Prior to this patch `path` was a required positional argument but it becomes optional here. It is now consistent with, for example, the csv writer.