### PR TITLE
REGR/PERF: Index.is_ performance regression

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -545,7 +545,7 @@ class Index(IndexOpsMixin, PandasObject):
             return True
         elif not hasattr(other, "_id"):
             return False
-        elif com.any_none(self._id, other._id):
+        elif self._id is None or other._id is None:
             return False
         else:
             return self._id is other._id


### PR DESCRIPTION
Fixes https://github.com/pandas-dev/pandas/pull/37321#issuecomment-715878012

The offender is actually #37321. Apparantly is's a bit slow to do the check using a generator like `com.any_none`.

```python
In [1]: from pandas import *
In [2]: idx_large_fast = RangeIndex(100000)
   ...: idx_small_slow = date_range(start="1/1/2012", periods=1)
   ...: mi_large_slow = MultiIndex.from_product([idx_large_fast, idx_small_slow])
   ...:
   ...: idx_non_object = RangeIndex(1)
In[3]: %timeit mi_large_slow.equals(idx_non_object)
3.13 µs ± 79.4 ns per loop  # master
2.09 µs ± 31.1 ns per loop  # This PR
```