### PR TITLE
BUG: nunique not ignoring both None and np.nan

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -562,6 +562,7 @@ Other
 - Bug in :meth:`Index.union` behaving differently depending on whether operand is a :class:`Index` or other list-like (:issue:`36384`)
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError``, from a bare ``Exception`` previously (:issue:`35744`)
 - Bug in ``accessor.DirNamesMixin``, where ``dir(obj)`` wouldn't show attributes defined on the instance (:issue:`37173`).
+- Bug in :meth:`nunique` with ``dropna = True`` returns wrong result when different kinds of NA-like values exist (:issue:`37566`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -562,7 +562,7 @@ Other
 - Bug in :meth:`Index.union` behaving differently depending on whether operand is a :class:`Index` or other list-like (:issue:`36384`)
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError``, from a bare ``Exception`` previously (:issue:`35744`)
 - Bug in ``accessor.DirNamesMixin``, where ``dir(obj)`` wouldn't show attributes defined on the instance (:issue:`37173`).
-- Bug in :meth:`nunique` with ``dropna = True`` returns wrong result when different kinds of NA-like values exist (:issue:`37566`)
+- Bug in :meth:`Series.nunique` with ``dropna = True`` was returning incorrect results when both ``NA`` and ``None`` missing values were present (:issue:`37566`)
 
 .. ---------------------------------------------------------------------------
 

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -562,7 +562,7 @@ Other
 - Bug in :meth:`Index.union` behaving differently depending on whether operand is a :class:`Index` or other list-like (:issue:`36384`)
 - Passing an array with 2 or more dimensions to the :class:`Series` constructor now raises the more specific ``ValueError``, from a bare ``Exception`` previously (:issue:`35744`)
 - Bug in ``accessor.DirNamesMixin``, where ``dir(obj)`` wouldn't show attributes defined on the instance (:issue:`37173`).
-- Bug in :meth:`Series.nunique` with ``dropna = True`` was returning incorrect results when both ``NA`` and ``None`` missing values were present (:issue:`37566`)
+- Bug in :meth:`Series.nunique` with ``dropna=True`` was returning incorrect results when both ``NA`` and ``None`` missing values were present (:issue:`37566`)
 
 .. ---------------------------------------------------------------------------
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1032,12 +1032,8 @@ class IndexOpsMixin(OpsMixin):
         >>> s.nunique()
         4
         """
-        if dropna:
-            uniqs = self.dropna().unique()
-        else:
-            uniqs = self.unique()
-        n = len(uniqs)
-        return n
+        obj = self.dropna() if dropna else self
+        return len(obj.unique())
 
     @property
     def is_unique(self) -> bool:

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1032,10 +1032,11 @@ class IndexOpsMixin(OpsMixin):
         >>> s.nunique()
         4
         """
-        uniqs = self.unique()
+        if dropna:
+            uniqs = self.dropna().unique()
+        else:
+            uniqs = self.unique()
         n = len(uniqs)
-        if dropna and isna(uniqs).any():
-            n -= 1
         return n
 
     @property

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -33,7 +33,7 @@ from pandas.core.dtypes.common import (
     is_scalar,
 )
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndexClass, ABCSeries
-from pandas.core.dtypes.missing import isna
+from pandas.core.dtypes.missing import isna, remove_na_arraylike
 
 from pandas.core import algorithms
 from pandas.core.accessor import DirNamesMixin
@@ -1032,7 +1032,7 @@ class IndexOpsMixin(OpsMixin):
         >>> s.nunique()
         4
         """
-        obj = self.dropna() if dropna else self
+        obj = remove_na_arraylike(self) if dropna else self
         return len(obj.unique())
 
     @property

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -122,10 +122,10 @@ def test_unique_bad_unicode(idx_or_series_w_bad_unicode):
         expected = np.array(["\ud83d"], dtype=object)
         tm.assert_numpy_array_equal(result, expected)
 
+
 def test_nunique_dropna():
     # test for #37566
-    s = pd.Series(['yes','yes', pd.NA, np.nan, None, pd.NaT])
-    res = s.nunique(dropna = True)
+    s = pd.Series(['yes', 'yes', pd.NA, np.nan, None, pd.NaT])
+    res = s.nunique(dropna=True)
     expected = 1
     assert res == expected
-    

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -127,5 +127,5 @@ def test_unique_bad_unicode(idx_or_series_w_bad_unicode):
 def test_nunique_dropna(dropna):
     # GH37566
     s = pd.Series(["yes", "yes", pd.NA, np.nan, None, pd.NaT])
-    res = s.nunique(dropna=True)
+    res = s.nunique(dropna)
     assert res == 1 if dropna else 5

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -123,9 +123,9 @@ def test_unique_bad_unicode(idx_or_series_w_bad_unicode):
         tm.assert_numpy_array_equal(result, expected)
 
 
-def test_nunique_dropna():
-    # test for #37566
+@pytest.mark.parametrize("dropna", [True, False])
+def test_nunique_dropna(dropna):
+    # GH37566
     s = pd.Series(['yes', 'yes', pd.NA, np.nan, None, pd.NaT])
     res = s.nunique(dropna=True)
-    expected = 1
-    assert res == expected
+    assert res == 1 if dropna else 5

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -121,3 +121,11 @@ def test_unique_bad_unicode(idx_or_series_w_bad_unicode):
     else:
         expected = np.array(["\ud83d"], dtype=object)
         tm.assert_numpy_array_equal(result, expected)
+
+def test_nunique_dropna():
+    # test for #37566
+    s = pd.Series(['yes','yes', pd.NA, np.nan, None, pd.NaT])
+    res = s.nunique(dropna = True)
+    expected = 1
+    assert res == expected
+    

--- a/pandas/tests/base/test_unique.py
+++ b/pandas/tests/base/test_unique.py
@@ -126,6 +126,6 @@ def test_unique_bad_unicode(idx_or_series_w_bad_unicode):
 @pytest.mark.parametrize("dropna", [True, False])
 def test_nunique_dropna(dropna):
     # GH37566
-    s = pd.Series(['yes', 'yes', pd.NA, np.nan, None, pd.NaT])
+    s = pd.Series(["yes", "yes", pd.NA, np.nan, None, pd.NaT])
     res = s.nunique(dropna=True)
     assert res == 1 if dropna else 5


### PR DESCRIPTION
- [x] closes #37566
- [x] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
