### PR TITLE
REGR: fix inplace arithmetic operation on Series no longer updating parent DataFrame

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -29,6 +29,7 @@ Fixed regressions
 - Fixed regression in :class:`StataReader` which required ``chunksize`` to be manually set when using an iterator to read a dataset (:issue:`37280`)
 - Fixed regression in setitem with :meth:`DataFrame.iloc` which raised error when trying to set a value while filtering with a boolean list (:issue:`36741`)
 - Fixed regression in :attr:`MultiIndex.is_monotonic_increasing` returning wrong results with ``NaN`` in at least one of the levels (:issue:`37220`)
+- Fixed regression in inplace arithmetic operation on a Series not updating the parent DataFrame (:issue:`36373`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -11115,9 +11115,6 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         result = op(self, other)
 
-        # Delete cacher
-        self._reset_cacher()
-
         # this makes sure that we are aligned like the input
         # we are updating inplace so we want to ignore is_copy
         self._update_inplace(

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -424,7 +424,13 @@ class TestDataFrameDrop:
     @pytest.mark.parametrize(
         "operation", ["__iadd__", "__isub__", "__imul__", "__ipow__"]
     )
-    @pytest.mark.parametrize("inplace", [False, True])
+    @pytest.mark.parametrize(
+        "inplace",
+        [
+            False,
+            pytest.param(True, marks=pytest.mark.xfail(reason="reverted - GH36373")),
+        ],
+    )
     def test_inplace_drop_and_operation(self, operation, inplace):
         # GH#30484
         df = DataFrame({"x": range(5)})

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1698,3 +1698,12 @@ def test_arith_list_of_arraylike_raise(to_add):
         df + to_add
     with pytest.raises(ValueError, match=msg):
         to_add + df
+
+
+def test_inplace_arithmetic_series_update():
+    # https://github.com/pandas-dev/pandas/issues/36373
+    df = DataFrame({"A": [1, 2, 3]})
+    series = df["A"]
+    series += 1
+    expected = DataFrame({"A": [2, 3, 4]})
+    tm.assert_frame_equal(df, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -888,6 +888,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         original_series[:3] = [7, 8, 9]
         assert all(sliced_series[:3] == [7, 8, 9])
 
+    @pytest.mark.xfail(reason="accidental fix reverted - GH37497")
     def test_loc_copy_vs_view(self):
         # GH 15631
         x = DataFrame(zip(range(3), range(3)), columns=["a", "b"])


### PR DESCRIPTION
Closes #36373

See discussion at https://github.com/pandas-dev/pandas/pull/36498#issuecomment-708578774 for reverting the original fix (https://github.com/pandas-dev/pandas/pull/30501 for #30484)