### PR TITLE
BUG: nanstd with td64 and skipna=False

### DIFF
--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -385,10 +385,10 @@ class TimedeltaArray(dtl.TimelikeOps):
             return NaT
 
         result = nanops.nansum(
-            self._data, axis=axis, skipna=skipna, min_count=min_count
+            self._ndarray, axis=axis, skipna=skipna, min_count=min_count
         )
-        if is_scalar(result):
-            return Timedelta(result)
+        if axis is None or self.ndim == 1:
+            return self._box_func(result)
         return self._from_backing_data(result)
 
     def std(
@@ -403,13 +403,13 @@ class TimedeltaArray(dtl.TimelikeOps):
         nv.validate_stat_ddof_func(
             (), dict(dtype=dtype, out=out, keepdims=keepdims), fname="std"
         )
-        if not len(self):
-            return NaT
-        if not skipna and self._hasnans:
+        if not self.size and (self.ndim == 1 or axis is None):
             return NaT
 
-        result = nanops.nanstd(self._data, axis=axis, skipna=skipna, ddof=ddof)
-        return Timedelta(result)
+        result = nanops.nanstd(self._ndarray, axis=axis, skipna=skipna, ddof=ddof)
+        if axis is None or self.ndim == 1:
+            return self._box_func(result)
+        return self._from_backing_data(result)
 
     # ----------------------------------------------------------------
     # Rendering Methods

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -228,7 +228,7 @@ def _maybe_get_mask(
             # Boolean data cannot contain nulls, so signal via mask being None
             return None
 
-        if skipna:
+        if skipna or needs_i8_conversion(values.dtype):
             mask = isna(values)
 
     return mask

--- a/pandas/tests/arrays/test_timedeltas.py
+++ b/pandas/tests/arrays/test_timedeltas.py
@@ -3,6 +3,7 @@ import pytest
 
 import pandas as pd
 import pandas._testing as tm
+from pandas.core import nanops
 from pandas.core.arrays import TimedeltaArray
 
 
@@ -288,10 +289,17 @@ class TestReductions:
         assert isinstance(result, pd.Timedelta)
         assert result == expected
 
+        result = nanops.nanstd(np.asarray(arr), skipna=True)
+        assert isinstance(result, pd.Timedelta)
+        assert result == expected
+
         result = arr.std(skipna=False)
         assert result is pd.NaT
 
         result = tdi.std(skipna=False)
+        assert result is pd.NaT
+
+        result = nanops.nanstd(np.asarray(arr), skipna=False)
         assert result is pd.NaT
 
     def test_median(self):
@@ -307,8 +315,8 @@ class TestReductions:
         assert isinstance(result, pd.Timedelta)
         assert result == expected
 
-        result = arr.std(skipna=False)
+        result = arr.median(skipna=False)
         assert result is pd.NaT
 
-        result = tdi.std(skipna=False)
+        result = tdi.median(skipna=False)
         assert result is pd.NaT


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

The actual bugfix is the one line changed in nanops; the test is rolled in to the existing TDA.std test.  Everything else is cleanup that was involved in tracking down the bug.