### PR TITLE
TST: Add test for KeyError with MultiIndex

### DIFF
--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -602,7 +602,7 @@ def test_getitem_loc_commutability(multiindex_year_month_day_dataframe_random_da
 
 def test_getitem_non_found_tuple():
     # GH: 25236
-    df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"]).set_index(
+    df = DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"]).set_index(
         ["a", "b", "c"]
     )
     with pytest.raises(KeyError, match=r"\(2\.0, 2\.0, 3\.0\)"):

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -598,3 +598,10 @@ def test_getitem_loc_commutability(multiindex_year_month_day_dataframe_random_da
     result = ser[2000, 5]
     expected = df.loc[2000, 5]["A"]
     tm.assert_series_equal(result, expected)
+
+
+def test_getitem_non_found_tuple():
+    # GH: 25236
+    df = pd.DataFrame([[1, 2, 3, 4]], columns=['a', 'b', 'c', 'd']).set_index(['a', 'b', 'c'])
+    with pytest.raises(KeyError, match=r"\(2\.0, 2\.0, 3\.0\)"):
+        df.loc[(2., 2., 3.)]

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -602,6 +602,8 @@ def test_getitem_loc_commutability(multiindex_year_month_day_dataframe_random_da
 
 def test_getitem_non_found_tuple():
     # GH: 25236
-    df = pd.DataFrame([[1, 2, 3, 4]], columns=['a', 'b', 'c', 'd']).set_index(['a', 'b', 'c'])
+    df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"]).set_index(
+        ["a", "b", "c"]
+    )
     with pytest.raises(KeyError, match=r"\(2\.0, 2\.0, 3\.0\)"):
-        df.loc[(2., 2., 3.)]
+        df.loc[(2.0, 2.0, 3.0)]


### PR DESCRIPTION
- [x] closes #25236
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

cc @jreback Added a test