### PR TITLE
DOC: Fix typo

### DIFF
--- a/pandas/core/shared_docs.py
+++ b/pandas/core/shared_docs.py
@@ -91,7 +91,7 @@ by : mapping, function, label, or list of labels
     index. If a dict or Series is passed, the Series or dict VALUES
     will be used to determine the groups (the Series' values are first
     aligned; see ``.align()`` method). If an ndarray is passed, the
-    values are used as-is determine the groups. A label or list of
+    values are used as-is to determine the groups. A label or list of
     labels may be passed to group by the columns in ``self``. Notice
     that a tuple is interpreted as a (single) key.
 axis : {0 or 'index', 1 or 'columns'}, default 0


### PR DESCRIPTION
I'm not entirely sure about this one, but "If an ndarray is passed, the values are used as-is determine the groups." does sound odd to me, so I do believe it was missing the "to".
