### PR TITLE
TST: Different tests were collected between gw0 and gw1

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -117,7 +117,7 @@ def _is_py3_complex_incompat(result, expected):
     return isinstance(expected, (complex, np.complexfloating)) and np.isnan(result)
 
 
-_good_arith_ops = set(ARITH_OPS_SYMS).difference(SPECIAL_CASE_ARITH_OPS_SYMS)
+_good_arith_ops = sorted(set(ARITH_OPS_SYMS).difference(SPECIAL_CASE_ARITH_OPS_SYMS))
 
 
 # TODO: using range(5) here is a kludge

--- a/pandas/tests/frame/apply/test_frame_transform.py
+++ b/pandas/tests/frame/apply/test_frame_transform.py
@@ -20,7 +20,7 @@ def test_transform_ufunc(axis, float_frame):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("op", transformation_kernels)
+@pytest.mark.parametrize("op", sorted(transformation_kernels))
 def test_transform_groupby_kernel(axis, float_frame, op):
     # GH 35964
     if op == "cumcount":
@@ -161,7 +161,7 @@ def test_transform_reducer_raises(all_reductions):
 
 # mypy doesn't allow adding lists of different types
 # https://github.com/python/mypy/issues/5492
-@pytest.mark.parametrize("op", [*transformation_kernels, lambda x: x + 1])
+@pytest.mark.parametrize("op", [*sorted(transformation_kernels), lambda x: x + 1])
 def test_transform_bad_dtype(op):
     # GH 35964
     df = DataFrame({"A": 3 * [object]})  # DataFrame that will fail on most transforms
@@ -182,7 +182,7 @@ def test_transform_bad_dtype(op):
             df.transform({"A": [op]})
 
 
-@pytest.mark.parametrize("op", transformation_kernels)
+@pytest.mark.parametrize("op", sorted(transformation_kernels))
 def test_transform_partial_failure(op):
     # GH 35964
     wont_fail = ["ffill", "bfill", "fillna", "pad", "backfill", "shift"]

--- a/pandas/tests/series/apply/test_series_transform.py
+++ b/pandas/tests/series/apply/test_series_transform.py
@@ -18,7 +18,7 @@ def test_transform_ufunc(string_series):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize("op", transformation_kernels)
+@pytest.mark.parametrize("op", sorted(transformation_kernels))
 def test_transform_groupby_kernel(string_series, op):
     # GH 35964
     if op == "cumcount":
@@ -144,7 +144,7 @@ def test_transform_reducer_raises(all_reductions):
 
 # mypy doesn't allow adding lists of different types
 # https://github.com/python/mypy/issues/5492
-@pytest.mark.parametrize("op", [*transformation_kernels, lambda x: x + 1])
+@pytest.mark.parametrize("op", [*sorted(transformation_kernels), lambda x: x + 1])
 def test_transform_bad_dtype(op):
     # GH 35964
     s = Series(3 * [object])  # Series that will fail on most transforms


### PR DESCRIPTION
not sure if anyone else if having issue running tests locally. have created a clean pandas-dev env on a different machine so maybe a transient thing.

https://github.com/pytest-dev/pytest-xdist/issues/432

<details>

```
INSTALLED VERSIONS
------------------
commit           : dce547ea2fe7f8c5c51c04d0a87704a2b4abf476
python           : 3.8.6.final.0
python-bits      : 64
OS               : Windows
OS-release       : 10
Version          : 10.0.18362
machine          : AMD64
processor        : Intel64 Family 6 Model 142 Stepping 12, GenuineIntel
byteorder        : little
LC_ALL           : None
LANG             : en_GB.UTF-8
LOCALE           : English_United Kingdom.1252

pandas           : 1.2.0.dev0+908.gdce547ea2f
numpy            : 1.19.2
pytz             : 2020.1
dateutil         : 2.8.1
pip              : 20.2.4
setuptools       : 49.6.0.post20201009
Cython           : 0.29.21
pytest           : 6.1.1
hypothesis       : 5.37.4
sphinx           : 3.2.1
blosc            : None
feather          : None
xlsxwriter       : 1.3.7
lxml.etree       : 4.6.1
html5lib         : 1.1
pymysql          : None
psycopg2         : None
jinja2           : 2.11.2
IPython          : 7.18.1
pandas_datareader: None
bs4              : 4.9.3
bottleneck       : 1.3.2
fsspec           : 0.8.4
fastparquet      : 0.4.1
gcsfs            : 0.7.1
matplotlib       : 3.3.2
numexpr          : 2.7.1
odfpy            : None
openpyxl         : 3.0.5
pandas_gbq       : None
pyarrow          : 2.0.0
pyxlsb           : None
s3fs             : 0.4.2
scipy            : 1.5.0
sqlalchemy       : 1.3.20
tables           : 3.6.1
tabulate         : 0.8.7
xarray           : 0.16.1
xlrd             : 1.2.0
xlwt             : 1.3.0
numba            : 0.51.2
```
</details>