### PR TITLE
REGR: fix isin for large series with nan and mixed object dtype (causing regression in read_csv)

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -15,6 +15,7 @@ including other versions of pandas.
 Fixed regressions
 ~~~~~~~~~~~~~~~~~
 - Fixed regression in :func:`read_csv` raising a ``ValueError`` when ``names`` was of type ``dict_keys`` (:issue:`36928`)
+- Fixed regression in :func:`read_csv` with more than 1M rows and specifying a ``index_col`` argument (:issue:`37094`)
 - Fixed regression where attempting to mutate a :class:`DateOffset` object would no longer raise an ``AttributeError`` (:issue:`36940`)
 - Fixed regression where :meth:`DataFrame.agg` would fail with :exc:`TypeError` when passed positional arguments to be passed on to the aggregation function (:issue:`36948`).
 - Fixed regression in :class:`RollingGroupby` with ``sort=False`` not being respected (:issue:`36889`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -438,14 +438,10 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
 
     # GH16012
     # Ensure np.in1d doesn't get object types or it *may* throw an exception
-    if (
-        len(comps) > 1_000_000
-        and not is_object_dtype(comps)
-        and not is_object_dtype(values)
-    ):
+    if len(comps) > 1_000_000 and not is_object_dtype(comps):
         # If the the values include nan we need to check for nan explicitly
         # since np.nan it not equal to np.nan
-        if np.isnan(values).any():
+        if isna(values).any():
             f = lambda c, v: np.logical_or(np.in1d(c, v), np.isnan(c))
         else:
             f = np.in1d

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -438,7 +438,11 @@ def isin(comps: AnyArrayLike, values: AnyArrayLike) -> np.ndarray:
 
     # GH16012
     # Ensure np.in1d doesn't get object types or it *may* throw an exception
-    if len(comps) > 1_000_000 and not is_object_dtype(comps):
+    if (
+        len(comps) > 1_000_000
+        and not is_object_dtype(comps)
+        and not is_object_dtype(values)
+    ):
         # If the the values include nan we need to check for nan explicitly
         # since np.nan it not equal to np.nan
         if np.isnan(values).any():

--- a/pandas/tests/io/parser/test_index_col.py
+++ b/pandas/tests/io/parser/test_index_col.py
@@ -207,3 +207,18 @@ I2,1,3
 
     result = parser.read_csv(StringIO(data), index_col="I11", header=0)
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.slow
+def test_index_col_large_csv(all_parsers):
+    # https://github.com/pandas-dev/pandas/issues/37094
+    parser = all_parsers
+
+    N = 1_000_001
+    df = DataFrame({"a": range(N), "b": np.random.randn(N)})
+
+    with tm.ensure_clean() as path:
+        df.to_csv(path, index=False)
+        result = parser.read_csv(path, index_col=[0])
+
+    tm.assert_frame_equal(result, df.set_index("a"))

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -89,3 +89,13 @@ class TestSeriesIsIn:
         result = s.isin(arr)
         expected = Series([True, True, True])
         tm.assert_series_equal(result, expected)
+
+
+def test_isin_large_series_mixed_dtypes_and_nan():
+    # https://github.com/pandas-dev/pandas/issues/37094
+    # combination of object dtype for the values, > 1_000_000 elements
+    # and the presence of NaNs in the Series
+    ser = Series([1, 2, np.nan] * 1_000_000)
+    result = ser.isin({"foo", "bar"})
+    expected = Series([False] * 3 * 1_000_000)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -91,6 +91,7 @@ class TestSeriesIsIn:
         tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.slow
 def test_isin_large_series_mixed_dtypes_and_nan():
     # https://github.com/pandas-dev/pandas/issues/37094
     # combination of object dtype for the valuesa and > 1_000_000 elements

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -93,8 +93,7 @@ class TestSeriesIsIn:
 
 def test_isin_large_series_mixed_dtypes_and_nan():
     # https://github.com/pandas-dev/pandas/issues/37094
-    # combination of object dtype for the values, > 1_000_000 elements
-    # and the presence of NaNs in the Series
+    # combination of object dtype for the valuesa and > 1_000_000 elements
     ser = Series([1, 2, np.nan] * 1_000_000)
     result = ser.isin({"foo", "bar"})
     expected = Series([False] * 3 * 1_000_000)

--- a/pandas/tests/series/methods/test_isin.py
+++ b/pandas/tests/series/methods/test_isin.py
@@ -94,7 +94,7 @@ class TestSeriesIsIn:
 @pytest.mark.slow
 def test_isin_large_series_mixed_dtypes_and_nan():
     # https://github.com/pandas-dev/pandas/issues/37094
-    # combination of object dtype for the valuesa and > 1_000_000 elements
+    # combination of object dtype for the values and > 1_000_000 elements
     ser = Series([1, 2, np.nan] * 1_000_000)
     result = ser.isin({"foo", "bar"})
     expected = Series([False] * 3 * 1_000_000)


### PR DESCRIPTION
Closes #37094
