### PR TITLE
CI: Use conda deactivate instead of source deactivate

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -91,8 +91,8 @@ else
     echo "Not using ccache"
 fi
 
-echo "source deactivate"
-source deactivate
+echo "conda deactivate"
+conda deactivate
 
 echo "conda list (root environment)"
 conda list


### PR DESCRIPTION
Seen in the logs when running `setup_env.sh`

```
DeprecationWarning: 'source deactivate' is deprecated. Use 'conda deactivate'.
```