### PR TITLE
CI/CLN: Add more test file linting

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -178,10 +178,10 @@ if [[ -z "$CHECK" || "$CHECK" == "patterns" ]]; then
     RET=$(($RET + $?)) ; echo $MSG "DONE"
 
     MSG='Check for inconsistent use of pandas namespace in tests' ; echo $MSG
-    check_namespace "Series"
-    RET=$(($RET + $?))
-    check_namespace "DataFrame"
-    RET=$(($RET + $?))
+    for class in "Series" "DataFrame" "Index"; do
+        check_namespace ${class}
+        RET=$(($RET + $?))
+    done
     echo $MSG "DONE"
 fi
 

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -42,7 +42,7 @@ def adjust_negative_zero(zero, expected):
 # TODO: remove this kludge once mypy stops giving false positives here
 # List comprehension has incompatible type List[PandasObject]; expected List[RangeIndex]
 #  See GH#29725
-ser_or_index: List[Any] = [Series, pd.Index]
+ser_or_index: List[Any] = [Series, Index]
 lefts: List[Any] = [pd.RangeIndex(10, 40, 10)]
 lefts.extend(
     [
@@ -100,7 +100,7 @@ class TestNumericComparisons:
     def test_numeric_cmp_string_numexpr_path(self, box_with_array):
         # GH#36377, GH#35700
         box = box_with_array
-        xbox = box if box is not pd.Index else np.ndarray
+        xbox = box if box is not Index else np.ndarray
 
         obj = Series(np.random.randn(10 ** 5))
         obj = tm.box_expected(obj, box, transpose=False)
@@ -126,7 +126,7 @@ class TestNumericComparisons:
 class TestNumericArraylikeArithmeticWithDatetimeLike:
 
     # TODO: also check name retentention
-    @pytest.mark.parametrize("box_cls", [np.array, pd.Index, Series])
+    @pytest.mark.parametrize("box_cls", [np.array, Index, Series])
     @pytest.mark.parametrize(
         "left", lefts, ids=lambda x: type(x).__name__ + str(x.dtype)
     )
@@ -146,7 +146,7 @@ class TestNumericArraylikeArithmeticWithDatetimeLike:
         tm.assert_equal(result, expected)
 
     # TODO: also check name retentention
-    @pytest.mark.parametrize("box_cls", [np.array, pd.Index, Series])
+    @pytest.mark.parametrize("box_cls", [np.array, Index, Series])
     @pytest.mark.parametrize(
         "left", lefts, ids=lambda x: type(x).__name__ + str(x.dtype)
     )
@@ -318,7 +318,7 @@ class TestDivisionByZero:
     def test_div_zero(self, zero, numeric_idx):
         idx = numeric_idx
 
-        expected = pd.Index([np.nan, np.inf, np.inf, np.inf, np.inf], dtype=np.float64)
+        expected = Index([np.nan, np.inf, np.inf, np.inf, np.inf], dtype=np.float64)
         # We only adjust for Index, because Series does not yet apply
         #  the adjustment correctly.
         expected2 = adjust_negative_zero(zero, expected)
@@ -331,7 +331,7 @@ class TestDivisionByZero:
     def test_floordiv_zero(self, zero, numeric_idx):
         idx = numeric_idx
 
-        expected = pd.Index([np.nan, np.inf, np.inf, np.inf, np.inf], dtype=np.float64)
+        expected = Index([np.nan, np.inf, np.inf, np.inf, np.inf], dtype=np.float64)
         # We only adjust for Index, because Series does not yet apply
         #  the adjustment correctly.
         expected2 = adjust_negative_zero(zero, expected)
@@ -344,7 +344,7 @@ class TestDivisionByZero:
     def test_mod_zero(self, zero, numeric_idx):
         idx = numeric_idx
 
-        expected = pd.Index([np.nan, np.nan, np.nan, np.nan, np.nan], dtype=np.float64)
+        expected = Index([np.nan, np.nan, np.nan, np.nan, np.nan], dtype=np.float64)
         result = idx % zero
         tm.assert_index_equal(result, expected)
         ser_compat = Series(idx).astype("i8") % np.array(zero).astype("i8")
@@ -353,8 +353,8 @@ class TestDivisionByZero:
     def test_divmod_zero(self, zero, numeric_idx):
         idx = numeric_idx
 
-        exleft = pd.Index([np.nan, np.inf, np.inf, np.inf, np.inf], dtype=np.float64)
-        exright = pd.Index([np.nan, np.nan, np.nan, np.nan, np.nan], dtype=np.float64)
+        exleft = Index([np.nan, np.inf, np.inf, np.inf, np.inf], dtype=np.float64)
+        exright = Index([np.nan, np.nan, np.nan, np.nan, np.nan], dtype=np.float64)
         exleft = adjust_negative_zero(zero, exleft)
 
         result = divmod(idx, zero)
@@ -368,9 +368,7 @@ class TestDivisionByZero:
             return
         idx = numeric_idx - 3
 
-        expected = pd.Index(
-            [-np.inf, -np.inf, -np.inf, np.nan, np.inf], dtype=np.float64
-        )
+        expected = Index([-np.inf, -np.inf, -np.inf, np.nan, np.inf], dtype=np.float64)
         expected = adjust_negative_zero(zero, expected)
 
         result = op(idx, zero)
@@ -1045,7 +1043,7 @@ class TestUFuncCompat:
         [pd.Int64Index, pd.UInt64Index, pd.Float64Index, pd.RangeIndex, Series],
     )
     def test_ufunc_compat(self, holder):
-        box = Series if holder is Series else pd.Index
+        box = Series if holder is Series else Index
 
         if holder is pd.RangeIndex:
             idx = pd.RangeIndex(0, 5)
@@ -1060,7 +1058,7 @@ class TestUFuncCompat:
     )
     def test_ufunc_coercions(self, holder):
         idx = holder([1, 2, 3, 4, 5], name="x")
-        box = Series if holder is Series else pd.Index
+        box = Series if holder is Series else Index
 
         result = np.sqrt(idx)
         assert result.dtype == "f8" and isinstance(result, box)
@@ -1104,7 +1102,7 @@ class TestUFuncCompat:
     )
     def test_ufunc_multiple_return_values(self, holder):
         obj = holder([1, 2, 3], name="x")
-        box = Series if holder is Series else pd.Index
+        box = Series if holder is Series else Index
 
         result = np.modf(obj)
         assert isinstance(result, tuple)
@@ -1299,14 +1297,14 @@ class TestNumericArithmeticUnsorted:
     def test_addsub_arithmetic(self, dtype, delta):
         # GH#8142
         delta = dtype(delta)
-        index = pd.Index([10, 11, 12], dtype=dtype)
+        index = Index([10, 11, 12], dtype=dtype)
         result = index + delta
-        expected = pd.Index(index.values + delta, dtype=dtype)
+        expected = Index(index.values + delta, dtype=dtype)
         tm.assert_index_equal(result, expected)
 
         # this subtraction used to fail
         result = index - delta
-        expected = pd.Index(index.values - delta, dtype=dtype)
+        expected = Index(index.values - delta, dtype=dtype)
         tm.assert_index_equal(result, expected)
 
         tm.assert_index_equal(index + index, 2 * index)

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -638,7 +638,7 @@ class TestCategoricalConstructors:
     def test_constructor_string_and_tuples(self):
         # GH 21416
         c = pd.Categorical(np.array(["c", ("a", "b"), ("b", "a"), "c"], dtype=object))
-        expected_index = pd.Index([("a", "b"), ("b", "a"), "c"])
+        expected_index = Index([("a", "b"), ("b", "a"), "c"])
         assert c.categories.equals(expected_index)
 
     def test_interval(self):

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -200,6 +200,6 @@ def test_access_by_position(index):
 
 def test_get_indexer_non_unique_dtype_mismatch():
     # GH 25459
-    indexes, missing = pd.Index(["A", "B"]).get_indexer_non_unique(pd.Index([0]))
+    indexes, missing = Index(["A", "B"]).get_indexer_non_unique(Index([0]))
     tm.assert_numpy_array_equal(np.array([-1], dtype=np.intp), indexes)
     tm.assert_numpy_array_equal(np.array([0], dtype=np.intp), missing)

--- a/pandas/tests/base/test_value_counts.py
+++ b/pandas/tests/base/test_value_counts.py
@@ -33,7 +33,7 @@ def test_value_counts(index_or_series_obj):
     expected = Series(dict(counter.most_common()), dtype=np.int64, name=obj.name)
     expected.index = expected.index.astype(obj.dtype)
     if isinstance(obj, pd.MultiIndex):
-        expected.index = pd.Index(expected.index)
+        expected.index = Index(expected.index)
 
     # TODO: Order of entries with the same count is inconsistent on CI (gh-32449)
     if obj.duplicated().any():

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -584,7 +584,7 @@ class TestInference:
 
     def test_maybe_convert_objects_bool_nan(self):
         # GH32146
-        ind = pd.Index([True, False, np.nan], dtype=object)
+        ind = Index([True, False, np.nan], dtype=object)
         exp = np.array([True, False, np.nan], dtype=object)
         out = lib.maybe_convert_objects(ind.values, safe=1)
         tm.assert_numpy_array_equal(out, exp)

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -801,7 +801,7 @@ class TestDataFrameIndexing:
 
     def test_setitem_with_empty_listlike(self):
         # GH #17101
-        index = pd.Index([], name="idx")
+        index = Index([], name="idx")
         result = DataFrame(columns=["A"], index=index)
         result["A"] = []
         expected = DataFrame(columns=["A"], index=index)
@@ -1630,11 +1630,11 @@ class TestDataFrameIndexing:
     @pytest.mark.parametrize("tpl", [tuple([1]), tuple([1, 2])])
     def test_loc_getitem_index_single_double_tuples(self, tpl):
         # GH 20991
-        idx = pd.Index([tuple([1]), tuple([1, 2])], name="A", tupleize_cols=False)
+        idx = Index([tuple([1]), tuple([1, 2])], name="A", tupleize_cols=False)
         df = DataFrame(index=idx)
 
         result = df.loc[[tpl]]
-        idx = pd.Index([tpl], name="A", tupleize_cols=False)
+        idx = Index([tpl], name="A", tupleize_cols=False)
         expected = DataFrame(index=idx)
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/indexing/test_xs.py
+++ b/pandas/tests/frame/indexing/test_xs.py
@@ -3,8 +3,7 @@ import re
 import numpy as np
 import pytest
 
-import pandas as pd
-from pandas import DataFrame, Series
+from pandas import DataFrame, Index, Series
 import pandas._testing as tm
 
 from pandas.tseries.offsets import BDay
@@ -59,7 +58,7 @@ class TestXS:
         # no columns but Index(dtype=object)
         df = DataFrame(index=["a", "b", "c"])
         result = df.xs("a")
-        expected = Series([], name="a", index=pd.Index([]), dtype=np.float64)
+        expected = Series([], name="a", index=Index([]), dtype=np.float64)
         tm.assert_series_equal(result, expected)
 
     def test_xs_duplicates(self):

--- a/pandas/tests/frame/methods/test_align.py
+++ b/pandas/tests/frame/methods/test_align.py
@@ -160,8 +160,8 @@ class TestDataFrameAlign:
         "l_ordered,r_ordered,expected",
         [
             [True, True, pd.CategoricalIndex],
-            [True, False, pd.Index],
-            [False, True, pd.Index],
+            [True, False, Index],
+            [False, True, Index],
             [False, False, pd.CategoricalIndex],
         ],
     )
@@ -196,7 +196,7 @@ class TestDataFrameAlign:
         midx = pd.MultiIndex.from_product(
             [range(2), range(3), range(2)], names=("a", "b", "c")
         )
-        idx = pd.Index(range(2), name="b")
+        idx = Index(range(2), name="b")
         df1 = DataFrame(np.arange(12, dtype="int64"), index=midx)
         df2 = DataFrame(np.arange(2, dtype="int64"), index=idx)
 

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -141,7 +141,7 @@ class TestDataFrameDrop:
         tm.assert_frame_equal(nu_df.drop("b", axis="columns"), nu_df["a"])
         tm.assert_frame_equal(nu_df.drop([]), nu_df)  # GH 16398
 
-        nu_df = nu_df.set_index(pd.Index(["X", "Y", "X"]))
+        nu_df = nu_df.set_index(Index(["X", "Y", "X"]))
         nu_df.columns = list("abc")
         tm.assert_frame_equal(nu_df.drop("X", axis="rows"), nu_df.loc[["Y"], :])
         tm.assert_frame_equal(nu_df.drop(["X", "Y"], axis=0), nu_df.loc[[], :])

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1661,16 +1661,16 @@ class TestDataFrameConstructors:
     def test_constructor_index_names(self, name_in1, name_in2, name_in3, name_out):
         # GH13475
         indices = [
-            pd.Index(["a", "b", "c"], name=name_in1),
-            pd.Index(["b", "c", "d"], name=name_in2),
-            pd.Index(["c", "d", "e"], name=name_in3),
+            Index(["a", "b", "c"], name=name_in1),
+            Index(["b", "c", "d"], name=name_in2),
+            Index(["c", "d", "e"], name=name_in3),
         ]
         series = {
             c: Series([0, 1, 2], index=i) for i, c in zip(indices, ["x", "y", "z"])
         }
         result = DataFrame(series)
 
-        exp_ind = pd.Index(["a", "b", "c", "d", "e"], name=name_out)
+        exp_ind = Index(["a", "b", "c", "d", "e"], name=name_out)
         expected = DataFrame(
             {
                 "x": [0, 1, 2, np.nan, np.nan],

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -280,7 +280,7 @@ class TestDataFrameReshape:
                 ],
                 names=[None, ("A", "a")],
             ),
-            index=pd.Index([1, 2, 3], name=("B", "b")),
+            index=Index([1, 2, 3], name=("B", "b")),
         )
         tm.assert_frame_equal(result, expected)
 
@@ -301,7 +301,7 @@ class TestDataFrameReshape:
             (
                 (("A", "a"), "B"),
                 [[1, 1, 1, 1, 2, 2, 2, 2], [1, 1, 1, 1, 2, 2, 2, 2]],
-                pd.Index([3, 4], name="C"),
+                Index([3, 4], name="C"),
                 pd.MultiIndex.from_tuples(
                     [
                         ("d", "a", 1),
@@ -512,7 +512,7 @@ class TestDataFrameReshape:
                 [[np.nan, 0], [0, np.nan], [np.nan, 0], [0, np.nan]], dtype=np.float64
             ),
             index=expected_mi,
-            columns=pd.Index(["a", "b"], name="third"),
+            columns=Index(["a", "b"], name="third"),
         )
 
         tm.assert_frame_equal(result, expected)
@@ -703,7 +703,7 @@ class TestDataFrameReshape:
                 [[0, 0, 1, 0, 0, 0, 1]],
                 names=["c1", "i2", "i3", "i4", "i5", "i6", "i7"],
             ),
