### PR TITLE
ENH: add DataFrame.is_unique method

### DIFF
--- a/doc/source/reference/frame.rst
+++ b/doc/source/reference/frame.rst
@@ -190,6 +190,7 @@ Reindexing / selection / label manipulation
    DataFrame.head
    DataFrame.idxmax
    DataFrame.idxmin
+   DataFrame.is_unique
    DataFrame.last
    DataFrame.reindex
    DataFrame.reindex_like

--- a/doc/source/whatsnew/v1.3.0.rst
+++ b/doc/source/whatsnew/v1.3.0.rst
@@ -57,6 +57,7 @@ Other enhancements
 - :meth:`.Styler.set_tooltips_class` and :meth:`.Styler.set_table_styles` amended to optionally allow certain css-string input arguments (:issue:`39564`)
 - :meth:`.Styler.apply` now more consistently accepts ndarray function returns, i.e. in all cases for ``axis`` is ``0, 1 or None``. (:issue:`39359`)
 - :meth:`Series.loc.__getitem__` and :meth:`Series.loc.__setitem__` with :class:`MultiIndex` now raising helpful error message when indexer has too many dimensions (:issue:`35349`)
+- Added :meth:`DataFrame.is_unique` method for finding columns with unique values (:issue:`37565`)
 - :meth:`pandas.read_stata` and :class:`StataReader` support reading data from compressed files.
 
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1105,16 +1105,19 @@ class IndexOpsMixin(OpsMixin):
         obj = remove_na_arraylike(self) if dropna else self
         return len(obj.unique())
 
+    def _is_unique(self) -> bool:
+        return self.nunique(dropna=False) == len(self)
+
     @property
     def is_unique(self) -> bool:
         """
-        Return boolean if values in the object are unique.
+        Return True if values in the object are unique, else False.
 
         Returns
         -------
         bool
         """
-        return self.nunique(dropna=False) == len(self)
+        return self._is_unique()
 
     @property
     def is_monotonic(self) -> bool:

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1105,9 +1105,6 @@ class IndexOpsMixin(OpsMixin):
         obj = remove_na_arraylike(self) if dropna else self
         return len(obj.unique())
 
-    def _is_unique(self) -> bool:
-        return self.nunique(dropna=False) == len(self)
-
     @property
     def is_unique(self) -> bool:
         """
@@ -1117,7 +1114,7 @@ class IndexOpsMixin(OpsMixin):
         -------
         bool
         """
-        return self._is_unique()
+        return self.nunique(dropna=False) == len(self)
 
     @property
     def is_monotonic(self) -> bool:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5376,12 +5376,12 @@ class DataFrame(NDFrame, OpsMixin):
         self, subset: Optional[Union[Hashable, Sequence[Hashable]]] = None
     ) -> Series:
         """
-        Return boolean Series denoting columns with unique values.
+        Return boolean Series denoting which columns have unique values.
 
         Parameters
         ----------
         subset : column label or sequence of labels, optional
-            Only consider certain columns for finding uniques. by default use columns.
+            Only check subset of columns for uniques. By default checks all columns.
 
         Returns
         -------
@@ -5390,9 +5390,32 @@ class DataFrame(NDFrame, OpsMixin):
         See Also
         --------
         DataFrame.duplicated : Indicate duplicate rows.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame([('falcon', 'bird', 389.0),
+        ...                    ('parrot', 'bird', 24.0),
+        ...                    ('lion', 'mammal', 80.5),
+        ...                    ('monkey', 'mammal', np.nan)],
+        ...                   columns=('name', 'class', 'max_speed'))
+        >>> df
+             name   class  max_speed
+        0  falcon    bird      389.0
+        1  parrot    bird       24.0
+        2    lion  mammal       80.5
+        3  monkey  mammal        NaN
+        >>> df.is_unique()
+        name          True
+        class        False
+        max_speed     True
+        dtype: bool
+        >>> df.is_unique(["name", "class"])
+        name          True
+        class        False
+        dtype: bool
         """
         if subset is not None:
-            subset = subset if is_list_like(subset) else [subset]
+            subset = com.maybe_make_list(subset)
             self = self[subset]
 
         if len(self.columns):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5372,6 +5372,34 @@ class DataFrame(NDFrame, OpsMixin):
         else:
             return result
 
