### PR TITLE
BUG: with integer column labels, .info() throws KeyError 

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -30,6 +30,7 @@ Bug fixes
 - Bug causing ``groupby(...).sum()`` and similar to not preserve metadata (:issue:`29442`)
 - Bug in :meth:`Series.isin` and :meth:`DataFrame.isin` raising a ``ValueError`` when the target was read-only (:issue:`37174`)
 - Bug in :meth:`GroupBy.fillna` that introduced a performance regression after 1.0.5 (:issue:`36757`)
+- Bug in :meth:`DataFrame.info` was raising a ``KeyError`` when the DataFrame has integer column names (:issue:`37245`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/io/formats/info.py
+++ b/pandas/io/formats/info.py
@@ -340,13 +340,13 @@ class DataFrameInfo(BaseInfo):
         lines.append(top_separator)
 
         for i, col in enumerate(ids):
-            dtype = dtypes[i]
+            dtype = dtypes.iloc[i]
             col = pprint_thing(col)
 
             line_no = _put_str(f" {i}", space_num)
             count = ""
             if show_counts:
-                count = counts[i]
+                count = counts.iloc[i]
 
             lines.append(
                 line_no

--- a/pandas/tests/io/formats/test_info.py
+++ b/pandas/tests/io/formats/test_info.py
@@ -459,3 +459,25 @@ def test_info_categorical():
 
     buf = StringIO()
     df.info(buf=buf)
+
+
+def test_info_int_columns():
+    # GH#37245
+    df = DataFrame({1: [1, 2], 2: [2, 3]}, index=["A", "B"])
+    buf = StringIO()
+    df.info(null_counts=True, buf=buf)
+    result = buf.getvalue()
+    expected = textwrap.dedent(
+        """\
+        <class 'pandas.core.frame.DataFrame'>
+        Index: 2 entries, A to B
+        Data columns (total 2 columns):
+         #   Column  Non-Null Count  Dtype
+        ---  ------  --------------  -----
+         0   1       2 non-null      int64
+         1   2       2 non-null      int64
+        dtypes: int64(2)
+        memory usage: 48.0+ bytes
+        """
+    )
+    assert result == expected


### PR DESCRIPTION
- [ ] closes #37245
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
