### PR TITLE
#31793 Add support for subtracting datetime from Timestamp

### DIFF
--- a/doc/source/whatsnew/v1.4.0.rst
+++ b/doc/source/whatsnew/v1.4.0.rst
@@ -715,6 +715,7 @@ Timezones
 ^^^^^^^^^
 - Bug in :func:`to_datetime` with ``infer_datetime_format=True`` failing to parse zero UTC offset (``Z``) correctly (:issue:`41047`)
 - Bug in :meth:`Series.dt.tz_convert` resetting index in a :class:`Series` with :class:`CategoricalIndex` (:issue:`43080`)
+- Bug in ``Timestamp`` and ``DatetimeIndex`` incorrectly raising a ``TypeError`` when subtracting two timezone-aware objects with mismatched timezones (:issue:`31793`)
 -
 
 Numeric

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -342,10 +342,10 @@ cdef class _Timestamp(ABCTimestamp):
             else:
                 self = type(other)(self)
 
-            # validate tz's
-            if not tz_compare(self.tzinfo, other.tzinfo):
-                raise TypeError("Timestamp subtraction must have the "
-                                "same timezones or no timezones")
+            if (self.tzinfo is None) ^ (other.tzinfo is None):
+                raise TypeError(
+                    "Cannot subtract tz-naive and tz-aware datetime-like objects."
+                )
 
             # scalar Timestamp/datetime - Timestamp/datetime -> yields a
             # Timedelta

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -728,12 +728,11 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
             assert is_datetime64_dtype(other)
             other = type(self)(other)
 
-        if not self._has_same_tz(other):
-            # require tz compat
-            raise TypeError(
-                f"{type(self).__name__} subtraction must have the same "
-                "timezones or no timezones"
-            )
+        try:
+            self._assert_tzawareness_compat(other)
+        except TypeError as error:
+            new_message = str(error).replace("compare", "subtract")
+            raise type(error)(new_message) from error
 
         self_i8 = self.asi8
         other_i8 = other.asi8
@@ -779,11 +778,11 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
         if other is NaT:  # type: ignore[comparison-overlap]
             return self - NaT
 
-        if not self._has_same_tz(other):
-            # require tz compat
-            raise TypeError(
-                "Timestamp subtraction must have the same timezones or no timezones"
-            )
+        try:
+            self._assert_tzawareness_compat(other)
+        except TypeError as error:
+            new_message = str(error).replace("compare", "subtract")
+            raise type(error)(new_message) from error
 
         i8 = self.asi8
         result = checked_add_with_arr(i8, -other.value, arr_mask=self._isnan)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -387,35 +387,29 @@ class TestTimedelta64ArithmeticUnsorted:
         _check(result, expected)
 
         # tz mismatches
-        msg = "Timestamp subtraction must have the same timezones or no timezones"
+        msg = "Cannot subtract tz-naive and tz-aware datetime-like objects."
         with pytest.raises(TypeError, match=msg):
             dt_tz - ts
         msg = "can't subtract offset-naive and offset-aware datetimes"
         with pytest.raises(TypeError, match=msg):
             dt_tz - dt
-        msg = "Timestamp subtraction must have the same timezones or no timezones"
-        with pytest.raises(TypeError, match=msg):
-            dt_tz - ts_tz2
         msg = "can't subtract offset-naive and offset-aware datetimes"
         with pytest.raises(TypeError, match=msg):
             dt - dt_tz
-        msg = "Timestamp subtraction must have the same timezones or no timezones"
+        msg = "Cannot subtract tz-naive and tz-aware datetime-like objects."
         with pytest.raises(TypeError, match=msg):
             ts - dt_tz
         with pytest.raises(TypeError, match=msg):
             ts_tz2 - ts
         with pytest.raises(TypeError, match=msg):
             ts_tz2 - dt
-        with pytest.raises(TypeError, match=msg):
-            ts_tz - ts_tz2
 
+        msg = "Cannot subtract tz-naive and tz-aware"
         # with dti
         with pytest.raises(TypeError, match=msg):
             dti - ts_tz
         with pytest.raises(TypeError, match=msg):
             dti_tz - ts
-        with pytest.raises(TypeError, match=msg):
-            dti_tz - ts_tz2
 
         result = dti_tz - dt_tz
         expected = TimedeltaIndex(["0 days", "1 days", "2 days"])

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -357,13 +357,15 @@ class TestTimedelta64ArithmeticUnsorted:
         expected = DatetimeIndex(["20121231", NaT, "20121230"], name="foo")
         tm.assert_index_equal(result, expected)
 
-    def test_subtraction_ops_with_tz(self):
+    def test_subtraction_ops_with_tz(self, box_with_array):
 
         # check that dt/dti subtraction ops with tz are validated
         dti = pd.date_range("20130101", periods=3)
+        dti = tm.box_expected(dti, box_with_array)
         ts = Timestamp("20130101")
         dt = ts.to_pydatetime()
         dti_tz = pd.date_range("20130101", periods=3).tz_localize("US/Eastern")
+        dti_tz = tm.box_expected(dti_tz, box_with_array)
         ts_tz = Timestamp("20130101").tz_localize("US/Eastern")
         ts_tz2 = Timestamp("20130101").tz_localize("CET")
         dt_tz = ts_tz.to_pydatetime()
