### PR TITLE
BUG: Series.replace does not preserve dtype of original Series

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1165,6 +1165,13 @@ class Block(PandasObject):
         if is_dtype_equal(self.dtype, dtype):
             return self
 
+        if self._can_hold_element(other):
+            return self
+        elif self.is_categorical:
+            # Note: this will be wrong if we ever have a tuple category
+            cat = self.values.add_categories(other)
+            return self.make_block(cat)
+
         if self.is_bool or is_object_dtype(dtype) or is_bool_dtype(dtype):
             # we don't upcast to bool
             return self.astype(object)


### PR DESCRIPTION
- [x] closes #33484
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Reheating #33622 (stale)