### PR TITLE
TYP: PoC for honest ABC

### DIFF
--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -29,6 +29,7 @@ import numpy as np
 if TYPE_CHECKING:
     from pandas._libs import Period, Timedelta, Timestamp
 
+    from pandas.core.dtypes.abcs.ndframe import ABCNDFrame
     from pandas.core.dtypes.dtypes import ExtensionDtype
 
     from pandas import Interval
@@ -81,7 +82,7 @@ FrameOrSeriesUnion = Union["DataFrame", "Series"]
 # used. E.g. `def func(a: FrameOrSeries) -> FrameOrSeries: ...` means that if a
 # Series is passed into a function, a Series is always returned and if a DataFrame is
 # passed in, a DataFrame is always returned.
-FrameOrSeries = TypeVar("FrameOrSeries", bound="NDFrame")
+FrameOrSeries = TypeVar("FrameOrSeries", bound="ABCNDFrame")
 
 Axis = Union[str, int]
 Label = Optional[Hashable]

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -29,6 +29,7 @@ import numpy as np
 if TYPE_CHECKING:
     from pandas._libs import Period, Timedelta, Timestamp
 
+    from pandas.core.dtypes.abcs import ABCNDFrame  # noqa: F401
     from pandas.core.dtypes.dtypes import ExtensionDtype
 
     from pandas import Interval

--- a/pandas/_typing.py
+++ b/pandas/_typing.py
@@ -29,7 +29,6 @@ import numpy as np
 if TYPE_CHECKING:
     from pandas._libs import Period, Timedelta, Timestamp
 
-    from pandas.core.dtypes.abcs.ndframe import ABCNDFrame
     from pandas.core.dtypes.dtypes import ExtensionDtype
 
     from pandas import Interval

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -30,7 +30,7 @@ from pandas._typing import (
     Label,
 )
 
-from pandas.core.dtypes.abcs.ndframe import ABCNDFrame
+from pandas.core.dtypes.abcs import ABCNDFrame
 from pandas.core.dtypes.cast import is_nested_object
 from pandas.core.dtypes.common import is_dict_like, is_list_like
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries

--- a/pandas/core/aggregation.py
+++ b/pandas/core/aggregation.py
@@ -30,9 +30,10 @@ from pandas._typing import (
     Label,
 )
 
+from pandas.core.dtypes.abcs.ndframe import ABCNDFrame
 from pandas.core.dtypes.cast import is_nested_object
 from pandas.core.dtypes.common import is_dict_like, is_list_like
-from pandas.core.dtypes.generic import ABCDataFrame, ABCNDFrame, ABCSeries
+from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 
 from pandas.core.base import DataError, SpecificationError
 import pandas.core.common as com

--- a/pandas/core/dtypes/abcs/__init__.py
+++ b/pandas/core/dtypes/abcs/__init__.py
@@ -1,0 +1,3 @@
+from pandas.core.dtypes.abcs.ndframe import ABCNDFrame
+
+__all__ = ["ABCNDFrame"]

--- a/pandas/core/dtypes/abcs/ndframe.py
+++ b/pandas/core/dtypes/abcs/ndframe.py
@@ -21,8 +21,16 @@ from typing import (
 
 import numpy as np
 
+from pandas._libs import lib
+from pandas.util._decorators import Appender, doc, rewrite_axis_style_signature
+
+from pandas.core import indexing
+from pandas.core.base import PandasObject, SelectionMixin
+from pandas.core.shared_docs import _shared_docs
+
+from pandas.io.formats import format as fmt
+
 if TYPE_CHECKING:
-    from pandas._libs import lib
     from pandas._libs.tslibs import BaseOffset
     from pandas._typing import (
         Axis,
@@ -41,25 +49,17 @@ if TYPE_CHECKING:
         ValueKeyFunc,
     )
     from pandas.errors import AbstractMethodError
-    from pandas.util._decorators import Appender, doc, rewrite_axis_style_signature
 
     from pandas.core.dtypes.generic import ABCSeries
 
-    import pandas as pd
-    from pandas.core import indexing
-    from pandas.core.base import PandasObject, SelectionMixin
     import pandas.core.common as com
     from pandas.core.flags import Flags
-    from pandas.core.frame import DataFrame
     from pandas.core.indexes.api import Index, MultiIndex
     from pandas.core.internals import BlockManager
     from pandas.core.resample import Resampler
     from pandas.core.series import Series
-    from pandas.core.shared_docs import _shared_docs
-    from pandas.core.window import Expanding, ExponentialMovingWindow, Rolling
+    from pandas.core.window import Expanding, ExponentialMovingWindow
     from pandas.core.window.indexers import BaseIndexer
-
-    from pandas.io.formats import format as fmt
 
 # goal is to be able to define the docs close to function, while still being
 # able to share
@@ -7771,7 +7771,7 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         """
         raise AbstractMethodError(cls)
 
-    @doc(Rolling)
+    # @doc(Rolling)
     def rolling(
         self,
         window: Union[int, timedelta, BaseOffset, BaseIndexer],
@@ -7784,13 +7784,13 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     ):
         raise AbstractMethodError(self)
 
-    @doc(Expanding)
+    # @doc(Expanding)
     def expanding(
         self, min_periods: int = 1, center: Optional[bool_t] = None, axis: Axis = 0
     ) -> Expanding:
         raise AbstractMethodError(self)
 
-    @doc(ExponentialMovingWindow)
+    # @doc(ExponentialMovingWindow)
     def ewm(
         self,
         com: Optional[float] = None,

--- a/pandas/core/dtypes/abcs/ndframe.py
+++ b/pandas/core/dtypes/abcs/ndframe.py
@@ -1,36 +1,35 @@
 from __future__ import annotations
 
-from abc import ABC
-from datetime import timedelta
-import pickle
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    FrozenSet,
-    Hashable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
-
-import numpy as np
+from typing import TYPE_CHECKING
 
 from pandas._libs import lib
-from pandas.util._decorators import Appender, doc, rewrite_axis_style_signature
+from pandas.util._decorators import rewrite_axis_style_signature
 
 from pandas.core import indexing
 from pandas.core.base import PandasObject, SelectionMixin
-from pandas.core.shared_docs import _shared_docs
-
-from pandas.io.formats import format as fmt
 
 if TYPE_CHECKING:
+    from abc import ABC
+    from datetime import timedelta
+    import pickle
+    from typing import (
+        Any,
+        Callable,
+        Dict,
+        FrozenSet,
+        Hashable,
+        List,
+        Mapping,
+        Optional,
+        Sequence,
+        Set,
+        Tuple,
+        Type,
+        Union,
+    )
+
+    import numpy as np
+
     from pandas._libs.tslibs import BaseOffset
     from pandas._typing import (
         Axis,
@@ -52,7 +51,6 @@ if TYPE_CHECKING:
 
     from pandas.core.dtypes.generic import ABCSeries
 
-    import pandas.core.common as com
     from pandas.core.flags import Flags
     from pandas.core.indexes.api import Index, MultiIndex
     from pandas.core.internals import BlockManager
@@ -61,34 +59,10 @@ if TYPE_CHECKING:
     from pandas.core.window import Expanding, ExponentialMovingWindow
     from pandas.core.window.indexers import BaseIndexer
 
-# goal is to be able to define the docs close to function, while still being
-# able to share
-_shared_docs = {**_shared_docs}
-_shared_doc_kwargs = dict(
-    axes="keywords for axes",
-    klass="Series/DataFrame",
-    axes_single_arg="int or labels for object",
-    args_transpose="axes to permute (int or label for object)",
-    optional_by="""
-        by : str or list of str
-            Name or list of names to sort by""",
-)
-
 bool_t = bool  # Need alias because NDFrame has def bool:
 
 
 class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
-    """
-    N-dimensional analogue of DataFrame. Store multi-dimensional in a
-    size-mutable, labeled data structure
-
-    Parameters
-    ----------
-    data : BlockManager
-    axes : list
-    copy : bool, default False
-    """
-
     _internal_names: List[str] = [
         "_mgr",
         "_cacher",
@@ -119,7 +93,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @classmethod
     def _init_mgr(cls, mgr, axes, dtype=None, copy: bool = False) -> BlockManager:
-        """ passed a manager and a axes dict """
         raise NotImplementedError
 
     # ----------------------------------------------------------------------
@@ -127,17 +100,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @property
     def attrs(self) -> Dict[Optional[Hashable], Any]:
-        """
-        Dictionary of global attributes of this dataset.
-
-        .. warning::
-
-           attrs is experimental and may change without warning.
-
-        See Also
-        --------
-        DataFrame.flags : Global flags applying to this object.
-        """
         raise NotImplementedError
 
     @attrs.setter
@@ -146,42 +108,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @property
     def flags(self) -> Flags:
-        """
-        Get the properties associated with this pandas object.
-
-        The available flags are
-
-        * :attr:`Flags.allows_duplicate_labels`
-
-        See Also
-        --------
-        Flags : Flags that apply to pandas objects.
-        DataFrame.attrs : Global metadata applying to this dataset.
-
-        Notes
-        -----
-        "Flags" differ from "metadata". Flags reflect properties of the
-        pandas object (the Series or DataFrame). Metadata refer to properties
-        of the dataset, and should be stored in :attr:`DataFrame.attrs`.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({"A": [1, 2]})
-        >>> df.flags
-        <Flags(allows_duplicate_labels=True)>
-
-        Flags can be get or set using ``.``
-
-        >>> df.flags.allows_duplicate_labels
-        True
-        >>> df.flags.allows_duplicate_labels = False
-
-        Or by slicing with a key
-
-        >>> df.flags["allows_duplicate_labels"]
-        False
-        >>> df.flags["allows_duplicate_labels"] = True
-        """
         raise NotImplementedError
 
     def set_flags(
@@ -190,77 +116,25 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         copy: bool = False,
         allows_duplicate_labels: Optional[bool] = None,
     ):
-        """
-        Return a new object with updated flags.
-
-        Parameters
-        ----------
-        allows_duplicate_labels : bool, optional
-            Whether the returned object allows duplicate labels.
-
-        Returns
-        -------
-        Series or DataFrame
-            The same type as the caller.
-
-        See Also
-        --------
-        DataFrame.attrs : Global metadata applying to this dataset.
-        DataFrame.flags : Global flags applying to this object.
-
-        Notes
-        -----
-        This method returns a new object that's a view on the same data
-        as the input. Mutating the input or the output values will be reflected
-        in the other.
-
-        This method is intended to be used in method chains.
-
-        "Flags" differ from "metadata". Flags reflect properties of the
-        pandas object (the Series or DataFrame). Metadata refer to properties
-        of the dataset, and should be stored in :attr:`DataFrame.attrs`.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({"A": [1, 2]})
-        >>> df.flags.allows_duplicate_labels
-        True
-        >>> df2 = df.set_flags(allows_duplicate_labels=False)
-        >>> df2.flags.allows_duplicate_labels
-        False
-        """
         raise NotImplementedError
 
     @classmethod
     def _validate_dtype(cls, dtype):
-        """ validate the passed dtype """
         raise NotImplementedError
 
     # ----------------------------------------------------------------------
     # Construction
 
-    # @property
-    # def _constructor(self: FrameOrSeries) -> Type[FrameOrSeries]:
-    #     """
-    #     Used when a manipulation result has the same dimensions as the
-    #     original.
-    #     """
-    #     raise AbstractMethodError(self)
+    @property
+    def _constructor(self: FrameOrSeries) -> Type[FrameOrSeries]:
+        raise AbstractMethodError(self)
 
     @property
     def _constructor_sliced(self):
-        """
-        Used when a manipulation result has one lower dimension(s) as the
-        original, such as DataFrame single columns slicing.
-        """
         raise AbstractMethodError(self)
 
     @property
     def _constructor_expanddim(self):
-        """
-        Used when a manipulation result has one higher dimension as the
-        original, such as Series.to_frame()
-        """
         raise NotImplementedError
 
     # ----------------------------------------------------------------------
@@ -284,33 +158,19 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @property
     def _AXIS_NUMBERS(self) -> Dict[str, int]:
-        """.. deprecated:: 1.1.0"""
         raise AbstractMethodError(self)
 
     @property
     def _AXIS_NAMES(self) -> Dict[int, str]:
-        """.. deprecated:: 1.1.0"""
         raise AbstractMethodError(self)
 
     def _construct_axes_dict(self, axes=None, **kwargs):
-        """Return an axes dictionary for myself."""
         raise AbstractMethodError(self)
 
     @classmethod
     def _construct_axes_from_arguments(
         cls, args, kwargs, require_all: bool = False, sentinel=None
     ):
-        """
-        Construct and returns axes if supplied in args/kwargs.
-
-        If require_all, raise if all axis arguments are not supplied
-        return a tuple of (axes, kwargs).
-
-        sentinel specifies the default parameter when an axis is not
-        supplied; useful to distinguish when a user explicitly passes None
-        in scenarios where None has special meaning.
-        """
-        # construct the args
         raise AbstractMethodError(cls)
 
     @classmethod
@@ -326,7 +186,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @classmethod
     def _get_block_manager_axis(cls, axis: Axis) -> int:
-        """Map the axis to the block_manager axis."""
         raise AbstractMethodError(cls)
 
     def _get_axis_resolvers(self, axis: str) -> Dict[str, Union[Series, MultiIndex]]:
@@ -336,13 +195,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         raise AbstractMethodError(self)
 
     def _get_cleaned_column_resolvers(self) -> Dict[str, ABCSeries]:
-        """
-        Return the special character free column resolvers of a dataframe.
-
-        Column names with special characters are 'cleaned up' so that they can
-        be referred to by backtick quoting.
-        Used in :meth:`DataFrame.eval`.
-        """
         raise AbstractMethodError(self)
 
     @property
@@ -355,288 +207,47 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @property
     def shape(self) -> Tuple[int, ...]:
-        """
-        Return a tuple of axis dimensions
-        """
         raise AbstractMethodError(self)
 
     @property
     def axes(self) -> List[Index]:
-        """
-        Return index label(s) of the internal NDFrame
-        """
         raise AbstractMethodError(self)
 
     @property
     def ndim(self) -> int:
-        """
-        Return an int representing the number of axes / array dimensions.
-
-        Return 1 if Series. Otherwise return 2 if DataFrame.
-
-        See Also
-        --------
-        ndarray.ndim : Number of array dimensions.
-
-        Examples
-        --------
-        >>> s = pd.Series({'a': 1, 'b': 2, 'c': 3})
-        >>> s.ndim
-        1
-
-        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
-        >>> df.ndim
-        2
-        """
         raise AbstractMethodError(self)
 
     @property
     def size(self) -> int:
-        """
-        Return an int representing the number of elements in this object.
-
-        Return the number of rows if Series. Otherwise return the number of
-        rows times number of columns if DataFrame.
-
-        See Also
-        --------
-        ndarray.size : Number of elements in the array.
-
-        Examples
-        --------
-        >>> s = pd.Series({'a': 1, 'b': 2, 'c': 3})
-        >>> s.size
-        3
-
-        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
-        >>> df.size
-        4
-        """
         raise AbstractMethodError(self)
 
     @property
     def _selected_obj(self: FrameOrSeries) -> FrameOrSeries:
-        """ internal compat with SelectionMixin """
         raise AbstractMethodError(self)
 
     @property
     def _obj_with_exclusions(self: FrameOrSeries) -> FrameOrSeries:
-        """ internal compat with SelectionMixin """
         raise AbstractMethodError(self)
 
     def set_axis(self, labels, axis: Axis = 0, inplace: bool = False):
-        """
-        Assign desired index to given axis.
-
-        Indexes for%(extended_summary_sub)s row labels can be changed by assigning
-        a list-like or Index.
-
-        Parameters
-        ----------
-        labels : list-like, Index
-            The values for the new index.
-
-        axis : %(axes_single_arg)s, default 0
-            The axis to update. The value 0 identifies the rows%(axis_description_sub)s.
-
-        inplace : bool, default False
-            Whether to return a new %(klass)s instance.
-
-        Returns
-        -------
-        renamed : %(klass)s or None
-            An object of type %(klass)s or None if ``inplace=True``.
-
-        See Also
-        --------
-        %(klass)s.rename_axis : Alter the name of the index%(see_also_sub)s.
-        """
         raise AbstractMethodError(self)
 
     def _set_axis_nocheck(self, labels, axis: Axis, inplace: bool):
-        # NDFrame.rename with inplace=False calls set_axis(inplace=True) on a copy.
         raise AbstractMethodError(self)
 
     def _set_axis(self, axis: int, labels: Index) -> None:
         raise AbstractMethodError(self)
 
     def swapaxes(self: FrameOrSeries, axis1, axis2, copy=True) -> FrameOrSeries:
-        """
-        Interchange axes and swap values axes appropriately.
-
-        Returns
-        -------
-        y : same as input
-        """
         raise AbstractMethodError(self)
 
     def droplevel(self: FrameOrSeries, level, axis=0) -> FrameOrSeries:
-        """
-        Return DataFrame with requested index / column level(s) removed.
-
-        .. versionadded:: 0.24.0
-
-        Parameters
-        ----------
-        level : int, str, or list-like
-            If a string is given, must be the name of a level
-            If list-like, elements must be names or positional indexes
-            of levels.
-
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-            Axis along which the level(s) is removed:
-
-            * 0 or 'index': remove level(s) in column.
-            * 1 or 'columns': remove level(s) in row.
-
-        Returns
-        -------
-        DataFrame
-            DataFrame with requested index / column level(s) removed.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame([
-        ...     [1, 2, 3, 4],
-        ...     [5, 6, 7, 8],
-        ...     [9, 10, 11, 12]
-        ... ]).set_index([0, 1]).rename_axis(['a', 'b'])
-
-        >>> df.columns = pd.MultiIndex.from_tuples([
-        ...     ('c', 'e'), ('d', 'f')
-        ... ], names=['level_1', 'level_2'])
-
-        >>> df
-        level_1   c   d
-        level_2   e   f
-        a b
-        1 2      3   4
-        5 6      7   8
-        9 10    11  12
-
-        >>> df.droplevel('a')
-        level_1   c   d
-        level_2   e   f
-        b
-        2        3   4
-        6        7   8
-        10      11  12
-
-        >>> df.droplevel('level_2', axis=1)
-        level_1   c   d
-        a b
-        1 2      3   4
-        5 6      7   8
-        9 10    11  12
-        """
         raise AbstractMethodError(self)
 
     def pop(self, item: Label) -> Union[Series, Any]:
         raise AbstractMethodError(self)
 
     def squeeze(self, axis=None):
-        """
-        Squeeze 1 dimensional axis objects into scalars.
-
-        Series or DataFrames with a single element are squeezed to a scalar.
-        DataFrames with a single column or a single row are squeezed to a
-        Series. Otherwise the object is unchanged.
-
-        This method is most useful when you don't know if your
-        object is a Series or DataFrame, but you do know it has just a single
-        column. In that case you can safely call `squeeze` to ensure you have a
-        Series.
-
-        Parameters
-        ----------
-        axis : {0 or 'index', 1 or 'columns', None}, default None
-            A specific axis to squeeze. By default, all length-1 axes are
-            squeezed.
-
-        Returns
-        -------
-        DataFrame, Series, or scalar
-            The projection after squeezing `axis` or all the axes.
-
-        See Also
-        --------
-        Series.iloc : Integer-location based indexing for selecting scalars.
-        DataFrame.iloc : Integer-location based indexing for selecting Series.
-        Series.to_frame : Inverse of DataFrame.squeeze for a
-            single-column DataFrame.
-
-        Examples
-        --------
-        >>> primes = pd.Series([2, 3, 5, 7])
-
-        Slicing might produce a Series with a single value:
-
-        >>> even_primes = primes[primes % 2 == 0]
-        >>> even_primes
-        0    2
-        dtype: int64
-
-        >>> even_primes.squeeze()
-        2
-
-        Squeezing objects with more than one value in every axis does nothing:
-
-        >>> odd_primes = primes[primes % 2 == 1]
-        >>> odd_primes
-        1    3
-        2    5
-        3    7
-        dtype: int64
-
-        >>> odd_primes.squeeze()
-        1    3
-        2    5
-        3    7
-        dtype: int64
-
-        Squeezing is even more effective when used with DataFrames.
-
-        >>> df = pd.DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
-        >>> df
-           a  b
-        0  1  2
-        1  3  4
-
-        Slicing a single column will produce a DataFrame with the columns
-        having only one value:
-
-        >>> df_a = df[['a']]
-        >>> df_a
-           a
-        0  1
-        1  3
-
-        So the columns can be squeezed down, resulting in a Series:
-
-        >>> df_a.squeeze('columns')
-        0    1
-        1    3
-        Name: a, dtype: int64
-
-        Slicing a single row from a single column will produce a single
-        scalar DataFrame:
-
-        >>> df_0a = df.loc[df.index < 1, ['a']]
-        >>> df_0a
-           a
-        0  1
-
-        Squeezing the rows produces a single scalar Series:
-
-        >>> df_0a.squeeze('rows')
-        a    1
-        Name: 0, dtype: int64
-
-        Squeezing all axes will project directly into a scalar:
-
-        >>> df_0a.squeeze()
-        1
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
@@ -654,299 +265,13 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         level: Optional[Level] = None,
         errors: str = "ignore",
     ) -> Optional[FrameOrSeries]:
-        """
-        Alter axes input function or functions. Function / dict values must be
-        unique (1-to-1). Labels not contained in a dict / Series will be left
-        as-is. Extra labels listed don't throw an error. Alternatively, change
-        ``Series.name`` with a scalar value (Series only).
-
-        Parameters
-        ----------
-        %(axes)s : scalar, list-like, dict-like or function, optional
-            Scalar or list-like will alter the ``Series.name`` attribute,
-            and raise on DataFrame.
-            dict-like or functions are transformations to apply to
-            that axis' values
-        copy : bool, default True
-            Also copy underlying data.
-        inplace : bool, default False
-            Whether to return a new {klass}. If True then value of copy is
-            ignored.
-        level : int or level name, default None
-            In case of a MultiIndex, only rename labels in the specified
-            level.
-        errors : {'ignore', 'raise'}, default 'ignore'
-            If 'raise', raise a `KeyError` when a dict-like `mapper`, `index`,
-            or `columns` contains labels that are not present in the Index
-            being transformed.
-            If 'ignore', existing keys will be renamed and extra keys will be
-            ignored.
-
-        Returns
-        -------
-        renamed : {klass} (new object)
-
-        Raises
-        ------
-        KeyError
-            If any of the labels is not found in the selected axis and
-            "errors='raise'".
-
-        See Also
-        --------
-        NDFrame.rename_axis
-
-        Examples
-        --------
-        >>> s = pd.Series([1, 2, 3])
-        >>> s
-        0    1
-        1    2
-        2    3
-        dtype: int64
-        >>> s.rename("my_name") # scalar, changes Series.name
-        0    1
-        1    2
-        2    3
-        Name: my_name, dtype: int64
-        >>> s.rename(lambda x: x ** 2)  # function, changes labels
-        0    1
-        1    2
-        4    3
-        dtype: int64
-        >>> s.rename({1: 3, 2: 5})  # mapping, changes labels
-        0    1
-        3    2
-        5    3
-        dtype: int64
-
-        Since ``DataFrame`` doesn't have a ``.name`` attribute,
-        only mapping-type arguments are allowed.
-
-        >>> df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        >>> df.rename(2)
-        Traceback (most recent call last):
-        ...
-        TypeError: 'int' object is not callable
-
-        ``DataFrame.rename`` supports two calling conventions
-
-        * ``(index=index_mapper, columns=columns_mapper, ...)``
-        * ``(mapper, axis={'index', 'columns'}, ...)``
-
-        We *highly* recommend using keyword arguments to clarify your
-        intent.
-
-        >>> df.rename(index=str, columns={"A": "a", "B": "c"})
-           a  c
-        0  1  4
-        1  2  5
-        2  3  6
-
-        >>> df.rename(index=str, columns={"A": "a", "C": "c"})
-           a  B
-        0  1  4
-        1  2  5
-        2  3  6
-
-        Using axis-style parameters
-
-        >>> df.rename(str.lower, axis='columns')
-           a  b
-        0  1  4
-        1  2  5
-        2  3  6
-
-        >>> df.rename({1: 2, 2: 4}, axis='index')
-           A  B
-        0  1  4
-        2  2  5
-        4  3  6
-
-        See the :ref:`user guide <basics.rename>` for more.
-        """
         raise AbstractMethodError(self)
 
     @rewrite_axis_style_signature("mapper", [("copy", True), ("inplace", False)])
     def rename_axis(self, mapper=lib.no_default, **kwargs):
-        """
-        Set the name of the axis for the index or columns.
-
-        Parameters
-        ----------
-        mapper : scalar, list-like, optional
-            Value to set the axis name attribute.
-        index, columns : scalar, list-like, dict-like or function, optional
-            A scalar, list-like, dict-like or functions transformations to
-            apply to that axis' values.
-            Note that the ``columns`` parameter is not allowed if the
-            object is a Series. This parameter only apply for DataFrame
-            type objects.
-
-            Use either ``mapper`` and ``axis`` to
-            specify the axis to target with ``mapper``, or ``index``
-            and/or ``columns``.
-
-            .. versionchanged:: 0.24.0
-
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-            The axis to rename.
-        copy : bool, default True
-            Also copy underlying data.
-        inplace : bool, default False
-            Modifies the object directly, instead of creating a new Series
-            or DataFrame.
-
-        Returns
-        -------
-        Series, DataFrame, or None
-            The same type as the caller or None if ``inplace=True``.
-
-        See Also
-        --------
-        Series.rename : Alter Series index labels or name.
-        DataFrame.rename : Alter DataFrame index labels or name.
-        Index.rename : Set new names on index.
-
-        Notes
-        -----
-        ``DataFrame.rename_axis`` supports two calling conventions
-
-        * ``(index=index_mapper, columns=columns_mapper, ...)``
-        * ``(mapper, axis={'index', 'columns'}, ...)``
-
-        The first calling convention will only modify the names of
-        the index and/or the names of the Index object that is the columns.
-        In this case, the parameter ``copy`` is ignored.
-
-        The second calling convention will modify the names of the
-        the corresponding index if mapper is a list or a scalar.
-        However, if mapper is dict-like or a function, it will use the
-        deprecated behavior of modifying the axis *labels*.
-
-        We *highly* recommend using keyword arguments to clarify your
-        intent.
-
-        Examples
-        --------
-        **Series**
-
-        >>> s = pd.Series(["dog", "cat", "monkey"])
-        >>> s
-        0       dog
-        1       cat
-        2    monkey
-        dtype: object
-        >>> s.rename_axis("animal")
-        animal
-        0    dog
-        1    cat
-        2    monkey
-        dtype: object
-
-        **DataFrame**
-
-        >>> df = pd.DataFrame({"num_legs": [4, 4, 2],
-        ...                    "num_arms": [0, 0, 2]},
-        ...                   ["dog", "cat", "monkey"])
-        >>> df
-                num_legs  num_arms
-        dog            4         0
-        cat            4         0
-        monkey         2         2
-        >>> df = df.rename_axis("animal")
-        >>> df
-                num_legs  num_arms
-        animal
-        dog            4         0
-        cat            4         0
-        monkey         2         2
-        >>> df = df.rename_axis("limbs", axis="columns")
-        >>> df
-        limbs   num_legs  num_arms
-        animal
-        dog            4         0
-        cat            4         0
-        monkey         2         2
-
-        **MultiIndex**
-
-        >>> df.index = pd.MultiIndex.from_product([['mammal'],
-        ...                                        ['dog', 'cat', 'monkey']],
-        ...                                       names=['type', 'name'])
-        >>> df
-        limbs          num_legs  num_arms
-        type   name
-        mammal dog            4         0
-               cat            4         0
-               monkey         2         2
-
-        >>> df.rename_axis(index={'type': 'class'})
-        limbs          num_legs  num_arms
-        class  name
-        mammal dog            4         0
-               cat            4         0
-               monkey         2         2
-
-        >>> df.rename_axis(columns=str.upper)
-        LIMBS          num_legs  num_arms
-        type   name
-        mammal dog            4         0
-               cat            4         0
-               monkey         2         2
-        """
         raise AbstractMethodError(self)
 
     def _set_axis_name(self, name, axis=0, inplace=False):
-        """
-        Set the name(s) of the axis.
-
-        Parameters
-        ----------
-        name : str or list of str
-            Name(s) to set.
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-            The axis to set the label. The value 0 or 'index' specifies index,
-            and the value 1 or 'columns' specifies columns.
-        inplace : bool, default False
-            If `True`, do operation inplace and return None.
-
-        Returns
-        -------
-        Series, DataFrame, or None
-            The same type as the caller or `None` if `inplace` is `True`.
-
-        See Also
-        --------
-        DataFrame.rename : Alter the axis labels of :class:`DataFrame`.
-        Series.rename : Alter the index labels or set the index name
-            of :class:`Series`.
-        Index.rename : Set the name of :class:`Index` or :class:`MultiIndex`.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({"num_legs": [4, 4, 2]},
-        ...                   ["dog", "cat", "monkey"])
-        >>> df
-                num_legs
-        dog            4
-        cat            4
-        monkey         2
-        >>> df._set_axis_name("animal")
-                num_legs
-        animal
-        dog            4
-        cat            4
-        monkey         2
-        >>> df.index = pd.MultiIndex.from_product(
-        ...                [["mammal"], ['dog', 'cat', 'monkey']])
-        >>> df._set_axis_name(["type", "name"])
-                       num_legs
-        type   name
-        mammal dog        4
-               cat        4
-               monkey     2
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
@@ -956,83 +281,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         raise AbstractMethodError(self)
 
     def equals(self, other: object) -> bool:
-        """
-        Test whether two objects contain the same elements.
-
-        This function allows two Series or DataFrames to be compared against
-        each other to see if they have the same shape and elements. NaNs in
-        the same location are considered equal.
-
-        The row/column index do not need to have the same type, as long
-        as the values are considered equal. Corresponding columns must be of
-        the same dtype.
-
-        Parameters
-        ----------
-        other : Series or DataFrame
-            The other Series or DataFrame to be compared with the first.
-
-        Returns
-        -------
-        bool
-            True if all elements are the same in both objects, False
-            otherwise.
-
-        See Also
-        --------
-        Series.eq : Compare two Series objects of the same length
-            and return a Series where each element is True if the element
-            in each Series is equal, False otherwise.
-        DataFrame.eq : Compare two DataFrame objects of the same shape and
-            return a DataFrame where each element is True if the respective
-            element in each DataFrame is equal, False otherwise.
-        testing.assert_series_equal : Raises an AssertionError if left and
-            right are not equal. Provides an easy interface to ignore
-            inequality in dtypes, indexes and precision among others.
-        testing.assert_frame_equal : Like assert_series_equal, but targets
-            DataFrames.
-        numpy.array_equal : Return True if two arrays have the same shape
-            and elements, False otherwise.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({1: [10], 2: [20]})
-        >>> df
-            1   2
-        0  10  20
-
-        DataFrames df and exactly_equal have the same types and values for
-        their elements and column labels, which will return True.
-
-        >>> exactly_equal = pd.DataFrame({1: [10], 2: [20]})
-        >>> exactly_equal
-            1   2
-        0  10  20
-        >>> df.equals(exactly_equal)
-        True
-
-        DataFrames df and different_column_type have the same element
-        types and values, but have different types for the column labels,
-        which will still return True.
-
-        >>> different_column_type = pd.DataFrame({1.0: [10], 2.0: [20]})
-        >>> different_column_type
-           1.0  2.0
-        0   10   20
-        >>> df.equals(different_column_type)
-        True
-
-        DataFrames df and different_data_type have different types for the
-        same values for their elements, and will return False even though
-        their column labels are the same values and types.
-
-        >>> different_data_type = pd.DataFrame({1: [10.0], 2: [20.0]})
-        >>> different_data_type
-              1     2
-        0  10.0  20.0
-        >>> df.equals(different_data_type)
-        False
-        """
         raise AbstractMethodError(self)
 
     # -------------------------------------------------------------------------
@@ -1053,38 +301,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     __bool__ = __nonzero__
 
     def bool(self):
-        """
-        Return the bool of a single element Series or DataFrame.
-
-        This must be a boolean scalar value, either True or False. It will raise a
-        ValueError if the Series or DataFrame does not have exactly 1 element, or that
-        element is not boolean (integer values 0 and 1 will also raise an exception).
-
-        Returns
-        -------
-        bool
-            The value in the Series or DataFrame.
-
-        See Also
-        --------
-        Series.astype : Change the data type of a Series, including to boolean.
-        DataFrame.astype : Change the data type of a DataFrame, including to boolean.
-        numpy.bool_ : NumPy boolean data type, used by pandas for boolean values.
-
-        Examples
-        --------
-        The method will only work for single element objects with a boolean value:
-
-        >>> pd.Series([True]).bool()
-        True
-        >>> pd.Series([False]).bool()
-        False
-
-        >>> pd.DataFrame({'col': [True]}).bool()
-        True
-        >>> pd.DataFrame({'col': [False]}).bool()
-        False
-        """
         raise AbstractMethodError(self)
 
     def __abs__(self: FrameOrSeries) -> FrameOrSeries:
@@ -1102,154 +318,21 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     # have consistent precedence and validation logic throughout the library.
 
     def _is_level_reference(self, key, axis=0):
-        """
-        Test whether a key is a level reference for a given axis.
-
-        To be considered a level reference, `key` must be a string that:
-          - (axis=0): Matches the name of an index level and does NOT match
-            a column label.
-          - (axis=1): Matches the name of a column level and does NOT match
-            an index label.
-
-        Parameters
-        ----------
-        key : str
-            Potential level name for the given axis
-        axis : int, default 0
-            Axis that levels are associated with (0 for index, 1 for columns)
-
-        Returns
-        -------
-        is_level : bool
-        """
         raise AbstractMethodError(self)
 
     def _is_label_reference(self, key, axis=0) -> bool_t:
-        """
-        Test whether a key is a label reference for a given axis.
-
-        To be considered a label reference, `key` must be a string that:
-          - (axis=0): Matches a column label
-          - (axis=1): Matches an index label
-
-        Parameters
-        ----------
-        key: str
-            Potential label name
-        axis: int, default 0
-            Axis perpendicular to the axis that labels are associated with
-            (0 means search for column labels, 1 means search for index labels)
-
-        Returns
-        -------
-        is_label: bool
-        """
         raise AbstractMethodError(self)
 
     def _is_label_or_level_reference(self, key: str, axis: int = 0) -> bool_t:
-        """
-        Test whether a key is a label or level reference for a given axis.
-
-        To be considered either a label or a level reference, `key` must be a
-        string that:
-          - (axis=0): Matches a column label or an index level
-          - (axis=1): Matches an index label or a column level
-
-        Parameters
-        ----------
-        key: str
-            Potential label or level name
-        axis: int, default 0
-            Axis that levels are associated with (0 for index, 1 for columns)
-
-        Returns
-        -------
-        is_label_or_level: bool
-        """
         raise AbstractMethodError(self)
 
     def _check_label_or_level_ambiguity(self, key, axis: int = 0) -> None:
-        """
-        Check whether `key` is ambiguous.
-
-        By ambiguous, we mean that it matches both a level of the input
-        `axis` and a label of the other axis.
-
-        Parameters
-        ----------
-        key: str or object
-            Label or level name.
-        axis: int, default 0
-            Axis that levels are associated with (0 for index, 1 for columns).
-
-        Raises
-        ------
-        ValueError: `key` is ambiguous
-        """
         raise AbstractMethodError(self)
 
     def _get_label_or_level_values(self, key: str, axis: int = 0) -> np.ndarray:
-        """
-        Return a 1-D array of values associated with `key`, a label or level
-        from the given `axis`.
-
-        Retrieval logic:
-          - (axis=0): Return column values if `key` matches a column label.
-            Otherwise return index level values if `key` matches an index
-            level.
-          - (axis=1): Return row values if `key` matches an index label.
-            Otherwise return column level values if 'key' matches a column
-            level
-
-        Parameters
-        ----------
-        key: str
-            Label or level name.
-        axis: int, default 0
-            Axis that levels are associated with (0 for index, 1 for columns)
-
-        Returns
-        -------
-        values: np.ndarray
-
-        Raises
-        ------
-        KeyError
-            if `key` matches neither a label nor a level
-        ValueError
-            if `key` matches multiple labels
-        FutureWarning
-            if `key` is ambiguous. This will become an ambiguity error in a
-            future version
-        """
         raise AbstractMethodError(self)
 
     def _drop_labels_or_levels(self, keys, axis: int = 0):
-        """
-        Drop labels and/or levels for the given `axis`.
-
-        For each key in `keys`:
-          - (axis=0): If key matches a column label then drop the column.
-            Otherwise if key matches an index level then drop the level.
-          - (axis=1): If key matches an index label then drop the row.
-            Otherwise if key matches a column level then drop the level.
-
-        Parameters
-        ----------
-        keys: str or list of str
-            labels or levels to drop
-        axis: int, default 0
-            Axis that levels are associated with (0 for index, 1 for columns)
-
-        Returns
-        -------
-        dropped: DataFrame
-
-        Raises
-        ------
-        ValueError
-            if any `keys` match neither a label nor a level
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
@@ -1259,102 +342,26 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         raise AbstractMethodError(self)
 
     def __iter__(self):
-        """
-        Iterate over info axis.
-
-        Returns
-        -------
-        iterator
-            Info axis as iterator.
-        """
         raise AbstractMethodError(self)
 
     # can we get a better explanation of this?
     def keys(self):
-        """
-        Get the 'info axis' (see Indexing for more).
-
-        This is index for Series, columns for DataFrame.
-
-        Returns
-        -------
-        Index
-            Info axis.
-        """
         raise AbstractMethodError(self)
 
     def items(self):
-        """
-        Iterate over (label, values) on info axis
-
-        This is index for Series and columns for DataFrame.
-
-        Returns
-        -------
-        Generator
-        """
         raise AbstractMethodError(self)
 
-    @doc(items)
     def iteritems(self):
         raise AbstractMethodError(self)
 
     def __len__(self) -> int:
-        """Returns length of info axis"""
         raise AbstractMethodError(self)
 
     def __contains__(self, key) -> bool_t:
-        """True if the key is in the info axis"""
         raise AbstractMethodError(self)
 
     @property
     def empty(self) -> bool_t:
-        """
-        Indicator whether DataFrame is empty.
-
-        True if DataFrame is entirely empty (no items), meaning any of the
-        axes are of length 0.
-
-        Returns
-        -------
-        bool
-            If DataFrame is empty, return True, if not return False.
-
-        See Also
-        --------
-        Series.dropna : Return series without null values.
-        DataFrame.dropna : Return DataFrame with labels on given axis omitted
-            where (all or any) data are missing.
-
-        Notes
-        -----
-        If DataFrame contains only NaNs, it is still not considered empty. See
-        the example below.
-
-        Examples
-        --------
-        An example of an actual empty DataFrame. Notice the index is empty:
-
-        >>> df_empty = pd.DataFrame({'A' : []})
-        >>> df_empty
-        Empty DataFrame
-        Columns: [A]
-        Index: []
-        >>> df_empty.empty
-        True
-
-        If we only have NaNs in our DataFrame, it is not considered empty! We
-        will need to drop the NaNs to make the DataFrame empty:
-
-        >>> df = pd.DataFrame({'A' : [np.nan]})
-        >>> df
-            A
-        0 NaN
-        >>> df.empty
-        False
-        >>> df.dropna().empty
-        True
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
@@ -1372,23 +379,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         result: np.ndarray,
         context: Optional[Tuple[Callable, Tuple[Any, ...], int]] = None,
     ):