@@ -413,19 +415,23 @@ class TestTimedelta64ArithmeticUnsorted:
 
         result = dti_tz - dt_tz
         expected = TimedeltaIndex(["0 days", "1 days", "2 days"])
-        tm.assert_index_equal(result, expected)
+        expected = tm.box_expected(expected, box_with_array)
+        tm.assert_equal(result, expected)
 
         result = dt_tz - dti_tz
         expected = TimedeltaIndex(["0 days", "-1 days", "-2 days"])
-        tm.assert_index_equal(result, expected)
+        expected = tm.box_expected(expected, box_with_array)
+        tm.assert_equal(result, expected)
 
         result = dti_tz - ts_tz
         expected = TimedeltaIndex(["0 days", "1 days", "2 days"])
-        tm.assert_index_equal(result, expected)
+        expected = tm.box_expected(expected, box_with_array)
+        tm.assert_equal(result, expected)
 
         result = ts_tz - dti_tz
         expected = TimedeltaIndex(["0 days", "-1 days", "-2 days"])
-        tm.assert_index_equal(result, expected)
+        expected = tm.box_expected(expected, box_with_array)
+        tm.assert_equal(result, expected)
 
         result = td - td
         expected = Timedelta("0 days")
@@ -433,7 +439,8 @@ class TestTimedelta64ArithmeticUnsorted:
 
         result = dti_tz - td
         expected = DatetimeIndex(["20121231", "20130101", "20130102"], tz="US/Eastern")
-        tm.assert_index_equal(result, expected)
+        expected = tm.box_expected(expected, box_with_array)
+        tm.assert_equal(result, expected)
 
     def test_dti_tdi_numeric_ops(self):
         # These are normally union/diff set-like ops

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -1,6 +1,7 @@
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 
 import numpy as np
@@ -99,7 +100,7 @@ class TestTimestampArithmetic:
         if tz_naive_fixture is None:
             assert other.to_datetime64() - ts == td
         else:
-            msg = "subtraction must have"
+            msg = "Cannot subtract tz-naive and tz-aware datetime-like objects"
             with pytest.raises(TypeError, match=msg):
                 other.to_datetime64() - ts
 
@@ -108,6 +109,37 @@ class TestTimestampArithmetic:
         ts = Timestamp(datetime(2013, 10, 13))
         assert (ts - dt).days == 1
         assert (dt - ts).days == -1
+
+    def test_subtract_tzaware_datetime(self):
+        t1 = Timestamp("2020-10-22T22:00:00+00:00")
+        t2 = datetime(2020, 10, 22, 22, tzinfo=timezone.utc)
+
+        result = t1 - t2
+
+        assert isinstance(result, Timedelta)
+        assert result == Timedelta("0 days")
+
+    def test_subtract_timestamp_from_different_timezone(self):
+        t1 = Timestamp("20130101").tz_localize("US/Eastern")
+        t2 = Timestamp("20130101").tz_localize("CET")
+
+        result = t1 - t2
+
+        assert isinstance(result, Timedelta)
+        assert result == Timedelta("0 days 06:00:00")
+
+    def test_subtracting_involving_datetime_with_different_tz(self):
+        t1 = datetime(2013, 1, 1, tzinfo=timezone(timedelta(hours=-5)))
+        t2 = Timestamp("20130101").tz_localize("CET")
+
+        result = t1 - t2
+
+        assert isinstance(result, Timedelta)
+        assert result == Timedelta("0 days 06:00:00")
+
+        result = t2 - t1
+        assert isinstance(result, Timedelta)
+        assert result == Timedelta("-1 days +18:00:00")
 
     def test_addition_subtraction_types(self):
         # Assert on the types resulting from Timestamp +/- various date/time

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -141,6 +141,16 @@ class TestTimestampArithmetic:
         assert isinstance(result, Timedelta)
         assert result == Timedelta("-1 days +18:00:00")
 
+    def test_subtracting_different_timezones(self, tz_aware_fixture):
+        t_raw = Timestamp("20130101")
+        t_UTC = t_raw.tz_localize("UTC")
+        t_diff = t_UTC.tz_convert(tz_aware_fixture) + Timedelta("0 days 05:00:00")
+
+        result = t_diff - t_UTC
+
+        assert isinstance(result, Timedelta)
+        assert result == Timedelta("0 days 05:00:00")
+
     def test_addition_subtraction_types(self):
         # Assert on the types resulting from Timestamp +/- various date/time
         # objects


### PR DESCRIPTION
- [x] closes #31793
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Based on the discussion in the attached issue, i've made the following changes:

1. add support for subtracting when the two items have different timezones
2. raise an error if one (but not both) timezone is naive

The root cause of 31793 was that the tzinfo objects were from different libraries -- `Timestamp` makes a `pytz.UTC` whereas a datetime object might just have `datetime.timezone.utc`. These objects are not necessarily equal, even if they represent the same timezone.

In addition, this change *adds* support for time-deltas where the timezone of each date is not the same. This follows the behaviour of `datetime` more closely.


I reference the [python `datetime` module documentation](https://docs.python.org/3/library/datetime.html) which defines when a datetime is naive: when its `tzinfo` is `None` or a call to `item.tzinfo.utcoffset(item)` returns `None`.