### PR TITLE
DOC: Remove confusing description from `core.DataFrame.iterrows`

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -971,7 +971,6 @@ class DataFrame(NDFrame, OpsMixin):
         data : Series
             The data of the row as a Series.
 
-
         See Also
         --------
         DataFrame.itertuples : Iterate over DataFrame rows as namedtuples of the values.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -971,8 +971,6 @@ class DataFrame(NDFrame, OpsMixin):
         data : Series
             The data of the row as a Series.
 
-        it : generator
-            A generator that iterates over the rows of the frame.
 
         See Also
         --------


### PR DESCRIPTION
Current [`core.DataFrame.iterrows`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.iterrows.html) is as follows
![image](https://user-images.githubusercontent.com/5734732/96833205-00176c00-147b-11eb-8dc3-6371b2718e76.png)

However, `core.DataFrame.iterrows` actually returns an iterator which yields `(index, data)`, not `(index, data, it)`.
This PRs remove such confusing description like [https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.iteritems.html?highlight=yields]

- [ ] closes #xxxx (no issues found)
- [ ] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
