### PR TITLE
TST: fix xfailing indexing test

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1710,6 +1710,9 @@ class _iLocIndexer(_LocationIndexer):
                     self._setitem_single_column(loc, v, plane_indexer)
         else:
 
+            if isinstance(indexer[0], np.ndarray) and indexer[0].ndim > 2:
+                raise ValueError(r"Cannot set values with ndim > 2")
+
             # scalar value
             for loc in ilocs:
                 self._setitem_single_column(loc, value, plane_indexer)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -139,7 +139,6 @@ class TestFancy:
         with pytest.raises(err, match=msg):
             idxr[nd3] = 0
 
-    @pytest.mark.xfail(reason="gh-32896")
     def test_setitem_ndarray_3d_does_not_fail_for_iloc_empty_dataframe(self):
         # when fixing this, please remove the pytest.skip in test_setitem_ndarray_3d
         i = Index([])


### PR DESCRIPTION
When moving to the always-go-split_path, a bunch of tests fail without this fix.