### PR TITLE
TST: RollingGroupby(..., center=True, on=...)

### DIFF
--- a/pandas/tests/window/test_grouper.py
+++ b/pandas/tests/window/test_grouper.py
@@ -297,6 +297,41 @@ class TestGrouperGrouping:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_groupby_rolling_center_on(self):
+        # GH 37141
+        df = pd.DataFrame(
+            data={
+                "Date": pd.date_range("2020-01-01", "2020-01-10"),
+                "gb": ["group_1"] * 6 + ["group_2"] * 4,
+                "value": range(10),
+            }
+        )
+        result = (
+            df.groupby("gb")
+            .rolling(6, on="Date", center=True, min_periods=1)
+            .value.mean()
+        )
+        expected = Series(
+            [1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 7.0, 7.5, 7.5, 7.5],
+            name="value",
+            index=pd.MultiIndex.from_tuples(
+                (
+                    ("group_1", pd.Timestamp("2020-01-01")),
+                    ("group_1", pd.Timestamp("2020-01-02")),
+                    ("group_1", pd.Timestamp("2020-01-03")),
+                    ("group_1", pd.Timestamp("2020-01-04")),
+                    ("group_1", pd.Timestamp("2020-01-05")),
+                    ("group_1", pd.Timestamp("2020-01-06")),
+                    ("group_2", pd.Timestamp("2020-01-07")),
+                    ("group_2", pd.Timestamp("2020-01-08")),
+                    ("group_2", pd.Timestamp("2020-01-09")),
+                    ("group_2", pd.Timestamp("2020-01-10")),
+                ),
+                names=["gb", "Date"],
+            ),
+        )
+        tm.assert_series_equal(result, expected)
+
     @pytest.mark.parametrize("min_periods", [5, 4, 3])
     def test_groupby_rolling_center_min_periods(self, min_periods):
         # GH 36040


### PR DESCRIPTION
- [x] closes #37141
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Didn't look like we had a test case that exactly covered this.