+    def is_unique(
+        self, subset: Optional[Union[Hashable, Sequence[Hashable]]] = None
+    ) -> Series:
+        """
+        Return boolean Series denoting columns with unique values.
+
+        Parameter
+        ---------
+        subset : column label or sequence of labels, optional
+            Only consider certain columns for finding uniques. by default use columns.
+
+        Returns
+        -------
+        Series
+
+        See Also:
+        ---------
+        DataFrame.duplicated : Indicate duplicate rows.
+        """
+        if subset is not None:
+            subset = subset if is_list_like(subset) else [subset]
+            return self.loc[:, subset].is_unique()
+
+        if len(self.columns):
+            return self.apply(Series._is_unique)
+        else:
+            return self._constructor_sliced(dtype=bool)
+
     def duplicated(
         self,
         subset: Optional[Union[Hashable, Sequence[Hashable]]] = None,
@@ -5405,6 +5433,7 @@ class DataFrame(NDFrame, OpsMixin):
         Series.duplicated : Equivalent method on Series.
         Series.drop_duplicates : Remove duplicate values from Series.
         DataFrame.drop_duplicates : Remove duplicate values from DataFrame.
+        DataFrame.is_unique : Indicate columns with unique values.
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5396,7 +5396,7 @@ class DataFrame(NDFrame, OpsMixin):
             self = self[subset]
 
         if len(self.columns):
-            return self.apply(Series._is_unique)
+            return self.apply(lambda x: x.is_unique)
         else:
             return self._constructor_sliced(dtype=bool)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5393,7 +5393,7 @@ class DataFrame(NDFrame, OpsMixin):
         """
         if subset is not None:
             subset = subset if is_list_like(subset) else [subset]
-            return self.loc[:, subset].is_unique()
+            self = self[subset]
 
         if len(self.columns):
             return self.apply(Series._is_unique)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5378,6 +5378,8 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Return boolean Series denoting which columns have unique values.
 
+        .. versionadded:: 1.3.0
+
         Parameters
         ----------
         subset : column label or sequence of labels, optional

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5378,8 +5378,8 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Return boolean Series denoting columns with unique values.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         subset : column label or sequence of labels, optional
             Only consider certain columns for finding uniques. by default use columns.
 
@@ -5387,8 +5387,8 @@ class DataFrame(NDFrame, OpsMixin):
         -------
         Series
 
-        See Also:
-        ---------
+        See Also
+        --------
         DataFrame.duplicated : Indicate duplicate rows.
         """
         if subset is not None:

--- a/pandas/tests/frame/methods/test_is_unique.py
+++ b/pandas/tests/frame/methods/test_is_unique.py
@@ -1,0 +1,60 @@
+import re
+
+import numpy as np
+import pytest
+
+from pandas import DataFrame, Series, date_range
+import pandas._testing as tm
+
+
+@pytest.mark.parametrize(
+    "frame, expected",
+    [
+        # single column
+        [DataFrame(), Series(dtype=bool)],
+        [DataFrame({"a": ["x"]}), Series({"a": True})],
+        [DataFrame({"a": ["x", "y"]}), Series({"a": True})],
+        [DataFrame({"a": ["x", "x"]}), Series({"a": False})],
+        [DataFrame({"a": ["x", "y", "y"]}), Series({"a": False})],
+        # multiple columns
+        [DataFrame(columns=["a", "b"]), Series({"a": True, "b": True})],
+        [DataFrame({"a": ["x"], "b": ["y"]}), Series({"a": True, "b": True})],
+        [
+            DataFrame({"a": ["x", "y"], "b": ["x", "x"]}),
+            Series({"a": True, "b": False}),
+        ],
+        # multiple columns, same column name
+        [DataFrame(columns=["a", "a"]), Series([True, True], index=["a", "a"])],
+        [
+            DataFrame([["x", "y"]], columns=["a", "a"]),
+            Series([True, True], index=["a", "a"]),
+        ],
+        [
+            DataFrame([["x", "y"], ["y", "y"]], columns=["a", "a"]),
+            Series([True, False], index=["a", "a"]),
+        ],
+    ],
+)
+def test_is_unique(frame, expected):
+    # GH37565
+    result = frame.is_unique()
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "frame, subset, expected",
+    [
+        [DataFrame(columns=["a", "b"]), ["a"], Series({"a": True})],
+        [DataFrame({"a": ["x"], "b": ["y"]}), "a", Series({"a": True})],
+        [DataFrame({"a": ["x"], "b": ["y"]}), ["a"], Series({"a": True})],
+        [
+            DataFrame({"a": ["x", "y"], "b": ["x", "x"]}),
+            ["a", "b"],
+            Series({"a": True, "b": False}),
+        ],
+    ],
+)
+def test_is_unique_subsetting(frame, subset, expected):
+    # GH37565
+    result = frame.is_unique(subset=subset)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/frame/methods/test_is_unique.py
+++ b/pandas/tests/frame/methods/test_is_unique.py
@@ -1,9 +1,6 @@
-import re
-
-import numpy as np
 import pytest
 
-from pandas import DataFrame, Series, date_range
+from pandas import DataFrame, Series
 import pandas._testing as tm
 
 


### PR DESCRIPTION
Currently, to see columns with unique values, we have to do `df.apply(lambda x: x.is_unique)`, which is a bit awkward.

IMO checking for unique columns in a DataFrame is a common enough need to justify a method for that specific purpose.

Xref: #11948