### PR TITLE
BUG: Series.loc[timestamp] with MultiIndex with DTI first-level

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3677,7 +3677,9 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         index = self.index
         if isinstance(index, MultiIndex):
             try:
-                loc, new_index = self.index.get_loc_level(key, drop_level=drop_level)
+                loc, new_index = self.index.get_loc_level(
+                    key, level=self.index.names[0], drop_level=drop_level
+                )
             except TypeError as e:
                 raise TypeError(f"Expected label or tuple of labels, got {key}") from e
         else:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1551,13 +1551,18 @@ class Index(IndexOpsMixin, PandasObject):
             level = [level]
 
         levnums = sorted(self._get_level_number(lev) for lev in level)[::-1]
+        return self._drop_level_nums(levnums)
 
-        if len(level) == 0:
+    def _drop_level_nums(self, levnums: List[int]) -> "MultiIndex":
+        """
+        Drop MultiIndex levels by level _number_, not name.
+        """
+        if len(levnums) == 0:
             return self
-        if len(level) >= self.nlevels:
+        if len(levnums) >= self.nlevels:
             raise ValueError(
-                f"Cannot remove {len(level)} levels from an index with {self.nlevels} "
-                "levels: at least one level must be left."
+                f"Cannot remove {len(levnums)} levels from an index with "
+                f"{self.nlevels} levels: at least one level must be left."
             )
         # The two checks above guarantee that here self is a MultiIndex
         self = cast("MultiIndex", self)

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -522,3 +522,20 @@ def test_loc_with_mi_indexer():
         columns=["author", "price"],
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_loc_mi_with_datetimeindex_level():
+    dti = pd.date_range("2016-01-01", periods=3, tz="US/Pacific")
+
+    ser = pd.Series(range(3), index=dti)
+    df = ser.to_frame()
+    df[1] = dti
+
+    df2 = df.set_index(0, append=True)
+    ser2 = df2[1]
+
+    ser2.index.get_loc(dti[0])  # smoke test
+    result = ser2.loc[dti[0]]
+
+    expected = ser2.iloc[[0]].droplevel(None)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The underlying problem here is that `MultiIndex._get_level_number` is not idempotent.