### PR TITLE
DOC: capitalize Gregorian and fix word order

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -2316,7 +2316,7 @@ class Period(_Period):
     freq : str, default None
         One of pandas period strings or corresponding objects.
     ordinal : int, default None
-        The period offset from the gregorian proleptic epoch.
+        The period offset from the proleptic Gregorian epoch.
     year : int, default None
         Year value of the period.
     month : int, default 1


### PR DESCRIPTION
Gregorian is a proper noun
(https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar). Also,
"proleptic" is modifying the compound noun "Gregorian epoch" rather than
"Gregorian" modifying a "proleptic epoch".

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