-        """
-        Gets called after a ufunc and other functions.
-
-        Parameters
-        ----------
-        result: np.ndarray
-            The result of the ufunc or other function called on the NumPy array
-            returned by __array__
-        context: tuple of (func, tuple, int)
-            This parameter is returned by ufuncs as a 3-element tuple: (name of the
-            ufunc, arguments of the ufunc, domain of the ufunc), but is not set by
-            other numpy functions.q
-
-        Notes
-        -----
-        Series implements __array_ufunc_ so this not called for ufunc on Series.
-        """
         raise AbstractMethodError(self)
 
     # ideally we would define this to avoid the getattr checks, but
@@ -1415,23 +405,14 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         raise AbstractMethodError(self)
 
     def _repr_latex_(self):
-        """
-        Returns a LaTeX representation for a particular object.
-        Mainly for use with nbconvert (jupyter notebook conversion to pdf).
-        """
         raise AbstractMethodError(self)
 
     def _repr_data_resource_(self):
-        """
-        Not a real Jupyter special repr method, but we use the same
-        naming convention.
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
     # I/O Methods
 
-    @doc(klass="object")
     def to_excel(
         self,
         excel_writer,
@@ -1451,113 +432,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         verbose=True,
         freeze_panes=None,
     ) -> None:
-        """
-        Write {klass} to an Excel sheet.
-
-        To write a single {klass} to an Excel .xlsx file it is only necessary to
-        specify a target file name. To write to multiple sheets it is necessary to
-        create an `ExcelWriter` object with a target file name, and specify a sheet
-        in the file to write to.
-
-        Multiple sheets may be written to by specifying unique `sheet_name`.
-        With all data written to the file it is necessary to save the changes.
-        Note that creating an `ExcelWriter` object with a file name that already
-        exists will result in the contents of the existing file being erased.
-
-        Parameters
-        ----------
-        excel_writer : str or ExcelWriter object
-            File path or existing ExcelWriter.
-        sheet_name : str, default 'Sheet1'
-            Name of sheet which will contain DataFrame.
-        na_rep : str, default ''
-            Missing data representation.
-        float_format : str, optional
-            Format string for floating point numbers. For example
-            ``float_format="%.2f"`` will format 0.1234 to 0.12.
-        columns : sequence or list of str, optional
-            Columns to write.
-        header : bool or list of str, default True
-            Write out the column names. If a list of string is given it is
-            assumed to be aliases for the column names.
-        index : bool, default True
-            Write row names (index).
-        index_label : str or sequence, optional
-            Column label for index column(s) if desired. If not specified, and
-            `header` and `index` are True, then the index names are used. A
-            sequence should be given if the DataFrame uses MultiIndex.
-        startrow : int, default 0
-            Upper left cell row to dump data frame.
-        startcol : int, default 0
-            Upper left cell column to dump data frame.
-        engine : str, optional
-            Write engine to use, 'openpyxl' or 'xlsxwriter'. You can also set this
-            via the options ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
-            ``io.excel.xlsm.writer``.
-        merge_cells : bool, default True
-            Write MultiIndex and Hierarchical Rows as merged cells.
-        encoding : str, optional
-            Encoding of the resulting excel file. Only necessary for xlwt,
-            other writers support unicode natively.
-        inf_rep : str, default 'inf'
-            Representation for infinity (there is no native representation for
-            infinity in Excel).
-        verbose : bool, default True
-            Display more information in the error logs.
-        freeze_panes : tuple of int (length 2), optional
-            Specifies the one-based bottommost row and rightmost column that
-            is to be frozen.
-
-        See Also
-        --------
-        to_csv : Write DataFrame to a comma-separated values (csv) file.
-        ExcelWriter : Class for writing DataFrame objects into excel sheets.
-        read_excel : Read an Excel file into a pandas DataFrame.
-        read_csv : Read a comma-separated values (csv) file into DataFrame.
-
-        Notes
-        -----
-        For compatibility with :meth:`~DataFrame.to_csv`,
-        to_excel serializes lists and dicts to strings before writing.
-
-        Once a workbook has been saved it is not possible write further data
-        without rewriting the whole workbook.
-
-        Examples
-        --------
-
-        Create, write to and save a workbook:
-
-        >>> df1 = pd.DataFrame([['a', 'b'], ['c', 'd']],
-        ...                    index=['row 1', 'row 2'],
-        ...                    columns=['col 1', 'col 2'])
-        >>> df1.to_excel("output.xlsx")  # doctest: +SKIP
-
-        To specify the sheet name:
-
-        >>> df1.to_excel("output.xlsx",
-        ...              sheet_name='Sheet_name_1')  # doctest: +SKIP
-
-        If you wish to write to more than one sheet in the workbook, it is
-        necessary to specify an ExcelWriter object:
-
-        >>> df2 = df1.copy()
-        >>> with pd.ExcelWriter('output.xlsx') as writer:  # doctest: +SKIP
-        ...     df1.to_excel(writer, sheet_name='Sheet_name_1')
-        ...     df2.to_excel(writer, sheet_name='Sheet_name_2')
-
-        ExcelWriter can also be used to append to an existing Excel file:
-
-        >>> with pd.ExcelWriter('output.xlsx',
-        ...                     mode='a') as writer:  # doctest: +SKIP
-        ...     df.to_excel(writer, sheet_name='Sheet_name_3')
-
-        To set the library that is used to write the Excel file,
-        you can pass the `engine` keyword (the default engine is
-        automatically chosen depending on the file extension):
-
-        >>> df1.to_excel('output1.xlsx', engine='xlsxwriter')  # doctest: +SKIP
-        """
         raise AbstractMethodError(self)
 
     def to_json(
@@ -1575,252 +449,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         indent: Optional[int] = None,
         storage_options: StorageOptions = None,
     ) -> Optional[str]:
-        """
-        Convert the object to a JSON string.
-
-        Note NaN's and None will be converted to null and datetime objects
-        will be converted to UNIX timestamps.
-
-        Parameters
-        ----------
-        path_or_buf : str or file handle, optional
-            File path or object. If not specified, the result is returned as
-            a string.
-        orient : str
-            Indication of expected JSON string format.
-
-            * Series:
-
-                - default is 'index'
-                - allowed values are: {'split','records','index','table'}.
-
-            * DataFrame:
-
-                - default is 'columns'
-                - allowed values are: {'split', 'records', 'index', 'columns',
-                  'values', 'table'}.
-
-            * The format of the JSON string:
-
-                - 'split' : dict like {'index' -> [index], 'columns' -> [columns],
-                  'data' -> [values]}
-                - 'records' : list like [{column -> value}, ... , {column -> value}]
-                - 'index' : dict like {index -> {column -> value}}
-                - 'columns' : dict like {column -> {index -> value}}
-                - 'values' : just the values array
-                - 'table' : dict like {'schema': {schema}, 'data': {data}}
-
-                Describing the data, where data component is like ``orient='records'``.
-
-        date_format : {None, 'epoch', 'iso'}
-            Type of date conversion. 'epoch' = epoch milliseconds,
-            'iso' = ISO8601. The default depends on the `orient`. For
-            ``orient='table'``, the default is 'iso'. For all other orients,
-            the default is 'epoch'.
-        double_precision : int, default 10
-            The number of decimal places to use when encoding
-            floating point values.
-        force_ascii : bool, default True
-            Force encoded string to be ASCII.
-        date_unit : str, default 'ms' (milliseconds)
-            The time unit to encode to, governs timestamp and ISO8601
-            precision.  One of 's', 'ms', 'us', 'ns' for second, millisecond,
-            microsecond, and nanosecond respectively.
-        default_handler : callable, default None
-            Handler to call if object cannot otherwise be converted to a
-            suitable format for JSON. Should receive a single argument which is
-            the object to convert and return a serialisable object.
-        lines : bool, default False
-            If 'orient' is 'records' write out line delimited json format. Will
-            throw ValueError if incorrect 'orient' since others are not list
-            like.
-
-        compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}
-
-            A string representing the compression to use in the output file,
-            only used when the first argument is a filename. By default, the
-            compression is inferred from the filename.
-
-            .. versionchanged:: 0.24.0
-               'infer' option added and set to default
-        index : bool, default True
-            Whether to include the index values in the JSON string. Not
-            including the index (``index=False``) is only supported when
-            orient is 'split' or 'table'.
-        indent : int, optional
-           Length of whitespace used to indent each record.
-
-           .. versionadded:: 1.0.0
-
-        storage_options : dict, optional
-            Extra options that make sense for a particular storage connection, e.g.
-            host, port, username, password, etc., if using a URL that will
-            be parsed by ``fsspec``, e.g., starting "s3://", "gcs://". An error
-            will be raised if providing this argument with a local path or
-            a file-like buffer. See the fsspec and backend storage implementation
-            docs for the set of allowed keys and values.
-
-            .. versionadded:: 1.2.0
-
-        Returns
-        -------
-        None or str
-            If path_or_buf is None, returns the resulting json format as a
-            string. Otherwise returns None.
-
-        See Also
-        --------
-        read_json : Convert a JSON string to pandas object.
-
-        Notes
-        -----
-        The behavior of ``indent=0`` varies from the stdlib, which does not
-        indent the output but does insert newlines. Currently, ``indent=0``
-        and the default ``indent=None`` are equivalent in pandas, though this
-        may change in a future release.
-
-        ``orient='table'`` contains a 'pandas_version' field under 'schema'.
-        This stores the version of `pandas` used in the latest revision of the
-        schema.
-
-        Examples
-        --------
-        >>> import json
-        >>> df = pd.DataFrame(
-        ...     [["a", "b"], ["c", "d"]],
-        ...     index=["row 1", "row 2"],
-        ...     columns=["col 1", "col 2"],
-        ... )
-
-        >>> result = df.to_json(orient="split")
-        >>> parsed = json.loads(result)
-        >>> json.dumps(parsed, indent=4)  # doctest: +SKIP
-        {
-            "columns": [
-                "col 1",
-                "col 2"
-            ],
-            "index": [
-                "row 1",
-                "row 2"
-            ],
-            "data": [
-                [
-                    "a",
-                    "b"
-                ],
-                [
-                    "c",
-                    "d"
-                ]
-            ]
-        }
-
-        Encoding/decoding a Dataframe using ``'records'`` formatted JSON.
-        Note that index labels are not preserved with this encoding.
-
-        >>> result = df.to_json(orient="records")
-        >>> parsed = json.loads(result)
-        >>> json.dumps(parsed, indent=4)  # doctest: +SKIP
-        [
-            {
-                "col 1": "a",
-                "col 2": "b"
-            },
-            {
-                "col 1": "c",
-                "col 2": "d"
-            }
-        ]
-
-        Encoding/decoding a Dataframe using ``'index'`` formatted JSON:
-
-        >>> result = df.to_json(orient="index")
-        >>> parsed = json.loads(result)
-        >>> json.dumps(parsed, indent=4)  # doctest: +SKIP
-        {
-            "row 1": {
-                "col 1": "a",
-                "col 2": "b"
-            },
-            "row 2": {
-                "col 1": "c",
-                "col 2": "d"
-            }
-        }
-
-        Encoding/decoding a Dataframe using ``'columns'`` formatted JSON:
-
-        >>> result = df.to_json(orient="columns")
-        >>> parsed = json.loads(result)
-        >>> json.dumps(parsed, indent=4)  # doctest: +SKIP
-        {
-            "col 1": {
-                "row 1": "a",
-                "row 2": "c"
-            },
-            "col 2": {
-                "row 1": "b",
-                "row 2": "d"
-            }
-        }
-
-        Encoding/decoding a Dataframe using ``'values'`` formatted JSON:
-
-        >>> result = df.to_json(orient="values")
-        >>> parsed = json.loads(result)
-        >>> json.dumps(parsed, indent=4)  # doctest: +SKIP
-        [
-            [
-                "a",
-                "b"
-            ],
-            [
-                "c",
-                "d"
-            ]
-        ]
-
-        Encoding with Table Schema:
-
-        >>> result = df.to_json(orient="table")
-        >>> parsed = json.loads(result)
-        >>> json.dumps(parsed, indent=4)  # doctest: +SKIP
-        {
-            "schema": {
-                "fields": [
-                    {
-                        "name": "index",
-                        "type": "string"
-                    },
-                    {
-                        "name": "col 1",
-                        "type": "string"
-                    },
-                    {
-                        "name": "col 2",
-                        "type": "string"
-                    }
-                ],
-                "primaryKey": [
-                    "index"
-                ],
-                "pandas_version": "0.20.0"
-            },
-            "data": [
-                {
-                    "index": "row 1",
-                    "col 1": "a",
-                    "col 2": "b"
-                },
-                {
-                    "index": "row 2",
-                    "col 1": "c",
-                    "col 2": "d"
-                }
-            ]
-        }
-        """
         raise AbstractMethodError(self)
 
     def to_hdf(
@@ -1840,110 +468,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         errors: str = "strict",
         encoding: str = "UTF-8",
     ) -> None:
-        """
-        Write the contained data to an HDF5 file using HDFStore.
-
-        Hierarchical Data Format (HDF) is self-describing, allowing an
-        application to interpret the structure and contents of a file with
-        no outside information. One HDF file can hold a mix of related objects
-        which can be accessed as a group or as individual objects.
-
-        In order to add another DataFrame or Series to an existing HDF file
-        please use append mode and a different a key.
-
-        For more information see the :ref:`user guide <io.hdf5>`.
-
-        Parameters
-        ----------
-        path_or_buf : str or pandas.HDFStore
-            File path or HDFStore object.
-        key : str
-            Identifier for the group in the store.
-        mode : {'a', 'w', 'r+'}, default 'a'
-            Mode to open file:
-
-            - 'w': write, a new file is created (an existing file with
-              the same name would be deleted).
-            - 'a': append, an existing file is opened for reading and
-              writing, and if the file does not exist it is created.
-            - 'r+': similar to 'a', but the file must already exist.
-        complevel : {0-9}, optional
-            Specifies a compression level for data.
-            A value of 0 disables compression.
-        complib : {'zlib', 'lzo', 'bzip2', 'blosc'}, default 'zlib'
-            Specifies the compression library to be used.
-            As of v0.20.2 these additional compressors for Blosc are supported
-            (default if no compressor specified: 'blosc:blosclz'):
-            {'blosc:blosclz', 'blosc:lz4', 'blosc:lz4hc', 'blosc:snappy',
-            'blosc:zlib', 'blosc:zstd'}.
-            Specifying a compression library which is not available issues
-            a ValueError.
-        append : bool, default False
-            For Table formats, append the input data to the existing.
-        format : {'fixed', 'table', None}, default 'fixed'
-            Possible values:
-
-            - 'fixed': Fixed format. Fast writing/reading. Not-appendable,
-              nor searchable.
-            - 'table': Table format. Write as a PyTables Table structure
-              which may perform worse but allow more flexible operations
-              like searching / selecting subsets of the data.
-            - If None, pd.get_option('io.hdf.default_format') is checked,
-              followed by fallback to "fixed"
-        errors : str, default 'strict'
-            Specifies how encoding and decoding errors are to be handled.
-            See the errors argument for :func:`open` for a full list
-            of options.
-        encoding : str, default "UTF-8"
-        min_itemsize : dict or int, optional
-            Map column names to minimum string sizes for columns.
-        nan_rep : Any, optional
-            How to represent null values as str.
-            Not allowed with append=True.
-        data_columns : list of columns or True, optional
-            List of columns to create as indexed data columns for on-disk
-            queries, or True to use all columns. By default only the axes
-            of the object are indexed. See :ref:`io.hdf5-query-data-columns`.
-            Applicable only to format='table'.
-
-        See Also
-        --------
-        DataFrame.read_hdf : Read from HDF file.
-        DataFrame.to_parquet : Write a DataFrame to the binary parquet format.
-        DataFrame.to_sql : Write to a sql table.
-        DataFrame.to_feather : Write out feather-format for DataFrames.
-        DataFrame.to_csv : Write out to a csv file.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]},
-        ...                   index=['a', 'b', 'c'])
-        >>> df.to_hdf('data.h5', key='df', mode='w')
-
-        We can add another object to the same file:
-
-        >>> s = pd.Series([1, 2, 3, 4])
-        >>> s.to_hdf('data.h5', key='s')
-
-        Reading from HDF file:
-
-        >>> pd.read_hdf('data.h5', 'df')
-        A  B
-        a  1  4
-        b  2  5
-        c  3  6
-        >>> pd.read_hdf('data.h5', 's')
-        0    1
-        1    2
-        2    3
-        3    4
-        dtype: int64
-
-        Deleting file with data:
-
-        >>> import os
-        >>> os.remove('data.h5')
-        """
         raise AbstractMethodError(self)
 
     def to_sql(
@@ -1958,146 +482,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         dtype=None,
         method=None,
     ) -> None:
-        """
-        Write records stored in a DataFrame to a SQL database.
-
-        Databases supported by SQLAlchemy [1]_ are supported. Tables can be
-        newly created, appended to, or overwritten.
-
-        Parameters
-        ----------
-        name : str
-            Name of SQL table.
-        con : sqlalchemy.engine.(Engine or Connection) or sqlite3.Connection
-            Using SQLAlchemy makes it possible to use any DB supported by that
-            library. Legacy support is provided for sqlite3.Connection objects. The user
-            is responsible for engine disposal and connection closure for the SQLAlchemy
-            connectable See `here \
-                <https://docs.sqlalchemy.org/en/13/core/connections.html>`_.
-
-        schema : str, optional
-            Specify the schema (if database flavor supports this). If None, use
-            default schema.
-        if_exists : {'fail', 'replace', 'append'}, default 'fail'
-            How to behave if the table already exists.
-
-            * fail: Raise a ValueError.
-            * replace: Drop the table before inserting new values.
-            * append: Insert new values to the existing table.
-
-        index : bool, default True
-            Write DataFrame index as a column. Uses `index_label` as the column
-            name in the table.
-        index_label : str or sequence, default None
-            Column label for index column(s). If None is given (default) and
-            `index` is True, then the index names are used.
-            A sequence should be given if the DataFrame uses MultiIndex.
-        chunksize : int, optional
-            Specify the number of rows in each batch to be written at a time.
-            By default, all rows will be written at once.
-        dtype : dict or scalar, optional
-            Specifying the datatype for columns. If a dictionary is used, the
-            keys should be the column names and the values should be the
-            SQLAlchemy types or strings for the sqlite3 legacy mode. If a
-            scalar is provided, it will be applied to all columns.
-        method : {None, 'multi', callable}, optional
-            Controls the SQL insertion clause used:
-
-            * None : Uses standard SQL ``INSERT`` clause (one per row).
-            * 'multi': Pass multiple values in a single ``INSERT`` clause.
-            * callable with signature ``(pd_table, conn, keys, data_iter)``.
-
-            Details and a sample callable implementation can be found in the
-            section :ref:`insert method <io.sql.method>`.
-
-            .. versionadded:: 0.24.0
-
-        Raises
-        ------
-        ValueError
-            When the table already exists and `if_exists` is 'fail' (the
-            default).
-
-        See Also
-        --------
-        read_sql : Read a DataFrame from a table.
-
-        Notes
-        -----
-        Timezone aware datetime columns will be written as
-        ``Timestamp with timezone`` type with SQLAlchemy if supported by the
-        database. Otherwise, the datetimes will be stored as timezone unaware
-        timestamps local to the original timezone.
-
-        .. versionadded:: 0.24.0
-
-        References
-        ----------
-        .. [1] https://docs.sqlalchemy.org
-        .. [2] https://www.python.org/dev/peps/pep-0249/
-
-        Examples
-        --------
-        Create an in-memory SQLite database.
-
-        >>> from sqlalchemy import create_engine
-        >>> engine = create_engine('sqlite://', echo=False)
-
-        Create a table from scratch with 3 rows.
-
-        >>> df = pd.DataFrame({'name' : ['User 1', 'User 2', 'User 3']})
-        >>> df
-             name
-        0  User 1
-        1  User 2
-        2  User 3
-
-        >>> df.to_sql('users', con=engine)
-        >>> engine.execute("SELECT * FROM users").fetchall()
-        [(0, 'User 1'), (1, 'User 2'), (2, 'User 3')]
-
-        An `sqlalchemy.engine.Connection` can also be passed to to `con`:
-
-        >>> with engine.begin() as connection:
-        ...     df1 = pd.DataFrame({'name' : ['User 4', 'User 5']})
-        ...     df1.to_sql('users', con=connection, if_exists='append')
-
-        This is allowed to support operations that require that the same
-        DBAPI connection is used for the entire operation.
-
-        >>> df2 = pd.DataFrame({'name' : ['User 6', 'User 7']})
-        >>> df2.to_sql('users', con=engine, if_exists='append')
-        >>> engine.execute("SELECT * FROM users").fetchall()
-        [(0, 'User 1'), (1, 'User 2'), (2, 'User 3'),
-         (0, 'User 4'), (1, 'User 5'), (0, 'User 6'),
-         (1, 'User 7')]
-
-        Overwrite the table with just ``df2``.
-
-        >>> df2.to_sql('users', con=engine, if_exists='replace',
-        ...            index_label='id')
-        >>> engine.execute("SELECT * FROM users").fetchall()
-        [(0, 'User 6'), (1, 'User 7')]
-
-        Specify the dtype (especially useful for integers with missing values).
-        Notice that while pandas is forced to store the data as floating point,
-        the database supports nullable integers. When fetching the data with
-        Python, we get back integer scalars.
-
-        >>> df = pd.DataFrame({"A": [1, None, 2]})
-        >>> df
-             A
-        0  1.0
-        1  NaN
-        2  2.0
-
-        >>> from sqlalchemy.types import Integer
-        >>> df.to_sql('integers', con=engine, index=False,
-        ...           dtype={"A": Integer()})
-
-        >>> engine.execute("SELECT * FROM integers").fetchall()
-        [(1,), (None,), (2,)]
-        """
         raise AbstractMethodError(self)
 
     def to_pickle(
@@ -2107,206 +491,16 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         protocol: int = pickle.HIGHEST_PROTOCOL,
         storage_options: StorageOptions = None,
     ) -> None:
-        """
-        Pickle (serialize) object to file.
-
-        Parameters
-        ----------
-        path : str
-            File path where the pickled object will be stored.
-        compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, \
-        default 'infer'
-            A string representing the compression to use in the output file. By
-            default, infers from the file extension in specified path.
-        protocol : int
-            Int which indicates which protocol should be used by the pickler,
-            default HIGHEST_PROTOCOL (see [1]_ paragraph 12.1.2). The possible
-            values are 0, 1, 2, 3, 4, 5. A negative value for the protocol
-            parameter is equivalent to setting its value to HIGHEST_PROTOCOL.
-
-            .. [1] https://docs.python.org/3/library/pickle.html.
-
-        storage_options : dict, optional
-            Extra options that make sense for a particular storage connection, e.g.
-            host, port, username, password, etc., if using a URL that will
-            be parsed by ``fsspec``, e.g., starting "s3://", "gcs://". An error
-            will be raised if providing this argument with a local path or
-            a file-like buffer. See the fsspec and backend storage implementation
-            docs for the set of allowed keys and values.
-
-            .. versionadded:: 1.2.0
-
-        See Also
-        --------
-        read_pickle : Load pickled pandas object (or any object) from file.
-        DataFrame.to_hdf : Write DataFrame to an HDF5 file.
-        DataFrame.to_sql : Write DataFrame to a SQL database.
-        DataFrame.to_parquet : Write a DataFrame to the binary parquet format.
-
-        Examples
-        --------
-        >>> original_df = pd.DataFrame({"foo": range(5), "bar": range(5, 10)})
-        >>> original_df
-           foo  bar
-        0    0    5
-        1    1    6
-        2    2    7
-        3    3    8
-        4    4    9
-        >>> original_df.to_pickle("./dummy.pkl")
-
-        >>> unpickled_df = pd.read_pickle("./dummy.pkl")
-        >>> unpickled_df
-           foo  bar
-        0    0    5
-        1    1    6
-        2    2    7
-        3    3    8
-        4    4    9
-
-        >>> import os
-        >>> os.remove("./dummy.pkl")
-        """
         raise AbstractMethodError(self)
 
     def to_clipboard(
         self, excel: bool_t = True, sep: Optional[str] = None, **kwargs
     ) -> None:
-        r"""
-        Copy object to the system clipboard.
-
-        Write a text representation of object to the system clipboard.
-        This can be pasted into Excel, for example.
-
-        Parameters
-        ----------
-        excel : bool, default True
-            Produce output in a csv format for easy pasting into excel.
-
-            - True, use the provided separator for csv pasting.
-            - False, write a string representation of the object to the clipboard.
-
-        sep : str, default ``'\t'``
-            Field delimiter.
-        **kwargs
-            These parameters will be passed to DataFrame.to_csv.
-
-        See Also
-        --------
-        DataFrame.to_csv : Write a DataFrame to a comma-separated values
-            (csv) file.
-        read_clipboard : Read text from clipboard and pass to read_table.
-
-        Notes
-        -----
-        Requirements for your platform.
-
-          - Linux : `xclip`, or `xsel` (with `PyQt4` modules)
-          - Windows : none
-          - OS X : none
-
-        Examples
-        --------
-        Copy the contents of a DataFrame to the clipboard.
-
-        >>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
-
-        >>> df.to_clipboard(sep=',')  # doctest: +SKIP
-        ... # Wrote the following to the system clipboard:
-        ... # ,A,B,C
-        ... # 0,1,2,3
-        ... # 1,4,5,6
-
-        We can omit the index by passing the keyword `index` and setting
-        it to false.
-
-        >>> df.to_clipboard(sep=',', index=False)  # doctest: +SKIP
-        ... # Wrote the following to the system clipboard:
-        ... # A,B,C
-        ... # 1,2,3
-        ... # 4,5,6
-        """
         raise AbstractMethodError(self)
 
     def to_xarray(self):
-        """
-        Return an xarray object from the pandas object.
-
-        Returns
-        -------
-        xarray.DataArray or xarray.Dataset
-            Data in the pandas structure converted to Dataset if the object is
-            a DataFrame, or a DataArray if the object is a Series.
-
-        See Also
-        --------
-        DataFrame.to_hdf : Write DataFrame to an HDF5 file.
-        DataFrame.to_parquet : Write a DataFrame to the binary parquet format.
-
-        Notes
-        -----
-        See the `xarray docs <https://xarray.pydata.org/en/stable/>`__
-
-        Examples
-        --------
-        >>> df = pd.DataFrame([('falcon', 'bird', 389.0, 2),
-        ...                    ('parrot', 'bird', 24.0, 2),
-        ...                    ('lion', 'mammal', 80.5, 4),
-        ...                    ('monkey', 'mammal', np.nan, 4)],
-        ...                   columns=['name', 'class', 'max_speed',
-        ...                            'num_legs'])
-        >>> df
-             name   class  max_speed  num_legs
-        0  falcon    bird      389.0         2
-        1  parrot    bird       24.0         2
-        2    lion  mammal       80.5         4
-        3  monkey  mammal        NaN         4
-
-        >>> df.to_xarray()
-        <xarray.Dataset>
-        Dimensions:    (index: 4)
-        Coordinates:
-          * index      (index) int64 0 1 2 3
-        Data variables:
-            name       (index) object 'falcon' 'parrot' 'lion' 'monkey'
-            class      (index) object 'bird' 'bird' 'mammal' 'mammal'
-            max_speed  (index) float64 389.0 24.0 80.5 nan
-            num_legs   (index) int64 2 2 4 4
-
-        >>> df['max_speed'].to_xarray()
-        <xarray.DataArray 'max_speed' (index: 4)>
-        array([389. ,  24. ,  80.5,   nan])
-        Coordinates:
-          * index    (index) int64 0 1 2 3
-
-        >>> dates = pd.to_datetime(['2018-01-01', '2018-01-01',
-        ...                         '2018-01-02', '2018-01-02'])
-        >>> df_multiindex = pd.DataFrame({'date': dates,
-        ...                               'animal': ['falcon', 'parrot',
-        ...                                          'falcon', 'parrot'],
-        ...                               'speed': [350, 18, 361, 15]})
-        >>> df_multiindex = df_multiindex.set_index(['date', 'animal'])
-
-        >>> df_multiindex
-                           speed
-        date       animal
-        2018-01-01 falcon    350
-                   parrot     18
-        2018-01-02 falcon    361
-                   parrot     15
-
-        >>> df_multiindex.to_xarray()
-        <xarray.Dataset>
-        Dimensions:  (animal: 2, date: 2)
-        Coordinates:
-          * date     (date) datetime64[ns] 2018-01-01 2018-01-02
-          * animal   (animal) object 'falcon' 'parrot'
-        Data variables:
-            speed    (date, animal) int64 350 18 361 15
-        """
         raise AbstractMethodError(self)
 
-    @doc(returns=fmt.return_docstring)
     def to_latex(
         self,
         buf=None,
@@ -2332,122 +526,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         label=None,
         position=None,
     ):
-        r"""
-        Render object to a LaTeX tabular, longtable, or nested table/tabular.
-
-        Requires ``\usepackage{{booktabs}}``.  The output can be copy/pasted
-        into a main LaTeX document or read from an external file
-        with ``\input{{table.tex}}``.
-
-        .. versionchanged:: 1.0.0
-           Added caption and label arguments.
-
-        .. versionchanged:: 1.2.0
-           Added position argument, changed meaning of caption argument.
-
-        Parameters
-        ----------
-        buf : str, Path or StringIO-like, optional, default None
-            Buffer to write to. If None, the output is returned as a string.
-        columns : list of label, optional
-            The subset of columns to write. Writes all columns by default.
-        col_space : int, optional
-            The minimum width of each column.
-        header : bool or list of str, default True
-            Write out the column names. If a list of strings is given,
-            it is assumed to be aliases for the column names.
-        index : bool, default True
-            Write row names (index).
-        na_rep : str, default 'NaN'
-            Missing data representation.
-        formatters : list of functions or dict of {{str: function}}, optional
-            Formatter functions to apply to columns' elements by position or
-            name. The result of each function must be a unicode string.
-            List must be of length equal to the number of columns.
-        float_format : one-parameter function or str, optional, default None
-            Formatter for floating point numbers. For example
-            ``float_format="%.2f"`` and ``float_format="{{:0.2f}}".format`` will
-            both result in 0.1234 being formatted as 0.12.
-        sparsify : bool, optional
-            Set to False for a DataFrame with a hierarchical index to print
-            every multiindex key at each row. By default, the value will be
-            read from the config module.
-        index_names : bool, default True
-            Prints the names of the indexes.
-        bold_rows : bool, default False
-            Make the row labels bold in the output.
-        column_format : str, optional
-            The columns format as specified in `LaTeX table format
-            <https://en.wikibooks.org/wiki/LaTeX/Tables>`__ e.g. 'rcl' for 3
-            columns. By default, 'l' will be used for all columns except
-            columns of numbers, which default to 'r'.
-        longtable : bool, optional
-            By default, the value will be read from the pandas config
-            module. Use a longtable environment instead of tabular. Requires
-            adding a \usepackage{{longtable}} to your LaTeX preamble.
-        escape : bool, optional
-            By default, the value will be read from the pandas config
-            module. When set to False prevents from escaping latex special
-            characters in column names.
-        encoding : str, optional
-            A string representing the encoding to use in the output file,
-            defaults to 'utf-8'.
-        decimal : str, default '.'
-            Character recognized as decimal separator, e.g. ',' in Europe.
-        multicolumn : bool, default True
-            Use \multicolumn to enhance MultiIndex columns.
-            The default will be read from the config module.
-        multicolumn_format : str, default 'l'
-            The alignment for multicolumns, similar to `column_format`
-            The default will be read from the config module.
-        multirow : bool, default False
-            Use \multirow to enhance MultiIndex rows. Requires adding a
-            \usepackage{{multirow}} to your LaTeX preamble. Will print
-            centered labels (instead of top-aligned) across the contained
-            rows, separating groups via clines. The default will be read
-            from the pandas config module.
-        caption : str or tuple, optional
-            Tuple (full_caption, short_caption),
-            which results in ``\caption[short_caption]{{full_caption}}``;
-            if a single string is passed, no short caption will be set.
-
-            .. versionadded:: 1.0.0
-
-            .. versionchanged:: 1.2.0
-               Optionally allow caption to be a tuple ``(full_caption, short_caption)``.
-
-        label : str, optional
-            The LaTeX label to be placed inside ``\label{{}}`` in the output.
-            This is used with ``\ref{{}}`` in the main ``.tex`` file.
-
-            .. versionadded:: 1.0.0
-        position : str, optional
-            The LaTeX positional argument for tables, to be placed after
-            ``\begin{{}}`` in the output.
-
-            .. versionadded:: 1.2.0
-        {returns}
-        See Also
-        --------
-        DataFrame.to_string : Render a DataFrame to a console-friendly
-            tabular output.
-        DataFrame.to_html : Render a DataFrame as an HTML table.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame(dict(name=['Raphael', 'Donatello'],
-        ...                   mask=['red', 'purple'],
-        ...                   weapon=['sai', 'bo staff']))
-        >>> print(df.to_latex(index=False))  # doctest: +NORMALIZE_WHITESPACE
-        \begin{{tabular}}{{lll}}
-         \toprule
-               name &    mask &    weapon \\
-         \midrule
-            Raphael &     red &       sai \\
-          Donatello &  purple &  bo staff \\
-        \bottomrule
-        \end{{tabular}}
-        """
         raise AbstractMethodError(self)
 
     def to_csv(
@@ -2474,206 +552,30 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         errors: str = "strict",
         storage_options: StorageOptions = None,
     ) -> Optional[str]:
-        r"""
-        Write object to a comma-separated values (csv) file.
-
-        .. versionchanged:: 0.24.0
-            The order of arguments for Series was changed.
-
-        Parameters
-        ----------
-        path_or_buf : str or file handle, default None
-            File path or object, if None is provided the result is returned as
-            a string.  If a non-binary file object is passed, it should be opened
-            with `newline=''`, disabling universal newlines. If a binary
-            file object is passed, `mode` needs to contain a `'b'`.
-
-            .. versionchanged:: 0.24.0
-
-               Was previously named "path" for Series.
-
-            .. versionchanged:: 1.2.0
-
-               Support for binary file objects was introduced.
-
-        sep : str, default ','
-            String of length 1. Field delimiter for the output file.
-        na_rep : str, default ''
-            Missing data representation.
-        float_format : str, default None
-            Format string for floating point numbers.
-        columns : sequence, optional
-            Columns to write.
-        header : bool or list of str, default True
-            Write out the column names. If a list of strings is given it is
-            assumed to be aliases for the column names.
-
-            .. versionchanged:: 0.24.0
-
-               Previously defaulted to False for Series.
-
-        index : bool, default True
-            Write row names (index).
-        index_label : str or sequence, or False, default None
-            Column label for index column(s) if desired. If None is given, and
-            `header` and `index` are True, then the index names are used. A
-            sequence should be given if the object uses MultiIndex. If
-            False do not print fields for index names. Use index_label=False
-            for easier importing in R.
-        mode : str
-            Python write mode, default 'w'.
-        encoding : str, optional
-            A string representing the encoding to use in the output file,
-            defaults to 'utf-8'. `encoding` is not supported if `path_or_buf`
-            is a non-binary file object.
-        compression : str or dict, default 'infer'
-            If str, represents compression mode. If dict, value at 'method' is
-            the compression mode. Compression mode may be any of the following
-            possible values: {'infer', 'gzip', 'bz2', 'zip', 'xz', None}. If
-            compression mode is 'infer' and `path_or_buf` is path-like, then
-            detect compression mode from the following extensions: '.gz',
-            '.bz2', '.zip' or '.xz'. (otherwise no compression). If dict given
-            and mode is one of {'zip', 'gzip', 'bz2'}, or inferred as
-            one of the above, other entries passed as
-            additional compression options.
-
-            .. versionchanged:: 1.0.0
-
-               May now be a dict with key 'method' as compression mode
-               and other entries as additional compression options if
-               compression mode is 'zip'.
-
-            .. versionchanged:: 1.1.0
-
-               Passing compression options as keys in dict is
-               supported for compression modes 'gzip' and 'bz2'
-               as well as 'zip'.
-
-            .. versionchanged:: 1.2.0
-
-                Compression is supported for binary file objects.
-
-            .. versionchanged:: 1.2.0
-
-                Previous versions forwarded dict entries for 'gzip' to
-                `gzip.open` instead of `gzip.GzipFile` which prevented
-                setting `mtime`.
-
-        quoting : optional constant from csv module
-            Defaults to csv.QUOTE_MINIMAL. If you have set a `float_format`
-            then floats are converted to strings and thus csv.QUOTE_NONNUMERIC
-            will treat them as non-numeric.
-        quotechar : str, default '\"'
-            String of length 1. Character used to quote fields.
-        line_terminator : str, optional
-            The newline character or character sequence to use in the output
-            file. Defaults to `os.linesep`, which depends on the OS in which
-            this method is called ('\n' for linux, '\r\n' for Windows, i.e.).
-
-            .. versionchanged:: 0.24.0
-        chunksize : int or None
-            Rows to write at a time.
-        date_format : str, default None
-            Format string for datetime objects.
-        doublequote : bool, default True
-            Control quoting of `quotechar` inside a field.
-        escapechar : str, default None
-            String of length 1. Character used to escape `sep` and `quotechar`
-            when appropriate.
-        decimal : str, default '.'
-            Character recognized as decimal separator. E.g. use ',' for
-            European data.
-        errors : str, default 'strict'
-            Specifies how encoding and decoding errors are to be handled.
-            See the errors argument for :func:`open` for a full list
-            of options.
-
-            .. versionadded:: 1.1.0
-
-        storage_options : dict, optional
-            Extra options that make sense for a particular storage connection, e.g.
-            host, port, username, password, etc., if using a URL that will
-            be parsed by ``fsspec``, e.g., starting "s3://", "gcs://". An error
-            will be raised if providing this argument with a local path or
-            a file-like buffer. See the fsspec and backend storage implementation
-            docs for the set of allowed keys and values.
-
-            .. versionadded:: 1.2.0
-
-        Returns
-        -------
-        None or str
-            If path_or_buf is None, returns the resulting csv format as a
-            string. Otherwise returns None.
-
-        See Also
-        --------
-        read_csv : Load a CSV file into a DataFrame.
-        to_excel : Write DataFrame to an Excel file.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({'name': ['Raphael', 'Donatello'],
-        ...                    'mask': ['red', 'purple'],
-        ...                    'weapon': ['sai', 'bo staff']})
-        >>> df.to_csv(index=False)
-        'name,mask,weapon\nRaphael,red,sai\nDonatello,purple,bo staff\n'
-
-        Create 'out.zip' containing 'out.csv'
-
-        >>> compression_opts = dict(method='zip',
-        ...                         archive_name='out.csv')  # doctest: +SKIP
-        >>> df.to_csv('out.zip', index=False,
-        ...           compression=compression_opts)  # doctest: +SKIP
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
     # Lookup Caching
 
     def _set_as_cached(self, item, cacher) -> None:
