### PR TITLE
Failing test_missing_required_dependency in pandas-wheels

### DIFF
--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -151,11 +151,17 @@ def test_missing_required_dependency():
 
     pyexe = sys.executable.replace("\\", "/")
 
+    # We skip this test if pandas is installed as a site package. We first
+    # import the package normally and check the path to the module before
+    # executing the test which imports pandas with site packages disabled.
     call = [pyexe, "-c", "import pandas;print(pandas.__file__)"]
     output = subprocess.check_output(call).decode()
     if "site-packages" in output:
         pytest.skip("pandas installed as site package")
 
+    # This test will fail if pandas is installed as a site package. The flags
+    # prevent pandas being imported and the test will report Failed: DID NOT
+    # RAISE <class 'subprocess.CalledProcessError'>
     call = [pyexe, "-sSE", "-c", "import pandas"]
 
     msg = (

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -151,7 +151,7 @@ def test_missing_required_dependency():
 
     pyexe = sys.executable.replace("\\", "/")
 
-    call = [pyexe, "-c", "import pandas;pandas.__file__"]
+    call = [pyexe, "-c", "import pandas;print(pandas.__file__)"]
     output = subprocess.check_output(call).decode()
     if "site-packages" in output:
         pytest.skip("pandas installed as site package")

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -150,6 +150,12 @@ def test_missing_required_dependency():
     # https://github.com/MacPython/pandas-wheels/pull/50
 
     pyexe = sys.executable.replace("\\", "/")
+
+    call = [pyexe, "-c", "import pandas;pandas.__file__"]
+    output = subprocess.check_output(call).decode()
+    if "site-packages" in output:
+        pytest.skip("pandas installed as site package")
+
     call = [pyexe, "-sSE", "-c", "import pandas"]
 
     msg = (


### PR DESCRIPTION
- [ ] closes #33999
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

tested at https://github.com/simonjayhawkins/pandas-release/actions/runs/329803554 ( patched from Gist https://gist.github.com/simonjayhawkins/f26d3e26fd55159299b38204f7f3295c and skips for test_missing_required_dependencies removed for conda and pip tests)

following merge can also remove from https://github.com/MacPython/pandas-wheels/blob/5543626b261f5cb55cebfb300c156718c1796ce3/config.sh#L34