-            index=pd.Index([0], name="i1"),
+            index=Index([0], name="i1"),
         )
         tm.assert_frame_equal(result, expected)
 
@@ -1153,7 +1153,7 @@ def test_unstack_timezone_aware_values():
     result = df.set_index(["a", "b"]).unstack()
     expected = DataFrame(
         [[pd.Timestamp("2017-08-27 01:00:00.709949+0000", tz="UTC"), "c"]],
-        index=pd.Index(["a"], name="a"),
+        index=Index(["a"], name="a"),
         columns=pd.MultiIndex(
             levels=[["timestamp", "c"], ["b"]],
             codes=[[0, 1], [0, 0]],
@@ -1216,7 +1216,7 @@ def test_stack_positional_level_duplicate_column_names():
     df = DataFrame([[1, 1, 1, 1]], columns=columns)
     result = df.stack(0)
 
-    new_columns = pd.Index(["y", "z"], name="a")
+    new_columns = Index(["y", "z"], name="a")
     new_index = pd.MultiIndex.from_tuples([(0, "x"), (0, "y")], names=[None, "a"])
     expected = DataFrame([[1, 1], [1, 1]], index=new_index, columns=new_columns)
 
@@ -1276,7 +1276,7 @@ class TestStackUnstackMultiLevel:
             columns=pd.MultiIndex.from_product(
                 [result_columns[2:], [index_product]], names=[None, "ix2"]
             ),
-            index=pd.Index([2], name="ix1"),
+            index=Index([2], name="ix1"),
         )
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -135,7 +135,7 @@ class TestDataFrameToCSV:
             dt = pd.Timedelta(seconds=1)
             df = DataFrame(
                 {"dt_data": [i * dt for i in range(3)]},
-                index=pd.Index([i * dt for i in range(3)], name="dt_index"),
+                index=Index([i * dt for i in range(3)], name="dt_index"),
             )
             df.to_csv(path)
 
@@ -1310,7 +1310,7 @@ class TestDataFrameToCSV:
 
     def test_to_csv_single_level_multi_index(self):
         # see gh-26303
-        index = pd.Index([(1,), (2,), (3,)])
+        index = Index([(1,), (2,), (3,)])
         df = DataFrame([[1, 2, 3]], columns=index)
         df = df.reindex(columns=[(1,), (3,)])
         expected = ",1,3\n0,1,3\n"

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -132,7 +132,7 @@ def test_agg_apply_corner(ts, tsframe):
     assert ts.dtype == np.float64
 
     # groupby float64 values results in Float64Index
-    exp = Series([], dtype=np.float64, index=pd.Index([], dtype=np.float64))
+    exp = Series([], dtype=np.float64, index=Index([], dtype=np.float64))
     tm.assert_series_equal(grouped.sum(), exp)
     tm.assert_series_equal(grouped.agg(np.sum), exp)
     tm.assert_series_equal(grouped.apply(np.sum), exp, check_index_type=False)
@@ -140,7 +140,7 @@ def test_agg_apply_corner(ts, tsframe):
     # DataFrame
     grouped = tsframe.groupby(tsframe["A"] * np.nan)
     exp_df = DataFrame(
-        columns=tsframe.columns, dtype=float, index=pd.Index([], dtype=np.float64)
+        columns=tsframe.columns, dtype=float, index=Index([], dtype=np.float64)
     )
     tm.assert_frame_equal(grouped.sum(), exp_df, check_names=False)
     tm.assert_frame_equal(grouped.agg(np.sum), exp_df, check_names=False)
@@ -427,7 +427,7 @@ def test_order_aggregate_multiple_funcs():
     res = df.groupby("A").agg(["sum", "max", "mean", "ohlc", "min"])
     result = res.columns.levels[1]
 
-    expected = pd.Index(["sum", "max", "mean", "ohlc", "min"])
+    expected = Index(["sum", "max", "mean", "ohlc", "min"])
 
     tm.assert_index_equal(result, expected)
 
@@ -481,7 +481,7 @@ def test_agg_split_block():
     result = df.groupby("key1").min()
     expected = DataFrame(
         {"key2": ["one", "one"], "key3": ["six", "six"]},
-        index=pd.Index(["a", "b"], name="key1"),
+        index=Index(["a", "b"], name="key1"),
     )
     tm.assert_frame_equal(result, expected)
 
@@ -573,7 +573,7 @@ class TestNamedAggregationDataFrame:
         result = df.groupby("group").agg(a_max=("A", "max"), b_max=("B", "max"))
         expected = DataFrame(
             {"a_max": [1, 3], "b_max": [6, 8]},
-            index=pd.Index(["a", "b"], name="group"),
+            index=Index(["a", "b"], name="group"),
             columns=["a_max", "b_max"],
         )
         tm.assert_frame_equal(result, expected)
@@ -597,7 +597,7 @@ class TestNamedAggregationDataFrame:
                 "b_max": [6, 8],
                 "a_98": [0.98, 2.98],
             },
-            index=pd.Index(["a", "b"], name="group"),
+            index=Index(["a", "b"], name="group"),
             columns=["b_min", "a_min", "a_mean", "a_max", "b_max", "a_98"],
         )
         tm.assert_frame_equal(result, expected)
@@ -608,9 +608,7 @@ class TestNamedAggregationDataFrame:
         )
 
         result = df.groupby("group").agg(**{"my col": ("A", "max")})
-        expected = DataFrame(
-            {"my col": [1, 3]}, index=pd.Index(["a", "b"], name="group")
-        )
+        expected = DataFrame({"my col": [1, 3]}, index=Index(["a", "b"], name="group"))
         tm.assert_frame_equal(result, expected)
 
     def test_duplicate_no_raises(self):
@@ -619,9 +617,7 @@ class TestNamedAggregationDataFrame:
         df = DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
 
         grouped = df.groupby("A").agg(a=("B", "min"), b=("B", "min"))
-        expected = DataFrame(
-            {"a": [1, 3], "b": [1, 3]}, index=pd.Index([0, 1], name="A")
-        )
+        expected = DataFrame({"a": [1, 3], "b": [1, 3]}, index=Index([0, 1], name="A"))
         tm.assert_frame_equal(grouped, expected)
 
         quant50 = functools.partial(np.percentile, q=50)
@@ -636,7 +632,7 @@ class TestNamedAggregationDataFrame:
         )
         expected = DataFrame(
             {"quantile_50": [1.5, 4.0], "quantile_70": [1.7, 4.4]},
-            index=pd.Index(["a", "b"], name="col1"),
+            index=Index(["a", "b"], name="col1"),
         )
         tm.assert_frame_equal(grouped, expected)
 
@@ -682,9 +678,7 @@ class TestNamedAggregationDataFrame:
     def test_mangled(self):
         df = DataFrame({"A": [0, 1], "B": [1, 2], "C": [3, 4]})
         result = df.groupby("A").agg(b=("B", lambda x: 0), c=("C", lambda x: 1))
-        expected = DataFrame(
-            {"b": [0, 0], "c": [1, 1]}, index=pd.Index([0, 1], name="A")
-        )
+        expected = DataFrame({"b": [0, 0], "c": [1, 1]}, index=Index([0, 1], name="A"))
         tm.assert_frame_equal(result, expected)
 
 
@@ -725,7 +719,7 @@ def test_agg_relabel_multiindex_column(
         {"group": ["a", "a", "b", "b"], "A": [0, 1, 2, 3], "B": [5, 6, 7, 8]}
     )
     df.columns = pd.MultiIndex.from_tuples([("x", "group"), ("y", "A"), ("y", "B")])
-    idx = pd.Index(["a", "b"], name=("x", "group"))
+    idx = Index(["a", "b"], name=("x", "group"))
 
     result = df.groupby(("x", "group")).agg(a_max=(("y", "A"), "max"))
     expected = DataFrame({"a_max": [1, 3]}, index=idx)
@@ -763,7 +757,7 @@ def test_agg_relabel_multiindex_duplicates():
     result = df.groupby(("x", "group")).agg(
         a=(("y", "A"), "min"), b=(("y", "A"), "min")
     )
-    idx = pd.Index(["a", "b"], name=("x", "group"))
+    idx = Index(["a", "b"], name=("x", "group"))
     expected = DataFrame({"a": [0, 2], "b": [0, 2]}, index=idx)
     tm.assert_frame_equal(result, expected)
 
@@ -775,7 +769,7 @@ def test_groupby_aggregate_empty_key(kwargs):
     result = df.groupby("a").agg(kwargs)
     expected = DataFrame(
         [1, 4],
-        index=pd.Index([1, 2], dtype="int64", name="a"),
+        index=Index([1, 2], dtype="int64", name="a"),
         columns=pd.MultiIndex.from_tuples([["c", "min"]]),
     )
     tm.assert_frame_equal(result, expected)
@@ -936,7 +930,7 @@ class TestLambdaMangling:
 
         expected = DataFrame(
             {("B", "<lambda_0>"): [0, 0], ("B", "<lambda_1>"): [1, 1]},
-            index=pd.Index([0, 1], name="A"),
+            index=Index([0, 1], name="A"),
         )
         tm.assert_frame_equal(result, expected)
 
@@ -975,7 +969,7 @@ class TestLambdaMangling:
                 "height_max": [9.5, 34.0],
                 "weight_max": [9.9, 198.0],
             },
-            index=pd.Index(["cat", "dog"], name="kind"),
+            index=Index(["cat", "dog"], name="kind"),
             columns=columns,
         )
 
@@ -1022,7 +1016,7 @@ class TestLambdaMangling:
                 "height_max_2": [9.5, 34.0],
                 "weight_min": [7.9, 7.5],
             },
-            index=pd.Index(["cat", "dog"], name="kind"),
+            index=Index(["cat", "dog"], name="kind"),
             columns=columns,
         )
 

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -40,7 +40,7 @@ def test_apply_issues():
     # GH 5789
     # don't auto coerce dates
     df = pd.read_csv(StringIO(s), header=None, names=["date", "time", "value"])
-    exp_idx = pd.Index(
+    exp_idx = Index(
         ["2011.05.16", "2011.05.17", "2011.05.18"], dtype=object, name="date"
     )
     expected = Series(["00:00", "02:00", "02:00"], index=exp_idx)
@@ -886,7 +886,7 @@ def test_apply_multi_level_name(category):
         b = pd.Categorical(b, categories=[1, 2, 3])
         expected_index = pd.CategoricalIndex([1, 2], categories=[1, 2, 3], name="B")
     else:
-        expected_index = pd.Index([1, 2], name="B")
+        expected_index = Index([1, 2], name="B")
     df = DataFrame(
         {"A": np.arange(10), "B": b, "C": list(range(10)), "D": list(range(10))}
     ).set_index(["A", "B"])
@@ -951,7 +951,7 @@ def test_apply_function_returns_non_pandas_non_scalar(function, expected_values)
     # GH 31441
     df = DataFrame(["A", "A", "B", "B"], columns=["groups"])
     result = df.groupby("groups").apply(function)
-    expected = Series(expected_values, index=pd.Index(["A", "B"], name="groups"))
+    expected = Series(expected_values, index=Index(["A", "B"], name="groups"))
     tm.assert_series_equal(result, expected)
 
 
@@ -964,7 +964,7 @@ def test_apply_function_returns_numpy_array():
 
     result = df.groupby("A").apply(fct)
     expected = Series(
-        [[1.0, 2.0], [3.0], [np.nan]], index=pd.Index(["a", "b", "none"], name="A")
+        [[1.0, 2.0], [3.0], [np.nan]], index=Index(["a", "b", "none"], name="A")
     )
     tm.assert_series_equal(result, expected)
 
@@ -975,8 +975,8 @@ def test_apply_function_index_return(function):
     df = DataFrame([1, 2, 2, 2, 1, 2, 3, 1, 3, 1], columns=["id"])
     result = df.groupby("id").apply(function)
     expected = Series(
-        [pd.Index([0, 4, 7, 9]), pd.Index([1, 2, 3, 5]), pd.Index([6, 8])],
-        index=pd.Index([1, 2, 3], name="id"),
+        [Index([0, 4, 7, 9]), Index([1, 2, 3, 5]), Index([6, 8])],
+        index=Index([1, 2, 3], name="id"),
     )
     tm.assert_series_equal(result, expected)
 
@@ -1042,7 +1042,7 @@ def test_apply_is_unchanged_when_other_methods_are_called_first(reduction_func):
 
     expected = DataFrame(
         {"a": [264, 297], "b": [15, 6], "c": [150, 60]},
-        index=pd.Index([88, 99], name="a"),
+        index=Index([88, 99], name="a"),
     )
 
     # Check output when no other methods are called before .apply()
@@ -1072,7 +1072,7 @@ def test_apply_with_date_in_multiindex_does_not_convert_to_timestamp():
             ],
             "C": [1, 2, 3, 4],
         },
-        index=pd.Index([100, 101, 102, 103], name="idx"),
+        index=Index([100, 101, 102, 103], name="idx"),
     )
 
     grp = df.groupby(["A", "B"])

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -1447,7 +1447,7 @@ def test_groupby_agg_categorical_columns(func, expected_values):
     result = df.groupby("groups").agg(func)
 
     expected = DataFrame(
-        {"value": expected_values}, index=pd.Index([0, 1, 2], name="groups")
+        {"value": expected_values}, index=Index([0, 1, 2], name="groups")
     )
     tm.assert_frame_equal(result, expected)
 
@@ -1470,7 +1470,7 @@ def test_groupy_first_returned_categorical_instead_of_dataframe(func):
     df = DataFrame({"A": [1997], "B": Series(["b"], dtype="category").cat.as_ordered()})
     df_grouped = df.groupby("A")["B"]
     result = getattr(df_grouped, func)()
-    expected = Series(["b"], index=pd.Index([1997], name="A"), name="B")
+    expected = Series(["b"], index=Index([1997], name="A"), name="B")
     tm.assert_series_equal(result, expected)
 
 
@@ -1537,9 +1537,7 @@ def test_agg_cython_category_not_implemented_fallback():
     df["col_cat"] = df["col_num"].astype("category")
 
     result = df.groupby("col_num").col_cat.first()
-    expected = Series(
-        [1, 2, 3], index=pd.Index([1, 2, 3], name="col_num"), name="col_cat"
-    )
+    expected = Series([1, 2, 3], index=Index([1, 2, 3], name="col_num"), name="col_cat")
     tm.assert_series_equal(result, expected)
 
     result = df.groupby("col_num").agg({"col_cat": "first"})