-        """
-        Set the _cacher attribute on the calling object with a weakref to
-        cacher.
-        """
         raise AbstractMethodError(self)
 
     def _reset_cacher(self) -> None:
-        """
-        Reset the cacher.
-        """
-        if hasattr(self, "_cacher"):
-            del self._cacher
+        raise AbstractMethodError(self)
 
     def _maybe_cache_changed(self, item, value) -> None:
-        """
-        The object has called back to us saying maybe it has changed.
-        """
         raise AbstractMethodError(self)
 
     @property
     def _is_cached(self) -> bool_t:
-        """Return boolean indicating if self is cached or not."""
         raise AbstractMethodError(self)
 
     def _get_cacher(self):
-        """return my cacher or None"""
         raise AbstractMethodError(self)
 
     def _maybe_update_cacher(
         self, clear: bool_t = False, verify_is_copy: bool_t = True
     ) -> None:
-        """
-        See if we need to update our parent cacher if clear, then clear our
-        cache.
-
-        Parameters
-        ----------
-        clear : bool, default False
-            Clear the item cache.
-        verify_is_copy : bool, default True
-            Provide is_copy checks.
-        """
         raise AbstractMethodError(self)
 
     def _clear_item_cache(self) -> None:
@@ -2685,211 +587,21 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     def take(
         self: FrameOrSeries, indices, axis=0, is_copy: Optional[bool_t] = None, **kwargs
     ) -> FrameOrSeries:
-        """
-        Return the elements in the given *positional* indices along an axis.
-
-        This means that we are not indexing according to actual values in
-        the index attribute of the object. We are indexing according to the
-        actual position of the element in the object.
-
-        Parameters
-        ----------
-        indices : array-like
-            An array of ints indicating which positions to take.
-        axis : {0 or 'index', 1 or 'columns', None}, default 0
-            The axis on which to select elements. ``0`` means that we are
-            selecting rows, ``1`` means that we are selecting columns.
-        is_copy : bool
-            Before pandas 1.0, ``is_copy=False`` can be specified to ensure
-            that the return value is an actual copy. Starting with pandas 1.0,
-            ``take`` always returns a copy, and the keyword is therefore
-            deprecated.
-
-            .. deprecated:: 1.0.0
-        **kwargs
-            For compatibility with :meth:`numpy.take`. Has no effect on the
-            output.
-
-        Returns
-        -------
-        taken : same type as caller
-            An array-like containing the elements taken from the object.
-
-        See Also
-        --------
-        DataFrame.loc : Select a subset of a DataFrame by labels.
-        DataFrame.iloc : Select a subset of a DataFrame by positions.
-        numpy.take : Take elements from an array along an axis.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame([('falcon', 'bird', 389.0),
-        ...                    ('parrot', 'bird', 24.0),
-        ...                    ('lion', 'mammal', 80.5),
-        ...                    ('monkey', 'mammal', np.nan)],
-        ...                   columns=['name', 'class', 'max_speed'],
-        ...                   index=[0, 2, 3, 1])
-        >>> df
-             name   class  max_speed
-        0  falcon    bird      389.0
-        2  parrot    bird       24.0
-        3    lion  mammal       80.5
-        1  monkey  mammal        NaN
-
-        Take elements at positions 0 and 3 along the axis 0 (default).
-
-        Note how the actual indices selected (0 and 1) do not correspond to
-        our selected indices 0 and 3. That's because we are selecting the 0th
-        and 3rd rows, not rows whose indices equal 0 and 3.
-
-        >>> df.take([0, 3])
-             name   class  max_speed
-        0  falcon    bird      389.0
-        1  monkey  mammal        NaN
-
-        Take elements at indices 1 and 2 along the axis 1 (column selection).
-
-        >>> df.take([1, 2], axis=1)
-            class  max_speed
-        0    bird      389.0
-        2    bird       24.0
-        3  mammal       80.5
-        1  mammal        NaN
-
-        We may take elements using negative integers for positive indices,
-        starting from the end of the object, just like with Python lists.
-
-        >>> df.take([-1, -2])
-             name   class  max_speed
-        1  monkey  mammal        NaN
-        3    lion  mammal       80.5
-        """
         raise AbstractMethodError(self)
 
     def _take_with_is_copy(self: FrameOrSeries, indices, axis=0) -> FrameOrSeries:
-        """
-        Internal version of the `take` method that sets the `_is_copy`
-        attribute to keep track of the parent dataframe (using in indexing
-        for the SettingWithCopyWarning).
-
-        See the docstring of `take` for full explanation of the parameters.
-        """
         raise AbstractMethodError(self)
 
     def xs(self, key, axis=0, level=None, drop_level: bool_t = True):
-        """
-        Return cross-section from the Series/DataFrame.
-
-        This method takes a `key` argument to select data at a particular
-        level of a MultiIndex.
-
-        Parameters
-        ----------
-        key : label or tuple of label
-            Label contained in the index, or partially in a MultiIndex.
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-            Axis to retrieve cross-section on.
-        level : object, defaults to first n levels (n=1 or len(key))
-            In case of a key partially contained in a MultiIndex, indicate
-            which levels are used. Levels can be referred by label or position.
-        drop_level : bool, default True
-            If False, returns object with same levels as self.
-
-        Returns
-        -------
-        Series or DataFrame
-            Cross-section from the original Series or DataFrame
-            corresponding to the selected index levels.
-
-        See Also
-        --------
-        DataFrame.loc : Access a group of rows and columns
-            by label(s) or a boolean array.
-        DataFrame.iloc : Purely integer-location based indexing
-            for selection by position.
-
-        Notes
-        -----
-        `xs` can not be used to set values.
-
-        MultiIndex Slicers is a generic way to get/set values on
-        any level or levels.
-        It is a superset of `xs` functionality, see
-        :ref:`MultiIndex Slicers <advanced.mi_slicers>`.
-
-        Examples
-        --------
-        >>> d = {'num_legs': [4, 4, 2, 2],
-        ...      'num_wings': [0, 0, 2, 2],
-        ...      'class': ['mammal', 'mammal', 'mammal', 'bird'],
-        ...      'animal': ['cat', 'dog', 'bat', 'penguin'],
-        ...      'locomotion': ['walks', 'walks', 'flies', 'walks']}
-        >>> df = pd.DataFrame(data=d)
-        >>> df = df.set_index(['class', 'animal', 'locomotion'])
-        >>> df
-                                   num_legs  num_wings
-        class  animal  locomotion
-        mammal cat     walks              4          0
-               dog     walks              4          0
-               bat     flies              2          2
-        bird   penguin walks              2          2
-
-        Get values at specified index
-
-        >>> df.xs('mammal')
-                           num_legs  num_wings
-        animal locomotion
-        cat    walks              4          0
-        dog    walks              4          0
-        bat    flies              2          2
-
-        Get values at several indexes
-
-        >>> df.xs(('mammal', 'dog'))
-                    num_legs  num_wings
-        locomotion
-        walks              4          0
-
-        Get values at specified index and level
-
-        >>> df.xs('cat', level=1)
-                           num_legs  num_wings
-        class  locomotion
-        mammal walks              4          0
-
-        Get values at several indexes and levels
-
-        >>> df.xs(('bird', 'walks'),
-        ...       level=[0, 'locomotion'])
-                 num_legs  num_wings
-        animal
-        penguin         2          2
-
-        Get values at specified column and axis
-
-        >>> df.xs('num_wings', axis=1)
-        class   animal   locomotion
-        mammal  cat      walks         0
-                dog      walks         0
-                bat      flies         2
-        bird    penguin  walks         2
-        Name: num_wings, dtype: int64
-        """
         raise AbstractMethodError(self)
 
     def __getitem__(self, item):
         raise AbstractMethodError(self)
 
     def _get_item_cache(self, item):
-        """Return the cached item, item represents a label indexer."""
         raise AbstractMethodError(self)
 
     def _slice(self: FrameOrSeries, slobj: slice, axis=0) -> FrameOrSeries:
-        """
-        Construct a slice of this container.
-
-        Slicing with this method is *always* positional.
-        """
         raise AbstractMethodError(self)
 
     def _iset_item(self, loc: int, value) -> None:
@@ -2902,54 +614,12 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         raise AbstractMethodError(self)
 
     def _check_is_chained_assignment_possible(self) -> bool_t:
-        """
-        Check if we are a view, have a cacher, and are of mixed type.
-        If so, then force a setitem_copy check.
-
-        Should be called just near setting a value
-
-        Will return a boolean if it we are a view and are cached, but a
-        single-dtype meaning that the cacher should be updated following
-        setting.
-        """
         raise AbstractMethodError(self)
 
     def _check_setitem_copy(self, stacklevel=4, t="setting", force=False):
-        """
-
-        Parameters
-        ----------
-        stacklevel : int, default 4
-           the level to show of the stack when the error is output
-        t : str, the type of setting error
-        force : bool, default False
-           If True, then force showing an error.
-
-        validate if we are doing a setitem on a chained copy.
-
-        If you call this function, be sure to set the stacklevel such that the
-        user will see the error *at the level of setting*
-
-        It is technically possible to figure out that we are setting on
-        a copy even WITH a multi-dtyped pandas object. In other words, some
-        blocks may be views while other are not. Currently _is_view will ALWAYS
-        return False for multi-blocks to avoid having to handle this case.
-
-        df = DataFrame(np.arange(0,9), columns=['count'])
-        df['group'] = 'b'
-
-        # This technically need not raise SettingWithCopy if both are view
-        # (which is not # generally guaranteed but is usually True.  However,
-        # this is in general not a good practice and we recommend using .loc.
-        df.iloc[0:5]['group'] = 'a'
-
-        """
         raise AbstractMethodError(self)
 
     def __delitem__(self, key) -> None:
