### PR TITLE
DOC: add value counts as related method to count

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8518,6 +8518,7 @@ NaN 12.3   33.0
         See Also
         --------
         Series.count: Number of non-NA elements in a Series.
+        DataFrame.value_counts: Count unique combinations of columns.
         DataFrame.shape: Number of DataFrame rows and columns (including NA
             elements).
         DataFrame.isna: Boolean same-sized DataFrame showing places of NA


### PR DESCRIPTION
Counting values using `.value_counts()`, more generally, is a counting task, so it felt natural to link the `.count()` page to `.value_counts()`.

I copied the description for `.value_counts()` from the "See also" box in [`.drop_duplicates()`](https://github.com/pandas-dev/pandas/blob/9fed16cd4c302e47383480361260d63dc23cbefc/pandas/core/frame.py#L5102).

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
