### PR TITLE
DOC: add examples to insert and update generally

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3741,6 +3741,8 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Insert column into DataFrame at specified location.
 
+        Performs column insertion in-place.
+
         Raises a ValueError if `column` is already contained in the DataFrame,
         unless `allow_duplicates` is set to True.
 
@@ -3751,7 +3753,31 @@ class DataFrame(NDFrame, OpsMixin):
         column : str, number, or hashable object
             Label of the inserted column.
         value : int, Series, or array-like
+            Input data to be inserted.
         allow_duplicates : bool, optional
+            Whether to allow duplicate column label names.
+
+        See Also
+        --------
+        Index.insert : Insert new item by index.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df
+           col1  col2
+        0     1     3
+        1     2     4
+        >>> df.insert(1, "newcol", [99, 99])
+        >>> df
+           col1  newcol  col2
+        0     1      99     3
+        1     2      99     4
+        >>> df.insert(0, "col1", [100, 100], allow_duplicates=True)
+        >>> df
+           col1  col1  newcol  col2
+        0   100     1      99     3
+        1   100     2      99     4
         """
         if allow_duplicates and not self.flags.allows_duplicate_labels:
             raise ValueError(

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3741,8 +3741,6 @@ class DataFrame(NDFrame, OpsMixin):
         """
         Insert column into DataFrame at specified location.
 
-        Performs column insertion in-place.
-
         Raises a ValueError if `column` is already contained in the DataFrame,
         unless `allow_duplicates` is set to True.
 
@@ -3753,9 +3751,7 @@ class DataFrame(NDFrame, OpsMixin):
         column : str, number, or hashable object
             Label of the inserted column.
         value : int, Series, or array-like
-            Input data to be inserted.
         allow_duplicates : bool, optional
-            Whether to allow duplicate column label names.
 
         See Also
         --------


### PR DESCRIPTION
This commit mainly adds examples on usage. This commit also fills in
information suggested by `validate_docstrings.py` script.

Ran

```
python scripts/validate_docstrings.py pandas.DataFrame.insert
```

to check docs and added in suggested information (e.g., See Also section).

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