-        """
-        Delete item
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
@@ -2959,24 +629,10 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         raise AbstractMethodError(self)
 
     def get(self, key, default=None):
-        """
-        Get item from object for given key (ex: DataFrame column).
-
-        Returns default value if not found.
-
-        Parameters
-        ----------
-        key : object
-
-        Returns
-        -------
-        value : same type as items contained in object
-        """
         raise AbstractMethodError(self)
 
     @property
     def _is_view(self) -> bool_t:
-        """Return boolean indicating if self is view of another array """
         raise AbstractMethodError(self)
 
     def reindex_like(
@@ -2987,99 +643,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         limit=None,
         tolerance=None,
     ) -> FrameOrSeries:
-        """
-        Return an object with matching indices as other object.
-
-        Conform the object to the same index on all axes. Optional
-        filling logic, placing NaN in locations having no value
-        in the previous index. A new object is produced unless the
-        new index is equivalent to the current one and copy=False.
-
-        Parameters
-        ----------
-        other : Object of the same data type
-            Its row and column indices are used to define the new indices
-            of this object.
-        method : {None, 'backfill'/'bfill', 'pad'/'ffill', 'nearest'}
-            Method to use for filling holes in reindexed DataFrame.
-            Please note: this is only applicable to DataFrames/Series with a
-            monotonically increasing/decreasing index.
-
-            * None (default): don't fill gaps
-            * pad / ffill: propagate last valid observation forward to next
-              valid
-            * backfill / bfill: use next valid observation to fill gap
-            * nearest: use nearest valid observations to fill gap.
-
-        copy : bool, default True
-            Return a new object, even if the passed indexes are the same.
-        limit : int, default None
-            Maximum number of consecutive labels to fill for inexact matches.
-        tolerance : optional
-            Maximum distance between original and new labels for inexact
-            matches. The values of the index at the matching locations must
-            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
-            Tolerance may be a scalar value, which applies the same tolerance
-            to all values, or list-like, which applies variable tolerance per
-            element. List-like includes list, tuple, array, Series, and must be
-            the same size as the index and its dtype must exactly match the
-            index's type.
-
-        Returns
-        -------
-        Series or DataFrame
-            Same type as caller, but with changed indices on each axis.
-
-        See Also
-        --------
-        DataFrame.set_index : Set row labels.
-        DataFrame.reset_index : Remove row labels or move them to new columns.
-        DataFrame.reindex : Change to new indices or expand indices.
-
-        Notes
-        -----
-        Same as calling
-        ``.reindex(index=other.index, columns=other.columns,...)``.
-
-        Examples
-        --------
-        >>> df1 = pd.DataFrame([[24.3, 75.7, 'high'],
-        ...                     [31, 87.8, 'high'],
-        ...                     [22, 71.6, 'medium'],
-        ...                     [35, 95, 'medium']],
-        ...                    columns=['temp_celsius', 'temp_fahrenheit',
-        ...                             'windspeed'],
-        ...                    index=pd.date_range(start='2014-02-12',
-        ...                                        end='2014-02-15', freq='D'))
-
-        >>> df1
-                    temp_celsius  temp_fahrenheit windspeed
-        2014-02-12          24.3             75.7      high
-        2014-02-13          31.0             87.8      high
-        2014-02-14          22.0             71.6    medium
-        2014-02-15          35.0             95.0    medium
-
-        >>> df2 = pd.DataFrame([[28, 'low'],
-        ...                     [30, 'low'],
-        ...                     [35.1, 'medium']],
-        ...                    columns=['temp_celsius', 'windspeed'],
-        ...                    index=pd.DatetimeIndex(['2014-02-12', '2014-02-13',
-        ...                                            '2014-02-15']))
-
-        >>> df2
-                    temp_celsius windspeed
-        2014-02-12          28.0       low
-        2014-02-13          30.0       low
-        2014-02-15          35.1    medium
-
-        >>> df2.reindex_like(df1)
-                    temp_celsius  temp_fahrenheit windspeed
-        2014-02-12          28.0              NaN       low
-        2014-02-13          30.0              NaN       low
-        2014-02-14           NaN              NaN       NaN
-        2014-02-15          35.1              NaN    medium
-        """
         raise AbstractMethodError(self)
 
     def drop(
@@ -3097,144 +660,15 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     def _drop_axis(
         self: FrameOrSeries, labels, axis, level=None, errors: str = "raise"
     ) -> FrameOrSeries:
-        """
-        Drop labels from specified axis. Used in the ``drop`` method
-        internally.
-
-        Parameters
-        ----------
-        labels : single label or list-like
-        axis : int or axis name
-        level : int or level name, default None
-            For MultiIndex
-        errors : {'ignore', 'raise'}, default 'raise'
-            If 'ignore', suppress error and existing labels are dropped.
-
-        """
         raise AbstractMethodError(self)
 
     def _update_inplace(self, result, verify_is_copy: bool_t = True) -> None:
-        """
-        Replace self internals with result.
-
-        Parameters
-        ----------
-        result : same type as self
-        verify_is_copy : bool, default True
-            Provide is_copy checks.
-        """
         raise AbstractMethodError(self)
 
     def add_prefix(self: FrameOrSeries, prefix: str) -> FrameOrSeries:
-        """
-        Prefix labels with string `prefix`.
-
-        For Series, the row labels are prefixed.
-        For DataFrame, the column labels are prefixed.
-
-        Parameters
-        ----------
-        prefix : str
-            The string to add before each label.
-
-        Returns
-        -------
-        Series or DataFrame
-            New Series or DataFrame with updated labels.
-
-        See Also
-        --------
-        Series.add_suffix: Suffix row labels with string `suffix`.
-        DataFrame.add_suffix: Suffix column labels with string `suffix`.
-
-        Examples
-        --------
-        >>> s = pd.Series([1, 2, 3, 4])
-        >>> s
-        0    1
-        1    2
-        2    3
-        3    4
-        dtype: int64
-
-        >>> s.add_prefix('item_')
-        item_0    1
-        item_1    2
-        item_2    3
-        item_3    4
-        dtype: int64
-
-        >>> df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [3, 4, 5, 6]})
-        >>> df
-           A  B
-        0  1  3
-        1  2  4
-        2  3  5
-        3  4  6
-
-        >>> df.add_prefix('col_')
-             col_A  col_B
-        0       1       3
-        1       2       4
-        2       3       5
-        3       4       6
-        """
         raise AbstractMethodError(self)
 
     def add_suffix(self: FrameOrSeries, suffix: str) -> FrameOrSeries:
-        """
-        Suffix labels with string `suffix`.
-
-        For Series, the row labels are suffixed.
-        For DataFrame, the column labels are suffixed.
-
-        Parameters
-        ----------
-        suffix : str
-            The string to add after each label.
-
-        Returns
-        -------
-        Series or DataFrame
-            New Series or DataFrame with updated labels.
-
-        See Also
-        --------
-        Series.add_prefix: Prefix row labels with string `prefix`.
-        DataFrame.add_prefix: Prefix column labels with string `prefix`.
-
-        Examples
-        --------
-        >>> s = pd.Series([1, 2, 3, 4])
-        >>> s
-        0    1
-        1    2
-        2    3
-        3    4
-        dtype: int64
-
-        >>> s.add_suffix('_item')
-        0_item    1
-        1_item    2
-        2_item    3
-        3_item    4
-        dtype: int64
-
-        >>> df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [3, 4, 5, 6]})
-        >>> df
-           A  B
-        0  1  3
-        1  2  4
-        2  3  5
-        3  4  6
-
-        >>> df.add_suffix('_col')
-             A_col  B_col
-        0       1       3
-        1       2       4
-        2       3       5
-        3       4       6
-        """
         raise AbstractMethodError(self)
 
     def sort_values(
@@ -3247,150 +681,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         ignore_index: bool_t = False,
         key: ValueKeyFunc = None,
     ):
-        """
-        Sort by the values along either axis.
-
-        Parameters
-        ----------%(optional_by)s
-        axis : %(axes_single_arg)s, default 0
-             Axis to be sorted.
-        ascending : bool or list of bool, default True
-             Sort ascending vs. descending. Specify list for multiple sort
-             orders.  If this is a list of bools, must match the length of
-             the by.
-        inplace : bool, default False
-             If True, perform operation in-place.
-        kind : {'quicksort', 'mergesort', 'heapsort'}, default 'quicksort'
-             Choice of sorting algorithm. See also ndarray.np.sort for more
-             information.  `mergesort` is the only stable algorithm. For
-             DataFrames, this option is only applied when sorting on a single
-             column or label.
-        na_position : {'first', 'last'}, default 'last'
-             Puts NaNs at the beginning if `first`; `last` puts NaNs at the
-             end.
-        ignore_index : bool, default False
-             If True, the resulting axis will be labeled 0, 1, …, n - 1.
-
-             .. versionadded:: 1.0.0
-
-        key : callable, optional
-            Apply the key function to the values
-            before sorting. This is similar to the `key` argument in the
-            builtin :meth:`sorted` function, with the notable difference that
-            this `key` function should be *vectorized*. It should expect a
-            ``Series`` and return a Series with the same shape as the input.
-            It will be applied to each column in `by` independently.
-
-            .. versionadded:: 1.1.0
-
-        Returns
-        -------
-        DataFrame or None
-            DataFrame with sorted values or None if ``inplace=True``.
-
-        See Also
-        --------
-        DataFrame.sort_index : Sort a DataFrame by the index.
-        Series.sort_values : Similar method for a Series.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({
-        ...     'col1': ['A', 'A', 'B', np.nan, 'D', 'C'],
-        ...     'col2': [2, 1, 9, 8, 7, 4],
-        ...     'col3': [0, 1, 9, 4, 2, 3],
-        ...     'col4': ['a', 'B', 'c', 'D', 'e', 'F']
-        ... })
-        >>> df
-          col1  col2  col3 col4
-        0    A     2     0    a
-        1    A     1     1    B
-        2    B     9     9    c
-        3  NaN     8     4    D
-        4    D     7     2    e
-        5    C     4     3    F
-
-        Sort by col1
-
-        >>> df.sort_values(by=['col1'])
-          col1  col2  col3 col4
-        0    A     2     0    a
-        1    A     1     1    B
-        2    B     9     9    c
-        5    C     4     3    F
-        4    D     7     2    e
-        3  NaN     8     4    D
-
-        Sort by multiple columns
-
-        >>> df.sort_values(by=['col1', 'col2'])
-          col1  col2  col3 col4
-        1    A     1     1    B
-        0    A     2     0    a
-        2    B     9     9    c
-        5    C     4     3    F
-        4    D     7     2    e
-        3  NaN     8     4    D
-
-        Sort Descending
-
-        >>> df.sort_values(by='col1', ascending=False)
-          col1  col2  col3 col4
-        4    D     7     2    e
-        5    C     4     3    F
-        2    B     9     9    c
-        0    A     2     0    a
-        1    A     1     1    B
-        3  NaN     8     4    D
-
-        Putting NAs first
-
-        >>> df.sort_values(by='col1', ascending=False, na_position='first')
-          col1  col2  col3 col4
-        3  NaN     8     4    D
-        4    D     7     2    e
-        5    C     4     3    F
-        2    B     9     9    c
-        0    A     2     0    a
-        1    A     1     1    B
-
-        Sorting with a key function
-
-        >>> df.sort_values(by='col4', key=lambda col: col.str.lower())
-           col1  col2  col3 col4
-        0    A     2     0    a
-        1    A     1     1    B
-        2    B     9     9    c
-        3  NaN     8     4    D
-        4    D     7     2    e
-        5    C     4     3    F
-
-        Natural sort with the key argument,
-        using the `natsort <https://github.com/SethMMorton/natsort>` package.
-
-        >>> df = pd.DataFrame({
-        ...    "time": ['0hr', '128hr', '72hr', '48hr', '96hr'],
-        ...    "value": [10, 20, 30, 40, 50]
-        ... })
-        >>> df
-            time  value
-        0    0hr     10
-        1  128hr     20
-        2   72hr     30
-        3   48hr     40
-        4   96hr     50
-        >>> from natsort import index_natsorted
-        >>> df.sort_values(
-        ...    by="time",
-        ...    key=lambda x: np.argsort(index_natsorted(df["time"]))
-        ... )
-            time  value
-        0    0hr     10
-        3   48hr     40
-        2   72hr     30
-        4   96hr     50
-        1  128hr     20
-        """
         raise AbstractMethodError(self)
 
     def sort_index(
@@ -3407,228 +697,16 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     ):
         raise AbstractMethodError(self)
 
-    @doc(
-        klass=_shared_doc_kwargs["klass"],
-        axes=_shared_doc_kwargs["axes"],
-        optional_labels="",
-        optional_axis="",
-    )
     def reindex(self: FrameOrSeries, *args, **kwargs) -> FrameOrSeries:
-        """
-        Conform {klass} to new index with optional filling logic.
-
-        Places NA/NaN in locations having no value in the previous index. A new object
-        is produced unless the new index is equivalent to the current one and
-        ``copy=False``.
-
-        Parameters
-        ----------
-        {optional_labels}
-        {axes} : array-like, optional
-            New labels / index to conform to, should be specified using
-            keywords. Preferably an Index object to avoid duplicating data.
-        {optional_axis}
-        method : {{None, 'backfill'/'bfill', 'pad'/'ffill', 'nearest'}}
-            Method to use for filling holes in reindexed DataFrame.
-            Please note: this is only applicable to DataFrames/Series with a
-            monotonically increasing/decreasing index.
-
-            * None (default): don't fill gaps
-            * pad / ffill: Propagate last valid observation forward to next
-              valid.
-            * backfill / bfill: Use next valid observation to fill gap.
-            * nearest: Use nearest valid observations to fill gap.
-
-        copy : bool, default True
-            Return a new object, even if the passed indexes are the same.
-        level : int or name
-            Broadcast across a level, matching Index values on the
-            passed MultiIndex level.
-        fill_value : scalar, default np.NaN
-            Value to use for missing values. Defaults to NaN, but can be any
-            "compatible" value.
-        limit : int, default None
-            Maximum number of consecutive elements to forward or backward fill.
-        tolerance : optional
-            Maximum distance between original and new labels for inexact
-            matches. The values of the index at the matching locations most
-            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
-
-            Tolerance may be a scalar value, which applies the same tolerance
-            to all values, or list-like, which applies variable tolerance per
-            element. List-like includes list, tuple, array, Series, and must be
-            the same size as the index and its dtype must exactly match the
-            index's type.
-
-        Returns
-        -------
-        {klass} with changed index.
-
-        See Also
-        --------
-        DataFrame.set_index : Set row labels.
-        DataFrame.reset_index : Remove row labels or move them to new columns.
-        DataFrame.reindex_like : Change to same indices as other DataFrame.
-
-        Examples
-        --------
-        ``DataFrame.reindex`` supports two calling conventions
-
-        * ``(index=index_labels, columns=column_labels, ...)``
-        * ``(labels, axis={{'index', 'columns'}}, ...)``
-
-        We *highly* recommend using keyword arguments to clarify your
-        intent.
-
-        Create a dataframe with some fictional data.
-
-        >>> index = ['Firefox', 'Chrome', 'Safari', 'IE10', 'Konqueror']
-        >>> df = pd.DataFrame({{'http_status': [200, 200, 404, 404, 301],
-        ...                   'response_time': [0.04, 0.02, 0.07, 0.08, 1.0]}},
-        ...                   index=index)
-        >>> df
-                   http_status  response_time
-        Firefox            200           0.04
-        Chrome             200           0.02
-        Safari             404           0.07
-        IE10               404           0.08
-        Konqueror          301           1.00
-
-        Create a new index and reindex the dataframe. By default
-        values in the new index that do not have corresponding
-        records in the dataframe are assigned ``NaN``.
-
-        >>> new_index = ['Safari', 'Iceweasel', 'Comodo Dragon', 'IE10',
-        ...              'Chrome']
-        >>> df.reindex(new_index)
-                       http_status  response_time
-        Safari               404.0           0.07
-        Iceweasel              NaN            NaN
-        Comodo Dragon          NaN            NaN
-        IE10                 404.0           0.08
-        Chrome               200.0           0.02
-
-        We can fill in the missing values by passing a value to
-        the keyword ``fill_value``. Because the index is not monotonically
-        increasing or decreasing, we cannot use arguments to the keyword
-        ``method`` to fill the ``NaN`` values.
-
-        >>> df.reindex(new_index, fill_value=0)
-                       http_status  response_time
-        Safari                 404           0.07
-        Iceweasel                0           0.00
-        Comodo Dragon            0           0.00
-        IE10                   404           0.08
-        Chrome                 200           0.02
-
-        >>> df.reindex(new_index, fill_value='missing')
-                      http_status response_time
-        Safari                404          0.07
-        Iceweasel         missing       missing
-        Comodo Dragon     missing       missing
-        IE10                  404          0.08
-        Chrome                200          0.02
-
-        We can also reindex the columns.
-
-        >>> df.reindex(columns=['http_status', 'user_agent'])
-                   http_status  user_agent
-        Firefox            200         NaN
-        Chrome             200         NaN
-        Safari             404         NaN
-        IE10               404         NaN
-        Konqueror          301         NaN
-
-        Or we can use "axis-style" keyword arguments
-
-        >>> df.reindex(['http_status', 'user_agent'], axis="columns")
-                   http_status  user_agent
-        Firefox            200         NaN
-        Chrome             200         NaN
-        Safari             404         NaN
-        IE10               404         NaN
-        Konqueror          301         NaN
-
-        To further illustrate the filling functionality in
-        ``reindex``, we will create a dataframe with a
-        monotonically increasing index (for example, a sequence
-        of dates).
-
-        >>> date_index = pd.date_range('1/1/2010', periods=6, freq='D')
-        >>> df2 = pd.DataFrame({{"prices": [100, 101, np.nan, 100, 89, 88]}},
-        ...                    index=date_index)
-        >>> df2
-                    prices
-        2010-01-01   100.0
-        2010-01-02   101.0
-        2010-01-03     NaN
-        2010-01-04   100.0
-        2010-01-05    89.0
-        2010-01-06    88.0
-
-        Suppose we decide to expand the dataframe to cover a wider
-        date range.
-
-        >>> date_index2 = pd.date_range('12/29/2009', periods=10, freq='D')
-        >>> df2.reindex(date_index2)
-                    prices
-        2009-12-29     NaN
-        2009-12-30     NaN
-        2009-12-31     NaN
-        2010-01-01   100.0
-        2010-01-02   101.0
-        2010-01-03     NaN
-        2010-01-04   100.0
-        2010-01-05    89.0
-        2010-01-06    88.0
-        2010-01-07     NaN
-
-        The index entries that did not have a value in the original data frame
-        (for example, '2009-12-29') are by default filled with ``NaN``.
-        If desired, we can fill in the missing values using one of several
-        options.
-
-        For example, to back-propagate the last valid value to fill the ``NaN``
-        values, pass ``bfill`` as an argument to the ``method`` keyword.
-
-        >>> df2.reindex(date_index2, method='bfill')
-                    prices
-        2009-12-29   100.0
-        2009-12-30   100.0
-        2009-12-31   100.0
-        2010-01-01   100.0
-        2010-01-02   101.0
-        2010-01-03     NaN
-        2010-01-04   100.0
-        2010-01-05    89.0
-        2010-01-06    88.0
-        2010-01-07     NaN
-
-        Please note that the ``NaN`` value present in the original dataframe
-        (at index value 2010-01-03) will not be filled by any of the
-        value propagation schemes. This is because filling while reindexing
-        does not look at dataframe values, but only compares the original and
-        desired indexes. If you do want to fill in the ``NaN`` values present
-        in the original dataframe, use the ``fillna()`` method.
-
-        See the :ref:`user guide <basics.reindexing>` for more.
-        """
         raise AbstractMethodError(self)
 
     def _reindex_axes(
         self: FrameOrSeries, axes, level, limit, tolerance, method, fill_value, copy
     ) -> FrameOrSeries:
-        """Perform the reindex for all the axes."""
         raise AbstractMethodError(self)
 
     def _needs_reindex_multi(self, axes, method, level) -> bool_t:
-        """Check if we do need a multi reindex."""
-        return (
-            (com.count_not_none(*axes.values()) == self._AXIS_LEN)
-            and method is None
-            and level is None
-            and not self._is_mixed_type
-        )
+        raise AbstractMethodError(self)
 
     def _reindex_multi(self, axes, copy, fill_value):
         raise AbstractMethodError(self)
@@ -3640,7 +718,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         copy: bool_t = False,
         allow_dups: bool_t = False,
     ) -> FrameOrSeries:
-        """allow_dups indicates an internal call here """
         raise AbstractMethodError(self)
 
     def filter(
@@ -3650,213 +727,12 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         regex: Optional[str] = None,
         axis=None,
     ) -> FrameOrSeries:
-        """
-        Subset the dataframe rows or columns according to the specified index labels.
-
-        Note that this routine does not filter a dataframe on its
-        contents. The filter is applied to the labels of the index.
-
-        Parameters
-        ----------
-        items : list-like
-            Keep labels from axis which are in items.
-        like : str
-            Keep labels from axis for which "like in label == True".
-        regex : str (regular expression)
-            Keep labels from axis for which re.search(regex, label) == True.
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default None
-            The axis to filter on, expressed either as an index (int)
-            or axis name (str). By default this is the info axis,
-            'index' for Series, 'columns' for DataFrame.
-
-        Returns
-        -------
-        same type as input object
-
-        See Also
-        --------
-        DataFrame.loc : Access a group of rows and columns
-            by label(s) or a boolean array.
-
-        Notes
-        -----
-        The ``items``, ``like``, and ``regex`` parameters are
-        enforced to be mutually exclusive.
-
-        ``axis`` defaults to the info axis that is used when indexing
-        with ``[]``.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame(np.array(([1, 2, 3], [4, 5, 6])),
-        ...                   index=['mouse', 'rabbit'],
-        ...                   columns=['one', 'two', 'three'])
-        >>> df
-                one  two  three
-        mouse     1    2      3
-        rabbit    4    5      6
-
-        >>> # select columns by name
-        >>> df.filter(items=['one', 'three'])
-                 one  three
-        mouse     1      3
-        rabbit    4      6
-
-        >>> # select columns by regular expression
-        >>> df.filter(regex='e$', axis=1)
-                 one  three
-        mouse     1      3
-        rabbit    4      6
-
-        >>> # select rows containing 'bbi'
-        >>> df.filter(like='bbi', axis=0)
-                 one  two  three
-        rabbit    4    5      6
-        """
         raise AbstractMethodError(self)
 
     def head(self: FrameOrSeries, n: int = 5) -> FrameOrSeries:
-        """
-        Return the first `n` rows.
-
-        This function returns the first `n` rows for the object based
-        on position. It is useful for quickly testing if your object
-        has the right type of data in it.
-
-        For negative values of `n`, this function returns all rows except
-        the last `n` rows, equivalent to ``df[:-n]``.
-
-        Parameters
-        ----------
-        n : int, default 5
-            Number of rows to select.
-
-        Returns
-        -------
-        same type as caller
-            The first `n` rows of the caller object.
-
-        See Also
-        --------
-        DataFrame.tail: Returns the last `n` rows.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({'animal': ['alligator', 'bee', 'falcon', 'lion',
-        ...                    'monkey', 'parrot', 'shark', 'whale', 'zebra']})
-        >>> df
-              animal
-        0  alligator
-        1        bee
-        2     falcon
-        3       lion
-        4     monkey
-        5     parrot
-        6      shark
-        7      whale
-        8      zebra
-
-        Viewing the first 5 lines
-
-        >>> df.head()
-              animal
-        0  alligator
-        1        bee
-        2     falcon
-        3       lion
-        4     monkey
-
-        Viewing the first `n` lines (three in this case)
-
-        >>> df.head(3)
-              animal
-        0  alligator
-        1        bee
-        2     falcon
-
-        For negative values of `n`
-
-        >>> df.head(-3)
-              animal
-        0  alligator
-        1        bee
-        2     falcon
-        3       lion
-        4     monkey
-        5     parrot
-        """
         raise AbstractMethodError(self)
 
     def tail(self: FrameOrSeries, n: int = 5) -> FrameOrSeries:
-        """
-        Return the last `n` rows.
-
-        This function returns last `n` rows from the object based on
-        position. It is useful for quickly verifying data, for example,
-        after sorting or appending rows.
-
-        For negative values of `n`, this function returns all rows except
-        the first `n` rows, equivalent to ``df[n:]``.
-
-        Parameters
-        ----------
-        n : int, default 5
-            Number of rows to select.
-
-        Returns
-        -------
-        type of caller
-            The last `n` rows of the caller object.
-
-        See Also
-        --------
-        DataFrame.head : The first `n` rows of the caller object.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({'animal': ['alligator', 'bee', 'falcon', 'lion',
-        ...                    'monkey', 'parrot', 'shark', 'whale', 'zebra']})
-        >>> df
-              animal
-        0  alligator
-        1        bee
-        2     falcon
-        3       lion
-        4     monkey
-        5     parrot
-        6      shark
-        7      whale
-        8      zebra
-
-        Viewing the last 5 lines
-
-        >>> df.tail()
-           animal
-        4  monkey
-        5  parrot
-        6   shark
-        7   whale
-        8   zebra
-
-        Viewing the last `n` lines (three in this case)
-
-        >>> df.tail(3)
-          animal
-        6  shark
-        7  whale
-        8  zebra
-
-        For negative values of `n`
-
-        >>> df.tail(-3)
-           animal
-        3    lion
-        4  monkey
-        5  parrot
-        6   shark
-        7   whale
-        8   zebra
-        """
         raise AbstractMethodError(self)
 
     def sample(
@@ -3868,172 +744,9 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         random_state=None,
         axis=None,
     ) -> FrameOrSeries:
-        """
-        Return a random sample of items from an axis of object.
-
-        You can use `random_state` for reproducibility.
-
-        Parameters
-        ----------
-        n : int, optional
-            Number of items from axis to return. Cannot be used with `frac`.
-            Default = 1 if `frac` = None.
-        frac : float, optional
-            Fraction of axis items to return. Cannot be used with `n`.
-        replace : bool, default False
-            Allow or disallow sampling of the same row more than once.
-        weights : str or ndarray-like, optional
-            Default 'None' results in equal probability weighting.
-            If passed a Series, will align with target object on index. Index
-            values in weights not found in sampled object will be ignored and
-            index values in sampled object not in weights will be assigned
-            weights of zero.
-            If called on a DataFrame, will accept the name of a column
-            when axis = 0.
-            Unless weights are a Series, weights must be same length as axis
-            being sampled.
-            If weights do not sum to 1, they will be normalized to sum to 1.
-            Missing values in the weights column will be treated as zero.
-            Infinite values not allowed.
-        random_state : int, array-like, BitGenerator, np.random.RandomState, optional
-            If int, array-like, or BitGenerator (NumPy>=1.17), seed for
-            random number generator
-            If np.random.RandomState, use as numpy RandomState object.
-
-            .. versionchanged:: 1.1.0
-
-                array-like and BitGenerator (for NumPy>=1.17) object now passed to
-                np.random.RandomState() as seed
-
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default None
-            Axis to sample. Accepts axis number or name. Default is stat axis
-            for given data type (0 for Series and DataFrames).
-
-        Returns
-        -------
-        Series or DataFrame
-            A new object of same type as caller containing `n` items randomly
-            sampled from the caller object.
-
-        See Also
-        --------
-        DataFrameGroupBy.sample: Generates random samples from each group of a
-            DataFrame object.
-        SeriesGroupBy.sample: Generates random samples from each group of a
-            Series object.
-        numpy.random.choice: Generates a random sample from a given 1-D numpy
-            array.
-
-        Notes
-        -----
-        If `frac` > 1, `replacement` should be set to `True`.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({'num_legs': [2, 4, 8, 0],
-        ...                    'num_wings': [2, 0, 0, 0],
-        ...                    'num_specimen_seen': [10, 2, 1, 8]},
-        ...                   index=['falcon', 'dog', 'spider', 'fish'])
-        >>> df
-                num_legs  num_wings  num_specimen_seen
-        falcon         2          2                 10
-        dog            4          0                  2
-        spider         8          0                  1
-        fish           0          0                  8
-
-        Extract 3 random elements from the ``Series`` ``df['num_legs']``:
-        Note that we use `random_state` to ensure the reproducibility of
-        the examples.
-
-        >>> df['num_legs'].sample(n=3, random_state=1)
-        fish      0
-        spider    8
-        falcon    2
-        Name: num_legs, dtype: int64
-
-        A random 50% sample of the ``DataFrame`` with replacement:
-
-        >>> df.sample(frac=0.5, replace=True, random_state=1)
-              num_legs  num_wings  num_specimen_seen
-        dog          4          0                  2
-        fish         0          0                  8
-
-        An upsample sample of the ``DataFrame`` with replacement:
-        Note that `replace` parameter has to be `True` for `frac` parameter > 1.
-
-        >>> df.sample(frac=2, replace=True, random_state=1)
-                num_legs  num_wings  num_specimen_seen
-        dog            4          0                  2
-        fish           0          0                  8
-        falcon         2          2                 10
-        falcon         2          2                 10
-        fish           0          0                  8
-        dog            4          0                  2
-        fish           0          0                  8
-        dog            4          0                  2
-
-        Using a DataFrame column as weights. Rows with larger value in the
-        `num_specimen_seen` column are more likely to be sampled.
-
-        >>> df.sample(n=2, weights='num_specimen_seen', random_state=1)
-                num_legs  num_wings  num_specimen_seen
-        falcon         2          2                 10
-        fish           0          0                  8
-        """
         raise AbstractMethodError(self)
 
-    @doc(klass=_shared_doc_kwargs["klass"])
     def pipe(self, func, *args, **kwargs):
-        r"""
-        Apply func(self, \*args, \*\*kwargs).
-
-        Parameters
-        ----------
-        func : function
-            Function to apply to the {klass}.
-            ``args``, and ``kwargs`` are passed into ``func``.
-            Alternatively a ``(callable, data_keyword)`` tuple where
-            ``data_keyword`` is a string indicating the keyword of
-            ``callable`` that expects the {klass}.
-        args : iterable, optional
-            Positional arguments passed into ``func``.
-        kwargs : mapping, optional
-            A dictionary of keyword arguments passed into ``func``.
-
-        Returns
-        -------
-        object : the return type of ``func``.
-
-        See Also
-        --------
-        DataFrame.apply : Apply a function along input axis of DataFrame.
-        DataFrame.applymap : Apply a function elementwise on a whole DataFrame.
-        Series.map : Apply a mapping correspondence on a
-            :class:`~pandas.Series`.
-
-        Notes
-        -----
-        Use ``.pipe`` when chaining together functions that expect
-        Series, DataFrames or GroupBy objects. Instead of writing
-
-        >>> func(g(h(df), arg1=a), arg2=b, arg3=c)  # doctest: +SKIP
-
-        You can write
-
-        >>> (df.pipe(h)
-        ...    .pipe(g, arg1=a)
-        ...    .pipe(func, arg2=b, arg3=c)
-        ... )  # doctest: +SKIP
-
-        If you have a function that takes the data as (say) the second
-        argument, pass a tuple indicating which keyword expects the
-        data. For example, suppose ``f`` takes its data as ``arg2``:
-
-        >>> (df.pipe(h)
-        ...    .pipe(g, arg1=a)
-        ...    .pipe((func, 'arg2'), arg1=a, arg3=c)
-        ...  )  # doctest: +SKIP
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
@@ -4042,68 +755,27 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     def __finalize__(
         self: FrameOrSeries, other, method: Optional[str] = None, **kwargs
     ) -> FrameOrSeries:
-        """
-        Propagate metadata from other to self.
-
-        Parameters
-        ----------
-        other : the object from which to get the attributes that we are going
-            to propagate
-        method : str, optional
-            A passed method name providing context on where ``__finalize__``
-            was called.
-
-            .. warning::
-
-               The value passed as `method` are not currently considered
-               stable across pandas releases.
-        """
         raise AbstractMethodError(self)
 
     def __getattr__(self, name: str):
-        """
-        After regular attribute access, try looking up the name
-        This allows simpler access to columns for interactive use.
-        """
         raise AbstractMethodError(self)
 
     def __setattr__(self, name: str, value) -> None:
-        """
-        After regular attribute access, try setting the name
-        This allows simpler access to columns for interactive use.
-        """
         raise AbstractMethodError(self)
 
     def _dir_additions(self) -> Set[str]:
-        """
-        add the string-like attributes from the info_axis.
-        If info_axis is a MultiIndex, it's first level values are used.
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
     # Consolidation of internals
 
     def _protect_consolidate(self, f):
-        """
-        Consolidate _mgr -- if the blocks have changed, then clear the
-        cache
-        """
         raise AbstractMethodError(self)
 
     def _consolidate_inplace(self) -> None:
-        """Consolidate data in place and return None"""
         raise AbstractMethodError(self)
 
     def _consolidate(self):
-        """
-        Compute NDFrame with "consolidated" internals (data of each dtype
-        grouped together in a single ndarray).
-
-        Returns
-        -------
-        consolidated : same type as caller
-        """
         raise AbstractMethodError(self)
 
     @property
@@ -4111,7 +783,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         raise AbstractMethodError(self)
 
     def _check_inplace_setting(self, value) -> bool_t:
-        """ check whether we allow in-place setting with this type of value """
         raise AbstractMethodError(self)
 
     def _get_numeric_data(self):
@@ -4125,361 +796,31 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
 
     @property
     def values(self) -> np.ndarray:
-        """
-        Return a Numpy representation of the DataFrame.
-
-        .. warning::
-
-           We recommend using :meth:`DataFrame.to_numpy` instead.
-
-        Only the values in the DataFrame will be returned, the axes labels
-        will be removed.
-
-        Returns
-        -------
-        numpy.ndarray
-            The values of the DataFrame.
-
-        See Also
-        --------
-        DataFrame.to_numpy : Recommended alternative to this method.
-        DataFrame.index : Retrieve the index labels.
-        DataFrame.columns : Retrieving the column names.
-
-        Notes
-        -----
-        The dtype will be a lower-common-denominator dtype (implicit
-        upcasting); that is to say if the dtypes (even of numeric types)
-        are mixed, the one that accommodates all will be chosen. Use this
-        with care if you are not dealing with the blocks.
-
-        e.g. If the dtypes are float16 and float32, dtype will be upcast to
-        float32.  If dtypes are int32 and uint8, dtype will be upcast to
-        int32. By :func:`numpy.find_common_type` convention, mixing int64
-        and uint64 will result in a float64 dtype.
-
-        Examples
-        --------
-        A DataFrame where all columns are the same type (e.g., int64) results
-        in an array of the same type.
-
-        >>> df = pd.DataFrame({'age':    [ 3,  29],
-        ...                    'height': [94, 170],
-        ...                    'weight': [31, 115]})
-        >>> df
-           age  height  weight
-        0    3      94      31
-        1   29     170     115
-        >>> df.dtypes
-        age       int64
-        height    int64
-        weight    int64
-        dtype: object
-        >>> df.values
-        array([[  3,  94,  31],
-               [ 29, 170, 115]])
-
-        A DataFrame with mixed type columns(e.g., str/object, int64, float32)
-        results in an ndarray of the broadest type that accommodates these
-        mixed types (e.g., object).
-
-        >>> df2 = pd.DataFrame([('parrot',   24.0, 'second'),
-        ...                     ('lion',     80.5, 1),
-        ...                     ('monkey', np.nan, None)],
-        ...                   columns=('name', 'max_speed', 'rank'))
-        >>> df2.dtypes
-        name          object
-        max_speed    float64
-        rank          object
-        dtype: object
-        >>> df2.values
-        array([['parrot', 24.0, 'second'],
-               ['lion', 80.5, 1],
-               ['monkey', nan, None]], dtype=object)
-        """
         raise AbstractMethodError(self)
 
     @property
     def _values(self) -> np.ndarray:
-        """internal implementation"""
         raise AbstractMethodError(self)
 
     @property
     def dtypes(self):
-        """
-        Return the dtypes in the DataFrame.
-
-        This returns a Series with the data type of each column.
-        The result's index is the original DataFrame's columns. Columns
-        with mixed types are stored with the ``object`` dtype. See
-        :ref:`the User Guide <basics.dtypes>` for more.
-
-        Returns
-        -------
-        pandas.Series
-            The data type of each column.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({'float': [1.0],
-        ...                    'int': [1],
-        ...                    'datetime': [pd.Timestamp('20180310')],
-        ...                    'string': ['foo']})
-        >>> df.dtypes
-        float              float64
-        int                  int64
-        datetime    datetime64[ns]
-        string              object
-        dtype: object
-        """
         raise AbstractMethodError(self)
 
     def _to_dict_of_blocks(self, copy: bool_t = True):
-        """
-        Return a dict of dtype -> Constructor Types that
-        each is a homogeneous dtype.
-
-        Internal ONLY
-        """
         raise AbstractMethodError(self)
 
     def astype(
         self: FrameOrSeries, dtype, copy: bool_t = True, errors: str = "raise"
     ) -> FrameOrSeries:
-        """
-        Cast a pandas object to a specified dtype ``dtype``.
-
-        Parameters
-        ----------
-        dtype : data type, or dict of column name -> data type
-            Use a numpy.dtype or Python type to cast entire pandas object to
-            the same type. Alternatively, use {col: dtype, ...}, where col is a
-            column label and dtype is a numpy.dtype or Python type to cast one
-            or more of the DataFrame's columns to column-specific types.
-        copy : bool, default True
-            Return a copy when ``copy=True`` (be very careful setting
-            ``copy=False`` as changes to values then may propagate to other
-            pandas objects).
-        errors : {'raise', 'ignore'}, default 'raise'
-            Control raising of exceptions on invalid data for provided dtype.
-
-            - ``raise`` : allow exceptions to be raised
-            - ``ignore`` : suppress exceptions. On error return original object.
-
-        Returns
-        -------
-        casted : same type as caller
-
-        See Also
-        --------
-        to_datetime : Convert argument to datetime.
-        to_timedelta : Convert argument to timedelta.
-        to_numeric : Convert argument to a numeric type.
-        numpy.ndarray.astype : Cast a numpy array to a specified type.
-
-        Examples
-        --------
-        Create a DataFrame:
-
-        >>> d = {'col1': [1, 2], 'col2': [3, 4]}
-        >>> df = pd.DataFrame(data=d)
-        >>> df.dtypes
-        col1    int64
-        col2    int64
-        dtype: object
-
-        Cast all columns to int32:
-
-        >>> df.astype('int32').dtypes
-        col1    int32
-        col2    int32
-        dtype: object
-
-        Cast col1 to int32 using a dictionary:
-
-        >>> df.astype({'col1': 'int32'}).dtypes
-        col1    int32
-        col2    int64
-        dtype: object
-
-        Create a series:
-
-        >>> ser = pd.Series([1, 2], dtype='int32')
-        >>> ser
-        0    1
-        1    2
-        dtype: int32
-        >>> ser.astype('int64')
-        0    1
-        1    2
-        dtype: int64
-
-        Convert to categorical type:
-
-        >>> ser.astype('category')
-        0    1
-        1    2
-        dtype: category
-        Categories (2, int64): [1, 2]
-
-        Convert to ordered categorical type with custom ordering:
-
-        >>> cat_dtype = pd.api.types.CategoricalDtype(
-        ...     categories=[2, 1], ordered=True)
-        >>> ser.astype(cat_dtype)
-        0    1
-        1    2
-        dtype: category
-        Categories (2, int64): [2 < 1]
-
-        Note that using ``copy=False`` and changing data on a new
-        pandas object may propagate changes:
-
-        >>> s1 = pd.Series([1, 2])
-        >>> s2 = s1.astype('int64', copy=False)
-        >>> s2[0] = 10
-        >>> s1  # note that s1[0] has changed too
-        0    10
-        1     2
-        dtype: int64
-
-        Create a series of dates:
-
-        >>> ser_date = pd.Series(pd.date_range('20200101', periods=3))
-        >>> ser_date
-        0   2020-01-01
-        1   2020-01-02
-        2   2020-01-03
-        dtype: datetime64[ns]
-
-        Datetimes are localized to UTC first before
-        converting to the specified timezone:
-
-        >>> ser_date.astype('datetime64[ns, US/Eastern]')
-        0   2019-12-31 19:00:00-05:00
-        1   2020-01-01 19:00:00-05:00
-        2   2020-01-02 19:00:00-05:00
-        dtype: datetime64[ns, US/Eastern]
-        """
         raise AbstractMethodError(self)
 
     def copy(self: FrameOrSeries, deep: bool_t = True) -> FrameOrSeries:
-        """
-        Make a copy of this object's indices and data.
-
-        When ``deep=True`` (default), a new object will be created with a
-        copy of the calling object's data and indices. Modifications to
-        the data or indices of the copy will not be reflected in the
-        original object (see notes below).
-
-        When ``deep=False``, a new object will be created without copying
-        the calling object's data or index (only references to the data
-        and index are copied). Any changes to the data of the original
-        will be reflected in the shallow copy (and vice versa).
-
-        Parameters
-        ----------
-        deep : bool, default True
-            Make a deep copy, including a copy of the data and the indices.
-            With ``deep=False`` neither the indices nor the data are copied.
-
-        Returns
-        -------
-        copy : Series or DataFrame
-            Object type matches caller.
-
-        Notes
-        -----
-        When ``deep=True``, data is copied but actual Python objects
-        will not be copied recursively, only the reference to the object.
-        This is in contrast to `copy.deepcopy` in the Standard Library,
-        which recursively copies object data (see examples below).
-
-        While ``Index`` objects are copied when ``deep=True``, the underlying
-        numpy array is not copied for performance reasons. Since ``Index`` is
-        immutable, the underlying data can be safely shared and a copy
-        is not needed.
-
-        Examples
-        --------
-        >>> s = pd.Series([1, 2], index=["a", "b"])
-        >>> s
-        a    1
-        b    2
-        dtype: int64
-
-        >>> s_copy = s.copy()
-        >>> s_copy
-        a    1
-        b    2
-        dtype: int64
-
-        **Shallow copy versus default (deep) copy:**
-
-        >>> s = pd.Series([1, 2], index=["a", "b"])
-        >>> deep = s.copy()
-        >>> shallow = s.copy(deep=False)
-
-        Shallow copy shares data and index with original.
-
-        >>> s is shallow
-        False
-        >>> s.values is shallow.values and s.index is shallow.index
-        True
-
-        Deep copy has own copy of data and index.
-
-        >>> s is deep
-        False
-        >>> s.values is deep.values or s.index is deep.index
-        False
-
-        Updates to the data shared by shallow copy and original is reflected
-        in both; deep copy remains unchanged.
-
-        >>> s[0] = 3
-        >>> shallow[1] = 4
-        >>> s
-        a    3
-        b    4
-        dtype: int64
-        >>> shallow
-        a    3
-        b    4
-        dtype: int64
-        >>> deep
-        a    1
-        b    2
-        dtype: int64
-
-        Note that when copying an object containing Python objects, a deep copy
-        will copy the data, but will not do so recursively. Updating a nested
-        data object will be reflected in the deep copy.
-
-        >>> s = pd.Series([[1, 2], [3, 4]])
-        >>> deep = s.copy()
-        >>> s[0][0] = 10
-        >>> s
-        0    [10, 2]
-        1     [3, 4]
-        dtype: object
-        >>> deep
-        0    [10, 2]
-        1     [3, 4]
-        dtype: object
-        """
         raise AbstractMethodError(self)
 
     def __copy__(self: FrameOrSeries, deep: bool_t = True) -> FrameOrSeries:
         raise AbstractMethodError(self)
 
     def __deepcopy__(self: FrameOrSeries, memo=None) -> FrameOrSeries:
-        """
-        Parameters
-        ----------
-        memo, default None
-            Standard signature. Unused
-        """
         raise AbstractMethodError(self)
 
     def _convert(
@@ -4489,66 +830,9 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         timedelta: bool_t = False,
         coerce: bool_t = False,
     ) -> FrameOrSeries:
-        """
-        Attempt to infer better dtype for object columns
-
-        Parameters
-        ----------
-        datetime : bool, default False
-            If True, convert to date where possible.
-        numeric : bool, default False
-            If True, attempt to convert to numbers (including strings), with
-            unconvertible values becoming NaN.
-        timedelta : bool, default False
-            If True, convert to timedelta where possible.
-        coerce : bool, default False
-            If True, force conversion with unconvertible values converted to
-            nulls (NaN or NaT).
-
-        Returns
-        -------
-        converted : same as input object
-        """
         raise AbstractMethodError(self)
 
     def infer_objects(self: FrameOrSeries) -> FrameOrSeries:
-        """
-        Attempt to infer better dtypes for object columns.
-
-        Attempts soft conversion of object-dtyped
-        columns, leaving non-object and unconvertible
-        columns unchanged. The inference rules are the
-        same as during normal Series/DataFrame construction.
-
-        Returns
-        -------
-        converted : same type as input object
-
-        See Also
-        --------
-        to_datetime : Convert argument to datetime.
-        to_timedelta : Convert argument to timedelta.
-        to_numeric : Convert argument to numeric type.
-        convert_dtypes : Convert argument to best possible dtype.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({"A": ["a", 1, 2, 3]})
-        >>> df = df.iloc[1:]
-        >>> df
-           A
-        1  1
-        2  2
-        3  3
-
-        >>> df.dtypes
-        A    object
-        dtype: object
-
-        >>> df.infer_objects().dtypes
-        A    int64
-        dtype: object
-        """
         raise AbstractMethodError(self)
 
     def convert_dtypes(
@@ -4558,126 +842,11 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         convert_integer: bool_t = True,
         convert_boolean: bool_t = True,
     ) -> FrameOrSeries:
-        """
-        Convert columns to best possible dtypes using dtypes supporting ``pd.NA``.
-
-        .. versionadded:: 1.0.0
-
-        Parameters
-        ----------
-        infer_objects : bool, default True
-            Whether object dtypes should be converted to the best possible types.
-        convert_string : bool, default True
-            Whether object dtypes should be converted to ``StringDtype()``.
-        convert_integer : bool, default True
-            Whether, if possible, conversion can be done to integer extension types.
-        convert_boolean : bool, defaults True
-            Whether object dtypes should be converted to ``BooleanDtypes()``.
-
-        Returns
-        -------
-        Series or DataFrame
-            Copy of input object with new dtype.
-
-        See Also
-        --------
-        infer_objects : Infer dtypes of objects.
-        to_datetime : Convert argument to datetime.
-        to_timedelta : Convert argument to timedelta.
-        to_numeric : Convert argument to a numeric type.
-
-        Notes
-        -----
-        By default, ``convert_dtypes`` will attempt to convert a Series (or each
-        Series in a DataFrame) to dtypes that support ``pd.NA``. By using the options
-        ``convert_string``, ``convert_integer``, and ``convert_boolean``, it is
-        possible to turn off individual conversions to ``StringDtype``, the integer
-        extension types or ``BooleanDtype``, respectively.
-
-        For object-dtyped columns, if ``infer_objects`` is ``True``, use the inference
-        rules as during normal Series/DataFrame construction.  Then, if possible,
-        convert to ``StringDtype``, ``BooleanDtype`` or an appropriate integer extension
-        type, otherwise leave as ``object``.
-
-        If the dtype is integer, convert to an appropriate integer extension type.
-
-        If the dtype is numeric, and consists of all integers, convert to an
-        appropriate integer extension type.
-
-        In the future, as new dtypes are added that support ``pd.NA``, the results
-        of this method will change to support those new dtypes.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame(
-        ...     {
-        ...         "a": pd.Series([1, 2, 3], dtype=np.dtype("int32")),
-        ...         "b": pd.Series(["x", "y", "z"], dtype=np.dtype("O")),
-        ...         "c": pd.Series([True, False, np.nan], dtype=np.dtype("O")),
-        ...         "d": pd.Series(["h", "i", np.nan], dtype=np.dtype("O")),
-        ...         "e": pd.Series([10, np.nan, 20], dtype=np.dtype("float")),
-        ...         "f": pd.Series([np.nan, 100.5, 200], dtype=np.dtype("float")),
-        ...     }
-        ... )
-
-        Start with a DataFrame with default dtypes.
-
-        >>> df
-           a  b      c    d     e      f
-        0  1  x   True    h  10.0    NaN
-        1  2  y  False    i   NaN  100.5
-        2  3  z    NaN  NaN  20.0  200.0
-
-        >>> df.dtypes
-        a      int32
-        b     object
-        c     object
-        d     object
-        e    float64
-        f    float64
-        dtype: object
-
-        Convert the DataFrame to use best possible dtypes.
-
-        >>> dfn = df.convert_dtypes()
-        >>> dfn
-           a  b      c     d     e      f
-        0  1  x   True     h    10    NaN
-        1  2  y  False     i  <NA>  100.5
-        2  3  z   <NA>  <NA>    20  200.0
-
-        >>> dfn.dtypes
-        a      Int32
-        b     string
-        c    boolean
-        d     string
-        e      Int64
-        f    float64
-        dtype: object
-
-        Start with a Series of strings and missing data represented by ``np.nan``.
-
-        >>> s = pd.Series(["a", "b", np.nan])
-        >>> s
-        0      a
-        1      b
-        2    NaN
-        dtype: object
-
-        Obtain a Series with dtype ``StringDtype``.
-
-        >>> s.convert_dtypes()
-        0       a
-        1       b
-        2    <NA>
-        dtype: string
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
     # Filling NA's
 
