### PR TITLE
DEPR: Add FutureWarning when matching NaN with NaN in merge/join

### DIFF
--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1983,7 +1983,7 @@ def _factorize_keys(
             "Matching nan on nan in merge is not supported and will not match in "
             "a future version.",
             FutureWarning,
-            stacklevel=8
+            stacklevel=8,
         )
     if lany or rany:
         if lany:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1978,7 +1978,6 @@ def _factorize_keys(
     lany = lmask.any()
     rmask = rlab == -1
     rany = rmask.any()
-    raise ValueError
     if lany and rany:
         warnings.warn(
             "Matching nan on nan in merge is not supported and will not match in "

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1978,7 +1978,14 @@ def _factorize_keys(
     lany = lmask.any()
     rmask = rlab == -1
     rany = rmask.any()
-
+    raise ValueError
+    if lany and rany:
+        warnings.warn(
+            "Matching nan on nan in merge is not supported and will not match in "
+            "a future version.",
+            FutureWarning,
+            stacklevel=8
+        )
     if lany or rany:
         if lany:
             np.putmask(llab, lmask, count)


### PR DESCRIPTION
- [x] xref #32306 (and a few others, will add them later
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

cc @WillAyd 

I started with raising a FutureWarning when merging nan on nan. This works, if ``left_index`` and ``right_index`` are not both True.

If both are True, we are dispatching to the Index methods. Should we deprecate this for indexes too? Additionally, should we remove this for ``intersection`` of index in the future too? Will continue after receiving feedback :)