### PR TITLE
REF: simplify cycling through colors

### DIFF
--- a/pandas/plotting/_matplotlib/style.py
+++ b/pandas/plotting/_matplotlib/style.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import (
     TYPE_CHECKING,
     Collection,
@@ -74,7 +75,7 @@ def get_standard_colors(
         num_colors=num_colors,
     )
 
-    return _cycle_colors(colors, num_colors=num_colors)
+    return list(_cycle_colors(colors, num_colors=num_colors))
 
 
 def _derive_colors(
@@ -128,19 +129,15 @@ def _derive_colors(
         return _get_colors_from_color_type(color_type, num_colors=num_colors)
 
 
-def _cycle_colors(colors: List[Color], num_colors: int) -> List[Color]:
-    """Append more colors by cycling if there is not enough color.
+def _cycle_colors(colors: List[Color], num_colors: int) -> Iterator[Color]:
+    """Cycle colors until achieving max of `num_colors` or length of `colors`.
 
     Extra colors will be ignored by matplotlib if there are more colors
     than needed and nothing needs to be done here.
     """
-    if len(colors) < num_colors:
-        multiple = num_colors // len(colors) - 1
-        mod = num_colors % len(colors)
-        colors += multiple * colors
-        colors += colors[:mod]
-
-    return colors
+    max_colors = max(num_colors, len(colors))
+    for _, col in zip(range(max_colors), itertools.cycle(colors)):
+        yield col
 
 
 def _get_colors_from_colormap(

--- a/pandas/plotting/_matplotlib/style.py
+++ b/pandas/plotting/_matplotlib/style.py
@@ -136,7 +136,7 @@ def _cycle_colors(colors: List[Color], num_colors: int) -> Iterator[Color]:
     than needed and nothing needs to be done here.
     """
     max_colors = max(num_colors, len(colors))
-    yield from itertools.islice(itertools.cycle(colors), 0, max_colors)
+    yield from itertools.islice(itertools.cycle(colors), max_colors)
 
 
 def _get_colors_from_colormap(

--- a/pandas/plotting/_matplotlib/style.py
+++ b/pandas/plotting/_matplotlib/style.py
@@ -136,8 +136,7 @@ def _cycle_colors(colors: List[Color], num_colors: int) -> Iterator[Color]:
     than needed and nothing needs to be done here.
     """
     max_colors = max(num_colors, len(colors))
-    for _, col in zip(range(max_colors), itertools.cycle(colors)):
-        yield col
+    yield from itertools.islice(itertools.cycle(colors), 0, max_colors)
 
 
 def _get_colors_from_colormap(


### PR DESCRIPTION
- [ ] closes #37604
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I tried to address #37604, but it turns out that on some occasions it is absolutely mandatory to return more colors than ``num_colors`` says.
In particular, this is the test that cannot be updated and the underlying code cannot be easily modified as well.

```
pandas/tests/plotting/test_frame.py
...
class TestDataFramePlots(TestPlotBase):
...
    def test_bar_user_colors(self):
        df = DataFrame(
            {"A": range(4), "B": range(1, 5), "color": ["red", "blue", "blue", "red"]}
        )
        # This should *only* work when `y` is specified, else
        # we use one color per column
        ax = df.plot.bar(y="A", color=df["color"])
        result = [p.get_facecolor() for p in ax.patches]
        expected = [
            (1.0, 0.0, 0.0, 1.0),
            (0.0, 0.0, 1.0, 1.0),
            (0.0, 0.0, 1.0, 1.0),
            (1.0, 0.0, 0.0, 1.0),
        ]
        assert result == expected
```

When "y" is specified, then the number of colors must be the length of the series df["A"],
but inside the BarPlot class there is no opportunity to check for that condition.

So, let ``get_standard_colors`` return maximum of ``num_colors`` and ``len(colors)``.
This way all tests work without modifications,
just minor improvement in the cycling function.