### PR TITLE
Fixed the documentation for pandas.DataFrame.set_index inplace parameter

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4525,7 +4525,7 @@ class DataFrame(NDFrame, OpsMixin):
         append : bool, default False
             Whether to append columns to existing index.
         inplace : bool, default False
-            If set to True, modifies the DataFrame in place (do not create a new object).
+            If True, modifies the DataFrame in place (do not create a new object).
         verify_integrity : bool, default False
             Check the new index for duplicates. Otherwise defer the check until
             necessary. Setting to False will improve the performance of this

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4525,7 +4525,7 @@ class DataFrame(NDFrame, OpsMixin):
         append : bool, default False
             Whether to append columns to existing index.
         inplace : bool, default False
-            Modify the DataFrame in place (do not create a new object).
+            If set to True, modifies the DataFrame in place (do not create a new object).
         verify_integrity : bool, default False
             Check the new index for duplicates. Otherwise defer the check until
             necessary. Setting to False will improve the performance of this


### PR DESCRIPTION
Fixed the documentation for `pandas.DataFrame.set_index` 's `inplace` parameter.
Added proper explanation for True case.
