### PR TITLE
BUG: Regression in Resample.apply raised error when apply affected only a Series

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -20,6 +20,7 @@ Fixed regressions
 - Fixed regression in :class:`RollingGroupby` with ``sort=False`` not being respected (:issue:`36889`)
 - Fixed regression in :meth:`Series.astype` converting ``None`` to ``"nan"`` when casting to string (:issue:`36904`)
 - Fixed regression in :class:`RollingGroupby` causing a segmentation fault with Index of dtype object (:issue:`36727`)
+- Fixed regression in :meth:`Resample.apply` raised ``AttributeError`` when input was a :class:`DataFrame` and only a :class:`Series` was evaluated (:issue:`36951`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -20,7 +20,7 @@ Fixed regressions
 - Fixed regression in :class:`RollingGroupby` with ``sort=False`` not being respected (:issue:`36889`)
 - Fixed regression in :meth:`Series.astype` converting ``None`` to ``"nan"`` when casting to string (:issue:`36904`)
 - Fixed regression in :class:`RollingGroupby` causing a segmentation fault with Index of dtype object (:issue:`36727`)
-- Fixed regression in :meth:`Resample.apply` raised ``AttributeError`` when input was a :class:`DataFrame` and only a :class:`Series` was evaluated (:issue:`36951`)
+- Fixed regression in :meth:`DataFrame.resample(...).apply(...)` raised ``AttributeError`` when input was a :class:`DataFrame` and only a :class:`Series` was evaluated (:issue:`36951`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -369,8 +369,9 @@ class Resampler(BaseGroupBy, ShallowMixin):
                 result = grouped._aggregate_item_by_item(how, *args, **kwargs)
             else:
                 result = grouped.aggregate(how, *args, **kwargs)
-        except DataError:
+        except (DataError, AttributeError):
             # we have a non-reducing function; try to evaluate
+            # alternatively we want to evaluate only a column of the input
             result = grouped.apply(how, *args, **kwargs)
         except ValueError as err:
             if "Must produce aggregated value" in str(err):

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -369,7 +369,7 @@ class Resampler(BaseGroupBy, ShallowMixin):
                 result = grouped._aggregate_item_by_item(how, *args, **kwargs)
             else:
                 result = grouped.aggregate(how, *args, **kwargs)
-        except (DataError, AttributeError):
+        except (DataError, AttributeError, KeyError):
             # we have a non-reducing function; try to evaluate
             # alternatively we want to evaluate only a column of the input
             result = grouped.apply(how, *args, **kwargs)

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -347,3 +347,16 @@ def test_median_duplicate_columns():
     result = df.resample("5s").median()
     expected.columns = result.columns
     tm.assert_frame_equal(result, expected)
+
+
+def test_apply_to_one_column_of_df():
+    # GH: 36951
+    df = pd.DataFrame(
+        {"col": range(10), "col1": range(10, 20)},
+        index=pd.date_range("2012-01-01", periods=10, freq="20min"),
+    )
+    result = df.resample("H").apply(lambda group: group.col.sum())
+    expected = pd.Series(
+        [3, 12, 21, 9], index=pd.date_range("2012-01-01", periods=4, freq="H")
+    )
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/resample/test_resampler_grouper.py
+++ b/pandas/tests/resample/test_resampler_grouper.py
@@ -360,3 +360,5 @@ def test_apply_to_one_column_of_df():
         [3, 12, 21, 9], index=pd.date_range("2012-01-01", periods=4, freq="H")
     )
     tm.assert_series_equal(result, expected)
+    result = df.resample("H").apply(lambda group: group["col"].sum())
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #36951
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Error was no longer caught as before.

Sorry made a mistake when pushing...