### PR TITLE
BUG: record warnings related to DatetimeIndex

### DIFF
--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -2,6 +2,7 @@
 from datetime import date, datetime, time, timedelta
 import pickle
 import sys
+import warnings
 
 import numpy as np
 import pytest
@@ -291,9 +292,16 @@ class TestTSPlot(TestPlotBase):
         _, ax = self.plt.subplots()
         df2 = df.copy()
         df2.index = df.index.astype(object)
-        df2.plot(ax=ax)
-        diffs = Series(ax.get_lines()[0].get_xydata()[:, 0]).diff()
-        assert (np.fabs(diffs[1:] - sec) < 1e-8).all()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", FutureWarning)
+            df2.plot(ax=ax)
+            diffs = Series(ax.get_lines()[0].get_xydata()[:, 0]).diff()
+            assert (np.fabs(diffs[1:] - sec) < 1e-8).all()
+            match = (
+                "Automatically casting object-dtype Index of datetimes "
+                "to DatetimeIndex is deprecated"
+            )
+            assert match in str(w[0].message)
 
     def test_irregular_datetime64_repr_bug(self):
         ser = tm.makeTimeSeries()
@@ -1028,9 +1036,16 @@ class TestTSPlot(TestPlotBase):
         # np.datetime64
         idx = date_range("1/1/2000", periods=10)
         idx = idx[[0, 2, 5, 9]].astype(object)
-        df = DataFrame(np.random.randn(len(idx), 3), idx)
-        _, ax = self.plt.subplots()
-        _check_plot_works(df.plot, ax=ax)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", FutureWarning)
+            df = DataFrame(np.random.randn(len(idx), 3), idx)
+            _, ax = self.plt.subplots()
+            _check_plot_works(df.plot, ax=ax)
+            match = (
+                "Automatically casting object-dtype Index of datetimes "
+                "to DatetimeIndex is deprecated"
+            )
+            assert match in str(w[0].message)
 
     @pytest.mark.slow
     def test_time(self):

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -2,7 +2,6 @@
 from datetime import date, datetime, time, timedelta
 import pickle
 import sys
-import warnings
 
 import numpy as np
 import pytest
@@ -292,16 +291,16 @@ class TestTSPlot(TestPlotBase):
         _, ax = self.plt.subplots()
         df2 = df.copy()
         df2.index = df.index.astype(object)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always", FutureWarning)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            # This warning will be emitted
+            # pandas/core/frame.py:3216:
+            # FutureWarning: Automatically casting object-dtype Index of datetimes
+            # to DatetimeIndex is deprecated and will be removed in a future version.
+            # Explicitly cast to DatetimeIndex instead.
+            # return klass(values, index=self.index, name=name, fastpath=True)
             df2.plot(ax=ax)
             diffs = Series(ax.get_lines()[0].get_xydata()[:, 0]).diff()
             assert (np.fabs(diffs[1:] - sec) < 1e-8).all()
-            match = (
-                "Automatically casting object-dtype Index of datetimes "
-                "to DatetimeIndex is deprecated"
-            )
-            assert match in str(w[0].message)
 
     def test_irregular_datetime64_repr_bug(self):
         ser = tm.makeTimeSeries()
@@ -1036,16 +1035,16 @@ class TestTSPlot(TestPlotBase):
         # np.datetime64
         idx = date_range("1/1/2000", periods=10)
         idx = idx[[0, 2, 5, 9]].astype(object)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always", FutureWarning)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            # This warning will be emitted
+            # pandas/core/frame.py:3216:
+            # FutureWarning: Automatically casting object-dtype Index of datetimes
+            # to DatetimeIndex is deprecated and will be removed in a future version.
+            # Explicitly cast to DatetimeIndex instead.
+            # return klass(values, index=self.index, name=name, fastpath=True)
             df = DataFrame(np.random.randn(len(idx), 3), idx)
             _, ax = self.plt.subplots()
             _check_plot_works(df.plot, ax=ax)
-            match = (
-                "Automatically casting object-dtype Index of datetimes "
-                "to DatetimeIndex is deprecated"
-            )
-            assert match in str(w[0].message)
 
     @pytest.mark.slow
     def test_time(self):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This PR handles warnings emitted when running tests in ``pandas/tests/plotting/test_datetimelike.py``.
Warnings looked like this:

```
pandas/tests/plotting/test_datetimelike.py::TestTSPlot::test_irreg_dtypes
  /workspaces/pandas/pandas/core/frame.py:3216: FutureWarning: Automatically casting object-dtype Index of datetimes to DatetimeIndex is deprecated and will be removed in a future version.  Explicitly cast to DatetimeIndex instead.
    return klass(values, index=self.index, name=name, fastpath=True)
```

Presumably it started after implementing this: https://github.com/pandas-dev/pandas/pull/36697/

The reason for not using ``tm.assert_produces_warning`` is that when I use it,
then I get an error that the warning is raised with the incorrect stacklevel.