-    @doc(**_shared_doc_kwargs)
     def fillna(
         self: FrameOrSeries,
         value=None,
@@ -4687,102 +856,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         limit=None,
         downcast=None,
     ) -> Optional[FrameOrSeries]:
-        """
-        Fill NA/NaN values using the specified method.
-
-        Parameters
-        ----------
-        value : scalar, dict, Series, or DataFrame
-            Value to use to fill holes (e.g. 0), alternately a
-            dict/Series/DataFrame of values specifying which value to use for
-            each index (for a Series) or column (for a DataFrame).  Values not
-            in the dict/Series/DataFrame will not be filled. This value cannot
-            be a list.
-        method : {{'backfill', 'bfill', 'pad', 'ffill', None}}, default None
-            Method to use for filling holes in reindexed Series
-            pad / ffill: propagate last valid observation forward to next valid
-            backfill / bfill: use next valid observation to fill gap.
-        axis : {axes_single_arg}
-            Axis along which to fill missing values.
-        inplace : bool, default False
-            If True, fill in-place. Note: this will modify any
-            other views on this object (e.g., a no-copy slice for a column in a
-            DataFrame).
-        limit : int, default None
-            If method is specified, this is the maximum number of consecutive
-            NaN values to forward/backward fill. In other words, if there is
-            a gap with more than this number of consecutive NaNs, it will only
-            be partially filled. If method is not specified, this is the
-            maximum number of entries along the entire axis where NaNs will be
-            filled. Must be greater than 0 if not None.
-        downcast : dict, default is None
-            A dict of item->dtype of what to downcast if possible,
-            or the string 'infer' which will try to downcast to an appropriate
-            equal type (e.g. float64 to int64 if possible).
-
-        Returns
-        -------
-        {klass} or None
-            Object with missing values filled or None if ``inplace=True``.
-
-        See Also
-        --------
-        interpolate : Fill NaN values using interpolation.
-        reindex : Conform object to new index.
-        asfreq : Convert TimeSeries to specified frequency.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0],
-        ...                    [3, 4, np.nan, 1],
-        ...                    [np.nan, np.nan, np.nan, 5],
-        ...                    [np.nan, 3, np.nan, 4]],
-        ...                   columns=list('ABCD'))
-        >>> df
-             A    B   C  D
-        0  NaN  2.0 NaN  0
-        1  3.0  4.0 NaN  1
-        2  NaN  NaN NaN  5
-        3  NaN  3.0 NaN  4
-
-        Replace all NaN elements with 0s.
-
-        >>> df.fillna(0)
-            A   B   C   D
-        0   0.0 2.0 0.0 0
-        1   3.0 4.0 0.0 1
-        2   0.0 0.0 0.0 5
-        3   0.0 3.0 0.0 4
-
-        We can also propagate non-null values forward or backward.
-
-        >>> df.fillna(method='ffill')
-            A   B   C   D
-        0   NaN 2.0 NaN 0
-        1   3.0 4.0 NaN 1
-        2   3.0 4.0 NaN 5
-        3   3.0 3.0 NaN 4
-
-        Replace all NaN elements in column 'A', 'B', 'C', and 'D', with 0, 1,
-        2, and 3 respectively.
-
-        >>> values = {{'A': 0, 'B': 1, 'C': 2, 'D': 3}}
-        >>> df.fillna(value=values)
-            A   B   C   D
-        0   0.0 2.0 2.0 0
-        1   3.0 4.0 2.0 1
-        2   0.0 1.0 2.0 5
-        3   0.0 3.0 2.0 4
-
-        Only replace the first NaN element.
-
-        >>> df.fillna(value=values, limit=1)
-            A   B   C   D
-        0   0.0 2.0 2.0 0
-        1   3.0 4.0 NaN 1
-        2   NaN 1.0 NaN 5
-        3   NaN 3.0 NaN 4
-        """
         raise AbstractMethodError(self)
 
     def ffill(
@@ -4792,14 +865,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         limit=None,
         downcast=None,
     ) -> Optional[FrameOrSeries]:
-        """
-        Synonym for :meth:`DataFrame.fillna` with ``method='ffill'``.
-
-        Returns
-        -------
-        {klass} or None
-            Object with missing values filled or None if ``inplace=True``.
-        """
         raise AbstractMethodError(self)
 
     pad = ffill
@@ -4811,19 +876,10 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         limit=None,
         downcast=None,
     ) -> Optional[FrameOrSeries]:
-        """
-        Synonym for :meth:`DataFrame.fillna` with ``method='bfill'``.
-
-        Returns
-        -------
-        {klass} or None
-            Object with missing values filled or None if ``inplace=True``.
-        """
         raise AbstractMethodError(self)
 
     backfill = bfill
 
-    @doc(klass=_shared_doc_kwargs["klass"])
     def replace(
         self,
         to_replace=None,
@@ -4833,282 +889,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         regex=False,
         method="pad",
     ):
-        """
-        Replace values given in `to_replace` with `value`.
-
-        Values of the {klass} are replaced with other values dynamically.
-        This differs from updating with ``.loc`` or ``.iloc``, which require
-        you to specify a location to update with some value.
-
-        Parameters
-        ----------
-        to_replace : str, regex, list, dict, Series, int, float, or None
-            How to find the values that will be replaced.
-
-            * numeric, str or regex:
-
-                - numeric: numeric values equal to `to_replace` will be
-                  replaced with `value`
-                - str: string exactly matching `to_replace` will be replaced
-                  with `value`
-                - regex: regexs matching `to_replace` will be replaced with
-                  `value`
-
-            * list of str, regex, or numeric:
-
-                - First, if `to_replace` and `value` are both lists, they
-                  **must** be the same length.
-                - Second, if ``regex=True`` then all of the strings in **both**
-                  lists will be interpreted as regexs otherwise they will match
-                  directly. This doesn't matter much for `value` since there
-                  are only a few possible substitution regexes you can use.
-                - str, regex and numeric rules apply as above.
-
-            * dict:
-
-                - Dicts can be used to specify different replacement values
-                  for different existing values. For example,
-                  ``{{'a': 'b', 'y': 'z'}}`` replaces the value 'a' with 'b' and
-                  'y' with 'z'. To use a dict in this way the `value`
-                  parameter should be `None`.
-                - For a DataFrame a dict can specify that different values
-                  should be replaced in different columns. For example,
-                  ``{{'a': 1, 'b': 'z'}}`` looks for the value 1 in column 'a'
-                  and the value 'z' in column 'b' and replaces these values
-                  with whatever is specified in `value`. The `value` parameter
-                  should not be ``None`` in this case. You can treat this as a
-                  special case of passing two lists except that you are
-                  specifying the column to search in.
-                - For a DataFrame nested dictionaries, e.g.,
-                  ``{{'a': {{'b': np.nan}}}}``, are read as follows: look in column
-                  'a' for the value 'b' and replace it with NaN. The `value`
-                  parameter should be ``None`` to use a nested dict in this
-                  way. You can nest regular expressions as well. Note that
-                  column names (the top-level dictionary keys in a nested
-                  dictionary) **cannot** be regular expressions.
-
-            * None:
-
-                - This means that the `regex` argument must be a string,
-                  compiled regular expression, or list, dict, ndarray or
-                  Series of such elements. If `value` is also ``None`` then
-                  this **must** be a nested dictionary or Series.
-
-            See the examples section for examples of each of these.
-        value : scalar, dict, list, str, regex, default None
-            Value to replace any values matching `to_replace` with.
-            For a DataFrame a dict of values can be used to specify which
-            value to use for each column (columns not in the dict will not be
-            filled). Regular expressions, strings and lists or dicts of such
-            objects are also allowed.
-        inplace : bool, default False
-            If True, in place. Note: this will modify any
-            other views on this object (e.g. a column from a DataFrame).
-            Returns the caller if this is True.
-        limit : int or None, default None
-            Maximum size gap to forward or backward fill.
-        regex : bool or same types as `to_replace`, default False
-            Whether to interpret `to_replace` and/or `value` as regular
-            expressions. If this is ``True`` then `to_replace` *must* be a
-            string. Alternatively, this could be a regular expression or a
-            list, dict, or array of regular expressions in which case
-            `to_replace` must be ``None``.
-        method : {{'pad', 'ffill', 'bfill', `None`}}
-            The method to use when for replacement, when `to_replace` is a
-            scalar, list or tuple and `value` is ``None``.
-
-        Returns
-        -------
-        {klass} or None
-            Object after replacement or None if ``inplace=True``.
-
-        Raises
-        ------
-        AssertionError
-            * If `regex` is not a ``bool`` and `to_replace` is not
-              ``None``.
-
-        TypeError
-            * If `to_replace` is not a scalar, array-like, ``dict``, or ``None``
-            * If `to_replace` is a ``dict`` and `value` is not a ``list``,
-              ``dict``, ``ndarray``, or ``Series``
-            * If `to_replace` is ``None`` and `regex` is not compilable
-              into a regular expression or is a list, dict, ndarray, or
-              Series.
-            * When replacing multiple ``bool`` or ``datetime64`` objects and
-              the arguments to `to_replace` does not match the type of the
-              value being replaced
-
-        ValueError
-            * If a ``list`` or an ``ndarray`` is passed to `to_replace` and
-              `value` but they are not the same length.
-
-        See Also
-        --------
-        {klass}.fillna : Fill NA values.
-        {klass}.where : Replace values based on boolean condition.
-        Series.str.replace : Simple string replacement.
-
-        Notes
-        -----
-        * Regex substitution is performed under the hood with ``re.sub``. The
-          rules for substitution for ``re.sub`` are the same.
-        * Regular expressions will only substitute on strings, meaning you
-          cannot provide, for example, a regular expression matching floating
-          point numbers and expect the columns in your frame that have a
-          numeric dtype to be matched. However, if those floating point
-          numbers *are* strings, then you can do this.
-        * This method has *a lot* of options. You are encouraged to experiment
-          and play with this method to gain intuition about how it works.
-        * When dict is used as the `to_replace` value, it is like
-          key(s) in the dict are the to_replace part and
-          value(s) in the dict are the value parameter.
-
-        Examples
-        --------
-
-        **Scalar `to_replace` and `value`**
-
-        >>> s = pd.Series([0, 1, 2, 3, 4])
-        >>> s.replace(0, 5)
-        0    5
-        1    1
-        2    2
-        3    3
-        4    4
-        dtype: int64
-
-        >>> df = pd.DataFrame({{'A': [0, 1, 2, 3, 4],
-        ...                    'B': [5, 6, 7, 8, 9],
-        ...                    'C': ['a', 'b', 'c', 'd', 'e']}})
-        >>> df.replace(0, 5)
-           A  B  C
-        0  5  5  a
-        1  1  6  b
-        2  2  7  c
-        3  3  8  d
-        4  4  9  e
-
-        **List-like `to_replace`**
-
-        >>> df.replace([0, 1, 2, 3], 4)
-           A  B  C
-        0  4  5  a
-        1  4  6  b
-        2  4  7  c
-        3  4  8  d
-        4  4  9  e
-
-        >>> df.replace([0, 1, 2, 3], [4, 3, 2, 1])
-           A  B  C
-        0  4  5  a
-        1  3  6  b
-        2  2  7  c
-        3  1  8  d
-        4  4  9  e
-
-        >>> s.replace([1, 2], method='bfill')
-        0    0
-        1    3
-        2    3
-        3    3
-        4    4
-        dtype: int64
-
-        **dict-like `to_replace`**
-
-        >>> df.replace({{0: 10, 1: 100}})
-             A  B  C
-        0   10  5  a
-        1  100  6  b
-        2    2  7  c
-        3    3  8  d
-        4    4  9  e
-
-        >>> df.replace({{'A': 0, 'B': 5}}, 100)
-             A    B  C
-        0  100  100  a
-        1    1    6  b
-        2    2    7  c
-        3    3    8  d
-        4    4    9  e
-
-        >>> df.replace({{'A': {{0: 100, 4: 400}}}})
-             A  B  C
-        0  100  5  a
-        1    1  6  b
-        2    2  7  c
-        3    3  8  d
-        4  400  9  e
-
-        **Regular expression `to_replace`**
-
-        >>> df = pd.DataFrame({{'A': ['bat', 'foo', 'bait'],
-        ...                    'B': ['abc', 'bar', 'xyz']}})
-        >>> df.replace(to_replace=r'^ba.$', value='new', regex=True)
-              A    B
-        0   new  abc
-        1   foo  new
-        2  bait  xyz
-
-        >>> df.replace({{'A': r'^ba.$'}}, {{'A': 'new'}}, regex=True)
-              A    B
-        0   new  abc
-        1   foo  bar
-        2  bait  xyz
-
-        >>> df.replace(regex=r'^ba.$', value='new')
-              A    B
-        0   new  abc
-        1   foo  new
-        2  bait  xyz
-
-        >>> df.replace(regex={{r'^ba.$': 'new', 'foo': 'xyz'}})
-              A    B
-        0   new  abc
-        1   xyz  new
-        2  bait  xyz
-
-        >>> df.replace(regex=[r'^ba.$', 'foo'], value='new')
-              A    B
-        0   new  abc
-        1   new  new
-        2  bait  xyz
-
-        Compare the behavior of ``s.replace({{'a': None}})`` and
-        ``s.replace('a', None)`` to understand the peculiarities
-        of the `to_replace` parameter:
-
-        >>> s = pd.Series([10, 'a', 'a', 'b', 'a'])
-
-        When one uses a dict as the `to_replace` value, it is like the
-        value(s) in the dict are equal to the `value` parameter.
-        ``s.replace({{'a': None}})`` is equivalent to
-        ``s.replace(to_replace={{'a': None}}, value=None, method=None)``:
-
-        >>> s.replace({{'a': None}})
-        0      10
-        1    None
-        2    None
-        3       b
-        4    None
-        dtype: object
-
-        When ``value=None`` and `to_replace` is a scalar, list or
-        tuple, `replace` uses the method parameter (default 'pad') to do the
-        replacement. So this is why the 'a' values are being replaced by 10
-        in rows 1 and 2 and 'b' in row 4 in this case.
-        The command ``s.replace('a', None)`` is actually equivalent to
-        ``s.replace(to_replace='a', value=None, method='pad')``:
-
-        >>> s.replace('a', None)
-        0    10
-        1    10
-        2    10
-        3     b
-        4     b
-        dtype: object
-        """
         raise AbstractMethodError(self)
 
     def interpolate(
@@ -5122,439 +902,26 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         downcast: Optional[str] = None,
         **kwargs,
     ) -> Optional[FrameOrSeries]:
-        """
-        Fill NaN values using an interpolation method.
-
-        Please note that only ``method='linear'`` is supported for
-        DataFrame/Series with a MultiIndex.
-
-        Parameters
-        ----------
-        method : str, default 'linear'
-            Interpolation technique to use. One of:
-
-            * 'linear': Ignore the index and treat the values as equally
-              spaced. This is the only method supported on MultiIndexes.
-            * 'time': Works on daily and higher resolution data to interpolate
-              given length of interval.
-            * 'index', 'values': use the actual numerical values of the index.
-            * 'pad': Fill in NaNs using existing values.
-            * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic', 'spline',
-              'barycentric', 'polynomial': Passed to
-              `scipy.interpolate.interp1d`. These methods use the numerical
-              values of the index.  Both 'polynomial' and 'spline' require that
-              you also specify an `order` (int), e.g.
-              ``df.interpolate(method='polynomial', order=5)``.
-            * 'krogh', 'piecewise_polynomial', 'spline', 'pchip', 'akima',
-              'cubicspline': Wrappers around the SciPy interpolation methods of
-              similar names. See `Notes`.
-            * 'from_derivatives': Refers to
-              `scipy.interpolate.BPoly.from_derivatives` which
-              replaces 'piecewise_polynomial' interpolation method in
-              scipy 0.18.
-
-        axis : {{0 or 'index', 1 or 'columns', None}}, default None
-            Axis to interpolate along.
-        limit : int, optional
-            Maximum number of consecutive NaNs to fill. Must be greater than
-            0.
-        inplace : bool, default False
-            Update the data in place if possible.
-        limit_direction : {{'forward', 'backward', 'both'}}, Optional
-            Consecutive NaNs will be filled in this direction.
-
-            If limit is specified:
-                * If 'method' is 'pad' or 'ffill', 'limit_direction' must be 'forward'.
-                * If 'method' is 'backfill' or 'bfill', 'limit_direction' must be
-                  'backwards'.
-
-            If 'limit' is not specified:
-                * If 'method' is 'backfill' or 'bfill', the default is 'backward'
-                * else the default is 'forward'
-
-            .. versionchanged:: 1.1.0
-                raises ValueError if `limit_direction` is 'forward' or 'both' and
-                    method is 'backfill' or 'bfill'.
-                raises ValueError if `limit_direction` is 'backward' or 'both' and
-                    method is 'pad' or 'ffill'.
-
-        limit_area : {{`None`, 'inside', 'outside'}}, default None
-            If limit is specified, consecutive NaNs will be filled with this
-            restriction.
-
-            * ``None``: No fill restriction.
-            * 'inside': Only fill NaNs surrounded by valid values
-              (interpolate).
-            * 'outside': Only fill NaNs outside valid values (extrapolate).
-
-        downcast : optional, 'infer' or None, defaults to None
-            Downcast dtypes if possible.
-        ``**kwargs`` : optional
-            Keyword arguments to pass on to the interpolating function.
-
-        Returns
-        -------
-        Series or DataFrame or None
-            Returns the same object type as the caller, interpolated at
-            some or all ``NaN`` values or None if ``inplace=True``.
-
-        See Also
-        --------
-        fillna : Fill missing values using different methods.
-        scipy.interpolate.Akima1DInterpolator : Piecewise cubic polynomials
-            (Akima interpolator).
-        scipy.interpolate.BPoly.from_derivatives : Piecewise polynomial in the
-            Bernstein basis.
-        scipy.interpolate.interp1d : Interpolate a 1-D function.
-        scipy.interpolate.KroghInterpolator : Interpolate polynomial (Krogh
-            interpolator).
-        scipy.interpolate.PchipInterpolator : PCHIP 1-d monotonic cubic
-            interpolation.
-        scipy.interpolate.CubicSpline : Cubic spline data interpolator.
-
-        Notes
-        -----
-        The 'krogh', 'piecewise_polynomial', 'spline', 'pchip' and 'akima'
-        methods are wrappers around the respective SciPy implementations of
-        similar names. These use the actual numerical values of the index.
-        For more information on their behavior, see the
-        `SciPy documentation
-        <https://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation>`__
-        and `SciPy tutorial
-        <https://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html>`__.
-
-        Examples
-        --------
-        Filling in ``NaN`` in a :class:`~pandas.Series` via linear
-        interpolation.
-
-        >>> s = pd.Series([0, 1, np.nan, 3])
-        >>> s
-        0    0.0
-        1    1.0
-        2    NaN
-        3    3.0
-        dtype: float64
-        >>> s.interpolate()
-        0    0.0
-        1    1.0
-        2    2.0
-        3    3.0
-        dtype: float64
-
-        Filling in ``NaN`` in a Series by padding, but filling at most two
-        consecutive ``NaN`` at a time.
-
-        >>> s = pd.Series([np.nan, "single_one", np.nan,
-        ...                "fill_two_more", np.nan, np.nan, np.nan,
-        ...                4.71, np.nan])
-        >>> s
-        0              NaN
-        1       single_one
-        2              NaN
-        3    fill_two_more
-        4              NaN
-        5              NaN
-        6              NaN
-        7             4.71
-        8              NaN
-        dtype: object
-        >>> s.interpolate(method='pad', limit=2)
-        0              NaN
-        1       single_one
-        2       single_one
-        3    fill_two_more
-        4    fill_two_more
-        5    fill_two_more
-        6              NaN
-        7             4.71
-        8             4.71
-        dtype: object
-
-        Filling in ``NaN`` in a Series via polynomial interpolation or splines:
-        Both 'polynomial' and 'spline' methods require that you also specify
-        an ``order`` (int).
-
-        >>> s = pd.Series([0, 2, np.nan, 8])
-        >>> s.interpolate(method='polynomial', order=2)
-        0    0.000000
-        1    2.000000
-        2    4.666667
-        3    8.000000
-        dtype: float64
-
-        Fill the DataFrame forward (that is, going down) along each column
-        using linear interpolation.
-
-        Note how the last entry in column 'a' is interpolated differently,
-        because there is no entry after it to use for interpolation.
-        Note how the first entry in column 'b' remains ``NaN``, because there
-        is no entry before it to use for interpolation.
-
-        >>> df = pd.DataFrame([(0.0, np.nan, -1.0, 1.0),
-        ...                    (np.nan, 2.0, np.nan, np.nan),
-        ...                    (2.0, 3.0, np.nan, 9.0),
-        ...                    (np.nan, 4.0, -4.0, 16.0)],
-        ...                   columns=list('abcd'))
-        >>> df
-             a    b    c     d
-        0  0.0  NaN -1.0   1.0
-        1  NaN  2.0  NaN   NaN
-        2  2.0  3.0  NaN   9.0
-        3  NaN  4.0 -4.0  16.0
-        >>> df.interpolate(method='linear', limit_direction='forward', axis=0)
-             a    b    c     d
-        0  0.0  NaN -1.0   1.0
-        1  1.0  2.0 -2.0   5.0
-        2  2.0  3.0 -3.0   9.0
-        3  2.0  4.0 -4.0  16.0
-
-        Using polynomial interpolation.
-
-        >>> df['d'].interpolate(method='polynomial', order=2)
-        0     1.0
-        1     4.0
-        2     9.0
-        3    16.0
-        Name: d, dtype: float64
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
     # Timeseries methods Methods
 
     def asof(self, where, subset=None):
-        """
-        Return the last row(s) without any NaNs before `where`.
-
-        The last row (for each element in `where`, if list) without any
-        NaN is taken.
-        In case of a :class:`~pandas.DataFrame`, the last row without NaN
-        considering only the subset of columns (if not `None`)
-
-        If there is no good value, NaN is returned for a Series or
-        a Series of NaN values for a DataFrame
-
-        Parameters
-        ----------
-        where : date or array-like of dates
-            Date(s) before which the last row(s) are returned.
-        subset : str or array-like of str, default `None`
-            For DataFrame, if not `None`, only use these columns to
-            check for NaNs.
-
-        Returns
-        -------
-        scalar, Series, or DataFrame
-
-            The return can be:
-
-            * scalar : when `self` is a Series and `where` is a scalar
-            * Series: when `self` is a Series and `where` is an array-like,
-              or when `self` is a DataFrame and `where` is a scalar
-            * DataFrame : when `self` is a DataFrame and `where` is an
-              array-like
-
-            Return scalar, Series, or DataFrame.
-
-        See Also
-        --------
-        merge_asof : Perform an asof merge. Similar to left join.
-
-        Notes
-        -----
-        Dates are assumed to be sorted. Raises if this is not the case.
-
-        Examples
-        --------
-        A Series and a scalar `where`.
-
-        >>> s = pd.Series([1, 2, np.nan, 4], index=[10, 20, 30, 40])
-        >>> s
-        10    1.0
-        20    2.0
-        30    NaN
-        40    4.0
-        dtype: float64
-
-        >>> s.asof(20)
-        2.0
-
-        For a sequence `where`, a Series is returned. The first value is
-        NaN, because the first element of `where` is before the first
-        index value.
-
-        >>> s.asof([5, 20])
-        5     NaN
-        20    2.0
-        dtype: float64
-
-        Missing values are not considered. The following is ``2.0``, not
-        NaN, even though NaN is at the index location for ``30``.
-
-        >>> s.asof(30)
-        2.0
-
-        Take all columns into consideration
-
-        >>> df = pd.DataFrame({'a': [10, 20, 30, 40, 50],
-        ...                    'b': [None, None, None, None, 500]},
-        ...                   index=pd.DatetimeIndex(['2018-02-27 09:01:00',
-        ...                                           '2018-02-27 09:02:00',
-        ...                                           '2018-02-27 09:03:00',
-        ...                                           '2018-02-27 09:04:00',
-        ...                                           '2018-02-27 09:05:00']))
-        >>> df.asof(pd.DatetimeIndex(['2018-02-27 09:03:30',
-        ...                           '2018-02-27 09:04:30']))
-                              a   b
-        2018-02-27 09:03:30 NaN NaN
-        2018-02-27 09:04:30 NaN NaN
-
-        Take a single column into consideration
-
-        >>> df.asof(pd.DatetimeIndex(['2018-02-27 09:03:30',
-        ...                           '2018-02-27 09:04:30']),
-        ...         subset=['a'])
-                                 a   b
-        2018-02-27 09:03:30   30.0 NaN
-        2018-02-27 09:04:30   40.0 NaN
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
     # Action Methods
 
