### PR TITLE
REGR: revert behaviour of getitem with assigning with a Series

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -28,6 +28,7 @@ Fixed regressions
 - Fixed regression in certain offsets (:meth:`pd.offsets.Day() <pandas.tseries.offsets.Day>` and below) no longer being hashable (:issue:`37267`)
 - Fixed regression in :class:`StataReader` which required ``chunksize`` to be manually set when using an iterator to read a dataset (:issue:`37280`)
 - Fixed regression in setitem with :meth:`DataFrame.iloc` which raised error when trying to set a value while filtering with a boolean list (:issue:`36741`)
+- Fixed regression in setitem with a Series getting aligned before setting the values (:issue:`37427`)
 - Fixed regression in :attr:`MultiIndex.is_monotonic_increasing` returning wrong results with ``NaN`` in at least one of the levels (:issue:`37220`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1084,7 +1084,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def _set_values(self, key, value):
         if isinstance(key, Series):
             key = key._values
-        self._mgr = self._mgr.setitem(indexer=key, value=value)
+        self._mgr = self._mgr.setitem(  # type: ignore[assignment]
+            indexer=key, value=value
+        )
         self._maybe_update_cacher()
 
     def _set_value(self, label, value, takeable: bool = False):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1078,7 +1078,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         indexer: np.ndarray = self.index.get_indexer(key)
         mask = indexer == -1
         if mask.any():
-            raise ValueError(f"{key[mask]} not contained in the index")
+            raise KeyError(f"{key[mask]} not in index")
         self._set_values(indexer, value)
 
     def _set_values(self, key, value):

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -290,3 +290,13 @@ def test_getitem_multilevel_scalar_slice_not_implemented(
     msg = r"\(2000, slice\(3, 4, None\)\)"
     with pytest.raises(TypeError, match=msg):
         ser[2000, 3:4]
+
+
+def test_getitem_assignment_series_aligment():
+    # https://github.com/pandas-dev/pandas/issues/37427
+    # with getitem, when assigning with a Series, it is not first aligned
+    s = pd.Series(range(10))
+    idx = np.array([2, 4, 9])
+    s[idx] = pd.Series([10, 11, 12])
+    expected = pd.Series([0, 1, 10, 3, 11, 5, 6, 7, 8, 12])
+    tm.assert_series_equal(s, expected)

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -295,8 +295,8 @@ def test_getitem_multilevel_scalar_slice_not_implemented(
 def test_getitem_assignment_series_aligment():
     # https://github.com/pandas-dev/pandas/issues/37427
     # with getitem, when assigning with a Series, it is not first aligned
-    s = pd.Series(range(10))
+    s = Series(range(10))
     idx = np.array([2, 4, 9])
-    s[idx] = pd.Series([10, 11, 12])
-    expected = pd.Series([0, 1, 10, 3, 11, 5, 6, 7, 8, 12])
+    s[idx] = Series([10, 11, 12])
+    expected = Series([0, 1, 10, 3, 11, 5, 6, 7, 8, 12])
     tm.assert_series_equal(s, expected)


### PR DESCRIPTION
Closes #37427

@jbrockmendel this is reverting part of the clean-up you did in https://github.com/pandas-dev/pandas/pull/33643. I think the behavioural change was unintentional in that PR. We might still want to do it for 1.2, but then with a deprecation first.