### PR TITLE
CI move check incorrect sphinx directives to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
             |function|image|important|include|ipython|literalinclude
             |math|module|note|raw|seealso|toctree|versionadded
             |versionchanged|warning):[^:]
-        files: .(py|pyx)$
+        files: .(py|pyx|rst)$
 -   repo: https://github.com/asottile/yesqa
     rev: v1.2.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,11 @@ repos:
         types: [rst]
         args: [--filename=*.rst]
         additional_dependencies: [flake8-rst==0.7.0, flake8==3.7.9]
+    -   id: incorrect-sphinx-directives
+        name: Check for incorrect Sphinx incorrect-sphinx-directives
+        language: pygrep
+        entry: '\.\. (autosummary|contents|currentmodule|deprecated|function|image|important|include|ipython|literalinclude|math|module|note|raw|seealso|toctree|versionadded|versionchanged|warning):[^:]'
+        files: .(py|pyx)$
 -   repo: https://github.com/asottile/yesqa
     rev: v1.2.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,11 @@ repos:
     -   id: incorrect-sphinx-directives
         name: Check for incorrect Sphinx directives
         language: pygrep
-        entry: '\.\. (autosummary|contents|currentmodule|deprecated|function|image|important|include|ipython|literalinclude|math|module|note|raw|seealso|toctree|versionadded|versionchanged|warning):[^:]'
+        entry: >-
+            \.\. (autosummary|contents|currentmodule|deprecated
+            |function|image|important|include|ipython|literalinclude
+            |math|module|note|raw|seealso|toctree|versionadded
+            |versionchanged|warning):[^:]
         files: .(py|pyx)$
 -   repo: https://github.com/asottile/yesqa
     rev: v1.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,4 +70,4 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: end-of-file-fixer
-        exclude: ^LICENSES/|\.(html|csv|txt|svg|py)
+        exclude: ^LICENSES/|\.(html|csv|txt|svg|py)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
             |function|image|important|include|ipython|literalinclude
             |math|module|note|raw|seealso|toctree|versionadded
             |versionchanged|warning):[^:]
-        files: .(py|pyx|rst)$
+        files: \.(py|pyx|rst)$
 -   repo: https://github.com/asottile/yesqa
     rev: v1.2.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         args: [--filename=*.rst]
         additional_dependencies: [flake8-rst==0.7.0, flake8==3.7.9]
     -   id: incorrect-sphinx-directives
-        name: Check for incorrect Sphinx incorrect-sphinx-directives
+        name: Check for incorrect Sphinx directives
         language: pygrep
         entry: '\.\. (autosummary|contents|currentmodule|deprecated|function|image|important|include|ipython|literalinclude|math|module|note|raw|seealso|toctree|versionadded|versionchanged|warning):[^:]'
         files: .(py|pyx)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,4 +70,4 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: end-of-file-fixer
-        exclude: '.html$|^LICENSES/|.csv$|.txt$|.svg$|.py$'
+        exclude: ^LICENSES/|\.(html|csv|txt|svg|py)

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -214,10 +214,6 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     invgrep -R --include="*.rst" -E "[a-zA-Z0-9]\`\`?[a-zA-Z0-9]" doc/source/
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
-    MSG='Check for incorrect sphinx directives' ; echo $MSG
-    invgrep -R --include="*.py" --include="*.pyx" --include="*.rst" -E "\.\. (autosummary|contents|currentmodule|deprecated|function|image|important|include|ipython|literalinclude|math|module|note|raw|seealso|toctree|versionadded|versionchanged|warning):[^:]" ./pandas ./doc/source
-    RET=$(($RET + $?)) ; echo $MSG "DONE"
-
     # Check for the following code in testing: `unittest.mock`, `mock.Mock()` or `mock.patch`
     MSG='Check that unittest.mock is not used (pytest builtin monkeypatch fixture should be used instead)' ; echo $MSG
     invgrep -r -E --include '*.py' '(unittest(\.| import )mock|mock\.Mock\(\)|mock\.patch)' pandas/tests/

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5343,7 +5343,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
             A passed method name providing context on where ``__finalize__``
             was called.
 
-            .. warning:
+            .. warning::
 
                The value passed as `method` are not currently considered
                stable across pandas releases.


### PR DESCRIPTION
Currently, the check (which uses `grep` with the return codes inverted) doesn't catch

```python
    .. warning:
```
, while using `pygrep` from `pre-commit` (which is a Python implementation of `grep` with inverted return codes) does. I think this is because grep doesn't count the newline as a character

Advantages of moving this (and, later, other) `invgrep` checks to pre-commit are:

- they'll be cross-platform
- they'll be simpler to write/maintain because `pre-commit` comes with `pygrep` built-in, so there's no need to manually define something like `invgrep`
- they'll give devs faster feedback on when they introduce unwanted patterns