### PR TITLE
CI: xfail windows numexpr test

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -209,6 +209,7 @@ class TestEvalNumexprPandas:
             and rhs.shape == (10, 5)
             and np_version_under1p17
             and is_platform_windows()
+            and compat.PY38
         ):
             mark = pytest.mark.xfail(
                 reason="GH#37328 floating point precision on Windows builds"

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -9,6 +9,8 @@ import numpy as np
 from numpy.random import rand, randint, randn
 import pytest
 
+from pandas.compat import is_platform_windows
+from pandas.compat.numpy import np_version_under1p17
 from pandas.errors import PerformanceWarning
 import pandas.util._test_decorators as td
 
@@ -197,7 +199,22 @@ class TestEvalNumexprPandas:
             self.check_simple_cmp_op(lhs, cmp_op, rhs)
 
     @pytest.mark.parametrize("op", _good_arith_ops)
-    def test_binary_arith_ops(self, op, lhs, rhs):
+    def test_binary_arith_ops(self, op, lhs, rhs, request):
+
+        if (
+            op == "/"
+            and isinstance(lhs, DataFrame)
+            and isinstance(rhs, DataFrame)
+            and not lhs.isna().any().any()
+            and rhs.shape == (10, 5)
+            and np_version_under1p17
+            and is_platform_windows()
+        ):
+            mark = pytest.mark.xfail(
+                reason="GH#37328 floating point precision on Windows builds"
+            )
+            request.node.add_marker(mark)
+
         self.check_binary_arith_op(lhs, op, rhs)
 
     def test_modulus(self, lhs, rhs):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
