### PR TITLE
DOC: Remove redundant table in Series docs

### DIFF
--- a/doc/source/reference/series.rst
+++ b/doc/source/reference/series.rst
@@ -22,10 +22,6 @@ Attributes
    :toctree: api/
 
    Series.index
-
-.. autosummary::
-   :toctree: api/
-
    Series.array
    Series.values
    Series.dtype


### PR DESCRIPTION
The attribute `Series.index` was separated in another table, which makes
the rendering of the documentation slightly inconsistent. This commit
consolidates the tables together to make the documentation consistent
and aligned.

**Live site** (https://pandas.pydata.org/docs/reference/series.html):

![image](https://user-images.githubusercontent.com/2754821/96168089-20708500-0ed5-11eb-8bab-cc34ebb7f7bc.png)

**Locally rendered change**:

![image](https://user-images.githubusercontent.com/2754821/96168171-4007ad80-0ed5-11eb-99a2-48c200602213.png)

I'm not sure why the color changed. My guess is because I just rendered that page with `python make.py --single reference/series.rst`, so the links to those pages are nonexistent.

If this separate table was intentional, feel free to close this PR. Thanks for considering this!

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