@@ -1553,7 +1551,7 @@ def test_aggregate_categorical_lost_index(func: str):
     ds = Series(["b"], dtype="category").cat.as_ordered()
     df = DataFrame({"A": [1997], "B": ds})
     result = df.groupby("A").agg({"B": func})
-    expected = DataFrame({"B": ["b"]}, index=pd.Index([1997], name="A"))
+    expected = DataFrame({"B": ["b"]}, index=Index([1997], name="A"))
     tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -303,7 +303,7 @@ def test_non_cython_api():
     tm.assert_frame_equal(result, expected)
 
     # describe
-    expected_index = pd.Index([1, 3], name="A")
+    expected_index = Index([1, 3], name="A")
     expected_col = pd.MultiIndex(
         levels=[["B"], ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]],
         codes=[[0] * 8, list(range(8))],
@@ -325,7 +325,7 @@ def test_non_cython_api():
             df[df.A == 3].describe().unstack().to_frame().T,
         ]
     )
-    expected.index = pd.Index([0, 1])
+    expected.index = Index([0, 1])
     result = gni.describe()
     tm.assert_frame_equal(result, expected)
 
@@ -933,7 +933,7 @@ def test_frame_describe_unstacked_format():
     ]
     expected = DataFrame(
         data,
-        index=pd.Index([24990, 25499], name="PRICE"),
+        index=Index([24990, 25499], name="PRICE"),
         columns=["count", "mean", "std", "min", "25%", "50%", "75%", "max"],
     )
     tm.assert_frame_equal(result, expected)
@@ -989,7 +989,7 @@ def test_describe_with_duplicate_output_column_names(as_index):
         .T
     )
     expected.columns.names = [None, None]
-    expected.index = pd.Index([88, 99], name="a")
+    expected.index = Index([88, 99], name="a")
 
     if as_index:
         expected = expected.drop(columns=["a"], level=0)
@@ -1027,7 +1027,7 @@ def test_apply_to_nullable_integer_returns_float(values, function):
     # https://github.com/pandas-dev/pandas/issues/32219
     output = 0.5 if function == "var" else 1.5
     arr = np.array([output] * 3, dtype=float)
-    idx = pd.Index([1, 2, 3], dtype=object, name="a")
+    idx = Index([1, 2, 3], dtype=object, name="a")
     expected = DataFrame({"b": arr}, index=idx)
 
     groups = DataFrame(values, dtype="Int64").groupby("a")
@@ -1047,7 +1047,7 @@ def test_groupby_sum_below_mincount_nullable_integer():
     # https://github.com/pandas-dev/pandas/issues/32861
     df = DataFrame({"a": [0, 1, 2], "b": [0, 1, 2], "c": [0, 1, 2]}, dtype="Int64")
     grouped = df.groupby("a")
-    idx = pd.Index([0, 1, 2], dtype=object, name="a")
+    idx = Index([0, 1, 2], dtype=object, name="a")
 
     result = grouped["b"].sum(min_count=2)
     expected = Series([pd.NA] * 3, dtype="Int64", index=idx, name="b")

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1255,7 +1255,7 @@ def test_groupby_nat_exclude():
     )
     grouped = df.groupby("dt")
 
-    expected = [pd.Index([1, 7]), pd.Index([3, 5])]
+    expected = [Index([1, 7]), Index([3, 5])]
     keys = sorted(grouped.groups.keys())
     assert len(keys) == 2
     for k, e in zip(keys, expected):
@@ -1775,7 +1775,7 @@ def test_tuple_as_grouping():
         df[["a", "b", "c"]].groupby(("a", "b"))
 
     result = df.groupby(("a", "b"))["c"].sum()
-    expected = Series([4], name="c", index=pd.Index([1], name=("a", "b")))
+    expected = Series([4], name="c", index=Index([1], name=("a", "b")))
     tm.assert_series_equal(result, expected)
 
 
@@ -1990,7 +1990,7 @@ def test_bool_aggs_dup_column_labels(bool_agg_func):
 
 
 @pytest.mark.parametrize(
-    "idx", [pd.Index(["a", "a"]), pd.MultiIndex.from_tuples((("a", "a"), ("a", "a")))]
+    "idx", [Index(["a", "a"]), pd.MultiIndex.from_tuples((("a", "a"), ("a", "a")))]
 )
 @pytest.mark.filterwarnings("ignore:tshift is deprecated:FutureWarning")
 def test_dup_labels_output_shape(groupby_func, idx):
@@ -2118,7 +2118,7 @@ def test_subsetting_columns_keeps_attrs(klass, attr, value):
 @pytest.mark.parametrize("func", ["sum", "any", "shift"])
 def test_groupby_column_index_name_lost(func):
     # GH: 29764 groupby loses index sometimes
-    expected = pd.Index(["a"], name="idx")
+    expected = Index(["a"], name="idx")
     df = DataFrame([[1]], columns=expected)
     df_grouped = df.groupby([1])
     result = getattr(df_grouped, func)().columns

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -167,7 +167,7 @@ class TestGrouping:
             .sum()
         )
         # reset index changes columns dtype to object
-        expected.columns = pd.Index([0], dtype="int64")
+        expected.columns = Index([0], dtype="int64")
 
         result = df.groupby(
             [pd.Grouper(level="foo", freq="W"), pd.Grouper(level="bar", freq="W")]
@@ -297,7 +297,7 @@ class TestGrouping:
 
         tm.assert_frame_equal(by_levels, by_columns, check_column_type=False)
 
-        by_columns.columns = pd.Index(by_columns.columns, dtype=np.int64)
+        by_columns.columns = Index(by_columns.columns, dtype=np.int64)
         tm.assert_frame_equal(by_levels, by_columns)
 
     def test_groupby_categorical_index_and_columns(self, observed):
@@ -602,7 +602,7 @@ class TestGrouping:
 
         # Grouper in a list grouping
         result = df.groupby([grouper])
-        expected = {pd.Timestamp("2011-01-01"): pd.Index(list(range(364)))}
+        expected = {pd.Timestamp("2011-01-01"): Index(list(range(364)))}
         tm.assert_dict_equal(result.groups, expected)
 
         # Test case without a list
@@ -787,7 +787,7 @@ class TestGetGroup:
         df = DataFrame({"a": list("abssbab")})
         tm.assert_frame_equal(df.groupby("a").get_group("a"), df.iloc[[0, 5]])
         # GH 13530
-        exp = DataFrame(index=pd.Index(["a", "b", "s"], name="a"))
+        exp = DataFrame(index=Index(["a", "b", "s"], name="a"))
         tm.assert_frame_equal(df.groupby("a").count(), exp)
         tm.assert_frame_equal(df.groupby("a").sum(), exp)
         tm.assert_frame_equal(df.groupby("a").nth(1), exp)

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -66,7 +66,7 @@ def test_first_last_with_na_object(method, nulls_fixture):
         values = [2, 3]
 
     values = np.array(values, dtype=result["b"].dtype)
-    idx = pd.Index([1, 2], name="a")
+    idx = Index([1, 2], name="a")
     expected = DataFrame({"b": values}, index=idx)
 
     tm.assert_frame_equal(result, expected)
@@ -84,7 +84,7 @@ def test_nth_with_na_object(index, nulls_fixture):
         values = [2, nulls_fixture]
 
     values = np.array(values, dtype=result["b"].dtype)
-    idx = pd.Index([1, 2], name="a")
+    idx = Index([1, 2], name="a")
     expected = DataFrame({"b": values}, index=idx)
 
     tm.assert_frame_equal(result, expected)
@@ -398,7 +398,7 @@ def test_first_last_tz_multi_column(method, ts, alpha):
             ),
             "datetimetz": [ts, Timestamp("2013-01-03", tz="US/Eastern")],
         },
-        index=pd.Index([1, 2], name="group"),
+        index=Index([1, 2], name="group"),
     )
     tm.assert_frame_equal(result, expected)
 
@@ -496,9 +496,7 @@ def test_groupby_head_tail():
     tm.assert_frame_equal(df.loc[[0, 2]], g_not_as.head(1))
     tm.assert_frame_equal(df.loc[[1, 2]], g_not_as.tail(1))
 
-    empty_not_as = DataFrame(
-        columns=df.columns, index=pd.Index([], dtype=df.index.dtype)
-    )
+    empty_not_as = DataFrame(columns=df.columns, index=Index([], dtype=df.index.dtype))
     empty_not_as["A"] = empty_not_as["A"].astype(df.A.dtype)
     empty_not_as["B"] = empty_not_as["B"].astype(df.B.dtype)
     tm.assert_frame_equal(empty_not_as, g_not_as.head(0))

--- a/pandas/tests/groupby/test_pipe.py
+++ b/pandas/tests/groupby/test_pipe.py
@@ -64,7 +64,7 @@ def test_pipe_args():
     result = df.groupby("group").pipe(f, 0).pipe(g, 10).pipe(h, 100)
 
     # Assert the results here
-    index = pd.Index(["A", "B", "C"], name="group")
+    index = Index(["A", "B", "C"], name="group")
     expected = pd.Series([-79.5160891089, -78.4839108911, -80], index=index)
 
     tm.assert_series_equal(expected, result)

