### PR TITLE
Upgrade pygrep, use in-built rst-directive-colons

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,7 @@ repos:
     -   id: flake8
         name: flake8 (cython template)
         files: \.pxi\.in$
-        types:
-          - file
+        types: [text]
         args: [--append-config=flake8/cython-template.cfg]
 -   repo: https://github.com/PyCQA/isort
     rev: 5.6.3
@@ -32,9 +31,13 @@ repos:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.6.0
+    rev: v1.7.0
     hooks:
       - id: rst-backticks
+      - id: rst-directive-colons
+        types: [text]
+      - id: rst-inline-touching-normal
+        types: [text]
 -   repo: local
     hooks:
     -   id: pip_to_conda
@@ -53,19 +56,6 @@ repos:
         types: [rst]
         args: [--filename=*.rst]
         additional_dependencies: [flake8-rst==0.7.0, flake8==3.7.9]
-    -   id: incorrect-sphinx-directives
-        name: Check for incorrect Sphinx directives
-        language: pygrep
-        entry: |
-            (?x)
-            # Check for cases of e.g. .. warning: instead of .. warning::
-            \.\.\ (
-                autosummary|contents|currentmodule|deprecated|
-                function|image|important|include|ipython|literalinclude|
-                math|module|note|raw|seealso|toctree|versionadded|
-                versionchanged|warning
-            ):[^:]
-        files: \.(py|pyx|rst)$
     -   id: non-standard-imports
         name: Check for non-standard imports
         language: pygrep

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -201,7 +201,7 @@ Jupyter notebooks can be converted to a number of open standard output formats
 Python) through 'Download As' in the web interface and ``jupyter convert``
 in a shell.
 
-pandas DataFrames implement ``_repr_html_``and ``_repr_latex`` methods
+pandas DataFrames implement ``_repr_html_`` and ``_repr_latex`` methods
 which are utilized by Jupyter Notebook for displaying
 (abbreviated) HTML or LaTeX tables. LaTeX output is properly escaped.
 (Note: HTML tables may or may not be

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3938,7 +3938,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         This is an ndarray or ExtensionArray.
 
-        ``_values`` are consistent between``Series`` and ``Index``.
+        ``_values`` are consistent between ``Series`` and ``Index``.
 
         It may differ from the public '.values' method.
 


### PR DESCRIPTION
I got a PR in to pre-commit/pygrep-hooks to make the "incorrect-sphinx-directives" hook a built-in one (as it's not specific to pandas) :tada: So, let's use it?

They also have another useful hook (`rst-inline-touching-normal`), which caught a couple of errors which I've fixed below.

The reason why I've kept `rst-backticks` to just `rst` files (as opposed to `types: [text]` like the other two) is that in docstrings, the numpy guide instructs to use single backticks for variable (though if it was ever desirable to change that, then this hook would make it pretty easy to check for consistency)