### PR TITLE
REF: de-duplicate _validate_insert_value with _validate_scalar

### DIFF
--- a/pandas/core/arrays/_mixins.py
+++ b/pandas/core/arrays/_mixins.py
@@ -45,7 +45,7 @@ class NDArrayBackedExtensionArray(ExtensionArray):
         """
         return x
 
-    def _validate_insert_value(self, value):
+    def _validate_scalar(self, value):
         # used by NDArrayBackedExtensionIndex.insert
         raise AbstractMethodError(self)
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1177,9 +1177,6 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
     # -------------------------------------------------------------
     # Validators; ideally these can be de-duplicated
 
-    def _validate_insert_value(self, value) -> int:
-        return self._validate_fill_value(value)
-
     def _validate_searchsorted_value(self, value):
         # searchsorted is very performance sensitive. By converting codes
         # to same dtype as self.codes, we get much faster performance.
@@ -1218,6 +1215,8 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
                 "in this Categorical's categories"
             )
         return fill_value
+
+    _validate_scalar = _validate_fill_value
 
     # -------------------------------------------------------------
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -479,10 +479,12 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             f"Got '{str(fill_value)}'."
         )
         try:
-            fill_value = self._validate_scalar(fill_value)
+            return self._validate_scalar(fill_value)
         except TypeError as err:
+            if "Cannot compare tz-naive and tz-aware" in str(err):
+                # tzawareness-compat
+                raise
             raise ValueError(msg) from err
-        return self._unbox(fill_value, setitem=True)
 
     def _validate_shift_value(self, fill_value):
         # TODO(2.0): once this deprecation is enforced, use _validate_fill_value
@@ -511,7 +513,14 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
         return self._unbox(fill_value, setitem=True)
 
-    def _validate_scalar(self, value, allow_listlike: bool = False):
+    def _validate_scalar(
+        self,
+        value,
+        *,
+        allow_listlike: bool = False,
+        setitem: bool = True,
+        unbox: bool = True,
+    ):
         """
         Validate that the input value can be cast to our scalar_type.
 
@@ -521,6 +530,11 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         allow_listlike: bool, default False
             When raising an exception, whether the message should say
             listlike inputs are allowed.
+        setitem : bool, default True
+            Whether to check compatibility with setitem strictness.
+        unbox : bool, default True
+            Whether to unbox the result before returning.  Note: unbox=False
+            skips the setitem compatibility check.
 
         Returns
         -------
@@ -546,7 +560,12 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
             msg = self._validation_error_message(value, allow_listlike)
             raise TypeError(msg)
 
-        return value
+        if not unbox:
+            # NB: In general NDArrayBackedExtensionArray will unbox here;
+            #  this option exists to prevent a performance hit in
+            #  TimedeltaIndex.get_loc
+            return value
+        return self._unbox_scalar(value, setitem=setitem)
 
     def _validation_error_message(self, value, allow_listlike: bool = False) -> str:
         """
@@ -611,7 +630,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
 
     def _validate_searchsorted_value(self, value):
         if not is_list_like(value):
-            value = self._validate_scalar(value, True)
+            return self._validate_scalar(value, allow_listlike=True, setitem=False)
         else:
             value = self._validate_listlike(value)
 
@@ -621,12 +640,7 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
         if is_list_like(value):
             value = self._validate_listlike(value)
         else:
-            value = self._validate_scalar(value, True)
-
-        return self._unbox(value, setitem=True)
-
-    def _validate_insert_value(self, value):
-        value = self._validate_scalar(value)
+            return self._validate_scalar(value, allow_listlike=True)
 
         return self._unbox(value, setitem=True)
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -889,9 +889,6 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             )
             raise TypeError(msg) from err
 
-    def _validate_insert_value(self, value):
-        return self._validate_scalar(value)
-
     def _validate_setitem_value(self, value):
         needs_float_conversion = False
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2292,7 +2292,7 @@ class Index(IndexOpsMixin, PandasObject):
         DataFrame.fillna : Fill NaN values of a DataFrame.
         Series.fillna : Fill NaN Values of a Series.
         """
-        value = self._validate_scalar(value)
+        value = self._require_scalar(value)
         if self.hasnans:
             result = self.putmask(self._isnan, value)
             if downcast is None:
@@ -4140,7 +4140,7 @@ class Index(IndexOpsMixin, PandasObject):
         return value
 
     @final
-    def _validate_scalar(self, value):
+    def _require_scalar(self, value):
         """
         Check that this is a scalar value that we can use for setitem-like
         operations without changing dtype.

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -382,7 +382,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
 
     @doc(Index.fillna)
     def fillna(self, value, downcast=None):
-        value = self._validate_scalar(value)
+        value = self._require_scalar(value)
         cat = self._data.fillna(value)
         return type(self)._simple_new(cat, name=self.name)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -581,7 +581,7 @@ class DatetimeIndexOpsMixin(NDArrayBackedExtensionIndex):
         """
         Find the `freq` for self.insert(loc, item).
         """
-        value = self._data._validate_insert_value(item)
+        value = self._data._validate_scalar(item)
         item = self._data._box_func(value)
 
         freq = None

--- a/pandas/core/indexes/extension.py
+++ b/pandas/core/indexes/extension.py
@@ -335,7 +335,7 @@ class NDArrayBackedExtensionIndex(ExtensionIndex):
         ValueError if the item is not valid for this dtype.
         """
         arr = self._data
-        code = arr._validate_insert_value(item)
+        code = arr._validate_scalar(item)
 
         new_vals = np.concatenate((arr._ndarray[:loc], [code], arr._ndarray[loc:]))
         new_arr = arr._from_backing_data(new_vals)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -903,7 +903,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex):
         -------
         IntervalIndex
         """
-        left_insert, right_insert = self._data._validate_insert_value(item)
+        left_insert, right_insert = self._data._validate_scalar(item)
 
         new_left = self.left.insert(loc, left_insert)
         new_right = self.right.insert(loc, right_insert)

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -215,7 +215,7 @@ class TimedeltaIndex(DatetimeTimedeltaMixin):
             raise InvalidIndexError(key)
 
         try:
-            key = self._data._validate_scalar(key)
+            key = self._data._validate_scalar(key, unbox=False)
         except TypeError as err:
             raise KeyError(key) from err
 


### PR DESCRIPTION
There is only one place where `_validate_insert_value` isnt identical to `_validate_scalar`, and that is in `DatetimeLikeArrayMixin._validate_scalar`, which ATM does not unbox (which all the other `_validate_scalar` methods do).  This updates `_validate_scalar` to unbox.

If we stopped there, `TimedeltaIndex.get_loc` would take a pretty significant performance hit, so I added a `unbox=True` kwarg to `_validate_scalar` that TDI.get_loc uses to keep perf flat.

Made `_validate_scalar` keyword-only past the first (non-self) argument.

Last, renamed `Index._validate_scalar` to `Index._require_scalar` to disambiguate the names.  (one of the two uses of `Index._validate_scalar` is wrong and will be removed, but thats a whole different can of worms)