### PR TITLE
ENH: option to plot data points on top of boxplot

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -265,6 +265,7 @@ figsize : A tuple (width, height) in inches
 layout : tuple (rows, columns), optional
     For example, (3, 5) will display the subplots
     using 3 columns and 5 rows, starting from the top-left.
+plot_points : Plot data points as scatter plot on top of box plot.
 return_type : {'axes', 'dict', 'both'} or None, default 'axes'
     The kind of object to return. The default is ``axes``.
 
@@ -456,6 +457,7 @@ def boxplot(
     figsize=None,
     layout=None,
     return_type=None,
+    plot_points=False,
     **kwargs,
 ):
     plot_backend = _get_plot_backend("matplotlib")
@@ -470,6 +472,7 @@ def boxplot(
         figsize=figsize,
         layout=layout,
         return_type=return_type,
+        plot_points=plot_points,
         **kwargs,
     )
 
@@ -488,6 +491,7 @@ def boxplot_frame(
     layout=None,
     return_type=None,
     backend=None,
+    plot_points=False,
     **kwargs,
 ):
     plot_backend = _get_plot_backend(backend)
@@ -502,6 +506,7 @@ def boxplot_frame(
         figsize=figsize,
         layout=layout,
         return_type=return_type,
+        plot_points=plot_points,
         **kwargs,
     )
 

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -242,6 +242,7 @@ def boxplot(
     figsize=None,
     layout=None,
     return_type=None,
+    plot_points=False,
     **kwds,
 ):
 
@@ -296,10 +297,16 @@ def boxplot(
         if not kwds.get("capprops"):
             setp(bp["caps"], color=colors[3], alpha=1)
 
-    def plot_group(keys, values, ax: "Axes"):
+    def plot_group(keys, values, ax: "Axes", plot_points: bool=False):
         keys = [pprint_thing(x) for x in keys]
         values = [np.asarray(remove_na_arraylike(v), dtype=object) for v in values]
         bp = ax.boxplot(values, **kwds)
+
+        if plot_points:
+            # if plot_points
+            for x, ys in enumerate(values):
+                ax.plot(x + np.random.normal(size=len(ys))*.04 + 1, ys, 'ro', alpha=.5)
+
         if fontsize is not None:
             ax.tick_params(axis="both", labelsize=fontsize)
         if kwds.get("vert", 1):
@@ -360,7 +367,7 @@ def boxplot(
         else:
             data = data[columns]
 
-        result = plot_group(columns, data.values.T, ax)
+        result = plot_group(columns, data.values.T, ax, plot_points)
         ax.grid(grid)
 
     return result

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -303,7 +303,6 @@ def boxplot(
         bp = ax.boxplot(values, **kwds)
 
         if plot_points:
-            # if plot_points
             for x, ys in enumerate(values):
                 ax.plot(
                     x + np.random.normal(size=len(ys)) * 0.04 + 1, ys, "ro", alpha=0.5

--- a/pandas/plotting/_matplotlib/boxplot.py
+++ b/pandas/plotting/_matplotlib/boxplot.py
@@ -297,7 +297,7 @@ def boxplot(
         if not kwds.get("capprops"):
             setp(bp["caps"], color=colors[3], alpha=1)
 
-    def plot_group(keys, values, ax: "Axes", plot_points: bool=False):
+    def plot_group(keys, values, ax: "Axes", plot_points: bool = False):
         keys = [pprint_thing(x) for x in keys]
         values = [np.asarray(remove_na_arraylike(v), dtype=object) for v in values]
         bp = ax.boxplot(values, **kwds)
@@ -305,7 +305,9 @@ def boxplot(
         if plot_points:
             # if plot_points
             for x, ys in enumerate(values):
-                ax.plot(x + np.random.normal(size=len(ys))*.04 + 1, ys, 'ro', alpha=.5)
+                ax.plot(
+                    x + np.random.normal(size=len(ys)) * 0.04 + 1, ys, "ro", alpha=0.5
+                )
 
         if fontsize is not None:
             ax.tick_params(axis="both", labelsize=fontsize)

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -217,6 +217,9 @@ class TestDataFramePlots(TestPlotBase):
 
         assert result[expected][0].get_color() == "C1"
 
+    def test_plot_points(self):
+        _check_plot_works(self.hist_df.boxplot, plot_points=True)
+
 
 @td.skip_if_no_mpl
 class TestDataFrameGroupByPlots(TestPlotBase):


### PR DESCRIPTION
- [x ] tests added / passed 
- [x ] passes `black pandas`
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry - not sure how to do this. I guess I have to wait until pull request is complete.

This change is a a feature I often want, which is the ability to add raw data on top of a boxplot to get a better idea of data distribution.
