### PR TITLE
REF: avoid access to _mgr.blocks -> _mgr._is_single_block

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5474,7 +5474,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @property
     def _is_mixed_type(self) -> bool_t:
-        if len(self._mgr.blocks) == 1:
+        if self._mgr._is_single_block:
             return False
 
         if self._mgr.any_extension_types:
@@ -6262,7 +6262,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         axis = self._get_axis_number(axis)
 
         if value is None:
-            if len(self._mgr.blocks) > 1 and axis == 1:
+            if not self._mgr._is_single_block and axis == 1:
                 if inplace:
                     raise NotImplementedError()
                 result = self.T.fillna(method=method, limit=limit).T

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5474,7 +5474,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @property
     def _is_mixed_type(self) -> bool_t:
-        if self._mgr._is_single_block:
+        if self._mgr.is_single_block:
             return False
 
         if self._mgr.any_extension_types:
@@ -6262,7 +6262,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         axis = self._get_axis_number(axis)
 
         if value is None:
-            if not self._mgr._is_single_block and axis == 1:
+            if not self._mgr.is_single_block and axis == 1:
                 if inplace:
                     raise NotImplementedError()
                 result = self.T.fillna(method=method, limit=limit).T

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1540,7 +1540,7 @@ class _iLocIndexer(_LocationIndexer):
         info_axis = self.obj._info_axis_number
 
         # maybe partial set
-        take_split_path = len(self.obj._mgr.blocks) > 1
+        take_split_path = not self.obj._mgr._is_single_block
 
         # if there is only one block/type, still have to take split path
         # unless the block is one-dimensional or it can hold the value

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1540,7 +1540,7 @@ class _iLocIndexer(_LocationIndexer):
         info_axis = self.obj._info_axis_number
 
         # maybe partial set
-        take_split_path = not self.obj._mgr._is_single_block
+        take_split_path = not self.obj._mgr.is_single_block
 
         # if there is only one block/type, still have to take split path
         # unless the block is one-dimensional or it can hold the value

--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -115,7 +115,7 @@ def _get_mgr_concatenation_plan(mgr, indexers):
         blklocs = algos.take_1d(mgr.blklocs, ax0_indexer, fill_value=-1)
     else:
 
-        if mgr._is_single_block:
+        if mgr.is_single_block:
             blk = mgr.blocks[0]
             return [(blk.mgr_locs, JoinUnit(blk, mgr_shape, indexers))]
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -225,7 +225,7 @@ class BlockManager(PandasObject):
         self.axes[axis] = new_labels
 
     @property
-    def _is_single_block(self) -> bool:
+    def is_single_block(self) -> bool:
         # Assumes we are 2D; overridden by SingleBlockManager
         return len(self.blocks) == 1
 
@@ -833,7 +833,7 @@ class BlockManager(PandasObject):
         # mutating the original object
         copy = copy or na_value is not lib.no_default
 
-        if self._is_single_block:
+        if self.is_single_block:
             blk = self.blocks[0]
             if blk.is_extension:
                 # Avoid implicit conversion of extension blocks to object
@@ -1313,7 +1313,7 @@ class BlockManager(PandasObject):
             slice_or_indexer, self.shape[0], allow_fill=allow_fill
         )
 
-        if self._is_single_block:
+        if self.is_single_block:
             blk = self.blocks[0]
 
             if sl_type in ("slice", "mask"):
@@ -1503,7 +1503,7 @@ class SingleBlockManager(BlockManager):
     _is_consolidated = True
     _known_consolidated = True
     __slots__ = ()
-    _is_single_block = True
+    is_single_block = True
 
     def __init__(
         self,


### PR DESCRIPTION
@jbrockmendel a small follow-up on https://github.com/pandas-dev/pandas/pull/36873. It keeps the same spirit of that PR (I think), but just replacing the access of `len(self._mgr.blocks)` with an existing attribute on the manager (could also remove the leading underscore on the attribute). 
(this makes it easier to override this attribute in the ArrayManager, and limits the access to the blocks outside of the internals)