### PR TITLE
Backport PR #37508: REGR: inplace Series op not actually operating inplace

### DIFF
--- a/doc/source/whatsnew/v1.1.4.rst
+++ b/doc/source/whatsnew/v1.1.4.rst
@@ -29,6 +29,7 @@ Fixed regressions
 - Fixed regression in :class:`StataReader` which required ``chunksize`` to be manually set when using an iterator to read a dataset (:issue:`37280`)
 - Fixed regression in setitem with :meth:`DataFrame.iloc` which raised error when trying to set a value while filtering with a boolean list (:issue:`36741`)
 - Fixed regression in :attr:`MultiIndex.is_monotonic_increasing` returning wrong results with ``NaN`` in at least one of the levels (:issue:`37220`)
+- Fixed regression in inplace arithmetic operation on a Series not updating the parent DataFrame (:issue:`36373`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/ops/methods.py
+++ b/pandas/core/ops/methods.py
@@ -93,8 +93,19 @@ def add_special_arithmetic_methods(cls):
 
         def f(self, other):
             result = method(self, other)
+
+            if (
+                self.ndim == 1
+                and result._indexed_same(self)
+                and result.dtype == self.dtype
+            ):
+                # GH#36498 this inplace op can _actually_ be inplace.
+                self._values[:] = result._values
+                return self
+
             # Delete cacher
             self._reset_cacher()
+
             # this makes sure that we are aligned like the input
             # we are updating inplace so we want to ignore is_copy
             self._update_inplace(

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1566,3 +1566,16 @@ def test_arith_reindex_with_duplicates():
     result = df1 + df2
     expected = pd.DataFrame([[np.nan, 0, 0]], columns=["first", "second", "second"])
     tm.assert_frame_equal(result, expected)
+
+
+def test_inplace_arithmetic_series_update():
+    # https://github.com/pandas-dev/pandas/issues/36373
+    df = DataFrame({"A": [1, 2, 3]})
+    series = df["A"]
+    vals = series._values
+
+    series += 1
+    assert series._values is vals
+
+    expected = DataFrame({"A": [2, 3, 4]})
+    tm.assert_frame_equal(df, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -896,6 +896,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         original_series[:3] = [7, 8, 9]
         assert all(sliced_series[:3] == [7, 8, 9])
 
+    @pytest.mark.xfail(reason="accidental fix reverted - GH37497")
     def test_loc_copy_vs_view(self):
         # GH 15631
         x = DataFrame(zip(range(3), range(3)), columns=["a", "b"])


### PR DESCRIPTION
Backport of https://github.com/pandas-dev/pandas/pull/37508