### PR TITLE
CLN: _replace_single

### DIFF
--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -819,7 +819,13 @@ class Block(PandasObject):
         return blocks
 
     def _replace_single(
-        self, to_replace, value, inplace=False, regex=False, convert=True, mask=None
+        self,
+        to_replace,
+        value,
+        inplace: bool = False,
+        regex: bool = False,
+        convert=True,
+        mask=None,
     ) -> List["Block"]:
         """ no-op on a non-ObjectBlock """
         return [self] if inplace else [self.copy()]
@@ -860,9 +866,9 @@ class Block(PandasObject):
                 m = masks[i]
                 convert = i == src_len  # only convert once at the end
                 result = blk._replace_coerce(
-                    mask=m,
                     to_replace=src,
                     value=dest,
+                    mask=m,
                     inplace=inplace,
                     regex=regex,
                 )
@@ -1567,9 +1573,9 @@ class Block(PandasObject):
         self,
         to_replace,
         value,
+        mask: np.ndarray,
         inplace: bool = True,
         regex: bool = False,
-        mask=None,
     ) -> List["Block"]:
         """
         Replace value corresponding to the given boolean array with another
@@ -1581,12 +1587,12 @@ class Block(PandasObject):
             Scalar to replace or regular expression to match.
         value : object
             Replacement object.
+        mask : np.ndarray[bool]
+            True indicate corresponding element is ignored.
         inplace : bool, default True
             Perform inplace modification.
         regex : bool, default False
             If true, perform regular expression substitution.
-        mask : array-like of bool, optional
-            True indicate corresponding element is ignored.
 
         Returns
         -------
@@ -2495,7 +2501,12 @@ class ObjectBlock(Block):
         return True
 
     def replace(
-        self, to_replace, value, inplace=False, regex=False, convert=True
+        self,
+        to_replace,
+        value,
+        inplace: bool = False,
+        regex: bool = False,
+        convert=True,
     ) -> List["Block"]:
         to_rep_is_list = is_list_like(to_replace)
         value_is_list = is_list_like(value)
@@ -2540,7 +2551,13 @@ class ObjectBlock(Block):
         )
 
     def _replace_single(
-        self, to_replace, value, inplace=False, regex=False, convert=True, mask=None
+        self,
+        to_replace,
+        value,
+        inplace: bool = False,
+        regex: bool = False,
+        convert=True,
+        mask=None,
     ) -> List["Block"]:
         """
         Replace elements by the given value.
@@ -2567,23 +2584,7 @@ class ObjectBlock(Block):
         inplace = validate_bool_kwarg(inplace, "inplace")
 
         # to_replace is regex compilable
-        to_rep_re = regex and is_re_compilable(to_replace)
-
-        # regex is regex compilable
-        regex_re = is_re_compilable(regex)
-
-        # only one will survive
-        if to_rep_re and regex_re:
-            raise AssertionError(
-                "only one of to_replace and regex can be regex compilable"
-            )
-
-        # if regex was passed as something that can be a regex (rather than a
-        # boolean)
-        if regex_re:
-            to_replace = regex
-
-        regex = regex_re or to_rep_re
+        regex = regex and is_re_compilable(to_replace)
 
         # try to get the pattern attribute (compiled re) or it's a string
         if is_re(to_replace):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -824,7 +824,7 @@ class Block(PandasObject):
         value,
         inplace: bool = False,
         regex: bool = False,
-        convert=True,
+        convert: bool = True,
         mask=None,
     ) -> List["Block"]:
         """ no-op on a non-ObjectBlock """
@@ -2506,7 +2506,7 @@ class ObjectBlock(Block):
         value,
         inplace: bool = False,
         regex: bool = False,
-        convert=True,
+        convert: bool = True,
     ) -> List["Block"]:
         to_rep_is_list = is_list_like(to_replace)
         value_is_list = is_list_like(value)
@@ -2556,7 +2556,7 @@ class ObjectBlock(Block):
         value,
         inplace: bool = False,
         regex: bool = False,
-        convert=True,
+        convert: bool = True,
         mask=None,
     ) -> List["Block"]:
         """

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -726,7 +726,6 @@ class Block(PandasObject):
         value,
         inplace: bool = False,
         regex: bool = False,
-        convert: bool = True,
     ) -> List["Block"]:
         """
         replace the to_replace value with value, possible to create new
