### PR TITLE
pd.Series.loc.__getitem__ promotes to float64 instead of raising KeyError

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1514,7 +1514,7 @@ def test_series_loc_getitem_label_list_missing_values():
 
 def test_series_getitem_label_list_missing_integer_values():
     # GH: 25927
-    s = pd.Series(
+    s = Series(
         index=np.array([9730701000001104, 10049011000001109]),
         data=np.array([999000011000001104, 999000011000001104]),
     )

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1512,6 +1512,16 @@ def test_series_loc_getitem_label_list_missing_values():
         s.loc[key]
 
 
+def test_series_getitem_label_list_missing_integer_values():
+    # GH: 25927
+    s = pd.Series(
+        index=np.array([9730701000001104, 10049011000001109]),
+        data=np.array([999000011000001104, 999000011000001104]),
+    )
+    with pytest.raises(KeyError, match="with any missing labels"):
+        s.loc[np.array([9730701000001104, 10047311000001102])]
+
+
 @pytest.mark.parametrize(
     "columns, column_key, expected_columns, check_column_type",
     [


### PR DESCRIPTION
- [x] closes #25927
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

cc @jreback Added a test. The test above was the only one explicitly added for the ``KeyError``
