### PR TITLE
BUG: raise when doing arithmetic on DataFrame and list of iterables

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -492,6 +492,7 @@ Other
 - Fixed metadata propagation in the :class:`Series.dt` and :class:`Series.str` accessors (:issue:`28283`)
 - Bug in :meth:`Index.union` behaving differently depending on whether operand is a :class:`Index` or other list-like (:issue:`36384`)
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError``, from a bare ``Exception`` previously (:issue:`35744`)
+- Bug in :class:`DataFrame` allowing arithmetic operations with list of array-likes with undefined results. Behavior changed to raising ``ValueError`` (:issue:`36702`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -371,6 +371,7 @@ Numeric
 - Bug in :meth:`DataFrame.diff` with ``datetime64`` dtypes including ``NaT`` values failing to fill ``NaT`` results correctly (:issue:`32441`)
 - Bug in :class:`DataFrame` arithmetic ops incorrectly accepting keyword arguments (:issue:`36843`)
 - Bug in :class:`IntervalArray` comparisons with :class:`Series` not returning :class:`Series` (:issue:`36908`)
+- Bug in :class:`DataFrame` allowing arithmetic operations with list of array-likes with undefined results. Behavior changed to raising ``ValueError`` (:issue:`36702`)
 
 Conversion
 ^^^^^^^^^^
@@ -494,7 +495,6 @@ Other
 - Fixed metadata propagation in the :class:`Series.dt` and :class:`Series.str` accessors (:issue:`28283`)
 - Bug in :meth:`Index.union` behaving differently depending on whether operand is a :class:`Index` or other list-like (:issue:`36384`)
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError``, from a bare ``Exception`` previously (:issue:`35744`)
-- Bug in :class:`DataFrame` allowing arithmetic operations with list of array-likes with undefined results. Behavior changed to raising ``ValueError`` (:issue:`36702`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -313,8 +313,9 @@ def align_method_FRAME(
     elif is_list_like(right) and not isinstance(right, (ABCSeries, ABCDataFrame)):
         # GH 36702. Raise when attempting arithmetic with list of array-like.
         if any([is_array_like(el) for el in right]):
-            raise ValueError(f"Unable to coerce list of {type(right[0])} "
-                             "to Series/DataFrame")
+            raise ValueError(
+                f"Unable to coerce list of {type(right[0])} " "to Series/DataFrame"
+            )
         # GH17901
         right = to_series(right)
 

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -13,7 +13,7 @@ from pandas._libs.ops_dispatch import maybe_dispatch_ufunc_to_dunder_op  # noqa:
 from pandas._typing import Level
 from pandas.util._decorators import Appender
 
-from pandas.core.dtypes.common import is_list_like
+from pandas.core.dtypes.common import is_array_like, is_list_like
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.missing import isna
 
@@ -311,6 +311,10 @@ def align_method_FRAME(
             )
 
     elif is_list_like(right) and not isinstance(right, (ABCSeries, ABCDataFrame)):
+        # GH 36702. Raise when attempting arithmetic with list of array-like.
+        if any([is_array_like(el) for el in right]):
+            raise ValueError(f"Unable to coerce list of {type(right[0])} "
+                             "to Series/DataFrame")
         # GH17901
         right = to_series(right)
 

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -314,7 +314,7 @@ def align_method_FRAME(
         # GH 36702. Raise when attempting arithmetic with list of array-like.
         if any(is_array_like(el) for el in right):
             raise ValueError(
-                f"Unable to coerce list of {type(right[0])} " "to Series/DataFrame"
+                f"Unable to coerce list of {type(right[0])} to Series/DataFrame"
             )
         # GH17901
         right = to_series(right)

--- a/pandas/core/ops/__init__.py
+++ b/pandas/core/ops/__init__.py
@@ -312,7 +312,7 @@ def align_method_FRAME(
 
     elif is_list_like(right) and not isinstance(right, (ABCSeries, ABCDataFrame)):
         # GH 36702. Raise when attempting arithmetic with list of array-like.
-        if any([is_array_like(el) for el in right]):
+        if any(is_array_like(el) for el in right):
             raise ValueError(
                 f"Unable to coerce list of {type(right[0])} " "to Series/DataFrame"
             )

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1581,7 +1581,7 @@ def test_arith_reindex_with_duplicates():
 
 def test_arith_list_of_arraylike_raise():
     # GH 36702. Raise when trying to add list of array-like to DataFrame
-    df = pd.DataFrame({'x': [1, 2], 'y': [1, 2]})
+    df = pd.DataFrame({"x": [1, 2], "y": [1, 2]})
     ser = pd.Series([1, 1])
 
     msg = f"Unable to coerce list of {type(ser)} to Series/DataFrame"

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1577,3 +1577,13 @@ def test_arith_reindex_with_duplicates():
     result = df1 + df2
     expected = pd.DataFrame([[np.nan, 0, 0]], columns=["first", "second", "second"])
     tm.assert_frame_equal(result, expected)
+
+
+def test_arith_list_of_arraylike_raise():
+    # GH 36702. Raise when trying to add list of array-like to DataFrame
+    df = pd.DataFrame({'x': [1, 2], 'y': [1, 2]})
+    ser = pd.Series([1, 1])
+
+    msg = "Cannot perform arithmetic on DataFrame or Series and a list of array-like."
+    with pytest.raises(ValueError, match=msg):
+        result = df + [ser, ser]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1579,11 +1579,15 @@ def test_arith_reindex_with_duplicates():
     tm.assert_frame_equal(result, expected)
 
 
-def test_arith_list_of_arraylike_raise():
+@pytest.mark.parametrize("arg1", [pd.DataFrame({"x": [1, 2], "y": [1, 2]})])
+@pytest.mark.parametrize(
+    "arg2", [[pd.Series([1, 1])], [pd.Series([1, 1]), pd.Series([1, 1])]]
+)
+def test_arith_list_of_arraylike_raise(arg1, arg2):
     # GH 36702. Raise when trying to add list of array-like to DataFrame
-    df = pd.DataFrame({"x": [1, 2], "y": [1, 2]})
-    ser = pd.Series([1, 1])
 
-    msg = f"Unable to coerce list of {type(ser)} to Series/DataFrame"
+    msg = f"Unable to coerce list of {type(arg2[0])} to Series/DataFrame"
     with pytest.raises(ValueError, match=msg):
-        df + [ser, ser]
+        arg1 + arg2
+    with pytest.raises(ValueError, match=msg):
+        arg2 + arg1

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1584,6 +1584,6 @@ def test_arith_list_of_arraylike_raise():
     df = pd.DataFrame({'x': [1, 2], 'y': [1, 2]})
     ser = pd.Series([1, 1])
 
-    msg = "Cannot perform arithmetic on DataFrame or Series and a list of array-like."
+    msg = f"Unable to coerce list of {type(ser)} to Series/DataFrame"
     with pytest.raises(ValueError, match=msg):
         result = df + [ser, ser]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1586,4 +1586,4 @@ def test_arith_list_of_arraylike_raise():
 
     msg = f"Unable to coerce list of {type(ser)} to Series/DataFrame"
     with pytest.raises(ValueError, match=msg):
-        result = df + [ser, ser]
+        df + [ser, ser]

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1579,15 +1579,15 @@ def test_arith_reindex_with_duplicates():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("arg1", [pd.DataFrame({"x": [1, 2], "y": [1, 2]})])
 @pytest.mark.parametrize(
-    "arg2", [[pd.Series([1, 1])], [pd.Series([1, 1]), pd.Series([1, 1])]]
+    "to_add", [[pd.Series([1, 1])], [pd.Series([1, 1]), pd.Series([1, 1])]]
 )
-def test_arith_list_of_arraylike_raise(arg1, arg2):
+def test_arith_list_of_arraylike_raise(to_add):
     # GH 36702. Raise when trying to add list of array-like to DataFrame
+    df = pd.DataFrame({"x": [1, 2], "y": [1, 2]})
 
-    msg = f"Unable to coerce list of {type(arg2[0])} to Series/DataFrame"
+    msg = f"Unable to coerce list of {type(to_add[0])} to Series/DataFrame"
     with pytest.raises(ValueError, match=msg):
-        arg1 + arg2
+        df + to_add
     with pytest.raises(ValueError, match=msg):
-        arg2 + arg1
+        to_add + df


### PR DESCRIPTION
- [X] closes #36702
- [X] tests 1 added / 1 passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

## Problem

We currently allow doing arithmetic on a DataFrame, and, for example, a list of Series. The latter gets broadcast with `align_method_FRAME` and this leads to weirdness.

## Solution

We should raise. There is no definite answer to how such arithmetic should be handled, and the user should just make another DataFrame and add that to the frame instead of doing stuff like `[Series, Series]`. 