@@ -755,9 +754,7 @@ class Block(PandasObject):
             if len(to_replace) == 1:
                 # _can_hold_element checks have reduced this back to the
                 #  scalar case and we can avoid a costly object cast
-                return self.replace(
-                    to_replace[0], value, inplace=inplace, regex=regex, convert=convert
-                )
+                return self.replace(to_replace[0], value, inplace=inplace, regex=regex)
 
             # GH 22083, TypeError or ValueError occurred within error handling
             # causes infinite loop. Cast and retry only if not objectblock.
@@ -771,7 +768,6 @@ class Block(PandasObject):
                 value=value,
                 inplace=inplace,
                 regex=regex,
-                convert=convert,
             )
 
         values = self.values
@@ -810,12 +806,11 @@ class Block(PandasObject):
                 value=value,
                 inplace=inplace,
                 regex=regex,
-                convert=convert,
             )
-        if convert:
-            blocks = extend_blocks(
-                [b.convert(numeric=False, copy=not inplace) for b in blocks]
-            )
+
+        blocks = extend_blocks(
+            [b.convert(numeric=False, copy=not inplace) for b in blocks]
+        )
         return blocks
 
     def _replace_single(
@@ -2506,7 +2501,6 @@ class ObjectBlock(Block):
         value,
         inplace: bool = False,
         regex: bool = False,
-        convert: bool = True,
     ) -> List["Block"]:
         to_rep_is_list = is_list_like(to_replace)
         value_is_list = is_list_like(value)
@@ -2517,20 +2511,14 @@ class ObjectBlock(Block):
         blocks: List["Block"] = [self]
 
         if not either_list and is_re(to_replace):
-            return self._replace_single(
-                to_replace, value, inplace=inplace, regex=True, convert=convert
-            )
+            return self._replace_single(to_replace, value, inplace=inplace, regex=True)
         elif not (either_list or regex):
-            return super().replace(
-                to_replace, value, inplace=inplace, regex=regex, convert=convert
-            )
+            return super().replace(to_replace, value, inplace=inplace, regex=regex)
         elif both_lists:
             for to_rep, v in zip(to_replace, value):
                 result_blocks = []
                 for b in blocks:
-                    result = b._replace_single(
-                        to_rep, v, inplace=inplace, regex=regex, convert=convert
-                    )
+                    result = b._replace_single(to_rep, v, inplace=inplace, regex=regex)
                     result_blocks.extend(result)
                 blocks = result_blocks
             return result_blocks
@@ -2540,15 +2528,13 @@ class ObjectBlock(Block):
                 result_blocks = []
                 for b in blocks:
                     result = b._replace_single(
-                        to_rep, value, inplace=inplace, regex=regex, convert=convert
+                        to_rep, value, inplace=inplace, regex=regex
                     )
                     result_blocks.extend(result)
                 blocks = result_blocks
             return result_blocks
 
-        return self._replace_single(
-            to_replace, value, inplace=inplace, convert=convert, regex=regex
-        )
+        return self._replace_single(to_replace, value, inplace=inplace, regex=regex)
 
     def _replace_single(
         self,
@@ -2647,7 +2633,6 @@ class CategoricalBlock(ExtensionBlock):
         value,
         inplace: bool = False,
         regex: bool = False,
-        convert: bool = True,
     ) -> List["Block"]:
         inplace = validate_bool_kwarg(inplace, "inplace")
         result = self if inplace else self.copy()

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -638,9 +638,11 @@ class BlockManager(PandasObject):
             coerce=coerce,
         )
 
-    def replace(self, value, **kwargs) -> "BlockManager":
+    def replace(self, to_replace, value, inplace: bool, regex: bool) -> "BlockManager":
         assert np.ndim(value) == 0, value
-        return self.apply("replace", value=value, **kwargs)
+        return self.apply(
+            "replace", to_replace=to_replace, value=value, inplace=inplace, regex=regex
+        )
 
     def replace_list(
         self: T,


### PR DESCRIPTION
Confirmed that the `regex` kwarg is always bool, which lets us remove some gymnastics (L2570-L2586).  Then removed always-True `convert` kwarg.