### PR TITLE
TST: move and reformat latex_na_rep test

### DIFF
--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -972,6 +972,30 @@ class TestToLatexFormatters:
         )
         assert result == expected
 
+    @pytest.mark.parametrize("na_rep", ["NaN", "Ted"])
+    def test_to_latex_na_rep_and_float_format(self, na_rep):
+        df = DataFrame(
+            [
+                ["A", 1.2225],
+                ["A", None],
+            ],
+            columns=["Group", "Data"],
+        )
+        result = df.to_latex(na_rep=na_rep, float_format="{:.2f}".format)
+        expected = _dedent(
+            fr"""
+            \begin{{tabular}}{{llr}}
+            \toprule
+            {{}} & Group &  Data \\
+            \midrule
+            0 &     A &  1.22 \\
+            1 &     A &   {na_rep} \\
+            \bottomrule
+            \end{{tabular}}
+            """
+        )
+        assert result == expected
+
 
 class TestToLatexMultiindex:
     @pytest.fixture
@@ -1431,24 +1455,3 @@ class TestRowStringConverter:
         )
 
         assert row_string_converter.get_strrow(row_num=row_num) == expected
-
-    @pytest.mark.parametrize("na_rep", ["NaN", "Ted"])
-    def test_to_latex_na_rep_and_float_format(self, na_rep):
-        df = DataFrame(
-            [
-                ["A", 1.2225],
-                ["A", None],
-            ],
-            columns=["Group", "Data"],
-        )
-        result = df.to_latex(na_rep=na_rep, float_format="{:.2f}".format)
-        expected = f"""\\begin{{tabular}}{{llr}}
-\\toprule
-{{}} & Group &  Data \\\\
-\\midrule
-0 &     A &  1.22 \\\\
-1 &     A &   {na_rep} \\\\
-\\bottomrule
-\\end{{tabular}}
-"""
-        assert result == expected


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Move test to a more suitable location (``class TestToLatexFormatters``)
and reformat using ``_dedent`` and raw string for better readability.