### PR TITLE
REF: prelims for single-path setitem_with_indexer

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1592,7 +1592,11 @@ class _iLocIndexer(_LocationIndexer):
                             return
 
                         # add a new item with the dtype setup
-                        self.obj[key] = infer_fill_value(value)
+                        if com.is_null_slice(indexer[0]):
+                            # We are setting an entire column
+                            self.obj[key] = value
+                        else:
+                            self.obj[key] = infer_fill_value(value)
 
                         new_indexer = convert_from_missing_indexer_tuple(
                             indexer, self.obj.axes
@@ -1641,6 +1645,8 @@ class _iLocIndexer(_LocationIndexer):
 
         if not isinstance(indexer, tuple):
             indexer = _tuplify(self.ndim, indexer)
+        if len(indexer) > self.ndim:
+            raise IndexError("too many indices for array")
 
         if isinstance(value, ABCSeries):
             value = self._align_series(indexer, value)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -116,10 +116,6 @@ class TestFancy:
         idxr = idxr(obj)
         nd3 = np.random.randint(5, size=(2, 2, 2))
 
-        if (len(index) == 0) and (idxr_id == "iloc") and isinstance(obj, pd.DataFrame):
-            # gh-32896
-            pytest.skip("This is currently failing. There's an xfailed test below.")
-
         if idxr_id == "iloc":
             err = ValueError
             msg = f"Cannot set values with ndim > {obj.ndim}"
@@ -140,7 +136,6 @@ class TestFancy:
             idxr[nd3] = 0
 
     def test_setitem_ndarray_3d_does_not_fail_for_iloc_empty_dataframe(self):
-        # when fixing this, please remove the pytest.skip in test_setitem_ndarray_3d
         i = Index([])
         obj = DataFrame(np.random.randn(len(i), len(i)), index=i, columns=i)
         nd3 = np.random.randint(5, size=(2, 2, 2))


### PR DESCRIPTION
Removes a pytest.skip that was supposed to have been removed along with an xfail in a previous step.