### PR TITLE
BUG: JoinUnit.is_na wrong for CategoricalDtype

### DIFF
--- a/pandas/core/internals/concat.py
+++ b/pandas/core/internals/concat.py
@@ -217,9 +217,7 @@ class JoinUnit:
         # a block is NOT null, chunks should help in such cases.  1000 value
         # was chosen rather arbitrarily.
         values = self.block.values
-        if self.block.is_categorical:
-            values_flat = values.categories
-        elif is_sparse(self.block.values.dtype):
+        if is_sparse(self.block.values.dtype):
             return False
         elif self.block.is_extension:
             # TODO(EA2D): no need for special case with 2D EAs


### PR DESCRIPTION
- [x] closes #20833
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

JoinUnit.is_na is basically checking `isna(self.block.values).all()`.  The check for is_categorical is an attempted optimization bc values.categories is often much smaller than values.  But Categorical represents its NAs in its codes, not in its categories.  So this will incorrectly always return False in the status quo. 

Having trouble coming up with a useful test.  I can adapt a test from test_concat that returns an incorrect answer from is_na, but that does not appear to affect the result of the higher-level pd.concat call.