### PR TITLE
CI: temporary skip parquet tz test for pyarrow>=2.0.0

### DIFF
--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -765,6 +765,10 @@ class TestParquetPyArrow(Base):
         check_round_trip(df, pa, write_kwargs={"version": "2.0"})
 
     def test_timezone_aware_index(self, pa, timezone_aware_date_list):
+        if LooseVersion(pyarrow.__version__) >= LooseVersion("2.0.0"):
+            # temporary skip this test until it is properly resolved
+            # https://github.com/pandas-dev/pandas/issues/37286
+            pytest.skip()
         idx = 5 * [timezone_aware_date_list]
         df = pd.DataFrame(index=idx, data={"index_as_col": idx})
 


### PR DESCRIPTION
See https://github.com/pandas-dev/pandas/issues/37286, this PR is not the actual fix, but at least ensures we don't have failing CI in other PRs (I prefer to skip the test instead of pinning pyarrow to <= 1.0, since all other tests are passing on 2.0, which is good to still run)