### PR TITLE
BUG: Fix isin with read-only target

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -35,6 +35,7 @@ Bug fixes
 
 Other
 ~~~~~
+- Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` raising a ``ValueError`` when the target was read-only (:issue:`37174`)
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -28,14 +28,14 @@ Fixed regressions
 Bug fixes
 ~~~~~~~~~
 - Bug causing ``groupby(...).sum()`` and similar to not preserve metadata (:issue:`29442`)
+- Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` raising a ``ValueError`` when the target was read-only (:issue:`37174`)
 
 .. ---------------------------------------------------------------------------
 
 .. _whatsnew_114.other:
 
-Indexing
-~~~~~~~~
-- Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` raising a ``ValueError`` when the target was read-only (:issue:`37174`)
+Other
+~~~~~
 -
 
 .. ---------------------------------------------------------------------------

--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -33,8 +33,8 @@ Bug fixes
 
 .. _whatsnew_114.other:
 
-Other
-~~~~~
+Indexing
+~~~~~~~~
 - Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` raising a ``ValueError`` when the target was read-only (:issue:`37174`)
 -
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -498,6 +498,7 @@ Other
 - Fixed metadata propagation in the :class:`Series.dt` and :class:`Series.str` accessors (:issue:`28283`)
 - Bug in :meth:`Index.union` behaving differently depending on whether operand is a :class:`Index` or other list-like (:issue:`36384`)
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError``, from a bare ``Exception`` previously (:issue:`35744`)
+- Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` raising a ``ValueError`` when the target was read-only (:issue:`37174`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -348,8 +348,7 @@ Datetimelike
 Timedelta
 ^^^^^^^^^
 - Bug in :class:`TimedeltaIndex`, :class:`Series`, and :class:`DataFrame` floor-division with ``timedelta64`` dtypes and ``NaT`` in the denominator (:issue:`35529`)
--
--
+- Bug in parsing of ISO 8601 durations in :class:`Timedelta`, :meth:`pd.to_datetime` (:issue:`37159`, fixes :issue:`29773` and :issue:`36204`)
 
 Timezones
 ^^^^^^^^^
@@ -498,7 +497,6 @@ Other
 - Fixed metadata propagation in the :class:`Series.dt` and :class:`Series.str` accessors (:issue:`28283`)
 - Bug in :meth:`Index.union` behaving differently depending on whether operand is a :class:`Index` or other list-like (:issue:`36384`)
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError``, from a bare ``Exception`` previously (:issue:`35744`)
-- Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` raising a ``ValueError`` when the target was read-only (:issue:`37174`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -208,7 +208,7 @@ def duplicated_{{dtype}}(const {{c_type}}[:] values, object keep='first'):
 {{if dtype == 'object'}}
 def ismember_{{dtype}}(ndarray[{{c_type}}] arr, ndarray[{{c_type}}] values):
 {{else}}
-def ismember_{{dtype}}(const {{c_type}}[:] arr, {{c_type}}[:] values):
+def ismember_{{dtype}}(const {{c_type}}[:] arr, const {{c_type}}[:] values):
 {{endif}}
     """
     Return boolean of values in arr on an

--- a/pandas/tests/frame/methods/test_isin.py
+++ b/pandas/tests/frame/methods/test_isin.py
@@ -204,3 +204,12 @@ class TestDataFrameIsIn:
 
         result = df.isin(values)
         tm.assert_frame_equal(result, expected)
+
+    def test_isin_read_only(self):
+        # https://github.com/pandas-dev/pandas/issues/37174
+        arr = np.array([1, 2, 3])
+        arr.setflags(write=False)
+        df = DataFrame([1, 2, 3])
+        result = df.isin(arr)
+        expected = DataFrame([True, True, True])
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -80,3 +80,12 @@ class TestSeriesIsIn:
 
         result = s.isin(empty)
         tm.assert_series_equal(expected, result)
+
+    def test_isin_read_only(self):
+        # https://github.com/pandas-dev/pandas/issues/37174
+        arr = np.array([1, 2, 3])
+        arr.setflags(write=False)
+        s = pd.Series([1, 2, 3])
+        result = s.isin(arr)
+        expected = Series([True, True, True])
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -85,7 +85,7 @@ class TestSeriesIsIn:
         # https://github.com/pandas-dev/pandas/issues/37174
         arr = np.array([1, 2, 3])
         arr.setflags(write=False)
-        s = pd.Series([1, 2, 3])
+        s = Series([1, 2, 3])
         result = s.isin(arr)
         expected = Series([True, True, True])
         tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #37174
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
