### PR TITLE
CLN: indexing

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3091,7 +3091,7 @@ class DataFrame(NDFrame, OpsMixin):
                 for k1, k2 in zip(key, value.columns):
                     self[k1] = value[k2]
             else:
-                self.loc._ensure_listlike_indexer(key, axis=1)
+                self.loc._ensure_listlike_indexer(key, axis=1, value=value)
                 indexer = self.loc._get_listlike_indexer(
                     key, axis=1, raise_missing=False
                 )[1]

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -340,7 +340,7 @@ class Block(PandasObject):
     def iget(self, i):
         return self.values[i]
 
-    def set(self, locs, values):
+    def set_inplace(self, locs, values):
         """
         Modify block values in-place with new item value.
 
@@ -1676,7 +1676,9 @@ class ExtensionBlock(Block):
                 raise IndexError(f"{self} only contains one item")
             return self.values
 
-    def set(self, locs, values):
+    def set_inplace(self, locs, values):
+        # NB: This is a misnomer, is supposed to be inplace but is not,
+        #  see GH#33457
         assert locs.tolist() == [0]
         self.values = values
 
@@ -2231,7 +2233,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin):
 
         return is_valid_nat_for_dtype(element, self.dtype)
 
-    def set(self, locs, values):
+    def set_inplace(self, locs, values):
         """
         See Block.set.__doc__
         """

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1083,7 +1083,7 @@ class BlockManager(PandasObject):
             blk = self.blocks[blkno]
             blk_locs = blklocs[val_locs.indexer]
             if blk.should_store(value):
-                blk.set(blk_locs, value_getitem(val_locs))
+                blk.set_inplace(blk_locs, value_getitem(val_locs))
             else:
                 unfit_mgr_locs.append(blk.mgr_locs.as_array[blk_locs])
                 unfit_val_locs.append(val_locs)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Working on refactoring the indexing setitem code so that we go down the same path regardless of consolidation status.  This splits off a small piece of that as a prelim.