--- a/pandas/tests/indexes/base_class/test_reshape.py
+++ b/pandas/tests/indexes/base_class/test_reshape.py
@@ -3,7 +3,6 @@ Tests for ndarray-like method on the base Index class
 """
 import pytest
 
-import pandas as pd
 from pandas import Index
 import pandas._testing as tm
 
@@ -11,8 +10,8 @@ import pandas._testing as tm
 class TestReshape:
     def test_repeat(self):
         repeats = 2
-        index = pd.Index([1, 2, 3])
-        expected = pd.Index([1, 1, 2, 2, 3, 3])
+        index = Index([1, 2, 3])
+        expected = Index([1, 1, 2, 2, 3, 3])
 
         result = index.repeat(repeats)
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/base_class/test_setops.py
+++ b/pandas/tests/indexes/base_class/test_setops.py
@@ -12,14 +12,14 @@ class TestIndexSetOps:
         "method", ["union", "intersection", "difference", "symmetric_difference"]
     )
     def test_setops_disallow_true(self, method):
-        idx1 = pd.Index(["a", "b"])
-        idx2 = pd.Index(["b", "c"])
+        idx1 = Index(["a", "b"])
+        idx2 = Index(["b", "c"])
 
         with pytest.raises(ValueError, match="The 'sort' keyword only takes"):
             getattr(idx1, method)(idx2, sort=True)
 
     def test_setops_preserve_object_dtype(self):
-        idx = pd.Index([1, 2, 3], dtype=object)
+        idx = Index([1, 2, 3], dtype=object)
         result = idx.intersection(idx[1:])
         expected = idx[1:]
         tm.assert_index_equal(result, expected)
@@ -67,7 +67,7 @@ class TestIndexSetOps:
 
     def test_union_sort_other_incomparable(self):
         # https://github.com/pandas-dev/pandas/issues/24959
-        idx = pd.Index([1, pd.Timestamp("2000")])
+        idx = Index([1, pd.Timestamp("2000")])
         # default (sort=None)
         with tm.assert_produces_warning(RuntimeWarning):
             result = idx.union(idx[:1])
@@ -87,7 +87,7 @@ class TestIndexSetOps:
     def test_union_sort_other_incomparable_true(self):
         # TODO decide on True behaviour
         # sort=True
-        idx = pd.Index([1, pd.Timestamp("2000")])
+        idx = Index([1, pd.Timestamp("2000")])
         with pytest.raises(TypeError, match=".*"):
             idx.union(idx[:1], sort=True)
 
@@ -112,12 +112,12 @@ class TestIndexSetOps:
         assert tm.equalContents(result, second)
 
     def test_intersect_nosort(self):
-        result = pd.Index(["c", "b", "a"]).intersection(["b", "a"])
-        expected = pd.Index(["b", "a"])
+        result = Index(["c", "b", "a"]).intersection(["b", "a"])
+        expected = Index(["b", "a"])
         tm.assert_index_equal(result, expected)
 
     def test_intersection_equal_sort(self):
-        idx = pd.Index(["c", "a", "b"])
+        idx = Index(["c", "a", "b"])
         tm.assert_index_equal(idx.intersection(idx, sort=False), idx)
         tm.assert_index_equal(idx.intersection(idx, sort=None), idx)
 

--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -42,7 +42,7 @@ class TestCategoricalIndex(Base):
     def test_disallow_addsub_ops(self, func, op_name):
         # GH 10039
         # set ops (+/-) raise TypeError
-        idx = pd.Index(pd.Categorical(["a", "b"]))
+        idx = Index(pd.Categorical(["a", "b"]))
         cat_or_list = "'(Categorical|list)' and '(Categorical|list)'"
         msg = "|".join(
             [

--- a/pandas/tests/indexes/categorical/test_map.py
+++ b/pandas/tests/indexes/categorical/test_map.py
@@ -64,13 +64,13 @@ class TestMap:
 
     def test_map_with_categorical_series(self):
         # GH 12756
-        a = pd.Index([1, 2, 3, 4])
+        a = Index([1, 2, 3, 4])
         b = pd.Series(["even", "odd", "even", "odd"], dtype="category")
         c = pd.Series(["even", "odd", "even", "odd"])
 
         exp = CategoricalIndex(["odd", "even", "odd", np.nan])
         tm.assert_index_equal(a.map(b), exp)
-        exp = pd.Index(["odd", "even", "odd", np.nan])
+        exp = Index(["odd", "even", "odd", np.nan])
         tm.assert_index_equal(a.map(c), exp)
 
     @pytest.mark.parametrize(
@@ -91,5 +91,5 @@ class TestMap:
             expected = pd.Categorical([False, False, np.nan])
             tm.assert_categorical_equal(result, expected)
         else:
-            expected = pd.Index([False, False, np.nan])
+            expected = Index([False, False, np.nan])
             tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -93,15 +93,15 @@ class Base:
         expected = self.create_index()
         if not isinstance(expected, MultiIndex):
             expected.name = "foo"
-            result = pd.Index(expected)
+            result = Index(expected)
             tm.assert_index_equal(result, expected)
 
-            result = pd.Index(expected, name="bar")
+            result = Index(expected, name="bar")
             expected.name = "bar"
             tm.assert_index_equal(result, expected)
         else:
             expected.names = ["foo", "bar"]
-            result = pd.Index(expected)
+            result = Index(expected)
             tm.assert_index_equal(
                 result,
                 Index(
@@ -120,7 +120,7 @@ class Base:
                 ),
             )
 
-            result = pd.Index(expected, names=["A", "B"])
+            result = Index(expected, names=["A", "B"])
             tm.assert_index_equal(
                 result,
                 Index(
@@ -410,12 +410,12 @@ class Base:
     def test_repeat(self):
         rep = 2
         i = self.create_index()
-        expected = pd.Index(i.values.repeat(rep), name=i.name)
+        expected = Index(i.values.repeat(rep), name=i.name)
         tm.assert_index_equal(i.repeat(rep), expected)
 
         i = self.create_index()
         rep = np.arange(len(i))
-        expected = pd.Index(i.values.repeat(rep), name=i.name)
+        expected = Index(i.values.repeat(rep), name=i.name)
         tm.assert_index_equal(i.repeat(rep), expected)
 
     def test_numpy_repeat(self):
@@ -441,7 +441,7 @@ class Base:
         tm.assert_index_equal(result, expected)
 
         cond = [False] + [True] * len(i[1:])
-        expected = pd.Index([i._na_value] + i[1:].tolist(), dtype=i.dtype)
+        expected = Index([i._na_value] + i[1:].tolist(), dtype=i.dtype)
         result = i.where(klass(cond))
         tm.assert_index_equal(result, expected)
 
@@ -824,7 +824,7 @@ class Base:
         tm.assert_index_equal(result, expected)
 
         # empty mappable
-        expected = pd.Index([np.nan] * len(index))
+        expected = Index([np.nan] * len(index))
         result = index.map(mapper(expected, index))
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -179,7 +179,7 @@ class TestDatetimeIndex:
             Timestamp("2013-03-31", tz=tz),
             Timestamp("2013-04-30", tz=tz),
         ]
-        expected = pd.Index(expected_list, dtype=object, name="idx")
+        expected = Index(expected_list, dtype=object, name="idx")
         result = idx.astype(object)
         tm.assert_index_equal(result, expected)
         assert idx.tolist() == expected_list
@@ -195,7 +195,7 @@ class TestDatetimeIndex:
             pd.NaT,
             Timestamp("2013-01-04"),
         ]
-        expected = pd.Index(expected_list, dtype=object, name="idx")
+        expected = Index(expected_list, dtype=object, name="idx")
         result = idx.astype(object)
         tm.assert_index_equal(result, expected)
         assert idx.tolist() == expected_list
@@ -269,7 +269,7 @@ class TestDatetimeIndex:
     def test_integer_index_astype_datetime(self, tz, dtype):
         # GH 20997, 20964, 24559
         val = [pd.Timestamp("2018-01-01", tz=tz).value]
-        result = pd.Index(val, name="idx").astype(dtype)
+        result = Index(val, name="idx").astype(dtype)
         expected = pd.DatetimeIndex(["2018-01-01"], tz=tz, name="idx")
         tm.assert_index_equal(result, expected)
 
@@ -304,7 +304,7 @@ class TestAstype:
     def test_astype_array_fallback(self, tz):
         obj = pd.date_range("2000", periods=2, tz=tz, name="idx")
         result = obj.astype(bool)
-        expected = pd.Index(np.array([True, True]), name="idx")
+        expected = Index(np.array([True, True]), name="idx")
         tm.assert_index_equal(result, expected)
 
         result = obj._data.astype(bool)

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -464,12 +464,12 @@ class TestDatetimeIndex:
 
     def test_construction_base_constructor(self):
         arr = [pd.Timestamp("2011-01-01"), pd.NaT, pd.Timestamp("2011-01-03")]
-        tm.assert_index_equal(pd.Index(arr), pd.DatetimeIndex(arr))
-        tm.assert_index_equal(pd.Index(np.array(arr)), pd.DatetimeIndex(np.array(arr)))
+        tm.assert_index_equal(Index(arr), pd.DatetimeIndex(arr))
+        tm.assert_index_equal(Index(np.array(arr)), pd.DatetimeIndex(np.array(arr)))
 
         arr = [np.nan, pd.NaT, pd.Timestamp("2011-01-03")]
-        tm.assert_index_equal(pd.Index(arr), pd.DatetimeIndex(arr))
-        tm.assert_index_equal(pd.Index(np.array(arr)), pd.DatetimeIndex(np.array(arr)))
+        tm.assert_index_equal(Index(arr), pd.DatetimeIndex(arr))
+        tm.assert_index_equal(Index(np.array(arr)), pd.DatetimeIndex(np.array(arr)))
 
     def test_construction_outofbounds(self):
         # GH 13663
@@ -856,7 +856,7 @@ class TestDatetimeIndex:
             pd.DatetimeIndex(["2000"], dtype="datetime64")
 
         with pytest.raises(ValueError, match=msg):
-            pd.Index(["2000"], dtype="datetime64")
+            Index(["2000"], dtype="datetime64")
 
     def test_constructor_wrong_precision_raises(self):
         msg = "Unexpected value for 'dtype': 'datetime64\\[us\\]'"

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -375,7 +375,7 @@ class TestDatetime64:
     def test_nanosecond_field(self):
         dti = DatetimeIndex(np.arange(10))
 
-        tm.assert_index_equal(dti.nanosecond, pd.Index(np.arange(10, dtype=np.int64)))
+        tm.assert_index_equal(dti.nanosecond, Index(np.arange(10, dtype=np.int64)))
 
 
 def test_iter_readonly():

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -349,7 +349,7 @@ class TestDatetimeIndexOps:
         assert not idx.equals(Series(idx3))
 
         # check that we do not raise when comparing with OutOfBounds objects
-        oob = pd.Index([datetime(2500, 1, 1)] * 3, dtype=object)
+        oob = Index([datetime(2500, 1, 1)] * 3, dtype=object)
         assert not idx.equals(oob)
         assert not idx2.equals(oob)
         assert not idx3.equals(oob)

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -201,7 +201,7 @@ class TestDatetimeIndexSetOps:
 
         third = Index(["a", "b", "c"])
         result = first.intersection(third)
-        expected = pd.Index([], dtype=object)
+        expected = Index([], dtype=object)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(

--- a/pandas/tests/indexes/multi/test_analytics.py
+++ b/pandas/tests/indexes/multi/test_analytics.py
@@ -127,9 +127,9 @@ def test_append_mixed_dtypes():
             [1, 2, 3, "x", "y", "z"],
             [1.1, np.nan, 3.3, "x", "y", "z"],
             ["a", "b", "c", "x", "y", "z"],
-            dti.append(pd.Index(["x", "y", "z"])),
-            dti_tz.append(pd.Index(["x", "y", "z"])),
-            pi.append(pd.Index(["x", "y", "z"])),
+            dti.append(Index(["x", "y", "z"])),
+            dti_tz.append(Index(["x", "y", "z"])),
+            pi.append(Index(["x", "y", "z"])),
         ]
     )
     tm.assert_index_equal(res, exp)
@@ -203,7 +203,7 @@ def test_map_dictlike(idx, mapper):
     tm.assert_index_equal(result, expected)
 
     # empty mappable
-    expected = pd.Index([np.nan] * len(idx))
+    expected = Index([np.nan] * len(idx))
     result = idx.map(mapper(expected, idx))
     tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -402,9 +402,9 @@ def test_tuples_with_name_string():
     li = [(0, 0, 1), (0, 1, 0), (1, 0, 0)]
     msg = "Names should be list-like for a MultiIndex"
     with pytest.raises(ValueError, match=msg):
-        pd.Index(li, name="abc")
+        Index(li, name="abc")
     with pytest.raises(ValueError, match=msg):
-        pd.Index(li, name="a")
+        Index(li, name="a")
 
 
 def test_from_tuples_with_tuple_label():
@@ -429,7 +429,7 @@ def test_from_product_empty_zero_levels():
 
 def test_from_product_empty_one_level():
     result = MultiIndex.from_product([[]], names=["A"])
-    expected = pd.Index([], name="A")
+    expected = Index([], name="A")
     tm.assert_index_equal(result.levels[0], expected)
     assert result.names == ["A"]
 
@@ -597,7 +597,7 @@ def test_create_index_existing_name(idx):
     # specified, the new index should inherit the previous object name
     index = idx
     index.names = ["foo", "bar"]
-    result = pd.Index(index)
+    result = Index(index)
     expected = Index(
         Index(
             [
@@ -613,7 +613,7 @@ def test_create_index_existing_name(idx):
     )
     tm.assert_index_equal(result, expected)
 
-    result = pd.Index(index, name="A")
+    result = Index(index, name="A")
     expected = Index(
         Index(
             [
@@ -652,7 +652,7 @@ def test_from_frame():
         Series([1, 2, 3, 4]),
         [1, 2, 3, 4],
         [[1, 2], [3, 4], [5, 6]],
-        pd.Index([1, 2, 3, 4]),
+        Index([1, 2, 3, 4]),
         np.array([[1, 2], [3, 4], [5, 6]]),
         27,
     ],

--- a/pandas/tests/indexes/multi/test_get_level_values.py
+++ b/pandas/tests/indexes/multi/test_get_level_values.py
@@ -44,11 +44,11 @@ def test_get_level_values_all_na():
     arrays = [[np.nan, np.nan, np.nan], ["a", np.nan, 1]]
     index = pd.MultiIndex.from_arrays(arrays)
     result = index.get_level_values(0)
-    expected = pd.Index([np.nan, np.nan, np.nan], dtype=np.float64)
+    expected = Index([np.nan, np.nan, np.nan], dtype=np.float64)
     tm.assert_index_equal(result, expected)
 
     result = index.get_level_values(1)
-    expected = pd.Index(["a", np.nan, 1], dtype=object)
+    expected = Index(["a", np.nan, 1], dtype=object)
     tm.assert_index_equal(result, expected)
 
 
@@ -71,11 +71,11 @@ def test_get_level_values_na():
     arrays = [[np.nan, np.nan, np.nan], ["a", np.nan, 1]]
     index = pd.MultiIndex.from_arrays(arrays)
     result = index.get_level_values(0)
-    expected = pd.Index([np.nan, np.nan, np.nan])
+    expected = Index([np.nan, np.nan, np.nan])
     tm.assert_index_equal(result, expected)
 
     result = index.get_level_values(1)
-    expected = pd.Index(["a", np.nan, 1])
+    expected = Index(["a", np.nan, 1])
     tm.assert_index_equal(result, expected)
 
     arrays = [["a", "b", "b"], pd.DatetimeIndex([0, 1, pd.NaT])]
@@ -87,7 +87,7 @@ def test_get_level_values_na():
     arrays = [[], []]
     index = pd.MultiIndex.from_arrays(arrays)
     result = index.get_level_values(0)
-    expected = pd.Index([], dtype=object)
+    expected = Index([], dtype=object)
     tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -461,10 +461,10 @@ def test_getitem_group_select(idx):
     assert sorted_idx.get_loc("foo") == slice(0, 2)
 
 
-@pytest.mark.parametrize("ind1", [[True] * 5, pd.Index([True] * 5)])
+@pytest.mark.parametrize("ind1", [[True] * 5, Index([True] * 5)])
 @pytest.mark.parametrize(
     "ind2",
-    [[True, False, True, False, False], pd.Index([True, False, True, False, False])],
+    [[True, False, True, False, False], Index([True, False, True, False, False])],
 )
 def test_getitem_bool_index_all(ind1, ind2):
     # GH#22533
@@ -475,8 +475,8 @@ def test_getitem_bool_index_all(ind1, ind2):
     tm.assert_index_equal(idx[ind2], expected)
 
 
-@pytest.mark.parametrize("ind1", [[True], pd.Index([True])])
-@pytest.mark.parametrize("ind2", [[False], pd.Index([False])])
+@pytest.mark.parametrize("ind1", [[True], Index([True])])
+@pytest.mark.parametrize("ind2", [[False], Index([False])])
 def test_getitem_bool_index_single(ind1, ind2):
     # GH#22533
     idx = MultiIndex.from_tuples([(10, 1)])

--- a/pandas/tests/indexes/multi/test_join.py
+++ b/pandas/tests/indexes/multi/test_join.py
@@ -52,7 +52,7 @@ def test_join_self(idx, join_type):
 def test_join_multi():
     # GH 10665
     midx = pd.MultiIndex.from_product([np.arange(4), np.arange(4)], names=["a", "b"])
-    idx = pd.Index([1, 2, 5], name="b")
+    idx = Index([1, 2, 5], name="b")
 
     # inner
     jidx, lidx, ridx = midx.join(idx, how="inner", return_indexers=True)

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -105,7 +105,7 @@ class TestRangeIndex(Numeric):
             tm.assert_index_equal(result, expected)
 
         result = RangeIndex(5).insert(1, pd.NaT)
-        expected = pd.Index([0, pd.NaT, 1, 2, 3, 4], dtype=object)
+        expected = Index([0, pd.NaT, 1, 2, 3, 4], dtype=object)
         tm.assert_index_equal(result, expected)
 
     def test_delete(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -108,9 +108,9 @@ class TestIndex(Base):
     )
     def test_constructor_from_index_dtlike(self, cast_as_obj, index):
         if cast_as_obj:
-            result = pd.Index(index.astype(object))
+            result = Index(index.astype(object))
         else:
-            result = pd.Index(index)
+            result = Index(index)
 
         tm.assert_index_equal(result, index)
 
@@ -121,7 +121,7 @@ class TestIndex(Base):
                 #  incorrectly raise ValueError, and that nanoseconds are not
                 #  dropped
                 index += pd.Timedelta(nanoseconds=50)
-                result = pd.Index(index, dtype=object)
+                result = Index(index, dtype=object)
                 assert result.dtype == np.object_
                 assert list(result) == list(index)
 
@@ -137,7 +137,7 @@ class TestIndex(Base):
         ],
     )
     def test_constructor_from_series_dtlike(self, index, has_tz):
-        result = pd.Index(Series(index))
+        result = Index(Series(index))
         tm.assert_index_equal(result, index)
 
         if has_tz:
@@ -195,8 +195,8 @@ class TestIndex(Base):
             def __array__(self, dtype=None) -> np.ndarray:
                 return self.array
 
-        expected = pd.Index(array)
-        result = pd.Index(ArrayLike(array))
+        expected = Index(array)
+        result = Index(ArrayLike(array))
         tm.assert_index_equal(result, expected)
 
     def test_constructor_int_dtype_nan(self):
@@ -216,8 +216,8 @@ class TestIndex(Base):
 
     def test_constructor_no_pandas_array(self):
         ser = Series([1, 2, 3])
-        result = pd.Index(ser.array)
-        expected = pd.Index([1, 2, 3])
+        result = Index(ser.array)
+        expected = Index([1, 2, 3])
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize(
@@ -338,7 +338,7 @@ class TestIndex(Base):
             assert isinstance(index, TimedeltaIndex)
 
     @pytest.mark.parametrize("attr", ["values", "asi8"])
-    @pytest.mark.parametrize("klass", [pd.Index, pd.DatetimeIndex])
+    @pytest.mark.parametrize("klass", [Index, pd.DatetimeIndex])
     def test_constructor_dtypes_datetime(self, tz_naive_fixture, attr, klass):
         # Test constructing with a datetimetz dtype
         # .values produces numpy datetimes, so these are considered naive
@@ -375,7 +375,7 @@ class TestIndex(Base):
         tm.assert_index_equal(result, index)
 
     @pytest.mark.parametrize("attr", ["values", "asi8"])
-    @pytest.mark.parametrize("klass", [pd.Index, pd.TimedeltaIndex])
+    @pytest.mark.parametrize("klass", [Index, pd.TimedeltaIndex])
     def test_constructor_dtypes_timedelta(self, attr, klass):
         index = pd.timedelta_range("1 days", periods=5)
         index = index._with_freq(None)  # wont be preserved by constructors
@@ -706,8 +706,8 @@ class TestIndex(Base):
     @pytest.mark.xfail(reason="Not implemented")
     def test_intersection_equal_sort_true(self):
         # TODO decide on True behaviour
-        idx = pd.Index(["c", "a", "b"])
-        sorted_ = pd.Index(["a", "b", "c"])
+        idx = Index(["c", "a", "b"])
+        sorted_ = Index(["a", "b", "c"])
         tm.assert_index_equal(idx.intersection(idx, sort=True), sorted_)
 
     def test_chained_union(self, sort):
@@ -741,7 +741,7 @@ class TestIndex(Base):
     def test_union_sort_other_special(self, slice_):
         # https://github.com/pandas-dev/pandas/issues/24959
 
-        idx = pd.Index([1, 0, 2])
+        idx = Index([1, 0, 2])
         # default, sort=None
         other = idx[slice_]
         tm.assert_index_equal(idx.union(other), idx)
@@ -755,12 +755,12 @@ class TestIndex(Base):
     def test_union_sort_special_true(self, slice_):
         # TODO decide on True behaviour
         # sort=True
-        idx = pd.Index([1, 0, 2])
+        idx = Index([1, 0, 2])
         # default, sort=None
         other = idx[slice_]
 
         result = idx.union(other, sort=True)
-        expected = pd.Index([0, 1, 2])
+        expected = Index([0, 1, 2])
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("klass", [np.array, Series, list])
@@ -1016,13 +1016,13 @@ class TestIndex(Base):
 
     @pytest.mark.parametrize("opname", ["difference", "symmetric_difference"])
     def test_difference_incomparable(self, opname):
-        a = pd.Index([3, pd.Timestamp("2000"), 1])
-        b = pd.Index([2, pd.Timestamp("1999"), 1])
+        a = Index([3, pd.Timestamp("2000"), 1])
+        b = Index([2, pd.Timestamp("1999"), 1])
         op = operator.methodcaller(opname, b)
 
         # sort=None, the default
         result = op(a)
-        expected = pd.Index([3, pd.Timestamp("2000"), 2, pd.Timestamp("1999")])
+        expected = Index([3, pd.Timestamp("2000"), 2, pd.Timestamp("1999")])
         if opname == "difference":
             expected = expected[:2]
         tm.assert_index_equal(result, expected)
@@ -1037,8 +1037,8 @@ class TestIndex(Base):
     def test_difference_incomparable_true(self, opname):
         # TODO decide on True behaviour
         # # sort=True, raises
-        a = pd.Index([3, pd.Timestamp("2000"), 1])
-        b = pd.Index([2, pd.Timestamp("1999"), 1])
+        a = Index([3, pd.Timestamp("2000"), 1])
+        b = Index([2, pd.Timestamp("1999"), 1])
         op = operator.methodcaller(opname, b, sort=True)
 
         with pytest.raises(TypeError, match="Cannot compare"):
@@ -1337,13 +1337,13 @@ class TestIndex(Base):
         ],
     )
     def test_get_indexer_strings(self, method, expected):
-        index = pd.Index(["b", "c"])
+        index = Index(["b", "c"])
         actual = index.get_indexer(["a", "b", "c", "d"], method=method)
 
         tm.assert_numpy_array_equal(actual, expected)
 
     def test_get_indexer_strings_raises(self):
-        index = pd.Index(["b", "c"])
+        index = Index(["b", "c"])
 
         msg = r"unsupported operand type\(s\) for -: 'str' and 'str'"
         with pytest.raises(TypeError, match=msg):
@@ -1375,7 +1375,7 @@ class TestIndex(Base):
         if unique_nulls_fixture is unique_nulls_fixture2:
             return  # skip it, values are not unique
         arr = np.array([unique_nulls_fixture, unique_nulls_fixture2], dtype=object)
-        index = pd.Index(arr, dtype=object)
+        index = Index(arr, dtype=object)
         result = index.get_indexer(
             [unique_nulls_fixture, unique_nulls_fixture2, "Unknown"]
         )
@@ -1384,7 +1384,7 @@ class TestIndex(Base):
 
     @pytest.mark.parametrize("method", [None, "pad", "backfill", "nearest"])
     def test_get_loc(self, method):
-        index = pd.Index([0, 1, 2])
+        index = Index([0, 1, 2])
         assert index.get_loc(1, method=method) == 1
 
         if method:
@@ -1392,7 +1392,7 @@ class TestIndex(Base):
 
     @pytest.mark.parametrize("method", [None, "pad", "backfill", "nearest"])
     def test_get_loc_raises_bad_label(self, method):
-        index = pd.Index([0, 1, 2])
+        index = Index([0, 1, 2])
         if method:
             msg = "not supported between"
         else:
@@ -1405,38 +1405,38 @@ class TestIndex(Base):
         "method,loc", [("pad", 1), ("backfill", 2), ("nearest", 1)]
     )
     def test_get_loc_tolerance(self, method, loc):
-        index = pd.Index([0, 1, 2])
+        index = Index([0, 1, 2])
         assert index.get_loc(1.1, method) == loc
         assert index.get_loc(1.1, method, tolerance=1) == loc
 
     @pytest.mark.parametrize("method", ["pad", "backfill", "nearest"])
     def test_get_loc_outside_tolerance_raises(self, method):
-        index = pd.Index([0, 1, 2])
+        index = Index([0, 1, 2])
         with pytest.raises(KeyError, match="1.1"):
             index.get_loc(1.1, method, tolerance=0.05)
 
     def test_get_loc_bad_tolerance_raises(self):
-        index = pd.Index([0, 1, 2])
+        index = Index([0, 1, 2])
         with pytest.raises(ValueError, match="must be numeric"):
             index.get_loc(1.1, "nearest", tolerance="invalid")
 
     def test_get_loc_tolerance_no_method_raises(self):
-        index = pd.Index([0, 1, 2])
+        index = Index([0, 1, 2])
         with pytest.raises(ValueError, match="tolerance .* valid if"):
             index.get_loc(1.1, tolerance=1)
 
     def test_get_loc_raises_missized_tolerance(self):
-        index = pd.Index([0, 1, 2])
+        index = Index([0, 1, 2])
         with pytest.raises(ValueError, match="tolerance size must match"):
             index.get_loc(1.1, "nearest", tolerance=[1, 1])
 
     def test_get_loc_raises_object_nearest(self):
-        index = pd.Index(["a", "c"])
+        index = Index(["a", "c"])
         with pytest.raises(TypeError, match="unsupported operand type"):
             index.get_loc("a", method="nearest")
 
     def test_get_loc_raises_object_tolerance(self):
-        index = pd.Index(["a", "c"])
+        index = Index(["a", "c"])
         with pytest.raises(TypeError, match="unsupported operand type"):
             index.get_loc("a", method="pad", tolerance="invalid")
 
@@ -1535,7 +1535,7 @@ class TestIndex(Base):
 
         s_start, s_stop = index.slice_locs(in_slice.start, in_slice.stop, in_slice.step)
         result = index[s_start : s_stop : in_slice.step]
-        expected = pd.Index(list(expected))
+        expected = Index(list(expected))
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("index", ["string", "int", "float"], indirect=True)
@@ -1600,8 +1600,8 @@ class TestIndex(Base):
     @pytest.mark.parametrize("to_drop", [[("c", "d"), "a"], ["a", ("c", "d")]])
     def test_drop_tuple(self, values, to_drop):
         # GH 18304
-        index = pd.Index(values)
-        expected = pd.Index(["b"])
+        index = Index(values)
+        expected = Index(["b"])
 
         result = index.drop(to_drop)
         tm.assert_index_equal(result, expected)
@@ -1916,8 +1916,8 @@ class TestIndex(Base):
     def test_indexing_doesnt_change_class(self):
         index = Index([1, 2, 3, "a", "b", "c"])
 
-        assert index[1:3].identical(pd.Index([2, 3], dtype=np.object_))
-        assert index[[0, 1]].identical(pd.Index([1, 2], dtype=np.object_))
+        assert index[1:3].identical(Index([2, 3], dtype=np.object_))
+        assert index[[0, 1]].identical(Index([1, 2], dtype=np.object_))
 
     def test_outer_join_sort(self):
         left_index = Index(np.random.permutation(15))
@@ -1941,23 +1941,23 @@ class TestIndex(Base):
 
     def test_take_fill_value(self):
         # GH 12631
-        index = pd.Index(list("ABC"), name="xxx")
+        index = Index(list("ABC"), name="xxx")
         result = index.take(np.array([1, 0, -1]))
-        expected = pd.Index(list("BAC"), name="xxx")
+        expected = Index(list("BAC"), name="xxx")
         tm.assert_index_equal(result, expected)
 
         # fill_value
         result = index.take(np.array([1, 0, -1]), fill_value=True)
-        expected = pd.Index(["B", "A", np.nan], name="xxx")
+        expected = Index(["B", "A", np.nan], name="xxx")
         tm.assert_index_equal(result, expected)
 
         # allow_fill=False
         result = index.take(np.array([1, 0, -1]), allow_fill=False, fill_value=True)
-        expected = pd.Index(["B", "A", "C"], name="xxx")
+        expected = Index(["B", "A", "C"], name="xxx")
         tm.assert_index_equal(result, expected)
 
     def test_take_fill_value_none_raises(self):
-        index = pd.Index(list("ABC"), name="xxx")
+        index = Index(list("ABC"), name="xxx")
         msg = (
             "When allow_fill=True and fill_value is not None, "
             "all indices must be >= -1"
@@ -1969,7 +1969,7 @@ class TestIndex(Base):
             index.take(np.array([1, 0, -5]), fill_value=True)
 
     def test_take_bad_bounds_raises(self):
-        index = pd.Index(list("ABC"), name="xxx")
+        index = Index(list("ABC"), name="xxx")
         with pytest.raises(IndexError, match="out of bounds"):
             index.take(np.array([1, -5]))
 
@@ -1990,14 +1990,14 @@ class TestIndex(Base):
     )
     def test_reindex_preserves_name_if_target_is_list_or_ndarray(self, name, labels):
         # GH6552
-        index = pd.Index([0, 1, 2])
+        index = Index([0, 1, 2])
         index.name = name
         assert index.reindex(labels)[0].name == name
 
     @pytest.mark.parametrize("labels", [[], np.array([]), np.array([], dtype=np.int64)])
     def test_reindex_preserves_type_if_target_is_empty_list_or_array(self, labels):
         # GH7774
-        index = pd.Index(list("abc"))
+        index = Index(list("abc"))
         assert index.reindex(labels)[0].dtype.type == np.object_
 
     @pytest.mark.parametrize(
@@ -2010,11 +2010,11 @@ class TestIndex(Base):
     )
     def test_reindex_doesnt_preserve_type_if_target_is_empty_index(self, labels, dtype):
         # GH7774
-        index = pd.Index(list("abc"))
+        index = Index(list("abc"))
         assert index.reindex(labels)[0].dtype.type == dtype
 
     def test_reindex_no_type_preserve_target_empty_mi(self):
-        index = pd.Index(list("abc"))
+        index = Index(list("abc"))
         result = index.reindex(
             pd.MultiIndex([pd.Int64Index([]), pd.Float64Index([])], [[], []])
         )[0]
@@ -2024,7 +2024,7 @@ class TestIndex(Base):
     def test_groupby(self):
         index = Index(range(5))
         result = index.groupby(np.array([1, 1, 2, 2, 2]))
-        expected = {1: pd.Index([0, 1]), 2: pd.Index([2, 3, 4])}
+        expected = {1: Index([0, 1]), 2: Index([2, 3, 4])}
 
         tm.assert_dict_equal(result, expected)
 
@@ -2074,7 +2074,7 @@ class TestIndex(Base):
     @pytest.mark.parametrize("dt_conv", [pd.to_datetime, pd.to_timedelta])
     def test_dt_conversion_preserves_name(self, dt_conv):
         # GH 10875
-        index = pd.Index(["01:02:03", "01:02:04"], name="label")
+        index = Index(["01:02:03", "01:02:04"], name="label")
         assert index.name == dt_conv(index).name
 
     @pytest.mark.parametrize(
@@ -2083,12 +2083,12 @@ class TestIndex(Base):
             # ASCII
             # short
             (
-                pd.Index(["a", "bb", "ccc"]),
+                Index(["a", "bb", "ccc"]),
                 """Index(['a', 'bb', 'ccc'], dtype='object')""",
             ),
             # multiple lines
             (
-                pd.Index(["a", "bb", "ccc"] * 10),
+                Index(["a", "bb", "ccc"] * 10),
                 """\
 Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc',
        'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc',
