### PR TITLE
API: Index.__cmp__(Series) return NotImplemented

### DIFF
--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -10,7 +10,7 @@ from pandas.errors import AbstractMethodError
 from pandas.util._decorators import cache_readonly, doc
 
 from pandas.core.dtypes.common import is_dtype_equal, is_object_dtype
-from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
+from pandas.core.dtypes.generic import ABCDataFrame
 
 from pandas.core.arrays import ExtensionArray
 from pandas.core.indexers import deprecate_ndim_indexing
@@ -118,11 +118,6 @@ def _make_wrapped_comparison_op(opname: str):
     """
 
     def wrapper(self, other):
-        if isinstance(other, ABCSeries):
-            # the arrays defer to Series for comparison ops but the indexes
-            #  don't, so we have to unwrap here.
-            other = other._values
-
         other = _maybe_unwrap_index(other)
 
         op = getattr(self._data, opname)

--- a/pandas/core/ops/common.py
+++ b/pandas/core/ops/common.py
@@ -45,20 +45,15 @@ def _unpack_zerodim_and_defer(method, name: str):
     -------
     method
     """
-    is_cmp = name.strip("__") in {"eq", "ne", "lt", "le", "gt", "ge"}
 
     @wraps(method)
     def new_method(self, other):
 
-        if is_cmp and isinstance(self, ABCIndexClass) and isinstance(other, ABCSeries):
-            # For comparison ops, Index does *not* defer to Series
-            pass
-        else:
-            for cls in [ABCDataFrame, ABCSeries, ABCIndexClass]:
-                if isinstance(self, cls):
-                    break
-                if isinstance(other, cls):
-                    return NotImplemented
+        for cls in [ABCDataFrame, ABCSeries, ABCIndexClass]:
+            if isinstance(self, cls):
+                break
+            if isinstance(other, cls):
+                return NotImplemented
 
         other = item_from_zerodim(other)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4977,11 +4977,14 @@ Keep all original rows and also all original values
 
         if isinstance(other, Series) and not self._indexed_same(other):
             raise ValueError("Can only compare identically-labeled Series objects")
+        if isinstance(other, MultiIndex):
+            res_values = op(self._values, other)
+        else:
+            lvalues = extract_array(self, extract_numpy=True)
 
-        lvalues = extract_array(self, extract_numpy=True)
-        rvalues = extract_array(other, extract_numpy=True)
+            rvalues = extract_array(other, extract_numpy=True)
 
-        res_values = ops.comparison_op(lvalues, rvalues, op)
+            res_values = ops.comparison_op(lvalues, rvalues, op)
 
         return self._construct_result(res_values, name=res_name)
 

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -744,11 +744,13 @@ class TestDatetimeIndexComparisons:
 
         result = dti == other
         expected = np.array([False] * 10)
-        tm.assert_numpy_array_equal(result, expected)
+        if isinstance(other, Series):
+            expected = Series(expected, index=other.index)
+        tm.assert_equal(result, expected)
 
         result = dti != other
-        expected = np.array([True] * 10)
-        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_equal(result, ~expected)
+
         msg = "Invalid comparison between"
         with pytest.raises(TypeError, match=msg):
             dti < other

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -645,8 +645,8 @@ class Base:
         with pytest.raises(ValueError, match=msg):
             index_a == series_b
 
-        tm.assert_numpy_array_equal(index_a == series_a, expected1)
-        tm.assert_numpy_array_equal(index_a == series_c, expected2)
+        tm.assert_series_equal(index_a == series_a, Series(expected1))
+        tm.assert_series_equal(index_a == series_c, Series(expected2))
 
         # cases where length is 1 for one of them
         with pytest.raises(ValueError, match="Lengths must match"):

--- a/pandas/tests/indexes/multi/test_equivalence.py
+++ b/pandas/tests/indexes/multi/test_equivalence.py
@@ -56,8 +56,8 @@ def test_equals_op(idx):
     with pytest.raises(ValueError, match="Lengths must match"):
         index_a == series_b
 
-    tm.assert_numpy_array_equal(index_a == series_a, expected1)
-    tm.assert_numpy_array_equal(index_a == series_c, expected2)
+    tm.assert_series_equal(index_a == series_a, Series(expected1))
+    tm.assert_series_equal(index_a == series_c, Series(expected2))
 
     # cases where length is 1 for one of them
     with pytest.raises(ValueError, match="Lengths must match"):


### PR DESCRIPTION
- [x] closes #36759
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Gets rid of an unnecessary special case.

Could do this as a deprecation first.