-    @doc(klass=_shared_doc_kwargs["klass"])
     def isna(self: FrameOrSeries) -> FrameOrSeries:
-        """
-        Detect missing values.
-
-        Return a boolean same-sized object indicating if the values are NA.
-        NA values, such as None or :attr:`numpy.NaN`, gets mapped to True
-        values.
-        Everything else gets mapped to False values. Characters such as empty
-        strings ``''`` or :attr:`numpy.inf` are not considered NA values
-        (unless you set ``pandas.options.mode.use_inf_as_na = True``).
-
-        Returns
-        -------
-        {klass}
-            Mask of bool values for each element in {klass} that
-            indicates whether an element is an NA value.
-
-        See Also
-        --------
-        {klass}.isnull : Alias of isna.
-        {klass}.notna : Boolean inverse of isna.
-        {klass}.dropna : Omit axes labels with missing values.
-        isna : Top-level isna.
-
-        Examples
-        --------
-        Show which entries in a DataFrame are NA.
-
-        >>> df = pd.DataFrame(dict(age=[5, 6, np.NaN],
-        ...                    born=[pd.NaT, pd.Timestamp('1939-05-27'),
-        ...                             pd.Timestamp('1940-04-25')],
-        ...                    name=['Alfred', 'Batman', ''],
-        ...                    toy=[None, 'Batmobile', 'Joker']))
-        >>> df
-           age       born    name        toy
-        0  5.0        NaT  Alfred       None
-        1  6.0 1939-05-27  Batman  Batmobile
-        2  NaN 1940-04-25              Joker
-
-        >>> df.isna()
-             age   born   name    toy
-        0  False   True  False   True
-        1  False  False  False  False
-        2   True  False  False  False
-
-        Show which entries in a Series are NA.
-
-        >>> ser = pd.Series([5, 6, np.NaN])
-        >>> ser
-        0    5.0
-        1    6.0
-        2    NaN
-        dtype: float64
-
-        >>> ser.isna()
-        0    False
-        1    False
-        2     True
-        dtype: bool
-        """
         raise AbstractMethodError(self)
 
-    @doc(isna, klass=_shared_doc_kwargs["klass"])
     def isnull(self: FrameOrSeries) -> FrameOrSeries:
         raise AbstractMethodError(self)
 
-    @doc(klass=_shared_doc_kwargs["klass"])
     def notna(self: FrameOrSeries) -> FrameOrSeries:
-        """
-        Detect existing (non-missing) values.
-
-        Return a boolean same-sized object indicating if the values are not NA.
-        Non-missing values get mapped to True. Characters such as empty
-        strings ``''`` or :attr:`numpy.inf` are not considered NA values
-        (unless you set ``pandas.options.mode.use_inf_as_na = True``).
-        NA values, such as None or :attr:`numpy.NaN`, get mapped to False
-        values.
-
-        Returns
-        -------
-        {klass}
-            Mask of bool values for each element in {klass} that
-            indicates whether an element is not an NA value.
-
-        See Also
-        --------
-        {klass}.notnull : Alias of notna.
-        {klass}.isna : Boolean inverse of notna.
-        {klass}.dropna : Omit axes labels with missing values.
-        notna : Top-level notna.
-
-        Examples
-        --------
-        Show which entries in a DataFrame are not NA.
-
-        >>> df = pd.DataFrame(dict(age=[5, 6, np.NaN],
-        ...                    born=[pd.NaT, pd.Timestamp('1939-05-27'),
-        ...                             pd.Timestamp('1940-04-25')],
-        ...                    name=['Alfred', 'Batman', ''],
-        ...                    toy=[None, 'Batmobile', 'Joker']))
-        >>> df
-           age       born    name        toy
-        0  5.0        NaT  Alfred       None
-        1  6.0 1939-05-27  Batman  Batmobile
-        2  NaN 1940-04-25              Joker
-
-        >>> df.notna()
-             age   born  name    toy
-        0   True  False  True  False
-        1   True   True  True   True
-        2  False   True  True   True
-
-        Show which entries in a Series are not NA.
-
-        >>> ser = pd.Series([5, 6, np.NaN])
-        >>> ser
-        0    5.0
-        1    6.0
-        2    NaN
-        dtype: float64
-
-        >>> ser.notna()
-        0     True
-        1     True
-        2    False
-        dtype: bool
-        """
         raise AbstractMethodError(self)
 
-    @doc(notna, klass=_shared_doc_kwargs["klass"])
     def notnull(self: FrameOrSeries) -> FrameOrSeries:
         raise AbstractMethodError(self)
 
@@ -5573,82 +940,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         *args,
         **kwargs,
     ) -> FrameOrSeries:
-        """
-        Trim values at input threshold(s).
-
-        Assigns values outside boundary to boundary values. Thresholds
-        can be singular values or array like, and in the latter case
-        the clipping is performed element-wise in the specified axis.
-
-        Parameters
-        ----------
-        lower : float or array_like, default None
-            Minimum threshold value. All values below this
-            threshold will be set to it.
-        upper : float or array_like, default None
-            Maximum threshold value. All values above this
-            threshold will be set to it.
-        axis : int or str axis name, optional
-            Align object with lower and upper along the given axis.
-        inplace : bool, default False
-            Whether to perform the operation in place on the data.
-        *args, **kwargs
-            Additional keywords have no effect but might be accepted
-            for compatibility with numpy.
-
-        Returns
-        -------
-        Series or DataFrame or None
-            Same type as calling object with the values outside the
-            clip boundaries replaced or None if ``inplace=True``.
-
-        See Also
-        --------
-        Series.clip : Trim values at input threshold in series.
-        DataFrame.clip : Trim values at input threshold in dataframe.
-        numpy.clip : Clip (limit) the values in an array.
-
-        Examples
-        --------
-        >>> data = {'col_0': [9, -3, 0, -1, 5], 'col_1': [-2, -7, 6, 8, -5]}
-        >>> df = pd.DataFrame(data)
-        >>> df
-           col_0  col_1
-        0      9     -2
-        1     -3     -7
-        2      0      6
-        3     -1      8
-        4      5     -5
-
-        Clips per column using lower and upper thresholds:
-
-        >>> df.clip(-4, 6)
-           col_0  col_1
-        0      6     -2
-        1     -3     -4
-        2      0      6
-        3     -1      6
-        4      5     -4
-
-        Clips using specific lower and upper thresholds per column element:
-
-        >>> t = pd.Series([2, -4, -1, 6, 3])
-        >>> t
-        0    2
-        1   -4
-        2   -1
-        3    6
-        4    3
-        dtype: int64
-
-        >>> df.clip(t, t + 4, axis=0)
-           col_0  col_1
-        0      6      2
-        1     -3     -4
-        2      0      3
-        3      6      8
-        4      5      3
-        """
         raise AbstractMethodError(self)
 
     def asfreq(
@@ -5659,146 +950,11 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         normalize: bool_t = False,
         fill_value=None,
     ) -> FrameOrSeries:
-        """
-        Convert TimeSeries to specified frequency.
-
-        Optionally provide filling method to pad/backfill missing values.
-
-        Returns the original data conformed to a new index with the specified
-        frequency. ``resample`` is more appropriate if an operation, such as
-        summarization, is necessary to represent the data at the new frequency.
-
-        Parameters
-        ----------
-        freq : DateOffset or str
-            Frequency DateOffset or string.
-        method : {'backfill'/'bfill', 'pad'/'ffill'}, default None
-            Method to use for filling holes in reindexed Series (note this
-            does not fill NaNs that already were present):
-
-            * 'pad' / 'ffill': propagate last valid observation forward to next
-              valid
-            * 'backfill' / 'bfill': use NEXT valid observation to fill.
-        how : {'start', 'end'}, default end
-            For PeriodIndex only (see PeriodIndex.asfreq).
-        normalize : bool, default False
-            Whether to reset output index to midnight.
-        fill_value : scalar, optional
-            Value to use for missing values, applied during upsampling (note
-            this does not fill NaNs that already were present).
-
-        Returns
-        -------
-        Same type as caller
-            Object converted to the specified frequency.
-
-        See Also
-        --------
-        reindex : Conform DataFrame to new index with optional filling logic.
-
-        Notes
-        -----
-        To learn more about the frequency strings, please see `this link
-        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`__.
-
-        Examples
-        --------
-        Start by creating a series with 4 one minute timestamps.
-
-        >>> index = pd.date_range('1/1/2000', periods=4, freq='T')
-        >>> series = pd.Series([0.0, None, 2.0, 3.0], index=index)
-        >>> df = pd.DataFrame({'s':series})
-        >>> df
-                               s
-        2000-01-01 00:00:00    0.0
-        2000-01-01 00:01:00    NaN
-        2000-01-01 00:02:00    2.0
-        2000-01-01 00:03:00    3.0
-
-        Upsample the series into 30 second bins.
-
-        >>> df.asfreq(freq='30S')
-                               s
-        2000-01-01 00:00:00    0.0
-        2000-01-01 00:00:30    NaN
-        2000-01-01 00:01:00    NaN
-        2000-01-01 00:01:30    NaN
-        2000-01-01 00:02:00    2.0
-        2000-01-01 00:02:30    NaN
-        2000-01-01 00:03:00    3.0
-
-        Upsample again, providing a ``fill value``.
-
-        >>> df.asfreq(freq='30S', fill_value=9.0)
-                               s
-        2000-01-01 00:00:00    0.0
-        2000-01-01 00:00:30    9.0
-        2000-01-01 00:01:00    NaN
-        2000-01-01 00:01:30    9.0
-        2000-01-01 00:02:00    2.0
-        2000-01-01 00:02:30    9.0
-        2000-01-01 00:03:00    3.0
-
-        Upsample again, providing a ``method``.
-
-        >>> df.asfreq(freq='30S', method='bfill')
-                               s
-        2000-01-01 00:00:00    0.0
-        2000-01-01 00:00:30    NaN
-        2000-01-01 00:01:00    NaN
-        2000-01-01 00:01:30    2.0
-        2000-01-01 00:02:00    2.0
-        2000-01-01 00:02:30    3.0
-        2000-01-01 00:03:00    3.0
-        """
         raise AbstractMethodError(self)
 
     def at_time(
         self: FrameOrSeries, time, asof: bool_t = False, axis=None
     ) -> FrameOrSeries:
-        """
-        Select values at particular time of day (e.g., 9:30AM).
-
-        Parameters
-        ----------
-        time : datetime.time or str
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-
-            .. versionadded:: 0.24.0
-
-        Returns
-        -------
-        Series or DataFrame
-
-        Raises
-        ------
-        TypeError
-            If the index is not  a :class:`DatetimeIndex`
-
-        See Also
-        --------
-        between_time : Select values between particular times of the day.
-        first : Select initial periods of time series based on a date offset.
-        last : Select final periods of time series based on a date offset.
-        DatetimeIndex.indexer_at_time : Get just the index locations for
-            values at particular time of the day.
-
-        Examples
-        --------
-        >>> i = pd.date_range('2018-04-09', periods=4, freq='12H')
-        >>> ts = pd.DataFrame({'A': [1, 2, 3, 4]}, index=i)
-        >>> ts
-                             A
-        2018-04-09 00:00:00  1
-        2018-04-09 12:00:00  2
-        2018-04-10 00:00:00  3
-        2018-04-10 12:00:00  4
-
-        >>> ts.at_time('12:00')
-                             A
-        2018-04-09 12:00:00  2
-        2018-04-10 12:00:00  4
-        """
         raise AbstractMethodError(self)
 
     def between_time(
@@ -5809,69 +965,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         include_end: bool_t = True,
         axis=None,
     ) -> FrameOrSeries:
-        """
-        Select values between particular times of the day (e.g., 9:00-9:30 AM).
-
-        By setting ``start_time`` to be later than ``end_time``,
-        you can get the times that are *not* between the two times.
-
-        Parameters
-        ----------
-        start_time : datetime.time or str
-            Initial time as a time filter limit.
-        end_time : datetime.time or str
-            End time as a time filter limit.
-        include_start : bool, default True
-            Whether the start time needs to be included in the result.
-        include_end : bool, default True
-            Whether the end time needs to be included in the result.
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-            Determine range time on index or columns value.
-
-            .. versionadded:: 0.24.0
-
-        Returns
-        -------
-        Series or DataFrame
-            Data from the original object filtered to the specified dates range.
-
-        Raises
-        ------
-        TypeError
-            If the index is not  a :class:`DatetimeIndex`
-
-        See Also
-        --------
-        at_time : Select values at a particular time of the day.
-        first : Select initial periods of time series based on a date offset.
-        last : Select final periods of time series based on a date offset.
-        DatetimeIndex.indexer_between_time : Get just the index locations for
-            values between particular times of the day.
-
-        Examples
-        --------
-        >>> i = pd.date_range('2018-04-09', periods=4, freq='1D20min')
-        >>> ts = pd.DataFrame({'A': [1, 2, 3, 4]}, index=i)
-        >>> ts
-                             A
-        2018-04-09 00:00:00  1
-        2018-04-10 00:20:00  2
-        2018-04-11 00:40:00  3
-        2018-04-12 01:00:00  4
-
-        >>> ts.between_time('0:15', '0:45')
-                             A
-        2018-04-10 00:20:00  2
-        2018-04-11 00:40:00  3
-
-        You get the times that are *not* between two times by setting
-        ``start_time`` later than ``end_time``:
-
-        >>> ts.between_time('0:45', '0:15')
-                             A
-        2018-04-09 00:00:00  1
-        2018-04-12 01:00:00  4
-        """
         raise AbstractMethodError(self)
 
     def resample(
@@ -5889,479 +982,12 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         origin: Union[str, TimestampConvertibleTypes] = "start_day",
         offset: Optional[TimedeltaConvertibleTypes] = None,
     ) -> Resampler:
-        """
-        Resample time-series data.
-
-        Convenience method for frequency conversion and resampling of time
-        series. Object must have a datetime-like index (`DatetimeIndex`,
-        `PeriodIndex`, or `TimedeltaIndex`), or pass datetime-like values
-        to the `on` or `level` keyword.
-
-        Parameters
-        ----------
-        rule : DateOffset, Timedelta or str
-            The offset string or object representing target conversion.
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-            Which axis to use for up- or down-sampling. For `Series` this
-            will default to 0, i.e. along the rows. Must be
-            `DatetimeIndex`, `TimedeltaIndex` or `PeriodIndex`.
-        closed : {'right', 'left'}, default None
-            Which side of bin interval is closed. The default is 'left'
-            for all frequency offsets except for 'M', 'A', 'Q', 'BM',
-            'BA', 'BQ', and 'W' which all have a default of 'right'.
-        label : {'right', 'left'}, default None
-            Which bin edge label to label bucket with. The default is 'left'
-            for all frequency offsets except for 'M', 'A', 'Q', 'BM',
-            'BA', 'BQ', and 'W' which all have a default of 'right'.
-        convention : {'start', 'end', 's', 'e'}, default 'start'
-            For `PeriodIndex` only, controls whether to use the start or
-            end of `rule`.
-        kind : {'timestamp', 'period'}, optional, default None
-            Pass 'timestamp' to convert the resulting index to a
-            `DateTimeIndex` or 'period' to convert it to a `PeriodIndex`.
-            By default the input representation is retained.
-        loffset : timedelta, default None
-            Adjust the resampled time labels.
-
-            .. deprecated:: 1.1.0
-                You should add the loffset to the `df.index` after the resample.
-                See below.
-
-        base : int, default 0
-            For frequencies that evenly subdivide 1 day, the "origin" of the
-            aggregated intervals. For example, for '5min' frequency, base could
-            range from 0 through 4. Defaults to 0.
-
-            .. deprecated:: 1.1.0
-                The new arguments that you should use are 'offset' or 'origin'.
-
-        on : str, optional
-            For a DataFrame, column to use instead of index for resampling.
-            Column must be datetime-like.
-        level : str or int, optional
-            For a MultiIndex, level (name or number) to use for
-            resampling. `level` must be datetime-like.
-        origin : {'epoch', 'start', 'start_day'}, Timestamp or str, default 'start_day'
-            The timestamp on which to adjust the grouping. The timezone of origin
-            must match the timezone of the index.
-            If a timestamp is not used, these values are also supported:
-
-            - 'epoch': `origin` is 1970-01-01
-            - 'start': `origin` is the first value of the timeseries
-            - 'start_day': `origin` is the first day at midnight of the timeseries
-
-            .. versionadded:: 1.1.0
-
-        offset : Timedelta or str, default is None
-            An offset timedelta added to the origin.
-
-            .. versionadded:: 1.1.0
-
-        Returns
-        -------
-        Resampler object
-
-        See Also
-        --------
-        groupby : Group by mapping, function, label, or list of labels.
-        Series.resample : Resample a Series.
-        DataFrame.resample: Resample a DataFrame.
-
-        Notes
-        -----
-        See the `user guide
-        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#resampling>`_
-        for more.
-
-        To learn more about the offset strings, please see `this link
-        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects>`__.
-
-        Examples
-        --------
-        Start by creating a series with 9 one minute timestamps.
-
-        >>> index = pd.date_range('1/1/2000', periods=9, freq='T')
-        >>> series = pd.Series(range(9), index=index)
-        >>> series
-        2000-01-01 00:00:00    0
-        2000-01-01 00:01:00    1
-        2000-01-01 00:02:00    2
-        2000-01-01 00:03:00    3
-        2000-01-01 00:04:00    4
-        2000-01-01 00:05:00    5
-        2000-01-01 00:06:00    6
-        2000-01-01 00:07:00    7
-        2000-01-01 00:08:00    8
-        Freq: T, dtype: int64
-
-        Downsample the series into 3 minute bins and sum the values
-        of the timestamps falling into a bin.
-
-        >>> series.resample('3T').sum()
-        2000-01-01 00:00:00     3
-        2000-01-01 00:03:00    12
-        2000-01-01 00:06:00    21
-        Freq: 3T, dtype: int64
-
-        Downsample the series into 3 minute bins as above, but label each
-        bin using the right edge instead of the left. Please note that the
-        value in the bucket used as the label is not included in the bucket,
-        which it labels. For example, in the original series the
-        bucket ``2000-01-01 00:03:00`` contains the value 3, but the summed
-        value in the resampled bucket with the label ``2000-01-01 00:03:00``
-        does not include 3 (if it did, the summed value would be 6, not 3).
-        To include this value close the right side of the bin interval as
-        illustrated in the example below this one.
-
-        >>> series.resample('3T', label='right').sum()
-        2000-01-01 00:03:00     3
-        2000-01-01 00:06:00    12
-        2000-01-01 00:09:00    21
-        Freq: 3T, dtype: int64
-
-        Downsample the series into 3 minute bins as above, but close the right
-        side of the bin interval.
-
-        >>> series.resample('3T', label='right', closed='right').sum()
-        2000-01-01 00:00:00     0
-        2000-01-01 00:03:00     6
-        2000-01-01 00:06:00    15
-        2000-01-01 00:09:00    15
-        Freq: 3T, dtype: int64
-
-        Upsample the series into 30 second bins.
-
-        >>> series.resample('30S').asfreq()[0:5]   # Select first 5 rows
-        2000-01-01 00:00:00   0.0
-        2000-01-01 00:00:30   NaN
-        2000-01-01 00:01:00   1.0
-        2000-01-01 00:01:30   NaN
-        2000-01-01 00:02:00   2.0
-        Freq: 30S, dtype: float64
-
-        Upsample the series into 30 second bins and fill the ``NaN``
-        values using the ``pad`` method.
-
-        >>> series.resample('30S').pad()[0:5]
-        2000-01-01 00:00:00    0
-        2000-01-01 00:00:30    0
-        2000-01-01 00:01:00    1
-        2000-01-01 00:01:30    1
-        2000-01-01 00:02:00    2
-        Freq: 30S, dtype: int64
-
-        Upsample the series into 30 second bins and fill the
-        ``NaN`` values using the ``bfill`` method.
-
-        >>> series.resample('30S').bfill()[0:5]
-        2000-01-01 00:00:00    0
-        2000-01-01 00:00:30    1
-        2000-01-01 00:01:00    1
-        2000-01-01 00:01:30    2
-        2000-01-01 00:02:00    2
-        Freq: 30S, dtype: int64
-
-        Pass a custom function via ``apply``
-
-        >>> def custom_resampler(array_like):
-        ...     return np.sum(array_like) + 5
-        ...
-        >>> series.resample('3T').apply(custom_resampler)
-        2000-01-01 00:00:00     8
-        2000-01-01 00:03:00    17
-        2000-01-01 00:06:00    26
-        Freq: 3T, dtype: int64
-
-        For a Series with a PeriodIndex, the keyword `convention` can be
-        used to control whether to use the start or end of `rule`.
-
-        Resample a year by quarter using 'start' `convention`. Values are
-        assigned to the first quarter of the period.
-
-        >>> s = pd.Series([1, 2], index=pd.period_range('2012-01-01',
-        ...                                             freq='A',
-        ...                                             periods=2))
-        >>> s
-        2012    1
-        2013    2
-        Freq: A-DEC, dtype: int64
-        >>> s.resample('Q', convention='start').asfreq()
-        2012Q1    1.0
-        2012Q2    NaN
-        2012Q3    NaN
-        2012Q4    NaN
-        2013Q1    2.0
-        2013Q2    NaN
-        2013Q3    NaN
-        2013Q4    NaN
-        Freq: Q-DEC, dtype: float64
-
-        Resample quarters by month using 'end' `convention`. Values are
-        assigned to the last month of the period.
-
-        >>> q = pd.Series([1, 2, 3, 4], index=pd.period_range('2018-01-01',
-        ...                                                   freq='Q',
-        ...                                                   periods=4))
-        >>> q
-        2018Q1    1
-        2018Q2    2
-        2018Q3    3
-        2018Q4    4
-        Freq: Q-DEC, dtype: int64
-        >>> q.resample('M', convention='end').asfreq()
-        2018-03    1.0
-        2018-04    NaN
-        2018-05    NaN
-        2018-06    2.0
-        2018-07    NaN
-        2018-08    NaN
-        2018-09    3.0
-        2018-10    NaN
-        2018-11    NaN
-        2018-12    4.0
-        Freq: M, dtype: float64
-
-        For DataFrame objects, the keyword `on` can be used to specify the
-        column instead of the index for resampling.
-
-        >>> d = dict({'price': [10, 11, 9, 13, 14, 18, 17, 19],
-        ...           'volume': [50, 60, 40, 100, 50, 100, 40, 50]})
-        >>> df = pd.DataFrame(d)
-        >>> df['week_starting'] = pd.date_range('01/01/2018',
-        ...                                     periods=8,
-        ...                                     freq='W')
-        >>> df
-           price  volume week_starting
-        0     10      50    2018-01-07
-        1     11      60    2018-01-14
-        2      9      40    2018-01-21
-        3     13     100    2018-01-28
-        4     14      50    2018-02-04
-        5     18     100    2018-02-11
-        6     17      40    2018-02-18
-        7     19      50    2018-02-25
-        >>> df.resample('M', on='week_starting').mean()
-                       price  volume
-        week_starting
-        2018-01-31     10.75    62.5
-        2018-02-28     17.00    60.0
-
-        For a DataFrame with MultiIndex, the keyword `level` can be used to
-        specify on which level the resampling needs to take place.
-
-        >>> days = pd.date_range('1/1/2000', periods=4, freq='D')
-        >>> d2 = dict({'price': [10, 11, 9, 13, 14, 18, 17, 19],
-        ...            'volume': [50, 60, 40, 100, 50, 100, 40, 50]})
-        >>> df2 = pd.DataFrame(d2,
-        ...                    index=pd.MultiIndex.from_product([days,
-        ...                                                     ['morning',
-        ...                                                      'afternoon']]
-        ...                                                     ))
-        >>> df2
-                              price  volume
-        2000-01-01 morning       10      50
-                   afternoon     11      60
-        2000-01-02 morning        9      40
-                   afternoon     13     100
-        2000-01-03 morning       14      50
-                   afternoon     18     100
-        2000-01-04 morning       17      40
-                   afternoon     19      50
-        >>> df2.resample('D', level=0).sum()
-                    price  volume
-        2000-01-01     21     110
-        2000-01-02     22     140
-        2000-01-03     32     150
-        2000-01-04     36      90
-
-        If you want to adjust the start of the bins based on a fixed timestamp:
-
-        >>> start, end = '2000-10-01 23:30:00', '2000-10-02 00:30:00'
-        >>> rng = pd.date_range(start, end, freq='7min')
-        >>> ts = pd.Series(np.arange(len(rng)) * 3, index=rng)
-        >>> ts
-        2000-10-01 23:30:00     0
-        2000-10-01 23:37:00     3
-        2000-10-01 23:44:00     6
-        2000-10-01 23:51:00     9
-        2000-10-01 23:58:00    12
-        2000-10-02 00:05:00    15
-        2000-10-02 00:12:00    18
-        2000-10-02 00:19:00    21
-        2000-10-02 00:26:00    24
-        Freq: 7T, dtype: int64
-
-        >>> ts.resample('17min').sum()
-        2000-10-01 23:14:00     0
-        2000-10-01 23:31:00     9
-        2000-10-01 23:48:00    21
-        2000-10-02 00:05:00    54
-        2000-10-02 00:22:00    24
-        Freq: 17T, dtype: int64
-
-        >>> ts.resample('17min', origin='epoch').sum()
-        2000-10-01 23:18:00     0
-        2000-10-01 23:35:00    18
-        2000-10-01 23:52:00    27
-        2000-10-02 00:09:00    39
-        2000-10-02 00:26:00    24
-        Freq: 17T, dtype: int64
-
-        >>> ts.resample('17min', origin='2000-01-01').sum()
-        2000-10-01 23:24:00     3
-        2000-10-01 23:41:00    15
-        2000-10-01 23:58:00    45
-        2000-10-02 00:15:00    45
-        Freq: 17T, dtype: int64
-
-        If you want to adjust the start of the bins with an `offset` Timedelta, the two
-        following lines are equivalent:
-
-        >>> ts.resample('17min', origin='start').sum()
-        2000-10-01 23:30:00     9
-        2000-10-01 23:47:00    21
-        2000-10-02 00:04:00    54
-        2000-10-02 00:21:00    24
-        Freq: 17T, dtype: int64
-
-        >>> ts.resample('17min', offset='23h30min').sum()
-        2000-10-01 23:30:00     9
-        2000-10-01 23:47:00    21
-        2000-10-02 00:04:00    54
-        2000-10-02 00:21:00    24
-        Freq: 17T, dtype: int64
-
-        To replace the use of the deprecated `base` argument, you can now use `offset`,
-        in this example it is equivalent to have `base=2`:
-
-        >>> ts.resample('17min', offset='2min').sum()
-        2000-10-01 23:16:00     0
-        2000-10-01 23:33:00     9
-        2000-10-01 23:50:00    36
-        2000-10-02 00:07:00    39
-        2000-10-02 00:24:00    24
-        Freq: 17T, dtype: int64
-
-        To replace the use of the deprecated `loffset` argument:
-
-        >>> from pandas.tseries.frequencies import to_offset
-        >>> loffset = '19min'
-        >>> ts_out = ts.resample('17min').sum()
-        >>> ts_out.index = ts_out.index + to_offset(loffset)
-        >>> ts_out
-        2000-10-01 23:33:00     0
-        2000-10-01 23:50:00     9
-        2000-10-02 00:07:00    21
-        2000-10-02 00:24:00    54
-        2000-10-02 00:41:00    24
-        Freq: 17T, dtype: int64
-        """
         raise AbstractMethodError(self)
 
     def first(self: FrameOrSeries, offset) -> FrameOrSeries:
-        """
-        Select initial periods of time series data based on a date offset.
-
-        When having a DataFrame with dates as index, this function can
-        select the first few rows based on a date offset.
-
-        Parameters
-        ----------
-        offset : str, DateOffset or dateutil.relativedelta
-            The offset length of the data that will be selected. For instance,
-            '1M' will display all the rows having their index within the first month.
-
-        Returns
-        -------
-        Series or DataFrame
-            A subset of the caller.
-
-        Raises
-        ------
-        TypeError
-            If the index is not  a :class:`DatetimeIndex`
-
-        See Also
-        --------
-        last : Select final periods of time series based on a date offset.
-        at_time : Select values at a particular time of the day.
-        between_time : Select values between particular times of the day.
-
-        Examples
-        --------
-        >>> i = pd.date_range('2018-04-09', periods=4, freq='2D')
-        >>> ts = pd.DataFrame({'A': [1, 2, 3, 4]}, index=i)
-        >>> ts
-                    A
-        2018-04-09  1
-        2018-04-11  2
-        2018-04-13  3
-        2018-04-15  4
-
-        Get the rows for the first 3 days:
-
-        >>> ts.first('3D')
-                    A
-        2018-04-09  1
-        2018-04-11  2
-
-        Notice the data for 3 first calendar days were returned, not the first
-        3 days observed in the dataset, and therefore data for 2018-04-13 was
-        not returned.
-        """
         raise AbstractMethodError(self)
 
     def last(self: FrameOrSeries, offset) -> FrameOrSeries:
-        """
-        Select final periods of time series data based on a date offset.
-
-        When having a DataFrame with dates as index, this function can
-        select the last few rows based on a date offset.
-
-        Parameters
-        ----------
-        offset : str, DateOffset, dateutil.relativedelta
-            The offset length of the data that will be selected. For instance,
-            '3D' will display all the rows having their index within the last 3 days.
-
-        Returns
-        -------
-        Series or DataFrame
-            A subset of the caller.
-
-        Raises
-        ------
-        TypeError
-            If the index is not  a :class:`DatetimeIndex`
-
-        See Also
-        --------
-        first : Select initial periods of time series based on a date offset.
-        at_time : Select values at a particular time of the day.
-        between_time : Select values between particular times of the day.
-
-        Examples
-        --------
-        >>> i = pd.date_range('2018-04-09', periods=4, freq='2D')
-        >>> ts = pd.DataFrame({'A': [1, 2, 3, 4]}, index=i)
-        >>> ts
-                    A
-        2018-04-09  1
-        2018-04-11  2
-        2018-04-13  3
-        2018-04-15  4
-
-        Get the rows for the last 3 days:
-
-        >>> ts.last('3D')
-                    A
-        2018-04-13  3
-        2018-04-15  4
-
-        Notice the data for 3 last calendar days were returned, not the last
-        3 observed days in the dataset, and therefore data for 2018-04-11 was
-        not returned.
-        """
         raise AbstractMethodError(self)
 
     def rank(
@@ -6373,90 +999,8 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         ascending: bool_t = True,
         pct: bool_t = False,
     ) -> FrameOrSeries:
-        """
-        Compute numerical data ranks (1 through n) along axis.
-
-        By default, equal values are assigned a rank that is the average of the
-        ranks of those values.
-
-        Parameters
-        ----------
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-            Index to direct ranking.
-        method : {'average', 'min', 'max', 'first', 'dense'}, default 'average'
-            How to rank the group of records that have the same value (i.e. ties):
-
-            * average: average rank of the group
-            * min: lowest rank in the group
-            * max: highest rank in the group
-            * first: ranks assigned in order they appear in the array
-            * dense: like 'min', but rank always increases by 1 between groups.
-
-        numeric_only : bool, optional
-            For DataFrame objects, rank only numeric columns if set to True.
-        na_option : {'keep', 'top', 'bottom'}, default 'keep'
-            How to rank NaN values:
-
-            * keep: assign NaN rank to NaN values
-            * top: assign smallest rank to NaN values if ascending
-            * bottom: assign highest rank to NaN values if ascending.
-
-        ascending : bool, default True
-            Whether or not the elements should be ranked in ascending order.
-        pct : bool, default False
-            Whether or not to display the returned rankings in percentile
-            form.
-
-        Returns
-        -------
-        same type as caller
-            Return a Series or DataFrame with data ranks as values.
-
-        See Also
-        --------
-        core.groupby.GroupBy.rank : Rank of values within each group.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame(data={'Animal': ['cat', 'penguin', 'dog',
-        ...                                    'spider', 'snake'],
-        ...                         'Number_legs': [4, 2, 4, 8, np.nan]})
-        >>> df
-            Animal  Number_legs
-        0      cat          4.0
-        1  penguin          2.0
-        2      dog          4.0
-        3   spider          8.0
-        4    snake          NaN
-
-        The following example shows how the method behaves with the above
-        parameters:
-
-        * default_rank: this is the default behaviour obtained without using
-          any parameter.
-        * max_rank: setting ``method = 'max'`` the records that have the
-          same values are ranked using the highest rank (e.g.: since 'cat'
-          and 'dog' are both in the 2nd and 3rd position, rank 3 is assigned.)
-        * NA_bottom: choosing ``na_option = 'bottom'``, if there are records
-          with NaN values they are placed at the bottom of the ranking.
-        * pct_rank: when setting ``pct = True``, the ranking is expressed as
-          percentile rank.
-
-        >>> df['default_rank'] = df['Number_legs'].rank()
-        >>> df['max_rank'] = df['Number_legs'].rank(method='max')
-        >>> df['NA_bottom'] = df['Number_legs'].rank(na_option='bottom')
-        >>> df['pct_rank'] = df['Number_legs'].rank(pct=True)
-        >>> df
-            Animal  Number_legs  default_rank  max_rank  NA_bottom  pct_rank
-        0      cat          4.0           2.5       3.0        2.5     0.625
-        1  penguin          2.0           1.0       1.0        1.0     0.250
-        2      dog          4.0           2.5       3.0        2.5     0.625
-        3   spider          8.0           4.0       4.0        4.0     1.000
-        4    snake          NaN           NaN       NaN        5.0       NaN
-        """
         raise AbstractMethodError(self)
 
