### PR TITLE
DOC: Add example to Series.divmod

### DIFF
--- a/pandas/core/ops/docstrings.py
+++ b/pandas/core/ops/docstrings.py
@@ -26,6 +26,8 @@ def make_flex_doc(op_name: str, typ: str) -> str:
     assert op_desc_op is not None  # for mypy
     if op_name.startswith("r"):
         equiv = "other " + op_desc_op + " " + typ
+    elif op_name == "divmod":
+        equiv = f"{op_name}({typ}, other)"
     else:
         equiv = typ + " " + op_desc_op + " other"
 
@@ -159,6 +161,25 @@ c    NaN
 d    0.0
 e    NaN
 dtype: float64
+"""
+)
+
+_divmod_example_SERIES = (
+    _common_examples_algebra_SERIES
+    + """
+>>> a.divmod(b, fill_value=0)
+(a    1.0
+ b    NaN
+ c    NaN
+ d    0.0
+ e    NaN
+ dtype: float64,
+ a    0.0
+ b    NaN
+ c    NaN
+ d    0.0
+ e    NaN
+ dtype: float64)
 """
 )
 
@@ -332,7 +353,7 @@ _op_descriptions: Dict[str, Dict[str, Optional[str]]] = {
         "op": "divmod",
         "desc": "Integer division and modulo",
         "reverse": "rdivmod",
-        "series_examples": None,
+        "series_examples": _divmod_example_SERIES,
         "series_returns": _returns_tuple,
         "df_examples": None,
     },


### PR DESCRIPTION

- [x] closes #24589
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

-----
[Current doc](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.divmod.html); Rendered doc:
![Screenshot 2020-10-17 at 10 44 26 AM](https://user-images.githubusercontent.com/19281800/96326790-3d888d80-1066-11eb-94e7-0a4e0db5d4ba.png)
