### PR TITLE
CLN: Clean indexing tests

### DIFF
--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -615,7 +615,6 @@ class TestiLoc2:
         # UserWarnings from reindex of a boolean mask
         with catch_warnings(record=True):
             simplefilter("ignore", UserWarning)
-            result = dict()
             for idx in [None, "index", "locs"]:
                 mask = (df.nums > 2).values
                 if idx:

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -843,6 +843,7 @@ class TestMisc:
 
         result = maybe_numeric_slice(df, None, include_bool=True)
         expected = pd.IndexSlice[:, ["A", "C"]]
+        assert all(result[1] == expected[1])
         result = maybe_numeric_slice(df, [1])
         expected = [1]
         assert result == expected

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1192,8 +1192,7 @@ class TestLocWithMultiIndex:
         times = date_range("2000-01-01", freq="10min", periods=100000)
         ser = Series(range(100000), times)
         result = ser.loc[datetime(1900, 1, 1) : datetime(2100, 1, 1)]
-        expected = Series(range(100000), times)
-        tm.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, ser)
 
 
 class TestLocSetitemWithExpansion:

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -1191,7 +1191,9 @@ class TestLocWithMultiIndex:
     def test_loc_getitem_slice_datetime_objs_with_datetimeindex(self):
         times = date_range("2000-01-01", freq="10min", periods=100000)
         ser = Series(range(100000), times)
-        ser.loc[datetime(1900, 1, 1) : datetime(2100, 1, 1)]
+        result = ser.loc[datetime(1900, 1, 1) : datetime(2100, 1, 1)]
+        expected = Series(range(100000), times)
+        tm.assert_series_equal(result, expected)
 
 
 class TestLocSetitemWithExpansion:

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -185,14 +185,14 @@ class TestPartialSetting:
         # loc equiv to .reindex
         expected = Series([np.nan, 0.2, np.nan], index=[3, 2, 3])
         with pytest.raises(KeyError, match="with any missing labels"):
-            result = ser.loc[[3, 2, 3]]
+            ser.loc[[3, 2, 3]]
 
         result = ser.reindex([3, 2, 3])
         tm.assert_series_equal(result, expected, check_index_type=True)
 
         expected = Series([np.nan, 0.2, np.nan, np.nan], index=[3, 2, 3, "x"])
         with pytest.raises(KeyError, match="with any missing labels"):
-            result = ser.loc[[3, 2, 3, "x"]]
+            ser.loc[[3, 2, 3, "x"]]
 
         result = ser.reindex([3, 2, 3, "x"])
         tm.assert_series_equal(result, expected, check_index_type=True)
@@ -203,7 +203,7 @@ class TestPartialSetting:
 
         expected = Series([0.2, 0.2, np.nan, 0.1], index=[2, 2, "x", 1])
         with pytest.raises(KeyError, match="with any missing labels"):
-            result = ser.loc[[2, 2, "x", 1]]
+            ser.loc[[2, 2, "x", 1]]
 
         result = ser.reindex([2, 2, "x", 1])
         tm.assert_series_equal(result, expected, check_index_type=True)


### PR DESCRIPTION
- [x] tests passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Found a few unuesed statements