-    @Appender(_shared_docs["compare"] % _shared_doc_kwargs)
     def compare(
         self,
         other,
@@ -6466,7 +1010,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     ):
         raise AbstractMethodError(self)
 
-    @doc(**_shared_doc_kwargs)
     def align(
         self,
         other,
@@ -6480,50 +1023,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         fill_axis=0,
         broadcast_axis=None,
     ):
-        """
-        Align two objects on their axes with the specified join method.
-
-        Join method is specified for each axis Index.
-
-        Parameters
-        ----------
-        other : DataFrame or Series
-        join : {{'outer', 'inner', 'left', 'right'}}, default 'outer'
-        axis : allowed axis of the other object, default None
-            Align on index (0), columns (1), or both (None).
-        level : int or level name, default None
-            Broadcast across a level, matching Index values on the
-            passed MultiIndex level.
-        copy : bool, default True
-            Always returns new objects. If copy=False and no reindexing is
-            required then original objects are returned.
-        fill_value : scalar, default np.NaN
-            Value to use for missing values. Defaults to NaN, but can be any
-            "compatible" value.
-        method : {{'backfill', 'bfill', 'pad', 'ffill', None}}, default None
-            Method to use for filling holes in reindexed Series:
-
-            - pad / ffill: propagate last valid observation forward to next valid.
-            - backfill / bfill: use NEXT valid observation to fill gap.
-
-        limit : int, default None
-            If method is specified, this is the maximum number of consecutive
-            NaN values to forward/backward fill. In other words, if there is
-            a gap with more than this number of consecutive NaNs, it will only
-            be partially filled. If method is not specified, this is the
-            maximum number of entries along the entire axis where NaNs will be
-            filled. Must be greater than 0 if not None.
-        fill_axis : {axes_single_arg}, default 0
-            Filling axis, method and limit.
-        broadcast_axis : {axes_single_arg}, default None
-            Broadcast values along this axis, if aligning two objects of
-            different dimensions.
-
-        Returns
-        -------
-        (left, right) : ({klass}, type of other)
-            Aligned objects.
-        """
         raise AbstractMethodError(self)
 
     def _align_frame(
@@ -6564,19 +1063,8 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         errors="raise",
         try_cast=False,
     ):
-        """
-        Equivalent to public method `where`, except that `other` is not
-        applied as a function even if callable. Used in __setitem__.
-        """
         raise AbstractMethodError(self)
 
-    @doc(
-        klass=_shared_doc_kwargs["klass"],
-        cond="True",
-        cond_rev="False",
-        name="where",
-        name_other="mask",
-    )
     def where(
         self,
         cond,
@@ -6587,136 +1075,8 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         errors="raise",
         try_cast=False,
     ):
-        """
-        Replace values where the condition is {cond_rev}.
-
-        Parameters
-        ----------
-        cond : bool {klass}, array-like, or callable
-            Where `cond` is {cond}, keep the original value. Where
-            {cond_rev}, replace with corresponding value from `other`.
-            If `cond` is callable, it is computed on the {klass} and
-            should return boolean {klass} or array. The callable must
-            not change input {klass} (though pandas doesn't check it).
-        other : scalar, {klass}, or callable
-            Entries where `cond` is {cond_rev} are replaced with
-            corresponding value from `other`.
-            If other is callable, it is computed on the {klass} and
-            should return scalar or {klass}. The callable must not
-            change input {klass} (though pandas doesn't check it).
-        inplace : bool, default False
-            Whether to perform the operation in place on the data.
-        axis : int, default None
-            Alignment axis if needed.
-        level : int, default None
-            Alignment level if needed.
-        errors : str, {{'raise', 'ignore'}}, default 'raise'
-            Note that currently this parameter won't affect
-            the results and will always coerce to a suitable dtype.
-
-            - 'raise' : allow exceptions to be raised.
-            - 'ignore' : suppress exceptions. On error return original object.
-
-        try_cast : bool, default False
-            Try to cast the result back to the input type (if possible).
-
-        Returns
-        -------
-        Same type as caller or None if ``inplace=True``.
-
-        See Also
-        --------
-        :func:`DataFrame.{name_other}` : Return an object of same shape as
-            self.
-
-        Notes
-        -----
-        The {name} method is an application of the if-then idiom. For each
-        element in the calling DataFrame, if ``cond`` is ``{cond}`` the
-        element is used; otherwise the corresponding element from the DataFrame
-        ``other`` is used.
-
-        The signature for :func:`DataFrame.where` differs from
-        :func:`numpy.where`. Roughly ``df1.where(m, df2)`` is equivalent to
-        ``np.where(m, df1, df2)``.
-
-        For further details and examples see the ``{name}`` documentation in
-        :ref:`indexing <indexing.where_mask>`.
-
-        Examples
-        --------
-        >>> s = pd.Series(range(5))
-        >>> s.where(s > 0)
-        0    NaN
-        1    1.0
-        2    2.0
-        3    3.0
-        4    4.0
-        dtype: float64
-        >>> s.mask(s > 0)
-        0    0.0
-        1    NaN
-        2    NaN
-        3    NaN
-        4    NaN
-        dtype: float64
-
-        >>> s.where(s > 1, 10)
-        0    10
-        1    10
-        2    2
-        3    3
-        4    4
-        dtype: int64
-        >>> s.mask(s > 1, 10)
-        0     0
-        1     1
-        2    10
-        3    10
-        4    10
-        dtype: int64
-
-        >>> df = pd.DataFrame(np.arange(10).reshape(-1, 2), columns=['A', 'B'])
-        >>> df
-           A  B
-        0  0  1
-        1  2  3
-        2  4  5
-        3  6  7
-        4  8  9
-        >>> m = df % 3 == 0
-        >>> df.where(m, -df)
-           A  B
-        0  0 -1
-        1 -2  3
-        2 -4 -5
-        3  6 -7
-        4 -8  9
-        >>> df.where(m, -df) == np.where(m, df, -df)
-              A     B
-        0  True  True
-        1  True  True
-        2  True  True
-        3  True  True
-        4  True  True
-        >>> df.where(m, -df) == df.mask(~m, -df)
-              A     B
-        0  True  True
-        1  True  True
-        2  True  True
-        3  True  True
-        4  True  True
-        """
         raise AbstractMethodError(self)
 
-    @doc(
-        where,
-        klass=_shared_doc_kwargs["klass"],
-        cond="False",
-        cond_rev="True",
-        name="mask",
-        name_other="where",
-    )
     def mask(
         self,
         cond,
@@ -6729,314 +1089,27 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     ):
         raise AbstractMethodError(self)
 
-    @doc(klass=_shared_doc_kwargs["klass"])
     def shift(
         self: FrameOrSeries, periods=1, freq=None, axis=0, fill_value=None
     ) -> FrameOrSeries:
-        """
-        Shift index by desired number of periods with an optional time `freq`.
-
-        When `freq` is not passed, shift the index without realigning the data.
-        If `freq` is passed (in this case, the index must be date or datetime,
-        or it will raise a `NotImplementedError`), the index will be
-        increased using the periods and the `freq`. `freq` can be inferred
-        when specified as "infer" as long as either freq or inferred_freq
-        attribute is set in the index.
-
-        Parameters
-        ----------
-        periods : int
-            Number of periods to shift. Can be positive or negative.
-        freq : DateOffset, tseries.offsets, timedelta, or str, optional
-            Offset to use from the tseries module or time rule (e.g. 'EOM').
-            If `freq` is specified then the index values are shifted but the
-            data is not realigned. That is, use `freq` if you would like to
-            extend the index when shifting and preserve the original data.
-            If `freq` is specified as "infer" then it will be inferred from
-            the freq or inferred_freq attributes of the index. If neither of
-            those attributes exist, a ValueError is thrown.
-        axis : {{0 or 'index', 1 or 'columns', None}}, default None
-            Shift direction.
-        fill_value : object, optional
-            The scalar value to use for newly introduced missing values.
-            the default depends on the dtype of `self`.
-            For numeric data, ``np.nan`` is used.
-            For datetime, timedelta, or period data, etc. :attr:`NaT` is used.
-            For extension dtypes, ``self.dtype.na_value`` is used.
-
-            .. versionchanged:: 1.1.0
-
-        Returns
-        -------
-        {klass}
-            Copy of input object, shifted.
-
-        See Also
-        --------
-        Index.shift : Shift values of Index.
-        DatetimeIndex.shift : Shift values of DatetimeIndex.
-        PeriodIndex.shift : Shift values of PeriodIndex.
-        tshift : Shift the time index, using the index's frequency if
-            available.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({{"Col1": [10, 20, 15, 30, 45],
-        ...                    "Col2": [13, 23, 18, 33, 48],
-        ...                    "Col3": [17, 27, 22, 37, 52]}},
-        ...                   index=pd.date_range("2020-01-01", "2020-01-05"))
-        >>> df
-                    Col1  Col2  Col3
-        2020-01-01    10    13    17
-        2020-01-02    20    23    27
-        2020-01-03    15    18    22
-        2020-01-04    30    33    37
-        2020-01-05    45    48    52
-
-        >>> df.shift(periods=3)
-                    Col1  Col2  Col3
-        2020-01-01   NaN   NaN   NaN
-        2020-01-02   NaN   NaN   NaN
-        2020-01-03   NaN   NaN   NaN
-        2020-01-04  10.0  13.0  17.0
-        2020-01-05  20.0  23.0  27.0
-
-        >>> df.shift(periods=1, axis="columns")
-                    Col1  Col2  Col3
-        2020-01-01   NaN    10    13
-        2020-01-02   NaN    20    23
-        2020-01-03   NaN    15    18
-        2020-01-04   NaN    30    33
-        2020-01-05   NaN    45    48
-
-        >>> df.shift(periods=3, fill_value=0)
-                    Col1  Col2  Col3
-        2020-01-01     0     0     0
-        2020-01-02     0     0     0
-        2020-01-03     0     0     0
-        2020-01-04    10    13    17
-        2020-01-05    20    23    27
-
-        >>> df.shift(periods=3, freq="D")
-                    Col1  Col2  Col3
-        2020-01-04    10    13    17
-        2020-01-05    20    23    27
-        2020-01-06    15    18    22
-        2020-01-07    30    33    37
-        2020-01-08    45    48    52
-
-        >>> df.shift(periods=3, freq="infer")
-                    Col1  Col2  Col3
-        2020-01-04    10    13    17
-        2020-01-05    20    23    27
-        2020-01-06    15    18    22
-        2020-01-07    30    33    37
-        2020-01-08    45    48    52
-        """
         raise AbstractMethodError(self)
 
     def slice_shift(self: FrameOrSeries, periods: int = 1, axis=0) -> FrameOrSeries:
-        """
-        Equivalent to `shift` without copying data.
-
-        The shifted data will not include the dropped periods and the
-        shifted axis will be smaller than the original.
-
-        Parameters
-        ----------
-        periods : int
-            Number of periods to move, can be positive or negative.
-
-        Returns
-        -------
-        shifted : same type as caller
-
-        Notes
-        -----
-        While the `slice_shift` is faster than `shift`, you may pay for it
-        later during alignment.
-        """
         raise AbstractMethodError(self)
 
     def tshift(
         self: FrameOrSeries, periods: int = 1, freq=None, axis: Axis = 0
     ) -> FrameOrSeries:
-        """
-        Shift the time index, using the index's frequency if available.
-
-        .. deprecated:: 1.1.0
-            Use `shift` instead.
-
-        Parameters
-        ----------
-        periods : int
-            Number of periods to move, can be positive or negative.
-        freq : DateOffset, timedelta, or str, default None
-            Increment to use from the tseries module
-            or time rule expressed as a string (e.g. 'EOM').
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
-            Corresponds to the axis that contains the Index.
-
-        Returns
-        -------
-        shifted : Series/DataFrame
-
-        Notes
-        -----
-        If freq is not specified then tries to use the freq or inferred_freq
-        attributes of the index. If neither of those attributes exist, a
-        ValueError is thrown
-        """
         raise AbstractMethodError(self)
 
     def truncate(
         self: FrameOrSeries, before=None, after=None, axis=None, copy: bool_t = True
     ) -> FrameOrSeries:
-        """
-        Truncate a Series or DataFrame before and after some index value.
-
-        This is a useful shorthand for boolean indexing based on index
-        values above or below certain thresholds.
-
-        Parameters
-        ----------
-        before : date, str, int
-            Truncate all rows before this index value.
-        after : date, str, int
-            Truncate all rows after this index value.
-        axis : {0 or 'index', 1 or 'columns'}, optional
-            Axis to truncate. Truncates the index (rows) by default.
-        copy : bool, default is True,
-            Return a copy of the truncated section.
-
-        Returns
-        -------
-        type of caller
-            The truncated Series or DataFrame.
-
-        See Also
-        --------
-        DataFrame.loc : Select a subset of a DataFrame by label.
-        DataFrame.iloc : Select a subset of a DataFrame by position.
-
-        Notes
-        -----
-        If the index being truncated contains only datetime values,
-        `before` and `after` may be specified as strings instead of
-        Timestamps.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({'A': ['a', 'b', 'c', 'd', 'e'],
-        ...                    'B': ['f', 'g', 'h', 'i', 'j'],
-        ...                    'C': ['k', 'l', 'm', 'n', 'o']},
-        ...                   index=[1, 2, 3, 4, 5])
-        >>> df
-           A  B  C
-        1  a  f  k
-        2  b  g  l
-        3  c  h  m
-        4  d  i  n
-        5  e  j  o
-
-        >>> df.truncate(before=2, after=4)
-           A  B  C
-        2  b  g  l
-        3  c  h  m
-        4  d  i  n
-
-        The columns of a DataFrame can be truncated.
-
-        >>> df.truncate(before="A", after="B", axis="columns")
-           A  B
-        1  a  f
-        2  b  g
-        3  c  h
-        4  d  i
-        5  e  j
-
-        For Series, only rows can be truncated.
-
-        >>> df['A'].truncate(before=2, after=4)
-        2    b
-        3    c
-        4    d
-        Name: A, dtype: object
-
-        The index values in ``truncate`` can be datetimes or string
-        dates.
-
-        >>> dates = pd.date_range('2016-01-01', '2016-02-01', freq='s')
-        >>> df = pd.DataFrame(index=dates, data={'A': 1})
-        >>> df.tail()
-                             A
-        2016-01-31 23:59:56  1
-        2016-01-31 23:59:57  1
-        2016-01-31 23:59:58  1
-        2016-01-31 23:59:59  1
-        2016-02-01 00:00:00  1
-
-        >>> df.truncate(before=pd.Timestamp('2016-01-05'),
-        ...             after=pd.Timestamp('2016-01-10')).tail()
-                             A
-        2016-01-09 23:59:56  1
-        2016-01-09 23:59:57  1
-        2016-01-09 23:59:58  1
-        2016-01-09 23:59:59  1
-        2016-01-10 00:00:00  1
-
-        Because the index is a DatetimeIndex containing only dates, we can
-        specify `before` and `after` as strings. They will be coerced to
-        Timestamps before truncation.
-
-        >>> df.truncate('2016-01-05', '2016-01-10').tail()
-                             A
-        2016-01-09 23:59:56  1
-        2016-01-09 23:59:57  1
-        2016-01-09 23:59:58  1
-        2016-01-09 23:59:59  1
-        2016-01-10 00:00:00  1
-
-        Note that ``truncate`` assumes a 0 value for any unspecified time
-        component (midnight). This differs from partial string slicing, which
-        returns any partially matching dates.
-
-        >>> df.loc['2016-01-05':'2016-01-10', :].tail()
-                             A
-        2016-01-10 23:59:55  1
-        2016-01-10 23:59:56  1
-        2016-01-10 23:59:57  1
-        2016-01-10 23:59:58  1
-        2016-01-10 23:59:59  1
-        """
         raise AbstractMethodError(self)
 
     def tz_convert(
         self: FrameOrSeries, tz, axis=0, level=None, copy: bool_t = True
     ) -> FrameOrSeries:
-        """
-        Convert tz-aware axis to target time zone.
-
-        Parameters
-        ----------
-        tz : str or tzinfo object
-        axis : the axis to convert
-        level : int, str, default None
-            If axis is a MultiIndex, convert a specific level. Otherwise
-            must be None.
-        copy : bool, default True
-            Also make a copy of the underlying data.
-
-        Returns
-        -------
-        {klass}
-            Object with time zone converted axis.
-
-        Raises
-        ------
-        TypeError
-            If the axis is tz-naive.
-        """
         raise AbstractMethodError(self)
 
     def tz_localize(
@@ -7048,198 +1121,12 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         ambiguous="raise",
         nonexistent: str = "raise",
     ) -> FrameOrSeries:
-        """
-        Localize tz-naive index of a Series or DataFrame to target time zone.
-
-        This operation localizes the Index. To localize the values in a
-        timezone-naive Series, use :meth:`Series.dt.tz_localize`.
-
-        Parameters
-        ----------
-        tz : str or tzinfo
-        axis : the axis to localize
-        level : int, str, default None
-            If axis ia a MultiIndex, localize a specific level. Otherwise
-            must be None.
-        copy : bool, default True
-            Also make a copy of the underlying data.
-        ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
-            When clocks moved backward due to DST, ambiguous times may arise.
-            For example in Central European Time (UTC+01), when going from
-            03:00 DST to 02:00 non-DST, 02:30:00 local time occurs both at
-            00:30:00 UTC and at 01:30:00 UTC. In such a situation, the
-            `ambiguous` parameter dictates how ambiguous times should be
-            handled.
-
-            - 'infer' will attempt to infer fall dst-transition hours based on
-              order
-            - bool-ndarray where True signifies a DST time, False designates
-              a non-DST time (note that this flag is only applicable for
-              ambiguous times)
-            - 'NaT' will return NaT where there are ambiguous times
-            - 'raise' will raise an AmbiguousTimeError if there are ambiguous
-              times.
-        nonexistent : str, default 'raise'
-            A nonexistent time does not exist in a particular timezone
-            where clocks moved forward due to DST. Valid values are:
-
-            - 'shift_forward' will shift the nonexistent time forward to the
-              closest existing time
-            - 'shift_backward' will shift the nonexistent time backward to the
-              closest existing time
-            - 'NaT' will return NaT where there are nonexistent times
-            - timedelta objects will shift nonexistent times by the timedelta
-            - 'raise' will raise an NonExistentTimeError if there are
-              nonexistent times.
-
-            .. versionadded:: 0.24.0
-
-        Returns
-        -------
-        Series or DataFrame
-            Same type as the input.
-
-        Raises
-        ------
-        TypeError
-            If the TimeSeries is tz-aware and tz is not None.
-
-        Examples
-        --------
-        Localize local times:
-
-        >>> s = pd.Series([1],
-        ...               index=pd.DatetimeIndex(['2018-09-15 01:30:00']))
-        >>> s.tz_localize('CET')
-        2018-09-15 01:30:00+02:00    1
-        dtype: int64
-
-        Be careful with DST changes. When there is sequential data, pandas
-        can infer the DST time:
-
-        >>> s = pd.Series(range(7),
-        ...               index=pd.DatetimeIndex(['2018-10-28 01:30:00',
-        ...                                       '2018-10-28 02:00:00',
-        ...                                       '2018-10-28 02:30:00',
-        ...                                       '2018-10-28 02:00:00',
-        ...                                       '2018-10-28 02:30:00',
-        ...                                       '2018-10-28 03:00:00',
-        ...                                       '2018-10-28 03:30:00']))
-        >>> s.tz_localize('CET', ambiguous='infer')
-        2018-10-28 01:30:00+02:00    0
-        2018-10-28 02:00:00+02:00    1
-        2018-10-28 02:30:00+02:00    2
-        2018-10-28 02:00:00+01:00    3
-        2018-10-28 02:30:00+01:00    4
-        2018-10-28 03:00:00+01:00    5
-        2018-10-28 03:30:00+01:00    6
-        dtype: int64
-
-        In some cases, inferring the DST is impossible. In such cases, you can
-        pass an ndarray to the ambiguous parameter to set the DST explicitly
-
-        >>> s = pd.Series(range(3),
-        ...               index=pd.DatetimeIndex(['2018-10-28 01:20:00',
-        ...                                       '2018-10-28 02:36:00',
-        ...                                       '2018-10-28 03:46:00']))
-        >>> s.tz_localize('CET', ambiguous=np.array([True, True, False]))
-        2018-10-28 01:20:00+02:00    0
-        2018-10-28 02:36:00+02:00    1
-        2018-10-28 03:46:00+01:00    2
-        dtype: int64
-
-        If the DST transition causes nonexistent times, you can shift these
-        dates forward or backward with a timedelta object or `'shift_forward'`
-        or `'shift_backward'`.
-
-        >>> s = pd.Series(range(2),
-        ...               index=pd.DatetimeIndex(['2015-03-29 02:30:00',
-        ...                                       '2015-03-29 03:30:00']))
-        >>> s.tz_localize('Europe/Warsaw', nonexistent='shift_forward')
-        2015-03-29 03:00:00+02:00    0
-        2015-03-29 03:30:00+02:00    1
-        dtype: int64
-        >>> s.tz_localize('Europe/Warsaw', nonexistent='shift_backward')
-        2015-03-29 01:59:59.999999999+01:00    0
-        2015-03-29 03:30:00+02:00              1
-        dtype: int64
-        >>> s.tz_localize('Europe/Warsaw', nonexistent=pd.Timedelta('1H'))
-        2015-03-29 03:30:00+02:00    0
-        2015-03-29 03:30:00+02:00    1
-        dtype: int64
-        """
         raise AbstractMethodError(self)
 
     # ----------------------------------------------------------------------
     # Numeric Methods
 
     def abs(self: FrameOrSeries) -> FrameOrSeries:
-        """
-        Return a Series/DataFrame with absolute numeric value of each element.
-
-        This function only applies to elements that are all numeric.
-
-        Returns
-        -------
-        abs
-            Series/DataFrame containing the absolute value of each element.
-
-        See Also
-        --------
-        numpy.absolute : Calculate the absolute value element-wise.
-
-        Notes
-        -----
-        For ``complex`` inputs, ``1.2 + 1j``, the absolute value is
-        :math:`\\sqrt{ a^2 + b^2 }`.
-
-        Examples
-        --------
-        Absolute numeric values in a Series.
-
-        >>> s = pd.Series([-1.10, 2, -3.33, 4])
-        >>> s.abs()
-        0    1.10
-        1    2.00
-        2    3.33
-        3    4.00
-        dtype: float64
-
-        Absolute numeric values in a Series with complex numbers.
-
-        >>> s = pd.Series([1.2 + 1j])
-        >>> s.abs()
-        0    1.56205
-        dtype: float64
-
-        Absolute numeric values in a Series with a Timedelta element.
-
-        >>> s = pd.Series([pd.Timedelta('1 days')])
-        >>> s.abs()
-        0   1 days
-        dtype: timedelta64[ns]
-
-        Select rows with data closest to certain value using argsort (from
-        `StackOverflow <https://stackoverflow.com/a/17758115>`__).
-
-        >>> df = pd.DataFrame({
-        ...     'a': [4, 5, 6, 7],
-        ...     'b': [10, 20, 30, 40],
-        ...     'c': [100, 50, -30, -50]
-        ... })
-        >>> df
-             a    b    c
-        0    4   10  100
-        1    5   20   50
-        2    6   30  -30
-        3    7   40  -50
-        >>> df.loc[(df.c - 43).abs().argsort()]
-             a    b    c
-        1    5   20   50
-        0    4   10  100
-        2    6   30  -30
-        3    7   40  -50
-        """
         raise AbstractMethodError(self)
 
     def describe(
@@ -7249,247 +1136,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         exclude=None,
         datetime_is_numeric=False,
     ) -> FrameOrSeries:
-        """
-        Generate descriptive statistics.
-
-        Descriptive statistics include those that summarize the central
-        tendency, dispersion and shape of a
-        dataset's distribution, excluding ``NaN`` values.
-
-        Analyzes both numeric and object series, as well
-        as ``DataFrame`` column sets of mixed data types. The output
-        will vary depending on what is provided. Refer to the notes
-        below for more detail.
-
-        Parameters
-        ----------
-        percentiles : list-like of numbers, optional
-            The percentiles to include in the output. All should
-            fall between 0 and 1. The default is
-            ``[.25, .5, .75]``, which returns the 25th, 50th, and
-            75th percentiles.
-        include : 'all', list-like of dtypes or None (default), optional
-            A white list of data types to include in the result. Ignored
-            for ``Series``. Here are the options:
-
-            - 'all' : All columns of the input will be included in the output.
-            - A list-like of dtypes : Limits the results to the
-              provided data types.
-              To limit the result to numeric types submit
-              ``numpy.number``. To limit it instead to object columns submit
-              the ``numpy.object`` data type. Strings
-              can also be used in the style of
-              ``select_dtypes`` (e.g. ``df.describe(include=['O'])``). To
-              select pandas categorical columns, use ``'category'``
-            - None (default) : The result will include all numeric columns.
-        exclude : list-like of dtypes or None (default), optional,
-            A black list of data types to omit from the result. Ignored
-            for ``Series``. Here are the options:
-
-            - A list-like of dtypes : Excludes the provided data types
-              from the result. To exclude numeric types submit
-              ``numpy.number``. To exclude object columns submit the data
-              type ``numpy.object``. Strings can also be used in the style of
-              ``select_dtypes`` (e.g. ``df.describe(include=['O'])``). To
-              exclude pandas categorical columns, use ``'category'``
-            - None (default) : The result will exclude nothing.
-        datetime_is_numeric : bool, default False
-            Whether to treat datetime dtypes as numeric. This affects statistics
-            calculated for the column. For DataFrame input, this also
-            controls whether datetime columns are included by default.
-
-            .. versionadded:: 1.1.0
-
-        Returns
-        -------
-        Series or DataFrame
-            Summary statistics of the Series or Dataframe provided.
-
-        See Also
-        --------
-        DataFrame.count: Count number of non-NA/null observations.
-        DataFrame.max: Maximum of the values in the object.
-        DataFrame.min: Minimum of the values in the object.
-        DataFrame.mean: Mean of the values.
-        DataFrame.std: Standard deviation of the observations.
-        DataFrame.select_dtypes: Subset of a DataFrame including/excluding
-            columns based on their dtype.
-
-        Notes
-        -----
-        For numeric data, the result's index will include ``count``,
-        ``mean``, ``std``, ``min``, ``max`` as well as lower, ``50`` and
-        upper percentiles. By default the lower percentile is ``25`` and the
-        upper percentile is ``75``. The ``50`` percentile is the
-        same as the median.
-
-        For object data (e.g. strings or timestamps), the result's index
-        will include ``count``, ``unique``, ``top``, and ``freq``. The ``top``
-        is the most common value. The ``freq`` is the most common value's
-        frequency. Timestamps also include the ``first`` and ``last`` items.
-
-        If multiple object values have the highest count, then the
-        ``count`` and ``top`` results will be arbitrarily chosen from
-        among those with the highest count.
-
-        For mixed data types provided via a ``DataFrame``, the default is to
-        return only an analysis of numeric columns. If the dataframe consists
-        only of object and categorical data without any numeric columns, the
-        default is to return an analysis of both the object and categorical
-        columns. If ``include='all'`` is provided as an option, the result
-        will include a union of attributes of each type.
-
-        The `include` and `exclude` parameters can be used to limit
-        which columns in a ``DataFrame`` are analyzed for the output.
-        The parameters are ignored when analyzing a ``Series``.
-
-        Examples
-        --------
-        Describing a numeric ``Series``.
-
-        >>> s = pd.Series([1, 2, 3])
-        >>> s.describe()
-        count    3.0
-        mean     2.0
-        std      1.0
-        min      1.0
-        25%      1.5
-        50%      2.0
-        75%      2.5
-        max      3.0
-        dtype: float64
-
-        Describing a categorical ``Series``.
-
-        >>> s = pd.Series(['a', 'a', 'b', 'c'])
-        >>> s.describe()
-        count     4
-        unique    3
-        top       a
-        freq      2
-        dtype: object
-
-        Describing a timestamp ``Series``.
-
-        >>> s = pd.Series([
-        ...   np.datetime64("2000-01-01"),
-        ...   np.datetime64("2010-01-01"),
-        ...   np.datetime64("2010-01-01")
-        ... ])
-        >>> s.describe(datetime_is_numeric=True)
-        count                      3
-        mean     2006-09-01 08:00:00
-        min      2000-01-01 00:00:00
-        25%      2004-12-31 12:00:00
-        50%      2010-01-01 00:00:00
-        75%      2010-01-01 00:00:00
-        max      2010-01-01 00:00:00
-        dtype: object
-
-        Describing a ``DataFrame``. By default only numeric fields
-        are returned.
-
-        >>> df = pd.DataFrame({'categorical': pd.Categorical(['d','e','f']),
-        ...                    'numeric': [1, 2, 3],
-        ...                    'object': ['a', 'b', 'c']
-        ...                   })
-        >>> df.describe()
-               numeric
-        count      3.0
-        mean       2.0
-        std        1.0
-        min        1.0
-        25%        1.5
-        50%        2.0
-        75%        2.5
-        max        3.0
-
-        Describing all columns of a ``DataFrame`` regardless of data type.
-
-        >>> df.describe(include='all')  # doctest: +SKIP
-               categorical  numeric object
-        count            3      3.0      3
-        unique           3      NaN      3
-        top              f      NaN      a
-        freq             1      NaN      1
-        mean           NaN      2.0    NaN
-        std            NaN      1.0    NaN
-        min            NaN      1.0    NaN
-        25%            NaN      1.5    NaN
-        50%            NaN      2.0    NaN
-        75%            NaN      2.5    NaN
-        max            NaN      3.0    NaN
-
-        Describing a column from a ``DataFrame`` by accessing it as
-        an attribute.
-
-        >>> df.numeric.describe()
-        count    3.0
-        mean     2.0
-        std      1.0
-        min      1.0
-        25%      1.5
-        50%      2.0
-        75%      2.5
-        max      3.0
-        Name: numeric, dtype: float64
-
-        Including only numeric columns in a ``DataFrame`` description.
-
-        >>> df.describe(include=[np.number])
-               numeric
-        count      3.0
-        mean       2.0
-        std        1.0
-        min        1.0
-        25%        1.5
-        50%        2.0
-        75%        2.5
-        max        3.0
-
-        Including only string columns in a ``DataFrame`` description.
-
-        >>> df.describe(include=[object])  # doctest: +SKIP
-               object
-        count       3
-        unique      3
-        top         a
-        freq        1
-
-        Including only categorical columns from a ``DataFrame`` description.
-
-        >>> df.describe(include=['category'])
-               categorical
-        count            3
-        unique           3
-        top              d
-        freq             1
-
-        Excluding numeric columns from a ``DataFrame`` description.
-
-        >>> df.describe(exclude=[np.number])  # doctest: +SKIP
-               categorical object
-        count            3      3
-        unique           3      3
-        top              f      a
-        freq             1      1
-
-        Excluding object columns from a ``DataFrame`` description.
-
-        >>> df.describe(exclude=[object])  # doctest: +SKIP
-               categorical  numeric
-        count            3      3.0
-        unique           3      NaN
-        top              f      NaN
-        freq             1      NaN
-        mean           NaN      2.0
-        std            NaN      1.0
-        min            NaN      1.0
-        25%            NaN      1.5
-        50%            NaN      2.0
-        75%            NaN      2.5
-        max            NaN      3.0
-        """
         raise AbstractMethodError(self)
 
     def pct_change(
@@ -7500,120 +1146,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
         freq=None,
         **kwargs,
     ) -> FrameOrSeries:
-        """
-        Percentage change between the current and a prior element.
-
-        Computes the percentage change from the immediately previous row by
-        default. This is useful in comparing the percentage of change in a time
-        series of elements.
-
-        Parameters
-        ----------
-        periods : int, default 1
-            Periods to shift for forming percent change.
-        fill_method : str, default 'pad'
-            How to handle NAs before computing percent changes.
-        limit : int, default None
-            The number of consecutive NAs to fill before stopping.
-        freq : DateOffset, timedelta, or str, optional
-            Increment to use from time series API (e.g. 'M' or BDay()).
-        **kwargs
-            Additional keyword arguments are passed into
-            `DataFrame.shift` or `Series.shift`.
-
-        Returns
-        -------
-        chg : Series or DataFrame
-            The same type as the calling object.
-
-        See Also
-        --------
-        Series.diff : Compute the difference of two elements in a Series.
-        DataFrame.diff : Compute the difference of two elements in a DataFrame.
-        Series.shift : Shift the index by some number of periods.
-        DataFrame.shift : Shift the index by some number of periods.
-
-        Examples
-        --------
-        **Series**
-
-        >>> s = pd.Series([90, 91, 85])
-        >>> s
-        0    90
-        1    91
-        2    85
-        dtype: int64
-
-        >>> s.pct_change()
-        0         NaN
-        1    0.011111
-        2   -0.065934
-        dtype: float64
-
-        >>> s.pct_change(periods=2)
-        0         NaN
-        1         NaN
-        2   -0.055556
-        dtype: float64
-
-        See the percentage change in a Series where filling NAs with last
-        valid observation forward to next valid.
-
-        >>> s = pd.Series([90, 91, None, 85])
-        >>> s
-        0    90.0
-        1    91.0
-        2     NaN
-        3    85.0
-        dtype: float64
-
-        >>> s.pct_change(fill_method='ffill')
-        0         NaN
-        1    0.011111
-        2    0.000000
-        3   -0.065934
-        dtype: float64
-
-        **DataFrame**
-
-        Percentage change in French franc, Deutsche Mark, and Italian lira from
-        1980-01-01 to 1980-03-01.
-
-        >>> df = pd.DataFrame(dict(
-        ...     FR=[4.0405, 4.0963, 4.3149],
-        ...     GR=[1.7246, 1.7482, 1.8519],
-        ...     IT=[804.74, 810.01, 860.13]),
-        ...     index=['1980-01-01', '1980-02-01', '1980-03-01'])
-        >>> df
-                        FR      GR      IT
-        1980-01-01  4.0405  1.7246  804.74
-        1980-02-01  4.0963  1.7482  810.01
-        1980-03-01  4.3149  1.8519  860.13
-
-        >>> df.pct_change()
-                          FR        GR        IT
-        1980-01-01       NaN       NaN       NaN
-        1980-02-01  0.013810  0.013684  0.006549
-        1980-03-01  0.053365  0.059318  0.061876
-
-        Percentage of change in GOOG and APPL stock volume. Shows computing
-        the percentage change between columns.
-
-        >>> df = pd.DataFrame(dict([
-        ...     ('2016', [1769950, 30586265]),
-        ...     ('2015', [1500923, 40912316]),
-        ...     ('2014', [1371819, 41403351])]),
-        ...     index=['GOOG', 'APPL'])
-        >>> df
-                  2016      2015      2014
-        GOOG   1769950   1500923   1371819
-        APPL  30586265  40912316  41403351
-
-        >>> df.pct_change(axis='columns')
-              2016      2015      2014
-        GOOG   NaN -0.151997 -0.086016
-        APPL   NaN  0.337604  0.012002
-        """
         raise AbstractMethodError(self)
 
     def _agg_by_level(self, name, axis=0, level=0, skipna=True, **kwargs):
@@ -7743,35 +1275,12 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     product = prod
 
     def mad(self, axis=None, skipna=None, level=None):
-        """
-        {desc}
-
-        Parameters
-        ----------
-        axis : {axis_descr}
-            Axis for the function to be applied on.
-        skipna : bool, default None
-            Exclude NA/null values when computing the result.
-        level : int or level name, default None
-            If the axis is a MultiIndex (hierarchical), count along a
-            particular level, collapsing into a {name1}.
-
-        Returns
-        -------
-        {name1} or {name2} (if level specified)\
-        {see_also}\
-        {examples}
-        """
         raise AbstractMethodError(self)
 
     @classmethod
     def _add_numeric_operations(cls):
-        """
-        Add the operations to the cls; evaluate the doc strings again
-        """
         raise AbstractMethodError(cls)
 
-    # @doc(Rolling)
     def rolling(
         self,
         window: Union[int, timedelta, BaseOffset, BaseIndexer],
@@ -7784,13 +1293,11 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     ):
         raise AbstractMethodError(self)
 
-    # @doc(Expanding)
     def expanding(
         self, min_periods: int = 1, center: Optional[bool_t] = None, axis: Axis = 0
     ) -> Expanding:
         raise AbstractMethodError(self)
 
-    # @doc(ExponentialMovingWindow)
     def ewm(
         self,
         com: Optional[float] = None,
@@ -7809,9 +1316,6 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     # Arithmetic Methods
 
     def _inplace_method(self, other, op):
-        """
-        Wrap arithmetic method to operate inplace.
-        """
         raise AbstractMethodError(self)
 
     def __iadd__(self, other):
@@ -7848,690 +1352,10 @@ class ABCNDFrame(ABC, PandasObject, SelectionMixin, indexing.IndexingMixin):
     # Misc methods
 
     def _find_valid_index(self, how: str):
-        """
-        Retrieves the index of the first valid value.
-
-        Parameters
-        ----------
-        how : {'first', 'last'}
-            Use this parameter to change between the first or last valid index.
-
-        Returns
-        -------
-        idx_first_valid : type of index
-        """
         raise AbstractMethodError(self)
 
-    @doc(position="first", klass=_shared_doc_kwargs["klass"])
     def first_valid_index(self):
-        """
-        Return index for {position} non-NA/null value.
-
-        Returns
-        -------
-        scalar : type of index
-
-        Notes
-        -----
-        If all elements are non-NA/null, returns None.
-        Also returns None for empty {klass}.
-        """
         raise AbstractMethodError(self)
 
-    @doc(first_valid_index, position="last", klass=_shared_doc_kwargs["klass"])
     def last_valid_index(self):
         raise AbstractMethodError(self)
-
-
-def _doc_parms(cls):
-    """Return a tuple of the doc parms."""
-    raise AbstractMethodError(cls)
-
-
-_num_doc = """
-{desc}
-
-Parameters
-----------
-axis : {axis_descr}
-    Axis for the function to be applied on.
-skipna : bool, default True
-    Exclude NA/null values when computing the result.
-level : int or level name, default None
-    If the axis is a MultiIndex (hierarchical), count along a
-    particular level, collapsing into a {name1}.
-numeric_only : bool, default None
-    Include only float, int, boolean columns. If None, will attempt to use
-    everything, then use only numeric data. Not implemented for Series.
-{min_count}\
-**kwargs
-    Additional keyword arguments to be passed to the function.
-
-Returns
--------
-{name1} or {name2} (if level specified)\
-{see_also}\
-{examples}
-"""
-
-_num_ddof_doc = """
-{desc}
-
-Parameters
-----------
-axis : {axis_descr}
-skipna : bool, default True
-    Exclude NA/null values. If an entire row/column is NA, the result
-    will be NA.
-level : int or level name, default None
-    If the axis is a MultiIndex (hierarchical), count along a
-    particular level, collapsing into a {name1}.
-ddof : int, default 1
-    Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
-    where N represents the number of elements.
-numeric_only : bool, default None
-    Include only float, int, boolean columns. If None, will attempt to use
-    everything, then use only numeric data. Not implemented for Series.
-
-Returns
--------
-{name1} or {name2} (if level specified)
-
-Notes
------
-To have the same behaviour as `numpy.std`, use `ddof=0` (instead of the
-default `ddof=1`)\n"""
-
-_bool_doc = """
-{desc}
-
-Parameters
-----------
-axis : {{0 or 'index', 1 or 'columns', None}}, default 0
-    Indicate which axis or axes should be reduced.
-
-    * 0 / 'index' : reduce the index, return a Series whose index is the
-      original column labels.
-    * 1 / 'columns' : reduce the columns, return a Series whose index is the
-      original index.
-    * None : reduce all axes, return a scalar.
-
-bool_only : bool, default None
-    Include only boolean columns. If None, will attempt to use everything,
-    then use only boolean data. Not implemented for Series.
-skipna : bool, default True
-    Exclude NA/null values. If the entire row/column is NA and skipna is
-    True, then the result will be {empty_value}, as for an empty row/column.
-    If skipna is False, then NA are treated as True, because these are not
-    equal to zero.
-level : int or level name, default None
-    If the axis is a MultiIndex (hierarchical), count along a
-    particular level, collapsing into a {name1}.
-**kwargs : any, default None
-    Additional keywords have no effect but might be accepted for
-    compatibility with NumPy.
-
-Returns
--------
-{name1} or {name2}
-    If level is specified, then, {name2} is returned; otherwise, {name1}
-    is returned.
-
-{see_also}
-{examples}"""
-
-_all_desc = """\
-Return whether all elements are True, potentially over an axis.
-
-Returns True unless there at least one element within a series or
-along a Dataframe axis that is False or equivalent (e.g. zero or
-empty)."""
-
-_all_examples = """\
-Examples
---------
-**Series**
-
->>> pd.Series([True, True]).all()
-True
->>> pd.Series([True, False]).all()
-False
->>> pd.Series([]).all()
-True
->>> pd.Series([np.nan]).all()
-True
->>> pd.Series([np.nan]).all(skipna=False)
-True
-
-**DataFrames**
-
-Create a dataframe from a dictionary.
-
->>> df = pd.DataFrame({'col1': [True, True], 'col2': [True, False]})
->>> df
-   col1   col2
-0  True   True
-1  True  False
-
-Default behaviour checks if column-wise values all return True.
-
->>> df.all()
-col1     True
-col2    False
-dtype: bool
-
-Specify ``axis='columns'`` to check if row-wise values all return True.
-
->>> df.all(axis='columns')
-0     True
-1    False
-dtype: bool
-
-Or ``axis=None`` for whether every value is True.
-
->>> df.all(axis=None)
-False
-"""
-
-_all_see_also = """\
-See Also
---------
-Series.all : Return True if all elements are True.
-DataFrame.any : Return True if one (or more) elements are True.
-"""
-
-_cnum_doc = """
-Return cumulative {desc} over a DataFrame or Series axis.
-
-Returns a DataFrame or Series of the same size containing the cumulative
-{desc}.
-
-Parameters
-----------
-axis : {{0 or 'index', 1 or 'columns'}}, default 0
-    The index or the name of the axis. 0 is equivalent to None or 'index'.
-skipna : bool, default True
-    Exclude NA/null values. If an entire row/column is NA, the result
-    will be NA.
-*args, **kwargs
-    Additional keywords have no effect but might be accepted for
-    compatibility with NumPy.
-
-Returns
--------
-{name1} or {name2}
-    Return cumulative {desc} of {name1} or {name2}.
-
-See Also
---------
-core.window.Expanding.{accum_func_name} : Similar functionality
-    but ignores ``NaN`` values.
-{name2}.{accum_func_name} : Return the {desc} over
-    {name2} axis.
-{name2}.cummax : Return cumulative maximum over {name2} axis.
-{name2}.cummin : Return cumulative minimum over {name2} axis.
-{name2}.cumsum : Return cumulative sum over {name2} axis.
-{name2}.cumprod : Return cumulative product over {name2} axis.
-
-{examples}"""
-
-_cummin_examples = """\
-Examples
---------
-**Series**
-
->>> s = pd.Series([2, np.nan, 5, -1, 0])
->>> s
-0    2.0
-1    NaN
-2    5.0
-3   -1.0
-4    0.0
-dtype: float64
-
-By default, NA values are ignored.
-
->>> s.cummin()
-0    2.0
-1    NaN
-2    2.0
-3   -1.0
-4   -1.0
-dtype: float64
-
-To include NA values in the operation, use ``skipna=False``
-
->>> s.cummin(skipna=False)
-0    2.0
-1    NaN
-2    NaN
-3    NaN
-4    NaN
-dtype: float64
-
-**DataFrame**
-
->>> df = pd.DataFrame([[2.0, 1.0],
-...                    [3.0, np.nan],
-...                    [1.0, 0.0]],
-...                    columns=list('AB'))
->>> df
-     A    B
-0  2.0  1.0
-1  3.0  NaN
-2  1.0  0.0
-
-By default, iterates over rows and finds the minimum
-in each column. This is equivalent to ``axis=None`` or ``axis='index'``.
-
->>> df.cummin()
-     A    B
-0  2.0  1.0
-1  2.0  NaN
-2  1.0  0.0
-
-To iterate over columns and find the minimum in each row,
-use ``axis=1``
-
->>> df.cummin(axis=1)
-     A    B
-0  2.0  1.0
-1  3.0  NaN
-2  1.0  0.0
-"""
-
-_cumsum_examples = """\
-Examples
---------
-**Series**
-
->>> s = pd.Series([2, np.nan, 5, -1, 0])
->>> s
-0    2.0
-1    NaN
-2    5.0
-3   -1.0
-4    0.0
-dtype: float64
-
-By default, NA values are ignored.
-
->>> s.cumsum()
-0    2.0
-1    NaN
-2    7.0
-3    6.0
-4    6.0
-dtype: float64
-
-To include NA values in the operation, use ``skipna=False``
-
->>> s.cumsum(skipna=False)
-0    2.0
-1    NaN
-2    NaN
-3    NaN
-4    NaN
-dtype: float64
-
-**DataFrame**
-
->>> df = pd.DataFrame([[2.0, 1.0],
-...                    [3.0, np.nan],
-...                    [1.0, 0.0]],
-...                    columns=list('AB'))
->>> df
-     A    B
-0  2.0  1.0
-1  3.0  NaN
-2  1.0  0.0
-
-By default, iterates over rows and finds the sum
-in each column. This is equivalent to ``axis=None`` or ``axis='index'``.
-
->>> df.cumsum()
-     A    B
-0  2.0  1.0
-1  5.0  NaN
-2  6.0  1.0
-
-To iterate over columns and find the sum in each row,
-use ``axis=1``
-
->>> df.cumsum(axis=1)
-     A    B
-0  2.0  3.0
-1  3.0  NaN
-2  1.0  1.0
-"""
-
-_cumprod_examples = """\
-Examples
---------
-**Series**
-
->>> s = pd.Series([2, np.nan, 5, -1, 0])
->>> s
-0    2.0
-1    NaN
-2    5.0
-3   -1.0
-4    0.0
-dtype: float64
-
-By default, NA values are ignored.
-
->>> s.cumprod()
-0     2.0
-1     NaN
-2    10.0
-3   -10.0
-4    -0.0
-dtype: float64
-
-To include NA values in the operation, use ``skipna=False``
-
->>> s.cumprod(skipna=False)
-0    2.0
-1    NaN
-2    NaN
-3    NaN
-4    NaN
-dtype: float64
-
-**DataFrame**
-
->>> df = pd.DataFrame([[2.0, 1.0],
-...                    [3.0, np.nan],
-...                    [1.0, 0.0]],
-...                    columns=list('AB'))
->>> df
-     A    B
-0  2.0  1.0
-1  3.0  NaN
-2  1.0  0.0
-
-By default, iterates over rows and finds the product
-in each column. This is equivalent to ``axis=None`` or ``axis='index'``.
-
->>> df.cumprod()
-     A    B
-0  2.0  1.0
-1  6.0  NaN
-2  6.0  0.0
-
-To iterate over columns and find the product in each row,
-use ``axis=1``
-
->>> df.cumprod(axis=1)
-     A    B
-0  2.0  2.0
-1  3.0  NaN
-2  1.0  0.0
-"""
-
-_cummax_examples = """\
-Examples
---------
-**Series**
-
->>> s = pd.Series([2, np.nan, 5, -1, 0])
->>> s
-0    2.0
-1    NaN
-2    5.0
-3   -1.0
-4    0.0
-dtype: float64
-
-By default, NA values are ignored.
-
->>> s.cummax()
-0    2.0
-1    NaN
-2    5.0
-3    5.0
-4    5.0
-dtype: float64
-
-To include NA values in the operation, use ``skipna=False``
-
->>> s.cummax(skipna=False)
-0    2.0
-1    NaN
-2    NaN
-3    NaN
-4    NaN
-dtype: float64
-
-**DataFrame**
-
->>> df = pd.DataFrame([[2.0, 1.0],
-...                    [3.0, np.nan],
-...                    [1.0, 0.0]],
-...                    columns=list('AB'))
->>> df
-     A    B
-0  2.0  1.0
-1  3.0  NaN
-2  1.0  0.0
-
-By default, iterates over rows and finds the maximum
-in each column. This is equivalent to ``axis=None`` or ``axis='index'``.
-
->>> df.cummax()
-     A    B
-0  2.0  1.0
-1  3.0  NaN
-2  3.0  1.0
-
-To iterate over columns and find the maximum in each row,
-use ``axis=1``
-
->>> df.cummax(axis=1)
-     A    B
-0  2.0  2.0
-1  3.0  NaN
-2  1.0  1.0
-"""
-
-_any_see_also = """\
-See Also
---------
-numpy.any : Numpy version of this method.
-Series.any : Return whether any element is True.
-Series.all : Return whether all elements are True.
-DataFrame.any : Return whether any element is True over requested axis.
-DataFrame.all : Return whether all elements are True over requested axis.
-"""
-
-_any_desc = """\
-Return whether any element is True, potentially over an axis.
-
-Returns False unless there at least one element within a series or
-along a Dataframe axis that is True or equivalent (e.g. non-zero or
-non-empty)."""
-
-_any_examples = """\
-Examples
---------
-**Series**
-
-For Series input, the output is a scalar indicating whether any element
-is True.
-
->>> pd.Series([False, False]).any()
-False
->>> pd.Series([True, False]).any()
-True
->>> pd.Series([]).any()
-False
->>> pd.Series([np.nan]).any()
-False
->>> pd.Series([np.nan]).any(skipna=False)
-True
-
-**DataFrame**
-
-Whether each column contains at least one True element (the default).
-
->>> df = pd.DataFrame({"A": [1, 2], "B": [0, 2], "C": [0, 0]})
->>> df
-   A  B  C
-0  1  0  0
-1  2  2  0
-
->>> df.any()
-A     True
-B     True
-C    False
-dtype: bool
-
-Aggregating over the columns.
-
->>> df = pd.DataFrame({"A": [True, False], "B": [1, 2]})
->>> df
-       A  B
-0   True  1
-1  False  2
-
->>> df.any(axis='columns')
-0    True
-1    True
-dtype: bool
-
->>> df = pd.DataFrame({"A": [True, False], "B": [1, 0]})
->>> df
-       A  B
-0   True  1
-1  False  0
-
->>> df.any(axis='columns')
-0    True
-1    False
-dtype: bool
-
-Aggregating over the entire DataFrame with ``axis=None``.
-
->>> df.any(axis=None)
-True
-
-`any` for an empty DataFrame is an empty Series.
-
->>> pd.DataFrame([]).any()
-Series([], dtype: bool)
-"""
-
-_shared_docs[
-    "stat_func_example"
-] = """
-
-Examples
---------
->>> idx = pd.MultiIndex.from_arrays([
-...     ['warm', 'warm', 'cold', 'cold'],
-...     ['dog', 'falcon', 'fish', 'spider']],
-...     names=['blooded', 'animal'])
->>> s = pd.Series([4, 2, 0, 8], name='legs', index=idx)
->>> s
-blooded  animal
-warm     dog       4
-         falcon    2
-cold     fish      0
-         spider    8
-Name: legs, dtype: int64
-
->>> s.{stat_func}()
-{default_output}
-
-{verb} using level names, as well as indices.
-
->>> s.{stat_func}(level='blooded')
-blooded
-warm    {level_output_0}
-cold    {level_output_1}
-Name: legs, dtype: int64
-
->>> s.{stat_func}(level=0)
-blooded
-warm    {level_output_0}
-cold    {level_output_1}
-Name: legs, dtype: int64"""
-
-_sum_examples = _shared_docs["stat_func_example"].format(
-    stat_func="sum", verb="Sum", default_output=14, level_output_0=6, level_output_1=8
-)
-
-_sum_examples += """
-
-By default, the sum of an empty or all-NA Series is ``0``.
-
->>> pd.Series([]).sum()  # min_count=0 is the default
-0.0
-
-This can be controlled with the ``min_count`` parameter. For example, if
-you'd like the sum of an empty series to be NaN, pass ``min_count=1``.
-
->>> pd.Series([]).sum(min_count=1)
-nan
-
-Thanks to the ``skipna`` parameter, ``min_count`` handles all-NA and
-empty series identically.
-
->>> pd.Series([np.nan]).sum()
-0.0
-
->>> pd.Series([np.nan]).sum(min_count=1)
-nan"""
-
-_max_examples = _shared_docs["stat_func_example"].format(
-    stat_func="max", verb="Max", default_output=8, level_output_0=4, level_output_1=8
-)
-
-_min_examples = _shared_docs["stat_func_example"].format(
-    stat_func="min", verb="Min", default_output=0, level_output_0=2, level_output_1=0
-)
-
-_stat_func_see_also = """
-
-See Also
---------
-Series.sum : Return the sum.
-Series.min : Return the minimum.
-Series.max : Return the maximum.
-Series.idxmin : Return the index of the minimum.
-Series.idxmax : Return the index of the maximum.
-DataFrame.sum : Return the sum over the requested axis.
-DataFrame.min : Return the minimum over the requested axis.
-DataFrame.max : Return the maximum over the requested axis.
-DataFrame.idxmin : Return the index of the minimum over the requested axis.
-DataFrame.idxmax : Return the index of the maximum over the requested axis."""
-
-_prod_examples = """
-
-Examples
---------
-By default, the product of an empty or all-NA Series is ``1``
-
->>> pd.Series([]).prod()
-1.0
-
-This can be controlled with the ``min_count`` parameter
-
->>> pd.Series([]).prod(min_count=1)
-nan
-
-Thanks to the ``skipna`` parameter, ``min_count`` handles all-NA and
-empty series identically.
-
->>> pd.Series([np.nan]).prod()
-1.0
-
->>> pd.Series([np.nan]).prod(min_count=1)
-nan"""
-
-_min_count_stub = """\
-min_count : int, default 0
-    The required number of valid values to perform the operation. If fewer than
-    ``min_count`` non-NA values are present the result will be NA.
-"""

--- a/pandas/core/dtypes/generic.py
+++ b/pandas/core/dtypes/generic.py
@@ -53,7 +53,6 @@ ABCIndexClass = create_pandas_abc_type(
     },
 )
 
-ABCNDFrame = create_pandas_abc_type("ABCNDFrame", "_typ", ("series", "dataframe"))
 ABCSeries = create_pandas_abc_type("ABCSeries", "_typ", ("series",))
 ABCDataFrame = create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4711,9 +4711,7 @@ class DataFrame(NDFrame, OpsMixin):
             return frame
 
     @overload
-    # https://github.com/python/mypy/issues/6580
-    # Overloaded function signatures 1 and 2 overlap with incompatible return types
-    def reset_index(  # type: ignore[misc]
+    def reset_index(
         self,
         level: Optional[Union[Hashable, Sequence[Hashable]]] = ...,
         drop: bool = ...,
@@ -4723,8 +4721,10 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> DataFrame:
         ...
 
+    # https://github.com/python/mypy/issues/6580
+    # Overloaded function signatures 1 and 2 overlap with incompatible return types
     @overload
-    def reset_index(
+    def reset_index(  # type: ignore[misc]
         self,
         level: Optional[Union[Hashable, Sequence[Hashable]]] = ...,
         drop: bool = ...,
@@ -5335,8 +5335,7 @@ class DataFrame(NDFrame, OpsMixin):
     # TODO: Just move the sort_values doc here.
     @Substitution(**_shared_doc_kwargs)
     @Appender(NDFrame.sort_values.__doc__)
-    # error: Signature of "sort_values" incompatible with supertype "NDFrame"
-    def sort_values(  # type: ignore[override]
+    def sort_values(
         self,
         by,
         axis=0,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -60,7 +60,7 @@ from pandas.util._validators import (
     validate_percentile,
 )
 
-from pandas.core.dtypes.abcs.ndframe import ABCNDFrame
+from pandas.core.dtypes.abcs import ABCNDFrame
 from pandas.core.dtypes.common import (
     ensure_int64,
     ensure_object,
@@ -908,117 +908,6 @@ class NDFrame(ABCNDFrame, PandasObject, SelectionMixin, indexing.IndexingMixin):
         level: Optional[Level] = None,
         errors: str = "ignore",
     ) -> Optional[FrameOrSeries]:
-        """
-        Alter axes input function or functions. Function / dict values must be
-        unique (1-to-1). Labels not contained in a dict / Series will be left
-        as-is. Extra labels listed don't throw an error. Alternatively, change
-        ``Series.name`` with a scalar value (Series only).
-
-        Parameters
-        ----------
-        %(axes)s : scalar, list-like, dict-like or function, optional
-            Scalar or list-like will alter the ``Series.name`` attribute,
-            and raise on DataFrame.
-            dict-like or functions are transformations to apply to
-            that axis' values
-        copy : bool, default True
-            Also copy underlying data.
-        inplace : bool, default False
-            Whether to return a new {klass}. If True then value of copy is
-            ignored.
-        level : int or level name, default None
-            In case of a MultiIndex, only rename labels in the specified
-            level.
-        errors : {'ignore', 'raise'}, default 'ignore'
-            If 'raise', raise a `KeyError` when a dict-like `mapper`, `index`,
-            or `columns` contains labels that are not present in the Index
-            being transformed.
-            If 'ignore', existing keys will be renamed and extra keys will be
-            ignored.
-
-        Returns
-        -------
-        renamed : {klass} (new object)
-
-        Raises
-        ------
-        KeyError
-            If any of the labels is not found in the selected axis and
-            "errors='raise'".
-
-        See Also
-        --------
-        NDFrame.rename_axis
-
-        Examples
-        --------
-        >>> s = pd.Series([1, 2, 3])
-        >>> s
-        0    1
-        1    2
-        2    3
-        dtype: int64
-        >>> s.rename("my_name") # scalar, changes Series.name
-        0    1
-        1    2
-        2    3
-        Name: my_name, dtype: int64
-        >>> s.rename(lambda x: x ** 2)  # function, changes labels
-        0    1
-        1    2
-        4    3
-        dtype: int64
-        >>> s.rename({1: 3, 2: 5})  # mapping, changes labels
-        0    1
-        3    2
-        5    3
-        dtype: int64
-
-        Since ``DataFrame`` doesn't have a ``.name`` attribute,
-        only mapping-type arguments are allowed.
-
-        >>> df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        >>> df.rename(2)
-        Traceback (most recent call last):
-        ...
-        TypeError: 'int' object is not callable
-
-        ``DataFrame.rename`` supports two calling conventions
-
-        * ``(index=index_mapper, columns=columns_mapper, ...)``
-        * ``(mapper, axis={'index', 'columns'}, ...)``
-
-        We *highly* recommend using keyword arguments to clarify your
-        intent.
-
-        >>> df.rename(index=str, columns={"A": "a", "B": "c"})
-           a  c
-        0  1  4
-        1  2  5
-        2  3  6
-
-        >>> df.rename(index=str, columns={"A": "a", "C": "c"})
-           a  B
-        0  1  4
-        1  2  5
-        2  3  6
-
-        Using axis-style parameters
-
-        >>> df.rename(str.lower, axis='columns')
-           a  b
-        0  1  4
-        1  2  5
-        2  3  6
-
-        >>> df.rename({1: 2, 2: 4}, axis='index')
-           A  B
-        0  1  4
-        2  2  5
-        4  3  6
-
-        See the :ref:`user guide <basics.rename>` for more.
-        """
         if mapper is None and index is None and columns is None:
             raise TypeError("must pass an index to rename")
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -704,11 +704,10 @@ class NDFrame(ABCNDFrame, PandasObject, SelectionMixin, indexing.IndexingMixin):
         if copy:
             new_values = new_values.copy()
 
-        # ignore needed because of NDFrame constructor is different than
         # DataFrame/Series constructors.
-        return self._constructor(
-            new_values, *new_axes  # type: ignore[arg-type]
-        ).__finalize__(self, method="swapaxes")
+        return self._constructor(new_values, *new_axes).__finalize__(
+            self, method="swapaxes"
+        )
 
     def droplevel(self: FrameOrSeries, level, axis=0) -> FrameOrSeries:
         """

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -532,7 +532,7 @@ class BaseGroupBy(PandasObject, SelectionMixin, Generic[FrameOrSeries]):
 
         self._selection = selection
 
-        assert isinstance(obj, NDFrame), type(obj)
+        # assert isinstance(obj, NDFrame), type(obj)
 
         self.level = level
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -30,6 +30,8 @@ import pandas.core.indexes.base as ibase
 from pandas.core.internals import concatenate_block_managers
 
 if TYPE_CHECKING:
+    from pandas.core.dtypes.abcs.ndframe import ABCNDFrame
+
     from pandas import DataFrame, Series
     from pandas.core.generic import NDFrame
 
@@ -55,7 +57,7 @@ def concat(
 
 @overload
 def concat(
-    objs: Union[Iterable["NDFrame"], Mapping[Label, "NDFrame"]],
+    objs: Union[Iterable["ABCNDFrame"], Mapping[Label, "ABCNDFrame"]],
     axis=0,
     join: str = "outer",
     ignore_index: bool = False,
@@ -70,7 +72,7 @@ def concat(
 
 
 def concat(
-    objs: Union[Iterable["NDFrame"], Mapping[Label, "NDFrame"]],
+    objs,
     axis=0,
     join="outer",
     ignore_index: bool = False,

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -30,10 +30,9 @@ import pandas.core.indexes.base as ibase
 from pandas.core.internals import concatenate_block_managers
 
 if TYPE_CHECKING:
-    from pandas.core.dtypes.abcs.ndframe import ABCNDFrame
+    from pandas.core.dtypes.abcs import ABCNDFrame
 
     from pandas import DataFrame, Series
-    from pandas.core.generic import NDFrame
 
 # ---------------------------------------------------------------------
 # Concatenate DataFrame objects

--- a/pandas/io/json/_json.py
+++ b/pandas/io/json/_json.py
@@ -1035,9 +1035,9 @@ class SeriesParser(Parser):
         elif self.orient in ["columns", "index"]:
             # error: "create_series_with_explicit_dtype"
             #  gets multiple values for keyword argument "dtype_if_empty
-            self.obj = create_series_with_explicit_dtype(
+            self.obj = create_series_with_explicit_dtype(  # type: ignore[misc]
                 *data, dtype_if_empty=object
-            )  # type:ignore[misc]
+            )
         else:
             self.obj = create_series_with_explicit_dtype(data, dtype_if_empty=object)
 


### PR DESCRIPTION
PoC implementation for using honest ABCs for pandas objects. Currently only implements ABCNDFrame. Compare:

```
def foo(obj: ABCNDFrame):
    reveal_type(obj.attrs)


def bar(obj: ABCDataFrame):
    reveal_type(obj.attrs)
```

In this PR, mypy will output `Revealed type is 'builtins.dict[Union[typing.Hashable, None], Any]'` for the former whereas the latter is `Revealed type is 'Any'`.

A script can be written (and I plan to, if this idea gets buy-in) to generate the ABC class off of the concrete class. Likewise, tests can be written to ensure that ABCNDFrame and NDFrame don't diverge.

docstrings can be removed from the ABC class; I just wanted to highlight that we could just have the docs in the ABC class (don't know if that would be desirable).

cc @simonjayhawkins, @jreback, @jbrockmendel 