### PR TITLE
Bug in loc raised for numeric label even when label is in Index

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -464,6 +464,7 @@ Indexing
 - Bug in indexing on a :class:`Series` or :class:`DataFrame` with a :class:`MultiIndex` with a level named "0" (:issue:`37194`)
 - Bug in :meth:`Series.__getitem__` when using an unsigned integer array as an indexer giving incorrect results or segfaulting instead of raising ``KeyError`` (:issue:`37218`)
 - Bug in :meth:`Index.where` incorrectly casting numeric values to strings (:issue:`37591`)
+- Bug in :meth:`Series.loc` and :meth:`DataFrame.loc` raises when numeric label was given for object :class:`Index` although label was in :class:`Index` (:issue:`26491`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5200,13 +5200,14 @@ class Index(IndexOpsMixin, PandasObject):
         # We are a plain index here (sub-class override this method if they
         # wish to have special treatment for floats/ints, e.g. Float64Index and
         # datetimelike Indexes
-        # reject them
-        if is_float(label):
+        # reject them, if index does not contain label
+        if is_float(label) and label not in self.values:
             self._invalid_indexer("slice", label)
 
         # we are trying to find integer bounds on a non-integer based index
-        # this is rejected (generally .loc gets you here)
-        elif is_integer(label):
+        # this is rejected (generally .loc gets you here) if label is not in
+        # index
+        elif is_integer(label) and label not in self.values:
             self._invalid_indexer("slice", label)
 
         return label

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -5201,13 +5201,7 @@ class Index(IndexOpsMixin, PandasObject):
         # wish to have special treatment for floats/ints, e.g. Float64Index and
         # datetimelike Indexes
         # reject them, if index does not contain label
-        if is_float(label) and label not in self.values:
-            self._invalid_indexer("slice", label)
-
-        # we are trying to find integer bounds on a non-integer based index
-        # this is rejected (generally .loc gets you here) if label is not in
-        # index
-        elif is_integer(label) and label not in self.values:
+        if (is_float(label) or is_integer(label)) and label not in self.values:
             self._invalid_indexer("slice", label)
 
         return label

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1581,11 +1581,10 @@ class TestLocSeries:
         assert result == expected
 
 
-@pytest.mark.parametrize("klass", [DataFrame, Series])
 @pytest.mark.parametrize("value", [1, 1.5])
-def test_loc_int_in_object_index(klass, value):
+def test_loc_int_in_object_index(frame_or_series, value):
     # GH: 26491
-    obj = klass(range(4), index=[value, "first", 2, "third"])
+    obj = frame_or_series(range(4), index=[value, "first", 2, "third"])
     result = obj.loc[value:"third"]
-    expected = klass(range(4), index=[value, "first", 2, "third"])
+    expected = frame_or_series(range(4), index=[value, "first", 2, "third"])
     tm.assert_equal(result, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1579,3 +1579,13 @@ class TestLocSeries:
         s2["a"] = expected
         result = s2["a"]
         assert result == expected
+
+
+@pytest.mark.parametrize("klass", [DataFrame, Series])
+@pytest.mark.parametrize("value", [1, 1.5])
+def test_loc_int_in_object_index(klass, value):
+    # GH: 26491
+    obj = klass(range(4), index=[value, "first", 2, "third"])
+    result = obj.loc[value:"third"]
+    expected = klass(range(4), index=[value, "first", 2, "third"])
+    tm.assert_equal(result, expected)


### PR DESCRIPTION
- [x] closes #26491
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Additionally checking for the label inside values, this fixes the problem.