### PR TITLE
TST: fix warning for pie chart

### DIFF
--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -2650,11 +2650,20 @@ class TestDataFramePlots(TestPlotBase):
             self._check_colors(ax.patches, facecolors=color_args)
 
     def test_pie_df_nan(self):
+        import matplotlib as mpl
+
         df = DataFrame(np.random.rand(4, 4))
         for i in range(4):
             df.iloc[i, i] = np.nan
         fig, axes = self.plt.subplots(ncols=4)
-        df.plot.pie(subplots=True, ax=axes, legend=True, normalize=True)
+
+        # GH 37668
+        if mpl.__version__ >= "3.3":
+            kwargs = {"normalize": True}
+        else:
+            kwargs = {}
+
+        df.plot.pie(subplots=True, ax=axes, legend=True, **kwargs)
 
         base_expected = ["0", "1", "2", "3"]
         for i, ax in enumerate(axes):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -2659,11 +2659,10 @@ class TestDataFramePlots(TestPlotBase):
 
         # GH 37668
         if mpl.__version__ >= "3.3":
-            kwargs = {"normalize": True}
+            with tm.assert_produces_warning(None):
+                df.plot.pie(subplots=True, ax=axes, legend=True, normalize=True)
         else:
-            kwargs = {}
-
-        df.plot.pie(subplots=True, ax=axes, legend=True, **kwargs)
+            df.plot.pie(subplots=True, ax=axes, legend=True)
 
         base_expected = ["0", "1", "2", "3"]
         for i, ax in enumerate(axes):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -2658,11 +2658,12 @@ class TestDataFramePlots(TestPlotBase):
         fig, axes = self.plt.subplots(ncols=4)
 
         # GH 37668
+        kwargs = {}
         if mpl.__version__ >= "3.3":
-            with tm.assert_produces_warning(None):
-                df.plot.pie(subplots=True, ax=axes, legend=True, normalize=True)
-        else:
-            df.plot.pie(subplots=True, ax=axes, legend=True)
+            kwargs = {"normalize": True}
+
+        with tm.assert_produces_warning(None):
+            df.plot.pie(subplots=True, ax=axes, legend=True, **kwargs)
 
         base_expected = ["0", "1", "2", "3"]
         for i, ax in enumerate(axes):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -2654,7 +2654,7 @@ class TestDataFramePlots(TestPlotBase):
         for i in range(4):
             df.iloc[i, i] = np.nan
         fig, axes = self.plt.subplots(ncols=4)
-        df.plot.pie(subplots=True, ax=axes, legend=True)
+        df.plot.pie(subplots=True, ax=axes, legend=True, normalize=True)
 
         base_expected = ["0", "1", "2", "3"]
         for i, ax in enumerate(axes):


### PR DESCRIPTION
- [ ] closes #37668
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Fix MatplotlibDeprecationWarning for pie chart by specifically passing ``normalize=True``.