### PR TITLE
PERF: compare RangeIndex to equal RangeIndex

### DIFF
--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -811,6 +811,15 @@ class RangeIndex(Int64Index):
 
     # --------------------------------------------------------------------
 
+    def _cmp_method(self, other, op):
+        if isinstance(other, RangeIndex) and self._range == other._range:
+            if op in {operator.eq, operator.le, operator.ge}:
+                return np.ones(len(self), dtype=bool)
+            elif op in {operator.ne, operator.lt, operator.gt}:
+                return np.zeros(len(self), dtype=bool)
+
+        return super()._cmp_method(other, op)
+
     def _arith_method(self, other, op):
         """
         Parameters


### PR DESCRIPTION
Fastpath for RangeIndexes with equal `_range` attribute.

Notice this works even if the RangeIndexes are not identical.

Example:

```python
>>>  n = 100_000
>>> rng1 = pd.RangeIndex(n)
>>> rng2 = pd.RangeIndex(n)
>>> %timeit rng1 == rng2
374 µs ± 15.1 µs per loop  # master
10.4 µs ± 157 ns per loop  # this PR
```

Somewhat related to #37109