### PR TITLE
BUG: DataFrame.groupby(., dropna=True, axis=0) incorrectly throws ShapeError [RESUBMIT]

### DIFF
--- a/doc/source/whatsnew/v1.2.0.rst
+++ b/doc/source/whatsnew/v1.2.0.rst
@@ -470,7 +470,7 @@ Missing
 ^^^^^^^
 
 - Bug in :meth:`SeriesGroupBy.transform` now correctly handles missing values for ``dropna=False`` (:issue:`35014`)
--
+- Bug in :class:`Grouper` now correctly propagates ``dropna`` argument and :meth:`DataFrameGroupBy.transform` now correctly handles missing values for ``dropna=True``(:issue:`35612`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -556,7 +556,6 @@ class SeriesGroupBy(GroupBy[Series]):
                 result = maybe_downcast_numeric(result, self._selected_obj.dtype)
 
         result.name = self._selected_obj.name
-        result.index = self._selected_obj.index
         return result
 
     def _transform_fast(self, result) -> Series:

--- a/pandas/tests/groupby/test_groupby_dropna.py
+++ b/pandas/tests/groupby/test_groupby_dropna.py
@@ -171,36 +171,53 @@ def test_grouper_dropna_propagation(dropna):
 
 
 @pytest.mark.parametrize(
-    "dropna,df_expected,s_expected",
+    "dropna,input_index,expected_data,expected_index",
     [
-        pytest.param(
+        (True, pd.RangeIndex(0, 4), {"B": [2, 2, 1]}, pd.RangeIndex(0, 3)),
+        (True, list("abcd"), {"B": [2, 2, 1]}, list("abc")),
+        (
             True,
-            pd.DataFrame({"B": [2, 2, 1]}),
-            pd.Series(data=[2, 2, 1], name="B"),
-            marks=pytest.mark.xfail(raises=ValueError),
+            pd.MultiIndex.from_tuples(
+                [(1, "R"), (1, "B"), (2, "R"), (2, "B")], names=["num", "col"]
+            ),
+            {"B": [2, 2, 1]},
+            pd.MultiIndex.from_tuples(
+                [(1, "R"), (1, "B"), (2, "R")], names=["num", "col"]
+            ),
         ),
+        (False, pd.RangeIndex(0, 4), {"B": [2, 2, 1, 1]}, pd.RangeIndex(0, 4)),
+        (False, list("abcd"), {"B": [2, 2, 1, 1]}, list("abcd")),
         (
             False,
-            pd.DataFrame({"B": [2, 2, 1, 1]}),
-            pd.Series(data=[2, 2, 1, 1], name="B"),
+            pd.MultiIndex.from_tuples(
+                [(1, "R"), (1, "B"), (2, "R"), (2, "B")], names=["num", "col"]
+            ),
+            {"B": [2, 2, 1, 1]},
+            pd.MultiIndex.from_tuples(
+                [(1, "R"), (1, "B"), (2, "R"), (2, "B")], names=["num", "col"]
+            ),
         ),
     ],
 )
-def test_slice_groupby_then_transform(dropna, df_expected, s_expected):
-    # GH35014
+def test_groupby_dataframe_slice_then_transform(
+    dropna, input_index, expected_data, expected_index
+):
+    # GH35014 & GH35612
 
-    df = pd.DataFrame({"A": [0, 0, 1, None], "B": [1, 2, 3, None]})
+    df = pd.DataFrame({"A": [0, 0, 1, None], "B": [1, 2, 3, None]}, index=input_index)
     gb = df.groupby("A", dropna=dropna)
 
-    res = gb.transform(len)
-    tm.assert_frame_equal(res, df_expected)
+    result = gb.transform(len)
+    expected = pd.DataFrame(expected_data, index=expected_index)
+    tm.assert_frame_equal(result, expected)
 
-    gb_slice = gb[["B"]]
-    res = gb_slice.transform(len)
-    tm.assert_frame_equal(res, df_expected)
+    result = gb[["B"]].transform(len)
+    expected = pd.DataFrame(expected_data, index=expected_index)
+    tm.assert_frame_equal(result, expected)
 
-    res = gb["B"].transform(len)
-    tm.assert_series_equal(res, s_expected)
+    result = gb["B"].transform(len)
+    expected = pd.Series(expected_data["B"], index=expected_index, name="B")
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -627,7 +627,7 @@ class TestGrouping:
         [
             (
                 "transform",
-                Series(name=2, dtype=np.float64, index=pd.RangeIndex(0, 0, 1)),
+                Series(name=2, dtype=np.float64, index=Index([])),
             ),
             (
                 "agg",


### PR DESCRIPTION
- [x] closes #35612
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Resubmitting #35751 to see if I can get to green here