### PR TITLE
CI: tz dtype mismatch in test_parquet following pyarrow upgrade

### DIFF
--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -196,6 +196,7 @@ def check_round_trip(
                 check_names=check_names,
                 check_like=check_like,
                 check_dtype=check_dtype,
+                check_categorical=check_dtype,
             )
 
     if path is None:


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
