### PR TITLE
#37535 pandas-CI: revert disable of windows window tests

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -22,12 +22,6 @@ fi
 
 PYTEST_CMD="${XVFB}pytest -m \"$PATTERN\" -n $PYTEST_WORKERS --dist=loadfile -s --strict --durations=30 --junitxml=test-data.xml $TEST_ARGS $COVERAGE pandas"
 
-if [[ $(uname) != "Linux"  && $(uname) != "Darwin" ]]; then
-    # GH#37455 windows py38 build appears to be running out of memory
-    #  skip collection of window tests
-    PYTEST_CMD="$PYTEST_CMD --ignore=pandas/tests/window/"
-fi
-
 echo $PYTEST_CMD
 sh -c "$PYTEST_CMD"
 


### PR DESCRIPTION
- [x] closes #37535 
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
removed the restrictions on windows test
