### PR TITLE
BUG: preserve fold in Timestamp.replace

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -412,7 +412,7 @@ Timezones
 ^^^^^^^^^
 
 - Bug in :func:`date_range` was raising AmbiguousTimeError for valid input with ``ambiguous=False`` (:issue:`35297`)
--
+- Bug in :meth:`Timestamp.replace` was losing fold information (:issue:`37610`)
 
 
 Numeric

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -774,7 +774,7 @@ default 'raise'
         microsecond : int, optional
         nanosecond : int, optional
         tzinfo : tz-convertible, optional
-        fold : int, optional, default is 0
+        fold : int, optional
 
         Returns
         -------

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -1374,7 +1374,7 @@ default 'raise'
         microsecond=None,
         nanosecond=None,
         tzinfo=object,
-        fold=0,
+        fold=None,
     ):
         """
         implements datetime.replace, handles nanoseconds.
@@ -1390,7 +1390,7 @@ default 'raise'
         microsecond : int, optional
         nanosecond : int, optional
         tzinfo : tz-convertible, optional
-        fold : int, optional, default is 0
+        fold : int, optional
 
         Returns
         -------
@@ -1407,6 +1407,11 @@ default 'raise'
         # set to naive if needed
         tzobj = self.tzinfo
         value = self.value
+
+        # GH 37610. Preserve fold when replacing.
+        if fold is None:
+            fold = self.fold
+
         if tzobj is not None:
             value = tz_convert_from_utc_single(value, tzobj)
 

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -1190,3 +1190,13 @@ def test_tz_localize_invalidates_freq():
     dti2 = dti[:1]
     result = dti2.tz_localize("US/Eastern")
     assert result.freq == "H"
+
+
+def test_replace_preserves_fold():
+    # GH 37610. Check that replace preserves Timestamp fold property
+    tz = gettz("Europe/Moscow")
+
+    result = Timestamp(1256427000000000000, tz=tz, unit="ns").replace(tzinfo=tz).fold
+    expected = 1
+
+    assert result == expected

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -1190,13 +1190,3 @@ def test_tz_localize_invalidates_freq():
     dti2 = dti[:1]
     result = dti2.tz_localize("US/Eastern")
     assert result.freq == "H"
-
-
-def test_replace_preserves_fold():
-    # GH 37610. Check that replace preserves Timestamp fold property
-    tz = gettz("Europe/Moscow")
-
-    result = Timestamp(1256427000000000000, tz=tz, unit="ns").replace(tzinfo=tz).fold
-    expected = 1
-
-    assert result == expected

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -431,7 +431,7 @@ def test_replace_preserves_fold(fold):
     # GH 37610. Check that replace preserves Timestamp fold property
     tz = gettz("Europe/Moscow")
 
-    ts = Timestamp(year=2009, month=10, day=25, hour=2, minute=30, fold=fold, tz=tz)
+    ts = Timestamp(year=2009, month=10, day=25, hour=2, minute=30, fold=fold, tzinfo=tz)
     ts_replaced = ts.replace(second=1)
 
     assert ts_replaced.fold == fold

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -424,3 +424,13 @@ class TestTimestampUnaryOps:
             # should agree with datetime.timestamp method
             dt = ts.to_pydatetime()
             assert dt.timestamp() == ts.timestamp()
+
+
+def test_replace_preserves_fold():
+    # GH 37610. Check that replace preserves Timestamp fold property
+    tz = gettz("Europe/Moscow")
+
+    result = Timestamp(1256427000000000000, tz=tz, unit="ns").replace(tzinfo=tz).fold
+    expected = 1
+
+    assert result == expected

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -430,7 +430,9 @@ def test_replace_preserves_fold():
     # GH 37610. Check that replace preserves Timestamp fold property
     tz = gettz("Europe/Moscow")
 
-    result = Timestamp(1256427000000000000, tz=tz, unit="ns").replace(tzinfo=tz).fold
-    expected = 1
+    dt = datetime(year=2009, month=10, day=25, hour=2, minute=30, fold=1, tzinfo=tz)
+    ts = Timestamp(year=2009, month=10, day=25, hour=2, minute=30, fold=1, tz=tz)
+    result = ts.replace(tzinfo=tz).fold
+    expected = dt.replace(tzinfo=tz).fold
 
     assert result == expected

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -432,6 +432,6 @@ def test_replace_preserves_fold(fold):
     tz = gettz("Europe/Moscow")
 
     ts = Timestamp(year=2009, month=10, day=25, hour=2, minute=30, fold=fold, tz=tz)
-    ts_replaced = ts.replace(tzinfo=tz)
+    ts_replaced = ts.replace(second=1)
 
     assert ts_replaced.fold == fold

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -426,13 +426,12 @@ class TestTimestampUnaryOps:
             assert dt.timestamp() == ts.timestamp()
 
 
-def test_replace_preserves_fold():
+@pytest.mark.parametrize("fold", [0, 1])
+def test_replace_preserves_fold(fold):
     # GH 37610. Check that replace preserves Timestamp fold property
     tz = gettz("Europe/Moscow")
 
-    dt = datetime(year=2009, month=10, day=25, hour=2, minute=30, fold=1, tzinfo=tz)
-    ts = Timestamp(year=2009, month=10, day=25, hour=2, minute=30, fold=1, tz=tz)
-    result = ts.replace(tzinfo=tz).fold
-    expected = dt.replace(tzinfo=tz).fold
+    ts = Timestamp(year=2009, month=10, day=25, hour=2, minute=30, fold=fold, tz=tz)
+    ts_replaced = ts.replace(tzinfo=tz)
 
-    assert result == expected
+    assert ts_replaced.fold == fold


### PR DESCRIPTION
- [X] closes #37610
- [X] 1 tests added / 1 passed
- [X] passes `black pandas`
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

## Problem
We currently lose `fold` information (whether the Timestamp corresponds to the first or second instance of wall clock time in a DST transition) when calling `Timestamp.replace`.

## Solution
A simple addition to the code of `Timestamp.replace` should fix this.

## Test
I added the test for the use case I came up with in the issue discussion. The OP example is losing `fold` when deleting timezone information with `Timetsamp.replace`, and that's not really a bug, but replacing a valid dateutil timezone with itself and losing `fold` definitely is.

The proposed solution fixes the original example as well. I just don't think we should be tracking it in tests, as it's not clear to me why `fold` must be preserved in a `Timestamp` with no timezone information (but it is the convention recommended in [PEP 495, fold section](https://www.python.org/dev/peps/pep-0495/#the-fold-attribute) to let users keep invalid fold and to just ignore it).

## Some details
IIRC, we ignore `fold`, when it doesn't do anything, so we should be safe preserving `fold` while replacing tzinfo with None, as in the OP example. I remember this coming up when we introduced fold support, and we made sure that the fold-aware functions don't care what fold is outside of a DST transition with a dateutil timezone (this was done to satisfy the requirements of [PEP 495, fold section](https://www.python.org/dev/peps/pep-0495/#the-fold-attribute)).