### PR TITLE
BUG: CategoricalIndex.equals casting non-categories to np.nan

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -380,7 +380,7 @@ Categorical
 ^^^^^^^^^^^
 - :meth:`Categorical.fillna` will always return a copy, will validate a passed fill value regardless of whether there are any NAs to fill, and will disallow a ``NaT`` as a fill value for numeric categories (:issue:`36530`)
 - Bug in :meth:`Categorical.__setitem__` that incorrectly raised when trying to set a tuple value (:issue:`20439`)
-- Bug in :meth:`CategoricalIndex.equals` incorrectly casting non-category entries to ``np.nan`` (:issue:`???`)
+- Bug in :meth:`CategoricalIndex.equals` incorrectly casting non-category entries to ``np.nan`` (:issue:`37667`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -380,7 +380,7 @@ Categorical
 ^^^^^^^^^^^
 - :meth:`Categorical.fillna` will always return a copy, will validate a passed fill value regardless of whether there are any NAs to fill, and will disallow a ``NaT`` as a fill value for numeric categories (:issue:`36530`)
 - Bug in :meth:`Categorical.__setitem__` that incorrectly raised when trying to set a tuple value (:issue:`20439`)
--
+- Bug in :meth:`CategoricalIndex.equals` incorrectly casting non-category entries to ``np.nan`` (:issue:`???`)
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -273,7 +273,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
             other = other._values
 
             if not ((other == values) | (isna(other) & isna(values))).all():
-                # GH#???? see test_equals_non_category
+                # GH#37667 see test_equals_non_category
                 raise TypeError(
                     "categories must match existing categories when appending"
                 )

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -20,7 +20,7 @@ from pandas.core.dtypes.common import (
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import CategoricalDtype
-from pandas.core.dtypes.missing import is_valid_nat_for_dtype, notna
+from pandas.core.dtypes.missing import is_valid_nat_for_dtype, isna, notna
 
 from pandas.core import accessor
 from pandas.core.arrays.categorical import Categorical, contains
@@ -263,6 +263,7 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
             values = other
             if not is_list_like(values):
                 values = [values]
+
             cat = Categorical(other, dtype=self.dtype)
             other = CategoricalIndex(cat)
             if not other.isin(values).all():
@@ -270,6 +271,12 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
                     "cannot append a non-category item to a CategoricalIndex"
                 )
             other = other._values
+
+            if not ((other == values) | (isna(other) & isna(values))).all():
+                # GH#???? see test_equals_non_category
+                raise TypeError(
+                    "categories must match existing categories when appending"
+                )
 
         return other
 
@@ -291,13 +298,10 @@ class CategoricalIndex(NDArrayBackedExtensionIndex, accessor.PandasDelegate):
 
         try:
             other = self._is_dtype_compat(other)
-            if isinstance(other, type(self)):
-                other = other._data
-            return self._data.equals(other)
         except (TypeError, ValueError):
-            pass
+            return False
 
-        return False
+        return self._data.equals(other)
 
     # --------------------------------------------------------------------
     # Rendering Methods

--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -445,8 +445,8 @@ class TestCategoricalIndex(Base):
         assert not b.equals(c)
 
     def test_equals_non_category(self):
-        # Case where other contains a value not among ci's categories ("D") and
-        #  also contains np.nan
+        # GH#37667 Case where other contains a value not among ci's
+        #  categories ("D") and also contains np.nan
         ci = CategoricalIndex(["A", "B", np.nan, np.nan])
         other = Index(["A", "B", "D", np.nan])
 

--- a/pandas/tests/indexes/categorical/test_category.py
+++ b/pandas/tests/indexes/categorical/test_category.py
@@ -444,6 +444,14 @@ class TestCategoricalIndex(Base):
         assert not a.equals(c)
         assert not b.equals(c)
 
+    def test_equals_non_category(self):
+        # Case where other contains a value not among ci's categories ("D") and
+        #  also contains np.nan
+        ci = CategoricalIndex(["A", "B", np.nan, np.nan])
+        other = Index(["A", "B", "D", np.nan])
+
+        assert not ci.equals(other)
+
     def test_frame_repr(self):
         df = pd.DataFrame({"A": [1, 2, 3]}, index=CategoricalIndex(["a", "b", "c"]))
         result = repr(df)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