@@ -2097,7 +2097,7 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc',
             ),
             # truncated
             (
-                pd.Index(["a", "bb", "ccc"] * 100),
+                Index(["a", "bb", "ccc"] * 100),
                 """\
 Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
        ...
@@ -2107,12 +2107,12 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
             # Non-ASCII
             # short
             (
-                pd.Index(["あ", "いい", "ううう"]),
+                Index(["あ", "いい", "ううう"]),
                 """Index(['あ', 'いい', 'ううう'], dtype='object')""",
             ),
             # multiple lines
             (
-                pd.Index(["あ", "いい", "ううう"] * 10),
+                Index(["あ", "いい", "ううう"] * 10),
                 (
                     "Index(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', "
                     "'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',\n"
@@ -2125,7 +2125,7 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
             ),
             # truncated
             (
-                pd.Index(["あ", "いい", "ううう"] * 100),
+                Index(["あ", "いい", "ううう"] * 100),
                 (
                     "Index(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', "
                     "'あ', 'いい', 'ううう', 'あ',\n"
@@ -2146,12 +2146,12 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
         [
             # short
             (
-                pd.Index(["あ", "いい", "ううう"]),
+                Index(["あ", "いい", "ううう"]),
                 ("Index(['あ', 'いい', 'ううう'], dtype='object')"),
             ),
             # multiple lines
             (
-                pd.Index(["あ", "いい", "ううう"] * 10),
+                Index(["あ", "いい", "ううう"] * 10),
                 (
                     "Index(['あ', 'いい', 'ううう', 'あ', 'いい', "
                     "'ううう', 'あ', 'いい', 'ううう',\n"
@@ -2166,7 +2166,7 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
             ),
             # truncated
             (
-                pd.Index(["あ", "いい", "ううう"] * 100),
+                Index(["あ", "いい", "ううう"] * 100),
                 (
                     "Index(['あ', 'いい', 'ううう', 'あ', 'いい', "
                     "'ううう', 'あ', 'いい', 'ううう',\n"
@@ -2187,7 +2187,7 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
             assert result == expected
 
     def test_cached_properties_not_settable(self):
-        index = pd.Index([1, 2, 3])
+        index = Index([1, 2, 3])
         with pytest.raises(AttributeError, match="Can't set attribute"):
             index.is_unique = False
 
@@ -2197,7 +2197,7 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
         pytest.importorskip("IPython", minversion="6.0.0")
         from IPython.core.completer import provisionalcompleter
 
-        code = "import pandas as pd; idx = pd.Index([1, 2])"
+        code = "import pandas as pd; idx = Index([1, 2])"
         await ip.run_code(code)
 
         # GH 31324 newer jedi version raises Deprecation warning
@@ -2223,7 +2223,7 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
                 index.contains(1)
 
     def test_sortlevel(self):
-        index = pd.Index([5, 4, 3, 2, 1])
+        index = Index([5, 4, 3, 2, 1])
         with pytest.raises(Exception, match="ascending must be a single bool value or"):
             index.sortlevel(ascending="True")
 
@@ -2235,15 +2235,15 @@ Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
         with pytest.raises(Exception, match="ascending must be a bool value"):
             index.sortlevel(ascending=["True"])
 
-        expected = pd.Index([1, 2, 3, 4, 5])
+        expected = Index([1, 2, 3, 4, 5])
         result = index.sortlevel(ascending=[True])
         tm.assert_index_equal(result[0], expected)
 
-        expected = pd.Index([1, 2, 3, 4, 5])
+        expected = Index([1, 2, 3, 4, 5])
         result = index.sortlevel(ascending=True)
         tm.assert_index_equal(result[0], expected)
 
-        expected = pd.Index([5, 4, 3, 2, 1])
+        expected = Index([5, 4, 3, 2, 1])
         result = index.sortlevel(ascending=False)
         tm.assert_index_equal(result[0], expected)
 
@@ -2296,7 +2296,7 @@ class TestMixedIntIndex(Base):
     def test_copy_name2(self):
         # Check that adding a "name" parameter to the copy is honored
         # GH14302
-        index = pd.Index([1, 2], name="MyName")
+        index = Index([1, 2], name="MyName")
         index1 = index.copy()
 
         tm.assert_index_equal(index, index1)
@@ -2314,8 +2314,8 @@ class TestMixedIntIndex(Base):
         assert index3.names == ["NewName"]
 
     def test_unique_na(self):
-        idx = pd.Index([2, np.nan, 2, 1], name="my_index")
-        expected = pd.Index([2, np.nan, 1], name="my_index")
+        idx = Index([2, np.nan, 2, 1], name="my_index")
+        expected = Index([2, np.nan, 1], name="my_index")
         result = idx.unique()
         tm.assert_index_equal(result, expected)
 
@@ -2338,9 +2338,9 @@ class TestMixedIntIndex(Base):
     )
     def test_dropna(self, how, dtype, vals, expected):
         # GH 6194
-        index = pd.Index(vals, dtype=dtype)
+        index = Index(vals, dtype=dtype)
         result = index.dropna(how=how)
-        expected = pd.Index(expected, dtype=dtype)
+        expected = Index(expected, dtype=dtype)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("how", ["any", "all"])
@@ -2380,7 +2380,7 @@ class TestMixedIntIndex(Base):
     def test_dropna_invalid_how_raises(self):
         msg = "invalid how option: xxx"
         with pytest.raises(ValueError, match=msg):
-            pd.Index([1, 2, 3]).dropna(how="xxx")
+            Index([1, 2, 3]).dropna(how="xxx")
 
     def test_get_combined_index(self):
         result = _get_combined_index([])
@@ -2390,10 +2390,10 @@ class TestMixedIntIndex(Base):
     @pytest.mark.parametrize(
         "index",
         [
-            pd.Index([np.nan]),
-            pd.Index([np.nan, 1]),
-            pd.Index([1, 2, np.nan]),
-            pd.Index(["a", "b", np.nan]),
+            Index([np.nan]),
+            Index([np.nan, 1]),
+            Index([1, 2, np.nan]),
+            Index(["a", "b", np.nan]),
             pd.to_datetime(["NaT"]),
             pd.to_datetime(["NaT", "2000-01-01"]),
             pd.to_datetime(["2000-01-01", "NaT", "2000-01-02"]),
@@ -2408,7 +2408,7 @@ class TestMixedIntIndex(Base):
 
     def test_repr_summary(self):
         with cf.option_context("display.max_seq_items", 10):
-            result = repr(pd.Index(np.arange(1000)))
+            result = repr(Index(np.arange(1000)))
             assert len(result) < 200
             assert "..." in result
 
@@ -2519,7 +2519,7 @@ class TestIndexUtils:
 )
 def test_generated_op_names(opname, index):
     if isinstance(index, ABCIndex) and opname == "rsub":
-        # pd.Index.__rsub__ does not exist; though the method does exist
+        # Index.__rsub__ does not exist; though the method does exist
         # for subclasses.  see GH#19723
         return
     opname = f"__{opname}__"
@@ -2537,7 +2537,7 @@ def test_index_subclass_constructor_wrong_kwargs(index_maker):
 def test_deprecated_fastpath():
     msg = "[Uu]nexpected keyword argument"
     with pytest.raises(TypeError, match=msg):
-        pd.Index(np.array(["a", "b"], dtype=object), name="test", fastpath=True)
+        Index(np.array(["a", "b"], dtype=object), name="test", fastpath=True)
 
     with pytest.raises(TypeError, match=msg):
         pd.Int64Index(np.array([1, 2, 3], dtype="int64"), name="test", fastpath=True)
@@ -2555,7 +2555,7 @@ def test_shape_of_invalid_index():
     # about this). However, as long as this is not solved in general,this test ensures
     # that the returned shape is consistent with this underlying array for
     # compat with matplotlib (see https://github.com/pandas-dev/pandas/issues/27775)
-    idx = pd.Index([0, 1, 2, 3])
+    idx = Index([0, 1, 2, 3])
     with tm.assert_produces_warning(FutureWarning):
         # GH#30588 multi-dimensional indexing deprecated
         assert idx[:, None].shape == (4, 1)
@@ -2567,7 +2567,7 @@ def test_validate_1d_input():
 
     arr = np.arange(8).reshape(2, 2, 2)
     with pytest.raises(ValueError, match=msg):
-        pd.Index(arr)
+        Index(arr)
 
     with pytest.raises(ValueError, match=msg):
         pd.Float64Index(arr.astype(np.float64))
@@ -2580,7 +2580,7 @@ def test_validate_1d_input():
 
     df = pd.DataFrame(arr.reshape(4, 2))
     with pytest.raises(ValueError, match=msg):
-        pd.Index(df)
+        Index(df)
 
     # GH#13601 trying to assign a multi-dimensional array to an index is not
     #  allowed
@@ -2622,7 +2622,7 @@ def test_get_indexer_non_unique_wrong_dtype(ldtype, rdtype):
         if dtype is dtlike_dtypes[-1]:
             # PeriodArray will try to cast ints to strings
             return pd.DatetimeIndex(vals).astype(dtype)
-        return pd.Index(vals, dtype=dtype)
+        return Index(vals, dtype=dtype)
 
     left = construct(ldtype)
     right = construct(rdtype)

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -521,7 +521,7 @@ class TestInt64Index(NumericInt):
             Index([-1], dtype=uint_dtype)
 
     def test_constructor_unwraps_index(self):
-        idx = pd.Index([1, 2])
+        idx = Index([1, 2])
         result = pd.Int64Index(idx)
         expected = np.array([1, 2], dtype="int64")
         tm.assert_numpy_array_equal(result._data, expected)
@@ -613,7 +613,7 @@ class TestUInt64Index(NumericInt):
 def test_int_float_union_dtype(dtype):
     # https://github.com/pandas-dev/pandas/issues/26778
     # [u]int | float -> float
-    index = pd.Index([0, 2, 3], dtype=dtype)
+    index = Index([0, 2, 3], dtype=dtype)
     other = pd.Float64Index([0.5, 1.5])
     expected = pd.Float64Index([0.0, 0.5, 1.5, 2.0, 3.0])
     result = index.union(other)
@@ -637,7 +637,7 @@ def test_range_float_union_dtype():
 
 @pytest.mark.parametrize(
     "box",
-    [list, lambda x: np.array(x, dtype=object), lambda x: pd.Index(x, dtype=object)],
+    [list, lambda x: np.array(x, dtype=object), lambda x: Index(x, dtype=object)],
 )
 def test_uint_index_does_not_convert_to_float64(box):
     # https://github.com/pandas-dev/pandas/issues/28279
@@ -667,8 +667,8 @@ def test_uint_index_does_not_convert_to_float64(box):
 
 def test_float64_index_equals():
     # https://github.com/pandas-dev/pandas/issues/35217
-    float_index = pd.Index([1.0, 2, 3])
-    string_index = pd.Index(["1", "2", "3"])
+    float_index = Index([1.0, 2, 3])
+    string_index = Index(["1", "2", "3"])
 
     result = float_index.equals(string_index)
     assert result is False
@@ -679,8 +679,8 @@ def test_float64_index_equals():
 
 def test_float64_index_difference():
     # https://github.com/pandas-dev/pandas/issues/35217
-    float_index = pd.Index([1.0, 2, 3])
-    string_index = pd.Index(["1", "2", "3"])
+    float_index = Index([1.0, 2, 3])
+    string_index = Index(["1", "2", "3"])
 
     result = float_index.difference(string_index)
     tm.assert_index_equal(result, float_index)

--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -117,7 +117,7 @@ class TestTimedeltaIndex:
     def test_astype_array_fallback(self):
         obj = pd.timedelta_range("1H", periods=2)
         result = obj.astype(bool)
-        expected = pd.Index(np.array([True, True]))
+        expected = Index(np.array([True, True]))
         tm.assert_index_equal(result, expected)
 
         result = obj._data.astype(bool)

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -70,7 +70,7 @@ class TestMultiIndexBasic:
         # GH#30892
 
         dti = pd.to_datetime(["20190101", "20190101", "20190102"])
-        idx = pd.Index(["a", "a", "c"])
+        idx = Index(["a", "a", "c"])
         mi = pd.MultiIndex.from_arrays([dti, idx], names=["index1", "index2"])
 
         df = DataFrame({"c1": [1, 2, 3], "c2": [np.nan, np.nan, np.nan]}, index=mi)

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -613,7 +613,7 @@ class TestBlockManager:
 
         reindexed = mgr.reindex_axis(["g", "c", "a", "d"], axis=0)
         assert reindexed.nblocks == 2
-        tm.assert_index_equal(reindexed.items, pd.Index(["g", "c", "a", "d"]))
+        tm.assert_index_equal(reindexed.items, Index(["g", "c", "a", "d"]))
         tm.assert_almost_equal(
             mgr.iget(6).internal_values(), reindexed.iget(0).internal_values()
         )
@@ -636,9 +636,7 @@ class TestBlockManager:
         mgr.iset(5, np.array([1, 2, 3], dtype=np.object_))
 
         numeric = mgr.get_numeric_data()
-        tm.assert_index_equal(
-            numeric.items, pd.Index(["int", "float", "complex", "bool"])
-        )
+        tm.assert_index_equal(numeric.items, Index(["int", "float", "complex", "bool"]))
         tm.assert_almost_equal(
             mgr.iget(mgr.items.get_loc("float")).internal_values(),
             numeric.iget(numeric.items.get_loc("float")).internal_values(),
@@ -652,9 +650,7 @@ class TestBlockManager:
         )
 
         numeric2 = mgr.get_numeric_data(copy=True)
-        tm.assert_index_equal(
-            numeric.items, pd.Index(["int", "float", "complex", "bool"])
-        )
+        tm.assert_index_equal(numeric.items, Index(["int", "float", "complex", "bool"]))
         numeric2.iset(
             numeric2.items.get_loc("float"), np.array([1000.0, 2000.0, 3000.0])
         )
@@ -672,7 +668,7 @@ class TestBlockManager:
         mgr.iset(6, np.array([True, False, True], dtype=np.object_))
 
         bools = mgr.get_bool_data()
-        tm.assert_index_equal(bools.items, pd.Index(["bool"]))
+        tm.assert_index_equal(bools.items, Index(["bool"]))
         tm.assert_almost_equal(
             mgr.iget(mgr.items.get_loc("bool")).internal_values(),
             bools.iget(bools.items.get_loc("bool")).internal_values(),
@@ -840,14 +836,12 @@ class TestIndexing:
             tm.assert_index_equal(reindexed.axes[axis], new_labels)
 
         for ax in range(mgr.ndim):
-            assert_reindex_axis_is_ok(mgr, ax, pd.Index([]), fill_value)
+            assert_reindex_axis_is_ok(mgr, ax, Index([]), fill_value)
             assert_reindex_axis_is_ok(mgr, ax, mgr.axes[ax], fill_value)
             assert_reindex_axis_is_ok(mgr, ax, mgr.axes[ax][[0, 0, 0]], fill_value)
+            assert_reindex_axis_is_ok(mgr, ax, Index(["foo", "bar", "baz"]), fill_value)
             assert_reindex_axis_is_ok(
-                mgr, ax, pd.Index(["foo", "bar", "baz"]), fill_value
-            )
-            assert_reindex_axis_is_ok(
-                mgr, ax, pd.Index(["foo", mgr.axes[ax][0], "baz"]), fill_value
+                mgr, ax, Index(["foo", mgr.axes[ax][0], "baz"]), fill_value
             )
 
             if mgr.shape[ax] >= 3:
@@ -872,14 +866,14 @@ class TestIndexing:
             tm.assert_index_equal(reindexed.axes[axis], new_labels)
 
         for ax in range(mgr.ndim):
-            assert_reindex_indexer_is_ok(mgr, ax, pd.Index([]), [], fill_value)
+            assert_reindex_indexer_is_ok(mgr, ax, Index([]), [], fill_value)
             assert_reindex_indexer_is_ok(
                 mgr, ax, mgr.axes[ax], np.arange(mgr.shape[ax]), fill_value
             )
             assert_reindex_indexer_is_ok(
                 mgr,
                 ax,
-                pd.Index(["foo"] * mgr.shape[ax]),
+                Index(["foo"] * mgr.shape[ax]),
                 np.arange(mgr.shape[ax]),
                 fill_value,
             )
@@ -890,22 +884,22 @@ class TestIndexing:
                 mgr, ax, mgr.axes[ax], np.arange(mgr.shape[ax])[::-1], fill_value
             )
             assert_reindex_indexer_is_ok(
-                mgr, ax, pd.Index(["foo", "bar", "baz"]), [0, 0, 0], fill_value
+                mgr, ax, Index(["foo", "bar", "baz"]), [0, 0, 0], fill_value
             )
             assert_reindex_indexer_is_ok(
-                mgr, ax, pd.Index(["foo", "bar", "baz"]), [-1, 0, -1], fill_value
+                mgr, ax, Index(["foo", "bar", "baz"]), [-1, 0, -1], fill_value
             )
             assert_reindex_indexer_is_ok(
                 mgr,
                 ax,
-                pd.Index(["foo", mgr.axes[ax][0], "baz"]),
+                Index(["foo", mgr.axes[ax][0], "baz"]),
                 [-1, -1, -1],
                 fill_value,
             )
 
             if mgr.shape[ax] >= 3:
                 assert_reindex_indexer_is_ok(
-                    mgr, ax, pd.Index(["foo", "bar", "baz"]), [0, 1, 2], fill_value
+                    mgr, ax, Index(["foo", "bar", "baz"]), [0, 1, 2], fill_value
                 )
 
 
@@ -1215,7 +1209,7 @@ def test_validate_ndim():
 
 
 def test_block_shape():
-    idx = pd.Index([0, 1, 2, 3, 4])
+    idx = Index([0, 1, 2, 3, 4])
     a = Series([1, 2, 3]).reindex(idx)
     b = Series(pd.Categorical([1, 2, 3])).reindex(idx)
 

--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -1167,7 +1167,7 @@ class TestExcelFileRead:
     @pytest.mark.parametrize("filename", ["df_empty.xlsx", "df_equals.xlsx"])
     def test_header_with_index_col(self, engine, filename):
         # GH 33476
-        idx = pd.Index(["Z"], name="I2")
+        idx = Index(["Z"], name="I2")
         cols = pd.MultiIndex.from_tuples(
             [("A", "B"), ("A", "B.1")], names=["I11", "I12"]
         )

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -643,7 +643,7 @@ class TestDataFrameFormatting:
         # index name
         df = DataFrame(
             {"a": ["あああああ", "い", "う", "えええ"], "b": ["あ", "いいい", "う", "ええええええ"]},
-            index=pd.Index(["あ", "い", "うう", "え"], name="おおおお"),
+            index=Index(["あ", "い", "うう", "え"], name="おおおお"),
         )
         expected = (
             "          a       b\n"
@@ -658,7 +658,7 @@ class TestDataFrameFormatting:
         # all
         df = DataFrame(
             {"あああ": ["あああ", "い", "う", "えええええ"], "いいいいい": ["あ", "いいい", "う", "ええ"]},
-            index=pd.Index(["あ", "いいい", "うう", "え"], name="お"),
+            index=Index(["あ", "いいい", "うう", "え"], name="お"),
         )
         expected = (
             "       あああ いいいいい\n"
@@ -787,7 +787,7 @@ class TestDataFrameFormatting:
             # index name
             df = DataFrame(
                 {"a": ["あああああ", "い", "う", "えええ"], "b": ["あ", "いいい", "う", "ええええええ"]},
-                index=pd.Index(["あ", "い", "うう", "え"], name="おおおお"),
+                index=Index(["あ", "い", "うう", "え"], name="おおおお"),
             )
             expected = (
                 "                   a             b\n"
@@ -802,7 +802,7 @@ class TestDataFrameFormatting:
             # all
             df = DataFrame(
                 {"あああ": ["あああ", "い", "う", "えええええ"], "いいいいい": ["あ", "いいい", "う", "ええ"]},
-                index=pd.Index(["あ", "いいい", "うう", "え"], name="お"),
+                index=Index(["あ", "いいい", "うう", "え"], name="お"),
             )
             expected = (
                 "            あああ いいいいい\n"

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -1509,7 +1509,7 @@ class TestHDFStore:
     def test_to_hdf_errors(self, format, setup_path):
 
         data = ["\ud800foo"]
-        ser = Series(data, index=pd.Index(data))
+        ser = Series(data, index=Index(data))
         with ensure_clean_path(setup_path) as path:
             # GH 20835
             ser.to_hdf(path, "table", format=format, errors="surrogatepass")
@@ -2533,11 +2533,11 @@ class TestHDFStore:
     @pytest.mark.parametrize("table_format", ["table", "fixed"])
     def test_store_index_name_numpy_str(self, table_format, setup_path):
         # GH #13492
-        idx = pd.Index(
+        idx = Index(
             pd.to_datetime([datetime.date(2000, 1, 1), datetime.date(2000, 1, 2)]),
             name="cols\u05d2",
         )
-        idx1 = pd.Index(
+        idx1 = Index(
             pd.to_datetime([datetime.date(2010, 1, 1), datetime.date(2010, 1, 2)]),
             name="rows\u05d0",
         )
@@ -4139,7 +4139,7 @@ class TestHDFStore:
             expected = DataFrame(
                 [[1, 2, 3, "D"]],
                 columns=["A", "B", "C", "D"],
-                index=pd.Index(["ABC"], name="INDEX_NAME"),
+                index=Index(["ABC"], name="INDEX_NAME"),
             )
             tm.assert_frame_equal(expected, result)
 
@@ -4154,7 +4154,7 @@ class TestHDFStore:
             expected = DataFrame(
                 [[pd.Timestamp("2020-02-06T18:00")]],
                 columns=["A"],
-                index=pd.Index(["date"]),
+                index=Index(["date"]),
             )
             tm.assert_frame_equal(expected, result)
 

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -791,15 +791,15 @@ def _join_by_hand(a, b, how="left"):
 
 def test_join_inner_multiindex_deterministic_order():
     # GH: 36910
-    left = pd.DataFrame(
+    left = DataFrame(
         data={"e": 5},
         index=pd.MultiIndex.from_tuples([(1, 2, 4)], names=("a", "b", "d")),
     )
-    right = pd.DataFrame(
+    right = DataFrame(
         data={"f": 6}, index=pd.MultiIndex.from_tuples([(2, 3)], names=("b", "c"))
     )
     result = left.join(right, how="inner")
-    expected = pd.DataFrame(
+    expected = DataFrame(
         {"e": [5], "f": [6]},
         index=pd.MultiIndex.from_tuples([(2, 1, 4, 3)], names=("b", "a", "d", "c")),
     )

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -505,7 +505,7 @@ class TestJoin:
 
         # smoke test
         joined = left.join(right, on="key", sort=False)
-        tm.assert_index_equal(joined.index, pd.Index(list(range(4))))
+        tm.assert_index_equal(joined.index, Index(list(range(4))))
 
     def test_join_mixed_non_unique_index(self):
         # GH 12814, unorderable types in py3 with a non-unique index

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -86,7 +86,7 @@ class TestConcatAppendCommon:
         Check whether obj has expected dtype depending on label
         considering not-supported dtypes
         """
-        if isinstance(obj, pd.Index):
+        if isinstance(obj, Index):
             if label == "bool":
                 assert obj.dtype == "object"
             else:
@@ -102,7 +102,7 @@ class TestConcatAppendCommon:
     def test_dtypes(self):
         # to confirm test case covers intended dtypes
         for typ, vals in self.data.items():
-            self._check_expected_dtype(pd.Index(vals), typ)
+            self._check_expected_dtype(Index(vals), typ)
             self._check_expected_dtype(Series(vals), typ)
 
     def test_concatlike_same_dtypes(self):
@@ -122,35 +122,35 @@ class TestConcatAppendCommon:
             # ----- Index ----- #
 
             # index.append
-            res = pd.Index(vals1).append(pd.Index(vals2))
-            exp = pd.Index(exp_data)
+            res = Index(vals1).append(Index(vals2))
+            exp = Index(exp_data)
             tm.assert_index_equal(res, exp)
 
             # 3 elements
-            res = pd.Index(vals1).append([pd.Index(vals2), pd.Index(vals3)])
-            exp = pd.Index(exp_data3)
+            res = Index(vals1).append([Index(vals2), Index(vals3)])
+            exp = Index(exp_data3)
             tm.assert_index_equal(res, exp)
 
             # index.append name mismatch
-            i1 = pd.Index(vals1, name="x")
-            i2 = pd.Index(vals2, name="y")
+            i1 = Index(vals1, name="x")
+            i2 = Index(vals2, name="y")
             res = i1.append(i2)
-            exp = pd.Index(exp_data)
+            exp = Index(exp_data)
             tm.assert_index_equal(res, exp)
 
             # index.append name match
-            i1 = pd.Index(vals1, name="x")
-            i2 = pd.Index(vals2, name="x")
+            i1 = Index(vals1, name="x")
+            i2 = Index(vals2, name="x")
             res = i1.append(i2)
-            exp = pd.Index(exp_data, name="x")
+            exp = Index(exp_data, name="x")
             tm.assert_index_equal(res, exp)
 
             # cannot append non-index
             with pytest.raises(TypeError, match="all inputs must be Index"):
-                pd.Index(vals1).append(vals2)
+                Index(vals1).append(vals2)
 
             with pytest.raises(TypeError, match="all inputs must be Index"):
-                pd.Index(vals1).append([pd.Index(vals2), vals3])
+                Index(vals1).append([Index(vals2), vals3])
 
             # ----- Series ----- #
 
@@ -253,13 +253,13 @@ class TestConcatAppendCommon:
                 # ----- Index ----- #
 
                 # index.append
-                res = pd.Index(vals1).append(pd.Index(vals2))
-                exp = pd.Index(exp_data, dtype=exp_index_dtype)
+                res = Index(vals1).append(Index(vals2))
+                exp = Index(exp_data, dtype=exp_index_dtype)
                 tm.assert_index_equal(res, exp)
 
                 # 3 elements
-                res = pd.Index(vals1).append([pd.Index(vals2), pd.Index(vals3)])
-                exp = pd.Index(exp_data3, dtype=exp_index_dtype)
+                res = Index(vals1).append([Index(vals2), Index(vals3)])
+                exp = Index(exp_data3, dtype=exp_index_dtype)
                 tm.assert_index_equal(res, exp)
 
                 # ----- Series ----- #
@@ -292,7 +292,7 @@ class TestConcatAppendCommon:
         dti = pd.DatetimeIndex(["2011-01-01", "2011-01-02"])
         tdi = pd.TimedeltaIndex(["1 days", "2 days"])
 
-        exp = pd.Index(
+        exp = Index(
             [
                 pd.Timestamp("2011-01-01"),
                 pd.Timestamp("2011-01-02"),
@@ -364,7 +364,7 @@ class TestConcatAppendCommon:
         dti1 = pd.DatetimeIndex(["2011-01-01", "2011-01-02"], tz=tz)
         dti2 = pd.DatetimeIndex(["2012-01-01", "2012-01-02"])
 
-        exp = pd.Index(
+        exp = Index(
             [
                 pd.Timestamp("2011-01-01", tz=tz),
                 pd.Timestamp("2011-01-02", tz=tz),
@@ -388,7 +388,7 @@ class TestConcatAppendCommon:
         # different tz
         dti3 = pd.DatetimeIndex(["2012-01-01", "2012-01-02"], tz="US/Pacific")
 
-        exp = pd.Index(
+        exp = Index(
             [
                 pd.Timestamp("2011-01-01", tz=tz),
                 pd.Timestamp("2011-01-02", tz=tz),
@@ -432,7 +432,7 @@ class TestConcatAppendCommon:
         pi1 = pd.PeriodIndex(["2011-01", "2011-02"], freq="M")
         pi2 = pd.PeriodIndex(["2012-01-01", "2012-02-01"], freq="D")
 
-        exp = pd.Index(
+        exp = Index(
             [
                 pd.Period("2011-01", freq="M"),
                 pd.Period("2011-02", freq="M"),
@@ -458,7 +458,7 @@ class TestConcatAppendCommon:
         # different datetimelike
         pi1 = pd.PeriodIndex(["2011-01", "2011-02"], freq="M")
         tdi = pd.TimedeltaIndex(["1 days", "2 days"])
-        exp = pd.Index(
+        exp = Index(
             [
                 pd.Period("2011-01", freq="M"),
                 pd.Period("2011-02", freq="M"),
@@ -480,7 +480,7 @@ class TestConcatAppendCommon:
         tm.assert_series_equal(res, Series(exp, index=[0, 1, 0, 1]))
 
         # inverse
-        exp = pd.Index(
+        exp = Index(
             [
                 pd.Timedelta("1 days"),
                 pd.Timedelta("2 days"),
@@ -911,9 +911,9 @@ class TestAppend:
 
     indexes_can_append = [
         pd.RangeIndex(3),
-        pd.Index([4, 5, 6]),
-        pd.Index([4.5, 5.5, 6.5]),
-        pd.Index(list("abc")),
+        Index([4, 5, 6]),
+        Index([4.5, 5.5, 6.5]),
+        Index(list("abc")),
         pd.CategoricalIndex("A B C".split()),
         pd.CategoricalIndex("D E F".split(), ordered=True),
         pd.IntervalIndex.from_breaks([7, 8, 9, 10]),
@@ -1309,16 +1309,16 @@ class TestConcatenate:
     def test_concat_same_index_names(self, name_in1, name_in2, name_in3, name_out):
         # GH13475
         indices = [
-            pd.Index(["a", "b", "c"], name=name_in1),
-            pd.Index(["b", "c", "d"], name=name_in2),
-            pd.Index(["c", "d", "e"], name=name_in3),
+            Index(["a", "b", "c"], name=name_in1),
+            Index(["b", "c", "d"], name=name_in2),
+            Index(["c", "d", "e"], name=name_in3),
         ]
         frames = [
             DataFrame({c: [0, 1, 2]}, index=i) for i, c in zip(indices, ["x", "y", "z"])
         ]
         result = pd.concat(frames, axis=1)
 
-        exp_ind = pd.Index(["a", "b", "c", "d", "e"], name=name_out)
+        exp_ind = Index(["a", "b", "c", "d", "e"], name=name_out)
         expected = DataFrame(
             {
                 "x": [0, 1, 2, np.nan, np.nan],
@@ -1759,7 +1759,7 @@ class TestConcatenate:
         s2 = Series([4, 5, 6])
         result = concat([s, s2], axis=1, keys=["a", "b"], names=["A"])
         expected = DataFrame(
-            [[1, 4], [2, 5], [3, 6]], columns=pd.Index(["a", "b"], name="A")
+            [[1, 4], [2, 5], [3, 6]], columns=Index(["a", "b"], name="A")
         )
         tm.assert_frame_equal(result, expected)
 
@@ -2223,7 +2223,7 @@ bar2,12,13,14,15
         res = pd.concat([s1, s2], axis=1)
         exp = DataFrame(
             {"x": [1, 2, 3], "y": [np.nan, np.nan, np.nan]},
-            index=pd.Index([0, 1, 2], dtype="O"),
+            index=Index([0, 1, 2], dtype="O"),
         )
         tm.assert_frame_equal(res, exp)
 
@@ -2241,7 +2241,7 @@ bar2,12,13,14,15
         exp = DataFrame(
             {"x": [1, 2, 3], 0: [np.nan, np.nan, np.nan]},
             columns=["x", 0],
-            index=pd.Index([0, 1, 2], dtype="O"),
+            index=Index([0, 1, 2], dtype="O"),
         )
         tm.assert_frame_equal(res, exp)
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -243,7 +243,7 @@ class TestPivotTable:
         result = df.pivot_table(index="A", values="B", dropna=dropna)
         expected = DataFrame(
             {"B": [2, 3]},
-            index=pd.Index(
+            index=Index(
                 pd.Categorical.from_codes(
                     [0, 1], categories=["low", "high"], ordered=True
                 ),
@@ -268,7 +268,7 @@ class TestPivotTable:
         result = df.pivot_table(index="A", values="B", dropna=dropna)
         expected = DataFrame(
             {"B": [2, 3, 0]},
-            index=pd.Index(
+            index=Index(
                 pd.Categorical.from_codes(
                     [0, 1, 2], categories=["low", "high", "left"], ordered=True
                 ),
@@ -617,7 +617,7 @@ class TestPivotTable:
                     pd.Timestamp("2016-08-25 11:00:00-0700", tz="US/Pacific"),
                 ]
             ],
-            index=pd.Index(["aa"], name="uid"),
+            index=Index(["aa"], name="uid"),
             columns=pd.DatetimeIndex(
                 [
                     pd.Timestamp("2016-08-12 00:00:00", tz="US/Pacific"),
@@ -691,10 +691,8 @@ class TestPivotTable:
 
         expected = DataFrame(
             data=1.0,
-            index=pd.Index([1, 2, "All"], name="a"),
-            columns=pd.Index(
-                [pd.Period("2019Q1"), pd.Period("2019Q2"), "All"], name="b"
-            ),
+            index=Index([1, 2, "All"], name="a"),
+            columns=Index([pd.Period("2019Q1"), pd.Period("2019Q2"), "All"], name="b"),
         )
 
         result = df.pivot_table(index="a", columns="b", values="x", margins=True)
@@ -706,7 +704,7 @@ class TestPivotTable:
             ["baz", "zoo"],
             np.array(["baz", "zoo"]),
             Series(["baz", "zoo"]),
-            pd.Index(["baz", "zoo"]),
+            Index(["baz", "zoo"]),
         ],
     )
     @pytest.mark.parametrize("method", [True, False])
@@ -742,7 +740,7 @@ class TestPivotTable:
             ["bar", "baz"],
             np.array(["bar", "baz"]),
             Series(["bar", "baz"]),
-            pd.Index(["bar", "baz"]),
+            Index(["bar", "baz"]),
         ],
     )
     @pytest.mark.parametrize("method", [True, False])
@@ -1696,7 +1694,7 @@ class TestPivotTable:
             margins_name=margins_name,
             aggfunc=[np.mean, max],
         )
-        ix = pd.Index(["bacon", "cheese", margins_name], dtype="object", name="item")
+        ix = Index(["bacon", "cheese", margins_name], dtype="object", name="item")
         tups = [
             ("mean", "cost", "M"),
             ("mean", "cost", "T"),
@@ -1752,7 +1750,7 @@ class TestPivotTable:
         result = pd.pivot_table(df, index="D", margins=True)
         expected = DataFrame(
             {"A": [3, 7, 5], "B": [2.5, 6.5, 4.5], "C": [2, 5, 3.5]},
-            index=pd.Index(["X", "Y", "All"], name="D"),
+            index=Index(["X", "Y", "All"], name="D"),
         )
         tm.assert_frame_equal(result, expected)
 
@@ -1806,7 +1804,7 @@ class TestPivotTable:
         expected_index = pd.CategoricalIndex(
             ["A", "B", "C"], categories=["A", "B", "C"], ordered=False, name="C1"
         )
-        expected_columns = pd.Index(["a", "b"], name="C2")
+        expected_columns = Index(["a", "b"], name="C2")
         expected_data = np.array([[1, 0], [1, 0], [0, 2]], dtype=np.int64)
         expected = DataFrame(
             expected_data, index=expected_index, columns=expected_columns
@@ -1892,7 +1890,7 @@ class TestPivotTable:
         table = pd.pivot_table(
             frame, index=["foo"], aggfunc=len, margins=True, margins_name=greek
         )
-        index = pd.Index([1, 2, 3, greek], dtype="object", name="foo")
+        index = Index([1, 2, 3, greek], dtype="object", name="foo")
         expected = DataFrame(index=index)
         tm.assert_frame_equal(table, expected)
 
@@ -2033,7 +2031,7 @@ class TestPivotTable:
         result = pd.pivot_table(df, columns="A", aggfunc=np.mean, dropna=dropna)
 
         data = [[2.5, np.nan], [1, np.nan]]
-        col = pd.Index(["one", "two"], name="A")
+        col = Index(["one", "two"], name="A")
         expected = DataFrame(data, index=["x", "y"], columns=col)
 
         if dropna:

--- a/pandas/tests/series/apply/test_series_apply.py
+++ b/pandas/tests/series/apply/test_series_apply.py
@@ -25,7 +25,7 @@ class TestSeriesApply:
             )
 
         # empty series
-        s = Series(dtype=object, name="foo", index=pd.Index([], name="bar"))
+        s = Series(dtype=object, name="foo", index=Index([], name="bar"))
         rs = s.apply(lambda x: x)
         tm.assert_series_equal(s, rs)
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -155,7 +155,7 @@ class TestSeriesMisc:
         _d.insert(0, ("z", d["z"]))
         result = Series(d)
         expected = Series(
-            [x[1] for x in _d], index=pd.Index([x[0] for x in _d], tupleize_cols=False)
+            [x[1] for x in _d], index=Index([x[0] for x in _d], tupleize_cols=False)
         )
         result = result.reindex(index=expected.index)
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -176,7 +176,7 @@ class TestSeriesConstructors:
         "dtype",
         ["f8", "i8", "M8[ns]", "m8[ns]", "category", "object", "datetime64[ns, UTC]"],
     )
-    @pytest.mark.parametrize("index", [None, pd.Index([])])
+    @pytest.mark.parametrize("index", [None, Index([])])
     def test_constructor_dtype_only(self, dtype, index):
         # GH-20865
         result = Series(dtype=dtype, index=index)
@@ -383,12 +383,12 @@ class TestSeriesConstructors:
             ["a", "b"], dtype=CategoricalDtype(["a", "b", "c"], ordered=True)
         )
         assert is_categorical_dtype(result.dtype) is True
-        tm.assert_index_equal(result.cat.categories, pd.Index(["a", "b", "c"]))
+        tm.assert_index_equal(result.cat.categories, Index(["a", "b", "c"]))
         assert result.cat.ordered
 
         result = Series(["a", "b"], dtype=CategoricalDtype(["b", "a"]))
         assert is_categorical_dtype(result.dtype)
-        tm.assert_index_equal(result.cat.categories, pd.Index(["b", "a"]))
+        tm.assert_index_equal(result.cat.categories, Index(["b", "a"]))
         assert result.cat.ordered is False
 
         # GH 19565 - Check broadcasting of scalar with Categorical dtype
@@ -546,7 +546,7 @@ class TestSeriesConstructors:
 
     def test_constructor_default_index(self):
         s = Series([0, 1, 2])
-        tm.assert_index_equal(s.index, pd.Index(np.arange(3)))
+        tm.assert_index_equal(s.index, Index(np.arange(3)))
 
     @pytest.mark.parametrize(
         "input",
@@ -619,7 +619,7 @@ class TestSeriesConstructors:
             pd.date_range("20170101", periods=3),
             pd.timedelta_range("1 day", periods=3),
             pd.period_range("2012Q1", periods=3, freq="Q"),
-            pd.Index(list("abc")),
+            Index(list("abc")),
             pd.Int64Index([1, 2, 3]),
             pd.RangeIndex(0, 3),
         ],
@@ -1406,7 +1406,7 @@ class TestSeriesConstructors:
         exp = Series(index).astype(object)
         tm.assert_series_equal(s, exp)
 
-        s = Series(pd.Index(index, dtype=object), dtype=object)
+        s = Series(Index(index, dtype=object), dtype=object)
         exp = Series(index).astype(object)
         tm.assert_series_equal(s, exp)
 

--- a/pandas/tests/series/test_logical_ops.py
+++ b/pandas/tests/series/test_logical_ops.py
@@ -4,7 +4,6 @@ import operator
 import numpy as np
 import pytest
 
-import pandas as pd
 from pandas import DataFrame, Index, Series, bdate_range
 import pandas._testing as tm
 from pandas.core import ops
@@ -161,7 +160,7 @@ class TestSeriesLogicalOps:
         tm.assert_series_equal(result, expected)
         result = left & np.array(right)
         tm.assert_series_equal(result, expected)
-        result = left & pd.Index(right)
+        result = left & Index(right)
         tm.assert_series_equal(result, expected)
         result = left & Series(right)
         tm.assert_series_equal(result, expected)
@@ -171,7 +170,7 @@ class TestSeriesLogicalOps:
         tm.assert_series_equal(result, expected)
         result = left | np.array(right)
         tm.assert_series_equal(result, expected)
-        result = left | pd.Index(right)
+        result = left | Index(right)
         tm.assert_series_equal(result, expected)
         result = left | Series(right)
         tm.assert_series_equal(result, expected)
@@ -181,7 +180,7 @@ class TestSeriesLogicalOps:
         tm.assert_series_equal(result, expected)
         result = left ^ np.array(right)
         tm.assert_series_equal(result, expected)
-        result = left ^ pd.Index(right)
+        result = left ^ Index(right)
         tm.assert_series_equal(result, expected)
         result = left ^ Series(right)
         tm.assert_series_equal(result, expected)
@@ -315,9 +314,9 @@ class TestSeriesLogicalOps:
     @pytest.mark.parametrize(
         "op, expected",
         [
-            (ops.rand_, pd.Index([False, True])),
-            (ops.ror_, pd.Index([False, True])),
-            (ops.rxor, pd.Index([])),
+            (ops.rand_, Index([False, True])),
+            (ops.ror_, Index([False, True])),
+            (ops.rxor, Index([])),
         ],
     )
     def test_reverse_ops_with_index(self, op, expected):

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -252,7 +252,7 @@ class TestCategoricalRepr:
                 return self.name + ", " + self.state
 
         cat = pd.Categorical([County() for _ in range(61)])
-        idx = pd.Index(cat)
+        idx = Index(cat)
         ser = idx.to_series()
 
         repr(ser)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -320,7 +320,7 @@ class TestTimeConversionFormats:
     def test_to_datetime_parse_tzname_or_tzoffset(self, fmt, dates, expected_dates):
         # GH 13486
         result = pd.to_datetime(dates, format=fmt)
-        expected = pd.Index(expected_dates)
+        expected = Index(expected_dates)
         tm.assert_equal(result, expected)
 
     def test_to_datetime_parse_tzname_or_tzoffset_different_tz_to_utc(self):
@@ -357,7 +357,7 @@ class TestTimeConversionFormats:
     def test_to_datetime_parse_timezone_keeps_name(self):
         # GH 21697
         fmt = "%Y-%m-%d %H:%M:%S %z"
-        arg = pd.Index(["2010-01-01 12:00:00 Z"], name="foo")
+        arg = Index(["2010-01-01 12:00:00 Z"], name="foo")
         result = pd.to_datetime(arg, format=fmt)
         expected = pd.DatetimeIndex(["2010-01-01 12:00:00"], tz="UTC", name="foo")
         tm.assert_index_equal(result, expected)
@@ -613,7 +613,7 @@ class TestToDatetime:
         # numpy is either a python datetime.datetime or datetime.date
         tm.assert_index_equal(
             pd.to_datetime(dts_with_oob, errors="ignore", cache=cache),
-            pd.Index([dt.item() for dt in dts_with_oob]),
+            Index([dt.item() for dt in dts_with_oob]),
         )
 
     @pytest.mark.parametrize("cache", [True, False])
@@ -650,7 +650,7 @@ class TestToDatetime:
         ts_string_1 = "March 1, 2018 12:00:00+0400"
         ts_string_2 = "March 1, 2018 12:00:00+0500"
         arr = [ts_string_1] * 5 + [ts_string_2] * 5
-        expected = pd.Index([parse(x) for x in arr])
+        expected = Index([parse(x) for x in arr])
         result = pd.to_datetime(arr, cache=cache)
         tm.assert_index_equal(result, expected)
 
@@ -876,7 +876,7 @@ class TestToDatetime:
         res = pd.to_datetime(
             values, errors="ignore", format=format, infer_datetime_format=infer
         )
-        tm.assert_index_equal(res, pd.Index(values))
+        tm.assert_index_equal(res, Index(values))
 
         res = pd.to_datetime(
             values, errors="coerce", format=format, infer_datetime_format=infer
@@ -895,7 +895,7 @@ class TestToDatetime:
 
     @pytest.mark.parametrize("utc", [True, None])
     @pytest.mark.parametrize("format", ["%Y%m%d %H:%M:%S", None])
-    @pytest.mark.parametrize("constructor", [list, tuple, np.array, pd.Index, deque])
+    @pytest.mark.parametrize("constructor", [list, tuple, np.array, Index, deque])
     def test_to_datetime_cache(self, utc, format, constructor):
         date = "20130101 00:00:00"
         test_dates = [date] * 10 ** 5
@@ -1246,7 +1246,7 @@ class TestToDatetimeUnit:
     @pytest.mark.parametrize("cache", [True, False])
     def test_unit_ignore_keeps_name(self, cache):
         # GH 21697
-        expected = pd.Index([15e9] * 2, name="name")
+        expected = Index([15e9] * 2, name="name")
         result = pd.to_datetime(expected, errors="ignore", unit="s", cache=cache)
         tm.assert_index_equal(result, expected)
 


### PR DESCRIPTION
Fixing use of pd.Index when Index is imported directly