### PR TITLE
CLN: Simplify gathering of results in aggregate

### DIFF
--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -53,6 +53,7 @@ ABCIndexClass = create_pandas_abc_type(
     },
 )
 
+ABCNDFrame = create_pandas_abc_type("ABCNDFrame", "_typ", ("series", "dataframe"))
 ABCSeries = create_pandas_abc_type("ABCSeries", "_typ", ("series",))
 ABCDataFrame = create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7426,9 +7426,9 @@ NaN 12.3   33.0
 
     >>> df.agg({'A' : ['sum', 'min'], 'B' : ['min', 'max']})
             A    B
-    max   NaN  8.0
-    min   1.0  2.0
     sum  12.0  NaN
+    min   1.0  2.0
+    max   NaN  8.0
 
     Aggregate different functions over the columns and rename the index of the resulting
     DataFrame.

--- a/pandas/tests/frame/apply/test_frame_apply.py
+++ b/pandas/tests/frame/apply/test_frame_apply.py
@@ -1254,7 +1254,7 @@ class TestDataFrameAggregate:
         # dict input with lists with multiple
         func = dict([(name1, ["mean", "sum"]), (name2, ["sum", "max"])])
         result = float_frame.agg(func, axis=axis)
-        expected = DataFrame(
+        expected = pd.concat(
             dict(
                 [
                     (
@@ -1278,7 +1278,8 @@ class TestDataFrameAggregate:
                         ),
                     ),
                 ]
-            )
+            ),
+            axis=1,
         )
         expected = expected.T if axis in {1, "columns"} else expected
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Reduces the number of paths when collecting results in `aggregation.aggregate`; one where we are gathering NDFrames using `concat` and the other where we are gathering scalars using `Series`.

The reason for the one test change is as follows. In one case, we previously gathered results using `DataFrame`. When this occurs and the indexes are not all equal, `DataFrame` will sort the index whereas `concat` will have the index in order of appearance. For example with

```
df = DataFrame(
    {
        'A': pd.Series([1, 2], index=['b', 'a']),
        'B': pd.Series([3, 4], index=['c', 'a'])
    }
)
```

gives 

```
     A    B
a  2.0  4.0
b  1.0  NaN
c  NaN  3.0
```

whereas using `concat` instead of `DataFrame` on the first line with `axis=1` gives:

```
     A    B
b  1.0  NaN
a  2.0  4.0
c  NaN  3.0
```

If in this example you replace the 2nd index with ['b', 'a'] (so that they are equal), then both `Dataframe` and `concat` will produce the same result with index `['b', 'a']`. If on the other hand you replace the 2nd index with `['a', 'b']`, then `DataFrame` will result in index `['a', 'b']` whereas concat will result in index `['b', 'a']`.